### PR TITLE
Fix standalone SessionStart hook helper packaging

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -268,9 +268,21 @@ jobs:
             exit 1
           fi
 
+          set +e
           printf '%s' \
             "{\"hook_event_name\":\"SessionStart\",\"session_id\":\"ci-upgrade-test\",\"cwd\":\"$GITHUB_WORKSPACE\"}" \
             | node "$SESSION_HOOK" 1>"$RUNNER_TEMP/session.stdout.log" 2>"$RUNNER_TEMP/session.stderr.log"
+          SESSION_EXIT=$?
+          set -e
+
+          if [ "$SESSION_EXIT" -ne 0 ]; then
+            echo "FAIL: SessionStart hook exited with code $SESSION_EXIT"
+            echo "stderr:"
+            cat "$RUNNER_TEMP/session.stderr.log"
+            echo "stdout:"
+            cat "$RUNNER_TEMP/session.stdout.log"
+            exit 1
+          fi
 
           if [ -s "$RUNNER_TEMP/session.stderr.log" ]; then
             echo "FAIL: SessionStart hook produced stderr:"

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -654,7 +654,7 @@ describe('Installer Constants', () => {
       const libFiles = readdirSync(templatesLibDir);
 
       // Required lib files that must be present
-      const requiredFiles = ['stdin.mjs', 'atomic-write.mjs', 'config-dir.mjs'];
+      const requiredFiles = ['stdin.mjs', 'atomic-write.mjs', 'config-dir.mjs', 'state-root.mjs', 'model-routing-override-message.mjs'];
       for (const file of requiredFiles) {
         expect(libFiles).toContain(file);
       }

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -107,6 +108,44 @@ describe('install() standalone hook reconciliation', () => {
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');
+  });
+
+  it('installs a standalone SessionStart hook with all runtime helper imports', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'omc-standalone-session-start-project-'));
+    try {
+      mkdirSync(join(projectDir, '.git'), { recursive: true });
+
+      const { install } = await loadInstaller();
+      const result = install({
+        force: true,
+        skipClaudeCheck: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(existsSync(join(testClaudeDir, 'hooks', 'lib', 'state-root.mjs'))).toBe(true);
+      expect(existsSync(join(testClaudeDir, 'hooks', 'lib', 'model-routing-override-message.mjs'))).toBe(true);
+
+      const raw = execFileSync(process.execPath, [join(testClaudeDir, 'hooks', 'session-start.mjs')], {
+        input: JSON.stringify({
+          hook_event_name: 'SessionStart',
+          session_id: 'ci-upgrade-test',
+          cwd: projectDir,
+        }),
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: testClaudeDir,
+          HOME: testHomeDir,
+          USERPROFILE: testHomeDir,
+        },
+        timeout: 15000,
+      }).trim();
+
+      const parsed = JSON.parse(raw) as { continue?: boolean };
+      expect(parsed.continue).toBe(true);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 
   it('preserves non-OMC ~/.claude/hooks commands while adding standalone OMC hooks', async () => {

--- a/templates/hooks/lib/state-root.mjs
+++ b/templates/hooks/lib/state-root.mjs
@@ -1,0 +1,90 @@
+// Thin delegator → src/lib/worktree-paths.ts::resolveSessionStatePaths. DO NOT reimplement here.
+
+/**
+ * State Root Resolver (ESM)
+ *
+ * Single authoritative entry point for resolving the .omc root directory in
+ * hook scripts, respecting the OMC_STATE_DIR environment variable.
+ *
+ * Delegates to getOmcRoot() from dist/lib/worktree-paths.js (the canonical
+ * implementation) when CLAUDE_PLUGIN_ROOT is available. Falls back to inline
+ * logic when dist is not built — this should never happen in production, but
+ * provides a safe fallback during development or first-run scenarios.
+ *
+ * Inline fallback notes:
+ *   - Uses directory path as hash source (not git remote URL). Matches
+ *     canonical behavior for local-only repos; may differ for remote-backed
+ *     repos when dist is missing — acceptable since dist is always present
+ *     in production (CLAUDE_PLUGIN_ROOT is always set).
+ */
+
+import { join, basename } from 'path';
+import { existsSync } from 'fs';
+import { createHash } from 'crypto';
+import { pathToFileURL } from 'url';
+
+/**
+ * Resolve the .omc root directory, respecting OMC_STATE_DIR.
+ *
+ * @param {string} directory - Worktree root directory
+ * @returns {Promise<string>} Absolute path to the .omc root
+ */
+export async function resolveOmcStateRoot(directory) {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (pluginRoot) {
+    try {
+      const { getOmcRoot } = await import(
+        pathToFileURL(join(pluginRoot, 'dist', 'lib', 'worktree-paths.js')).href
+      );
+      return getOmcRoot(directory);
+    } catch {
+      // dist not built or unavailable — fall through to inline fallback
+    }
+  }
+
+  // Inline fallback: respects OMC_STATE_DIR with simplified project identifier
+  const customDir = process.env.OMC_STATE_DIR;
+  if (customDir) {
+    const hash = createHash('sha256').update(directory).digest('hex').slice(0, 16);
+    const dirName = basename(directory).replace(/[^a-zA-Z0-9_-]/g, '_');
+    return join(customDir, `${dirName}-${hash}`);
+  }
+  return join(directory, '.omc');
+}
+
+/**
+ * Resolve session-scoped state paths for a given directory, state name, and session ID.
+ * Delegates to resolveSessionStatePaths() in dist/lib/worktree-paths.js.
+ *
+ * @param {string} directory - Worktree root directory
+ * @param {string} stateName - State name (e.g., "ralph", "ultrawork")
+ * @param {string} [sessionId] - Optional session identifier
+ * @returns {Promise<{readPath: string, writePath: string}>} Unbranded path pair
+ */
+export async function resolveSessionStatePathsForHook(directory, stateName, sessionId) {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (pluginRoot) {
+    try {
+      const { resolveSessionStatePaths } = await import(
+        pathToFileURL(join(pluginRoot, 'dist', 'lib', 'worktree-paths.js')).href
+      );
+      const result = resolveSessionStatePaths(stateName, sessionId, directory);
+      return { readPath: result.effectiveRead, writePath: result.effectiveWrite };
+    } catch {
+      // dist not built or unavailable — fall through to inline fallback
+    }
+  }
+
+  // Inline fallback: basic session-scoped path derivation (production always uses dist above)
+  const omcRoot = await resolveOmcStateRoot(directory);
+  const normalizedName = stateName.endsWith('-state') ? stateName : `${stateName}-state`;
+  const legacy = join(omcRoot, 'state', `${normalizedName}.json`);
+  if (!sessionId) {
+    return { readPath: legacy, writePath: legacy };
+  }
+  const sessionScoped = join(omcRoot, 'state', 'sessions', sessionId, `${normalizedName}.json`);
+  // effectiveRead probes the session-scoped file first and falls back to the
+  // legacy path when it does not exist yet (mirrors resolveSessionStatePaths).
+  const readPath = existsSync(sessionScoped) ? sessionScoped : legacy;
+  return { readPath, writePath: sessionScoped };
+}

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -12,7 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const { getClaudeConfigDir, getUpdateCheckCachePath } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
 const configDir = getClaudeConfigDir();
-const { resolveSessionStatePathsForHook, resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveSessionStatePathsForHook, resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 // Import timeout-protected stdin reader (prevents hangs on Linux/Windows, see issue #240, #524)
 let readStdin;


### PR DESCRIPTION
## Summary
- package `state-root.mjs` with standalone hook templates and update the SessionStart hook to import it from the installed hook lib directory
- add a regression that executes the installed standalone SessionStart hook after install
- make Upgrade Test capture SessionStart hook exit/stdout/stderr before failing, so future hook failures are diagnosable

## Validation
- `npx vitest run src/installer/__tests__/standalone-hook-reconcile.test.ts src/installer/__tests__/session-start-template.test.ts src/__tests__/installer.test.ts src/__tests__/update-check-path.test.ts --pool=forks --reporter=dot`
- local upgrade-shape reproduction: install 4.9.3, install local 4.14.4 tarball, run `omc update-reconcile`, execute installed `~/.claude/hooks/session-start.mjs`
- `npm run build`
- `npm run lint` (passes with existing warnings)