### PR TITLE
Honor workspace Claude skills during OMC slash execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Wrap handler at server.py:42 in try/except ClientDisconnectedError...
 **Skillify:** `/skillify` extracts reusable patterns with strict quality gates
 **Auto-inject:** Matching skills load into context automatically — no manual recall needed
 
-Project-scoped skills are stored in `.omc/skills/` and are intended to be committed when you want them shared. If you create them inside a linked git worktree and do not commit them, they disappear when that worktree is removed.
+Project-scoped OMC-authored skills are stored in `.omc/skills/` and are intended to be committed when you want them shared. During slash/skill execution OMC also reads Claude Code workspace skills from `.claude/skills/` and compatibility skills from `.agents/skills/`, so existing workspace-local `SKILL.md` packages remain callable without copying them into user-global skills. If you create project-local skills inside a linked git worktree and do not commit them, they disappear when that worktree is removed.
 
 [Full feature list →](docs/REFERENCE.md)
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -168,7 +168,7 @@ The `plugin.json` defines the plugin's metadata and tools:
 
 ### Skill and Agent Discovery
 
-**Skills** are discovered from `SKILL.md` files in the skills directory. OMC's canonical project-local write target remains `.omc/skills/`, and it now also reads project-local compatibility skills from `.agents/skills/`. Each skill directory must contain a SKILL.md with frontmatter:
+**Skills** are discovered from `SKILL.md` files in supported skills directories. OMC's canonical project-local write target remains `.omc/skills/`, and it also reads Claude Code project skills from `.claude/skills/` plus project-local compatibility skills from `.agents/skills/`. Each skill directory must contain a SKILL.md with frontmatter:
 
 ```markdown
 ---

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -804,7 +804,7 @@ When present, OMC appends a standardized **Skill Pipeline** section to the rende
 
 ### Skills 2.0 Compatibility (MVP)
 
-OMC's canonical project-local skill directory remains `.omc/skills/`, but the runtime now also reads compatibility skills from `.agents/skills/`.
+OMC's canonical project-local skill directory remains `.omc/skills/`, and the runtime also reads Claude Code project skills from `.claude/skills/` plus compatibility skills from `.agents/skills/`.
 
 For builtin and slash-loaded skills, OMC also appends a standardized **Skill Resources** section when the skill directory contains bundled assets such as helper scripts, templates, or support libraries. This helps agents reuse packaged skill resources instead of recreating them ad hoc.
 

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -242,6 +242,52 @@ Compatibility body`
     expect(result.replacementText).toContain('`templates/`');
   });
 
