### PR TITLE
Document Claude /goal adapter boundary

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -14,6 +14,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [Agents (29 Total)](#agents-29-total)
 - [Skills (38 Total)](#skills-38-total)
 - [Slash Commands](#slash-commands)
+- [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
 - [Hooks System](#hooks-system)
 - [Magic Keywords](#magic-keywords)
 - [Platform Support](#platform-support)
@@ -619,6 +620,20 @@ When present, OMC appends a standardized **Skill Pipeline** section to the rende
 OMC's canonical project-local skill directory remains `.omc/skills/`, but the runtime now also reads compatibility skills from `.agents/skills/`.
 
 For builtin and slash-loaded skills, OMC also appends a standardized **Skill Resources** section when the skill directory contains bundled assets such as helper scripts, templates, or support libraries. This helps agents reuse packaged skill resources instead of recreating them ad hoc.
+
+---
+
+## Claude Code `/goal` Adapter Design
+
+OMC treats Claude Code `/goal` as a native execution loop that can be handed off to, not as the durable source of truth for OMC completion. The design contract is documented in [docs/design/CLAUDE_CODE_GOAL_ADAPTER.md](./design/CLAUDE_CODE_GOAL_ADAPTER.md).
+
+Key contract points:
+
+- Claude Code `/goal` facts must cite Claude Code or Anthropic sources only. OpenAI/Codex references are comparison sources, not authority for Claude Code behavior.
+- The adapter renders a measurable `/goal <condition>` handoff; it must not mutate hidden Claude Code session state directly.
+- The deterministic conflict policy is exactly one of `refuse`, `adopt_existing`, or `artifact_only`; competing Ralph/autopilot/Stop-hook/Team/UltraQA loops must not continue with only a warning.
+- `/goal` evaluator success is evidence for OMC final review, not completion by itself; OMC still requires surfaced command/test/docs evidence.
+- OMC stores durable goal ledgers and evidence under OMC-owned logical artifacts and `.omc/`-resolved paths, not hardcoded `.omx/` paths.
 
 ---
 

--- a/docs/design/CLAUDE_CODE_GOAL_ADAPTER.md
+++ b/docs/design/CLAUDE_CODE_GOAL_ADAPTER.md
@@ -1,0 +1,96 @@
+# Claude Code `/goal` Adapter Design
+
+## Context
+
+Claude Code exposes `/goal` as a native, session-scoped work loop. OMC can use that loop as an execution surface, but OMC must keep its own durable audit trail, hook safety rules, and Ralph/Team/UltraQA boundaries. The adapter described here is a design contract for future implementation; it does not mutate hidden Claude Code goal state.
+
+## Source authority boundary
+
+Claude Code `/goal` facts in OMC docs and code comments must come only from Claude Code or Anthropic sources, such as:
+
+- Claude Code docs: <https://code.claude.com/docs/en/goal>
+- Anthropic Claude Code changelog: <https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md>
+
+OpenAI, Codex, OMX, or OMO references may be used for comparisons with their own goal/runtime behavior, but they are not authority for Claude Code `/goal` facts.
+
+## Adapter responsibilities
+
+The Claude Code `/goal` adapter is an OMC-facing boundary that renders safe handoff text and durable evidence. It must:
+
+1. Detect or receive a capability verdict for `/goal` before suggesting native handoff.
+2. Render a measurable `/goal <completion condition>` handoff prompt instead of writing hidden Claude Code session state directly.
+3. Preserve OMC auditability by recording the requested condition, status snapshots, surfaced evaluator reasons, command evidence, and final review outcome in OMC-owned artifacts.
+4. Refuse or degrade when workspace trust, hook settings, or managed-hook policy makes `/goal` unavailable.
+5. Enforce one active loop authority per session so `/goal` does not compete with Ralph, Team, autopilot, UltraQA, or Stop-hook continuation loops.
+
+## Goal contract subset
+
+Future implementation should map each goal item into the shared durable contract below:
+
+| Field                  | Required behavior                                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `goal_id`              | Stable repo-local identifier for handoffs, checkpoints, and review.                                             |
+| `objective`            | Human-readable outcome.                                                                                         |
+| `completion_condition` | Measurable condition suitable for `/goal <condition>` handoff.                                                  |
+| `runtime_target`       | `claude-code-goal` for native `/goal`, or `artifact-only` fallback.                                             |
+| `loop_authority`       | Exactly one primary authority: `claude-code-goal`, `ralph`, `team`, `ultraqa`, `autopilot`, or `artifact-only`. |
+| `conflict_policy`      | One of `refuse`, `adopt_existing`, or `artifact_only`.                                                          |
+| `source_refs`          | Claude Code `/goal` claims cite only Claude Code/Anthropic sources.                                             |
+| `evidence`             | Surfaced command output, docs updates, test output, reviewer verdicts, and status snapshots.                    |
+| `status`               | Distinguishes evaluator success from OMC final review: `evaluator_passed` is not `complete`.                    |
+
+## Deterministic loop conflict policy
+
+When another primary loop is active, the adapter must apply one of these deterministic policies and record the decision in evidence:
+
+| Policy           | Behavior                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `refuse`         | Stop before rendering a `/goal` handoff. Explain the active authority and the exact command or state the user must clear first. |
+| `adopt_existing` | Keep the existing loop authority and attach the goal contract as evidence/checkpoints for that loop. Do not start `/goal`.      |
+| `artifact_only`  | Write the durable goal ledger and handoff artifact only. Do not ask Claude Code to activate `/goal`.                            |
+
+The adapter must never “warn and continue” with a competing loop. Any unknown policy is invalid and must fail with an actionable diagnostic.
+
+## Availability and fallback matrix
+
+| Condition                                                       | Adapter result                                                                            |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `/goal` supported, trusted workspace, no competing loop         | Render `/goal <condition>` handoff and record intended loop authority.                    |
+| Hook-disabling settings block `/goal`                           | Use `refuse` or `artifact_only`; include the hook policy in diagnostics.                  |
+| Managed hooks prevent `/goal`                                   | Use `refuse` or `artifact_only`; do not suggest bypassing policy.                         |
+| Workspace is not trusted                                        | Refuse native handoff until trust is established, or create artifact-only evidence.       |
+| Ralph/autopilot/Stop-hook/Team/UltraQA is already authoritative | Apply `conflict_policy` exactly.                                                          |
+| Capability cannot be determined                                 | Prefer `artifact_only` unless the user explicitly requests manual native `/goal` handoff. |
+
+## Handoff rendering contract
+
+A native handoff must be explicit and verifiable:
+
+```text
+/goal Complete <objective> when <measurable condition>. Before claiming completion, surface evidence from: <proof command>, <docs check>, and <final review checkpoint>.
+```
+
+Handoff text must remind the agent that the `/goal` evaluator judges surfaced conversation evidence. It must not imply that the evaluator independently reads files or runs commands.
+
+## Final review gate
+
+OMC completion requires a final review after any `/goal` evaluator success:
+
+1. `/goal` evaluator passes from surfaced evidence.
+2. OMC records `evaluator_passed` with the status snapshot/evaluator reason.
+3. OMC runs or records required verification evidence.
+4. A final reviewer marks `complete`, `review_blocked`, or `failed`.
+
+Direct `evaluator_passed -> complete` transitions are invalid because they skip OMC-owned verification.
+
+## Storage boundary
+
+The adapter should use logical artifact names first and resolve them through OMC runtime paths second:
+
+| Logical artifact    | OMC path intent                                                |
+| ------------------- | -------------------------------------------------------------- |
+| Goal ledger         | `.omc/goals/` or the configured OMC state root.                |
+| Handoff artifact    | `.omc/context/` or configured handoff directory.               |
+| Completion evidence | `.omc/goals/<goal_id>/evidence/` or configured evidence store. |
+
+Docs may compare OMX `.omx` or OMO-native paths, but OMC adapter code must not require `.omx/` to exist in an OMC-only workspace.

--- a/src/__tests__/claude-goal-adapter-doc.test.ts
+++ b/src/__tests__/claude-goal-adapter-doc.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, "../..");
+
+function readProjectFile(...segments: string[]): string {
+  return readFileSync(join(PROJECT_ROOT, ...segments), "utf-8");
+}
+
+describe("Claude Code /goal adapter docs contract", () => {
+  const adapterDoc = readProjectFile(
+    "docs",
+    "design",
+    "CLAUDE_CODE_GOAL_ADAPTER.md",
+  );
+  const referenceDoc = readProjectFile("docs", "REFERENCE.md");
+
+  it("documents Claude/Anthropic as the only authority for Claude Code /goal facts", () => {
+    expect(adapterDoc).toContain("https://code.claude.com/docs/en/goal");
+    expect(adapterDoc).toContain(
+      "https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md",
+    );
+    expect(adapterDoc).toContain(
+      "they are not authority for Claude Code `/goal` facts",
+    );
+  });
+
+  it("locks deterministic loop conflict policy values and forbids warn-and-continue behavior", () => {
+    for (const policy of ["`refuse`", "`adopt_existing`", "`artifact_only`"]) {
+      expect(adapterDoc).toContain(policy);
+    }
+
+    expect(adapterDoc).toContain("must never “warn and continue”");
+    expect(adapterDoc).toContain("Any unknown policy is invalid");
+  });
+
+  it("keeps evaluator success separate from OMC final completion", () => {
+    expect(adapterDoc).toContain("`evaluator_passed` is not `complete`");
+    expect(adapterDoc).toContain(
+      "Direct `evaluator_passed -> complete` transitions are invalid",
+    );
+    expect(adapterDoc).toContain(
+      "the `/goal` evaluator judges surfaced conversation evidence",
+    );
+    expect(adapterDoc).not.toContain(
+      "the evaluator independently reads files and runs commands",
+    );
+  });
+
+  it("links the adapter design from REFERENCE.md", () => {
+    expect(referenceDoc).toContain(
+      "[Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)",
+    );
+    expect(referenceDoc).toContain("./design/CLAUDE_CODE_GOAL_ADAPTER.md");
+  });
+});

--- a/src/__tests__/claude-goal-adapter-doc.test.ts
+++ b/src/__tests__/claude-goal-adapter-doc.test.ts
@@ -29,6 +29,18 @@ describe("Claude Code /goal adapter docs contract", () => {
     );
   });
 
+  it("documents the hidden-state non-mutation boundary", () => {
+    expect(adapterDoc).toContain(
+      "it does not mutate hidden Claude Code goal state",
+    );
+    expect(adapterDoc).toContain(
+      "instead of writing hidden Claude Code session state directly",
+    );
+    expect(referenceDoc).toContain(
+      "it must not mutate hidden Claude Code session state directly",
+    );
+  });
+
   it("locks deterministic loop conflict policy values and forbids warn-and-continue behavior", () => {
     for (const policy of ["`refuse`", "`adopt_existing`", "`artifact_only`"]) {
       expect(adapterDoc).toContain(policy);


### PR DESCRIPTION
## Scope
- Adds the Claude Code /goal adapter design doc.
- Links the design from REFERENCE.
- Adds a docs-contract test for source authority, deterministic conflict policies, evaluator/final-review separation, and hidden-state non-mutation.

## Validation
- npm run test:run -- src/__tests__/claude-goal-adapter-doc.test.ts
- npx tsc --noEmit
- git diff --check

## Notes
- Claude Code /goal facts are sourced from Claude Code/Anthropic docs only; OpenAI/Codex docs are explicitly not authority for this behavior.