### PR TITLE
Fail closed on incomplete plugin cache payloads

### DIFF
--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -26,12 +26,14 @@ vi.mock('fs', async () => {
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
     renameSync: vi.fn(),
+    readdirSync: vi.fn(),
     rmSync: vi.fn(),
+    statSync: vi.fn(),
   };
 });
 
 import { execSync, execFileSync } from 'child_process';
-import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { install, isProjectScopedPlugin, checkNodeVersion, CLAUDE_CONFIG_DIR } from '../installer/index.js';
 import {
@@ -50,6 +52,8 @@ const mockedMkdirSync = vi.mocked(mkdirSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedWriteFileSync = vi.mocked(writeFileSync);
 const mockedRenameSync = vi.mocked(renameSync);
+const mockedReaddirSync = vi.mocked(readdirSync);
+const mockedStatSync = vi.mocked(statSync);
 const mockedInstall = vi.mocked(install);
 const mockedIsProjectScopedPlugin = vi.mocked(isProjectScopedPlugin);
 const mockedCheckNodeVersion = vi.mocked(checkNodeVersion);
@@ -73,8 +77,32 @@ describe('auto-update reconciliation', () => {
     mockedExistsSync.mockReturnValue(true);
     mockedIsProjectScopedPlugin.mockReturnValue(false);
     mockedRenameSync.mockImplementation(() => undefined);
+    mockedStatSync.mockImplementation((path: Parameters<typeof statSync>[0]) => {
+      if (!mockedExistsSync(path)) {
+        throw new Error(`ENOENT: no such file or directory, stat '${String(path)}'`);
+      }
+      return { isFile: () => true } as ReturnType<typeof statSync>;
+    });
+    mockedReaddirSync.mockImplementation((path: Parameters<typeof readdirSync>[0], options?: Parameters<typeof readdirSync>[1]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/commands')) {
+        return options && typeof options === 'object' && 'withFileTypes' in options
+          ? [{ name: 'omc-setup.md', isFile: () => true, isDirectory: () => false }] as any
+          : ['omc-setup.md'] as any;
+      }
+      if (normalized.endsWith('/skills')) {
+        return options && typeof options === 'object' && 'withFileTypes' in options
+          ? [{ name: 'plan', isFile: () => false, isDirectory: () => true }] as any
+          : ['plan'] as any;
+      }
+      return [] as any;
+    });
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
-      if (String(path).includes('.omc-version.json')) {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
+      if (normalized.includes('.omc-version.json')) {
         return JSON.stringify({
           version: '4.1.5',
           installedAt: '2026-02-09T00:00:00.000Z',
@@ -304,6 +332,9 @@ describe('auto-update reconciliation', () => {
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized.includes('.omc-version.json')) {
         return JSON.stringify({
           version: '4.1.5',
@@ -323,6 +354,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized.endsWith('/plugins/installed_plugins.json')) {
         return true;
       }
@@ -356,11 +390,56 @@ describe('auto-update reconciliation', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('[omc update] Synced plugin cache');
   });
 
+
+
+  it('fails reconciliation when active plugin cache repair reports validation errors', () => {
+    const activeRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.1');
+
+    mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
+      if (normalized.endsWith('/plugins/installed_plugins.json')) {
+        return JSON.stringify({
+          plugins: {
+            'oh-my-claudecode': [{ installPath: activeRoot }],
+          },
+        });
+      }
+      return '';
+    });
+    mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
+      if (normalized.endsWith('/plugins/installed_plugins.json') || normalized === activeRoot.replace(/\\/g, '/')) {
+        return true;
+      }
+      if (normalized.endsWith('/dist/hooks/skill-bridge.cjs')) {
+        return false;
+      }
+      return true;
+    });
+
+    const result = reconcileUpdateRuntime({ verbose: false });
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('Plugin cache sync failed:'),
+      expect.stringContaining('dist/hooks/skill-bridge.cjs'),
+    ]));
+  });
+
   it('skips plugin cache sync silently when no active plugin roots exist', () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized.endsWith('/plugins/installed_plugins.json')) {
         return false;
       }
@@ -389,6 +468,9 @@ describe('auto-update reconciliation', () => {
     });
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === '/usr/lib/node_modules/oh-my-claude-sisyphus/package.json') {
         return JSON.stringify({ version: '4.14.1' });
       }
@@ -406,6 +488,7 @@ describe('auto-update reconciliation', () => {
       const normalized = String(path).replace(/\\/g, '/');
       return normalized.endsWith('/plugins/cache/omc/oh-my-claudecode')
         || normalized.endsWith('/plugins/installed_plugins.json')
+        || normalized.startsWith(join(cacheRoot, '4.14.1').replace(/\\/g, '/'))
         || normalized.startsWith('/usr/lib/node_modules/oh-my-claude-sisyphus');
     });
 
@@ -434,6 +517,9 @@ describe('auto-update reconciliation', () => {
     });
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/oh-my-claude-sisyphus/package.json') {
         return JSON.stringify({ version: '4.14.1' });
       }
@@ -451,6 +537,7 @@ describe('auto-update reconciliation', () => {
       const normalized = String(path).replace(/\\/g, '/');
       return normalized === cacheRoot.replace(/\\/g, '/')
         || normalized.endsWith('/plugins/installed_plugins.json')
+        || normalized.startsWith(join(cacheRoot, '4.14.1').replace(/\\/g, '/'))
         || normalized.startsWith('C:/Users/bellman/AppData/Roaming/npm/node_modules/oh-my-claude-sisyphus');
     });
 
@@ -475,6 +562,9 @@ describe('auto-update reconciliation', () => {
     });
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === '/usr/lib/node_modules/oh-my-claude-sisyphus/package.json') {
         return JSON.stringify({ version: '4.14.1' });
       }
