### PR TITLE
Keep upgrade CI deterministic before npm publish

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -78,6 +78,37 @@ jobs:
       # Note: syncMarketplaceClone() is best-effort and skips gracefully when
       # the marketplace clone (~/.claude/plugins/marketplaces/omc/) doesn't exist,
       # so CI runners with a fresh home directory are handled correctly.
+      #
+      # dev can legitimately carry a package/release-notes version bump before
+      # that version is published to npm. In that window the old 4.9.3 updater
+      # still tries `npm install -g ...@latest`, which fails with ETARGET before
+      # any current update/reconcile code can run. Keep the real `omc update`
+      # path when the current package version exists on npm; otherwise install
+      # the just-built local package tarball and run the same post-update
+      # reconciliation command directly. This preserves deterministic coverage
+      # for OMC-owned install, reconcile, and SessionStart artifacts without
+      # requiring release publishing from CI.
+
+      - name: Build current package for deterministic fallback
+        run: npm run build
+
+      - name: Prepare local package tarball
+        run: |
+          set -euo pipefail
+          CURRENT_PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          TARBALL_NAME="$(npm pack --pack-destination "$RUNNER_TEMP" --silent)"
+          {
+            echo "OMC_UPGRADE_TEST_EXPECTED_VERSION=$CURRENT_PACKAGE_VERSION"
+            echo "OMC_UPGRADE_TEST_TARBALL=$RUNNER_TEMP/$TARBALL_NAME"
+          } >> "$GITHUB_ENV"
+
+          if npm view "oh-my-claude-sisyphus@$CURRENT_PACKAGE_VERSION" version >/dev/null 2>&1; then
+            echo "OMC_UPGRADE_TEST_USE_LOCAL_TARBALL=false" >> "$GITHUB_ENV"
+            echo "Package $CURRENT_PACKAGE_VERSION is published; testing the live omc update path."
+          else
+            echo "OMC_UPGRADE_TEST_USE_LOCAL_TARBALL=true" >> "$GITHUB_ENV"
+            echo "Package $CURRENT_PACKAGE_VERSION is not published; testing local tarball + update-reconcile."
+          fi
 
       - name: Run omc update
         id: omc-update
@@ -87,16 +118,25 @@ jobs:
         run: |
           set -o pipefail
 
-          # Capture exit code of omc update itself (PIPESTATUS[0])
-          # npm install may emit deprecation warnings to stderr — those are not
-          # omc errors. Filter those out and fail on everything else.
+          # Capture exit code of omc update itself (or the deterministic
+          # unpublished-version fallback). npm install may emit deprecation
+          # warnings to stderr — those are not omc errors. Filter those out and
+          # fail on everything else.
           set +e
-          omc update 1>"$RUNNER_TEMP/omc-update.stdout.log" 2>"$RUNNER_TEMP/omc-update.stderr.log"
+          if [ "$OMC_UPGRADE_TEST_USE_LOCAL_TARBALL" = "true" ]; then
+            {
+              echo "Using local package tarball because $OMC_UPGRADE_TEST_EXPECTED_VERSION is not published to npm."
+              npm install -g "$OMC_UPGRADE_TEST_TARBALL"
+              omc update-reconcile
+            } 1>"$RUNNER_TEMP/omc-update.stdout.log" 2>"$RUNNER_TEMP/omc-update.stderr.log"
+          else
+            omc update 1>"$RUNNER_TEMP/omc-update.stdout.log" 2>"$RUNNER_TEMP/omc-update.stderr.log"
+          fi
           UPDATE_EXIT=$?
           set -e
 
           # Check for non-npm stderr (omc warnings/errors/exceptions)
-          # Exclude npm deprecation warnings: "npm deprecated ..." or lines not starting with npm/
+          # Exclude npm deprecation warnings: "npm deprecated ...".
           # All other stderr lines (omc console.warn, error, exception, fail patterns) are failures.
           if grep -vE '^npm deprecated ' "$RUNNER_TEMP/omc-update.stderr.log" 2>/dev/null | grep -qiE '^(error|exception|fail|critical|warn|omc)'; then
             echo "FAIL: omc update produced stderr:"
@@ -115,11 +155,15 @@ jobs:
             exit 1
           fi
 
-          echo "PASS: omc update succeeded"
+          if [ "$OMC_UPGRADE_TEST_USE_LOCAL_TARBALL" = "true" ]; then
+            echo "PASS: local tarball install + update-reconcile succeeded"
+          else
+            echo "PASS: omc update succeeded"
+          fi
 
       # ── 5. Verify new omc version installed ──────────────────────────────────
 
-      - name: Verify omc version is latest after update
+      - name: Verify omc version after update
         run: |
           omc --version > "$RUNNER_TEMP/omc-post-update.version" 2>&1
           VERSION_EXIT=$?
@@ -138,6 +182,10 @@ jobs:
           fi
           if [ "$UPDATED_VERSION" = "4.9.3" ]; then
             echo "FAIL: omc version still 4.9.3 after update"
+            exit 1
+          fi
+          if [ "$OMC_UPGRADE_TEST_USE_LOCAL_TARBALL" = "true" ] && [ "$UPDATED_VERSION" != "$OMC_UPGRADE_TEST_EXPECTED_VERSION" ]; then
+            echo "FAIL: local tarball fallback installed $UPDATED_VERSION, expected $OMC_UPGRADE_TEST_EXPECTED_VERSION"
             exit 1
           fi
           echo "PASS: omc updated from 4.9.3 to $UPDATED_VERSION"


### PR DESCRIPTION
## Summary
- Keep Upgrade Test on the live `omc update` path whenever the current package version is available on npm.
- Add a deterministic fallback for the dev release-bump window: build/pack the checked-out package, install that tarball globally, and run `omc update-reconcile` directly.
- Verify fallback installs the expected package version before running existing SessionStart hook checks.

## Why
The failed dev run hit a release/npm timing gap: the old installed `omc@4.9.3` updater tried `npm install -g oh-my-claude-sisyphus@latest`, but the release/version bump pointed at a version that was not available from npm at that moment. Publishing is outside bot authority, so CI should not fail solely because dev has advanced before npm publication.

## Verification
- `npm ci`
- `npm run build`
- `npm test -- --run src/__tests__/auto-update.test.ts`
- Parsed `.github/workflows/upgrade-test.yml` with PyYAML
- Temp-prefix live upgrade smoke: install `oh-my-claude-sisyphus@4.9.3`, run `omc update`, verify `omc --version` is `4.14.0`, execute installed SessionStart hook
- Forced local-tarball fallback smoke: install `4.9.3`, install packed checkout tarball, run `omc update-reconcile`, verify version and SessionStart hook
- `git diff --check`

Note: `actionlint` was not installed locally, so GitHub Actions will provide workflow validation in CI.

*[repo owner's gaebal-gajae (clawdbot) 🦞]*
