### PR TITLE
feat: persist ultragoal and enforce Claude goal activation

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -228,7 +228,7 @@ See the [Magic Keywords](#magic-keywords) section for the full keyword list.
 Enforces continuation when an execution mode is active. This is the hook that keeps skills like autopilot, ralph, and ultrawork running.
 
 - **Event**: Stop
-- **Behavior**: Checks `.omc/state/` for active mode state files. If any mode (ralph, autopilot, ultrawork, ultraqa, team, pipeline) is active, injects a reinforcement message to prevent Claude from stopping.
+- **Behavior**: Checks `.omc/state/` for active mode state files. If any mode (ralph, ultragoal, autopilot, ultrawork, ultraqa, team, pipeline) is active, injects a reinforcement message to prevent Claude from stopping.
 - **Reinforcement message**: "The boulder never stops" — prompts Claude to continue working
 - **Staleness check**: States older than 2 hours are treated as inactive to prevent stale state from blocking new sessions
 - **Notification**: Sends Discord/Telegram/Slack notification on first stop (if configured)
@@ -255,6 +255,17 @@ Execution mode hooks manage state files in the `.omc/state/` directory.
 ```
 
 When a session ID is present, state is stored in session scope under `.omc/state/sessions/{sessionId}/`.
+
+
+#### ultragoal-state.json lifecycle
+
+`ultragoal-state.json` is the session-scoped Stop/PreToolUse guard for `$ultragoal` runs. The durable plan and audit trail remain `.omc/ultragoal/goals.json` and `.omc/ultragoal/ledger.jsonl`; the state file only records the active runtime guard.
+
+- **Location**: `.omc/state/sessions/{sessionId}/ultragoal-state.json` when a Claude session id is available; legacy fallback is `.omc/state/ultragoal-state.json`.
+- **Active fields**: `active: true`, `session_id`, `project_path`, `started_at`, `last_checked_at`, `current_phase`, optional `claude_goal_objective`, and `reinforcement_count`.
+- **Stop hook**: reinforces only when the state is active, fresh (within the normal 2-hour mode-state freshness window), session-matching, and project-matching. Terminal phases (`complete`, `completed`, `done`, `all-done`, `failed`, `cancelled`) and all-done `.omc/ultragoal/goals.json` plans are ignored.
+- **PreToolUse guard**: while active, tools are denied unless the hook can see a matching active Claude `/goal` snapshot. Use `ALLOW_ULTRAGOAL_WITHOUT_GOAL=1` only as an intentional local bypass.
+- **Completion**: after the final quality gate and ultragoal checkpoint, mark the state inactive or run `/oh-my-claudecode:cancel` so the state file is cleared with other workflow state.
 
 #### Canceling a Mode
 

--- a/docs/shared/features.md
+++ b/docs/shared/features.md
@@ -111,6 +111,7 @@ Standardized state file locations.
 | Mode | State File |
 |------|-----------|
 | ralph | `ralph-state.json` |
+| ultragoal | `ultragoal-state.json` |
 | autopilot | `autopilot-state.json` |
 | ultrawork | `ultrawork-state.json` |
 |  | `-state.json` |

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -630,6 +630,46 @@ function hasActionableKeyword(text, pattern) {
   return false;
 }
 
+
+function hasExplicitWorkflowInvocationContext(text, position, keywordLength, keywordText) {
+  const prefix = text.slice(0, position);
+  if (/^\s*(?:[$/!]\s*|force:\s*|oh-my-(?:claudecode|codex):\s*)$/i.test(prefix)) {
+    return true;
+  }
+
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
+  const context = text.slice(start, end);
+  return hasActivationIntentNearKeyword(context, keywordText);
+}
+
+function hasExplicitActionableKeyword(text, pattern) {
+  const searchText = looksLikeSystemEcho(text)
+    ? stripSystemEchoes(text)
+    : text;
+
+  const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  const globalPattern = new RegExp(pattern.source, flags);
+
+  for (const match of searchText.matchAll(globalPattern)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    if (isInformationalKeywordContext(searchText, match.index, match[0].length, match[0])) {
+      continue;
+    }
+
+    if (!hasExplicitWorkflowInvocationContext(searchText, match.index, match[0].length, match[0])) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
 function hasActionableRalplanKeyword(text, pattern) {
   // Same echo guard as hasActionableKeyword.
   const searchText = looksLikeSystemEcho(text)
@@ -1051,7 +1091,7 @@ async function main() {
     }
 
     // Ultragoal keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ultragoal)\b/i)) {
+    if (hasExplicitActionableKeyword(cleanPrompt, /\b(ultragoal)\b/i)) {
       matches.push({ name: 'ultragoal', args: '' });
     }
 

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -473,7 +473,7 @@ function sanitizePromptForState(prompt) {
     : base;
 }
 const MODE_REFERENCE_PATTERN =
-  /\b(?:ralph|autopilot|auto[\s-]?pilot|ultrawork|ulw|ralplan|ultrathink|deepsearch|deep[\s-]?analyze|deepanalyze|deep[\s-]interview|ouroboros|ccg|claude-codex-gemini|deerflow)\b/gi;
+  /\b(?:ralph|autopilot|auto[\s-]?pilot|ultragoal|ultrawork|ulw|ralplan|ultrathink|deepsearch|deep[\s-]?analyze|deepanalyze|deep[\s-]interview|ouroboros|ccg|claude-codex-gemini|deerflow)\b/gi;
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -690,6 +690,21 @@ function activateState(directory, prompt, stateName, sessionId) {
       started_at: now,
       session_id: sessionId || undefined,
       project_path: directory,
+      awaiting_confirmation: true,
+      awaiting_confirmation_set_at: now,
+      last_checked_at: now
+    };
+  } else if (stateName === 'ultragoal') {
+    // Ultragoal persists a durable goal workflow and requires Claude /goal parity.
+    state = {
+      active: true,
+      started_at: now,
+      current_phase: 'executing',
+      original_prompt: safePrompt,
+      session_id: sessionId || undefined,
+      project_path: directory,
+      reinforcement_count: 0,
+      max_reinforcements: 50,
       awaiting_confirmation: true,
       awaiting_confirmation_set_at: now,
       last_checked_at: now
@@ -924,7 +939,7 @@ function resolveConflicts(matches) {
   // Team keyword detection removed — team is now explicit-only via /team skill.
 
   // Sort by priority order
-  const priorityOrder = ['cancel','ralph','autopilot','ultrawork',
+  const priorityOrder = ['cancel','ralph','ultragoal','autopilot','ultrawork',
     'ccg','ralplan','deep-interview','ai-slop-cleaner','tdd','code-review','security-review','ultrathink','deepsearch','analyze'];
   resolved.sort((a, b) => priorityOrder.indexOf(a.name) - priorityOrder.indexOf(b.name));
 
@@ -1033,6 +1048,11 @@ async function main() {
         hasActionableKeyword(cleanPrompt, /\bend\s+to\s+end\b/i) ||
         hasActionableKeyword(cleanPrompt, /\be2e\s+this\b/i)) {
       matches.push({ name: 'autopilot', args: '' });
+    }
+
+    // Ultragoal keywords
+    if (hasActionableKeyword(cleanPrompt, /\b(ultragoal)\b/i)) {
+      matches.push({ name: 'ultragoal', args: '' });
     }
 
     // Ultrapilot keywords removed — routed to team which is now explicit-only (/team).
@@ -1185,13 +1205,13 @@ async function main() {
 
     // Handle cancel specially - clear states and emit
     if (resolved.length > 0 && resolved[0].name === 'cancel') {
-      clearStateFiles(directory, ['ralph', 'autopilot', 'ultrawork', 'swarm', 'ralplan'], sessionId);
+      clearStateFiles(directory, ['ralph', 'ultragoal', 'autopilot', 'ultrawork', 'swarm', 'ralplan'], sessionId);
       console.log(JSON.stringify(createHookOutput(createSkillInvocation('cancel', prompt))));
       return;
     }
 
     // Activate states for modes that need them (team removed — explicit-only via /team skill)
-    const stateModes = resolved.filter(m => ['ralph', 'autopilot', 'ultrawork', 'ralplan'].includes(m.name));
+    const stateModes = resolved.filter(m => ['ralph', 'ultragoal', 'autopilot', 'ultrawork', 'ralplan'].includes(m.name));
     for (const mode of stateModes) {
       activateState(directory, prompt, mode.name, sessionId);
     }

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -5,7 +5,7 @@
  * Minimal continuation enforcer for all OMC modes.
  * Stripped down for reliability — no optional imports, no PRD, no notepad pruning.
  *
- * Supported modes: ralph, autopilot, ultrapilot, swarm, ultrawork, ultraqa, pipeline, team
+ * Supported modes: ralph, ultragoal, autopilot, ultrapilot, swarm, ultrawork, ultraqa, pipeline, team
  */
 
 import {
@@ -193,6 +193,17 @@ const TEAM_TERMINAL_PHASES = new Set([
   "aborted",
   "terminated",
   "done",
+]);
+const ULTRAGOAL_TERMINAL_PHASES = new Set([
+  "complete",
+  "completed",
+  "done",
+  "all-done",
+  "all_done",
+  "failed",
+  "cancelled",
+  "canceled",
+  "aborted",
 ]);
 const TEAM_ACTIVE_PHASES = new Set([
   "team-plan",
@@ -499,6 +510,55 @@ function isAuthoritativeModeActive(stateDir, mode, loaded, sessionId) {
   return true;
 }
 
+function normalizePhaseValue(value) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim().toLowerCase()
+    : "";
+}
+
+function isUltragoalTerminalState(state, directory) {
+  if (!state || typeof state !== "object") return false;
+  if (state.active === false) return true;
+  if (typeof state.completed_at === "string" && state.completed_at.length > 0) return true;
+  if (state.all_done === true || state.done === true) return true;
+
+  const phase = normalizePhaseValue(state.current_phase ?? state.phase ?? state.status);
+  if (phase && ULTRAGOAL_TERMINAL_PHASES.has(phase)) return true;
+
+  const plan = readJsonFile(join(directory, ".omc", "ultragoal", "goals.json"));
+  if (!plan || typeof plan !== "object") return false;
+  if (plan.aggregateCompletion?.status === "complete") return true;
+  if (!Array.isArray(plan.goals) || plan.goals.length === 0) return false;
+  return plan.goals.every((goal) => {
+    const status = normalizePhaseValue(goal?.status);
+    return status === "complete" || status === "review_blocked";
+  });
+}
+
+function getUltragoalObjective(state, directory) {
+  const candidates = [
+    state?.claude_goal_objective,
+    state?.claudeGoalObjective,
+    state?.codex_objective,
+    state?.codexObjective,
+    state?.goal_objective,
+    state?.goalObjective,
+    state?.objective,
+    state?.prompt,
+    state?.original_prompt,
+  ];
+  for (const value of candidates) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  const plan = readJsonFile(join(directory, ".omc", "ultragoal", "goals.json"));
+  if (typeof plan?.claudeObjective === "string" && plan.claudeObjective.trim()) return plan.claudeObjective.trim();
+  if (typeof plan?.aggregateCompletion?.objective === "string" && plan.aggregateCompletion.objective.trim()) {
+    return plan.aggregateCompletion.objective.trim();
+  }
+  const activeGoal = Array.isArray(plan?.goals) ? plan.goals.find((goal) => goal?.status === "in_progress") : null;
+  if (typeof activeGoal?.objective === "string" && activeGoal.objective.trim()) return activeGoal.objective.trim();
+  return "";
+}
 
 function isSessionCancelInProgress(stateDir, sessionId) {
   const isActiveSignal = (signalPath) => {
@@ -876,6 +936,12 @@ async function main() {
       "ralph-state.json",
       sessionId,
     );
+    const ultragoal = readStateFileWithSession(
+      stateDir,
+      globalStateDir,
+      "ultragoal-state.json",
+      sessionId,
+    );
     const autopilot = readStateFileWithSession(
       stateDir,
       globalStateDir,
@@ -1009,6 +1075,47 @@ async function main() {
             reason: ralphExtendedReason,
           }),
         );
+        return;
+      }
+    }
+
+    // Priority 1.5: Ultragoal durable goal execution
+    if (
+      isAuthoritativeModeActive(stateDir, "ultragoal", ultragoal, sessionId) && !isAwaitingConfirmation(ultragoal.state) &&
+      !isStaleState(ultragoal.state) &&
+      isStateForCurrentProject(ultragoal.state, directory, ultragoal.isGlobal)
+    ) {
+      const sessionMatches = hasValidSessionId
+        ? ultragoal.state.session_id === sessionId
+        : !ultragoal.state.session_id || ultragoal.state.session_id === sessionId;
+      if (sessionMatches && !isUltragoalTerminalState(ultragoal.state, directory)) {
+        const newCount = (ultragoal.state.reinforcement_count || 0) + 1;
+        const maxReinforcements = ultragoal.state.max_reinforcements || 50;
+
+        if (newCount > maxReinforcements) {
+          console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+          return;
+        }
+
+        const toolError = readLastToolError(stateDir);
+        const errorGuidance = getToolErrorRetryGuidance(toolError);
+
+        ultragoal.state.reinforcement_count = newCount;
+        ultragoal.state.last_checked_at = new Date().toISOString();
+        if (!shouldWriteStateBack(ultragoal.path)) {
+          console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+          return;
+        }
+        writeJsonFile(ultragoal.path, ultragoal.state);
+
+        let reason = `[ULTRAGOAL #${newCount}/${maxReinforcements}] Ultragoal mode is active. Continue the durable goal workflow, keep the matching Claude /goal active, and checkpoint .omc/ultragoal/ledger.jsonl before stopping. When all ultragoal stories are complete and the final quality gate passes, run /oh-my-claudecode:cancel to cleanly exit.`;
+        const objective = getUltragoalObjective(ultragoal.state, directory);
+        if (objective) reason += `\nClaude /goal objective: ${objective}`;
+        if (errorGuidance) {
+          reason = errorGuidance + reason;
+        }
+
+        console.log(JSON.stringify({ decision: "block", reason }));
         return;
       }
     }

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -580,11 +580,19 @@ function extractClaudeGoalSnapshot(data) {
   return null;
 }
 
