### PR TITLE
hud: human-friendly session-duration formatting (m / h / d)

### DIFF
--- a/src/__tests__/hud/session.test.ts
+++ b/src/__tests__/hud/session.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { formatSessionDuration, renderSession } from '../../hud/elements/session.js';
+
+describe('formatSessionDuration', () => {
+  it('returns minutes under 1 hour', () => {
+    expect(formatSessionDuration(0)).toBe('0m');
+    expect(formatSessionDuration(1)).toBe('1m');
+    expect(formatSessionDuration(42)).toBe('42m');
+    expect(formatSessionDuration(59)).toBe('59m');
+  });
+
+  it('returns hours (no minutes) between 1h and 24h', () => {
+    expect(formatSessionDuration(60)).toBe('1h');
+    expect(formatSessionDuration(90)).toBe('1h');   // floor: 1h 30m → 1h
+    expect(formatSessionDuration(120)).toBe('2h');
+    expect(formatSessionDuration(1439)).toBe('23h');
+  });
+
+  it('returns days+hours past 24h', () => {
+    expect(formatSessionDuration(1440)).toBe('1d');         // exact day → drop trailing 0h
+    expect(formatSessionDuration(1500)).toBe('1d1h');
+    expect(formatSessionDuration(2880)).toBe('2d');
+    expect(formatSessionDuration(4755)).toBe('3d7h');       // 79.25h → 3d 7h
+  });
+});
+
+describe('renderSession', () => {
+  it('returns null for a null session', () => {
+    expect(renderSession(null)).toBeNull();
+  });
+
+  it('includes the formatted duration in the output', () => {
+    const out = renderSession({
+      durationMinutes: 4755,
+      messageCount: 100,
+      health: 'healthy',
+    });
+    expect(out).toContain('3d7h');
+    expect(out).not.toContain('4755m');
+  });
+
+  it('uses minute formatting for short sessions', () => {
+    const out = renderSession({
+      durationMinutes: 45,
+      messageCount: 12,
+      health: 'healthy',
+    });
+    expect(out).toContain('45m');
+  });
+
+  it('applies color codes based on health level', () => {
+    const healthy = renderSession({ durationMinutes: 30, messageCount: 5, health: 'healthy' });
+    const warning = renderSession({ durationMinutes: 30, messageCount: 5, health: 'warning' });
+    const critical = renderSession({ durationMinutes: 30, messageCount: 5, health: 'critical' });
+    expect(healthy).not.toBe(warning);
+    expect(warning).not.toBe(critical);
+    expect(healthy).not.toBe(critical);
+  });
+});

--- a/src/hud/elements/session.ts
+++ b/src/hud/elements/session.ts
@@ -8,9 +8,30 @@ import type { SessionHealth } from '../types.js';
 import { green, red, yellow } from '../colors.js';
 
 /**
+ * Format a duration in minutes as a compact, human-readable string.
+ *
+ * Auto-scales to the largest natural unit so long-running sessions don't
+ * render as e.g. "4755m" (~3 days) — which is hard to read at a glance.
+ *
+ *   42        -> "42m"
+ *   90        -> "1h"
+ *   1500      -> "1d1h"
+ *   4755      -> "3d7h"
+ *   2880      -> "2d"   (exact-day boundaries drop the trailing 0h)
+ */
+export function formatSessionDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours > 0 ? `${days}d${remHours}h` : `${days}d`;
+}
+
+/**
  * Render session health indicator.
  *
- * Format: session:45m or session:45m (healthy)
+ * Format: session:45m / session:2h / session:3d7h
  */
 export function renderSession(session: SessionHealth | null): string | null {
   if (!session) return null;
@@ -19,5 +40,5 @@ export function renderSession(session: SessionHealth | null): string | null {
     : session.health === 'warning' ? yellow
     : green;
 
-  return `session:${colorize(`${session.durationMinutes}m`)}`;
+  return `session:${colorize(formatSessionDuration(session.durationMinutes))}`;
 }


### PR DESCRIPTION
## Summary

The HUD session-health element renders duration as raw minutes (`session:4755m`), which becomes hard to parse at a glance once sessions get long. 4755 minutes is ~3 days, but you have to do the math every time you look at the status line.

This PR auto-scales to the largest natural unit:

| Input (minutes) | Before | After |
|---|---|---|
| 42 | `42m` | `42m` |
| 90 | `90m` | `1h` |
| 1500 | `1500m` | `1d1h` |
| 4755 | `4755m` | `3d7h` |
| 2880 | `2880m` | `2d` |

Backwards-compatible — same `session:<val>` shape, just a more readable `<val>`. Color logic for healthy/warning/critical unchanged.

## Implementation

Adds a small `formatSessionDuration(minutes)` helper in `src/hud/elements/session.ts`:

- `< 60` → minutes (`Xm`)
- `< 24h` → hours, floor (`Xh`)
- `≥ 24h` → days + remaining hours (`XdYh`); drops trailing `0h` on exact-day boundaries

`renderSession` calls the helper. Same code path otherwise.

## Test plan

- [x] New unit tests in `src/__tests__/hud/session.test.ts` (7 tests) cover both the formatter and the renderer
- [x] `npx vitest run src/__tests__/hud/session.test.ts` — all 7 pass locally
- [x] Edge cases tested: 0 min, exact-hour boundary, exact-day boundary, sub-day, multi-day
- [x] Renderer test verifies output contains the formatted string and that the three health levels still produce different ANSI color codes

## Motivation

Reported by a user who saw `session:4755m` in the status line and had to mentally divide by 1440 to figure out it was 3 days. Discord/Issue context: it's a minor readability fix but the kind of small ergonomic improvement that adds up.