### PR TITLE
Make SessionStart update notices user-visible

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -476,6 +476,15 @@ function compactBudgetedText(text, maxChars) {
   return `${text.slice(0, maxChars - notice.length).trimEnd()}${notice}`;
 }
 
+function formatUpdateNoticeForUser(updateInfo, options = {}) {
+  const latestVersion = updateInfo?.latestVersion || 'latest';
+  const currentVersion = updateInfo?.currentVersion || 'unknown';
+  const action = options.autoUpgradePrompt === false
+    ? 'To update later, run: omc update'
+    : 'Run /update to upgrade now, or use /plugin install oh-my-claudecode';
+  return `[OMC UPDATE AVAILABLE] oh-my-claudecode v${latestVersion} is available (current: v${currentVersion}). ${action}`;
+}
+
 function buildSessionStartAdditionalContext(messages) {
   if (!Array.isArray(messages) || messages.length === 0) return '';
 
@@ -758,6 +767,7 @@ async function main() {
     const sessionId = data.session_id || data.sessionId || '';
     const omcRoot = await resolveOmcStateRoot(directory);
     const messages = [];
+    const userMessages = [];
 
     // Fire sibling-retrofit warning once per session (lifted off getOmcRoot hot path)
     try {
@@ -793,7 +803,8 @@ async function main() {
       if (pluginVersion) {
         const updateInfo = await checkNpmUpdate(pluginVersion);
         if (updateInfo) {
-          messages.push(`<session-restore>\n\n[OMC UPDATE AVAILABLE]\n\nA new version of oh-my-claudecode is available: v${updateInfo.latestVersion} (current: v${updateInfo.currentVersion})\n\nTo update, run: omc update\n(This syncs plugin, npm package, and CLAUDE.md together)\n\n</session-restore>\n\n---\n`);
+          const omcConfig = readJsonFile(join(configDir, '.omc-config.json')) || {};
+          userMessages.push(formatUpdateNoticeForUser(updateInfo, { autoUpgradePrompt: omcConfig.autoUpgradePrompt !== false }));
         }
       }
     } catch {}
@@ -1094,14 +1105,20 @@ ${cleanContent}
       // Notification module not available, skip silently
     }
 
-    if (messages.length > 0) {
-      console.log(JSON.stringify({
+    if (messages.length > 0 || userMessages.length > 0) {
+      const output = {
         continue: true,
-        hookSpecificOutput: {
+      };
+      if (userMessages.length > 0) {
+        output.systemMessage = userMessages.join('\n');
+      }
+      if (messages.length > 0) {
+        output.hookSpecificOutput = {
           hookEventName: 'SessionStart',
           additionalContext: buildSessionStartAdditionalContext(messages)
-        }
-      }));
+        };
+      }
+      console.log(JSON.stringify(output));
     } else {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     }

--- a/src/__tests__/session-start-script-context.test.ts
+++ b/src/__tests__/session-start-script-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -196,6 +196,57 @@ ${'- oversized startup guidance\n'.repeat(700)}
     expect(context).not.toContain('Do NOT pass the `model` parameter');
     expect(context).not.toContain('Omit it entirely');
     expect(context.length).toBeLessThanOrEqual(6000);
+  });
+
+  it('surfaces update notices through systemMessage without injecting them into additionalContext', () => {
+    const claudeDir = join(fakeHome, '.claude');
+    const pluginRoot = join(tempDir, 'plugin');
+    mkdirSync(join(claudeDir, '.omc'), { recursive: true });
+    mkdirSync(join(claudeDir, 'hud'), { recursive: true });
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '1.0.0', type: 'module' }));
+    writeFileSync(join(claudeDir, 'hud', 'omc-hud.mjs'), '');
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({ statusLine: 'node ~/.claude/hud/omc-hud.mjs' }));
+    writeFileSync(
+      join(claudeDir, '.omc', 'update-check.json'),
+      JSON.stringify({
+        timestamp: Date.now(),
+        latestVersion: '999.0.0',
+        currentVersion: '1.0.0',
+        updateAvailable: true,
+      }),
+    );
+
+    const result = spawnSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'session-update-script',
+        cwd: fakeProject,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        OMC_NOTIFY: '0',
+      },
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const output = JSON.parse(result.stdout) as {
+      continue: boolean;
+      systemMessage?: string;
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    expect(output.continue).toBe(true);
+    expect(output.systemMessage).toContain('[OMC UPDATE AVAILABLE]');
+    expect(output.systemMessage).toContain('v999.0.0');
+    expect(output.systemMessage).toContain('/update');
+    expect(output.hookSpecificOutput?.additionalContext ?? '').not.toContain('[OMC UPDATE AVAILABLE]');
+    expect(output.hookSpecificOutput?.additionalContext ?? '').not.toContain('999.0.0');
   });
 
 });

