### PR TITLE
Align OMC guidance with advisory routing doctrine

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.8.2 -->
+<!-- OMC:VERSION:4.14.1 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
@@ -16,18 +16,18 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.
-Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
+Route code to `executor`; use a current locally documented high-capability model alias or full model id for complex work only when an explicit override is needed. Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
-Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
+Use role fit and current local model defaults. Treat model aliases or family names as runtime facts from the current Claude CLI/help or OMC agent catalog, not permanent doctrine.
+Direct writes to `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, or `AGENTS.md` are OK only when the task explicitly includes OMC/guidance/state maintenance. For ordinary tasks, inspect first and preserve the owning source/template contract.
 </model_routing>
 
 <agent_catalog>
 Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
 
-explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (sonnet), executor (sonnet), verifier (sonnet), tracer (sonnet), security-reviewer (sonnet), code-reviewer (opus), test-engineer (sonnet), designer (sonnet), writer (haiku), qa-tester (sonnet), scientist (sonnet), document-specialist (sonnet), git-master (sonnet), code-simplifier (opus), critic (opus)
+explore, analyst, planner, architect, debugger, executor, verifier, tracer, security-reviewer, code-reviewer, test-engineer, designer, writer, qa-tester, scientist, document-specialist, git-master, code-simplifier, critic. Model selection comes from current OMC/Claude configuration, not this catalog line.
 </agent_catalog>
 
 <tools>
@@ -40,10 +40,10 @@ Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp
 </tools>
 
 <skills>
-Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
+Explicit `/oh-my-claudecode:<name>` invocations and hook-detected trigger patterns are agent-internal routing evidence; use them only when they fit the current task and runtime.
 
 Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`
-Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
+Known trigger examples include autopilot, ralph, ultrawork, ralplan, deep-interview, ai-slop-cleaner, analysis, TDD, codebase search, deep reasoning, and cancel. Treat them as advisory examples, not a hard user-facing command table; inspect the current skill registry when exact behavior matters. Team orchestration remains explicit.
 Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
 </skills>
 
@@ -53,7 +53,7 @@ Fix loop bounded by max attempts. `team ralph` links both modes.
 </team_pipeline>
 
 <verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
+Verify before claiming completion. Size appropriately using current locally documented model aliases or role defaults; do not treat model-family names as permanent doctrine.
 If verification fails, keep iterating.
 </verification>
 
@@ -95,7 +95,7 @@ Not-tested: Auth service cold-start latency >500ms
 </commit_protocol>
 
 <hooks_and_context>
-Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
+Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (routing hint; confirm task/runtime fit before activation), `The boulder never stops` (ralph/ultrawork active).
 Persistence: `<remember>` (7 days), `<remember priority>` (permanent).
 Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
 </hooks_and_context>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ Required schema sections and this template's mapping:
 - **Recovery & Lifecycle Overlays**: runtime/team overlays are appended by marker-bounded runtime hooks.
 
 Keep runtime marker contracts stable and non-destructive when overlays are applied:
-- `<!-- OMX:RUNTIME:START --> ... <!-- OMX:RUNTIME:END -->`
-- `<!-- OMX:TEAM:WORKER:START --> ... <!-- OMX:TEAM:WORKER:END -->`
+- `<!-- OMC:RUNTIME:START --> ... <!-- OMC:RUNTIME:END -->`
+- `<!-- OMC:TEAM:WORKER:START --> ... <!-- OMC:TEAM:WORKER:END -->`
 </guidance_schema_contract>
 
 <operating_principles>
@@ -61,11 +61,11 @@ For non-trivial SDK/API/framework usage, delegate to `dependency-expert` to chec
 
 <child_agent_protocol>
 Claude Code spawns child agents via the `spawn_agent` tool (requires `multi_agent = true`).
-To inject role-specific behavior, the parent MUST read the role prompt and pass it in the spawned agent message.
+To inject role-specific behavior, the parent reads the role prompt from the active OMC agent catalog (for example `agents/{role}.md` in the plugin/cache or project-local OMC surface) and passes it in the spawned agent message.
 
 Delegation steps:
 1. Decide which agent role to delegate to (e.g., `architect`, `executor`, `debugger`)
-2. Read the role prompt: `~/.codex/prompts/{role}.md`
+2. Read the role prompt from the active OMC agent catalog, such as `agents/{role}.md`
 3. Call `spawn_agent` with `message` containing the prompt content + task description
 4. The child agent receives full role context and executes the task independently
 
