### PR TITLE
Fix SessionEnd cleanup latency

### DIFF
--- a/src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts
@@ -20,10 +20,10 @@ vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
   })),
 }));
 
-import { processSessionEnd } from '../index.js';
+import { processSessionEndCleanupWorker } from '../index.js';
 import { cleanupBridgeSessions } from '../../../tools/python-repl/bridge-manager.js';
 
-describe('processSessionEnd python bridge cleanup', () => {
+describe('processSessionEndCleanupWorker python bridge cleanup', () => {
   let tmpDir: string;
   let transcriptPath: string;
 
@@ -51,13 +51,11 @@ describe('processSessionEnd python bridge cleanup', () => {
     ];
     fs.writeFileSync(transcriptPath, transcriptLines.join('\n'), 'utf-8');
 
-    await processSessionEnd({
-      session_id: 'session-123',
-      transcript_path: transcriptPath,
-      cwd: tmpDir,
-      permission_mode: 'default',
-      hook_event_name: 'SessionEnd',
-      reason: 'clear',
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId: 'session-123',
+      transcriptPath,
+      cleanupBudgetMs: 2000,
     });
 
     expect(cleanupBridgeSessions).toHaveBeenCalledTimes(1);

--- a/src/hooks/session-end/__tests__/session-end-timeout.test.ts
+++ b/src/hooks/session-end/__tests__/session-end-timeout.test.ts
@@ -61,8 +61,27 @@ vi.mock('../../../openclaw/index.js', () => ({
   wakeOpenClaw: vi.fn().mockResolvedValue({ gateway: 'test', success: true }),
 }));
 
-import { processSessionEnd } from '../index.js';
+const childProcessMocks = vi.hoisted(() => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: childProcessMocks.spawn,
+  };
+});
+
+import { processSessionEnd, processSessionEndCleanupWorker, resolveSessionEndCleanupBudgetMs } from '../index.js';
 import { triggerStopCallbacks } from '../callbacks.js';
+import { cleanupBridgeSessions } from '../../../tools/python-repl/bridge-manager.js';
+
+function decodeSpawnedCleanupPayload(): { sessionId?: string; initialTeamNames?: string[] } {
+  const spawnArgs = (childProcessMocks.spawn.mock.calls as unknown as Array<[unknown, string[]]>)[0]?.[1];
+  const encodedPayload = spawnArgs?.[spawnArgs.indexOf('--omc-session-end-cleanup-worker') + 1];
+  return JSON.parse(Buffer.from(encodedPayload ?? '', 'base64url').toString('utf-8'));
+}
 
 describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
   let tmpDir: string;
@@ -87,6 +106,90 @@ describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
     vi.restoreAllMocks();
   });
 
+
+  it('processSessionEnd captures session team state in the detached cleanup payload', async () => {
+    const sessionId = 'timeout-test-team-payload';
+    const cwd = process.cwd();
+    const sessionDir = path.join(cwd, '.omc', 'state', 'sessions', sessionId);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, 'team-state.json'),
+      JSON.stringify({ active: true, session_id: sessionId, team_name: 'payload-team' }),
+      'utf-8',
+    );
+
+    try {
+      await processSessionEnd({
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        cwd,
+        permission_mode: 'default',
+        hook_event_name: 'SessionEnd',
+        reason: 'clear',
+      });
+
+      expect(decodeSpawnedCleanupPayload()).toEqual(expect.objectContaining({
+        sessionId,
+        initialTeamNames: ['payload-team'],
+      }));
+    } finally {
+      fs.rmSync(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  it('processSessionEnd schedules detached resource cleanup instead of running it in-process', async () => {
+    await processSessionEnd({
+      session_id: 'timeout-test-python',
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['--omc-session-end-cleanup-worker']),
+      expect.objectContaining({ detached: true, stdio: 'ignore' }),
+    );
+    expect(cleanupBridgeSessions).not.toHaveBeenCalled();
+  });
+
+  it('cleanup worker applies bounded parallel Python REPL cleanup options', async () => {
+    fs.writeFileSync(
+      transcriptPath,
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'python_repl', input: { researchSessionID: 'py-worker' } }] },
+      }),
+      'utf-8',
+    );
+
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId: 'timeout-test-python-worker',
+      transcriptPath,
+      cleanupBudgetMs: 250,
+    });
+
+    expect(cleanupBridgeSessions).toHaveBeenCalledWith(
+      ['py-worker'],
+      expect.objectContaining({
+        gracePeriodMs: 100,
+        sigtermGraceMs: 100,
+        finalWaitMs: 50,
+        parallel: true,
+      }),
+    );
+  });
+
+  it('resolves bounded cleanup budget from env with sane defaults and cap', () => {
+    expect(resolveSessionEndCleanupBudgetMs({})).toBe(2000);
+    expect(resolveSessionEndCleanupBudgetMs({ OMC_SESSIONEND_CLEANUP_BUDGET_MS: '250' })).toBe(250);
+    expect(resolveSessionEndCleanupBudgetMs({ OMC_SESSIONEND_CLEANUP_BUDGET_MS: '25000' })).toBe(10000);
+    expect(resolveSessionEndCleanupBudgetMs({ OMC_SESSIONEND_CLEANUP_BUDGET_MS: 'not-a-number' })).toBe(2000);
+  });
+
   it('processSessionEnd completes well before slow notifications finish', async () => {
     const start = Date.now();
 
@@ -105,8 +208,7 @@ describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
     expect(triggerStopCallbacks).toHaveBeenCalled();
 
     // The function should complete in well under the 2s mock delay.
-    // With fire-and-forget, it races with a 5s cap, but the synchronous
-    // work should be fast. We give generous margin but ensure it's not
+    // Fire-and-forget cleanup should keep synchronous work fast and avoid
     // waiting the full 2s for the mock notification to resolve.
     // In practice this finishes in <100ms; 1500ms is a safe CI threshold.
     expect(elapsed).toBeLessThan(1500);

--- a/src/hooks/session-end/__tests__/team-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/team-cleanup.test.ts
@@ -70,7 +70,24 @@ vi.mock('../../../lib/worktree-paths.js', async () => {
   };
 });
 
-import { processSessionEnd } from '../index.js';
+import { processSessionEndCleanupWorker } from '../index.js';
+
+async function waitForAssertion(assertion: () => void, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  if (lastError) {
+    throw lastError;
+  }
+}
 
 describe('processSessionEnd team cleanup (#1632)', () => {
   let tmpDir: string;
@@ -115,21 +132,21 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: 'worker-1', pane_id: '%1' }],
     } as never);
 
