### PR TITLE
Restore portable node resolution for hooks

### DIFF
--- a/scripts/find-node.sh
+++ b/scripts/find-node.sh
@@ -9,12 +9,14 @@
 #   1. nodeBinary stored in ~/.claude/.omc-config.json (set at setup time)
 #   2. `which node` (node is on PATH)
 #   3. nvm versioned paths  (~/.nvm/versions/node/*/bin/node)
-#   4. fnm versioned paths  (~/.fnm/node-versions/*/installation/bin/node)
-#   5. Homebrew / system paths (/opt/homebrew/bin/node, /usr/local/bin/node)
+#   4. fnm versioned paths and aliases
+#   5. volta/asdf/nodenv shims
+#   6. Homebrew / system paths (/opt/homebrew/bin/node, /usr/local/bin/node)
 #
 # Exits 0 on failure so it never blocks Claude Code hook processing.
 
 NODE_BIN=""
+DEFERRED_NODE_BIN=""
 
 case "$0" in
   */*)
@@ -39,7 +41,14 @@ if [ -f "$CONFIG_FILE" ]; then
     | head -1 \
     | sed 's/.*"nodeBinary" *: *"//;s/".*//')
   if [ -n "$_stored" ] && [ -x "$_stored" ]; then
-    NODE_BIN="$_stored"
+    case "$_stored" in
+      "$HOME/.volta/bin/node"|"$HOME/.asdf/shims/node"|"$HOME/.nodenv/shims/node")
+        DEFERRED_NODE_BIN="$_stored"
+        ;;
+      *)
+        NODE_BIN="$_stored"
+        ;;
+    esac
   fi
 fi
 
@@ -49,7 +58,14 @@ fi
 if [ -z "$NODE_BIN" ]; then
   _resolved=$(command -v node 2>/dev/null)
   if [ -n "$_resolved" ]; then
-    NODE_BIN="$_resolved"
+    case "$_resolved" in
+      "$HOME/.volta/bin/node"|"$HOME/.asdf/shims/node"|"$HOME/.nodenv/shims/node")
+        DEFERRED_NODE_BIN="$_resolved"
+        ;;
+      *)
+        NODE_BIN="$_resolved"
+        ;;
+    esac
   fi
 fi
 