+  it('discovers workspace-local Claude Code skills from .claude/skills before OMC compatibility skills', async () => {
+    mkdirSync(join(tempProjectDir, '.claude', 'skills', 'workspace-skill', 'references'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.claude', 'skills', 'workspace-skill', 'SKILL.md'),
+      `---
+name: workspace-skill
+description: Workspace Claude skill
+---
+
+Workspace Claude skill body`
+    );
+    writeFileSync(
+      join(tempProjectDir, '.claude', 'skills', 'workspace-skill', 'references', 'example.md'),
+      'example'
+    );
+
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'workspace-skill'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'workspace-skill', 'SKILL.md'),
+      `---
+name: workspace-skill
+description: Compatibility duplicate
+---
+
+Compatibility duplicate body`
+    );
+
+    const { findCommand, executeSlashCommand, listAvailableCommands } = await loadExecutor();
+
+    expect(findCommand('workspace-skill')?.path).toContain(join('.claude', 'skills', 'workspace-skill', 'SKILL.md'));
+    expect(listAvailableCommands().some((command) => command.name === 'workspace-skill')).toBe(true);
+
+    const result = executeSlashCommand({
+      command: 'workspace-skill',
+      args: '',
+      raw: '/workspace-skill',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('Workspace Claude skill body');
+    expect(result.replacementText).toContain('## Skill Resources');
+    expect(result.replacementText).toContain('.claude/skills/workspace-skill');
+    expect(result.replacementText).toContain('`references/`');
+    expect(result.replacementText).not.toContain('Compatibility duplicate body');
+  });
+
   it('renders deterministic autoresearch bridge guidance for deep-interview autoresearch mode', async () => {
     mkdirSync(join(tempConfigDir, 'skills', 'deep-interview'), { recursive: true });
     writeFileSync(

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -19,7 +19,7 @@ import type {
 } from './types.js';
 import { resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
-import { formatOmcCliInvocation, rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
+import { rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
 import { renderSkillResourcesGuidance } from '../../utils/skill-resources.js';
 import { renderSkillRuntimeGuidance } from '../../features/builtin-skills/runtime-guidance.js';
@@ -192,21 +192,24 @@ function discoverSkillsFromDir(skillsDir: string): CommandInfo[] {
 export function discoverAllCommands(): CommandInfo[] {
   const userCommandsDir = join(CLAUDE_CONFIG_DIR, 'commands');
   const projectCommandsDir = join(process.cwd(), '.claude', 'commands');
+  const projectClaudeSkillsDir = join(process.cwd(), '.claude', 'skills');
   const projectOmcSkillsDir = join(getOmcRoot(), 'skills');
   const projectAgentSkillsDir = join(process.cwd(), '.agents', 'skills');
   const userSkillsDir = join(CLAUDE_CONFIG_DIR, 'skills');
 
   const userCommands = discoverCommandsFromDir(userCommandsDir, 'user');
   const projectCommands = discoverCommandsFromDir(projectCommandsDir, 'project');
+  const projectClaudeSkills = discoverSkillsFromDir(projectClaudeSkillsDir);
   const projectOmcSkills = discoverSkillsFromDir(projectOmcSkillsDir);
   const projectAgentSkills = discoverSkillsFromDir(projectAgentSkillsDir);
   const userSkills = discoverSkillsFromDir(userSkillsDir);
   const builtinSkills = discoverSkillsFromDir(getSkillsDir());
 
-  // Priority: project commands > user commands > project OMC skills > project compatibility skills > user skills > builtin skills
+  // Priority: project commands > user commands > project Claude Code skills > project OMC skills > project compatibility skills > user skills > builtin skills
   const prioritized = [
     ...projectCommands,
     ...userCommands,
+    ...projectClaudeSkills,
     ...projectOmcSkills,
     ...projectAgentSkills,
     ...userSkills,

--- a/src/hooks/auto-slash-command/index.ts
+++ b/src/hooks/auto-slash-command/index.ts
@@ -3,7 +3,7 @@
  *
  * Detects and expands slash commands in user prompts.
  * Complements Claude Code's native slash command system by adding:
- * - Skill-based commands from ~/.claude/skills/
+ * - Skill-based commands from ~/.claude/skills/ and .claude/skills/
  * - Project-level commands from .claude/commands/
  * - Template expansion with $ARGUMENTS placeholder
  *


### PR DESCRIPTION
## Summary
- Treat issue #3185 as a real OMC discovery gap: workspace `.claude/skills/<name>/SKILL.md` was not included in OMC auto slash/skill discovery.
- Add `.claude/skills` as a project-local skill source before `.omc/skills`, `.agents/skills`, user skills, and bundled skills.
- Document the callable contract in README, REFERENCE, and COMPATIBILITY.

## Evidence / Investigation
- OMC launch preserves workspace cwd for direct/tmux Claude invocation (`src/cli/launch.ts`).
- Team worker panes are launched with the team/worker cwd (`src/team/runtime-v2.ts`, `src/team/tmux-session.ts`).
- The actionable gap was `discoverAllCommands()` omitting `process.cwd()/.claude/skills` while already reading `.claude/commands`, `.omc/skills`, `.agents/skills`, user `~/.claude/skills`, and bundled skills.

## Tests
- `npm test -- --run src/__tests__/auto-slash-aliases.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/hooks/auto-slash-command/executor.ts src/hooks/auto-slash-command/index.ts src/__tests__/auto-slash-aliases.test.ts`
- `npm run lint` (passes with existing warnings outside this diff)
- `npm run build`
- `git diff --check`

Fixes #3185

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
