### PR TITLE
fix: preserve AskUserQuestion mobile reply round-trip

### DIFF
--- a/src/hooks/__tests__/askuserquestion-lifecycle.test.ts
+++ b/src/hooks/__tests__/askuserquestion-lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   processHook,
   resetSkipHooksCache,
   dispatchAskUserQuestionNotification,
+  extractAskUserQuestionPrompts,
   _notify,
   type HookInput,
 } from "../bridge.js";
@@ -54,6 +55,24 @@ describe("AskUserQuestion notification lifecycle (issue #597)", () => {
     },
     directory: "/tmp/test-issue-597",
   };
+
+  it("extractAskUserQuestionPrompts preserves option labels/descriptions for notifications", () => {
+    const prompts = extractAskUserQuestionPrompts(askUserInput.toolInput);
+
+    expect(prompts).toEqual([
+      {
+        question: "Which database should we use?",
+        header: "Database",
+        options: [
+          { label: "PostgreSQL", description: "Relational DB" },
+          { label: "MongoDB", description: "Document DB" },
+        ],
+        allowOther: true,
+        otherLabel: "Other",
+        multiSelect: false,
+      },
+    ]);
+  });
 
   // ---- PreToolUse: notification MUST fire ----
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -2168,6 +2168,70 @@ The CLAUDE.md instruction "Pass model on Task calls: haiku, sonnet, opus" applie
   return { continue: true };
 }
 
