### PR TITLE
fix(team): allow Claude worker notify when idle prompt is visible

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -29607,6 +29607,12 @@ function paneHasTrustPrompt(captured) {
   const hasChoices = tail.some((l) => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
   return hasQuestion && hasChoices;
 }
+
+function paneHasClaudeIdlePrompt(captured) {
+  return /Claude Code[\s\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\s\S]*[❯›>]/u.test(captured);
+}
+
 function paneHasClaudeStartupBanner(captured) {
   const lines = captured.split("\n").map((line) => line.replace(/\r/g, "").trim()).filter((line) => line.length > 0).slice(-20);
   const lastPromptIndex = lines.findLastIndex((line) => /^\s*[›>❯]\s*/u.test(line));
@@ -29650,7 +29656,7 @@ async function waitForPaneReady(paneId, opts = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const captured = await capturePaneAsync(paneId);
-    if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+    if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
       return true;
     }
     await sleep4(pollIntervalMs);
@@ -29695,7 +29701,11 @@ async function sendToWorker(_sessionName, paneId, message) {
       return false;
     }
     const initialCapture = await capturePaneAsync(paneId);
-    if (paneHasClaudeStartupBanner(initialCapture)) {
+    if (
+      paneHasClaudeStartupBanner(initialCapture) &&
+      !paneLooksReady(initialCapture) &&
+      !paneHasClaudeIdlePrompt(initialCapture)
+    ) {
       return false;
     }
     const paneBusy = paneHasActiveTask(initialCapture);

--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -605,6 +605,12 @@ function paneHasTrustPrompt(captured) {
   const hasChoices = tail.some((l) => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
   return hasQuestion && hasChoices;
 }
+
+function paneHasClaudeIdlePrompt(captured) {
+  return /Claude Code[\s\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\s\S]*[❯›>]/u.test(captured);
+}
+
 function paneHasClaudeStartupBanner(captured) {
   const lines = captured.split("\n").map((line) => line.replace(/\r/g, "").trim()).filter((line) => line.length > 0).slice(-20);
   const lastPromptIndex = lines.findLastIndex((line) => /^\s*[›>❯]\s*/u.test(line));
@@ -648,7 +654,7 @@ async function waitForPaneReady(paneId, opts = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const captured = await capturePaneAsync(paneId);
-    if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+    if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
       return true;
     }
     await sleep(pollIntervalMs);
@@ -693,7 +699,11 @@ async function sendToWorker(_sessionName, paneId, message) {
       return false;
     }
     const initialCapture = await capturePaneAsync(paneId);
-    if (paneHasClaudeStartupBanner(initialCapture)) {
+    if (
+      paneHasClaudeStartupBanner(initialCapture) &&
+      !paneLooksReady(initialCapture) &&
+      !paneHasClaudeIdlePrompt(initialCapture)
+    ) {
       return false;
     }
     const paneBusy = paneHasActiveTask(initialCapture);

--- a/bridge/team-mcp.cjs
+++ b/bridge/team-mcp.cjs
@@ -17905,6 +17905,12 @@ function paneHasTrustPrompt(captured) {
   const hasChoices = tail.some((l) => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
   return hasQuestion && hasChoices;
 }
+
+function paneHasClaudeIdlePrompt(captured) {
+  return /Claude Code[\s\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\s\S]*[❯›>]/u.test(captured);
+}
+
 function paneHasClaudeStartupBanner(captured) {
   const lines = captured.split("\n").map((line) => line.replace(/\r/g, "").trim()).filter((line) => line.length > 0).slice(-20);
   const lastPromptIndex = lines.findLastIndex((line) => /^\s*[›>❯]\s*/u.test(line));
@@ -17976,7 +17982,11 @@ async function sendToWorker(_sessionName, paneId, message) {
       return false;
     }
     const initialCapture = await capturePaneAsync(paneId);
-    if (paneHasClaudeStartupBanner(initialCapture)) {
+    if (
+      paneHasClaudeStartupBanner(initialCapture) &&
+      !paneLooksReady(initialCapture) &&
+      !paneHasClaudeIdlePrompt(initialCapture)
+    ) {
       return false;
     }
     const paneBusy = paneHasActiveTask(initialCapture);

--- a/bridge/team.js
+++ b/bridge/team.js
@@ -2211,6 +2211,12 @@ function paneHasTrustPrompt(captured) {
   const hasChoices = tail.some((l) => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
   return hasQuestion && hasChoices;
 }
+
+function paneHasClaudeIdlePrompt(captured) {
+  return /Claude Code[\s\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\s\S]*[❯›>]/u.test(captured);
+}
+
 function paneHasClaudeStartupBanner(captured) {
   const lines = captured.split("\n").map((line) => line.replace(/\r/g, "").trim()).filter((line) => line.length > 0).slice(-20);
   const lastPromptIndex = lines.findLastIndex((line) => /^\s*[›>❯]\s*/u.test(line));
@@ -2254,7 +2260,7 @@ async function waitForPaneReady(paneId, opts = {}) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const captured = await capturePaneAsync(paneId);
-    if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+    if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
       return true;
     }
     await sleep(pollIntervalMs);
@@ -2299,7 +2305,11 @@ async function sendToWorker(_sessionName, paneId, message) {
       return false;
     }
     const initialCapture = await capturePaneAsync(paneId);
-    if (paneHasClaudeStartupBanner(initialCapture)) {
+    if (
+      paneHasClaudeStartupBanner(initialCapture) &&
+      !paneLooksReady(initialCapture) &&
+      !paneHasClaudeIdlePrompt(initialCapture)
+    ) {
       return false;
     }
     const paneBusy = paneHasActiveTask(initialCapture);

--- a/dist/team/tmux-session.js
+++ b/dist/team/tmux-session.js
@@ -547,6 +547,12 @@ function paneHasTrustPrompt(captured) {
     const hasChoices = tail.some(l => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
     return hasQuestion && hasChoices;
 }
+
+function paneHasClaudeIdlePrompt(captured) {
+  return /Claude Code[\s\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\s\S]*[❯›>]/u.test(captured);
+}
+
 function paneHasClaudeStartupBanner(captured) {
     const lines = captured
         .split('\n')
@@ -613,7 +619,7 @@ export async function waitForPaneReady(paneId, opts = {}) {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
         const captured = await capturePaneAsync(paneId);
-        if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+        if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
             return true;
         }
         await sleep(pollIntervalMs);
@@ -675,7 +681,9 @@ export async function sendToWorker(_sessionName, paneId, message) {
         }
         // Check for trust prompt and auto-dismiss before sending our text
         const initialCapture = await capturePaneAsync(paneId);
-        if (paneHasClaudeStartupBanner(initialCapture)) {
+        if (paneHasClaudeStartupBanner(initialCapture) &&
+            !paneLooksReady(initialCapture) &&
+            !paneHasClaudeIdlePrompt(initialCapture)) {
             return false;
         }
         const paneBusy = paneHasActiveTask(initialCapture);

--- a/patch_omc_claude_worker.py
+++ b/patch_omc_claude_worker.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Patch OMC Claude worker startup/notification handling.
+
+Run this from the root of your forked oh-my-claudecode repository:
+
+    cd ~/contrib/oh-my-claudecode
+    python3 patch_omc_claude_worker.py --source-only
+
+For local smoke testing against generated/bundled files as well:
+
+    python3 patch_omc_claude_worker.py --with-bundles
+
+What it changes:
+1. Adds a Claude idle prompt detector.
+2. Allows readiness when Claude Code is showing an idle prompt.
+3. Prevents sendToWorker() from rejecting Claude startup banner when the idle prompt is visible.
+
+It intentionally does NOT blindly remove startup-banner protection. It only relaxes it
+when Claude Code already appears interactive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import time
+from pathlib import Path
+
+
+SOURCE_TARGETS = [
+    Path("src/team/tmux-session.ts"),
+]
+
+BUNDLE_TARGETS = [
+    Path("bridge/cli.cjs"),
+    Path("bridge/team.js"),
+    Path("bridge/runtime-cli.cjs"),
+    Path("bridge/team-mcp.cjs"),
+    Path("dist/team/tmux-session.js"),
+    Path("dist/team/tmux-comm.js"),
+]
+
+HELPER_TS = """
+function paneHasClaudeIdlePrompt(captured: string): boolean {
+  return /Claude Code[\\s\\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\\s\\S]*[❯›>]/u.test(captured);
+}
+"""
+
+HELPER_JS = """
+function paneHasClaudeIdlePrompt(captured) {
+  return /Claude Code[\\s\\S]*[❯›>]/u.test(captured) ||
+    /Welcome back[\\s\\S]*[❯›>]/u.test(captured);
+}
+"""
+
+
+def backup(path: Path) -> Path:
+    backup_path = path.with_suffix(path.suffix + f".bak.claude-worker.{int(time.time())}")
+    shutil.copy2(path, backup_path)
+    return backup_path
+
+
+def ensure_helper(text: str, helper: str) -> tuple[str, bool]:
+    if "function paneHasClaudeIdlePrompt" in text:
+        return text, False
+
+    anchor = "function paneHasClaudeStartupBanner"
+    idx = text.find(anchor)
+    if idx == -1:
+        return text, False
+
+    return text[:idx] + helper + "\n" + text[idx:], True
+
+
+def patch_ready_loop(text: str) -> tuple[str, bool]:
+    changed = False
+
+    old_variants = [
+        """    const captured = await capturePaneAsync(paneId);
+    if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+      return true;
+    }
+""",
+        """        const captured = await capturePaneAsync(paneId);
+        if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+            return true;
+        }
+""",
+    ]
+
+    new_variants = [
+        """    const captured = await capturePaneAsync(paneId);
+    if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
+      return true;
+    }
+""",
+        """        const captured = await capturePaneAsync(paneId);
+        if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
+            return true;
+        }
+""",
+    ]
+
+    for old, new in zip(old_variants, new_variants):
+        if old in text and new not in text:
+            text = text.replace(old, new)
+            changed = True
+
+    return text, changed
+
+
+def patch_startup_banner_guard(text: str) -> tuple[str, bool]:
+    changed = False
+
+    old_variants = [
+        """    if (paneHasClaudeStartupBanner(initialCapture)) {
+      return false;
+    }
+""",
+        """    if (paneHasClaudeStartupBanner(initialCapture) && !paneLooksReady(initialCapture)) {
+      return false;
+    }
+""",
+        """        if (paneHasClaudeStartupBanner(initialCapture)) {
+            return false;
+        }
+""",
+        """        if (paneHasClaudeStartupBanner(initialCapture) && !paneLooksReady(initialCapture)) {
+            return false;
+        }
+""",
+    ]
+
+    new_variants = [
+        """    if (
+      paneHasClaudeStartupBanner(initialCapture) &&
+      !paneLooksReady(initialCapture) &&
+      !paneHasClaudeIdlePrompt(initialCapture)
+    ) {
+      return false;
+    }
+""",
+        """    if (
+      paneHasClaudeStartupBanner(initialCapture) &&
+      !paneLooksReady(initialCapture) &&
+      !paneHasClaudeIdlePrompt(initialCapture)
+    ) {
+      return false;
+    }
+""",
+        """        if (paneHasClaudeStartupBanner(initialCapture) &&
+            !paneLooksReady(initialCapture) &&
+            !paneHasClaudeIdlePrompt(initialCapture)) {
+            return false;
+        }
+""",
+        """        if (paneHasClaudeStartupBanner(initialCapture) &&
+            !paneLooksReady(initialCapture) &&
+            !paneHasClaudeIdlePrompt(initialCapture)) {
+            return false;
+        }
+""",
+    ]
+
+    for old, new in zip(old_variants, new_variants):
+        if old in text and new not in text:
+            text = text.replace(old, new)
+            changed = True
+
+    return text, changed
+
+
+def patch_file(path: Path) -> bool:
+    if not path.exists():
+        print(f"SKIP missing: {path}")
+        return False
+
+    text = path.read_text(encoding="utf-8")
+
+    is_ts = path.suffix == ".ts"
+    helper = HELPER_TS if is_ts else HELPER_JS
+
+    original = text
+    text, helper_changed = ensure_helper(text, helper)
+    text, ready_changed = patch_ready_loop(text)
+    text, guard_changed = patch_startup_banner_guard(text)
+
+    if text == original:
+        print(f"NO CHANGE: {path}")
+        return False
+
+    backup_path = backup(path)
+    path.write_text(text, encoding="utf-8")
+    print(f"PATCHED: {path}")
+    print(f"BACKUP:  {backup_path}")
+    print(f"  helper={helper_changed} ready_loop={ready_changed} startup_guard={guard_changed}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--with-bundles",
+        action="store_true",
+        help="Also patch generated bridge/dist files for local smoke testing.",
+    )
+    parser.add_argument(
+        "--source-only",
+        action="store_true",
+        help="Patch only source files. Recommended for PR preparation.",
+    )
+    args = parser.parse_args()
+
+    if args.source_only and args.with_bundles:
+        print("Choose only one of --source-only or --with-bundles", file=sys.stderr)
+        return 2
+
+    repo_root = Path.cwd()
+    if not (repo_root / "package.json").exists():
+        print("Run this script from the oh-my-claudecode repository root.", file=sys.stderr)
+        return 2
+
+    targets = list(SOURCE_TARGETS)
+    if args.with_bundles:
+        targets.extend(BUNDLE_TARGETS)
+
+    changed_any = False
+    for target in targets:
+        changed_any = patch_file(repo_root / target) or changed_any
+
+    print()
+    if changed_any:
+        print("Patch complete.")
+        print("Suggested next steps:")
+        print("  git diff -- src/team/tmux-session.ts")
+        print("  npm test -- --runInBand src/team/__tests__/tmux-session.test.ts  # if supported")
+        print("  npm run build  # if the repo requires generated bridge/dist updates")
+    else:
+        print("No files changed. The patch may already be applied or patterns did not match.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/team/tmux-session.ts.bak.claude-worker.1778877174
+++ b/src/team/tmux-session.ts.bak.claude-worker.1778877174
@@ -650,12 +650,6 @@ function paneHasTrustPrompt(captured: string): boolean {
   return hasQuestion && hasChoices;
 }
 
-
-function paneHasClaudeIdlePrompt(captured: string): boolean {
-  return /Claude Code[\s\S]*[❯›>]/u.test(captured) ||
-    /Welcome back[\s\S]*[❯›>]/u.test(captured);
-}
-
 function paneHasClaudeStartupBanner(captured: string): boolean {
   const lines = captured
     .split('\n')
@@ -731,7 +725,7 @@ export async function waitForPaneReady(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const captured = await capturePaneAsync(paneId);
-    if ((paneLooksReady(captured) || paneHasClaudeIdlePrompt(captured)) && !paneHasActiveTask(captured)) {
+    if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
       return true;
     }
     await sleep(pollIntervalMs);
@@ -805,11 +799,7 @@ export async function sendToWorker(
 
     // Check for trust prompt and auto-dismiss before sending our text
     const initialCapture = await capturePaneAsync(paneId);
-    if (
-      paneHasClaudeStartupBanner(initialCapture) &&
-      !paneLooksReady(initialCapture) &&
-      !paneHasClaudeIdlePrompt(initialCapture)
-    ) {
+    if (paneHasClaudeStartupBanner(initialCapture)) {
       return false;
     }
     const paneBusy = paneHasActiveTask(initialCapture);


### PR DESCRIPTION
This PR fixes a Claude worker startup/notification issue in `omc team 1:claude`.

In some Claude Code sessions, the tmux pane still contains the Claude startup banner while the idle prompt (`❯`) is already visible. In that state, the current `sendToWorker()` path treats the startup banner as a blocker and refuses to notify the worker, leaving the task stuck in `pending`.

This change allows worker notification to continue when Claude Code is already showing an idle prompt.

## Problem

Before this patch, `omc team 1:claude ...` could fail with:

```text
startup_manual_intervention_required:worker-1:worker_notify_failed