### PR TITLE
test(utils): add unit tests for ssrf-guard and jsonc modules

### DIFF
--- a/src/utils/__tests__/jsonc.test.ts
+++ b/src/utils/__tests__/jsonc.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { parseJsonc, stripJsoncComments } from '../jsonc.js';
+
+describe('stripJsoncComments', () => {
+  it('strips single-line comments', () => {
+    const input = '{\n  "key": "value" // this is a comment\n}';
+    const result = stripJsoncComments(input);
+    expect(result).toContain('"key": "value"');
+    expect(result).not.toContain('this is a comment');
+  });
+
+  it('strips multi-line comments', () => {
+    const input = '{\n  /* comment */\n  "key": "value"\n}';
+    const result = stripJsoncComments(input);
+    expect(result).toContain('"key": "value"');
+    expect(result).not.toContain('comment');
+  });
+
+  it('preserves strings containing comment-like content', () => {
+    const input = '{"url": "http://example.com"}';
+    const result = stripJsoncComments(input);
+    expect(result).toContain('http://example.com');
+  });
+
+  it('preserves strings with // inside quotes', () => {
+    const input = '{"path": "C://Users//test"}';
+    const result = stripJsoncComments(input);
+    expect(result).toContain('C://Users//test');
+  });
+
+  it('handles escaped quotes in strings', () => {
+    const input = '{"msg": "say \\"hello\\""}';
+    const result = stripJsoncComments(input);
+    expect(result).toBe(input);
+  });
+
+  it('handles empty input', () => {
+    expect(stripJsoncComments('')).toBe('');
+  });
+
+  it('handles input with no comments', () => {
+    const input = '{"key": "value"}';
+    expect(stripJsoncComments(input)).toBe(input);
+  });
+
+  it('handles multiple single-line comments', () => {
+    const input = '{\n  // first\n  "a": 1,\n  // second\n  "b": 2\n}';
+    const result = stripJsoncComments(input);
+    expect(result).not.toContain('first');
+    expect(result).not.toContain('second');
+    expect(result).toContain('"a": 1');
+    expect(result).toContain('"b": 2');
+  });
+
+  it('handles multi-line comment spanning lines', () => {
+    const input = '{\n  /*\n   * block\n   * comment\n   */\n  "key": 1\n}';
+    const result = stripJsoncComments(input);
+    expect(result).not.toContain('block');
+    expect(result).toContain('"key": 1');
+  });
+
+  it('handles comment at end of file without newline', () => {
+    const input = '{"key": 1} // trailing';
+    const result = stripJsoncComments(input);
+    expect(result).toContain('"key": 1');
+    expect(result).not.toContain('trailing');
+  });
+});
+
+describe('parseJsonc', () => {
+  it('parses valid JSON', () => {
+    expect(parseJsonc('{"key": "value"}')).toEqual({ key: 'value' });
+  });
+
+  it('parses JSONC with single-line comments', () => {
+    const input = '{\n  // comment\n  "key": "value"\n}';
+    expect(parseJsonc(input)).toEqual({ key: 'value' });
+  });
+
+  it('parses JSONC with multi-line comments', () => {
+    const input = '{\n  /* comment */\n  "key": 42\n}';
+    expect(parseJsonc(input)).toEqual({ key: 42 });
+  });
+
+  it('parses JSONC with trailing commas stripped by comments', () => {
+    const input = '{\n  "a": 1,\n  "b": 2 // no trailing comma issue\n}';
+    expect(parseJsonc(input)).toEqual({ a: 1, b: 2 });
+  });
+
+  it('throws on invalid JSON after stripping comments', () => {
+    expect(() => parseJsonc('{invalid}')).toThrow();
+  });
+
+  it('parses arrays', () => {
+    expect(parseJsonc('[1, 2, 3] // array')).toEqual([1, 2, 3]);
+  });
+
+  it('parses nested objects with comments', () => {
+    const input = '{\n  "outer": {\n    // inner comment\n    "inner": true\n  }\n}';
+    expect(parseJsonc(input)).toEqual({ outer: { inner: true } });
+  });
+});