@@ -492,6 +582,7 @@ describe('auto-update reconciliation', () => {
       const normalized = String(path).replace(/\\/g, '/');
       return normalized.endsWith('/plugins/cache/omc/oh-my-claudecode')
         || normalized.endsWith('/plugins/installed_plugins.json')
+        || normalized.startsWith(join(cacheRoot, '4.14.1').replace(/\\/g, '/'))
         || normalized.startsWith('/usr/lib/node_modules/oh-my-claude-sisyphus');
     });
     mockedCpSync.mockImplementationOnce(() => {
@@ -501,6 +592,55 @@ describe('auto-update reconciliation', () => {
     const result = syncPluginCache(false);
 
     expect(result.errors).toContain(`Failed to sync dist to ${join(cacheRoot, '4.14.1')}: copy failed`);
+    expect(mockedWriteFileSync.mock.calls.some(([path]) => String(path).includes('installed_plugins.json.tmp-'))).toBe(false);
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(expect.stringContaining('installed_plugins.json.tmp-'), expect.anything());
+  });
+  it('does not rewrite installed_plugins.json when the versioned cache is missing runtime-critical files after sync', () => {
+    const cacheRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const versionedCacheRoot = join(cacheRoot, '4.14.1');
+
+    mockedExecSync.mockImplementation((command: string) => {
+      if (command === 'npm root -g') {
+        return '/usr/lib/node_modules\n';
+      }
+      return '';
+    });
+    mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
+      if (normalized === '/usr/lib/node_modules/oh-my-claude-sisyphus/package.json') {
+        return JSON.stringify({ version: '4.14.1' });
+      }
+      if (normalized.endsWith('/plugins/installed_plugins.json')) {
+        return JSON.stringify({
+          version: 2,
+          plugins: {
+            'oh-my-claudecode@omc': [{ installPath: join(cacheRoot, '4.14.0'), version: '4.14.0' }],
+          },
+        });
+      }
+      return '';
+    });
+    mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
+      const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
+      if (normalized === `${versionedCacheRoot.replace(/\\/g, '/')}/dist/hooks/skill-bridge.cjs`) {
+        return false;
+      }
+      return normalized.endsWith('/plugins/cache/omc/oh-my-claudecode')
+        || normalized.endsWith('/plugins/installed_plugins.json')
+        || normalized.startsWith('/usr/lib/node_modules/oh-my-claude-sisyphus')
+        || normalized.startsWith(versionedCacheRoot.replace(/\\/g, '/'));
+    });
+
+    const result = syncPluginCache(false);
+
+    expect(result.synced).toBe(false);
+    expect(result.errors).toContain(`${versionedCacheRoot}: Missing required plugin payload file: dist/hooks/skill-bridge.cjs`);
     expect(mockedWriteFileSync.mock.calls.some(([path]) => String(path).includes('installed_plugins.json.tmp-'))).toBe(false);
     expect(mockedRenameSync).not.toHaveBeenCalledWith(expect.stringContaining('installed_plugins.json.tmp-'), expect.anything());
   });
@@ -519,6 +659,9 @@ describe('auto-update reconciliation', () => {
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === '/usr/lib/node_modules/oh-my-claude-sisyphus/package.json') {
         return JSON.stringify({ version: '4.9.0' });
       }
@@ -534,11 +677,23 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === cacheRoot) {
         return true;
       }
       if (normalized.startsWith('/usr/lib/node_modules/oh-my-claude-sisyphus/')) {
-        return normalized.endsWith('/dist') || normalized.endsWith('/package.json');
+        return normalized.endsWith('/dist')
+          || normalized.endsWith('/package.json')
+          || normalized.endsWith('/.claude-plugin/plugin.json')
+          || normalized.endsWith('/dist/hooks/skill-bridge.cjs')
+          || normalized.endsWith('/bridge/cli.cjs')
+          || normalized.endsWith('/hooks/hooks.json')
+          || normalized.endsWith('/commands')
+          || normalized.endsWith('/commands/omc-setup.md')
+          || normalized.endsWith('/skills')
+          || normalized.endsWith('/skills/plan/SKILL.md');
       }
       return true;
     });
@@ -569,6 +724,9 @@ describe('auto-update reconciliation', () => {
     const cacheRoot = join(CLAUDE_CONFIG_DIR, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === cacheRoot) {
         return false;
       }
@@ -596,6 +754,9 @@ describe('auto-update reconciliation', () => {
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === '/usr/lib/node_modules/oh-my-claude-sisyphus/package.json') {
         return JSON.stringify({ version: '4.9.0' });
       }
@@ -611,11 +772,23 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === cacheRoot) {
         return true;
       }
       if (normalized.startsWith('/usr/lib/node_modules/oh-my-claude-sisyphus/')) {
-        return normalized.endsWith('/dist');
+        return normalized.endsWith('/dist')
+          || normalized.endsWith('/package.json')
+          || normalized.endsWith('/.claude-plugin/plugin.json')
+          || normalized.endsWith('/dist/hooks/skill-bridge.cjs')
+          || normalized.endsWith('/bridge/cli.cjs')
+          || normalized.endsWith('/hooks/hooks.json')
+          || normalized.endsWith('/commands')
+          || normalized.endsWith('/commands/omc-setup.md')
+          || normalized.endsWith('/skills')
+          || normalized.endsWith('/skills/plan/SKILL.md');
       }
       return true;
     });
