### PR TITLE
Self-heal stale Windows hook manifest at runtime (run.cjs)

### DIFF
--- a/scripts/lib/win-hook-heal.cjs
+++ b/scripts/lib/win-hook-heal.cjs
@@ -1,0 +1,109 @@
+'use strict';
+/**
+ * Windows hook-manifest self-heal (win-hook-heal.cjs)
+ *
+ * On native Windows the shipped hooks.json bootstraps every hook through
+ *   sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ...
+ * which Claude Code cannot execute on win32 — every hook is mislabeled as a
+ * failure with `/usr/bin/sh: cannot execute binary file`.
+ *
+ * Setup-time rewriting (patchHooksJsonForWindows in src/hooks/setup, and
+ * scripts/plugin-setup.mjs) already converts the manifest to the direct
+ * `node ... run.cjs` form, but neither runs on a fresh marketplace install:
+ * there is no npm postinstall, and the SessionStart:init hook that would trigger
+ * the rewrite is itself shipped in the broken sh form. The only hook shipped in
+ * the Windows-safe `node ... run.cjs` form is SessionEnd, so run.cjs is the one
+ * node entry point Claude Code reaches on Windows. Healing the manifest from
+ * there lets a fresh install converge to the working node form after the first
+ * session, and re-heals automatically after every plugin update.
+ *
+ * find-node.sh is intentionally kept on Unix for nvm/fnm Node discovery
+ * (issue #892), so this rewrite must only ever be applied on win32. The win32
+ * guard lives at the call site (run.cjs); the rewrite itself is platform-neutral
+ * so it can be unit-tested on any OS.
+ *
+ * See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/3121
+ */
+
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+// Mirrors patchHooksJsonForWindows (src/hooks/setup/index.ts) so the runtime
+// self-heal and the setup-time rewrite always produce identical commands.
+//
+// Current/cache form:
+//   sh|"/bin/sh" "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/X.mjs [args]
+const CURRENT_PATTERN =
+  /^(?:"\/bin\/sh"|sh) "\$CLAUDE_PLUGIN_ROOT"\/scripts\/find-node\.sh "\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs "\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^\s]+)(.*)$/;
+// Legacy form:
+//   sh "${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/X.mjs" [args]
+const LEGACY_PATTERN =
+  /^sh "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/find-node\.sh" "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([^"]+)"(.*)$/;
+
+/**
+ * Rewrite a single hook command from the sh/find-node bootstrap to the direct
+ * `node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ...` form. Returns the rewritten
+ * command, or null when the command does not match a known sh bootstrap form.
+ */
+function rewriteCommand(command) {
+  if (typeof command !== 'string') return null;
+  const m = command.match(CURRENT_PATTERN) || command.match(LEGACY_PATTERN);
+  if (!m) return null;
+  return `node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/${m[1]}${m[2]}`;
+}
+
+/**
+ * Rewrite sh+find-node.sh hook commands in <pluginRoot>/hooks/hooks.json to the
+ * direct `node run.cjs` form. Best-effort and idempotent: only writes when at
+ * least one command actually changed. Returns true when the file was rewritten.
+ */
+function healWindowsHookManifest(pluginRoot) {
+  if (!pluginRoot) return false;
+
+  const hooksJsonPath = join(pluginRoot, 'hooks', 'hooks.json');
+  if (!existsSync(hooksJsonPath)) return false;
+
+  let content;
+  try {
+    content = readFileSync(hooksJsonPath, 'utf-8');
+  } catch {
+    return false;
+  }
+
+  // Cheap gate: once the manifest no longer bootstraps through find-node.sh
+  // there is nothing to heal, so we avoid parsing on every hook invocation.
+  if (!content.includes('find-node.sh')) return false;
+
+  let data;
+  try {
+    data = JSON.parse(content);
+  } catch {
+    return false;
+  }
+
+  let patched = false;
+  for (const groups of Object.values(data.hooks || {})) {
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups) {
+      const hooks = group && Array.isArray(group.hooks) ? group.hooks : [];
+      for (const hook of hooks) {
+        const rewritten = rewriteCommand(hook && hook.command);
+        if (rewritten) {
+          hook.command = rewritten;
+          patched = true;
+        }
+      }
+    }
+  }
+
+  if (!patched) return false;
+
+  try {
+    writeFileSync(hooksJsonPath, JSON.stringify(data, null, 2) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { healWindowsHookManifest, rewriteCommand };

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -27,6 +27,26 @@ const { existsSync, readFileSync, realpathSync } = require('fs');
 const { join, basename, dirname } = require('path');
 
 const target = process.argv[2];
+
+// On native Windows, opportunistically rewrite the plugin hooks.json away from
+// the sh/find-node.sh bootstrap that Claude Code cannot execute on win32. This
+// runner is the only node entry point Claude Code reaches on a fresh Windows
+// marketplace install (via the SessionEnd hook, the one command shipped in the
+// `node ... run.cjs` form), so healing here makes hooks converge to the working
+// form after the first session and re-heals after every plugin update.
+// Unix keeps find-node.sh for nvm/fnm Node discovery (issue #892), hence the
+// win32 guard. Best-effort: a heal failure must never block hook execution.
+// See: https://github.com/Yeachan-Heo/oh-my-claudecode/issues/3121
+if (process.platform === 'win32') {
+  try {
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT
+      || (target ? dirname(dirname(target)) : '');
+    require('./lib/win-hook-heal.cjs').healWindowsHookManifest(pluginRoot);
+  } catch {
+    // Ignore — self-heal is opportunistic and must not affect hook output.
+  }
+}
+
 if (!target) {
   // Nothing to run — exit cleanly so Claude Code hooks are never blocked.
   process.exit(0);

--- a/src/__tests__/win-hook-heal.test.ts
+++ b/src/__tests__/win-hook-heal.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the run.cjs Windows hook-manifest self-heal (issue #3121).
+ *
+ * On a fresh native-Windows marketplace install neither setup-time rewriter
+ * runs (no npm postinstall; the SessionStart:init hook that would trigger the
+ * rewrite is itself shipped in the broken sh form), so Claude Code reads the
+ * unpatched hooks.json directly and every hook fails with
+ * `/usr/bin/sh: cannot execute binary file`. run.cjs — reached on Windows via
+ * the SessionEnd hook, the only command shipped in `node ... run.cjs` form —
+ * heals the manifest by rewriting the sh/find-node.sh bootstrap to the direct
+ * `node ... run.cjs` form.
+ *
+ * The rewrite itself is platform-neutral (the win32 guard lives in run.cjs), so
+ * these tests exercise it on any OS, matching windows-patch.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, copyFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import { tmpdir } from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '..', '..');
+
+const require = createRequire(import.meta.url);
+const { healWindowsHookManifest, rewriteCommand } = require(
+  join(repoRoot, 'scripts', 'lib', 'win-hook-heal.cjs'),
+) as {
+  healWindowsHookManifest: (pluginRoot: string) => boolean;
+  rewriteCommand: (command: unknown) => string | null;
+};
+
+/** Minimal hooks.json structure matching the plugin's format. */
+function makeHooksJson(commands: string[]): object {
+  return {
+    description: 'test',
+    hooks: {
+      UserPromptSubmit: commands.map(command => ({
+        matcher: '*',
+        hooks: [{ type: 'command', command, timeout: 5 }],
+      })),
+    },
+  };
+}
+
+describe('healWindowsHookManifest', () => {
+  let pluginRoot: string;
+  let hooksDir: string;
+  let hooksJsonPath: string;
+
+  beforeEach(() => {
+    pluginRoot = mkdtempSync(join(tmpdir(), 'omc-win-heal-'));
+    hooksDir = join(pluginRoot, 'hooks');
+    mkdirSync(hooksDir, { recursive: true });
+    hooksJsonPath = join(hooksDir, 'hooks.json');
+  });
+
+  afterEach(() => {
+    rmSync(pluginRoot, { recursive: true, force: true });
+  });
+
+  it('rewrites the current sh+find-node+run.cjs command to the run.cjs wrapper', () => {
+    const original = makeHooksJson([
+      'sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/post-tool-verifier.mjs',
+    ]);
+    writeFileSync(hooksJsonPath, JSON.stringify(original, null, 2));
+
+    expect(healWindowsHookManifest(pluginRoot)).toBe(true);
+
+    const patched = JSON.parse(readFileSync(hooksJsonPath, 'utf-8'));
+    expect(patched.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/post-tool-verifier.mjs',
+    );
+  });
+
+  it('rewrites the quoted /bin/sh cache form and preserves trailing arguments', () => {
+    const original = makeHooksJson([
+      '"/bin/sh" "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/subagent-tracker.mjs start',
+    ]);
+    writeFileSync(hooksJsonPath, JSON.stringify(original, null, 2));
+
+    expect(healWindowsHookManifest(pluginRoot)).toBe(true);
+
+    const patched = JSON.parse(readFileSync(hooksJsonPath, 'utf-8'));
+    expect(patched.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/subagent-tracker.mjs start',
+    );
+  });
+
+  it('rewrites the legacy ${CLAUDE_PLUGIN_ROOT} find-node form', () => {
+    const original = makeHooksJson([
+      'sh "${CLAUDE_PLUGIN_ROOT}/scripts/find-node.sh" "${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.mjs"',
+    ]);
+    writeFileSync(hooksJsonPath, JSON.stringify(original, null, 2));
+
+    expect(healWindowsHookManifest(pluginRoot)).toBe(true);
+
+    const patched = JSON.parse(readFileSync(hooksJsonPath, 'utf-8'));
+    expect(patched.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/keyword-detector.mjs',
+    );
+  });
+
+  it('is idempotent — already-healed manifests are left untouched and not rewritten', () => {
+    const already = makeHooksJson([
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/keyword-detector.mjs',
+    ]);
+    const json = JSON.stringify(already, null, 2);
+    writeFileSync(hooksJsonPath, json);
+
+    expect(healWindowsHookManifest(pluginRoot)).toBe(false);
+    expect(readFileSync(hooksJsonPath, 'utf-8')).toBe(json);
+  });
+
+  it('heals every sh/find-node command in the bundled manifest while leaving SessionEnd node commands intact', () => {
+    copyFileSync(join(repoRoot, 'hooks', 'hooks.json'), hooksJsonPath);
+
+    expect(healWindowsHookManifest(pluginRoot)).toBe(true);
+
+    const patched = JSON.parse(readFileSync(hooksJsonPath, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command?: string }> }>>;
+    };
+    const commands = Object.entries(patched.hooks).flatMap(([event, groups]) =>
+      groups.flatMap(group =>
+        group.hooks
+          .map(hook => hook.command)
+          .filter((command): command is string => typeof command === 'string')
+          .map(command => ({ event, command })),
+      ),
+    );
+
+    expect(commands.length).toBeGreaterThan(0);
+    for (const { event, command } of commands) {
+      expect(command, event).toMatch(/^node "\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs /);
+      expect(command, event).not.toContain('find-node.sh');
+      expect(command, event).not.toContain('/bin/sh');
+      expect(command, event).not.toMatch(/^sh /);
+    }
+    // SessionEnd already shipped in node form — it must survive unchanged.
+    expect(commands.some(({ event }) => event === 'SessionEnd')).toBe(true);
+
+    // Second pass is a no-op once the manifest is clean.
+    expect(healWindowsHookManifest(pluginRoot)).toBe(false);
+  });
+
+  it('returns false (no throw) when hooks.json does not exist', () => {
+    expect(() => healWindowsHookManifest(pluginRoot)).not.toThrow();
+    expect(healWindowsHookManifest(pluginRoot)).toBe(false);
+  });
+
+  it('returns false when pluginRoot is empty', () => {
+    expect(healWindowsHookManifest('')).toBe(false);
+  });
+});
+
+describe('rewriteCommand', () => {
+  it('returns null for non-matching or non-string commands', () => {
+    expect(rewriteCommand('node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/x.mjs')).toBeNull();
+    expect(rewriteCommand('echo hi')).toBeNull();
+    expect(rewriteCommand(undefined)).toBeNull();
+    expect(rewriteCommand(42)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Native Windows still hits `/usr/bin/sh: cannot execute binary file` on every hook for a **fresh marketplace install** (#3121), even after #3118.

Root cause: on a fresh install, no manifest patcher ever runs —
- there is no npm `postinstall`;
- `.claude-plugin/plugin.json` declares no install-time node hook;
- and the `SessionStart:init` hook that triggers `patchHooksJsonForWindows` is itself shipped in the broken `sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh ...` form, so it never fires on win32.

Claude Code therefore reads `hooks/hooks.json` directly and every hook fails.

This adds a runtime self-heal in `scripts/run.cjs` — the one node entry point Claude Code reaches on Windows for such an install, via `SessionEnd` (the only command already shipped in the `node ... run.cjs` form). On win32 it rewrites the cache manifest's `sh` / `/bin/sh` + `find-node.sh` + `run.cjs` commands to the direct `node ... run.cjs` form (identical output to `patchHooksJsonForWindows`). Unix is untouched thanks to the win32 guard, so `find-node.sh` still handles nvm/fnm Node discovery (#892).

Effect: the manifest converges to the working form after the first session and re-heals automatically after every plugin update — no `omc setup` or reinstall required.

Complementary to the manifest-level fix in progress on #3121: even once the shipped manifest is Windows-safe for *new* installs, this repairs the stale cached manifests already on disk for existing v4.14.x Windows users.

## Changes
- `scripts/lib/win-hook-heal.cjs` — platform-neutral `healWindowsHookManifest()` / `rewriteCommand()`, mirroring `patchHooksJsonForWindows`.
- `scripts/run.cjs` — win32-guarded, best-effort heal on startup (never blocks hook execution).
- `src/__tests__/win-hook-heal.test.ts` — regression coverage: current / `/bin/sh` / legacy command forms, trailing-arg preservation, idempotency, full bundled-manifest sweep (SessionEnd `node` form preserved), and no-throw edge cases.

## Tests
- `npx vitest run src/__tests__/win-hook-heal.test.ts src/hooks/setup/__tests__/windows-patch.test.ts src/__tests__/run-cjs-graceful-fallback.test.ts` — 28 passing
- `npm run build`
- `npm run lint` — 0 errors

Refs #3121
