### PR TITLE
feat(ultragoal): add durable Claude goal workflow

### DIFF
--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -1,0 +1,106 @@
+# omc ultragoal
+
+`omc ultragoal` is a durable, repo-native multi-goal workflow that pairs with
+the Claude Code `/goal` slash command. It stores plan/ledger artifacts under
+`.omc/ultragoal/` and prints model-facing handoff text that tells the active
+Claude agent when to invoke `/goal <condition>`, when to clear it, and what
+snapshot JSON to share back for ledger reconciliation.
+
+## What it is (and isn't)
+
+- **It is**: a small filesystem state machine for breaking a brief into
+  ordered stories, recording attempts/checkpoints, and gating final
+  completion behind `ai-slop-cleaner` + verification + `$code-review`
+  evidence.
+- **It isn't**: a way for a shell command to mutate Claude Code `/goal`
+  state. Claude `/goal` is a session-scoped, model-facing directive (it
+  registers a stop hook until a condition holds, and auto-clears on
+  success). OMC cannot invoke `/goal` for the model — the handoff text is
+  instructions the active Claude agent reads and acts on itself.
+
+## Artifacts
+
+```
+.omc/ultragoal/
+  brief.md       The free-text brief used to seed the plan
+  goals.json     The structured plan (version 1) with stories and mode
+  ledger.jsonl   Append-only audit trail of plan/goal events
+```
+
+The plan stores a `claudeGoalMode`:
+
+- `aggregate` (default): one Claude `/goal` covers the whole ultragoal run;
+  OMC stories `G001`/`G002`/… are bookkeeping in the ledger.
+- `per_story`: each ultragoal story corresponds to its own Claude `/goal`
+  directive. Use this when stories are large and you want each one cleared
+  individually.
+
+## Commands
+
+```
+omc ultragoal create-goals  [--brief <text> | --brief-file <path> | --from-stdin]
+                            [--goal <title::objective>]...
+                            [--claude-goal-mode <aggregate|per-story>] [--force] [--json]
+omc ultragoal complete-goals  [--retry-failed] [--json]
+omc ultragoal add-goal       --title <title> --objective <text> [--evidence <text>] [--json]
+omc ultragoal record-review-blockers
+                            --goal-id <id> --title <title> --objective <text>
+                            --evidence <review-findings>
+                            --claude-goal-json <active-json-or-path> [--json]
+omc ultragoal checkpoint    --goal-id <id> --status <complete|failed|blocked>
+                            [--evidence <text>]
+                            [--claude-goal-json <json-or-path>]
+                            [--quality-gate-json <json-or-path>] [--json]
+omc ultragoal status        [--claude-goal-json <json-or-path>] [--json]
+```
+
+Aliases: `create` → `create-goals`, `complete|next|start-next` →
+`complete-goals`.
+
+## Claude `/goal` snapshots
+
+`--claude-goal-json` accepts either inline JSON or a path to a JSON file
+containing the snapshot the model shares from the active Claude session.
+Accepted shapes:
+
+```json
+{ "goal": { "objective": "...", "status": "active|complete|cancelled" } }
+{ "objective": "...", "status": "complete" }
+{ "goal": { "condition": "...", "status": "cleared" } }
+```
+
+`condition` is accepted as a synonym for `objective` (Claude `/goal` calls
+the directive a "condition"). `cleared` is treated as `cancelled`.
+
+## Final quality gate
+
+The final completion of an ultragoal run is mandatory-gated. The model
+must run `ai-slop-cleaner` on changed files (even when it is a no-op),
+rerun verification, then run `$code-review`, and finally pass
+`--quality-gate-json` with this shape:
+
+```json
+{
+  "aiSlopCleaner": { "status": "passed", "evidence": "..." },
+  "verification":  { "status": "passed", "commands": ["..."], "evidence": "..." },
+  "codeReview":    { "recommendation": "APPROVE", "architectStatus": "CLEAR", "evidence": "..." }
+}
+```
+
+If the final review is not clean, the model should call
+`omc ultragoal record-review-blockers` instead of trying to mark the goal
+complete. That records the unresolved review findings, appends a blocker
+story, and keeps the Claude `/goal` active.
+
+## Limitations
+
+- The Claude `/goal` slash command is a session-scoped, in-session
+  directive. Shell tools cannot directly invoke it, set its condition, or
+  clear it. The handoff text instructs the active Claude agent to do so
+  itself in-session. The snapshot the model shares is treated as the
+  authoritative proof; OMC only verifies textual consistency between the
+  snapshot, the plan's expected objective, and the ledger event being
+  recorded.
+- If a future Claude tool name changes (`/goal` → something else), the
+  handoff text and snapshot field names will need to be updated; the
+  reconciliation logic itself is name-agnostic.

--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ultragoal
+description: Durable multi-goal workflow that persists plan/ledger artifacts under .omc/ultragoal and prints Claude /goal handoff text for the active session
+argument-hint: "<brief or subcommand>"
+level: 3
+---
+
+<Purpose>
+Ultragoal breaks a brief into an ordered set of goals, records start/checkpoint/blocker/failure events in a durable append-only ledger, and tells the active Claude agent how to drive the Claude Code `/goal` slash command alongside the plan. It does not — and cannot — mutate Claude `/goal` state from the shell; it persists durable repo state and prints a model-facing handoff that the active agent must act on in-session.
+</Purpose>
+
+<Use_When>
+- The user wants a durable, repo-native way to track an ultragoal across multiple Claude sessions or worktrees
+- The work is large enough to warrant multiple ordered "stories" with attempt counts and per-story evidence
+- The user wants the final completion gated behind ai-slop-cleaner + verification + $code-review
+- The user wants the active Claude `/goal` directive coordinated with the ledger so that a session restart does not lose progress
+</Use_When>
+
+<Do_Not_Use_When>
+- The task is a single small change — use direct delegation or `ralph` instead
+- The user wants the assistant to literally invoke `/goal` itself from the shell — that is not possible; `omc ultragoal` only writes artifacts and prints handoff text
+- The user wants a planning-only artifact with no execution loop — use `plan` instead
+</Do_Not_Use_When>
+
+<Why_This_Exists>
+Claude Code `/goal` is a session-scoped Stop hook: it blocks the session from stopping until a condition holds, and auto-clears on success. That is a great single-session execution primitive, but it loses state across sessions and does not by itself enforce a final review gate. `omc ultragoal` adds a durable plan, ledger, and gating layer so a long multi-step initiative can survive session restarts, fresh worktrees, and review iterations while still leveraging Claude `/goal` to keep the active agent focused.
+</Why_This_Exists>
+
+<How_To_Use>
+
+1. Create a plan from a brief:
+   ```
+   omc ultragoal create-goals --brief-file plan.md
+   ```
+   Or with explicit stories:
+   ```
+   omc ultragoal create-goals --brief "ship the migration" \
+     --goal "Schema::Add new columns" \
+     --goal "Backfill::Backfill rows in batches" \
+     --goal "Cutover::Drop old columns and switch reads"
+   ```
+   The default mode is `aggregate` (one Claude `/goal` covers the run).
+   Pass `--claude-goal-mode per-story` if you want each story to have its own `/goal`.
+
+2. Start (or resume) the next story:
+   ```
+   omc ultragoal complete-goals
+   ```
+   This prints a model-facing handoff. The active Claude agent must read it and:
+   - Confirm/Set the active `/goal` condition in this session.
+   - Work the story.
+   - When the story is complete (and for the final story, after the full quality gate), share back a snapshot of the active `/goal` state and call `checkpoint`.
+
+3. Checkpoint a story:
+   ```
+   omc ultragoal checkpoint --goal-id G001-... --status complete \
+     --evidence "tests/files/PR evidence" \
+     --claude-goal-json '{"goal":{"objective":"...","status":"active"}}'
+   ```
+   For the final story, also pass `--quality-gate-json` containing
+   `aiSlopCleaner`, `verification`, and `codeReview` evidence (all clean).
+
+4. If the final review is not clean, do NOT mark complete. Record blockers:
+   ```
+   omc ultragoal record-review-blockers --goal-id G00X-... \
+     --title "Resolve final code-review blockers" \
+     --objective "Fix the listed review findings and rerun final gates" \
+     --evidence "<the review findings>" \
+     --claude-goal-json '{"goal":{"objective":"...","status":"active"}}'
+   ```
+   This appends a new blocker story and keeps the Claude `/goal` active.
+
+5. Inspect state at any time:
+   ```
+   omc ultragoal status
+   ```
+
+</How_To_Use>
+
+<Important_Limitations>
+- The shell cannot invoke or mutate Claude Code `/goal` state. `omc ultragoal` only persists durable artifacts and prints instructions that the active Claude agent reads and acts on in-session.
+- Snapshots passed via `--claude-goal-json` are model-supplied proof of the active `/goal` state; OMC validates them for textual consistency with the plan's expected objective and ledger event, but it cannot independently observe Claude `/goal` state.
+- If the Claude `/goal` slash command is renamed or restructured, only the handoff wording needs to change; the reconciliation logic is name-agnostic.
+</Important_Limitations>