--- a/src/installer/__tests__/session-start-template.test.ts
+++ b/src/installer/__tests__/session-start-template.test.ts
@@ -215,6 +215,83 @@ ${'- oversized startup guidance\n'.repeat(700)}
     expect(context.length).toBeLessThanOrEqual(6000);
   });
 
+  it('surfaces update notices through systemMessage without injecting them into additionalContext', () => {
+    const omcDir = join(fakeHome, '.claude', '.omc');
+    mkdirSync(omcDir, { recursive: true });
+    writeFileSync(
+      join(omcDir, 'update-check.json'),
+      JSON.stringify({
+        timestamp: Date.now(),
+        latestVersion: '999.0.0',
+        currentVersion: '1.0.0',
+        updateAvailable: true,
+      }),
+    );
+
+    const result = spawnSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'session-update-visible',
+        cwd: fakeProject,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+      },
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const output = JSON.parse(result.stdout) as {
+      continue: boolean;
+      systemMessage?: string;
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    expect(output.continue).toBe(true);
+    expect(output.systemMessage).toContain('[OMC UPDATE AVAILABLE]');
+    expect(output.systemMessage).toContain('v999.0.0');
+    expect(output.systemMessage).toContain('/update');
+    expect(output.hookSpecificOutput?.additionalContext ?? '').not.toContain('[OMC UPDATE AVAILABLE]');
+    expect(output.hookSpecificOutput?.additionalContext ?? '').not.toContain('999.0.0');
+  });
+
+  it('honors autoUpgradePrompt=false with passive systemMessage wording', () => {
+    const omcDir = join(fakeHome, '.claude', '.omc');
+    mkdirSync(omcDir, { recursive: true });
+    writeFileSync(join(fakeHome, '.claude', '.omc-config.json'), JSON.stringify({ autoUpgradePrompt: false }));
+    writeFileSync(
+      join(omcDir, 'update-check.json'),
+      JSON.stringify({
+        timestamp: Date.now(),
+        latestVersion: '999.0.0',
+        currentVersion: '1.0.0',
+        updateAvailable: true,
+      }),
+    );
+
+    const result = spawnSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'session-update-passive',
+        cwd: fakeProject,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+      },
+      timeout: 15000,
+    });
+
+    const output = JSON.parse(result.stdout) as { systemMessage?: string };
+    expect(output.systemMessage).toContain('To update later, run: omc update');
+    expect(output.systemMessage).not.toContain('Run /update to upgrade now');
+  });
+
 });
 
 // ==========================================================================
@@ -350,8 +427,9 @@ describe('session-start template cwd validation (Wave B1)', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'omc-session-start-cwdval-'));
     fakeHome = join(tempDir, 'home');
     mkdirSync(fakeHome, { recursive: true });
