### PR TITLE
Harden team worker pane startup delivery

### DIFF
--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from 'os';
 const tmuxCalls = vi.hoisted(() => ({
   args: [] as string[][],
   capturePaneText: '❯ ready\n',
+  lastLiteralSend: '',
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -28,11 +29,19 @@ vi.mock('child_process', async (importOriginal) => {
     tmuxCalls.args.push(args);
     if (args[0] === 'split-window') {
       cb(null, '%42\n', '');
+    } else if (args[0] === 'send-keys' && args.includes('-l')) {
+      tmuxCalls.lastLiteralSend = args[args.length - 1] ?? '';
+      cb(null, '', '');
+    } else if (args[0] === 'send-keys') {
+      tmuxCalls.lastLiteralSend = '';
+      cb(null, '', '');
     } else if (args[0] === 'capture-pane') {
-      cb(null, tmuxCalls.capturePaneText, '');
+      cb(null, `${tmuxCalls.lastLiteralSend}\n${tmuxCalls.capturePaneText}`, '');
     } else if (args[0] === 'display-message') {
-      // pane_dead check → "0" means alive; pane_in_mode → "0" means not in copy mode
-      cb(null, '0', '');
+      // pane_dead check → "0" means alive; pane_current_command zsh means shell is ready;
+      // pane_in_mode → "0" means not in copy mode.
+      const format = args[args.length - 1] ?? '';
+      cb(null, format.includes('pane_current_command') ? '0 zsh\n' : '0\n', '');
     } else {
       cb(null, '', '');
     }
@@ -45,11 +54,20 @@ vi.mock('child_process', async (importOriginal) => {
     if (args[0] === 'split-window') {
       return { stdout: '%42\n', stderr: '' };
     }
+    if (args[0] === 'send-keys' && args.includes('-l')) {
+      tmuxCalls.lastLiteralSend = args[args.length - 1] ?? '';
+      return { stdout: '', stderr: '' };
+    }
+    if (args[0] === 'send-keys') {
+      tmuxCalls.lastLiteralSend = '';
+      return { stdout: '', stderr: '' };
+    }
     if (args[0] === 'capture-pane') {
-      return { stdout: tmuxCalls.capturePaneText, stderr: '' };
+      return { stdout: `${tmuxCalls.lastLiteralSend}\n${tmuxCalls.capturePaneText}`, stderr: '' };
     }
     if (args[0] === 'display-message') {
-      return { stdout: '0', stderr: '' };
+      const format = args[args.length - 1] ?? '';
+      return { stdout: format.includes('pane_current_command') ? '0 zsh\n' : '0\n', stderr: '' };
     }
     return { stdout: '', stderr: '' };
   };
@@ -57,6 +75,8 @@ vi.mock('child_process', async (importOriginal) => {
   function mockExec(cmd: string, cb: (err: Error | null, stdout: string, stderr: string) => void) {
     if (cmd.includes('display-message') && cmd.includes('#{window_width}')) {
       cb(null, '160\n', '');
+    } else if (cmd.includes('display-message') && cmd.includes('#{pane_current_command}')) {
+      cb(null, '0 zsh\n', '');
     } else {
       cb(null, '', '');
     }
@@ -66,6 +86,9 @@ vi.mock('child_process', async (importOriginal) => {
   (mockExec as any)[utilPromisify.custom] = async (cmd: string) => {
     if (cmd.includes('display-message') && cmd.includes('#{window_width}')) {
       return { stdout: '160\n', stderr: '' };
+    }
+    if (cmd.includes('display-message') && cmd.includes('#{pane_current_command}')) {
+      return { stdout: '0 zsh\n', stderr: '' };
     }
     return { stdout: '', stderr: '' };
   };
@@ -130,6 +153,7 @@ describe('spawnWorkerForTask – prompt mode and interactive worker launch', () 
   beforeEach(() => {
     tmuxCalls.args = [];
     tmuxCalls.capturePaneText = '❯ ready\n';
+    tmuxCalls.lastLiteralSend = '';
     delete process.env.OMC_SHELL_READY_TIMEOUT_MS;
     cwd = mkdtempSync(join(tmpdir(), 'runtime-gemini-prompt-'));
     setupTaskDir(cwd);
@@ -288,6 +312,7 @@ describe('spawnWorkerForTask – model passthrough from environment variables', 
   beforeEach(() => {
     tmuxCalls.args = [];
     tmuxCalls.capturePaneText = '❯ ready\n';
+    tmuxCalls.lastLiteralSend = '';
     delete process.env.OMC_SHELL_READY_TIMEOUT_MS;
     // Clear model/provider env vars before each test
     delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CODEX_MODEL;

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -643,6 +643,33 @@ describe('runtime v2 startup inbox dispatch', () => {
   });
 
 
+
+  it('aborts startup without persisting a live worker when worker start command delivery fails', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-start-delivery-fail-'));
+    mocks.spawnWorkerInPane.mockRejectedValueOnce(new Error('worker_start_delivery_unverified:worker-1:%2:abc123'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    await expect(startTeamV2({
+      teamName: 'dispatch-team',
+      workerCount: 1,
+      agentTypes: ['codex'],
+      tasks: [{ subject: 'Dispatch test', description: 'Verify start command delivery failure aborts startup' }],
+      cwd,
+    })).rejects.toThrow('worker_start_delivery_unverified:worker-1:%2:abc123');
+
+    expect(mocks.spawnWorkerInPane).toHaveBeenCalledTimes(1);
+    expect(mocks.killTeamSession).toHaveBeenCalledWith(
+      'dispatch-session',
+      [],
+      '%1',
+      { sessionMode: 'split-pane' },
+    );
+    const configPath = join(cwd, '.omc', 'state', 'team', 'dispatch-team', 'config.json');
+    const persisted = JSON.parse(await readFile(configPath, 'utf-8'));
+    expect(persisted.workers[0].pane_id).toBeUndefined();
+    expect(persisted.workers[0].assigned_tasks).toEqual([]);
+  });
+
   it('does not auto-kill a worker pane when startup readiness fails', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-no-autokill-ready-'));
     mocks.waitForPaneReady.mockResolvedValue(false);

--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -33,6 +33,10 @@ vi.mock('child_process', async (importOriginal) => {
       return { stdout: '160\n', stderr: '' };
     }
 
+    if (args[0] === 'display-message' && args.includes('#{pane_dead} #{pane_current_command}')) {
+      return { stdout: '0 zsh\n', stderr: '' };
+    }
+
     if (args[0] === 'split-window') {
       mockedCalls.splitCount += 1;
       return { stdout: `%50${mockedCalls.splitCount}\n`, stderr: '' };

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -6,6 +6,7 @@ const mockedCalls = vi.hoisted(() => ({
   paneCapture: '',
   paneStatus: '0 zsh\n',
   echoOnLiteralSend: true,
+  wrapLiteralCapture: false,
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -38,10 +39,16 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
     tmuxExecAsync: vi.fn(async (args: string[]) => {
       mockedCalls.tmuxArgs.push(args);
       if (args[0] === 'capture-pane') {
-        return { stdout: mockedCalls.paneCapture, stderr: '' };
+        const stdout = args.includes('-J')
+          ? mockedCalls.paneCapture.replace(/\n/g, '')
+          : mockedCalls.paneCapture;
+        return { stdout, stderr: '' };
       }
       if (args[0] === 'send-keys' && args.includes('-l') && mockedCalls.echoOnLiteralSend) {
-        mockedCalls.paneCapture = args[args.length - 1] ?? '';
+        const literal = args[args.length - 1] ?? '';
+        mockedCalls.paneCapture = mockedCalls.wrapLiteralCapture
+          ? `${literal.slice(0, 80)}\n${literal.slice(80)}`
+          : literal;
       }
       return { stdout: '', stderr: '' };
     }),
@@ -64,6 +71,7 @@ describe('spawnWorkerInPane', () => {
     mockedCalls.paneCapture = '';
     mockedCalls.paneStatus = '0 zsh\n';
     mockedCalls.echoOnLiteralSend = true;
+    mockedCalls.wrapLiteralCapture = false;
     vi.unstubAllEnvs();
   });
 
@@ -165,6 +173,27 @@ describe('spawnWorkerInPane', () => {
 
     const enterSend = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys' && args.at(-1) === 'Enter');
     expect(enterSend).toBeUndefined();
+  });
+
+  it('verifies wrapped worker start commands with joined tmux capture before Enter', async () => {
+    mockedCalls.wrapLiteralCapture = true;
+
+    await spawnWorkerInPane('session:0', '%2', {
+      teamName: 'safe-team',
+      workerName: 'worker-1',
+      envVars: {
+        OMC_TEAM_NAME: 'safe-team',
+        OMC_TEAM_WORKER: 'safe-team/worker-1',
+        OMC_TEAM_LONG_VALUE: 'x'.repeat(160),
+      },
+      launchBinary: 'codex',
+      launchArgs: ['--full-auto', '--model', 'gpt-5.5', '--reasoning-effort', 'high'],
+      cwd: '/tmp',
+    });
+
+    expect(mockedCalls.tmuxArgs).toContainEqual(['capture-pane', '-J', '-t', '%2', '-p', '-S', '-80']);
+    const enterSend = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys' && args.at(-1) === 'Enter');
+    expect(enterSend).toBeDefined();
   });
 
   it('fails before send-keys when the target pane shell never becomes ready', async () => {

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockedCalls = vi.hoisted(() => ({
   tmuxArgs: [] as string[][],
   cmuxArgs: [] as string[][],
+  paneCapture: '',
+  paneStatus: '0 zsh\n',
+  echoOnLiteralSend: true,
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -34,6 +37,19 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
     }),
     tmuxExecAsync: vi.fn(async (args: string[]) => {
       mockedCalls.tmuxArgs.push(args);
+      if (args[0] === 'capture-pane') {
+        return { stdout: mockedCalls.paneCapture, stderr: '' };
+      }
+      if (args[0] === 'send-keys' && args.includes('-l') && mockedCalls.echoOnLiteralSend) {
+        mockedCalls.paneCapture = args[args.length - 1] ?? '';
+      }
+      return { stdout: '', stderr: '' };
+    }),
+    tmuxCmdAsync: vi.fn(async (args: string[]) => {
+      mockedCalls.tmuxArgs.push(args);
+      if (args[0] === 'display-message' && args.includes('#{pane_dead} #{pane_current_command}')) {
+        return { stdout: mockedCalls.paneStatus, stderr: '' };
+      }
       return { stdout: '', stderr: '' };
     }),
   };
@@ -45,6 +61,9 @@ describe('spawnWorkerInPane', () => {
   beforeEach(() => {
     mockedCalls.tmuxArgs = [];
     mockedCalls.cmuxArgs = [];
+    mockedCalls.paneCapture = '';
+    mockedCalls.paneStatus = '0 zsh\n';
+    mockedCalls.echoOnLiteralSend = true;
     vi.unstubAllEnvs();
   });
 
@@ -124,6 +143,47 @@ describe('spawnWorkerInPane', () => {
     expect(launchLine).toContain('/tmp/bridge-entry.js');
     expect(launchLine).toContain('--config');
     expect(launchLine).not.toMatch(/^node\s/);
+  });
+
+
+  it('fails before Enter when tmux does not echo the delivered start command', async () => {
+    mockedCalls.paneCapture = '';
+    mockedCalls.echoOnLiteralSend = false;
+    await expect(
+      spawnWorkerInPane('session:0', '%2', {
+        teamName: 'safe-team',
+        workerName: 'worker-1',
+        envVars: {
+          OMC_TEAM_NAME: 'safe-team',
+          OMC_TEAM_WORKER: 'safe-team/worker-1',
+        },
+        launchBinary: 'codex',
+        launchArgs: ['--full-auto'],
+        cwd: '/tmp',
+      })
+    ).rejects.toThrow(/worker_start_delivery_unverified:worker-1:%2:/);
+
+    const enterSend = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys' && args.at(-1) === 'Enter');
+    expect(enterSend).toBeUndefined();
+  });
+
+  it('fails before send-keys when the target pane shell never becomes ready', async () => {
+    mockedCalls.paneStatus = '1 zsh\n';
+    await expect(
+      spawnWorkerInPane('session:0', '%2', {
+        teamName: 'safe-team',
+        workerName: 'worker-1',
+        envVars: {
+          OMC_TEAM_NAME: 'safe-team',
+          OMC_TEAM_WORKER: 'safe-team/worker-1',
+        },
+        launchBinary: 'codex',
+        launchArgs: ['--full-auto'],
+        cwd: '/tmp',
+      })
+    ).rejects.toThrow(/worker_start_shell_not_ready:worker-1:%2:/);
+
+    expect(mockedCalls.tmuxArgs.some((args) => args[0] === 'send-keys' && args.includes('-l'))).toBe(false);
   });
 
   it('rejects invalid team names before command construction', async () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -8,6 +8,7 @@
  */
 
 import { existsSync } from 'fs';
+import { createHash } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { join, basename, isAbsolute, win32 } from 'path';
@@ -247,6 +248,96 @@ export function buildWorkerLaunchSpec(shellPath?: string): WorkerLaunchSpec {
 
   // Final fallback
   return { shell: '/bin/sh', rcFile: null };
+}
+
+
+function commandFingerprint(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function redactWorkerStartCommandForLog(command: string): string {
+  return command
+    // POSIX env assignments in the generated launch command.
+    .replace(/\b([A-Za-z_][A-Za-z0-9_]*)='[^']*'/g, "$1='<redacted>'")
+    // Windows cmd env assignments.
+    .replace(/set "([A-Za-z_][A-Za-z0-9_]*)=[^"]*"/g, 'set "$1=<redacted>"')
+    // PowerShell env assignments.
+    .replace(/\$env:([A-Za-z_][A-Za-z0-9_]*)='[^']*'/g, "$env:$1='<redacted>'")
+    // Sensitive CLI flags that may appear in launchArgs.
+    .replace(
+      /(--?[A-Za-z0-9_-]*(?:api[-_]?key|token|secret|password|credential|auth)[A-Za-z0-9_-]*)(?:=|\s+)(?:'[^']*'|"[^"]*"|\S+)/gi,
+      '$1=<redacted>',
+    );
+}
+
+function workerStartCommandPreview(command: string, maxLength = 180): string {
+  const redacted = redactWorkerStartCommandForLog(command).replace(/\s+/g, ' ').trim();
+  return redacted.length > maxLength ? `${redacted.slice(0, maxLength)}…` : redacted;
+}
+
+function logWorkerSpawnDiagnostic(message: string): void {
+  process.stderr.write(`[team/tmux-session] ${message}\n`);
+}
+
+function paneCurrentCommandLooksReady(command: string): boolean {
+  const normalized = basename(command.replace(/\\/g, '/')).replace(/\.(exe|cmd|bat)$/i, '').toLowerCase();
+  return SUPPORTED_POSIX_SHELLS.has(normalized)
+    || ['cmd', 'powershell', 'pwsh', 'nu', 'elvish'].includes(normalized);
+}
+
+export interface WaitForShellReadyOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+async function waitForShellReady(paneId: string, opts: WaitForShellReadyOptions = {}): Promise<boolean> {
+  if (isCmuxSurfaceTarget(paneId)) return true;
+  const envTimeout = Number.parseInt(process.env.OMC_TEAM_SHELL_READY_TIMEOUT_MS ?? '', 10);
+  const timeoutMs = Number.isFinite(opts.timeoutMs) && (opts.timeoutMs ?? 0) > 0
+    ? Number(opts.timeoutMs)
+    : (Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : 5_000);
+  const pollIntervalMs = Number.isFinite(opts.pollIntervalMs) && (opts.pollIntervalMs ?? 0) > 0
+    ? Number(opts.pollIntervalMs)
+    : 50;
+
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = '';
+  while (Date.now() < deadline) {
+    try {
+      const result = await tmuxCmdAsync([
+        'display-message', '-p', '-t', paneId,
+        '#{pane_dead} #{pane_current_command}',
+      ], { timeout: 1000 });
+      lastStatus = result.stdout.trim();
+      const [dead, ...commandParts] = lastStatus.split(/\s+/);
+      if (dead === '1') return false;
+      const currentCommand = commandParts.join(' ');
+      if (currentCommand && paneCurrentCommandLooksReady(currentCommand)) {
+        return true;
+      }
+    } catch (error) {
+      lastStatus = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  logWorkerSpawnDiagnostic(
+    `worker shell readiness timed out pane=${paneId} timeoutMs=${timeoutMs} lastStatus=${JSON.stringify(lastStatus)}`,
+  );
+  return false;
+}
+
+async function verifyWorkerStartCommandDelivered(paneId: string, startCmd: string): Promise<boolean> {
+  if (isCmuxSurfaceTarget(paneId)) return true;
+  const expected = normalizeTmuxCapture(startCmd);
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const captured = await capturePaneAsync(paneId);
+    if (normalizeTmuxCapture(captured).includes(expected)) {
+      return true;
+    }
+    await sleep(50);
+  }
+  return false;
 }
 
 function escapeForCmdSet(value: string): string {
@@ -676,7 +767,6 @@ export async function createTeamSession(
         } catch { /* ignore */ }
       }
     }
-    await new Promise(r => setTimeout(r, 300));
     return { sessionName: teamTarget, leaderPaneId, workerPaneIds, sessionMode };
   }
 
@@ -714,7 +804,7 @@ export async function createTeamSession(
       } catch { /* ignore */ }
     }
   }
-  await new Promise(r => setTimeout(r, 300));
+  await Promise.all(workerPaneIds.map((workerPaneId) => waitForShellReady(workerPaneId, { timeoutMs: 5_000 })));
 
   return { sessionName: teamTarget, leaderPaneId, workerPaneIds, sessionMode };
 }
@@ -731,18 +821,82 @@ export async function spawnWorkerInPane(
 ): Promise<void> {
   validateTeamName(config.teamName);
   const startCmd = buildWorkerStartCommand(config);
+  const fingerprint = commandFingerprint(startCmd);
+  const preview = workerStartCommandPreview(startCmd);
+
+  logWorkerSpawnDiagnostic(
+    `worker start delivery begin session=${sessionName} pane=${paneId} ` +
+    `worker=${config.workerName} cmdSha=${fingerprint} cmdPreview=${JSON.stringify(preview)}`,
+  );
 
   if (isCmuxSurfaceTarget(paneId)) {
-    await cmuxSendSurface(paneId, startCmd);
-    await cmuxSendSurfaceKey(paneId, 'Enter');
-    return;
+    try {
+      await cmuxSendSurface(paneId, startCmd);
+      await cmuxSendSurfaceKey(paneId, 'Enter');
+      logWorkerSpawnDiagnostic(
+        `worker start delivery sent session=${sessionName} pane=${paneId} ` +
+        `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=0`,
+      );
+      return;
+    } catch (error) {
+      logWorkerSpawnDiagnostic(
+        `worker start delivery failed session=${sessionName} pane=${paneId} ` +
+        `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=1 error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+      );
+      throw error;
+    }
   }
 
-  // Use -l (literal) flag to prevent tmux key-name parsing of the command string
-  await tmuxExecAsync([
-    'send-keys', '-t', paneId, '-l', startCmd
-  ]);
-  await tmuxExecAsync(['send-keys', '-t', paneId, 'Enter']);
+  const shellReady = await waitForShellReady(paneId);
+  if (!shellReady) {
+    const reason = `worker_start_shell_not_ready:${config.workerName}:${paneId}:${fingerprint}`;
+    logWorkerSpawnDiagnostic(
+      `worker start delivery failed session=${sessionName} pane=${paneId} ` +
+      `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=not_attempted reason=shell_not_ready`,
+    );
+    throw new Error(reason);
+  }
+
+  try {
+    // Use -l (literal) flag to prevent tmux key-name parsing of the command string.
+    const sendResult = await tmuxExecAsync([
+      'send-keys', '-t', paneId, '-l', startCmd
+    ], { timeout: 5000 });
+    logWorkerSpawnDiagnostic(
+      `worker start send-keys literal session=${sessionName} pane=${paneId} ` +
+      `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=0 stderr=${JSON.stringify(sendResult.stderr.trim())}`,
+    );
+  } catch (error) {
+    logWorkerSpawnDiagnostic(
+      `worker start send-keys literal failed session=${sessionName} pane=${paneId} ` +
+      `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=1 error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+    );
+    throw error;
+  }
+
+  const delivered = await verifyWorkerStartCommandDelivered(paneId, startCmd);
+  if (!delivered) {
+    const reason = `worker_start_delivery_unverified:${config.workerName}:${paneId}:${fingerprint}`;
+    logWorkerSpawnDiagnostic(
+      `worker start delivery verification failed session=${sessionName} pane=${paneId} ` +
+      `worker=${config.workerName} cmdSha=${fingerprint} cmdPreview=${JSON.stringify(preview)}`,
+    );
+    throw new Error(reason);
+  }
+
+  try {
+    const enterResult = await tmuxExecAsync(['send-keys', '-t', paneId, 'Enter'], { timeout: 5000 });
+    logWorkerSpawnDiagnostic(
+      `worker start submit sent session=${sessionName} pane=${paneId} ` +
+      `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=0 stderr=${JSON.stringify(enterResult.stderr.trim())}`,
+    );
+  } catch (error) {
+    logWorkerSpawnDiagnostic(
+      `worker start submit failed session=${sessionName} pane=${paneId} ` +
+      `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=1 error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+    );
+    throw error;
+  }
 }
 
 function normalizeTmuxCapture(value: string): string {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -331,7 +331,7 @@ async function verifyWorkerStartCommandDelivered(paneId: string, startCmd: strin
   if (isCmuxSurfaceTarget(paneId)) return true;
   const expected = normalizeTmuxCapture(startCmd);
   for (let attempt = 1; attempt <= 5; attempt++) {
-    const captured = await capturePaneAsync(paneId);
+    const captured = await capturePaneAsync(paneId, { joinWrappedLines: true });
     if (normalizeTmuxCapture(captured).includes(expected)) {
       return true;
     }
@@ -903,12 +903,15 @@ function normalizeTmuxCapture(value: string): string {
   return value.replace(/\r/g, '').replace(/\s+/g, ' ').trim();
 }
 
-async function capturePaneAsync(paneId: string): Promise<string> {
+async function capturePaneAsync(paneId: string, opts: { joinWrappedLines?: boolean } = {}): Promise<string> {
   try {
     if (isCmuxSurfaceTarget(paneId)) {
       return await cmuxCaptureSurface(paneId);
     }
-    const result = await tmuxExecAsync(['capture-pane', '-t', paneId, '-p', '-S', '-80']);
+    const args = opts.joinWrappedLines
+      ? ['capture-pane', '-J', '-t', paneId, '-p', '-S', '-80']
+      : ['capture-pane', '-t', paneId, '-p', '-S', '-80'];
+    const result = await tmuxExecAsync(args);
     return result.stdout;
   } catch {
     return '';


### PR DESCRIPTION
## Summary
- harden team worker tmux pane startup delivery with readiness polling and delivery verification
- fail worker spawn cleanly when startup delivery cannot be verified
- add regression coverage for pane readiness, delivery diagnostics, and runtime-v2 startup abort behavior

## Tests
- `npm test -- --run src/team/__tests__/tmux-session.create-team.test.ts src/team/__tests__/tmux-session.spawn.test.ts src/team/__tests__/runtime-v2.dispatch.test.ts`
- `npm run lint && npm run build && git diff --check`

Signed-off-by: Codex <codex@openai.com>