@@ -630,6 +803,9 @@ describe('auto-update reconciliation', () => {
     expect(result.skipped).toBe(false);
     expect(result.errors).toEqual([
       `Failed to sync dist to ${versionedCacheRoot}: copy failed`,
+      `Failed to sync skills to ${versionedCacheRoot}: copy failed`,
+      `Failed to sync commands to ${versionedCacheRoot}: copy failed`,
+      `Failed to sync package.json to ${versionedCacheRoot}: copy failed`,
     ]);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       `[omc update] Plugin cache sync warning: Failed to sync dist to ${versionedCacheRoot}: copy failed`,
@@ -662,6 +838,9 @@ describe('auto-update reconciliation', () => {
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized.includes('.omc-version.json')) {
         return JSON.stringify({
           version: '4.1.5',
@@ -684,6 +863,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized.endsWith('/plugins/installed_plugins.json')) {
         return true;
       }
@@ -740,6 +922,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === pluginRoot.replace(/\\/g, '/')) {
         return true;
       }
@@ -778,6 +963,9 @@ describe('auto-update reconciliation', () => {
     let claudeCodePackageCheckCount = 0;
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === '/usr/lib/node_modules/@anthropic-ai/claude-code/package.json') {
         claudeCodePackageCheckCount += 1;
         return claudeCodePackageCheckCount === 1 || claudeCodePackageCheckCount === 3;
@@ -793,6 +981,9 @@ describe('auto-update reconciliation', () => {
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === '/usr/lib/node_modules/@anthropic-ai/claude-code/package.json') {
         return JSON.stringify({ version: '1.2.3' });
       }
@@ -853,6 +1044,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === '/usr/lib/node_modules/@anthropic-ai/claude-code/package.json') {
         return false;
       }
@@ -900,6 +1094,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized.endsWith('/plugins/marketplaces/omc')) {
         return false;
       }
@@ -948,6 +1145,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === '/usr/lib/node_modules/@anthropic-ai/claude-code/package.json') {
         return true;
       }
@@ -963,6 +1163,9 @@ describe('auto-update reconciliation', () => {
     let claudeCodeReadCount = 0;
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === '/usr/lib/node_modules/@anthropic-ai/claude-code/package.json') {
         claudeCodeReadCount += 1;
         if (claudeCodeReadCount === 2) {
@@ -1022,6 +1225,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
         return false;
       }
@@ -1087,6 +1293,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
         return false;
       }
@@ -1147,6 +1356,9 @@ describe('auto-update reconciliation', () => {
     let claudeCodePackageCheckCount = 0;
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
         claudeCodePackageCheckCount += 1;
         return claudeCodePackageCheckCount === 1 || claudeCodePackageCheckCount === 3;
@@ -1162,6 +1374,9 @@ describe('auto-update reconciliation', () => {
 
     mockedReadFileSync.mockImplementation((path: Parameters<typeof readFileSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] });
+      }
       if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
         return JSON.stringify({ version: '1.2.3' });
       }
@@ -1456,6 +1671,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized === 'C:/Users/bellman/AppData/Roaming/npm/node_modules/@anthropic-ai/claude-code/package.json') {
         return false;
       }
@@ -1526,6 +1744,9 @@ describe('auto-update reconciliation', () => {
 
     mockedExistsSync.mockImplementation((path: Parameters<typeof existsSync>[0]) => {
       const normalized = String(path).replace(/\\/g, '/');
+      if (normalized.endsWith('/.claude-plugin/plugin.json')) {
+        return true;
+      }
       if (normalized.endsWith('/plugins/marketplaces/omc')) {
         return false;
       }

--- a/src/__tests__/installer-omc-reference.test.ts
+++ b/src/__tests__/installer-omc-reference.test.ts
@@ -70,6 +70,29 @@ function writeEnabledPluginSettings(claudeConfigDir: string): void {
   );
 }
 
+function writeMinimallyCompletePluginPayload(pluginRoot: string): void {
+  mkdirSync(join(pluginRoot, 'dist', 'hooks'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'dist', 'hooks', 'skill-bridge.cjs'), 'console.log("skill bridge");\n');
+  mkdirSync(join(pluginRoot, 'bridge'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'bridge', 'cli.cjs'), 'console.log("bridge");\n');
+  mkdirSync(join(pluginRoot, 'hooks'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'hooks', 'hooks.json'), '{}\n');
+  mkdirSync(join(pluginRoot, 'commands'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md.\n');
+  mkdirSync(join(pluginRoot, 'skills', 'ralph'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'skills', 'ralph', 'SKILL.md'), 'name: ralph\n');
+  mkdirSync(join(pluginRoot, '.claude-plugin'), { recursive: true });
+  writeFileSync(
+    join(pluginRoot, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({
+      name: 'oh-my-claudecode',
+      commands: './commands/',
+      skills: ['./skills/ralph/'],
+    }, null, 2)
+  );
+  writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ name: 'oh-my-claude-sisyphus', version: '4.10.2' }, null, 2));
+}
+
 function getBundledSkillNames(): string[] {
   const skininthegamebrosOnlySkills = new Set(['remember', 'verify', 'debug']);
 
@@ -173,8 +196,7 @@ describe('installer bundled + standalone skill sync', () => {
 
   it('skips bundled skill sync when an installed plugin already provides skills', async () => {
     const pluginRoot = join(tempRoot, 'plugin-cache', 'oh-my-claudecode', '4.10.2');
-    mkdirSync(join(pluginRoot, 'skills', 'ralph'), { recursive: true });
-    writeFileSync(join(pluginRoot, 'skills', 'ralph', 'SKILL.md'), 'name: ralph\n');
+    writeMinimallyCompletePluginPayload(pluginRoot);
     writeInstalledPluginRegistry(claudeConfigDir, pluginRoot);
     writeEnabledPluginSettings(claudeConfigDir);
 

--- a/src/__tests__/installer-plugin-agents.test.ts
+++ b/src/__tests__/installer-plugin-agents.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 
 vi.mock('fs', async () => {
@@ -50,6 +50,25 @@ async function loadInstallerWithEnv(claudeConfigDir: string, homeDir: string) {
   return import('../installer/index.js');
 }
 
+function writePluginFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function writeCompletePluginPayload(root: string): void {
+  writePluginFile(join(root, 'dist', 'hooks', 'skill-bridge.cjs'), 'console.log("skill bridge");\n');
+  writePluginFile(join(root, 'bridge', 'cli.cjs'), 'console.log("bridge");\n');
+  writePluginFile(join(root, 'hooks', 'hooks.json'), '{}\n');
+  writePluginFile(join(root, 'skills', 'plan', 'SKILL.md'), '# plan\n');
+  writePluginFile(join(root, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md and pass $ARGUMENTS.\n');
+  writePluginFile(join(root, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'oh-my-claudecode',
+    commands: './commands/',
+    skills: ['./skills/plan/'],
+  }, null, 2));
+  writePluginFile(join(root, 'package.json'), JSON.stringify({ name: 'oh-my-claude-sisyphus', version: '9.9.9' }, null, 2));
+}
+
 describe('installer legacy agent sync gating (issue #1502)', () => {
   let tempRoot: string;
   let homeDir: string;
@@ -95,6 +114,7 @@ describe('installer legacy agent sync gating (issue #1502)', () => {
       '9.9.9'
     );
     const pluginAgentsDir = join(pluginInstallPath, 'agents');
+    writeCompletePluginPayload(pluginInstallPath);
     mkdirSync(pluginAgentsDir, { recursive: true });
     writeFileSync(join(pluginAgentsDir, 'executor.md'), '---\nname: executor\ndescription: test\n---\n');
 

--- a/src/__tests__/npm-package-hook-surface.test.ts
+++ b/src/__tests__/npm-package-hook-surface.test.ts
@@ -138,6 +138,14 @@ describe('npm package hook surface regression', () => {
     expect(packedFiles.has('.claude-plugin/plugin.json')).toBe(true);
   });
 
+  it('packs the runtime-critical plugin cache payload surface', () => {
+    const packedFiles = getPackedFiles();
+    expect(packedFiles.has('commands/omc-setup.md')).toBe(true);
+    expect(packedFiles.has('dist/hooks/skill-bridge.cjs')).toBe(true);
+    expect(packedFiles.has('bridge/cli.cjs')).toBe(true);
+    expect(packedFiles.has('.claude-plugin/plugin.json')).toBe(true);
+  });
+
   it('packs hooks.json, hook entry scripts, and their local script dependencies', () => {
     const requiredFiles = new Set<string>(['hooks/hooks.json']);
 

--- a/src/__tests__/plugin-skill-budget.test.ts
+++ b/src/__tests__/plugin-skill-budget.test.ts
@@ -126,11 +126,21 @@ describe('plugin skill context budget gate (issues #2943, #2986)', () => {
       const targetRoot = join(tempRoot, 'cache', 'omc', 'oh-my-claudecode', '4.14.1');
       mkdirSync(join(sourceRoot, '.claude-plugin'), { recursive: true });
       mkdirSync(join(sourceRoot, 'commands'), { recursive: true });
+      mkdirSync(join(sourceRoot, 'dist', 'hooks'), { recursive: true });
+      mkdirSync(join(sourceRoot, 'bridge'), { recursive: true });
+      mkdirSync(join(sourceRoot, 'hooks'), { recursive: true });
+      mkdirSync(join(sourceRoot, 'skills', 'plan'), { recursive: true });
       writeFileSync(join(sourceRoot, '.claude-plugin', 'plugin.json'), JSON.stringify({
         name: 'oh-my-claudecode',
         commands: './commands/',
+        skills: ['./skills/plan/'],
       }, null, 2));
       writeFileSync(join(sourceRoot, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md and pass $ARGUMENTS.\n');
+      writeFileSync(join(sourceRoot, 'dist', 'hooks', 'skill-bridge.cjs'), 'console.log("skill bridge");\n');
+      writeFileSync(join(sourceRoot, 'bridge', 'cli.cjs'), 'console.log("bridge");\n');
+      writeFileSync(join(sourceRoot, 'hooks', 'hooks.json'), '{}\n');
+      writeFileSync(join(sourceRoot, 'skills', 'plan', 'SKILL.md'), 'name: plan\n');
+      writeFileSync(join(sourceRoot, 'package.json'), JSON.stringify({ name: 'oh-my-claude-sisyphus', version: '4.14.1' }));
 
       const result = copyPluginSyncPayload(sourceRoot, [targetRoot]);
 
@@ -139,8 +149,9 @@ describe('plugin skill context budget gate (issues #2943, #2986)', () => {
 
       const manifest = JSON.parse(
         readFileSync(join(targetRoot, '.claude-plugin', 'plugin.json'), 'utf-8')
-      ) as { commands?: string };
+      ) as { commands?: string; skills?: string[] };
       expect(manifest.commands).toBe('./commands/');
+      expect(manifest.skills).toEqual(['./skills/plan/']);
       expect(existsSync(join(targetRoot, 'commands'))).toBe(true);
       expect(readFileSync(join(targetRoot, 'commands', 'omc-setup.md'), 'utf-8')).toContain('$ARGUMENTS');
     } finally {

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -1012,15 +1012,19 @@ export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGraceP
 
   try {
     const pluginSyncResult = syncActivePluginCache();
-    if (pluginSyncResult.errors.length > 0 && options?.verbose) {
-      for (const err of pluginSyncResult.errors) {
-        console.warn(`[omc] Plugin cache sync warning: ${err}`);
+    if (pluginSyncResult.errors.length > 0) {
+      errors.push(...pluginSyncResult.errors.map(err => `Plugin cache sync failed: ${err}`));
+      if (options?.verbose) {
+        for (const err of pluginSyncResult.errors) {
+          console.warn(`[omc] Plugin cache sync error: ${err}`);
+        }
       }
     }
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(`Plugin cache sync failed: ${message}`);
     if (options?.verbose) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[omc] Plugin cache sync warning: ${message}`);
+      console.warn(`[omc] Plugin cache sync error: ${message}`);
     }
   }
 
@@ -1121,7 +1125,12 @@ export async function performUpdate(options?: {
         console.warn(`[omc update] ${marketplaceSync.message}`);
       }
 
-      syncPluginCache(options?.verbose ?? false);
+      const pluginCacheSync = syncPluginCache(options?.verbose ?? false);
+      if (pluginCacheSync.errors.length > 0 && options?.verbose) {
+        for (const error of pluginCacheSync.errors) {
+          console.warn(`[omc update] Plugin cache sync warning: ${error}`);
+        }
+      }
 
       // CRITICAL FIX: After npm updates the global package, the current process
       // still has OLD code loaded in memory. We must re-exec to run reconciliation

--- a/src/installer/__tests__/plugin-cache-sync.test.ts
+++ b/src/installer/__tests__/plugin-cache-sync.test.ts
@@ -13,6 +13,7 @@ function writeFile(path: string, content: string): void {
 function writePayloadTree(root: string, version = '9.9.9-test'): void {
   mkdirSync(root, { recursive: true });
   writeFile(join(root, 'dist', 'lib', 'worktree-paths.js'), 'export const test = true;\n');
+  writeFile(join(root, 'dist', 'hooks', 'skill-bridge.cjs'), 'console.log("skill bridge");\n');
   writeFile(join(root, 'bridge', 'cli.cjs'), 'console.log("bridge");\n');
   writeFile(join(root, 'hooks', 'hooks.json'), '{}\n');
   writeFile(join(root, 'scripts', 'run.cjs'), 'console.log("run");\n');
@@ -21,7 +22,7 @@ function writePayloadTree(root: string, version = '9.9.9-test'): void {
   writeFile(join(root, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md and pass $ARGUMENTS.\n');
   writeFile(join(root, 'templates', 'deliverables.json'), '{}\n');
   writeFile(join(root, 'docs', 'CLAUDE.md'), '# docs\n');
-  writeFile(join(root, '.claude-plugin', 'plugin.json'), '{"name":"oh-my-claudecode"}\n');
+  writeFile(join(root, '.claude-plugin', 'plugin.json'), JSON.stringify({ name: 'oh-my-claudecode', commands: './commands/', skills: ['./skills/plan/'] }, null, 2));
   writeFile(join(root, '.mcp.json'), '{}\n');
   writeFile(join(root, 'README.md'), '# readme\n');
   writeFile(join(root, 'LICENSE'), 'MIT\n');
@@ -144,6 +145,234 @@ describe('syncInstalledPluginPayload', () => {
     expect(existsSync(join(cacheRoot, 'hooks', 'hooks.json'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'commands', 'omc-setup.md'))).toBe(true);
+  });
+
+  it('does not accept a cache root as plugin-provided when required commands are missing', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+
+    writePayloadTree(cacheRoot, '4.14.4');
+    rmSync(join(cacheRoot, 'commands'), { recursive: true, force: true });
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.14.4' }],
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+
+    expect(installer.validatePluginCachePayload(cacheRoot)).toMatchObject({ valid: false });
+    expect(installer.validatePluginCachePayload(cacheRoot).errors).toContain('Missing required plugin command markdown files in commands/');
+    expect(installer.hasPluginProvidedAgentFiles()).toBe(false);
+    expect(installer.hasPluginProvidedSkillFiles()).toBe(false);
+    expect(installer.hasPluginProvidedHookFiles()).toBe(false);
+  });
+
+  it('rejects malformed plugin manifests instead of treating sentinel files as complete', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+
+    writePayloadTree(cacheRoot, '4.14.4');
+    writeFileSync(join(cacheRoot, '.claude-plugin', 'plugin.json'), '{not valid json');
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.14.4' }],
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const validation = installer.validatePluginCachePayload(cacheRoot);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('Invalid plugin manifest: .claude-plugin/plugin.json'),
+    ]));
+    expect(installer.hasPluginProvidedAgentFiles()).toBe(false);
+  });
+
+  it('rejects partial command and manifest-declared skill surfaces', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+
+    writePayloadTree(cacheRoot, '4.14.4');
+    rmSync(join(cacheRoot, 'commands', 'omc-setup.md'), { force: true });
+    writeFile(join(cacheRoot, 'commands', 'unrelated.md'), '# unrelated\n');
+    rmSync(join(cacheRoot, 'skills', 'plan'), { recursive: true, force: true });
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.14.4' }],
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const validation = installer.validatePluginCachePayload(cacheRoot);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toEqual(expect.arrayContaining([
+      'Missing required plugin command file: commands/omc-setup.md',
+      'Missing required plugin skill definitions in skills/',
+      'Missing declared plugin skill file: skills/plan/SKILL.md',
+    ]));
+    expect(installer.hasPluginProvidedAgentFiles()).toBe(false);
+  });
+
+  it('rejects schema-malformed plugin manifests even when payload files exist', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+
+    writePayloadTree(cacheRoot, '4.14.4');
+    writeFileSync(join(cacheRoot, '.claude-plugin', 'plugin.json'), JSON.stringify({
+      name: 'oh-my-claudecode',
+      commands: 17,
+      skills: './skills/plan/',
+    }));
+
+    const installer = await freshInstaller();
+    const validation = installer.validatePluginCachePayload(cacheRoot);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toEqual(expect.arrayContaining([
+      'Invalid plugin manifest: .claude-plugin/plugin.json commands must be a non-empty relative path',
+      'Invalid plugin manifest: .claude-plugin/plugin.json skills must be a non-empty array',
+    ]));
+  });
+
+  it('rejects manifest-declared skill paths that escape the plugin root', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+
+    writePayloadTree(cacheRoot, '4.14.4');
+    writeFileSync(join(cacheRoot, '.claude-plugin', 'plugin.json'), JSON.stringify({
+      name: 'oh-my-claudecode',
+      commands: './commands/',
+      skills: ['../outside/'],
+    }));
+
+    const installer = await freshInstaller();
+    const validation = installer.validatePluginCachePayload(cacheRoot);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toContain('Invalid plugin skill declaration outside plugin root: ../outside/');
+  });
+
+  it('rejects required plugin file paths that exist only as directories', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+
+    writePayloadTree(cacheRoot, '4.14.4');
+    rmSync(join(cacheRoot, 'dist', 'hooks', 'skill-bridge.cjs'), { force: true });
+    mkdirSync(join(cacheRoot, 'dist', 'hooks', 'skill-bridge.cjs'), { recursive: true });
+    rmSync(join(cacheRoot, 'commands', 'omc-setup.md'), { force: true });
+    mkdirSync(join(cacheRoot, 'commands', 'omc-setup.md'), { recursive: true });
+    rmSync(join(cacheRoot, 'skills', 'plan', 'SKILL.md'), { force: true });
+    mkdirSync(join(cacheRoot, 'skills', 'plan', 'SKILL.md'), { recursive: true });
+
+    const installer = await freshInstaller();
+    const validation = installer.validatePluginCachePayload(cacheRoot);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toEqual(expect.arrayContaining([
+      'Missing required plugin payload file: dist/hooks/skill-bridge.cjs',
+      'Missing required plugin command file: commands/omc-setup.md',
+      'Missing declared plugin skill file: skills/plan/SKILL.md',
+    ]));
+  });
+
+  it('repairs cache roots missing commands, runtime dist hook, and bridge from a complete source', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+    const sourceRoot = join(tempRoot, 'complete-marketplace-source');
+
+    writePayloadTree(sourceRoot, '4.14.4');
+    writePayloadTree(cacheRoot, '4.14.4');
+    rmSync(join(cacheRoot, 'commands'), { recursive: true, force: true });
+    rmSync(join(cacheRoot, 'dist', 'hooks'), { recursive: true, force: true });
+    rmSync(join(cacheRoot, 'bridge'), { recursive: true, force: true });
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.14.4' }],
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({
+        omc: {
+          installLocation: sourceRoot,
+          source: { source: 'directory', path: sourceRoot },
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const result = installer.syncInstalledPluginPayload();
+
+    expect(result.synced).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(installer.validatePluginCachePayload(cacheRoot)).toEqual({ valid: true, errors: [] });
+    expect(existsSync(join(cacheRoot, 'commands', 'omc-setup.md'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'dist', 'hooks', 'skill-bridge.cjs'))).toBe(true);
+    expect(existsSync(join(cacheRoot, 'bridge', 'cli.cjs'))).toBe(true);
+  });
+
+  it('rejects package sources missing runtime-critical dist hook or bridge files', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.14.4');
+    const incompleteSourceRoot = join(tempRoot, 'incomplete-marketplace-source');
+
+    writePayloadTree(incompleteSourceRoot, '4.14.4');
+    rmSync(join(incompleteSourceRoot, 'dist', 'hooks'), { recursive: true, force: true });
+    rmSync(join(incompleteSourceRoot, 'bridge'), { recursive: true, force: true });
+    mkdirSync(cacheRoot, { recursive: true });
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.14.4' }],
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({
+        omc: {
+          installLocation: incompleteSourceRoot,
+          source: { source: 'directory', path: incompleteSourceRoot },
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const result = installer.copyPluginSyncPayload(incompleteSourceRoot, [cacheRoot]);
+
+    expect(result.synced).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      `${incompleteSourceRoot}: Missing required plugin payload file: dist/hooks/skill-bridge.cjs`,
+      `${incompleteSourceRoot}: Missing required plugin payload file: bridge/cli.cjs`,
+    ]));
+
+    expect(existsSync(join(cacheRoot, 'package.json'))).toBe(false);
   });
 
   it('rejects cache install roots that escape the cache directory via .. segments', async () => {

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 const originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
@@ -13,6 +13,27 @@ let testHomeDir: string;
 async function loadInstaller() {
   vi.resetModules();
   return import('../index.js');
+}
+
+function writePluginFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function writeCompletePluginPayload(root: string): void {
+  writePluginFile(join(root, 'dist', 'hooks', 'skill-bridge.cjs'), 'console.log("skill bridge");\n');
+  writePluginFile(join(root, 'bridge', 'cli.cjs'), 'console.log("bridge");\n');
+  writePluginFile(join(root, 'hooks', 'hooks.json'), JSON.stringify({
+    hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node test.mjs' }] }] },
+  }));
+  writePluginFile(join(root, 'skills', 'plan', 'SKILL.md'), '# plan\n');
+  writePluginFile(join(root, 'commands', 'omc-setup.md'), 'Read skills/omc-setup/SKILL.md and pass $ARGUMENTS.\n');
+  writePluginFile(join(root, '.claude-plugin', 'plugin.json'), JSON.stringify({
+    name: 'oh-my-claudecode',
+    commands: './commands/',
+    skills: ['./skills/plan/'],
+  }, null, 2));
+  writePluginFile(join(root, 'package.json'), JSON.stringify({ name: 'oh-my-claude-sisyphus', version: '9.9.9' }, null, 2));
 }
 
 describe('install() standalone hook reconciliation', () => {
@@ -224,13 +245,10 @@ describe('install() plugin-provided hook deduplication (#2252)', () => {
   });
 
   function setupPluginWithHooks() {
-    // Create a fake plugin root with hooks/hooks.json
+    // Create a fake plugin root with the complete runtime payload required
+    // before installer code may trust plugin-provided hooks.
     fakePluginRoot = mkdtempSync(join(tmpdir(), 'omc-fake-plugin-'));
-    const hooksDir = join(fakePluginRoot, 'hooks');
-    mkdirSync(hooksDir, { recursive: true });
-    writeFileSync(join(hooksDir, 'hooks.json'), JSON.stringify({
-      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node test.mjs' }] }] },
-    }));
+    writeCompletePluginPayload(fakePluginRoot);
 
     // Register plugin in installed_plugins.json
     const pluginsDir = join(testClaudeDir, 'plugins');

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -8,8 +8,8 @@
  * Bash hook scripts were removed in v3.9.0.
  */
 
-import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, chmodSync, readdirSync, cpSync, unlinkSync, rmSync, realpathSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, chmodSync, readdirSync, cpSync, unlinkSync, rmSync, realpathSync, statSync } from 'fs';
+import { join, dirname, resolve, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
@@ -922,7 +922,17 @@ function directoryHasMarkdownFiles(directory: string): boolean {
   }
 
   try {
-    return readdirSync(directory).some(file => file.endsWith('.md'));
+    return readdirSync(directory, { withFileTypes: true }).some(entry =>
+      entry.isFile() && entry.name.endsWith('.md')
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isRegularFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
   } catch {
     return false;
   }
@@ -995,6 +1005,143 @@ const PLUGIN_SYNC_PAYLOAD = [
   'LICENSE',
   'package.json',
 ] as const;
+
+const REQUIRED_PLUGIN_PAYLOAD_FILES = [
+  '.claude-plugin/plugin.json',
+  'package.json',
+  'dist/hooks/skill-bridge.cjs',
+  'bridge/cli.cjs',
+  'hooks/hooks.json',
+] as const;
+
+const REQUIRED_PLUGIN_COMMAND_FILES = [
+  'commands/omc-setup.md',
+] as const;
+
+function readPluginManifest(root: string): { manifest: Record<string, unknown> | null; errors: string[] } {
+  const manifestPath = join(root, '.claude-plugin', 'plugin.json');
+  if (!existsSync(manifestPath)) {
+    return { manifest: null, errors: [] };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { manifest: null, errors: ['Invalid plugin manifest: .claude-plugin/plugin.json must be a JSON object'] };
+    }
+    return { manifest: parsed as Record<string, unknown>, errors: [] };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { manifest: null, errors: [`Invalid plugin manifest: .claude-plugin/plugin.json: ${message}`] };
+  }
+}
+
+function normalizePluginRelPath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
+function isSafePluginRelPath(value: string): boolean {
+  const normalized = normalizePluginRelPath(value);
+  return normalized.length > 0
+    && !isAbsolute(value)
+    && !/^[A-Za-z]:[\\/]/.test(value)
+    && !normalized.split('/').includes('..');
+}
+
+function validatePluginManifestSchema(root: string, manifest: Record<string, unknown> | null): string[] {
+  const errors: string[] = [];
+
+  if (!manifest) {
+    return errors;
+  }
+
+  if (typeof manifest.name !== 'string' || manifest.name.trim().length === 0) {
+    errors.push('Invalid plugin manifest: .claude-plugin/plugin.json name must be a non-empty string');
+  }
+
+  if (typeof manifest.commands !== 'string' || manifest.commands.trim().length === 0) {
+    errors.push('Invalid plugin manifest: .claude-plugin/plugin.json commands must be a non-empty relative path');
+  } else if (!isSafePluginRelPath(manifest.commands)) {
+    errors.push('Invalid plugin manifest: .claude-plugin/plugin.json commands must stay inside the plugin root');
+  } else if (!directoryHasMarkdownFiles(join(root, normalizePluginRelPath(manifest.commands)))) {
+    errors.push(`Missing declared plugin command markdown files in ${normalizePluginRelPath(manifest.commands)}/`);
+  }
+
+  if (!Array.isArray(manifest.skills) || manifest.skills.length === 0) {
+    errors.push('Invalid plugin manifest: .claude-plugin/plugin.json skills must be a non-empty array');
+  }
+
+  return errors;
+}
+
+function validateDeclaredPluginSkills(root: string, manifest: Record<string, unknown> | null): string[] {
+  const errors: string[] = [];
+  const declaredSkills = manifest?.skills;
+
+  if (!Array.isArray(declaredSkills)) {
+    return errors;
+  }
+
+  for (const declaredSkill of declaredSkills) {
+    if (typeof declaredSkill !== 'string' || declaredSkill.trim().length === 0) {
+      errors.push('Invalid plugin skill declaration in .claude-plugin/plugin.json');
+      continue;
+    }
+
+    if (!isSafePluginRelPath(declaredSkill)) {
+      errors.push(`Invalid plugin skill declaration outside plugin root: ${declaredSkill}`);
+      continue;
+    }
+
+    const relPath = normalizePluginRelPath(declaredSkill);
+    const skillPath = relPath.endsWith('/SKILL.md') ? relPath : `${relPath}/SKILL.md`;
+    if (!isRegularFile(join(root, skillPath))) {
+      errors.push(`Missing declared plugin skill file: ${skillPath}`);
+    }
+  }
+
+  return errors;
+}
+
+function validatePluginSyncPayload(root: string): string[] {
+  const errors: string[] = [];
+
+  for (const relPath of REQUIRED_PLUGIN_PAYLOAD_FILES) {
+    if (!isRegularFile(join(root, relPath))) {
+      errors.push(`Missing required plugin payload file: ${relPath}`);
+    }
+  }
+
+  for (const relPath of REQUIRED_PLUGIN_COMMAND_FILES) {
+    if (!isRegularFile(join(root, relPath))) {
+      errors.push(`Missing required plugin command file: ${relPath}`);
+    }
+  }
+
+  if (!directoryHasMarkdownFiles(join(root, 'commands'))) {
+    errors.push('Missing required plugin command markdown files in commands/');
+  }
+
+  if (!directoryHasSkillDefinitions(join(root, 'skills'))) {
+    errors.push('Missing required plugin skill definitions in skills/');
+  }
+
+  const manifestResult = readPluginManifest(root);
+  errors.push(...manifestResult.errors);
+  errors.push(...validatePluginManifestSchema(root, manifestResult.manifest));
+  errors.push(...validateDeclaredPluginSkills(root, manifestResult.manifest));
+
+  return errors;
+}
+
+export function validatePluginCachePayload(root: string): { valid: boolean; errors: string[] } {
+  const errors = validatePluginSyncPayload(root);
+  return { valid: errors.length === 0, errors };
+}
+
+function hasCompletePluginPayload(root: string): boolean {
+  return validatePluginSyncPayload(root).length === 0;
+}
 
 function countPluginSyncPayloadEntries(root: string): number {
   let score = 0;
@@ -1073,7 +1220,7 @@ function isCacheInstalledPluginRoot(root: string): boolean {
   return canonicalRoot === canonicalCacheBase || canonicalRoot.startsWith(`${canonicalCacheBase}/`);
 }
 
-function resolveBestPluginSyncSource(targetRoots: string[]): string | null {
+function resolveBestPluginSyncSource(targetRoots: string[]): { sourceRoot: string | null; errors: string[] } {
   const excludedRoots = new Set(targetRoots.map(normalizePath));
   const seen = new Set<string>();
   const globalPackageRoot = getGlobalInstalledPackageRoot();
@@ -1084,6 +1231,7 @@ function resolveBestPluginSyncSource(targetRoots: string[]): string | null {
   ];
 
   let bestRoot: string | null = null;
+  const errors: string[] = [];
   let bestScore = -1;
   let bestOrder = Number.POSITIVE_INFINITY;
 
@@ -1093,6 +1241,12 @@ function resolveBestPluginSyncSource(targetRoots: string[]): string | null {
       continue;
     }
     seen.add(normalizedCandidate);
+
+    const sourceValidationErrors = validatePluginSyncPayload(candidate);
+    if (sourceValidationErrors.length > 0) {
+      errors.push(...sourceValidationErrors.map(error => `${candidate}: ${error}`));
+      continue;
+    }
 
     const score = countPluginSyncPayloadEntries(candidate);
     if (score === 0) {
@@ -1106,7 +1260,7 @@ function resolveBestPluginSyncSource(targetRoots: string[]): string | null {
     }
   }
 
-  return bestRoot;
+  return { sourceRoot: bestRoot, errors: bestRoot ? [] : errors };
 }
 
 
@@ -1217,6 +1371,14 @@ export function copyPluginSyncPayload(sourceRoot: string, targetRoots: string[])
     return { synced: false, errors: [] };
   }
 
+  const sourceValidationErrors = validatePluginSyncPayload(sourceRoot);
+  if (sourceValidationErrors.length > 0) {
+    return {
+      synced: false,
+      errors: sourceValidationErrors.map(error => `${sourceRoot}: ${error}`),
+    };
+  }
+
   let synced = false;
   const errors: string[] = [];
 
@@ -1248,7 +1410,12 @@ export function copyPluginSyncPayload(sourceRoot: string, targetRoots: string[])
       errors.push(...compactResult.errors);
     }
 
-    synced = synced || copiedToTarget;
+    if (copiedToTarget) {
+      const targetValidationErrors = validatePluginSyncPayload(targetRoot);
+      errors.push(...targetValidationErrors.map(error => `${targetRoot}: ${error}`));
+    }
+
+    synced = synced || (copiedToTarget && !errors.some(error => error.startsWith(`${targetRoot}: `)));
   }
 
   return { synced, errors };
@@ -1267,11 +1434,15 @@ export function syncInstalledPluginPayload(): {
     return { synced: false, errors: [], sourceRoot: null, targetRoots: [] };
   }
 
-  const sourceRoot = resolveBestPluginSyncSource(targetRoots);
+  const sourceResolution = resolveBestPluginSyncSource(targetRoots);
+  const sourceRoot = sourceResolution.sourceRoot;
   if (!sourceRoot) {
     return {
       synced: false,
-      errors: ['Unable to find a complete OMC package source to repair installed plugin roots'],
+      errors: [
+        'Unable to find a complete OMC package source to repair installed plugin roots',
+        ...sourceResolution.errors,
+      ],
       sourceRoot: null,
       targetRoots,
     };
@@ -1287,19 +1458,19 @@ export function syncInstalledPluginPayload(): {
  */
 export function hasPluginProvidedAgentFiles(): boolean {
   return getInstalledOmcPluginRoots().some(pluginRoot =>
-    directoryHasMarkdownFiles(join(pluginRoot, 'agents'))
+    hasCompletePluginPayload(pluginRoot) && directoryHasMarkdownFiles(join(pluginRoot, 'agents'))
   );
 }
 
 export function hasPluginProvidedSkillFiles(): boolean {
   return getInstalledOmcPluginRoots().some(pluginRoot =>
-    directoryHasSkillDefinitions(join(pluginRoot, 'skills'))
+    hasCompletePluginPayload(pluginRoot) && directoryHasSkillDefinitions(join(pluginRoot, 'skills'))
   );
 }
 
 export function hasPluginProvidedHookFiles(): boolean {
   return getInstalledOmcPluginRoots().some(pluginRoot =>
-    existsSync(join(pluginRoot, 'hooks', 'hooks.json'))
+    hasCompletePluginPayload(pluginRoot) && existsSync(join(pluginRoot, 'hooks', 'hooks.json'))
   );
 }
 
@@ -1729,7 +1900,12 @@ export function install(options: InstallOptions = {}): InstallResult {
   const pluginPayloadSync = syncInstalledPluginPayload();
   if (pluginPayloadSync.errors.length > 0) {
     for (const error of pluginPayloadSync.errors) {
-      log(`Plugin cache sync warning: ${error}`);
+      log(`Plugin cache sync error: ${error}`);
+    }
+    if (pluginPayloadSync.targetRoots.length > 0) {
+      result.errors.push(...pluginPayloadSync.errors.map(error => `Plugin cache sync failed: ${error}`));
+      result.message = 'Installation failed: OMC plugin cache is incomplete and could not be repaired';
+      return result;
     }
   }
   if (pluginPayloadSync.synced) {


### PR DESCRIPTION
## Summary
- fail closed when installed plugin cache payloads are incomplete or malformed
- validate repair sources and repaired targets for runtime bridge files, command wrappers, manifest-declared skills, and regular-file payload integrity
- propagate plugin cache repair failures through install/reconciliation instead of treating broken caches as plugin-provided surfaces

Closes #3160

## Verification
- `npm test -- src/installer/__tests__/plugin-cache-sync.test.ts src/__tests__/auto-update.test.ts src/__tests__/plugin-skill-budget.test.ts src/__tests__/npm-package-hook-surface.test.ts src/installer/__tests__/standalone-hook-reconcile.test.ts src/__tests__/installer-plugin-agents.test.ts`
- `npm run build`
- `npm run lint` (passes with existing warnings outside changed files)
- `git diff --check`

## Independent review
- Code review: APPROVE
- Architecture review: CLEAR

🤖 Generated with Codex via oh-my-codex ultragoal.
