### PR TITLE
feat(team): add Grok Build as a team worker + ask provider (v2, addresses #3156 review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ OMC exposes two different surfaces:
 | Feature                                        | Terminal CLI                                  | In-session skill                                                        | Notes                                                                                                                                |
 | ---------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Setup                                          | `omc setup`                                   | `/setup` or `/omc-setup`                                                | Both are real entrypoints. `/setup` is the easiest plugin-first path.                                                                |
-| Ask providers                                  | `omc ask codex "review this patch"`           | `/ask codex "review this patch"`                                        | Both route through the same advisor flow.                                                                                            |
+| Ask providers                                  | `omc ask codex "review this patch"`           | `/ask codex "review this patch"`                                        | Both route through the same advisor flow. Providers: `claude`, `codex`, `gemini`, `grok`.                                            |
 | Team orchestration                             | `omc team 2:codex "review auth flow"`         | `/team 3:executor "fix all TypeScript errors"`                          | Both exist, but they are different runtimes: `omc team` launches tmux CLI workers; `/team` runs the in-session native team workflow. |
 | Autopilot / Ralph / Ultrawork / Deep Interview | —                                             | `/autopilot ...`, `/ralph ...`, `/ultrawork ...`, `/deep-interview ...` | These are in-session skills. There is no `omc autopilot` / `omc ralph` / `omc ultrawork` CLI subcommand in this repo.                |
 | Autoresearch                                   | `omc autoresearch` (**hard-deprecated shim**) | `/deep-interview --autoresearch ...` + `/oh-my-claudecode:autoresearch` | Setup stays in deep-interview; execution now belongs to the stateful skill.                                                          |
@@ -177,6 +177,7 @@ For mixed Codex + Gemini work in one command, use the **`/ccg`** skill (routes v
 | ------------------------- | ------------------------ | -------------------------------------------- |
 | `omc team N:codex "..."`  | N Codex CLI panes        | Code review, security analysis, architecture |
 | `omc team N:gemini "..."` | N Gemini CLI panes       | UI/UX design, docs, large-context tasks      |
+| `omc team N:grok "..."`   | N Grok Build CLI panes   | Code review, analysis cross-check            |
 | `omc team N:claude "..."` | N Claude CLI panes       | General tasks via Claude CLI in tmux         |
 | `/ccg`                    | /ask codex + /ask gemini | Tri-model advisor synthesis                  |
 
@@ -246,7 +247,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 | Mode                        | What it is                                                                              | Use For                                                                 |
 | --------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | **Team (recommended)**      | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list                         |
-| **omc team (CLI)**          | tmux CLI workers — real `claude`/`codex`/`gemini` processes in split-panes              | Codex/Gemini CLI tasks; on-demand spawn, die when done                  |
+| **omc team (CLI)**          | tmux CLI workers — real `claude`/`codex`/`gemini`/`grok` processes in split-panes       | Codex/Gemini/Grok CLI tasks; on-demand spawn, die when done             |
 | **ccg**                     | Tri-model advisors via `/ask codex` + `/ask gemini`, Claude synthesizes                 | Mixed backend+UI work needing both Codex and Gemini                     |
 | **Autopilot**               | Autonomous execution (single lead agent)                                                | End-to-end feature work with minimal ceremony                           |
 | **Ultrawork**               | Maximum parallelism (non-team)                                                          | Burst parallel fixes/refactors where Team isn't needed                  |
@@ -362,6 +363,7 @@ Run local provider CLIs and save a markdown artifact under `.omc/artifacts/ask/`
 omc ask claude "review this migration plan"
 omc ask codex --prompt "identify architecture risks"
 omc ask gemini --prompt "propose UI polish ideas"
+omc ask grok --prompt "cross-check this code review"
 omc ask claude --agent-prompt executor --prompt "draft implementation steps"
 
 # Inside a Claude Code / OMC session
@@ -549,6 +551,7 @@ OMC can optionally orchestrate external AI providers for cross-validation and de
 | --------------------------------------------------------- | ----------------------------------- | ------------------------------------------------ |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `npm install -g @google/gemini-cli` | Design review, UI consistency (1M token context) |
 | [Codex CLI](https://github.com/openai/codex)              | `npm install -g @openai/codex`      | Architecture validation, code review cross-check |
+| [Grok Build](https://build.grok.com)                      | Download from build.grok.com (`grok` at `~/.grok/bin/grok`) | Code review, analysis cross-check                |
 
 **Cost:** 3 Pro plans (Claude + Gemini + ChatGPT) cover everything for ~$60/month.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ This enables:
 - Tool path restriction (AST tools confined to project root)
 - Python REPL sandbox (dangerous modules/builtins blocked)
 - Remote MCP server disable (Exa, Context7 not started)
-- External LLM disable (Codex, Gemini workers blocked in team mode)
+- External LLM disable (Codex, Gemini, Grok workers blocked in team mode)
 - Auto-update disable (prevents unverified version installs)
 - Hard max iterations for persistent modes (200 cap)
 
@@ -71,7 +71,9 @@ Prevents Exa (web search) and Context7 (external documentation) MCP servers from
 
 ### External LLM Disable (`disableExternalLLM`)
 
-Blocks Codex (OpenAI) and Gemini (Google) CLI workers from being spawned in team mode. Only Claude workers are allowed. Enforced at the `getContract()` level in the team worker contract system.
+Blocks Codex (OpenAI), Gemini (Google), and Grok (xAI, "Grok Build") CLI workers from being spawned in team mode. Only Claude workers are allowed. Enforced at the `getContract()` level in the team worker contract system: any non-Claude provider throws `External LLM provider "<provider>" is blocked by security policy (disableExternalLLM)`. `OMC_SECURITY=strict` sets this on. Affects `omc team N:<provider>` and `omc ask <provider>` alike.
+
+> **Auto-approval risk class.** Headless CLI workers launch with auto-approve flags so they can run unattended: Codex uses `--dangerously-bypass-approvals-and-sandbox`, Gemini uses `--approval-mode yolo`, and Grok uses `--always-approve`. All three auto-approve the worker's own tool calls — treat them as the same risk class as Claude's `--dangerously-skip-permissions`. The resolved CLI binary path is checked against a trusted-prefix allowlist — `/usr/local/bin`, `/usr/bin`, `/opt/homebrew/`, `~/.local/bin`, `~/.nvm/`, `~/.cargo/bin`, and the Grok-specific `~/.grok/bin` (extend via `OMC_TRUSTED_CLI_DIRS`); the check is directory-boundary safe, so a sibling like `~/.grok/bin-evil` is not treated as trusted. A binary resolving outside the allowlist logs a security **warning** (advisory, not a hard block); only temp/shared-memory locations (`/tmp`, `/var/tmp`, `/dev/shm`) and relative paths are hard-rejected. Use `OMC_SECURITY=strict` (or `"disableExternalLLM": true`) to disable all external providers — including Grok — in untrusted environments.
 
 ### Auto-Update Disable (`disableAutoUpdate`)
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -108,6 +108,7 @@ If both configurations exist, **project-scoped takes precedence** over global:
 | `OMC_PARALLEL_EXECUTION`   | `true`               | Enable/disable parallel agent execution                                                                                                                                                                                                                                     |
 | `OMC_CODEX_DEFAULT_MODEL`  | _(provider default)_ | Default model for Codex CLI workers                                                                                                                                                                                                                                         |
 | `OMC_GEMINI_DEFAULT_MODEL` | _(provider default)_ | Default model for Gemini CLI workers                                                                                                                                                                                                                                        |
+| `OMC_GROK_DEFAULT_MODEL`   | _(provider default)_ | Default model for Grok Build CLI workers                                                                                                                                                                                                                                    |
 | `OMC_LSP_TIMEOUT_MS`       | `15000`              | Timeout (ms) for LSP requests. Increase for large repos or slow language servers                                                                                                                                                                                            |
 | `OMC_MIGRATE_LEGACY_STATE` | _(unset)_            | Set to `1` to enable one-shot legacy→session-scoped state migration on next read. See [Legacy state migration](#legacy-state-migration-omc_migrate_legacy_state) below.                                                                                                      |
 | `OMC_DISABLE_MULTIREPO`    | _(unset)_            | Set to `1` to disable workspace-marker resolution and fall back to git-root + cwd resolution order. `OMC_STATE_DIR` is still honoured. See [Rollback / disable multi-repo](#rollback--disable-multi-repo-omc_disable_multirepo) below.                                       |
@@ -497,11 +498,11 @@ omc ask gemini --prompt "suggest UX improvements"
 omc ask claude --agent-prompt executor --prompt "create an implementation plan"
 ```
 
-- Provider matrix: `claude | codex | gemini`
+- Provider matrix: `claude | codex | gemini | grok`
 - Artifacts: `.omc/artifacts/ask/{provider}-{slug}-{timestamp}.md`
 - Canonical env vars: `OMC_ASK_ADVISOR_SCRIPT`, `OMC_ASK_ORIGINAL_TASK`
 - Phase-1 aliases (deprecated warning): `OMX_ASK_ADVISOR_SCRIPT`, `OMX_ASK_ORIGINAL_TASK`
-- Skill entrypoint: `/oh-my-claudecode:ask <claude|codex|gemini> <prompt>` routes to this command
+- Skill entrypoint: `/oh-my-claudecode:ask <claude|codex|gemini|grok> <prompt>` routes to this command
 
 ### `omc team` (CLI runtime surface)
 
@@ -716,7 +717,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | Skill                     | Description                                                      | Manual Command                              |
 | ------------------------- | ---------------------------------------------------------------- | ------------------------------------------- |
 | `ai-slop-cleaner`         | Anti-slop cleanup workflow with optional reviewer-only `--review` pass | `/oh-my-claudecode:ai-slop-cleaner`         |
-| `ask`                     | Ask Claude, Codex, or Gemini via local CLI and capture a reusable artifact | `/oh-my-claudecode:ask`               |
+| `ask`                     | Ask Claude, Codex, Gemini, or Grok via local CLI and capture a reusable artifact | `/oh-my-claudecode:ask`               |
 | `autoresearch`            | Stateful single-mission evaluator-driven improvement loop           | `/oh-my-claudecode:autoresearch`            |
 | `autopilot`               | Full autonomous execution from idea to working code              | `/oh-my-claudecode:autopilot`               |
 | `cancel`                  | Unified cancellation for active modes                            | `/oh-my-claudecode:cancel`                  |
@@ -762,7 +763,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | Command                                                  | Description                                                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `/oh-my-claudecode:ai-slop-cleaner <target>`             | Run the anti-slop cleanup workflow (`--review` for reviewer-only pass)                        |
-| `/oh-my-claudecode:ask <claude\|codex\|gemini> <prompt>` | Route a prompt through the selected advisor CLI and capture an ask artifact                   |
+| `/oh-my-claudecode:ask <claude\|codex\|gemini\|grok> <prompt>` | Route a prompt through the selected advisor CLI and capture an ask artifact                   |
 | `/oh-my-claudecode:autopilot <task>`                     | Full autonomous execution                                                                     |
 | `/oh-my-claudecode:configure-notifications`              | Configure notification integrations                                                           |
 | `/oh-my-claudecode:deep-dive <problem>`                  | Run the trace → deep-interview pipeline                                                       |

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -206,7 +206,7 @@ function isExplicitRalplanSlashInvocation(prompt) {
 }
 
 function isExplicitAskSlashInvocation(prompt) {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini)\b/i.test(prompt);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|grok)\b/i.test(prompt);
 }
 
 // Sanitize text to prevent false positives from code blocks, XML tags, URLs, and file paths

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -9,6 +9,7 @@ const PROVIDER_BINARIES = {
   claude: 'claude',
   codex: 'codex',
   gemini: 'gemini',
+  grok: 'grok',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
@@ -17,6 +18,8 @@ const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
  * - claude: `claude -p <prompt>`
  * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
  * - gemini: `gemini -p <prompt> --yolo`
+ * - grok: `grok -p <prompt> --always-approve` (headless mode takes the prompt
+ *   as an arg; grok's stdin is reserved for ACP JSON-RPC, never the prompt)
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
@@ -24,6 +27,11 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
   }
   if (provider === 'gemini') {
     return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
+  }
+  if (provider === 'grok') {
+    // Grok's headless mode always takes the prompt as a `-p` arg; its stdin is
+    // for ACP JSON-RPC, not the prompt, so it never uses the stdin pipe path.
+    return ['-p', prompt, '--always-approve'];
   }
   return ['-p', prompt];
 }
@@ -44,8 +52,8 @@ const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
 const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
-  console.error('Usage: omc ask <claude|codex|gemini> "<prompt>"');
-  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini> <prompt...>');
+  console.error('Usage: omc ask <claude|codex|gemini|grok> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|grok> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
 }

--- a/src/__tests__/runtime-guidance-plan-ralph.test.ts
+++ b/src/__tests__/runtime-guidance-plan-ralph.test.ts
@@ -6,6 +6,7 @@ const availability = vi.hoisted(() => ({
   codex: false,
   gemini: false,
   cursor: false,
+  grok: false,
 }));
 
 vi.mock('../team/model-contract.js', () => ({

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -272,6 +272,8 @@ describe('parseAskArgs', () => {
     expect(parseAskArgs(['claude', '--print', 'draft', 'summary'])).toEqual({ provider: 'claude', prompt: 'draft summary' });
     expect(parseAskArgs(['gemini', '--prompt=ship safely'])).toEqual({ provider: 'gemini', prompt: 'ship safely' });
     expect(parseAskArgs(['codex', 'review', 'this'])).toEqual({ provider: 'codex', prompt: 'review this' });
+    expect(parseAskArgs(['grok', 'review', 'this'])).toEqual({ provider: 'grok', prompt: 'review this' });
+    expect(parseAskArgs(['grok', '-p', 'brainstorm'])).toEqual({ provider: 'grok', prompt: 'brainstorm' });
   });
 
   it('supports --agent-prompt flag and equals syntax', () => {
@@ -485,6 +487,7 @@ describe('run-provider-advisor script contract', () => {
     ['claude', ['claude', '--prompt', 'nested claude prompt']],
     ['codex', ['codex', '--prompt', 'nested codex prompt']],
     ['gemini', ['gemini', '--prompt', 'nested gemini prompt']],
+    ['grok', ['grok', '--prompt', 'nested grok prompt']],
   ] as const)('strips Claude session env vars for %s advisor spawns', (provider, args) => {
     const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-advisor-env-`));
     try {
@@ -528,6 +531,41 @@ describe('run-provider-advisor script contract', () => {
           CLAUDE_CODE_ENTRYPOINT: null,
         });
       }
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('launches grok as `grok -p <prompt> --always-approve` and never pipes stdin', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-grok-args-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      // A multiline prompt is piped over stdin for codex/gemini; grok reserves stdin
+      // for ACP JSON-RPC, so it must take the prompt as a `-p` arg instead.
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['grok', '--prompt', 'review this\nand that'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { input: string | null };
+      }>;
+
+      // version probe + launch, both via the `grok` binary
+      expect(calls).toHaveLength(2);
+      const launch = calls.find((c) => !c.args.includes('--version'));
+      expect(launch).toBeDefined();
+      expect(launch!.command).toBe('grok');
+      expect(launch!.args).toEqual(['-p', 'review this\nand that', '--always-approve']);
+      expect(launch!.options.input ?? null).toBeNull();
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,15 @@ import { fileURLToPath } from 'url';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export const ASK_USAGE = [
-  'Usage: omc ask <claude|codex|gemini> <question or task>',
-  '   or: omc ask <claude|codex|gemini> -p "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --print "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --prompt "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt <role> "<prompt>"',
-  '   or: omc ask <claude|codex|gemini> --agent-prompt=<role> --prompt "<prompt>"',
+  'Usage: omc ask <claude|codex|gemini|grok> <question or task>',
+  '   or: omc ask <claude|codex|gemini|grok> -p "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|grok> --print "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|grok> --prompt "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|grok> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|grok> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'codex', 'gemini'] as const;
+const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'grok'] as const;
 export type AskProvider = (typeof ASK_PROVIDERS)[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 

--- a/src/cli/commands/doctor-team-routing.ts
+++ b/src/cli/commands/doctor-team-routing.ts
@@ -24,6 +24,7 @@ const PROVIDER_BINARY: Record<TeamRoleProvider, string> = {
   claude: 'claude',
   codex: 'codex',
   gemini: 'gemini',
+  grok: 'grok',
 };
 
 function probeProvider(provider: TeamRoleProvider): ProviderProbe {
@@ -61,7 +62,7 @@ function collectConfiguredProviders(): Set<TeamRoleProvider> {
   const roleRouting = cfg.team?.roleRouting ?? {};
   for (const spec of Object.values(roleRouting)) {
     const provider = spec?.provider as TeamRoleProvider | undefined;
-    if (provider === 'claude' || provider === 'codex' || provider === 'gemini') {
+    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'grok') {
       providers.add(provider);
     }
   }

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -26,7 +26,7 @@ import { getOmcRoot } from '../../lib/worktree-paths.js';
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
-const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini']);
+const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'grok']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
 const TEAM_HELP = `

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -16,7 +16,7 @@ import { readApprovedExecutionLaunchHintOutcome } from '../planning/artifacts.js
 import { getOmcRoot } from '../lib/worktree-paths.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor']);
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'grok']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
 const SUPPORTED_API_OPERATIONS = new Set([
@@ -794,7 +794,7 @@ export async function teamCleanupCommand(
 
 export const TEAM_USAGE = `
 Usage:
-  omc team start --agent <claude|codex|gemini|cursor>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--auto-merge] [--json]
+  omc team start --agent <claude|codex|gemini|cursor|grok>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--auto-merge] [--json]
   omc team status <job_id|team_name> [--json] [--cwd DIR]
   omc team wait <job_id> [--timeout-ms MS] [--json]
   omc team cleanup <job_id> [--grace-ms MS] [--json]

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -381,6 +381,14 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     externalModelsDefaults.geminiModel = process.env.OMC_GEMINI_DEFAULT_MODEL;
   }
 
+  if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL) {
+    externalModelsDefaults.grokModel =
+      process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+  } else if (process.env.OMC_GROK_DEFAULT_MODEL) {
+    // Legacy fallback
+    externalModelsDefaults.grokModel = process.env.OMC_GROK_DEFAULT_MODEL;
+  }
+
   const externalModelsFallback: ExternalModelsConfig["fallbackPolicy"] = {
     onModelFailure: "provider_chain",
   };
@@ -476,8 +484,8 @@ function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
  */
 const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
-// /team CLI workers — codex/gemini here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
-const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini"]);
+// /team CLI workers — codex/gemini/grok here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
+const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "grok"]);
 const TEAM_ROLE_TIERS = new Set(["HIGH", "MEDIUM", "LOW"]);
 
 export function validateTeamConfig(config: PluginConfig): void {
@@ -974,7 +982,7 @@ export function generateConfigSchema(): object {
       },
       externalModels: {
         type: "object",
-        description: "External model provider configuration (Codex, Gemini)",
+        description: "External model provider configuration (Codex, Gemini, Grok)",
         properties: {
           defaults: {
             type: "object",
@@ -994,6 +1002,10 @@ export function generateConfigSchema(): object {
                 type: "string",
                 default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel,
                 description: "Default Gemini model",
+              },
+              grokModel: {
+                type: "string",
+                description: "Default Grok Build model",
               },
             },
           },
@@ -1094,7 +1106,7 @@ export function generateConfigSchema(): object {
               maxAgents: { type: "integer", minimum: 1 },
               defaultAgentType: {
                 type: "string",
-                enum: ["claude", "codex", "gemini"],
+                enum: ["claude", "codex", "gemini", "grok"],
                 default: "claude",
               },
               monitorIntervalMs: { type: "integer", minimum: 1 },
@@ -1108,7 +1120,7 @@ export function generateConfigSchema(): object {
             additionalProperties: {
               type: "object",
               properties: {
-                provider: { type: "string", enum: ["claude", "codex", "gemini"] },
+                provider: { type: "string", enum: ["claude", "codex", "gemini", "grok"] },
                 model: { type: "string" },
                 agent: { type: "string" },
               },

--- a/src/features/builtin-skills/runtime-guidance.ts
+++ b/src/features/builtin-skills/runtime-guidance.ts
@@ -4,6 +4,7 @@ export interface SkillRuntimeAvailability {
   claude: boolean;
   codex: boolean;
   gemini: boolean;
+  grok: boolean;
 }
 
 export function detectSkillRuntimeAvailability(
@@ -20,6 +21,7 @@ export function detectSkillRuntimeAvailability(
     claude: safeDetect('claude'),
     codex: safeDetect('codex'),
     gemini: safeDetect('gemini'),
+    grok: safeDetect('grok'),
   };
 }
 

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -863,6 +863,27 @@ $ ultrawork search the codebase`,
       }
     });
 
+    it('does not arm ralplan state for keywords inside delegated /ask grok prompts', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-ask-grok-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'ask-grok-session';
+
+        const result = await processHook('keyword-detector', {
+          sessionId,
+          prompt: '/ask grok 지금까지 논의한걸 ralplan으로 계획서 작성해줘',
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toBeUndefined();
+        expect((result as unknown as Record<string, unknown>).hookSpecificOutput).toBeUndefined();
+        expect(existsSync(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json'))).toBe(false);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('activates ralplan state when Skill tool invokes plan in consensus mode', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-plan-consensus-skill-'));
       try {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1232,7 +1232,7 @@ function getPromptText(input: HookInput): string {
 }
 
 function isExplicitAskSlashInvocation(promptText: string): boolean {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini)\b/i.test(promptText);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|grok)\b/i.test(promptText);
 }
 
 function activateRalplanStartupState(directory: string, sessionId?: string): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -293,6 +293,7 @@ export interface ExternalModelsDefaults {
   provider?: ExternalModelProvider;
   codexModel?: string;
   geminiModel?: string;
+  grokModel?: string;
 }
 
 /**
@@ -414,7 +415,7 @@ export const CANONICAL_TEAM_ROLES = [
 export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
 
 /** Provider for /team role routing. */
-export type TeamRoleProvider = 'claude' | 'codex' | 'gemini';
+export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'grok';
 
 /** Tier name accepted in role-assignment `model` field. */
 export type TeamRoleTier = 'HIGH' | 'MEDIUM' | 'LOW';

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -161,6 +161,12 @@ describe('model-contract', () => {
       expect(c.agentType).toBe('gemini');
       expect(c.binary).toBe('gemini');
     });
+    it('returns contract for grok', () => {
+      const c = getContract('grok');
+      expect(c.agentType).toBe('grok');
+      expect(c.binary).toBe('grok');
+      expect(c.supportsPromptMode).toBe(true);
+    });
     it('throws for unknown agent type', () => {
       expect(() => getContract('unknown' as any)).toThrow('Unknown agent type');
     });
@@ -190,6 +196,24 @@ describe('model-contract', () => {
         const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
         clearSecurityConfigCache();
         expect(() => getContract('gemini')).toThrow('blocked by security policy');
+      } finally {
+        if (origSecurity === undefined) {
+          delete process.env.OMC_SECURITY;
+        } else {
+          process.env.OMC_SECURITY = origSecurity;
+        }
+        const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
+        clearSecurityConfigCache();
+      }
+    });
+
+    it('blocks grok when external LLM is disabled', async () => {
+      const origSecurity = process.env.OMC_SECURITY;
+      process.env.OMC_SECURITY = 'strict';
+      try {
+        const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
+        clearSecurityConfigCache();
+        expect(() => getContract('grok')).toThrow('blocked by security policy');
       } finally {
         if (origSecurity === undefined) {
           delete process.env.OMC_SECURITY;
@@ -267,6 +291,14 @@ describe('model-contract', () => {
       expect(args).toContain('--approval-mode');
       expect(args).toContain('yolo');
       expect(args).not.toContain('-p');
+    });
+    it('grok includes --always-approve with no model and appends --model <m> when given', () => {
+      const noModel = buildLaunchArgs('grok', { teamName: 't', workerName: 'w', cwd: '/tmp' });
+      expect(noModel).toEqual(['--always-approve']);
+      expect(noModel).not.toContain('--model');
+
+      const withModel = buildLaunchArgs('grok', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'grok-4-fast' });
+      expect(withModel).toEqual(['--always-approve', '--model', 'grok-4-fast']);
     });
     it('passes model flag when specified', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4' });
@@ -490,6 +522,18 @@ describe('model-contract', () => {
       const c = getContract('codex');
       expect(c.supportsPromptMode).toBe(false);
       expect(c.promptModeFlag).toBeUndefined();
+    });
+
+    it('grok supports prompt mode', () => {
+      expect(isPromptModeAgent('grok')).toBe(true);
+      const c = getContract('grok');
+      expect(c.supportsPromptMode).toBe(true);
+      expect(c.promptModeFlag).toBe('-p');
+    });
+
+    it('getPromptModeArgs returns flag + instruction for grok', () => {
+      const args = getPromptModeArgs('grok', 'Read inbox');
+      expect(args).toEqual(['-p', 'Read inbox']);
     });
 
     it('getPromptModeArgs returns flag + instruction for gemini', () => {

--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -110,7 +110,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 import { spawnWorkerForTask, type TeamRuntime } from '../runtime.js';
 
-function makeRuntime(cwd: string, agentType: 'gemini' | 'codex' | 'claude'): TeamRuntime {
+function makeRuntime(cwd: string, agentType: 'gemini' | 'codex' | 'claude' | 'grok'): TeamRuntime {
   return {
     teamName: 'test-team',
     sessionName: 'test-session:0',
@@ -319,6 +319,8 @@ describe('spawnWorkerForTask – model passthrough from environment variables', 
     delete process.env.OMC_CODEX_DEFAULT_MODEL;
     delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL;
     delete process.env.OMC_GEMINI_DEFAULT_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+    delete process.env.OMC_GROK_DEFAULT_MODEL;
     delete process.env.ANTHROPIC_MODEL;
     delete process.env.CLAUDE_MODEL;
     delete process.env.ANTHROPIC_BASE_URL;
@@ -437,6 +439,85 @@ describe('spawnWorkerForTask – model passthrough from environment variables', 
     const launchCmd = launchCall![launchCall!.length - 1];
 
     expect(launchCmd).toContain("'--model' 'gemini-2.0-flash'");
+  });
+
+  it('grok worker passes model from OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL', async () => {
+    process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL = 'grok-4-fast';
+    const runtime = makeRuntime(cwd, 'grok');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    expect(launchCmd).toContain("'--always-approve'");
+    expect(launchCmd).toContain("'--model'");
+    expect(launchCmd).toContain("'grok-4-fast'");
+  });
+
+  it('grok worker falls back to OMC_GROK_DEFAULT_MODEL', async () => {
+    process.env.OMC_GROK_DEFAULT_MODEL = 'grok-code-fast-1';
+    const runtime = makeRuntime(cwd, 'grok');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    expect(launchCmd).toContain("'--model'");
+    expect(launchCmd).toContain("'grok-code-fast-1'");
+  });
+
+  it('grok worker prefers OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL over legacy fallback', async () => {
+    process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL = 'grok-4-fast';
+    process.env.OMC_GROK_DEFAULT_MODEL = 'grok-code-fast-1';
+    const runtime = makeRuntime(cwd, 'grok');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    expect(launchCmd).toContain("'--model' 'grok-4-fast'");
+  });
+
+  it('direct grok worker does not fall through to a Claude/Bedrock model (maintainer key ask)', async () => {
+    // A DIRECT grok launch must resolve its model only from grok env vars.
+    // Even with Bedrock/Claude model env present, grok must NOT receive any
+    // --model flag (its grok env vars are unset here) and must NOT pick up a
+    // Claude/Bedrock model id via resolveClaudeWorkerModel().
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    process.env.ANTHROPIC_MODEL = 'us.anthropic.claude-sonnet-4-6-v1:0';
+    process.env.CLAUDE_CODE_BEDROCK_SONNET_MODEL = 'us.anthropic.claude-sonnet-4-6-v1:0';
+    process.env.OMC_MODEL_MEDIUM = 'us.anthropic.claude-sonnet-4-6-v1:0';
+    const runtime = makeRuntime(cwd, 'grok');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    // grok env vars unset → no --model flag at all. The grok IIFE branch returns
+    // undefined and never falls through to resolveClaudeWorkerModel(), so the
+    // Claude/Bedrock model id is never passed as a `--model` CLI argument.
+    // (The Bedrock ids still appear in the forwarded env prefix via the worker
+    //  model-env allowlist, exactly as they would for any non-claude worker —
+    //  that is pane startup env, not the grok model selection.)
+    expect(launchCmd).toContain("'--always-approve'");
+    expect(launchCmd).not.toContain("'--model'");
+    expect(launchCmd).not.toContain("'--model' 'us.anthropic.claude-sonnet-4-6-v1:0'");
   });
 
   it('claude worker does not pass model flag (not supported)', async () => {

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -42,6 +42,7 @@ const modelContractMocks = vi.hoisted(() => ({
   getWorkerEnv: vi.fn(() => ({ OMC_TEAM_WORKER: 'dispatch-team/worker-1' })),
   isPromptModeAgent: vi.fn(() => false),
   getPromptModeArgs: vi.fn((_agentType: string, instruction: string) => [instruction]),
+  resolveClaudeWorkerModel: vi.fn(() => undefined),
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -67,7 +68,7 @@ vi.mock('../model-contract.js', () => ({
   getWorkerEnv: modelContractMocks.getWorkerEnv,
   isPromptModeAgent: modelContractMocks.isPromptModeAgent,
   getPromptModeArgs: modelContractMocks.getPromptModeArgs,
-  resolveClaudeWorkerModel: vi.fn(() => undefined),
+  resolveClaudeWorkerModel: modelContractMocks.resolveClaudeWorkerModel,
 }));
 
 vi.mock('../tmux-session.js', async (importOriginal) => {
@@ -123,6 +124,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     modelContractMocks.getWorkerEnv.mockReset();
     modelContractMocks.isPromptModeAgent.mockReset();
     modelContractMocks.getPromptModeArgs.mockReset();
+    modelContractMocks.resolveClaudeWorkerModel.mockReset();
     mergeMocks.startMergeOrchestrator.mockReset();
     mergeMocks.recoverFromRestart.mockReset();
     mergeMocks.registerWorker.mockReset();
@@ -152,6 +154,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     });
     modelContractMocks.isPromptModeAgent.mockReturnValue(false);
     modelContractMocks.getPromptModeArgs.mockImplementation((_agentType: string, instruction: string) => [instruction]);
+    modelContractMocks.resolveClaudeWorkerModel.mockReturnValue(undefined);
     mergeMocks.recoverFromRestart.mockResolvedValue(undefined);
     mergeMocks.registerWorker.mockResolvedValue(undefined);
     mergeMocks.unregisterWorker.mockResolvedValue(undefined);
@@ -821,6 +824,68 @@ describe('runtime v2 startup inbox dispatch', () => {
 
     expect(runtime.config.workers[0]?.assigned_tasks).toEqual(['1']);
     expect(mocks.sendToWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it('direct grok launch resolves model from grok env vars and never calls resolveClaudeWorkerModel', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-grok-direct-'));
+    const originalGrokModel = process.env.OMC_GROK_DEFAULT_MODEL;
+    const originalGrokExternal = process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+    delete process.env.OMC_GROK_DEFAULT_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+    try {
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 1,
+        agentTypes: ['grok'],
+        tasks: [{ subject: 'Grok dispatch', description: 'Verify direct grok model resolution' }],
+        cwd,
+      });
+
+      // DIRECT grok launch: no grok env set → model is undefined (NOT a Claude id).
+      expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+        'grok',
+        expect.objectContaining({ model: undefined }),
+      );
+      // crucially, a grok worker must never fall through to the Claude/Bedrock resolver.
+      expect(modelContractMocks.resolveClaudeWorkerModel).not.toHaveBeenCalled();
+    } finally {
+      if (originalGrokModel === undefined) delete process.env.OMC_GROK_DEFAULT_MODEL;
+      else process.env.OMC_GROK_DEFAULT_MODEL = originalGrokModel;
+      if (originalGrokExternal === undefined) delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+      else process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL = originalGrokExternal;
+    }
+  });
+
+  it('direct grok launch passes OMC_GROK_DEFAULT_MODEL through to buildWorkerArgv', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-grok-model-'));
+    const originalGrokModel = process.env.OMC_GROK_DEFAULT_MODEL;
+    const originalGrokExternal = process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+    process.env.OMC_GROK_DEFAULT_MODEL = 'grok-4-fast';
+    try {
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 1,
+        agentTypes: ['grok'],
+        tasks: [{ subject: 'Grok dispatch', description: 'Verify grok env model passthrough' }],
+        cwd,
+      });
+
+      expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+        'grok',
+        expect.objectContaining({ model: 'grok-4-fast' }),
+      );
+      expect(modelContractMocks.resolveClaudeWorkerModel).not.toHaveBeenCalled();
+    } finally {
+      if (originalGrokModel === undefined) delete process.env.OMC_GROK_DEFAULT_MODEL;
+      else process.env.OMC_GROK_DEFAULT_MODEL = originalGrokModel;
+      if (originalGrokExternal === undefined) delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL;
+      else process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL = originalGrokExternal;
+    }
   });
 
   it('keeps gemini prompt-mode launch args to a short inbox pointer and waits for claim evidence', async () => {

--- a/src/team/__tests__/stage-router.test.ts
+++ b/src/team/__tests__/stage-router.test.ts
@@ -90,6 +90,50 @@ describe('stage-router resolveRoleAssignment', () => {
       expect(out.agent).toBe('codeReviewer');
     });
 
+    it('respects provider=grok and resolves to empty model (no Claude fallthrough) when omitted', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { 'code-reviewer': { provider: 'grok' } } },
+      };
+      const out = resolveRoleAssignment('code-reviewer', cfg);
+      expect(out.provider).toBe('grok');
+      // grok has no builtin default model and none configured → resolves to ''
+      // (NOT a Claude tier model id).
+      expect(out.model).toBe('');
+      expect(out.model).not.toBe(CLAUDE_FAMILY_DEFAULTS.OPUS);
+      expect(out.agent).toBe('codeReviewer');
+    });
+
+    it('respects provider=grok with explicit model passthrough', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { critic: { provider: 'grok', model: 'grok-4-fast' } } },
+      };
+      const out = resolveRoleAssignment('critic', cfg);
+      expect(out.provider).toBe('grok');
+      expect(out.model).toBe('grok-4-fast');
+      expect(out.agent).toBe('critic');
+    });
+
+    it('grok resolves configured externalModels.defaults.grokModel when model omitted', () => {
+      const cfg: PluginConfig = {
+        externalModels: { defaults: { grokModel: 'grok-code-fast-1' } },
+        team: { roleRouting: { 'code-reviewer': { provider: 'grok' } } },
+      };
+      const out = resolveRoleAssignment('code-reviewer', cfg);
+      expect(out.provider).toBe('grok');
+      expect(out.model).toBe('grok-code-fast-1');
+    });
+
+    it('tier name on grok provider falls back to provider default (tiers are claude-centric)', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { executor: { provider: 'grok', model: 'HIGH' } } },
+      };
+      const out = resolveRoleAssignment('executor', cfg);
+      expect(out.provider).toBe('grok');
+      // tier names are claude-centric → grok ignores them and uses its (empty) default
+      expect(out.model).toBe('');
+      expect(out.model).not.toBe(CLAUDE_FAMILY_DEFAULTS.OPUS);
+    });
+
     it('resolves tier name (HIGH) into Claude opus model for claude provider', () => {
       const cfg: PluginConfig = {
         team: { roleRouting: { executor: { provider: 'claude', model: 'HIGH' } } },

--- a/src/team/capabilities.ts
+++ b/src/team/capabilities.ts
@@ -19,6 +19,7 @@ const DEFAULT_CAPABILITIES: Record<WorkerBackend, WorkerCapability[]> = {
   'tmux-codex': ['code-review', 'security-review', 'architecture', 'refactoring'],
   'tmux-gemini': ['ui-design', 'documentation', 'research', 'code-edit'],
   'tmux-cursor': ['code-edit', 'refactoring', 'general'],
+  'tmux-grok': ['code-edit', 'code-review', 'refactoring', 'general'],
 };
 
 /**

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -36,5 +36,6 @@ export function detectAllClis(): Record<string, CliInfo> {
     codex: detectCli('codex'),
     gemini: detectCli('gemini'),
     cursor: detectCli('cursor-agent'),
+    grok: detectCli('grok'),
   };
 }

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,7 +5,7 @@ import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'grok';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -66,6 +66,7 @@ function getTrustedPrefixes(): string[] {
     trusted.push(`${home}/.local/bin`);
     trusted.push(`${home}/.nvm/`);
     trusted.push(`${home}/.cargo/bin`);
+    trusted.push(`${home}/.grok/bin`);
   }
 
   const custom = (process.env.OMC_TRUSTED_CLI_DIRS ?? '')
@@ -250,6 +251,21 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       return rawOutput.trim();
     },
   },
+  grok: {
+    agentType: 'grok',
+    binary: 'grok',
+    installInstructions: 'Install Grok Build: https://build.grok.com',
+    supportsPromptMode: true,
+    promptModeFlag: '-p',
+    buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
+      const args = ['--always-approve'];
+      if (model) args.push('--model', model);
+      return [...args, ...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
   cursor: {
     agentType: 'cursor',
     binary: 'cursor-agent',
@@ -388,6 +404,8 @@ const WORKER_MODEL_ENV_ALLOWLIST = [
   'OMC_CODEX_DEFAULT_MODEL',
   'OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL',
   'OMC_GEMINI_DEFAULT_MODEL',
+  'OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL',
+  'OMC_GROK_DEFAULT_MODEL',
 ] as const;
 
 export function getWorkerEnv(

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -677,6 +677,11 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
         || process.env.OMC_GEMINI_DEFAULT_MODEL
         || undefined;
     }
+    if (opts.agentType === 'grok') {
+      return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL
+        || process.env.OMC_GROK_DEFAULT_MODEL
+        || undefined;
+    }
     // Claude agents: resolve Bedrock/Vertex model when on those providers
     return resolveClaudeWorkerModel();
   })();

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -505,7 +505,7 @@ export async function monitorTeam(teamName: string, cwd: string, workerPaneIds: 
 
     workers.push(status);
     if (!alive) deadWorkers.push(wName);
-    // Note: CLI workers (codex/gemini) may not write heartbeat.json — stall is advisory only
+    // Note: CLI workers (codex/gemini/grok) may not write heartbeat.json — stall is advisory only
   }
   const workerScanMs = Date.now() - workerScanStartedAt;
 
@@ -735,6 +735,11 @@ export async function spawnWorkerForTask(
         || process.env.OMC_GEMINI_DEFAULT_MODEL
         || undefined;
     }
+    if (agentType === 'grok') {
+      return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL
+        || process.env.OMC_GROK_DEFAULT_MODEL
+        || undefined;
+    }
     // Claude agents: resolve Bedrock/Vertex model when on those providers
     return resolveClaudeWorkerModel();
   })();
@@ -922,11 +927,11 @@ export async function shutdownTeam(
 
   const configData = await readJsonSafe<TeamConfig>(join(root, 'config.json'));
 
-  // CLI workers (claude/codex/gemini tmux pane processes) never write shutdown-ack.json.
+  // CLI workers (claude/codex/gemini/grok tmux pane processes) never write shutdown-ack.json.
   // Polling for ACK files on CLI worker teams wastes the full timeoutMs on every shutdown.
   // Detect CLI worker teams by checking if all agent types are known CLI types, and skip
   // ACK polling — the tmux kill below handles process cleanup instead.
-  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini']);
+  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini', 'grok']);
   const agentTypes: string[] = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every(t => CLI_AGENT_TYPES.has(t));
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -54,7 +54,7 @@ import {
 // ── Environment gate ──────────────────────────────────────────────────────────
 
 const OMC_TEAM_SCALING_ENABLED_ENV = 'OMC_TEAM_SCALING_ENABLED';
-const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini']);
+const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini', 'grok']);
 
 export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMC_TEAM_SCALING_ENABLED_ENV];

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -132,7 +132,7 @@ function resolveClaudeModel(
  * explicit non-tier model ID is passed through.
  */
 function resolveExternalModel(
-  provider: 'codex' | 'gemini',
+  provider: 'codex' | 'gemini' | 'grok',
   raw: string | undefined,
   cfg: PluginConfig,
 ): string {
@@ -142,6 +142,9 @@ function resolveExternalModel(
   const defaults = cfg.externalModels?.defaults;
   if (provider === 'codex') {
     return defaults?.codexModel ?? BUILTIN_EXTERNAL_MODEL_DEFAULTS.codexModel;
+  }
+  if (provider === 'grok') {
+    return defaults?.grokModel ?? '';
   }
   return defaults?.geminiModel ?? BUILTIN_EXTERNAL_MODEL_DEFAULTS.geminiModel;
 }

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -59,7 +59,7 @@ function peekRecentOutboxMessages(
 
 export interface WorkerStatus {
   workerName: string;
-  provider: 'claude' | 'codex' | 'gemini';
+  provider: 'claude' | 'codex' | 'gemini' | 'grok';
   heartbeat: HeartbeatData | null;
   isAlive: boolean;
   currentTask: TaskFile | null;
@@ -133,7 +133,7 @@ export function getTeamStatus(
     };
 
     const currentTask = workerTasks.find(t => t.status === 'in_progress') || null;
-    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini';
+    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini' | 'grok';
 
     return {
       workerName: w.name,

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -138,7 +138,7 @@ export interface TaskFailureSidecar {
 }
 
 /** Worker backend type */
-export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-cursor';
+export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-cursor' | 'tmux-grok';
 
 /** Worker capability tag */
 export type WorkerCapability =
@@ -278,7 +278,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'grok';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -102,6 +102,13 @@ function agentTypeGuidance(agentType: CliAgentType): string {
         `- You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Then keep waiting for the next mailbox message; do NOT type \`/exit\` unless the leader sends an explicit shutdown.`,
         '- Reviewer/critic/security-review roles are NOT supported for cursor workers — those require a verdict-file write-and-exit which the REPL does not perform. Take only executor-style tasks.',
       ].join('\n');
+    case 'grok':
+      return [
+        '### Agent-Type Guidance (grok)',
+        `- Prefer short, explicit \`${teamApiCommand} ... --json\` commands and parse outputs before next step.`,
+        '- If a command fails, report the exact stderr to leader-fixed before retrying.',
+        `- You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done.`,
+      ].join('\n');
     case 'claude':
     default:
       return [

--- a/src/team/worker-commit-cadence.ts
+++ b/src/team/worker-commit-cadence.ts
@@ -24,7 +24,7 @@ export interface WorkerCadenceContext {
   teamName: string;
   workerName: string;
   worktreePath: string;
-  agentType: 'claude' | 'codex' | 'gemini' | 'cursor';
+  agentType: 'claude' | 'codex' | 'gemini' | 'cursor' | 'grok';
   enabled: boolean;
 }
 

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -146,7 +146,7 @@ function extractPrompt(input) {
 }
 
 function isExplicitAskSlashInvocation(prompt) {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini)\b/i.test(prompt);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|grok)\b/i.test(prompt);
 }
 
 // Sanitize text to prevent false positives from code blocks, XML tags, URLs, and file paths


### PR DESCRIPTION
Re-submission of #3156 (closed with changes-requested) — both review blockers addressed, and rebased onto current `dev` so this is a clean **grok-only** diff (the #3152 boundary fix it previously stacked on is now merged). #3156 couldn't be reopened (external PR), hence a fresh PR.

## Addresses the #3156 review

**1. Trusted-prefix contract/docs alignment** — softened `SECURITY.md` to match the actual warning-only behavior. The resolved binary path is checked against the trusted-prefix allowlist; resolving *outside* it logs an advisory **warning** (not a hard block), and only temp/shared-memory (`/tmp`, `/var/tmp`, `/dev/shm`) + relative paths are hard-rejected. The docs now describe what the code does (no behavioral change to the existing warn-only model, which is shared by all providers).

**2. Direct provider-advisor execution coverage** — added tests in `src/cli/__tests__/ask.test.ts` proving the advisor invokes Grok as `grok -p <prompt> --always-approve` (a multiline prompt stays a `-p` arg, **never piped over stdin** — stdin reserved for ACP JSON-RPC) and strips Claude session env vars like the other providers (`grok` added to the env-strip `it.each`).

## What

Adds **Grok Build** (`grok`) as a tmux CLI team worker (`omc team N:grok`) and ask provider (`omc ask grok`). Grok is typed through the worker contracts, blocked by `disableExternalLLM`, and avoids Claude/Bedrock model fallthrough in both runtime paths (`runtime-v2.modelForAgent` + `runtime.modelForAgent`) and role routing (`stage-router.resolveExternalModel`).

- `/ask` suppression regex updated in all 3 copies (`src/hooks/bridge.ts`, `scripts/keyword-detector.mjs`, `templates/hooks/keyword-detector.mjs`).
- Grok is **team + ask only** — deliberately NOT in `DelegationProvider`/`ExternalModelProvider`/delegation-routing enums, and the MCP-daemon paths (`mcp-team-bridge`, `job-management`, `prompt-persistence`, `usage-tracker`) stay codex/gemini-only (grok is a tmux CLI worker).
- Docs: README (team/ask tables + install), `docs/REFERENCE.md` (`OMC_GROK_DEFAULT_MODEL` + ask provider matrix/entrypoints), `SECURITY.md`.

## Verification

`npx tsc --noEmit` clean. `ask.test.ts` (25) + the team model/routing/stage-router tests pass. Full suite: only the 5 pre-existing `team.test.ts` governance flakes fail (on base `dev` too). Source-only (no `bridge/`/`dist/`).

Authored by Claude Opus 4.7; reviewed pre-submission by Codex (GPT-5.5), Gemini, Grok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
