### PR TITLE
Fix psmux PowerShell worker startup on native Windows

### DIFF
--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -130,6 +130,102 @@ describe('buildWorkerStartCommand', () => {
     })).not.toThrow();
   });
 
+  it('uses PowerShell syntax for native Windows psmux worker panes', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: { OMC_TEAM_WORKER: 'team/worker-1' },
+      launchBinary: 'C:\\Users\\tester\\AppData\\Local\\Programs\\claude\\claude.exe',
+      launchArgs: ['--agent-id', 'worker-1'],
+      cwd: 'C:\\repo'
+    });
+
+    expect(cmd).toBe(
+      "$env:OMC_TEAM_WORKER='team/worker-1'; " +
+      "& 'C:\\Users\\tester\\AppData\\Local\\Programs\\claude\\claude.exe' '--agent-id' 'worker-1'"
+    );
+    expect(cmd).not.toContain('cmd.exe');
+    expect(cmd).not.toContain('/d /s /c');
+    expect(cmd).not.toContain('set "');
+  });
+
+  it('escapes psmux PowerShell env vars and quoted launch args without cmd.exe set syntax', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: {
+        OMC_TEAM_WORKER: "team name/worker 'one'",
+        OMC_TEAM_STATE_ROOT: 'C:\\Users\\Test User\\AppData\\Local\\omc state',
+        CLAUDE_CODE_USE_BEDROCK: 'value with spaces & [brackets] "quotes"',
+      },
+      launchBinary: 'C:\\Program Files\\Claude Code\\claude.exe',
+      launchArgs: [
+        '--model',
+        'sonnet "quoted"',
+        "--label=worker 'one'",
+      ],
+      cwd: 'C:\\repo'
+    });
+
+    expect(cmd).toContain("$env:OMC_TEAM_WORKER='team name/worker ''one'''");
+    expect(cmd).toContain("$env:OMC_TEAM_STATE_ROOT='C:\\Users\\Test User\\AppData\\Local\\omc state'");
+    expect(cmd).toContain("$env:CLAUDE_CODE_USE_BEDROCK='value with spaces & [brackets] \"quotes\"'");
+    expect(cmd).toContain("& 'C:\\Program Files\\Claude Code\\claude.exe' '--model' 'sonnet \"quoted\"' '--label=worker ''one'''");
+    expect(cmd).not.toContain('cmd.exe');
+    expect(cmd).not.toContain('/d /s /c');
+    expect(cmd).not.toContain('set "');
+  });
+
+  it('keeps cmd.exe worker startup syntax for native Windows without psmux', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: { OMC_TEAM_WORKER: 'team/worker-1' },
+      launchBinary: 'C:\\Program Files\\OpenAI\\Codex\\codex.exe',
+      launchArgs: ['--full-auto'],
+      cwd: 'C:\\repo'
+    });
+
+    expect(cmd).toBe(
+      'C:\\Windows\\System32\\cmd.exe /d /s /c "set "OMC_TEAM_WORKER=team/worker-1" && ' +
+      '"C:\\Program Files\\OpenAI\\Codex\\codex.exe" "--full-auto""'
+    );
+  });
+
+  it('keeps MSYS/Git Bash worker startup syntax even when psmux env is present', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('MSYSTEM', 'MINGW64');
+    vi.stubEnv('SHELL', '/usr/bin/bash');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: { OMC_TEAM_WORKER: 'team/worker-1' },
+      launchBinary: '/c/Program Files/Git/bin/bash.exe',
+      launchArgs: ['--login'],
+      cwd: '/c/repo'
+    });
+
+    expect(cmd).toContain("'env' OMC_TEAM_WORKER='team/worker-1'");
+    expect(cmd).toContain("'/usr/bin/bash' '-lc'");
+    expect(cmd).toContain("'--' '/c/Program Files/Git/bin/bash.exe' '--login'");
+    expect(cmd).not.toContain('/d /s /c');
+    expect(cmd).not.toContain('$env:OMC_TEAM_WORKER');
+  });
+
   it('uses exec \"$@\" for launchBinary with non-fish shells', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
     vi.stubEnv('SHELL', '/bin/zsh');

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -252,6 +252,18 @@ function escapeForCmdSet(value: string): string {
   return value.replace(/"/g, '""');
 }
 
+function escapeForPowerShellSingleQuotedString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function isNativeWindowsPsmuxPowerShellPane(): boolean {
+  // psmux sets PSMUX_SESSION in panes. Native psmux defaults to PowerShell,
+  // while MSYS/Git Bash psmux panes still need the POSIX branch below.
+  return process.platform === 'win32' &&
+    !isUnixLikeOnWindows() &&
+    !!process.env.PSMUX_SESSION;
+}
+
 function shellNameFromPath(shellPath: string): string {
   const shellName = basename(shellPath.replace(/\\/g, '/'));
   return shellName.replace(/\.(exe|cmd|bat)$/i, '');
@@ -306,6 +318,19 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
   const launchSpec = buildWorkerLaunchSpec(process.env.SHELL);
   const launchWords = getLaunchWords(config);
   const shouldSourceRc = process.env.OMC_TEAM_NO_RC !== '1';
+
+  if (isNativeWindowsPsmuxPowerShellPane()) {
+    const envStatements = Object.entries(config.envVars)
+      .map(([k, v]) => {
+        assertSafeEnvKey(k);
+        return `$env:${k}=${escapeForPowerShellSingleQuotedString(v)}`;
+      });
+    const launch = [
+      '&',
+      ...launchWords.map(escapeForPowerShellSingleQuotedString),
+    ].join(' ');
+    return [...envStatements, launch].join('; ');
+  }
 
   if (process.platform === 'win32' && !isUnixLikeOnWindows()) {
     const envPrefix = Object.entries(config.envVars)


### PR DESCRIPTION
## Summary
- Add a narrow native Windows psmux branch in `buildWorkerStartCommand()` that emits PowerShell-compatible `$env:KEY='value'; & 'binary' 'args'` startup syntax.
- Preserve the existing native Windows `cmd.exe /d /s /c "set ..."` fallback when `PSMUX_SESSION` is absent.
- Preserve the MSYS/Git Bash POSIX startup path even when `PSMUX_SESSION` is present.
- Add focused tests for PowerShell escaping, env vars with spaces/special chars, quoted launch binary/args, and no cmd.exe `set` syntax reaching psmux PowerShell panes.

## Evidence
- `npm test -- src/team/__tests__/tmux-session.test.ts --run` ✅
- `npm test -- src/team/__tests__/tmux-session.test.ts src/team/__tests__/tmux-session.spawn.test.ts src/team/__tests__/tmux-session.create-team.test.ts src/team/__tests__/tmux-session.kill-team-session.test.ts src/team/__tests__/tmux-session-liveness.test.ts src/team/__tests__/tmux-session-prereqs.test.ts --run` ✅
- `npx tsc --noEmit` ✅
- `npx eslint src/team/tmux-session.ts src/team/__tests__/tmux-session.test.ts` ✅
- `npm run build` ✅
- `npm run lint` ✅ (existing warnings only; 0 errors)
- `git diff --check` ✅
- Diff-only secret/path scan ✅

## Notes
- Not live-tested in a Windows psmux PowerShell pane from this Linux/UTC maintainer environment.
- Do not merge until reviewed.

Fixes #3075

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
