### PR TITLE
Harden HUD cache stale lock cleanup

### DIFF
--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -17,11 +17,50 @@ CONFIG_DIR=${CLAUDE_CONFIG_DIR:-$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd -P)}
 CACHE_DIR=${OMC_HUD_CACHE_DIR:-"$CONFIG_DIR/hud/cache"}
 HUD_SCRIPT=${1:-"$SCRIPT_DIR/omc-hud.mjs"}
 INPUT_TMP="$CACHE_DIR/stdin.$$.tmp"
+LOCK_STALE_SECONDS=${OMC_HUD_LOCK_STALE_SECONDS:-10}
 
 mkdir -p "$CACHE_DIR" 2>/dev/null || {
   printf '[OMC] Starting...\n'
   exit 0
 }
+CACHE_DIR=$(cd "$CACHE_DIR" 2>/dev/null && pwd -P) || {
+  printf '[OMC] Starting...\n'
+  exit 0
+}
+INPUT_TMP="$CACHE_DIR/stdin.$$.tmp"
+
+file_mtime() {
+  (stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null) | head -1
+}
+
+is_stale_path() {
+  path=$1
+  now=$(date +%s 2>/dev/null || printf '0')
+  path_mtime=$(file_mtime "$path")
+  [ -n "$path_mtime" ] || return 1
+  [ "$now" -gt 0 ] || return 1
+  [ $((now - path_mtime)) -gt "$LOCK_STALE_SECONDS" ] || return 1
+}
+
+cleanup_empty_temp_files() {
+  for temp_path in "$CACHE_DIR"/stdin.*.tmp "$CACHE_DIR"/statusline.*.tmp "$CACHE_DIR"/statusline.*.err; do
+    [ -f "$temp_path" ] || continue
+    [ -s "$temp_path" ] && continue
+    is_stale_path "$temp_path" || continue
+    rm -f "$temp_path" 2>/dev/null || :
+  done
+}
+
+cleanup_stale_render_locks() {
+  for stale_lock_dir in "$CACHE_DIR"/render.*.lock; do
+    [ -d "$stale_lock_dir" ] || continue
+    is_stale_path "$stale_lock_dir" || continue
+    rm -rf "$stale_lock_dir" 2>/dev/null || :
+  done
+}
+
+cleanup_empty_temp_files
+cleanup_stale_render_locks
 
 # Capture Claude's current statusLine stdin first so rendered output can be
 # scoped per session/worktree instead of leaking across concurrent sessions.
@@ -79,9 +118,7 @@ fi
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
   # Recover from stale locks left by crashes.
   if [ -d "$LOCK_DIR" ]; then
-    now=$(date +%s 2>/dev/null || printf '0')
-    lock_mtime=$( (stat -c %Y "$LOCK_DIR" 2>/dev/null || stat -f %m "$LOCK_DIR" 2>/dev/null) | head -1 )
-    if [ -n "$lock_mtime" ] && [ "$now" -gt 0 ] && [ $((now - lock_mtime)) -gt 10 ]; then
+    if is_stale_path "$LOCK_DIR"; then
       rm -rf "$LOCK_DIR" 2>/dev/null || :
       mkdir "$LOCK_DIR" 2>/dev/null || exit 0
     else
