### PR TITLE
Add plugin-scoped manual compact command

### DIFF
--- a/commands/compact.md
+++ b/commands/compact.md
@@ -1,0 +1,26 @@
+---
+description: "Manually trigger Claude Code context compaction with OMC pre-compact preservation."
+argument-hint: "[optional compaction note]"
+---
+
+# OMC Manual Context Compaction
+
+This command intentionally uses the plugin-scoped name `/oh-my-claudecode:compact` instead of the bare `/compact` command. Bare `/compact` is reserved for Claude Code's native compaction command and must not be shadowed by OMC.
+
+## Dispatch
+
+1. Treat this as a request to compact the current Claude Code conversation now. Do not create a separate OMC summarizer and do not replace existing auto-compress behavior.
+2. Preserve any user note for the compaction request:
+
+```text
+$ARGUMENTS
+```
+
+3. Invoke Claude Code's native compaction capability immediately:
+
+```text
+Skill("compact")
+```
+
+4. Rely on Claude Code's normal `PreCompact` lifecycle to run OMC's existing pre-compact hooks (`pre-compact`, project memory, and wiki preservation) before the native compaction occurs.
+5. If the native compact capability is unavailable in this host, tell the user to run Claude Code's built-in `/compact` command directly; do not attempt to manually summarize the session.

--- a/commands/compact.md
+++ b/commands/compact.md
@@ -1,26 +1,35 @@
 ---
-description: "Manually trigger Claude Code context compaction with OMC pre-compact preservation."
+description: "Prepare OMC context for a manual Claude Code /compact handoff."
 argument-hint: "[optional compaction note]"
 ---
 
-# OMC Manual Context Compaction
+# OMC Manual Context Compaction Helper
 
 This command intentionally uses the plugin-scoped name `/oh-my-claudecode:compact` instead of the bare `/compact` command. Bare `/compact` is reserved for Claude Code's native compaction command and must not be shadowed by OMC.
 
+OMC cannot invoke Claude Code's built-in `/compact` from a plugin command: `/compact` is a native slash command, not a prompt skill, and a prompt-skill call for `compact` is not a supported handoff. This helper is instruction-only and must not claim that OMC triggers compaction itself.
+
 ## Dispatch
 
-1. Treat this as a request to compact the current Claude Code conversation now. Do not create a separate OMC summarizer and do not replace existing auto-compress behavior.
+1. Treat this as a request to prepare for manual Claude Code conversation compaction. Do not create a separate OMC summarizer and do not replace existing auto-compress behavior.
 2. Preserve any user note for the compaction request:
 
 ```text
 $ARGUMENTS
 ```
 
-3. Invoke Claude Code's native compaction capability immediately:
+3. Tell the user to run Claude Code's built-in bare `/compact` command directly. If the note above is non-empty, tell them to include it with `/compact`.
+4. Before handing off, remind the user that Claude Code's normal `PreCompact` lifecycle should run OMC's existing pre-compact hooks (`pre-compact`, project memory, and wiki preservation) when the native compaction occurs.
+5. Do not invoke a `compact` skill, do not attempt to call `/compact` on the user's behalf, and do not manually summarize the session.
+
+## User-facing handoff
+
+Use this wording, adapting only the note text:
 
 ```text
-Skill("compact")
-```
+OMC prepared the compaction context, but plugin commands cannot trigger Claude Code's native /compact directly. Run this as a bare Claude Code command now:
 
-4. Rely on Claude Code's normal `PreCompact` lifecycle to run OMC's existing pre-compact hooks (`pre-compact`, project memory, and wiki preservation) before the native compaction occurs.
-5. If the native compact capability is unavailable in this host, tell the user to run Claude Code's built-in `/compact` command directly; do not attempt to manually summarize the session.
+/compact $ARGUMENTS
+
+Bare /compact remains Claude Code's native command; OMC does not shadow or invoke it.
+```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -758,7 +758,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 
 ## Slash Commands
 
-Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list; the commands below highlight common entrypoints and aliases. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands.
+Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list; the commands below highlight common entrypoints and aliases. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction entrypoint is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC.
 
 | Command                                                  | Description                                                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -766,6 +766,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:ask <claude\|codex\|gemini\|grok> <prompt>` | Route a prompt through the selected advisor CLI and capture an ask artifact                   |
 | `/oh-my-claudecode:autopilot <task>`                     | Full autonomous execution                                                                     |
 | `/oh-my-claudecode:configure-notifications`              | Configure notification integrations                                                           |
