### PR TITLE
Fix remaining standalone hook state-root imports

### DIFF
--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -110,8 +110,8 @@ describe('install() standalone hook reconciliation', () => {
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');
   });
 
-  it('installs a standalone SessionStart hook with all runtime helper imports', async () => {
-    const projectDir = mkdtempSync(join(tmpdir(), 'omc-standalone-session-start-project-'));
+  it('installs standalone hooks with all runtime helper imports', async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'omc-standalone-hook-project-'));
     try {
       mkdirSync(join(projectDir, '.git'), { recursive: true });
 
@@ -125,24 +125,53 @@ describe('install() standalone hook reconciliation', () => {
       expect(existsSync(join(testClaudeDir, 'hooks', 'lib', 'state-root.mjs'))).toBe(true);
       expect(existsSync(join(testClaudeDir, 'hooks', 'lib', 'model-routing-override-message.mjs'))).toBe(true);
 
-      const raw = execFileSync(process.execPath, [join(testClaudeDir, 'hooks', 'session-start.mjs')], {
-        input: JSON.stringify({
-          hook_event_name: 'SessionStart',
-          session_id: 'ci-upgrade-test',
-          cwd: projectDir,
-        }),
-        encoding: 'utf-8',
-        env: {
-          ...process.env,
-          CLAUDE_CONFIG_DIR: testClaudeDir,
-          HOME: testHomeDir,
-          USERPROFILE: testHomeDir,
+      const hookInputs: Array<{ file: string; input: Record<string, unknown> }> = [
+        {
+          file: 'session-start.mjs',
+          input: { hook_event_name: 'SessionStart', session_id: 'ci-upgrade-test', cwd: projectDir },
         },
-        timeout: 15000,
-      }).trim();
+        {
+          file: 'keyword-detector.mjs',
+          input: { hook_event_name: 'UserPromptSubmit', session_id: 'ci-upgrade-test', cwd: projectDir, prompt: 'hello' },
+        },
+        {
+          file: 'pre-tool-use.mjs',
+          input: { hook_event_name: 'PreToolUse', session_id: 'ci-upgrade-test', cwd: projectDir, tool_name: 'Read', tool_input: {} },
+        },
+        {
+          file: 'post-tool-use.mjs',
+          input: { hook_event_name: 'PostToolUse', session_id: 'ci-upgrade-test', cwd: projectDir, tool_name: 'Read', tool_input: {}, tool_response: 'ok' },
+        },
+        {
+          file: 'post-tool-use-failure.mjs',
+          input: { hook_event_name: 'PostToolUseFailure', session_id: 'ci-upgrade-test', cwd: projectDir, tool_name: 'Read', tool_input: {}, error: 'synthetic failure' },
+        },
+        {
+          file: 'persistent-mode.mjs',
+          input: { hook_event_name: 'Stop', session_id: 'ci-upgrade-test', cwd: projectDir },
+        },
+        {
+          file: 'code-simplifier.mjs',
+          input: { hook_event_name: 'Stop', session_id: 'ci-upgrade-test', cwd: projectDir },
+        },
+      ];
 
-      const parsed = JSON.parse(raw) as { continue?: boolean };
-      expect(parsed.continue).toBe(true);
+      for (const { file, input } of hookInputs) {
+        const raw = execFileSync(process.execPath, [join(testClaudeDir, 'hooks', file)], {
+          input: JSON.stringify(input),
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            CLAUDE_CONFIG_DIR: testClaudeDir,
+            HOME: testHomeDir,
+            USERPROFILE: testHomeDir,
+          },
+          timeout: 15000,
+        }).trim();
+
+        const parsed = JSON.parse(raw) as { continue?: boolean };
+        expect(parsed.continue, file).toBe(true);
+      }
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }

--- a/templates/hooks/code-simplifier.mjs
+++ b/templates/hooks/code-simplifier.mjs
@@ -28,7 +28,7 @@ const __dirname = dirname(__filename);
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
-const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 const DEFAULT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs'];
 const DEFAULT_MAX_FILES = 10;

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -35,7 +35,7 @@ const __dirname = dirname(__filename);
 const { readStdin } = await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href);
 const { atomicWriteFileSync } = await import(pathToFileURL(join(__dirname, 'lib', 'atomic-write.mjs')).href);
 const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
-const { resolveSessionStatePathsForHook } = await import(pathToFileURL(join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveSessionStatePathsForHook } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 
 const _omcRoot = process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..');

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -29,7 +29,7 @@ const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, 'lib',
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, "lib", "stdin.mjs")).href
 );
-const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 function readJsonFile(path) {
   try {

--- a/templates/hooks/post-tool-use-failure.mjs
+++ b/templates/hooks/post-tool-use-failure.mjs
@@ -14,7 +14,7 @@ const __dirname = dirname(__filename);
 // Dynamic imports for shared modules
 const { readStdin } = await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href);
 const { atomicWriteFileSync, ensureDirSync } = await import(pathToFileURL(join(__dirname, 'lib', 'atomic-write.mjs')).href);
-const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 // ============================================================================
 // Session ID resolution (mirrors src/lib/session-id.ts — inlined for .mjs)

--- a/templates/hooks/post-tool-use.mjs
+++ b/templates/hooks/post-tool-use.mjs
@@ -14,7 +14,7 @@ const __dirname = dirname(__filename);
 // Dynamic imports for shared modules (use pathToFileURL for Windows compatibility, #524)
 const { readStdin } = await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href);
 const { atomicWriteFileSync } = await import(pathToFileURL(join(__dirname, 'lib', 'atomic-write.mjs')).href);
-const { resolveSessionStatePathsForHook, resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveSessionStatePathsForHook, resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 // Constants
 const NOTEPAD_TEMPLATE = '# Notepad\n' +

--- a/templates/hooks/pre-tool-use.mjs
+++ b/templates/hooks/pre-tool-use.mjs
@@ -16,7 +16,7 @@ const __dirname = dirname(__filename);
 
 // Dynamic import for the shared stdin module
 const { readStdin } = await import(pathToFileURL(path.join(__dirname, 'lib', 'stdin.mjs')).href);
-const { resolveOmcStateRoot } = await import(pathToFileURL(path.join(__dirname, '..', '..', 'scripts', 'lib', 'state-root.mjs')).href);
+const { resolveOmcStateRoot } = await import(pathToFileURL(path.join(__dirname, 'lib', 'state-root.mjs')).href);
 
 // ---------------------------------------------------------------------------
 // Skill Active State (issue #1033)


### PR DESCRIPTION
## Summary
- Follow-up to merged #3188: make all standalone hook templates resolve `state-root.mjs` from installed `~/.claude/hooks/lib`.
- Extend installer regression coverage to execute every installed standalone hook that uses the state-root helper.
- Keep scope limited to standalone hook packaging/import resolution.

## Root cause
#3188 fixed SessionStart, but the other standalone hook templates still imported `../../scripts/lib/state-root.mjs`. After install into `~/.claude/hooks`, that path resolves outside the package to `~/scripts/lib/state-root.mjs` and can fail with `ERR_MODULE_NOT_FOUND`.

## Validation
- `npm test -- --run src/installer/__tests__/standalone-hook-reconcile.test.ts src/installer/__tests__/session-start-template.test.ts src/__tests__/installer.test.ts src/__tests__/update-check-path.test.ts`
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- Local npm pack + `omc install` simulation executed all installed standalone hooks: session-start, keyword-detector, pre-tool-use, post-tool-use, post-tool-use-failure, persistent-mode, code-simplifier.