+
+function isUltragoalBootstrapTool(toolName, toolInput) {
+  if (toolName === 'Skill' && extractSkillName(toolInput) === 'ultragoal') return true;
+  if (toolName !== 'Bash') return false;
+  const command = typeof toolInput.command === 'string' ? toolInput.command : '';
+  return /(?:^|[;&|\s])(?:omc|oh-my-claudecode)\s+ultragoal\s+(?:create(?:-goals)?|create-goals|complete(?:-goals)?|complete-goals|next|start-next|status)\b/.test(command);
+}
+
 function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, data) {
   if (process.env.ALLOW_ULTRAGOAL_WITHOUT_GOAL === '1') return null;
   const toolName = data.tool_name || data.toolName || '';
   const toolInput = data.toolInput || data.tool_input || {};
-  if (toolName === 'Skill' && extractSkillName(toolInput) === 'ultragoal') return null;
+  if (isUltragoalBootstrapTool(toolName, toolInput)) return null;
   const loaded = readSessionModeState(stateDir, 'ultragoal', sessionId);
   const state = loaded.state;
   if (!state?.active) return null;

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -311,6 +311,7 @@ const MODE_STATE_FILES = [
   'autopilot-state.json',
   'ultrapilot-state.json',
   'ralph-state.json',
+  'ultragoal-state.json',
   'ultrawork-state.json',
   'ultraqa-state.json',
   'pipeline-state.json',
@@ -463,6 +464,148 @@ function readJsonFile(filePath) {
   } catch {
     return null;
   }
+}
+
+const STATE_STALE_MS = 2 * 60 * 60 * 1000;
+const ULTRAGOAL_TERMINAL_PHASES = new Set([
+  'complete',
+  'completed',
+  'done',
+  'all-done',
+  'all_done',
+  'failed',
+  'cancelled',
+  'canceled',
+  'aborted',
+]);
+
+function isStaleModeState(state) {
+  if (!state || typeof state !== 'object') return true;
+  const timestamps = [state.last_checked_at, state.updated_at, state.started_at]
+    .filter(value => typeof value === 'string' && value.length > 0)
+    .map(value => new Date(value).getTime())
+    .filter(value => Number.isFinite(value));
+  if (timestamps.length === 0) return true;
+  return Date.now() - Math.max(...timestamps) > STATE_STALE_MS;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ').toLowerCase() : '';
+}
+
+function normalizePhase(value) {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim().toLowerCase() : '';
+}
+
+function isUltragoalTerminalState(state, directory) {
+  if (!state || typeof state !== 'object') return true;
+  if (state.active === false) return true;
+  if (typeof state.completed_at === 'string' && state.completed_at.length > 0) return true;
+  if (state.all_done === true || state.done === true) return true;
+
+  const phase = normalizePhase(state.current_phase ?? state.phase ?? state.status);
+  if (phase && ULTRAGOAL_TERMINAL_PHASES.has(phase)) return true;
+
+  const plan = readJsonFile(join(directory, '.omc', 'ultragoal', 'goals.json'));
+  if (!plan || typeof plan !== 'object') return false;
+  if (plan.aggregateCompletion?.status === 'complete') return true;
+  if (!Array.isArray(plan.goals) || plan.goals.length === 0) return false;
+  return plan.goals.every(goal => {
+    const status = normalizePhase(goal?.status);
+    return status === 'complete' || status === 'review_blocked';
+  });
+}
+
+function readSessionModeState(stateDir, mode, sessionId) {
+  const filename = `${mode}-state.json`;
+  const safeSessionId = isValidSessionId(sessionId) ? sessionId : '';
+  const candidates = safeSessionId
+    ? [join(stateDir, 'sessions', safeSessionId, filename), join(stateDir, filename)]
+    : [join(stateDir, filename)];
+  for (const statePath of candidates) {
+    const state = readJsonFile(statePath);
+    if (!state) continue;
+    if (safeSessionId && state.session_id && state.session_id !== safeSessionId) continue;
+    return { state, path: statePath };
+  }
+  return { state: null, path: '' };
+}
+
+function getExpectedUltragoalObjective(state, directory) {
+  const candidates = [
+    state?.claude_goal_objective,
+    state?.claudeGoalObjective,
+    state?.codex_objective,
+    state?.codexObjective,
+    state?.goal_objective,
+    state?.goalObjective,
+    state?.objective,
+  ];
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+
+  const plan = readJsonFile(join(directory, '.omc', 'ultragoal', 'goals.json'));
+  if (typeof plan?.claudeObjective === 'string' && plan.claudeObjective.trim()) return plan.claudeObjective.trim();
+  if (typeof plan?.aggregateCompletion?.objective === 'string' && plan.aggregateCompletion.objective.trim()) {
+    return plan.aggregateCompletion.objective.trim();
+  }
+  const activeGoal = Array.isArray(plan?.goals) ? plan.goals.find(goal => goal?.status === 'in_progress') : null;
+  if (typeof activeGoal?.objective === 'string' && activeGoal.objective.trim()) return activeGoal.objective.trim();
+  return '';
+}
+
+function extractClaudeGoalSnapshot(data) {
+  const candidates = [
+    data.goal,
+    data.claude_goal,
+    data.claudeGoal,
+    data.goal_state,
+    data.goalState,
+    data.codex_goal,
+    data.codexGoal,
+    data.context?.goal,
+    data.context?.claude_goal,
+  ];
+  for (const candidate of candidates) {
+    const goal = candidate?.goal && typeof candidate.goal === 'object' ? candidate.goal : candidate;
+    if (goal && typeof goal === 'object') {
+      const objective = goal.objective ?? goal.condition ?? goal.prompt ?? goal.description;
+      const status = goal.status ?? goal.state;
+      if (typeof objective === 'string' || typeof status === 'string') {
+        return { objective: typeof objective === 'string' ? objective : '', status: typeof status === 'string' ? status : '' };
+      }
+    }
+  }
+  return null;
+}
+
+function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, data) {
+  if (process.env.ALLOW_ULTRAGOAL_WITHOUT_GOAL === '1') return null;
+  const toolName = data.tool_name || data.toolName || '';
+  const toolInput = data.toolInput || data.tool_input || {};
+  if (toolName === 'Skill' && extractSkillName(toolInput) === 'ultragoal') return null;
+  const loaded = readSessionModeState(stateDir, 'ultragoal', sessionId);
+  const state = loaded.state;
+  if (!state?.active) return null;
+  if (isStaleModeState(state)) return null;
+  if (state.project_path && resolve(String(state.project_path)) !== resolve(directory)) return null;
+  if (isUltragoalTerminalState(state, directory)) return null;
+
+  const expected = getExpectedUltragoalObjective(state, directory);
+  const actual = extractClaudeGoalSnapshot(data);
+  const actualObjective = normalizeText(actual?.objective);
+  const expectedObjective = normalizeText(expected);
+  const status = normalizePhase(actual?.status);
+  const objectiveMatches = Boolean(actualObjective && expectedObjective && actualObjective === expectedObjective);
+  const activeStatus = status === '' || status === 'active' || status === 'in_progress' || status === 'running';
+
+  if (objectiveMatches && activeStatus) return null;
+
+  const mismatch = actualObjective
+    ? `current Claude /goal appears unrelated: "${actual.objective}".`
+    : 'no active Claude /goal snapshot was visible to the hook.';
+  return `[ULTRAGOAL /GOAL REQUIRED] Active ultragoal state requires the matching Claude /goal before tools run; ${mismatch} Activate /goal with the ultragoal objective, or set ALLOW_ULTRAGOAL_WITHOUT_GOAL=1 to bypass this guard intentionally. Expected objective: ${expected || '<record one in ultragoal-state.json or .omc/ultragoal/goals.json>'}`;
 }
 
 function hasActiveJsonMode(stateDir, { allowSessionTagged = false } = {}) {
@@ -681,7 +824,7 @@ const SKILL_PROTECTION_CONFIGS = {
 
 const SKILL_PROTECTION_MAP = {
   // === Already have mode state → no additional protection ===
-  autopilot: 'none', ralph: 'none', ultrawork: 'none', team: 'none',
+  autopilot: 'none', ralph: 'none', ultragoal: 'none', ultrawork: 'none', team: 'none',
   'omc-teams': 'none', ultraqa: 'none', cancel: 'none',
 
   // === Instant / read-only → no protection needed ===
@@ -841,6 +984,9 @@ function confirmSkillModeStates(stateDir, skillName, sessionId) {
       clearAwaitingConfirmationFlag(stateDir, 'ralph', sessionId);
       clearAwaitingConfirmationFlag(stateDir, 'ultrawork', sessionId);
       break;
+    case 'ultragoal':
+      clearAwaitingConfirmationFlag(stateDir, 'ultragoal', sessionId);
+      break;
     case 'ultrawork':
       clearAwaitingConfirmationFlag(stateDir, 'ultrawork', sessionId);
       break;
@@ -920,6 +1066,20 @@ async function main() {
         : typeof data.sessionId === 'string'
           ? data.sessionId
           : '';
+
+    const ultragoalDenyReason = evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, data);
+    if (ultragoalDenyReason) {
+      console.log(JSON.stringify({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: ultragoalDenyReason
+        }
+      }));
+      return;
+    }
+
     const modeActive = hasActiveMode(stateDir, sessionId);
 
     // Force-inherit check: deny Task/Agent calls with invalid model param when forceInherit is

--- a/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { describe, expect, it } from 'vitest';
+
+const persistentModeScript = join(process.cwd(), 'scripts', 'persistent-mode.mjs');
+const preToolScript = join(process.cwd(), 'scripts', 'pre-tool-enforcer.mjs');
+const keywordScript = join(process.cwd(), 'scripts', 'keyword-detector.mjs');
+
+function runHook(script: string, payload: Record<string, unknown>, env: Record<string, string> = {}) {
+  const stdout = execFileSync(process.execPath, [script], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    cwd: process.cwd(),
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: '', ...env },
+  });
+  return JSON.parse(stdout);
+}
+
+function makeTempProject(prefix: string) {
+  const cwd = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(cwd, '.omc', 'state', 'sessions', 'session-a'), { recursive: true });
+  return cwd;
+}
+
+function writeUltragoalState(cwd: string, overrides: Record<string, unknown> = {}) {
+  const now = new Date().toISOString();
+  const state = {
+    active: true,
+    started_at: now,
+    last_checked_at: now,
+    session_id: 'session-a',
+    project_path: cwd,
+    current_phase: 'executing',
+    claude_goal_objective: 'Complete issue #3098 ultragoal persistence.',
+    ...overrides,
+  };
+  writeFileSync(
+    join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json'),
+    `${JSON.stringify(state, null, 2)}\n`,
+  );
+  return state;
+}
+
+describe('ultragoal persistence and Claude /goal enforcement', () => {
+  it('allows PreToolUse when active ultragoal has a matching active Claude /goal', () => {
+    const cwd = makeTempProject('omc-ultragoal-pass-');
+    writeUltragoalState(cwd);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      goal: { objective: 'Complete issue #3098 ultragoal persistence.', status: 'active' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('denies PreToolUse when active ultragoal has no visible Claude /goal', () => {
+    const cwd = makeTempProject('omc-ultragoal-deny-');
+    writeUltragoalState(cwd);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+    expect(result.hookSpecificOutput?.permissionDecisionReason).toContain('ALLOW_ULTRAGOAL_WITHOUT_GOAL=1');
+  });
+
+  it('ignores stale ultragoal state in PreToolUse and Stop enforcement', () => {
+    const cwd = makeTempProject('omc-ultragoal-stale-');
+    writeUltragoalState(cwd, {
+      started_at: '2000-01-01T00:00:00.000Z',
+      last_checked_at: '2000-01-01T00:00:00.000Z',
+    });
+
+    const preTool = runHook(preToolScript, { cwd, session_id: 'session-a', tool_name: 'Bash', tool_input: {} });
+    const stop = runHook(persistentModeScript, { cwd, session_id: 'session-a' });
+
+    expect(preTool.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    expect(stop.continue).toBe(true);
+  });
+
+  it('ignores ultragoal state for another worktree', () => {
+    const cwd = makeTempProject('omc-ultragoal-worktree-a-');
+    const other = makeTempProject('omc-ultragoal-worktree-b-');
+    writeUltragoalState(cwd, { project_path: other });
+
+    const preTool = runHook(preToolScript, { cwd, session_id: 'session-a', tool_name: 'Bash', tool_input: {} });
+    const stop = runHook(persistentModeScript, { cwd, session_id: 'session-a' });
+
+    expect(preTool.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    expect(stop.continue).toBe(true);
+  });
+
+  it('does not reinject Stop continuation after ultragoal is all done', () => {
+    const cwd = makeTempProject('omc-ultragoal-done-');
+    writeUltragoalState(cwd, { current_phase: 'all-done', all_done: true });
+
+    const stop = runHook(persistentModeScript, { cwd, session_id: 'session-a' });
+
+    expect(stop.continue).toBe(true);
+    expect(stop.decision).toBeUndefined();
+  });
+
+  it('activates ultragoal session state from keyword-detector', () => {
+    const cwd = makeTempProject('omc-ultragoal-keyword-');
+
+    runHook(keywordScript, { cwd, session_id: 'session-a', prompt: '$ultragoal fix issue #3098' });
+
+    const statePath = join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json');
+    const state = JSON.parse(execFileSync('cat', [statePath], { encoding: 'utf-8' }));
+    expect(state.active).toBe(true);
+    expect(state.session_id).toBe('session-a');
+    expect(state.current_phase).toBe('executing');
+  });
+});

--- a/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -59,6 +59,27 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
     expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
   });
 
+  it('allows ultragoal CLI bootstrap commands before Claude /goal is visible', () => {
+    const cwd = makeTempProject('omc-ultragoal-bootstrap-');
+    writeUltragoalState(cwd);
+
+    const createGoals = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal create-goals --brief "fix issue"' },
+    });
+    const completeGoals = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal complete-goals' },
+    });
+
+    expect(createGoals.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    expect(completeGoals.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
   it('denies PreToolUse when active ultragoal has no visible Claude /goal', () => {
     const cwd = makeTempProject('omc-ultragoal-deny-');
     writeUltragoalState(cwd);
@@ -108,6 +129,29 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
 
     expect(stop.continue).toBe(true);
     expect(stop.decision).toBeUndefined();
+  });
+
+  it('does not activate ultragoal state for unrelated prose mentions', () => {
+    const cwd = makeTempProject('omc-ultragoal-keyword-prose-');
+
+    runHook(keywordScript, {
+      cwd,
+      session_id: 'session-a',
+      prompt: 'Review whether ultragoal keyword activation steals unrelated prompts',
+    });
+
+    const statePath = join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json');
+    expect(existsSync(statePath)).toBe(false);
+  });
+
+  it('activates ultragoal session state from explicit natural-language invocation', () => {
+    const cwd = makeTempProject('omc-ultragoal-keyword-natural-');
+
+    runHook(keywordScript, { cwd, session_id: 'session-a', prompt: 'run ultragoal for issue #3098' });
+
+    const statePath = join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json');
+    const state = JSON.parse(execFileSync('cat', [statePath], { encoding: 'utf-8' }));
+    expect(state.active).toBe(true);
   });
 
   it('activates ultragoal session state from keyword-detector', () => {


### PR DESCRIPTION
## Summary
- Add `ultragoal-state.json` to script-level persistent Stop enforcement with ralph-style stale/session/project guards and all-done terminal suppression.
- Add `$ultragoal` keyword activation state plus cancel cleanup.
- Add PreToolUse `/goal` enforcement for active ultragoal runs, with `ALLOW_ULTRAGOAL_WITHOUT_GOAL=1` bypass.
- Document the `ultragoal-state.json` lifecycle and add focused hook regressions.

## Tests
- `npm test -- --run src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts`
- `npm test -- --run src/hooks/persistent-mode/stop-hook-blocking.test.ts src/hooks/persistent-mode/session-isolation.test.ts src/hooks/__tests__/bridge-routing.test.ts`
- `npm run build`
- `npm run lint` (passes with existing warnings)
- `node --check scripts/persistent-mode.mjs && node --check scripts/keyword-detector.mjs && node --check scripts/pre-tool-enforcer.mjs && git diff --check`

Fixes #3098

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
