### PR TITLE
Reduce ralph/ultrawork keyword false positives

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -620,6 +620,36 @@ function hasDiagnosticIntentNearKeyword(context, keyword) {
   return patterns.some((pattern) => pattern.test(context));
 }
 
+function isRalphUltraworkMetaOrBanterContext(context, keywordText) {
+  const normalizedKeyword = (keywordText || '').toLowerCase().replace(/\s+/g, '');
+  if (!['ralph', '랄프', 'ultrawork', 'ulw', 'uw', '울트라워크'].includes(normalizedKeyword)) {
+    return false;
+  }
+
+  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프'
+    ? ['랄프']
+    : ['울트라워크'];
+  const currentKeywordPattern = currentKeywordAliases.join('|');
+  const imperativeVerbPattern = '켜|켜줘|실행|시작|돌려|돌려줘|써|써줘|사용해|진행해';
+  const koreanImperativePatterns = [
+    new RegExp(`(?:${currentKeywordPattern})[^?？\n]{0,16}(?:${imperativeVerbPattern})`, 'u'),
+    new RegExp(`(?:${imperativeVerbPattern})[^?？\n]{0,16}(?:${currentKeywordPattern})`, 'u'),
+  ];
+  if (koreanImperativePatterns.some((pattern) => pattern.test(context))) {
+    return false;
+  }
+
+  const metaOrBanterPatterns = [
+    /[?？].{0,12}(?:ㅋ{1,}|ㅎ{1,}|lol|lmao)/iu,
+    /(?:ㅋ{1,}|ㅎ{1,}|lol|lmao).{0,40}[?？]/iu,
+    /(?:ralph|랄프|ultrawork|ulw|uw|울트라워크).{0,40}(?:라도|줘야\s*해|쥐어\s*줘야\s*해|해야\s*해).{0,20}[?？]/iu,
+    /(?:관계|관련|연관|차이|비교).{0,40}(?:뭐|무엇|어떻게|설명|알려|궁금|인가|야|냐|니|까|[?？])/u,
+    /(?:뭐|무엇|어떻게|설명|알려|궁금).{0,40}(?:관계|관련|연관|차이|비교)/u,
+  ];
+
+  return metaOrBanterPatterns.some((pattern) => pattern.test(context));
+}
+
 function isInformationalKeywordContext(text, position, keywordLength, keywordText) {
   const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
   const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
@@ -632,6 +662,9 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   if (keywordText) {
     if (hasActivationIntentNearKeyword(context, keywordText)) {
       return false;
+    }
+    if (isRalphUltraworkMetaOrBanterContext(context, keywordText)) {
+      return true;
     }
     if (hasDiagnosticIntentNearKeyword(context, keywordText)) {
       return true;

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -482,6 +482,75 @@ diff --git a/a b/b
     expect(context).not.toContain('[MAGIC KEYWORD: CODE-REVIEW]');
   });
 
+  it('does not activate ralph for Korean banter/question wording from issue #3162', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ralph-banter-'));
+    const sessionId = 'session-3162-ralph-banter';
+    const output = runKeywordDetector('너도 ralph라도 쥐어줘야해?ㅋㅋ', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+    const ralphStatePath = join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(ralphStatePath)).toBe(false);
+  });
+
+  it('does not activate ralph or ultrawork for Korean relationship meta-question from issue #3162', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ultrawork-meta-'));
+    const sessionId = 'session-3162-ultrawork-meta';
+    const output = runKeywordDetector('울트라워크랑 랄프는 무슨 관계야?', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+    const stateDir = join(cwd, '.omc', 'state', 'sessions', sessionId);
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(context).not.toContain('[MAGIC KEYWORD: ULTRAWORK]');
+    expect(existsSync(join(stateDir, 'ralph-state.json'))).toBe(false);
+    expect(existsSync(join(stateDir, 'ultrawork-state.json'))).toBe(false);
+  });
+
+  it('still activates ralph and ultrawork for explicit imperative prompts from issue #3162', () => {
+    const cases = [
+      { prompt: '/ralph fix parser', mode: 'ralph' },
+      { prompt: 'run ralph on this issue', mode: 'ralph' },
+      { prompt: '랄프 켜', mode: 'ralph' },
+      { prompt: 'start ultrawork on this issue', mode: 'ultrawork' },
+      { prompt: '울트라워크 돌려', mode: 'ultrawork' },
+    ] as const;
+
+    for (const { prompt, mode } of cases) {
+      const cwd = mkdtempSync(join(tmpdir(), `keyword-detector-${mode}-positive-`));
+      const sessionId = `session-3162-${mode}-positive-${prompt.replace(/\W+/g, '-')}`;
+      const output = runKeywordDetector(prompt, cwd, sessionId);
+      const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+      expect(context).toContain(`[MAGIC KEYWORD: ${mode.toUpperCase()}]`);
+      expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, `${mode}-state.json`))).toBe(true);
+    }
+  });
+
+  it('only activates the explicitly commanded mode in mixed Korean meta-plus-imperative prompts', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-mixed-intent-'));
+    const sessionId = 'session-3162-mixed-intent';
+    const output = runKeywordDetector('랄프랑 울트라워크는 무슨 관계야? 울트라워크 돌려', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+    const stateDir = join(cwd, '.omc', 'state', 'sessions', sessionId);
+
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(context).toContain('[MAGIC KEYWORD: ULTRAWORK]');
+    expect(existsSync(join(stateDir, 'ralph-state.json'))).toBe(false);
+    expect(existsSync(join(stateDir, 'ultrawork-state.json'))).toBe(true);
+  });
+
+  it('does not activate script-only uw alias for Korean banter/question wording', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-uw-banter-'));
+    const sessionId = 'session-3162-uw-banter';
+    const output = runKeywordDetector('너도 uw라도 쥐어줘야해?ㅋㅋ', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).not.toContain('[MAGIC KEYWORD: ULTRAWORK]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json'))).toBe(false);
+  });
+
   // Regression: "autonomous" appearing in technical / research prose must not
   // trigger autopilot (false positive previously created spurious
   // autopilot-state.json and a stop-hook loop). The TS source and the

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -295,6 +295,17 @@ Final draft.`);
         expect(result).toEqual([]);
       });
 
+      it('should NOT detect Korean ralph banter as activation', () => {
+        const result = detectKeywordsWithType('너도 ralph라도 쥐어줘야해?ㅋㅋ');
+        expect(result).toEqual([]);
+      });
+
+      it('should still detect explicit ralph imperative activation', () => {
+        expect(detectKeywordsWithType('/ralph fix parser').find((r) => r.type === 'ralph')).toBeDefined();
+        expect(detectKeywordsWithType('run ralph on this issue').find((r) => r.type === 'ralph')).toBeDefined();
+        expect(detectKeywordsWithType('랄프 켜').find((r) => r.type === 'ralph')).toBeDefined();
+      });
+
       it('should NOT detect informational English questions about ralph', () => {
         const result = detectKeywordsWithType('What is ralph and how do I use it?');
         expect(result).toEqual([]);
@@ -477,6 +488,25 @@ OMC Ultrawork = "특수부대 작전 반"
       it('should NOT detect quoted follow-up references after a bad activation', () => {
         const result = detectKeywordsWithType('The article said "OMC Ultrawork", but why is the answer the same?');
         expect(result).toEqual([]);
+      });
+
+      it('should NOT detect Korean ultrawork/ralph relationship meta-question as activation', () => {
+        const result = detectKeywordsWithType('울트라워크랑 랄프는 무슨 관계야?');
+        expect(result).toEqual([]);
+      });
+
+      it('should still detect explicit ultrawork imperative activation', () => {
+        expect(detectKeywordsWithType('start ultrawork on this issue').find((r) => r.type === 'ultrawork')).toBeDefined();
+        expect(detectKeywordsWithType('울트라워크 돌려').find((r) => r.type === 'ultrawork')).toBeDefined();
+      });
+
+      it('should only detect the explicitly commanded mode in mixed Korean meta-plus-imperative prompts', () => {
+        expect(detectKeywordsWithType('랄프랑 울트라워크는 무슨 관계야? 울트라워크 돌려')).toEqual([
+          expect.objectContaining({ type: 'ultrawork', keyword: '울트라워크' }),
+        ]);
+        expect(detectKeywordsWithType('랄프랑 울트라워크는 무슨 관계야? 랄프 켜')).toEqual([
+          expect.objectContaining({ type: 'ralph', keyword: '랄프' }),
+        ]);
       });
 
       it('should NOT detect single-mode explanatory definitions followed by an unrelated question', () => {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -498,6 +498,36 @@ function hasDiagnosticIntentNearKeyword(context: string, keyword: string): boole
   return patterns.some((pattern) => pattern.test(context));
 }
 
+function isRalphUltraworkMetaOrBanterContext(context: string, keywordText: string): boolean {
+  const normalizedKeyword = keywordText.toLowerCase().replace(/\s+/g, '');
+  if (!['ralph', '랄프', 'ultrawork', 'ulw', 'uw', '울트라워크'].includes(normalizedKeyword)) {
+    return false;
+  }
+
+  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프'
+    ? ['랄프']
+    : ['울트라워크'];
+  const currentKeywordPattern = currentKeywordAliases.join('|');
+  const imperativeVerbPattern = '켜|켜줘|실행|시작|돌려|돌려줘|써|써줘|사용해|진행해';
+  const koreanImperativePatterns = [
+    new RegExp(`(?:${currentKeywordPattern})[^?？\n]{0,16}(?:${imperativeVerbPattern})`, 'u'),
+    new RegExp(`(?:${imperativeVerbPattern})[^?？\n]{0,16}(?:${currentKeywordPattern})`, 'u'),
+  ];
+  if (koreanImperativePatterns.some((pattern) => pattern.test(context))) {
+    return false;
+  }
+
+  const metaOrBanterPatterns = [
+    /[?？].{0,12}(?:ㅋ{1,}|ㅎ{1,}|lol|lmao)/iu,
+    /(?:ㅋ{1,}|ㅎ{1,}|lol|lmao).{0,40}[?？]/iu,
+    /(?:ralph|랄프|ultrawork|ulw|uw|울트라워크).{0,40}(?:라도|줘야\s*해|쥐어\s*줘야\s*해|해야\s*해).{0,20}[?？]/iu,
+    /(?:관계|관련|연관|차이|비교).{0,40}(?:뭐|무엇|어떻게|설명|알려|궁금|인가|야|냐|니|까|[?？])/u,
+    /(?:뭐|무엇|어떻게|설명|알려|궁금).{0,40}(?:관계|관련|연관|차이|비교)/u,
+  ];
+
+  return metaOrBanterPatterns.some((pattern) => pattern.test(context));
+}
+
 function isInformationalKeywordContext(text: string, position: number, keywordLength: number, keywordText?: string): boolean {
   const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
   const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
@@ -527,6 +557,10 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
 
     if (hasActivationIntent) {
       return false;
+    }
+
+    if (isRalphUltraworkMetaOrBanterContext(context, keywordText)) {
+      return true;
     }
 
     if (hasDiagnosticIntentNearKeyword(context, keywordText)) {

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -546,6 +546,36 @@ function hasDiagnosticIntentNearKeyword(context, keyword) {
   return patterns.some((pattern) => pattern.test(context));
 }
 
+function isRalphUltraworkMetaOrBanterContext(context, keywordText) {
+  const normalizedKeyword = (keywordText || '').toLowerCase().replace(/\s+/g, '');
+  if (!['ralph', '랄프', 'ultrawork', 'ulw', 'uw', '울트라워크'].includes(normalizedKeyword)) {
+    return false;
+  }
+
+  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프'
+    ? ['랄프']
+    : ['울트라워크'];
+  const currentKeywordPattern = currentKeywordAliases.join('|');
+  const imperativeVerbPattern = '켜|켜줘|실행|시작|돌려|돌려줘|써|써줘|사용해|진행해';
+  const koreanImperativePatterns = [
+    new RegExp(`(?:${currentKeywordPattern})[^?？\n]{0,16}(?:${imperativeVerbPattern})`, 'u'),
+    new RegExp(`(?:${imperativeVerbPattern})[^?？\n]{0,16}(?:${currentKeywordPattern})`, 'u'),
+  ];
+  if (koreanImperativePatterns.some((pattern) => pattern.test(context))) {
+    return false;
+  }
+
+  const metaOrBanterPatterns = [
+    /[?？].{0,12}(?:ㅋ{1,}|ㅎ{1,}|lol|lmao)/iu,
+    /(?:ㅋ{1,}|ㅎ{1,}|lol|lmao).{0,40}[?？]/iu,
+    /(?:ralph|랄프|ultrawork|ulw|uw|울트라워크).{0,40}(?:라도|줘야\s*해|쥐어\s*줘야\s*해|해야\s*해).{0,20}[?？]/iu,
+    /(?:관계|관련|연관|차이|비교).{0,40}(?:뭐|무엇|어떻게|설명|알려|궁금|인가|야|냐|니|까|[?？])/u,
+    /(?:뭐|무엇|어떻게|설명|알려|궁금).{0,40}(?:관계|관련|연관|차이|비교)/u,
+  ];
+
+  return metaOrBanterPatterns.some((pattern) => pattern.test(context));
+}
+
 function isInformationalKeywordContext(text, position, keywordLength, keywordText) {
   const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
   const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
@@ -558,6 +588,9 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   if (keywordText) {
     if (hasActivationIntentNearKeyword(context, keywordText)) {
       return false;
+    }
+    if (isRalphUltraworkMetaOrBanterContext(context, keywordText)) {
+      return true;
     }
     if (hasDiagnosticIntentNearKeyword(context, keywordText)) {
       return true;


### PR DESCRIPTION
## Summary
- Suppress scoped ralph/ultrawork activation for obvious Korean joke/meta/question wording, including the reported `너도 ralph라도 쥐어줘야해?ㅋㅋ` case.
- Preserve explicit activation paths such as `/ralph`, `run ralph`, `start ultrawork`, `랄프 켜`, and `울트라워크 돌려`.
- Add TS detector and deployed script regressions, including mixed meta-plus-imperative prompts and script-only `uw` banter suppression.

Closes #3162

## Verification
- `npm test -- --run src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/keyword-detector-script.test.ts` (383 tests)
- `npm run lint` (0 errors; existing repo warnings only)
- `npm run build`
- `npx eslint src/hooks/keyword-detector/index.ts src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/keyword-detector-script.test.ts`
- `npx tsc --noEmit --pretty false`
- `node --check scripts/keyword-detector.mjs && node --check templates/hooks/keyword-detector.mjs`

## Review
- Independent code-reviewer: APPROVE
- Independent architect: CLEAR after mixed-intent blocker fix