@@ -65,8 +81,20 @@ if [ -z "$NODE_BIN" ] && [ -d "$HOME/.nvm/versions/node" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 4. fnm versioned paths (Linux and macOS default locations)
+# 4. fnm versioned paths and aliases (Linux and macOS default locations)
 # ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ]; then
+  for _path in \
+    "$HOME/.fnm/aliases/default/bin/node" \
+    "$HOME/.local/share/fnm/aliases/default/bin/node" \
+    "$HOME/Library/Application Support/fnm/aliases/default/bin/node"; do
+    if [ -x "$_path" ]; then
+      NODE_BIN="$_path"
+      break
+    fi
+  done
+fi
+
 if [ -z "$NODE_BIN" ]; then
   for _fnm_base in \
     "$HOME/.fnm/node-versions" \
@@ -83,7 +111,26 @@ if [ -z "$NODE_BIN" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Common Homebrew / system paths
+# 5. Common version-manager shims that do not require shell init files
+# ---------------------------------------------------------------------------
+if [ -z "$NODE_BIN" ] && [ -n "$DEFERRED_NODE_BIN" ]; then
+  NODE_BIN="$DEFERRED_NODE_BIN"
+fi
+
+if [ -z "$NODE_BIN" ]; then
+  for _path in \
+    "$HOME/.volta/bin/node" \
+    "$HOME/.asdf/shims/node" \
+    "$HOME/.nodenv/shims/node"; do
+    if [ -x "$_path" ]; then
+      NODE_BIN="$_path"
+      break
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Common Homebrew / system paths
 # ---------------------------------------------------------------------------
 if [ -z "$NODE_BIN" ]; then
   for _path in /opt/homebrew/bin/node /usr/local/bin/node /usr/bin/node; do

--- a/scripts/lib/hook-command-normalizer.mjs
+++ b/scripts/lib/hook-command-normalizer.mjs
@@ -1,0 +1,49 @@
+export const WINDOWS_HOOK_PREFIX = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ';
+export const UNIX_HOOK_PREFIX = 'sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ';
+
+export function hookPrefixForPlatform(platform = process.platform) {
+  return platform === 'win32' ? WINDOWS_HOOK_PREFIX : UNIX_HOOK_PREFIX;
+}
+
+export function normalizeHookCommand(command, prefix = hookPrefixForPlatform()) {
+  const legacyFindNodePattern =
+    /^sh "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/find-node\.sh" "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([^"\s]+)"?(.*)$/;
+  const currentFindNodePattern =
+    /^(?:"\/bin\/sh"|sh) "\$CLAUDE_PLUGIN_ROOT"\/scripts\/find-node\.sh "\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs "\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^"\s]+)"?(.*)$/;
+  const directRunCjsPattern =
+    /^node\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^"\s]+)"?(.*)$/;
+  const absoluteNodeRunCjsPattern =
+    /^"([^"]*\/node|[A-Za-z]:\\[^"]*\\node(?:\.exe)?)"\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^"\s]+)"?(.*)$/;
+
+  const match = command.match(currentFindNodePattern)
+    ?? command.match(legacyFindNodePattern)
+    ?? command.match(directRunCjsPattern);
+  if (match) return `${prefix}"$CLAUDE_PLUGIN_ROOT"/scripts/${match[1]}${match[2]}`;
+
+  const absNodeMatch = command.match(absoluteNodeRunCjsPattern);
+  if (absNodeMatch) return `${prefix}"$CLAUDE_PLUGIN_ROOT"/scripts/${absNodeMatch[2]}${absNodeMatch[3]}`;
+
+  return command;
+}
+
+export function normalizeHooksDataForPlatform(data, platform = process.platform) {
+  const prefix = hookPrefixForPlatform(platform);
+  let patched = false;
+
+  for (const groups of Object.values(data?.hooks ?? {})) {
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups) {
+      if (!group || typeof group !== 'object' || !Array.isArray(group.hooks)) continue;
+      for (const hook of group.hooks) {
+        if (!hook || typeof hook !== 'object' || typeof hook.command !== 'string') continue;
+        const nextCommand = normalizeHookCommand(hook.command, prefix);
+        if (hook.command !== nextCommand) {
+          hook.command = nextCommand;
+          patched = true;
+        }
+      }
+    }
+  }
+
+  return patched;
+}

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -13,6 +13,7 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { buildHudWrapper } from './lib/hud-wrapper-template.mjs';
+import { hookPrefixForPlatform, normalizeHooksDataForPlatform } from './lib/hook-command-normalizer.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -113,11 +114,6 @@ try {
 //
 // Keep stale cache self-healing for older manifests that used sh/find-node, an
 // accidentally baked absolute node path, or the Windows-safe direct node form.
-const windowsRunCjsHookPrefix = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ';
-const unixFindNodeHookPrefix = 'sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs ';
-const platformHookPrefix = process.platform === 'win32'
-  ? windowsRunCjsHookPrefix
-  : unixFindNodeHookPrefix;
 //
 // Patterns handled:
 //  1. Current find-node.sh format – sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh ...
