### PR TITLE
Stabilize subagent lock benchmark on CI

### DIFF
--- a/tests/perf/subagent-lock.bench.ts
+++ b/tests/perf/subagent-lock.bench.ts
@@ -1,28 +1,31 @@
 /**
  * Benchmark: subagent-tracking RMW latency under no contention.
  *
- * Measures per-update wall time for N=100 sequential updates and asserts
- * p99 ≤ 8ms on Linux. On Windows and macOS, the p99 is logged without failing
- * (lock overhead varies significantly across platforms).
+ * Measures per-update wall time for sequential updates. Local Linux keeps the
+ * strict p99 <= 8ms guard; CI runners use repeated samples and a wider p99
+ * envelope so an isolated scheduler/filesystem stall does not fail dev, while
+ * still catching sustained lock slowdowns and hangs.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
 import { performance } from "perf_hooks";
-import { mkdirSync, rmSync, writeFileSync, existsSync } from "fs";
+import { mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
-  readTrackingState,
-  writeTrackingState,
   flushPendingWrites,
   executeFlush,
   type SubagentTrackingState,
 } from "../../src/hooks/subagent-tracker/index.js";
-import { resolveSessionStatePaths } from "../../src/lib/worktree-paths.js";
-import { lockPathFor } from "../../src/lib/file-lock.js";
 
 const N = 100;
-const P99_LIMIT_MS = 8;
+const WARMUP_RUNS = 1;
+const MEASURED_RUNS = 5;
+const LOCAL_P99_LIMIT_MS = 8;
+const CI_MEDIAN_P50_LIMIT_MS = 8;
+const CI_MEDIAN_P99_LIMIT_MS = 25;
+const CI_MAX_P99_LIMIT_MS = 100;
+const isCi = process.env.CI === "true" || process.env.CI === "1";
 
 function makeEmptyState(): SubagentTrackingState {
   return {
@@ -38,6 +41,27 @@ function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;
   const idx = Math.ceil((p / 100) * sorted.length) - 1;
   return sorted[Math.max(0, Math.min(idx, sorted.length - 1))];
+}
+
+type BenchmarkSummary = {
+  p50: number;
+  p95: number;
+  p99: number;
+  max: number;
+};
+
+function summarize(sorted: number[]): BenchmarkSummary {
+  return {
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+    max: sorted[sorted.length - 1] ?? 0,
+  };
+}
+
+function median(values: number[]): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  return percentile(sorted, 50);
 }
 
 describe("subagent-lock benchmark", () => {
@@ -87,20 +111,46 @@ describe("subagent-lock benchmark", () => {
     return samples.slice().sort((a, b) => a - b);
   }
 
-  // Linux-only hard assert
-  it.runIf(process.platform === "linux")(
-    `p99 of ${N} sequential locked updates ≤ ${P99_LIMIT_MS}ms (Linux)`,
-    () => {
+  function runMeasuredBenchmarks(): BenchmarkSummary[] {
+    const summaries: BenchmarkSummary[] = [];
+
+    for (let run = 0; run < WARMUP_RUNS + MEASURED_RUNS; run++) {
       const dir = makeTempDir();
-      const sessionId = `bench-session-${Date.now()}`;
+      const sessionId = `bench-session-${Date.now()}-${run}`;
+      const summary = summarize(runBenchmark(dir, sessionId));
+      if (run >= WARMUP_RUNS) summaries.push(summary);
+    }
 
-      const sorted = runBenchmark(dir, sessionId);
-      const p99 = percentile(sorted, 99);
-      const p50 = percentile(sorted, 50);
+    return summaries;
+  }
 
-      console.log(`[subagent-lock bench] Linux p50=${p50.toFixed(3)}ms  p99=${p99.toFixed(3)}ms  N=${N}`);
+  // Linux hard assertion with CI-noise-tolerant aggregation.
+  it.runIf(process.platform === "linux")(
+    `sequential locked updates stay within Linux latency guardrails`,
+    () => {
+      const summaries = runMeasuredBenchmarks();
+      const p50s = summaries.map((summary) => summary.p50);
+      const p99s = summaries.map((summary) => summary.p99);
+      const medianP50 = median(p50s);
+      const medianP99 = median(p99s);
+      const maxP99 = Math.max(...p99s);
 
-      expect(p99).toBeLessThanOrEqual(P99_LIMIT_MS);
+      console.log(
+        `[subagent-lock bench] Linux CI=${isCi} N=${N} measuredRuns=${MEASURED_RUNS}` +
+        ` medianP50=${medianP50.toFixed(3)}ms medianP99=${medianP99.toFixed(3)}ms` +
+        ` maxP99=${maxP99.toFixed(3)}ms p99s=${p99s.map((p99) => p99.toFixed(3)).join(",")}`,
+      );
+
+      if (isCi) {
+        // GitHub-hosted runners can occasionally pause a single filesystem op.
+        // Keep blocking coverage for sustained regressions via median p50/p99,
+        // and retain a generous max-p99 cap to catch hangs/pathological stalls.
+        expect(medianP50).toBeLessThanOrEqual(CI_MEDIAN_P50_LIMIT_MS);
+        expect(medianP99).toBeLessThanOrEqual(CI_MEDIAN_P99_LIMIT_MS);
+        expect(maxP99).toBeLessThanOrEqual(CI_MAX_P99_LIMIT_MS);
+      } else {
+        expect(medianP99).toBeLessThanOrEqual(LOCAL_P99_LIMIT_MS);
+      }
     },
   );
 
@@ -109,19 +159,16 @@ describe("subagent-lock benchmark", () => {
     const dir = makeTempDir();
     const sessionId = `bench-session-${Date.now()}`;
 
-    const sorted = runBenchmark(dir, sessionId);
-    const p50 = percentile(sorted, 50);
-    const p95 = percentile(sorted, 95);
-    const p99 = percentile(sorted, 99);
-    const max = sorted[sorted.length - 1] ?? 0;
+    const summary = summarize(runBenchmark(dir, sessionId));
 
     console.log(
       `[subagent-lock bench] platform=${process.platform}  N=${N}` +
-      `  p50=${p50.toFixed(3)}ms  p95=${p95.toFixed(3)}ms  p99=${p99.toFixed(3)}ms  max=${max.toFixed(3)}ms`,
+      `  p50=${summary.p50.toFixed(3)}ms  p95=${summary.p95.toFixed(3)}ms` +
+      `  p99=${summary.p99.toFixed(3)}ms  max=${summary.max.toFixed(3)}ms`,
     );
 
     // Sanity: p99 must always be positive and less than 30s (catches hangs)
-    expect(p99).toBeGreaterThan(0);
-    expect(p99).toBeLessThan(30_000);
+    expect(summary.p99).toBeGreaterThan(0);
+    expect(summary.p99).toBeLessThan(30_000);
   });
 });


### PR DESCRIPTION
## Summary
- Make the subagent lock benchmark use a warmup plus 5 measured runs instead of a single p99 sample.
- Keep the strict local Linux median p99 <= 8ms guard.
- Use CI-specific aggregate guardrails (median p50, median p99, max p99) so isolated hosted-runner filesystem stalls do not block dev while sustained lock slowdowns still fail.

## Validation
- `npm test -- --run tests/perf/subagent-lock.bench.ts`
- `CI=true npm test -- --run tests/perf/subagent-lock.bench.ts`
- `npm test -- --run src/hooks/subagent-tracker/__tests__/index.test.ts`
- `npm run lint` (passes with existing warnings)
- `npx tsc --noEmit`
- `npm test -- --run` (566 files passed, 1 skipped; 9638 tests passed, 7 skipped)

## Notes
- Did not run `npm run build` because it emits dist/bridge artifacts, and this fix intentionally avoids unrelated generated changes.