### PR TITLE
fix(security): directory-boundary check in isTrustedPrefix (CLI trusted-path)

### DIFF
--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -112,6 +112,38 @@ describe('model-contract', () => {
       expect(prefixes).toContain('/usr/local/bin');
       expect(prefixes).toContain('/usr/bin');
     });
+
+    it('isTrustedPrefix enforces directory boundaries (no sibling-prefix bypass)', () => {
+      const origHome = process.env.HOME;
+      process.env.HOME = '/home/tester';
+      try {
+        const { isTrustedPrefix } = _testInternals;
+        // exact trusted dir + true descendants are trusted
+        expect(isTrustedPrefix('/usr/bin')).toBe(true);
+        expect(isTrustedPrefix('/usr/bin/codex')).toBe(true);
+        expect(isTrustedPrefix('/usr/local/bin/claude')).toBe(true);
+        expect(isTrustedPrefix('/opt/homebrew/bin/gemini')).toBe(true);
+        expect(isTrustedPrefix('/home/tester/.local/bin/cli')).toBe(true);
+        // siblings whose name merely begins with a trusted prefix are NOT trusted
+        expect(isTrustedPrefix('/usr/bin-malicious/cli')).toBe(false);
+        expect(isTrustedPrefix('/home/tester/.local/bin-evil/cli')).toBe(false);
+        expect(isTrustedPrefix('/opt/homebrew-evil/x')).toBe(false);
+        expect(isTrustedPrefix('/home/tester/Downloads/cli')).toBe(false);
+        // custom trusted dirs (OMC_TRUSTED_CLI_DIRS) get the same boundary check
+        const origCustom = process.env.OMC_TRUSTED_CLI_DIRS;
+        process.env.OMC_TRUSTED_CLI_DIRS = '/opt/mybins';
+        try {
+          expect(isTrustedPrefix('/opt/mybins/grok')).toBe(true);
+          expect(isTrustedPrefix('/opt/mybins-evil/grok')).toBe(false);
+        } finally {
+          if (origCustom === undefined) delete process.env.OMC_TRUSTED_CLI_DIRS;
+          else process.env.OMC_TRUSTED_CLI_DIRS = origCustom;
+        }
+      } finally {
+        if (origHome === undefined) delete process.env.HOME;
+        else process.env.HOME = origHome;
+      }
+    });
   });
   describe('getContract', () => {
     it('returns contract for claude', () => {

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import { isAbsolute, normalize, win32 as win32Path } from 'path';
+import { isAbsolute, normalize, sep, win32 as win32Path } from 'path';
 import { validateTeamName } from './team-name.js';
 import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
@@ -80,7 +80,17 @@ function getTrustedPrefixes(): string[] {
 
 function isTrustedPrefix(resolvedPath: string): boolean {
   const normalized = normalize(resolvedPath);
-  return getTrustedPrefixes().some(prefix => normalized.startsWith(normalize(prefix)));
+  return getTrustedPrefixes().some(prefix => {
+    // `normalize` strips trailing separators, so a plain `startsWith` would treat
+    // a sibling whose name merely begins with the prefix as trusted — e.g.
+    // `/usr/bin` would match `/usr/bin-malicious/grok`, and `~/.local/bin` would
+    // match `~/.local/bin-evil/x`. Enforce a directory boundary: the resolved
+    // path must be the trusted dir itself or a true descendant (prefix + sep).
+    const p = normalize(prefix);
+    if (normalized === p) return true;
+    const withSep = p.endsWith(sep) ? p : p + sep;
+    return normalized.startsWith(withSep);
+  });
 }
 
 function assertBinaryName(binary: string): void {
@@ -155,6 +165,7 @@ export function validateCliBinaryPath(binary: string): CliBinaryValidation {
 export const _testInternals = {
   UNTRUSTED_PATH_PATTERNS,
   getTrustedPrefixes,
+  isTrustedPrefix,
 };
 
 /**


### PR DESCRIPTION
## What

`isTrustedPrefix()` (`src/team/model-contract.ts`) used `normalized.startsWith(normalize(prefix))` with **no directory boundary**, so a sibling directory whose name merely *begins with* a trusted prefix was treated as trusted:

- `/usr/bin-malicious/x` matched the trusted `/usr/bin`
- `~/.local/bin-evil/x` matched `~/.local/bin`
- `normalize()` strips trailing separators, so even prefixes written with a trailing slash (`/opt/homebrew/`) were affected

`isTrustedPrefix` gates the "resolved to non-standard path" `console.warn`, so the bug silently suppressed that warning for malicious sibling paths.

## Fix

Require an **exact match or a true descendant** (`prefix + path.sep`):

```ts
const p = normalize(prefix);
if (normalized === p) return true;
const withSep = p.endsWith(sep) ? p : p + sep;
return normalized.startsWith(withSep);
```

## Tests

`src/team/__tests__/model-contract.test.ts` — the sibling-prefix bypass is rejected while exact dirs and true descendants stay trusted, across `/usr/bin`, `/usr/local/bin`, `/opt/homebrew`, `~/.local/bin`, and custom `OMC_TRUSTED_CLI_DIRS` entries.

`npx tsc --noEmit` clean; `npx vitest run src/team/__tests__/model-contract.test.ts` → **52 passed**.

## Scope

This is the focused security split requested in the #3146 review (blocker #1), based on `dev`, independent of any provider feature. **realpath/symlink-target enforcement is intentionally out of scope** (separate PR if the threat model requires it).

A follow-up PR will carry the `antigravity` / `grok` provider contract with complete model-resolution coverage (incl. `runtime-v2` `modelForAgent`), `/ask` hook-suppression regex updates (`scripts/keyword-detector.mjs` + template), docs, and per-command-path tests.

## Review

Reviewed by a multi-model council before submission — **Codex (GPT-5.5)** and **Gemini** both assessed it **merge-ready**; the caveats they flagged (realpath, `OMC_TRUSTED_CLI_DIRS=/` foot-gun, Windows drive-letter `:` split) are pre-existing or out of scope.

Authored by Claude Opus 4.7; reviewed by Codex (GPT-5.5), Gemini, and Grok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