-    await processSessionEnd({
-      session_id: sessionId,
-      transcript_path: transcriptPath,
-      cwd: tmpDir,
-      permission_mode: 'default',
-      hook_event_name: 'SessionEnd',
-      reason: 'clear',
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId,
+      transcriptPath,
+      cleanupBudgetMs: 2000,
     });
 
-    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
-      'delivery-team',
-      tmpDir,
-      { force: true, timeoutMs: 0 },
-    );
-    expect(teamCleanupMocks.shutdownTeam).not.toHaveBeenCalled();
+    await waitForAssertion(() => {
+      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+        'delivery-team',
+        tmpDir,
+        { force: true, timeoutMs: 0 },
+      );
+      expect(teamCleanupMocks.shutdownTeam).not.toHaveBeenCalled();
+    });
   });
 
   it('force-shuts down a legacy runtime team referenced by the ending session', async () => {
@@ -149,25 +166,76 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       tmuxOwnsWindow: false,
     } as never);
 
-    await processSessionEnd({
-      session_id: sessionId,
-      transcript_path: transcriptPath,
-      cwd: tmpDir,
-      permission_mode: 'default',
-      hook_event_name: 'SessionEnd',
-      reason: 'clear',
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId,
+      transcriptPath,
+      cleanupBudgetMs: 2000,
     });
 