-    // A truly empty directory with no .omc-workspace or .git marker
-    emptyCwd = mkdtempSync(join(tmpdir(), 'omc-empty-cwd-'));
+    // A truly empty directory with no .omc-workspace or .git marker.
+    // Keep it under fakeHome so validateCwd stops before ambient /tmp markers.
+    emptyCwd = mkdtempSync(join(fakeHome, 'omc-empty-cwd-'));
   });
 
   afterEach(() => {

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -250,6 +250,15 @@ function compactOmcStartupGuidance(content) {
   return `${normalized.slice(0, OMC_STARTUP_GUIDANCE_MAX_CHARS - notice.length).trimEnd()}${notice}`;
 }
 
+function formatUpdateNoticeForUser(updateInfo, options = {}) {
+  const latestVersion = updateInfo?.latestVersion || 'latest';
+  const currentVersion = updateInfo?.currentVersion || 'unknown';
+  const action = options.autoUpgradePrompt === false
+    ? 'To update later, run: omc update'
+    : 'Run /update to upgrade now, or use /plugin install oh-my-claudecode';
+  return `[OMC UPDATE AVAILABLE] oh-my-claudecode v${latestVersion} is available (current: v${currentVersion}). ${action}`;
+}
+
 function buildSessionStartAdditionalContext(messages) {
   if (!Array.isArray(messages) || messages.length === 0) return '';
 
@@ -528,6 +537,7 @@ async function main() {
     }
     const sessionId = data.sessionId || data.session_id || data.sessionid || '';
     const messages = [];
+    const userMessages = [];
 
     // Check for updates (non-blocking)
     // Read version from OMC's own package.json, not the project's (fixes #516)
@@ -562,43 +572,11 @@ async function main() {
 
     const updateInfo = currentVersion ? await checkForUpdates(currentVersion) : null;
     if (updateInfo) {
-      // Read config to check autoUpgradePrompt preference
       const configPath = join(getClaudeConfigDir(), '.omc-config.json');
       const omcConfig = readJsonFile(configPath) || {};
-      const autoUpgradePrompt = omcConfig.autoUpgradePrompt !== false; // default: true
-
-      if (autoUpgradePrompt) {
-        messages.push(`<session-restore>
-
-[OMC AUTO-UPGRADE AVAILABLE]
-
-oh-my-claudecode v${updateInfo.latestVersion} is available (current: v${updateInfo.currentVersion}).
-
-ACTION: Use AskUserQuestion to ask the user if they want to upgrade now. Offer these options:
-- "Upgrade now" (Recommended): Run \`npm install -g oh-my-claude-sisyphus@latest\` via Bash, then run \`omc install --force --skip-claude-check --refresh-hooks\` to reconcile hooks and CLAUDE.md
-- "Skip this time": Continue the session without upgrading
-- "Don't ask again": Tell the user to set "autoUpgradePrompt": false in [$CLAUDE_CONFIG_DIR|~/.claude]/.omc-config.json to disable future prompts
-
-Keep the prompt brief. If the user accepts, execute the upgrade commands and report the result.
-
-</session-restore>
-
----
-`);
-      } else {
-        messages.push(`<session-restore>
-
-[OMC UPDATE AVAILABLE]
-
-A new version of oh-my-claudecode is available: v${updateInfo.latestVersion} (current: ${updateInfo.currentVersion})
-
-To update, run: omc update
-
-</session-restore>
-
----
-`);
-      }
+      userMessages.push(formatUpdateNoticeForUser(updateInfo, {
+        autoUpgradePrompt: omcConfig.autoUpgradePrompt !== false,
+      }));
     }
 
     if (await shouldEmitModelRoutingOverride(directory)) {
@@ -707,14 +685,20 @@ ${agentsContent}
       }
     }
 
-    if (messages.length > 0) {
-      console.log(JSON.stringify({
+    if (messages.length > 0 || userMessages.length > 0) {
+      const output = {
         continue: true,
-        hookSpecificOutput: {
+      };
+      if (userMessages.length > 0) {
+        output.systemMessage = userMessages.join('\n');
+      }
+      if (messages.length > 0) {
+        output.hookSpecificOutput = {
           hookEventName: 'SessionStart',
           additionalContext: buildSessionStartAdditionalContext(messages)
-        }
-      }));
+        };
+      }
+      console.log(JSON.stringify(output));
     } else {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     }


### PR DESCRIPTION
## Summary\n- move SessionStart update notices out of persistent model additionalContext and into user-visible hook systemMessage output\n- keep stdout JSON valid and preserve passive wording when autoUpgradePrompt=false\n- add focused regressions for both scripts/session-start.mjs and templates/hooks/session-start.mjs\n\n## Verification\n- npm test -- --run src/installer/__tests__/session-start-template.test.ts src/__tests__/session-start-script-context.test.ts\n- npx tsc --noEmit\n- npm run lint -- src/installer/__tests__/session-start-template.test.ts src/__tests__/session-start-script-context.test.ts (0 errors; existing repo warnings only)\n- git diff --check\n- node --check scripts/session-start.mjs\n- node --check templates/hooks/session-start.mjs\n\nFixes #3155