### PR TITLE
Throttle repeated pre-tool advisory reminders

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -7,6 +7,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'fs';
+import { createHash } from 'crypto';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
@@ -306,6 +307,96 @@ function generateSlopWarning(data, toolName) {
 
 function combineHookMessages(...messages) {
   return messages.filter(Boolean).join('\n\n');
+}
+
+
+const ADVISORY_THROTTLE_STATE_FILE = 'pre-tool-advisory-throttle.json';
+const ADVISORY_THROTTLE_MAX_ENTRIES = 100;
+const ADVISORY_THROTTLE_DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+const ADVISORY_THROTTLE_MIN_PRUNE_WINDOW_MS = 60 * 60 * 1000;
+
+function getAdvisoryThrottleCooldownMs() {
+  const raw = process.env.OMC_PRE_TOOL_ADVISORY_COOLDOWN_MS;
+  if (raw == null || raw === '') return ADVISORY_THROTTLE_DEFAULT_COOLDOWN_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return ADVISORY_THROTTLE_DEFAULT_COOLDOWN_MS;
+  return Math.max(0, parsed);
+}
+
+function getAdvisoryThrottleNowMs() {
+  const raw = process.env.OMC_PRE_TOOL_ADVISORY_NOW_MS;
+  if (raw != null && raw !== '') {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return Date.now();
+}
+
+function getAdvisoryThrottlePath(stateDir, sessionId) {
+  const safeSessionId = isValidSessionId(sessionId) ? sessionId : '';
+  return safeSessionId
+    ? join(stateDir, 'sessions', safeSessionId, ADVISORY_THROTTLE_STATE_FILE)
+    : join(stateDir, ADVISORY_THROTTLE_STATE_FILE);
+}
+
+function advisoryThrottleKey(message) {
+  return createHash('sha256').update(message).digest('hex');
+}
+
+function normalizeAdvisoryThrottleState(state) {
+  if (!state || typeof state !== 'object' || !state.entries || typeof state.entries !== 'object') {
+    return { version: 1, entries: {} };
+  }
+  return { ...state, version: 1, entries: state.entries };
+}
+
+function pruneAdvisoryThrottleEntries(entries, nowMs, cooldownMs) {
+  const pruneWindowMs = Math.max(cooldownMs * 2, ADVISORY_THROTTLE_MIN_PRUNE_WINDOW_MS);
+  const freshEntries = Object.entries(entries)
+    .filter(([, entry]) => {
+      const last = Number(entry?.last_emitted_at_ms);
+      return Number.isFinite(last) && last <= nowMs && nowMs - last <= pruneWindowMs;
+    })
+    .sort(([, a], [, b]) => Number(b?.last_emitted_at_ms || 0) - Number(a?.last_emitted_at_ms || 0))
+    .slice(0, ADVISORY_THROTTLE_MAX_ENTRIES);
+  return Object.fromEntries(freshEntries);
+}
+
+function shouldEmitAdvisoryMessage(stateDir, sessionId, message) {
+  const cooldownMs = getAdvisoryThrottleCooldownMs();
+  if (!message || cooldownMs <= 0) return true;
+
+  const nowMs = getAdvisoryThrottleNowMs();
+  const throttlePath = getAdvisoryThrottlePath(stateDir, sessionId);
+  const key = advisoryThrottleKey(message);
+
+  try {
+    const state = normalizeAdvisoryThrottleState(readJsonFile(throttlePath));
+    state.entries = pruneAdvisoryThrottleEntries(state.entries, nowMs, cooldownMs);
+
+    const previous = state.entries[key];
+    const previousMs = Number(previous?.last_emitted_at_ms);
+    const shouldEmit = !Number.isFinite(previousMs) || previousMs > nowMs || nowMs - previousMs >= cooldownMs;
+
+    if (shouldEmit) {
+      state.entries[key] = {
+        last_emitted_at_ms: nowMs,
+        message,
+      };
+      state.entries = pruneAdvisoryThrottleEntries(state.entries, nowMs, cooldownMs);
+      state.updated_at = new Date(nowMs).toISOString();
+      mkdirSync(dirname(throttlePath), { recursive: true });
+      const tmpPath = `${throttlePath}.tmp`;
+      writeFileSync(tmpPath, JSON.stringify(state, null, 2), { mode: 0o600 });
+      renameSync(tmpPath, throttlePath);
+    }
+
+    return shouldEmit;
+  } catch {
+    // Fail open: advisory throttling must never silence safety output because
+    // state IO failed. The hook may repeat a nudge rather than risk hiding it.
+    return true;
+  }
 }
 
 const SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
@@ -1337,6 +1428,11 @@ async function main() {
     message = combineHookMessages(slopWarning, message);
 
     if (!message) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (!shouldEmitAdvisoryMessage(stateDir, sessionId, message)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -76,6 +76,171 @@ function writeTranscriptWithContext(filePath: string, contextWindow: number, inp
   writeFileSync(filePath, `${line}\n`, 'utf-8');
 }
 
+
+describe('pre-tool-enforcer advisory throttling (issue #3163)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pre-tool-enforcer-advisory-throttle-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function runWithThrottle(toolName: string, nowMs = '1000'): Record<string, unknown> {
+    return runPreToolEnforcerWithEnv(
+      {
+        tool_name: toolName,
+        cwd: tempDir,
+        session_id: 'session-3163',
+      },
+      {
+        OMC_PRE_TOOL_ADVISORY_COOLDOWN_MS: '5000',
+        OMC_PRE_TOOL_ADVISORY_NOW_MS: nowMs,
+      },
+    );
+  }
+
+  it('emits the first advisory and suppresses an immediate repeated identical advisory', () => {
+    const first = runWithThrottle('Bash');
+    const repeated = runWithThrottle('Bash');
+
+    expect(first.continue).toBe(true);
+    expect((first.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'Use parallel execution for independent tasks',
+    );
+    expect(repeated).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('still emits a different advisory while the previous advisory is cooling down', () => {
+    const first = runWithThrottle('Bash');
+    const different = runWithThrottle('Edit');
+
+    expect((first.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'Use parallel execution for independent tasks',
+    );
+    expect((different.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'Verify changes work after editing',
+    );
+  });
+
+  it('does not throttle repeated hard-gate denials', () => {
+    const sessionId = 'session-3163';
+    writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ultragoal-state.json'), {
+      active: true,
+      session_id: sessionId,
+      project_path: tempDir,
+      objective: 'complete the aggregate ultragoal',
+      last_checked_at: new Date().toISOString(),
+    });
+
+    const input = {
+      tool_name: 'Bash',
+      cwd: tempDir,
+      session_id: sessionId,
+      tool_input: { command: 'echo safe' },
+    };
+    const env = {
+      OMC_PRE_TOOL_ADVISORY_COOLDOWN_MS: '5000',
+      OMC_PRE_TOOL_ADVISORY_NOW_MS: '1000',
+    };
+
+    const first = runPreToolEnforcerWithEnv(input, env);
+    const repeated = runPreToolEnforcerWithEnv(input, env);
+
+    for (const output of [first, repeated]) {
+      const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+      expect(output.continue).toBe(true);
+      expect(hookSpecificOutput.permissionDecision).toBe('deny');
+      expect(hookSpecificOutput.permissionDecisionReason).toContain('[ULTRAGOAL /GOAL REQUIRED]');
+    }
+  });
+
+  it('uses deterministic cooldown interval boundaries', () => {
+    const first = runWithThrottle('Bash', '1000');
+    const beforeCooldown = runWithThrottle('Bash', '5999');
+    const atCooldown = runWithThrottle('Bash', '6000');
+
+    expect((first.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'Use parallel execution for independent tasks',
+    );
+    expect(beforeCooldown).toEqual({ continue: true, suppressOutput: true });
+    expect((atCooldown.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'Use parallel execution for independent tasks',
+    );
+  });
+
+  it('does not let a future throttle timestamp suppress an advisory', () => {
+    runWithThrottle('Bash', '10000');
+
+    const output = runWithThrottle('Bash', '1000');
+
+    expect((output.hookSpecificOutput as Record<string, unknown>).additionalContext).toContain(
+      'Use parallel execution for independent tasks',
+    );
+  });
+
+  it('keeps advisory throttle state capped after adding a new entry', () => {
+    const sessionId = 'session-3163';
+    const throttlePath = join(
+      tempDir,
+      '.omc',
+      'state',
+      'sessions',
+      sessionId,
+      'pre-tool-advisory-throttle.json',
+    );
+    const entries = Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [
+        `old-${index}`,
+        {
+          last_emitted_at_ms: 10_000 - index,
+          message: `old message ${index}`,
+        },
+      ]),
+    );
+    writeJson(throttlePath, { version: 1, entries });
+
+    runWithThrottle('Bash', '20000');
+
+    const state = JSON.parse(readFileSync(throttlePath, 'utf-8')) as {
+      entries: Record<string, unknown>;
+    };
+    expect(Object.keys(state.entries)).toHaveLength(100);
+  });
+
+  it('prunes future throttle entries so they cannot consume the cap', () => {
+    const sessionId = 'session-3163';
+    const throttlePath = join(
+      tempDir,
+      '.omc',
+      'state',
+      'sessions',
+      sessionId,
+      'pre-tool-advisory-throttle.json',
+    );
+    const entries = Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [
+        `future-${index}`,
+        {
+          last_emitted_at_ms: 999_000 + index,
+          message: `future message ${index}`,
+        },
+      ]),
+    );
+    writeJson(throttlePath, { version: 1, entries });
+
+    runWithThrottle('Bash', '20000');
+
+    const state = JSON.parse(readFileSync(throttlePath, 'utf-8')) as {
+      entries: Record<string, { last_emitted_at_ms: number }>;
+    };
+    expect(Object.keys(state.entries)).toHaveLength(1);
+    expect(Object.values(state.entries)[0].last_emitted_at_ms).toBe(20_000);
+  });
+});
+
 describe('pre-tool-enforcer fallback gating (issue #970)', () => {
   let tempDir: string;
 


### PR DESCRIPTION
## Summary
- add a bounded per-session PreToolUse advisory throttle for repeated identical additionalContext messages
- keep hard permissionDecision/deny gates outside the throttle path
- cover first emit, repeated suppression, different advisory, hard gate, deterministic cooldown, future timestamps, and cap pruning

Closes #3163

## Verification
- `npm run test:run -- src/__tests__/pre-tool-enforcer.test.ts` (92 passed)
- `npm run lint` (0 errors; existing unrelated warnings remain)
- `git diff --check`
- `npm run build`
- independent code-reviewer: APPROVE
- independent architect: CLEAR

## Notes
- Build artifacts under `dist/` and `bridge/` were generated during verification and then reverted so the PR remains scoped to source + tests.
