### PR TITLE
fix(ralph): clear completed PRD on cancel to prevent stale state pollution

### DIFF
--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -23,6 +23,7 @@ import {
   findPrdPath,
   readPrd,
   getPrdStatus,
+  clearPrd,
   formatNextStoryPrompt,
   formatPrdStatus,
   type PRDStatus,
@@ -375,6 +376,12 @@ export function createRalphLoopHook(directory: string): RalphLoopHook {
     // Also clear linked ultrawork state if it was auto-activated
     if (state.linked_ultrawork) {
       clearLinkedUltraworkState(directory, sessionId);
+    }
+
+    // Clear completed PRD so it doesn't pollute the next ralph task
+    const prd = readPrd(directory, sessionId);
+    if (prd && getPrdStatus(prd).allComplete) {
+      clearPrd(directory, sessionId);
     }
 
     return clearRalphState(directory, sessionId);

--- a/src/hooks/ralph/prd.ts
+++ b/src/hooks/ralph/prd.ts
@@ -12,7 +12,7 @@
  * - notes: Optional notes from implementation
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { dirname, join } from 'path';
 import { ensureSessionStateDir, getOmcRoot, getSessionStateDir } from '../../lib/worktree-paths.js';
 
@@ -459,6 +459,26 @@ export function createSimplePrd(
 /**
  * Initialize a PRD in a directory
  */
+/**
+ * Clear (delete) the prd.json for a session or project.
+ * Used when a task completes to prevent stale PRD from polluting the next task.
+ */
+export function clearPrd(directory: string, sessionId?: string): boolean {
+  const prdPath = findPrdPath(directory, sessionId);
+  if (!prdPath) {
+    return true; // Already gone
+  }
+  try {
+    unlinkSync(prdPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return true;
+    }
+    return false;
+  }
+}
+
 export function initPrd(
   directory: string,
   project: string,
@@ -532,6 +552,31 @@ export function ensurePrdForStartup(
       path: existingPath,
       error: `${existingPath} must contain at least one user story for Ralph to start.`
     };
+  }
+
+  // If all stories are already complete and this PRD is not session-scoped,
+  // it's a leftover from a previous task. Ignore it and create a fresh scaffold.
+  if (sessionId) {
+    const sessionPath = getSessionPrdPath(directory, sessionId);
+    const isStaleCompletedPrd =
+      getPrdStatus(parsed.prd).allComplete && existingPath !== sessionPath;
+
+    if (isStaleCompletedPrd) {
+      const created = initPrd(directory, project, branchName, description, stories, sessionId);
+      const createdPath = findPrdPath(directory, sessionId);
+      const prd = created ? readPrd(directory, sessionId) : null;
+
+      if (!created || !createdPath || !prd) {
+        return {
+          ok: false,
+          created: false,
+          path: createdPath ?? null,
+          error: `Ralph requires a valid ${PRD_FILENAME} at startup, but scaffold creation failed.`
+        };
+      }
+
+      return { ok: true, created: true, path: createdPath, prd };
+    }
   }
 
   if (sessionId) {


### PR DESCRIPTION
## Summary

- `cancelLoop()` now calls `clearPrd()` when all stories pass, removing `prd.json` at task completion
- `ensurePrdForStartup()` detects a stale completed PRD (all `passes: true`, not session-scoped) and creates a fresh scaffold instead of reusing it

## Problem

When a ralph task completes and `/cancel` is called, `prd.json` was left on disk. On the next ralph invocation, the old completed PRD was detected and reused, causing ralph to misinterpret the new task as already done — skipping PRD generation and looking for other work (e.g. `tasks/todo.md`).

## Fix Design

Two-layer approach:

**Layer 1 (primary):** `cancelLoop()` in `loop.ts` clears the PRD when all stories pass at cancel time.

**Layer 2 (defensive):** `ensurePrdForStartup()` in `prd.ts` detects a stale completed PRD at startup (all `passes: true` and not session-scoped) and creates a fresh scaffold instead of reusing it. This handles crash/force-quit scenarios where cancel didn't run.

## Test plan

- [ ] Run a ralph task to completion, verify `prd.json` is removed after `/cancel`
- [ ] Manually leave a completed `prd.json` in `.omc/`, start a new ralph task, verify a fresh PRD is created
- [ ] Resume an in-progress ralph task (partial `passes`), verify existing PRD is correctly reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)