### PR TITLE
feat(omc-doctor): detect SKININTHEGAMEBROS skill access restrictions

### DIFF
--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -133,6 +133,18 @@ ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills/ 2>/dev/null
 **Known plugin command names** (check commands/ for these):
 `ultrawork.md`, `deepsearch.md`
 
+### Step 8: Check Skill Access Restrictions
+
+OMC restricts certain skills (`remember`, `verify`, `debug`) to specific user types. If `USER_TYPE` is not set to `"ant"`, these skills will be silently excluded from the skill registry — they exist on disk but will never load.
+
+```bash
+echo "USER_TYPE=${USER_TYPE:-(not set)}"
+```
+
+**Diagnosis**:
+- If `USER_TYPE=ant`: OK — all skills are accessible
+- If `USER_TYPE` is set to any other value or not set: WARN — skills `remember`, `verify`, `debug` are restricted and will not be available. This is expected for standard users; these skills are gated behind a user-type check in the skill loader.
+
 ---
 
 ## Report Format
@@ -158,6 +170,7 @@ After running all checks, output a report:
 | Legacy Agents (~/.claude/agents/) | OK/WARN | ... |
 | Legacy Commands (~/.claude/commands/) | OK/WARN | ... |
 | Legacy Skills (~/.claude/skills/) | OK/WARN | ... |
+| Skill Access Restrictions | OK/WARN | ... |
 
 ### Issues Found
 1. [Issue description]
@@ -221,6 +234,18 @@ rm -rf "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills
 ```
 
 **Note**: Only remove if these contain oh-my-claudecode-related files. If user has custom agents/commands/skills, warn them and ask before removing.
+
+### Fix: Skill Access Restrictions
+
+If `USER_TYPE` is not set to `"ant"`, the skills `remember`, `verify`, and `debug` are restricted. This is by design for standard users. No action is needed unless you have been granted access to these skills.
+
+If you have been granted access, set the environment variable:
+
+```bash
+export USER_TYPE=ant
+```
+
+To make this permanent, add it to your shell profile (`~/.zshrc` or `~/.bashrc`).
 
 ---
 


### PR DESCRIPTION
## Summary

OMC silently restricts `remember`, `verify`, and `debug` skills to users with `USER_TYPE=ant`. When this env var is not set (the default), these skills are excluded from the skill registry without any warning. Users see "No commands match" with no explanation of why.

This PR adds a diagnostic check to surface this restriction in omc-doctor output.

## Problem

Users report "No commands match `/remember`" even when the plugin is enabled and command files exist on disk. Root cause: `SKININTHEGAMEBROS_ONLY_SKILLS` in `src/features/builtin-skills/skills.ts` (line 72) silently skips loading `remember`, `verify`, and `debug` unless `USER_TYPE=ant`.

This is invisible to users — omc-doctor shows all green, but the skills simply don't load.

## Changes

**File modified:** `skills/omc-doctor/SKILL.md`

| Change | Detail |
|--------|--------|
| New Step 8 | Check Skill Access Restrictions — reads `USER_TYPE` env var |
| Report table | Added `Skill Access Restrictions` row (OK/WARN) |
| Auto-Fix | Added guidance: set `export USER_TYPE=ant` if granted access |

## Diagnosis logic

- `USER_TYPE=ant` → OK — all skills accessible
- `USER_TYPE` not set or other value → WARN — `remember`, `verify`, `debug` are restricted (expected for standard users)

## Context

From `src/features/builtin-skills/skills.ts`:
```typescript
const SKININTHEGAMEBROS_ONLY_SKILLS = new Set(['remember', 'verify', 'debug']);

// In loadSkillsFromDirectory():
if (SKININTHEGAMEBROS_ONLY_SKILLS.has(entry.name) && !isSkininthegamebrosUser()) {
  continue; // silently skip
}
```

From `src/utils/skininthegamebros-user.ts`:
```typescript
export function isSkininthegamebrosUser(): boolean {
  return process.env.USER_TYPE === "ant";
}
```

## Test plan

- [x] Steps numbered 1-8 continuously
- [x] Report table has 10 rows
- [x] Auto-fix section has 8 fix routines

🤖 Generated with [Claude Code](https://claude.ai/code)