### PR TITLE
Clarify goal workflow UX boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,31 @@ _Don't learn Claude Code. Just use OMC._
 
 ## Core Maintainers
 
-| Role | Name | GitHub |
-| --- | --- | --- |
+| Role           | Name        | GitHub                                         |
+| -------------- | ----------- | ---------------------------------------------- |
 | Creator & Lead | Yeachan Heo | [@Yeachan-Heo](https://github.com/Yeachan-Heo) |
 
 ## Ambassadors
 
-| Name | GitHub |
-| --- | --- |
+| Name       | GitHub                                           |
+| ---------- | ------------------------------------------------ |
 | Sigrid Jin | [@sigridjineth](https://github.com/sigridjineth) |
 
 ## Document Specialists
 
-| Name | GitHub |
-| --- | --- |
+| Name    | GitHub                                 |
+| ------- | -------------------------------------- |
 | devswha | [@devswha](https://github.com/devswha) |
 
 ## Top Collaborators
 
-| Name | GitHub | Commits |
-| --- | --- | --- |
-| JunghwanNA | [@shaun0927](https://github.com/shaun0927) | 65 |
-| riftzen-bit | [@riftzen-bit](https://github.com/riftzen-bit) | 52 |
-| Seunggwan Song | [@Nathan-Song](https://github.com/Nathan-Song) | 20 |
-| BLUE | [@blue-int](https://github.com/blue-int) | 20 |
-| Junho Yeo | [@junhoyeo](https://github.com/junhoyeo) | 15 |
+| Name           | GitHub                                         | Commits |
+| -------------- | ---------------------------------------------- | ------- |
+| JunghwanNA     | [@shaun0927](https://github.com/shaun0927)     | 65      |
+| riftzen-bit    | [@riftzen-bit](https://github.com/riftzen-bit) | 52      |
+| Seunggwan Song | [@Nathan-Song](https://github.com/Nathan-Song) | 20      |
+| BLUE           | [@blue-int](https://github.com/blue-int)       | 20      |
+| Junho Yeo      | [@junhoyeo](https://github.com/junhoyeo)       | 15      |
 
 ## Quick Start
 
@@ -109,13 +109,13 @@ OMC exposes two different surfaces:
 - **Terminal CLI commands**: run `omc ...` from your shell after installing the npm/runtime path (`npm i -g oh-my-claude-sisyphus@latest`) or from a local checkout.
 - **In-session skills**: run `/...` inside a Claude Code session after installing the plugin/setup flow.
 
-| Feature | Terminal CLI | In-session skill | Notes |
-| --- | --- | --- | --- |
-| Setup | `omc setup` | `/setup` or `/omc-setup` | Both are real entrypoints. `/setup` is the easiest plugin-first path. |
-| Ask providers | `omc ask codex "review this patch"` | `/ask codex "review this patch"` | Both route through the same advisor flow. |
-| Team orchestration | `omc team 2:codex "review auth flow"` | `/team 3:executor "fix all TypeScript errors"` | Both exist, but they are different runtimes: `omc team` launches tmux CLI workers; `/team` runs the in-session native team workflow. |
-| Autopilot / Ralph / Ultrawork / Deep Interview | — | `/autopilot ...`, `/ralph ...`, `/ultrawork ...`, `/deep-interview ...` | These are in-session skills. There is no `omc autopilot` / `omc ralph` / `omc ultrawork` CLI subcommand in this repo. |
-| Autoresearch | `omc autoresearch` (**hard-deprecated shim**) | `/deep-interview --autoresearch ...` + `/oh-my-claudecode:autoresearch` | Setup stays in deep-interview; execution now belongs to the stateful skill. |
+| Feature                                        | Terminal CLI                                  | In-session skill                                                        | Notes                                                                                                                                |
+| ---------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Setup                                          | `omc setup`                                   | `/setup` or `/omc-setup`                                                | Both are real entrypoints. `/setup` is the easiest plugin-first path.                                                                |
+| Ask providers                                  | `omc ask codex "review this patch"`           | `/ask codex "review this patch"`                                        | Both route through the same advisor flow.                                                                                            |
+| Team orchestration                             | `omc team 2:codex "review auth flow"`         | `/team 3:executor "fix all TypeScript errors"`                          | Both exist, but they are different runtimes: `omc team` launches tmux CLI workers; `/team` runs the in-session native team workflow. |
+| Autopilot / Ralph / Ultrawork / Deep Interview | —                                             | `/autopilot ...`, `/ralph ...`, `/ultrawork ...`, `/deep-interview ...` | These are in-session skills. There is no `omc autopilot` / `omc ralph` / `omc ultrawork` CLI subcommand in this repo.                |
+| Autoresearch                                   | `omc autoresearch` (**hard-deprecated shim**) | `/deep-interview --autoresearch ...` + `/oh-my-claudecode:autoresearch` | Setup stays in deep-interview; execution now belongs to the stateful skill.                                                          |
 
 ### Not Sure Where to Start?
 
@@ -173,12 +173,12 @@ For mixed Codex + Gemini work in one command, use the **`/ccg`** skill (routes v
 /ccg Review this PR — architecture (Codex) and UI components (Gemini)
 ```
 
-| Surface                   | Workers            | Best For                                     |
-| ------------------------- | ------------------ | -------------------------------------------- |
-| `omc team N:codex "..."`  | N Codex CLI panes  | Code review, security analysis, architecture |
-| `omc team N:gemini "..."` | N Gemini CLI panes | UI/UX design, docs, large-context tasks      |
-| `omc team N:claude "..."` | N Claude CLI panes | General tasks via Claude CLI in tmux         |
-| `/ccg`                    | /ask codex + /ask gemini | Tri-model advisor synthesis           |
+| Surface                   | Workers                  | Best For                                     |
+| ------------------------- | ------------------------ | -------------------------------------------- |
+| `omc team N:codex "..."`  | N Codex CLI panes        | Code review, security analysis, architecture |
+| `omc team N:gemini "..."` | N Gemini CLI panes       | UI/UX design, docs, large-context tasks      |
+| `omc team N:claude "..."` | N Claude CLI panes       | General tasks via Claude CLI in tmux         |
+| `/ccg`                    | /ask codex + /ask gemini | Tri-model advisor synthesis                  |
 
 Workers spawn on-demand and die when their task completes — no idle resource usage. Requires `codex` / `gemini` CLIs installed and an active tmux session.
 
@@ -243,16 +243,25 @@ If you experience issues after updating, clear the old plugin cache:
 
 Multiple strategies for different use cases — from Team-backed orchestration to token-efficient refactoring. [Learn more →](https://yeachan-heo.github.io/oh-my-claudecode-website/docs/#execution-modes)
 
-| Mode                    | What it is                                                                              | Use For                                                |
-| ----------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| **Team (recommended)**  | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list        |
-| **omc team (CLI)**      | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes              | Codex/Gemini CLI tasks; on-demand spawn, die when done |
-| **ccg**                 | Tri-model advisors via `/ask codex` + `/ask gemini`, Claude synthesizes                   | Mixed backend+UI work needing both Codex and Gemini    |
-| **Autopilot**           | Autonomous execution (single lead agent)                                                | End-to-end feature work with minimal ceremony          |
-| **Ultrawork**           | Maximum parallelism (non-team)                                                          | Burst parallel fixes/refactors where Team isn't needed |
-| **Ralph**               | Persistent mode with verify/fix loops                                                   | Tasks that must complete fully (no silent partials)    |
-| **Pipeline**            | Sequential, staged processing                                                           | Multi-step transformations with strict ordering        |
-| **Ultrapilot (legacy)** | Deprecated compatibility mode (autopilot pipeline alias)                                | Existing workflows and older docs                      |
+| Mode                        | What it is                                                                              | Use For                                                                 |
+| --------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **Team (recommended)**      | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list                         |
+| **omc team (CLI)**          | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes              | Codex/Gemini CLI tasks; on-demand spawn, die when done                  |
+| **ccg**                     | Tri-model advisors via `/ask codex` + `/ask gemini`, Claude synthesizes                 | Mixed backend+UI work needing both Codex and Gemini                     |
+| **Autopilot**               | Autonomous execution (single lead agent)                                                | End-to-end feature work with minimal ceremony                           |
+| **Ultrawork**               | Maximum parallelism (non-team)                                                          | Burst parallel fixes/refactors where Team isn't needed                  |
+| **Ralph**                   | Persistent mode with verify/fix loops                                                   | Tasks that must complete fully (no silent partials)                     |
+| **UltraQA**                 | QA cycling until tests/build/lint/typecheck goals pass                                  | Quality gates that need repeat diagnose/fix cycles                      |
+| **Claude Code `/goal`**     | Native Claude Code cross-turn goal loop                                                 | One measurable session completion condition; not an OMC evidence ledger |
+| **Artifact-only Ultragoal** | Durable goal/checkpoint/evidence artifacts without starting a loop                      | Handoffs, audits, or unavailable/conflicting loop runtimes              |
+| **Pipeline**                | Sequential, staged processing                                                           | Multi-step transformations with strict ordering                         |
+| **Ultrapilot (legacy)**     | Deprecated compatibility mode (autopilot pipeline alias)                                | Existing workflows and older docs                                       |
+
+### Goal Workflow Guidance
+
+Use only one primary loop authority in a session. Claude Code `/goal` is useful for a native cross-turn completion condition, while Ralph owns single-agent verified completion, Team owns parallel staged execution, and UltraQA owns repeated quality-gate cycling. Artifact-only Ultragoal is the safe fallback when you need durable goal artifacts and evidence without starting another loop.
+
+For `/goal` behavior, rely on Claude Code/Anthropic sources: the [Claude Code `/goal` docs](https://code.claude.com/docs/en/goal) and [Anthropic Claude Code changelog](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md). Do **not** claim the `/goal` evaluator independently runs commands or reads files; surface test output, diffs, and review evidence in the conversation before treating a goal as proven.
 
 ### Intelligent Orchestration
 
@@ -276,11 +285,11 @@ Want to contribute to OMC? See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full
 
 Learn once, reuse forever. OMC extracts hard-won debugging knowledge into portable skill files that auto-inject when relevant.
 
-| | Project Scope | User Scope |
-|---|---|---|
-| **Path** | `.omc/skills/` | `~/.omc/skills/` |
+|                 | Project Scope                                            | User Scope        |
+| --------------- | -------------------------------------------------------- | ----------------- |
+| **Path**        | `.omc/skills/`                                           | `~/.omc/skills/`  |
 | **Shared with** | Team (commit the skill file to keep it across worktrees) | All your projects |
-| **Priority** | Higher (overrides user) | Lower (fallback) |
+| **Priority**    | Higher (overrides user)                                  | Lower (fallback)  |
 
 ```yaml
 # .omc/skills/fix-proxy-crash.md
@@ -307,18 +316,18 @@ Project-scoped skills are stored in `.omc/skills/` and are intended to be commit
 
 These shortcuts run **inside a Claude Code / OMC session**, not as terminal CLI commands. For shell commands, use the `omc ...` forms shown above. Team mode is explicit: use `/team ...` in-session or `omc team ...` from your shell rather than expecting a bare `team` keyword trigger.
 
-| In-session form        | Kind                  | Effect                              | Example                                        |
-| ---------------------- | --------------------- | ----------------------------------- | ---------------------------------------------- |
-| `/team`                | Slash skill           | Canonical Team orchestration        | `/team 3:executor "fix all TypeScript errors"` |
-| `/ccg`                 | Slash skill           | `/ask codex` + `/ask gemini` synthesis | `/ccg review this PR`                       |
-| `/autopilot` / `autopilot` | Skill / prompt trigger | Full autonomous execution       | `/autopilot "build a todo app"`                |
-| `/ralph` / `ralph`     | Skill / prompt trigger | Persistence mode                   | `/ralph "refactor auth"`                       |
-| `/ultrawork` / `ulw`   | Skill / prompt trigger | Maximum parallelism                | `/ultrawork "fix all errors"`                  |
-| `/ralplan` / `ralplan` | Skill / prompt trigger | Iterative planning consensus       | `/ralplan "plan this feature"`                 |
-| `/deep-interview`      | Slash skill           | Socratic requirements clarification | `/deep-interview "vague idea"`                 |
-| `deepsearch`           | Prompt trigger        | Codebase-focused search routing     | `deepsearch for auth middleware`               |
-| `ultrathink`           | Prompt trigger        | Deep reasoning mode                 | `ultrathink about this architecture`           |
-| `cancelomc`, `stopomc` | Prompt trigger        | Stop active OMC modes               | `stopomc`                                      |
+| In-session form            | Kind                   | Effect                                 | Example                                        |
+| -------------------------- | ---------------------- | -------------------------------------- | ---------------------------------------------- |
+| `/team`                    | Slash skill            | Canonical Team orchestration           | `/team 3:executor "fix all TypeScript errors"` |
+| `/ccg`                     | Slash skill            | `/ask codex` + `/ask gemini` synthesis | `/ccg review this PR`                          |
+| `/autopilot` / `autopilot` | Skill / prompt trigger | Full autonomous execution              | `/autopilot "build a todo app"`                |
+| `/ralph` / `ralph`         | Skill / prompt trigger | Persistence mode                       | `/ralph "refactor auth"`                       |
+| `/ultrawork` / `ulw`       | Skill / prompt trigger | Maximum parallelism                    | `/ultrawork "fix all errors"`                  |
+| `/ralplan` / `ralplan`     | Skill / prompt trigger | Iterative planning consensus           | `/ralplan "plan this feature"`                 |
+| `/deep-interview`          | Slash skill            | Socratic requirements clarification    | `/deep-interview "vague idea"`                 |
+| `deepsearch`               | Prompt trigger         | Codebase-focused search routing        | `deepsearch for auth middleware`               |
+| `ultrathink`               | Prompt trigger         | Deep reasoning mode                    | `ultrathink about this architecture`           |
+| `cancelomc`, `stopomc`     | Prompt trigger         | Stop active OMC modes                  | `stopomc`                                      |
 
 **Notes:**
 
@@ -435,38 +444,46 @@ Forward Claude Code session events to an [OpenClaw](https://openclaw.ai/) gatewa
     }
   },
   "hooks": {
-    "session-start": { "gateway": "my-gateway", "instruction": "Session started for {{projectName}}", "enabled": true },
-    "stop":          { "gateway": "my-gateway", "instruction": "Session stopping for {{projectName}}", "enabled": true }
+    "session-start": {
+      "gateway": "my-gateway",
+      "instruction": "Session started for {{projectName}}",
+      "enabled": true
+    },
+    "stop": {
+      "gateway": "my-gateway",
+      "instruction": "Session stopping for {{projectName}}",
+      "enabled": true
+    }
   }
 }
 ```
 
 **Environment variables:**
 
-| Variable | Description |
-|----------|-------------|
-| `OMC_OPENCLAW=1` | Enable OpenClaw |
-| `OMC_OPENCLAW_DEBUG=1` | Enable debug logging |
+| Variable                                   | Description               |
+| ------------------------------------------ | ------------------------- |
+| `OMC_OPENCLAW=1`                           | Enable OpenClaw           |
+| `OMC_OPENCLAW_DEBUG=1`                     | Enable debug logging      |
 | `OMC_OPENCLAW_CONFIG=/path/to/config.json` | Override config file path |
 
 **Supported hook events (6 active in bridge.ts):**
 
-| Event | Trigger | Key template variables |
-|-------|---------|----------------------|
-| `session-start` | Session begins | `{{sessionId}}`, `{{projectName}}`, `{{projectPath}}` |
-| `stop` | Claude response completes | `{{sessionId}}`, `{{projectName}}` |
-| `keyword-detector` | Every prompt submission | `{{prompt}}`, `{{sessionId}}` |
-| `ask-user-question` | Claude requests user input | `{{question}}`, `{{sessionId}}` |
-| `pre-tool-use` | Before tool invocation (high frequency) | `{{toolName}}`, `{{sessionId}}` |
-| `post-tool-use` | After tool invocation (high frequency) | `{{toolName}}`, `{{sessionId}}` |
+| Event               | Trigger                                 | Key template variables                                |
+| ------------------- | --------------------------------------- | ----------------------------------------------------- |
+| `session-start`     | Session begins                          | `{{sessionId}}`, `{{projectName}}`, `{{projectPath}}` |
+| `stop`              | Claude response completes               | `{{sessionId}}`, `{{projectName}}`                    |
+| `keyword-detector`  | Every prompt submission                 | `{{prompt}}`, `{{sessionId}}`                         |
+| `ask-user-question` | Claude requests user input              | `{{question}}`, `{{sessionId}}`                       |
+| `pre-tool-use`      | Before tool invocation (high frequency) | `{{toolName}}`, `{{sessionId}}`                       |
+| `post-tool-use`     | After tool invocation (high frequency)  | `{{toolName}}`, `{{sessionId}}`                       |
 
 **Reply channel environment variables:**
 
-| Variable | Description |
-|----------|-------------|
+| Variable                 | Description                    |
+| ------------------------ | ------------------------------ |
 | `OPENCLAW_REPLY_CHANNEL` | Reply channel (e.g. `discord`) |
-| `OPENCLAW_REPLY_TARGET` | Channel ID |
-| `OPENCLAW_REPLY_THREAD` | Thread ID |
+| `OPENCLAW_REPLY_TARGET`  | Channel ID                     |
+| `OPENCLAW_REPLY_THREAD`  | Thread ID                      |
 
 See `scripts/openclaw-gateway-demo.mjs` for a reference gateway that relays OpenClaw payloads to Discord via ClawdBot.
 
@@ -496,14 +513,14 @@ See `scripts/openclaw-gateway-demo.mjs` for a reference gateway that relays Open
 
 OMC features like `omc team` and rate-limit detection require **tmux**:
 
-| Platform       | tmux provider                                            | Install                |
-| -------------- | -------------------------------------------------------- | ---------------------- |
-| macOS          | [tmux](https://github.com/tmux/tmux)                    | `brew install tmux`    |
-| Ubuntu/Debian  | tmux                                                     | `sudo apt install tmux`|
-| Fedora         | tmux                                                     | `sudo dnf install tmux`|
-| Arch           | tmux                                                     | `sudo pacman -S tmux`  |
-| Windows        | [psmux](https://github.com/marlocarlo/psmux) (native)   | `winget install psmux` |
-| Windows (WSL2) | tmux (inside WSL)                                        | `sudo apt install tmux`|
+| Platform       | tmux provider                                         | Install                 |
+| -------------- | ----------------------------------------------------- | ----------------------- |
+| macOS          | [tmux](https://github.com/tmux/tmux)                  | `brew install tmux`     |
+| Ubuntu/Debian  | tmux                                                  | `sudo apt install tmux` |
+| Fedora         | tmux                                                  | `sudo dnf install tmux` |
+| Arch           | tmux                                                  | `sudo pacman -S tmux`   |
+| Windows        | [psmux](https://github.com/marlocarlo/psmux) (native) | `winget install psmux`  |
+| Windows (WSL2) | tmux (inside WSL)                                     | `sudo apt install tmux` |
 
 > **Windows users:** [psmux](https://github.com/marlocarlo/psmux) provides a native `tmux` binary for Windows with 76 tmux-compatible commands. No WSL required.
 
@@ -535,6 +552,7 @@ MIT
 </div>
 
 <!-- OMC:FEATURED-CONTRIBUTORS:START -->
+
 ## Featured by OmC Contributors
 
 Top personal non-fork, non-archived repos from all-time OMC contributors (100+ GitHub stars).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -564,6 +564,7 @@ Includes bundled workflow, utility, domain, and compatibility skills. Runtime tr
 Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files during `omc setup`: Claude Code receives concise registry descriptions for every bundled skill, while the full on-demand instructions are preserved under `skill-bodies/*/SKILL.md` and loaded by OMC when a skill is invoked. Source checkouts and standalone installs keep the full `skills/*/SKILL.md` bodies in place.
 
 
+
 | Skill                     | Description                                                      | Manual Command                              |
 | ------------------------- | ---------------------------------------------------------------- | ------------------------------------------- |
 | `ai-slop-cleaner`         | Anti-slop cleanup workflow with optional reviewer-only `--review` pass | `/oh-my-claudecode:ai-slop-cleaner`         |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -12,6 +12,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated)
 - [Agents (29 Total)](#agents-29-total)
+- [Goal Workflow UX: `/goal`, Ralph, Team, UltraQA, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultraqa-ultragoal)
 - [Skills (38 Total)](#skills-38-total)
 - [Slash Commands](#slash-commands)
 - [Hooks System](#hooks-system)
@@ -80,13 +81,13 @@ Configure omc for all Claude Code sessions:
 
 ### What Configuration Enables
 
-| Feature           | Without     | With omc Config            |
-| ----------------- | ----------- | -------------------------- |
-| Agent delegation  | Manual only | Automatic based on task    |
-| Keyword detection | Disabled    | ultrawork, search |
-| Todo continuation | Basic       | Enforced completion        |
-| Model routing     | Default     | Smart tier selection       |
-| Skill composition | None        | Auto-combines skills       |
+| Feature           | Without     | With omc Config         |
+| ----------------- | ----------- | ----------------------- |
+| Agent delegation  | Manual only | Automatic based on task |
+| Keyword detection | Disabled    | ultrawork, search       |
+| Todo continuation | Basic       | Enforced completion     |
+| Model routing     | Default     | Smart tier selection    |
+| Skill composition | None        | Auto-combines skills    |
 
 ### Configuration Precedence
 
@@ -171,8 +172,8 @@ Configure it in the standard OMC config files:
 {
   "companyContext": {
     "tool": "mcp__vendor__get_company_context",
-    "onError": "warn"
-  }
+    "onError": "warn",
+  },
 }
 ```
 
@@ -327,13 +328,13 @@ claude --plugin-dir /path/to/oh-my-claudecode
 
 ### Decision matrix: which flag/mode to use?
 
-| Your setup | Launch command | Setup command | Expected behavior |
-|---|---|---|---|
-| **Marketplace plugin** (recommended) | `omc` or `claude` (default) | `omc setup` | Normal: agents/skills copied to `~/.claude/` |
-| **Local dev checkout, want OMC shim** | `omc --plugin-dir /path` | `omc setup --plugin-dir-mode` | Dev mode: agents/skills loaded from `/path`, not copied |
-| **Local dev checkout, no OMC shim** | `claude --plugin-dir /path` + `export OMC_PLUGIN_ROOT=/path` | `omc setup --plugin-dir-mode` | Dev mode + manual env: agents/skills loaded from `/path` |
-| **Local dev, want bundled skills** | `omc --plugin-dir /path` | `omc setup --no-plugin` | Forces local bundled skills to `~/.claude/skills/`, ignoring plugin |
-| **Troubleshooting a specific path** | N/A | `omc doctor --plugin-dir /path` | Diagnostics show status for `/path` |
+| Your setup                            | Launch command                                               | Setup command                   | Expected behavior                                                   |
+| ------------------------------------- | ------------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------------- |
+| **Marketplace plugin** (recommended)  | `omc` or `claude` (default)                                  | `omc setup`                     | Normal: agents/skills copied to `~/.claude/`                        |
+| **Local dev checkout, want OMC shim** | `omc --plugin-dir /path`                                     | `omc setup --plugin-dir-mode`   | Dev mode: agents/skills loaded from `/path`, not copied             |
+| **Local dev checkout, no OMC shim**   | `claude --plugin-dir /path` + `export OMC_PLUGIN_ROOT=/path` | `omc setup --plugin-dir-mode`   | Dev mode + manual env: agents/skills loaded from `/path`            |
+| **Local dev, want bundled skills**    | `omc --plugin-dir /path`                                     | `omc setup --no-plugin`         | Forces local bundled skills to `~/.claude/skills/`, ignoring plugin |
+| **Troubleshooting a specific path**   | N/A                                                          | `omc doctor --plugin-dir /path` | Diagnostics show status for `/path`                                 |
 
 ---
 
@@ -368,6 +369,7 @@ Supported entrypoints: direct start (`omc team [N:agent] "<task>"`), `status`, `
 Native team worker worktrees are an opt-in/config-gated runtime-v2 rollout. See [Native Team Worktree Mode](TEAM-WORKTREE-MODE.md) for the worktree path contract, canonical `OMC_TEAM_STATE_ROOT` behavior, status fields, and dirty-worktree cleanup policy.
 
 Topology behavior:
+
 - inside classic tmux (`$TMUX` set): reuse the current tmux surface for split-pane or `--new-window` layouts
 - inside cmux (`CMUX_SURFACE_ID` without `$TMUX`): launch a detached tmux session for team workers
 - plain terminal: launch a detached tmux session for team workers
@@ -439,16 +441,16 @@ OMC handoffs follow an artifact-first discipline:
 
 Canonical descriptor fields:
 
-| Field | Meaning |
-|------|---------|
-| `kind` | Artifact type such as `plan`, `prompt`, `result`, or `trace` |
-| `path` | Durable artifact path |
-| `contentHash?` | Optional integrity hint |
-| `createdAt` | Artifact creation timestamp |
-| `producer` | Owning worker/tool/skill |
-| `sizeBytes?` | Optional size for threshold checks |
-| `retention` | Retention/ownership hint |
-| `expiresAt?` | Optional expiry for short-lived artifacts |
+| Field          | Meaning                                                      |
+| -------------- | ------------------------------------------------------------ |
+| `kind`         | Artifact type such as `plan`, `prompt`, `result`, or `trace` |
+| `path`         | Durable artifact path                                        |
+| `contentHash?` | Optional integrity hint                                      |
+| `createdAt`    | Artifact creation timestamp                                  |
+| `producer`     | Owning worker/tool/skill                                     |
+| `sizeBytes?`   | Optional size for threshold checks                           |
+| `retention`    | Retention/ownership hint                                     |
+| `expiresAt?`   | Optional expiry for short-lived artifacts                    |
 
 Bounded handoff policy:
 
@@ -462,71 +464,105 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ### By Domain and Tier
 
-| Domain           | LOW (Haiku)             | MEDIUM (Sonnet)       | HIGH (Opus)         |
-| ---------------- | ----------------------- | --------------------- | ------------------- |
-| **Analysis**     | `architect-low`         | `architect-medium`    | `architect`         |
-| **Execution**    | `executor-low`          | `executor`            | `executor-high`     |
-| **Search**       | `explore`               | -                     | `explore-high`      |
-| **Research**     | -                       | `document-specialist` | -                   |
-| **Frontend**     | `designer-low`          | `designer`            | `designer-high`     |
-| **Docs**         | `writer`                | -                     | -                   |
-| **Visual**       | -                       | `vision`              | -                   |
-| **Planning**     | -                       | -                     | `planner`           |
-| **Critique**     | -                       | -                     | `critic`            |
-| **Pre-Planning** | -                       | -                     | `analyst`           |
-| **Testing**      | -                       | `qa-tester`           | -                   |
-| **Tracing**      | -                       | `tracer`              | -                   |
-| **Security**     | `security-reviewer-low` | -                     | `security-reviewer` |
-| **Build**        | -                       | `debugger`            | -                   |
-| **TDD**          | -                       | `test-engineer`       | -                   |
-| **Code Review**  | -                       | -                     | `code-reviewer`     |
-| **Data Science** | -                       | `scientist`           | `scientist-high`    |
-| **Git**          | -                       | `git-master`          | -                   |
-| **Simplification** | -                     | -                     | `code-simplifier`   |
+| Domain             | LOW (Haiku)             | MEDIUM (Sonnet)       | HIGH (Opus)         |
+| ------------------ | ----------------------- | --------------------- | ------------------- |
+| **Analysis**       | `architect-low`         | `architect-medium`    | `architect`         |
+| **Execution**      | `executor-low`          | `executor`            | `executor-high`     |
+| **Search**         | `explore`               | -                     | `explore-high`      |
+| **Research**       | -                       | `document-specialist` | -                   |
+| **Frontend**       | `designer-low`          | `designer`            | `designer-high`     |
+| **Docs**           | `writer`                | -                     | -                   |
+| **Visual**         | -                       | `vision`              | -                   |
+| **Planning**       | -                       | -                     | `planner`           |
+| **Critique**       | -                       | -                     | `critic`            |
+| **Pre-Planning**   | -                       | -                     | `analyst`           |
+| **Testing**        | -                       | `qa-tester`           | -                   |
+| **Tracing**        | -                       | `tracer`              | -                   |
+| **Security**       | `security-reviewer-low` | -                     | `security-reviewer` |
+| **Build**          | -                       | `debugger`            | -                   |
+| **TDD**            | -                       | `test-engineer`       | -                   |
+| **Code Review**    | -                       | -                     | `code-reviewer`     |
+| **Data Science**   | -                       | `scientist`           | `scientist-high`    |
+| **Git**            | -                       | `git-master`          | -                   |
+| **Simplification** | -                       | -                     | `code-simplifier`   |
 
 ### Agent Selection Guide
 
-| Task Type                    | Best Agent                    | Model  |
-| ---------------------------- | ----------------------------- | ------ |
-| Quick code lookup            | `explore`                     | haiku  |
-| Find files/patterns          | `explore`                     | haiku  |
-| Complex architectural search | `explore-high`                | opus   |
-| Simple code change           | `executor-low`                | haiku  |
-| Feature implementation       | `executor`                    | sonnet |
-| Complex refactoring          | `executor-high`               | opus   |
-| Debug simple issue           | `architect-low`               | haiku  |
-| Debug complex issue          | `architect`                   | opus   |
-| UI component                 | `designer`                    | sonnet |
-| Complex UI system            | `designer-high`               | opus   |
-| Write docs/comments          | `writer`                      | haiku  |
-| Research docs/APIs           | `document-specialist` (repo docs first; optional Context Hub / `chub`) | sonnet |
-| Analyze images/diagrams      | `vision`                      | sonnet |
-| Strategic planning           | `planner`                     | opus   |
-| Review/critique plan         | `critic`                      | opus   |
-| Pre-planning analysis        | `analyst`                     | opus   |
-| Test CLI interactively       | `qa-tester`                   | sonnet |
-| Evidence-driven causal tracing | `tracer`                    | sonnet |
-| Security review              | `security-reviewer`           | sonnet |
-| Quick security scan          | `security-reviewer-low`       | haiku  |
-| Fix build errors             | `debugger`                    | sonnet |
-| Simple build fix             | `debugger` (model=haiku)      | haiku  |
-| TDD workflow                 | `test-engineer`               | sonnet |
-| Quick test suggestions       | `test-engineer` (model=haiku) | haiku  |
-| Code review                  | `code-reviewer`               | opus   |
-| Quick code check             | `code-reviewer` (model=haiku) | haiku  |
-| Data analysis/stats          | `scientist`                   | sonnet |
-| Quick data inspection        | `scientist` (model=haiku)     | haiku  |
-| Complex ML/hypothesis        | `scientist-high`              | opus   |
-| Git operations               | `git-master`                  | sonnet |
-| Code simplification          | `code-simplifier`             | opus   |
+| Task Type                      | Best Agent                                                             | Model  |
+| ------------------------------ | ---------------------------------------------------------------------- | ------ |
+| Quick code lookup              | `explore`                                                              | haiku  |
+| Find files/patterns            | `explore`                                                              | haiku  |
+| Complex architectural search   | `explore-high`                                                         | opus   |
+| Simple code change             | `executor-low`                                                         | haiku  |
+| Feature implementation         | `executor`                                                             | sonnet |
+| Complex refactoring            | `executor-high`                                                        | opus   |
+| Debug simple issue             | `architect-low`                                                        | haiku  |
+| Debug complex issue            | `architect`                                                            | opus   |
+| UI component                   | `designer`                                                             | sonnet |
+| Complex UI system              | `designer-high`                                                        | opus   |
+| Write docs/comments            | `writer`                                                               | haiku  |
+| Research docs/APIs             | `document-specialist` (repo docs first; optional Context Hub / `chub`) | sonnet |
+| Analyze images/diagrams        | `vision`                                                               | sonnet |
+| Strategic planning             | `planner`                                                              | opus   |
+| Review/critique plan           | `critic`                                                               | opus   |
+| Pre-planning analysis          | `analyst`                                                              | opus   |
+| Test CLI interactively         | `qa-tester`                                                            | sonnet |
+| Evidence-driven causal tracing | `tracer`                                                               | sonnet |
+| Security review                | `security-reviewer`                                                    | sonnet |
+| Quick security scan            | `security-reviewer-low`                                                | haiku  |
+| Fix build errors               | `debugger`                                                             | sonnet |
+| Simple build fix               | `debugger` (model=haiku)                                               | haiku  |
+| TDD workflow                   | `test-engineer`                                                        | sonnet |
+| Quick test suggestions         | `test-engineer` (model=haiku)                                          | haiku  |
+| Code review                    | `code-reviewer`                                                        | opus   |
+| Quick code check               | `code-reviewer` (model=haiku)                                          | haiku  |
+| Data analysis/stats            | `scientist`                                                            | sonnet |
+| Quick data inspection          | `scientist` (model=haiku)                                              | haiku  |
+| Complex ML/hypothesis          | `scientist-high`                                                       | opus   |
+| Git operations                 | `git-master`                                                           | sonnet |
+| Code simplification            | `code-simplifier`                                                      | opus   |
 
 ---
+
+## Goal Workflow UX: `/goal`, Ralph, Team, UltraQA, Ultragoal
+
+OMC exposes several ways to pursue a goal-shaped task. They are complementary, not interchangeable. Choose one primary loop authority per session and use the others as evidence producers or handoff targets.
+
+| Surface                 | Runtime owner                                     | User-facing promise                                           | Completion evidence                                                          | Notes                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude Code `/goal`     | Claude Code native session loop                   | Keep working toward one stated completion condition           | Evidence surfaced in the conversation for the `/goal` evaluator              | Cite Claude Code/Anthropic docs or changelog only for `/goal` behavior. The evaluator must not be described as independently running commands or reading files. |
+| Ralph                   | OMC skill + Stop-hook enforcement                 | Persistent single-owner implementation until PRD stories pass | Tests/build/lint/typecheck plus reviewer verification                        | Prefer when correctness depends on OMC's PRD, progress, and reviewer gates.                                                                                     |
+| Team                    | OMC native/team or CLI team runtime               | Coordinated multi-agent execution over assigned tasks         | Worker task results, commits, staged `team-verify`/`team-fix` evidence       | Prefer when ownership boundaries and parallel lanes matter.                                                                                                     |
+| UltraQA                 | OMC QA cycling skill                              | Repeat diagnose/fix cycles until a quality gate passes        | Command output from the requested QA goal each cycle                         | Prefer after the implementation target is known but verification still fails.                                                                                   |
+| Artifact-only Ultragoal | Durable goal ledger/checkpoints/handoff artifacts | Track goal state without starting another active loop         | Goal artifact, checkpoints, handoff prompt, attached command/review evidence | Prefer when `/goal` is unavailable, unsafe, or conflicts with an active OMC loop.                                                                               |
+
+### `/goal` source and evidence boundary
+
+Use Claude Code/Anthropic sources for `/goal` facts, including:
+
+- Claude Code `/goal` documentation: <https://code.claude.com/docs/en/goal>
+- Anthropic Claude Code changelog: <https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md>
+
+Do not cite OpenAI/Codex documentation as authority for Claude Code `/goal`. In OMC docs, examples, and handoff prompts, keep this limitation explicit: the `/goal` evaluator judges visible conversation evidence. It should not be described as independently executing shell commands, reading files, inspecting hidden state, or replacing OMC's final review gates.
+
+### Recommended conflict handling
+
+When multiple loops could apply, use this deterministic policy:
+
+1. **refuse**: if Ralph, Team, UltraQA, autopilot, or another Stop-hook loop is already active and a new `/goal` would compete for continuation authority.
+2. **adopt_existing**: if Claude Code `/goal` is already active and the OMC workflow can attach evidence to that same condition without changing loop ownership.
+3. **artifact_only**: if `/goal` is unavailable because of hooks/trust/settings, or if the user only needs durable planning, checkpointing, and evidence capture.
+
+`/goal` evaluator success can be useful evidence, but OMC completion should still require the relevant durable proof: command output, changed files, reviewer verdicts, task results, or release artifacts.
+
+For the shorter user-facing chooser, see [Mode Selection Guide](./shared/mode-selection-guide.md#goal-oriented-workflow-selection).
 
 ## Skills (38 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
 Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files during `omc setup`: Claude Code receives concise registry descriptions for every bundled skill, while the full on-demand instructions are preserved under `skill-bodies/*/SKILL.md` and loaded by OMC when a skill is invoked. Source checkouts and standalone installs keep the full `skills/*/SKILL.md` bodies in place.
+
 
 | Skill                     | Description                                                      | Manual Command                              |
 | ------------------------- | ---------------------------------------------------------------- | ------------------------------------------- |
@@ -573,6 +609,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 ## Slash Commands
 
 Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list; the commands below highlight common entrypoints and aliases. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands.
+
 
 | Command                                     | Description                                                                                   |
 | ------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -628,19 +665,19 @@ OMC registers 20 hook scripts across 11 Claude Code lifecycle events. For detail
 
 ### Hooks by Lifecycle Event
 
-| Event | Scripts | Timeout |
-|-------|---------|---------|
-| **UserPromptSubmit** | `keyword-detector.mjs`, `skill-injector.mjs` | 5s, 3s |
-| **SessionStart** | `session-start.mjs`, `project-memory-session.mjs`, `setup-init.mjs` (init), `setup-maintenance.mjs` (maintenance) | 5s, 5s, 30s, 60s |
-| **PreToolUse** | `pre-tool-enforcer.mjs` | 3s |
-| **PermissionRequest** | `permission-handler.mjs` (Bash only) | 5s |
-| **PostToolUse** | `post-tool-verifier.mjs`, `project-memory-posttool.mjs` | 3s, 3s |
-| **PostToolUseFailure** | `post-tool-use-failure.mjs` | 3s |
-| **SubagentStart** | `subagent-tracker.mjs start` | 3s |
-| **SubagentStop** | `subagent-tracker.mjs stop`, `verify-deliverables.mjs` | 5s, 5s |
-| **PreCompact** | `pre-compact.mjs`, `project-memory-precompact.mjs` | 10s, 5s |
-| **Stop** | `context-guard-stop.mjs`, `persistent-mode.cjs`, `code-simplifier.mjs` | 5s, 10s, 5s |
-| **SessionEnd** | `session-end.mjs` | 30s |
+| Event                  | Scripts                                                                                                           | Timeout          |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------- |
+| **UserPromptSubmit**   | `keyword-detector.mjs`, `skill-injector.mjs`                                                                      | 5s, 3s           |
+| **SessionStart**       | `session-start.mjs`, `project-memory-session.mjs`, `setup-init.mjs` (init), `setup-maintenance.mjs` (maintenance) | 5s, 5s, 30s, 60s |
+| **PreToolUse**         | `pre-tool-enforcer.mjs`                                                                                           | 3s               |
+| **PermissionRequest**  | `permission-handler.mjs` (Bash only)                                                                              | 5s               |
+| **PostToolUse**        | `post-tool-verifier.mjs`, `project-memory-posttool.mjs`                                                           | 3s, 3s           |
+| **PostToolUseFailure** | `post-tool-use-failure.mjs`                                                                                       | 3s               |
+| **SubagentStart**      | `subagent-tracker.mjs start`                                                                                      | 3s               |
+| **SubagentStop**       | `subagent-tracker.mjs stop`, `verify-deliverables.mjs`                                                            | 5s, 5s           |
+| **PreCompact**         | `pre-compact.mjs`, `project-memory-precompact.mjs`                                                                | 10s, 5s          |
+| **Stop**               | `context-guard-stop.mjs`, `persistent-mode.cjs`, `code-simplifier.mjs`                                            | 5s, 10s, 5s      |
+| **SessionEnd**         | `session-end.mjs`                                                                                                 | 30s              |
 
 > **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills** (activated via keyword-detector), not hooks. The `persistent-mode.cjs` hook enforces their continuation by blocking the Stop event.
 
@@ -697,22 +734,22 @@ explicitly enabled via the global OMC config file:
 
 Use these trigger phrases in natural language prompts to activate enhanced modes:
 
-| Keyword                                                 | Effect                                                                                        |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `ultrawork`, `ulw`, `uw`                                | Activates parallel agent orchestration                                                        |
-| `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `e2e this` | Full autonomous execution                                              |
-| `deslop`, `anti-slop`, cleanup/refactor + slop smells         | Anti-slop cleanup workflow (`ai-slop-cleaner`)                                               |
-| `ralph`, `don't stop`, `must complete`, `until done`    | Persistence until verified complete                                                           |
-| `ccg`, `claude-codex-gemini`                            | Claude-Codex-Gemini orchestration                                                             |
-| `ralplan`                                               | Iterative planning consensus with structured deliberation (`--deliberate` for high-risk mode) |
-| `deep interview`, `ouroboros`                           | Deep Socratic interview with mathematical clarity gating                                      |
-| `deepsearch`, `search the codebase`, `find in codebase` | Codebase-focused search mode                                                                  |
-| `deepanalyze`, `deep-analyze`                           | Deep analysis mode                                                                            |
-| `ultrathink`, `think hard`, `think deeply`              | Deep reasoning mode                                                                           |
-| `tdd`, `test first`, `red green`                        | TDD workflow enforcement                                                                      |
-| `code review`, `review code`                            | Comprehensive code review mode                                                                |
-| `security review`, `review security`                    | Security-focused review mode                                                                  |
-| `cancelomc`, `stopomc`                                  | Unified cancellation                                                                          |
+| Keyword                                                                        | Effect                                                                                        |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `ultrawork`, `ulw`, `uw`                                                       | Activates parallel agent orchestration                                                        |
+| `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `e2e this` | Full autonomous execution                                                                     |
+| `deslop`, `anti-slop`, cleanup/refactor + slop smells                          | Anti-slop cleanup workflow (`ai-slop-cleaner`)                                                |
+| `ralph`, `don't stop`, `must complete`, `until done`                           | Persistence until verified complete                                                           |
+| `ccg`, `claude-codex-gemini`                                                   | Claude-Codex-Gemini orchestration                                                             |
+| `ralplan`                                                                      | Iterative planning consensus with structured deliberation (`--deliberate` for high-risk mode) |
+| `deep interview`, `ouroboros`                                                  | Deep Socratic interview with mathematical clarity gating                                      |
+| `deepsearch`, `search the codebase`, `find in codebase`                        | Codebase-focused search mode                                                                  |
+| `deepanalyze`, `deep-analyze`                                                  | Deep analysis mode                                                                            |
+| `ultrathink`, `think hard`, `think deeply`                                     | Deep reasoning mode                                                                           |
+| `tdd`, `test first`, `red green`                                               | TDD workflow enforcement                                                                      |
+| `code review`, `review code`                                                   | Comprehensive code review mode                                                                |
+| `security review`, `review security`                                           | Security-focused review mode                                                                  |
+| `cancelomc`, `stopomc`                                                         | Unified cancellation                                                                          |
 
 ### Examples
 
@@ -818,13 +855,13 @@ For complete documentation, see **[Performance Monitoring Guide](./PERFORMANCE-M
 
 ### Quick Overview
 
-| Feature                 | Description                                     | Access                               |
-| ----------------------- | ----------------------------------------------- | ------------------------------------ |
-| **Agent Observatory**   | Real-time agent status, efficiency, bottlenecks | HUD / API                            |
-| **Session-End Summaries** | Persisted per-session summaries and callback payloads | `.omc/sessions/*.json`, `session-end` |
-| **Session Replay**      | Event timeline for post-session analysis        | `.omc/state/agent-replay-*.jsonl`    |
-| **Session Search**      | Search prior local transcript/session artifacts  | `omc session search`, `session_search` |
-| **Intervention System** | Auto-detection of stale agents, cost overruns   | Automatic                            |
+| Feature                   | Description                                           | Access                                 |
+| ------------------------- | ----------------------------------------------------- | -------------------------------------- |
+| **Agent Observatory**     | Real-time agent status, efficiency, bottlenecks       | HUD / API                              |
+| **Session-End Summaries** | Persisted per-session summaries and callback payloads | `.omc/sessions/*.json`, `session-end`  |
+| **Session Replay**        | Event timeline for post-session analysis              | `.omc/state/agent-replay-*.jsonl`      |
+| **Session Search**        | Search prior local transcript/session artifacts       | `omc session search`, `session_search` |
+| **Intervention System**   | Auto-detection of stale agents, cost overruns         | Automatic                              |
 
 ### CLI Commands
 
@@ -895,17 +932,17 @@ Configure HUD elements in `~/.claude/settings.json`:
 }
 ```
 
-| Element      | Description                                                                                       | Default |
-| ------------ | ------------------------------------------------------------------------------------------------- | ------- |
-| `cwd`        | Show current working directory                                                                    | `false` |
-| `gitRepo`    | Show git repository name                                                                          | `false` |
-| `gitBranch`  | Show current git branch                                                                           | `false` |
-| `omcLabel`   | Show [OMC] label                                                                                  | `true`  |
-| `contextBar` | Show context window usage                                                                         | `true`  |
-| `agents`     | Show active agents count                                                                          | `true`  |
-| `todos`      | Show todo progress                                                                                | `true`  |
-| `ralph`      | Show ralph loop status                                                                            | `true`  |
-| `autopilot`  | Show autopilot status                                                                             | `true`  |
+| Element      | Description                                                                                                          | Default |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- | ------- |
+| `cwd`        | Show current working directory                                                                                       | `false` |
+| `gitRepo`    | Show git repository name                                                                                             | `false` |
+| `gitBranch`  | Show current git branch                                                                                              | `false` |
+| `omcLabel`   | Show [OMC] label                                                                                                     | `true`  |
+| `contextBar` | Show context window usage                                                                                            | `true`  |
+| `agents`     | Show active agents count                                                                                             | `true`  |
+| `todos`      | Show todo progress                                                                                                   | `true`  |
+| `ralph`      | Show ralph loop status                                                                                               | `true`  |
+| `autopilot`  | Show autopilot status                                                                                                | `true`  |
 | `showTokens` | Show transcript-derived token usage (`tok:i1.2k/o340`, plus `r...` reasoning and `s...` session total when reliable) | `false` |
 
 Additional `omcHud` layout and label options (top-level):

--- a/docs/shared/mode-selection-guide.md
+++ b/docs/shared/mode-selection-guide.md
@@ -2,15 +2,17 @@
 
 ## Quick Decision
 
-| If you want... | Use this | Keyword |
-|----------------|----------|---------|
-| Clarify vague requirements first | `deep-interview` | "deep interview", "ouroboros", "don't assume" |
-| Full autonomous build from idea | `autopilot` | "autopilot", "build me", "I want a" |
-| Parallel autonomous (3-5x faster) | `team` (replaces `ultrapilot`) | `/team N:executor "task"` |
-| Persistence until verified done | `ralph` | "ralph", "don't stop" |
-| Parallel execution, manual oversight | `ultrawork` | "ulw", "ultrawork" |
-| Cost-efficient execution | `` (modifier) | "eco", "budget" |
-| Many similar independent tasks | `team` (replaces `swarm`) | `/team N:executor "task"` |
+| If you want...                                                        | Use this                       | Keyword                                        |
+| --------------------------------------------------------------------- | ------------------------------ | ---------------------------------------------- |
+| Clarify vague requirements first                                      | `deep-interview`               | "deep interview", "ouroboros", "don't assume"  |
+| Full autonomous build from idea                                       | `autopilot`                    | "autopilot", "build me", "I want a"            |
+| Parallel autonomous (3-5x faster)                                     | `team` (replaces `ultrapilot`) | `/team N:executor "task"`                      |
+| Persistence until verified done                                       | `ralph`                        | "ralph", "don't stop"                          |
+| Parallel execution, manual oversight                                  | `ultrawork`                    | "ulw", "ultrawork"                             |
+| Cost-efficient execution                                              | `` (modifier)                  | "eco", "budget"                                |
+| Many similar independent tasks                                        | `team` (replaces `swarm`)      | `/team N:executor "task"`                      |
+| Native Claude Code cross-turn loop with a single completion condition | Claude Code `/goal`            | `/goal "condition with proof"`                 |
+| Durable goal ledger without starting another loop                     | artifact-only Ultragoal        | Write goal artifacts/checkpoints/evidence only |
 
 > **Note:** `ultrapilot` and `swarm` are **deprecated** — they now route to `team` mode.
 
@@ -41,52 +43,95 @@ Want autonomous execution?
 
 Have many similar independent tasks (e.g., "fix 47 errors")?
 └── YES: team N:executor (N agents claiming from task pool)
+
+Already have one measurable completion condition and want Claude Code to keep the session moving?
+└── YES: Claude Code /goal, unless Ralph/Team/UltraQA/autopilot already owns the loop
+
+Need durable tracking but no active execution loop yet?
+└── YES: artifact-only Ultragoal ledger/checkpoints/evidence
 ```
+
+## Goal-Oriented Workflow Selection
+
+Claude Code `/goal`, Ralph, Team, UltraQA, and artifact-only Ultragoal all help with "keep going until done" work, but they own different parts of the workflow. Pick one primary loop authority for a session; do not run competing persistence loops at the same time.
+
+| Workflow                | Primary authority                      | Best fit                                                                                | Evidence and completion rule                                                                 | Avoid when                                                                                 |
+| ----------------------- | -------------------------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Claude Code `/goal`     | Claude Code native goal loop           | One active session needs a measurable completion condition and cross-turn persistence   | Surface proof in the conversation, then let the `/goal` evaluator judge the stated condition | Ralph, Team, UltraQA, autopilot, or another Stop-hook loop is already driving continuation |
+| Ralph                   | OMC persistence loop                   | Single-owner implementation that must finish all PRD stories with reviewer verification | Fresh tests/build/lint plus reviewer approval against PRD criteria                           | Work should be split across several owners first                                           |
+| Team                    | OMC coordinated team pipeline          | Parallel work with explicit task ownership and staged verification                      | Task results, worker commits, team verification/fix loop evidence                            | One person can finish faster than coordination overhead                                    |
+| UltraQA                 | OMC QA cycling loop                    | Repeated test/build/lint/typecheck failures until a quality gate passes                 | Command output for the chosen QA goal on every cycle                                         | Requirements or implementation scope are still undefined                                   |
+| Artifact-only Ultragoal | Durable goal artifacts, no active loop | Planning, handoff, or audit trail when a runtime loop is unavailable or unsafe          | Goal ledger, checkpoints, handoff prompts, and attached evidence                             | The user expects automatic execution without selecting Ralph/Team/`/goal`                  |
+
+### Claude Code `/goal` source boundary
+
+OMC docs treat `/goal` facts as Claude Code facts. Cite Claude Code or Anthropic sources only when documenting its behavior: the [Claude Code `/goal` docs](https://code.claude.com/docs/en/goal) and [Anthropic Claude Code changelog](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md). Do not use OpenAI/Codex documentation as authority for `/goal`.
+
+Important limitation: the `/goal` evaluator judges from evidence surfaced in the Claude Code conversation. OMC docs and handoffs must not claim that the evaluator independently runs shell commands, reads files, or inspects hidden repository state. If tests, diffs, or logs matter, run them through the normal OMC/Claude Code tools and include the result in the visible evidence before relying on `/goal` status.
+
+### Conflict policy
+
+Use the deterministic policy names `refuse`, `adopt_existing`, and `artifact_only` when documenting or implementing loop-conflict handling.
+
+When a goal-like request enters an OMC session:
+
+1. If Ralph, Team, UltraQA, autopilot, or a Stop-hook loop is active, keep that OMC loop as the authority and use `/goal` only as a documented handoff option.
+2. If Claude Code `/goal` is already active, either adopt that existing goal explicitly, refuse to start a competing OMC loop, or degrade to artifact-only Ultragoal documentation.
+3. If hooks, workspace trust, or managed settings make `/goal` unavailable, use Ralph/Team/UltraQA or artifact-only Ultragoal instead of pretending `/goal` is active.
+4. Always attach command/test/review evidence before declaring durable OMC completion. `/goal` evaluator success alone is not the OMC final-review gate.
 
 ## Examples
 
-| User Request | Best Mode | Why |
-|--------------|-----------|-----|
-| "Build me a REST API" | autopilot | Single coherent deliverable |
-| "Build frontend, backend, and database" | team 3:executor | Clear component boundaries |
-| "Fix all 47 TypeScript errors" | team 5:executor | Many independent similar tasks |
-| "Refactor auth module thoroughly" | ralph | Need persistence + verification |
-| "Quick parallel execution" | ultrawork | Manual oversight preferred |
-| "Save tokens while fixing errors" |  + ultrawork | Cost-conscious parallel |
-| "Don't stop until done" | ralph | Persistence keyword detected |
+| User Request                            | Best Mode       | Why                             |
+| --------------------------------------- | --------------- | ------------------------------- |
+| "Build me a REST API"                   | autopilot       | Single coherent deliverable     |
+| "Build frontend, backend, and database" | team 3:executor | Clear component boundaries      |
+| "Fix all 47 TypeScript errors"          | team 5:executor | Many independent similar tasks  |
+| "Refactor auth module thoroughly"       | ralph           | Need persistence + verification |
+| "Quick parallel execution"              | ultrawork       | Manual oversight preferred      |
+| "Save tokens while fixing errors"       | + ultrawork     | Cost-conscious parallel         |
+| "Don't stop until done"                 | ralph           | Persistence keyword detected    |
 
 ## Mode Types
 
 ### Standalone Modes
+
 These run independently:
+
 - **autopilot**: Autonomous end-to-end execution
 - **team**: Canonical orchestration with coordinated agents (replaces `ultrapilot` and `swarm`)
 
 > **Deprecated:** `ultrapilot` and `swarm` now route to `team` mode.
 
 ### Wrapper Modes
+
 These wrap other modes:
+
 - **ralph**: Adds persistence + verification around ultrawork
 
 ### Component Modes
+
 These are used by other modes:
+
 - **ultrawork**: Parallel execution engine (used by ralph, autopilot)
 
 ### Modifier Modes
+
 These modify how other modes work:
-- ****: Changes model routing to prefer cheaper tiers
+
+- \*\*\*\*: Changes model routing to prefer cheaper tiers
 
 ## Valid Combinations
 
-| Combination | Effect |
-|-------------|--------|
-| `eco ralph` | Ralph persistence with cheaper agents |
+| Combination     | Effect                                 |
+| --------------- | -------------------------------------- |
+| `eco ralph`     | Ralph persistence with cheaper agents  |
 | `eco ultrawork` | Parallel execution with cheaper agents |
 | `eco autopilot` | Autonomous execution with cost savings |
 
 ## Invalid Combinations
 
-| Combination | Why Invalid |
-|-------------|-------------|
-| `autopilot team` | Both are standalone - use one |
-| `` alone | Needs an execution mode to modify |
+| Combination      | Why Invalid                       |
+| ---------------- | --------------------------------- |
+| `autopilot team` | Both are standalone - use one     |
+| `` alone         | Needs an execution mode to modify |

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -13,25 +13,28 @@ Plan creates comprehensive, actionable work plans through intelligent interactio
 </Purpose>
 
 <Use_When>
+
 - User wants to plan before implementing -- "plan this", "plan the", "let's plan"
 - User wants structured requirements gathering for a vague idea
 - User wants an existing plan reviewed -- "review this plan", `--review`
 - User wants multi-perspective consensus on a plan -- `--consensus`, "ralplan"
 - Task is broad or vague and needs scoping before any code is written
-</Use_When>
+  </Use_When>
 
 <Do_Not_Use_When>
+
 - User wants autonomous end-to-end execution -- use `autopilot` instead
 - User wants to start coding immediately with a clear task -- use `ralph` or delegate to executor
 - User asks a simple question that can be answered directly -- just answer it
 - Task is a single focused fix with obvious scope -- use an execution skill instead of running it from this planning module
-</Do_Not_Use_When>
+  </Do_Not_Use_When>
 
 <Why_This_Exists>
 Jumping into code without understanding requirements leads to rework, scope creep, and missed edge cases. Plan provides structured requirements gathering, expert analysis, and quality-gated plans so that execution starts from a solid foundation. The consensus mode adds multi-perspective validation for high-stakes projects.
 </Why_This_Exists>
 
 <Execution_Policy>
+
 - Auto-detect interview vs direct mode based on request specificity
 - Ask one question at a time during interviews -- never batch multiple questions
 - Gather codebase facts via `explore` agent before asking the user about them
@@ -39,18 +42,20 @@ Jumping into code without understanding requirements leads to rework, scope cree
 - Consensus mode runs fully automated by default; add `--interactive` to enable user prompts at draft review and final approval steps
 - Consensus mode uses RALPLAN-DR short mode by default; switch to deliberate mode with `--deliberate` or when the request explicitly signals high risk (auth/security, data migration, destructive/irreversible changes, production incident, compliance/PII, public API breakage)
 - **Planning/execution boundary:** planning modes inspect context and produce plans/specs/proposals only. They MUST mark artifacts as `pending approval` unless the user has explicitly opted into execution in the current turn or via the structured approval UI. Before explicit execution approval, planning modes MUST NOT run mutation-oriented shell commands, edit source files, commit, push, open PRs, invoke execution skills, or delegate implementation tasks.
-</Execution_Policy>
+- **Goal workflow boundary:** when a plan compares Claude Code `/goal`, Ralph, Team, UltraQA, or artifact-only Ultragoal, identify exactly one primary loop authority and use the deterministic conflict policies `refuse`, `adopt_existing`, and `artifact_only` rather than non-deterministic warning handling. `/goal` facts must cite Claude Code/Anthropic sources only (Claude Code `/goal` docs: https://code.claude.com/docs/en/goal; Anthropic Claude Code changelog: https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md), and plans MUST NOT claim the `/goal` evaluator independently runs commands or reads files; require surfaced proof evidence before any completion claim.
+- **Goal workflow doc target:** for user-facing comparisons, keep examples aligned with `docs/shared/mode-selection-guide.md#goal-oriented-workflow-selection` and `docs/REFERENCE.md#goal-workflow-ux-goal-ralph-team-ultraqa-ultragoal`.
+  </Execution_Policy>
 
 <Steps>
 
 ### Mode Selection
 
-| Mode | Trigger | Behavior |
-|------|---------|----------|
-| Interview | Default for broad requests | Interactive requirements gathering |
-| Direct | `--direct`, or detailed request | Skip interview, generate plan directly |
-| Consensus | `--consensus`, "ralplan" | Planner -> Architect -> Critic loop until agreement with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk); add `--interactive` for user prompts at draft and approval steps |
-| Review | `--review`, "review this plan" | Critic evaluation of existing plan |
+| Mode      | Trigger                         | Behavior                                                                                                                                                                                                       |
+| --------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Interview | Default for broad requests      | Interactive requirements gathering                                                                                                                                                                             |
+| Direct    | `--direct`, or detailed request | Skip interview, generate plan directly                                                                                                                                                                         |
+| Consensus | `--consensus`, "ralplan"        | Planner -> Architect -> Critic loop until agreement with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk); add `--interactive` for user prompts at draft and approval steps |
+| Review    | `--review`, "review this plan"  | Critic evaluation of existing plan                                                                                                                                                                             |
 
 ### Interview Mode (broad/vague requests)
 
@@ -72,11 +77,13 @@ Jumping into code without understanding requirements leads to rework, scope cree
 **RALPLAN-DR modes**: **Short** (default, bounded structure) and **Deliberate** (for `--deliberate` or explicit high-risk requests). Both modes keep the same Planner -> Architect -> Critic sequence and the same `AskUserQuestion` gates.
 
 **Provider overrides (supported when the provider CLI is installed):**
+
 - `--architect codex` — replace the Claude Architect pass with `omc ask codex --agent-prompt architect "..."` for implementation-heavy architecture review
 - `--critic codex` — replace the Claude Critic pass with `omc ask codex --agent-prompt critic "..."` for an external review pass before execution
 - If the requested provider is unavailable, briefly note that and continue with the default Claude Architect/Critic step for that stage
 
 **State lifecycle**: The persistent-mode stop hook uses `ralplan-state.json` to enforce continuation during the consensus loop. The skill **MUST** manage this state:
+
 - **On entry**: Call `state_write(mode="ralplan", active=true, session_id=<current_session_id>)` before step 1
 - **On handoff to execution** (approval → ralph/team): Call `state_write(mode="ralplan", active=false, session_id=<current_session_id>)`. Do NOT use `state_clear` here — `state_clear` writes a 30-second cancel signal that disables stop-hook enforcement for ALL modes, leaving the newly launched execution mode unprotected.
 - **On true terminal exit** (rejection, non-interactive plan output, error/abort): Call `state_clear(mode="ralplan", session_id=<current_session_id>)` — no execution mode follows, so the cancel signal window is harmless.
@@ -90,11 +97,11 @@ Without cleanup, the stop hook blocks all subsequent stops with `[RALPLAN - CONS
    - **Viable Options** (>=2) with bounded pros/cons for each option
    - If only one viable option remains, an explicit **invalidation rationale** for the alternatives that were rejected
    - In **deliberate mode**: a **pre-mortem** (3 failure scenarios) and an **expanded test plan** covering **unit / integration / e2e / observability**
-2. **User feedback** *(--interactive only)*: If running with `--interactive`, **MUST** use `AskUserQuestion` to present the draft plan **plus the RALPLAN-DR Principles / Decision Drivers / Options summary for early direction alignment** with these options:
+2. **User feedback** _(--interactive only)_: If running with `--interactive`, **MUST** use `AskUserQuestion` to present the draft plan **plus the RALPLAN-DR Principles / Decision Drivers / Options summary for early direction alignment** with these options:
    - **Proceed to review** — send to Architect and Critic for evaluation
    - **Request changes** — return to step 1 with user feedback incorporated
    - **Skip review** — go directly to final approval (step 7)
-   If NOT running with `--interactive`, automatically proceed to review (step 3).
+     If NOT running with `--interactive`, automatically proceed to review (step 3).
 3. **Architect** reviews for architectural soundness using `Task(subagent_type="oh-my-claudecode:architect", ...)`. Architect review **MUST** include: strongest steelman counterargument (antithesis) against the favored option, at least one meaningful tradeoff tension, and (when possible) a synthesis path. In deliberate mode, Architect should explicitly flag principle violations. **Wait for this step to complete before proceeding to step 4.** Do NOT run steps 3 and 4 in parallel.
 4. **Critic** evaluates against quality criteria using `Task(subagent_type="oh-my-claudecode:critic", ...)`. Critic **MUST** verify principle-option consistency, fair alternative exploration, risk mitigation clarity, testable acceptance criteria, and concrete verification steps. Critic **MUST** explicitly reject shallow alternatives, driver contradictions, vague risks, or weak verification. In deliberate mode, Critic **MUST** reject missing/weak pre-mortem or missing/weak expanded test plan. Run only after step 3 is complete.
 5. **Re-review loop** (max 5 iterations): If Critic rejects, execute this closed loop:
@@ -109,14 +116,14 @@ Without cleanup, the stop hook blocks all subsequent stops with `[RALPLAN - CONS
    b. Deduplicate and categorize the suggestions
    c. Update the plan file in `.omc/plans/` with the accepted improvements (add missing details, refine steps, strengthen acceptance criteria, ADR updates, etc.)
    d. Note which improvements were applied in a brief changelog section at the end of the plan
-7. On Critic approval (with improvements applied): mark the plan status as `pending approval` unless explicit execution approval has already been captured. *(--interactive only)* If running with `--interactive`, use `AskUserQuestion` to present the plan with these options:
+7. On Critic approval (with improvements applied): mark the plan status as `pending approval` unless explicit execution approval has already been captured. _(--interactive only)_ If running with `--interactive`, use `AskUserQuestion` to present the plan with these options:
    - **Approve execution via team** (Recommended) — explicit opt-in to proceed via coordinated parallel team agents (`/team`). Team is the canonical orchestration surface since v4.1.7.
    - **Approve execution via ralph** — explicit opt-in to proceed via ralph+ultrawork (sequential execution with verification)
    - **Approve execution after clearing context** — explicit opt-in to compact the context window first (recommended when context is large after planning), then start fresh implementation via ralph with the saved plan file
    - **Request changes** — return to step 1 with user feedback
    - **Reject** — discard the plan entirely
-   If NOT running with `--interactive`, output the final plan marked `pending approval`, call `state_clear(mode="ralplan", session_id=<current_session_id>)`, and stop. Do NOT auto-execute.
-8. *(--interactive only)* User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text). If user selects **Reject**, call `state_clear(mode="ralplan", session_id=<current_session_id>)` and stop.
+     If NOT running with `--interactive`, output the final plan marked `pending approval`, call `state_clear(mode="ralplan", session_id=<current_session_id>)`, and stop. Do NOT auto-execute.
+8. _(--interactive only)_ User chooses via the structured `AskUserQuestion` UI (never ask for approval in plain text). If user selects **Reject**, call `state_clear(mode="ralplan", session_id=<current_session_id>)` and stop.
 9. On user approval (--interactive only): Call `state_write(mode="ralplan", active=false, session_id=<current_session_id>)` **before** invoking the execution skill (ralph/team), so the stop hook does not interfere with the execution mode's own enforcement. Do NOT use `state_clear` here — it writes a cancel signal that disables enforcement for the newly launched mode.
    - **Approve execution via team**: **MUST** invoke `Skill("oh-my-claudecode:team")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. The team skill coordinates parallel agents across the staged pipeline for faster execution on large tasks. This is the recommended default execution path.
    - **Approve execution via ralph**: **MUST** invoke `Skill("oh-my-claudecode:ralph")` with the approved plan path from `.omc/plans/` as context. Do NOT implement directly. Do NOT edit source code files in the planning agent. The ralph skill handles execution via ultrawork parallel agents.
@@ -131,6 +138,7 @@ Without cleanup, the stop hook blocks all subsequent stops with `[RALPLAN - CONS
 ### Plan Output Format
 
 Every plan includes:
+
 - Requirements Summary
 - Acceptance Criteria (testable)
 - Implementation Steps (with file references)
@@ -144,6 +152,7 @@ Plans are saved to `.omc/plans/`. Drafts go to `.omc/drafts/`.
 </Steps>
 
 <Tool_Usage>
+
 - Use `AskUserQuestion` for preference questions (scope, priority, timeline, risk tolerance) -- provides clickable UI
 - Use plain text for questions needing specific values (port numbers, names, follow-up clarifications)
 - Use `explore` agent (Haiku, 30s timeout) to gather codebase facts before asking the user
@@ -157,7 +166,7 @@ Plans are saved to `.omc/plans/`. Drafts go to `.omc/drafts/`.
 - Before explicit execution approval, planning mode MUST NOT run mutation-oriented shell commands, edit files, commit, push, open PRs, invoke execution skills, or delegate implementation tasks; it may only inspect context and draft/update plan/spec/proposal artifacts.
 - When user selects "Approve execution after clearing context" in step 7 (--interactive only): call `state_write(mode="ralplan", active=false, session_id=<current_session_id>)` first, then invoke `Skill("compact")` to compress the accumulated planning context, then immediately invoke `Skill("oh-my-claudecode:ralph")` with the plan path -- the compact step is critical to free up context before the implementation loop begins
 - **CRITICAL — Consensus mode state lifecycle**: Always deactivate ralplan state before stopping or handing off to execution. Use `state_write(active=false)` for handoff paths (approval → ralph/team) and `state_clear` for true terminal exits (rejection, error). Never use `state_clear` before launching an execution mode — its cancel signal disables stop-hook enforcement for 30 seconds.
-</Tool_Usage>
+  </Tool_Usage>
 
 <Examples>
 <Good>
@@ -210,14 +219,16 @@ Why bad: Decision fatigue. Present one option with trade-offs, get reaction, the
 </Examples>
 
 <Escalation_And_Stop_Conditions>
+
 - Stop interviewing when requirements are clear enough to plan -- do not over-interview
 - In consensus mode, stop after 5 Planner/Architect/Critic iterations and present the best version. Do NOT clear ralplan state here — the user may still select "Request changes" in the subsequent step. State is cleared only on the user's final choice (approval/rejection) or when outputting the plan in non-interactive mode.
 - Consensus mode without `--interactive` outputs the final plan marked `pending approval` and stops; with `--interactive`, requires explicit user approval before any implementation begins. **Always** call `state_clear(mode="ralplan", session_id=<current_session_id>)` before stopping.
 - If the user says "just do it" or "skip planning" without explicitly naming an execution path, treat it as a request to end planning: output the current plan/spec/proposal as `pending approval` and ask for explicit execution approval via the structured approval UI. Do NOT invoke `Skill("oh-my-claudecode:ralph")`, mutate files, delegate implementation, commit, push, or open a PR from the planning module until that approval exists.
 - Escalate to the user when there are irreconcilable trade-offs that require a business decision
-</Escalation_And_Stop_Conditions>
+  </Escalation_And_Stop_Conditions>
 
 <Final_Checklist>
+
 - [ ] Plan has testable acceptance criteria (90%+ concrete)
 - [ ] Plan references specific files/lines where applicable (80%+ claims)
 - [ ] All risks have mitigations identified
@@ -228,7 +239,7 @@ Why bad: Decision fatigue. Present one option with trade-offs, get reaction, the
 - [ ] In deliberate consensus mode: pre-mortem (3 scenarios) + expanded test plan (unit/integration/e2e/observability) included
 - [ ] In consensus mode with `--interactive`: user explicitly approved before any execution; without `--interactive`: plan output marked `pending approval` only, no auto-execution
 - [ ] In consensus mode: ralplan state deactivated on every exit path — `state_write(active=false)` for handoff to execution, `state_clear` for terminal exits (rejection, error, non-interactive stop)
-</Final_Checklist>
+      </Final_Checklist>
 
 <Advanced>
 ## Design Option Presentation
@@ -243,6 +254,7 @@ When presenting design choices during interviews, chunk them:
 6. **Recommendation** (only after options discussed)
 
 Format for each option:
+
 ```
 ### Option A: [Name]
 **Approach:** [1 sentence]
@@ -256,21 +268,21 @@ What's your reaction to this approach?
 
 Before asking any interview question, classify it:
 
-| Type | Examples | Action |
-|------|----------|--------|
-| Codebase Fact | "What patterns exist?", "Where is X?" | Explore first, do not ask user |
-| User Preference | "Priority?", "Timeline?" | Ask user via AskUserQuestion |
-| Scope Decision | "Include feature Y?" | Ask user |
-| Requirement | "Performance constraints?" | Ask user |
+| Type            | Examples                              | Action                         |
+| --------------- | ------------------------------------- | ------------------------------ |
+| Codebase Fact   | "What patterns exist?", "Where is X?" | Explore first, do not ask user |
+| User Preference | "Priority?", "Timeline?"              | Ask user via AskUserQuestion   |
+| Scope Decision  | "Include feature Y?"                  | Ask user                       |
+| Requirement     | "Performance constraints?"            | Ask user                       |
 
 ## Review Quality Criteria
 
-| Criterion | Standard |
-|-----------|----------|
-| Clarity | 80%+ claims cite file/line |
-| Testability | 90%+ criteria are concrete |
-| Verification | All file refs exist |
-| Specificity | No vague terms |
+| Criterion    | Standard                   |
+| ------------ | -------------------------- |
+| Clarity      | 80%+ claims cite file/line |
+| Testability  | 90%+ criteria are concrete |
+| Verification | All file refs exist        |
+| Specificity  | No vague terms             |
 
 ## Deprecation Notice
 

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -14,26 +14,30 @@ Ralph is a PRD-driven persistence loop that keeps working on a task until ALL us
 </Purpose>
 
 <Use_When>
+
 - Task requires guaranteed completion with verification (not just "do your best")
 - User says "ralph", "don't stop", "must complete", "finish this", or "keep going until done"
 - Work may span multiple iterations and needs persistence across retries
 - Task benefits from structured PRD-driven execution with reviewer sign-off
-</Use_When>
+  </Use_When>
 
 <Do_Not_Use_When>
+
 - User wants a full autonomous pipeline from idea to code -- use `autopilot` instead
 - User wants to explore or plan before committing -- use `plan` skill instead
 - User wants a quick one-shot fix -- delegate directly to an executor agent
 - User wants manual control over completion -- use `ultrawork` directly
-</Do_Not_Use_When>
+- User already has an active Claude Code `/goal` and only wants that native goal loop monitored -- adopt the existing `/goal` explicitly or use artifact-only Ultragoal notes instead of starting Ralph as a competing persistence loop
+  </Do_Not_Use_When>
 
 <Why_This_Exists>
 Complex tasks often fail silently: partial implementations get declared "done", tests get skipped, edge cases get forgotten. Ralph prevents this by:
+
 1. Structuring work into discrete user stories with testable acceptance criteria (prd.json)
 2. Iterating story-by-story until each one passes
 3. Tracking progress and learnings across iterations (progress.txt)
 4. Requiring fresh reviewer verification against specific acceptance criteria before completion
-</Why_This_Exists>
+   </Why_This_Exists>
 
 <PRD_Mode>
 By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated when ralph starts if none exists. Active transient PRD state is session-scoped at `.omc/state/sessions/{sessionId}/prd.json` when a session ID is available; legacy project-level `prd.json` / `.omc/prd.json` files are read as startup migration inputs.
@@ -46,12 +50,14 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 </PRD_Mode>
 
 <Execution_Policy>
+
 - Fire independent agent calls simultaneously -- never wait sequentially for independent work
 - Use `run_in_background: true` for long operations (installs, builds, test suites)
 - Always pass the `model` parameter explicitly when delegating to agents
 - Read `docs/shared/agent-tiers.md` before first delegation to select correct agent tiers
 - Deliver the full implementation: no scope reduction, no partial completion, no deleting tests to make them pass
-</Execution_Policy>
+- If a Claude Code `/goal` is mentioned, treat it as a native session-loop handoff/evidence source only and use the deterministic conflict policies `refuse`, `adopt_existing`, and `artifact_only` rather than non-deterministic warning handling. Ralph remains the OMC loop authority for this run; do not claim `/goal` independently ran tests or read files, and do not treat evaluator success as a substitute for Ralph reviewer verification.
+  </Execution_Policy>
 
 <Steps>
 1. **PRD Setup** (first iteration only):
@@ -94,7 +100,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 7. **Reviewer verification** (tiered, against acceptance criteria):
    - <5 files, <100 lines with full tests: STANDARD tier minimum (architect-medium / Sonnet)
    - Standard changes: STANDARD tier (architect-medium / Sonnet)
-   - >20 files or security/architectural changes: THOROUGH tier (architect / Opus)
+   - > 20 files or security/architectural changes: THOROUGH tier (architect / Opus)
    - If `--critic=critic`, use the Claude `critic` agent for the approval pass
    - If `--critic=codex`, run `omc ask codex --agent-prompt critic "..."` for the approval pass. The Codex critic prompt MUST include:
      1. The full list of acceptance criteria from prd.json for verification
@@ -106,23 +112,26 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
    - **On APPROVAL: immediately proceed to Step 7.5 in the same turn. Do NOT pause to report the verdict to the user — reporting happens only at Step 8 (`/oh-my-claudecode:cancel`) or on rejection (Step 9). Treating an approved verdict as a reporting checkpoint is a polite-stop anti-pattern.**
 
 7.5 **Mandatory Deslop Pass** (runs unconditionally after Step 7 approval, unless `{{PROMPT}}` contains `--no-deslop`):
-   - **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`.** Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
-   - **ai-slop-cleaner is a SKILL, not an agent.** Do NOT call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")` — that subagent type does not exist and the call will fail with "Agent type not found". If you see that error, retry with the Skill tool — do NOT substitute a similarly-named agent like `code-simplifier` as a "closest match".
-   - Keep the scope bounded to the Ralph changed-file set; do not broaden the cleanup pass to unrelated files.
-   - If the reviewer approved the implementation but the deslop pass introduces follow-up edits, keep those edits inside the same changed-file scope before proceeding.
 
-7.6 **Regression Re-verification**:
-   - After the deslop pass, re-run all relevant tests, build, and lint checks for the Ralph session.
-   - Read the output and confirm the post-deslop regression run actually passes.
-   - If regression fails, roll back the cleaner changes or fix the regression, then rerun the verification loop until it passes.
-   - Only proceed to completion after the post-deslop regression run passes (or `--no-deslop` was explicitly specified).
+- **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`.** Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
+- **ai-slop-cleaner is a SKILL, not an agent.** Do NOT call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")` — that subagent type does not exist and the call will fail with "Agent type not found". If you see that error, retry with the Skill tool — do NOT substitute a similarly-named agent like `code-simplifier` as a "closest match".
+- Keep the scope bounded to the Ralph changed-file set; do not broaden the cleanup pass to unrelated files.
+- If the reviewer approved the implementation but the deslop pass introduces follow-up edits, keep those edits inside the same changed-file scope before proceeding.
+
+  7.6 **Regression Re-verification**:
+
+- After the deslop pass, re-run all relevant tests, build, and lint checks for the Ralph session.
+- Read the output and confirm the post-deslop regression run actually passes.
+- If regression fails, roll back the cleaner changes or fix the regression, then rerun the verification loop until it passes.
+- Only proceed to completion after the post-deslop regression run passes (or `--no-deslop` was explicitly specified).
 
 8. **On approval**: After Step 7.6 passes (with Step 7.5 completed, or skipped via `--no-deslop`), run `/oh-my-claudecode:cancel` to cleanly exit and clean up all state files
 
 9. **On rejection**: Fix the issues raised, re-verify with the same reviewer, then loop back to check if the story needs to be marked incomplete
-</Steps>
+   </Steps>
 
 <Tool_Usage>
+
 - Use `Task(subagent_type="oh-my-claudecode:architect", ...)` for architect verification cross-checks when changes are security-sensitive, architectural, or involve complex multi-system integration
 - Use `Task(subagent_type="oh-my-claudecode:critic", ...)` when `--critic=critic`
 - Use `omc ask codex --agent-prompt critic "..."` when `--critic=codex`. Construct the prompt to include: (a) prd.json acceptance criteria, (b) files changed + related files, (c) explicit optimality question: "Is there a meaningfully simpler, faster, or more maintainable approach that achieves the same acceptance criteria?"
@@ -130,7 +139,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 - Proceed with architect agent verification alone -- never block on unavailable tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
 - **Skill vs agent invocation**: `ai-slop-cleaner` is a skill, invoke via `Skill("ai-slop-cleaner")`. `architect`, `critic`, `executor` etc. are agents, invoke via `Task(subagent_type="oh-my-claudecode:<name>")`. If you ever get "Agent type ... not found" for an `oh-my-claudecode:<name>` identifier, the item is a skill — retry with the Skill tool. Do NOT substitute a similarly-named agent as a "closest match".
-</Tool_Usage>
+  </Tool_Usage>
 
 <Examples>
 <Good>
@@ -140,11 +149,12 @@ Auto-generated scaffold has:
   acceptanceCriteria: ["Implementation is complete", "Code compiles without errors"]
 
 After refinement:
-  acceptanceCriteria: [
-    "Legacy --no-prd text is stripped from the Ralph working prompt",
-    "Ralph startup still creates or validates prd.json when legacy --no-prd text is present",
-    "TypeScript compiles with no errors (npm run build)"
-  ]
+acceptanceCriteria: [
+"Legacy --no-prd text is stripped from the Ralph working prompt",
+"Ralph startup still creates or validates prd.json when legacy --no-prd text is present",
+"TypeScript compiles with no errors (npm run build)"
+]
+
 ```
 Why good: Generic criteria replaced with specific, testable criteria.
 </Good>
@@ -152,9 +162,11 @@ Why good: Generic criteria replaced with specific, testable criteria.
 <Good>
 Correct parallel delegation:
 ```
+
 Task(subagent_type="oh-my-claudecode:executor", model="haiku", prompt="Add type export for UserConfig")
 Task(subagent_type="oh-my-claudecode:executor", model="sonnet", prompt="Implement the caching layer for API responses")
 Task(subagent_type="oh-my-claudecode:executor", model="opus", prompt="Refactor auth module to support OAuth2 flow")
+
 ```
 Why good: Three independent tasks fired simultaneously at appropriate tiers.
 </Good>
@@ -162,12 +174,14 @@ Why good: Three independent tasks fired simultaneously at appropriate tiers.
 <Good>
 Story-by-story verification:
 ```
+
 1. Story US-001: "Add flag detection helpers"
    - Criterion: "Legacy --no-prd is stripped from the working prompt" → Run test → PASS
    - Criterion: "TypeScript compiles" → Run build → PASS
    - Mark US-001 passes: true
 2. Story US-002: "Wire PRD into bridge.ts"
    - Continue to next story...
+
 ```
 Why good: Each story verified against its own acceptance criteria before marking complete.
 </Good>
@@ -181,9 +195,11 @@ Why bad: Uses "should" and "look good" -- no fresh evidence, no story-by-story v
 <Bad>
 Sequential execution of independent tasks:
 ```
+
 Task(executor, "Add type export") → wait →
 Task(executor, "Implement caching") → wait →
 Task(executor, "Refactor auth")
+
 ```
 Why bad: These are independent tasks that should run in parallel, not sequentially.
 </Bad>
@@ -236,3 +252,4 @@ Why bad: Did not refine scaffold criteria into task-specific ones. This is PRD t
 
 Original task:
 {{PROMPT}}
+```

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -78,6 +78,7 @@ User: "/team 3:executor fix all TypeScript errors"
 ```
 
 **Storage layout (managed by Claude Code):**
+
 ```
 ~/.claude/
   teams/fix-ts-errors/
@@ -90,6 +91,10 @@ User: "/team 3:executor fix all TypeScript errors"
     ...
 ```
 
+## Goal Workflow Relationship
+
+Team is the OMC authority for parallel, staged execution. Use the deterministic conflict policies `refuse`, `adopt_existing`, and `artifact_only` rather than non-deterministic warning handling. If a task mentions Claude Code `/goal`, Ralph, UltraQA, or artifact-only Ultragoal, keep Team as the primary loop authority unless the leader explicitly hands off. Use `/goal` only as a documented native Claude Code handoff target or as visible evidence from the lead session; do not claim the `/goal` evaluator independently runs commands, reads files, or replaces `team-verify` / `team-fix`. Artifact-only Ultragoal references should be treated as durable goal ledger/checkpoint/evidence artifacts, not as worker execution by themselves.
+
 ## Staged Pipeline (Canonical Team Runtime)
 
 Team execution follows a staged pipeline:
@@ -100,13 +105,13 @@ Team execution follows a staged pipeline:
 
 Each pipeline stage uses **specialized agents** -- not just executors. The lead selects agents based on the stage and task characteristics.
 
-| Stage | Required Agents | Optional Agents | Selection Criteria |
-|-------|----------------|-----------------|-------------------|
-| **team-plan** | `explore` (haiku), `planner` (opus) | `analyst` (opus), `architect` (opus) | Use `analyst` for unclear requirements. Use `architect` for systems with complex boundaries. |
-| **team-prd** | `analyst` (opus) | `critic` (opus) | Use `critic` to challenge scope. |
-| **team-exec** | `executor` (sonnet) | `executor` (opus), `debugger` (sonnet), `designer` (sonnet), `writer` (haiku), `test-engineer` (sonnet) | Match agent to subtask type. Use `executor` (model=opus) for complex autonomous work, `designer` for UI, `debugger` for compilation issues, `writer` for docs, `test-engineer` for test creation. |
-| **team-verify** | `verifier` (sonnet) | `test-engineer` (sonnet), `security-reviewer` (sonnet), `code-reviewer` (opus) | Always run `verifier`. Add `security-reviewer` for auth/crypto changes. Add `code-reviewer` for >20 files or architectural changes. `code-reviewer` also covers style/formatting checks. |
-| **team-fix** | `executor` (sonnet) | `debugger` (sonnet), `executor` (opus) | Use `debugger` for type/build errors and regression isolation. Use `executor` (model=opus) for complex multi-file fixes. |
+| Stage           | Required Agents                     | Optional Agents                                                                                         | Selection Criteria                                                                                                                                                                                |
+| --------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **team-plan**   | `explore` (haiku), `planner` (opus) | `analyst` (opus), `architect` (opus)                                                                    | Use `analyst` for unclear requirements. Use `architect` for systems with complex boundaries.                                                                                                      |
+| **team-prd**    | `analyst` (opus)                    | `critic` (opus)                                                                                         | Use `critic` to challenge scope.                                                                                                                                                                  |
+| **team-exec**   | `executor` (sonnet)                 | `executor` (opus), `debugger` (sonnet), `designer` (sonnet), `writer` (haiku), `test-engineer` (sonnet) | Match agent to subtask type. Use `executor` (model=opus) for complex autonomous work, `designer` for UI, `debugger` for compilation issues, `writer` for docs, `test-engineer` for test creation. |
+| **team-verify** | `verifier` (sonnet)                 | `test-engineer` (sonnet), `security-reviewer` (sonnet), `code-reviewer` (opus)                          | Always run `verifier`. Add `security-reviewer` for auth/crypto changes. Add `code-reviewer` for >20 files or architectural changes. `code-reviewer` also covers style/formatting checks.          |
+| **team-fix**    | `executor` (sonnet)                 | `debugger` (sonnet), `executor` (opus)                                                                  | Use `debugger` for type/build errors and regression isolation. Use `executor` (model=opus) for complex multi-file fixes.                                                                          |
 
 **Routing rules:**
 
@@ -142,6 +147,7 @@ Each pipeline stage uses **specialized agents** -- not just executors. The lead 
 ### Verify/Fix Loop and Stop Conditions
 
 Continue `team-exec -> team-verify -> team-fix` until:
+
 1. verification passes and no required fix tasks remain, or
 2. work reaches an explicit terminal blocked/failed outcome with evidence.
 
@@ -159,6 +165,7 @@ The lead writes handoffs to `.omc/handoffs/<stage-name>.md`.
 
 ```markdown
 ## Handoff: <current-stage> → <next-stage>
+
 - **Decided**: [key decisions made in this stage]
 - **Rejected**: [alternatives considered and why they were rejected]
 - **Risks**: [identified risks for the next stage]
@@ -177,6 +184,7 @@ The lead writes handoffs to `.omc/handoffs/<stage-name>.md`.
 
 ```markdown
 ## Handoff: team-plan → team-exec
+
 - **Decided**: Microservice architecture with 3 services (auth, api, worker). PostgreSQL for persistence. JWT for auth tokens.
 - **Rejected**: Monolith (scaling concerns), MongoDB (team expertise is SQL), session cookies (API-first design).
 - **Risks**: Worker service needs Redis for job queue — not yet provisioned. Auth service has no rate limiting in initial design.
@@ -219,6 +227,7 @@ Call `TeamCreate` with a slug derived from the task:
 ```
 
 **Response:**
+
 ```json
 {
   "team_name": "fix-ts-errors",
@@ -248,18 +257,18 @@ state_write(mode="team", active=true, current_phase="team-plan", state={
 
 **State schema fields:**
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `active` | boolean | Whether team mode is active |
-| `current_phase` | string | Current pipeline stage: `team-plan`, `team-prd`, `team-exec`, `team-verify`, `team-fix` |
-| `team_name` | string | Slug name for the team |
-| `agent_count` | number | Number of worker agents |
-| `agent_types` | string | Comma-separated agent types used in team-exec |
-| `task` | string | Original task description |
-| `fix_loop_count` | number | Current fix iteration count |
-| `max_fix_loops` | number | Maximum fix iterations before failing (default: 3) |
-| `linked_ralph` | boolean | Whether team is linked to a ralph persistence loop |
-| `stage_history` | string | Comma-separated list of stage transitions with timestamps |
+| Field            | Type    | Description                                                                             |
+| ---------------- | ------- | --------------------------------------------------------------------------------------- |
+| `active`         | boolean | Whether team mode is active                                                             |
+| `current_phase`  | string  | Current pipeline stage: `team-plan`, `team-prd`, `team-exec`, `team-verify`, `team-fix` |
+| `team_name`      | string  | Slug name for the team                                                                  |
+| `agent_count`    | number  | Number of worker agents                                                                 |
+| `agent_types`    | string  | Comma-separated agent types used in team-exec                                           |
+| `task`           | string  | Original task description                                                               |
+| `fix_loop_count` | number  | Current fix iteration count                                                             |
+| `max_fix_loops`  | number  | Maximum fix iterations before failing (default: 3)                                      |
+| `linked_ralph`   | boolean | Whether team is linked to a ralph persistence loop                                      |
+| `stage_history`  | string  | Comma-separated list of stage transitions with timestamps                               |
 
 **Update state on every stage transition:**
 
@@ -291,6 +300,7 @@ Call `TaskCreate` for each subtask. Set dependencies with `TaskUpdate` using `ad
 ```
 
 **Response stores a task file (e.g. `1.json`):**
+
 ```json
 {
   "id": "1",
@@ -338,6 +348,7 @@ Spawn N teammates using `Task` with `team_name` and `name` parameters. Each team
 ```
 
 **Response:**
+
 ```json
 {
   "agent_id": "worker-1@fix-ts-errors",
@@ -347,6 +358,7 @@ Spawn N teammates using `Task` with `team_name` and `name` parameters. Each team
 ```
 
 **Side effects:**
+
 - Teammate added to `config.json` members array
 - An **internal task** is auto-created (with `metadata._internal: true`) tracking the agent lifecycle
 - Internal tasks appear in `TaskList` output -- filter them when counting real tasks
@@ -401,6 +413,7 @@ state_write(mode="team", current_phase="team-fix", state={
 ```
 
 This enables:
+
 - **Resume**: If the lead crashes, `state_read(mode="team")` reveals the last stage and team name for recovery
 - **Cancel**: The cancel skill reads `current_phase` to know what cleanup is needed
 - **Ralph integration**: Ralph can read team state to know if the pipeline completed or failed
@@ -533,6 +546,7 @@ This addendum must preserve the core rule: **worker = executor only, never leade
 **CRITICAL: Steps must execute in exact order. Never call TeamDelete before shutdown is confirmed.**
 
 **Step 1: Verify completion**
+
 ```
 Call TaskList — verify all real tasks (non-internal) are completed or failed.
 ```
@@ -540,6 +554,7 @@ Call TaskList — verify all real tasks (non-internal) are completed or failed.
 **Step 2: Request shutdown from each teammate**
 
 **Lead sends:**
+
 ```json
 {
   "type": "shutdown_request",
@@ -549,11 +564,13 @@ Call TaskList — verify all real tasks (non-internal) are completed or failed.
 ```
 
 **Step 3: Wait for responses (BLOCKING)**
+
 - Wait up to 30s per teammate for `shutdown_response`
 - Track which teammates confirmed vs timed out
 - If a teammate doesn't respond within 30s: log warning, mark as unresponsive
 
 **Teammate receives and responds:**
+
 ```json
 {
   "type": "shutdown_response",
@@ -563,11 +580,13 @@ Call TaskList — verify all real tasks (non-internal) are completed or failed.
 ```
 
 After approval:
+
 - Teammate process terminates
 - Teammate auto-removed from `config.json` members array
 - Internal task for that teammate completes
 
 **Step 4: TeamDelete — only after ALL teammates confirmed or timed out**
+
 ```json
 { "team_name": "fix-ts-errors" }
 ```
@@ -575,6 +594,7 @@ After approval:
 **Step 5: Orphan scan**
 
 Check for agent processes that survived TeamDelete:
+
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-orphans.mjs" --team-name fix-ts-errors
 ```
@@ -582,6 +602,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-orphans.mjs" --team-name fix-ts-erro
 This scans for processes matching the team name whose config no longer exists, and terminates them (SIGTERM → 5s wait → SIGKILL). Supports `--dry-run` for inspection.
 
 **Shutdown sequence is BLOCKING:** Do not proceed to TeamDelete until all teammates have either:
+
 - Confirmed shutdown (`shutdown_response` with `approve: true`), OR
 - Timed out (30s with no response)
 
@@ -595,11 +616,11 @@ The team skill supports **hybrid execution** combining Claude agent teammates wi
 
 Tasks are tagged with an execution mode during decomposition:
 
-| Execution Mode | Provider | Capabilities |
-|---------------|----------|-------------|
-| `claude_worker` | Claude agent | Full Claude Code tool access (Read/Write/Edit/Bash/Task). Best for tasks needing Claude's reasoning + iterative tool use. |
-| `codex_worker` | Codex CLI (tmux pane) | Full filesystem access in working_directory. Runs autonomously via tmux pane. Best for code review, security analysis, refactoring, architecture. Requires `npm install -g @openai/codex`. |
-| `gemini_worker` | Gemini CLI (tmux pane) | Full filesystem access in working_directory. Runs autonomously via tmux pane. Best for UI/design work, documentation, large-context tasks. Requires `npm install -g @google/gemini-cli`. |
+| Execution Mode  | Provider               | Capabilities                                                                                                                                                                               |
+| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `claude_worker` | Claude agent           | Full Claude Code tool access (Read/Write/Edit/Bash/Task). Best for tasks needing Claude's reasoning + iterative tool use.                                                                  |
+| `codex_worker`  | Codex CLI (tmux pane)  | Full filesystem access in working_directory. Runs autonomously via tmux pane. Best for code review, security analysis, refactoring, architecture. Requires `npm install -g @openai/codex`. |
+| `gemini_worker` | Gemini CLI (tmux pane) | Full filesystem access in working_directory. Runs autonomously via tmux pane. Best for UI/design work, documentation, large-context tasks. Requires `npm install -g @google/gemini-cli`.   |
 
 ### How CLI Workers Operate
 
@@ -612,6 +633,7 @@ Tmux CLI workers run in dedicated tmux panes with filesystem access. They are **
 5. Lead reads the output, marks the task complete, and feeds results to dependent tasks
 
 **Key difference from Claude teammates:**
+
 - CLI workers operate via tmux, not Claude Code's tool system
 - They cannot use TaskList/TaskUpdate/SendMessage (no team awareness)
 - They run as one-shot autonomous jobs, not persistent teammates
@@ -619,16 +641,16 @@ Tmux CLI workers run in dedicated tmux panes with filesystem access. They are **
 
 ### When to Route Where
 
-| Task Type | Best Route | Why |
-|-----------|-----------|-----|
-| Iterative multi-step work | Claude teammate | Needs tool-mediated iteration + team communication |
-| Code review / security audit | CLI worker or specialist agent | Autonomous execution, good at structured analysis |
-| Architecture analysis / planning | architect Claude agent | Strong analytical reasoning with codebase access |
-| Refactoring (well-scoped) | CLI worker or executor agent | Autonomous execution, good at structured transforms |
-| UI/frontend implementation | designer Claude agent | Design expertise, framework idioms |
-| Large-scale documentation | writer Claude agent | Writing expertise + large context for consistency |
-| Build/test iteration loops | Claude teammate | Needs Bash tool + iterative fix cycles |
-| Tasks needing team coordination | Claude teammate | Needs SendMessage for status updates |
+| Task Type                        | Best Route                     | Why                                                 |
+| -------------------------------- | ------------------------------ | --------------------------------------------------- |
+| Iterative multi-step work        | Claude teammate                | Needs tool-mediated iteration + team communication  |
+| Code review / security audit     | CLI worker or specialist agent | Autonomous execution, good at structured analysis   |
+| Architecture analysis / planning | architect Claude agent         | Strong analytical reasoning with codebase access    |
+| Refactoring (well-scoped)        | CLI worker or executor agent   | Autonomous execution, good at structured transforms |
+| UI/frontend implementation       | designer Claude agent          | Design expertise, framework idioms                  |
+| Large-scale documentation        | writer Claude agent            | Writing expertise + large context for consistency   |
+| Build/test iteration loops       | Claude teammate                | Needs Bash tool + iterative fix cycles              |
+| Tasks needing team coordination  | Claude teammate                | Needs SendMessage for status updates                |
 
 ### Example: Hybrid Team with CLI Workers
 
@@ -680,18 +702,18 @@ The `getTeamStatus(teamName, workingDirectory, heartbeatMaxAgeMs?)` function pro
 Example usage in the monitor loop:
 
 ```typescript
-const status = getTeamStatus('fix-ts-errors', workingDirectory);
+const status = getTeamStatus("fix-ts-errors", workingDirectory);
 
 for (const worker of status.workers) {
   if (!worker.isAlive) {
     // Worker is dead -- reassign its in-progress tasks
   }
   for (const msg of worker.recentMessages) {
-    if (msg.type === 'task_complete') {
+    if (msg.type === "task_complete") {
       // Mark task complete, unblock dependents
-    } else if (msg.type === 'task_failed') {
+    } else if (msg.type === "task_failed") {
       // Handle failure, possibly retry or reassign
-    } else if (msg.type === 'error') {
+    } else if (msg.type === "error") {
       // Log error, check if worker needs intervention
     }
   }
@@ -704,14 +726,14 @@ if (status.taskSummary.pending === 0 && status.taskSummary.inProgress === 0) {
 
 ### Event-Based Actions from Outbox Messages
 
-| Message Type | Action |
-|-------------|--------|
-| `task_complete` | Mark task completed, check if blocked tasks are now unblocked, notify dependent workers |
-| `task_failed` | Increment failure sidecar, decide retry vs reassign vs skip |
-| `idle` | Worker has no assigned tasks -- assign pending work or begin shutdown |
-| `error` | Log the error, check `consecutiveErrors` in heartbeat for quarantine threshold |
-| `shutdown_ack` | Worker acknowledged shutdown -- safe to remove from team |
-| `heartbeat` | Update liveness tracking (redundant with heartbeat files but useful for latency monitoring) |
+| Message Type    | Action                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `task_complete` | Mark task completed, check if blocked tasks are now unblocked, notify dependent workers     |
+| `task_failed`   | Increment failure sidecar, decide retry vs reassign vs skip                                 |
+| `idle`          | Worker has no assigned tasks -- assign pending work or begin shutdown                       |
+| `error`         | Log the error, check `consecutiveErrors` in heartbeat for quarantine threshold              |
+| `shutdown_ack`  | Worker acknowledged shutdown -- safe to remove from team                                    |
+| `heartbeat`     | Update liveness tracking (redundant with heartbeat files but useful for latency monitoring) |
 
 This approach complements the existing `SendMessage`-based communication by providing a pull-based mechanism for MCP workers that cannot use Claude Code's team messaging tools.
 
@@ -755,6 +777,7 @@ When the user invokes `/team ralph`, says "team ralph", or combines both keyword
 ### Activation
 
 Team+Ralph activates when:
+
 1. User invokes `/team ralph "task"` or `/oh-my-claudecode:team ralph "task"`
 2. Keyword detector finds both `team` and `ralph` in the prompt
 3. Hook detects `MAGIC KEYWORD: RALPH` alongside team context
@@ -791,6 +814,7 @@ state_write(mode="ralph", active=true, iteration=1, max_iterations=10, current_p
 ### Cancellation
 
 Cancel either mode cancels both:
+
 - **Cancel Ralph (linked):** Cancel Team first (graceful shutdown), then clear Ralph state
 - **Cancel Team (linked):** Clear Team, mark Ralph iteration cancelled, stop loop
 
@@ -810,21 +834,21 @@ This prevents duplicate teams and allows graceful recovery from lead failures.
 
 ## Comparison: Team vs Legacy Swarm
 
-| Aspect | Team (Native) | Swarm (Legacy SQLite) |
-|--------|--------------|----------------------|
-| **Storage** | JSON files in `~/.claude/teams/` and `~/.claude/tasks/` | SQLite in `.omc/state/swarm.db` |
-| **Dependencies** | `better-sqlite3` not needed | Requires `better-sqlite3` npm package |
-| **Task claiming** | `TaskUpdate(owner + in_progress)` -- lead pre-assigns | SQLite IMMEDIATE transaction -- atomic |
-| **Race conditions** | Possible if two agents claim same task (mitigate by pre-assigning) | None (SQLite transactions) |
-| **Communication** | `SendMessage` (DM, broadcast, shutdown) | None (fire-and-forget agents) |
-| **Task dependencies** | Built-in `blocks` / `blockedBy` arrays | Not supported |
-| **Heartbeat** | Automatic idle notifications from Claude Code | Manual heartbeat table + polling |
-| **Shutdown** | Graceful request/response protocol | Signal-based termination |
-| **Agent lifecycle** | Auto-tracked via internal tasks + config members | Manual tracking via heartbeat table |
-| **Progress visibility** | `TaskList` shows live status with owner | SQL queries on tasks table |
-| **Conflict prevention** | Owner field (lead-assigned) | Lease-based claiming with timeout |
-| **Crash recovery** | Lead detects via missing messages, reassigns | Auto-release after 5-min lease timeout |
-| **State cleanup** | `TeamDelete` removes everything | Manual `rm` of SQLite database |
+| Aspect                  | Team (Native)                                                      | Swarm (Legacy SQLite)                  |
+| ----------------------- | ------------------------------------------------------------------ | -------------------------------------- |
+| **Storage**             | JSON files in `~/.claude/teams/` and `~/.claude/tasks/`            | SQLite in `.omc/state/swarm.db`        |
+| **Dependencies**        | `better-sqlite3` not needed                                        | Requires `better-sqlite3` npm package  |
+| **Task claiming**       | `TaskUpdate(owner + in_progress)` -- lead pre-assigns              | SQLite IMMEDIATE transaction -- atomic |
+| **Race conditions**     | Possible if two agents claim same task (mitigate by pre-assigning) | None (SQLite transactions)             |
+| **Communication**       | `SendMessage` (DM, broadcast, shutdown)                            | None (fire-and-forget agents)          |
+| **Task dependencies**   | Built-in `blocks` / `blockedBy` arrays                             | Not supported                          |
+| **Heartbeat**           | Automatic idle notifications from Claude Code                      | Manual heartbeat table + polling       |
+| **Shutdown**            | Graceful request/response protocol                                 | Signal-based termination               |
+| **Agent lifecycle**     | Auto-tracked via internal tasks + config members                   | Manual tracking via heartbeat table    |
+| **Progress visibility** | `TaskList` shows live status with owner                            | SQL queries on tasks table             |
+| **Conflict prevention** | Owner field (lead-assigned)                                        | Lease-based claiming with timeout      |
+| **Crash recovery**      | Lead detects via missing messages, reassigns                       | Auto-release after 5-min lease timeout |
+| **State cleanup**       | `TeamDelete` removes everything                                    | Manual `rm` of SQLite database         |
 
 **When to use Team over Swarm:** Always prefer `/team` for new work. It uses Claude Code's built-in infrastructure, requires no external dependencies, supports inter-agent communication, and has task dependency management.
 
@@ -881,9 +905,9 @@ Optional settings live in `.claude/omc.jsonc` (project) or `~/.config/claude-omc
       "maxAgents": 20,
       "defaultAgentType": "claude",
       "monitorIntervalMs": 30000,
-      "shutdownTimeoutMs": 15000
-    }
-  }
+      "shutdownTimeoutMs": 15000,
+    },
+  },
 }
 ```
 
@@ -907,27 +931,27 @@ Declare which provider (`claude`, `codex`, `gemini`) and which model tier should
 {
   "team": {
     "roleRouting": {
-      "orchestrator":  { "model": "inherit" },
-      "planner":       { "provider": "claude", "model": "HIGH" },
-      "analyst":       { "provider": "claude", "model": "HIGH" },
-      "executor":      { "provider": "claude", "model": "MEDIUM" },
-      "critic":        { "provider": "codex" },
+      "orchestrator": { "model": "inherit" },
+      "planner": { "provider": "claude", "model": "HIGH" },
+      "analyst": { "provider": "claude", "model": "HIGH" },
+      "executor": { "provider": "claude", "model": "MEDIUM" },
+      "critic": { "provider": "codex" },
       "code-reviewer": { "provider": "gemini" },
-      "test-engineer": { "provider": "gemini", "model": "MEDIUM" }
-    }
-  }
+      "test-engineer": { "provider": "gemini", "model": "MEDIUM" },
+    },
+  },
 }
 ```
 
-| Role | Provider | Model |
-|---|---|---|
-| `orchestrator` | claude (pinned) | inherits invoking session |
-| `planner` | claude | `HIGH` (opus) |
-| `analyst` | claude | `HIGH` (opus) |
-| `executor` | claude | `MEDIUM` (sonnet) |
-| `critic` | codex | codex default |
-| `code-reviewer` | gemini | gemini default |
-| `test-engineer` | gemini | `MEDIUM` (sonnet) |
+| Role            | Provider        | Model                     |
+| --------------- | --------------- | ------------------------- |
+| `orchestrator`  | claude (pinned) | inherits invoking session |
+| `planner`       | claude          | `HIGH` (opus)             |
+| `analyst`       | claude          | `HIGH` (opus)             |
+| `executor`      | claude          | `MEDIUM` (sonnet)         |
+| `critic`        | codex           | codex default             |
+| `code-reviewer` | gemini          | gemini default            |
+| `test-engineer` | gemini          | `MEDIUM` (sonnet)         |
 
 ### Canonical roles
 
@@ -998,15 +1022,15 @@ MCP workers can operate in isolated git worktrees to prevent file conflicts betw
 
 ### API Reference
 
-| Function | Description |
-|----------|-------------|
-| `createWorkerWorktree(teamName, workerName, repoRoot, baseBranch?)` | Create isolated worktree |
-| `removeWorkerWorktree(teamName, workerName, repoRoot)` | Remove worktree and branch |
-| `listTeamWorktrees(teamName, repoRoot)` | List all team worktrees |
-| `cleanupTeamWorktrees(teamName, repoRoot)` | Remove all team worktrees |
-| `checkMergeConflicts(workerBranch, baseBranch, repoRoot)` | Non-destructive conflict check |
-| `mergeWorkerBranch(workerBranch, baseBranch, repoRoot)` | Merge worker branch (--no-ff) |
-| `mergeAllWorkerBranches(teamName, repoRoot, baseBranch?)` | Merge all completed workers |
+| Function                                                            | Description                    |
+| ------------------------------------------------------------------- | ------------------------------ |
+| `createWorkerWorktree(teamName, workerName, repoRoot, baseBranch?)` | Create isolated worktree       |
+| `removeWorkerWorktree(teamName, workerName, repoRoot)`              | Remove worktree and branch     |
+| `listTeamWorktrees(teamName, repoRoot)`                             | List all team worktrees        |
+| `cleanupTeamWorktrees(teamName, repoRoot)`                          | Remove all team worktrees      |
+| `checkMergeConflicts(workerBranch, baseBranch, repoRoot)`           | Non-destructive conflict check |
+| `mergeWorkerBranch(workerBranch, baseBranch, repoRoot)`             | Merge worker branch (--no-ff)  |
+| `mergeAllWorkerBranches(teamName, repoRoot, baseBranch?)`           | Merge all completed workers    |
 
 ### Important Notes
 

--- a/skills/ultraqa/SKILL.md
+++ b/skills/ultraqa/SKILL.md
@@ -15,17 +15,21 @@ You are now in **ULTRAQA** mode - an autonomous QA cycling workflow that runs un
 
 **Cycle**: qa-tester → architect verification → fix → repeat
 
+## Relationship to `/goal`, Ralph, Team, and Ultragoal
+
+UltraQA owns repeated quality-gate cycling only. Use the deterministic conflict policies `refuse`, `adopt_existing`, and `artifact_only` rather than non-deterministic warning handling. Use it after the target behavior is known and the remaining question is whether tests, build, lint, typecheck, or another explicit QA condition passes. If Claude Code `/goal` is active, UltraQA may produce visible command evidence for that goal, but must not describe the `/goal` evaluator as independently running commands or reading files. If Ralph or Team is active, UltraQA is a verification/fix sub-loop under that authority rather than a competing session loop. If no active loop is safe, record QA expectations and evidence in artifact-only Ultragoal notes instead of claiming automatic execution.
+
 ## Goal Parsing
 
 Parse the goal from arguments. Supported formats:
 
-| Invocation | Goal Type | What to Check |
-|------------|-----------|---------------|
-| `/oh-my-claudecode:ultraqa --tests` | tests | All test suites pass |
-| `/oh-my-claudecode:ultraqa --build` | build | Build succeeds with exit 0 |
-| `/oh-my-claudecode:ultraqa --lint` | lint | No lint errors |
-| `/oh-my-claudecode:ultraqa --typecheck` | typecheck | No TypeScript errors |
-| `/oh-my-claudecode:ultraqa --custom "pattern"` | custom | Custom success pattern in output |
+| Invocation                                     | Goal Type | What to Check                    |
+| ---------------------------------------------- | --------- | -------------------------------- |
+| `/oh-my-claudecode:ultraqa --tests`            | tests     | All test suites pass             |
+| `/oh-my-claudecode:ultraqa --build`            | build     | Build succeeds with exit 0       |
+| `/oh-my-claudecode:ultraqa --lint`             | lint      | No lint errors                   |
+| `/oh-my-claudecode:ultraqa --typecheck`        | typecheck | No TypeScript errors             |
+| `/oh-my-claudecode:ultraqa --custom "pattern"` | custom    | Custom success pattern in output |
 
 If no structured goal provided, interpret the argument as a custom goal.
 
@@ -52,6 +56,7 @@ If no structured goal provided, interpret the argument as a custom goal.
    - **NO** → Continue to step 3
 
 3. **ARCHITECT DIAGNOSIS**: Spawn architect to analyze failure
+
    ```
    Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="DIAGNOSE FAILURE:
    Goal: [goal type]
@@ -60,6 +65,7 @@ If no structured goal provided, interpret the argument as a custom goal.
    ```
 
 4. **FIX ISSUES**: Apply architect's recommendations
+
    ```
    Task(subagent_type="oh-my-claudecode:executor", model="sonnet", prompt="FIX:
    Issue: [architect diagnosis]
@@ -71,16 +77,17 @@ If no structured goal provided, interpret the argument as a custom goal.
 
 ## Exit Conditions
 
-| Condition | Action |
-|-----------|--------|
-| **Goal Met** | Exit with success: "ULTRAQA COMPLETE: Goal met after N cycles" |
-| **Cycle 5 Reached** | Exit with diagnosis: "ULTRAQA STOPPED: Max cycles. Diagnosis: ..." |
-| **Same Failure 3x** | Exit early: "ULTRAQA STOPPED: Same failure detected 3 times. Root cause: ..." |
-| **Environment Error** | Exit: "ULTRAQA ERROR: [tmux/port/dependency issue]" |
+| Condition             | Action                                                                        |
+| --------------------- | ----------------------------------------------------------------------------- |
+| **Goal Met**          | Exit with success: "ULTRAQA COMPLETE: Goal met after N cycles"                |
+| **Cycle 5 Reached**   | Exit with diagnosis: "ULTRAQA STOPPED: Max cycles. Diagnosis: ..."            |
+| **Same Failure 3x**   | Exit early: "ULTRAQA STOPPED: Same failure detected 3 times. Root cause: ..." |
+| **Environment Error** | Exit: "ULTRAQA ERROR: [tmux/port/dependency issue]"                           |
 
 ## Observability
 
 Output progress each cycle:
+
 ```
 [ULTRAQA Cycle 1/5] Running tests...
 [ULTRAQA Cycle 1/5] FAILED - 3 tests failing
@@ -94,6 +101,7 @@ Output progress each cycle:
 ## State Tracking
 
 Track state in `.omc/ultraqa-state.json`:
+
 ```json
 {
   "active": true,

--- a/src/__tests__/goal-docs-contract.test.ts
+++ b/src/__tests__/goal-docs-contract.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, "..", "..");
+
+const DOC_ROOTS = ["docs", "skills"] as const;
+
+function markdownFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      files.push(...markdownFiles(fullPath));
+    } else if (extname(entry.name) === ".md") {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function readMarkdownDocs(): Array<{ path: string; content: string }> {
+  return DOC_ROOTS.flatMap((root) => markdownFiles(join(REPO_ROOT, root))).map(
+    (file) => ({
+      path: relative(REPO_ROOT, file),
+      content: readFileSync(file, "utf-8"),
+    }),
+  );
+}
+
+function claudeGoalDocs() {
+  return readMarkdownDocs().filter(({ content }) =>
+    /Claude Code[\s\S]{0,80}\/goal|\/goal[\s\S]{0,80}Claude Code/i.test(
+      content,
+    ),
+  );
+}
+
+describe("Claude Code /goal docs contract", () => {
+  it("does not use OpenAI or Codex documentation as authority for Claude Code /goal facts", () => {
+    const violations = claudeGoalDocs().flatMap(({ path, content }) => {
+      const paragraphs = content.split(/\n\s*\n/);
+      return paragraphs
+        .map((paragraph, index) => ({ paragraph, index }))
+        .filter(({ paragraph }) =>
+          /Claude Code[\s\S]*\/goal|\/goal[\s\S]*Claude Code/i.test(paragraph),
+        )
+        .filter(({ paragraph }) =>
+          /OpenAI docs|OpenAI documentation|Codex docs|Codex documentation/i.test(
+            paragraph,
+          ),
+        )
+        .filter(
+          ({ paragraph }) =>
+            !/do not (?:cite|use) (?:OpenAI|Codex|OpenAI\/Codex)/i.test(
+              paragraph,
+            ),
+        )
+        .map(
+          ({ index, paragraph }) =>
+            `${path} paragraph ${index + 1}: ${paragraph.replace(/\s+/g, " ").trim()}`,
+        );
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps Claude Code /goal evaluator limitations explicit and evidence-based", () => {
+    const violations = claudeGoalDocs().flatMap(({ path, content }) => {
+      const forbiddenClaims = [
+        /evaluator\s+(?:can|will|does)\s+(?:independently\s+)?(?:run|execute)s?\s+commands/i,
+        /evaluator\s+(?:can|will|does)\s+(?:independently\s+)?read\s+files/i,
+        /evaluator\s+verifies\s+(?:hidden\s+)?filesystem\s+truth/i,
+      ];
+
+      return forbiddenClaims
+        .filter((pattern) => pattern.test(content))
+        .map(
+          (pattern) => `${path}: matched forbidden evaluator claim ${pattern}`,
+        );
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("forbids warn-only loop conflict policy in Claude Code /goal docs", () => {
+    const violations = claudeGoalDocs().flatMap(({ path, content }) => {
+      const issues: string[] = [];
+
+      if (/warn[- ]only|warn\s+and\s+proceed/i.test(content)) {
+        issues.push(`${path}: contains warn-only conflict handling`);
+      }
+
+      if (/conflict[_ -]policy|loop authority|active loop/i.test(content)) {
+        for (const requiredPolicy of [
+          "refuse",
+          "adopt_existing",
+          "artifact_only",
+        ]) {
+          if (!content.includes(requiredPolicy)) {
+            issues.push(`${path}: missing ${requiredPolicy} conflict policy`);
+          }
+        }
+      }
+
+      return issues;
+    });
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Scope
- Adds the user-facing goal workflow chooser across README/reference/shared guide.
- Updates plan/ralph/team/ultraqa skill guidance for one active loop authority.
- Adds docs-contract coverage for source authority, evaluator limitations, and deterministic conflict policies.

## Validation
- npm run test:run -- src/__tests__/goal-docs-contract.test.ts
- npx tsc --noEmit
- git diff --check

## Notes
- Keeps Claude Code /goal as a native handoff/evidence surface, not a replacement for OMC final review.