### PR TITLE
Fix XDG-aware global OMC config/state paths on Unix

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -512,7 +512,11 @@ Oh-my-claudecode includes 31 lifecycle hooks that enhance Claude Code's behavior
 
 The `code-simplifier` Stop hook automatically delegates recently modified source files to the
 `code-simplifier` agent after each Claude turn. It is **disabled by default** and must be
-explicitly enabled via `~/.omc/config.json`.
+explicitly enabled via the global OMC config file:
+
+- Linux/Unix default: `${XDG_CONFIG_HOME:-~/.config}/omc/config.json`
+- macOS/Windows legacy/default path: `~/.omc/config.json`
+- Existing legacy `~/.omc/config.json` continues to be read as a fallback where applicable.
 
 **Enable:**
 

--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -6,13 +6,19 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
+import { tmpdir } from 'os';
 
-const TEST_CLAUDE_DIR = join(homedir(), '.claude-test-doctor-conflicts');
-const TEST_PROJECT_DIR = join(homedir(), '.claude-test-doctor-project');
-const TEST_PROJECT_CLAUDE_DIR = join(TEST_PROJECT_DIR, '.claude');
+let TEST_CLAUDE_DIR = '';
+let TEST_PROJECT_DIR = '';
+let TEST_PROJECT_CLAUDE_DIR = '';
+
+function resetTestDirs(): void {
+  TEST_CLAUDE_DIR = mkdtempSync(join(tmpdir(), 'omc-doctor-conflicts-claude-'));
+  TEST_PROJECT_DIR = mkdtempSync(join(tmpdir(), 'omc-doctor-conflicts-project-'));
+  TEST_PROJECT_CLAUDE_DIR = join(TEST_PROJECT_DIR, '.claude');
+}
 
 // Mock getClaudeConfigDir before importing the module under test
 vi.mock('../utils/paths.js', async () => {
@@ -48,11 +54,11 @@ describe('doctor-conflicts: hook ownership classification', () => {
 
   beforeEach(() => {
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
-    mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
+    resetTestDirs();
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = TEST_CLAUDE_DIR;
     process.env.CLAUDE_MCP_CONFIG_PATH = join(TEST_CLAUDE_DIR, '..', '.claude.json');
@@ -60,13 +66,13 @@ describe('doctor-conflicts: hook ownership classification', () => {
   });
 
   afterEach(() => {
-    cwdSpy.mockRestore();
+    cwdSpy?.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
     delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.OMC_HOME;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
@@ -360,11 +366,11 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
 
   beforeEach(() => {
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
-    mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
+    resetTestDirs();
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = TEST_CLAUDE_DIR;
     process.env.CLAUDE_MCP_CONFIG_PATH = join(TEST_CLAUDE_DIR, '..', '.claude.json');
@@ -372,13 +378,13 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
   });
 
   afterEach(() => {
-    cwdSpy.mockRestore();
+    cwdSpy?.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
     delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.OMC_HOME;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
@@ -438,19 +444,19 @@ describe('doctor-conflicts: legacy skills collision check (issue #1101)', () => 
 
   beforeEach(() => {
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
-    mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
+    resetTestDirs();
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(TEST_PROJECT_DIR);
   });
 
   afterEach(() => {
-    cwdSpy.mockRestore();
+    cwdSpy?.mockRestore();
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
@@ -522,11 +528,11 @@ describe('doctor-conflicts: config known fields (issue #1499)', () => {
 
   beforeEach(() => {
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }
-    mkdirSync(TEST_CLAUDE_DIR, { recursive: true });
+    resetTestDirs();
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     mkdirSync(join(TEST_PROJECT_DIR, '.omc'), { recursive: true });
     mkdirSync(join(TEST_PROJECT_DIR, '.codex'), { recursive: true });
@@ -538,13 +544,13 @@ describe('doctor-conflicts: config known fields (issue #1499)', () => {
   });
 
   afterEach(() => {
-    cwdSpy.mockRestore();
+    cwdSpy?.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
     delete process.env.CLAUDE_MCP_CONFIG_PATH;
     delete process.env.OMC_HOME;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
-      if (existsSync(dir)) {
+      if (dir && existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
       }
     }

--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -15,9 +15,13 @@ const TEST_PROJECT_DIR = join(homedir(), '.claude-test-doctor-project');
 const TEST_PROJECT_CLAUDE_DIR = join(TEST_PROJECT_DIR, '.claude');
 
 // Mock getClaudeConfigDir before importing the module under test
-vi.mock('../utils/paths.js', () => ({
-  getClaudeConfigDir: () => TEST_CLAUDE_DIR,
-}));
+vi.mock('../utils/paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/paths.js')>('../utils/paths.js');
+  return {
+    ...actual,
+    getClaudeConfigDir: () => TEST_CLAUDE_DIR,
+  };
+});
 
 // Mock builtin skills to return a known list for testing
 vi.mock('../features/builtin-skills/skills.js', () => ({

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { readFile, rm } from 'fs/promises';
-import { homedir } from 'os';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { executeTeamApiOperation as executeCanonicalTeamApiOperation, resolveTeamApiOperation } from '../team/api-interop.js';
@@ -11,6 +10,7 @@ import { validateTeamName } from '../team/team-name.js';
 import { monitorTeam, resumeTeam, shutdownTeam } from '../team/runtime.js';
 import { readTeamConfig } from '../team/monitor.js';
 import { isProcessAlive } from '../platform/index.js';
+import { getGlobalOmcStatePath } from '../utils/paths.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,12}$/;
 const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
@@ -176,7 +176,7 @@ async function assertTeamSpawnAllowed(cwd: string, env: NodeJS.ProcessEnv = proc
 }
 
 function resolveJobsDir(env: NodeJS.ProcessEnv = process.env): string {
-  return env.OMC_JOBS_DIR || join(homedir(), '.omc', 'team-jobs');
+  return env.OMC_JOBS_DIR || getGlobalOmcStatePath('team-jobs');
 }
 
 function resolveRuntimeCliPath(env: NodeJS.ProcessEnv = process.env): string {

--- a/src/features/rate-limit-wait/daemon.ts
+++ b/src/features/rate-limit-wait/daemon.ts
@@ -15,9 +15,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, chmodSync, statSync, appendFileSync, renameSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { homedir } from 'os';
 import { spawn } from 'child_process';
 import { resolveDaemonModulePath } from '../../utils/daemon-module-path.js';
+import { getGlobalOmcStatePath } from '../../utils/paths.js';
 import {
   checkRateLimitStatus,
   formatRateLimitStatus,
@@ -45,9 +45,9 @@ const DEFAULT_CONFIG: Required<DaemonConfig> = {
   pollIntervalMs: 60 * 1000, // 1 minute
   paneLinesToCapture: 15,
   verbose: false,
-  stateFilePath: join(homedir(), '.omc', 'state', 'rate-limit-daemon.json'),
-  pidFilePath: join(homedir(), '.omc', 'state', 'rate-limit-daemon.pid'),
-  logFilePath: join(homedir(), '.omc', 'state', 'rate-limit-daemon.log'),
+  stateFilePath: getGlobalOmcStatePath('rate-limit-daemon.json'),
+  pidFilePath: getGlobalOmcStatePath('rate-limit-daemon.pid'),
+  logFilePath: getGlobalOmcStatePath('rate-limit-daemon.log'),
 };
 
 /** Maximum log file size before rotation (1MB) */

--- a/src/features/rate-limit-wait/types.ts
+++ b/src/features/rate-limit-wait/types.ts
@@ -113,11 +113,11 @@ export interface DaemonConfig {
   paneLinesToCapture?: number;
   /** Whether to log verbose output (default: false) */
   verbose?: boolean;
-  /** State file path (default: ~/.omc/state/rate-limit-daemon.json) */
+  /** State file path (default: XDG-aware global OMC state path) */
   stateFilePath?: string;
-  /** PID file path (default: ~/.omc/state/rate-limit-daemon.pid) */
+  /** PID file path (default: XDG-aware global OMC state path) */
   pidFilePath?: string;
-  /** Log file path (default: ~/.omc/state/rate-limit-daemon.log) */
+  /** Log file path (default: XDG-aware global OMC state path) */
   logFilePath?: string;
 }
 

--- a/src/features/state-manager/index.ts
+++ b/src/features/state-manager/index.ts
@@ -3,7 +3,7 @@
  *
  * Unified state management that standardizes state file locations:
  * - Local state: .omc/state/{name}.json
- * - Global state: ~/.omc/state/{name}.json
+ * - Global state: XDG-aware user OMC state with legacy ~/.omc/state fallback
  *
  * Features:
  * - Type-safe read/write operations
@@ -14,13 +14,13 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import * as os from "os";
 import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
 import {
   OmcPaths,
   getWorktreeRoot,
   validateWorkingDirectory,
 } from "../../lib/worktree-paths.js";
+import { getGlobalOmcStateRoot, getLegacyOmcPath } from "../../utils/paths.js";
 import {
   StateLocation,
   StateConfig,
@@ -45,7 +45,7 @@ function getLocalStateDir(): string {
  * @deprecated for mode state. Global state directory is only used for analytics and daemon state.
  * Mode state should use LOCAL_STATE_DIR exclusively.
  */
-const GLOBAL_STATE_DIR = path.join(os.homedir(), ".omc", "state");
+const GLOBAL_STATE_DIR = getGlobalOmcStateRoot();
 
 /** Maximum age for state files before they are considered stale (4 hours) */
 const MAX_STATE_AGE_MS = 4 * 60 * 60 * 1000;
@@ -96,8 +96,14 @@ export function getStatePath(name: string, location: StateLocation): string {
 /**
  * Get legacy paths for a state file (for migration)
  */
-export function getLegacyPaths(name: string): string[] {
-  return LEGACY_LOCATIONS[name] || [];
+export function getLegacyPaths(name: string, location: StateLocation = StateLocation.LOCAL): string[] {
+  const legacyPaths = [...(LEGACY_LOCATIONS[name] || [])];
+
+  if (location === StateLocation.GLOBAL) {
+    legacyPaths.push(getLegacyOmcPath("state", `${name}.json`));
+  }
+
+  return legacyPaths;
 }
 
 /**
@@ -124,7 +130,7 @@ export function readState<T = StateData>(
 ): StateReadResult<T> {
   const checkLegacy = options?.checkLegacy ?? DEFAULT_STATE_CONFIG.checkLegacy;
   const standardPath = getStatePath(name, location);
-  const legacyPaths = checkLegacy ? getLegacyPaths(name) : [];
+  const legacyPaths = checkLegacy ? getLegacyPaths(name, location) : [];
 
   // Try standard location first
   if (fs.existsSync(standardPath)) {
@@ -307,7 +313,7 @@ export function clearState(
   }
 
   // Remove from legacy locations
-  const legacyPaths = getLegacyPaths(name);
+  const legacyPaths = getLegacyPaths(name, location ?? StateLocation.LOCAL);
   for (const legacyPath of legacyPaths) {
     const resolvedPath = path.isAbsolute(legacyPath)
       ? legacyPath

--- a/src/features/state-manager/types.ts
+++ b/src/features/state-manager/types.ts
@@ -2,7 +2,7 @@
  * State Manager Types
  *
  * Type definitions for unified state management across
- * local (.omc/state/) and global (~/.omc/state/) locations.
+ * local (.omc/state/) and global (XDG-aware user OMC state with legacy ~/.omc/state fallback) locations.
  */
 
 /**
@@ -11,7 +11,7 @@
 export enum StateLocation {
   /** Local project state: .omc/state/{name}.json */
   LOCAL = 'local',
-  /** Global user state: ~/.omc/state/{name}.json */
+  /** Global user state: XDG-aware OMC state path with legacy ~/.omc/state fallback on reads */
   GLOBAL = 'global'
 }
 

--- a/src/hooks/code-simplifier/index.ts
+++ b/src/hooks/code-simplifier/index.ts
@@ -4,14 +4,14 @@
  * Intercepts Stop events to automatically delegate recently modified files
  * to the code-simplifier agent for cleanup and simplification.
  *
- * Opt-in via ~/.omc/config.json: { "codeSimplifier": { "enabled": true } }
+ * Opt-in via global OMC config.json (XDG-aware on Linux/Unix, legacy ~/.omc fallback)
  * Default: disabled (opt-in only)
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { execSync } from 'child_process';
+import { getGlobalOmcConfigCandidates } from '../../utils/paths.js';
 
 /** Config shape for the code-simplifier feature */
 export interface CodeSimplifierConfig {
@@ -40,21 +40,24 @@ const DEFAULT_MAX_FILES = 10;
 export const TRIGGER_MARKER_FILENAME = 'code-simplifier-triggered.marker';
 
 /**
- * Read the global OMC config from ~/.omc/config.json.
+ * Read the global OMC config from the XDG-aware location, with legacy
+ * ~/.omc/config.json fallback for backward compatibility.
  * Returns null if the file does not exist or cannot be parsed.
  */
 export function readOmcConfig(): OmcGlobalConfig | null {
-  const configPath = join(homedir(), '.omc', 'config.json');
+  for (const configPath of getGlobalOmcConfigCandidates('config.json')) {
+    if (!existsSync(configPath)) {
+      continue;
+    }
 
-  if (!existsSync(configPath)) {
-    return null;
+    try {
+      return JSON.parse(readFileSync(configPath, 'utf-8')) as OmcGlobalConfig;
+    } catch {
+      return null;
+    }
   }
 
-  try {
-    return JSON.parse(readFileSync(configPath, 'utf-8')) as OmcGlobalConfig;
-  } catch {
-    return null;
-  }
+  return null;
 }
 
 /**

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -31,11 +31,15 @@ vi.mock('../../../lib/atomic-write.js', () => ({
   atomicWriteJsonSync: vi.fn(),
 }));
 
+const { TEST_HOME } = vi.hoisted(() => ({
+  TEST_HOME: process.env.HOME || '/tmp/omc-test-home',
+}));
+
 vi.mock('os', async () => {
-  const actual = await vi.importActual('os');
+  const actual = await vi.importActual<typeof import('os')>('os');
   return {
     ...actual,
-    homedir: vi.fn().mockReturnValue('/home/testuser'),
+    homedir: vi.fn().mockReturnValue(TEST_HOME),
   };
 });
 
@@ -57,7 +61,7 @@ describe('getIdleNotificationCooldownSeconds', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.HOME = '/home/testuser';
+    process.env.HOME = TEST_HOME;
     delete process.env.XDG_CONFIG_HOME;
     delete process.env.XDG_STATE_HOME;
     delete process.env.OMC_HOME;

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { getGlobalOmcConfigCandidates } from '../../../utils/paths.js';
 import {
   getIdleNotificationCooldownSeconds,
   shouldSendIdleNotification,
@@ -47,8 +48,9 @@ const SESSION_COOLDOWN_PATH = join(
   TEST_SESSION_ID,
   'idle-notif-cooldown.json'
 );
-const CONFIG_PATH = '/home/testuser/.config/omc/config.json';
-const LEGACY_CONFIG_PATH = '/home/testuser/.omc/config.json';
+function getConfigPaths(): [string, string] {
+  return getGlobalOmcConfigCandidates('config.json') as [string, string];
+}
 
 describe('getIdleNotificationCooldownSeconds', () => {
   const originalHome = process.env.HOME;
@@ -56,13 +58,38 @@ describe('getIdleNotificationCooldownSeconds', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.HOME = '/home/testuser';
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.XDG_STATE_HOME;
+    delete process.env.OMC_HOME;
   });
+
+  const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  const originalXdgStateHome = process.env.XDG_STATE_HOME;
+  const originalOmcHome = process.env.OMC_HOME;
 
   afterEach(() => {
     if (originalHome === undefined) {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+
+    if (originalXdgStateHome === undefined) {
+      delete process.env.XDG_STATE_HOME;
+    } else {
+      process.env.XDG_STATE_HOME = originalXdgStateHome;
+    }
+
+    if (originalOmcHome === undefined) {
+      delete process.env.OMC_HOME;
+    } else {
+      process.env.OMC_HOME = originalOmcHome;
     }
   });
 
@@ -78,21 +105,24 @@ describe('getIdleNotificationCooldownSeconds', () => {
       JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 120 } })
     );
 
+    const [configPath] = getConfigPaths();
+
     expect(getIdleNotificationCooldownSeconds()).toBe(120);
-    expect(readFileSync).toHaveBeenCalledWith(CONFIG_PATH, 'utf-8');
+    expect(readFileSync).toHaveBeenCalledWith(configPath, 'utf-8');
   });
 
   it('falls back to legacy ~/.omc config when XDG config is absent', () => {
-    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === LEGACY_CONFIG_PATH);
+    const [, legacyConfigPath] = getConfigPaths();
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === legacyConfigPath);
     (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === LEGACY_CONFIG_PATH) {
+      if (p === legacyConfigPath) {
         return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 45 } });
       }
       throw new Error('not found');
     });
 
     expect(getIdleNotificationCooldownSeconds()).toBe(45);
-    expect(readFileSync).toHaveBeenCalledWith(LEGACY_CONFIG_PATH, 'utf-8');
+    expect(readFileSync).toHaveBeenCalledWith(legacyConfigPath, 'utf-8');
   });
 
   it('returns 0 when cooldown is disabled in config', () => {
@@ -178,7 +208,8 @@ describe('shouldSendIdleNotification', () => {
   it('returns true when no cooldown file exists', () => {
     // config exists but no cooldown file
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) return false; // use default 60s
+      const [configPath] = getConfigPaths();
+      if (p === configPath) return false; // use default 60s
       if (p === COOLDOWN_PATH) return false;
       return false;
     });
@@ -217,12 +248,14 @@ describe('shouldSendIdleNotification', () => {
   it('returns true when cooldown is disabled (0 seconds)', () => {
     const recentTimestamp = new Date(Date.now() - 5_000).toISOString(); // 5s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) return true;
+      const [configPath] = getConfigPaths();
+      if (p === configPath) return true;
       if (p === COOLDOWN_PATH) return true;
       return false;
     });
     (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH)
+      const [configPath] = getConfigPaths();
+      if (p === configPath)
         return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 0 } });
       if (p === COOLDOWN_PATH) return JSON.stringify({ lastSentAt: recentTimestamp });
       throw new Error('not found');
@@ -260,12 +293,14 @@ describe('shouldSendIdleNotification', () => {
   it('respects a custom cooldown from config', () => {
     const recentTimestamp = new Date(Date.now() - 10_000).toISOString(); // 10s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) return true;
+      const [configPath] = getConfigPaths();
+      if (p === configPath) return true;
       if (p === COOLDOWN_PATH) return true;
       return false;
     });
     (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH)
+      const [configPath] = getConfigPaths();
+      if (p === configPath)
         return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 5 } });
       if (p === COOLDOWN_PATH) return JSON.stringify({ lastSentAt: recentTimestamp });
       throw new Error('not found');
@@ -278,12 +313,14 @@ describe('shouldSendIdleNotification', () => {
   it('uses session-scoped cooldown file when sessionId is provided', () => {
     const recentTimestamp = new Date(Date.now() - 10_000).toISOString(); // 10s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) return true;
+      const [configPath] = getConfigPaths();
+      if (p === configPath) return true;
       if (p === SESSION_COOLDOWN_PATH) return true;
       return false;
     });
     (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) {
+      const [configPath] = getConfigPaths();
+      if (p === configPath) {
         return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 30 } });
       }
       if (p === SESSION_COOLDOWN_PATH) return JSON.stringify({ lastSentAt: recentTimestamp });
@@ -296,12 +333,14 @@ describe('shouldSendIdleNotification', () => {
   it('blocks notification when within custom shorter cooldown', () => {
     const recentTimestamp = new Date(Date.now() - 10_000).toISOString(); // 10s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) return true;
+      const [configPath] = getConfigPaths();
+      if (p === configPath) return true;
       if (p === COOLDOWN_PATH) return true;
       return false;
     });
     (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH)
+      const [configPath] = getConfigPaths();
+      if (p === configPath)
         return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 30 } });
       if (p === COOLDOWN_PATH) return JSON.stringify({ lastSentAt: recentTimestamp });
       throw new Error('not found');
@@ -314,12 +353,14 @@ describe('shouldSendIdleNotification', () => {
   it('treats negative sessionIdleSeconds as 0 (disabled), always sends', () => {
     const recentTimestamp = new Date(Date.now() - 5_000).toISOString(); // 5s ago
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH) return true;
+      const [configPath] = getConfigPaths();
+      if (p === configPath) return true;
       if (p === COOLDOWN_PATH) return true;
       return false;
     });
     (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
-      if (p === CONFIG_PATH)
+      const [configPath] = getConfigPaths();
+      if (p === configPath)
         return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: -30 } });
       if (p === COOLDOWN_PATH) return JSON.stringify({ lastSentAt: recentTimestamp });
       throw new Error('not found');

--- a/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts
@@ -3,7 +3,7 @@
  * Verifies that idle notifications are rate-limited per session.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import {
@@ -47,11 +47,23 @@ const SESSION_COOLDOWN_PATH = join(
   TEST_SESSION_ID,
   'idle-notif-cooldown.json'
 );
-const CONFIG_PATH = '/home/testuser/.omc/config.json';
+const CONFIG_PATH = '/home/testuser/.config/omc/config.json';
+const LEGACY_CONFIG_PATH = '/home/testuser/.omc/config.json';
 
 describe('getIdleNotificationCooldownSeconds', () => {
+  const originalHome = process.env.HOME;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.HOME = '/home/testuser';
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
   });
 
   it('returns 60 when config file does not exist', () => {
@@ -68,6 +80,19 @@ describe('getIdleNotificationCooldownSeconds', () => {
 
     expect(getIdleNotificationCooldownSeconds()).toBe(120);
     expect(readFileSync).toHaveBeenCalledWith(CONFIG_PATH, 'utf-8');
+  });
+
+  it('falls back to legacy ~/.omc config when XDG config is absent', () => {
+    (existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => p === LEGACY_CONFIG_PATH);
+    (readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      if (p === LEGACY_CONFIG_PATH) {
+        return JSON.stringify({ notificationCooldown: { sessionIdleSeconds: 45 } });
+      }
+      throw new Error('not found');
+    });
+
+    expect(getIdleNotificationCooldownSeconds()).toBe(45);
+    expect(readFileSync).toHaveBeenCalledWith(LEGACY_CONFIG_PATH, 'utf-8');
   });
 
   it('returns 0 when cooldown is disabled in config', () => {

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -13,8 +13,7 @@
 import { existsSync, readFileSync, unlinkSync, statSync, openSync, readSync, closeSync, mkdirSync } from 'fs';
 import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
 import { join } from 'path';
-import { homedir } from 'os';
-import { getClaudeConfigDir } from '../../utils/paths.js';
+import { getClaudeConfigDir, getGlobalOmcConfigCandidates } from '../../utils/paths.js';
 import {
   readUltraworkState,
   writeUltraworkState,
@@ -241,19 +240,21 @@ export function resetTodoContinuationAttempts(sessionId: string): void {
 }
 
 /**
- * Read the session-idle notification cooldown in seconds from ~/.omc/config.json.
+ * Read the session-idle notification cooldown in seconds from global OMC config.
  * Default: 60 seconds. 0 = disabled (no cooldown).
  */
 export function getIdleNotificationCooldownSeconds(): number {
-  const configPath = join(homedir(), '.omc', 'config.json');
-  try {
-    if (!existsSync(configPath)) return 60;
-    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
-    const cooldown = (config?.notificationCooldown as Record<string, unknown> | undefined);
-    const val = cooldown?.sessionIdleSeconds;
-    if (typeof val === 'number' && Number.isFinite(val)) return Math.max(0, val);
-  } catch {
-    // ignore parse errors
+  for (const configPath of getGlobalOmcConfigCandidates('config.json')) {
+    try {
+      if (!existsSync(configPath)) continue;
+      const config = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+      const cooldown = (config?.notificationCooldown as Record<string, unknown> | undefined);
+      const val = cooldown?.sessionIdleSeconds;
+      if (typeof val === 'number' && Number.isFinite(val)) return Math.max(0, val);
+      return 60;
+    } catch {
+      return 60;
+    }
   }
   return 60;
 }

--- a/src/installer/__tests__/mcp-registry.test.ts
+++ b/src/installer/__tests__/mcp-registry.test.ts
@@ -18,8 +18,12 @@ describe('unified MCP registry sync', () => {
   let claudeDir: string;
   let codexDir: string;
   let omcDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalPlatform: NodeJS.Platform;
 
   beforeEach(() => {
+    originalEnv = { ...process.env };
+    originalPlatform = process.platform;
     testRoot = mkdtempSync(join(tmpdir(), 'omc-mcp-registry-'));
     claudeDir = join(testRoot, '.claude');
     codexDir = join(testRoot, '.codex');
@@ -35,10 +39,8 @@ describe('unified MCP registry sync', () => {
   });
 
   afterEach(() => {
-    delete process.env.CLAUDE_CONFIG_DIR;
-    delete process.env.CLAUDE_MCP_CONFIG_PATH;
-    delete process.env.CODEX_HOME;
-    delete process.env.OMC_HOME;
+    process.env = originalEnv;
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
 
     if (existsSync(testRoot)) {
       rmSync(testRoot, { recursive: true, force: true });
@@ -321,5 +323,46 @@ describe('unified MCP registry sync', () => {
     expect(status.codexMissing).toEqual([]);
     expect(status.claudeMismatched).toEqual(['remoteOmc']);
     expect(status.codexMismatched).toEqual(['remoteOmc']);
+  });
+
+  it('uses XDG config/state defaults when OMC_HOME is unset on Linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.OMC_HOME;
+    process.env.HOME = testRoot;
+    process.env.XDG_CONFIG_HOME = join(testRoot, '.config');
+    process.env.XDG_STATE_HOME = join(testRoot, '.state');
+
+    const { result } = syncUnifiedMcpRegistryTargets({
+      mcpServers: {
+        gitnexus: {
+          command: 'gitnexus',
+          args: ['mcp'],
+        },
+      },
+    });
+
+    expect(result.registryPath).toBe(join(testRoot, '.config', 'omc', 'mcp-registry.json'));
+    expect(existsSync(join(testRoot, '.config', 'omc', 'mcp-registry.json'))).toBe(true);
+    expect(existsSync(join(testRoot, '.state', 'omc', 'mcp-registry-state.json'))).toBe(true);
+  });
+
+  it('falls back to legacy ~/.omc registry when the XDG registry does not exist', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.OMC_HOME;
+    process.env.HOME = testRoot;
+    process.env.XDG_CONFIG_HOME = join(testRoot, '.config');
+    process.env.XDG_STATE_HOME = join(testRoot, '.state');
+
+    const legacyRegistryDir = join(testRoot, '.omc');
+    mkdirSync(legacyRegistryDir, { recursive: true });
+    writeFileSync(join(legacyRegistryDir, 'mcp-registry.json'), JSON.stringify({
+      gitnexus: { command: 'gitnexus', args: ['mcp'] },
+    }, null, 2));
+
+    const { result } = syncUnifiedMcpRegistryTargets({ theme: 'dark' });
+
+    expect(result.registryExists).toBe(true);
+    expect(result.serverNames).toEqual(['gitnexus']);
+    expect(result.bootstrappedFromClaude).toBe(false);
   });
 });

--- a/src/installer/mcp-registry.ts
+++ b/src/installer/mcp-registry.ts
@@ -3,6 +3,12 @@ import { homedir } from 'os';
 import { dirname, join } from 'path';
 
 import { getConfigDir } from '../utils/config-dir.js';
+import {
+  getGlobalOmcConfigPath,
+  getGlobalOmcConfigCandidates,
+  getGlobalOmcStatePath,
+  getGlobalOmcStateCandidates,
+} from '../utils/paths.js';
 
 export interface UnifiedMcpRegistryEntry {
   command?: string;
@@ -40,16 +46,24 @@ export interface UnifiedMcpRegistryStatus {
 const MANAGED_START = '# BEGIN OMC MANAGED MCP REGISTRY';
 const MANAGED_END = '# END OMC MANAGED MCP REGISTRY';
 
-function getOmcHomeDir(): string {
-  return process.env.OMC_HOME?.trim() || join(homedir(), '.omc');
-}
-
 export function getUnifiedMcpRegistryPath(): string {
-  return process.env.OMC_MCP_REGISTRY_PATH?.trim() || join(getOmcHomeDir(), 'mcp-registry.json');
+  return process.env.OMC_MCP_REGISTRY_PATH?.trim() || getGlobalOmcConfigPath('mcp-registry.json');
 }
 
 function getUnifiedMcpRegistryStatePath(): string {
-  return join(getOmcHomeDir(), 'mcp-registry-state.json');
+  return getGlobalOmcStatePath('mcp-registry-state.json');
+}
+
+function getUnifiedMcpRegistryPathCandidates(): string[] {
+  if (process.env.OMC_MCP_REGISTRY_PATH?.trim()) {
+    return [process.env.OMC_MCP_REGISTRY_PATH.trim()];
+  }
+
+  return getGlobalOmcConfigCandidates('mcp-registry.json');
+}
+
+function getUnifiedMcpRegistryStatePathCandidates(): string[] {
+  return getGlobalOmcStateCandidates('mcp-registry-state.json');
 }
 
 export function getClaudeMcpConfigPath(): string {
@@ -146,19 +160,22 @@ function ensureParentDir(path: string): void {
 }
 
 function readManagedServerNames(): string[] {
-  const statePath = getUnifiedMcpRegistryStatePath();
-  if (!existsSync(statePath)) {
-    return [];
+  for (const statePath of getUnifiedMcpRegistryStatePathCandidates()) {
+    if (!existsSync(statePath)) {
+      continue;
+    }
+
+    try {
+      const state = JSON.parse(readFileSync(statePath, 'utf-8')) as { managedServers?: unknown };
+      return Array.isArray(state.managedServers)
+        ? state.managedServers.filter((item): item is string => typeof item === 'string').sort((a, b) => a.localeCompare(b))
+        : [];
+    } catch {
+      return [];
+    }
   }
 
-  try {
-    const state = JSON.parse(readFileSync(statePath, 'utf-8')) as { managedServers?: unknown };
-    return Array.isArray(state.managedServers)
-      ? state.managedServers.filter((item): item is string => typeof item === 'string').sort((a, b) => a.localeCompare(b))
-      : [];
-  } catch {
-    return [];
-  }
+  return [];
 }
 
 function writeManagedServerNames(serverNames: string[]): void {
@@ -183,15 +200,17 @@ function loadOrBootstrapRegistry(settings: Record<string, unknown>): {
   registryExists: boolean;
   bootstrappedFromClaude: boolean;
 } {
-  const registryPath = getUnifiedMcpRegistryPath();
-  if (existsSync(registryPath)) {
-    return {
-      registry: loadRegistryFromDisk(registryPath),
-      registryExists: true,
-      bootstrappedFromClaude: false,
-    };
+  for (const registryPath of getUnifiedMcpRegistryPathCandidates()) {
+    if (existsSync(registryPath)) {
+      return {
+        registry: loadRegistryFromDisk(registryPath),
+        registryExists: true,
+        bootstrappedFromClaude: false,
+      };
+    }
   }
 
+  const registryPath = getUnifiedMcpRegistryPath();
   const registry = bootstrapRegistryFromClaude(settings, registryPath);
   return {
     registry,

--- a/src/mcp/team-server.ts
+++ b/src/mcp/team-server.ts
@@ -16,7 +16,6 @@ import { fileURLToPath } from 'url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { homedir } from 'os';
 import { killWorkerPanes, killTeamSession } from '../team/tmux-session.js';
 import { validateTeamName } from '../team/team-name.js';
 import { NudgeTracker } from '../team/idle-nudge.js';
@@ -27,9 +26,10 @@ import {
 } from './team-job-convergence.js';
 import { isProcessAlive } from '../platform/index.js';
 import type { OmcTeamJob } from './team-job-convergence.js';
+import { getGlobalOmcStatePath } from '../utils/paths.js';
 
 const omcTeamJobs = new Map<string, OmcTeamJob>();
-const OMC_JOBS_DIR = process.env.OMC_JOBS_DIR || join(homedir(), '.omc', 'team-jobs');
+const OMC_JOBS_DIR = process.env.OMC_JOBS_DIR || getGlobalOmcStatePath('team-jobs');
 const DEPRECATION_CODE = 'deprecated_cli_only' as const;
 
 type DeprecatedTeamToolName =

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -19,10 +19,10 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, chmodSync, statSync, appendFileSync, renameSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
-import { homedir } from 'os';
 import { spawn } from 'child_process';
 import { request as httpsRequest } from 'https';
 import { resolveDaemonModulePath } from '../utils/daemon-module-path.js';
+import { getGlobalOmcStateRoot } from '../utils/paths.js';
 import {
   capturePaneContent,
   sendToPane,
@@ -76,7 +76,7 @@ const DAEMON_ENV_ALLOWLIST = [
 ] as const;
 
 /** Default paths */
-const DEFAULT_STATE_DIR = join(homedir(), '.omc', 'state');
+const DEFAULT_STATE_DIR = getGlobalOmcStateRoot();
 const PID_FILE_PATH = join(DEFAULT_STATE_DIR, 'reply-listener.pid');
 const STATE_FILE_PATH = join(DEFAULT_STATE_DIR, 'reply-listener-state.json');
 const LOG_FILE_PATH = join(DEFAULT_STATE_DIR, 'reply-listener.log');

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -5,7 +5,7 @@
  * Uses JSONL append format for atomic writes, following the pattern from
  * session-replay.ts with secure file permissions from daemon.ts.
  *
- * Registry location: ~/.omc/state/reply-session-registry.jsonl (global, not worktree-local)
+ * Registry location: XDG-aware global OMC state (legacy ~/.omc/state fallback for reads)
  * File permissions: 0600 (owner read/write only)
  */
 
@@ -22,9 +22,9 @@ import {
   constants,
 } from 'fs';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
 import { randomUUID } from 'crypto';
 import { isProcessAlive } from '../platform/index.js';
+import { getGlobalOmcStateCandidates, getGlobalOmcStateRoot } from '../utils/paths.js';
 
 // ============================================================================
 // Constants
@@ -44,16 +44,24 @@ const LOCK_MAX_WAIT_MS = 10000;
 
 /**
  * Return the registry state directory.
- * OMC_TEST_REGISTRY_DIR overrides the default (~/.omc/state) so that tests
+ * OMC_TEST_REGISTRY_DIR overrides the default global state dir so that tests
  * can redirect all I/O to a temporary directory without touching global state.
  */
 function getRegistryStateDir(): string {
-  return process.env['OMC_TEST_REGISTRY_DIR'] ?? join(homedir(), '.omc', 'state');
+  return process.env['OMC_TEST_REGISTRY_DIR'] ?? getGlobalOmcStateRoot();
 }
 
 /** Global registry JSONL path */
 function getRegistryPath(): string {
   return join(getRegistryStateDir(), 'reply-session-registry.jsonl');
+}
+
+function getRegistryReadPaths(): string[] {
+  if (process.env['OMC_TEST_REGISTRY_DIR']) {
+    return [getRegistryPath()];
+  }
+
+  return getGlobalOmcStateCandidates('reply-session-registry.jsonl');
 }
 
 /** Lock file path for cross-process synchronization */
@@ -337,26 +345,30 @@ export function loadAllMappings(): SessionMapping[] {
  * Caller must already hold lock (or accept race risk).
  */
 function readAllMappingsUnsafe(): SessionMapping[] {
-  if (!existsSync(getRegistryPath())) {
-    return [];
+  for (const registryPath of getRegistryReadPaths()) {
+    if (!existsSync(registryPath)) {
+      continue;
+    }
+
+    try {
+      const content = readFileSync(registryPath, 'utf-8');
+      return content
+        .split('\n')
+        .filter(line => line.trim())
+        .map(line => {
+          try {
+            return JSON.parse(line) as SessionMapping;
+          } catch {
+            return null;
+          }
+        })
+        .filter((m): m is SessionMapping => m !== null);
+    } catch {
+      continue;
+    }
   }
 
-  try {
-    const content = readFileSync(getRegistryPath(), 'utf-8');
-    return content
-      .split('\n')
-      .filter(line => line.trim())
-      .map(line => {
-        try {
-          return JSON.parse(line) as SessionMapping;
-        } catch {
-          return null;
-        }
-      })
-      .filter((m): m is SessionMapping => m !== null);
-  } catch {
-    return [];
-  }
+  return [];
 }
 
 /**

--- a/src/utils/__tests__/paths.test.ts
+++ b/src/utils/__tests__/paths.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { toForwardSlash, toShellPath, getDataDir, getConfigDir } from '../paths.js';
+import {
+  toForwardSlash,
+  toShellPath,
+  getDataDir,
+  getConfigDir,
+  getStateDir,
+  getGlobalOmcConfigRoot,
+  getGlobalOmcStateRoot,
+  getGlobalOmcConfigPath,
+  getGlobalOmcStatePath,
+  getGlobalOmcConfigCandidates,
+  getGlobalOmcStateCandidates,
+  getLegacyOmcDir,
+} from '../paths.js';
 
 describe('cross-platform path utilities', () => {
   describe('toForwardSlash', () => {
@@ -102,6 +115,110 @@ describe('cross-platform path utilities', () => {
       delete process.env.XDG_CONFIG_HOME;
       const result = getConfigDir();
       expect(result).toContain('.config');
+    });
+  });
+
+  describe('getStateDir', () => {
+    const originalPlatform = process.platform;
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      process.env = { ...originalEnv };
+    });
+
+    it('should use LOCALAPPDATA on Windows when set', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      process.env.LOCALAPPDATA = 'C:\\Users\\Test\\AppData\\Local';
+      expect(getStateDir()).toBe('C:\\Users\\Test\\AppData\\Local');
+    });
+
+    it('should use XDG_STATE_HOME on Unix when set', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      process.env.XDG_STATE_HOME = '/custom/state';
+      expect(getStateDir()).toBe('/custom/state');
+    });
+
+    it('should fall back to .local/state on Unix when XDG not set', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      delete process.env.XDG_STATE_HOME;
+      const result = getStateDir();
+      expect(result).toContain('.local');
+      expect(result).toContain('state');
+    });
+  });
+
+  describe('global OMC path helpers', () => {
+    const originalPlatform = process.platform;
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      process.env = { ...originalEnv };
+    });
+
+    it('should use XDG config root for global OMC config on Linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      process.env.XDG_CONFIG_HOME = '/custom/config';
+      delete process.env.OMC_HOME;
+
+      expect(getGlobalOmcConfigRoot()).toBe('/custom/config/omc');
+      expect(getGlobalOmcConfigPath('config.json')).toBe('/custom/config/omc/config.json');
+    });
+
+    it('should use XDG state root for global OMC state on Linux', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      process.env.XDG_STATE_HOME = '/custom/state';
+      delete process.env.OMC_HOME;
+
+      expect(getGlobalOmcStateRoot()).toBe('/custom/state/omc');
+      expect(getGlobalOmcStatePath('daemon.json')).toBe('/custom/state/omc/daemon.json');
+    });
+
+    it('should keep OMC_HOME authoritative for config and state roots', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      process.env.OMC_HOME = '/override/omc';
+      process.env.XDG_CONFIG_HOME = '/custom/config';
+      process.env.XDG_STATE_HOME = '/custom/state';
+
+      expect(getGlobalOmcConfigRoot()).toBe('/override/omc');
+      expect(getGlobalOmcStateRoot()).toBe('/override/omc/state');
+    });
+
+    it('should keep explicit OMC_HOME state candidates backward compatible', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      process.env.OMC_HOME = '/override/omc';
+
+      expect(getGlobalOmcStateCandidates('mcp-registry-state.json')).toEqual([
+        '/override/omc/state/mcp-registry-state.json',
+        '/override/omc/mcp-registry-state.json',
+      ]);
+    });
+
+    it('should fall back to legacy ~/.omc root on macOS', () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      delete process.env.OMC_HOME;
+      delete process.env.XDG_CONFIG_HOME;
+      delete process.env.XDG_STATE_HOME;
+
+      expect(getGlobalOmcConfigRoot()).toBe(getLegacyOmcDir());
+      expect(getGlobalOmcStateRoot()).toBe(`${getLegacyOmcDir()}/state`);
+    });
+
+    it('should include legacy fallback candidates for config and state paths', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      process.env.XDG_CONFIG_HOME = '/custom/config';
+      process.env.XDG_STATE_HOME = '/custom/state';
+      delete process.env.OMC_HOME;
+
+      expect(getGlobalOmcConfigCandidates('config.json')).toEqual([
+        '/custom/config/omc/config.json',
+        `${getLegacyOmcDir()}/config.json`,
+      ]);
+      expect(getGlobalOmcStateCandidates('reply-session-registry.jsonl')).toEqual([
+        '/custom/state/omc/reply-session-registry.jsonl',
+        `${getLegacyOmcDir()}/state/reply-session-registry.jsonl`,
+      ]);
     });
   });
 });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -63,6 +63,118 @@ export function getConfigDir(): string {
 }
 
 /**
+ * Get Windows-appropriate state directory.
+ */
+export function getStateDir(): string {
+  if (process.platform === 'win32') {
+    return process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local');
+  }
+
+  return process.env.XDG_STATE_HOME || join(homedir(), '.local', 'state');
+}
+
+function prefersXdgOmcDirs(): boolean {
+  return process.platform !== 'win32' && process.platform !== 'darwin';
+}
+
+function getUserHomeDir(): string {
+  if (process.platform === 'win32') {
+    return process.env.USERPROFILE || process.env.HOME || homedir();
+  }
+
+  return process.env.HOME || homedir();
+}
+
+/**
+ * Legacy global OMC directory under the user's home directory.
+ */
+export function getLegacyOmcDir(): string {
+  return join(getUserHomeDir(), '.omc');
+}
+
+/**
+ * Global OMC config directory.
+ *
+ * Precedence:
+ * 1. OMC_HOME (existing explicit override)
+ * 2. XDG-aware config root on Linux/Unix
+ * 3. Legacy ~/.omc elsewhere
+ */
+export function getGlobalOmcConfigRoot(): string {
+  const explicitRoot = process.env.OMC_HOME?.trim();
+  if (explicitRoot) {
+    return explicitRoot;
+  }
+
+  if (prefersXdgOmcDirs()) {
+    return join(getConfigDir(), 'omc');
+  }
+
+  return getLegacyOmcDir();
+}
+
+/**
+ * Global OMC state directory.
+ *
+ * When OMC_HOME is set, preserve that existing override semantics by treating
+ * it as the shared root and resolving state beneath it.
+ */
+export function getGlobalOmcStateRoot(): string {
+  const explicitRoot = process.env.OMC_HOME?.trim();
+  if (explicitRoot) {
+    return join(explicitRoot, 'state');
+  }
+
+  if (prefersXdgOmcDirs()) {
+    return join(getStateDir(), 'omc');
+  }
+
+  return join(getLegacyOmcDir(), 'state');
+}
+
+export function getGlobalOmcConfigPath(...segments: string[]): string {
+  return join(getGlobalOmcConfigRoot(), ...segments);
+}
+
+export function getGlobalOmcStatePath(...segments: string[]): string {
+  return join(getGlobalOmcStateRoot(), ...segments);
+}
+
+export function getLegacyOmcPath(...segments: string[]): string {
+  return join(getLegacyOmcDir(), ...segments);
+}
+
+function dedupePaths(paths: string[]): string[] {
+  return [...new Set(paths)];
+}
+
+export function getGlobalOmcConfigCandidates(...segments: string[]): string[] {
+  if (process.env.OMC_HOME?.trim()) {
+    return [getGlobalOmcConfigPath(...segments)];
+  }
+
+  return dedupePaths([
+    getGlobalOmcConfigPath(...segments),
+    getLegacyOmcPath(...segments),
+  ]);
+}
+
+export function getGlobalOmcStateCandidates(...segments: string[]): string[] {
+  const explicitRoot = process.env.OMC_HOME?.trim();
+  if (explicitRoot) {
+    return dedupePaths([
+      getGlobalOmcStatePath(...segments),
+      join(explicitRoot, ...segments),
+    ]);
+  }
+
+  return dedupePaths([
+    getGlobalOmcStatePath(...segments),
+    getLegacyOmcPath('state', ...segments),
+  ]);
+}
+
+/**
  * Get the plugin cache base directory for oh-my-claudecode.
  * This is the directory containing version subdirectories.
  *


### PR DESCRIPTION
## Summary
- fix issue #1897 by making user-global OMC config/state paths XDG-aware on Linux/Unix instead of defaulting to `~/.omc`
- keep explicit overrides (`OMC_HOME`, `OMC_JOBS_DIR`, `OMC_TEST_REGISTRY_DIR`, `OMC_MCP_REGISTRY_PATH`) authoritative
- preserve backward compatibility with legacy `~/.omc` fallback reads for touched config/state consumers

## What changed
- added shared global OMC path helpers in `src/utils/paths.ts`
- migrated targeted global consumers away from raw `~/.omc` joins:
  - team jobs CLI/MCP runtime
  - session registry and reply listener state
  - rate-limit daemon state files
  - state-manager global state path
  - code-simplifier + persistent-mode global config reads
  - installer MCP registry paths
- updated targeted docs/tests for XDG defaults and legacy fallback behavior

## Verification
- `npx vitest run src/utils/__tests__/paths.test.ts src/notifications/__tests__/session-registry.test.ts src/installer/__tests__/mcp-registry.test.ts src/__tests__/installer-mcp-config.test.ts src/hooks/persistent-mode/__tests__/idle-cooldown.test.ts`
- `npm run build`

## Compatibility notes
- project-local `.omc/` behavior is unchanged
- `OMC_STATE_DIR` semantics are unchanged
- legacy `~/.omc` config/state is still read as a fallback in the touched readers where needed