-    expect(teamCleanupMocks.shutdownTeam).toHaveBeenCalledWith(
-      'legacy-team',
-      'legacy-team:0',
-      tmpDir,
-      0,
-      undefined,
-      '%0',
-      false,
-    );
-    expect(teamCleanupMocks.shutdownTeamV2).not.toHaveBeenCalled();
+    await waitForAssertion(() => {
+      expect(teamCleanupMocks.shutdownTeam).toHaveBeenCalledWith(
+        'legacy-team',
+        'legacy-team:0',
+        tmpDir,
+        0,
+        undefined,
+        '%0',
+        false,
+      );
+      expect(teamCleanupMocks.shutdownTeamV2).not.toHaveBeenCalled();
+    });
+  });
+
+
+  it('uses initial team names when session-scoped mode state has already been deleted', async () => {
+    const sessionId = 'pid-1632-captured';
+
+    teamCleanupMocks.teamReadConfig.mockResolvedValue({
+      workers: [{ name: 'worker-1', pane_id: '%1' }],
+    } as never);
+
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId,
+      transcriptPath,
+      cleanupBudgetMs: 2000,
+      initialTeamNames: ['captured-team'],
+    });
+
+    await waitForAssertion(() => {
+      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+        'captured-team',
+        tmpDir,
+        { force: true, timeoutMs: 0 },
+      );
+    });
+  });
+
+
+  it('rejects unsafe initial team names before invoking cleanup operations', async () => {
+    const sessionId = 'pid-1632-unsafe';
+
+    teamCleanupMocks.teamReadConfig.mockResolvedValue({
+      workers: [{ name: 'worker-1', pane_id: '%1' }],
+    } as never);
+
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId,
+      transcriptPath,
+      cleanupBudgetMs: 2000,
+      initialTeamNames: ['../../evil', 'bad/name', '..', '', 'safe-team'],
+    });
+
+    await waitForAssertion(() => {
+      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
+      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+        'safe-team',
+        tmpDir,
+        { force: true, timeoutMs: 0 },
+      );
+    });
   });
 
   it('only cleans up manifests owned by the ending session', async () => {
@@ -190,20 +258,20 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: `${teamName}-worker`, pane_id: '%1' }],
     })) as never);
 
-    await processSessionEnd({
-      session_id: sessionId,
-      transcript_path: transcriptPath,
-      cwd: tmpDir,
-      permission_mode: 'default',
-      hook_event_name: 'SessionEnd',
-      reason: 'clear',
+    await processSessionEndCleanupWorker({
+      directory: tmpDir,
+      sessionId,
+      transcriptPath,
+      cleanupBudgetMs: 2000,
     });
 
-    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
-    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
-      'owned-team',
-      tmpDir,
-      { force: true, timeoutMs: 0 },
-    );
+    await waitForAssertion(() => {
+      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
+      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+        'owned-team',
+        tmpDir,
+        { force: true, timeoutMs: 0 },
+      );
+    });
   });
 });

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
+import { spawn as spawnChildProcess } from 'child_process';
+import { fileURLToPath } from 'url';
 import { triggerStopCallbacks } from './callbacks.js';
 import { getOMCConfig } from '../../features/auto-update.js';
 import { buildConfigFromEnv, getEnabledPlatforms, getNotificationConfig } from '../../notifications/config.js';