+type AskUserQuestionToolOption = {
+  label?: unknown;
+  value?: unknown;
+  description?: unknown;
+};
+
+type AskUserQuestionToolPrompt = {
+  question?: unknown;
+  header?: unknown;
+  options?: AskUserQuestionToolOption[];
+  allow_other?: unknown;
+  allowOther?: unknown;
+  other_label?: unknown;
+  otherLabel?: unknown;
+  multiSelect?: unknown;
+  multi_select?: unknown;
+};
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function extractAskUserQuestionPrompts(toolInput: unknown) {
+  const input = toolInput as { questions?: AskUserQuestionToolPrompt[] } | undefined;
+  const questions = Array.isArray(input?.questions) ? input.questions : [];
+
+  return questions
+    .map((question) => {
+      const questionText = stringOrUndefined(question.question);
+      if (!questionText) return null;
+
+      const rawOptions = Array.isArray(question.options) ? question.options : [];
+      const options = rawOptions
+        .map((option) => {
+          const label = stringOrUndefined(option.label);
+          if (!label) return null;
+          const value = stringOrUndefined(option.value);
+          const description = stringOrUndefined(option.description);
+          return {
+            label,
+            ...(value ? { value } : {}),
+            ...(description ? { description } : {}),
+          };
+        })
+        .filter((option): option is { label: string; value?: string; description?: string } => option !== null);
+
+      const allowOther = question.allowOther ?? question.allow_other;
+      const otherLabel = stringOrUndefined(question.otherLabel ?? question.other_label);
+      const multiSelect = question.multiSelect ?? question.multi_select;
+
+      const header = stringOrUndefined(question.header);
+
+      return {
+        question: questionText,
+        ...(header ? { header } : {}),
+        options,
+        allowOther: allowOther === false ? false : true,
+        otherLabel: otherLabel ?? "Other",
+        multiSelect: multiSelect === true,
+      };
+    })
+    .filter((question): question is NonNullable<typeof question> => question !== null);
+}
+
 /**
  * Fire-and-forget notification for AskUserQuestion (issue #597).
  * Extracted for testability; the dynamic import makes direct assertion
@@ -2178,13 +2242,10 @@ export function dispatchAskUserQuestionNotification(
   directory: string,
   toolInput: unknown,
 ): void {
-  const input = toolInput as
-    | { questions?: Array<{ question?: string }> }
-    | undefined;
-  const questions = input?.questions || [];
+  const prompts = extractAskUserQuestionPrompts(toolInput);
   const questionText =
-    questions
-      .map((q) => q.question || "")
+    prompts
+      .map((q) => q.question)
       .filter(Boolean)
       .join("; ") || "User input requested";
 
@@ -2192,6 +2253,7 @@ export function dispatchAskUserQuestionNotification(
     sessionId,
     projectPath: directory,
     question: questionText,
+    askUserQuestionPrompts: prompts,
     profileName: process.env.OMC_NOTIFY_PROFILE,
   });
 }

--- a/src/notifications/__tests__/formatter.test.ts
+++ b/src/notifications/__tests__/formatter.test.ts
@@ -5,6 +5,7 @@ import {
   formatAgentCall,
   formatNotification,
   parseTmuxTail,
+  formatAskUserQuestion,
 } from "../formatter.js";
 import type { NotificationPayload } from "../types.js";
 
@@ -564,5 +565,36 @@ describe("tmuxTail in formatters", () => {
     expect(result).toContain("**Recent output:**");
     expect(result).toContain("Build complete");
     expect(result).toContain("Done in 5.2s");
+  });
+});
+
+describe("formatAskUserQuestion", () => {
+  it("includes AskUserQuestion options and the free-text Other choice", () => {
+    const result = formatAskUserQuestion({
+      event: "ask-user-question",
+      sessionId: "sess-3039",
+      message: "",
+      timestamp: new Date("2026-05-19T00:00:00Z").toISOString(),
+      projectPath: "/tmp/project",
+      question: "Which database should we use?",
+      askUserQuestionPrompts: [
+        {
+          question: "Which database should we use?",
+          header: "Database",
+          options: [
+            { label: "PostgreSQL", description: "Relational DB" },
+            { label: "MongoDB", description: "Document DB" },
+          ],
+          allowOther: true,
+          otherLabel: "Other",
+          multiSelect: false,
+        },
+      ],
+    });
+
+    expect(result).toContain("**Options:**");
+    expect(result).toContain("1. PostgreSQL — Relational DB");
+    expect(result).toContain("2. MongoDB — Document DB");
+    expect(result).toContain("3. Other — reply with free text");
   });
 });

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeReplyInput } from "../reply-listener.js";
+import { buildReplyInjectionSteps, sanitizeReplyInput } from "../reply-listener.js";
 
 describe("reply-listener", () => {
   describe("sanitizeReplyInput", () => {
@@ -62,6 +62,39 @@ describe("reply-listener", () => {
       expect(result).toContain('\\$(sub)');
       expect(result).toContain('\\${var}');
       expect(result).not.toContain('\x00');
+    });
+  });
+
+  describe("AskUserQuestion reply injection", () => {
+    it("targets the Other/free-text field before submitting mobile reply text", () => {
+      const steps = buildReplyInjectionSteps(
+        "Use SQLite for tests",
+        "telegram",
+        { includePrefix: false, maxMessageLength: 500 },
+        { event: "ask-user-question", askUserQuestionOptionCount: 2, askUserQuestionAllowOther: true },
+      );
+
+      expect(steps).toEqual([
+        { kind: "key", value: "Down" },
+        { kind: "key", value: "Down" },
+        { kind: "key", value: "Enter" },
+        { kind: "literal", value: "Use SQLite for tests" },
+        { kind: "key", value: "Enter" },
+      ]);
+    });
+
+    it("keeps normal reply injection semantics for non AskUserQuestion messages", () => {
+      const steps = buildReplyInjectionSteps(
+        "continue",
+        "slack",
+        { includePrefix: true, maxMessageLength: 500 },
+        { event: "session-idle" },
+      );
+
+      expect(steps).toEqual([
+        { kind: "literal", value: "[reply:slack] continue" },
+        { kind: "key", value: "Enter" },
+      ]);
     });
   });
 

--- a/src/notifications/dispatcher.ts
+++ b/src/notifications/dispatcher.ts
@@ -524,6 +524,7 @@ export async function sendWebhook(
         reason: payload.reason,
         active_mode: payload.activeMode,
         question: payload.question,
+        ask_user_question_prompts: payload.askUserQuestionPrompts,
         ...(payload.replyChannel && { channel: payload.replyChannel }),
         ...(payload.replyTarget && { to: payload.replyTarget }),
         ...(payload.replyThread && { thread_id: payload.replyThread }),

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -433,6 +433,25 @@ export function formatAskUserQuestion(payload: NotificationPayload): string {
     lines.push("");
   }
 
+  if (payload.askUserQuestionPrompts?.length) {
+    for (const [promptIndex, prompt] of payload.askUserQuestionPrompts.entries()) {
+      if (payload.askUserQuestionPrompts.length > 1) {
+        lines.push(`**${prompt.header || `Question ${promptIndex + 1}`}:** ${prompt.question}`);
+      }
+      if (prompt.options.length > 0 || prompt.allowOther !== false) {
+        lines.push("**Options:**");
+        prompt.options.forEach((option, optionIndex) => {
+          const description = option.description ? ` — ${option.description}` : "";
+          lines.push(`${optionIndex + 1}. ${option.label}${description}`);
+        });
+        if (prompt.allowOther !== false) {
+          lines.push(`${prompt.options.length + 1}. ${prompt.otherLabel || "Other"} — reply with free text`);
+        }
+        lines.push("");
+      }
+    }
+  }
+
   lines.push(`Claude is waiting for your response.`);
   lines.push("");
   lines.push(buildFooter(payload, true));

--- a/src/notifications/hook-config-types.ts
+++ b/src/notifications/hook-config-types.ts
@@ -14,7 +14,7 @@ export type TemplateVariable =
   | "projectPath" | "projectName" | "modesUsed" | "contextSummary"
   | "durationMs" | "agentsSpawned" | "agentsCompleted"
   | "reason" | "activeMode" | "iteration" | "maxIterations"
-  | "question" | "incompleteTasks" | "agentName" | "agentType"
+  | "question" | "questionOptions" | "incompleteTasks" | "agentName" | "agentType"
   | "tmuxTail" | "tmuxPaneId"
   | "replyChannel" | "replyTarget" | "replyThread"
   // Computed variables (derived from payload, not direct fields)

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -170,6 +170,7 @@ export async function notify(
       iteration: data.iteration,
       maxIterations: data.maxIterations,
       question: data.question,
+      askUserQuestionPrompts: data.askUserQuestionPrompts,
       incompleteTasks: data.incompleteTasks,
       agentName: data.agentName,
       agentType: data.agentType,
@@ -256,6 +257,12 @@ export async function notify(
               event: payload.event,
               createdAt: new Date().toISOString(),
               projectPath: payload.projectPath,
+              ...(payload.event === "ask-user-question" && payload.askUserQuestionPrompts?.[0]
+                ? {
+                    askUserQuestionOptionCount: payload.askUserQuestionPrompts[0].options.length,
+                    askUserQuestionAllowOther: payload.askUserQuestionPrompts[0].allowOther !== false,
+                  }
+                : {}),
             });
           }
         }

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, chmodSy
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
+import { tmuxExec } from '../cli/tmux-utils.js';
 import { request as httpsRequest } from 'https';
 import { resolveDaemonModulePath } from '../utils/daemon-module-path.js';
 import { getGlobalOmcStateRoot } from '../utils/paths.js';
@@ -32,6 +33,7 @@ import {
   lookupByMessageId,
   removeMessagesByPane,
   pruneStale,
+  type SessionMapping,
 } from './session-registry.js';
 import type { ReplyConfig } from './types.js';
 import { parseMentionAllowedMentions } from './config.js';
@@ -358,11 +360,62 @@ class RateLimiter {
  *
  * Returns true if injection succeeded, false otherwise.
  */
