### PR TITLE
feat(omc-doctor): add plugin enabled/disabled status check

### DIFF
--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -74,7 +74,18 @@ grep -o "CLAUDE-[^ )]*\.md" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/d
 - If `OMC:VERSION` marker is missing from deterministic CLAUDE source scan (base + referenced companion): WARN - cannot verify CLAUDE.md freshness
 - If `CLAUDE.md OMC version` != `Latest cached plugin version`: WARN - version drift detected (run `omc update` or `omc setup`)
 
-### Step 5: Check Ralph Ruby Dependency
+### Step 5: Check Plugin Enable Status
+
+```bash
+claude plugin list 2>&1
+```
+
+**Diagnosis**:
+- If all OMC plugin entries show `Status: ✔ enabled`: OK
+- If any OMC plugin entry shows `Status: ✘ disabled`: CRITICAL — plugin is disabled, skills and commands will not load
+- If `claude plugin list` command fails: WARN — cannot verify plugin status
+
+### Step 6: Check Ralph Ruby Dependency
 
 Ralph workflows require Ruby. Check for Ruby explicitly so fresh installations get actionable guidance instead of a later opaque Ralph failure.
 
@@ -92,7 +103,7 @@ fi
 - If Ruby is found: OK - Ralph dependency present
 - If Ruby is missing: WARN - Ralph workflows may fail until Ruby is installed
 
-### Step 6: Check for Stale Plugin Cache
+### Step 7: Check for Stale Plugin Cache
 
 ```bash
 # Count versions in cache (cross-platform)
@@ -102,7 +113,7 @@ node -e "const p=require('path'),f=require('fs'),h=require('os').homedir(),d=pro
 **Diagnosis**:
 - If > 1 version: WARN - multiple cached versions (cleanup recommended)
 
-### Step 7: Check for Legacy Curl-Installed Content
+### Step 8: Check for Legacy Curl-Installed Content
 
 Check for legacy agents, commands, and skills installed via curl (before plugin system).
 **Important**: Only flag files whose names match actual plugin-provided names. Do NOT flag user's custom agents/commands/skills that are unrelated to OMC.
@@ -150,6 +161,7 @@ After running all checks, output a report:
 | Check | Status | Details |
 |-------|--------|---------|
 | Plugin Version | OK/WARN/CRITICAL | ... |
+| Plugin Status | OK/CRITICAL | ... |
 | Legacy Hooks (settings.json) | OK/CRITICAL | ... |
 | Legacy Scripts (~/.claude/hooks/) | OK/WARN | ... |
 | CLAUDE.md | OK/WARN/CRITICAL | ... |
@@ -177,6 +189,11 @@ If yes, apply fixes:
 
 ### Fix: Legacy Hooks in settings.json
 Remove the `"hooks"` section from `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json` (keep other settings intact)
+
+### Fix: Disabled Plugin
+```bash
+claude plugin enable oh-my-claudecode@omc
+```
 
 ### Fix: Legacy Bash Scripts
 ```bash


### PR DESCRIPTION
## Summary

omc-doctor currently checks file-level installation (plugin version, hooks, CLAUDE.md, cache, legacy content) but **does not check the runtime plugin state** in Claude Code. When the plugin is disabled via `claude plugin disable`, all skills and commands stop loading, but doctor still reports everything as OK.

This PR adds a new diagnostic step to detect this scenario and provide an auto-fix.

## Problem

Users have reported that `/oh-my-claudecode:remember` and other skills stop working even though `omc-doctor` shows all checks passing. Root cause: the plugin was disabled in Claude Code's plugin system, but omc-doctor has no check for this.

## Changes

**File modified:** `skills/omc-doctor/SKILL.md`

| Change | Detail |
|--------|--------|
| New Step 5 | Check Plugin Enable Status — runs `claude plugin list` and checks for `Status: ✘ disabled` |
| Renumbered | Old Steps 5-7 → Steps 6-8 |
| Report table | Added `Plugin Status` row (OK/CRITICAL) |
| Auto-Fix | Added "Fix: Disabled Plugin" — runs `claude plugin enable oh-my-claudecode@omc` |

## Diagnosis logic

- `Status: ✔ enabled` → OK
- `Status: ✘ disabled` → **CRITICAL** — plugin is disabled, skills and commands will not load
- `claude plugin list` fails → WARN — cannot verify plugin status

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format` passes
- [x] Steps numbered 1-8 continuously
- [x] Report table has 10 rows
- [x] Auto-fix section has 7 fix routines

🤖 Generated with [Claude Code](https://claude.ai/code)