### PR TITLE
feat(team): add Antigravity (agy) and Grok Build workers

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -4321,7 +4321,7 @@ var init_loader = __esm({
     DEFAULT_CONFIG = buildDefaultConfig();
     CANONICAL_TEAM_ROLE_SET = new Set(CANONICAL_TEAM_ROLES);
     KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
-    TEAM_ROLE_PROVIDERS = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+    TEAM_ROLE_PROVIDERS = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "antigravity", "grok"]);
     TEAM_ROLE_TIERS = /* @__PURE__ */ new Set(["HIGH", "MEDIUM", "LOW"]);
     OMC_STARTUP_COMPACTABLE_SECTIONS = [
       "agent_catalog",
@@ -29184,6 +29184,7 @@ function getTrustedPrefixes() {
     trusted.push(`${home}/.local/bin`);
     trusted.push(`${home}/.nvm/`);
     trusted.push(`${home}/.cargo/bin`);
+    trusted.push(`${home}/.grok/bin`);
   }
   const custom3 = (process.env.OMC_TRUSTED_CLI_DIRS ?? "").split(":").map((part) => part.trim()).filter(Boolean).filter((part) => (0, import_path84.isAbsolute)(part));
   trusted.push(...custom3);
@@ -29440,6 +29441,34 @@ var init_model_contract = __esm({
         supportsPromptMode: false,
         buildLaunchArgs(_model, extraFlags = []) {
           return [...extraFlags];
+        },
+        parseOutput(rawOutput) {
+          return rawOutput.trim();
+        }
+      },
+      antigravity: {
+        agentType: "antigravity",
+        binary: "agy",
+        installInstructions: "Install Antigravity CLI: https://antigravity.dev",
+        supportsPromptMode: true,
+        promptModeFlag: "-p",
+        buildLaunchArgs(_model, extraFlags = []) {
+          return ["--dangerously-skip-permissions", ...extraFlags];
+        },
+        parseOutput(rawOutput) {
+          return rawOutput.trim();
+        }
+      },
+      grok: {
+        agentType: "grok",
+        binary: "grok",
+        installInstructions: "Install Grok Build: https://build.grok.com",
+        supportsPromptMode: true,
+        promptModeFlag: "-p",
+        buildLaunchArgs(model, extraFlags = []) {
+          const args = ["--always-approve"];
+          if (model) args.push("--model", model);
+          return [...args, ...extraFlags];
         },
         parseOutput(rawOutput) {
           return rawOutput.trim();
@@ -35466,7 +35495,7 @@ async function shutdownTeam(teamName, sessionName2, cwd2, timeoutMs = 3e4, worke
     teamName
   });
   const configData = await readJsonSafe5((0, import_path93.join)(root2, "config.json"));
-  const CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+  const CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "cursor", "antigravity", "grok"]);
   const agentTypes = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every((t) => CLI_AGENT_TYPES.has(t));
   if (!isCliWorkerTeam) {
@@ -83858,7 +83887,7 @@ function getPromptText(input) {
   return "";
 }
 function isExplicitAskSlashInvocation(promptText) {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini)\b/i.test(promptText);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|antigravity|grok)\b/i.test(promptText);
 }
 function activateRalplanStartupState(directory, sessionId) {
   const now = (/* @__PURE__ */ new Date()).toISOString();
@@ -85591,7 +85620,9 @@ function detectSkillRuntimeAvailability(detector = isCliAvailable) {
   return {
     claude: safeDetect("claude"),
     codex: safeDetect("codex"),
-    gemini: safeDetect("gemini")
+    gemini: safeDetect("gemini"),
+    antigravity: safeDetect("antigravity"),
+    grok: safeDetect("grok")
   };
 }
 function normalizeSkillName(skillName) {
@@ -87562,7 +87593,9 @@ init_loader();
 var PROVIDER_BINARY = {
   claude: "claude",
   codex: "codex",
-  gemini: "gemini"
+  gemini: "gemini",
+  antigravity: "agy",
+  grok: "grok"
 };
 function probeProvider(provider) {
   const binary = PROVIDER_BINARY[provider];
@@ -87590,7 +87623,7 @@ function collectConfiguredProviders() {
   const roleRouting = cfg.team?.roleRouting ?? {};
   for (const spec of Object.values(roleRouting)) {
     const provider = spec?.provider;
-    if (provider === "claude" || provider === "codex" || provider === "gemini") {
+    if (provider === "claude" || provider === "codex" || provider === "gemini" || provider === "antigravity" || provider === "grok") {
       providers.add(provider);
     }
   }
@@ -88561,7 +88594,7 @@ init_tmux_utils();
 var HELP_TOKENS = /* @__PURE__ */ new Set(["--help", "-h", "help"]);
 var MIN_WORKER_COUNT = 1;
 var MAX_WORKER_COUNT = 20;
-var VALID_TEAM_CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+var VALID_TEAM_CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "antigravity", "grok"]);
 var DEFAULT_TEAM_CLI_AGENT_TYPE = "claude";
 var TEAM_HELP = `
 Usage: omc team [N:agent-type[:role]] [--new-window] [--auto-merge] [--no-decompose] "<task description>"
@@ -92278,14 +92311,14 @@ var import_path122 = require("path");
 var import_url15 = require("url");
 init_security_config();
 var ASK_USAGE = [
-  "Usage: omc ask <claude|codex|gemini> <question or task>",
-  '   or: omc ask <claude|codex|gemini> -p "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --print "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --prompt "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt=<role> --prompt "<prompt>"'
+  "Usage: omc ask <claude|codex|gemini|antigravity|grok> <question or task>",
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> -p "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --print "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --prompt "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --agent-prompt=<role> --prompt "<prompt>"'
 ].join("\n");
-var ASK_PROVIDERS = ["claude", "codex", "gemini"];
+var ASK_PROVIDERS = ["claude", "codex", "gemini", "antigravity", "grok"];
 var ASK_PROVIDER_SET = new Set(ASK_PROVIDERS);
 var ASK_AGENT_PROMPT_FLAG = "--agent-prompt";
 var SAFE_ROLE_PATTERN = /^[a-z][a-z0-9-]*$/;

--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -2208,7 +2208,7 @@ function warnOnDeprecatedDelegationRouting(config) {
 }
 var CANONICAL_TEAM_ROLE_SET = new Set(CANONICAL_TEAM_ROLES);
 var KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
-var TEAM_ROLE_PROVIDERS = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+var TEAM_ROLE_PROVIDERS = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "antigravity", "grok"]);
 var TEAM_ROLE_TIERS = /* @__PURE__ */ new Set(["HIGH", "MEDIUM", "LOW"]);
 function validateTeamConfig(config) {
   const team = config.team;
@@ -2916,6 +2916,7 @@ function getTrustedPrefixes() {
     trusted.push(`${home}/.local/bin`);
     trusted.push(`${home}/.nvm/`);
     trusted.push(`${home}/.cargo/bin`);
+    trusted.push(`${home}/.grok/bin`);
   }
   const custom = (process.env.OMC_TRUSTED_CLI_DIRS ?? "").split(":").map((part) => part.trim()).filter(Boolean).filter((part) => (0, import_path7.isAbsolute)(part));
   trusted.push(...custom);
@@ -3039,6 +3040,34 @@ var CONTRACTS = {
     supportsPromptMode: false,
     buildLaunchArgs(_model, extraFlags = []) {
       return [...extraFlags];
+    },
+    parseOutput(rawOutput) {
+      return rawOutput.trim();
+    }
+  },
+  antigravity: {
+    agentType: "antigravity",
+    binary: "agy",
+    installInstructions: "Install Antigravity CLI: https://antigravity.dev",
+    supportsPromptMode: true,
+    promptModeFlag: "-p",
+    buildLaunchArgs(_model, extraFlags = []) {
+      return ["--dangerously-skip-permissions", ...extraFlags];
+    },
+    parseOutput(rawOutput) {
+      return rawOutput.trim();
+    }
+  },
+  grok: {
+    agentType: "grok",
+    binary: "grok",
+    installInstructions: "Install Grok Build: https://build.grok.com",
+    supportsPromptMode: true,
+    promptModeFlag: "-p",
+    buildLaunchArgs(model, extraFlags = []) {
+      const args = ["--always-approve"];
+      if (model) args.push("--model", model);
+      return [...args, ...extraFlags];
     },
     parseOutput(rawOutput) {
       return rawOutput.trim();
@@ -4805,7 +4834,7 @@ async function shutdownTeam(teamName, sessionName2, cwd, timeoutMs = 3e4, worker
     teamName
   });
   const configData = await readJsonSafe((0, import_path14.join)(root, "config.json"));
-  const CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+  const CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "cursor", "antigravity", "grok"]);
   const agentTypes = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every((t) => CLI_AGENT_TYPES.has(t));
   if (!isCliWorkerTeam) {

--- a/bridge/team.js
+++ b/bridge/team.js
@@ -3867,7 +3867,7 @@ var init_loader = __esm({
     DEFAULT_CONFIG = buildDefaultConfig();
     CANONICAL_TEAM_ROLE_SET = new Set(CANONICAL_TEAM_ROLES);
     KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
-    TEAM_ROLE_PROVIDERS = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+    TEAM_ROLE_PROVIDERS = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "antigravity", "grok"]);
     TEAM_ROLE_TIERS = /* @__PURE__ */ new Set(["HIGH", "MEDIUM", "LOW"]);
   }
 });
@@ -4590,6 +4590,7 @@ function getTrustedPrefixes() {
     trusted.push(`${home}/.local/bin`);
     trusted.push(`${home}/.nvm/`);
     trusted.push(`${home}/.cargo/bin`);
+    trusted.push(`${home}/.grok/bin`);
   }
   const custom = (process.env.OMC_TRUSTED_CLI_DIRS ?? "").split(":").map((part) => part.trim()).filter(Boolean).filter((part) => isAbsolute5(part));
   trusted.push(...custom);
@@ -4826,6 +4827,34 @@ var init_model_contract = __esm({
         supportsPromptMode: false,
         buildLaunchArgs(_model, extraFlags = []) {
           return [...extraFlags];
+        },
+        parseOutput(rawOutput) {
+          return rawOutput.trim();
+        }
+      },
+      antigravity: {
+        agentType: "antigravity",
+        binary: "agy",
+        installInstructions: "Install Antigravity CLI: https://antigravity.dev",
+        supportsPromptMode: true,
+        promptModeFlag: "-p",
+        buildLaunchArgs(_model, extraFlags = []) {
+          return ["--dangerously-skip-permissions", ...extraFlags];
+        },
+        parseOutput(rawOutput) {
+          return rawOutput.trim();
+        }
+      },
+      grok: {
+        agentType: "grok",
+        binary: "grok",
+        installInstructions: "Install Grok Build: https://build.grok.com",
+        supportsPromptMode: true,
+        promptModeFlag: "-p",
+        buildLaunchArgs(model, extraFlags = []) {
+          const args = ["--always-approve"];
+          if (model) args.push("--model", model);
+          return [...args, ...extraFlags];
         },
         parseOutput(rawOutput) {
           return rawOutput.trim();
@@ -9367,7 +9396,7 @@ async function shutdownTeam(teamName, sessionName2, cwd, timeoutMs = 3e4, worker
     teamName
   });
   const configData = await readJsonSafe2(join18(root, "config.json"));
-  const CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini"]);
+  const CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "cursor", "antigravity", "grok"]);
   const agentTypes = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every((t) => CLI_AGENT_TYPES.has(t));
   if (!isCliWorkerTeam) {
@@ -10560,7 +10589,7 @@ function readApprovedExecutionLaunchHintOutcome(cwd, mode, options = {}) {
 
 // src/cli/team.ts
 var JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-var VALID_CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "cursor"]);
+var VALID_CLI_AGENT_TYPES = /* @__PURE__ */ new Set(["claude", "codex", "gemini", "cursor", "antigravity", "grok"]);
 var SUBCOMMANDS = /* @__PURE__ */ new Set(["start", "status", "wait", "cleanup", "resume", "shutdown", "api", "help", "--help", "-h"]);
 var SUPPORTED_API_OPERATIONS = /* @__PURE__ */ new Set([
   "send-message",

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -8,6 +8,8 @@ const PROVIDER_BINARIES = {
   claude: 'claude',
   codex: 'codex',
   gemini: 'gemini',
+  antigravity: 'agy',
+  grok: 'grok',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
@@ -16,6 +18,8 @@ const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
  * - claude: `claude -p <prompt>`
  * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
  * - gemini: `gemini -p <prompt> --yolo`
+ * - antigravity: `agy -p <prompt> --dangerously-skip-permissions`
+ * - grok: `grok -p <prompt> --always-approve`
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
@@ -23,6 +27,12 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
   }
   if (provider === 'gemini') {
     return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
+  }
+  if (provider === 'antigravity') {
+    return ['-p', prompt, '--dangerously-skip-permissions'];
+  }
+  if (provider === 'grok') {
+    return ['-p', prompt, '--always-approve'];
   }
   return ['-p', prompt];
 }
@@ -43,8 +53,8 @@ const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
 const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
-  console.error('Usage: omc ask <claude|codex|gemini> "<prompt>"');
-  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini> <prompt...>');
+  console.error('Usage: omc ask <claude|codex|gemini|antigravity|grok> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|antigravity|grok> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
 }

--- a/src/__tests__/runtime-guidance-plan-ralph.test.ts
+++ b/src/__tests__/runtime-guidance-plan-ralph.test.ts
@@ -6,6 +6,7 @@ const availability = vi.hoisted(() => ({
   codex: false,
   gemini: false,
   cursor: false,
+  antigravity: false,
 }));
 
 vi.mock('../team/model-contract.js', () => ({

--- a/src/__tests__/runtime-guidance-plan-ralph.test.ts
+++ b/src/__tests__/runtime-guidance-plan-ralph.test.ts
@@ -7,6 +7,7 @@ const availability = vi.hoisted(() => ({
   gemini: false,
   cursor: false,
   antigravity: false,
+  grok: false,
 }));
 
 vi.mock('../team/model-contract.js', () => ({

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,15 @@ import { fileURLToPath } from 'url';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export const ASK_USAGE = [
-  'Usage: omc ask <claude|codex|gemini> <question or task>',
-  '   or: omc ask <claude|codex|gemini> -p "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --print "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --prompt "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  'Usage: omc ask <claude|codex|gemini|antigravity> <question or task>',
+  '   or: omc ask <claude|codex|gemini|antigravity> -p "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity> --print "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity> --prompt "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'codex', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'antigravity'] as const;
 export type AskProvider = (typeof ASK_PROVIDERS)[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,15 @@ import { fileURLToPath } from 'url';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export const ASK_USAGE = [
-  'Usage: omc ask <claude|codex|gemini|antigravity> <question or task>',
-  '   or: omc ask <claude|codex|gemini|antigravity> -p "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity> --print "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity> --prompt "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity> --agent-prompt <role> "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity> --agent-prompt=<role> --prompt "<prompt>"',
+  'Usage: omc ask <claude|codex|gemini|antigravity|grok> <question or task>',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> -p "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --print "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --prompt "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'antigravity'] as const;
+const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'antigravity', 'grok'] as const;
 export type AskProvider = (typeof ASK_PROVIDERS)[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 

--- a/src/cli/commands/doctor-team-routing.ts
+++ b/src/cli/commands/doctor-team-routing.ts
@@ -25,6 +25,7 @@ const PROVIDER_BINARY: Record<TeamRoleProvider, string> = {
   codex: 'codex',
   gemini: 'gemini',
   antigravity: 'agy',
+  grok: 'grok',
 };
 
 function probeProvider(provider: TeamRoleProvider): ProviderProbe {
@@ -62,7 +63,7 @@ function collectConfiguredProviders(): Set<TeamRoleProvider> {
   const roleRouting = cfg.team?.roleRouting ?? {};
   for (const spec of Object.values(roleRouting)) {
     const provider = spec?.provider as TeamRoleProvider | undefined;
-    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'antigravity') {
+    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'antigravity' || provider === 'grok') {
       providers.add(provider);
     }
   }

--- a/src/cli/commands/doctor-team-routing.ts
+++ b/src/cli/commands/doctor-team-routing.ts
@@ -24,6 +24,7 @@ const PROVIDER_BINARY: Record<TeamRoleProvider, string> = {
   claude: 'claude',
   codex: 'codex',
   gemini: 'gemini',
+  antigravity: 'agy',
 };
 
 function probeProvider(provider: TeamRoleProvider): ProviderProbe {
@@ -61,7 +62,7 @@ function collectConfiguredProviders(): Set<TeamRoleProvider> {
   const roleRouting = cfg.team?.roleRouting ?? {};
   for (const spec of Object.values(roleRouting)) {
     const provider = spec?.provider as TeamRoleProvider | undefined;
-    if (provider === 'claude' || provider === 'codex' || provider === 'gemini') {
+    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'antigravity') {
       providers.add(provider);
     }
   }

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -25,7 +25,7 @@ import { tmuxExec } from '../tmux-utils.js';
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
-const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
+const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'antigravity']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
 const TEAM_HELP = `

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -25,7 +25,7 @@ import { tmuxExec } from '../tmux-utils.js';
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
-const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'antigravity']);
+const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'antigravity', 'grok']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
 const TEAM_HELP = `

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -15,7 +15,7 @@ import { getGlobalOmcStatePath } from '../utils/paths.js';
 import { readApprovedExecutionLaunchHintOutcome } from '../planning/artifacts.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'antigravity']);
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'antigravity', 'grok']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
 const SUPPORTED_API_OPERATIONS = new Set([

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -15,7 +15,7 @@ import { getGlobalOmcStatePath } from '../utils/paths.js';
 import { readApprovedExecutionLaunchHintOutcome } from '../planning/artifacts.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor']);
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'antigravity']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
 const SUPPORTED_API_OPERATIONS = new Set([

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -477,7 +477,7 @@ function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
 const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
 // /team CLI workers — codex/gemini here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
-const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini"]);
+const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "antigravity", "grok"]);
 const TEAM_ROLE_TIERS = new Set(["HIGH", "MEDIUM", "LOW"]);
 
 export function validateTeamConfig(config: PluginConfig): void {
@@ -1059,7 +1059,7 @@ export function generateConfigSchema(): object {
           },
           defaultProvider: {
             type: "string",
-            enum: ["claude", "codex", "gemini"],
+            enum: ["claude", "codex", "gemini", "antigravity", "grok"],
             default: "claude",
             description:
               "Default provider for delegation routing when no specific role mapping exists",
@@ -1072,7 +1072,7 @@ export function generateConfigSchema(): object {
               properties: {
                 provider: {
                   type: "string",
-                  enum: ["claude", "codex", "gemini"],
+                  enum: ["claude", "codex", "gemini", "antigravity", "grok"],
                 },
                 tool: { type: "string", enum: ["Task"] },
                 model: { type: "string" },
@@ -1094,7 +1094,7 @@ export function generateConfigSchema(): object {
               maxAgents: { type: "integer", minimum: 1 },
               defaultAgentType: {
                 type: "string",
-                enum: ["claude", "codex", "gemini"],
+                enum: ["claude", "codex", "gemini", "antigravity", "grok"],
                 default: "claude",
               },
               monitorIntervalMs: { type: "integer", minimum: 1 },
@@ -1108,7 +1108,7 @@ export function generateConfigSchema(): object {
             additionalProperties: {
               type: "object",
               properties: {
-                provider: { type: "string", enum: ["claude", "codex", "gemini"] },
+                provider: { type: "string", enum: ["claude", "codex", "gemini", "antigravity", "grok"] },
                 model: { type: "string" },
                 agent: { type: "string" },
               },

--- a/src/features/builtin-skills/runtime-guidance.ts
+++ b/src/features/builtin-skills/runtime-guidance.ts
@@ -5,6 +5,7 @@ export interface SkillRuntimeAvailability {
   codex: boolean;
   gemini: boolean;
   antigravity: boolean;
+  grok: boolean;
 }
 
 export function detectSkillRuntimeAvailability(
@@ -22,6 +23,7 @@ export function detectSkillRuntimeAvailability(
     codex: safeDetect('codex'),
     gemini: safeDetect('gemini'),
     antigravity: safeDetect('antigravity'),
+    grok: safeDetect('grok'),
   };
 }
 

--- a/src/features/builtin-skills/runtime-guidance.ts
+++ b/src/features/builtin-skills/runtime-guidance.ts
@@ -4,6 +4,7 @@ export interface SkillRuntimeAvailability {
   claude: boolean;
   codex: boolean;
   gemini: boolean;
+  antigravity: boolean;
 }
 
 export function detectSkillRuntimeAvailability(
@@ -20,6 +21,7 @@ export function detectSkillRuntimeAvailability(
     claude: safeDetect('claude'),
     codex: safeDetect('codex'),
     gemini: safeDetect('gemini'),
+    antigravity: safeDetect('antigravity'),
   };
 }
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1232,7 +1232,7 @@ function getPromptText(input: HookInput): string {
 }
 
 function isExplicitAskSlashInvocation(promptText: string): boolean {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini)\b/i.test(promptText);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|antigravity|grok)\b/i.test(promptText);
 }
 
 function activateRalplanStartupState(directory: string, sessionId?: string): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -414,7 +414,7 @@ export const CANONICAL_TEAM_ROLES = [
 export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
 
 /** Provider for /team role routing. */
-export type TeamRoleProvider = 'claude' | 'codex' | 'gemini';
+export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'antigravity';
 
 /** Tier name accepted in role-assignment `model` field. */
 export type TeamRoleTier = 'HIGH' | 'MEDIUM' | 'LOW';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -414,7 +414,7 @@ export const CANONICAL_TEAM_ROLES = [
 export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
 
 /** Provider for /team role routing. */
-export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'antigravity';
+export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'antigravity' | 'grok';
 
 /** Tier name accepted in role-assignment `model` field. */
 export type TeamRoleTier = 'HIGH' | 'MEDIUM' | 'LOW';

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -37,5 +37,6 @@ export function detectAllClis(): Record<string, CliInfo> {
     gemini: detectCli('gemini'),
     cursor: detectCli('cursor-agent'),
     antigravity: detectCli('agy'),
+    grok: detectCli('grok'),
   };
 }

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -36,5 +36,6 @@ export function detectAllClis(): Record<string, CliInfo> {
     codex: detectCli('codex'),
     gemini: detectCli('gemini'),
     cursor: detectCli('cursor-agent'),
+    antigravity: detectCli('agy'),
   };
 }

--- a/src/team/cli-worker-contract.ts
+++ b/src/team/cli-worker-contract.ts
@@ -2,17 +2,16 @@
  * CLI-worker output contract (Option E, plan AC-7).
  *
  * When a /team critic/reviewer stage is routed to an external CLI worker
- * (codex or gemini), the worker may not call TaskUpdate directly. To surface
- * a structured verdict back to the team leader, the worker writes a JSON
- * payload to a pre-agreed file path. The leader's worker-completion handler
- * in runtime-v2 reads the file and calls TaskUpdate with verdict metadata.
+ * (codex, gemini, antigravity, grok, etc.), the worker may not call
+ * TaskUpdate directly. To surface a structured verdict back to the team
+ * leader, the worker writes a JSON payload to a pre-agreed file path. The
+ * leader's worker-completion handler in runtime-v2 reads the file and calls
+ * TaskUpdate with verdict metadata.
  *
  * Applies to roles in CONTRACT_ROLES (critic, code-reviewer,
- * security-reviewer, test-engineer) when the resolved provider is
- * `codex` or `gemini`. Claude workers participate in team messaging
- * directly and do not use this contract. Codex team workers are launched as
- * persistent `codex` panes, not `codex exec`; they still receive this verdict
- * contract in their inbox when assigned reviewer-style roles.
+ * security-reviewer, test-engineer) for any non-claude, non-cursor provider.
+ * Claude workers participate in team messaging directly and do not use this
+ * contract.
  */
 
 import type { CanonicalTeamRole } from '../shared/types.js';

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,7 +5,7 @@ import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'antigravity';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'antigravity' | 'grok';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -66,6 +66,7 @@ function getTrustedPrefixes(): string[] {
     trusted.push(`${home}/.local/bin`);
     trusted.push(`${home}/.nvm/`);
     trusted.push(`${home}/.cargo/bin`);
+    trusted.push(`${home}/.grok/bin`);
   }
 
   const custom = (process.env.OMC_TRUSTED_CLI_DIRS ?? '')
@@ -266,6 +267,21 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     buildLaunchArgs(_model?: string, extraFlags: string[] = []): string[] {
       // agy does not accept --model; model is set in ~/.gemini/antigravity-cli/settings.json
       return ['--dangerously-skip-permissions', ...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
+  grok: {
+    agentType: 'grok',
+    binary: 'grok',
+    installInstructions: 'Install Grok CLI: https://build.grok.com',
+    supportsPromptMode: true,
+    promptModeFlag: '-p',
+    buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
+      const args = ['--always-approve'];
+      if (model) args.push('--model', model);
+      return [...args, ...extraFlags];
     },
     parseOutput(rawOutput: string): string {
       return rawOutput.trim();

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -275,7 +275,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
   grok: {
     agentType: 'grok',
     binary: 'grok',
-    installInstructions: 'Install Grok CLI: https://build.grok.com',
+    installInstructions: 'Install Grok Build: https://build.grok.com',
     supportsPromptMode: true,
     promptModeFlag: '-p',
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,7 +5,7 @@ import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'antigravity';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -252,6 +252,20 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       // Minimal flags — cursor-agent owns its own session/auth state.
       // The model is selected interactively inside cursor-agent itself.
       return [...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
+  antigravity: {
+    agentType: 'antigravity',
+    binary: 'agy',
+    installInstructions: 'Install Antigravity CLI: https://antigravity.dev',
+    supportsPromptMode: true,
+    promptModeFlag: '-p',
+    buildLaunchArgs(_model?: string, extraFlags: string[] = []): string[] {
+      // agy does not accept --model; model is set in ~/.gemini/antigravity-cli/settings.json
+      return ['--dangerously-skip-permissions', ...extraFlags];
     },
     parseOutput(rawOutput: string): string {
       return rawOutput.trim();

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -926,7 +926,7 @@ export async function shutdownTeam(
   // Polling for ACK files on CLI worker teams wastes the full timeoutMs on every shutdown.
   // Detect CLI worker teams by checking if all agent types are known CLI types, and skip
   // ACK polling — the tmux kill below handles process cleanup instead.
-  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini']);
+  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini', 'cursor', 'antigravity', 'grok']);
   const agentTypes: string[] = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every(t => CLI_AGENT_TYPES.has(t));
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -54,7 +54,7 @@ import {
 // ── Environment gate ──────────────────────────────────────────────────────────
 
 const OMC_TEAM_SCALING_ENABLED_ENV = 'OMC_TEAM_SCALING_ENABLED';
-const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini']);
+const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini', 'cursor', 'antigravity', 'grok']);
 
 export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMC_TEAM_SCALING_ENABLED_ENV];

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -132,7 +132,7 @@ function resolveClaudeModel(
  * explicit non-tier model ID is passed through.
  */
 function resolveExternalModel(
-  provider: 'codex' | 'gemini',
+  provider: 'codex' | 'gemini' | 'antigravity',
   raw: string | undefined,
   cfg: PluginConfig,
 ): string {

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -132,7 +132,7 @@ function resolveClaudeModel(
  * explicit non-tier model ID is passed through.
  */
 function resolveExternalModel(
-  provider: 'codex' | 'gemini' | 'antigravity',
+  provider: 'codex' | 'gemini' | 'antigravity' | 'grok',
   raw: string | undefined,
   cfg: PluginConfig,
 ): string {

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -278,7 +278,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'antigravity';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'antigravity' | 'grok';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -278,7 +278,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'antigravity';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/worker-commit-cadence.ts
+++ b/src/team/worker-commit-cadence.ts
@@ -24,7 +24,7 @@ export interface WorkerCadenceContext {
   teamName: string;
   workerName: string;
   worktreePath: string;
-  agentType: 'claude' | 'codex' | 'gemini' | 'cursor';
+  agentType: 'claude' | 'codex' | 'gemini' | 'cursor' | 'antigravity';
   enabled: boolean;
 }
 

--- a/src/team/worker-commit-cadence.ts
+++ b/src/team/worker-commit-cadence.ts
@@ -24,7 +24,7 @@ export interface WorkerCadenceContext {
   teamName: string;
   workerName: string;
   worktreePath: string;
-  agentType: 'claude' | 'codex' | 'gemini' | 'cursor' | 'antigravity';
+  agentType: 'claude' | 'codex' | 'gemini' | 'cursor' | 'antigravity' | 'grok';
   enabled: boolean;
 }
 


### PR DESCRIPTION
## Summary

Registers two new CLI providers as first-class `CliAgentType` workers alongside `claude`, `codex`, `gemini`, and `cursor`.

### Antigravity CLI (`agy`)
- Binary: `agy`, installs to `~/.local/bin/agy` (Linux & macOS, via `agy install`)
- `-p` / `--print` headless mode
- `--dangerously-skip-permissions` for auto-approval
- No `--model` flag (model is config-driven in `~/.gemini/antigravity-cli/settings.json`)

### Grok Build (`grok`)
- Binary: `grok`, installs to `~/.grok/bin/grok`
- `-p` / `--single` headless mode
- `--always-approve` for auto-approval
- `--model <MODEL>` supported (e.g. `grok-3`)
- `~/.grok/bin` added to `getTrustedPrefixes()` so no manual `OMC_TRUSTED_CLI_DIRS` config needed

Both providers degrade gracefully — `isCliAvailable` returns false on systems without the binary installed.

## Files changed

- `src/team/model-contract.ts` — `CliAgentType` union, `CONTRACTS` entries, trusted paths
- `src/team/cli-detection.ts` — `detectAllClis()` entries
- `src/team/stage-router.ts` — `resolveExternalModel` signature
- `src/team/types.ts` + `src/team/worker-commit-cadence.ts` — union updates
- `src/shared/types.ts` — `TeamRoleProvider` union
- `src/cli/team.ts` + `src/cli/commands/team.ts` — valid agent type sets
- `src/cli/ask.ts` — `ASK_PROVIDERS` + usage string
- `src/cli/commands/doctor-team-routing.ts` — `PROVIDER_BINARY` map + config probe
- `src/features/builtin-skills/runtime-guidance.ts` — `SkillRuntimeAvailability` interface
- `src/__tests__/runtime-guidance-plan-ralph.test.ts` — test fixture
- `scripts/run-provider-advisor.js` — `PROVIDER_BINARIES` + `buildProviderArgs` for antigravity/grok

## Test plan

- [x] `omc ask antigravity -p "say hi"` → routes correctly, exit 0
- [x] `omc ask grok -p "say hi"` → routes correctly, exit 0
- [ ] `omc team 1:antigravity "task"` launches `agy` worker in tmux pane
- [ ] `omc team 1:grok "task"` launches `grok` worker in tmux pane
- [ ] `omc doctor team-routing` reports presence/absence of `agy` and `grok`
- [ ] On systems without the binaries: graceful `isCliAvailable` false, no crash
- [x] `npm run build` passes clean

## Platform compatibility

| Binary | Linux | macOS | Windows |
|--------|-------|-------|---------|
| `agy` | ✅ `~/.local/bin` | ✅ `~/.local/bin` | unknown |
| `grok` | ✅ `~/.grok/bin` | likely ✅ | unknown |

🤖 Generated with [Claude Code](https://claude.com/claude-code)