### PR TITLE
Fix cmux team worker spawning

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -414,7 +414,7 @@ Native team worker worktrees are an opt-in/config-gated runtime-v2 rollout. See 
 Topology behavior:
 
 - inside classic tmux (`$TMUX` set): reuse the current tmux surface for split-pane or `--new-window` layouts
-- inside cmux (`CMUX_SURFACE_ID` without `$TMUX`): launch a detached tmux session for team workers
+- inside cmux (`CMUX_SURFACE_ID` without `$TMUX`): create native cmux splits for visible team workers
 - plain terminal: launch a detached tmux session for team workers
 
 ### `omc session search`

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -35,8 +35,8 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 
 ## Requirements
 
-- **tmux binary** must be installed and discoverable (`command -v tmux`)
-- **Classic tmux session optional** for in-place pane splitting (`$TMUX` set). Inside cmux or a plain terminal, `omc team` falls back to a detached tmux session instead of splitting the current surface.
+- **tmux binary** must be installed and discoverable (`command -v tmux`) when running from a plain terminal; classic tmux sessions reuse the current tmux surface.
+- **cmux surface optional** for in-place native splits (`CMUX_SURFACE_ID` set without `$TMUX`). Plain terminals still use the detached tmux fallback.
 - **claude** CLI: `npm install -g @anthropic-ai/claude-code`
 - **codex** CLI: `npm install -g @openai/codex`
 - **gemini** CLI: `npm install -g @google/gemini-cli`
@@ -45,15 +45,15 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 
 ### Phase 0: Verify prerequisites
 
-Check tmux explicitly before claiming it is missing:
+Check the active multiplexer before claiming tmux is missing. If `$TMUX` is empty and `CMUX_SURFACE_ID` is also empty, check tmux explicitly:
 
 ```bash
 command -v tmux >/dev/null 2>&1
 ```
 
-- If this fails, report that **tmux is not installed** and stop.
+- If the plain-terminal tmux check fails, report that **tmux is not installed** and stop.
 - If `$TMUX` is set, `omc team` can reuse the current tmux window/panes directly.
-- If `$TMUX` is empty but `CMUX_SURFACE_ID` is set, report that the user is running inside **cmux**. Do **not** say tmux is missing or that they are "not inside tmux"; `omc team` will launch a **detached tmux session** for workers instead of splitting the cmux surface.
+- If `$TMUX` is empty but `CMUX_SURFACE_ID` is set, report that the user is running inside **cmux**. Do **not** say tmux is missing or that they are "not inside tmux"; `omc team` will create **native cmux splits** for workers.
 - If neither `$TMUX` nor `CMUX_SURFACE_ID` is set, report that the user is in a **plain terminal**. `omc team` can still launch a **detached tmux session**, but if they specifically want in-place pane/window topology they should start from a classic tmux session first.
 - If you need to confirm the active tmux session, use:
 
@@ -174,7 +174,7 @@ If encountered, switch to `omc team ...` CLI commands.
 | Error                        | Cause                               | Fix                                                                                 |
 | ---------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
 | `not inside tmux`            | Requested in-place pane topology from a non-tmux surface | Start tmux and rerun, or let `omc team` use its detached-session fallback           |
-| `cmux surface detected`      | Running inside cmux without `$TMUX` | Use the normal `omc team ...` flow; OMC will launch a detached tmux session         |
+| `cmux surface detected`      | Running inside cmux without `$TMUX` | Use the normal `omc team ...` flow; OMC will create native cmux worker splits      |
 | `Unsupported agent type`     | Requested agent is not claude/codex/gemini | Use `claude`, `codex`, or `gemini`; for native Claude Code agents use `/oh-my-claudecode:team` |
 | `codex: command not found`   | Codex CLI not installed             | `npm install -g @openai/codex`                                                      |
 | `gemini: command not found`  | Gemini CLI not installed            | `npm install -g @google/gemini-cli`                                                 |

--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -37,6 +37,11 @@ vi.mock('child_process', async (importOriginal) => {
       return { stdout: `%50${mockedCalls.splitCount}\n`, stderr: '' };
     }
 
+    if (args[0] === 'new-split') {
+      mockedCalls.splitCount += 1;
+      return { stdout: `cmux-worker-${mockedCalls.splitCount}\n`, stderr: '' };
+    }
+
     return { stdout: '', stderr: '' };
   };
 
@@ -141,25 +146,22 @@ describe('createTeamSession context resolution', () => {
     expect(session.sessionMode).toBe('detached-session');
   });
 
