### PR TITLE
Fix Slack Socket control frame validation

### DIFF
--- a/src/notifications/__tests__/slack-socket.test.ts
+++ b/src/notifications/__tests__/slack-socket.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SlackSocketClient } from "../slack-socket.js";
+import { SlackSocketClient, validateSlackEnvelope } from "../slack-socket.js";
 
 describe("SlackSocketClient", () => {
   const config = {
@@ -203,6 +203,27 @@ describe("SlackSocketClient", () => {
     });
   });
 
+  describe("validateSlackEnvelope()", () => {
+    it("accepts hello control frames without envelope_id", () => {
+      expect(validateSlackEnvelope({ type: "hello" })).toEqual({ valid: true });
+    });
+
+    it("accepts disconnect control frames without envelope_id", () => {
+      expect(validateSlackEnvelope({ type: "disconnect" })).toEqual({
+        valid: true,
+      });
+    });
+
+    it("rejects non-control envelopes without envelope_id", () => {
+      expect(
+        validateSlackEnvelope({
+          type: "events_api",
+          payload: { event: { type: "message" } },
+        }),
+      ).toEqual({ valid: false, reason: "Missing or empty envelope_id" });
+    });
+  });
+
   describe("handleEnvelope()", () => {
     async function getMessageHandler() {
       mockFetchSuccess();
@@ -221,6 +242,24 @@ describe("SlackSocketClient", () => {
 
       return { client, handler };
     }
+
+    it("authenticates when hello control frame omits envelope_id", async () => {
+      mockFetchSuccess();
+      const client = new SlackSocketClient(config, mockHandler, mockLog);
+      await client.start();
+      const messageCall = mockWsInstance.addEventListener.mock.calls.find(
+        (call: unknown[]) => call[0] === "message",
+      );
+      const handler = messageCall![1] as (event: { data?: unknown }) => void;
+
+      handler({ data: JSON.stringify({ type: "hello" }) });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(client.getConnectionState().getState()).toBe("authenticated");
+      expect(mockLog).toHaveBeenCalledWith(
+        expect.stringContaining("authenticated (hello received)"),
+      );
+    });
 
     it("acknowledges envelopes with envelope_id", async () => {
       const { handler } = await getMessageHandler();

--- a/src/notifications/slack-socket.ts
+++ b/src/notifications/slack-socket.ts
@@ -62,7 +62,7 @@ export interface SlackValidationResult {
 
 /** Slack Socket Mode message envelope */
 export interface SlackSocketEnvelope {
-  envelope_id: string;
+  envelope_id?: string;
   type: string;
   payload?: Record<string, unknown>;
   accepts_response_payload?: boolean;
@@ -158,15 +158,7 @@ export function validateSlackEnvelope(
 
   const envelope = data as Record<string, unknown>;
 
-  // envelope_id is required for Socket Mode messages
-  if (
-    typeof envelope.envelope_id !== 'string' ||
-    !envelope.envelope_id.trim()
-  ) {
-    return { valid: false, reason: 'Missing or empty envelope_id' };
-  }
-
-  // type is required
+  // type is required and must be known before type-specific requirements.
   if (typeof envelope.type !== 'string' || !envelope.type.trim()) {
     return { valid: false, reason: 'Missing or empty message type' };
   }
@@ -177,6 +169,19 @@ export function validateSlackEnvelope(
       valid: false,
       reason: `Unknown envelope type: ${envelope.type}`,
     };
+  }
+
+  const isControlFrame =
+    envelope.type === 'hello' || envelope.type === 'disconnect';
+
+  // envelope_id is required for envelopes that Slack expects us to ACK.
+  // Protocol control frames may legitimately omit it.
+  if (
+    !isControlFrame &&
+    (typeof envelope.envelope_id !== 'string' ||
+      !envelope.envelope_id.trim())
+  ) {
+    return { valid: false, reason: 'Missing or empty envelope_id' };
   }
 
   // events_api type must have a payload
@@ -590,7 +595,7 @@ export class SlackSocketClient {
       }
 
       const envelope = parsed as {
-        envelope_id: string;
+        envelope_id?: string;
         type: string;
         payload?: {
           event?: SlackMessageEvent & { subtype?: string };


### PR DESCRIPTION
## Summary
- Fixes #3178 by validating Slack Socket Mode envelope `type` before enforcing `envelope_id`.
- Allows Slack protocol control frames `hello` and `disconnect` to omit `envelope_id`.
- Preserves `envelope_id` validation for non-control envelopes such as `events_api`, `slash_commands`, and `interactive`.
- Adds regression coverage for `validateSlackEnvelope` and verifies `hello` without `envelope_id` authenticates the connection.

## Validation
- `npm test -- src/notifications/__tests__/slack-socket.test.ts --run` — 21 passed
- `npm run build` — passed; generated `bridge/` and `dist/` dirt was restored before commit
- `npm run lint` — passed with existing warnings only
- `git diff --check` — passed

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
