### PR TITLE
test(hud-wrapper-env): replace 99.99.99 stub with 0.0.0-test-stub semver

### DIFF
--- a/src/installer/__tests__/hud-wrapper-env.test.ts
+++ b/src/installer/__tests__/hud-wrapper-env.test.ts
@@ -19,11 +19,11 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { OMC_PLUGIN_ROOT_ENV } from '../../lib/env-vars.js';
 
-const CACHE_STUB_MARKER = 'FROM_CACHE_STUB_99_99_99';
+const CACHE_STUB_MARKER = 'FROM_CACHE_STUB_TEST';
 
 /**
  * Build an isolated CLAUDE_CONFIG_DIR with a stub HUD at
- * `<configDir>/plugins/cache/omc/oh-my-claudecode/99.99.99/dist/hud/index.js`.
+ * `<configDir>/plugins/cache/omc/oh-my-claudecode/0.0.0-test-stub/dist/hud/index.js`.
  * Used to pin the cache-fallback step (step 2 in the wrapper) so tests can
  * assert the wrapper actually executed that branch instead of accidentally
  * matching a globally-installed npm fallback (step 4).
@@ -32,7 +32,7 @@ function makeStubConfigDir(rootDir: string): string {
   const configDir = join(rootDir, 'isolated-config');
   const stubDir = join(
     configDir,
-    'plugins', 'cache', 'omc', 'oh-my-claudecode', '99.99.99', 'dist', 'hud',
+    'plugins', 'cache', 'omc', 'oh-my-claudecode', '0.0.0-test-stub', 'dist', 'hud',
   );
   mkdirSync(stubDir, { recursive: true });
   writeFileSync(


### PR DESCRIPTION
Retargets #3064 at `dev` per maintainer feedback. Full bug report + impact in #3065.

## Problem

`src/installer/__tests__/hud-wrapper-env.test.ts` uses the literal string `99.99.99` as a stub version directory name to pin the cache-fallback path (step 2 of the wrapper). External tools that scan `~/.claude/plugins/cache/<plugin>/<plugin>/<version>/` for version-shaped strings (e.g. session-shim systems that auto-symlink stranded plugin version dirs) mis-identify `99.99.99` as a legitimate version. When the test runs and materializes a real `99.99.99` directory under tmpdir, those scanners can pick it as "highest semver" and create symlinks pointing at it that break when the test tears down.

In one 5-host homelab fleet this triggered a broken-symlink loop chain (`4.14.0 -> 99.99.99 -> 4.14.0`), wiped the real `4.14.0` directory, and caused `UserPromptSubmit hook error: Plugin directory does not exist: .../oh-my-claudecode/4.14.0` errors across every Claude Code session until the cache was manually rebuilt from the marketplace source tree.

## Fix

Replace `99.99.99` with `0.0.0-test-stub`:
- Still valid semver — any test logic joining paths from the literal string is unchanged.
- `0.0.0` major + explicit `-test-stub` pre-release suffix lets external scanners filter the fixture without a special-case allowlist for `99.99.99`.
- Self-documenting — a future reader sees `0.0.0-test-stub` and knows it's not a real release pin.

## Scope

3 lines in one file:
- `CACHE_STUB_MARKER` constant
- docstring example path
- path literal inside `makeStubConfigDir()`

No other `99.99.99` references in `.ts` source. `dist/` regenerates on next build.

## Optional follow-up

A more defensive fix moves the stub out of any version-shaped directory entirely (e.g. `__test-fixtures__/hud/index.js`). Happy to draft if preferred.