### PR TITLE
Reduce false-positive review-gate risk assessment

### DIFF
--- a/scripts/review-gate.mjs
+++ b/scripts/review-gate.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { assessRisk } from './risk-assess.mjs';
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--commit' || arg === '--staged' || arg === '--staged-only') options.stagedOnly = true;
+    else if (arg === '--context') options.context = argv[++index];
+    else if (arg === '--cwd') options.cwd = argv[++index];
+    else if (arg === '--json') options.json = true;
+  }
+  if (!options.context && process.env.OMC_REVIEW_GATE_CONTEXT) {
+    options.context = process.env.OMC_REVIEW_GATE_CONTEXT;
+  }
+  if (options.context === 'commit') options.stagedOnly = true;
+  return options;
+}
+
+export function evaluateReviewGate(options = {}) {
+  const risk = assessRisk(options);
+  if (risk.level === 'unknown') {
+    return { action: 'BLOCK', exitCode: 2, message: `Review gate could not assess risk: ${risk.reason}`, risk };
+  }
+  if (risk.level === 'none' || risk.level === 'low') {
+    return { action: 'ALLOW', exitCode: 0, message: `Review gate passed: ${risk.reason}`, risk };
+  }
+  if (risk.level === 'critical' || risk.level === 'high') {
+    return { action: 'BLOCK', exitCode: 2, message: `Review required for ${risk.level}-risk changes: ${risk.reason}`, risk };
+  }
+  return { action: 'WARN', exitCode: 1, message: `Review recommended for medium-risk changes: ${risk.reason}`, risk };
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const options = parseArgs(process.argv.slice(2));
+  const result = evaluateReviewGate(options);
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(result.message);
+  }
+  process.exit(result.exitCode);
+}

