### PR TITLE
Add opt-in force-agent-delegation preflight (#3095)

### DIFF
--- a/scripts/lib/force-agent-delegation-preflight.mjs
+++ b/scripts/lib/force-agent-delegation-preflight.mjs
@@ -1,0 +1,167 @@
+// Force Agent Delegation Preflight
+//
+// Symmetric counterpart to evaluateAgentHeavyPreflight: where preflight blocks
+// agent spawning when context is exhausted, this evaluator blocks raw
+// Read/Edit/Write/Grep/Glob when delegation rules indicate the work should be
+// routed to a specialised agent instead.
+//
+// Opt-in: default OFF. Enable via `.omc/config.json`:
+//
+//   {
+//     "routing": {
+//       "forceDelegation": {
+//         "enforce": true,
+//         "rules": [
+//           {
+//             "pattern": "Read",
+//             "threshold": { "count": 10, "windowSeconds": 120 },
+//             "denyMessage": "10+ raw Reads in 2 min — spawn Agent(subagent_type='oh-my-claudecode:explore', model='haiku', ...). Bypass: ALLOW_RAW_READ=1.",
+//             "bypassEnv": "ALLOW_RAW_READ"
+//           }
+//         ]
+//       }
+//     }
+//   }
+//
+// State persistence: a 1h sliding window of tool-use events is stored under
+// `<stateDir>/force-agent-delegation-events.json` so the threshold counter
+// survives across PreToolUse invocations (each invocation is a fresh Node
+// process). State writes fail open — missing/corrupt files just reset the
+// window without blocking the tool call.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const STATE_FILENAME = 'force-agent-delegation-events.json';
+const EVENT_RETENTION_SECONDS = 3600;
+const DEFAULT_WINDOW_SECONDS = 120;
+
+function nowSec() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function loadEvents(stateDir) {
+  if (!stateDir) return [];
+  try {
+    const p = join(stateDir, STATE_FILENAME);
+    if (!existsSync(p)) return [];
+    const parsed = JSON.parse(readFileSync(p, 'utf-8'));
+    return Array.isArray(parsed?.events) ? parsed.events : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveEvents(stateDir, events) {
+  if (!stateDir) return;
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, STATE_FILENAME),
+      JSON.stringify({ events }, null, 2),
+    );
+  } catch {
+    // Non-critical — counter resets if write fails.
+  }
+}
+
+function pruneAndAppend(events, toolName) {
+  const cutoff = nowSec() - EVENT_RETENTION_SECONDS;
+  const pruned = events.filter((e) => typeof e?.t === 'number' && e.t > cutoff);
+  pruned.push({ tool: toolName, t: nowSec() });
+  return pruned;
+}
+
+function patternMatches(pattern, toolName) {
+  if (!pattern || typeof pattern !== 'string') return false;
+  try {
+    return new RegExp(`^(?:${pattern})$`).test(toolName);
+  } catch {
+    return false;
+  }
+}
+
+function countInWindow(events, pattern, windowSeconds) {
+  const cutoff = nowSec() - windowSeconds;
+  return events.filter(
+    (e) =>
+      typeof e?.t === 'number' &&
+      e.t > cutoff &&
+      typeof e?.tool === 'string' &&
+      patternMatches(pattern, e.tool),
+  ).length;
+}
+
+function readDelegationConfig(loadOmcConfig) {
+  try {
+    const cfg = typeof loadOmcConfig === 'function' ? loadOmcConfig() : null;
+    return cfg?.routing?.forceDelegation ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Evaluate force-agent-delegation rules for the current PreToolUse call.
+ *
+ * @param {object} args
+ * @param {string} args.toolName - Claude Code tool name (Read|Edit|Write|...)
+ * @param {string} [args.stateDir] - Directory used to persist the event window.
+ *   Typically `<cwd>/.omc/state` to mirror the rest of OMC state storage.
+ * @param {object} [args.env=process.env] - Environment for bypass-flag lookup.
+ * @param {Function} [args.loadOmcConfig] - Function returning the resolved OMC
+ *   config object. Injecting it keeps this module decoupled from the existing
+ *   loader inside scripts/pre-tool-enforcer.mjs.
+ * @returns {null | { decision: 'block', reason: string }}
+ *   Returns null when the call should proceed unchanged (default off, no
+ *   matching rule, threshold not reached, or bypass flag set).
+ */
+export function evaluateForceAgentDelegation({
+  toolName,
+  stateDir,
+  env = process.env,
+  loadOmcConfig,
+} = {}) {
+  if (!toolName) return null;
+
+  const cfg = readDelegationConfig(loadOmcConfig);
+  if (!cfg || cfg.enforce !== true || !Array.isArray(cfg.rules)) {
+    return null;
+  }
+
+  // Record this attempt up front so later calls have an accurate window.
+  const updated = pruneAndAppend(loadEvents(stateDir), toolName);
+  saveEvents(stateDir, updated);
+
+  for (const rule of cfg.rules) {
+    if (!rule || typeof rule !== 'object') continue;
+    if (!patternMatches(rule.pattern, toolName)) continue;
+
+    if (rule.bypassEnv && env[rule.bypassEnv] === '1') continue;
+
+    if (rule.threshold && typeof rule.threshold === 'object') {
+      const count = Number.isFinite(rule.threshold.count)
+        ? rule.threshold.count
+        : 0;
+      const windowSeconds = Number.isFinite(rule.threshold.windowSeconds)
+        ? rule.threshold.windowSeconds
+        : DEFAULT_WINDOW_SECONDS;
+      if (count <= 0) continue;
+
+      const observed = countInWindow(updated, rule.pattern, windowSeconds);
+      if (observed >= count) {
+        return {
+          decision: 'block',
+          reason:
+            typeof rule.denyMessage === 'string' && rule.denyMessage
+              ? rule.denyMessage
+              : `[OMC] Force-agent-delegation: ${observed} ${toolName} in last ${windowSeconds}s ` +
+                `(threshold ${count}). Delegate to an Agent instead. ` +
+                `Bypass: ${rule.bypassEnv || 'ALLOW_RAW_READ'}=1.`,
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -12,6 +12,7 @@ import { execSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { evaluateAgentHeavyPreflight } from './lib/pre-tool-enforcer-preflight.mjs';
+import { evaluateForceAgentDelegation } from './lib/force-agent-delegation-preflight.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
@@ -1050,6 +1051,31 @@ async function main() {
     }
 
     const todoStatus = getTodoStatus(directory);
+
+    // Force-agent-delegation: symmetric to evaluateAgentHeavyPreflight. Where
+    // preflight blocks Task/Agent spawning when context is exhausted, this
+    // evaluator blocks raw Read/Edit/Write/Grep/Glob when configured rules
+    // indicate the work should be delegated to a specialised agent. Default OFF
+    // — only fires when `.omc/config.json` has `routing.forceDelegation.enforce`.
+    const delegationBlock = evaluateForceAgentDelegation({
+      toolName,
+      stateDir,
+      loadOmcConfig,
+    });
+    if (delegationBlock) {
+      // Force-delegation preflight returns `{ decision: 'block', reason }` to
+      // match the agent-heavy preflight contract. Translate to the
+      // Claude Code hookSpecificOutput shape (`permissionDecision: 'deny'`).
+      console.log(JSON.stringify({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: delegationBlock.reason,
+        },
+      }));
+      return;
+    }
 
     if (toolName === 'Task' || toolName === 'Agent') {
       const rawTranscriptPath = data.transcript_path || data.transcriptPath || '';

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -1823,3 +1823,166 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     ).toBe(false);
   });
 });
+
+// === Force-agent-delegation tests (issue #3095) ===
+
+describe('pre-tool-enforcer force-agent-delegation enforcement', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pre-tool-enforcer-fad-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeDelegationConfig(rules: Array<Record<string, unknown>>, enforce = true): void {
+    writeJson(join(tempDir, '.omc', 'config.json'), {
+      routing: {
+        forceDelegation: { enforce, rules },
+      },
+    });
+  }
+
+  it('does nothing when force-delegation config is absent (default off)', () => {
+    for (let i = 0; i < 5; i++) {
+      const output = runPreToolEnforcer({
+        tool_name: 'Read',
+        toolInput: { file_path: `${tempDir}/file-${i}.ts` },
+        cwd: tempDir,
+        session_id: 'session-fad-no-config',
+      });
+      expect(output.continue).toBe(true);
+      const hookOutput = (output.hookSpecificOutput as Record<string, unknown>) || {};
+      expect(hookOutput.permissionDecision).toBeUndefined();
+    }
+  });
+
+  it('does nothing when enforce: false even if rules are defined', () => {
+    writeDelegationConfig(
+      [{ pattern: 'Read', threshold: { count: 2, windowSeconds: 60 } }],
+      false,
+    );
+    for (let i = 0; i < 5; i++) {
+      const output = runPreToolEnforcer({
+        tool_name: 'Read',
+        toolInput: { file_path: `${tempDir}/file-${i}.ts` },
+        cwd: tempDir,
+        session_id: 'session-fad-disabled',
+      });
+      expect(output.continue).toBe(true);
+      const hookOutput = (output.hookSpecificOutput as Record<string, unknown>) || {};
+      expect(hookOutput.permissionDecision).toBeUndefined();
+    }
+  });
+
+  it('allows tool calls under the configured threshold', () => {
+    writeDelegationConfig([
+      { pattern: 'Read', threshold: { count: 5, windowSeconds: 60 } },
+    ]);
+    for (let i = 0; i < 4; i++) {
+      const output = runPreToolEnforcer({
+        tool_name: 'Read',
+        toolInput: { file_path: `${tempDir}/file-${i}.ts` },
+        cwd: tempDir,
+        session_id: 'session-fad-under',
+      });
+      const hookOutput = (output.hookSpecificOutput as Record<string, unknown>) || {};
+      expect(hookOutput.permissionDecision).toBeUndefined();
+    }
+  });
+
+  it('blocks the call that crosses the threshold and surfaces the configured deny message', () => {
+    const denyMessage =
+      'Too many Reads — spawn Agent(subagent_type=\'oh-my-claudecode:explore\', model=\'haiku\'). Bypass: ALLOW_RAW_READ=1.';
+    writeDelegationConfig([
+      {
+        pattern: 'Read',
+        threshold: { count: 3, windowSeconds: 60 },
+        denyMessage,
+        bypassEnv: 'ALLOW_RAW_READ',
+      },
+    ]);
+
+    let lastOutput: Record<string, unknown> = {};
+    for (let i = 0; i < 3; i++) {
+      lastOutput = runPreToolEnforcer({
+        tool_name: 'Read',
+        toolInput: { file_path: `${tempDir}/file-${i}.ts` },
+        cwd: tempDir,
+        session_id: 'session-fad-block',
+      });
+    }
+
+    const hookOutput = lastOutput.hookSpecificOutput as Record<string, unknown>;
+    expect(lastOutput.continue).toBe(true);
+    expect(hookOutput.hookEventName).toBe('PreToolUse');
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(hookOutput.permissionDecisionReason).toBe(denyMessage);
+  });
+
+  it('respects the per-rule bypass env var', () => {
+    writeDelegationConfig([
+      {
+        pattern: 'Read',
+        threshold: { count: 2, windowSeconds: 60 },
+        bypassEnv: 'ALLOW_RAW_READ',
+      },
+    ]);
+
+    for (let i = 0; i < 5; i++) {
+      const output = runPreToolEnforcerWithEnv(
+        {
+          tool_name: 'Read',
+          toolInput: { file_path: `${tempDir}/file-${i}.ts` },
+          cwd: tempDir,
+          session_id: 'session-fad-bypass',
+        },
+        { ALLOW_RAW_READ: '1' },
+      );
+      const hookOutput = (output.hookSpecificOutput as Record<string, unknown>) || {};
+      expect(hookOutput.permissionDecision).toBeUndefined();
+    }
+  });
+
+  it('matches only the configured pattern and ignores other tools', () => {
+    writeDelegationConfig([
+      { pattern: 'Read', threshold: { count: 2, windowSeconds: 60 } },
+    ]);
+
+    for (let i = 0; i < 5; i++) {
+      const output = runPreToolEnforcer({
+        tool_name: 'Bash',
+        toolInput: { command: `echo ${i}` },
+        cwd: tempDir,
+        session_id: 'session-fad-other-tool',
+      });
+      const hookOutput = (output.hookSpecificOutput as Record<string, unknown>) || {};
+      expect(hookOutput.permissionDecision).toBeUndefined();
+    }
+  });
+
+  it('supports alternation patterns for Read|Grep|Glob', () => {
+    writeDelegationConfig([
+      {
+        pattern: 'Read|Grep|Glob',
+        threshold: { count: 3, windowSeconds: 60 },
+        denyMessage: 'Investigation budget exhausted — delegate to explore agent.',
+      },
+    ]);
+
+    runPreToolEnforcer({ tool_name: 'Read', cwd: tempDir, session_id: 'session-fad-alt' });
+    runPreToolEnforcer({ tool_name: 'Grep', cwd: tempDir, session_id: 'session-fad-alt', toolInput: { pattern: 'foo' } });
+    const third = runPreToolEnforcer({
+      tool_name: 'Glob',
+      cwd: tempDir,
+      session_id: 'session-fad-alt',
+      toolInput: { pattern: '**/*.ts' },
+    });
+
+    const hookOutput = third.hookSpecificOutput as Record<string, unknown>;
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(String(hookOutput.permissionDecisionReason)).toContain('Investigation budget');
+  });
+});


### PR DESCRIPTION
Closes #3095 (proof-of-concept implementation, design feedback welcome before broadening scope).

## What

Adds an opt-in PreToolUse evaluator that is symmetric to \`evaluateAgentHeavyPreflight\`:

| Existing | New |
|---|---|
| Blocks \`Task\`/\`Agent\` when context > 72% | Blocks \`Read\`/\`Edit\`/\`Write\`/\`Grep\`/\`Glob\` when configured delegation rules trigger |
| Always-on, context-driven | Default OFF, config-driven |
| Hard-coded threshold + env override | Per-rule threshold + per-rule bypass env |

The goal stated in #3095: close the gap between the \"intelligent routing\" doctrine in CLAUDE.md / agent catalogs and the empirical reality that the main context never delegates without an enforcement mechanism.

## How

- **New module** \`scripts/lib/force-agent-delegation-preflight.mjs\` exports \`evaluateForceAgentDelegation({ toolName, stateDir, env, loadOmcConfig })\`. Mirrors the contract of \`evaluateAgentHeavyPreflight\` (\`{ decision: 'block', reason }\` on enforcement, \`null\` otherwise). Persists a 1h sliding window of tool events under \`<stateDir>/force-agent-delegation-events.json\`.
- **Integration in \`scripts/pre-tool-enforcer.mjs\`** (12 lines): one import + one call site right after \`getTodoStatus\`, before the existing agent-heavy preflight. Translates the module's \`decision: 'block'\` to the Claude Code hookSpecificOutput \`permissionDecision: 'deny'\` shape.
- **Tests** appended to \`src/__tests__/pre-tool-enforcer.test.ts\` in a new \`describe\` block. 7 cases cover: default-off, enforce:false, under-threshold, threshold-crossed deny message, bypass env, non-matching tool, alternation patterns.

## Configuration

\`\`\`json
{
  \"routing\": {
    \"forceDelegation\": {
      \"enforce\": true,
      \"rules\": [
        {
          \"pattern\": \"Read|Grep|Glob\",
          \"threshold\": { \"count\": 10, \"windowSeconds\": 120 },
          \"denyMessage\": \"10+ raw investigations in 2 min — spawn Agent(subagent_type='oh-my-claudecode:explore', model='haiku'). Bypass: ALLOW_RAW_READ=1.\",
          \"bypassEnv\": \"ALLOW_RAW_READ\"
        }
      ]
    }
  }
}
\`\`\`

## Tests

\`\`\`
npx vitest run src/__tests__/pre-tool-enforcer.test.ts
Test Files  1 passed (1)
     Tests  85 passed (85)
\`\`\`

= 78 pre-existing tests **untouched** + 7 new tests covering the opt-in path.

## Why this is a draft

The issue (#3095) listed three rule families: count-based threshold (this PR), per-edit LOC, and per-window file-count. I implemented only the threshold primitive so the design surface — config schema, opt-in mechanism, integration site, deny translation — can be reviewed in isolation before extending. If the design direction is OK, follow-up commits can add:

- \`rule.lineCount\` for \`Edit\`/\`Write\` (parse \`tool_input.new_string\` / \`content\`)
- \`rule.fileCount\` for distinct file paths in window
- Telemetry hook into \`subagent-tracker.mjs\` (\`delegation_rate\` metric)
- Surface in \`status.mjs\`

Happy to keep iterating on the same branch or split per-rule.

## Notes on style

- Commit body follows your structured \`Constraint:/Rejected:/Confidence:/Scope-risk:/Directive:/Tested:/Not-tested:\` template observed in recent PRs (#3004, #3005, #3006).
- Module docstring at top explains the contract for future maintainers.
- No changes to \`dist/\` or generated artifacts — kept the PR diff to the source modules only.
- No new dependencies.

## Empirical motivation (from issue #3095)

Multi-hour Claude Code sessions on a repo with rich \`.claude/agents/\` catalog (specialized RGPD/security/RAG agents) show 0 \`SubagentStart\` events in \`subagent-tracker.mjs\` over 35+ tool calls — 100% on main-context Opus. This hook gives operators the option to enforce the routing they want without waiting for self-discipline.