--- a/src/utils/__tests__/ssrf-guard.test.ts
+++ b/src/utils/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { validateUrlForSSRF, validateAnthropicBaseUrl } from '../ssrf-guard.js';
+
+describe('validateUrlForSSRF', () => {
+  describe('allowed URLs', () => {
+    it('allows standard HTTPS URLs', () => {
+      expect(validateUrlForSSRF('https://api.example.com/v1')).toEqual({ allowed: true });
+    });
+
+    it('allows standard HTTP URLs', () => {
+      expect(validateUrlForSSRF('http://api.example.com/v1')).toEqual({ allowed: true });
+    });
+
+    it('allows public IP addresses', () => {
+      expect(validateUrlForSSRF('https://8.8.8.8/dns')).toEqual({ allowed: true });
+    });
+
+    it('allows URLs with ports', () => {
+      expect(validateUrlForSSRF('https://api.example.com:8443/v1')).toEqual({ allowed: true });
+    });
+
+    it('allows URLs with query params', () => {
+      expect(validateUrlForSSRF('https://api.example.com?key=value')).toEqual({ allowed: true });
+    });
+  });
+
+  describe('blocked: empty/invalid', () => {
+    it('blocks empty string', () => {
+      const result = validateUrlForSSRF('');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks invalid URL', () => {
+      const result = validateUrlForSSRF('not-a-url');
+      expect(result.allowed).toBe(false);
+    });
+
+    it('blocks null-like inputs', () => {
+      const result = validateUrlForSSRF(null as unknown as string);
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe('blocked: private IPs', () => {
+    it('blocks localhost', () => {
+      const result = validateUrlForSSRF('http://localhost:8080');
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('blocked');
+    });
+
+    it('blocks 127.0.0.1 (loopback)', () => {
+      expect(validateUrlForSSRF('http://127.0.0.1').allowed).toBe(false);
+    });
+
+    it('blocks 10.x.x.x (Class A private)', () => {
+      expect(validateUrlForSSRF('http://10.0.0.1').allowed).toBe(false);
+    });
+
+    it('blocks 172.16.x.x (Class B private)', () => {
+      expect(validateUrlForSSRF('http://172.16.0.1').allowed).toBe(false);
+    });
+
+    it('blocks 172.31.x.x (Class B private upper)', () => {
+      expect(validateUrlForSSRF('http://172.31.255.255').allowed).toBe(false);
+    });
+
+    it('allows 172.15.x.x (not private)', () => {
+      expect(validateUrlForSSRF('http://172.15.0.1').allowed).toBe(true);
+    });
+
+    it('blocks 192.168.x.x (Class C private)', () => {
+      expect(validateUrlForSSRF('http://192.168.1.1').allowed).toBe(false);
+    });
+
+    it('blocks 169.254.x.x (link-local)', () => {
+      expect(validateUrlForSSRF('http://169.254.169.254').allowed).toBe(false);
+    });
+  });
+
+  describe('blocked: IPv6', () => {
+    it('blocks IPv6 loopback ::1', () => {
+      expect(validateUrlForSSRF('http://[::1]').allowed).toBe(false);
+    });
+
+    it('blocks IPv6 unique local fc00:', () => {
+      expect(validateUrlForSSRF('http://[fc00::1]').allowed).toBe(false);
+    });
+
+    it('blocks IPv6 link-local fe80:', () => {
+      expect(validateUrlForSSRF('http://[fe80::1]').allowed).toBe(false);
+    });
+  });
+
+  describe('blocked: protocol', () => {
+    it('blocks file:// protocol', () => {
+      expect(validateUrlForSSRF('file:///etc/passwd').allowed).toBe(false);
+    });
+
+    it('blocks ftp:// protocol', () => {
+      expect(validateUrlForSSRF('ftp://evil.com/file').allowed).toBe(false);
+    });
+  });
+
+  describe('blocked: IP encoding tricks', () => {
+    it('blocks hex-encoded IP', () => {
+      expect(validateUrlForSSRF('http://0x7f000001').allowed).toBe(false);
+    });
+
+    it('blocks decimal-encoded IP', () => {
+      expect(validateUrlForSSRF('http://2130706433').allowed).toBe(false);
+    });
+
+    it('blocks octal-encoded IP', () => {
+      expect(validateUrlForSSRF('http://0177.0.0.1').allowed).toBe(false);
+    });
+  });
+
+  describe('blocked: credentials', () => {
+    it('blocks URLs with username', () => {
+      expect(validateUrlForSSRF('http://admin@example.com').allowed).toBe(false);
+    });
+
+    it('blocks URLs with username:password', () => {
+      expect(validateUrlForSSRF('http://admin:pass@example.com').allowed).toBe(false);
+    });
+  });
+
+  describe('blocked: cloud metadata paths', () => {
+    it('blocks /metadata path', () => {
+      expect(validateUrlForSSRF('http://example.com/metadata').allowed).toBe(false);
+    });
+
+    it('blocks /latest/meta-data (AWS)', () => {
+      expect(validateUrlForSSRF('http://example.com/latest/meta-data').allowed).toBe(false);
+    });
+
+    it('blocks /computeMetadata (GCP)', () => {
+      expect(validateUrlForSSRF('http://example.com/computeMetadata/v1').allowed).toBe(false);
+    });
+
+    it('allows /metadata-api (not exact match)', () => {
+      expect(validateUrlForSSRF('http://example.com/api/metadata-stuff').allowed).toBe(true);
+    });
+  });
+});
+
+describe('validateAnthropicBaseUrl', () => {
+  it('allows valid HTTPS URL', () => {
+    expect(validateAnthropicBaseUrl('https://api.anthropic.com').allowed).toBe(true);
+  });
+
+  it('blocks private IPs', () => {
+    expect(validateAnthropicBaseUrl('http://192.168.1.1').allowed).toBe(false);
+  });
+
+  it('allows HTTP with warning (for local dev)', () => {
+    expect(validateAnthropicBaseUrl('http://api.example.com').allowed).toBe(true);
+  });
+
+  it('blocks invalid URL', () => {
+    expect(validateAnthropicBaseUrl('not-a-url').allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds 42 unit tests for two untested utility modules:

### `ssrf-guard.test.ts` (25 tests)
Comprehensive SSRF validation coverage:
- Allowed URLs (public HTTPS/HTTP, public IPs, with ports/params)
- Blocked private IPs (Class A/B/C, loopback, link-local)
- Blocked IPv6 (loopback, unique-local, link-local)
- Blocked protocols (file://, ftp://)
- IP encoding bypass prevention (hex, decimal, octal)
- Credential detection, cloud metadata path blocking
- `validateAnthropicBaseUrl` convenience function

### `jsonc.test.ts` (17 tests)
JSON with Comments parser coverage:
- `stripJsoncComments`: single-line, multi-line, string preservation, escaped quotes, edge cases
- `parseJsonc`: valid JSON, JSONC with comments, nested objects, arrays, error handling

### Motivation
Both modules had zero test coverage. `ssrf-guard` is security-critical (prevents SSRF attacks) and `jsonc` is used for config parsing — both deserve thorough testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)