@@ -93,8 +130,19 @@ if ! mkdir "$LOCK_DIR" 2>/dev/null; then
 fi
 
 refresh_cache() {
-  if [ ! -s "$INPUT_FILE" ]; then
+  cleanup_refresh_artifacts() {
+    rm -f "$NODE_STDOUT_TMP" 2>/dev/null || :
+    if [ ! -s "$NODE_STDERR_TMP" ]; then
+      rm -f "$NODE_STDERR_TMP" 2>/dev/null || :
+    fi
     rm -rf "$LOCK_DIR" 2>/dev/null || :
+  }
+
+  trap 'cleanup_refresh_artifacts' EXIT
+  trap 'cleanup_refresh_artifacts; exit 0' HUP INT TERM
+
+  if [ ! -s "$INPUT_FILE" ]; then
+    cleanup_refresh_artifacts
     return
   fi
 
@@ -111,6 +159,7 @@ refresh_cache() {
 
   rm -f "$NODE_STDOUT_TMP" "$NODE_STDERR_TMP" 2>/dev/null || :
   rm -rf "$LOCK_DIR" 2>/dev/null || :
+  trap - EXIT HUP INT TERM
 }
 
 if [ "${OMC_HUD_SYNC_REFRESH:-0}" = "1" ]; then

--- a/src/__tests__/hud-cache-wrapper.test.ts
+++ b/src/__tests__/hud-cache-wrapper.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const root = resolve(__dirname, '..', '..');
+const wrapperPath = join(root, 'scripts', 'lib', 'hud-cache-wrapper.sh');
+
+function makeOld(path: string): void {
+  const old = new Date(Date.now() - 30_000);
+  // Directory mtimes are enough for the wrapper's stale lock check.
+  utimesSync(path, old, old);
+}
+
+describe('HUD cache wrapper stale render cleanup', () => {
+  it('removes stale render locks and zero-byte temp files without deleting diagnostics', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-cache-wrapper-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const currentLock = join(cacheDir, 'render.issue-3002.lock');
+    const otherLock = join(cacheDir, 'render.other-session.lock');
+    mkdirSync(currentLock);
+    mkdirSync(otherLock);
+    makeOld(currentLock);
+    makeOld(otherLock);
+
+    const emptyStdoutTmp = join(cacheDir, 'statusline.issue-3002.123.tmp');
+    const emptyStderrTmp = join(cacheDir, 'statusline.issue-3002.123.err');
+    const emptyInputTmp = join(cacheDir, 'stdin.123.tmp');
+    const diagnosticErr = join(cacheDir, 'statusline.issue-3002.diagnostic.err');
+    writeFileSync(emptyStdoutTmp, '');
+    writeFileSync(emptyStderrTmp, '');
+    writeFileSync(emptyInputTmp, '');
+    makeOld(emptyStdoutTmp);
+    makeOld(emptyStderrTmp);
+    makeOld(emptyInputTmp);
+    writeFileSync(diagnosticErr, 'renderer exploded\n');
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('rendered issue 3002'));\n");
+
+    const output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'issue-3002', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        OMC_HUD_CACHE_DIR: cacheDir,
+        OMC_HUD_SYNC_REFRESH: '1',
+      },
+    });
+
+    expect(output).toBe('[OMC] Starting...\n');
+    expect(() => statSync(currentLock)).toThrow();
+    expect(() => statSync(otherLock)).toThrow();
+    expect(() => statSync(emptyStdoutTmp)).toThrow();
+    expect(() => statSync(emptyStderrTmp)).toThrow();
+    expect(() => statSync(emptyInputTmp)).toThrow();
+    expect(readFileSync(diagnosticErr, 'utf8')).toBe('renderer exploded\n');
+    expect(readFileSync(join(cacheDir, 'statusline.issue-3002.txt'), 'utf8')).toBe('rendered issue 3002\n');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #3002.
- Resolves the HUD cache dir before cleanup and performs early stale render lock GC inside that resolved directory.
- Removes only stale zero-byte HUD temp/error files while preserving non-empty diagnostics.
- Adds background refresh EXIT/signal cleanup for render locks and stdout temp files without adding blocking waits to the statusLine hot path.
- Adds a Vitest regression for stale render lock and empty temp cleanup.

## Verification
- `sh -n scripts/lib/hud-cache-wrapper.sh`
- `npm test -- --run src/__tests__/hud-cache-wrapper.test.ts src/__tests__/hud-wrapper-template-sync.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `git diff --check`

## Residual risk
- Not manually reproduced with a live Claude Code renderer kill; covered with focused shell-level wrapper regression.
