### PR TITLE
fix(hud): stop cmd.exe black-window flash on Windows

### DIFF
--- a/src/hud/elements/git.ts
+++ b/src/hud/elements/git.ts
@@ -4,7 +4,7 @@
  * Renders git repository name and branch information.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { resolve, basename } from 'node:path';
 import { dim, cyan, green, red } from '../colors.js';
@@ -64,12 +64,12 @@ export function getGitRepoName(cwd?: string): string | null {
 
   let result: string | null = null;
   try {
-    const url = execSync('git remote get-url origin', {
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], {
       cwd,
       encoding: 'utf-8',
       timeout: 1000,
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+      windowsHide: true,
     }).trim();
 
     if (!url) {
@@ -103,12 +103,12 @@ export function getGitBranch(cwd?: string): string | null {
 
   let result: string | null = null;
   try {
-    const branch = execSync('git branch --show-current', {
+    const branch = execFileSync('git', ['branch', '--show-current'], {
       cwd,
       encoding: 'utf-8',
       timeout: 1000,
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+      windowsHide: true,
     }).trim();
 
     result = branch || null;
@@ -140,13 +140,13 @@ export function getWorktreeInfo(cwd?: string): WorktreeDetection {
     encoding: 'utf-8' as BufferEncoding,
     timeout: 1000,
     stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'],
-    shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+    windowsHide: true,
   };
 
   let result: WorktreeDetection = { isWorktree: false, worktreeName: null };
   try {
-    const gitDir = (execSync('git rev-parse --git-dir', execOpts) as string).trim();
-    const gitCommonDir = (execSync('git rev-parse --git-common-dir', execOpts) as string).trim();
+    const gitDir = (execFileSync('git', ['rev-parse', '--git-dir'], execOpts) as string).trim();
+    const gitCommonDir = (execFileSync('git', ['rev-parse', '--git-common-dir'], execOpts) as string).trim();
 
     // Canonicalize via realpathSync to handle symlinked repo paths
     let resolvedGitDir = resolve(key, gitDir);
@@ -215,12 +215,12 @@ export function getGitStatusCounts(cwd?: string): GitStatusCounts | null {
 
   let result: GitStatusCounts | null = null;
   try {
-    const output = execSync('git --no-optional-locks status --porcelain -b', {
+    const output = execFileSync('git', ['--no-optional-locks', 'status', '--porcelain', '-b'], {
       cwd,
       encoding: 'utf-8',
       timeout: 1000,
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+      windowsHide: true,
     }).trim();
 
     let staged = 0, modified = 0, untracked = 0, ahead = 0, behind = 0;


### PR DESCRIPTION
## Problem

On Windows, the OMC HUD spawns a visible cmd.exe black window every second. Each HUD refresh triggers a chain of `bash.exe` → `cmd.exe` → `git.exe` → `conhost.exe` processes that flash visually and interfere with mouse focus.

## Root Cause

All four `execSync` calls in `src/hud/elements/git.ts` use `shell: process.platform === 'win32' ? 'cmd.exe' : undefined`. When `shell` is set to `cmd.exe`, Node.js spawns a cmd.exe console process. Since cmd.exe is a console application, Windows allocates a `conhost.exe` for it — and even with `windowsHide: true` on the `execSync` options, the conhost window briefly flashes at 1-second HUD refresh intervals.

## Fix

Replace all 4 `execSync` calls with `execFileSync`, passing git arguments as an array and setting `windowsHide: true`:

```ts
// Before
execSync('git remote get-url origin', {
  shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
})

// After
execFileSync('git', ['remote', 'get-url', 'origin'], {
  windowsHide: true,
})
```

`execFileSync` spawns `git.exe` directly without a shell — no `cmd.exe`, no `conhost.exe` allocation. The `windowsHide: true` flag suppresses any residual window creation at the Win32 level.

## Files Changed

- `src/hud/elements/git.ts` — 4 call sites changed:
  1. `getGitRepoName`: `git remote get-url origin`
  2. `getGitBranch`: `git branch --show-current`
  3. `getWorktreeInfo` (shared `execOpts`): `git rev-parse --git-dir` and `git rev-parse --git-common-dir`
  4. `getGitStatusCounts`: `git --no-optional-locks status --porcelain -b`

## Verification

Applied the same fix as a hot patch to the local plugin cache:
`C:/Users/alan2024/.claude/plugins/cache/omc/oh-my-claudecode/4.14.1/dist/hud/elements/git.js`

A 60-second short-lived process monitor confirmed:
- **Before**: `git.exe ×4` + `cmd.exe ×1` + `conhost.exe ×2` spawned every second
- **After**: zero cmd.exe / conhost.exe spawns; git.exe invocations complete silently in background

## Environment

- Windows 11 Pro 10.0.26200
- Node.js 20.x
- Claude Code CLI with OMC plugin v4.14.1