### PR TITLE
Avoid Windows shell flashes in HUD git polling

### DIFF
--- a/src/__tests__/hud/git.test.ts
+++ b/src/__tests__/hud/git.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getGitRepoName, getGitBranch, getWorktreeInfo, renderGitRepo, renderGitBranch, resetGitCache } from '../../hud/elements/git.js';
 
-// Mock child_process.execSync
+// Mock child_process.execFileSync
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-import { execSync } from 'node:child_process';
-const mockExecSync = vi.mocked(execSync);
+import { execFileSync } from 'node:child_process';
+const mockExecFileSync = vi.mocked(execFileSync);
 
 describe('git elements', () => {
   beforeEach(() => {
@@ -17,97 +17,99 @@ describe('git elements', () => {
 
   describe('getGitRepoName', () => {
     it('extracts repo name from HTTPS URL', () => {
-      mockExecSync.mockReturnValue('https://github.com/user/my-repo.git\n');
+      mockExecFileSync.mockReturnValue('https://github.com/user/my-repo.git\n');
       expect(getGitRepoName()).toBe('my-repo');
     });
 
     it('extracts repo name from HTTPS URL without .git', () => {
-      mockExecSync.mockReturnValue('https://github.com/user/my-repo\n');
+      mockExecFileSync.mockReturnValue('https://github.com/user/my-repo\n');
       expect(getGitRepoName()).toBe('my-repo');
     });
 
     it('extracts repo name from SSH URL', () => {
-      mockExecSync.mockReturnValue('git@github.com:user/my-repo.git\n');
+      mockExecFileSync.mockReturnValue('git@github.com:user/my-repo.git\n');
       expect(getGitRepoName()).toBe('my-repo');
     });
 
     it('extracts repo name from SSH URL without .git', () => {
-      mockExecSync.mockReturnValue('git@github.com:user/my-repo\n');
+      mockExecFileSync.mockReturnValue('git@github.com:user/my-repo\n');
       expect(getGitRepoName()).toBe('my-repo');
     });
 
     it('returns null when git command fails', () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Not a git repository');
       });
       expect(getGitRepoName()).toBeNull();
     });
 
     it('returns null for empty output', () => {
-      mockExecSync.mockReturnValue('');
+      mockExecFileSync.mockReturnValue('');
       expect(getGitRepoName()).toBeNull();
     });
 
-    it('passes cwd option to execSync', () => {
-      mockExecSync.mockReturnValue('https://github.com/user/repo.git\n');
+    it('passes cwd option to execFileSync', () => {
+      mockExecFileSync.mockReturnValue('https://github.com/user/repo.git\n');
       getGitRepoName('/some/path');
-      expect(mockExecSync).toHaveBeenCalledWith(
-        'git remote get-url origin',
-        expect.objectContaining({ cwd: '/some/path' })
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'git',
+        ['remote', 'get-url', 'origin'],
+        expect.objectContaining({ cwd: '/some/path', windowsHide: true })
       );
     });
   });
 
   describe('getGitBranch', () => {
     it('returns current branch name', () => {
-      mockExecSync.mockReturnValue('main\n');
+      mockExecFileSync.mockReturnValue('main\n');
       expect(getGitBranch()).toBe('main');
     });
 
     it('handles feature branch names', () => {
-      mockExecSync.mockReturnValue('feature/my-feature\n');
+      mockExecFileSync.mockReturnValue('feature/my-feature\n');
       expect(getGitBranch()).toBe('feature/my-feature');
     });
 
     it('returns null when git command fails', () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Not a git repository');
       });
       expect(getGitBranch()).toBeNull();
     });
 
     it('returns null for empty output', () => {
-      mockExecSync.mockReturnValue('');
+      mockExecFileSync.mockReturnValue('');
       expect(getGitBranch()).toBeNull();
     });
 
-    it('passes cwd option to execSync', () => {
-      mockExecSync.mockReturnValue('main\n');
+    it('passes cwd option to execFileSync', () => {
+      mockExecFileSync.mockReturnValue('main\n');
       getGitBranch('/some/path');
-      expect(mockExecSync).toHaveBeenCalledWith(
-        'git branch --show-current',
-        expect.objectContaining({ cwd: '/some/path' })
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'git',
+        ['branch', '--show-current'],
+        expect.objectContaining({ cwd: '/some/path', windowsHide: true })
       );
     });
   });
 
   describe('renderGitRepo', () => {
     it('renders formatted repo name', () => {
-      mockExecSync.mockReturnValue('https://github.com/user/my-repo.git\n');
+      mockExecFileSync.mockReturnValue('https://github.com/user/my-repo.git\n');
       const result = renderGitRepo();
       expect(result).toContain('repo:');
       expect(result).toContain('my-repo');
     });
 
     it('returns null when repo not available', () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Not a git repository');
       });
       expect(renderGitRepo()).toBeNull();
     });
 
     it('applies styling', () => {
-      mockExecSync.mockReturnValue('https://github.com/user/repo.git\n');
+      mockExecFileSync.mockReturnValue('https://github.com/user/repo.git\n');
       const result = renderGitRepo();
       expect(result).toContain('\x1b['); // contains ANSI escape codes
     });
@@ -115,9 +117,9 @@ describe('git elements', () => {
 
   describe('getWorktreeInfo', () => {
     it('returns isWorktree false for normal repo', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --git-dir') return '.git\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '.git\n';
+      mockExecFileSync.mockImplementation((_file: string, args?: readonly string[]) => {
+        if (args?.join(' ') === 'rev-parse --git-dir') return '.git\n';
+        if (args?.join(' ') === 'rev-parse --git-common-dir') return '.git\n';
         return '';
       });
       const result = getWorktreeInfo('/some/repo');
@@ -126,9 +128,9 @@ describe('git elements', () => {
     });
 
     it('detects linked worktree and extracts worktree name from git-dir', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --git-dir') return '/main-repo/.git/worktrees/my-wt\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '/main-repo/.git\n';
+      mockExecFileSync.mockImplementation((_file: string, args?: readonly string[]) => {
+        if (args?.join(' ') === 'rev-parse --git-dir') return '/main-repo/.git/worktrees/my-wt\n';
+        if (args?.join(' ') === 'rev-parse --git-common-dir') return '/main-repo/.git\n';
         return '';
       });
 
@@ -138,9 +140,9 @@ describe('git elements', () => {
     });
 
     it('extracts worktree name with nested path segments', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --git-dir') return '/repo/.git/worktrees/feature-NAVERCAFE-12345\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '/repo/.git\n';
+      mockExecFileSync.mockImplementation((_file: string, args?: readonly string[]) => {
+        if (args?.join(' ') === 'rev-parse --git-dir') return '/repo/.git/worktrees/feature-NAVERCAFE-12345\n';
+        if (args?.join(' ') === 'rev-parse --git-common-dir') return '/repo/.git\n';
         return '';
       });
 
@@ -150,7 +152,7 @@ describe('git elements', () => {
     });
 
     it('returns not a worktree when git commands fail', () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Not a git repository');
       });
       const result = getWorktreeInfo();
@@ -159,46 +161,46 @@ describe('git elements', () => {
     });
 
     it('caches result for same cwd', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --git-dir') return '.git\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '.git\n';
+      mockExecFileSync.mockImplementation((_file: string, args?: readonly string[]) => {
+        if (args?.join(' ') === 'rev-parse --git-dir') return '.git\n';
+        if (args?.join(' ') === 'rev-parse --git-common-dir') return '.git\n';
         return '';
       });
 
       getWorktreeInfo('/cached/path');
       getWorktreeInfo('/cached/path');
 
-      const gitDirCalls = mockExecSync.mock.calls.filter(c => c[0] === 'git rev-parse --git-dir');
+      const gitDirCalls = mockExecFileSync.mock.calls.filter(c => Array.isArray(c[1]) && c[1].join(' ') === 'rev-parse --git-dir');
       expect(gitDirCalls).toHaveLength(1);
     });
   });
 
   describe('renderGitBranch', () => {
     it('renders formatted branch name', () => {
-      mockExecSync.mockReturnValue('main\n');
+      mockExecFileSync.mockReturnValue('main\n');
       const result = renderGitBranch();
       expect(result).toContain('branch:');
       expect(result).toContain('main');
     });
 
     it('returns null when branch not available', () => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         throw new Error('Not a git repository');
       });
       expect(renderGitBranch()).toBeNull();
     });
 
     it('applies styling', () => {
-      mockExecSync.mockReturnValue('main\n');
+      mockExecFileSync.mockReturnValue('main\n');
       const result = renderGitBranch();
       expect(result).toContain('\x1b['); // contains ANSI escape codes
     });
 
     it('shows worktree suffix with worktree name when in a linked worktree', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git branch --show-current') return 'feature-x\n';
-        if (cmd === 'git rev-parse --git-dir') return '/main/.git/worktrees/my-wt\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '/main/.git\n';
+      mockExecFileSync.mockImplementation((_file: string, args?: readonly string[]) => {
+        if (args?.join(' ') === 'branch --show-current') return 'feature-x\n';
+        if (args?.join(' ') === 'rev-parse --git-dir') return '/main/.git/worktrees/my-wt\n';
+        if (args?.join(' ') === 'rev-parse --git-common-dir') return '/main/.git\n';
         return '';
       });
 
@@ -210,10 +212,10 @@ describe('git elements', () => {
     });
 
     it('does not show worktree suffix in normal repo', () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git branch --show-current') return 'main\n';
-        if (cmd === 'git rev-parse --git-dir') return '.git\n';
-        if (cmd === 'git rev-parse --git-common-dir') return '.git\n';
+      mockExecFileSync.mockImplementation((_file: string, args?: readonly string[]) => {
+        if (args?.join(' ') === 'branch --show-current') return 'main\n';
+        if (args?.join(' ') === 'rev-parse --git-dir') return '.git\n';
+        if (args?.join(' ') === 'rev-parse --git-common-dir') return '.git\n';
         return '';
       });
 

--- a/src/__tests__/hud/windows-platform.test.ts
+++ b/src/__tests__/hud/windows-platform.test.ts
@@ -14,7 +14,7 @@ const packageRoot = join(__dirname, '..', '..', '..');
  * 1. Checking bridge NODE_PATH separator uses platform-aware logic
  * 2. Mocking process.platform to test Windows code paths
  * 3. Verifying ASCII fallback for emoji on Windows
- * 4. Verifying shell option for git execSync on Windows
+ * 4. Verifying git HUD uses shell-free execFileSync argv on Windows
  * 5. Verifying safe mode auto-enable on Windows
  *
  * Related: GitHub Issue #739
@@ -29,10 +29,6 @@ function isWin32(platform: string): boolean {
 
 function getSeparator(platform: string): string {
   return isWin32(platform) ? ';' : ':';
-}
-
-function getShellOption(platform: string): string | undefined {
-  return isWin32(platform) ? 'cmd.exe' : undefined;
 }
 
 function getSafeMode(configSafeMode: boolean, platform: string): boolean {
@@ -188,27 +184,22 @@ describe('Windows HUD Platform Fixes (#739)', () => {
   });
 
   // =========================================================================
-  // P1: Git shell option on Windows
+  // P1: Git execFileSync argv on Windows
   // =========================================================================
-  describe('P1: Git execSync shell option', () => {
-    it('git.ts should use conditional shell option', () => {
+  describe('P1: Git shell-free execFileSync on Windows', () => {
+    it('git.ts should call git via execFileSync argv with windowsHide', () => {
       const content = readFileSync(
         join(packageRoot, 'src', 'hud', 'elements', 'git.ts'),
         'utf-8',
       );
-      expect(content).toContain("shell: process.platform === 'win32' ? 'cmd.exe' : undefined");
-    });
 
-    it('shell option logic should produce cmd.exe on win32', () => {
-      expect(getShellOption('win32')).toBe('cmd.exe');
-    });
+      expect(content).toContain("import { execFileSync } from 'node:child_process'");
+      expect(content).toContain("execFileSync('git', args, {");
+      expect(content).toContain('windowsHide: true');
 
-    it('shell option logic should produce undefined on darwin', () => {
-      expect(getShellOption('darwin')).toBeUndefined();
-    });
-
-    it('shell option logic should produce undefined on linux', () => {
-      expect(getShellOption('linux')).toBeUndefined();
+      expect(content).not.toContain("shell: process.platform === 'win32' ? 'cmd.exe' : undefined");
+      expect(content).not.toContain('cmd.exe');
+      expect(content).not.toContain('execSync');
     });
   });
 

--- a/src/hud/__tests__/git-status.test.ts
+++ b/src/hud/__tests__/git-status.test.ts
@@ -8,19 +8,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   return {
     ...actual,
-    execSync: vi.fn(),
+    execFileSync: vi.fn(),
   };
 });
 
 import { getGitStatusCounts, renderGitStatus, resetGitCache } from '../elements/git.js';
 
-const mockedExecSync = vi.mocked(execSync);
+const mockedExecFileSync = vi.mocked(execFileSync);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -32,27 +32,27 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 describe('getGitStatusCounts', () => {
   it('returns zeros for clean repo', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts).toEqual({ staged: 0, modified: 0, untracked: 0, ahead: 0, behind: 0 });
   });
 
   it('counts staged files', () => {
-    mockedExecSync.mockReturnValue('## main\nM  file1.ts\nA  file2.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\nM  file1.ts\nA  file2.ts\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.staged).toBe(2);
     expect(counts?.modified).toBe(0);
   });
 
   it('counts modified (unstaged) files', () => {
-    mockedExecSync.mockReturnValue('## main\n M file1.ts\n D file2.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\n M file1.ts\n D file2.ts\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.staged).toBe(0);
     expect(counts?.modified).toBe(2);
   });
 
   it('counts untracked files', () => {
-    mockedExecSync.mockReturnValue('## main\n?? newfile.ts\n?? another.ts\n?? third.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\n?? newfile.ts\n?? another.ts\n?? third.ts\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.untracked).toBe(3);
     expect(counts?.staged).toBe(0);
@@ -61,35 +61,35 @@ describe('getGitStatusCounts', () => {
 
   it('counts both staged and modified for same file', () => {
     // MM means staged + modified
-    mockedExecSync.mockReturnValue('## main\nMM file.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\nMM file.ts\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.staged).toBe(1);
     expect(counts?.modified).toBe(1);
   });
 
   it('parses ahead count', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main [ahead 3]\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main [ahead 3]\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.ahead).toBe(3);
     expect(counts?.behind).toBe(0);
   });
 
   it('parses behind count', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main [behind 2]\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main [behind 2]\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.ahead).toBe(0);
     expect(counts?.behind).toBe(2);
   });
 
   it('parses ahead and behind', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main [ahead 5, behind 2]\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main [ahead 5, behind 2]\n' as any);
     const counts = getGitStatusCounts('/tmp');
     expect(counts?.ahead).toBe(5);
     expect(counts?.behind).toBe(2);
   });
 
   it('handles mixed status', () => {
-    mockedExecSync.mockReturnValue((
+    mockedExecFileSync.mockReturnValue((
       '## feat...origin/feat [ahead 1, behind 3]\n' +
       'M  staged.ts\n' +
       ' M modified.ts\n' +
@@ -103,23 +103,24 @@ describe('getGitStatusCounts', () => {
   });
 
   it('returns null on git error', () => {
-    mockedExecSync.mockImplementation(() => { throw new Error('not a git repo'); });
+    mockedExecFileSync.mockImplementation(() => { throw new Error('not a git repo'); });
     expect(getGitStatusCounts('/tmp')).toBeNull();
   });
 
   it('returns cached result on second call', () => {
-    mockedExecSync.mockReturnValue('## main\n?? file.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\n?? file.ts\n' as any);
     getGitStatusCounts('/tmp');
     getGitStatusCounts('/tmp');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('disables optional git locks for background HUD polling', () => {
-    mockedExecSync.mockReturnValue('## main\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\n' as any);
     getGitStatusCounts('/tmp');
-    expect(mockedExecSync).toHaveBeenCalledWith(
-      'git --no-optional-locks status --porcelain -b',
-      expect.objectContaining({ cwd: '/tmp' }),
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['--no-optional-locks', 'status', '--porcelain', '-b'],
+      expect.objectContaining({ cwd: '/tmp', windowsHide: true }),
     );
   });
 });
@@ -129,45 +130,45 @@ describe('getGitStatusCounts', () => {
 // ---------------------------------------------------------------------------
 describe('renderGitStatus', () => {
   it('returns null for clean repo', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main\n' as any);
     expect(renderGitStatus('/tmp')).toBeNull();
   });
 
   it('returns null on git error', () => {
-    mockedExecSync.mockImplementation(() => { throw new Error('fail'); });
+    mockedExecFileSync.mockImplementation(() => { throw new Error('fail'); });
     expect(renderGitStatus('/tmp')).toBeNull();
   });
 
   it('shows staged count with + prefix', () => {
-    mockedExecSync.mockReturnValue('## main\nA  file.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\nA  file.ts\n' as any);
     const result = renderGitStatus('/tmp')!;
     expect(result).toContain('+');
     expect(result).toContain('1');
   });
 
   it('shows modified count with ! prefix', () => {
-    mockedExecSync.mockReturnValue('## main\n M file.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\n M file.ts\n' as any);
     const result = renderGitStatus('/tmp')!;
     expect(result).toContain('!');
     expect(result).toContain('1');
   });
 
   it('shows untracked count with ? prefix', () => {
-    mockedExecSync.mockReturnValue('## main\n?? file.ts\n' as any);
+    mockedExecFileSync.mockReturnValue('## main\n?? file.ts\n' as any);
     const result = renderGitStatus('/tmp')!;
     expect(result).toContain('?');
     expect(result).toContain('1');
   });
 
   it('shows ahead with ⇡', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main [ahead 2]\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main [ahead 2]\n' as any);
     const result = renderGitStatus('/tmp')!;
     expect(result).toContain('⇡');
     expect(result).toContain('2');
   });
 
   it('shows behind with ⇣', () => {
-    mockedExecSync.mockReturnValue('## main...origin/main [behind 4]\n' as any);
+    mockedExecFileSync.mockReturnValue('## main...origin/main [behind 4]\n' as any);
     const result = renderGitStatus('/tmp')!;
     expect(result).toContain('⇣');
     expect(result).toContain('4');
@@ -175,7 +176,7 @@ describe('renderGitStatus', () => {
 
 
   it('uses configured status labels without changing counts', () => {
-    mockedExecSync.mockReturnValue((
+    mockedExecFileSync.mockReturnValue((
       '## main...origin/main [ahead 2, behind 4]\n' +
       'A  staged.ts\n' +
       ' M modified.ts\n' +

--- a/src/hud/elements/git.ts
+++ b/src/hud/elements/git.ts
@@ -4,7 +4,7 @@
  * Renders git repository name and branch information.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { resolve, basename } from 'node:path';
 import { dim, cyan, green, red } from '../colors.js';
@@ -36,6 +36,16 @@ const branchCache = new Map<string, CacheEntry<string | null>>();
 const worktreeCache = new Map<string, CacheEntry<WorktreeDetection>>();
 const statusCache = new Map<string, CacheEntry<GitStatusCounts | null>>();
 
+function git(args: string[], cwd?: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 1000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  }).trim();
+}
+
 /**
  * Clear all git caches. Call in tests beforeEach to ensure a clean slate.
  */
@@ -64,13 +74,7 @@ export function getGitRepoName(cwd?: string): string | null {
 
   let result: string | null = null;
   try {
-    const url = execSync('git remote get-url origin', {
-      cwd,
-      encoding: 'utf-8',
-      timeout: 1000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
-    }).trim();
+    const url = git(['remote', 'get-url', 'origin'], cwd);
 
     if (!url) {
       result = null;
@@ -103,13 +107,7 @@ export function getGitBranch(cwd?: string): string | null {
 
   let result: string | null = null;
   try {
-    const branch = execSync('git branch --show-current', {
-      cwd,
-      encoding: 'utf-8',
-      timeout: 1000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
-    }).trim();
+    const branch = git(['branch', '--show-current'], cwd);
 
     result = branch || null;
   } catch {
@@ -135,18 +133,10 @@ export function getWorktreeInfo(cwd?: string): WorktreeDetection {
     return cached.value;
   }
 
-  const execOpts = {
-    cwd,
-    encoding: 'utf-8' as BufferEncoding,
-    timeout: 1000,
-    stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'],
-    shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
-  };
-
   let result: WorktreeDetection = { isWorktree: false, worktreeName: null };
   try {
-    const gitDir = (execSync('git rev-parse --git-dir', execOpts) as string).trim();
-    const gitCommonDir = (execSync('git rev-parse --git-common-dir', execOpts) as string).trim();
+    const gitDir = git(['rev-parse', '--git-dir'], cwd);
+    const gitCommonDir = git(['rev-parse', '--git-common-dir'], cwd);
 
     // Canonicalize via realpathSync to handle symlinked repo paths
     let resolvedGitDir = resolve(key, gitDir);
@@ -215,13 +205,7 @@ export function getGitStatusCounts(cwd?: string): GitStatusCounts | null {
 
   let result: GitStatusCounts | null = null;
   try {
-    const output = execSync('git --no-optional-locks status --porcelain -b', {
-      cwd,
-      encoding: 'utf-8',
-      timeout: 1000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
-    }).trim();
+    const output = git(['--no-optional-locks', 'status', '--porcelain', '-b'], cwd);
 
     let staged = 0, modified = 0, untracked = 0, ahead = 0, behind = 0;
 


### PR DESCRIPTION
## Summary
- Reimplements the concrete fix from closed PR #3087 on top of `dev` instead of reopening the old `main`-target PR.
- Replaces HUD git `execSync` shell-string calls with `execFileSync('git', args, ...)` and `windowsHide: true`.
- Preserves existing output parsing, timeouts, stdio behavior, caching, and null-on-error handling.

## Verification
- `npm test -- --run src/__tests__/hud/git.test.ts src/hud/__tests__/git-status.test.ts` (45 tests)
- `npm run build`
- `npx tsc --noEmit`
- `npm run lint` (exits 0; existing warnings outside changed files remain)

Refs closed PR #3087.