--- a/scripts/risk-assess.mjs
+++ b/scripts/risk-assess.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const RISK_LEVELS = ['none', 'low', 'medium', 'high', 'critical', 'unknown'];
+
+const DOC_EXTENSIONS = new Set(['.md', '.mdx', '.txt', '.rst', '.adoc']);
+const CODE_EXTENSIONS = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.tsx', '.py', '.rb', '.go', '.rs', '.java', '.kt', '.swift', '.c', '.cc', '.cpp', '.h', '.hpp', '.cs', '.php', '.sh', '.bash', '.zsh']);
+const CONFIG_FILENAMES = new Set(['package.json', 'package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'bun.lockb', 'tsconfig.json', 'eslint.config.js', 'vite.config.ts', 'vitest.config.ts', 'webpack.config.js', 'rollup.config.js', 'dockerfile', 'docker-compose.yml']);
+const CONFIG_EXTENSIONS = new Set(['.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini']);
+const HIGH_RISK_SEGMENTS = new Set(['auth', 'authentication', 'authorization', 'oauth', 'password', 'secret', 'secrets', 'credential', 'credentials', 'token', 'tokens', 'session', 'sessions', 'permission', 'permissions', 'migration', 'migrations', 'schema', 'schemas', 'database', 'db', 'security', 'crypto', 'encryption']);
+const HIGH_RISK_FILENAMES = new Set(['schema.prisma']);
+
+function normalizeFile(file) {
+  return String(file || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+export function isNoisePath(file) {
+  const normalized = normalizeFile(file).toLowerCase();
+  if (!normalized) return true;
+  const base = path.posix.basename(normalized);
+  if (base.endsWith('.log')) return true;
+  if (base === 'harness-state.json' || base.endsWith('.snapshot.json') || base.endsWith('.snap.json')) return true;
+  return normalized.startsWith('.omc/harness-state/') ||
+    normalized === '.omc/harness-state' ||
+    normalized.startsWith('.omc/state/') ||
+    normalized.startsWith('.omx/state/') ||
+    normalized.startsWith('logs/');
+}
+
+function pathSegments(file) {
+  return normalizeFile(file).split('/').filter(Boolean);
+}
+
+function hasHighRiskToken(segment) {
+  const ext = path.posix.extname(segment);
+  const stem = ext ? segment.slice(0, -ext.length) : segment;
+  const camelSpaced = stem
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+  const lowerSegment = segment.toLowerCase();
+  const lowerStem = camelSpaced.toLowerCase();
+  if (HIGH_RISK_SEGMENTS.has(lowerSegment) || HIGH_RISK_SEGMENTS.has(lowerStem)) return true;
+  return lowerStem.split(/[^a-z0-9]+/u).some(token => HIGH_RISK_SEGMENTS.has(token));
+}
+
+export function hasHighRiskPath(file) {
+  const normalized = normalizeFile(file);
+  if (isDocsPath(normalized)) return false;
+  const base = path.posix.basename(normalized).toLowerCase();
+  if (HIGH_RISK_FILENAMES.has(base)) return true;
+  return pathSegments(normalized).some(segment => hasHighRiskToken(segment));
+}
+
+function isDocsPath(file) {
+  const normalized = normalizeFile(file).toLowerCase();
+  const ext = path.posix.extname(normalized);
+  return normalized.startsWith('docs/') || normalized.includes('/docs/') || DOC_EXTENSIONS.has(ext) || normalized.startsWith('readme');
+}
+
+function isCodePath(file) {
+  return CODE_EXTENSIONS.has(path.posix.extname(normalizeFile(file).toLowerCase()));
+}
+
+function isConfigPath(file) {
+  const normalized = normalizeFile(file).toLowerCase();
+  const base = path.posix.basename(normalized);
+  return CONFIG_FILENAMES.has(base) ||
+    CONFIG_EXTENSIONS.has(path.posix.extname(normalized)) ||
+    base === '.env' ||
+    base.startsWith('.env.') ||
+    normalized.startsWith('.github/workflows/');
+}
+
+function runGit(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function parseNameStatus(output) {
+  const files = [];
+  for (const line of output.split('\n')) {
+    if (!line.trim()) continue;
+    const parts = line.split('\t');
+    const status = parts[0] || '';
+    if (status.startsWith('R') || status.startsWith('C')) {
+      if (parts[1]) files.push(parts[1]);
+      if (parts[2]) files.push(parts[2]);
+    } else if (parts[1]) {
+      files.push(parts[1]);
+    }
+  }
+  return files;
+}
+
+function unique(files) {
+  return [...new Set(files.map(normalizeFile).filter(Boolean))];
+}
+
+function getChangedFiles(cwd, { stagedOnly = false } = {}) {
+  if (stagedOnly) {
+    return unique(parseNameStatus(runGit(cwd, ['diff', '--cached', '--name-status'])));
+  }
+  return unique([
+    ...parseNameStatus(runGit(cwd, ['diff', '--cached', '--name-status'])),
+    ...parseNameStatus(runGit(cwd, ['diff', '--name-status'])),
+  ]);
+}
+
+function numstatPathCandidates(file) {
+  const normalized = normalizeFile(file);
+  const braceRename = normalized.match(/^(.*)\{(.+) => (.+)\}(.*)$/u);
+  if (braceRename) {
+    const [, prefix, oldPart, newPart, suffix] = braceRename;
+    return [normalizeFile(`${prefix}${oldPart}${suffix}`), normalizeFile(`${prefix}${newPart}${suffix}`)];
+  }
+  const arrowRename = normalized.match(/^(.+) => (.+)$/u);
+  if (arrowRename) {
+    return [normalizeFile(arrowRename[1]), normalizeFile(arrowRename[2])];
+  }
+  return [normalized];
+}
+
+function countNumstatLines(output, relevant) {
+  let lines = 0;
+  for (const line of output.split('\n')) {
+    if (!line.trim()) continue;
+    const [insertions, deletions, maybePath, renamePath] = line.split('\t');
+    const candidates = numstatPathCandidates(renamePath || maybePath || '');
+    if (!candidates.some(file => relevant.has(file) && !isNoisePath(file))) continue;
+    const add = Number.parseInt(insertions, 10);
+    const del = Number.parseInt(deletions, 10);
+    lines += (Number.isFinite(add) ? add : 0) + (Number.isFinite(del) ? del : 0);
+  }
+  return lines;
+}
+
+function getWeightedDiffSize(cwd, changedFiles, { stagedOnly = false } = {}) {
+  const relevant = new Set(changedFiles.filter(file => !isNoisePath(file)));
+  if (stagedOnly) {
+    return countNumstatLines(runGit(cwd, ['diff', '--numstat', '--cached']), relevant);
+  }
+  return countNumstatLines(runGit(cwd, ['diff', '--numstat', '--cached']), relevant) +
+    countNumstatLines(runGit(cwd, ['diff', '--numstat']), relevant);
+}
+
+export function classifyChangedFiles(changedFiles, diffSize = 0) {
+  const relevantFiles = unique(changedFiles).filter(file => !isNoisePath(file));
+  if (relevantFiles.length === 0) {
+    return { level: 'none', reason: 'No relevant changed files after ignoring review-gate noise paths', relevantFiles };
+  }
+
+  const docsOnly = relevantFiles.every(isDocsPath);
+  const hasCode = relevantFiles.some(isCodePath);
+  const hasConfig = relevantFiles.some(isConfigPath);
+  const hasHighRisk = relevantFiles.some(file => hasHighRiskPath(file) && !isDocsPath(file));
+
+  if (hasHighRisk) {
+    return { level: 'critical', reason: 'Sensitive source/config path segment changed', relevantFiles };
+  }
+  if (docsOnly) {
+    return { level: 'low', reason: 'Documentation-only changes', relevantFiles };
+  }
+  if (hasCode && diffSize > 100) {
+    return { level: 'high', reason: `Code changes exceed 100 relevant diff lines (${diffSize})`, relevantFiles };
+  }
+  if (hasCode) {
+    return { level: diffSize <= 20 ? 'low' : 'medium', reason: `Code changes with ${diffSize} relevant diff lines`, relevantFiles };
+  }
+  if (hasConfig) {
+    return { level: 'medium', reason: 'Configuration/build metadata changes', relevantFiles };
+  }
+  return { level: diffSize <= 20 ? 'low' : 'medium', reason: `Mixed non-code changes with ${diffSize} relevant diff lines`, relevantFiles };
+}
+
+export function assessRisk(options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const stagedOnly = Boolean(options.stagedOnly || options.context === 'commit');
+  try {
+    const changedFiles = getChangedFiles(cwd, { stagedOnly });
+    const relevantFiles = changedFiles.filter(file => !isNoisePath(file));
+    const diffSize = getWeightedDiffSize(cwd, changedFiles, { stagedOnly });
+    const classification = classifyChangedFiles(changedFiles, diffSize);
+    return {
+      level: classification.level,
+      reason: classification.reason,
+      changedFiles,
+      relevantFiles,
+      diffSize,
+      stagedOnly,
+    };
+  } catch (error) {
+    return {
+      level: 'unknown',
+      reason: `Unable to assess git diff: ${error instanceof Error ? error.message : String(error)}`,
+      changedFiles: [],
+      relevantFiles: [],
+      diffSize: 0,
+      stagedOnly,
+    };
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--commit' || arg === '--staged' || arg === '--staged-only') options.stagedOnly = true;
+    else if (arg === '--context') options.context = argv[++index];
+    else if (arg === '--cwd') options.cwd = argv[++index];
+  }
+  return options;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const result = assessRisk(parseArgs(process.argv.slice(2)));
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.level === 'unknown' ? 2 : 0);
+}

--- a/src/__tests__/risk-assess-review-gate.test.mjs
+++ b/src/__tests__/risk-assess-review-gate.test.mjs
@@ -1,0 +1,171 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import process from 'node:process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { assessRisk, classifyChangedFiles, hasHighRiskPath, isNoisePath } from '../../scripts/risk-assess.mjs';
+
+const repoRoot = process.cwd();
+const riskScript = join(repoRoot, 'scripts/risk-assess.mjs');
+const gateScript = join(repoRoot, 'scripts/review-gate.mjs');
+
+function git(cwd, args) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function write(repo, file, contents) {
+  const fullPath = join(repo, file);
+  mkdirSync(join(fullPath, '..'), { recursive: true });
+  writeFileSync(fullPath, contents);
+}
+
+function withRepo(fn) {
+  const repo = mkdtempSync(join(tmpdir(), 'risk-assess-'));
+  try {
+    git(repo, ['init']);
+    git(repo, ['config', 'user.email', 'test@example.com']);
+    git(repo, ['config', 'user.name', 'Test User']);
+    write(repo, 'README.md', '# fixture\n');
+    git(repo, ['add', 'README.md']);
+    git(repo, ['commit', '-m', 'initial']);
+    return fn(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+describe('risk-assess false-positive controls', () => {
+  it('does not treat high-risk words embedded in docs filenames as critical', () => {
+    expect(hasHighRiskPath('docs/authentication-design.md')).toBe(false);
+    const result = classifyChangedFiles(['docs/authentication-design.md'], 8);
+    expect(result.level).toBe('low');
+  });
+
+  it('still treats real source high-risk path segments as critical', () => {
+    expect(hasHighRiskPath('src/auth/login.ts')).toBe(true);
+    expect(hasHighRiskPath('src/auth.ts')).toBe(true);
+    expect(hasHighRiskPath('src/auth-service.ts')).toBe(true);
+    expect(hasHighRiskPath('src/authService.ts')).toBe(true);
+    expect(hasHighRiskPath('src/token-store.ts')).toBe(true);
+    expect(hasHighRiskPath('src/tokenStore.ts')).toBe(true);
+    expect(hasHighRiskPath('src/oauth-client.ts')).toBe(true);
+    expect(hasHighRiskPath('src/passwordReset.ts')).toBe(true);
+    expect(hasHighRiskPath('src/APIAuthClient.ts')).toBe(true);
+    expect(hasHighRiskPath('src/JWTTokenStore.ts')).toBe(true);
+    const result = classifyChangedFiles(['src/auth/login.ts'], 8);
+    expect(result.level).toBe('critical');
+  });
+
+  it('ignores .omc harness state and log files for classification', () => {
+    expect(isNoisePath('.omc/harness-state/session.json')).toBe(true);
+    expect(isNoisePath('runs/output.log')).toBe(true);
+    const result = classifyChangedFiles(['.omc/harness-state/session.json', 'runs/output.log'], 500);
+    expect(result.level).toBe('none');
+    expect(result.relevantFiles).toEqual([]);
+  });
+
+  it('ignores large noise diffs when classifying a small code change', () => withRepo((repo) => {
+    write(repo, 'src/index.ts', 'export const value = 0;\n');
+    write(repo, '.omc/harness-state/session.json', '{}\n');
+    git(repo, ['add', 'src/index.ts', '.omc/harness-state/session.json']);
+    git(repo, ['commit', '-m', 'fixture files']);
+
+    write(repo, 'src/index.ts', 'export const value = 1;\n');
+    write(repo, '.omc/harness-state/session.json', `${'{"event":"noise"}\n'.repeat(250)}`);
+
+    const result = assessRisk({ cwd: repo });
+
+    expect(result.changedFiles).toContain('src/index.ts');
+    expect(result.changedFiles).toContain('.omc/harness-state/session.json');
+    expect(result.relevantFiles).toEqual(['src/index.ts']);
+    expect(result.diffSize).toBeLessThan(20);
+    expect(result.level).toBe('low');
+  }));
+
+
+  it('counts staged diff size in default union context', () => withRepo((repo) => {
+    write(repo, 'src/large.ts', 'export const line0 = 0;\n');
+    git(repo, ['add', 'src/large.ts']);
+    git(repo, ['commit', '-m', 'large fixture']);
+
+    write(repo, 'src/large.ts', Array.from({ length: 150 }, (_, index) => `export const line${index} = ${index};`).join('\n') + '\n');
+    git(repo, ['add', 'src/large.ts']);
+
+    const result = assessRisk({ cwd: repo });
+
+    expect(result.relevantFiles).toEqual(['src/large.ts']);
+    expect(result.diffSize).toBeGreaterThan(100);
+    expect(result.level).toBe('high');
+  }));
+
+  it('does not ignore real source files under logs directories', () => {
+    const result = classifyChangedFiles(['src/auth/logs/session.ts'], 4);
+    expect(result.relevantFiles).toEqual(['src/auth/logs/session.ts']);
+    expect(result.level).toBe('critical');
+  });
+
+  it('treats env files as configuration changes', () => {
+    expect(classifyChangedFiles(['.env'], 1).level).toBe('medium');
+    expect(classifyChangedFiles(['config/.env.local'], 1).level).toBe('medium');
+  });
+
+
+  it('counts large staged rename edits toward the high-risk size gate', () => withRepo((repo) => {
+    write(repo, 'src/old-name.ts', 'export const line0 = 0;\n');
+    git(repo, ['add', 'src/old-name.ts']);
+    git(repo, ['commit', '-m', 'rename fixture']);
+
+    git(repo, ['mv', 'src/old-name.ts', 'src/new-name.ts']);
+    write(repo, 'src/new-name.ts', Array.from({ length: 150 }, (_, index) => `export const line${index} = ${index};`).join('\n') + '\n');
+    git(repo, ['add', 'src/new-name.ts']);
+
+    const result = assessRisk({ cwd: repo, stagedOnly: true });
+
+    expect(result.changedFiles).toContain('src/old-name.ts');
+    expect(result.changedFiles).toContain('src/new-name.ts');
+    expect(result.diffSize).toBeGreaterThan(100);
+    expect(result.level).toBe('high');
+  }));
+
+  it('fails closed when git diff cannot be assessed', () => {
+    const nonGitDir = mkdtempSync(join(tmpdir(), 'risk-assess-nongit-'));
+    try {
+      const risk = spawnSync(process.execPath, [riskScript, '--cwd', nonGitDir], { encoding: 'utf8' });
+      expect(risk.status).toBe(2);
+      expect(JSON.parse(risk.stdout).level).toBe('unknown');
+
+      const gate = spawnSync(process.execPath, [gateScript, '--cwd', nonGitDir, '--json'], { encoding: 'utf8' });
+      expect(gate.status).toBe(2);
+      const result = JSON.parse(gate.stdout);
+      expect(result.action).toBe('BLOCK');
+      expect(result.risk.level).toBe('unknown');
+    } finally {
+      rmSync(nonGitDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses staged-only input for explicit commit-context review gates', () => withRepo((repo) => {
+    write(repo, 'src/auth/login.ts', 'export const risky = false;\n');
+    git(repo, ['add', 'src/auth/login.ts']);
+    git(repo, ['commit', '-m', 'auth fixture']);
+
+    write(repo, 'src/small.ts', 'export const small = true;\n');
+    git(repo, ['add', 'src/small.ts']);
+    write(repo, 'src/auth/login.ts', 'export const risky = true;\n');
+
+    const commitContext = spawnSync(process.execPath, [gateScript, '--context', 'commit', '--cwd', repo, '--json'], { encoding: 'utf8' });
+    const normalContext = spawnSync(process.execPath, [riskScript, '--cwd', repo], { encoding: 'utf8' });
+
+    expect(commitContext.status).toBe(0);
+    const gate = JSON.parse(commitContext.stdout);
+    expect(gate.risk.stagedOnly).toBe(true);
+    expect(gate.risk.relevantFiles).toEqual(['src/small.ts']);
+    expect(gate.risk.level).toBe('low');
+
+    const risk = JSON.parse(normalContext.stdout);
+    expect(risk.relevantFiles).toContain('src/auth/login.ts');
+    expect(risk.level).toBe('critical');
+  }));
+});


### PR DESCRIPTION
## Summary

- add focused `risk-assess` and `review-gate` scripts with the existing risk enum contract
- ignore generated review noise (`.omc`/`.omx` state, harness state, `*.log`) for classification and diff-size accounting
- tighten sensitive matching to real path/name tokens while preserving critical gates for auth/token/session/schema/etc. source/config changes
- support explicit commit-context staged-only assessment and fail closed on unknown git failures

Closes #3164

## Verification

- `npm run test:run -- src/__tests__/risk-assess-review-gate.test.mjs`
- `node --check scripts/risk-assess.mjs scripts/review-gate.mjs`
- `npm run lint` (passes with pre-existing warnings outside this diff)
- `npm run build`
- `git diff --cached --check`
- independent code-reviewer: APPROVE
- independent architect: CLEAR
