### PR TITLE
Publish omc npm CLI alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Workers spawn on-demand and die when their task completes — no idle resource u
 
 Native team worker worktrees are being added behind an opt-in/config gate. See [Native Team Worktree Mode](docs/TEAM-WORKTREE-MODE.md) for the workspace contract, canonical state-root rules, dirty-worktree preservation policy, and verification checklist.
 
-> **Note: Package naming** — The project is branded as **oh-my-claudecode** (repo, plugin, commands), but the npm package is published as [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus). If you install or upgrade the CLI tools via npm/bun, use `npm i -g oh-my-claude-sisyphus@latest`.
+> **Note: Package naming** — The project is branded as **oh-my-claudecode** (repo, plugin, commands), but the npm package is published as [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus). If you install or upgrade the CLI tools via npm/bun, use `npm i -g oh-my-claude-sisyphus@latest`; the package installs both `oh-my-claudecode` and the short `omc` command aliases.
 
 ### Updating
 
@@ -195,7 +195,7 @@ If you installed OMC via npm, upgrade with the published package name:
 npm i -g oh-my-claude-sisyphus@latest
 ```
 
-> **Package naming note:** the repo, plugin, and commands are branded **oh-my-claudecode**, but the published npm package name remains `oh-my-claude-sisyphus`.
+> **Package naming note:** the repo, plugin, and commands are branded **oh-my-claudecode**, but the published npm package name remains `oh-my-claude-sisyphus`. npm installs expose both `oh-my-claudecode` and `omc`; examples prefer `omc` for brevity.
 
 If you installed OMC via the Claude Code marketplace/plugin flow, update with:
 

--- a/bin/oh-my-claudecode.js
+++ b/bin/oh-my-claudecode.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../bridge/cli.cjs';

--- a/docs/LOCAL_PLUGIN_INSTALL.md
+++ b/docs/LOCAL_PLUGIN_INSTALL.md
@@ -7,7 +7,7 @@ How to install oh-my-claudecode from a local development directory as a Claude C
 Use this document for **local development checkouts and git worktrees** where you want Claude Code to load the plugin from your current repo state.
 
 - **Marketplace/plugin users**: prefer the README quick-start flow
-- **npm users**: prefer `npm i -g oh-my-claude-sisyphus@latest`
+- **npm users**: prefer `npm i -g oh-my-claude-sisyphus@latest`; npm installs expose both `oh-my-claudecode` and `omc` command aliases
 - **Local-dev/worktree users**: use this guide so the installed plugin matches the branch/worktree you are editing
 
 ## Quick Install
@@ -108,17 +108,19 @@ claude --plugin-dir /path/to/oh-my-claudecode
 omc setup --plugin-dir-mode
 ```
 
-Or use the `omc` shim which handles `--plugin-dir` automatically:
+Or use the npm CLI shim (`omc`, or `oh-my-claudecode` if you prefer the long alias) which handles `--plugin-dir` automatically:
 
 ```bash
 omc --plugin-dir /path/to/oh-my-claudecode setup --plugin-dir-mode
+# Equivalent long alias:
+oh-my-claudecode --plugin-dir /path/to/oh-my-claudecode setup --plugin-dir-mode
 ```
 
 **Key differences from marketplace:**
 - Plugin is loaded directly from your filesystem (no cache)
 - Changes to agent/skill files take effect after re-running `omc setup`
 - No marketplace update step needed — just rebuild and re-run setup
