### PR TITLE
fix(session-end): move tmux team and python REPL cleanup off critical path

### DIFF
--- a/src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts
@@ -51,7 +51,7 @@ describe('processSessionEnd python bridge cleanup', () => {
     ];
     fs.writeFileSync(transcriptPath, transcriptLines.join('\n'), 'utf-8');
 
-    await processSessionEnd({
+    const result = await processSessionEnd({
       session_id: 'session-123',
       transcript_path: transcriptPath,
       cwd: tmpDir,
@@ -59,6 +59,7 @@ describe('processSessionEnd python bridge cleanup', () => {
       hook_event_name: 'SessionEnd',
       reason: 'clear',
     });
+    await result.pending;
 
     expect(cleanupBridgeSessions).toHaveBeenCalledTimes(1);
     const calledWith = vi.mocked(cleanupBridgeSessions).mock.calls[0]?.[0] as string[];

--- a/src/hooks/session-end/__tests__/team-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/team-cleanup.test.ts
@@ -115,7 +115,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: 'worker-1', pane_id: '%1' }],
     } as never);
 
-    await processSessionEnd({
+    const result = await processSessionEnd({
       session_id: sessionId,
       transcript_path: transcriptPath,
       cwd: tmpDir,
@@ -123,6 +123,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       hook_event_name: 'SessionEnd',
       reason: 'clear',
     });
+    await result.pending;
 
     expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
       'delivery-team',
@@ -149,7 +150,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       tmuxOwnsWindow: false,
     } as never);
 
-    await processSessionEnd({
+    const result = await processSessionEnd({
       session_id: sessionId,
       transcript_path: transcriptPath,
       cwd: tmpDir,
@@ -157,6 +158,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       hook_event_name: 'SessionEnd',
       reason: 'clear',
     });
+    await result.pending;
 
     expect(teamCleanupMocks.shutdownTeam).toHaveBeenCalledWith(
       'legacy-team',
@@ -190,7 +192,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: `${teamName}-worker`, pane_id: '%1' }],
     })) as never);
 
