### PR TITLE
Fix setup stale plugin cache repair after marketplace updates

### DIFF
--- a/scripts/repair-plugin-cache.mjs
+++ b/scripts/repair-plugin-cache.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Repair OMC plugin cache references after marketplace updates.
+ *
+ * Claude Code can keep a running session pointed at the previous plugin cache
+ * path while /plugin marketplace update installs a newer cache directory.  The
+ * setup wizard must not delete that old path before the plugin registry and
+ * long-running-session fallback are repaired, or every hook/skill invocation
+ * emits "Plugin directory does not exist" for the old version.
+ */
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function getClaudeConfigDir() {
+  const configured = (process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude')).replace(/[\\/]+$/, '');
+  if (configured === '~') return homedir();
+  if (configured.startsWith('~/') || configured.startsWith('~\\')) return join(homedir(), configured.slice(2));
+  return configured;
+}
+
+function parseVersion(version) {
+  const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?$/);
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+function compareVersionsDesc(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa && !pb) return 0;
+  if (!pa) return 1;
+  if (!pb) return -1;
+  for (let i = 0; i < 3; i += 1) {
+    const delta = pb[i] - pa[i];
+    if (delta !== 0) return delta;
+  }
+  return 0;
+}
+
+function isValidOmcPluginRoot(root) {
+  return existsSync(join(root, 'hooks', 'hooks.json'))
+    || existsSync(join(root, 'skills', 'omc-setup', 'SKILL.md'))
+    || existsSync(join(root, 'docs', 'CLAUDE.md'));
+}
+
+function latestValidCacheRoot(cacheBase) {
+  if (!existsSync(cacheBase)) return null;
+  try {
+    const versions = readdirSync(cacheBase, { withFileTypes: true })
+      .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
+      .map(entry => entry.name)
+      .filter(name => parseVersion(name))
+      .sort(compareVersionsDesc);
+
+    for (const version of versions) {
+      const root = join(cacheBase, version);
+      if (isValidOmcPluginRoot(root)) return root;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function readJson(path) {
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, 'utf-8').trim();
+  if (!raw) return null;
+  return JSON.parse(raw);
+}
+
+function writeJsonAtomic(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`);
+    renameSync(tmp, path);
+  } catch (error) {
+    try { rmSync(tmp, { force: true }); } catch {}
+    throw error;
+  }
+}
+
+function normalizePath(pathValue) {
+  return String(pathValue).replace(/\\/g, '/').replace(/\/+$/, '');
+}
+
+function rewriteOmcRegistryEntries(installedPluginsPath, latestRoot) {
+  const raw = readJson(installedPluginsPath);
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { updated: false, entries: 0, stalePaths: [] };
+  }
+
+  const plugins = raw.plugins && typeof raw.plugins === 'object' && !Array.isArray(raw.plugins)
+    ? raw.plugins
+    : raw;
+  const latestVersion = basename(latestRoot);
+  let updated = false;
+  let entries = 0;
+  const stalePaths = [];
+
+  for (const [pluginId, value] of Object.entries(plugins)) {
+    if (!pluginId.toLowerCase().includes('oh-my-claudecode') || !Array.isArray(value)) continue;
+
+    for (const entry of value) {
+      if (!entry || typeof entry !== 'object') continue;
+      entries += 1;
+      const currentPath = typeof entry.installPath === 'string' ? entry.installPath : '';
+      const currentVersion = typeof entry.version === 'string' ? entry.version : basename(currentPath);
+      const currentExists = currentPath ? existsSync(currentPath) : false;
+      const latestIsNewer = parseVersion(currentVersion) && compareVersionsDesc(latestVersion, currentVersion) < 0;
+
+      if (!currentExists || latestIsNewer || normalizePath(currentPath) !== normalizePath(latestRoot)) {
+        if (currentPath && normalizePath(currentPath) !== normalizePath(latestRoot)) {
+          stalePaths.push(currentPath);
+        }
+        entry.installPath = latestRoot;
+        entry.version = latestVersion;
+        updated = true;
+      }
+    }
+  }
+
+  if (updated) {
+    writeJsonAtomic(installedPluginsPath, raw);
+  }
+
+  return { updated, entries, stalePaths };
+}
+
+function replaceWithSymlink(versionPath, latestRoot) {
+  const latestVersion = basename(latestRoot);
+  if (basename(versionPath) === latestVersion) return false;
+
+  try {
+    const stat = lstatSync(versionPath);
+    if (stat.isSymbolicLink()) {
+      const target = readlinkSync(versionPath);
+      if (target === latestVersion || normalizePath(target) === normalizePath(latestRoot)) return false;
+    }
+  } catch {
+    mkdirSync(dirname(versionPath), { recursive: true });
+    symlinkSync(process.platform === 'win32' ? latestRoot : latestVersion, versionPath, process.platform === 'win32' ? 'junction' : 'dir');
+    return true;
+  }
+
+  rmSync(versionPath, { recursive: true, force: true });
+  symlinkSync(process.platform === 'win32' ? latestRoot : latestVersion, versionPath, process.platform === 'win32' ? 'junction' : 'dir');
+  return true;
+}
+
+export function repairPluginCacheReferences() {
+  const configDir = getClaudeConfigDir();
+  const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+  const latestRoot = latestValidCacheRoot(cacheBase);
+  const result = { latestRoot, registryUpdated: false, symlinked: 0, errors: [] };
+
+  if (!latestRoot) return result;
+
+  const installedPluginsPath = join(configDir, 'plugins', 'installed_plugins.json');
+  try {
+    const registry = rewriteOmcRegistryEntries(installedPluginsPath, latestRoot);
+    result.registryUpdated = registry.updated;
+    for (const stalePath of registry.stalePaths) {
+      const staleParent = normalizePath(dirname(stalePath));
+      if (staleParent === normalizePath(cacheBase) && parseVersion(basename(stalePath))) {
+        try {
+          if (replaceWithSymlink(stalePath, latestRoot)) result.symlinked += 1;
+        } catch (error) {
+          result.errors.push(`cache fallback repair failed for ${stalePath}: ${error instanceof Error ? error.message : error}`);
+        }
+      }
+    }
+  } catch (error) {
+    result.errors.push(`installed_plugins.json repair failed: ${error instanceof Error ? error.message : error}`);
+  }
+
+  try {
+    const latestVersion = basename(latestRoot);
+    const versions = readdirSync(cacheBase, { withFileTypes: true })
+      .filter(entry => (entry.isDirectory() || entry.isSymbolicLink()) && parseVersion(entry.name))
+      .map(entry => entry.name)
+      .filter(version => version !== latestVersion)
+      .sort(compareVersionsDesc);
+
+    for (const version of versions) {
+      try {
+        if (replaceWithSymlink(join(cacheBase, version), latestRoot)) {
+          result.symlinked += 1;
+        }
+      } catch (error) {
+        result.errors.push(`cache fallback repair failed for ${version}: ${error instanceof Error ? error.message : error}`);
+      }
+    }
+  } catch (error) {
+    result.errors.push(`cache scan failed: ${error instanceof Error ? error.message : error}`);
+  }
+
+  return result;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const result = repairPluginCacheReferences();
+  for (const error of result.errors) {
+    console.warn(`[OMC] Plugin cache repair warning: ${error}`);
+  }
+  if (!result.latestRoot) {
+    console.log('[OMC] No OMC plugin cache found (normal for new installs)');
+  } else if (result.registryUpdated || result.symlinked > 0) {
+    console.log(`[OMC] Repaired plugin cache references: active=${result.latestRoot}, symlinked=${result.symlinked}`);
+  } else {
+    console.log('[OMC] Plugin cache references are current');
+  }
+}

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -82,6 +82,22 @@ EXAMPLES:
 For more info: https://github.com/Yeachan-Heo/oh-my-claudecode
 ```
 
+
+## Active Plugin Root Resolution
+
+Before running setup shell commands or reading phase files, resolve the current OMC plugin root. This prevents an already-running Claude Code session from continuing to use a stale `CLAUDE_PLUGIN_ROOT` after `/plugin marketplace update omc` installs a newer cache version.
+
+```bash
+OMC_SETUP_PLUGIN_ROOT=$(node -e "const f=require('fs'),p=require('path'),h=require('os').homedir(),d=(process.env.CLAUDE_CONFIG_DIR||p.join(h,'.claude')).replace(/[\\/]+$/,''),b=p.join(d,'plugins','cache','omc','oh-my-claudecode'),valid=r=>f.existsSync(p.join(r,'skills','omc-setup','SKILL.md'))||f.existsSync(p.join(r,'hooks','hooks.json'))||f.existsSync(p.join(r,'docs','CLAUDE.md'));try{const vs=f.readdirSync(b,{withFileTypes:true}).filter(e=>(e.isDirectory()||e.isSymbolicLink())&&/^\d+\.\d+\.\d+/.test(e.name)).map(e=>e.name).sort((a,c)=>c.localeCompare(a,void 0,{numeric:true}));const hit=vs.map(v=>p.join(b,v)).find(valid);if(hit)console.log(hit);else if(process.env.CLAUDE_PLUGIN_ROOT)console.log(process.env.CLAUDE_PLUGIN_ROOT)}catch{if(process.env.CLAUDE_PLUGIN_ROOT)console.log(process.env.CLAUDE_PLUGIN_ROOT)}")
+export OMC_SETUP_PLUGIN_ROOT
+```
+
+Use `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` for all setup script and phase paths, then immediately repair stale cache references before any prompts or phase work:
+
+```bash
+node "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/repair-plugin-cache.mjs"
+```
+
 ## Pre-Setup Check: Already Configured?
 
 **CRITICAL**: Before doing anything else, check if setup has already been completed. This prevents users from having to re-run the full setup wizard after every update.
@@ -117,8 +133,8 @@ Use AskUserQuestion to prompt:
 
 **If user chooses "Update CLAUDE.md only":**
 - Detect if local (.claude/CLAUDE.md) or global (~/.claude/CLAUDE.md) config exists
-- If local exists, run: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-claude-md.sh" local`
-- If only global exists, run: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-claude-md.sh" global`
+- If local exists, run: `bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" local`
+- If only global exists, run: `bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" global`
 - Skip all other steps
 - Report success and exit
 
@@ -137,7 +153,7 @@ If user passes `--force` flag, skip this check and proceed directly to setup.
 Before starting any phase, check for existing state:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" resume
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" resume
 ```
 
 If state exists (output is not "fresh"), use AskUserQuestion to prompt:
@@ -150,29 +166,29 @@ If state exists (output is not "fresh"), use AskUserQuestion to prompt:
 
 If user chooses "Start fresh":
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" clear
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" clear
 ```
 
 ## Phase Execution
 
 ### For `--local` or `--global` flags:
-Read the file at `${CLAUDE_PLUGIN_ROOT}/skills/omc-setup/phases/01-install-claude-md.md` and follow its instructions.
+Read the file at `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/skills/omc-setup/phases/01-install-claude-md.md` and follow its instructions.
 (The phase file handles early exit for flag mode.)
 
 ### For full setup (default or --force):
 Execute phases sequentially. For each phase, read the corresponding file and follow its instructions:
 
-1. **Phase 1 - Install CLAUDE.md**: Read `${CLAUDE_PLUGIN_ROOT}/skills/omc-setup/phases/01-install-claude-md.md` and follow its instructions.
+1. **Phase 1 - Install CLAUDE.md**: Read `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/skills/omc-setup/phases/01-install-claude-md.md` and follow its instructions.
 
-2. **Phase 2 - Environment Configuration**: Read `${CLAUDE_PLUGIN_ROOT}/skills/omc-setup/phases/02-configure.md` and follow its instructions. Phase 2 must delegate HUD/statusLine setup to the `hud` skill; do not generate or patch `statusLine` paths inline here.
+2. **Phase 2 - Environment Configuration**: Read `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/skills/omc-setup/phases/02-configure.md` and follow its instructions. Phase 2 must delegate HUD/statusLine setup to the `hud` skill; do not generate or patch `statusLine` paths inline here.
 
-3. **Phase 3 - Integration Setup**: Read `${CLAUDE_PLUGIN_ROOT}/skills/omc-setup/phases/03-integrations.md` and follow its instructions.
+3. **Phase 3 - Integration Setup**: Read `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/skills/omc-setup/phases/03-integrations.md` and follow its instructions.
 
-4. **Phase 4 - Completion**: Read `${CLAUDE_PLUGIN_ROOT}/skills/omc-setup/phases/04-welcome.md` and follow its instructions.
+4. **Phase 4 - Completion**: Read `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/skills/omc-setup/phases/04-welcome.md` and follow its instructions.
 
 ## Graceful Interrupt Handling
 
-**IMPORTANT**: This setup process saves progress after each phase via `${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh`. If interrupted (Ctrl+C or connection loss), the setup can resume from where it left off.
+**IMPORTANT**: This setup process saves progress after each phase via `${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh`. If interrupted (Ctrl+C or connection loss), the setup can resume from where it left off.
 
 ## Keeping Up to Date
 

--- a/skills/omc-setup/phases/01-install-claude-md.md
+++ b/skills/omc-setup/phases/01-install-claude-md.md
@@ -30,7 +30,7 @@ Set `GLOBAL_INSTALL_STYLE=overwrite` or `preserve` based on the user's choice. I
 **MANDATORY**: Always run this command. Do NOT skip. Do NOT use the Write tool. Let the setup script choose the safest canonical source (bundled `docs/CLAUDE.md` first, GitHub fallback only if needed).
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-claude-md.sh" <CONFIG_TARGET> [GLOBAL_INSTALL_STYLE]
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" <CONFIG_TARGET> [GLOBAL_INSTALL_STYLE]
 ```
 
 Replace `<CONFIG_TARGET>` with `local` or `global`. For local installs, omit the optional style argument. For global installs, pass `overwrite` or `preserve` when you know the user's choice; otherwise let the script default to `overwrite`.
@@ -85,13 +85,13 @@ Note: Hooks are now managed by the plugin system automatically. No manual hook i
 ## Save Progress
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" save 2 <CONFIG_TARGET>
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" save 2 <CONFIG_TARGET>
 ```
 
 ## Early Exit for Flag Mode
 
 If `--local` or `--global` flag was used, clear state and **STOP HERE**:
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" clear
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" clear
 ```
 Do not continue to Phase 2 or other phases.

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -35,13 +35,15 @@ This will:
 After HUD setup completes, save progress:
 ```bash
 CONFIG_TYPE=$(jq -r '.configType // "unknown"' ".omc/state/setup-state.json" 2>/dev/null || echo "unknown")
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" save 3 "$CONFIG_TYPE"
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" save 3 "$CONFIG_TYPE"
 ```
 
-## Step 2.2: Clear Stale Plugin Cache
+## Step 2.2: Repair Stale Plugin Cache References
+
+After a marketplace update, Claude Code may still have old OMC cache paths in the running session or plugin registry. Repair those references before any cache cleanup so setup does not repeatedly emit stale plugin directory errors.
 
 ```bash
-node -e "const p=require('path'),f=require('fs'),h=require('os').homedir(),d=process.env.CLAUDE_CONFIG_DIR||p.join(h,'.claude'),b=p.join(d,'plugins','cache','omc','oh-my-claudecode');try{const v=f.readdirSync(b).filter(x=>/^\d/.test(x)).sort((a,c)=>a.localeCompare(c,void 0,{numeric:true}));if(v.length<=1){console.log('Cache is clean');process.exit()}v.slice(0,-1).forEach(x=>{f.rmSync(p.join(b,x),{recursive:true,force:true})});console.log('Cleared',v.length-1,'stale cache version(s)')}catch{console.log('No cache directory found (normal for new installs)')}"
+node "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/repair-plugin-cache.mjs"
 ```
 
 ## Step 2.3: Check for Updates
@@ -252,5 +254,5 @@ echo "Task tool set to: USER_CHOICE"
 
 ```bash
 CONFIG_TYPE=$(jq -r '.configType // "unknown"' ".omc/state/setup-state.json" 2>/dev/null || echo "unknown")
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" save 4 "$CONFIG_TYPE"
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" save 4 "$CONFIG_TYPE"
 ```

--- a/skills/omc-setup/phases/03-integrations.md
+++ b/skills/omc-setup/phases/03-integrations.md
@@ -229,5 +229,5 @@ Or by running `/oh-my-claudecode:omc-setup --force` and choosing to enable teams
 
 ```bash
 CONFIG_TYPE=$(jq -r '.configType // "unknown"' ".omc/state/setup-state.json" 2>/dev/null || echo "unknown")
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" save 6 "$CONFIG_TYPE"
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" save 6 "$CONFIG_TYPE"
 ```

--- a/skills/omc-setup/phases/04-welcome.md
+++ b/skills/omc-setup/phases/04-welcome.md
@@ -116,7 +116,7 @@ OMC includes rule templates you can copy to your project's `.claude/rules/` dire
 Copy with:
 ```bash
 mkdir -p .claude/rules
-cp "${CLAUDE_PLUGIN_ROOT}/templates/rules/"*.md .claude/rules/
+cp "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/templates/rules/"*.md .claude/rules/
 ```
 
 See `templates/rules/README.md` for details.
@@ -188,5 +188,5 @@ if [ -z "$OMC_VERSION" ]; then
   OMC_VERSION="unknown"
 fi
 
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup-progress.sh" complete "$OMC_VERSION"
+bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" complete "$OMC_VERSION"
 ```

--- a/src/__tests__/repair-plugin-cache-script.test.ts
+++ b/src/__tests__/repair-plugin-cache-script.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'repair-plugin-cache.mjs');
+const tempRoots: string[] = [];
+
+function writePluginRoot(root: string, version: string): void {
+  mkdirSync(join(root, 'hooks'), { recursive: true });
+  mkdirSync(join(root, 'skills', 'omc-setup'), { recursive: true });
+  mkdirSync(join(root, 'docs'), { recursive: true });
+  writeFileSync(join(root, 'hooks', 'hooks.json'), '{}\n');
+  writeFileSync(join(root, 'skills', 'omc-setup', 'SKILL.md'), '# setup\n');
+  writeFileSync(join(root, 'docs', 'CLAUDE.md'), `<!-- OMC:VERSION:${version} -->\n`);
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const root = tempRoots.pop();
+    if (root) rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('repair-plugin-cache.mjs', () => {
+  it('rewrites stale installed_plugins.json and keeps old cache path as a symlink fallback', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-repair-plugin-cache-'));
+    tempRoots.push(root);
+
+    const configDir = join(root, '.claude');
+    const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const oldRoot = join(cacheBase, '4.11.6');
+    const newRoot = join(cacheBase, '4.14.1');
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writePluginRoot(oldRoot, '4.11.6');
+    writePluginRoot(newRoot, '4.14.1');
+    writeFileSync(join(configDir, 'plugins', 'installed_plugins.json'), JSON.stringify({
+      version: 2,
+      plugins: {
+        'oh-my-claudecode@omc': [{ installPath: oldRoot, version: '4.11.6', enabled: true }],
+      },
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Repaired plugin cache references');
+
+    const registry = JSON.parse(readFileSync(join(configDir, 'plugins', 'installed_plugins.json'), 'utf-8'));
+    expect(registry.plugins['oh-my-claudecode@omc'][0]).toMatchObject({
+      installPath: newRoot,
+      version: '4.14.1',
+      enabled: true,
+    });
+    expect(existsSync(oldRoot)).toBe(true);
+    expect(lstatSync(oldRoot).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(oldRoot)).toBe('4.14.1');
+    expect(existsSync(join(oldRoot, 'hooks', 'hooks.json'))).toBe(true);
+  });
+
+  it('repairs a registry entry whose old cache path was already deleted', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-repair-missing-cache-'));
+    tempRoots.push(root);
+
+    const configDir = join(root, '.claude');
+    const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const oldRoot = join(cacheBase, '4.11.6');
+    const newRoot = join(cacheBase, '4.14.1');
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writePluginRoot(newRoot, '4.14.1');
+    writeFileSync(join(configDir, 'plugins', 'installed_plugins.json'), JSON.stringify({
+      'oh-my-claudecode@omc': [{ installPath: oldRoot, version: '4.11.6' }],
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(oldRoot)).toBe(true);
+    expect(lstatSync(oldRoot).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(oldRoot)).toBe('4.14.1');
+    expect(existsSync(join(oldRoot, 'hooks', 'hooks.json'))).toBe(true);
+    const registry = JSON.parse(readFileSync(join(configDir, 'plugins', 'installed_plugins.json'), 'utf-8'));
+    expect(registry['oh-my-claudecode@omc'][0]).toMatchObject({
+      installPath: newRoot,
+      version: '4.14.1',
+    });
+  });
+
+  it('setup instructions repair cache references before prompts and avoid direct cache deletion', () => {
+    const setupSkill = readFileSync(join(REPO_ROOT, 'skills', 'omc-setup', 'SKILL.md'), 'utf-8');
+    const phase = readFileSync(join(REPO_ROOT, 'skills', 'omc-setup', 'phases', '02-configure.md'), 'utf-8');
+
+    expect(setupSkill).toContain('Active Plugin Root Resolution');
+    expect(setupSkill).toContain('repair-plugin-cache.mjs');
+    expect(setupSkill.indexOf('repair-plugin-cache.mjs', setupSkill.indexOf('Active Plugin Root Resolution'))).toBeLessThan(setupSkill.indexOf('## Pre-Setup Check'));
+    expect(phase).toContain('Repair Stale Plugin Cache References');
+    expect(phase).toContain('repair-plugin-cache.mjs');
+    expect(phase).not.toContain('rmSync(p.join(b,x)');
+  });
+});


### PR DESCRIPTION
## Summary
- repair stale OMC plugin registry/cache references at the start of setup
- replace old cache versions with symlink fallbacks instead of deleting paths still used by running sessions
- route setup phase/script paths through the resolved current plugin root

## Root cause
Setup phase 2 deleted older plugin cache directories before repairing Claude Code's registry/running-session references. After `/plugin marketplace update omc`, a session could still point at the old version path, so each hook/skill launch emitted `Plugin directory does not exist` even though setup continued.

## Verification
- `npm run build`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing warnings)
- `npm test -- --run src/__tests__/repair-plugin-cache-script.test.ts src/skills/__tests__/skill-config-dir.test.ts src/skills/__tests__/mingw-escape.test.ts src/__tests__/setup-contracts-regression.test.ts src/installer/__tests__/plugin-cache-sync.test.ts src/__tests__/auto-update.test.ts src/__tests__/setup-claude-md-script.test.ts`
- `git diff --check`
- staged diff secret/path scan

Fixes #3077

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*