+| `/oh-my-claudecode:compact [note]`                        | Manually trigger Claude Code native context compaction with OMC pre-compact preservation       |
 | `/oh-my-claudecode:deep-dive <problem>`                  | Run the trace → deep-interview pipeline                                                       |
 | `/deep-interview <idea>`                                 | Socratic interview with ambiguity scoring before execution                                    |
 | `/oh-my-claudecode:deepinit [path]`                      | Index codebase with hierarchical AGENTS.md files                                              |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -758,7 +758,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 
 ## Slash Commands
 
-Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list; the commands below highlight common entrypoints and aliases. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction entrypoint is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC.
+Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list; the commands below highlight common entrypoints and aliases. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction helper is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC. The helper preserves the user's note and instructs them to run bare `/compact`; OMC does not invoke native compaction itself because Claude Code's built-in `/compact` is not a prompt skill.
 
 | Command                                                  | Description                                                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -766,7 +766,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:ask <claude\|codex\|gemini\|grok> <prompt>` | Route a prompt through the selected advisor CLI and capture an ask artifact                   |
 | `/oh-my-claudecode:autopilot <task>`                     | Full autonomous execution                                                                     |
 | `/oh-my-claudecode:configure-notifications`              | Configure notification integrations                                                           |
-| `/oh-my-claudecode:compact [note]`                        | Manually trigger Claude Code native context compaction with OMC pre-compact preservation       |
+| `/oh-my-claudecode:compact [note]`                        | Prepare an OMC-safe manual handoff telling the user to run bare `/compact [note]`              |
 | `/oh-my-claudecode:deep-dive <problem>`                  | Run the trace → deep-interview pipeline                                                       |
 | `/deep-interview <idea>`                                 | Socratic interview with ambiguity scoring before execution                                    |
 | `/oh-my-claudecode:deepinit [path]`                      | Index codebase with hierarchical AGENTS.md files                                              |

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -183,7 +183,11 @@ describe('Installer Constants', () => {
 
       for (const file of files) {
         const content = readFileSync(join(commandsDir, file), 'utf-8');
-        expect(content, `${file} should dispatch to a bundled skill`).toContain('SKILL.md');
+        if (file === 'compact.md') {
+          expect(content, 'compact.md should invoke the host/native compaction surface').toContain('Skill("compact")');
+        } else {
+          expect(content, `${file} should dispatch to a bundled skill`).toContain('SKILL.md');
+        }
         expect(content, `${file} should pass through user arguments`).toContain('$ARGUMENTS');
       }
     });

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -184,7 +184,8 @@ describe('Installer Constants', () => {
       for (const file of files) {
         const content = readFileSync(join(commandsDir, file), 'utf-8');
         if (file === 'compact.md') {
-          expect(content, 'compact.md should invoke the host/native compaction surface').toContain('Skill("compact")');
+          expect(content, 'compact.md should avoid unsupported Skill compact invocation').not.toContain('Skill("compact")');
+          expect(content, 'compact.md should provide a manual native /compact handoff').toContain('bare Claude Code command');
         } else {
           expect(content, `${file} should dispatch to a bundled skill`).toContain('SKILL.md');
         }

--- a/src/__tests__/manual-compact-command.test.ts
+++ b/src/__tests__/manual-compact-command.test.ts
@@ -42,7 +42,9 @@ describe('manual compact command', () => {
     const command = readFileSync(COMMAND_PATH, 'utf-8');
     expect(command).toContain('/oh-my-claudecode:compact');
     expect(command).toContain('Bare `/compact` is reserved for Claude Code');
-    expect(command).toContain('Skill("compact")');
+    expect(command).not.toContain('Skill("compact")');
+    expect(command).toContain('instruction-only');
+    expect(command).toContain('Run this as a bare Claude Code command now');
     expect(command).toContain('$ARGUMENTS');
     expect(command).toContain('PreCompact');
 
@@ -51,7 +53,7 @@ describe('manual compact command', () => {
     expect(detectSlashCommand('/compact')).toBeNull();
   });
 
-  it('expands through the command utility to the native compact trigger', async () => {
+  it('expands through the command utility to a safe manual handoff', async () => {
     writeFileSync(
       join(tempConfigDir, 'commands', 'compact.md'),
       readFileSync(COMMAND_PATH, 'utf-8'),
@@ -62,8 +64,10 @@ describe('manual compact command', () => {
     const expanded = expandCommand('compact', 'preserve current issue and PR state');
 
     expect(expanded).not.toBeNull();
-    expect(expanded?.description).toContain('Manually trigger Claude Code context compaction');
-    expect(expanded?.prompt).toContain('Skill("compact")');
+    expect(expanded?.description).toContain('Prepare OMC context for a manual Claude Code /compact handoff');
+    expect(expanded?.prompt).not.toContain('Skill("compact")');
+    expect(expanded?.prompt).toContain('/compact preserve current issue and PR state');
+    expect(expanded?.prompt).toContain('plugin commands cannot trigger Claude Code');
     expect(expanded?.prompt).toContain('preserve current issue and PR state');
     expect(expanded?.prompt).toContain('Do not create a separate OMC summarizer');
   });

--- a/src/__tests__/manual-compact-command.test.ts
+++ b/src/__tests__/manual-compact-command.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { detectSlashCommand } from '../hooks/auto-slash-command/detector.js';
+
+const PROJECT_ROOT = join(__dirname, '..', '..');
+const COMMAND_PATH = join(PROJECT_ROOT, 'commands', 'compact.md');
+const PLUGIN_MANIFEST_PATH = join(PROJECT_ROOT, '.claude-plugin', 'plugin.json');
+
+const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+let tempConfigDir: string;
+
+async function loadCommandsModule() {
+  // getClaudeConfigDir reads env at module load time in some call paths.
+  return import('../commands/index.js');
+}
+
+describe('manual compact command', () => {
+  beforeEach(() => {
+    tempConfigDir = join(tmpdir(), `omc-manual-compact-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(tempConfigDir, 'commands'), { recursive: true });
+    process.env.CLAUDE_CONFIG_DIR = tempConfigDir;
+  });
+
+  afterEach(() => {
+    rmSync(tempConfigDir, { recursive: true, force: true });
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+  });
+
+  it('ships a plugin-scoped compact command without shadowing native /compact', () => {
+    expect(existsSync(COMMAND_PATH)).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(PLUGIN_MANIFEST_PATH, 'utf-8')) as { commands?: unknown };
+    expect(manifest.commands).toBe('./commands/');
+
+    const command = readFileSync(COMMAND_PATH, 'utf-8');
+    expect(command).toContain('/oh-my-claudecode:compact');
+    expect(command).toContain('Bare `/compact` is reserved for Claude Code');
+    expect(command).toContain('Skill("compact")');
+    expect(command).toContain('$ARGUMENTS');
+    expect(command).toContain('PreCompact');
+
+    // OMC's auto slash expansion must continue to ignore bare /compact so the
+    // host/native command keeps its semantics.
+    expect(detectSlashCommand('/compact')).toBeNull();
+  });
+
+  it('expands through the command utility to the native compact trigger', async () => {
+    writeFileSync(
+      join(tempConfigDir, 'commands', 'compact.md'),
+      readFileSync(COMMAND_PATH, 'utf-8'),
+      'utf-8',
+    );
+
+    const { expandCommand } = await loadCommandsModule();
+    const expanded = expandCommand('compact', 'preserve current issue and PR state');
+
+    expect(expanded).not.toBeNull();
+    expect(expanded?.description).toContain('Manually trigger Claude Code context compaction');
+    expect(expanded?.prompt).toContain('Skill("compact")');
+    expect(expanded?.prompt).toContain('preserve current issue and PR state');
+    expect(expanded?.prompt).toContain('Do not create a separate OMC summarizer');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/oh-my-claudecode:compact [note]` as a plugin-scoped manual context compaction trigger.
- Delegate to Claude Code native compaction with `Skill("compact")` instead of adding a second OMC summarizer.
- Document why bare `/compact` remains host-native and unshadowed.

## Tests / verification
- `npm test -- --run src/__tests__/manual-compact-command.test.ts src/__tests__/compact-denylist.test.ts src/__tests__/installer.test.ts`
- `npm run build`
- `npm run lint` (passes with existing warnings only)
- `git diff --check`
- Independent code-reviewer: APPROVE
- Independent architect review: CLEAR

## Owner confirmation required
- [ ] Owner confirms `Skill("compact")` is the supported in-command handoff for Claude Code native compaction in plugin slash commands.
- [ ] Owner confirms the plugin-scoped command name `/oh-my-claudecode:compact` is preferred over shadowing bare `/compact`.

Closes #3172
