### PR TITLE
docs: add community plugins page (non-dev-output as first entry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ For `/goal` behavior, rely on Claude Code/Anthropic sources: the [Claude Code `/
 
 Want to contribute to OMC? See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full developer guide, including how to fork, set up a local checkout, link it as your active plugin, run tests, and submit PRs.
 
+### Community Plugins
+
+Third-party plugins built on top of OMC and Claude Code. See [docs/COMMUNITY-PLUGINS.md](./docs/COMMUNITY-PLUGINS.md) for the full list and install instructions.
+
 ### Custom Skills
 
 Learn once, reuse forever. OMC extracts hard-won debugging knowledge into portable skill files that auto-inject when relevant.

--- a/docs/COMMUNITY-PLUGINS.md
+++ b/docs/COMMUNITY-PLUGINS.md
@@ -1,0 +1,37 @@
+# Community Plugins
+
+Third-party plugins built for OMC and Claude Code.  
+Install any of them with `claude plugin marketplace add <repo-url>`.
+
+---
+
+## non-dev-output
+
+> Explains tech in plain language — no commands needed.
+
+**Author**: [@calmtiger86](https://github.com/calmtiger86)  
+**Repo**: https://github.com/calmtiger86/non-dev-output  
+**Language**: Korean / English / Chinese
+
+### What it does
+
+Two hooks run automatically on every session:
+
+- **SessionStart** — injects a two-block output rule (analogy block + reality block) into Claude's context
+- **UserPromptSubmit** — detects confusion signals (`"이해가 안 돼"`, `"I don't understand"`, …) and writing requests (`"블로그 써줘"`, `"write a blog post"`, …), then injects the matching instruction before Claude responds
+
+No slash commands. No manual mode switching.
+
+### Install
+
+```bash
+claude plugin marketplace add https://github.com/calmtiger86/non-dev-output
+claude plugin install non-dev-output@non-dev-output
+```
+
+---
+
+## Submit your plugin
+
+Open a PR adding a new section to this file.  
+Follow the format above: name, author, repo, what it does, install command.


### PR DESCRIPTION
## Summary

- Adds `docs/COMMUNITY-PLUGINS.md` as a home for third-party plugins built on OMC and Claude Code
- Lists **non-dev-output** as the first entry with install instructions
- Adds a `### Community Plugins` link in README.md under the Contributing section

## About non-dev-output

**non-dev-output** is a Claude Code plugin for non-developers that:

- Auto-detects confusion (`"이해가 안 돼"`, `"I don't understand"`, …) and switches to a two-block analogy mode
- Auto-detects writing requests (`"블로그 써줘"`, `"write a blog post"`, …) and removes AI clichés
- No slash commands — two hooks (SessionStart + UserPromptSubmit) handle everything automatically

Repo: https://github.com/calmtiger86/non-dev-output

## Why this PR

OMC doesn't currently have a place for community plugins. This PR proposes a lightweight docs page as that home — easy to maintain, easy for other plugin authors to submit to via subsequent PRs.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)