--- a/src/cli/commands/__tests__/ultragoal.test.ts
+++ b/src/cli/commands/__tests__/ultragoal.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ultragoalCommand } from '../ultragoal.js';
+
+async function withTempCwd<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-ultragoal-cli-'));
+  const original = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await run(cwd);
+  } finally {
+    process.chdir(original);
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+function captureConsole() {
+  const out: string[] = [];
+  const err: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    out.push(args.map(String).join(' '));
+  });
+  const error = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    err.push(args.map(String).join(' '));
+  });
+  return {
+    out,
+    err,
+    restore: () => {
+      log.mockRestore();
+      error.mockRestore();
+    },
+  };
+}
+
+describe('omc ultragoal CLI', () => {
+  let captured: ReturnType<typeof captureConsole>;
+
+  beforeEach(() => {
+    captured = captureConsole();
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    captured.restore();
+    process.exitCode = 0;
+  });
+
+  it('prints help when invoked with no subcommand', async () => {
+    await ultragoalCommand([]);
+    const joined = captured.out.join('\n');
+    expect(joined).toMatch(/omc ultragoal/);
+    expect(joined).toMatch(/Artifacts:[\s\S]*\.omc\/ultragoal\/brief\.md/);
+    expect(joined).toMatch(/Claude \/goal integration/);
+    expect(joined).not.toMatch(/\bomx\b/);
+  });
+
+  it('create-goals from positional brief writes .omc/ultragoal artifacts', async () => {
+    await withTempCwd(async (cwd) => {
+      await ultragoalCommand(['create-goals', '- First story\n- Second story']);
+      expect(process.exitCode).toBe(0);
+
+      const goals = JSON.parse(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')) as { goals: Array<{ id: string }>; claudeGoalMode: string };
+      expect(goals.claudeGoalMode).toBe('aggregate');
+      expect(goals.goals.map((g) => g.id)).toEqual(['G001-first-story', 'G002-second-story']);
+
+      const brief = await readFile(join(cwd, '.omc/ultragoal/brief.md'), 'utf-8');
+      expect(brief).toMatch(/First story/);
+      expect(brief).toMatch(/Second story/);
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"event":"plan_created"/);
+    });
+  });
+
+  it('complete-goals emits Claude /goal handoff text for the active story', async () => {
+    await withTempCwd(async () => {
+      await ultragoalCommand([
+        'create-goals',
+        '--brief', 'brief',
+        '--goal', 'First::Complete first milestone.',
+        '--goal', 'Second::Complete second milestone.',
+        '--claude-goal-mode', 'aggregate',
+      ]);
+      captured.out.length = 0;
+
+      await ultragoalCommand(['complete-goals']);
+      const joined = captured.out.join('\n');
+      expect(joined).toMatch(/Ultragoal aggregate-goal handoff/);
+      expect(joined).toMatch(/invoke \/goal/);
+      expect(joined).toMatch(/--claude-goal-json/);
+      expect(joined).toMatch(/Complete first milestone/);
+      expect(joined).not.toMatch(/\bomx\b/);
+      expect(joined).not.toMatch(/get_goal|create_goal|update_goal/);
+    });
+  });
+
+  it('checkpoint accepts a Claude /goal snapshot via inline JSON', async () => {
+    await withTempCwd(async (cwd) => {
+      await ultragoalCommand([
+        'create-goals',
+        '--brief', 'brief',
+        '--goal', 'First::Complete first milestone.',
+        '--goal', 'Second::Complete second milestone.',
+      ]);
+      const plan = JSON.parse(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')) as { claudeObjective: string };
+
+      await ultragoalCommand(['complete-goals']);
+      captured.out.length = 0;
+
+      const snapshot = JSON.stringify({ goal: { objective: plan.claudeObjective, status: 'active' } });
+      await ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first',
+        '--status', 'complete',
+        '--evidence', 'unit tests passed',
+        '--claude-goal-json', snapshot,
+      ]);
+      expect(process.exitCode).toBe(0);
+
+      const updated = JSON.parse(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')) as { goals: Array<{ id: string; status: string }> };
+      expect(updated.goals.find((g) => g.id === 'G001-first')?.status).toBe('complete');
+      expect(updated.goals.find((g) => g.id === 'G002-second')?.status).toBe('pending');
+    });
+  });
+
+  it('checkpoint accepts a Claude /goal snapshot file path', async () => {
+    await withTempCwd(async (cwd) => {
+      await ultragoalCommand([
+        'create-goals',
+        '--brief', 'brief',
+        '--goal', 'First::Complete first milestone.',
+      ]);
+      const plan = JSON.parse(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')) as { claudeObjective: string };
+      await ultragoalCommand(['complete-goals']);
+
+      const snapshotPath = join(cwd, 'goal-snapshot.json');
+      await writeFile(snapshotPath, JSON.stringify({ goal: { objective: plan.claudeObjective, status: 'complete' } }));
+      const qualityGate = {
+        aiSlopCleaner: { status: 'passed', evidence: 'cleaner ran' },
+        verification: { status: 'passed', commands: ['npm test'], evidence: 'tests passed' },
+        codeReview: { recommendation: 'APPROVE', architectStatus: 'CLEAR', evidence: 'review clean' },
+      };
+      const qualityPath = join(cwd, 'quality.json');
+      await writeFile(qualityPath, JSON.stringify(qualityGate));
+
+      captured.out.length = 0;
+      await ultragoalCommand([
+        'checkpoint',
+        '--goal-id', 'G001-first',
+        '--status', 'complete',
+        '--evidence', 'final gates passed',
+        '--claude-goal-json', 'goal-snapshot.json',
+        '--quality-gate-json', 'quality.json',
+      ]);
+      expect(process.exitCode).toBe(0);
+
+      const updated = JSON.parse(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')) as { goals: Array<{ status: string }> };
+      expect(updated.goals[0]?.status).toBe('complete');
+    });
+  });
+
+  it('reports unknown subcommands as a CLI error', async () => {
+    await withTempCwd(async () => {
+      await ultragoalCommand(['frobnicate']);
+      expect(process.exitCode).toBe(1);
+      expect(captured.err.join('\n')).toMatch(/\[ultragoal\] Unknown ultragoal command: frobnicate/);
+    });
+  });
+});

--- a/src/cli/commands/ultragoal.ts
+++ b/src/cli/commands/ultragoal.ts
@@ -1,0 +1,276 @@
+import { readFile } from 'node:fs/promises';
+import {
+  ClaudeGoalSnapshotError,
+  formatClaudeGoalReconciliation,
+  readClaudeGoalSnapshotInput,
+  reconcileClaudeGoalSnapshot,
+} from '../../goal-workflows/claude-goal-snapshot.js';
+import {
+  addUltragoalGoal,
+  buildClaudeGoalInstruction,
+  checkpointUltragoal,
+  createUltragoalPlan,
+  readUltragoalPlan,
+  recordFinalReviewBlockers,
+  startNextUltragoal,
+  summarizeUltragoalPlan,
+  type UltragoalItem,
+  UltragoalError,
+} from '../../ultragoal/artifacts.js';
+
+export const ULTRAGOAL_HELP = `omc ultragoal - Durable repo-native multi-goal workflow with Claude Code /goal handoff
+
+Usage:
+  omc ultragoal create-goals [--brief <text> | --brief-file <path> | --from-stdin] [--goal <title::objective>] [--claude-goal-mode <aggregate|per-story>] [--force] [--json]
+  omc ultragoal complete-goals [--retry-failed] [--json]
+  omc ultragoal add-goal --title <title> --objective <text> [--evidence <text>] [--json]
+  omc ultragoal record-review-blockers --goal-id <id> --title <title> --objective <text> --evidence <review-findings> --claude-goal-json <active-json-or-path> [--json]
+  omc ultragoal checkpoint --goal-id <id> --status <complete|failed|blocked> [--evidence <text>] [--claude-goal-json <json-or-path>] [--quality-gate-json <json-or-path>] [--json]
+  omc ultragoal status [--claude-goal-json <json-or-path>] [--json]
+
+Aliases:
+  create -> create-goals, complete|next|start-next -> complete-goals
+
+Artifacts:
+  .omc/ultragoal/brief.md
+  .omc/ultragoal/goals.json
+  .omc/ultragoal/ledger.jsonl
+
+Claude /goal integration:
+  This command cannot directly invoke the Claude Code /goal slash command from a shell;
+  /goal is a model-facing in-session directive that registers a session-scoped Stop hook
+  until its condition holds (auto-clears on success). complete-goals writes durable state
+  and prints a model-facing handoff that tells the active Claude agent when to invoke
+  /goal <condition>, when to clear it, and what snapshot JSON to share back.
+  New plans default to aggregate mode: one Claude /goal covers the whole ultragoal run
+  while OMC checkpoints G001/G002 stories in the durable ledger.
+  Final completion is mandatory-gated: run ai-slop-cleaner, rerun verification,
+  run $code-review, and pass --quality-gate-json with APPROVE + CLEAR evidence.
+  Non-clean final review must use record-review-blockers before clearing the /goal.
+`;
+
+function hasFlag(args: readonly string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function readValue(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const prefix = `${flag}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function readRepeated(args: readonly string[], flag: string): string[] {
+  const values: string[] = [];
+  const prefix = `${flag}=`;
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === flag && args[index + 1]) {
+      values.push(args[index + 1]);
+      index += 1;
+    } else if (arg.startsWith(prefix)) {
+      values.push(arg.slice(prefix.length));
+    }
+  }
+  return values;
+}
+
+function parseGoalArg(raw: string): { title?: string; objective: string; tokenBudget?: number } {
+  const [title, ...rest] = raw.split('::');
+  if (rest.length === 0) return { objective: raw.trim() };
+  return { title: title.trim(), objective: rest.join('::').trim() };
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function positionalText(args: readonly string[]): string {
+  const valueTaking = new Set(['--brief', '--brief-file', '--goal', '--goal-id', '--status', '--evidence', '--claude-goal-json', '--claude-goal-mode', '--title', '--objective', '--quality-gate-json']);
+  const words: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (valueTaking.has(arg)) { i += 1; continue; }
+    if (arg.startsWith('--')) continue;
+    words.push(arg);
+  }
+  return words.join(' ').trim();
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function normalizeClaudeGoalMode(raw: string | undefined): 'aggregate' | 'per_story' | undefined {
+  if (!raw) return undefined;
+  if (raw === 'aggregate') return 'aggregate';
+  if (raw === 'per-story' || raw === 'per_story') return 'per_story';
+  throw new UltragoalError('Invalid --claude-goal-mode; expected aggregate or per-story.');
+}
+
+function printStatus(plan: Awaited<ReturnType<typeof readUltragoalPlan>>): void {
+  const summary = summarizeUltragoalPlan(plan);
+  if (summary.aggregateComplete) {
+    console.log('ultragoal aggregate product: complete');
+    console.log(`microgoal ledger bookkeeping (progress-only): ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+  } else {
+    console.log(`ultragoal: ${summary.complete}/${summary.total} complete, ${summary.pending} pending, ${summary.inProgress} in progress, ${summary.failed} failed, ${summary.reviewBlocked} review-blocked`);
+  }
+  for (const goal of plan.goals) {
+    const marker = goal.id === plan.activeGoalId ? '*' : '-';
+    console.log(`${marker} ${goal.id} [${goal.status}] ${goal.title}`);
+  }
+}
+
+async function parseClaudeGoalJson(raw: string | undefined): Promise<unknown> {
+  if (!raw) return undefined;
+  return readClaudeGoalSnapshotInput(raw, process.cwd());
+}
+
+async function readJsonInput(raw: string | undefined): Promise<unknown> {
+  if (!raw) return undefined;
+  try {
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) return JSON.parse(trimmed);
+    return JSON.parse(await readFile(trimmed, 'utf-8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new UltragoalError(`Invalid --quality-gate-json: ${message}`);
+  }
+}
+
+export async function ultragoalCommand(args: string[]): Promise<void> {
+  const command = args[0] ?? 'help';
+  const rest = args.slice(1);
+  const json = hasFlag(rest, '--json');
+  const cwd = process.cwd();
+
+  try {
+    if (command === 'help' || command === '--help' || command === '-h') {
+      console.log(ULTRAGOAL_HELP);
+      return;
+    }
+
+    if (command === 'create' || command === 'create-goals') {
+      const briefFile = readValue(rest, '--brief-file');
+      const brief = readValue(rest, '--brief')
+        ?? (briefFile ? await readFile(briefFile, 'utf-8') : undefined)
+        ?? (hasFlag(rest, '--from-stdin') ? await readStdin() : undefined)
+        ?? positionalText(rest);
+      if (!brief.trim()) throw new UltragoalError('Missing brief text. Pass --brief, --brief-file, --from-stdin, or positional text.');
+      const goals = readRepeated(rest, '--goal').map(parseGoalArg);
+      const plan = await createUltragoalPlan(cwd, {
+        brief,
+        goals,
+        claudeGoalMode: normalizeClaudeGoalMode(readValue(rest, '--claude-goal-mode')),
+        force: hasFlag(rest, '--force'),
+      });
+      if (json) printJson({ ok: true, plan, summary: summarizeUltragoalPlan(plan) });
+      else {
+        console.log(`ultragoal plan created: ${plan.goals.length} goal(s)`);
+        console.log(`brief: ${plan.briefPath}`);
+        console.log(`goals: ${plan.goalsPath}`);
+        console.log(`ledger: ${plan.ledgerPath}`);
+      }
+      return;
+    }
+
+    if (command === 'status') {
+      const plan = await readUltragoalPlan(cwd);
+      const snapshot = await readClaudeGoalSnapshotInput(readValue(rest, '--claude-goal-json'), cwd);
+      const activeGoal = plan.goals.find((goal) => goal.id === plan.activeGoalId || goal.status === 'in_progress');
+      const expectedObjective = plan.claudeGoalMode === 'aggregate'
+        ? plan.claudeObjective
+        : activeGoal?.objective;
+      const reconciliation = activeGoal
+        ? reconcileClaudeGoalSnapshot(snapshot, {
+          expectedObjective: expectedObjective ?? activeGoal.objective,
+          allowedStatuses: plan.claudeGoalMode === 'aggregate' ? ['active'] : ['active', 'complete'],
+          requireSnapshot: false,
+        })
+        : null;
+      if (json) printJson({ plan, summary: summarizeUltragoalPlan(plan), reconciliation });
+      else {
+        printStatus(plan);
+        if (reconciliation && !reconciliation.ok) console.log(`claude goal warning: ${formatClaudeGoalReconciliation(reconciliation)}`);
+        else if (reconciliation?.warnings.length) console.log(`claude goal warning: ${formatClaudeGoalReconciliation(reconciliation)}`);
+      }
+      return;
+    }
+
+    if (command === 'add-goal') {
+      const title = readValue(rest, '--title');
+      const objective = readValue(rest, '--objective');
+      if (!title?.trim()) throw new UltragoalError('Missing --title.');
+      if (!objective?.trim()) throw new UltragoalError('Missing --objective.');
+      const result = await addUltragoalGoal(cwd, { title, objective, evidence: readValue(rest, '--evidence') });
+      if (json) printJson({ ok: true, plan: result.plan, addedGoal: result.goal, summary: summarizeUltragoalPlan(result.plan) });
+      else {
+        console.log(`ultragoal added goal: ${result.goal.id}`);
+        printStatus(result.plan);
+      }
+      return;
+    }
+
+    if (command === 'record-review-blockers') {
+      const goalId = readValue(rest, '--goal-id');
+      const title = readValue(rest, '--title');
+      const objective = readValue(rest, '--objective');
+      const evidence = readValue(rest, '--evidence');
+      if (!goalId) throw new UltragoalError('Missing --goal-id.');
+      if (!title?.trim()) throw new UltragoalError('Missing --title.');
+      if (!objective?.trim()) throw new UltragoalError('Missing --objective.');
+      if (!evidence?.trim()) throw new UltragoalError('Missing --evidence.');
+      const claudeGoal = await parseClaudeGoalJson(readValue(rest, '--claude-goal-json'));
+      const result = await recordFinalReviewBlockers(cwd, { goalId, title, objective, evidence, claudeGoal });
+      if (json) printJson({ ok: true, plan: result.plan, blockedGoal: result.blockedGoal, addedGoal: result.addedGoal, summary: summarizeUltragoalPlan(result.plan) });
+      else {
+        console.log(`ultragoal final review blockers recorded: ${result.blockedGoal.id} -> review_blocked; added ${result.addedGoal.id}`);
+        printStatus(result.plan);
+      }
+      return;
+    }
+
+    if (command === 'complete' || command === 'complete-goals' || command === 'next' || command === 'start-next') {
+      const result = await startNextUltragoal(cwd, { retryFailed: hasFlag(rest, '--retry-failed') });
+      if (!result.goal) {
+        if (json) printJson({ ok: true, done: result.done, summary: summarizeUltragoalPlan(result.plan) });
+        else console.log(result.done ? 'ultragoal: all goals complete' : 'ultragoal: no pending goals (use --retry-failed to retry failed goals)');
+        return;
+      }
+      const instruction = buildClaudeGoalInstruction(result.goal, result.plan);
+      if (json) printJson({ ok: true, resumed: result.resumed, goal: result.goal, instruction });
+      else console.log(instruction);
+      return;
+    }
+
+    if (command === 'checkpoint') {
+      const goalId = readValue(rest, '--goal-id');
+      const status = readValue(rest, '--status');
+      if (!goalId) throw new UltragoalError('Missing --goal-id.');
+      if (status !== 'complete' && status !== 'failed' && status !== 'blocked') throw new UltragoalError('Missing or invalid --status; expected complete, failed, or blocked.');
+      const evidence = readValue(rest, '--evidence');
+      const claudeGoal = await parseClaudeGoalJson(readValue(rest, '--claude-goal-json'));
+      const qualityGate = await readJsonInput(readValue(rest, '--quality-gate-json'));
+      const plan = await checkpointUltragoal(cwd, { goalId, status, evidence, claudeGoal, qualityGate });
+      if (json) printJson({ ok: true, plan, summary: summarizeUltragoalPlan(plan) });
+      else {
+        const goal = plan.goals.find((candidate: UltragoalItem) => candidate.id === goalId);
+        console.log(`ultragoal checkpoint: ${goalId} -> ${goal?.status ?? status}`);
+        printStatus(plan);
+      }
+      return;
+    }
+
+    throw new UltragoalError(`Unknown ultragoal command: ${command}\n\n${ULTRAGOAL_HELP}`);
+  } catch (error) {
+    if (error instanceof UltragoalError || error instanceof ClaudeGoalSnapshotError) {
+      console.error(`[ultragoal] ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,7 @@ import { doctorTeamRoutingCommand } from './commands/doctor-team-routing.js';
 import { sessionSearchCommand } from './commands/session-search.js';
 import { teamCommand } from './commands/team.js';
 import { ralphthonCommand } from './commands/ralphthon.js';
+import { ultragoalCommand, ULTRAGOAL_HELP } from './commands/ultragoal.js';
 import {
   teleportCommand,
   teleportListCommand,
@@ -1451,6 +1452,27 @@ program
   .argument('[args...]', 'ralphthon arguments')
   .action(async (args: string[]) => {
     await ralphthonCommand(args);
+  });
+
+/**
+ * Ultragoal command - Durable repo-native multi-goal workflow with Claude /goal handoff
+ *
+ * Writes plan/ledger artifacts under .omc/ultragoal/ and prints model-facing
+ * handoff text that tells the active Claude agent when to invoke /goal,
+ * checkpoint progress, and gate final completion behind ai-slop-cleaner +
+ * verification + $code-review evidence. The shell cannot mutate the Claude
+ * session /goal directive; this command only persists durable state.
+ */
+program
+  .command('ultragoal')
+  .description('Durable repo-native multi-goal workflow with Claude Code /goal handoff (see omc ultragoal help)')
+  .helpOption(false)
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .argument('[args...]', 'ultragoal subcommand arguments')
+  .addHelpText('after', `\n${ULTRAGOAL_HELP}`)
+  .action(async (args: string[]) => {
+    await ultragoalCommand(args);
   });
 
 /**

--- a/src/goal-workflows/__tests__/claude-goal-snapshot.test.ts
+++ b/src/goal-workflows/__tests__/claude-goal-snapshot.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  ClaudeGoalSnapshotError,
+  parseClaudeGoalSnapshot,
+  readClaudeGoalSnapshotInput,
+  reconcileClaudeGoalSnapshot,
+} from '../claude-goal-snapshot.js';
+
+describe('claude goal snapshot reconciliation', () => {
+  it('normalizes Claude /goal JSON shape with objective synonym', () => {
+    const snapshot = parseClaudeGoalSnapshot({
+      goal: { objective: 'Ship the feature', status: 'completed', token_budget: 1000 },
+      remainingTokens: 25,
+    });
+
+    expect(snapshot.available).toBe(true);
+    expect(snapshot.objective).toBe('Ship the feature');
+    expect(snapshot.status).toBe('complete');
+    expect(snapshot.tokenBudget).toBe(1000);
+    expect(snapshot.remainingTokens).toBe(25);
+  });
+
+  it('accepts `condition` as a synonym for objective and `cleared` as cancelled', () => {
+    const snapshot = parseClaudeGoalSnapshot({
+      goal: { condition: 'Hold until tests pass', status: 'cleared' },
+    });
+    expect(snapshot.available).toBe(true);
+    expect(snapshot.objective).toBe('Hold until tests pass');
+    expect(snapshot.status).toBe('cancelled');
+  });
+
+  it('reports absent snapshots as warnings unless required', () => {
+    const optional = reconcileClaudeGoalSnapshot(null, { expectedObjective: 'Ship' });
+    expect(optional.ok).toBe(true);
+    expect(optional.warnings.join('\n')).toMatch(/share the current \/goal condition/);
+
+    const required = reconcileClaudeGoalSnapshot(null, { expectedObjective: 'Ship', requireSnapshot: true });
+    expect(required.ok).toBe(false);
+    expect(required.errors.join('\n')).toMatch(/share the current \/goal condition/);
+  });
+
+  it('detects objective mismatches and incomplete completion proof', () => {
+    const mismatch = reconcileClaudeGoalSnapshot(
+      parseClaudeGoalSnapshot({ goal: { objective: 'Different', status: 'active' } }),
+      { expectedObjective: 'Expected', requireSnapshot: true, requireComplete: true },
+    );
+
+    expect(mismatch.ok).toBe(false);
+    expect(mismatch.errors.join('\n')).toMatch(/objective mismatch/);
+    expect(mismatch.errors.join('\n')).toMatch(/not complete/);
+  });
+
+  it('accepts compatible complete proof', () => {
+    const result = reconcileClaudeGoalSnapshot(
+      parseClaudeGoalSnapshot({ goal: { objective: 'Expected objective', status: 'complete' } }),
+      { expectedObjective: 'Expected objective', requireSnapshot: true, requireComplete: true },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reads inline JSON and path input but rejects malformed sources', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omc-claude-goal-snapshot-'));
+    try {
+      const fromJson = await readClaudeGoalSnapshotInput('{"goal":{"objective":"A","status":"active"}}', cwd);
+      expect(fromJson?.objective).toBe('A');
+
+      await writeFile(join(cwd, 'goal.json'), '{"goal":{"objective":"B","status":"complete"}}');
+      const fromPath = await readClaudeGoalSnapshotInput('goal.json', cwd);
+      expect(fromPath?.objective).toBe('B');
+
+      await expect(readClaudeGoalSnapshotInput('{not-json}', cwd)).rejects.toBeInstanceOf(ClaudeGoalSnapshotError);
+      await expect(readClaudeGoalSnapshotInput('missing.json', cwd)).rejects.toThrow(/neither valid JSON nor a readable path/);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/goal-workflows/claude-goal-snapshot.ts
+++ b/src/goal-workflows/claude-goal-snapshot.ts
@@ -1,0 +1,161 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export type ClaudeGoalSnapshotStatus = 'active' | 'complete' | 'cancelled' | 'failed' | 'unknown';
+
+export interface ClaudeGoalSnapshot {
+  available: boolean;
+  objective?: string;
+  status?: ClaudeGoalSnapshotStatus;
+  tokenBudget?: number;
+  remainingTokens?: number | null;
+  raw: unknown;
+}
+
+export interface ClaudeGoalReconciliation {
+  ok: boolean;
+  snapshot: ClaudeGoalSnapshot;
+  warnings: string[];
+  errors: string[];
+}
+
+export interface ReconcileClaudeGoalOptions {
+  expectedObjective: string;
+  allowedStatuses?: readonly ClaudeGoalSnapshotStatus[];
+  requireSnapshot?: boolean;
+  requireComplete?: boolean;
+}
+
+export class ClaudeGoalSnapshotError extends Error {}
+
+function safeObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function safeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeStatus(value: unknown): ClaudeGoalSnapshotStatus {
+  const status = safeString(value).toLowerCase();
+  if (status === 'complete' || status === 'completed' || status === 'done') return 'complete';
+  if (status === 'cancelled' || status === 'canceled' || status === 'cleared') return 'cancelled';
+  if (status === 'failed' || status === 'failure') return 'failed';
+  if (status === 'active' || status === 'in_progress' || status === 'pending' || status === 'running') return 'active';
+  return 'unknown';
+}
+
+function normalizeObjective(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse a Claude goal snapshot JSON payload.
+ *
+ * The payload is whatever the active Claude agent shares as proof of the
+ * current `/goal` condition state. Accepted shapes include:
+ *   { goal: { objective, status, ... } }
+ *   { objective, status, ... }
+ * with `condition` accepted as a synonym for `objective`.
+ *
+ * NOTE: The Claude Code `/goal` slash command is not invokable from a shell.
+ * This snapshot is a model-facing artifact; OMC only verifies textual
+ * consistency between the model's reported state and the ultragoal plan.
+ */
+export function parseClaudeGoalSnapshot(value: unknown): ClaudeGoalSnapshot {
+  const root = safeObject(value);
+  const goalValue = Object.hasOwn(root, 'goal') ? root.goal : value;
+  if (goalValue === null || goalValue === undefined || goalValue === false) {
+    return { available: false, raw: value };
+  }
+
+  const goal = safeObject(goalValue);
+  const objective = safeString(
+    goal.objective
+    ?? goal.condition
+    ?? goal.goal
+    ?? goal.description
+    ?? root.objective
+    ?? root.condition,
+  );
+  const status = normalizeStatus(goal.status ?? root.status);
+  const tokenBudget = safeNumber(
+    goal.token_budget
+    ?? goal.tokenBudget
+    ?? root.token_budget
+    ?? root.tokenBudget,
+  );
+  const remainingTokens = safeNumber(root.remainingTokens ?? root.remaining_tokens);
+
+  return {
+    available: Boolean(objective || status !== 'unknown'),
+    ...(objective ? { objective } : {}),
+    status,
+    ...(tokenBudget !== undefined ? { tokenBudget } : {}),
+    remainingTokens: remainingTokens ?? null,
+    raw: value,
+  };
+}
+
+export async function readClaudeGoalSnapshotInput(raw: string | undefined, cwd = process.cwd()): Promise<ClaudeGoalSnapshot | null> {
+  if (!raw?.trim()) return null;
+  const trimmed = raw.trim();
+  try {
+    return parseClaudeGoalSnapshot(JSON.parse(trimmed));
+  } catch {
+    const path = resolve(cwd, trimmed);
+    if (!existsSync(path)) {
+      throw new ClaudeGoalSnapshotError(`Claude goal snapshot is neither valid JSON nor a readable path: ${trimmed}`);
+    }
+    try {
+      return parseClaudeGoalSnapshot(JSON.parse(await readFile(path, 'utf-8')));
+    } catch (error) {
+      throw new ClaudeGoalSnapshotError(`Claude goal snapshot path does not contain valid JSON: ${trimmed}${error instanceof Error ? ` (${error.message})` : ''}`);
+    }
+  }
+}
+
+export function reconcileClaudeGoalSnapshot(
+  snapshot: ClaudeGoalSnapshot | null | undefined,
+  options: ReconcileClaudeGoalOptions,
+): ClaudeGoalReconciliation {
+  const effectiveSnapshot = snapshot ?? { available: false, raw: null };
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!effectiveSnapshot.available) {
+    const message = 'Claude goal snapshot is absent or reports no active goal; ask the active Claude agent to share the current /goal condition and pass its JSON with --claude-goal-json.';
+    if (options.requireSnapshot) errors.push(message);
+    else warnings.push(message);
+    return { ok: errors.length === 0, snapshot: effectiveSnapshot, warnings, errors };
+  }
+
+  const expected = normalizeObjective(options.expectedObjective);
+  const actual = normalizeObjective(effectiveSnapshot.objective ?? '');
+  if (!actual) {
+    errors.push('Claude goal snapshot is missing objective text.');
+  } else if (actual !== expected) {
+    errors.push(`Claude goal objective mismatch: expected "${expected}", got "${actual}".`);
+  }
+
+  const allowed = options.allowedStatuses ?? (options.requireComplete ? ['complete'] : ['active', 'complete']);
+  const actualStatus = effectiveSnapshot.status ?? 'unknown';
+  if (!allowed.includes(actualStatus)) {
+    errors.push(`Claude goal status mismatch: expected ${allowed.join(' or ')}, got ${actualStatus}.`);
+  }
+  if (options.requireComplete && actualStatus !== 'complete') {
+    errors.push(`Claude goal is not complete; only after the active condition is genuinely satisfied (the /goal hook auto-clears, or you run /goal clear), share the fresh snapshot.`);
+  }
+
+  return { ok: errors.length === 0, snapshot: effectiveSnapshot, warnings, errors };
+}
+
+export function formatClaudeGoalReconciliation(reconciliation: ClaudeGoalReconciliation): string {
+  const parts = [...reconciliation.errors, ...reconciliation.warnings];
+  return parts.join(' ');
+}

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -1,0 +1,553 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  addUltragoalGoal,
+  buildClaudeGoalInstruction,
+  checkpointUltragoal,
+  createUltragoalPlan,
+  isUltragoalDone,
+  readUltragoalPlan,
+  recordFinalReviewBlockers,
+  startNextUltragoal,
+} from '../artifacts.js';
+
+async function withTempRepo<T>(run: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-ultragoal-'));
+  try {
+    return await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+function cleanQualityGate(): object {
+  return {
+    aiSlopCleaner: { status: 'passed', evidence: 'ai-slop-cleaner ran on changed files' },
+    verification: { status: 'passed', commands: ['npm test'], evidence: 'tests passed after cleaner' },
+    codeReview: { recommendation: 'APPROVE', architectStatus: 'CLEAR', evidence: '$code-review approved with CLEAR architecture' },
+  };
+}
+
+describe('ultragoal artifacts', () => {
+  it('creates brief, goals, and ledger artifacts under .omc/ultragoal', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: '- Build the CLI\n- Add tests\n- Write docs',
+        now: new Date('2026-05-04T10:00:00Z'),
+      });
+
+      expect(plan.goals.length).toBe(3);
+      expect(plan.claudeGoalMode).toBe('aggregate');
+      expect(plan.claudeObjective ?? '').toMatch(/Complete all ultragoal stories/);
+      expect(plan.claudeObjective ?? '').toMatch(/G001-build-the-cli/);
+      expect(plan.goals[0]?.id).toBe('G001-build-the-cli');
+      expect(plan.goals[0]?.status).toBe('pending');
+      expect(plan.briefPath).toBe('.omc/ultragoal/brief.md');
+      expect(plan.goalsPath).toBe('.omc/ultragoal/goals.json');
+      expect(plan.ledgerPath).toBe('.omc/ultragoal/ledger.jsonl');
+      expect(await readFile(join(cwd, '.omc/ultragoal/brief.md'), 'utf-8')).toBe('- Build the CLI\n- Add tests\n- Write docs\n');
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"event":"plan_created"/);
+    });
+  });
+
+  it('starts one story at a time and emits an aggregate Claude /goal handoff by default', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+
+      const started = await startNextUltragoal(cwd, { now: new Date('2026-05-04T10:01:00Z') });
+      expect(started.goal?.id).toBe('G001-first');
+      expect(started.goal?.status).toBe('in_progress');
+      expect(started.plan.activeGoalId).toBe('G001-first');
+
+      const resumed = await startNextUltragoal(cwd, { now: new Date('2026-05-04T10:02:00Z') });
+      expect(resumed.goal?.id).toBe('G001-first');
+      expect(resumed.resumed).toBe(true);
+
+      const instruction = buildClaudeGoalInstruction(started.goal!, started.plan);
+      expect(instruction).toMatch(/active Claude \/goal condition/i);
+      expect(instruction).toMatch(/invoke \/goal/i);
+      expect(instruction).toMatch(/Claude \/goal = the whole ultragoal run/i);
+      expect(instruction).toMatch(/same aggregate objective as active/i);
+      expect(instruction).toMatch(/do not clear the \/goal yet/i);
+      expect(instruction).not.toMatch(/fresh Claude Code session/i);
+      expect(instruction).toMatch(/--claude-goal-json/);
+      expect(instruction).toMatch(/Complete all ultragoal stories/);
+      expect(instruction).toMatch(/Complete first milestone/);
+      expect(instruction).not.toMatch(/get_goal/);
+      expect(instruction).not.toMatch(/create_goal/);
+      expect(instruction).not.toMatch(/update_goal/);
+      expect(instruction).not.toMatch(/\bcodex\b/i);
+    });
+  });
+
+  it('checkpoints success, advances, and supports failed-goal retry', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      const aggregateObjective = first.plan.claudeObjective!;
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'premature aggregate completion',
+          claudeGoal: { goal: { objective: aggregateObjective, status: 'complete' } },
+        }),
+      ).rejects.toThrow(/expected active/);
+      await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'unit tests passed',
+        claudeGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+      });
+      const second = await startNextUltragoal(cwd);
+      expect(second.goal?.id).toBe('G002-second');
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: second.goal!.id,
+          status: 'complete',
+          evidence: 'not final yet',
+          claudeGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+        }),
+      ).rejects.toThrow(/not complete/);
+
+      await checkpointUltragoal(cwd, { goalId: second.goal!.id, status: 'failed', evidence: 'blocked' });
+      const noPending = await startNextUltragoal(cwd);
+      expect(noPending.goal).toBeNull();
+      expect(noPending.done).toBe(false);
+
+      const retry = await startNextUltragoal(cwd, { retryFailed: true });
+      expect(retry.goal?.id).toBe('G002-second');
+      expect(retry.goal?.status).toBe('in_progress');
+      expect(retry.goal?.attempt).toBe(2);
+
+      const plan = await readUltragoalPlan(cwd);
+      expect(plan.goals[0]?.evidence).toBe('unit tests passed');
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"event":"goal_completed"/);
+      expect(ledger).toMatch(/"event":"goal_failed"/);
+      expect(ledger).toMatch(/"event":"goal_retried"/);
+    });
+  });
+
+  it('reconciles completed task-scoped Claude snapshot to finish exploded aggregate ultragoal bookkeeping', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Fix the mismatch between Claude immutable completed /goal snapshots and OMC ultragoal checkpoint reconciliation.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: Array.from({ length: 136 }, (_, index) => ({
+          title: `Micro goal ${index + 1}`,
+          objective: `Synthetic bookkeeping slice ${index + 1}.`,
+        })),
+      });
+
+      const first = await startNextUltragoal(cwd);
+      expect(first.goal?.id).toBe('G001-micro-goal-1');
+
+      const reconciled = await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'Actual planned work done for .omc/ultragoal/goals.json G001-micro-goal-1; validation complete; reviews clean.',
+        claudeGoal: { goal: { objective: taskObjective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+        now: new Date('2026-05-04T10:04:00Z'),
+      });
+
+      expect(reconciled.goals.length).toBe(136);
+      expect(reconciled.goals.filter((goal) => goal.status === 'complete').length).toBe(0);
+      expect(reconciled.goals[0]?.status).toBe('in_progress');
+      expect(reconciled.activeGoalId).toBeUndefined();
+      expect(reconciled.aggregateCompletion?.status).toBe('complete');
+      expect(reconciled.aggregateCompletion?.evidence ?? '').toMatch(/planned work done/);
+      expect(isUltragoalDone(reconciled)).toBe(true);
+
+      const next = await startNextUltragoal(cwd);
+      expect(next.goal).toBeNull();
+      expect(next.done).toBe(true);
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/microgoal ledger progress remains independent/);
+      expect((ledger.match(/"event":"aggregate_completed"/g) ?? []).length).toBe(1);
+      expect((ledger.match(/"event":"goal_completed"/g) ?? []).length).toBe(0);
+    });
+  });
+
+  it('fails closed for task-scoped aggregate completion without plan mapping or evidence', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Implement the reconciler fix described in the approved ultragoal brief.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: [
+          { title: 'First', objective: 'Synthetic slice 1.' },
+          { title: 'Second', objective: 'Synthetic slice 2.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'Actual planned work done for .omc/ultragoal/goals.json G001-first; validation complete; reviews clean.',
+          claudeGoal: { goal: { objective: 'Unrelated completed task', status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+      ).rejects.toThrow(/objective mismatch/);
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'done',
+          claudeGoal: { goal: { objective: taskObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+      ).rejects.toThrow(/Completed task-scoped aggregate reconciliation requires .*active in-progress/);
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'Actual planned work done for .omc/ultragoal/goals.json G001-first; validation complete; reviews clean.',
+          claudeGoal: { goal: { objective: taskObjective, status: 'complete' } },
+        }),
+      ).rejects.toThrow(/quality-gate-json|quality gate/i);
+    });
+  });
+
+  it('fails closed for task-scoped aggregate completion on a non-active microgoal id', async () => {
+    await withTempRepo(async (cwd) => {
+      const taskObjective = 'Fix the mismatch between Claude immutable completed /goal snapshots and OMC ultragoal checkpoint reconciliation.';
+      await createUltragoalPlan(cwd, {
+        brief: taskObjective,
+        goals: [
+          { title: 'First', objective: 'Synthetic slice 1.' },
+          { title: 'Second', objective: 'Synthetic slice 2.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      expect(first.goal?.id).toBe('G001-first');
+      expect(first.plan.activeGoalId).toBe('G001-first');
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: 'G002-second',
+          status: 'complete',
+          evidence: 'Actual planned work done for .omc/ultragoal/goals.json G002-second; validation complete; reviews clean.',
+          claudeGoal: { goal: { objective: taskObjective, status: 'complete' } },
+          qualityGate: cleanQualityGate(),
+        }),
+      ).rejects.toThrow(/Completed task-scoped aggregate reconciliation requires .*active in-progress/);
+
+      const plan = await readUltragoalPlan(cwd);
+      expect(plan.activeGoalId).toBe('G001-first');
+      expect(plan.aggregateCompletion).toBeUndefined();
+      expect(plan.goals.find((goal) => goal.id === 'G001-first')?.status).toBe('in_progress');
+      expect(plan.goals.find((goal) => goal.id === 'G002-second')?.status).toBe('pending');
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect((ledger.match(/"event":"aggregate_completed"/g) ?? []).length).toBe(0);
+    });
+  });
+
+  it('requires aggregate Claude /goal completion only for the final story', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+          { title: 'Second', objective: 'Complete second milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      const aggregateObjective = first.plan.claudeObjective!;
+      await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'first audit passed',
+        claudeGoal: { goal: { objective: aggregateObjective, status: 'active' } },
+      });
+
+      const second = await startNextUltragoal(cwd);
+      await checkpointUltragoal(cwd, {
+        goalId: second.goal!.id,
+        status: 'complete',
+        evidence: 'final audit passed',
+        claudeGoal: { goal: { objective: aggregateObjective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+
+      const plan = await readUltragoalPlan(cwd);
+      expect(plan.goals.every((goal) => goal.status === 'complete')).toBe(true);
+      expect(plan.activeGoalId).toBeUndefined();
+    });
+  });
+
+  it('treats existing v1 plans without mode metadata as legacy per-story plans', async () => {
+    await withTempRepo(async (cwd) => {
+      const created = await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        claudeGoalMode: 'per_story',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+      delete created.claudeGoalMode;
+      delete created.claudeObjective;
+      await writeFile(join(cwd, '.omc/ultragoal/goals.json'), `${JSON.stringify(created, null, 2)}\n`);
+
+      const first = await startNextUltragoal(cwd);
+      const instruction = buildClaudeGoalInstruction(first.goal!, first.plan);
+      expect(instruction).toMatch(/Ultragoal active-goal handoff/);
+      expect(instruction).toMatch(/fresh Claude Code session/);
+
+      await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'complete',
+        evidence: 'legacy per-story audit passed',
+        claudeGoal: { goal: { objective: first.goal!.objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+
+      const plan = await readUltragoalPlan(cwd);
+      expect(plan.goals[0]?.status).toBe('complete');
+    });
+  });
+
+  it('appends goals without changing the stored aggregate objective', async () => {
+    await withTempRepo(async (cwd) => {
+      const plan = await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'First', objective: 'Complete first milestone.' }],
+      });
+      const objective = plan.claudeObjective;
+      const added = await addUltragoalGoal(cwd, {
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix review blockers and rerun final gates.',
+        evidence: 'review findings',
+      });
+
+      expect(added.goal.id).toBe('G002-resolve-final-code-review-blockers');
+      expect(added.goal.status).toBe('pending');
+      expect(added.plan.claudeObjective).toBe(objective);
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"event":"goal_added"/);
+    });
+  });
+
+  it('records final aggregate review blockers atomically and starts the blocker next', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.claudeObjective!;
+
+      const result = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers and rerun final gates.',
+        evidence: 'code-review REQUEST CHANGES',
+        claudeGoal: { goal: { objective, status: 'active' } },
+      });
+
+      expect(result.blockedGoal.status).toBe('review_blocked');
+      expect(result.addedGoal.status).toBe('pending');
+      expect(result.plan.activeGoalId).toBeUndefined();
+      expect(result.plan.claudeObjective).toBe(objective);
+
+      const next = await startNextUltragoal(cwd);
+      expect(next.goal?.id).toBe(result.addedGoal.id);
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"event":"final_review_failed"/);
+      expect(ledger).toMatch(/"event":"goal_review_blocked"/);
+    });
+  });
+
+  it('records final per-story review blockers without claiming Claude /goal completion', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        claudeGoalMode: 'per_story',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const result = await recordFinalReviewBlockers(cwd, {
+        goalId: started.goal!.id,
+        title: 'Resolve final code-review blockers',
+        objective: 'Fix final code-review blockers in a fresh goal context.',
+        evidence: 'architect BLOCK',
+        claudeGoal: { goal: { objective: started.goal!.objective, status: 'active' } },
+      });
+
+      expect(result.blockedGoal.status).toBe('review_blocked');
+      expect(result.addedGoal.status).toBe('pending');
+      expect(isUltragoalDone(result.plan)).toBe(false);
+    });
+  });
+
+  it('requires structured final quality gate evidence for clean completion', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [{ title: 'Final', objective: 'Complete final milestone.' }],
+      });
+      const started = await startNextUltragoal(cwd);
+      const objective = started.plan.claudeObjective!;
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          claudeGoal: { goal: { objective, status: 'complete' } },
+        }),
+      ).rejects.toThrow(/quality-gate-json|quality gate/i);
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          claudeGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            codeReview: { recommendation: 'COMMENT', architectStatus: 'CLEAR', evidence: 'not clean' },
+          },
+        }),
+      ).rejects.toThrow(/APPROVE/);
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: started.goal!.id,
+          status: 'complete',
+          evidence: 'tests passed',
+          claudeGoal: { goal: { objective, status: 'complete' } },
+          qualityGate: {
+            ...cleanQualityGate(),
+            aiSlopCleaner: { status: 'not_applicable', evidence: 'skipped cleaner' },
+          },
+        }),
+      ).rejects.toThrow(/aiSlopCleaner\.status="passed"/);
+
+      await checkpointUltragoal(cwd, {
+        goalId: started.goal!.id,
+        status: 'complete',
+        evidence: 'final gates passed',
+        claudeGoal: { goal: { objective, status: 'complete' } },
+        qualityGate: cleanQualityGate(),
+      });
+      const plan = await readUltragoalPlan(cwd);
+      expect(isUltragoalDone(plan)).toBe(true);
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"qualityGate"/);
+      expect(ledger).toMatch(/"aiSlopCleaner"/);
+      expect(ledger).toMatch(/"codeReview"/);
+    });
+  });
+
+  it('records a completed legacy Claude-goal blocker without failing the active ultragoal', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        claudeGoalMode: 'per_story',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      const blocked = await checkpointUltragoal(cwd, {
+        goalId: first.goal!.id,
+        status: 'blocked',
+        evidence: 'completed aggregate Claude /goal blocks new /goal',
+        claudeGoal: { goal: { objective: 'achieve all goals on this repo ultragoal status', status: 'complete' } },
+        now: new Date('2026-05-04T10:03:00Z'),
+      });
+
+      expect(blocked.activeGoalId).toBe(first.goal!.id);
+      expect(blocked.goals[0]?.status).toBe('in_progress');
+      expect(blocked.goals[0]?.failureReason).toBeUndefined();
+      expect(blocked.goals[0]?.failedAt).toBeUndefined();
+
+      const ledger = await readFile(join(cwd, '.omc/ultragoal/ledger.jsonl'), 'utf-8');
+      expect(ledger).toMatch(/"event":"goal_blocked"/);
+      expect(ledger).toMatch(/completed aggregate Claude \/goal blocks new \/goal/);
+    });
+  });
+
+  it('guides different completed legacy snapshots to blocked checkpoints and fresh sessions', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        claudeGoalMode: 'per_story',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'complete',
+          evidence: 'audit passed but wrong Claude /goal snapshot',
+          claudeGoal: { goal: { objective: 'Completed legacy objective', status: 'complete' } },
+        }),
+      ).rejects.toThrow(/objective mismatch[\s\S]*--status blocked[\s\S]*fresh Claude Code session/);
+    });
+  });
+
+  it('rejects blocked checkpoints for active or same-objective Claude goals', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        claudeGoalMode: 'per_story',
+        goals: [
+          { title: 'First', objective: 'Complete first milestone.' },
+        ],
+      });
+
+      const first = await startNextUltragoal(cwd);
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'blocked',
+          evidence: 'active wrong goal',
+          claudeGoal: { goal: { objective: 'Different active work', status: 'active' } },
+        }),
+      ).rejects.toThrow(/strict objective mismatch protection remains required/);
+
+      await expect(
+        checkpointUltragoal(cwd, {
+          goalId: first.goal!.id,
+          status: 'blocked',
+          evidence: 'same complete goal',
+          claudeGoal: { goal: { objective: first.goal!.objective, status: 'complete' } },
+        }),
+      ).rejects.toThrow(/different completed legacy Claude goal/);
+    });
+  });
+});

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -1,0 +1,768 @@
+import { existsSync } from 'node:fs';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import {
+  formatClaudeGoalReconciliation,
+  parseClaudeGoalSnapshot,
+  reconcileClaudeGoalSnapshot,
+} from '../goal-workflows/claude-goal-snapshot.js';
+
+export const ULTRAGOAL_DIR = '.omc/ultragoal';
+export const ULTRAGOAL_BRIEF = 'brief.md';
+export const ULTRAGOAL_GOALS = 'goals.json';
+export const ULTRAGOAL_LEDGER = 'ledger.jsonl';
+
+export type UltragoalStatus = 'pending' | 'in_progress' | 'complete' | 'failed' | 'review_blocked';
+export type UltragoalClaudeGoalMode = 'aggregate' | 'per_story';
+
+export interface UltragoalItem {
+  id: string;
+  title: string;
+  objective: string;
+  status: UltragoalStatus;
+  tokenBudget?: number;
+  attempt: number;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  reviewBlockedAt?: string;
+  evidence?: string;
+  failureReason?: string;
+}
+
+export interface UltragoalAggregateCompletion {
+  status: 'complete';
+  completedAt: string;
+  evidence: string;
+  claudeGoal?: unknown;
+}
+
+export interface UltragoalPlan {
+  version: 1;
+  createdAt: string;
+  updatedAt: string;
+  briefPath: string;
+  goalsPath: string;
+  ledgerPath: string;
+  claudeGoalMode?: UltragoalClaudeGoalMode;
+  claudeObjective?: string;
+  aggregateCompletion?: UltragoalAggregateCompletion;
+  activeGoalId?: string;
+  goals: UltragoalItem[];
+}
+
+export interface UltragoalLedgerEntry {
+  ts: string;
+  event:
+    | 'plan_created'
+    | 'goal_started'
+    | 'goal_resumed'
+    | 'goal_completed'
+    | 'goal_blocked'
+    | 'goal_failed'
+    | 'goal_retried'
+    | 'aggregate_completed'
+    | 'goal_added'
+    | 'final_review_failed'
+    | 'goal_review_blocked';
+  goalId?: string;
+  status?: UltragoalStatus;
+  message?: string;
+  claudeGoal?: unknown;
+  evidence?: string;
+  qualityGate?: UltragoalQualityGate;
+}
+
+export interface CreateUltragoalOptions {
+  brief: string;
+  goals?: Array<{ title?: string; objective: string; tokenBudget?: number }>;
+  claudeGoalMode?: UltragoalClaudeGoalMode;
+  now?: Date;
+  force?: boolean;
+}
+
+export interface StartNextOptions {
+  now?: Date;
+  retryFailed?: boolean;
+}
+
+export interface CheckpointOptions {
+  goalId: string;
+  status: Extract<UltragoalStatus, 'complete' | 'failed'> | 'blocked';
+  evidence?: string;
+  claudeGoal?: unknown;
+  qualityGate?: unknown;
+  allowActiveFinalClaudeGoal?: boolean;
+  now?: Date;
+}
+
+export interface AddUltragoalGoalOptions {
+  title: string;
+  objective: string;
+  evidence?: string;
+  now?: Date;
+}
+
+export interface RecordFinalReviewBlockersOptions extends AddUltragoalGoalOptions {
+  goalId: string;
+  claudeGoal?: unknown;
+}
+
+export interface UltragoalQualityGate {
+  aiSlopCleaner: {
+    status: 'passed';
+    evidence: string;
+  };
+  verification: {
+    status: 'passed';
+    commands: string[];
+    evidence: string;
+  };
+  codeReview: {
+    recommendation: 'APPROVE';
+    architectStatus: 'CLEAR';
+    evidence: string;
+  };
+}
+
+export class UltragoalError extends Error {}
+
+function iso(now = new Date()): string {
+  return now.toISOString();
+}
+
+export function ultragoalDir(cwd: string): string {
+  return join(cwd, ULTRAGOAL_DIR);
+}
+
+export function ultragoalBriefPath(cwd: string): string {
+  return join(ultragoalDir(cwd), ULTRAGOAL_BRIEF);
+}
+
+export function ultragoalGoalsPath(cwd: string): string {
+  return join(ultragoalDir(cwd), ULTRAGOAL_GOALS);
+}
+
+export function ultragoalLedgerPath(cwd: string): string {
+  return join(ultragoalDir(cwd), ULTRAGOAL_LEDGER);
+}
+
+function repoRelative(cwd: string, path: string): string {
+  return relative(cwd, path).split('\\').join('/');
+}
+
+function cleanLine(line: string): string {
+  return line.replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/, '').trim();
+}
+
+function normalizeObjective(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function textMentionsUltragoalPlanArtifact(value: string | undefined): boolean {
+  const normalized = (value ?? '').toLowerCase();
+  return normalized.includes(ULTRAGOAL_DIR.toLowerCase())
+    || normalized.includes(ULTRAGOAL_GOALS.toLowerCase())
+    || normalized.includes(ULTRAGOAL_LEDGER.toLowerCase());
+}
+
+function textMentionsGoalId(value: string | undefined, goalId: string): boolean {
+  return (value ?? '').toLowerCase().includes(goalId.toLowerCase());
+}
+
+function textHasCompletionValidationEvidence(value: string | undefined): boolean {
+  const normalized = (value ?? '').toLowerCase();
+  const hasImplementationCompletion = /\b(?:planned work|implementation|deliverables?|scope|task|work)\b/.test(normalized)
+    && /\b(?:done|complete|completed|finished|shipped)\b/.test(normalized);
+  const hasValidation = /\b(?:validation|verification|tests?|build|lint|review|quality gate|code-review)\b/.test(normalized)
+    && /\b(?:passed|complete|completed|clean|green|approve|approved|clear)\b/.test(normalized);
+  return hasImplementationCompletion && hasValidation;
+}
+
+async function snapshotObjectiveMapsToUltragoalPlan(cwd: string, snapshotObjective: string): Promise<boolean> {
+  const actual = normalizeObjective(snapshotObjective).toLowerCase();
+  if (textMentionsUltragoalPlanArtifact(actual)) return true;
+  if (actual.length < 24) return false;
+  try {
+    const brief = normalizeObjective(await readFile(ultragoalBriefPath(cwd), 'utf-8')).toLowerCase();
+    if (!brief || brief.length < 24) return false;
+    return brief.includes(actual) || actual.includes(brief);
+  } catch {
+    return false;
+  }
+}
+
+async function canReconcileCompletedTaskScopedAggregateSnapshot(
+  cwd: string,
+  plan: UltragoalPlan,
+  goal: UltragoalItem,
+  snapshotObjective: string,
+  evidence: string | undefined,
+): Promise<boolean> {
+  if (claudeGoalMode(plan) !== 'aggregate') return false;
+  if (goal.status !== 'in_progress' || plan.activeGoalId !== goal.id) return false;
+  if (!textMentionsUltragoalPlanArtifact(evidence)) return false;
+  if (!textMentionsGoalId(evidence, goal.id)) return false;
+  if (!textHasCompletionValidationEvidence(evidence)) return false;
+  return snapshotObjectiveMapsToUltragoalPlan(cwd, snapshotObjective);
+}
+
+function buildCompletedLegacyGoalRemediation(goal: UltragoalItem): string {
+  return [
+    'If the active /goal condition is a different completed legacy goal, do not repeat --status complete in this session.',
+    `Record a non-terminal blocker with: omc ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Claude goal blocks setting a new /goal in this session>" --claude-goal-json "<different completed goal snapshot JSON or path>".`,
+    'Then continue this ultragoal in a fresh Claude Code session in the same repo/worktree and set the intended /goal there.',
+  ].join(' ');
+}
+
+function claudeGoalMode(plan: UltragoalPlan): UltragoalClaudeGoalMode {
+  return plan.claudeGoalMode ?? 'per_story';
+}
+
+function isResolvedStatus(status: UltragoalStatus): boolean {
+  return status === 'complete' || status === 'review_blocked';
+}
+
+function aggregateClaudeObjective(goals: readonly UltragoalItem[]): string {
+  const prefix = `Complete all ultragoal stories in ${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}: `;
+  const suffix = goals.map((goal) => `${goal.id} ${goal.title}`).join('; ');
+  const full = `${prefix}${suffix}`;
+  if (full.length <= 4000) return full;
+  const fallback = `Complete all ultragoal stories listed in ${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}. Use ${ULTRAGOAL_DIR}/${ULTRAGOAL_LEDGER} as the durable audit trail.`;
+  if (fallback.length <= 4000) return fallback;
+  throw new UltragoalError('Generated aggregate Claude /goal objective exceeds the 4,000 character limit.');
+}
+
+function expectedClaudeObjective(plan: UltragoalPlan, goal: UltragoalItem): string {
+  return claudeGoalMode(plan) === 'aggregate'
+    ? (plan.claudeObjective ?? aggregateClaudeObjective(plan.goals))
+    : goal.objective;
+}
+
+export function isFinalRunCompletionCandidate(plan: UltragoalPlan, goal: UltragoalItem): boolean {
+  return plan.goals.every((candidate) => candidate.id === goal.id || isResolvedStatus(candidate.status));
+}
+
+export function isUltragoalDone(plan: UltragoalPlan): boolean {
+  if (plan.aggregateCompletion?.status === 'complete') return true;
+  if (plan.goals.length === 0) return true;
+  if (plan.goals.some((goal) => goal.status === 'pending' || goal.status === 'in_progress' || goal.status === 'failed')) return false;
+  if (!plan.goals.every((goal) => isResolvedStatus(goal.status))) return false;
+  const latestNonReviewBlocked = [...plan.goals].reverse().find((goal) => goal.status !== 'review_blocked');
+  return latestNonReviewBlocked?.status === 'complete';
+}
+
+function titleFromObjective(objective: string, fallback: string): string {
+  const firstLine = objective.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? fallback;
+  return firstLine.length > 72 ? `${firstLine.slice(0, 69).trimEnd()}...` : firstLine;
+}
+
+export function deriveGoalCandidates(brief: string): Array<{ title: string; objective: string }> {
+  const lines = brief.split(/\r?\n/);
+  const bulletGoals = lines
+    .map((line) => ({ original: line, cleaned: cleanLine(line) }))
+    .filter(({ cleaned }) => cleaned.length > 0 && cleaned.length <= 1200)
+    .filter(({ original, cleaned }, index, all) => (
+      /^\s*(?:[-*+]\s+|\d+[.)]\s+)/.test(original)
+      && all.findIndex((candidate) => candidate.cleaned === cleaned) === index
+    ))
+    .map(({ cleaned }) => cleaned);
+
+  const objectives = bulletGoals.length > 0
+    ? bulletGoals
+    : brief
+      .split(/\n\s*\n/)
+      .map((paragraph) => paragraph.trim())
+      .filter((paragraph) => paragraph.length > 0 && !paragraph.startsWith('#'));
+
+  const selected = objectives.length > 0 ? objectives : [brief.trim() || 'Complete the requested project objective.'];
+  return selected.map((objective, index) => ({
+    title: titleFromObjective(objective, `Goal ${index + 1}`),
+    objective,
+  }));
+}
+
+function normalizeGoalId(title: string, index: number): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 36)
+    .replace(/-+$/g, '');
+  return `G${String(index + 1).padStart(3, '0')}${slug ? `-${slug}` : ''}`;
+}
+
+async function appendLedger(cwd: string, entry: UltragoalLedgerEntry): Promise<void> {
+  await mkdir(ultragoalDir(cwd), { recursive: true });
+  const path = ultragoalLedgerPath(cwd);
+  await appendFile(path, `${JSON.stringify(entry)}\n`);
+}
+
+export async function readUltragoalPlan(cwd: string): Promise<UltragoalPlan> {
+  const path = ultragoalGoalsPath(cwd);
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf-8');
+  } catch {
+    throw new UltragoalError(`No ultragoal plan found at ${repoRelative(cwd, path)}. Run \`omc ultragoal create-goals ...\` first.`);
+  }
+  const parsed = JSON.parse(raw) as UltragoalPlan;
+  if (parsed.version !== 1 || !Array.isArray(parsed.goals)) {
+    throw new UltragoalError(`Invalid ultragoal plan at ${repoRelative(cwd, path)}.`);
+  }
+  return parsed;
+}
+
+async function writePlan(cwd: string, plan: UltragoalPlan): Promise<void> {
+  await mkdir(ultragoalDir(cwd), { recursive: true });
+  await writeFile(ultragoalGoalsPath(cwd), `${JSON.stringify(plan, null, 2)}\n`);
+}
+
+export async function createUltragoalPlan(cwd: string, options: CreateUltragoalOptions): Promise<UltragoalPlan> {
+  if (!options.force && existsSync(ultragoalGoalsPath(cwd))) {
+    throw new UltragoalError(`Refusing to overwrite existing ${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}; pass --force to recreate it.`);
+  }
+  const now = iso(options.now);
+  const sourceGoals: Array<{ title?: string; objective: string; tokenBudget?: number }> = options.goals?.length
+    ? options.goals
+    : deriveGoalCandidates(options.brief);
+  const candidates = sourceGoals
+    .map((goal, index): UltragoalItem => ({
+      id: normalizeGoalId(goal.title ?? titleFromObjective(goal.objective, `Goal ${index + 1}`), index),
+      title: goal.title ?? titleFromObjective(goal.objective, `Goal ${index + 1}`),
+      objective: goal.objective.trim(),
+      status: 'pending',
+      tokenBudget: goal.tokenBudget,
+      attempt: 0,
+      createdAt: now,
+      updatedAt: now,
+    }));
+
+  const plan: UltragoalPlan = {
+    version: 1,
+    createdAt: now,
+    updatedAt: now,
+    briefPath: `${ULTRAGOAL_DIR}/${ULTRAGOAL_BRIEF}`,
+    goalsPath: `${ULTRAGOAL_DIR}/${ULTRAGOAL_GOALS}`,
+    ledgerPath: `${ULTRAGOAL_DIR}/${ULTRAGOAL_LEDGER}`,
+    claudeGoalMode: options.claudeGoalMode ?? 'aggregate',
+    goals: candidates,
+  };
+  if (plan.claudeGoalMode === 'aggregate') plan.claudeObjective = aggregateClaudeObjective(candidates);
+
+  await mkdir(ultragoalDir(cwd), { recursive: true });
+  await writeFile(ultragoalBriefPath(cwd), options.brief.endsWith('\n') ? options.brief : `${options.brief}\n`);
+  await writePlan(cwd, plan);
+  await writeFile(ultragoalLedgerPath(cwd), '');
+  await appendLedger(cwd, { ts: now, event: 'plan_created', message: `${candidates.length} goal(s) created` });
+  return plan;
+}
+
+export function summarizeUltragoalPlan(plan: UltragoalPlan): { total: number; pending: number; inProgress: number; complete: number; failed: number; reviewBlocked: number; aggregateComplete: boolean; activeGoalId?: string } {
+  return {
+    total: plan.goals.length,
+    pending: plan.goals.filter((goal) => goal.status === 'pending').length,
+    inProgress: plan.goals.filter((goal) => goal.status === 'in_progress').length,
+    complete: plan.goals.filter((goal) => goal.status === 'complete').length,
+    failed: plan.goals.filter((goal) => goal.status === 'failed').length,
+    reviewBlocked: plan.goals.filter((goal) => goal.status === 'review_blocked').length,
+    aggregateComplete: plan.aggregateCompletion?.status === 'complete',
+    activeGoalId: plan.activeGoalId,
+  };
+}
+
+function assertNonEmpty(value: string | undefined, label: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new UltragoalError(`Missing ${label}.`);
+  return trimmed;
+}
+
+function appendGoalToPlan(plan: UltragoalPlan, options: AddUltragoalGoalOptions, now: string): UltragoalItem {
+  const title = assertNonEmpty(options.title, '--title');
+  const objective = assertNonEmpty(options.objective, '--objective');
+  const goal: UltragoalItem = {
+    id: normalizeGoalId(title, plan.goals.length),
+    title,
+    objective,
+    status: 'pending',
+    attempt: 0,
+    createdAt: now,
+    updatedAt: now,
+    evidence: options.evidence,
+  };
+  plan.goals.push(goal);
+  plan.updatedAt = now;
+  return goal;
+}
+
+export async function addUltragoalGoal(cwd: string, options: AddUltragoalGoalOptions): Promise<{ plan: UltragoalPlan; goal: UltragoalItem }> {
+  const plan = await readUltragoalPlan(cwd);
+  const now = iso(options.now);
+  const goal = appendGoalToPlan(plan, options, now);
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'goal_added',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    message: goal.title,
+  });
+  return { plan, goal };
+}
+
+function validateQualityGate(value: unknown): UltragoalQualityGate {
+  if (!value || typeof value !== 'object') {
+    throw new UltragoalError('Final ultragoal completion requires --quality-gate-json with ai-slop-cleaner, verification, and code-review evidence.');
+  }
+  const gate = value as Partial<UltragoalQualityGate>;
+  const cleaner = gate.aiSlopCleaner;
+  const verification = gate.verification;
+  const review = gate.codeReview;
+  if (!cleaner || typeof cleaner !== 'object') throw new UltragoalError('Final quality gate is missing aiSlopCleaner evidence.');
+  if (cleaner.status !== 'passed') {
+    throw new UltragoalError('Final quality gate requires aiSlopCleaner.status="passed"; run ai-slop-cleaner even when it is a no-op.');
+  }
+  assertNonEmpty(cleaner.evidence, 'aiSlopCleaner.evidence');
+  if (!verification || typeof verification !== 'object') throw new UltragoalError('Final quality gate is missing verification evidence.');
+  if (verification.status !== 'passed') throw new UltragoalError('Final quality gate requires verification.status="passed".');
+  if (!Array.isArray(verification.commands) || verification.commands.length === 0 || verification.commands.some((command) => typeof command !== 'string' || command.trim() === '')) {
+    throw new UltragoalError('Final quality gate requires non-empty verification.commands.');
+  }
+  assertNonEmpty(verification.evidence, 'verification.evidence');
+  if (!review || typeof review !== 'object') throw new UltragoalError('Final quality gate is missing codeReview evidence.');
+  if (review.recommendation !== 'APPROVE') {
+    throw new UltragoalError('Final code-review must be clean: codeReview.recommendation must be APPROVE; use record-review-blockers for COMMENT or REQUEST CHANGES.');
+  }
+  if (review.architectStatus !== 'CLEAR') {
+    throw new UltragoalError('Final code-review must be clean: codeReview.architectStatus must be CLEAR; use record-review-blockers for WATCH or BLOCK.');
+  }
+  assertNonEmpty(review.evidence, 'codeReview.evidence');
+  return gate as UltragoalQualityGate;
+}
+
+export async function startNextUltragoal(cwd: string, options: StartNextOptions = {}): Promise<{ plan: UltragoalPlan; goal: UltragoalItem | null; resumed: boolean; done: boolean }> {
+  const plan = await readUltragoalPlan(cwd);
+  const now = iso(options.now);
+  if (plan.aggregateCompletion?.status === 'complete') return { plan, goal: null, resumed: false, done: true };
+  const existing = plan.goals.find((goal) => goal.status === 'in_progress');
+  if (existing) {
+    await appendLedger(cwd, { ts: now, event: 'goal_resumed', goalId: existing.id, status: existing.status, message: 'Resuming active ultragoal' });
+    return { plan, goal: existing, resumed: true, done: false };
+  }
+
+  let next = plan.goals.find((goal) => goal.status === 'pending');
+  if (!next && options.retryFailed) {
+    next = plan.goals.find((goal) => goal.status === 'failed');
+    if (next) await appendLedger(cwd, { ts: now, event: 'goal_retried', goalId: next.id, status: 'pending', message: next.failureReason });
+  }
+  if (!next) return { plan, goal: null, resumed: false, done: isUltragoalDone(plan) };
+
+  next.status = 'in_progress';
+  next.attempt += 1;
+  next.startedAt = now;
+  next.failedAt = undefined;
+  next.failureReason = undefined;
+  next.updatedAt = now;
+  plan.activeGoalId = next.id;
+  plan.updatedAt = now;
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, { ts: now, event: 'goal_started', goalId: next.id, status: next.status, message: `Attempt ${next.attempt}` });
+  return { plan, goal: next, resumed: false, done: false };
+}
+
+export async function checkpointUltragoal(cwd: string, options: CheckpointOptions): Promise<UltragoalPlan> {
+  const plan = await readUltragoalPlan(cwd);
+  const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
+  if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  const now = iso(options.now);
+  if (options.status === 'blocked') {
+    if (goal.status !== 'in_progress') {
+      throw new UltragoalError(`Cannot record a blocked checkpoint for ${goal.id} while it is ${goal.status}; start or resume the ultragoal before recording a non-terminal blocker.`);
+    }
+    const snapshot = options.claudeGoal === undefined ? null : parseClaudeGoalSnapshot(options.claudeGoal);
+    if (!snapshot?.available) {
+      throw new UltragoalError('Blocked ultragoal checkpoints require a Claude /goal snapshot for the completed legacy goal that blocked a new /goal directive; pass --claude-goal-json.');
+    }
+    if (snapshot.status !== 'complete') {
+      throw new UltragoalError(`Cannot record a blocked ultragoal checkpoint while the existing Claude /goal is ${snapshot.status ?? 'unknown'}; strict objective mismatch protection remains required for active or incomplete goals.`);
+    }
+    if (!snapshot.objective) {
+      throw new UltragoalError('Blocked ultragoal checkpoint Claude snapshot is missing objective text.');
+    }
+    if (normalizeObjective(snapshot.objective) === normalizeObjective(expectedClaudeObjective(plan, goal))) {
+      throw new UltragoalError('Blocked ultragoal checkpoint is only for a different completed legacy Claude goal; complete this ultragoal with --status complete after its audit passes.');
+    }
+    goal.updatedAt = now;
+    plan.activeGoalId = goal.id;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan);
+    await appendLedger(cwd, {
+      ts: now,
+      event: 'goal_blocked',
+      goalId: goal.id,
+      status: goal.status,
+      evidence: options.evidence,
+      claudeGoal: options.claudeGoal,
+    });
+    return plan;
+  }
+  let aggregateCompletion: UltragoalAggregateCompletion | undefined;
+  if (options.status === 'complete') {
+    const expectedObjective = expectedClaudeObjective(plan, goal);
+    const aggregateMode = claudeGoalMode(plan) === 'aggregate';
+    const finalRunCheckpoint = isFinalRunCompletionCandidate(plan, goal);
+    const snapshot = options.claudeGoal === undefined ? null : parseClaudeGoalSnapshot(options.claudeGoal);
+    const reconciliation = reconcileClaudeGoalSnapshot(
+      snapshot,
+      {
+        expectedObjective,
+        allowedStatuses: aggregateMode
+          ? (finalRunCheckpoint && !options.allowActiveFinalClaudeGoal ? ['complete'] : ['active'])
+          : ['complete'],
+        requireSnapshot: true,
+        requireComplete: !aggregateMode || (finalRunCheckpoint && !options.allowActiveFinalClaudeGoal),
+      },
+    );
+    if (!reconciliation.ok) {
+      const completedTaskScopedAggregateSnapshot = snapshot?.available
+        && snapshot.status === 'complete'
+        && Boolean(snapshot.objective)
+        && normalizeObjective(snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
+        && await canReconcileCompletedTaskScopedAggregateSnapshot(cwd, plan, goal, snapshot.objective ?? '', options.evidence);
+      if (completedTaskScopedAggregateSnapshot) {
+        aggregateCompletion = {
+          status: 'complete',
+          completedAt: now,
+          evidence: assertNonEmpty(options.evidence, '--evidence'),
+          claudeGoal: options.claudeGoal,
+        };
+      } else {
+        const taskScopedRequirement = aggregateMode && snapshot?.status === 'complete' && Boolean(snapshot.objective)
+          ? ' Completed task-scoped aggregate reconciliation requires the checkpoint goal to be the active in-progress OMC goal, evidence that names that active OMC goal id, names .omc/ultragoal/goals.json or ledger.jsonl, includes completed implementation plus validation/review evidence, and a Claude /goal objective that maps to the ultragoal brief/artifact.'
+          : '';
+        const remediation = reconciliation.snapshot.available
+          && reconciliation.snapshot.status === 'complete'
+          && Boolean(reconciliation.snapshot.objective)
+          && normalizeObjective(reconciliation.snapshot.objective ?? '') !== normalizeObjective(expectedObjective)
+          ? ` ${buildCompletedLegacyGoalRemediation(goal)}`
+          : '';
+        throw new UltragoalError(`${formatClaudeGoalReconciliation(reconciliation)}${taskScopedRequirement}${remediation}`);
+      }
+    }
+    if (finalRunCheckpoint && !options.allowActiveFinalClaudeGoal) goal.evidence = options.evidence;
+  }
+  const qualityGate = options.status === 'complete' && (aggregateCompletion !== undefined || (isFinalRunCompletionCandidate(plan, goal) && !options.allowActiveFinalClaudeGoal))
+    ? validateQualityGate(options.qualityGate)
+    : undefined;
+  if (aggregateCompletion) {
+    plan.aggregateCompletion = aggregateCompletion;
+    if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan);
+    await appendLedger(cwd, {
+      ts: now,
+      event: 'aggregate_completed',
+      goalId: goal.id,
+      status: goal.status,
+      evidence: options.evidence,
+      claudeGoal: options.claudeGoal,
+      qualityGate,
+      message: 'Aggregate ultragoal plan completed via task-scoped Claude /goal snapshot; microgoal ledger progress remains independent.',
+    });
+    return plan;
+  }
+  goal.status = options.status;
+  goal.updatedAt = now;
+  if (options.status === 'complete') {
+    goal.completedAt = now;
+    goal.evidence = options.evidence;
+    goal.failureReason = undefined;
+    goal.failedAt = undefined;
+    if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+  } else {
+    goal.failedAt = now;
+    goal.failureReason = options.evidence;
+    if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+  }
+  plan.updatedAt = now;
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, {
+    ts: now,
+    event: options.status === 'complete' ? 'goal_completed' : 'goal_failed',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    claudeGoal: options.claudeGoal,
+    qualityGate,
+  });
+  return plan;
+}
+
+export async function recordFinalReviewBlockers(cwd: string, options: RecordFinalReviewBlockersOptions): Promise<{ plan: UltragoalPlan; blockedGoal: UltragoalItem; addedGoal: UltragoalItem }> {
+  const plan = await readUltragoalPlan(cwd);
+  const goal = plan.goals.find((candidate) => candidate.id === options.goalId);
+  if (!goal) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  assertNonEmpty(options.evidence, '--evidence');
+  if (goal.status !== 'in_progress') {
+    throw new UltragoalError(`Cannot record final review blockers for ${goal.id} while it is ${goal.status}; start or resume the ultragoal first.`);
+  }
+  if (!isFinalRunCompletionCandidate(plan, goal)) {
+    throw new UltragoalError(`Cannot record final review blockers for ${goal.id}; it is not the only unresolved ultragoal story.`);
+  }
+
+  const now = iso(options.now);
+  const expectedObjective = expectedClaudeObjective(plan, goal);
+  const aggregateMode = claudeGoalMode(plan) === 'aggregate';
+  const reconciliation = reconcileClaudeGoalSnapshot(
+    options.claudeGoal === undefined ? null : parseClaudeGoalSnapshot(options.claudeGoal),
+    {
+      expectedObjective,
+      allowedStatuses: ['active'],
+      requireSnapshot: true,
+      requireComplete: false,
+    },
+  );
+  if (!reconciliation.ok) {
+    throw new UltragoalError(formatClaudeGoalReconciliation(reconciliation));
+  }
+
+  const addedGoal = appendGoalToPlan(plan, options, now);
+  goal.status = 'review_blocked';
+  goal.reviewBlockedAt = now;
+  goal.updatedAt = now;
+  goal.completedAt = undefined;
+  goal.failedAt = undefined;
+  goal.failureReason = undefined;
+  goal.evidence = options.evidence;
+  if (plan.activeGoalId === goal.id) delete plan.activeGoalId;
+  plan.updatedAt = now;
+
+  await writePlan(cwd, plan);
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'final_review_failed',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    claudeGoal: options.claudeGoal,
+    message: aggregateMode
+      ? 'Final aggregate code-review was not clean; blocker story was appended while Claude /goal remains active.'
+      : 'Final per-story code-review was not clean; blocker story was appended and may require a fresh/available Claude /goal context.',
+  });
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'goal_added',
+    goalId: addedGoal.id,
+    status: addedGoal.status,
+    evidence: options.evidence,
+    message: addedGoal.title,
+  });
+  await appendLedger(cwd, {
+    ts: now,
+    event: 'goal_review_blocked',
+    goalId: goal.id,
+    status: goal.status,
+    evidence: options.evidence,
+    claudeGoal: options.claudeGoal,
+  });
+  return { plan, blockedGoal: goal, addedGoal };
+}
+
+export function buildClaudeGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
+  if (claudeGoalMode(plan) === 'aggregate') return buildAggregateClaudeGoalInstruction(goal, plan);
+  return buildPerStoryClaudeGoalInstruction(goal, plan);
+}
+
+function buildPerStoryClaudeGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
+  const createPayload = {
+    condition: goal.objective,
+    ...(goal.tokenBudget ? { token_budget: goal.tokenBudget } : {}),
+  };
+  const finalStory = isFinalRunCompletionCandidate(plan, goal);
+  return [
+    'Ultragoal active-goal handoff',
+    `Plan: ${plan.goalsPath}`,
+    `Ledger: ${plan.ledgerPath}`,
+    `Goal: ${goal.id} — ${goal.title}`,
+    '',
+    'Claude /goal integration constraints (model-facing — OMC cannot mutate Claude /goal state from a shell):',
+    '- First confirm the active Claude /goal condition for this session. If none is active, invoke /goal <condition> with the payload below.',
+    '- If a different active Claude /goal exists, finish or clear that /goal before starting this ultragoal.',
+    '- If the active /goal is a different completed legacy goal and the Claude session refuses to set a new /goal, continue this ultragoal in a fresh Claude Code session (same repo/worktree) and invoke /goal there.',
+    `- To preserve the durable ledger before switching sessions, record the non-terminal blocker without failing this goal: omc ultragoal checkpoint --goal-id ${goal.id} --status blocked --evidence "<completed legacy Claude goal blocks new /goal in this session>" --claude-goal-json "<goal snapshot JSON or path>"`,
+    '- Work only this goal until its completion audit passes.',
+    finalStory
+      ? '- Final mandatory quality gate: run ai-slop-cleaner on changed files even when it is a no-op, rerun verification, then run $code-review.'
+      : '- This is not the final ultragoal story; do not run the final ai-slop-cleaner/$code-review gate yet.',
+    finalStory
+      ? '- If final $code-review is not APPROVE with architect status CLEAR, do not clear the /goal. Record blockers with:'
+      : '- After the goal is actually complete, clear or update the active /goal (run /goal clear once the auto-clear has not already fired), then share a fresh /goal snapshot and checkpoint the ledger with:',
+    finalStory
+      ? `  omc ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --claude-goal-json "<active /goal snapshot JSON or path>"`
+      : `  omc ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --claude-goal-json "<fresh /goal snapshot JSON or path>"`,
+    finalStory
+      ? '- In legacy per-story mode, the blocker story may require a fresh/available Claude /goal context because this story remains an active incomplete /goal; do not claim it is complete.'
+      : null,
+    finalStory
+      ? '- If final $code-review is clean (APPROVE + CLEAR), clear the /goal (or wait for the auto-clear), then checkpoint with --quality-gate-json:'
+      : null,
+    finalStory
+      ? `  omc ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --claude-goal-json "<fresh complete /goal snapshot JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
+      : null,
+    '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
+    '',
+    'Suggested /goal payload (model-facing — invoke /goal yourself in-session):',
+    JSON.stringify(createPayload, null, 2),
+    '',
+    'Objective (use as the /goal condition):',
+    goal.objective,
+  ].filter((line): line is string => line !== null).join('\n');
+}
+
+function buildAggregateClaudeGoalInstruction(goal: UltragoalItem, plan: UltragoalPlan): string {
+  const objective = plan.claudeObjective ?? aggregateClaudeObjective(plan.goals);
+  const finalStory = isFinalRunCompletionCandidate(plan, goal);
+  const createPayload = { condition: objective };
+  const checkpointStatus = finalStory ? 'complete' : 'active';
+  return [
+    'Ultragoal aggregate-goal handoff',
+    `Plan: ${plan.goalsPath}`,
+    `Ledger: ${plan.ledgerPath}`,
+    `Goal: ${goal.id} — ${goal.title}`,
+    '',
+    'Claude /goal integration constraints (model-facing — OMC cannot mutate Claude /goal state from a shell):',
+    '- Claude /goal = the whole ultragoal run; OMC G001/G002/etc. = ledger stories.',
+    '- First confirm the active Claude /goal condition for this session. If none is active, invoke /goal <condition> with the aggregate payload below.',
+    '- If the active /goal already reports the same aggregate objective as active, continue this OMC story without setting a new /goal.',
+    '- If a different active or incomplete Claude /goal exists, finish or clear that /goal before starting this ultragoal; do not claim a shell command can replace Claude /goal state.',
+    finalStory
+      ? '- This is the final pending story: run the mandatory final ai-slop-cleaner pass, rerun verification, and run $code-review before any /goal clear.'
+      : '- This is not the final story: do not clear the /goal yet; the aggregate Claude /goal must remain active while later OMC stories remain.',
+    finalStory
+      ? '- If final $code-review is not APPROVE with architect status CLEAR, do not clear the /goal. Record durable blocker work first:'
+      : null,
+    finalStory
+      ? `  omc ultragoal record-review-blockers --goal-id ${goal.id} --title "Resolve final code-review blockers" --objective "<blocker-resolution objective>" --evidence "<review findings>" --claude-goal-json "<active /goal snapshot JSON or path>"`
+      : null,
+    finalStory
+      ? '- If final $code-review is clean (APPROVE + CLEAR), clear the /goal (or let the auto-clear fire when the condition holds), share a fresh complete /goal snapshot, then checkpoint with --quality-gate-json.'
+      : null,
+    `- Checkpoint this OMC story with a fresh /goal snapshot whose objective matches the aggregate payload and whose status is ${checkpointStatus}:`,
+    finalStory
+      ? `  omc ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --claude-goal-json "<fresh complete /goal snapshot JSON or path>" --quality-gate-json "<quality gate JSON or path>"`
+      : `  omc ultragoal checkpoint --goal-id ${goal.id} --status complete --evidence "<tests/files/PR evidence>" --claude-goal-json "<fresh /goal snapshot JSON or path>"`,
+    '- If blocked or failed, checkpoint with --status failed and the failure evidence; rerun complete-goals --retry-failed to resume.',
+    '',
+    'Suggested /goal payload (model-facing — invoke /goal yourself in-session):',
+    JSON.stringify(createPayload, null, 2),
+    '',
+    'Aggregate /goal condition:',
+    objective,
+    '',
+    'Current OMC story objective:',
+    goal.objective,
+  ].filter((line): line is string => line !== null).join('\n');
+}


### PR DESCRIPTION
## Summary
- Port OMX's durable `ultragoal` workflow into OMC as `omc ultragoal`
- Add `.omc/ultragoal` plan/ledger artifacts, Claude `/goal` snapshot reconciliation, and final quality-gate enforcement
- Add focused tests, docs, and a discoverable `skills/ultragoal` skill

## Notes
- This PR intentionally does **not** include rebuilt `bridge/` or `dist/` outputs. `npm run build` regenerates those artifacts locally, and the source diff stays limited to source/docs/skill/test files.
- The command does not claim shell-level mutation of Claude hidden `/goal` state. It persists durable repo state and prints model-facing handoff text for the active Claude session.

## Verification
- `npm run build` ✅
- `npx vitest run src/goal-workflows src/ultragoal src/cli/commands/__tests__/ultragoal.test.ts` ✅ — 27/27 passed
- `git diff --check HEAD~1..HEAD` ✅
- CLI smoke against rebuilt `bridge/cli.cjs` ✅ — `ultragoal help` prints help and `create-goals --brief demo` writes `.omc/ultragoal/{brief.md,goals.json,ledger.jsonl}`
- Independent review pass: no blocking code/security issues after honoring source-only/no-build-artifacts PR scope

## Remaining Risks
- Because generated CLI artifacts are intentionally excluded, consumers need the normal build/prepublish path to materialize `bridge/cli.cjs` before using the new command from packaged output.
- Snapshot reconciliation relies on model-supplied Claude `/goal` JSON, which is documented as the current integration boundary.