-    await processSessionEnd({
+    const result = await processSessionEnd({
       session_id: sessionId,
       transcript_path: transcriptPath,
       cwd: tmpDir,
@@ -198,6 +200,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       hook_event_name: 'SessionEnd',
       reason: 'clear',
     });
+    await result.pending;
 
     expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
     expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -33,6 +33,16 @@ export interface SessionMetrics {
 
 export interface HookOutput {
   continue: boolean;
+  /**
+   * Promise that resolves when all fire-and-forget cleanup work
+   * (notifications, team shutdown, python REPL bridge cleanup, reply listener
+   * cleanup) has settled. The hook runner does not need to await this — Node
+   * keeps the process alive until stdout closes — but tests and other
+   * in-process callers can await it to verify cleanup completion.
+   *
+   * Not serialized over the hook protocol. See `handleSessionEnd`.
+   */
+  pending?: Promise<unknown>;
 }
 
 interface SessionOwnedTeamCleanupResult {
@@ -753,12 +763,15 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   const metrics = recordSessionMetrics(directory, input);
   exportSessionSummary(directory, metrics);
 
-  // Best-effort cleanup for tmux-backed team workers owned by this Claude Code
-  // session. This does not fix upstream signal-forwarding behavior, but it
-  // meaningfully reduces orphaned panes/windows when SessionEnd runs normally.
-  await cleanupSessionOwnedTeams(directory, input.session_id);
+  // Kick off team cleanup BEFORE the mode-state wiping below. The synchronous
+  // portion of `cleanupSessionOwnedTeams` (specifically `readModeState('team', …)`
+  // inside `findSessionOwnedTeams`) must observe the live `team-state.json`
+  // before `cleanupModeStates` removes it. The remaining async shutdown work
+  // is pushed onto `fireAndForget` further below so it does not block the
+  // hook's critical path.
+  const teamCleanupPromise = cleanupSessionOwnedTeams(directory, input.session_id);
 
-  // Clean up transient state files
+  // Clean up transient state files (synchronous, fast).
   cleanupTransientState(directory, input.session_id);
 
   // Clean up mode state files to prevent stale state issues
@@ -774,17 +787,6 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // not treat it as hard-terminated.
   cleanupSessionStartedMarker(directory, input.session_id);
 
-  // Clean up Python REPL bridge sessions used in this transcript (#641).
-  // Best-effort only: session end should not fail because cleanup fails.
-  try {
-    const pythonSessionIds = await extractPythonReplSessionIdsFromTranscript(input.transcript_path);
-    if (pythonSessionIds.length > 0) {
-      await cleanupBridgeSessions(pythonSessionIds);
-    }
-  } catch {
-    // Ignore cleanup errors
-  }
-
   const profileName = process.env.OMC_NOTIFY_PROFILE;
   const notificationConfig = getNotificationConfig(profileName);
   const shouldUseNewNotificationSystem = Boolean(
@@ -799,6 +801,56 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // We collect the promises but don't await them — Node will flush them before
   // the process exits (the hook runner keeps the process alive until stdout closes).
   const fireAndForget: Promise<unknown>[] = [];
+
+  // Soft cap on tmux/python REPL cleanup so a hung worker can't push the hook
+  // toward the 30s SessionEnd timeout. Tunable via env for users who prefer
+  // longer cleanup windows. See discussion in the issue: tmux signal escalation
+  // (SIGINT -> SIGTERM -> SIGKILL with 100ms polling) and Python REPL bridge
+  // kill (5s SIGINT grace + 2.5s SIGTERM + poll) can take 15-25s combined on
+  // sessions with active teams + python REPL usage.
+  const cleanupBudgetMs = Number.parseInt(
+    process.env.OMC_SESSIONEND_CLEANUP_BUDGET_MS ?? '',
+    10,
+  );
+  const CLEANUP_BUDGET_MS = Number.isFinite(cleanupBudgetMs) && cleanupBudgetMs > 0
+    ? cleanupBudgetMs
+    : 2000;
+  const withCleanupBudget = <T>(p: Promise<T>): Promise<T | void> =>
+    Promise.race<T | void>([
+      p,
+      new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, CLEANUP_BUDGET_MS);
+        t.unref?.();
+      }),
+    ]);
+
+  // Best-effort cleanup for tmux-backed team workers owned by this Claude Code
+  // session. The promise was started above (before state wiping) so team
+  // discovery sees the live state; here we push it onto fireAndForget so the
+  // tmux signal-escalation tail does not block the hook's critical path.
+  // Internal timeout (`timeoutMs: 0` passed to `shutdownTeamV2 / shutdownTeam`)
+  // already caps per-team work, so we don't apply `withCleanupBudget` here —
+  // doing so would race the dynamic imports the cleanup needs to finish.
+  fireAndForget.push(
+    teamCleanupPromise.catch(() => { /* team cleanup failures must not block session end */ }),
+  );
+
+  // Clean up Python REPL bridge sessions used in this transcript (#641).
+  // Best-effort only. Moved off the critical path because the signal-escalation
+  // kill (5s SIGINT + 2.5s SIGTERM + poll) was adding up to 15s of blocking
+  // wait on sessions that used python_repl.
+  fireAndForget.push(
+    (async () => {
+      try {
+        const pythonSessionIds = await extractPythonReplSessionIdsFromTranscript(input.transcript_path);
+        if (pythonSessionIds.length > 0) {
+          await withCleanupBudget(cleanupBridgeSessions(pythonSessionIds));
+        }
+      } catch {
+        // Ignore cleanup errors
+      }
+    })(),
+  );
 
   // Trigger stop hook callbacks (#395). When an explicit session-end notification
   // config already covers Discord/Telegram, skip the overlapping legacy callback
@@ -858,15 +910,20 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // The hook runner keeps the process alive until stdout closes, so these
   // will settle naturally. Awaiting them would defeat the fire-and-forget
   // optimization and risk hitting the hook timeout (#1700).
-  void Promise.allSettled(fireAndForget);
+  // `pending` is exposed on the return value so in-process callers (tests,
+  // adjacent hooks) can await cleanup completion without blocking the hook.
+  const pending = Promise.allSettled(fireAndForget);
 
   // Return simple response - metrics are persisted to .omc/sessions/
-  return { continue: true };
+  return { continue: true, pending };
 }
 
 /**
- * Main hook entry point
+ * Main hook entry point. Strips the `pending` promise from the response so
+ * it isn't serialized over the hook protocol; the in-process work still
+ * completes because Node keeps the process alive until stdout closes.
  */
 export async function handleSessionEnd(input: SessionEndInput): Promise<HookOutput> {
-  return processSessionEnd(input);
+  const { continue: shouldContinue } = await processSessionEnd(input);
+  return { continue: shouldContinue };
 }


### PR DESCRIPTION
## Summary

SessionEnd hook currently performs two serial blocking awaits that can take **15–25s combined**, pushing every Claude Code session close right up against the 30s SessionEnd timeout. On affected sessions (active tmux teams and/or Python REPL usage on macOS with nvm), the user has to `Ctrl+C` the hook on exit.

This PR moves the two slow cleanups off the critical path of `processSessionEnd` while preserving correctness:

- **tmux team cleanup** (`cleanupSessionOwnedTeams`) — kicked off synchronously so team discovery still sees the live `team-state.json` before `cleanupModeStates` wipes it, but the tail (dynamic imports + tmux signal escalation) is awaited via `fireAndForget` only.
- **Python REPL bridge cleanup** (`cleanupBridgeSessions`) — moved entirely into `fireAndForget`, wrapped with a 2s budget (`OMC_SESSIONEND_CLEANUP_BUDGET_MS` for users who want a different cap).

Closes #3144.

## Root cause

In `src/hooks/session-end/index.ts` (before this PR):

```ts
// line 759 (blocking)
await cleanupSessionOwnedTeams(directory, input.session_id);

// lines 779-786 (blocking)
try {
  const pythonSessionIds = await extractPythonReplSessionIdsFromTranscript(input.transcript_path);
  if (pythonSessionIds.length > 0) {
    await cleanupBridgeSessions(pythonSessionIds);
  }
} catch { /* … */ }
```

`cleanupSessionOwnedTeams` invokes `shutdownTeamV2 / shutdownTeam`, which performs tmux signal escalation (`SIGINT → SIGTERM → SIGKILL` with 100ms polling) — variable 0–10s per team.

`cleanupBridgeSessions` calls `killBridgeWithEscalation` for each Python REPL session: default 5s SIGINT grace + 2.5s SIGTERM grace + poll — variable 0–15s.

Both run on the critical path before `processSessionEnd` returns, and the existing `fireAndForget` lane right below (already used for notifications and reply-listener cleanup, see #1700) was the natural place for them.

## Changes

- `src/hooks/session-end/index.ts`:
  - Kick off `cleanupSessionOwnedTeams` synchronously **before** `cleanupModeStates` so `readModeState('team', …)` inside `findSessionOwnedTeams` runs against the live state. The returned promise is pushed onto `fireAndForget`.
  - Move the Python REPL bridge cleanup block into `fireAndForget`, wrapped with `withCleanupBudget` (default 2000ms, overridable via `OMC_SESSIONEND_CLEANUP_BUDGET_MS`).
  - Expose a `pending` promise on the `HookOutput` returned by `processSessionEnd` so in-process callers (tests, adjacent hooks) can await full cleanup completion. `handleSessionEnd` strips `pending` before returning so it is not serialized over the hook protocol.
- Tests updated to `await result.pending` before asserting on the moved cleanups:
  - `src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts`
  - `src/hooks/session-end/__tests__/team-cleanup.test.ts`

## Trade-off

If the background cleanup overruns its budget, Node may exit before tmux/python workers fully die. The OS reaps orphans on next session, and the existing manifest-based reconciliation already handles this case on subsequent SessionStart events. The user-visible cost of hanging every session close outweighs occasional orphans that would have happened anyway when the user `Ctrl+C`'d.

## Verification

```sh
npx vitest run src/hooks/session-end/__tests__/
```

All 67 tests pass:

```
Test Files  10 passed (10)
Tests       67 passed (67)
```

Manual smoke test on macOS with nvm-installed Node:

1. Start a Claude Code session, run `omc team` to spawn tmux workers, use `python_repl` 2+ times.
2. Exit (`/exit` / terminal close).
3. Before this PR: SessionEnd hangs 10–25s.
4. After this PR: SessionEnd returns in <1s; tmux workers and Python bridges die in the background.

## Related

- #3144 — tracking issue with the full root-cause analysis
- #1700 — introduced the fire-and-forget pattern this PR extends
- #641 — added the Python REPL bridge cleanup that became the second slow await
- #395 — moved stop-hook callbacks to fire-and-forget; same pattern
- #3143 — separate hook regression on nvm/fnm (unrelated, but symptomatic of the same hook path)

## Notes for maintainer

CHANGELOG entry left out intentionally; happy to add one in whichever section you prefer for the next release (e.g. a new top-level "Bug Fixes" item under the next version).