@@ -130,49 +126,11 @@ try {
   const hooksJsonPath = join(__dirname, '..', 'hooks', 'hooks.json');
   if (existsSync(hooksJsonPath)) {
     const data = JSON.parse(readFileSync(hooksJsonPath, 'utf-8'));
-    let patched = false;
-
-    const legacyFindNodePattern =
-      /^sh "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/find-node\.sh" "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([^\"\s]+)"?(.*)$/;
-    const currentFindNodePattern =
-      /^(?:"\/bin\/sh"|sh) "\$CLAUDE_PLUGIN_ROOT"\/scripts\/find-node\.sh "\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs "\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^\"\s]+)"?(.*)$/;
-    const directRunCjsPattern =
-      /^node\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^\"\s]+)"?(.*)$/;
-    const absoluteNodeRunCjsPattern =
-      /^"([^\"]*\/node|[A-Za-z]:\\[^\"]*\\node(?:\.exe)?)"\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs\s+"\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^\"\s]+)"?(.*)$/;
-
-    for (const groups of Object.values(data.hooks ?? {})) {
-      for (const group of groups) {
-        for (const hook of (group.hooks ?? [])) {
-          if (typeof hook.command !== 'string') continue;
-
-          const match = hook.command.match(currentFindNodePattern)
-            ?? hook.command.match(legacyFindNodePattern)
-            ?? hook.command.match(directRunCjsPattern);
-          if (match) {
-            const nextCommand = `${platformHookPrefix}"$CLAUDE_PLUGIN_ROOT"/scripts/${match[1]}${match[2]}`;
-            if (hook.command !== nextCommand) {
-              hook.command = nextCommand;
-              patched = true;
-            }
-            continue;
-          }
-
-          const absNodeMatch = hook.command.match(absoluteNodeRunCjsPattern);
-          if (absNodeMatch) {
-            const nextCommand = `${platformHookPrefix}"$CLAUDE_PLUGIN_ROOT"/scripts/${absNodeMatch[2]}${absNodeMatch[3]}`;
-            if (hook.command !== nextCommand) {
-              hook.command = nextCommand;
-              patched = true;
-            }
-          }
-        }
-      }
-    }
+    const patched = normalizeHooksDataForPlatform(data);
 
     if (patched) {
       writeFileSync(hooksJsonPath, JSON.stringify(data, null, 2) + '\n');
-      const platformLabel = process.platform === 'win32' ? 'direct node run.cjs' : 'find-node.sh run.cjs';
+      const platformLabel = hookPrefixForPlatform().startsWith('node ') ? 'direct node run.cjs' : 'find-node.sh run.cjs';
       console.log(`[OMC] Patched hooks.json to use ${platformLabel} hook commands`);
     }
   }

--- a/scripts/repair-plugin-cache.mjs
+++ b/scripts/repair-plugin-cache.mjs
@@ -23,6 +23,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { normalizeHooksDataForPlatform } from './lib/hook-command-normalizer.mjs';
 
 function getClaudeConfigDir() {
   const configured = (process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude')).replace(/[\\/]+$/, '');
@@ -91,6 +92,18 @@ function writeJsonAtomic(path, value) {
     try { rmSync(tmp, { force: true }); } catch {}
     throw error;
   }
+}
+
+function patchHooksJsonForPlatform(pluginRoot, platform = process.platform) {
+  const hooksJsonPath = join(pluginRoot, 'hooks', 'hooks.json');
+  if (!existsSync(hooksJsonPath)) return false;
+
+  const data = readJson(hooksJsonPath);
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+
+  const patched = normalizeHooksDataForPlatform(data, platform);
+  if (patched) writeJsonAtomic(hooksJsonPath, data);
+  return patched;
 }
 
 function normalizePath(pathValue) {
@@ -165,9 +178,15 @@ export function repairPluginCacheReferences() {
   const configDir = getClaudeConfigDir();
   const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
   const latestRoot = latestValidCacheRoot(cacheBase);
-  const result = { latestRoot, registryUpdated: false, symlinked: 0, errors: [] };
+  const result = { latestRoot, registryUpdated: false, hooksPatched: false, symlinked: 0, errors: [] };
 
   if (!latestRoot) return result;
+
+  try {
+    result.hooksPatched = patchHooksJsonForPlatform(latestRoot, process.env.OMC_REPAIR_PLUGIN_CACHE_PLATFORM || process.platform);
+  } catch (error) {
+    result.errors.push(`hooks.json platform repair failed: ${error instanceof Error ? error.message : error}`);
+  }
 
   const installedPluginsPath = join(configDir, 'plugins', 'installed_plugins.json');
   try {
@@ -218,8 +237,8 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   }
   if (!result.latestRoot) {
     console.log('[OMC] No OMC plugin cache found (normal for new installs)');
-  } else if (result.registryUpdated || result.symlinked > 0) {
-    console.log(`[OMC] Repaired plugin cache references: active=${result.latestRoot}, symlinked=${result.symlinked}`);
+  } else if (result.registryUpdated || result.hooksPatched || result.symlinked > 0) {
+    console.log(`[OMC] Repaired plugin cache references: active=${result.latestRoot}, symlinked=${result.symlinked}${result.hooksPatched ? ', hooks=platform' : ''}`);
   } else {
     console.log('[OMC] Plugin cache references are current');
   }

--- a/src/__tests__/plugin-setup-deps.test.ts
+++ b/src/__tests__/plugin-setup-deps.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -129,8 +131,8 @@ describe('plugin-setup.mjs hook command portability', () => {
 
   it('selects direct node only on win32 and find-node bootstrap elsewhere', () => {
     expect(scriptContent).toContain("process.platform === 'win32'");
-    expect(scriptContent).toContain('windowsRunCjsHookPrefix');
-    expect(scriptContent).toContain('unixFindNodeHookPrefix');
+    expect(scriptContent).toContain('hookPrefixForPlatform');
+    expect(scriptContent).toContain('normalizeHooksDataForPlatform');
   });
 
   it('leaves the canonical sh+find-node+run.cjs command unchanged', () => {
@@ -238,5 +240,149 @@ describe('plugin-setup.mjs hook command portability', () => {
     expect(patchCommand(current, WINDOWS_PREFIX)).toBe(
       'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs',
     );
+  });
+
+  it.runIf(process.platform !== 'win32')('executes a Unix hook command with minimal PATH by resolving Volta-managed node', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-min-path-hook-'));
+    try {
+      const tempHome = join(tempRoot, 'home');
+      const tempBin = join(tempRoot, 'bin');
+      const voltaBin = join(tempHome, '.volta', 'bin');
+      mkdirSync(tempBin, { recursive: true });
+      mkdirSync(voltaBin, { recursive: true });
+      mkdirSync(join(tempHome, '.claude'), { recursive: true });
+
+      symlinkSync('/bin/sh', join(tempBin, 'sh'));
+
+      const argsFile = join(tempRoot, 'node-args.txt');
+      const fakeNode = join(voltaBin, 'node');
+      writeFileSync(
+        fakeNode,
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$OMC_FAKE_NODE_ARGS"\n',
+      );
+      chmodSync(fakeNode, 0o755);
+
+      const command = `${UNIX_PREFIX}"$CLAUDE_PLUGIN_ROOT"/scripts/keyword-detector.mjs --smoke`;
+
+      execFileSync('/bin/sh', ['-c', command], {
+        env: {
+          HOME: tempHome,
+          PATH: tempBin,
+          CLAUDE_PLUGIN_ROOT: PACKAGE_ROOT,
+          OMC_FAKE_NODE_ARGS: argsFile,
+        },
+        stdio: 'pipe',
+      });
+
+      const args = readFileSync(argsFile, 'utf-8').trim().split('\n');
+      expect(args[0]).toBe(join(PACKAGE_ROOT, 'scripts', 'run.cjs'));
+      expect(args[1]).toBe(join(PACKAGE_ROOT, 'scripts', 'keyword-detector.mjs'));
+      expect(args[2]).toBe('--smoke');
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('prefers concrete nvm node over a stale executable shim on PATH', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-min-path-nvm-'));
+    try {
+      const tempHome = join(tempRoot, 'home');
+      const tempBin = join(tempRoot, 'bin');
+      const asdfBin = join(tempHome, '.asdf', 'shims');
+      const nvmBin = join(tempHome, '.nvm', 'versions', 'node', 'v22.14.0', 'bin');
+      mkdirSync(tempBin, { recursive: true });
+      mkdirSync(asdfBin, { recursive: true });
+      mkdirSync(nvmBin, { recursive: true });
+      mkdirSync(join(tempHome, '.claude'), { recursive: true });
+
+      symlinkSync('/bin/sh', join(tempBin, 'sh'));
+
+      writeFileSync(join(asdfBin, 'node'), '#!/bin/sh\nexit 127\n');
+      chmodSync(join(asdfBin, 'node'), 0o755);
+
+      const argsFile = join(tempRoot, 'node-args.txt');
+      const fakeNode = join(nvmBin, 'node');
+      writeFileSync(
+        fakeNode,
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$OMC_FAKE_NODE_ARGS"\n',
+      );
+      chmodSync(fakeNode, 0o755);
+
+      const command = `${UNIX_PREFIX}"$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs`;
+      execFileSync('/bin/sh', ['-c', command], {
+        env: {
+          HOME: tempHome,
+          PATH: `${tempBin}:${asdfBin}`,
+          CLAUDE_PLUGIN_ROOT: PACKAGE_ROOT,
+          OMC_FAKE_NODE_ARGS: argsFile,
+        },
+        stdio: 'pipe',
+      });
+
+      const args = readFileSync(argsFile, 'utf-8').trim().split('\n');
+      expect(args[0]).toBe(join(PACKAGE_ROOT, 'scripts', 'run.cjs'));
+      expect(args[1]).toBe(join(PACKAGE_ROOT, 'scripts', 'session-end.mjs'));
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('prefers concrete nvm node over a stale stored nodeBinary shim', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-stored-shim-'));
+    try {
+      const tempHome = join(tempRoot, 'home');
+      const tempBin = join(tempRoot, 'bin');
+      const asdfBin = join(tempHome, '.asdf', 'shims');
+      const nvmBin = join(tempHome, '.nvm', 'versions', 'node', 'v22.14.0', 'bin');
+      const claudeDir = join(tempHome, '.claude');
+      mkdirSync(tempBin, { recursive: true });
+      mkdirSync(asdfBin, { recursive: true });
+      mkdirSync(nvmBin, { recursive: true });
+      mkdirSync(claudeDir, { recursive: true });
+
+      symlinkSync('/bin/sh', join(tempBin, 'sh'));
+
+      const staleShim = join(asdfBin, 'node');
+      writeFileSync(staleShim, '#!/bin/sh\nexit 127\n');
+      chmodSync(staleShim, 0o755);
+      writeFileSync(join(claudeDir, '.omc-config.json'), JSON.stringify({ nodeBinary: staleShim }));
+
+      const argsFile = join(tempRoot, 'node-args.txt');
+      const fakeNode = join(nvmBin, 'node');
+      writeFileSync(
+        fakeNode,
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$OMC_FAKE_NODE_ARGS"\n',
+      );
+      chmodSync(fakeNode, 0o755);
+
+      const command = `${UNIX_PREFIX}"$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs`;
+      execFileSync('/bin/sh', ['-c', command], {
+        env: {
+          HOME: tempHome,
+          PATH: tempBin,
+          CLAUDE_PLUGIN_ROOT: PACKAGE_ROOT,
+          OMC_FAKE_NODE_ARGS: argsFile,
+        },
+        stdio: 'pipe',
+      });
+
+      const args = readFileSync(argsFile, 'utf-8').trim().split('\n');
+      expect(args[0]).toBe(join(PACKAGE_ROOT, 'scripts', 'run.cjs'));
+      expect(args[1]).toBe(join(PACKAGE_ROOT, 'scripts', 'session-end.mjs'));
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the Windows hook command direct-node and shell-wrapper free', () => {
+    const command = patchCommand(
+      `${UNIX_PREFIX}"$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs`,
+      WINDOWS_PREFIX,
+    );
+
+    expect(command).toBe('node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs');
+    expect(command).not.toContain('find-node.sh');
+    expect(command).not.toMatch(/(?:^|\s)sh(?:\s|$)/);
+    expect(command).not.toContain('/bin/sh');
   });
 });

--- a/src/__tests__/repair-plugin-cache-script.test.ts
+++ b/src/__tests__/repair-plugin-cache-script.test.ts
@@ -53,7 +53,7 @@ describe('repair-plugin-cache.mjs', () => {
     }, null, 2));
 
     const result = spawnSync(process.execPath, [SCRIPT_PATH], {
-      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir, OMC_REPAIR_PLUGIN_CACHE_PLATFORM: 'linux' },
       encoding: 'utf-8',
     });
 
@@ -88,7 +88,7 @@ describe('repair-plugin-cache.mjs', () => {
     }, null, 2));
 
     const result = spawnSync(process.execPath, [SCRIPT_PATH], {
-      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir, OMC_REPAIR_PLUGIN_CACHE_PLATFORM: 'linux' },
       encoding: 'utf-8',
     });
 
@@ -102,6 +102,109 @@ describe('repair-plugin-cache.mjs', () => {
       installPath: newRoot,
       version: '4.14.1',
     });
+  });
+
+  it.runIf(process.platform !== 'win32')('repairs Unix cache hooks from direct node to the find-node bootstrap', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-repair-unix-hooks-'));
+    tempRoots.push(root);
+
+    const configDir = join(root, '.claude');
+    const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const pluginRoot = join(cacheBase, '4.14.4');
+    writePluginRoot(pluginRoot, '4.14.4');
+    writeFileSync(join(pluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionEnd: [{
+          matcher: '*',
+          hooks: [{
+            type: 'command',
+            command: 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs',
+          }],
+        }],
+      },
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('hooks=platform');
+    const hooksJson = JSON.parse(readFileSync(join(pluginRoot, 'hooks', 'hooks.json'), 'utf-8'));
+    expect(hooksJson.hooks.SessionEnd[0].hooks[0].command).toBe(
+      'sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs',
+    );
+  });
+
+  it.runIf(process.platform !== 'win32')('repairs every bundled direct-node hook command to find-node on Unix/macOS', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-repair-unix-bundled-hooks-'));
+    tempRoots.push(root);
+
+    const configDir = join(root, '.claude');
+    const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const pluginRoot = join(cacheBase, '4.14.4');
+    writePluginRoot(pluginRoot, '4.14.4');
+    writeFileSync(
+      join(pluginRoot, 'hooks', 'hooks.json'),
+      readFileSync(join(REPO_ROOT, 'hooks', 'hooks.json'), 'utf-8'),
+    );
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    const hooksJson = JSON.parse(readFileSync(join(pluginRoot, 'hooks', 'hooks.json'), 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ command?: string }> }>>;
+    };
+    const commands = Object.entries(hooksJson.hooks).flatMap(([event, groups]) =>
+      groups.flatMap(group =>
+        group.hooks
+          .map(hook => hook.command)
+          .filter((command): command is string => typeof command === 'string')
+          .map(command => ({ event, command })),
+      ),
+    );
+
+    expect(commands.length).toBeGreaterThan(0);
+    for (const { event, command } of commands) {
+      expect(command, event).toMatch(/^sh "\$CLAUDE_PLUGIN_ROOT"\/scripts\/find-node\.sh "\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs /);
+      expect(command, event).not.toContain('/bin/sh');
+    }
+  });
+
+  it('repairs Windows cache hooks from find-node to direct node', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-repair-win-hooks-'));
+    tempRoots.push(root);
+
+    const configDir = join(root, '.claude');
+    const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const pluginRoot = join(cacheBase, '4.14.4');
+    writePluginRoot(pluginRoot, '4.14.4');
+    writeFileSync(join(pluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionEnd: [{
+          matcher: '*',
+          hooks: [{
+            type: 'command',
+            command: 'sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs',
+          }],
+        }],
+      },
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      env: { ...process.env, CLAUDE_CONFIG_DIR: configDir, OMC_REPAIR_PLUGIN_CACHE_PLATFORM: 'win32' },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    const hooksJson = JSON.parse(readFileSync(join(pluginRoot, 'hooks', 'hooks.json'), 'utf-8'));
+    expect(hooksJson.hooks.SessionEnd[0].hooks[0].command).toBe(
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs',
+    );
   });
 
   it('setup instructions repair cache references before prompts and avoid direct cache deletion', () => {


### PR DESCRIPTION
Fixes #3143.

## Summary
- restore robust Unix hook node resolution for nvm/fnm/volta/minimal PATH environments
- normalize cached hook commands while preserving Windows hook runner behavior
- add regression coverage for setup deps and cache repair command normalization

## Verification
- `npm test -- --run src/__tests__/plugin-setup-deps.test.ts src/__tests__/repair-plugin-cache-script.test.ts src/hooks/setup/__tests__/windows-patch.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*