-  it('uses a detached tmux session when running inside cmux', async () => {
+  it('uses native cmux splits instead of a detached tmux session when running inside cmux', async () => {
     vi.stubEnv('TMUX', '');
     vi.stubEnv('TMUX_PANE', '');
-    vi.stubEnv('CMUX_SURFACE_ID', 'cmux-surface');
+    vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');
+    vi.stubEnv('CMUX_WORKSPACE_ID', 'workspace-1');
 
-    const session = await createTeamSession('race-team', 1, '/tmp', { newWindow: true });
+    const session = await createTeamSession('race-team', 2, '/tmp', { newWindow: true });
 
     expect(mockedCalls.execFileArgs.some((args) => args[0] === 'new-window')).toBe(false);
-    const detachedCreateCall = mockedCalls.execFileArgs.find((args) =>
-      args[0] === 'new-session' && args.includes('-d') && args.includes('-P'),
-    );
-    expect(detachedCreateCall).toBeDefined();
-
-    const firstSplitCall = mockedCalls.execFileArgs.find((args) => args[0] === 'split-window');
-    expect(firstSplitCall).toEqual(expect.arrayContaining(['split-window', '-h', '-t', '%91']));
-    expect(session.leaderPaneId).toBe('%91');
-    expect(session.sessionName).toBe('omc-team-race-team-detached:0');
-    expect(session.workerPaneIds).toEqual(['%501']);
-    expect(session.sessionMode).toBe('detached-session');
+    expect(mockedCalls.execFileArgs.some((args) => args[0] === 'new-session' && args.includes('-d'))).toBe(false);
+    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'right', '-t', 'cmux-leader', '--workspace', 'workspace-1']);
+    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'down', '-t', 'cmux-worker-1', '--workspace', 'workspace-1']);
+    expect(session.leaderPaneId).toBe('cmux-leader');
+    expect(session.sessionName).toBe('cmux:workspace-1');
+    expect(session.workerPaneIds).toEqual(['cmux-worker-1', 'cmux-worker-2']);
+    expect(session.sessionMode).toBe('split-pane');
   });
 
   it('anchors context to TMUX_PANE to avoid focus races', async () => {

--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -156,8 +156,8 @@ describe('createTeamSession context resolution', () => {
 
     expect(mockedCalls.execFileArgs.some((args) => args[0] === 'new-window')).toBe(false);
     expect(mockedCalls.execFileArgs.some((args) => args[0] === 'new-session' && args.includes('-d'))).toBe(false);
-    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'right', '-t', 'cmux-leader', '--workspace', 'workspace-1']);
-    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'down', '-t', 'cmux-worker-1', '--workspace', 'workspace-1']);
+    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'right', '--surface', 'cmux-leader', '--workspace', 'workspace-1']);
+    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'down', '--surface', 'cmux-worker-1', '--workspace', 'workspace-1']);
     expect(session.leaderPaneId).toBe('cmux-leader');
     expect(session.sessionName).toBe('cmux:workspace-1');
     expect(session.workerPaneIds).toEqual(['cmux-worker-1', 'cmux-worker-2']);

