### PR TITLE
Fix native Claude Code version detection on Windows

### DIFF
--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -1003,6 +1003,130 @@ describe('auto-update reconciliation', () => {
     expect(mockedExecFileSync).toHaveBeenCalledWith('npm', ['install', '-g', '@anthropic-ai/claude-code@1.2.3'], expect.any(Object));
   });
 
+  it('detects native Windows Claude Code via claude --version and does not attempt npm restore', async () => {
+    mockPlatform('win32');
+    process.env.OMC_UPDATE_RECONCILE = '1';
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    }));
+
+    mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
+        return false;
+      }
+      if (normalized.endsWith('/plugins/marketplaces/omc')) {
+        return false;
+      }
+      if (normalized.endsWith('/plugins/cache/omc/oh-my-claudecode')) {
+        return false;
+      }
+      return true;
+    });
+
+    mockedExecSync.mockImplementation((command: string) => {
+      if (command === 'npm root -g') {
+        return 'C:\\Users\\bellman\\AppData\\Roaming\\npm\\node_modules\r\n';
+      }
+      if (command === 'npm install -g oh-my-claude-sisyphus@latest') {
+        return '';
+      }
+      throw new Error(`Unexpected execSync command: ${command}`);
+    });
+
+    mockedExecFileSync.mockImplementation((command: string, args?: readonly string[]) => {
+      if (command === 'claude' && args?.join(' ') === '--version') {
+        return 'Claude Code 2.1.142\r\n';
+      }
+      if (command === 'where.exe' && args?.join(' ') === 'claude') {
+        return 'C:\\Program Files\\Claude Code\\claude.exe\r\n';
+      }
+      throw new Error(`Unexpected execFileSync command: ${command} ${args?.join(' ') ?? ''}`);
+    });
+
+    const result = await performUpdate({ verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('claude', ['--version'], expect.objectContaining({
+      shell: true,
+      windowsHide: true,
+    }));
+    expect(mockedExecFileSync).toHaveBeenCalledWith('where.exe', ['claude'], expect.objectContaining({
+      windowsHide: true,
+    }));
+    expect(mockedExecSync).not.toHaveBeenCalledWith('npm install -g @anthropic-ai/claude-code@2.1.142', expect.any(Object));
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith('npm', ['install', '-g', expect.stringContaining('@anthropic-ai/claude-code@')], expect.any(Object));
+  });
+
+  it('treats unknown Claude Code detection as non-restorable during Windows updates', async () => {
+    mockPlatform('win32');
+    process.env.OMC_UPDATE_RECONCILE = '1';
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v4.1.5',
+        name: '4.1.5',
+        published_at: '2026-02-09T00:00:00.000Z',
+        html_url: 'https://example.com/release',
+        body: 'notes',
+        prerelease: false,
+        draft: false,
+      }),
+    }));
+
+    mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
+        return false;
+      }
+      if (normalized.endsWith('/plugins/marketplaces/omc')) {
+        return false;
+      }
+      if (normalized.endsWith('/plugins/cache/omc/oh-my-claudecode')) {
+        return false;
+      }
+      return true;
+    });
+
+    mockedExecSync.mockImplementation((command: string) => {
+      if (command === 'npm root -g') {
+        return 'C:\\Users\\bellman\\AppData\\Roaming\\npm\\node_modules\r\n';
+      }
+      if (command === 'npm install -g oh-my-claude-sisyphus@latest') {
+        return '';
+      }
+      throw new Error(`Unexpected execSync command: ${command}`);
+    });
+
+    mockedExecFileSync.mockImplementation((command: string, args?: readonly string[]) => {
+      if (command === 'claude' && args?.join(' ') === '--version') {
+        throw new Error('claude version unavailable');
+      }
+      throw new Error(`Unexpected execFileSync command: ${command} ${args?.join(' ') ?? ''}`);
+    });
+
+    const result = await performUpdate({ verbose: false });
+
+    expect(result.success).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('claude', ['--version'], expect.objectContaining({
+      shell: true,
+      windowsHide: true,
+    }));
+    expect(mockedExecSync).not.toHaveBeenCalledWith('npm install -g @anthropic-ai/claude-code@latest', expect.any(Object));
+    expect(mockedExecFileSync).not.toHaveBeenCalledWith('npm', ['install', '-g', expect.stringContaining('@anthropic-ai/claude-code@')], expect.any(Object));
+  });
+
   it('uses Windows-safe npm options when restoring global Claude Code', async () => {
     mockPlatform('win32');
     process.env.OMC_UPDATE_RECONCILE = '1';
@@ -1380,13 +1504,13 @@ describe('auto-update reconciliation', () => {
     expect(mockedExecSync).toHaveBeenCalledWith('npm install -g oh-my-claude-sisyphus@latest', expect.objectContaining({
       windowsHide: true,
     }));
-    expect(mockedExecFileSync).toHaveBeenNthCalledWith(1, 'where.exe', ['omc.cmd'], expect.objectContaining({
+    expect(mockedExecFileSync).toHaveBeenCalledWith('where.exe', ['omc.cmd'], expect.objectContaining({
       encoding: 'utf-8',
       stdio: 'pipe',
       timeout: 5000,
       windowsHide: true,
     }));
-    expect(mockedExecFileSync).toHaveBeenNthCalledWith(2, 'C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd', ['update-reconcile'], expect.objectContaining({
+    expect(mockedExecFileSync).toHaveBeenCalledWith('C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd', ['update-reconcile'], expect.objectContaining({
       encoding: 'utf-8',
       stdio: 'pipe',
       timeout: 60000,
@@ -1440,7 +1564,7 @@ describe('auto-update reconciliation', () => {
     expect(result.success).toBe(false);
     expect(result.message).toBe('Updated to 4.1.6, but runtime reconciliation failed');
     expect(result.errors).toEqual(['spawnSync C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd ENOENT']);
-    expect(mockedExecFileSync).toHaveBeenNthCalledWith(2, 'C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd', ['update-reconcile'], expect.objectContaining({
+    expect(mockedExecFileSync).toHaveBeenCalledWith('C:\\Users\\bellman\\AppData\\Roaming\\npm\\omc.cmd', ['update-reconcile'], expect.objectContaining({
       shell: true,
       windowsHide: true,
       env: expect.objectContaining({ OMC_UPDATE_RECONCILE: '1' }),

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -39,6 +39,8 @@ const CLAUDE_CODE_NPM_PACKAGE = '@anthropic-ai/claude-code';
 interface GlobalClaudeCodeInstall {
   status: 'present' | 'absent' | 'unknown';
   version?: string;
+  installMethod?: 'npm' | 'native' | 'manual';
+  binaryPath?: string;
   error?: string;
 }
 
@@ -72,21 +74,106 @@ function npmInstallGlobalPackage(packageSpec: string, verbose: boolean = false):
   execFileSync('npm', ['install', '-g', packageSpec], npmExecOptions(verbose));
 }
 
-function detectGlobalClaudeCodeInstall(): GlobalClaudeCodeInstall {
+function parseClaudeCodeVersion(output: string): string | undefined {
+  const trimmed = output.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.match(/\b(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/)?.[1];
+}
+
+function getFirstResolvedBinaryPath(output: string, binaryName: string): string {
+  const resolved = output
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(Boolean);
+
+  if (!resolved) {
+    throw new Error(`Unable to resolve ${binaryName} binary path`);
+  }
+
+  return resolved;
+}
+
+function resolveClaudeBinaryPath(): string | undefined {
   try {
-    const npmRoot = String(execSync('npm root -g', {
+    if (process.platform === 'win32') {
+      return getFirstResolvedBinaryPath(execFileSync('where.exe', ['claude'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 5000,
+        windowsHide: true,
+      }), 'claude');
+    }
+
+    return getFirstResolvedBinaryPath(execSync('command -v claude 2>/dev/null || which claude 2>/dev/null', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 5000,
+    }), 'claude');
+  } catch {
+    return undefined;
+  }
+}
+
+function detectClaudeCodeFromBinary(npmRoot?: string): GlobalClaudeCodeInstall {
+  try {
+    const versionOutput = String(execFileSync('claude', ['--version'], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: 10000,
+      ...(process.platform === 'win32' ? { shell: true, windowsHide: true } : {}),
+    }) ?? '');
+    const binaryPath = resolveClaudeBinaryPath();
+    const version = parseClaudeCodeVersion(versionOutput);
+    if (!version && !binaryPath) {
+      return { status: 'unknown', error: 'claude --version returned no parseable version and binary path could not be resolved' };
+    }
+
+    const normalizedBinaryPath = binaryPath?.replace(/\\/g, '/').toLowerCase();
+    const normalizedNpmRoot = npmRoot?.replace(/\\/g, '/').toLowerCase();
+    const isNpmBinary = Boolean(
+      normalizedBinaryPath &&
+      normalizedNpmRoot &&
+      normalizedBinaryPath.startsWith(normalizedNpmRoot.replace(/\/node_modules$/, '')),
+    );
+
+    return {
+      status: 'present',
+      version,
+      installMethod: isNpmBinary ? 'npm' : process.platform === 'win32' ? 'native' : 'manual',
+      binaryPath,
+    };
+  } catch (error) {
+    return {
+      status: 'unknown',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function detectGlobalClaudeCodeInstall(): GlobalClaudeCodeInstall {
+  let npmRoot: string | undefined;
+
+  try {
+    npmRoot = String(execSync('npm root -g', {
       encoding: 'utf-8',
       stdio: 'pipe',
       timeout: 10000,
       ...(process.platform === 'win32' ? { windowsHide: true } : {}),
     }) ?? '').trim();
     if (!npmRoot) {
-      return { status: 'unknown', error: 'npm root -g returned an empty path' };
+      const binaryInstall = detectClaudeCodeFromBinary();
+      return binaryInstall.status === 'present'
+        ? binaryInstall
+        : { status: 'unknown', error: 'npm root -g returned an empty path' };
     }
 
     const packageJsonPath = join(npmRoot, '@anthropic-ai', 'claude-code', 'package.json');
     if (!existsSync(packageJsonPath)) {
-      return { status: 'absent' };
+      const binaryInstall = detectClaudeCodeFromBinary(npmRoot);
+      return binaryInstall.status === 'present' ? binaryInstall : { status: 'absent' };
     }
 
     const packageJson = JSON.parse(String(readFileSync(packageJsonPath, 'utf-8') ?? '')) as {
@@ -97,8 +184,14 @@ function detectGlobalClaudeCodeInstall(): GlobalClaudeCodeInstall {
       version: typeof packageJson.version === 'string' && packageJson.version.trim()
         ? packageJson.version.trim()
         : undefined,
+      installMethod: 'npm',
     };
   } catch (error) {
+    const binaryInstall = detectClaudeCodeFromBinary(npmRoot);
+    if (binaryInstall.status === 'present') {
+      return binaryInstall;
+    }
+
     return {
       status: 'unknown',
       error: error instanceof Error ? error.message : String(error),
@@ -110,7 +203,7 @@ function restoreGlobalClaudeCodeIfNeeded(
   beforeUpdate: GlobalClaudeCodeInstall,
   verbose: boolean = false,
 ): { restored: boolean } {
-  if (beforeUpdate.status !== 'present') {
+  if (beforeUpdate.status !== 'present' || beforeUpdate.installMethod !== 'npm') {
     return { restored: false };
   }
 
@@ -960,19 +1053,6 @@ export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGraceP
   };
 }
 
-function getFirstResolvedBinaryPath(output: string): string {
-  const resolved = output
-    .split(/\r?\n/)
-    .map(line => line.trim())
-    .find(Boolean);
-
-  if (!resolved) {
-    throw new Error('Unable to resolve omc binary path for update reconciliation');
-  }
-
-  return resolved;
-}
-
 function resolveOmcBinaryPath(): string {
   if (process.platform === 'win32') {
     return getFirstResolvedBinaryPath(execFileSync('where.exe', ['omc.cmd'], {
@@ -980,14 +1060,14 @@ function resolveOmcBinaryPath(): string {
       stdio: 'pipe',
       timeout: 5000,
       windowsHide: true,
-    }));
+    }), 'omc');
   }
 
   return getFirstResolvedBinaryPath(execSync('which omc 2>/dev/null || where omc 2>NUL', {
     encoding: 'utf-8',
     stdio: 'pipe',
     timeout: 5000,
-  }));
+  }), 'omc');
 }
 
 /**


### PR DESCRIPTION
Fixes #3107

## Summary
- Detect Claude Code from `claude --version` and resolved binary path when npm package metadata is absent
- Classify non-npm Claude Code installs as native/manual and only restore via npm for positively identified npm installs
- Add regression coverage for native Windows detection and unknown fallback behavior

## Tests
- npm test -- --run src/__tests__/auto-update.test.ts
- npx tsc --noEmit
- npx eslint src/features/auto-update.ts src/__tests__/auto-update.test.ts --max-warnings=0

## Notes
- Full `npm run lint -- --max-warnings=0` still fails on pre-existing warnings outside the changed files.