### PR TITLE
fix(ask): use --skip-trust instead of --yolo for gemini advisor (fixes one-shot hang)

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -15,14 +15,20 @@ const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
  * Build CLI args for a given provider.
  * - claude: `claude -p <prompt>`
  * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
- * - gemini: `gemini -p <prompt> --yolo`
+ * - gemini: `gemini -p <prompt> --skip-trust`
+ *
+ * NOTE: gemini uses `--skip-trust` (not `--yolo`). `--yolo` puts gemini into
+ * agentic auto-approve mode, where even a one-shot advisory question makes it
+ * attempt tool execution, which can hit rate limits / empty responses and
+ * retry indefinitely — so `omc ask gemini "..."` hangs. `--skip-trust` only
+ * bypasses the workspace trust prompt, keeping the call a single-shot answer.
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
     return ['exec', '--dangerously-bypass-approvals-and-sandbox', pipePromptViaStdin ? '-' : prompt];
   }
   if (provider === 'gemini') {
-    return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
+    return pipePromptViaStdin ? ['--skip-trust'] : ['-p', prompt, '--skip-trust'];
   }
   return ['-p', prompt];
 }


### PR DESCRIPTION
## Problem

`omc ask gemini "<prompt>"` hangs indefinitely on one-shot advisory questions and never returns.

## Root cause

In `scripts/run-provider-advisor.js`, gemini is invoked with `--yolo`:

```js
if (provider === 'gemini') {
  return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
}
```

`--yolo` (`-y`, per `gemini --help`: "Automatically accept all actions (aka YOLO mode)") puts gemini into **agentic auto-approve mode**. In that mode, even a single advisory question makes gemini attempt tool execution. That tool loop hits rate limits / empty responses and retries, so the one-shot advisor call never returns — it hangs.

`--yolo` was likely added to suppress the interactive workspace **trust** prompt, but it does far more than that.

## Fix

Use `--skip-trust` instead of `--yolo`. Per `gemini --help`:

```
--skip-trust   Trust the current workspace for this session.  [boolean] [default: false]
```

`--skip-trust` only bypasses the workspace trust prompt — exactly what an automated one-shot advisor needs — without entering agentic auto-approve mode. The call stays a single-shot answer.

```js
if (provider === 'gemini') {
  return pipePromptViaStdin ? ['--skip-trust'] : ['-p', prompt, '--skip-trust'];
}
```

## Verification

Local reproduction with the fixed args:

```
$ gemini -m gemini-2.5-flash -p "Reply with exactly: PONG" --skip-trust </dev/null
PONG
-> RC 0 in ~8s
```

The same one-shot with `--yolo` hangs.

We independently hit and fixed the identical bug in our own gemini wrapper by dropping `--approval-mode yolo` and switching to `--skip-trust`, which took the call from hanging to ~6s RC 0 — same root cause, same fix. This is what pointed us at the upstream `--yolo` here.

## Scope

One-line behavioral change (plus an explanatory comment) in `buildProviderArgs`. No change to claude/codex paths. `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)