+export type ReplyInjectionStep =
+  | { kind: 'literal'; value: string }
+  | { kind: 'key'; value: string };
+
+export function buildReplyInjectionSteps(
+  text: string,
+  platform: string,
+  config: Pick<ReplyListenerDaemonConfig, 'includePrefix' | 'maxMessageLength'>,
+  mapping?: Pick<SessionMapping, 'event' | 'askUserQuestionOptionCount' | 'askUserQuestionAllowOther'>,
+): ReplyInjectionStep[] {
+  const prefix = config.includePrefix ? `[reply:${platform}] ` : '';
+  const sanitized = sanitizeReplyInput(prefix + text);
+  const truncated = sanitized.slice(0, config.maxMessageLength);
+
+  if (
+    mapping?.event === 'ask-user-question' &&
+    mapping.askUserQuestionAllowOther !== false &&
+    Number.isFinite(mapping.askUserQuestionOptionCount)
+  ) {
+    const optionCount = Math.max(0, Math.floor(mapping.askUserQuestionOptionCount ?? 0));
+    return [
+      ...Array.from({ length: optionCount }, () => ({ kind: 'key' as const, value: 'Down' })),
+      { kind: 'key', value: 'Enter' },
+      { kind: 'literal', value: truncated },
+      { kind: 'key', value: 'Enter' },
+    ];
+  }
+
+  return [
+    { kind: 'literal', value: truncated },
+    { kind: 'key', value: 'Enter' },
+  ];
+}
+
+function sendReplyInjectionSteps(paneId: string, steps: ReplyInjectionStep[]): boolean {
+  try {
+    for (const step of steps) {
+      if (step.kind === 'literal') {
+        tmuxExec(['send-keys', '-t', paneId, '-l', step.value], { stripTmux: true, timeout: 2000 });
+      } else {
+        tmuxExec(['send-keys', '-t', paneId, step.value], { stripTmux: true, timeout: 2000 });
+      }
+    }
+    return true;
+  } catch (error) {
+    log(`ERROR: Failed to send reply injection steps to pane ${paneId}: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+
 function injectReply(
   paneId: string,
   text: string,
   platform: string,
   config: ReplyListenerDaemonConfig,
+  mapping?: SessionMapping,
 ): boolean {
   // 1. Verify pane has content (non-empty pane = active session per registry)
   const content = capturePaneContent(paneId, 15);
@@ -373,20 +426,15 @@ function injectReply(
     return false;
   }
 
-  // 2. Build prefixed text if configured
-  const prefix = config.includePrefix ? `[reply:${platform}] ` : '';
+  const steps = buildReplyInjectionSteps(text, platform, config, mapping);
+  const preview = steps.find((step) => step.kind === 'literal')?.value ?? '';
 
-  // 3. Sanitize the reply text
-  const sanitized = sanitizeReplyInput(prefix + text);
-
-  // 4. Truncate to max length
-  const truncated = sanitized.slice(0, config.maxMessageLength);
-
-  // 5. Inject via sendToPane (which applies its own sanitizeForTmux)
-  const success = sendToPane(paneId, truncated, true);
+  const success = mapping?.event === 'ask-user-question'
+    ? sendReplyInjectionSteps(paneId, steps)
+    : sendToPane(paneId, preview, true);
 
   if (success) {
-    log(`Injected reply from ${platform} into pane ${paneId}: "${truncated.slice(0, 50)}${truncated.length > 50 ? '...' : ''}"`);
+    log(`Injected reply from ${platform} into pane ${paneId}: "${preview.slice(0, 50)}${preview.length > 50 ? '...' : ''}"`);
   } else {
     log(`ERROR: Failed to inject reply into pane ${paneId}`);
   }
@@ -499,7 +547,7 @@ async function pollDiscord(
       writeDaemonState(state);
 
       // Inject reply
-      const success = injectReply(mapping.tmuxPaneId, msg.content, 'discord', config);
+      const success = injectReply(mapping.tmuxPaneId, msg.content, 'discord', config, mapping);
       if (success) {
         state.messagesInjected++;
 
@@ -663,7 +711,7 @@ async function pollTelegram(
       writeDaemonState(state);
 
       // Inject reply
-      const success = injectReply(mapping.tmuxPaneId, text, 'telegram', config);
+      const success = injectReply(mapping.tmuxPaneId, text, 'telegram', config, mapping);
       if (success) {
         state.messagesInjected++;
 
@@ -791,12 +839,14 @@ async function pollLoop(): Promise<void> {
 
             // Find target pane for injection
             let targetPaneId: string | null = null;
+            let targetMapping: SessionMapping | undefined;
 
             // Thread replies: look up parent message in session registry
             if (event.thread_ts && event.thread_ts !== event.ts) {
               const mapping = lookupByMessageId('slack-bot', event.thread_ts);
               if (mapping) {
                 targetPaneId = mapping.tmuxPaneId;
+                targetMapping = mapping;
               }
             }
 
@@ -809,7 +859,7 @@ async function pollLoop(): Promise<void> {
             }
 
             // Inject reply
-            const success = injectReply(targetPaneId, event.text, 'slack', config);
+            const success = injectReply(targetPaneId, event.text, 'slack', config, targetMapping);
             if (success) {
               state.messagesInjected++;
               writeDaemonState(state);

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -96,6 +96,9 @@ export interface SessionMapping {
   event: string;
   createdAt: string; // ISO timestamp
   projectPath?: string;
+  /** AskUserQuestion metadata used to target the Other/free-text field for mobile replies. */
+  askUserQuestionOptionCount?: number;
+  askUserQuestionAllowOther?: boolean;
 }
 
 // ============================================================================

--- a/src/notifications/template-engine.ts
+++ b/src/notifications/template-engine.ts
@@ -16,7 +16,7 @@ const KNOWN_VARIABLES = new Set<string>([
   "projectPath", "projectName", "modesUsed", "contextSummary",
   "durationMs", "agentsSpawned", "agentsCompleted",
   "reason", "activeMode", "iteration", "maxIterations",
-  "question", "incompleteTasks", "agentName", "agentType",
+  "question", "questionOptions", "incompleteTasks", "agentName", "agentType",
   "tmuxTail", "tmuxPaneId",
   "replyChannel", "replyTarget", "replyThread",
   // Computed variables
@@ -111,6 +111,16 @@ export function computeTemplateVariables(
   vars.maxIterations =
     payload.maxIterations != null ? String(payload.maxIterations) : "";
   vars.question = payload.question || "";
+  vars.questionOptions = payload.askUserQuestionPrompts?.map((prompt) => {
+    const optionLines = prompt.options.map((option, index) => {
+      const description = option.description ? ` — ${option.description}` : "";
+      return `${index + 1}. ${option.label}${description}`;
+    });
+    if (prompt.allowOther !== false) {
+      optionLines.push(`${prompt.options.length + 1}. ${prompt.otherLabel || "Other"} — reply with free text`);
+    }
+    return optionLines.join("\n");
+  }).filter(Boolean).join("\n\n") || "";
   // incompleteTasks: undefined/null → "" (so {{#if}} is falsy when unset)
   // 0 → "0" (distinguishable from unset; templates can display "0 incomplete tasks")
   vars.incompleteTasks =

--- a/src/notifications/template-variables.ts
+++ b/src/notifications/template-variables.ts
@@ -93,6 +93,11 @@ export const TEMPLATE_VARIABLES: Record<string, TemplateVariable> = {
     example: 'Which file should I edit?',
     availableIn: ['ask-user-question']
   },
+  questionOptions: {
+    description: 'Formatted AskUserQuestion options, including the Other/free-text choice when available',
+    example: '1. PostgreSQL — relational DB\n2. Other — reply with free text',
+    availableIn: ['ask-user-question']
+  },
 
   // Mode info
   activeMode: {

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -89,6 +89,21 @@ export interface SlackBotNotificationConfig {
 }
 
 /** Generic webhook configuration */
+export interface AskUserQuestionOption {
+  label: string;
+  value?: string;
+  description?: string;
+}
+
+export interface AskUserQuestionPrompt {
+  question: string;
+  header?: string;
+  options: AskUserQuestionOption[];
+  allowOther?: boolean;
+  otherLabel?: string;
+  multiSelect?: boolean;
+}
+
 export interface WebhookNotificationConfig {
   enabled: boolean;
   /** Webhook URL (POST with JSON body) */
@@ -187,6 +202,8 @@ export interface NotificationPayload {
   maxIterations?: number;
   /** Question text (for ask-user-question events) */
   question?: string;
+  /** Structured AskUserQuestion prompts/options preserved from tool input */
+  askUserQuestionPrompts?: AskUserQuestionPrompt[];
   /** Incomplete task count */
   incompleteTasks?: number;
   /** tmux pane ID for reply injection target */


### PR DESCRIPTION
## Summary
- Preserve structured AskUserQuestion options in notification payloads/templates so Telegram/Slack/mobile users can see the available choices.
- Persist AskUserQuestion option metadata in reply-session mappings for reply-capable bot notifications.
- Route inbound AskUserQuestion replies to the Other/free-text path by sending Down-to-Other, Enter, literal reply text, Enter instead of submitting the highlighted default option.

Fixes #3039

## Verification
- `npm test -- src/hooks/__tests__/askuserquestion-lifecycle.test.ts src/notifications/__tests__/formatter.test.ts src/notifications/__tests__/reply-listener.test.ts`
- `npx eslint src/hooks/bridge.ts src/notifications/reply-listener.ts src/notifications/formatter.ts src/notifications/index.ts src/notifications/dispatcher.ts src/notifications/template-engine.ts src/notifications/types.ts src/notifications/session-registry.ts src/hooks/__tests__/askuserquestion-lifecycle.test.ts src/notifications/__tests__/formatter.test.ts src/notifications/__tests__/reply-listener.test.ts`
- `npx tsc --noEmit`
- `git diff --check`

## Notes
- Kept separate from #3038; no shared helper or branch dependency was needed.
- Regression coverage added for option preservation and reply injection semantics.

🤖 Generated with OpenAI Codex