@@ -43,6 +45,67 @@ interface SessionOwnedTeamCleanupResult {
 
 type LegacyStopCallbackPlatform = 'file' | 'telegram' | 'discord';
 const SESSION_STARTED_MARKER_FILE = 'session-started.json';
+
+const DEFAULT_SESSION_END_CLEANUP_BUDGET_MS = 2_000;
+const MAX_SESSION_END_CLEANUP_BUDGET_MS = 10_000;
+const SESSION_END_CLEANUP_BUDGET_ENV = 'OMC_SESSIONEND_CLEANUP_BUDGET_MS';
+
+export interface SessionEndCleanupWorkerPayload {
+  directory: string;
+  sessionId: string;
+  transcriptPath: string;
+  cleanupBudgetMs: number;
+  initialTeamNames?: string[];
+}
+
+const SESSION_END_CLEANUP_WORKER_ARG = '--omc-session-end-cleanup-worker';
+
+const SESSION_END_SAFE_TEAM_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+function normalizeSessionEndTeamName(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!SESSION_END_SAFE_TEAM_NAME_PATTERN.test(trimmed)) return null;
+  if (trimmed.includes('..') || trimmed.includes('/') || trimmed.includes('\\')) return null;
+  return trimmed;
+}
+
+
+export function resolveSessionEndCleanupBudgetMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[SESSION_END_CLEANUP_BUDGET_ENV];
+  if (raw == null || raw.trim() === '') {
+    return DEFAULT_SESSION_END_CLEANUP_BUDGET_MS;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SESSION_END_CLEANUP_BUDGET_MS;
+  }
+
+  return Math.min(Math.floor(parsed), MAX_SESSION_END_CLEANUP_BUDGET_MS);
+}
+
+function unrefDelay(ms: number): Promise<'timeout'> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve('timeout'), ms);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  });
+}
+
+function runSessionEndCleanupWithBudget(
+  budgetMs: number,
+  cleanup: () => Promise<unknown>,
+): Promise<void> {
+  const cleanupPromise = cleanup().catch(() => undefined);
+  if (budgetMs <= 0) {
+    return cleanupPromise.then(() => undefined);
+  }
+  return Promise.race([cleanupPromise, unrefDelay(budgetMs)])
+    .then(() => undefined)
+    .catch(() => undefined);
+}
 
 function hasExplicitNotificationConfig(profileName?: string): boolean {
   const config = getOMCConfig();
@@ -610,10 +673,7 @@ function cleanupSessionStartedMarker(directory: string, sessionId: string): void
 
 function extractTeamNameFromState(state: Record<string, unknown> | null): string | null {
   if (!state || typeof state !== 'object') return null;
-  const rawTeamName = state.team_name ?? state.teamName;
-  return typeof rawTeamName === 'string' && rawTeamName.trim() !== ''
-    ? rawTeamName.trim()
-    : null;
+  return normalizeSessionEndTeamName(state.team_name ?? state.teamName);
 }
 
 async function findSessionOwnedTeams(directory: string, sessionId: string): Promise<string[]> {
@@ -652,11 +712,22 @@ async function findSessionOwnedTeams(directory: string, sessionId: string): Prom
   return [...teamNames];
 }
 
-async function cleanupSessionOwnedTeams(directory: string, sessionId: string): Promise<SessionOwnedTeamCleanupResult> {
+async function cleanupSessionOwnedTeams(
+  directory: string,
+  sessionId: string,
+  initialTeamNames: string[] = [],
+): Promise<SessionOwnedTeamCleanupResult> {
   const attempted: string[] = [];
   const cleaned: string[] = [];
   const failed: Array<{ teamName: string; error: string }> = [];
-  const teamNames = await findSessionOwnedTeams(directory, sessionId);
+  const discoveredTeamNames = await findSessionOwnedTeams(directory, sessionId);
+  const teamNames = [
+    ...new Set(
+      [...initialTeamNames, ...discoveredTeamNames]
+        .map(normalizeSessionEndTeamName)
+        .filter((teamName): teamName is string => teamName !== null),
+    ),
+  ];
 
   if (teamNames.length === 0) {
     return { attempted, cleaned, failed };
@@ -666,20 +737,20 @@ async function cleanupSessionOwnedTeams(directory: string, sessionId: string): P
   const { shutdownTeamV2 } = await import('../../team/runtime-v2.js');
   const { shutdownTeam } = await import('../../team/runtime.js');
 
-  for (const teamName of teamNames) {
+  await Promise.all(teamNames.map(async (teamName) => {
     attempted.push(teamName);
     try {
       const config = await teamReadConfig(teamName, directory) as unknown;
       if (!config || typeof config !== 'object') {
         await teamCleanup(teamName, directory);
         cleaned.push(teamName);
-        continue;
+        return;
       }
 
       if (Array.isArray((config as { workers?: unknown[] }).workers)) {
         await shutdownTeamV2(teamName, directory, { force: true, timeoutMs: 0 });
         cleaned.push(teamName);
-        continue;
+        return;
       }
 
       if (Array.isArray((config as { agentTypes?: unknown[] }).agentTypes)) {
@@ -696,7 +767,7 @@ async function cleanupSessionOwnedTeams(directory: string, sessionId: string): P
           : undefined;
         await shutdownTeam(teamName, sessionName, directory, 0, undefined, leaderPaneId, legacyConfig.tmuxOwnsWindow === true);
         cleaned.push(teamName);
-        continue;
+        return;
       }
 
       await teamCleanup(teamName, directory);
@@ -707,7 +778,7 @@ async function cleanupSessionOwnedTeams(directory: string, sessionId: string): P
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }
+  }));
 
   return { attempted, cleaned, failed };
 }
@@ -741,6 +812,96 @@ export function exportSessionSummary(directory: string, metrics: SessionMetrics)
   }
 }
 
+
+
+function splitPythonCleanupBudget(cleanupBudgetMs: number): { gracePeriodMs: number; sigtermGraceMs: number; finalWaitMs: number } {
+  const budget = Math.max(0, cleanupBudgetMs);
+  const gracePeriodMs = Math.min(500, Math.floor(budget * 0.4));
+  const sigtermGraceMs = Math.min(500, Math.floor(budget * 0.4));
+  const finalWaitMs = Math.min(250, Math.max(0, budget - gracePeriodMs - sigtermGraceMs));
+  return { gracePeriodMs, sigtermGraceMs, finalWaitMs };
+}
+
+function encodeCleanupWorkerPayload(payload: SessionEndCleanupWorkerPayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+}
+
+function decodeCleanupWorkerPayload(encoded: string): SessionEndCleanupWorkerPayload | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf-8')) as Partial<SessionEndCleanupWorkerPayload>;
+    if (
+      typeof parsed.directory !== 'string' ||
+      typeof parsed.sessionId !== 'string' ||
+      typeof parsed.transcriptPath !== 'string' ||
+      typeof parsed.cleanupBudgetMs !== 'number' ||
+      !Number.isFinite(parsed.cleanupBudgetMs) ||
+      (parsed.initialTeamNames !== undefined && !Array.isArray(parsed.initialTeamNames))
+    ) {
+      return null;
+    }
+    return {
+      directory: parsed.directory,
+      sessionId: parsed.sessionId,
+      transcriptPath: parsed.transcriptPath,
+      cleanupBudgetMs: parsed.cleanupBudgetMs,
+      initialTeamNames: parsed.initialTeamNames?.map(normalizeSessionEndTeamName).filter((value): value is string => value !== null),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function spawnSessionEndCleanupWorker(payload: SessionEndCleanupWorkerPayload): void {
+  try {
+    const child = spawnChildProcess(
+      process.execPath,
+      [fileURLToPath(import.meta.url), SESSION_END_CLEANUP_WORKER_ARG, encodeCleanupWorkerPayload(payload)],
+      {
+        detached: true,
+        stdio: 'ignore',
+        env: process.env,
+      },
+    );
+    child.unref();
+  } catch {
+    // SessionEnd must not fail if best-effort cleanup cannot be scheduled.
+  }
+}
+
+export async function processSessionEndCleanupWorker(payload: SessionEndCleanupWorkerPayload): Promise<void> {
+  const cleanupBudgetMs = Math.max(0, Math.min(payload.cleanupBudgetMs, MAX_SESSION_END_CLEANUP_BUDGET_MS));
+  const pythonCleanupBudget = splitPythonCleanupBudget(cleanupBudgetMs);
+
+  await Promise.allSettled([
+    runSessionEndCleanupWithBudget(cleanupBudgetMs, () =>
+      cleanupSessionOwnedTeams(payload.directory, payload.sessionId, payload.initialTeamNames),
+    ),
+    (async () => {
+      const pythonSessionIds = await extractPythonReplSessionIdsFromTranscript(payload.transcriptPath);
+      if (pythonSessionIds.length > 0) {
+        await cleanupBridgeSessions(pythonSessionIds, {
+          ...pythonCleanupBudget,
+          parallel: true,
+        });
+      }
+    })().catch(() => undefined),
+  ]);
+}
+
+function runSessionEndCleanupWorkerAndExit(payload: SessionEndCleanupWorkerPayload): void {
+  const cleanupBudgetMs = Math.max(0, Math.min(payload.cleanupBudgetMs, MAX_SESSION_END_CLEANUP_BUDGET_MS));
+  const forceExitTimer = setTimeout(() => {
+    process.exit(0);
+  }, Math.max(cleanupBudgetMs + 250, 250));
+
+  void processSessionEndCleanupWorker(payload)
+    .catch(() => undefined)
+    .finally(() => {
+      clearTimeout(forceExitTimer);
+      process.exit(0);
+    });
+}
+
 /**
  * Process session end
  */
@@ -753,10 +914,22 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   const metrics = recordSessionMetrics(directory, input);
   exportSessionSummary(directory, metrics);
 
-  // Best-effort cleanup for tmux-backed team workers owned by this Claude Code
-  // session. This does not fix upstream signal-forwarding behavior, but it
-  // meaningfully reduces orphaned panes/windows when SessionEnd runs normally.
-  await cleanupSessionOwnedTeams(directory, input.session_id);
+  const cleanupBudgetMs = resolveSessionEndCleanupBudgetMs();
+  const fireAndForget: Promise<unknown>[] = [];
+  const sessionTeamName = extractTeamNameFromState(
+    readModeState<Record<string, unknown>>('team', directory, input.session_id),
+  );
+
+  // Best-effort tmux/Python cleanup can involve ref'd timers and subprocesses.
+  // Run it in a detached bounded worker so SessionEnd hook latency is isolated
+  // from resource teardown while still attempting cleanup (#3144).
+  spawnSessionEndCleanupWorker({
+    directory,
+    sessionId: input.session_id,
+    transcriptPath: input.transcript_path,
+    cleanupBudgetMs,
+    initialTeamNames: sessionTeamName ? [sessionTeamName] : [],
+  });
 
   // Clean up transient state files
   cleanupTransientState(directory, input.session_id);
@@ -774,17 +947,6 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
   // not treat it as hard-terminated.
   cleanupSessionStartedMarker(directory, input.session_id);
 
-  // Clean up Python REPL bridge sessions used in this transcript (#641).
-  // Best-effort only: session end should not fail because cleanup fails.
-  try {
-    const pythonSessionIds = await extractPythonReplSessionIdsFromTranscript(input.transcript_path);
-    if (pythonSessionIds.length > 0) {
-      await cleanupBridgeSessions(pythonSessionIds);
-    }
-  } catch {
-    // Ignore cleanup errors
-  }
-
   const profileName = process.env.OMC_NOTIFY_PROFILE;
   const notificationConfig = getNotificationConfig(profileName);
   const shouldUseNewNotificationSystem = Boolean(
@@ -796,9 +958,9 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
 
   // Fire-and-forget: notifications and reply-listener cleanup are non-critical
   // and should not count against the SessionEnd hook timeout (#1700).
-  // We collect the promises but don't await them — Node will flush them before
-  // the process exits (the hook runner keeps the process alive until stdout closes).
-  const fireAndForget: Promise<unknown>[] = [];
+  // We collect the promises but don't await them — Node will flush what it can
+  // before the process exits (the hook runner keeps the process alive until
+  // stdout closes).
 
   // Trigger stop hook callbacks (#395). When an explicit session-end notification
   // config already covers Discord/Telegram, skip the overlapping legacy callback
@@ -867,6 +1029,17 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
 /**
  * Main hook entry point
  */
+
+const cleanupWorkerArgIndex = process.argv.indexOf(SESSION_END_CLEANUP_WORKER_ARG);
+if (cleanupWorkerArgIndex >= 0) {
+  const payload = decodeCleanupWorkerPayload(process.argv[cleanupWorkerArgIndex + 1] ?? '');
+  if (payload) {
+    runSessionEndCleanupWorkerAndExit(payload);
+  } else {
+    process.exit(0);
+  }
+}
+
 export async function handleSessionEnd(input: SessionEndInput): Promise<HookOutput> {
   return processSessionEnd(input);
 }

--- a/src/tools/python-repl/bridge-manager.ts
+++ b/src/tools/python-repl/bridge-manager.ts
@@ -49,6 +49,16 @@ export interface BridgeSessionCleanupResult {
   errors: string[];
 }
 
+export interface BridgeEscalationOptions {
+  gracePeriodMs?: number;
+  sigtermGraceMs?: number;
+  finalWaitMs?: number;
+}
+
+export interface BridgeSessionCleanupOptions extends BridgeEscalationOptions {
+  parallel?: boolean;
+}
+
 export interface StaleBridgeCleanupResult {
   scannedSessions: number;
   staleSessions: number;
@@ -579,9 +589,11 @@ export async function ensureBridge(sessionId: string, projectDir?: string): Prom
  */
 export async function killBridgeWithEscalation(
   sessionId: string,
-  options?: { gracePeriodMs?: number }
+  options?: BridgeEscalationOptions,
 ): Promise<EscalationResult> {
   const gracePeriod = options?.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS;
+  const sigtermGraceMs = options?.sigtermGraceMs ?? SIGTERM_GRACE_MS;
+  const finalWaitMs = options?.finalWaitMs ?? 1000;
   const startTime = Date.now();
 
   const metaPath = getBridgeMetaPath(sessionId);
@@ -629,11 +641,11 @@ export async function killBridgeWithEscalation(
     terminatedBy = 'SIGTERM';
     killProcessGroup(meta.pid, 'SIGTERM');
 
-    if (!(await waitForExit(SIGTERM_GRACE_MS))) {
+    if (!(await waitForExit(sigtermGraceMs))) {
       // Stage 3: SIGKILL
       terminatedBy = 'SIGKILL';
       killProcessGroup(meta.pid, 'SIGKILL');
-      await waitForExit(1000); // Brief wait for SIGKILL
+      await waitForExit(finalWaitMs); // Brief wait for SIGKILL
     }
   }
 
@@ -661,7 +673,8 @@ export async function killBridgeWithEscalation(
  * Used by session-end to terminate bridges created during the ending session.
  */
 export async function cleanupBridgeSessions(
-  sessionIds: Iterable<string>
+  sessionIds: Iterable<string>,
+  options: BridgeSessionCleanupOptions = {},
 ): Promise<BridgeSessionCleanupResult> {
   const uniqueSessionIds = [...new Set(Array.from(sessionIds).filter(Boolean))];
 
@@ -672,7 +685,7 @@ export async function cleanupBridgeSessions(
     errors: [],
   };
 
-  for (const sessionId of uniqueSessionIds) {
+  const cleanupOne = async (sessionId: string): Promise<void> => {
     try {
       ownedBridgeSessionIds.delete(sessionId);
       const metaPath = getBridgeMetaPath(sessionId);
@@ -683,14 +696,14 @@ export async function cleanupBridgeSessions(
         fs.existsSync(metaPath) || fs.existsSync(socketPath) || fs.existsSync(portPath) || fs.existsSync(lockPath);
 
       if (!hasArtifacts) {
-        continue;
+        return;
       }
 
       result.foundSessions++;
 
       const meta = await safeReadJson<BridgeMeta>(metaPath);
       if (meta && isValidBridgeMeta(meta)) {
-        const escalation = await killBridgeWithEscalation(sessionId);
+        const escalation = await killBridgeWithEscalation(sessionId, options);
         if (escalation.terminatedBy) {
           result.terminatedSessions++;
         }
@@ -704,6 +717,14 @@ export async function cleanupBridgeSessions(
       await removeFileIfExists(lockPath);
     } catch (error) {
       result.errors.push(`session=${sessionId}: ${(error as Error).message}`);
+    }
+  };
+
+  if (options.parallel) {
+    await Promise.all(uniqueSessionIds.map(cleanupOne));
+  } else {
+    for (const sessionId of uniqueSessionIds) {
+      await cleanupOne(sessionId);
     }
   }
 


### PR DESCRIPTION
## Summary
- move SessionEnd tmux/Python REPL cleanup into a detached bounded worker so hook close latency is no longer coupled to teardown
- capture session-owned team names before mode-state cleanup, validate team names, and reject unsafe payload targets
- parallelize/bound Python bridge cleanup with worker-specific escalation options and update regression coverage

Fixes #3144

## Tests
- `npm test -- --run src/hooks/session-end/__tests__/session-end-timeout.test.ts src/hooks/session-end/__tests__/team-cleanup.test.ts src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts src/hooks/session-end/__tests__/python-repl-cleanup.test.ts src/tools/python-repl/__tests__`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `git diff --check`

## Review
- code-reviewer: APPROVE
- architect: CLEAR