--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -5,6 +5,7 @@ type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) =>
 const mockedCalls = vi.hoisted(() => ({
   execFileArgs: [] as string[][],
   splitCount: 0,
+  newSplitStdouts: [] as string[],
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -39,7 +40,10 @@ vi.mock('child_process', async (importOriginal) => {
 
     if (args[0] === 'new-split') {
       mockedCalls.splitCount += 1;
-      return { stdout: `cmux-worker-${mockedCalls.splitCount}\n`, stderr: '' };
+      return {
+        stdout: mockedCalls.newSplitStdouts.shift() ?? `cmux-worker-${mockedCalls.splitCount}\n`,
+        stderr: '',
+      };
     }
 
     return { stdout: '', stderr: '' };
@@ -120,6 +124,7 @@ describe('createTeamSession context resolution', () => {
   beforeEach(() => {
     mockedCalls.execFileArgs = [];
     mockedCalls.splitCount = 0;
+    mockedCalls.newSplitStdouts = [];
   });
 
   afterEach(() => {
@@ -162,6 +167,24 @@ describe('createTeamSession context resolution', () => {
     expect(session.sessionName).toBe('cmux:workspace-1');
     expect(session.workerPaneIds).toEqual(['cmux-worker-1', 'cmux-worker-2']);
     expect(session.sessionMode).toBe('split-pane');
+  });
+
+  it('parses documented cmux new-split OK output without using OK as a surface', async () => {
+    vi.stubEnv('TMUX', '');
+    vi.stubEnv('TMUX_PANE', '');
+    vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');
+    vi.stubEnv('CMUX_WORKSPACE_ID', 'workspace-1');
+    mockedCalls.newSplitStdouts = [
+      '  OK   cmux-worker-1   workspace-1\n',
+      '\nOK\tcmux-worker-2\tworkspace-1  \n',
+    ];
+
+    const session = await createTeamSession('race-team', 2, '/tmp', { newWindow: true });
+
+    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'right', '--surface', 'cmux-leader', '--workspace', 'workspace-1']);
+    expect(mockedCalls.execFileArgs).toContainEqual(['new-split', 'down', '--surface', 'cmux-worker-1', '--workspace', 'workspace-1']);
+    expect(mockedCalls.execFileArgs).not.toContainEqual(expect.arrayContaining(['--surface', 'OK']));
+    expect(session.workerPaneIds).toEqual(['cmux-worker-1', 'cmux-worker-2']);
   });
 
   it('anchors context to TMUX_PANE to avoid focus races', async () => {

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -2,7 +2,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockedCalls = vi.hoisted(() => ({
   tmuxArgs: [] as string[][],
+  cmuxArgs: [] as string[][],
 }));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+  const execFileMock = vi.fn((_cmd: string, args: string[], cb: ExecFileCallback) => {
+    mockedCalls.cmuxArgs.push(args);
+    cb(null, '', '');
+    return {} as never;
+  });
+  const promisifyCustom = Symbol.for('nodejs.util.promisify.custom');
+  (execFileMock as unknown as Record<symbol, unknown>)[promisifyCustom] = async (_cmd: string, args: string[]) => {
+    mockedCalls.cmuxArgs.push(args);
+    return { stdout: '', stderr: '' };
+  };
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
 
 vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../cli/tmux-utils.js')>();
@@ -24,6 +44,8 @@ import { spawnBridgeInSession, spawnWorkerInPane } from '../tmux-session.js';
 describe('spawnWorkerInPane', () => {
   beforeEach(() => {
     mockedCalls.tmuxArgs = [];
+    mockedCalls.cmuxArgs = [];
+    vi.unstubAllEnvs();
   });
 
   it('uses argv-style launch with literal tmux send-keys', async () => {
@@ -48,6 +70,27 @@ describe('spawnWorkerInPane', () => {
     expect(launchLine).toContain("'--'");
     expect(launchLine).toContain("'gpt-5;touch /tmp/pwn'");
     expect(launchLine).not.toContain('exec codex --full-auto');
+  });
+
+  it('uses cmux send semantics for cmux surface worker panes', async () => {
+    vi.stubEnv('TMUX', '');
+    vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');
+
+    await spawnWorkerInPane('cmux:workspace-1', 'cmux-worker-1', {
+      teamName: 'safe-team',
+      workerName: 'worker-1',
+      envVars: {
+        OMC_TEAM_NAME: 'safe-team',
+        OMC_TEAM_WORKER: 'safe-team/worker-1',
+      },
+      launchBinary: 'codex',
+      launchArgs: ['--full-auto'],
+      cwd: '/tmp',
+    });
+
+    expect(mockedCalls.tmuxArgs.some((args) => args[0] === 'send-keys')).toBe(false);
+    expect(mockedCalls.cmuxArgs[0]).toEqual(expect.arrayContaining(['send', '--surface', 'cmux-worker-1']));
+    expect(mockedCalls.cmuxArgs[1]).toEqual(['send', '--surface', 'cmux-worker-1', 'Enter']);
   });
 
   it('uses current JS runtime when launching bridge-entry helpers', () => {

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
   };
 });
 
-import { spawnBridgeInSession, spawnWorkerInPane } from '../tmux-session.js';
+import { sendTeamPaneKey, spawnBridgeInSession, spawnWorkerInPane } from '../tmux-session.js';
 
 describe('spawnWorkerInPane', () => {
   beforeEach(() => {
@@ -72,7 +72,7 @@ describe('spawnWorkerInPane', () => {
     expect(launchLine).not.toContain('exec codex --full-auto');
   });
 
-  it('uses cmux send semantics for cmux surface worker panes', async () => {
+  it('sends cmux worker command text and submits with send-key', async () => {
     vi.stubEnv('TMUX', '');
     vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');
 
@@ -89,8 +89,29 @@ describe('spawnWorkerInPane', () => {
     });
 
     expect(mockedCalls.tmuxArgs.some((args) => args[0] === 'send-keys')).toBe(false);
+    expect(mockedCalls.cmuxArgs).toHaveLength(2);
     expect(mockedCalls.cmuxArgs[0]).toEqual(expect.arrayContaining(['send', '--surface', 'cmux-worker-1']));
-    expect(mockedCalls.cmuxArgs[1]).toEqual(['send', '--surface', 'cmux-worker-1', 'Enter']);
+    expect(mockedCalls.cmuxArgs[0]?.[0]).toBe('send');
+    expect(mockedCalls.cmuxArgs[0]?.at(-1)).toContain('exec "$@"');
+    expect(mockedCalls.cmuxArgs[1]).toEqual(['send-key', '--surface', 'cmux-worker-1', 'Enter']);
+  });
+
+  it('uses cmux send-key semantics for Enter and control keys', async () => {
+    vi.stubEnv('TMUX', '');
+    vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');
+
+    await sendTeamPaneKey('cmux-worker-1', 'Enter');
+    await sendTeamPaneKey('cmux-worker-1', 'Tab');
+    await sendTeamPaneKey('cmux-worker-1', 'C-m');
+    await sendTeamPaneKey('cmux-worker-1', 'C-u');
+
+    expect(mockedCalls.tmuxArgs.some((args) => args[0] === 'send-keys')).toBe(false);
+    expect(mockedCalls.cmuxArgs).toEqual([
+      ['send-key', '--surface', 'cmux-worker-1', 'Enter'],
+      ['send-key', '--surface', 'cmux-worker-1', 'Tab'],
+      ['send-key', '--surface', 'cmux-worker-1', 'C-m'],
+      ['send-key', '--surface', 'cmux-worker-1', 'C-u'],
+    ]);
   });
 
   it('uses current JS runtime when launching bridge-entry helpers', () => {

--- a/src/team/idle-nudge.ts
+++ b/src/team/idle-nudge.ts
@@ -11,8 +11,7 @@
  * @see https://github.com/anthropics/oh-my-claudecode/issues/1047
  */
 
-import { tmuxExecAsync } from '../cli/tmux-utils.js';
-import { paneLooksReady, paneHasActiveTask, sendToWorker } from './tmux-session.js';
+import { paneLooksReady, paneHasActiveTask, sendToWorker, captureTeamPane } from './tmux-session.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -37,14 +36,9 @@ export const DEFAULT_NUDGE_CONFIG: NudgeConfig = {
 // Pane capture + idle detection
 // ---------------------------------------------------------------------------
 
-/** Capture the last 80 lines of a tmux pane. Returns '' on error. */
+/** Capture the last 80 lines of a team pane. Returns '' on error. */
 export async function capturePane(paneId: string): Promise<string> {
-  try {
-    const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
-    return result.stdout ?? '';
-  } catch {
-    return '';
-  }
+  return captureTeamPane(paneId);
 }
 
 /**

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -63,7 +63,7 @@ import {
 } from './model-contract.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker, killTeamSession,
-  waitForPaneReady, paneHasActiveTask, paneLooksReady, applyMainVerticalLayout, getWorkerLiveness, type WorkerPaneConfig, type WorkerPaneLiveness, type TeamSessionMode,
+  waitForPaneReady, paneHasActiveTask, paneLooksReady, applyMainVerticalLayout, getWorkerLiveness, captureTeamPane, sendTeamPaneKey, type WorkerPaneConfig, type WorkerPaneLiveness, type TeamSessionMode,
 } from './tmux-session.js';
 import {
   composeInitialInbox,
@@ -349,12 +349,7 @@ async function getWorkerPaneLiveness(paneId: string | undefined): Promise<Worker
 
 async function captureWorkerPane(paneId: string | undefined): Promise<string> {
   if (!paneId) return '';
-  try {
-    const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
-    return result.stdout ?? '';
-  } catch {
-    return '';
-  }
+  return captureTeamPane(paneId);
 }
 
 function isFreshTimestamp(value: string | undefined, maxAgeMs: number = MONITOR_SIGNAL_STALE_MS): boolean {
@@ -794,7 +789,7 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     // retries so a truly hung worker still fails fast.
     for (let attempt = 1; !settled && attempt <= 4; attempt++) {
       try {
-        await tmuxExecAsync(['send-keys', '-t', paneId, 'Enter']);
+        await sendTeamPaneKey(paneId, 'Enter');
       } catch {
         break;
       }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -7,7 +7,7 @@ import { buildWorkerArgv, resolveValidatedBinaryPath, getWorkerEnv as getModelWo
 import { validateTeamName } from './team-name.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker,
-  isWorkerAlive, killTeamSession, resolveSplitPaneWorkerPaneIds, waitForPaneReady, applyMainVerticalLayout,
+  isWorkerAlive, killTeamSession, resolveSplitPaneWorkerPaneIds, waitForPaneReady, applyMainVerticalLayout, killTeamPane,
   type TeamSession, type WorkerPaneConfig,
 } from './tmux-session.js';
 import {
@@ -825,7 +825,7 @@ export async function killWorkerPane(
   paneId: string
 ): Promise<void> {
   try {
-    await tmuxExecAsync(['kill-pane', '-t', paneId]);
+    await killTeamPane(paneId);
   } catch {
     // idempotent: pane may already be gone
   }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -89,7 +89,7 @@ function parseCmuxSurfaceId(output: string): string {
 }
 
 async function cmuxSplitSurface(targetSurfaceId: string, direction: 'right' | 'down', _cwd: string): Promise<string> {
-  const args = ['new-split', direction, '-t', targetSurfaceId];
+  const args = ['new-split', direction, '--surface', targetSurfaceId];
   if (process.env.CMUX_WORKSPACE_ID) args.push('--workspace', process.env.CMUX_WORKSPACE_ID);
   const result = await cmuxExecAsync(args);
   return parseCmuxSurfaceId(result.stdout);
@@ -97,6 +97,10 @@ async function cmuxSplitSurface(targetSurfaceId: string, direction: 'right' | 'd
 
 async function cmuxSendSurface(surfaceId: string, text: string): Promise<void> {
   await cmuxExecAsync(['send', '--surface', surfaceId, text]);
+}
+
+async function cmuxSendSurfaceKey(surfaceId: string, key: string): Promise<void> {
+  await cmuxExecAsync(['send-key', '--surface', surfaceId, key]);
 }
 
 async function cmuxCaptureSurface(surfaceId: string): Promise<string> {
@@ -703,7 +707,7 @@ export async function spawnWorkerInPane(
 
   if (isCmuxSurfaceTarget(paneId)) {
     await cmuxSendSurface(paneId, startCmd);
-    await cmuxSendSurface(paneId, 'Enter');
+    await cmuxSendSurfaceKey(paneId, 'Enter');
     return;
   }
 
@@ -736,7 +740,7 @@ export async function captureTeamPane(paneId: string): Promise<string> {
 
 export async function sendTeamPaneKey(paneId: string, key: string): Promise<void> {
   if (isCmuxSurfaceTarget(paneId)) {
-    await cmuxSendSurface(paneId, key);
+    await cmuxSendSurfaceKey(paneId, key);
     return;
   }
   await tmuxExecAsync(['send-keys', '-t', paneId, key]);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -83,7 +83,8 @@ function parseCmuxSurfaceId(output: string): string {
   const trimmed = output.trim();
   const uuidMatch = trimmed.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
   if (uuidMatch) return uuidMatch[0];
-  const token = trimmed.split(/\s+/).find(Boolean);
+  const tokens = trimmed.split(/\s+/).filter(Boolean);
+  const token = tokens[0] === 'OK' ? tokens[1] : tokens[0];
   if (!token) throw new Error(`Failed to resolve cmux surface id: "${trimmed}"`);
   return token;
 }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -8,6 +8,8 @@
  */
 
 import { existsSync } from 'fs';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { join, basename, isAbsolute, win32 } from 'path';
 import fs from 'fs/promises';
 import { validateTeamName } from './team-name.js';
@@ -15,6 +17,7 @@ import { tmuxExec, tmuxExecAsync, tmuxShell, tmuxCmdAsync } from '../cli/tmux-ut
 import { configureTmuxClipboardForSession, configureTmuxClipboardForSessionAsync } from '../cli/tmux-clipboard.js';
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+const execFileAsync = promisify(execFile);
 
 const TMUX_SESSION_PREFIX = 'omc-team';
 
@@ -57,6 +60,52 @@ export async function applyMainVerticalLayout(teamTarget: string): Promise<void>
   } catch {
     /* ignore layout sizing errors */
   }
+}
+
+
+function isCmuxContext(): boolean {
+  return detectTeamMultiplexerContext() === 'cmux';
+}
+
+function isCmuxSurfaceTarget(value: string | undefined): value is string {
+  return isCmuxContext() && typeof value === 'string' && value.trim().length > 0 && !value.trim().startsWith('%');
+}
+
+async function cmuxExecAsync(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  const result = await execFileAsync('cmux', args, { encoding: 'utf-8' });
+  return {
+    stdout: typeof result.stdout === 'string' ? result.stdout : String(result.stdout ?? ''),
+    stderr: typeof result.stderr === 'string' ? result.stderr : String(result.stderr ?? ''),
+  };
+}
+
+function parseCmuxSurfaceId(output: string): string {
+  const trimmed = output.trim();
+  const uuidMatch = trimmed.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+  if (uuidMatch) return uuidMatch[0];
+  const token = trimmed.split(/\s+/).find(Boolean);
+  if (!token) throw new Error(`Failed to resolve cmux surface id: "${trimmed}"`);
+  return token;
+}
+
+async function cmuxSplitSurface(targetSurfaceId: string, direction: 'right' | 'down', _cwd: string): Promise<string> {
+  const args = ['new-split', direction, '-t', targetSurfaceId];
+  if (process.env.CMUX_WORKSPACE_ID) args.push('--workspace', process.env.CMUX_WORKSPACE_ID);
+  const result = await cmuxExecAsync(args);
+  return parseCmuxSurfaceId(result.stdout);
+}
+
+async function cmuxSendSurface(surfaceId: string, text: string): Promise<void> {
+  await cmuxExecAsync(['send', '--surface', surfaceId, text]);
+}
+
+async function cmuxCaptureSurface(surfaceId: string): Promise<string> {
+  const result = await cmuxExecAsync(['capture-pane', '--surface', surfaceId, '--scrollback']);
+  return result.stdout;
+}
+
+async function cmuxCloseSurface(surfaceId: string): Promise<void> {
+  await cmuxExecAsync(['close-surface', '--surface', surfaceId]);
 }
 
 export type TeamSessionMode = 'split-pane' | 'dedicated-window' | 'detached-session';
@@ -471,10 +520,10 @@ export function spawnBridgeInSession(
  * is true, creates a detached dedicated tmux window first and then splits worker
  * panes there.
  *
- * When running inside cmux (CMUX_SURFACE_ID without TMUX) or a plain terminal,
- * falls back to a detached tmux session because the current surface cannot be
- * targeted as a normal tmux pane/window. Returns sessionName in "session:window"
- * form.
+ * When running inside cmux (CMUX_SURFACE_ID without TMUX), creates native
+ * cmux splits from the current surface. When running in a plain terminal, falls
+ * back to a detached tmux session. Returns sessionName in "session:window" form
+ * for tmux and "cmux:<workspace>" form for cmux.
  *
  * Layout: leader pane on the left, worker panes stacked vertically on the right.
  * IMPORTANT: Uses pane IDs (%N format) not pane indices for stable targeting.
@@ -487,8 +536,9 @@ export async function createTeamSession(
 ): Promise<TeamSession> {
   const multiplexerContext = detectTeamMultiplexerContext();
   const inTmux = multiplexerContext === 'tmux';
+  const inCmux = multiplexerContext === 'cmux';
   const useDedicatedWindow = Boolean(options.newWindow && inTmux);
-  if (!inTmux) {
+  if (multiplexerContext === 'none') {
     validateTmux();
   }
 
@@ -500,11 +550,17 @@ export async function createTeamSession(
   let leaderPaneId = envPaneId;
   let sessionMode: TeamSessionMode = inTmux ? 'split-pane' : 'detached-session';
 
-  if (!inTmux) {
+  if (inCmux) {
+    const cmuxLeaderSurface = (process.env.CMUX_SURFACE_ID ?? '').trim();
+    if (!cmuxLeaderSurface) {
+      throw new Error('CMUX_SURFACE_ID is required to create a cmux team session');
+    }
+    sessionAndWindow = `cmux:${process.env.CMUX_WORKSPACE_ID || 'workspace'}`;
+    leaderPaneId = cmuxLeaderSurface;
+    sessionMode = 'split-pane';
+  } else if (!inTmux) {
     // Backward-compatible fallback: create an isolated detached tmux session
-    // so workflows can run when launched outside an attached tmux client. This
-    // also covers cmux, which exposes its own surface metadata without a tmux
-    // pane/window that OMC can split directly.
+    // so workflows can run when launched outside any multiplexer.
     const detachedSessionName = `${TMUX_SESSION_PREFIX}-${sanitizeName(teamName)}-${Date.now().toString(36)}`;
     const detachedResult = await tmuxExecAsync([
       'new-session', '-d', '-P', '-F', '#S:0 #{pane_id}',
@@ -565,25 +621,29 @@ export async function createTeamSession(
     sessionMode = 'dedicated-window';
   }
 
-  const teamTarget = sessionAndWindow; // "session:window" form
+  const teamTarget = sessionAndWindow; // "session:window" or "cmux:workspace" form
   const resolvedSessionName = teamTarget.split(':')[0];
 
-  try {
-    await configureTmuxClipboardForSessionAsync(resolvedSessionName);
-  } catch {
-    // Clipboard setup is best-effort so older tmux builds do not block team launch.
+  if (!inCmux) {
+    try {
+      await configureTmuxClipboardForSessionAsync(resolvedSessionName);
+    } catch {
+      // Clipboard setup is best-effort so older tmux builds do not block team launch.
+    }
   }
 
   const workerPaneIds: string[] = [];
 
   if (workerCount <= 0) {
-    try {
-      await tmuxExecAsync(['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
-    } catch { /* ignore */ }
-    if (sessionMode !== 'dedicated-window') {
+    if (!inCmux) {
       try {
-        await tmuxExecAsync(['select-pane', '-t', leaderPaneId]);
+        await tmuxExecAsync(['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
       } catch { /* ignore */ }
+      if (sessionMode !== 'dedicated-window') {
+        try {
+          await tmuxExecAsync(['select-pane', '-t', leaderPaneId]);
+        } catch { /* ignore */ }
+      }
     }
     await new Promise(r => setTimeout(r, 300));
     return { sessionName: teamTarget, leaderPaneId, workerPaneIds, sessionMode };
@@ -592,6 +652,12 @@ export async function createTeamSession(
   // Create worker panes: first via horizontal split off leader, rest stacked vertically on right.
   for (let i = 0; i < workerCount; i++) {
     const splitTarget = i === 0 ? leaderPaneId : workerPaneIds[i - 1];
+    if (inCmux) {
+      const direction = i === 0 ? 'right' : 'down';
+      workerPaneIds.push(await cmuxSplitSurface(splitTarget, direction, cwd));
+      continue;
+    }
+
     const splitType = i === 0 ? '-h' : '-v';
     const splitResult = await tmuxCmdAsync([
       'split-window', splitType, '-t', splitTarget,
@@ -604,16 +670,18 @@ export async function createTeamSession(
     }
   }
 
-  await applyMainVerticalLayout(teamTarget);
+  if (!inCmux) {
+    await applyMainVerticalLayout(teamTarget);
 
-  try {
-    await tmuxExecAsync(['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
-  } catch { /* ignore */ }
-
-  if (sessionMode !== 'dedicated-window') {
     try {
-      await tmuxExecAsync(['select-pane', '-t', leaderPaneId]);
+      await tmuxExecAsync(['set-option', '-t', resolvedSessionName, 'mouse', 'on']);
     } catch { /* ignore */ }
+
+    if (sessionMode !== 'dedicated-window') {
+      try {
+        await tmuxExecAsync(['select-pane', '-t', leaderPaneId]);
+      } catch { /* ignore */ }
+    }
   }
   await new Promise(r => setTimeout(r, 300));
 
@@ -633,6 +701,12 @@ export async function spawnWorkerInPane(
   validateTeamName(config.teamName);
   const startCmd = buildWorkerStartCommand(config);
 
+  if (isCmuxSurfaceTarget(paneId)) {
+    await cmuxSendSurface(paneId, startCmd);
+    await cmuxSendSurface(paneId, 'Enter');
+    return;
+  }
+
   // Use -l (literal) flag to prevent tmux key-name parsing of the command string
   await tmuxExecAsync([
     'send-keys', '-t', paneId, '-l', startCmd
@@ -646,11 +720,34 @@ function normalizeTmuxCapture(value: string): string {
 
 async function capturePaneAsync(paneId: string): Promise<string> {
   try {
+    if (isCmuxSurfaceTarget(paneId)) {
+      return await cmuxCaptureSurface(paneId);
+    }
     const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
     return result.stdout;
   } catch {
     return '';
   }
+}
+
+export async function captureTeamPane(paneId: string): Promise<string> {
+  return capturePaneAsync(paneId);
+}
+
+export async function sendTeamPaneKey(paneId: string, key: string): Promise<void> {
+  if (isCmuxSurfaceTarget(paneId)) {
+    await cmuxSendSurface(paneId, key);
+    return;
+  }
+  await tmuxExecAsync(['send-keys', '-t', paneId, key]);
+}
+
+export async function killTeamPane(paneId: string): Promise<void> {
+  if (isCmuxSurfaceTarget(paneId)) {
+    await cmuxCloseSurface(paneId);
+    return;
+  }
+  await tmuxExecAsync(['kill-pane', '-t', paneId]);
 }
 
 function paneHasTrustPrompt(captured: string): boolean {
@@ -768,6 +865,7 @@ function paneTailContainsLiteralLine(captured: string, text: string): boolean {
 async function paneInCopyMode(
   paneId: string,
 ): Promise<boolean> {
+  if (isCmuxSurfaceTarget(paneId)) return false;
   try {
     const result = await tmuxCmdAsync(['display-message', '-t', paneId, '-p', '#{pane_in_mode}']);
     return result.stdout.trim() === '1';
@@ -812,7 +910,7 @@ export async function sendToWorker(
   }
   try {
     const sendKey = async (key: string) => {
-      await tmuxExecAsync(['send-keys', '-t', paneId, key]);
+      await sendTeamPaneKey(paneId, key);
     };
 
     // Guard: copy-mode captures keys; skip injection entirely.
@@ -835,7 +933,11 @@ export async function sendToWorker(
     }
 
     // Send text in literal mode with -- separator
-    await tmuxExecAsync(['send-keys', '-t', paneId, '-l', '--', message]);
+    if (isCmuxSurfaceTarget(paneId)) {
+      await cmuxSendSurface(paneId, message);
+    } else {
+      await tmuxExecAsync(['send-keys', '-t', paneId, '-l', '--', message]);
+    }
 
     // Allow input buffer to settle
     await sleep(150);
@@ -886,7 +988,11 @@ export async function sendToWorker(
       if (await paneInCopyMode(paneId)) {
         return false;
       }
-      await tmuxExecAsync(['send-keys', '-t', paneId, '-l', '--', message]);
+      if (isCmuxSurfaceTarget(paneId)) {
+        await cmuxSendSurface(paneId, message);
+      } else {
+        await tmuxExecAsync(['send-keys', '-t', paneId, '-l', '--', message]);
+      }
       await sleep(120);
       for (let round = 0; round < 4; round++) {
         await sendKey('C-m');
@@ -968,6 +1074,15 @@ function isTmuxPaneNotFoundError(error: unknown): boolean {
 }
 
 export async function getWorkerLiveness(paneId: string): Promise<WorkerPaneLiveness> {
+  if (isCmuxSurfaceTarget(paneId)) {
+    try {
+      await cmuxCaptureSurface(paneId);
+      return 'alive';
+    } catch {
+      return 'unknown';
+    }
+  }
+
   try {
     const result = await tmuxCmdAsync([
       'display-message', '-t', paneId, '-p', '#{pane_dead}'
@@ -1011,13 +1126,14 @@ export async function killWorkerPanes(opts: {
   // 2. Force-kill each worker pane, guarding leader
   for (const paneId of paneIds) {
     if (paneId === leaderPaneId) continue;   // GUARD — never kill leader
-    try { await tmuxExecAsync(['kill-pane', '-t', paneId]); }
-    catch { /* pane already gone — OK */ }
+    try {
+      await killTeamPane(paneId);
+    } catch { /* pane already gone — OK */ }
   }
 }
 
 function isPaneId(value: string | undefined): value is string {
-  return typeof value === 'string' && /^%\d+$/.test(value.trim());
+  return typeof value === 'string' && (/^%\d+$/.test(value.trim()) || isCmuxSurfaceTarget(value));
 }
 
 function dedupeWorkerPaneIds(paneIds: Array<string | undefined>, leaderPaneId?: string): string[] {
@@ -1071,8 +1187,9 @@ export async function killTeamSession(
     if (!workerPaneIds?.length) return;
     for (const id of workerPaneIds) {
       if (id === leaderPaneId) continue;
-      try { await tmuxExecAsync(['kill-pane', '-t', id]); }
-      catch { /* already gone */ }
+      try {
+        await killTeamPane(id);
+      } catch { /* already gone */ }
     }
     return;
   }


### PR DESCRIPTION
## Summary
- add a narrow cmux-aware team topology path so `CMUX_SURFACE_ID` uses native `cmux new-split` instead of detached host tmux
- route worker send/capture/kill helpers through cmux semantics for cmux surface IDs while preserving classic tmux and plain-terminal detached fallback behavior
- update docs/skill guidance to describe cmux native splits

Fixes #3062.

## Tests
- `npm test -- src/team/__tests__/tmux-session.create-team.test.ts src/team/__tests__/tmux-session.spawn.test.ts src/team/__tests__/tmux-session.kill-team-session.test.ts src/cli/__tests__/tmux-utils.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `git diff --check`

## Notes
- Not live-tested inside a real cmux workspace in this session.
