### PR TITLE
Fix /team Windows psmux gate guidance

### DIFF
--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -198,6 +198,17 @@ The lead writes handoffs to `.omc/handoffs/<stage-name>.md`.
 - **Cancel:** `/oh-my-claudecode:cancel` requests teammate shutdown, waits for responses (best effort), marks phase `cancelled` with `active=false`, captures cancellation metadata, then deletes team resources and clears/preserves Team state per policy. Handoff files in `.omc/handoffs/` are preserved for potential resume.
 - Terminal states are `complete`, `failed`, and `cancelled`.
 
+## Windows psmux tmux-compatible gate
+
+On native Windows, do **not** tell users that `/team` requires WSL or that tmux is unavailable until the actual tmux-compatible binary has been checked. Native [psmux](https://github.com/psmux/psmux) installs a `tmux`-compatible command (often `tmux` / `tmux.cmd`) and is a supported Team multiplexer.
+
+Before blocking or falling back on Windows:
+
+1. Check `tmux -V` (or the platform equivalent such as `where tmux` followed by `tmux -V`).
+2. Treat a successful psmux-backed `tmux -V` as tmux available.
+3. If psmux/tmux is available, continue the normal Team flow; do not emit WSL-required guidance.
+4. Only when no tmux-compatible binary is available, tell the user to install psmux for native Windows support or use WSL2 as an alternative.
+
 ## Workflow
 
 ### Phase 1: Parse Input

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -779,6 +779,16 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('tmux capture-pane -pt <pane-id> -S -20');
     });
 
+    it('should accept native Windows psmux before emitting WSL-required team guidance', () => {
+      const skill = getBuiltinSkill('team');
+      expect(skill).toBeDefined();
+      expect(skill?.template).toContain('Windows psmux tmux-compatible gate');
+      expect(skill?.template).toContain('do **not** tell users that `/team` requires WSL');
+      expect(skill?.template).toContain('Treat a successful psmux-backed `tmux -V` as tmux available');
+      expect(skill?.template).toContain('continue the normal Team flow; do not emit WSL-required guidance');
+      expect(skill?.template).toContain('Only when no tmux-compatible binary is available');
+    });
+
     it('should document allowed omc-teams agent types and native team fallback', () => {
       const skill = getBuiltinSkill('omc-teams');
       expect(skill).toBeDefined();


### PR DESCRIPTION
## Summary
- update the `/team` skill guidance so native Windows checks tmux/psmux before WSL-required fallback messaging
- document successful psmux-backed `tmux -V` as Team-compatible
- add focused regression coverage for the user-facing gate text

Fixes #3151

## Verification
- npm test -- --run src/__tests__/skills.test.ts src/__tests__/cli-win32-warning.test.ts src/cli/__tests__/tmux-utils.test.ts
- npm test -- --run src/__tests__/skills.test.ts src/__tests__/cli-win32-warning.test.ts src/cli/__tests__/tmux-utils.test.ts -t "native Windows psmux|win32|tmux.cmd|psmux"
- npx tsc --noEmit --pretty false
- npx eslint src/__tests__/skills.test.ts
- git diff --check -- skills/team/SKILL.md src/__tests__/skills.test.ts

## Review
- code-reviewer: APPROVE
- architect: CLEAR

🤖 Generated with Codex / OMX ultragoal