### PR TITLE
Align built-in Opus HIGH default with Claude Opus 4.8

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -3682,7 +3682,7 @@ var init_models = __esm({
     CLAUDE_FAMILY_DEFAULTS = {
       HAIKU: "claude-haiku-4-5",
       SONNET: "claude-sonnet-4-6",
-      OPUS: "claude-opus-4-7"
+      OPUS: "claude-opus-4-8"
     };
     BUILTIN_TIER_MODEL_DEFAULTS = {
       LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -1672,7 +1672,7 @@ var TIER_ENV_KEYS = {
 var CLAUDE_FAMILY_DEFAULTS = {
   HAIKU: "claude-haiku-4-5",
   SONNET: "claude-sonnet-4-6",
-  OPUS: "claude-opus-4-7"
+  OPUS: "claude-opus-4-8"
 };
 var BUILTIN_TIER_MODEL_DEFAULTS = {
   LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/bridge/team-bridge.cjs
+++ b/bridge/team-bridge.cjs
@@ -1089,7 +1089,7 @@ function findPermissionViolations(changedPaths, permissions, cwd) {
 var CLAUDE_FAMILY_DEFAULTS = {
   HAIKU: "claude-haiku-4-5",
   SONNET: "claude-sonnet-4-6",
-  OPUS: "claude-opus-4-7"
+  OPUS: "claude-opus-4-8"
 };
 var BUILTIN_TIER_MODEL_DEFAULTS = {
   LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/bridge/team.js
+++ b/bridge/team.js
@@ -3314,7 +3314,7 @@ var init_models = __esm({
     CLAUDE_FAMILY_DEFAULTS = {
       HAIKU: "claude-haiku-4-5",
       SONNET: "claude-sonnet-4-6",
-      OPUS: "claude-opus-4-7"
+      OPUS: "claude-opus-4-8"
     };
     BUILTIN_TIER_MODEL_DEFAULTS = {
       LOW: CLAUDE_FAMILY_DEFAULTS.HAIKU,

--- a/dist/config/models.js
+++ b/dist/config/models.js
@@ -26,7 +26,7 @@ const TIER_ENV_KEYS = {
 export const CLAUDE_FAMILY_DEFAULTS = {
     HAIKU: 'claude-haiku-4-5',
     SONNET: 'claude-sonnet-4-6',
-    OPUS: 'claude-opus-4-7',
+    OPUS: 'claude-opus-4-8',
 };
 /** Canonical tier->model mapping used as built-in defaults */
 export const BUILTIN_TIER_MODEL_DEFAULTS = {

--- a/docs/agent-templates/tier-instructions.md
+++ b/docs/agent-templates/tier-instructions.md
@@ -40,7 +40,7 @@ This document defines the behavioral differences between agent tiers (LOW/MEDIUM
 ```
 
 ## HIGH Tier (Opus)
-**Model**: claude-opus-4-7
+**Model**: claude-opus-4-8
 **Focus**: Correctness and quality for complex tasks
 
 ```markdown

--- a/docs/agents/model-compatibility.md
+++ b/docs/agents/model-compatibility.md
@@ -11,11 +11,11 @@ are deliberately out of scope.
 
 | Agent | Role | Recommended (premium) | Recommended (cost-effective) | Avoid | Notes |
 |---|---|---|---|---|---|
-| Prometheus | Planning | Claude Opus 4.7, GPT-5.5 high | Sonnet 4.6 | — | Heavy reasoning; runs 1–2x per session |
-| Hyperplan | Planning | Claude Opus 4.7, GPT-5.5 high | Sonnet 4.6 | — | Same as Prometheus |
+| Prometheus | Planning | Claude Opus 4.8, GPT-5.5 high | Sonnet 4.6 | — | Heavy reasoning; runs 1–2x per session |
+| Hyperplan | Planning | Claude Opus 4.8, GPT-5.5 high | Sonnet 4.6 | — | Same as Prometheus |
 | Sisyphus | Implementation | Sonnet 4.6 | DeepSeek V4 Pro, Kimi K2.5 | — | Token-heavy; cost matters most here |
 | Hephaestus | Implementation | Sonnet 4.6, Kimi K2.5 | DeepSeek V4 Pro | **GPT-\* (tool-calling/format breakage)** | Tuned for non-GPT |
-| Oracle | Review | Claude Opus 4.7, GPT-5.5 high | Sonnet 4.6 | — | Quality > cost; called sparingly |
+| Oracle | Review | Claude Opus 4.8, GPT-5.5 high | Sonnet 4.6 | — | Quality > cost; called sparingly |
 | Aletheia | Review | Sonnet 4.6 | DeepSeek V4 Pro | — | |
 | Hermes | Coordination | Sonnet 4.6 | DeepSeek V4 Flash | — | Coordinator only, not direct executor |
 
@@ -54,11 +54,11 @@ reviews, architecture decisions.
 
 ```yaml
 agents:
-  Prometheus:  { model: claude-opus-4-7 }
-  Hyperplan:   { model: claude-opus-4-7 }
+  Prometheus:  { model: claude-opus-4-8 }
+  Hyperplan:   { model: claude-opus-4-8 }
   Sisyphus:    { model: claude-sonnet-4-6 }
   Hephaestus:  { model: claude-sonnet-4-6 }   # never GPT-*
-  Oracle:      { model: claude-opus-4-7 }
+  Oracle:      { model: claude-opus-4-8 }
   Aletheia:    { model: claude-sonnet-4-6 }
   Hermes:      { model: claude-sonnet-4-6 }
 ```

--- a/src/__tests__/agent-registry.test.ts
+++ b/src/__tests__/agent-registry.test.ts
@@ -146,7 +146,7 @@ describe('Agent Registry Validation', () => {
 
     expect(agents.executor?.model).toBe('kimi-k2.6:cloud');
     expect(agents.architect?.model).toBe('glm-5.1:cloud');
-    expect(agents.architect?.model).not.toBe('claude-opus-4-7');
+    expect(agents.architect?.model).not.toBe('claude-opus-4-8');
   });
 
   test('partial tier env override does not collapse all agents to inherit', () => {

--- a/src/__tests__/bedrock-model-routing.test.ts
+++ b/src/__tests__/bedrock-model-routing.test.ts
@@ -134,7 +134,7 @@ describe('Bedrock model routing repro', () => {
       const defs = getAgentDefinitions({ config });
       expect(defs['executor'].model).toBe('claude-sonnet-4-6');
       expect(defs['explore'].model).toBe('claude-haiku-4-5');
-      expect(defs['architect'].model).toBe('claude-opus-4-7');
+      expect(defs['architect'].model).toBe('claude-opus-4-8');
 
       // 4. enforceModel normalizes to bare CC-supported aliases (FIX)
       const { enforceModel } = await import('../features/delegation-enforcer.js');

--- a/src/__tests__/hud/model.test.ts
+++ b/src/__tests__/hud/model.test.ts
@@ -4,7 +4,7 @@ import { formatModelName, renderModel } from '../../hud/elements/model.js';
 describe('model element', () => {
   describe('formatModelName', () => {
     it('returns Opus for opus model IDs', () => {
-      expect(formatModelName('claude-opus-4-7-20260416')).toBe('Opus');
+      expect(formatModelName('claude-opus-4-8-20260528')).toBe('Opus');
       expect(formatModelName('claude-3-opus-20240229')).toBe('Opus');
     });
 
@@ -23,14 +23,14 @@ describe('model element', () => {
     });
 
     it('returns versioned name from model IDs', () => {
-      expect(formatModelName('claude-opus-4-7-20260416', 'versioned')).toBe('Opus 4.7');
+      expect(formatModelName('claude-opus-4-8-20260528', 'versioned')).toBe('Opus 4.8');
       expect(formatModelName('claude-sonnet-4-6-20260217', 'versioned')).toBe('Sonnet 4.6');
       expect(formatModelName('claude-haiku-4-5-20251001', 'versioned')).toBe('Haiku 4.5');
     });
 
     it('returns versioned name from display names', () => {
       expect(formatModelName('Sonnet 4.5', 'versioned')).toBe('Sonnet 4.5');
-      expect(formatModelName('Opus 4.7', 'versioned')).toBe('Opus 4.7');
+      expect(formatModelName('Opus 4.8', 'versioned')).toBe('Opus 4.8');
       expect(formatModelName('Haiku 4.5', 'versioned')).toBe('Haiku 4.5');
     });
 
@@ -46,7 +46,7 @@ describe('model element', () => {
     });
 
     it('returns full model ID in full format', () => {
-      expect(formatModelName('claude-opus-4-7-20260416', 'full')).toBe('claude-opus-4-7-20260416');
+      expect(formatModelName('claude-opus-4-8-20260528', 'full')).toBe('claude-opus-4-8-20260528');
     });
 
     it('truncates long unrecognized model names', () => {
@@ -57,21 +57,21 @@ describe('model element', () => {
 
   describe('renderModel', () => {
     it('renders formatted model name', () => {
-      const result = renderModel('claude-opus-4-7-20260416');
+      const result = renderModel('claude-opus-4-8-20260528');
       expect(result).not.toBeNull();
-      expect(result).toContain('Model: Opus 4.7');
+      expect(result).toContain('Model: Opus 4.8');
     });
 
     it('renders versioned format', () => {
-      const result = renderModel('claude-opus-4-7-20260416', 'versioned');
+      const result = renderModel('claude-opus-4-8-20260528', 'versioned');
       expect(result).not.toBeNull();
-      expect(result).toContain('Model: Opus 4.7');
+      expect(result).toContain('Model: Opus 4.8');
     });
 
     it('renders full format', () => {
-      const result = renderModel('claude-opus-4-7-20260416', 'full');
+      const result = renderModel('claude-opus-4-8-20260528', 'full');
       expect(result).not.toBeNull();
-      expect(result).toContain('Model: claude-opus-4-7');
+      expect(result).toContain('Model: claude-opus-4-8');
     });
 
     it('renders configured model label', () => {

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -56,14 +56,14 @@ describe('Type Tests', () => {
       const config: PluginConfig = {
         agents: {
           omc: { model: 'claude-sonnet-4-6' },
-          architect: { model: 'claude-opus-4-7' },
+          architect: { model: 'claude-opus-4-8' },
           explore: { model: 'claude-haiku-4-5' },
           documentSpecialist: { model: 'claude-haiku-4-5' },
         },
       };
 
       expect(config.agents?.omc?.model).toBe('claude-sonnet-4-6');
-      expect(config.agents?.architect?.model).toBe('claude-opus-4-7');
+      expect(config.agents?.architect?.model).toBe('claude-opus-4-8');
     });
 
     it('should support routing configuration', () => {
@@ -76,14 +76,14 @@ describe('Type Tests', () => {
           tierModels: {
             LOW: 'claude-haiku-4',
             MEDIUM: 'claude-sonnet-4-6',
-            HIGH: 'claude-opus-4-7',
+            HIGH: 'claude-opus-4-8',
           },
         },
       };
 
       expect(config.routing?.enabled).toBe(true);
       expect(config.routing?.defaultTier).toBe('MEDIUM');
-      expect(config.routing?.tierModels?.HIGH).toBe('claude-opus-4-7');
+      expect(config.routing?.tierModels?.HIGH).toBe('claude-opus-4-8');
     });
   });
 });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -32,7 +32,7 @@ const TIER_ENV_KEYS: Record<ModelTier, readonly string[]> = {
 export const CLAUDE_FAMILY_DEFAULTS: Record<ClaudeModelFamily, string> = {
   HAIKU: 'claude-haiku-4-5',
   SONNET: 'claude-sonnet-4-6',
-  OPUS: 'claude-opus-4-7',
+  OPUS: 'claude-opus-4-8',
 };
 
 /** Canonical tier->model mapping used as built-in defaults */

--- a/src/hooks/recovery/types.ts
+++ b/src/hooks/recovery/types.ts
@@ -44,7 +44,7 @@ export interface ParsedTokenLimitError {
   errorType: string;
   /** Provider ID (e.g., 'anthropic') */
   providerID?: string;
-  /** Model ID (e.g., 'claude-opus-4-7') */
+  /** Model ID (e.g., 'claude-opus-4-8') */
   modelID?: string;
   /** Index of the problematic message */
   messageIndex?: number;

--- a/src/hooks/think-mode/__tests__/index.test.ts
+++ b/src/hooks/think-mode/__tests__/index.test.ts
@@ -194,8 +194,8 @@ World`);
         expect(getHighVariant('claude-sonnet-4-6')).toBe('claude-sonnet-4-6-high');
       });
 
-      it('should return high variant for claude-opus-4-7', () => {
-        expect(getHighVariant('claude-opus-4-7')).toBe('claude-opus-4-7-high');
+      it('should return high variant for claude-opus-4-8', () => {
+        expect(getHighVariant('claude-opus-4-8')).toBe('claude-opus-4-8-high');
       });
 
       it('should return high variant for claude-3-5-sonnet', () => {
@@ -203,7 +203,7 @@ World`);
       });
 
       it('should return high variant for claude-3-opus', () => {
-        expect(getHighVariant('claude-3-opus')).toBe('claude-opus-4-7-high');
+        expect(getHighVariant('claude-3-opus')).toBe('claude-opus-4-8-high');
       });
 
       it('should handle version with dot notation', () => {

--- a/src/hud/elements/model.ts
+++ b/src/hud/elements/model.ts
@@ -10,7 +10,7 @@ import { DEFAULT_HUD_LABELS, type HudLabels, type ModelFormat } from '../types.j
 
 /**
  * Extract version from a model ID string.
- * E.g., 'claude-opus-4-7-20260416' -> '4.7'
+ * E.g., 'claude-opus-4-8-20260528' -> '4.8'
  *       'claude-sonnet-4-6-20260217' -> '4.6'
  *       'claude-haiku-4-5-20251001' -> '4.5'
  *       'claude-3-5-sonnet-20241022' -> '3.5'
@@ -27,7 +27,7 @@ function extractVersion(modelId: string): string | null {
     return legacyIdMatch[2] ? `${legacyIdMatch[1]}.${legacyIdMatch[2]}` : legacyIdMatch[1];
   }
 
-  // Match display name patterns like "Sonnet 4.5", "Opus 4.7"
+  // Match display name patterns like "Sonnet 4.5", "Opus 4.8"
   const displayMatch = modelId.match(/(?:opus|sonnet|haiku)\s+(\d+(?:\.\d+)?)/i);
   if (displayMatch) return displayMatch[1];
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -456,8 +456,8 @@ export type CwdFormat = 'relative' | 'absolute' | 'folder';
 /**
  * Model name format options:
  * - short: 'Opus', 'Sonnet', 'Haiku'
- * - versioned: 'Opus 4.7', 'Sonnet 4.5', 'Haiku 4.5'
- * - full: raw model ID like 'claude-opus-4-7-20260416'
+ * - versioned: 'Opus 4.8', 'Sonnet 4.5', 'Haiku 4.5'
+ * - full: raw model ID like 'claude-opus-4-8-20260528'
  */
 export type ModelFormat = 'short' | 'versioned' | 'full';
 


### PR DESCRIPTION
## Summary
- Bump OMC's built-in HIGH-tier Opus default from `claude-opus-4-7` to `claude-opus-4-8`. Claude Opus 4.8 shipped 2026-05-28, so users relying on built-in defaults now get the latest Opus without manually setting `OMC_MODEL_HIGH`.
- Mirror the bump into the committed runtime artifacts (`dist/config/models.js`, `bridge/{cli,runtime-cli,team-bridge,team}.*`) — the same artifact set the 4.6→4.7 bump (#2685) kept in sync.
- Align shipped docs/JSDoc that intentionally mirror the built-in default: `docs/agent-templates/tier-instructions.md`, the premium presets in `docs/agents/model-compatibility.md`, and the `recovery/types` + `hud` JSDoc examples.
- Update targeted tests covering default resolution, HUD display formatting, think-mode high-variant mapping, and the agent-registry default-leak guard.

Sonnet and Haiku are unaffected — `claude-sonnet-4-6` and `claude-haiku-4-5` are still current. The version regex and `getHighVariant` prefix handling already accept `4-8` without changes.

## Notes on the dateless ID
Starting with the 4.6 generation, the canonical Opus ID is dateless (`claude-opus-4-8`), which is what `CLAUDE_FAMILY_DEFAULTS.OPUS` uses. The HUD tests keep a synthetic date suffix (`claude-opus-4-8-20260528`) purely to preserve coverage of the date-stripping path in `extractVersion`, mirroring how #2685 used `-20260416`.

## Intentionally out of scope
- `agents/designer.md` — its "Opus 4.7 default house style" notes are model-behavior claims (cream/serif/terracotta editorial defaults) that can't be verified for 4.8 without testing the model's output. Left as-is to avoid an unverified behavioral assertion.
- `src/team/__tests__/tmux-session.test.ts` banner fixture (`Opus 4.7 (1M context)`) — model-agnostic pane-readiness fixture, not coupled to the default.
- `dist/` JSDoc/test artifacts and the various `*-4-6-v1:0` Bedrock-format / parser fixtures — build output and version-agnostic format fixtures, consistent with #2685's scope.

## Verification
- `npx vitest run src/__tests__/bedrock-model-routing.test.ts src/hooks/think-mode/__tests__/index.test.ts src/__tests__/types.test.ts src/__tests__/hud/model.test.ts src/__tests__/agent-registry.test.ts` → 159 passed
- `npx tsc --noEmit` → clean
- `npx vitest run` (full suite)