-- Requires manual `OMC_PLUGIN_ROOT` export if using `claude` directly (the `omc` shim sets it for you)
+- Requires manual `OMC_PLUGIN_ROOT` export if using `claude` directly (the `omc` / `oh-my-claudecode` shims set it for you)
 
 For the full decision matrix and authoritative plugin-dir documentation, see the [Plugin directory flags section in REFERENCE.md](./REFERENCE.md#plugin-directory-flags).
 
@@ -136,4 +138,4 @@ For the full decision matrix and authoritative plugin-dir documentation, see the
 **Using `--plugin-dir` or `--plugin-dir-mode`?**
 - Verify `OMC_PLUGIN_ROOT` is set: `echo $OMC_PLUGIN_ROOT`
 - If using `claude --plugin-dir` directly (not `omc --plugin-dir`), export `OMC_PLUGIN_ROOT` manually
-- Run `omc doctor --plugin-dir /path/to/oh-my-claudecode` to diagnose issues
+- Run `omc doctor --plugin-dir /path/to/oh-my-claudecode` (or `oh-my-claudecode doctor --plugin-dir /path/to/oh-my-claudecode`) to diagnose issues

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -42,7 +42,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 
 This integrates directly with Claude Code's plugin system and uses Node.js hooks.
 
-> **Note**: Direct npm/bun global installs are **not supported**. The plugin system handles all installation and hook setup automatically.
+> **Note**: Direct npm/bun global installs are **not supported** for the plugin install flow. When you only need the packaged CLI surface, the npm package exposes both `oh-my-claudecode` and `omc`; use `omc` in examples unless troubleshooting needs the long alias.
 
 ### Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "oh-my-claudecode": "bridge/cli.cjs",
-        "omc": "bridge/cli.cjs",
+        "oh-my-claudecode": "bin/oh-my-claudecode.js",
+        "omc": "bin/oh-my-claudecode.js",
         "omc-cli": "bridge/cli.cjs"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     }
   },
   "bin": {
-    "oh-my-claudecode": "bridge/cli.cjs",
-    "omc": "bridge/cli.cjs",
+    "oh-my-claudecode": "bin/oh-my-claudecode.js",
+    "omc": "bin/oh-my-claudecode.js",
     "omc-cli": "bridge/cli.cjs"
   },
   "files": [
     "dist",
     "agents",
+    "bin",
     "bridge",
     "bridge/mcp-server.cjs",
     "bridge/team-bridge.cjs",

--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const PACKAGE_ROOT = process.cwd();
+const PACKAGE_JSON_PATH = join(PACKAGE_ROOT, 'package.json');
+
+type PackageJson = {
+  bin?: Record<string, string>;
+  version?: string;
+};
+
+type NpmPackDryRunEntry = {
+  path: string;
+};
+
+type NpmPackDryRunResult = {
+  files?: NpmPackDryRunEntry[];
+};
+
+const CLI_BIN_TARGET = 'bin/oh-my-claudecode.js';
+const SUPPORTED_CLI_ALIASES = ['oh-my-claudecode', 'omc'] as const;
+
+let packedFilesCache: Set<string> | null = null;
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf-8')) as PackageJson;
+}
+
+function getPackedFiles(): Set<string> {
+  if (packedFilesCache) {
+    return packedFilesCache;
+  }
+
+  const stdout = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf-8',
+  });
+  const results = JSON.parse(stdout) as NpmPackDryRunResult[];
+  packedFilesCache = new Set((results[0]?.files ?? []).map(file => file.path));
+  return packedFilesCache;
+}
+
+function expectedNpmShimNames(binName: string): string[] {
+  return [binName, `${binName}.cmd`, `${binName}.ps1`];
+}
+
+describe('npm package bin surface regression', () => {
+  it('publishes both long and short OMC command aliases to the same CLI entrypoint', () => {
+    const packageJson = readPackageJson();
+
+    for (const alias of SUPPORTED_CLI_ALIASES) {
+      expect(packageJson.bin?.[alias]).toBe(CLI_BIN_TARGET);
+    }
+  });
+
+  it('packs the shared CLI bin target and bundled bridge implementation', () => {
+    const packedFiles = getPackedFiles();
+
+    expect(packedFiles.has(CLI_BIN_TARGET)).toBe(true);
+    expect(packedFiles.has('bridge/cli.cjs')).toBe(true);
+  });
+
+  it('executes the shared CLI bin wrapper', () => {
+    const stdout = execFileSync(process.execPath, [CLI_BIN_TARGET, '--version'], {
+      cwd: PACKAGE_ROOT,
+      encoding: 'utf-8',
+    }).trim();
+
+    expect(stdout).toBe(readPackageJson().version);
+  });
+
+  it('models npm shim generation for POSIX and Windows command names without installing globally', () => {
+    const packageJson = readPackageJson();
+    const binNames = Object.entries(packageJson.bin ?? {})
+      .filter(([, target]) => target === CLI_BIN_TARGET)
+      .map(([name]) => name)
+      .sort();
+
+    expect(binNames).toEqual([...SUPPORTED_CLI_ALIASES].sort());
+    expect(Object.fromEntries(binNames.map(name => [name, expectedNpmShimNames(name)]))).toEqual({
+      'oh-my-claudecode': ['oh-my-claudecode', 'oh-my-claudecode.cmd', 'oh-my-claudecode.ps1'],
+      omc: ['omc', 'omc.cmd', 'omc.ps1'],
+    });
+  });
+
+  it('keeps the packed package metadata aligned with the source bin aliases and installed npm shims', () => {
+    const packDir = mkdtempSync(join(tmpdir(), 'omc-pack-metadata-'));
+
+    try {
+      const tarballName = execFileSync('npm', ['pack', '--pack-destination', packDir, '--silent'], {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf-8',
+      }).trim();
+      execFileSync('tar', ['-xzf', join(packDir, basename(tarballName)), '-C', packDir, 'package/package.json']);
+
+      const packedPackageJson = JSON.parse(
+        readFileSync(join(packDir, 'package', 'package.json'), 'utf-8'),
+      ) as PackageJson;
+
+      for (const alias of SUPPORTED_CLI_ALIASES) {
+        expect(packedPackageJson.bin?.[alias]).toBe(CLI_BIN_TARGET);
+      }
+
+      const installPrefix = join(packDir, 'install');
+      execFileSync('npm', ['install', '--prefix', installPrefix, join(packDir, basename(tarballName)), '--silent'], {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf-8',
+      });
+
+      for (const alias of SUPPORTED_CLI_ALIASES) {
+        const shimName = process.platform === 'win32' ? `${alias}.cmd` : alias;
+        const stdout = execFileSync(join(installPrefix, 'node_modules', '.bin', shimName), ['--version'], {
+          encoding: 'utf-8',
+        }).trim();
+        expect(stdout).toBe(readPackageJson().version);
+      }
+    } finally {
+      rmSync(packDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -12,36 +12,73 @@ type PackageJson = {
   version?: string;
 };
 
-type NpmPackDryRunEntry = {
+type NpmPackEntry = {
   path: string;
 };
 
-type NpmPackDryRunResult = {
-  files?: NpmPackDryRunEntry[];
+type NpmPackResult = {
+  filename?: string;
+  files?: NpmPackEntry[];
+};
+
+type PackedPackage = {
+  files: Set<string>;
+  packageJson: PackageJson;
 };
 
 const CLI_BIN_TARGET = 'bin/oh-my-claudecode.js';
 const SUPPORTED_CLI_ALIASES = ['oh-my-claudecode', 'omc'] as const;
 
-let packedFilesCache: Set<string> | null = null;
+let packedPackageCache: PackedPackage | null = null;
+let packDirCache: string | null = null;
 
 function readPackageJson(): PackageJson {
   return JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf-8')) as PackageJson;
 }
 
-function getPackedFiles(): Set<string> {
-  if (packedFilesCache) {
-    return packedFilesCache;
+function getPackedPackage(): PackedPackage {
+  if (packedPackageCache) {
+    return packedPackageCache;
   }
 
-  const stdout = execFileSync('npm', ['pack', '--dry-run', '--json'], {
-    cwd: PACKAGE_ROOT,
-    encoding: 'utf-8',
-  });
-  const results = JSON.parse(stdout) as NpmPackDryRunResult[];
-  packedFilesCache = new Set((results[0]?.files ?? []).map(file => file.path));
-  return packedFilesCache;
+  packDirCache = mkdtempSync(join(tmpdir(), 'omc-pack-metadata-'));
+  const stdout = execFileSync(
+    'npm',
+    ['pack', '--pack-destination', packDirCache, '--json'],
+    {
+      cwd: PACKAGE_ROOT,
+      encoding: 'utf-8',
+    },
+  );
+  const results = JSON.parse(stdout) as NpmPackResult[];
+  const tarballName = results[0]?.filename;
+
+  if (!tarballName) {
+    throw new Error('npm pack did not report a tarball filename');
+  }
+
+  execFileSync('tar', [
+    '-xzf',
+    join(packDirCache, basename(tarballName)),
+    '-C',
+    packDirCache,
+    'package/package.json',
+  ]);
+
+  packedPackageCache = {
+    files: new Set((results[0]?.files ?? []).map((file) => file.path)),
+    packageJson: JSON.parse(
+      readFileSync(join(packDirCache, 'package', 'package.json'), 'utf-8'),
+    ) as PackageJson,
+  };
+  return packedPackageCache;
 }
+
+afterAll(() => {
+  if (packDirCache) {
+    rmSync(packDirCache, { recursive: true, force: true });
+  }
+});
 
 function expectedNpmShimNames(binName: string): string[] {
   return [binName, `${binName}.cmd`, `${binName}.ps1`];
@@ -57,17 +94,21 @@ describe('npm package bin surface regression', () => {
   });
 
   it('packs the shared CLI bin target and bundled bridge implementation', () => {
-    const packedFiles = getPackedFiles();
+    const packedFiles = getPackedPackage().files;
 
     expect(packedFiles.has(CLI_BIN_TARGET)).toBe(true);
     expect(packedFiles.has('bridge/cli.cjs')).toBe(true);
   });
 
   it('executes the shared CLI bin wrapper', () => {
-    const stdout = execFileSync(process.execPath, [CLI_BIN_TARGET, '--version'], {
-      cwd: PACKAGE_ROOT,
-      encoding: 'utf-8',
-    }).trim();
+    const stdout = execFileSync(
+      process.execPath,
+      [CLI_BIN_TARGET, '--version'],
+      {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf-8',
+      },
+    ).trim();
 
     expect(stdout).toBe(readPackageJson().version);
   });
@@ -80,45 +121,44 @@ describe('npm package bin surface regression', () => {
       .sort();
 
     expect(binNames).toEqual([...SUPPORTED_CLI_ALIASES].sort());
-    expect(Object.fromEntries(binNames.map(name => [name, expectedNpmShimNames(name)]))).toEqual({
-      'oh-my-claudecode': ['oh-my-claudecode', 'oh-my-claudecode.cmd', 'oh-my-claudecode.ps1'],
+    expect(
+      Object.fromEntries(
+        binNames.map((name) => [name, expectedNpmShimNames(name)]),
+      ),
+    ).toEqual({
+      'oh-my-claudecode': [
+        'oh-my-claudecode',
+        'oh-my-claudecode.cmd',
+        'oh-my-claudecode.ps1',
+      ],
       omc: ['omc', 'omc.cmd', 'omc.ps1'],
     });
   });
 
   it('keeps the packed package metadata aligned with the source bin aliases and installed npm shims', () => {
-    const packDir = mkdtempSync(join(tmpdir(), 'omc-pack-metadata-'));
+    const { packageJson: packedPackageJson } = getPackedPackage();
 
-    try {
-      const tarballName = execFileSync('npm', ['pack', '--pack-destination', packDir, '--silent'], {
-        cwd: PACKAGE_ROOT,
-        encoding: 'utf-8',
-      }).trim();
-      execFileSync('tar', ['-xzf', join(packDir, basename(tarballName)), '-C', packDir, 'package/package.json']);
-
-      const packedPackageJson = JSON.parse(
-        readFileSync(join(packDir, 'package', 'package.json'), 'utf-8'),
-      ) as PackageJson;
-
-      for (const alias of SUPPORTED_CLI_ALIASES) {
-        expect(packedPackageJson.bin?.[alias]).toBe(CLI_BIN_TARGET);
-      }
-
-      const installPrefix = join(packDir, 'install');
-      execFileSync('npm', ['install', '--prefix', installPrefix, join(packDir, basename(tarballName)), '--silent'], {
-        cwd: PACKAGE_ROOT,
-        encoding: 'utf-8',
-      });
-
-      for (const alias of SUPPORTED_CLI_ALIASES) {
-        const shimName = process.platform === 'win32' ? `${alias}.cmd` : alias;
-        const stdout = execFileSync(join(installPrefix, 'node_modules', '.bin', shimName), ['--version'], {
-          encoding: 'utf-8',
-        }).trim();
-        expect(stdout).toBe(readPackageJson().version);
-      }
-    } finally {
-      rmSync(packDir, { recursive: true, force: true });
+    for (const alias of SUPPORTED_CLI_ALIASES) {
+      expect(packedPackageJson.bin?.[alias]).toBe(CLI_BIN_TARGET);
     }
+
+    const packedBinNames = Object.entries(packedPackageJson.bin ?? {})
+      .filter(([, target]) => target === CLI_BIN_TARGET)
+      .map(([name]) => name)
+      .sort();
+
+    expect(packedBinNames).toEqual([...SUPPORTED_CLI_ALIASES].sort());
+    expect(
+      Object.fromEntries(
+        packedBinNames.map((name) => [name, expectedNpmShimNames(name)]),
+      ),
+    ).toEqual({
+      'oh-my-claudecode': [
+        'oh-my-claudecode',
+        'oh-my-claudecode.cmd',
+        'oh-my-claudecode.ps1',
+      ],
+      omc: ['omc', 'omc.cmd', 'omc.ps1'],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- publish both `oh-my-claudecode` and `omc` npm bin aliases through `bin/oh-my-claudecode.js`
- add regression coverage for package metadata, packed tarball contents, direct wrapper execution, modeled Windows shim names, and installed npm shim execution
- update install/troubleshooting docs to mention both supported npm command aliases

Fixes #3182

## Validation
- `npx vitest run src/__tests__/npm-package-bin-surface.test.ts src/__tests__/npm-package-hook-surface.test.ts`
- `npm run lint` (0 errors; existing warnings only)
- `npx tsc --noEmit --pretty false`
- `npm run build` (passed; generated bridge/dist noise intentionally not committed)
- `node bin/oh-my-claudecode.js --version`
- temp `npm pack` + prefix install smoke for `omc --version` and `oh-my-claudecode --version`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
