### PR TITLE
Fix project-memory list defaults

### DIFF
--- a/src/hooks/project-memory/__tests__/formatter.test.ts
+++ b/src/hooks/project-memory/__tests__/formatter.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from "vitest";
 import { formatContextSummary, formatFullContext } from "../formatter.js";
+import { normalizeProjectMemory } from "../storage.js";
 import { ProjectMemory } from "../types.js";
 import { SCHEMA_VERSION } from "../constants.js";
 
@@ -48,8 +49,43 @@ const createBaseMemory = (
   ...overrides,
 });
 
+const createLoadNormalizedMinimalMemory = (): ProjectMemory => {
+  const {
+    customNotes: _customNotes,
+    userDirectives: _userDirectives,
+    hotPaths: _hotPaths,
+    ...minimalPersistedMemory
+  } = createBaseMemory({
+    techStack: {
+      languages: [
+        {
+          name: "TypeScript",
+          version: null,
+          confidence: "high",
+          markers: ["tsconfig.json"],
+        },
+      ],
+      frameworks: [],
+      packageManager: "npm",
+      runtime: null,
+    },
+  });
+
+  return normalizeProjectMemory(minimalPersistedMemory as ProjectMemory);
+};
+
 describe("Project Memory Formatter", () => {
   describe("formatContextSummary", () => {
+    it("formats load-normalized minimal persisted memory with missing list fields", () => {
+      const memory = createLoadNormalizedMinimalMemory();
+
+      const summary = formatContextSummary(memory, { now: NOW });
+
+      expect(summary).toContain("[Project Environment]");
+      expect(summary).not.toContain("[Directives]");
+      expect(summary).not.toContain("[Recent Learnings]");
+    });
+
     it("formats the summary in progressive disclosure order", () => {
       const memory = createBaseMemory({
         techStack: {
@@ -286,6 +322,16 @@ describe("Project Memory Formatter", () => {
   });
 
   describe("formatFullContext", () => {
+    it("formats load-normalized minimal persisted memory with missing customNotes", () => {
+      const memory = createLoadNormalizedMinimalMemory();
+
+      const full = formatFullContext(memory);
+
+      expect(full).toContain("<project-memory>");
+      expect(full).toContain("TypeScript");
+      expect(full).not.toContain("**Custom Notes:**");
+    });
+
     it("should format complete project details", () => {
       const memory = createBaseMemory({
         techStack: {

--- a/src/hooks/project-memory/__tests__/learner.test.ts
+++ b/src/hooks/project-memory/__tests__/learner.test.ts
@@ -7,7 +7,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { learnFromToolOutput, addCustomNote } from '../learner.js';
-import { saveProjectMemory, loadProjectMemory } from '../storage.js';
+import { saveProjectMemory, loadProjectMemory, getMemoryPath } from '../storage.js';
 import { ProjectMemory } from '../types.js';
 import { SCHEMA_VERSION } from '../constants.js';
 
@@ -184,6 +184,28 @@ describe('Project Memory Learner', () => {
 
       const updated = await loadProjectMemory(tempDir);
       expect(updated?.customNotes).toHaveLength(0);
+    });
+
+    it('should initialize hot paths when saved memory is missing hotPaths', async () => {
+      const memoryPath = getMemoryPath(tempDir);
+      const minimalMemory = createBasicMemory();
+      const { hotPaths: _hotPaths, ...memoryWithoutHotPaths } = minimalMemory;
+      await fs.mkdir(path.dirname(memoryPath), { recursive: true });
+      await fs.writeFile(memoryPath, JSON.stringify(memoryWithoutHotPaths), 'utf-8');
+
+      await expect(
+        learnFromToolOutput('Read', { file_path: path.join(tempDir, 'src', 'index.ts') }, '', tempDir)
+      ).resolves.not.toThrow();
+
+      const updated = await loadProjectMemory(tempDir);
+      expect(Array.isArray(updated?.hotPaths)).toBe(true);
+      expect(updated?.hotPaths).toEqual([
+        expect.objectContaining({
+          path: 'src/index.ts',
+          accessCount: 1,
+          type: 'file',
+        }),
+      ]);
     });
 
     it('should do nothing if memory file does not exist', async () => {

--- a/src/hooks/project-memory/__tests__/pre-compact-storage.test.ts
+++ b/src/hooks/project-memory/__tests__/pre-compact-storage.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Integration coverage for project-memory PreCompact loading.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { processPreCompact, type PreCompactInput } from "../pre-compact.js";
+import { SCHEMA_VERSION } from "../constants.js";
+import type { ProjectMemory } from "../types.js";
+
+const tempDirs: string[] = [];
+
+const createMinimalPersistedMemory = (
+  projectRoot: string,
+): Omit<ProjectMemory, "customNotes" | "hotPaths" | "userDirectives"> => ({
+  version: SCHEMA_VERSION,
+  lastScanned: Date.now(),
+  projectRoot,
+  techStack: {
+    languages: [
+      {
+        name: "TypeScript",
+        version: null,
+        confidence: "high",
+        markers: ["tsconfig.json"],
+      },
+    ],
+    frameworks: [],
+    packageManager: "npm",
+    runtime: null,
+  },
+  build: {
+    buildCommand: "npm run build",
+    testCommand: null,
+    lintCommand: null,
+    devCommand: null,
+    scripts: {},
+  },
+  conventions: {
+    namingStyle: null,
+    importStyle: null,
+    testPattern: null,
+    fileOrganization: null,
+  },
+  structure: {
+    isMonorepo: false,
+    workspaces: [],
+    mainDirectories: [],
+    gitBranches: null,
+  },
+  directoryMap: {},
+});
+
+describe("Project Memory PreCompact storage integration", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("loads minimal persisted memory and formats compaction context without list fields", async () => {
+    delete process.env.OMC_STATE_DIR;
+    const projectRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "project-memory-precompact-"),
+    );
+    tempDirs.push(projectRoot);
+    await fs.writeFile(path.join(projectRoot, "package.json"), "{}\n");
+    await fs.mkdir(path.join(projectRoot, ".omc"), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, ".omc", "project-memory.json"),
+      JSON.stringify(createMinimalPersistedMemory(projectRoot)),
+      "utf-8",
+    );
+
+    const input: PreCompactInput = {
+      session_id: "test-session",
+      transcript_path: "/tmp/transcript",
+      cwd: projectRoot,
+      permission_mode: "default",
+      hook_event_name: "PreCompact",
+      trigger: "auto",
+    };
+
+    const result = await processPreCompact(input);
+
+    expect(result.continue).toBe(true);
+    expect(result.systemMessage).toContain("Project Memory");
+    expect(result.systemMessage).toContain("[Project Environment]");
+    expect(result.systemMessage).not.toContain("[Directives]");
+    expect(result.systemMessage).not.toContain("[Recent Learnings]");
+  });
+});

--- a/src/hooks/project-memory/__tests__/storage.test.ts
+++ b/src/hooks/project-memory/__tests__/storage.test.ts
@@ -13,6 +13,7 @@ import {
   deleteProjectMemory,
   getMemoryPath,
 } from '../storage.js';
+import { formatContextSummary, formatFullContext } from '../formatter.js';
 import { ProjectMemory } from '../types.js';
 import { SCHEMA_VERSION } from '../constants.js';
 import { getProjectIdentifier } from '../../../lib/worktree-paths.js';
@@ -206,6 +207,47 @@ describe('Project Memory Storage', () => {
       expect(loaded?.version).toBe(SCHEMA_VERSION);
       expect(loaded?.techStack.languages[0].name).toBe('Rust');
       expect(loaded?.build.buildCommand).toBe('cargo build');
+    });
+
+    it('should normalize missing runtime list fields when loading minimal persisted memory', async () => {
+      const memoryPath = getMemoryPath(projectRoot);
+      await fs.mkdir(path.dirname(memoryPath), { recursive: true });
+
+      const {
+        customNotes: _customNotes,
+        userDirectives: _userDirectives,
+        hotPaths: _hotPaths,
+        ...minimalPersistedMemory
+      } = createBaseMemory(projectRoot, {
+        techStack: {
+          languages: [
+            {
+              name: 'TypeScript',
+              version: null,
+              confidence: 'high',
+              markers: ['tsconfig.json'],
+            },
+          ],
+          frameworks: [],
+          packageManager: 'npm',
+          runtime: null,
+        },
+      });
+
+      await fs.writeFile(
+        memoryPath,
+        JSON.stringify(minimalPersistedMemory),
+        'utf-8',
+      );
+
+      const loaded = await loadProjectMemory(projectRoot);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded?.customNotes).toEqual([]);
+      expect(loaded?.userDirectives).toEqual([]);
+      expect(loaded?.hotPaths).toEqual([]);
+      expect(() => formatContextSummary(loaded!)).not.toThrow();
+      expect(() => formatFullContext(loaded!)).not.toThrow();
     });
 
     it('should return null for invalid JSON', async () => {

--- a/src/hooks/project-memory/directive-detector.ts
+++ b/src/hooks/project-memory/directive-detector.ts
@@ -126,31 +126,33 @@ function normalizeCommand(cmd: string): string {
  * Add directive if not duplicate
  */
 export function addDirective(
-  directives: UserDirective[],
+  directives: UserDirective[] | null | undefined,
   newDirective: UserDirective
 ): UserDirective[] {
+  const directiveList = Array.isArray(directives) ? directives : [];
+
   // Check for duplicates
-  const isDuplicate = directives.some(d =>
+  const isDuplicate = directiveList.some(d =>
     d.directive.toLowerCase() === newDirective.directive.toLowerCase()
   );
 
   if (!isDuplicate) {
-    directives.push(newDirective);
+    directiveList.push(newDirective);
 
     // Keep only most recent 20 directives
-    if (directives.length > 20) {
-      directives.sort((a, b) => {
+    if (directiveList.length > 20) {
+      directiveList.sort((a, b) => {
         // Sort by priority first, then by timestamp
         if (a.priority !== b.priority) {
           return a.priority === 'high' ? -1 : 1;
         }
         return b.timestamp - a.timestamp;
       });
-      directives.splice(20);
+      directiveList.splice(20);
     }
   }
 
-  return directives;
+  return directiveList;
 }
 
 /**

--- a/src/hooks/project-memory/hot-path-tracker.ts
+++ b/src/hooks/project-memory/hot-path-tracker.ts
@@ -12,7 +12,7 @@ const MAX_HOT_PATHS = 50;
  * Track file or directory access
  */
 export function trackAccess(
-  hotPaths: HotPath[],
+  hotPaths: HotPath[] | null | undefined,
   filePath: string,
   projectRoot: string,
   type: "file" | "directory",
@@ -21,17 +21,19 @@ export function trackAccess(
     ? path.relative(projectRoot, filePath)
     : filePath;
 
+  const normalizedHotPaths = ensureHotPathList(hotPaths);
+
   if (relativePath.startsWith("..") || shouldIgnorePath(relativePath)) {
-    return hotPaths;
+    return normalizedHotPaths;
   }
 
-  const existing = hotPaths.find((hp) => hp.path === relativePath);
+  const existing = normalizedHotPaths.find((hp) => hp.path === relativePath);
 
   if (existing) {
     existing.accessCount++;
     existing.lastAccessed = Date.now();
   } else {
-    hotPaths.push({
+    normalizedHotPaths.push({
       path: relativePath,
       accessCount: 1,
       lastAccessed: Date.now(),
@@ -39,13 +41,18 @@ export function trackAccess(
     });
   }
 
-  hotPaths.sort((a, b) => b.accessCount - a.accessCount);
+  normalizedHotPaths.sort((a, b) => b.accessCount - a.accessCount);
 
-  if (hotPaths.length > MAX_HOT_PATHS) {
-    hotPaths.splice(MAX_HOT_PATHS);
+  if (normalizedHotPaths.length > MAX_HOT_PATHS) {
+    normalizedHotPaths.splice(MAX_HOT_PATHS);
   }
 
-  return hotPaths;
+  return normalizedHotPaths;
+}
+
+
+function ensureHotPathList(hotPaths: HotPath[] | null | undefined): HotPath[] {
+  return Array.isArray(hotPaths) ? hotPaths : [];
 }
 
 function shouldIgnorePath(relativePath: string): boolean {
@@ -69,14 +76,14 @@ function shouldIgnorePath(relativePath: string): boolean {
  * Get top hot paths for display
  */
 export function getTopHotPaths(
-  hotPaths: HotPath[],
+  hotPaths: HotPath[] | null | undefined,
   limit: number = 10,
   context?: ProjectMemoryContext,
 ): HotPath[] {
   const now = context?.now ?? Date.now();
   const scopePath = normalizeScopePath(context?.workingDirectory);
 
-  return [...hotPaths]
+  return ensureHotPathList(hotPaths)
     .filter((hp) => !shouldIgnorePath(hp.path))
     .sort(
       (a, b) =>
@@ -88,11 +95,11 @@ export function getTopHotPaths(
 /**
  * Decay old hot paths (reduce access count over time)
  */
-export function decayHotPaths(hotPaths: HotPath[]): HotPath[] {
+export function decayHotPaths(hotPaths: HotPath[] | null | undefined): HotPath[] {
   const now = Date.now();
   const dayInMs = 24 * 60 * 60 * 1000;
 
-  return hotPaths
+  return ensureHotPathList(hotPaths)
     .map((hp) => {
       const age = now - hp.lastAccessed;
       if (age > dayInMs * 7) {

--- a/src/hooks/project-memory/index.ts
+++ b/src/hooks/project-memory/index.ts
@@ -27,9 +27,9 @@ function applyRescanMerge(
 ): ProjectMemory {
   const merged: ProjectMemory = {
     ...detected,
-    customNotes: existing.customNotes,
-    userDirectives: existing.userDirectives,
-    hotPaths: existing.hotPaths,
+    customNotes: Array.isArray(existing.customNotes) ? existing.customNotes : [],
+    userDirectives: Array.isArray(existing.userDirectives) ? existing.userDirectives : [],
+    hotPaths: Array.isArray(existing.hotPaths) ? existing.hotPaths : [],
   };
   for (const key of Object.keys(existing)) {
     if (!(key in merged)) {

--- a/src/hooks/project-memory/learner.ts
+++ b/src/hooks/project-memory/learner.ts
@@ -79,6 +79,7 @@ export async function learnFromToolOutput(
 
       // Detect directives from user messages
       if (userMessage) {
+        memory.userDirectives = Array.isArray(memory.userDirectives) ? memory.userDirectives : [];
         const detectedDirectives = detectDirectivesFromMessage(userMessage);
         for (const directive of detectedDirectives) {
           memory.userDirectives = addDirective(memory.userDirectives, directive);
@@ -120,6 +121,7 @@ export async function learnFromToolOutput(
         // Extract environment hints from output
         const hints = extractEnvironmentHints(toolOutput);
         if (hints.length > 0) {
+          memory.customNotes = Array.isArray(memory.customNotes) ? memory.customNotes : [];
           for (const hint of hints) {
             // Only add if not already present
             const exists = memory.customNotes.some(
@@ -255,6 +257,8 @@ export async function addCustomNote(
         if (!memory) {
           return;
         }
+
+        memory.customNotes = Array.isArray(memory.customNotes) ? memory.customNotes : [];
 
         memory.customNotes.push({
           timestamp: Date.now(),

--- a/src/hooks/project-memory/storage.ts
+++ b/src/hooks/project-memory/storage.ts
@@ -5,7 +5,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { ProjectMemory } from './types.js';
+import type { ProjectMemory } from './types.js';
 import { CACHE_EXPIRY_MS } from './constants.js';
 import { atomicWriteJson } from '../../lib/atomic-write.js';
 import { getWorktreeProjectMemoryPath } from '../../lib/worktree-paths.js';
@@ -16,6 +16,20 @@ import { lockPathFor, withFileLock, type FileLockOptions } from '../../lib/file-
  */
 export function getMemoryPath(projectRoot: string): string {
   return getWorktreeProjectMemoryPath(projectRoot);
+}
+
+/**
+ * Normalize persisted project memory into the current runtime shape.
+ * Older/minimal project-memory.json files may not contain list fields that
+ * read-only context and compaction paths iterate over.
+ */
+export function normalizeProjectMemory(memory: ProjectMemory): ProjectMemory {
+  return {
+    ...memory,
+    customNotes: Array.isArray(memory.customNotes) ? memory.customNotes : [],
+    userDirectives: Array.isArray(memory.userDirectives) ? memory.userDirectives : [],
+    hotPaths: Array.isArray(memory.hotPaths) ? memory.hotPaths : [],
+  };
 }
 
 /**
@@ -34,7 +48,7 @@ export async function loadProjectMemory(projectRoot: string): Promise<ProjectMem
       return null;
     }
 
-    return memory;
+    return normalizeProjectMemory(memory);
   } catch (_error) {
     // File doesn't exist or invalid JSON
     return null;

--- a/src/tools/__tests__/memory-tools.test.ts
+++ b/src/tools/__tests__/memory-tools.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { projectMemoryWriteTool } from '../memory-tools.js';
+import {
+  projectMemoryAddDirectiveTool,
+  projectMemoryAddNoteTool,
+  projectMemoryWriteTool,
+} from '../memory-tools.js';
 import { getProjectIdentifier } from '../../lib/worktree-paths.js';
 
 const TEST_DIR = '/tmp/memory-tools-test';
@@ -95,6 +99,58 @@ describe('memory-tools payload validation', () => {
     } finally {
       rmSync(stateDir, { recursive: true, force: true });
     }
+  });
+
+  it('should add a directive when existing memory lacks userDirectives', async () => {
+    const memoryPath = join(TEST_DIR, '.omc', 'project-memory.json');
+    writeFileSync(memoryPath, JSON.stringify({
+      version: '1.0.0',
+      lastScanned: Date.now(),
+      projectRoot: TEST_DIR,
+    }));
+
+    const result = await projectMemoryAddDirectiveTool.handler({
+      directive: 'Prefer focused regression tests',
+      workingDirectory: TEST_DIR,
+    });
+
+    const saved = JSON.parse(readFileSync(memoryPath, 'utf-8'));
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Successfully added directive');
+    expect(saved.userDirectives).toEqual([
+      expect.objectContaining({
+        directive: 'Prefer focused regression tests',
+        context: '',
+        source: 'explicit',
+        priority: 'normal',
+      }),
+    ]);
+  });
+
+  it('should add a note when existing memory lacks customNotes', async () => {
+    const memoryPath = join(TEST_DIR, '.omc', 'project-memory.json');
+    writeFileSync(memoryPath, JSON.stringify({
+      version: '1.0.0',
+      lastScanned: Date.now(),
+      projectRoot: TEST_DIR,
+    }));
+
+    const result = await projectMemoryAddNoteTool.handler({
+      category: 'test',
+      content: 'Minimal project memory fixtures are supported',
+      workingDirectory: TEST_DIR,
+    });
+
+    const saved = JSON.parse(readFileSync(memoryPath, 'utf-8'));
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Successfully added note');
+    expect(saved.customNotes).toEqual([
+      expect.objectContaining({
+        source: 'manual',
+        category: 'test',
+        content: 'Minimal project memory fixtures are supported',
+      }),
+    ]);
   });
 
   it('should allow normal-sized memory writes', async () => {


### PR DESCRIPTION
## Summary
- Fixes #3132 by normalizing missing project-memory list fields at mutation time.
- Allows `project_memory_add_directive` to succeed when `userDirectives` is absent.
- Adds sibling regression coverage for `project_memory_add_note` when `customNotes` is absent.

## Validation
- `npm test -- --run src/tools/__tests__/memory-tools.test.ts src/hooks/project-memory/__tests__/learner.test.ts src/hooks/project-memory/__tests__/storage.test.ts src/__tests__/project-memory-merge.test.ts`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run build`
- `git diff --check`

🤖 Generated with oh-my-codex
