### PR TITLE
fix(pre-tool-enforcer): cover extra naming slop boundary

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -169,6 +169,9 @@ const SLOP_RISK_TOOL_NAMES = new Set([
   'Write',
   'NotebookEdit',
 ]);
+// Keep the SLOP trigger tied to actual fallback/workaround semantics.
+// Primary-path domain names and comments often use neutral qualifiers such as
+// "extra" or "additional"; those words alone must not enter this gate.
 const SLOP_FALLBACK_LANGUAGE_PATTERN = /\b(?:fallback|fall\s+back|workaround|work\s+around)\b/i;
 const SLOP_FALLBACK_ACTION_PATTERNS = [
   /\b(?:add|build|create|implement|introduce|make|patch|use|using|write)\s+(?:an?\s+|the\s+)?(?:fallback|workaround)\b/i,

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -742,6 +742,55 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
   });
 
+  it('does not warn for primary-path extra/additional naming from issue #3012', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Edit',
+      toolInput: {
+        file_path: join(tempDir, 'token.go'),
+        old_string: 'type tokenRequest struct {}',
+        new_string: [
+          'type extraSecretFetch struct {',
+          '\tpath string',
+          '}',
+          '',
+          'type tokenRequest struct {',
+          '\textraSecrets []extraSecretFetch',
+          '}',
+          '',
+          '// Fetch additional SM paths as part of the primary dual-secret design.',
+          'func fetchTokenSecrets(extraSecrets []extraSecretFetch) {}',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-extra-additional-primary-path',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
+  it('does not warn for Task prompts that describe extra/additional primary-path fields', () => {
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Implement primary dual-secret token fetch',
+        prompt: [
+          'Implement the primary dual-secret path using extraSecretFetch.',
+          'The request type should include extraSecrets []extraSecretFetch.',
+          'Comments may describe additional SM paths because both paths are intentional.',
+        ].join('\n'),
+      },
+      cwd: tempDir,
+      session_id: 'session-slop-task-extra-additional-primary-path',
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    expect(output.continue).toBe(true);
+    expect(String(hookSpecificOutput.additionalContext)).not.toContain('[SLOP WARNING]');
+  });
+
   it('still warns for real SLOP intent from issue #2939', () => {
     const slopPrompts = [
       'If the preferred agent is unavailable, fallback to weaker model to keep going.',


### PR DESCRIPTION
## Summary
- Add regression coverage that `extraSecretFetch`, `extraSecrets []extraSecretFetch`, and `additional SM paths` primary-path wording do not trigger the pre-tool-enforcer SLOP warning.
- Document the SLOP gate invariant so neutral domain qualifiers like `extra`/`additional` stay outside fallback/workaround semantics.
- Preserve existing positive coverage for genuine fallback/workaround SLOP intent.

Closes #3012

## Verification
- `npm run test:run -- src/__tests__/pre-tool-enforcer.test.ts` — 78 passed
- `npm run lint` — passed with existing warnings, 0 errors
- `npm run build` — passed
- `git diff --check` — passed
- Final cleanup/review gate: ai-slop-cleaner scoped pass found no masking fallback slop; code-review APPROVE; architect CLEAR

🤖 Generated with Codex
