### PR TITLE
docs: document Ultragoal workflow selection

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -12,7 +12,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated)
 - [Agents (29 Total)](#agents-29-total)
-- [Skills (38 Total)](#skills-38-total)
+- [Skills (39 Total)](#skills-39-total)
 - [Slash Commands](#slash-commands)
 - [Hooks System](#hooks-system)
 - [Magic Keywords](#magic-keywords)
@@ -522,7 +522,7 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ---
 
-## Skills (38 Total)
+## Skills (39 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
@@ -561,6 +561,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `skill`                   | Manage local skills (list/add/remove/search/edit)                | `/oh-my-claudecode:skill`                   |
 | `team`                    | Coordinated multi-agent workflow                                 | `/oh-my-claudecode:team`                    |
 | `trace`                   | Evidence-driven tracing lane with parallel tracer hypotheses     | `/oh-my-claudecode:trace`                   |
+| `ultragoal`               | Durable multi-goal workflow with Claude `/goal` handoff and quality gate | `/oh-my-claudecode:ultragoal`       |
 | `ultraqa`                 | QA cycle until goal is met                                       | `/oh-my-claudecode:ultraqa`                 |
 | `ultrawork`               | Maximum parallel throughput mode                                 | `/oh-my-claudecode:ultrawork`               |
 | `visual-verdict`          | Structured visual QA verdict for screenshot/reference comparisons | `/oh-my-claudecode:visual-verdict`          |
@@ -597,6 +598,7 @@ Each installed skill is exposed as `/oh-my-claudecode:<skill-name>`. The skills 
 | `/oh-my-claudecode:sciomc <topic>`              | Parallel research orchestration                                                            |
 | `/oh-my-claudecode:team <N>:<agent> <task>`     | Coordinated native team workflow                                                           |
 | `/oh-my-claudecode:trace`                       | Evidence-driven tracing lane that orchestrates parallel tracer hypotheses in team mode     |
+| `/oh-my-claudecode:ultragoal <brief>`           | Durable multi-goal workflow with Claude `/goal` handoff                                    |
 | `/oh-my-claudecode:ultraqa <goal>`              | Autonomous QA cycling workflow                                                             |
 | `/oh-my-claudecode:ultrawork <task>`            | Maximum performance mode with parallel agents                                              |
 | `/oh-my-claudecode:visual-verdict <task>`       | Structured visual QA verdict for screenshot/reference comparisons                          |

--- a/docs/shared/mode-selection-guide.md
+++ b/docs/shared/mode-selection-guide.md
@@ -7,6 +7,7 @@
 | Clarify vague requirements first | `deep-interview` | "deep interview", "ouroboros", "don't assume" |
 | Full autonomous build from idea | `autopilot` | "autopilot", "build me", "I want a" |
 | Parallel autonomous (3-5x faster) | `team` (replaces `ultrapilot`) | `/team N:executor "task"` |
+| Durable multi-goal with `/goal` handoff | `ultragoal` | `omc ultragoal create-goals` |
 | Persistence until verified done | `ralph` | "ralph", "don't stop" |
 | Parallel execution, manual oversight | `ultrawork` | "ulw", "ultrawork" |
 | Cost-efficient execution | `` (modifier) | "eco", "budget" |
@@ -25,6 +26,12 @@
 ```
 Uncertain about requirements or have a vague idea?
 ├── YES: Use deep-interview to clarify before execution
+└── NO: Continue below
+
+Work spans multiple sessions or needs a durable ledger?
+├── YES: Many ordered stories with a quality gate?
+│   ├── YES: omc ultragoal (durable ledger + /goal handoff)
+│   └── NO: ralph (persistence + verification)
 └── NO: Continue below
 
 Want autonomous execution?
@@ -50,6 +57,7 @@ Have many similar independent tasks (e.g., "fix 47 errors")?
 | "Build me a REST API" | autopilot | Single coherent deliverable |
 | "Build frontend, backend, and database" | team 3:executor | Clear component boundaries |
 | "Fix all 47 TypeScript errors" | team 5:executor | Many independent similar tasks |
+| "Track 5 stories across sessions with final review gate" | ultragoal | Durable ledger + `/goal` coordination |
 | "Refactor auth module thoroughly" | ralph | Need persistence + verification |
 | "Quick parallel execution" | ultrawork | Manual oversight preferred |
 | "Save tokens while fixing errors" |  + ultrawork | Cost-conscious parallel |
@@ -61,6 +69,7 @@ Have many similar independent tasks (e.g., "fix 47 errors")?
 These run independently:
 - **autopilot**: Autonomous end-to-end execution
 - **team**: Canonical orchestration with coordinated agents (replaces `ultrapilot` and `swarm`)
+- **ultragoal**: Durable multi-goal workflow with Claude `/goal` handoff and quality gate
 
 > **Deprecated:** `ultrapilot` and `swarm` now route to `team` mode.
 

--- a/docs/ultragoal.md
+++ b/docs/ultragoal.md
@@ -104,3 +104,77 @@ story, and keeps the Claude `/goal` active.
 - If a future Claude tool name changes (`/goal` → something else), the
   handoff text and snapshot field names will need to be updated; the
   reconciliation logic itself is name-agnostic.
+
+## When to Use Ultragoal vs Other Workflows
+
+| Workflow | Scope | Persistence | Parallelism | Verification Gate | `/goal` Integration | Best For |
+|----------|-------|-------------|-------------|-------------------|---------------------|----------|
+| Claude `/goal` (bare) | Single session | None (session-scoped Stop hook) | No | No | Native | Quick single-session focus |
+| `ralph` | Single task | Yes (`prd.json` + `progress.txt`) | Via `ultrawork` | Mandatory architect review | No | Guaranteed completion with verification |
+| `team` | Multi-agent pipeline | Yes (staged state) | N coordinated agents | Per-stage verify/fix loop | No | Multi-component or many-task work |
+| `ultraqa` | QA cycling | State file only | Diagnosis + fix | Cycle until pass | No | "Make tests/build/lint pass" |
+| Stop hook (`code-simplifier`) | Per-turn trigger | None | No | Automatic | No | Background code hygiene |
+| `omc ultragoal` (artifact-only) | Multi-goal brief | Yes (ledger + `goals.json`) | No | Mandatory quality gate (slop + verify + review) | Handoff text only | Large initiatives spanning sessions |
+
+> The `/goal` evaluator is a session-scoped, model-facing directive. It
+> cannot independently inspect files, run commands, or observe external state.
+> `omc ultragoal` prints handoff text that the active Claude agent reads and
+> acts on; it does not, and cannot, invoke `/goal` from the shell.
+
+## Examples
+
+### Issue backlog
+
+```bash
+omc ultragoal create-goals --brief "Close issues #101-#105" \
+  --goal "Issue #101::Fix the reported regression and add evidence" \
+  --goal "Issue #102::Implement the requested docs update"
+omc ultragoal complete-goals
+```
+
+Use `ultragoal` instead of `ralph` when the issue set needs a durable ledger
+and final quality gate across multiple sessions.
+
+### Database migration
+
+```bash
+omc ultragoal create-goals --brief "Ship the migration" \
+  --goal "Schema::Add new columns" \
+  --goal "Backfill::Backfill rows in batches" \
+  --goal "Cutover::Drop old columns and switch reads"
+omc ultragoal status
+```
+
+Use `ultragoal` instead of `team` when the migration is ordered and stateful
+rather than parallel across independent files.
+
+### Test cleanup
+
+```bash
+omc ultragoal create-goals --brief "Fix flaky tests" \
+  --goal "Isolate::Identify the flaky test sources" \
+  --goal "Fix::Stabilize the tests and document evidence" \
+  --goal "CI::Rerun the narrow CI-equivalent command"
+omc ultragoal complete-goals --retry-failed
+```
+
+Use `ultragoal` instead of `ultraqa` when the cleanup spans several explicit
+stories and needs an auditable final review gate.
+
+### PRD implementation
+
+```bash
+omc ultragoal create-goals --brief-file prd.md --claude-goal-mode per-story
+omc ultragoal complete-goals
+```
+
+Use per-story `ultragoal` when a PRD should survive session restarts and each
+story should reconcile against its own Claude `/goal` handoff.
+
+## Related Documentation
+
+- [Artifact layout](./ultragoal.md#artifacts)
+- [Claude `/goal` snapshot reconciliation](./ultragoal.md#claude-goal-snapshots)
+- [Source boundary and evaluator limits](./ultragoal.md#limitations)
+- [Workflow selection](./shared/mode-selection-guide.md)
+- [Full skill instructions](../skills/ultragoal/SKILL.md)

--- a/src/__tests__/tier0-docs-consistency.test.ts
+++ b/src/__tests__/tier0-docs-consistency.test.ts
@@ -31,6 +31,29 @@ describe('Tier-0 contract docs consistency', () => {
     }
   });
 
+  it('keeps ultragoal source-boundary language in docs and skill', () => {
+    const ultragoalDoc = readProjectFile('docs', 'ultragoal.md');
+    const ultragoalSkill = readProjectFile('skills', 'ultragoal', 'SKILL.md');
+
+    expect(ultragoalDoc).toContain('cannot directly invoke');
+    expect(ultragoalSkill).toContain('cannot invoke or mutate Claude Code `/goal` state');
+    expect(ultragoalDoc).toContain('handoff text');
+    expect(ultragoalSkill).toContain('handoff text');
+  });
+
+  it('keeps ultragoal evaluator-limit language in docs and skill', () => {
+    const ultragoalDoc = readProjectFile('docs', 'ultragoal.md');
+    const ultragoalSkill = readProjectFile('skills', 'ultragoal', 'SKILL.md');
+
+    expect(ultragoalDoc).toContain('cannot independently');
+    expect(ultragoalSkill).toContain('cannot independently observe Claude `/goal` state');
+  });
+
+  it('documents ultragoal in REFERENCE.md skills and slash commands', () => {
+    expect(referenceDoc).toContain('| `ultragoal`');
+    expect(referenceDoc).toContain('/oh-my-claudecode:ultragoal');
+  });
+
   it('documents all Tier-0 keywords in CLAUDE.md', () => {
     for (const keyword of ['autopilot', 'ultrawork', 'ralph', 'team', 'ralplan']) {
       expect(claudeDoc).toContain(`\`${keyword}\``);


### PR DESCRIPTION
## Summary

Fixes #3008.

Adds Claude Code user guidance for choosing between `/goal`, Ralph, Team, UltraQA, Stop hook, and artifact-only Ultragoal. The docs include workflow-selection guidance, concrete examples, and explicit evaluator-limit/source-boundary language for `/goal`.

## Changes

- Added guidance for goal-oriented Claude Code workflow selection
- Documented when to use `/goal`, Ralph, Team, UltraQA, Stop hook, and artifact-only Ultragoal
- Added examples for issue backlog, migration, test cleanup, and PRD implementation
- Linked related Ultragoal adapter/storage/porting docs where relevant
- Added/updated docs-consistency coverage so evaluator-limit language does not regress

## Verification

- `npm test` — broad suite entered watch mode and reported 9 failed files / 12 failed tests
- `npx vitest run src/__tests__/tier0-docs-consistency.test.ts` — passed, 16 tests

## Notes

This PR is docs-focused and does not change runtime behavior. I did not run `npm audit fix` or modify dependency files because dependency updates are outside the scope of this issue.