### PR TITLE
Keep scaling tests off live tmux panes

### DIFF
--- a/src/team/__tests__/scaling-launch-config.test.ts
+++ b/src/team/__tests__/scaling-launch-config.test.ts
@@ -127,7 +127,10 @@ describe('scaleUp launch config', () => {
       if (args[0] === 'split-window') {
         return { status: 0, stdout: '%12\n', stderr: '' };
       }
-      if (args[0] === 'display-message') {
+      if (args[0] === 'display-message' && args.includes('#{session_name}:#{window_index}')) {
+        return { status: 0, stdout: 'demo-session:0\n', stderr: '' };
+      }
+      if (args[0] === 'display-message' && args.includes('#{pane_pid}')) {
         return { status: 0, stdout: '4321\n', stderr: '' };
       }
       return { status: 0, stdout: '', stderr: '' };
@@ -239,7 +242,6 @@ describe('scaleUp launch config', () => {
     expect(gitWorktreeMocks.removeWorkerWorktree).toHaveBeenCalledWith('demo-team', 'worker-1', resolve(cwd));
   });
 
-
   it('rolls back a pending worktree when root overlay installation fails', async () => {
     modelContractMocks.buildWorkerArgv.mockReturnValue(['/usr/bin/codex']);
     teamOpsMocks.teamReadConfig.mockResolvedValueOnce({
@@ -331,7 +333,6 @@ describe('scaleUp launch config', () => {
 
 
 
-
   it('keeps reused worktree worker tracked if post-drain cleanup safety fails', async () => {
     const config = {
       name: 'demo-team',
@@ -372,7 +373,6 @@ describe('scaleUp launch config', () => {
     expect(gitWorktreeMocks.prepareWorkerWorktreeForRemoval).toHaveBeenCalledWith('demo-team', 'worker-1', resolve(cwd), join(resolve(cwd), 'reuse'));
     expect(monitorMocks.saveTeamConfig).not.toHaveBeenCalled();
   });
-
 
   it('preserves worktree and config when target pane remains alive after kill request', async () => {
     const config = {

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -1,43 +1,106 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
-import { execFileSync } from 'child_process';
-import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 
-import { scaleUp } from '../scaling.js';
+const tmuxUtilsMocks = vi.hoisted(() => ({
+  tmuxExec: vi.fn(),
+  tmuxSpawn: vi.fn(),
+}));
 
-function killTmuxSession(sessionName: string): void {
-  try {
-    execFileSync('tmux', ['kill-session', '-t', sessionName], { stdio: 'pipe' });
-  } catch { /* session may not exist */ }
-}
+const modelContractMocks = vi.hoisted(() => ({
+  buildWorkerArgv: vi.fn(),
+  getWorkerEnv: vi.fn(),
+  resolveClaudeWorkerModel: vi.fn(),
+}));
+
+const teamOpsMocks = vi.hoisted(() => ({
+  teamReadConfig: vi.fn(),
+  teamWriteWorkerIdentity: vi.fn(),
+  teamReadWorkerStatus: vi.fn(),
+  teamAppendEvent: vi.fn(),
+  writeAtomic: vi.fn(),
+}));
+
+const monitorMocks = vi.hoisted(() => ({
+  withScalingLock: vi.fn(),
+  saveTeamConfig: vi.fn(),
+}));
+
+const tmuxSessionMocks = vi.hoisted(() => ({
+  sanitizeName: vi.fn((name: string) => name),
+  getWorkerLiveness: vi.fn(),
+  killWorkerPanes: vi.fn(),
+  buildWorkerStartCommand: vi.fn(() => 'start-worker'),
+  waitForPaneReady: vi.fn(),
+}));
+
+const gitWorktreeMocks = vi.hoisted(() => ({
+  ensureWorkerWorktree: vi.fn(),
+  installWorktreeRootAgents: vi.fn(),
+  removeWorkerWorktree: vi.fn(),
+  restoreWorktreeRootAgents: vi.fn(),
+  checkWorkerWorktreeRemovalSafety: vi.fn(),
+  prepareWorkerWorktreeForRemoval: vi.fn(),
+}));
+
+vi.mock('../../cli/tmux-utils.js', () => ({
+  tmuxExec: tmuxUtilsMocks.tmuxExec,
+  tmuxSpawn: tmuxUtilsMocks.tmuxSpawn,
+}));
+
+vi.mock('../model-contract.js', () => ({
+  buildWorkerArgv: modelContractMocks.buildWorkerArgv,
+  getWorkerEnv: modelContractMocks.getWorkerEnv,
+  resolveClaudeWorkerModel: modelContractMocks.resolveClaudeWorkerModel,
+}));
+
+vi.mock('../team-ops.js', () => ({
+  teamReadConfig: teamOpsMocks.teamReadConfig,
+  teamWriteWorkerIdentity: teamOpsMocks.teamWriteWorkerIdentity,
+  teamReadWorkerStatus: teamOpsMocks.teamReadWorkerStatus,
+  teamAppendEvent: teamOpsMocks.teamAppendEvent,
+  writeAtomic: teamOpsMocks.writeAtomic,
+}));
+
+vi.mock('../monitor.js', () => ({
+  withScalingLock: monitorMocks.withScalingLock,
+  saveTeamConfig: monitorMocks.saveTeamConfig,
+}));
+
+vi.mock('../tmux-session.js', () => ({
+  sanitizeName: tmuxSessionMocks.sanitizeName,
+  getWorkerLiveness: tmuxSessionMocks.getWorkerLiveness,
+  killWorkerPanes: tmuxSessionMocks.killWorkerPanes,
+  buildWorkerStartCommand: tmuxSessionMocks.buildWorkerStartCommand,
+  waitForPaneReady: tmuxSessionMocks.waitForPaneReady,
+}));
+
+vi.mock('../git-worktree.js', () => ({
+  ensureWorkerWorktree: gitWorktreeMocks.ensureWorkerWorktree,
+  installWorktreeRootAgents: gitWorktreeMocks.installWorktreeRootAgents,
+  removeWorkerWorktree: gitWorktreeMocks.removeWorkerWorktree,
+  restoreWorktreeRootAgents: gitWorktreeMocks.restoreWorktreeRootAgents,
+  checkWorkerWorktreeRemovalSafety: gitWorktreeMocks.checkWorkerWorktreeRemovalSafety,
+  prepareWorkerWorktreeForRemoval: gitWorktreeMocks.prepareWorkerWorktreeForRemoval,
+}));
+
+import { scaleUp } from '../scaling.js';
+import type { TeamConfig } from '../types.js';
 
 describe('scaleUp duplicate worker guard', () => {
   let cwd: string;
-  const tmuxSessions: string[] = [];
+  let config: TeamConfig;
 
-  afterEach(async () => {
-    for (const session of tmuxSessions) {
-      killTmuxSession(session);
-    }
-    tmuxSessions.length = 0;
-    if (cwd) await rm(cwd, { recursive: true, force: true });
-  });
-
-  it('skips past colliding worker names when next_worker_index is stale', async () => {
-    cwd = await mkdtemp(join(tmpdir(), 'omc-scaling-duplicate-'));
-    const teamName = 'demo-team';
-    tmuxSessions.push('demo-session');
-    const root = join(cwd, '.omc', 'state', 'team', teamName);
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, 'config.json'), JSON.stringify({
-      name: teamName,
+  function makeConfig(overrides: Partial<TeamConfig> = {}): TeamConfig {
+    const base: TeamConfig = {
+      name: 'demo-team',
       task: 'demo',
       agent_type: 'claude',
       worker_launch_mode: 'interactive',
       worker_count: 1,
       max_workers: 20,
-      workers: [{ name: 'worker-1', index: 1, role: 'claude', assigned_tasks: [] }],
+      workers: [{ name: 'worker-1', index: 1, role: 'claude', assigned_tasks: [], pane_id: '%1' }],
       created_at: new Date().toISOString(),
       tmux_session: 'demo-session:0',
       next_task_id: 2,
@@ -46,11 +109,58 @@ describe('scaleUp duplicate worker guard', () => {
       hud_pane_id: null,
       resize_hook_name: null,
       resize_hook_target: null,
-      team_state_root: root,
-    }, null, 2), 'utf-8');
+      team_state_root: `${resolve(cwd)}/.omc/state/team/demo-team`,
+    };
+    return { ...base, ...overrides };
+  }
 
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-scaling-duplicate-'));
+    vi.clearAllMocks();
+
+    monitorMocks.withScalingLock.mockImplementation(async (
+      _teamName: string,
+      _leaderCwd: string,
+      fn: () => Promise<unknown>,
+    ) => fn());
+    monitorMocks.saveTeamConfig.mockImplementation(async (nextConfig: TeamConfig) => {
+      config = nextConfig;
+    });
+
+    teamOpsMocks.teamReadConfig.mockImplementation(async () => config);
+    teamOpsMocks.teamWriteWorkerIdentity.mockResolvedValue(undefined);
+    teamOpsMocks.teamAppendEvent.mockResolvedValue(undefined);
+
+    modelContractMocks.buildWorkerArgv.mockReturnValue(['/usr/bin/claude']);
+    modelContractMocks.getWorkerEnv.mockImplementation((teamName: string, workerName: string, agentType: string) => ({
+      OMC_TEAM_WORKER: `${teamName}/${workerName}`,
+      OMC_TEAM_NAME: teamName,
+      OMC_WORKER_AGENT_TYPE: agentType,
+    }));
+
+    tmuxUtilsMocks.tmuxSpawn.mockImplementation((args: string[]) => {
+      if (args[0] === 'display-message' && args.includes('#{session_name}:#{window_index}')) {
+        return { status: 0, stdout: 'demo-session:0\n', stderr: '' };
+      }
+      if (args[0] === 'split-window') {
+        return { status: 0, stdout: '%12\n', stderr: '' };
+      }
+      if (args[0] === 'display-message' && args.includes('#{pane_pid}')) {
+        return { status: 0, stdout: '4321\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+    tmuxSessionMocks.waitForPaneReady.mockResolvedValue(undefined);
+    config = makeConfig();
+  });
+
+  afterEach(async () => {
+    if (cwd) await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('skips past colliding worker names when next_worker_index is stale without touching real tmux', async () => {
     const result = await scaleUp(
-      teamName,
+      'demo-team',
       1,
       'claude',
       [{ subject: 'demo', description: 'demo task' }],
@@ -58,47 +168,26 @@ describe('scaleUp duplicate worker guard', () => {
       { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
     );
 
-    // scaleUp skips worker-1 (collision) and tries worker-2.
-    // Tmux pane creation fails in test env, but must NOT fail with collision error.
-    if (!result.ok) {
-      expect(result.error).not.toContain('refusing to spawn duplicate worker identity');
-    }
-
-    const config = JSON.parse(await readFile(join(root, 'config.json'), 'utf-8')) as { workers: Array<{ name: string }>; next_worker_index?: number };
-    // next_worker_index must have advanced past the collision
-    expect(config.next_worker_index).toBeGreaterThan(1);
+    expect(result).toMatchObject({ ok: true, newWorkerCount: 2, nextWorkerIndex: 3 });
+    expect(config.next_worker_index).toBe(3);
+    expect(config.workers.map((worker) => worker.name)).toEqual(['worker-1', 'worker-2']);
+    expect(tmuxUtilsMocks.tmuxSpawn).toHaveBeenCalledWith([
+      'split-window', '-v', '-t', '%1', '-d', '-P', '-F', '#{pane_id}', '-c', resolve(cwd), 'start-worker',
+    ]);
   });
 
   it('self-heals across multiple collisions', async () => {
-    cwd = await mkdtemp(join(tmpdir(), 'omc-scaling-skip-'));
-    const teamName = 'skip-team';
-    tmuxSessions.push('skip-session');
-    const root = join(cwd, '.omc', 'state', 'team', teamName);
-    await mkdir(root, { recursive: true });
-    await writeFile(join(root, 'config.json'), JSON.stringify({
-      name: teamName,
-      task: 'demo',
-      agent_type: 'claude',
-      worker_launch_mode: 'interactive',
+    config = makeConfig({
       worker_count: 2,
-      max_workers: 20,
       workers: [
-        { name: 'worker-1', index: 1, role: 'claude', assigned_tasks: [] },
-        { name: 'worker-2', index: 2, role: 'claude', assigned_tasks: [] },
+        { name: 'worker-1', index: 1, role: 'claude', assigned_tasks: [], pane_id: '%1' },
+        { name: 'worker-2', index: 2, role: 'claude', assigned_tasks: [], pane_id: '%2' },
       ],
-      created_at: new Date().toISOString(),
-      tmux_session: 'skip-session:0',
-      next_task_id: 2,
       next_worker_index: 1,
-      leader_pane_id: '%0',
-      hud_pane_id: null,
-      resize_hook_name: null,
-      resize_hook_target: null,
-      team_state_root: root,
-    }, null, 2), 'utf-8');
+    });
 
-    await scaleUp(
-      teamName,
+    const result = await scaleUp(
+      'demo-team',
       1,
       'claude',
       [{ subject: 'demo', description: 'demo task' }],
@@ -106,8 +195,144 @@ describe('scaleUp duplicate worker guard', () => {
       { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
     );
 
-    // next_worker_index must skip past both worker-1 and worker-2
-    const config = JSON.parse(await readFile(join(root, 'config.json'), 'utf-8')) as { next_worker_index?: number };
-    expect(config.next_worker_index).toBeGreaterThan(2);
+    expect(result).toMatchObject({ ok: true, newWorkerCount: 3, nextWorkerIndex: 4 });
+    expect(config.next_worker_index).toBe(4);
+    expect(config.workers.map((worker) => worker.name)).toEqual(['worker-1', 'worker-2', 'worker-3']);
+  });
+
+  it('allows legacy session-only tmux_session configs while still validating the session before split-window', async () => {
+    config = makeConfig({
+      worker_count: 0,
+      workers: [],
+      next_worker_index: 1,
+      leader_pane_id: '%0',
+      tmux_session: 'demo-session',
+    });
+    tmuxUtilsMocks.tmuxSpawn.mockImplementation((args: string[]) => {
+      if (args[0] === 'display-message' && args.includes('#{session_name}')) {
+        return { status: 0, stdout: 'demo-session\n', stderr: '' };
+      }
+      if (args[0] === 'split-window') {
+        return { status: 0, stdout: '%12\n', stderr: '' };
+      }
+      if (args[0] === 'display-message' && args.includes('#{pane_pid}')) {
+        return { status: 0, stdout: '4321\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await scaleUp(
+      'demo-team',
+      1,
+      'claude',
+      [{ subject: 'demo', description: 'demo task' }],
+      cwd,
+      { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
+    );
+
+    expect(result).toMatchObject({ ok: true, newWorkerCount: 1, nextWorkerIndex: 2 });
+    expect(tmuxUtilsMocks.tmuxSpawn).toHaveBeenCalledWith([
+      'display-message', '-t', '%0', '-p', '#{session_name}',
+    ]);
+    expect(tmuxUtilsMocks.tmuxSpawn).toHaveBeenCalledWith(expect.arrayContaining(['split-window']));
+  });
+
+  it('fails loudly before filesystem/worktree side effects when tmux_session is missing from stale config', async () => {
+    config = makeConfig({
+      worker_count: 0,
+      workers: [],
+      next_worker_index: 1,
+      leader_pane_id: '%997',
+      tmux_session: undefined as unknown as string,
+    });
+
+    const result = await scaleUp(
+      'demo-team',
+      1,
+      'claude',
+      [{ subject: 'demo', description: 'demo task' }],
+      cwd,
+      { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
+    );
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('missing configured tmux_session');
+    }
+    expect(tmuxUtilsMocks.tmuxSpawn).not.toHaveBeenCalledWith(expect.arrayContaining(['split-window']));
+    expect(modelContractMocks.buildWorkerArgv).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly before split-window when the target pane belongs to another tmux session', async () => {
+    config = makeConfig({
+      worker_count: 0,
+      workers: [],
+      next_worker_index: 1,
+      leader_pane_id: '%999',
+      tmux_session: 'demo-session:0',
+    });
+    tmuxUtilsMocks.tmuxSpawn.mockImplementation((args: string[]) => {
+      if (args[0] === 'display-message' && args.includes('#{session_name}:#{window_index}')) {
+        return { status: 0, stdout: 'other-session\n', stderr: '' };
+      }
+      if (args[0] === 'split-window') {
+        throw new Error('split-window must not be called for an untrusted pane target');
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await scaleUp(
+      'demo-team',
+      1,
+      'claude',
+      [{ subject: 'demo', description: 'demo task' }],
+      cwd,
+      { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
+    );
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Refusing to split tmux pane %999');
+      expect(result.error).toContain('expected demo-session');
+    }
+    expect(tmuxUtilsMocks.tmuxSpawn).not.toHaveBeenCalledWith(expect.arrayContaining(['split-window']));
+  });
+
+  it('fails loudly before split-window when the target pane belongs to another window in the configured tmux session', async () => {
+    config = makeConfig({
+      worker_count: 0,
+      workers: [],
+      next_worker_index: 1,
+      leader_pane_id: '%998',
+      tmux_session: 'demo-session:0',
+    });
+    tmuxUtilsMocks.tmuxSpawn.mockImplementation((args: string[]) => {
+      if (args[0] === 'display-message' && args.includes('#{session_name}:#{window_index}')) {
+        return { status: 0, stdout: 'demo-session:1\n', stderr: '' };
+      }
+      if (args[0] === 'split-window') {
+        throw new Error('split-window must not be called for a pane in another team window');
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await scaleUp(
+      'demo-team',
+      1,
+      'claude',
+      [{ subject: 'demo', description: 'demo task' }],
+      cwd,
+      { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv,
+    );
+
+    expect(result).toMatchObject({ ok: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('Refusing to split tmux pane %998');
+      expect(result.error).toContain('expected demo-session:0');
+    }
+    expect(tmuxUtilsMocks.tmuxSpawn).not.toHaveBeenCalledWith(expect.arrayContaining(['split-window']));
   });
 });

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -81,6 +81,39 @@ function asCliAgentType(agentType: string): CliAgentType {
   );
 }
 
+function configuredTmuxTarget(tmuxSession: unknown): { expectedTarget: string; format: string } {
+  const expectedTarget = typeof tmuxSession === 'string' ? tmuxSession.trim() : '';
+  return {
+    expectedTarget,
+    format: expectedTarget.includes(':') ? '#{session_name}:#{window_index}' : '#{session_name}',
+  };
+}
+
+function validateSplitTargetPaneInConfiguredSession(splitTarget: string, tmuxSession: unknown): string | null {
+  const { expectedTarget, format } = configuredTmuxTarget(tmuxSession);
+  if (!splitTarget.trim()) {
+    return 'Refusing to split tmux pane: missing leader/worker pane target.';
+  }
+  if (!expectedTarget) {
+    return `Refusing to split tmux pane ${splitTarget}: missing configured tmux_session.`;
+  }
+
+  const result = tmuxSpawn(['display-message', '-t', splitTarget, '-p', format]);
+  if (result.status !== 0) {
+    const reason = (result.stderr || '').trim()
+      || (result.error instanceof Error ? result.error.message : undefined)
+      || `tmux display-message exited with status ${result.status}`;
+    return `Refusing to split tmux pane ${splitTarget}: unable to validate pane belongs to configured tmux_session ${expectedTarget} (${reason}).`;
+  }
+
+  const actualTarget = (result.stdout || '').trim().split('\n')[0]?.trim() ?? '';
+  if (actualTarget !== expectedTarget) {
+    return `Refusing to split tmux pane ${splitTarget}: pane belongs to tmux target ${actualTarget || '<unknown>'}, expected ${expectedTarget}.`;
+  }
+
+  return null;
+}
+
 // ── Result types ──────────────────────────────────────────────────────────────
 
 export interface ScaleUpResult {
@@ -223,6 +256,18 @@ export async function scaleUp(
           ok: false,
           error: `Worker ${workerName} already exists in team ${sanitized}; refusing to spawn duplicate worker identity.`,
         };
+      }
+
+      // Validate the tmux split target before creating worker directories,
+      // worktrees, or overlays so a stale/malformed pane id cannot cause side
+      // effects in the wrong live tmux session.
+      const splitTarget = config.workers.length > 0
+        ? (config.workers[config.workers.length - 1]?.pane_id ?? config.leader_pane_id ?? '')
+        : (config.leader_pane_id ?? '');
+      const splitDirection = splitTarget === (config.leader_pane_id ?? '') ? '-h' : '-v';
+      const splitTargetError = validateSplitTargetPaneInConfiguredSession(splitTarget, config.tmux_session);
+      if (splitTargetError) {
+        return await rollbackScaleUp(splitTargetError);
       }
 
       // Create worker directory
@@ -381,13 +426,7 @@ export async function scaleUp(
         );
       }
 
-
       // Split from the rightmost worker pane or the leader pane
-      const splitTarget = config.workers.length > 0
-        ? (config.workers[config.workers.length - 1]?.pane_id ?? config.leader_pane_id ?? '')
-        : (config.leader_pane_id ?? '');
-      const splitDirection = splitTarget === (config.leader_pane_id ?? '') ? '-h' : '-v';
-
       const result = tmuxSpawn([
         'split-window', splitDirection, '-t', splitTarget, '-d', '-P', '-F', '#{pane_id}', '-c', workerCwd, cmd,
       ]);


### PR DESCRIPTION
## Summary
- make `scaling.test.ts` a pure unit test with mocked tmux/team/worktree dependencies so it cannot spawn real panes
- validate scale-up split targets against the configured tmux session/window before worker filesystem/worktree/overlay side effects
- preserve duplicate worker-index self-healing and cover stale/malformed `tmux_session` plus legacy session-only configs

Fixes #3140

## Tests
- `npm test -- --run src/team/__tests__/scaling.test.ts src/team/__tests__/scaling-launch-config.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `git diff --check`

## Review
- independent code-reviewer: APPROVE, 0 issues
- independent architect: CLEAR
