### PR TITLE
Fix plugin cache command wrapper materialization

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -11014,6 +11014,7 @@ var init_installer = __esm({
       "scripts",
       "skills",
       "agents",
+      "commands",
       "templates",
       "docs",
       ".claude-plugin",

--- a/dist/installer/index.js
+++ b/dist/installer/index.js
@@ -833,6 +833,7 @@ const PLUGIN_SYNC_PAYLOAD = [
     'scripts',
     'skills',
     'agents',
+    'commands',
     'templates',
     'docs',
     '.claude-plugin',

--- a/src/__tests__/plugin-skill-budget.test.ts
+++ b/src/__tests__/plugin-skill-budget.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, win32 } from 'path';
 import { fileURLToPath } from 'url';
 import { isPathInsideOrEqual } from '../features/builtin-skills/skills.js';
-import { compactPluginSkillPayload } from '../installer/index.js';
+import { compactPluginSkillPayload, copyPluginSyncPayload } from '../installer/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -107,6 +116,35 @@ describe('plugin skill context budget gate (issues #2943, #2986)', () => {
         expect(commandContent).toContain(expectedSkillPath);
         expect(commandContent).toContain('$ARGUMENTS');
       }
+    }
+  });
+
+  it('materializes declared plugin command wrappers into cache sync targets', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-plugin-commands-cache-'));
+    try {
+      const sourceRoot = join(tempRoot, 'source');
+      const targetRoot = join(tempRoot, 'cache', 'omc', 'oh-my-claudecode', '4.14.1');
+      mkdirSync(join(sourceRoot, '.claude-plugin'), { recursive: true });
+      mkdirSync(join(sourceRoot, 'commands'), { recursive: true });
+      writeFileSync(join(sourceRoot, '.claude-plugin', 'plugin.json'), JSON.stringify({
+        name: 'oh-my-claudecode',
+        commands: './commands/',
+      }, null, 2));
+      writeFileSync(join(sourceRoot, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md and pass $ARGUMENTS.\n');
+
+      const result = copyPluginSyncPayload(sourceRoot, [targetRoot]);
+
+      expect(result.errors).toEqual([]);
+      expect(result.synced).toBe(true);
+
+      const manifest = JSON.parse(
+        readFileSync(join(targetRoot, '.claude-plugin', 'plugin.json'), 'utf-8')
+      ) as { commands?: string };
+      expect(manifest.commands).toBe('./commands/');
+      expect(existsSync(join(targetRoot, 'commands'))).toBe(true);
+      expect(readFileSync(join(targetRoot, 'commands', 'omc-setup.md'), 'utf-8')).toContain('$ARGUMENTS');
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
     }
   });
 

--- a/src/installer/__tests__/plugin-cache-sync.test.ts
+++ b/src/installer/__tests__/plugin-cache-sync.test.ts
@@ -18,6 +18,7 @@ function writePayloadTree(root: string, version = '9.9.9-test'): void {
   writeFile(join(root, 'scripts', 'run.cjs'), 'console.log("run");\n');
   writeFile(join(root, 'skills', 'plan', 'SKILL.md'), '# plan\n');
   writeFile(join(root, 'agents', 'executor.md'), '# executor\n');
+  writeFile(join(root, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md and pass $ARGUMENTS.\n');
   writeFile(join(root, 'templates', 'deliverables.json'), '{}\n');
   writeFile(join(root, 'docs', 'CLAUDE.md'), '# docs\n');
   writeFile(join(root, '.claude-plugin', 'plugin.json'), '{"name":"oh-my-claudecode"}\n');
@@ -90,6 +91,7 @@ describe('syncInstalledPluginPayload', () => {
     expect(existsSync(join(cacheRoot, 'skills', 'plan', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'hooks', 'hooks.json'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'commands', 'omc-setup.md'))).toBe(true);
     expect(JSON.parse(readFileSync(join(cacheRoot, 'package.json'), 'utf-8')).version).toBe('9.9.9-test');
   });
 
@@ -141,6 +143,7 @@ describe('syncInstalledPluginPayload', () => {
     expect(existsSync(join(cacheRoot, 'skills', 'plan', 'SKILL.md'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'hooks', 'hooks.json'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'commands', 'omc-setup.md'))).toBe(true);
   });
 
   it('rejects cache install roots that escape the cache directory via .. segments', async () => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -985,6 +985,7 @@ const PLUGIN_SYNC_PAYLOAD = [
   'scripts',
   'skills',
   'agents',
+  'commands',
   'templates',
   'docs',
   '.claude-plugin',


### PR DESCRIPTION
## Summary
- Include `commands/` in the plugin cache sync payload so repaired/materialized cache roots match `.claude-plugin/plugin.json` when it declares `commands: "./commands/"`.
- Add a regression test that copies a plugin source into a versioned cache root and proves the declared command wrapper path exists with `$ARGUMENTS` passthrough.
- Update generated `dist/installer/index.js` and `bridge/cli.cjs` for packaged CLI/runtime behavior.

## Verification
- `npm run build`
- `npx tsc --noEmit`
- `npm run lint` (exit 0; pre-existing warnings only)
- `npx vitest run src/__tests__/plugin-skill-budget.test.ts src/__tests__/installer.test.ts src/__tests__/npm-package-hook-surface.test.ts src/__tests__/repair-plugin-cache-script.test.ts src/__tests__/auto-update.test.ts` (88 passed)
- `npx eslint src/installer/index.ts src/__tests__/plugin-skill-budget.test.ts`
- `git diff --check`
- diff-only secret/path scan (no matches)

Fixes #3079.