@@ -77,7 +77,7 @@ spawn_agent(message: "<test-engineer prompt>\n\nTask: Write tests for the auth c
 ```
 
 Each child agent:
-- Receives its role-specific prompt (from ~/.codex/prompts/)
+- Receives its role-specific prompt from the active OMC agent catalog
 - Inherits AGENTS.md context (via child_agents_md feature flag)
 - Runs in an isolated context with its own tool access
 - Returns results to the parent when complete
@@ -90,13 +90,13 @@ Key constraints:
 </child_agent_protocol>
 
 <invocation_conventions>
-Claude Code uses these prefixes for custom commands:
+Claude Code recognizes these explicit prefixes; treat them as agent-internal capability signals, not required user-facing commands:
 - `/prompts:name` — invoke a custom prompt (e.g., `/prompts:architect "review auth module"`)
 - `$name` — invoke a skill (e.g., `$ralph "fix all tests"`, `$autopilot "build REST API"`)
 - `/skills` — browse available skills interactively
 
-Agent prompts (in `~/.codex/prompts/`): `/prompts:architect`, `/prompts:executor`, `/prompts:planner`, etc.
-Workflow skills (in `~/.agents/skills/`): `$ralph`, `$autopilot`, `$plan`, `$ralplan`, `$team`, etc.
+Agent prompts in the active OMC agent catalog: `/prompts:architect`, `/prompts:executor`, `/prompts:planner`, etc.
+Workflow skills in the active OMC skill catalog: `$ralph`, `$autopilot`, `$plan`, `$ralplan`, `$team`, etc.
 </invocation_conventions>
 
 <model_routing>
@@ -105,9 +105,9 @@ Match agent role to task complexity:
 - **Standard** (implementation, debugging, reviews): `executor`, `debugger`, `test-engineer`
 - **High complexity** (architecture, deep analysis, complex refactors): `architect`, `executor`, `critic`
 
-For interactive use: `/prompts:name` (e.g., `/prompts:architect "review auth"`)
+For explicit prompt invocation when it fits the task: `/prompts:name` (e.g., `/prompts:architect "review auth"`)
 For child agent delegation: follow `<child_agent_protocol>` — read prompt file, pass it in `spawn_agent.message`
-For workflow skills: `$name` (e.g., `$ralph "fix all tests"`)
+For workflow skills: treat `$name` as an explicit capability signal (e.g., `$ralph "fix all tests"`)
 </model_routing>
 
 ---
@@ -156,27 +156,27 @@ Coordination:
 ---
 
 <keyword_detection>
-When the user's message contains a magic keyword, activate the corresponding skill IMMEDIATELY.
-Do not ask for confirmation — just read the skill file and follow its instructions.
+When the user's message resembles a workflow trigger, treat it as advisory routing evidence.
+Select the skill only when it fits the task shape, runtime support, and current user intent.
 
-| Keyword(s) | Skill | Action |
+| Signal example(s) | Candidate surface | Fit check |
 |-------------|-------|--------|
-| "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Read `~/.agents/skills/ralph/SKILL.md`, execute persistence loop |
-| "autopilot", "build me", "I want a" | `$autopilot` | Read `~/.agents/skills/autopilot/SKILL.md`, execute autonomous pipeline |
-| "ultrawork", "ulw", "parallel" | `$ultrawork` | Read `~/.agents/skills/ultrawork/SKILL.md`, execute parallel agents |
-| "plan this", "plan the", "let's plan" | `$plan` | Read `~/.agents/skills/plan/SKILL.md`, start planning workflow |
-| "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Read `~/.agents/skills/deep-interview/SKILL.md`, run Ouroboros-inspired Socratic ambiguity-gated interview workflow |
-| "ralplan", "consensus plan" | `$ralplan` | Read `~/.agents/skills/ralplan/SKILL.md`, start consensus planning with RALPLAN-DR structured deliberation (short by default, `--deliberate` for high-risk) |
-| "ecomode", "eco", "budget" | `$ecomode` | Read `~/.agents/skills/ecomode/SKILL.md`, enable token-efficient mode |
-| "cancel", "stop", "abort" | `$cancel` | Read `~/.agents/skills/cancel/SKILL.md`, cancel active modes |
-| "tdd", "test first" | keyword mode | Inject TDD-mode guidance and favor test-first execution with `test-engineer` when appropriate |
-| "cleanup", "deslop", "anti-slop" | `$ai-slop-cleaner` | Read `~/.agents/skills/ai-slop-cleaner/SKILL.md`, plan and clean AI-generated slop with separate writer/reviewer passes |
-| "web-clone", "clone site", "clone website", "copy webpage" | `$web-clone` | Read `~/.agents/skills/web-clone/SKILL.md`, start website cloning pipeline |
+| "ralph", "don't stop", "must complete", "keep going" | `$ralph` | Use only for persistent single-owner verification loops |
+| "autopilot", "build me", "I want a" | `$autopilot` | Use only when autonomous pipeline scope is appropriate |
+| "ultrawork", "ulw", "parallel" | `$ultrawork` | Use only when parallel execution materially helps |
+| "plan this", "plan the", "let's plan" | `$plan` | Use for planning requests, not direct implementation |
+| "interview", "deep interview", "gather requirements", "interview me", "don't assume", "ouroboros" | `$deep-interview` | Use for ambiguity-gated requirement discovery |
+| "ralplan", "consensus plan" | `$ralplan` | Use for consensus planning when tradeoffs need review |
+| "ecomode", "eco", "budget" | `$ecomode` | Use only when budget constraints are explicit or clearly implied |
+| "cancel", "stop", "abort" | `$cancel` | Use to cancel active modes after checking current state |
+| "tdd", "test first" | keyword mode | Favor test-first execution with `test-engineer` when appropriate |
+| "cleanup", "deslop", "anti-slop" | `$ai-slop-cleaner` | Use for regression-safe cleanup with separate writer/reviewer passes |
+| "web-clone", "clone site", "clone website", "copy webpage" | `$web-clone` | Use only when the website-cloning workflow is installed and intended |
 
 Detection rules:
-- Keywords are case-insensitive and match anywhere in the user's message
-- If multiple keywords match, use the most specific (longest match)
-- Conflict resolution: explicit `$name` invocation overrides keyword detection
+- Routing phrases are case-insensitive signal candidates, not automatic commands
+- If multiple signals match, choose the one that best fits task shape and current runtime
+- Conflict resolution: explicit `$name` invocation is a strong signal, but still verify safety and runtime fit
 - The rest of the user's message (after keyword extraction) becomes the task description
 
 Ralph / Ralplan execution gate:
@@ -188,7 +188,7 @@ Ralph / Ralplan execution gate:
 ---
 
 <skills>
-Skills are workflow commands. Invoke via `$name` (e.g., `$ralph`) or browse with `/skills`.
+Skills are workflow capabilities. Explicit `$name` invocations are strong capability signals; natural-language intent remains the primary interface.
 
 Workflow Skills:
 - `autopilot`: Full autonomous execution from idea to working code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.9.1 -->
+<!-- OMC:VERSION:4.14.1 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 
@@ -16,18 +16,18 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.
-Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
+Route code to `executor`; use a current locally documented high-capability model alias or full model id for complex work only when an explicit override is needed. Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
-Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
+Use role fit and current local model defaults. Treat model aliases or family names as runtime facts from the current Claude CLI/help or OMC agent catalog, not permanent doctrine.
+Direct writes to `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, or `AGENTS.md` are OK only when the task explicitly includes OMC/guidance/state maintenance. For ordinary tasks, inspect first and preserve the owning source/template contract.
 </model_routing>
 
 <agent_catalog>
 Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
 
-explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (sonnet), executor (sonnet), verifier (sonnet), tracer (sonnet), security-reviewer (sonnet), code-reviewer (opus), test-engineer (sonnet), designer (sonnet), writer (haiku), qa-tester (sonnet), scientist (sonnet), document-specialist (sonnet), git-master (sonnet), code-simplifier (opus), critic (opus)
+explore, analyst, planner, architect, debugger, executor, verifier, tracer, security-reviewer, code-reviewer, test-engineer, designer, writer, qa-tester, scientist, document-specialist, git-master, code-simplifier, critic. Model selection comes from current OMC/Claude configuration, not this catalog line.
 </agent_catalog>
 
 <tools>
@@ -40,10 +40,10 @@ Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp
 </tools>
 
 <skills>
-Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
+Explicit `/oh-my-claudecode:<name>` invocations and hook-detected trigger patterns are agent-internal routing evidence; use them only when they fit the current task and runtime.
 
 Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`, `self-improve`
-Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
+Known trigger examples include autopilot, ralph, ultrawork, ralplan, deep-interview, ai-slop-cleaner, analysis, TDD, codebase search, deep reasoning, and cancel. Treat them as advisory examples, not a hard user-facing command table; inspect the current skill registry when exact behavior matters. Team orchestration remains explicit.
 Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
 Per-role `/team` routing: configure provider/model per canonical role (codex critic, gemini reviewer, etc.) in `.claude/omc.jsonc` under `team.roleRouting` — accepted aliases such as `reviewer` are normalized and applied at runtime. See `skills/team/SKILL.md#per-role-provider--model-routing`.
 </skills>
@@ -54,7 +54,7 @@ Fix loop bounded by max attempts. `team ralph` links both modes.
 </team_pipeline>
 
 <verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
+Verify before claiming completion. Size appropriately using current locally documented model aliases or role defaults; do not treat model-family names as permanent doctrine.
 If verification fails, keep iterating.
 </verification>
 
@@ -96,7 +96,7 @@ Not-tested: Auth service cold-start latency >500ms
 </commit_protocol>
 
 <hooks_and_context>
-Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
+Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (routing hint; confirm task/runtime fit before activation), `The boulder never stops` (ralph/ultrawork active).
 Persistence: `<remember>` (7 days), `<remember priority>` (permanent).
 Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
 </hooks_and_context>

--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -1,7 +1,6 @@
 ---
 name: analyst
-description: Pre-planning consultant for requirements analysis (Opus)
-model: opus
+description: Pre-planning consultant for requirements analysis
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,6 @@
 ---
 name: architect
-description: Strategic Architecture & Debugging Advisor (Opus, READ-ONLY)
-model: opus
+description: Strategic Architecture & Debugging Advisor (READ-ONLY)
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: code-reviewer
 description: Expert code review specialist with severity-rated feedback, logic defect detection, SOLID principle checks, style, performance, and quality strategy
-model: opus
 level: 3
 disallowedTools: Write, Edit
 ---
@@ -189,7 +188,7 @@ When reviewing APIs, additionally check:
 </API_Contract_Review>
 
   <Style_Review_Mode>
-    When invoked with model=haiku for lightweight style-only checks, code-reviewer also covers code style concerns:
+    When invoked for lightweight style-only checks, code-reviewer also covers code style concerns:
 
     **Scope**: formatting consistency, naming convention enforcement, language idiom verification, lint rule compliance, import organization.
 

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -1,7 +1,6 @@
 ---
 name: code-simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
-model: opus
 level: 3
 ---
 

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -1,7 +1,6 @@
 ---
 name: critic
-description: Work plan and code review expert — thorough, structured, multi-perspective (Opus)
-model: opus
+description: Work plan and code review expert — thorough, structured, multi-perspective
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -1,7 +1,6 @@
 ---
 name: debugger
 description: Root-cause analysis, regression isolation, stack trace analysis, build/compilation error resolution
-model: sonnet
 level: 3
 ---
 

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -1,7 +1,6 @@
 ---
 name: designer
-description: UI/UX Designer-Developer for stunning interfaces (Sonnet)
-model: sonnet
+description: UI/UX Designer-Developer for stunning interfaces
 level: 2
 ---
 

--- a/agents/document-specialist.md
+++ b/agents/document-specialist.md
@@ -1,7 +1,6 @@
 ---
 name: document-specialist
 description: External Documentation & Reference Specialist
-model: sonnet
 level: 2
 disallowedTools: Write, Edit
 ---
@@ -38,7 +37,7 @@ Implementing against outdated or incorrect API documentation causes bugs that ar
 <Tool_Usage> - Use Read to inspect local documentation files first when they are likely to answer the question (README, docs/, migration/reference guides). - Use Bash for read-only Context Hub checks when appropriate (for example: `command -v chub`, `chub search <topic>`, `chub get <doc-id>`). Do not install or mutate the environment unless explicitly asked. - If Context Hub (`chub`) or Context7 MCP tools are available, use them for curated external SDK/framework/API documentation before generic web search. - Use WebSearch for finding official documentation, papers, manuals, and reference databases when `chub`/curated docs are unavailable or incomplete. - Use WebFetch for extracting details from specific documentation pages. - Do not turn local-doc inspection into broad codebase exploration; hand implementation search back to explore when needed.
 </Tool_Usage>
 
-<Execution_Policy> - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override. - Behavioral effort guidance: medium (find the answer, cite the source). - Quick lookups (haiku tier): 1-2 searches, direct answer with one source URL. - Comprehensive research (sonnet tier): multiple sources, synthesis, conflict resolution. - Stop when the question is answered with cited sources.
+<Execution_Policy> - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override. - Behavioral effort guidance: medium (find the answer, cite the source). - Quick lookups (fast tier): 1-2 searches, direct answer with one source URL. - Comprehensive research (standard/high-capability tier): multiple sources, synthesis, conflict resolution. - Stop when the question is answered with cited sources.
 </Execution_Policy>
 
 <Output_Format> ## Research: [Query]

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -1,7 +1,6 @@
 ---
 name: executor
-description: Focused task executor for implementation work (Sonnet)
-model: sonnet
+description: Focused task executor for implementation work
 level: 2
 ---
 

--- a/agents/explore.md
+++ b/agents/explore.md
@@ -1,7 +1,6 @@
 ---
 name: explore
 description: Codebase search specialist for finding files and code patterns
-model: haiku
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/git-master.md
+++ b/agents/git-master.md
@@ -1,7 +1,6 @@
 ---
 name: git-master
 description: Git expert for atomic commits, rebasing, and history management with style detection
-model: sonnet
 level: 3
 ---
 

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -1,7 +1,6 @@
 ---
 name: planner
-description: Strategic planning consultant with interview workflow (Opus)
-model: opus
+description: Strategic planning consultant with interview workflow
 level: 4
 ---
 
@@ -63,7 +62,7 @@ level: 4
 
   <Tool_Usage>
     - Use AskUserQuestion for all preference/priority questions (provides clickable options).
-    - Spawn explore agent (model=haiku) for codebase context questions.
+    - Spawn the explore agent through the current model contract for codebase context questions.
     - Spawn document-specialist agent for external documentation needs.
     - Use Write to save plans to `.omc/plans/{name}.md`.
   </Tool_Usage>

--- a/agents/qa-tester.md
+++ b/agents/qa-tester.md
@@ -1,7 +1,6 @@
 ---
 name: qa-tester
 description: Interactive CLI testing specialist using tmux for session management
-model: sonnet
 level: 3
 ---
 
@@ -50,7 +49,7 @@ level: 3
   <Execution_Policy>
     - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
     - Behavioral effort guidance: medium (happy path + key error paths).
-    - Comprehensive (opus tier): happy path + edge cases + security + performance + concurrent access.
+    - Comprehensive (high-capability tier): happy path + edge cases + security + performance + concurrent access.
     - Stop when all test cases are executed and results are documented.
   </Execution_Policy>
 

--- a/agents/scientist.md
+++ b/agents/scientist.md
@@ -1,7 +1,6 @@
 ---
 name: scientist
 description: Data analysis and research execution specialist
-model: sonnet
 level: 3
 disallowedTools: Write, Edit
 ---
@@ -52,8 +51,8 @@ disallowedTools: Write, Edit
   <Execution_Policy>
     - Runtime effort inherits from the parent Claude Code session; no bundled agent frontmatter pins an effort override.
     - Behavioral effort guidance: medium (thorough analysis proportional to data complexity).
-    - Quick inspections (haiku tier): .head(), .describe(), value_counts. Speed over depth.
-    - Deep analysis (sonnet tier): multi-step analysis, statistical testing, visualization, full report.
+    - Quick inspections (fast tier): .head(), .describe(), value_counts. Speed over depth.
+    - Deep analysis (standard/high-capability tier): multi-step analysis, statistical testing, visualization, full report.
     - Stop when findings answer the objective and evidence is documented.
   </Execution_Policy>
 

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: security-reviewer
 description: Security vulnerability detection specialist (OWASP Top 10, secrets, unsafe patterns)
-model: opus
 level: 3
 disallowedTools: Write, Edit
 ---

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,7 +1,6 @@
 ---
 name: test-engineer
 description: Test strategy, integration/e2e coverage, flaky test hardening, TDD workflows
-model: sonnet
 level: 3
 ---
 

--- a/agents/tracer.md
+++ b/agents/tracer.md
@@ -1,7 +1,6 @@
 ---
 name: tracer
 description: Evidence-driven causal tracing with competing hypotheses, evidence for/against, uncertainty tracking, and next-probe recommendations
-model: sonnet
 level: 3
 ---
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -1,7 +1,6 @@
 ---
 name: verifier
 description: Verification strategy, evidence-based completion checks, test adequacy
-model: sonnet
 level: 3
 ---
 

--- a/agents/writer.md
+++ b/agents/writer.md
@@ -1,7 +1,6 @@
 ---
 name: writer
-description: Technical documentation writer for README, API docs, and comments (Haiku)
-model: haiku
+description: Technical documentation writer for README, API docs, and comments
 level: 2
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,63 +55,60 @@ OMC provides 19 specialized agents organized into 4 lanes. Each agent is invoked
 
 Covers the full development lifecycle from exploration to verification.
 
-| Agent | Default Model | Role |
-|-------|---------------|------|
-| `explore` | haiku | Codebase discovery, file/symbol mapping |
-| `analyst` | opus | Requirements analysis, hidden constraint discovery |
-| `planner` | opus | Task sequencing, execution plan creation |
-| `architect` | opus | System design, interface definition, trade-off analysis |
-| `debugger` | sonnet | Root-cause analysis, build error resolution |
-| `executor` | sonnet | Code implementation, refactoring |
-| `verifier` | sonnet | Completion verification, test adequacy confirmation |
-| `tracer` | sonnet | Evidence-driven causal tracing, competing hypothesis analysis |
+| Agent | Role |
+|-------|------|
+| `explore` | Codebase discovery, file/symbol mapping |
+| `analyst` | Requirements analysis, hidden constraint discovery |
+| `planner` | Task sequencing, execution plan creation |
+| `architect` | System design, interface definition, trade-off analysis |
+| `debugger` | Root-cause analysis, build error resolution |
+| `executor` | Code implementation, refactoring |
+| `verifier` | Completion verification, test adequacy confirmation |
+| `tracer` | Evidence-driven causal tracing, competing hypothesis analysis |
 
 ### Review Lane
 
 Quality gates before handoff. Catches correctness and security issues.
 
-| Agent | Default Model | Role |
-|-------|---------------|------|
-| `security-reviewer` | sonnet | Security vulnerabilities, trust boundaries, authn/authz review |
-| `code-reviewer` | opus | Comprehensive code review, API contracts, backward compatibility |
+| Agent | Role |
+|-------|------|
+| `security-reviewer` | Security vulnerabilities, trust boundaries, authn/authz review |
+| `code-reviewer` | Comprehensive code review, API contracts, backward compatibility |
 
 ### Domain Lane
 
 Domain experts called in when needed.
 
-| Agent | Default Model | Role |
-|-------|---------------|------|
-| `test-engineer` | sonnet | Test strategy, coverage, flaky-test hardening |
-| `designer` | sonnet | UI/UX architecture, interaction design |
-| `writer` | haiku | Documentation, migration notes |
-| `qa-tester` | sonnet | Interactive CLI/service runtime validation via tmux |
-| `scientist` | sonnet | Data analysis, statistical research |
-| `git-master` | sonnet | Git operations, commits, rebase, history management |
-| `document-specialist` | sonnet | External documentation, API/SDK reference lookup |
-| `code-simplifier` | opus | Code clarity, simplification, maintainability improvement |
+| Agent | Role |
+|-------|------|
+| `test-engineer` | Test strategy, coverage, flaky-test hardening |
+| `designer` | UI/UX architecture, interaction design |
+| `writer` | Documentation, migration notes |
+| `qa-tester` | Interactive CLI/service runtime validation via tmux |
+| `scientist` | Data analysis, statistical research |
+| `git-master` | Git operations, commits, rebase, history management |
+| `document-specialist` | External documentation, API/SDK reference lookup |
+| `code-simplifier` | Code clarity, simplification, maintainability improvement |
 
 ### Coordination Lane
 
 Challenges plans and designs made by other agents. A plan passes only when no gaps can be found.
 
-| Agent | Default Model | Role |
-|-------|---------------|------|
-| `critic` | opus | Gap analysis of plans and designs, multi-angle review |
+| Agent | Role |
+|-------|------|
+| `critic` | Gap analysis of plans and designs, multi-angle review |
 
 ### Model Routing
 
-OMC uses three model tiers:
+OMC resolves model choices through the current Claude/OMC runtime configuration. LOW, MEDIUM, and HIGH are capability tiers, not permanent model aliases or fixed model ids.
 
-| Tier | Model | Characteristics | Cost |
-|------|-------|-----------------|------|
-| LOW | haiku | Fast and inexpensive | Low |
-| MEDIUM | sonnet | Balanced performance and cost | Medium |
-| HIGH | opus | Highest-quality reasoning | High |
+| Tier | Characteristics | Cost |
+|------|-----------------|------|
+| LOW | Fast and inexpensive | Low |
+| MEDIUM | Balanced performance and cost | Medium |
+| HIGH | Highest-quality reasoning | High |
 
-Default assignments by role:
-- **haiku**: Fast lookups and simple tasks (`explore`, `writer`)
-- **sonnet**: Code implementation, debugging, testing (`executor`, `debugger`, `test-engineer`)
-- **opus**: Architecture, strategic analysis, review (`architect`, `planner`, `critic`, `code-reviewer`)
+Role-to-tier assignments are runtime facts from the active agent catalog and config. Do not copy them into prompt doctrine without a freshness source.
 
 ### Delegation
 
@@ -120,7 +117,7 @@ Work is delegated through the Task tool with intelligent model routing:
 ```typescript
 Task(
   subagent_type="oh-my-claudecode:executor",
-  model="sonnet",
+  model="<current runtime default or explicit override>",
   prompt="Implement feature..."
 )
 ```
@@ -139,19 +136,19 @@ Task(
 
 ### Agent Selection Guide
 
-| Task Type | Recommended Agent | Model |
-|-----------|-------------------|-------|
-| Quick code lookup | `explore` | haiku |
-| Feature implementation | `executor` | sonnet |
-| Complex refactoring | `executor` (model=opus) | opus |
-| Simple bug fix | `debugger` | sonnet |
-| Complex debugging | `architect` | opus |
-| UI component | `designer` | sonnet |
-| Documentation | `writer` | haiku |
-| Test strategy | `test-engineer` | sonnet |
-| Security review | `security-reviewer` | sonnet |
-| Code review | `code-reviewer` | opus |
-| Data analysis | `scientist` | sonnet |
+| Task Type | Recommended Agent | Capability |
+|-----------|-------------------|------------|
+| Quick code lookup | `explore` | LOW |
+| Feature implementation | `executor` | MEDIUM |
+| Complex refactoring | `executor` or `architect` | HIGH when justified |
+| Simple bug fix | `debugger` | MEDIUM |
+| Complex debugging | `architect` | HIGH |
+| UI component | `designer` | MEDIUM |
+| Documentation | `writer` | LOW or MEDIUM |
+| Test strategy | `test-engineer` | MEDIUM |
+| Security review | `security-reviewer` | MEDIUM or HIGH |
+| Code review | `code-reviewer` | HIGH |
+| Data analysis | `scientist` | MEDIUM |
 
 ### Typical Agent Workflow
 
@@ -217,12 +214,13 @@ Active skills: ultrawork + default + git-master
 /oh-my-claudecode:team 3:executor "implement fullstack app"
 ```
 
-**Magic keywords** — include a keyword in natural language and the skill activates automatically:
+**Routing phrases** — hooks may emit advisory context when a natural-language phrase resembles a workflow:
 ```bash
-autopilot build me a todo app      # activates autopilot
-ralph: refactor the auth module    # activates ralph
-ultrawork implement OAuth          # activates ultrawork
+autopilot build me a todo app      # candidate autopilot signal
+ralph: refactor the auth module    # candidate ralph signal
+ultrawork implement OAuth          # candidate ultrawork signal
 ```
+The acting agent must still validate task shape, runtime support, and user intent before treating a signal as activation.
 
 ### Core Workflow Skills
 
@@ -307,14 +305,14 @@ ralplan this feature
 
 ### Keyword Detection Sources
 
-Keywords are processed in two places:
+Routing signals are processed in two places:
 
 | Source | Role | Customizable |
 |--------|------|--------------|
-| `config.jsonc` `magicKeywords` | 4 categories (ultrawork, search, analyze, ultrathink) | Yes |
-| `keyword-detector` hook | 11+ triggers (autopilot, ralph, ccg, etc.) | No |
+| `config.jsonc` routing phrases | User-configured advisory categories | Yes |
+| `keyword-detector` hook | Built-in advisory workflow hints | Partly; inspect current registry |
 
-The `autopilot`, `ralph`, and `ccg` triggers are hardcoded in the hook and cannot be changed through config.
+Built-in trigger lists are implementation defaults. They provide routing hints; they do not replace the agent's task-shape and runtime-fit judgment.
 
 ---
 
@@ -330,7 +328,7 @@ Claude Code provides 11 lifecycle events. OMC registers hooks on these events:
 
 | Event | When It Fires | OMC Usage |
 |-------|---------------|-----------|
-| `UserPromptSubmit` | User submits a prompt | Magic keyword detection, skill injection |
+| `UserPromptSubmit` | User submits a prompt | Routing evidence and optional skill context |
 | `SessionStart` | Session begins | Initial setup, project memory load |
 | `PreToolUse` | Before a tool is used | Permission validation, parallel execution hints |
 | `PermissionRequest` | Permission requested | Bash command permission handling |
@@ -358,12 +356,12 @@ Injected pattern meanings:
 |---------|---------|
 | `hook success: Success` | Hook ran normally, continue as planned |
 | `hook additional context: ...` | Additional context information, take note |
-| `[MAGIC KEYWORD: ...]` | Magic keyword detected, execute indicated skill |
+| `[MAGIC KEYWORD: ...]` | Routing hint; validate task/runtime fit before activation |
 | `The boulder never stops` | ralph/ultrawork mode is active |
 
 ### Key Hooks
 
-**keyword-detector** — fires on `UserPromptSubmit`. Detects magic keywords in user input and activates the corresponding skill.
+**keyword-detector** — fires on `UserPromptSubmit`. Detects routing phrases in user input and emits advisory context for the acting agent.
 
 **persistent-mode** — fires on `Stop`. When a persistent mode (ralph, ultrawork) is active, prevents Claude from stopping until work is verified complete.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -16,24 +16,24 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.
-Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
+Route code to `executor`; use a current locally documented high-capability model alias or full model id for complex work only when an explicit override is needed. Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
-Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
+Use role fit and current local model defaults. Treat model aliases or family names as runtime facts from the current Claude CLI/help or OMC agent catalog, not permanent doctrine.
+Direct writes to `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, or `AGENTS.md` are OK only when the task explicitly includes OMC/guidance/state maintenance. For ordinary tasks, inspect first and preserve the owning source/template contract.
 </model_routing>
 
 <skills>
-Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
+Explicit `/oh-my-claudecode:<name>` invocations and hook-detected trigger patterns are agent-internal routing evidence; use them only when they fit the current task and runtime.
 Tier-0 workflows include `autopilot`, `ultrawork`, `ralph`, `team`, and `ralplan`.
-Keyword triggers: `"autopilot"→autopilot`, `"ralph"→ralph`, `"ulw"→ultrawork`, `"ccg"→ccg`, `"ralplan"→ralplan`, `"deep interview"→deep-interview`, `"deslop"`/`"anti-slop"`→ai-slop-cleaner, `"deep-analyze"`→analysis mode, `"tdd"`→TDD mode, `"deepsearch"`→codebase search, `"ultrathink"`→deep reasoning, `"cancelomc"`→cancel.
+Known trigger examples include autopilot, ralph, ultrawork, ralplan, deep-interview, ai-slop-cleaner, analysis, TDD, codebase search, deep reasoning, and cancel. Treat them as advisory examples, not a hard user-facing command table; inspect the current skill registry when exact behavior matters.
 Team orchestration is explicit via `/team`.
 Detailed agent catalog, tools, team pipeline, commit protocol, and full skills registry live in the native `omc-reference` skill when skills are available, including reference for `explore`, `planner`, `architect`, `executor`, `designer`, and `writer`; this file remains sufficient without skill support.
 </skills>
 
 <verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
+Verify before claiming completion. Size appropriately using current locally documented model aliases or role defaults; do not treat model-family names as permanent doctrine.
 If verification fails, keep iterating.
 </verification>
 
@@ -45,7 +45,7 @@ Before concluding: zero pending tasks, tests passing, verifier evidence collecte
 </execution_protocols>
 
 <hooks_and_context>
-Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
+Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (routing hint; confirm task/runtime fit before activation), `The boulder never stops` (ralph/ultrawork active).
 Persistence: `<remember>` (7 days), `<remember priority>` (permanent).
 Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
 </hooks_and_context>

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,12 +1,12 @@
 # Hooks System
 
-> OMC's 20 hooks intercept Claude Code lifecycle events to enable magic keywords, context injection, and quality enforcement.
+> OMC's 20 hooks intercept Claude Code lifecycle events to provide routing hints, context injection, and quality enforcement.
 
 ## What Are Hooks?
 
 Hooks are scripts that execute automatically in response to Claude Code lifecycle events. oh-my-claudecode extends Claude Code's default behavior with 20 hooks.
 
-When a user submits a prompt, a tool runs, or a session starts/ends, hooks fire automatically to inject additional context, activate modes, and manage state.
+When a user submits a prompt, a tool runs, or a session starts/ends, hooks fire automatically to inject additional context, maintain active modes, and manage state.
 
 ## How Hooks Work
 
@@ -42,11 +42,11 @@ OMC hooks fall into four categories:
 
 ### Core Hooks
 
-Handle orchestration, keyword detection, and mode persistence.
+Handle orchestration, routing phrase detection, and mode persistence.
 
 | Hook | Description |
 |------|-------------|
-| keyword-detector | Detects magic keywords and activates corresponding skills |
+| keyword-detector | Detects routing phrases and emits advisory skill or mode context |
 | persistent-mode | Enforces continuation when an execution mode (ralph, autopilot, ultrawork, etc.) is active — injects reinforcement messages on Stop to prevent premature halting |
 
 ### Context Management Hooks
@@ -97,10 +97,10 @@ Fires when the user submits a prompt.
 
 | Script | Role | Timeout |
 |--------|------|---------|
-| `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 5s |
+| `keyword-detector.mjs` | Detects routing phrases and emits advisory skill or mode context | 5s |
 | `skill-injector.mjs` | Injects skill prompts | 3s |
 
-Runs on all user input (`matcher: "*"`). When the keyword detector finds keywords like "ultrawork", "ralph", or "autopilot", it injects the corresponding skill invocation instruction via `additionalContext`.
+Runs on all user input (`matcher: "*"`). When the keyword detector finds phrases like "ultrawork", "ralph", or "autopilot", it injects advisory routing context via `additionalContext`; the acting agent still checks task fit, runtime support, and user intent.
 
 ### SessionStart
 
@@ -214,14 +214,14 @@ Saves agent activity, token usage, and other session data to `.omc/sessions/`. I
 
 #### keyword-detector
 
-Detects magic keywords in user prompts and invokes the corresponding skill.
+Detects routing phrases in user prompts and emits advisory skill or mode context.
 
 - **Event**: UserPromptSubmit
 - **Behavior**: Sanitizes the prompt (removes code blocks, URLs, file paths) then matches keyword patterns
 - **Conflict resolution**: cancel has highest priority, then ralph > autopilot > ultrawork
 - **Safety**: Disabled inside team workers to prevent infinite spawning
 
-See the [Magic Keywords](#magic-keywords) section for the full keyword list.
+See the [Routing Phrase Examples](#routing-phrase-examples) section for example signals.
 
 #### persistent-mode
 
@@ -234,7 +234,7 @@ Enforces continuation when an execution mode is active. This is the hook that ke
 - **Notification**: Sends Discord/Telegram/Slack notification on first stop (if configured)
 - **Cancel**: Use `/oh-my-claudecode:cancel` to deactivate modes
 
-> **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills** (invoked via keyword-detector), not hooks. The persistent-mode hook is what enforces their continuation by blocking the Stop event.
+> **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills**. The keyword detector may suggest them; the persistent-mode hook is what enforces continuation after a mode is actually active.
 
 ### Mode State Management
 
@@ -337,9 +337,9 @@ Session Start
 
 ---
 
-## Magic Keywords
+## Routing Phrase Examples
 
-Magic keywords automatically activate OMC skills or execution modes when specific words or patterns are detected in the user's natural language prompt. No slash command is needed — include a keyword in your prompt and the feature activates automatically.
+Routing phrases may emit OMC skill or execution-mode suggestions when specific words or patterns are detected in the user's natural language prompt. These suggestions are advisory: the acting agent must still validate task shape, runtime support, and user intent before activation.
 
 ### How keyword-detector Works
 
@@ -348,7 +348,7 @@ Magic keywords automatically activate OMC skills or execution modes when specifi
 1. Receives the user prompt and sanitizes it
 2. Removes code blocks, XML tags, URLs, and file paths to prevent false positives
 3. Matches keyword patterns against the sanitized text
-4. Resolves conflicts, then injects the skill invocation instruction
+4. Resolves conflicts, then injects advisory routing context
 
 **Safety measures:**
 
@@ -356,9 +356,9 @@ Magic keywords automatically activate OMC skills or execution modes when specifi
 - **Team worker protection**: Disabled when the `OMC_TEAM_WORKER` environment variable is set (prevents infinite spawning)
 - **Disable**: Set `DISABLE_OMC=1` or `OMC_SKIP_HOOKS=keyword-detector`
 
-### Execution Mode Keywords
+### Execution Mode Signals
 
-These keywords invoke a skill and create a state file.
+These phrases are examples of signals that may suggest a skill or execution mode. They are not a user-facing command table and do not replace task-shape or runtime checks.
 
 | Keyword | Skill | Description |
 |---------|-------|-------------|
@@ -370,25 +370,25 @@ These keywords invoke a skill and create a state file.
 | `ralplan` | ralplan | Consensus-based iterative planning |
 | `deep interview`, `ouroboros` | deep-interview | Socratic deep interview |
 
-### AI Slop Cleanup Keywords
+### AI Slop Cleanup Signals
 
 Supports two pattern types:
 
-**Explicit patterns** (activate on their own):
+**Explicit patterns** (strong advisory signals):
 
 - `ai-slop`, `anti-slop`, `deslop`, `de-slop`
 
-**Combination patterns** (activate when an action keyword is combined with a smell keyword):
+**Combination patterns** (advisory when an action phrase is combined with a smell phrase):
 
-| Action Keywords | Smell Keywords |
+| Action Signals | Smell Signals |
 |----------------|----------------|
 | `cleanup`, `refactor`, `simplify`, `dedupe`, `prune` | `slop`, `duplicate`, `dead code`, `unused code`, `over-abstraction`, `wrapper layers`, `needless abstractions`, `ai-generated`, `tech debt` |
 
-Example: "cleanup the duplicate code" → activates the ai-slop-cleaner skill.
+Example: "cleanup the duplicate code" may suggest the ai-slop-cleaner skill when the task fit and runtime support are present.
 
-### Agent Shortcut Keywords
+### Agent Shortcut Signals
 
-Activate agents with natural language instead of slash commands.
+These phrases may suggest agent modes with natural language instead of slash commands.
 
 | Keyword | Effect | Behavior |
 |---------|--------|----------|
@@ -396,15 +396,15 @@ Activate agents with natural language instead of slash commands.
 | `code review`, `review code` | Code review mode | Runs comprehensive code review |
 | `security review`, `review security` | Security review mode | Runs security-focused review |
 
-These keywords inject an inline mode message rather than invoking a skill.
+These signals inject advisory inline mode context rather than directly invoking a skill.
 
-### Reasoning Enhancement Keywords
+### Reasoning Enhancement Signals
 
 | Keyword | Effect |
 |---------|--------|
-| `ultrathink`, `think hard`, `think deeply` | Activates extended reasoning mode |
-| `deepsearch`, `search the codebase`, `find in codebase` | Activates codebase-focused search mode |
-| `deep-analyze`, `deepanalyze` | Activates deep analysis mode |
+| `ultrathink`, `think hard`, `think deeply` | Suggests extended reasoning mode |
+| `deepsearch`, `search the codebase`, `find in codebase` | Suggests codebase-focused search mode |
+| `deep-analyze`, `deepanalyze` | Suggests deep analysis mode |
 
 ### Priority and Conflict Resolution
 
@@ -427,7 +427,7 @@ cancel  (highest priority, exclusive)
                           → analyze
 ```
 
-`cancel` is exclusive — it ignores all other matches and only runs the cancel action. All other keywords can be matched together and are processed in priority order.
+`cancel` is exclusive because it is a lifecycle safety action. Other signals can be matched together and are processed in priority order before the acting agent validates fit.
 
 ### Usage Examples
 
@@ -453,9 +453,9 @@ code review the recent changes
 stopomc
 ```
 
-### Note on the `team` Keyword
+### Note on the `team` Signal
 
-`team` is not auto-detected. It must be invoked explicitly via the `/team` slash command to prevent infinite spawning.
+`team` is not treated as an implicit activation signal. It must be invoked explicitly via the `/team` slash command to prevent infinite spawning.
 
 ```
 /oh-my-claudecode:team 3:executor "build a fullstack todo app"

--- a/skills/omc-reference/SKILL.md
+++ b/skills/omc-reference/SKILL.md
@@ -12,31 +12,29 @@ Use this built-in reference when you need detailed OMC catalog information that 
 
 Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
 
-- `explore` (haiku) — fast codebase search and mapping
-- `analyst` (opus) — requirements clarity and hidden constraints
-- `planner` (opus) — sequencing and execution plans
-- `architect` (opus) — system design, boundaries, and long-horizon tradeoffs
-- `debugger` (sonnet) — root-cause analysis and failure diagnosis
-- `executor` (sonnet) — implementation and refactoring
-- `verifier` (sonnet) — completion evidence and validation
-- `tracer` (sonnet) — trace gathering and evidence capture
-- `security-reviewer` (sonnet) — trust boundaries and vulnerabilities
-- `code-reviewer` (opus) — comprehensive code review
-- `test-engineer` (sonnet) — testing strategy and regression coverage
-- `designer` (sonnet) — UX and interaction design
-- `writer` (haiku) — documentation and concise content work
-- `qa-tester` (sonnet) — runtime/manual validation
-- `scientist` (sonnet) — data analysis and statistical reasoning
-- `document-specialist` (sonnet) — SDK/API/framework documentation lookup
-- `git-master` (sonnet) — commit strategy and history hygiene
-- `code-simplifier` (opus) — behavior-preserving simplification
-- `critic` (opus) — plan/design challenge and review
+- `explore` — fast codebase search and mapping
+- `analyst` — requirements clarity and hidden constraints
+- `planner` — sequencing and execution plans
+- `architect` — system design, boundaries, and long-horizon tradeoffs
+- `debugger` — root-cause analysis and failure diagnosis
+- `executor` — implementation and refactoring
+- `verifier` — completion evidence and validation
+- `tracer` — trace gathering and evidence capture
+- `security-reviewer` — trust boundaries and vulnerabilities
+- `code-reviewer` — comprehensive code review
+- `test-engineer` — testing strategy and regression coverage
+- `designer` — UX and interaction design
+- `writer` — documentation and concise content work
+- `qa-tester` — runtime/manual validation
+- `scientist` — data analysis and statistical reasoning
+- `document-specialist` — SDK/API/framework documentation lookup
+- `git-master` — commit strategy and history hygiene
+- `code-simplifier` — behavior-preserving simplification
+- `critic` — plan/design challenge and review
 
 ## Model Routing
 
-- `haiku` — quick lookups, lightweight inspection, narrow docs work
-- `sonnet` — standard implementation, debugging, and review
-- `opus` — architecture, deep analysis, consensus planning, and high-risk review
+Use the current Claude/OMC model contract for concrete model names. This reference describes role capability, not permanent model IDs or aliases.
 
 ## Tools Reference
 
@@ -86,7 +84,7 @@ Invoke built-in workflows via `/oh-my-claudecode:<name>`.
 ### Utility skills
 - `ask`, `cancel`, `note`, `skillify`, `learner` (deprecated alias), `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `configure-notifications`
 
-### Keyword triggers kept compact in CLAUDE.md
+### Routing phrase examples kept compact in CLAUDE.md
 - `"autopilot"→autopilot`
 - `"ralph"→ralph`
 - `"ulw"→ultrawork`
@@ -99,7 +97,7 @@ Invoke built-in workflows via `/oh-my-claudecode:<name>`.
 - `"deepsearch"→codebase search`
 - `"ultrathink"→deep reasoning`
 - `"cancelomc"→cancel`
-- Team orchestration is explicit via `/team`.
+- Treat these as advisory routing examples, not hard command authority. Team orchestration is explicit via `/team`.
 
 ## Team Pipeline
 

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -66,16 +66,16 @@ OMC mode lifecycle: `.omc/state/sessions/{sessionId}/self-improve-state.json`
 
 All augmentations delivered via Task description context at spawn time. No modifications to existing agent .md files.
 
-| Step | Role | OMC Agent | Model |
-|------|------|-----------|-------|
-| Research | Codebase analysis + hypothesis generation | general-purpose Agent | opus |
-| Planning | Hypothesis → structured plan | oh-my-claudecode:planner | opus |
-| Architecture Review | 6-point plan review | oh-my-claudecode:architect | opus |
-| Critic Review | Harness rule enforcement | oh-my-claudecode:critic | opus |
-| Execution | Implement plan + run benchmark | oh-my-claudecode:executor | opus |
-| Git Operations | Atomic merge/tag/PR | oh-my-claudecode:git-master | sonnet |
+| Step | Role | OMC Agent | Capability |
+|------|------|-----------|------------|
+| Research | Codebase analysis + hypothesis generation | general-purpose Agent | high |
+| Planning | Hypothesis -> structured plan | oh-my-claudecode:planner | high |
+| Architecture Review | 6-point plan review | oh-my-claudecode:architect | high |
+| Critic Review | Harness rule enforcement | oh-my-claudecode:critic | high |
+| Execution | Implement plan + run benchmark | oh-my-claudecode:executor | high |
+| Git Operations | Atomic merge/tag/PR | oh-my-claudecode:git-master | standard |
 | Goal Setup | Interactive interview | (directly in this skill) | N/A |
-| Benchmark Setup | Create + validate benchmark | custom agent | opus |
+| Benchmark Setup | Create + validate benchmark | custom agent | high |
 
 **Research prompt**: Read `si-researcher.md` from this skill directory and pass its content as the agent prompt.
 
@@ -113,7 +113,7 @@ Read these files at startup and at the beginning of each iteration:
    d. Record consent: set `trust_confirmed: true` in agent-settings.json.
 5. Persist `topic_slug` into `config/settings.json` when the resolved root is topic-scoped so future resumes stay on the same track.
 6. If goal not set → read `si-goal-clarifier.md` from this skill directory and run the 4-dimension Socratic interview directly in this context (Objective, Metric, Target, Scope). Write result to `<self-improve-root>/config/goal.md`.
-6. If benchmark not set → read `si-benchmark-builder.md` from this skill directory, spawn a custom Agent(model=opus) with its content as prompt. The agent surveys the repo, creates or wraps a benchmark, validates 3x, and records baseline.
+6. If benchmark not set → read `si-benchmark-builder.md` from this skill directory, spawn a custom high-capability Agent with its content as prompt using the current local model contract. The agent surveys the repo, creates or wraps a benchmark, validates 3x, and records baseline.
    After benchmark is set, confirm the benchmark command with user:
       `"Benchmark command: {benchmark_command}. This will be run repeatedly during the loop. Confirm? [yes/no]"`
    If user declines: abort setup and exit.
@@ -187,7 +187,7 @@ Read `<self-improve-root>/config/idea.md`. If non-empty, snapshot contents for p
 
 ### Step 4 — Research
 
-Spawn 1 general-purpose Agent(model=opus) with the content of `si-researcher.md` as prompt.
+Spawn 1 general-purpose high-capability Agent with the content of `si-researcher.md` as prompt, using the current local model contract.
 
 Pass in the prompt:
 - Current iteration number
@@ -203,7 +203,7 @@ If researcher fails, proceed with history only.
 
 ### Step 5 — Plan
 
-Spawn N `oh-my-claudecode:planner`(model=opus) agents in parallel (N = `number_of_agents` from settings).
+Spawn N high-capability `oh-my-claudecode:planner` agents in parallel (N = `number_of_agents` from settings), using the current local model contract.
 
 Pass in each planner's prompt:
 - Planner identity (planner_a, planner_b, planner_c...)
@@ -243,7 +243,7 @@ If ALL plans rejected, log and skip to Step 9.
 
 ### Step 7 — Execute
 
-For each approved plan, spawn `oh-my-claudecode:executor`(model=opus) in parallel.
+For each approved plan, spawn a high-capability `oh-my-claudecode:executor` in parallel, using the current local model contract.
 
 **Before spawning**, create worktree:
 ```

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -105,20 +105,20 @@ Team execution follows a staged pipeline:
 
 Each pipeline stage uses **specialized agents** -- not just executors. The lead selects agents based on the stage and task characteristics.
 
-| Stage           | Required Agents                     | Optional Agents                                                                                         | Selection Criteria                                                                                                                                                                                |
-| --------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **team-plan**   | `explore` (haiku), `planner` (opus) | `analyst` (opus), `architect` (opus)                                                                    | Use `analyst` for unclear requirements. Use `architect` for systems with complex boundaries.                                                                                                      |
-| **team-prd**    | `analyst` (opus)                    | `critic` (opus)                                                                                         | Use `critic` to challenge scope.                                                                                                                                                                  |
-| **team-exec**   | `executor` (sonnet)                 | `executor` (opus), `debugger` (sonnet), `designer` (sonnet), `writer` (haiku), `test-engineer` (sonnet) | Match agent to subtask type. Use `executor` (model=opus) for complex autonomous work, `designer` for UI, `debugger` for compilation issues, `writer` for docs, `test-engineer` for test creation. |
-| **team-verify** | `verifier` (sonnet)                 | `test-engineer` (sonnet), `security-reviewer` (sonnet), `code-reviewer` (opus)                          | Always run `verifier`. Add `security-reviewer` for auth/crypto changes. Add `code-reviewer` for >20 files or architectural changes. `code-reviewer` also covers style/formatting checks.          |
-| **team-fix**    | `executor` (sonnet)                 | `debugger` (sonnet), `executor` (opus)                                                                  | Use `debugger` for type/build errors and regression isolation. Use `executor` (model=opus) for complex multi-file fixes.                                                                          |
+| Stage | Required Agents | Optional Agents | Selection Criteria |
+|-------|----------------|-----------------|-------------------|
+| **team-plan** | `explore`, `planner` | `analyst`, `architect` | Use `analyst` for unclear requirements. Use `architect` for systems with complex boundaries. |
+| **team-prd** | `analyst` | `critic` | Use `critic` to challenge scope. |
+| **team-exec** | `executor` | `executor`, `debugger`, `designer`, `writer`, `test-engineer` | Match agent to subtask type. Use a higher-capability executor only when the current model contract supports it and the task complexity justifies it. |
+| **team-verify** | `verifier` | `test-engineer`, `security-reviewer`, `code-reviewer` | Always run `verifier`. Add `security-reviewer` for auth/crypto changes. Add `code-reviewer` for >20 files or architectural changes. `code-reviewer` also covers style/formatting checks. |
+| **team-fix** | `executor` | `debugger`, `executor` | Use `debugger` for type/build errors and regression isolation. Use a higher-capability executor for complex multi-file fixes only when justified. |
 
 **Routing rules:**
 
 1. **The lead picks agents per stage, not the user.** The user's `N:agent-type` parameter only overrides the `team-exec` stage worker type. All other stages use stage-appropriate specialists.
 2. **Specialist agents complement executor agents.** Route analysis/review to architect/critic Claude agents and UI work to designer agents. Tmux CLI workers are one-shot and don't participate in team communication.
-3. **Cost mode affects model tier.** In downgrade: `opus` agents to `sonnet`, `sonnet` to `haiku` where quality permits. `team-verify` always uses at least `sonnet`.
-4. **Risk level escalates review.** Security-sensitive or >20 file changes must include `security-reviewer` + `code-reviewer` (opus) in `team-verify`.
+3. **Cost mode affects model tier.** Downgrade only through the current model contract and only where quality permits. `team-verify` always keeps enough capability for reliable verification.
+4. **Risk level escalates review.** Security-sensitive or >20 file changes must include `security-reviewer` + `code-reviewer` in `team-verify`.
 
 ### Stage Entry/Exit Criteria
 
@@ -943,15 +943,15 @@ Declare which provider (`claude`, `codex`, `gemini`) and which model tier should
 }
 ```
 
-| Role            | Provider        | Model                     |
-| --------------- | --------------- | ------------------------- |
-| `orchestrator`  | claude (pinned) | inherits invoking session |
-| `planner`       | claude          | `HIGH` (opus)             |
-| `analyst`       | claude          | `HIGH` (opus)             |
-| `executor`      | claude          | `MEDIUM` (sonnet)         |
-| `critic`        | codex           | codex default             |
-| `code-reviewer` | gemini          | gemini default            |
-| `test-engineer` | gemini          | `MEDIUM` (sonnet)         |
+| Role | Provider | Model |
+|---|---|---|
+| `orchestrator` | claude (pinned) | inherits invoking session |
+| `planner` | claude | `HIGH` |
+| `analyst` | claude | `HIGH` |
+| `executor` | claude | `MEDIUM` |
+| `critic` | codex | codex default |
+| `code-reviewer` | gemini | gemini default |
+| `test-engineer` | gemini | `MEDIUM` |
 
 ### Canonical roles
 
@@ -985,7 +985,7 @@ Resolved routing is immutable per team. Editing config mid-team-lifetime does no
 
 ### Zero-config behavior
 
-An empty `team.roleRouting` preserves pre-patch behavior: every worker is Claude, model tiers follow `routing.tierModels`, and `/team 3:executor ...` still spawns three Claude Sonnet executors.
+An empty `team.roleRouting` preserves pre-patch behavior: every worker is Claude, model tiers follow `routing.tierModels`, and `/team 3:executor ...` still spawns three Claude executors under the current model contract.
 
 ## State Cleanup
 


### PR DESCRIPTION
## Summary
- Reframe keyword/workflow detections as advisory routing evidence instead of invoke-skill authority.
- Remove hardcoded haiku/sonnet/opus model aliases from active OMC guidance and agent frontmatter.
- Separate OMC runtime markers from OMX marker names and keep model selection tied to runtime contracts.

## Verification
- rg stale-pattern scans for hard keyword activation, old model aliases, Codex path leakage, stale markers, and OMX marker leakage.
- Agent frontmatter parser check.
- git diff --cached --check.

## Notes
- Local installed v4.13.5 marketplace/cache was patched separately; this PR targets latest upstream main v4.14.1.
