### PR TITLE
feat(keyword-detector): add Japanese katakana keyword detection at Korean parity

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -615,6 +615,9 @@ function hasDiagnosticIntentNearKeyword(context, keyword) {
     new RegExp(`\\b${escaped}\\b[^\\n]{0,48}\\b(?:keeps?\\s+(?:looping|re-?running)|has\\s+(?:a\\s+)?(?:bug|issue|problem|error)|is\\s+(?:stuck|broken|failing)|loop(?:ing)?)\\b`, 'i'),
     new RegExp(`\\b(?:bug|issue|problem|error)\\b[^\\n]{0,16}\\b(?:with|in)\\s+\\b${escaped}\\b`, 'i'),
     new RegExp(`${escaped}.{0,14}(?:자꾸|계속).{0,14}(?:재실행|반복|루프|멈추)`, 'u'),
+    // Japanese: repeated-failure complaint — direct mirror of the Korean 자꾸/계속 line above
+    // (frequency adverb + problem verb). No P2 subject-particle pattern / no work-request escape: Korean parity.
+    new RegExp(`${escaped}[^\\n]{0,16}(?:また|何度も|ずっと|頻繁|繰り返|いつも)[^\\n]{0,16}(?:失敗|エラー|ループ|止ま|落ち|再実行|動かな|フリーズ|壊れ|クラッシュ|こけ|暴走|無限)`, 'u'),
   ];
 
   return patterns.some((pattern) => pattern.test(context));
@@ -622,13 +625,13 @@ function hasDiagnosticIntentNearKeyword(context, keyword) {
 
 function isRalphUltraworkMetaOrBanterContext(context, keywordText) {
   const normalizedKeyword = (keywordText || '').toLowerCase().replace(/\s+/g, '');
-  if (!['ralph', '랄프', 'ultrawork', 'ulw', 'uw', '울트라워크'].includes(normalizedKeyword)) {
+  if (!['ralph', '랄프', 'ラルフ', 'ultrawork', 'ulw', 'uw', '울트라워크', 'ウルトラワーク'].includes(normalizedKeyword)) {
     return false;
   }
 
-  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프'
-    ? ['랄프']
-    : ['울트라워크'];
+  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프' || normalizedKeyword === 'ラルフ'
+    ? ['랄프', 'ラルフ']
+    : ['울트라워크', 'ウルトラワーク'];
   const currentKeywordPattern = currentKeywordAliases.join('|');
   const imperativeVerbPattern = '켜|켜줘|실행|시작|돌려|돌려줘|써|써줘|사용해|진행해';
   const koreanImperativePatterns = [
@@ -1159,7 +1162,7 @@ async function main() {
     }
 
     // Ralph keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ralph|don't stop|must complete|until done)\b|(랄프)(?!로렌)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ralph|don't stop|must complete|until done)\b|(랄프)(?!로렌)|(ラルフ)(?!・?ローレン)/i)) {
       matches.push({ name: 'ralph', args: '' });
     }
 
@@ -1168,7 +1171,7 @@ async function main() {
     // research prose (e.g. "autonomous driving", "autonomous agent") to be a
     // reliable trigger. Aligns with src/hooks/keyword-detector/index.ts and
     // templates/hooks/keyword-detector.mjs, which already exclude it.
-    if (hasActionableKeyword(cleanPrompt, /\b(autopilot|auto pilot|auto-pilot|full auto|fullsend)\b|(오토파일럿)/i) ||
+    if (hasActionableKeyword(cleanPrompt, /\b(autopilot|auto pilot|auto-pilot|full auto|fullsend)\b|(오토파일럿)|(オートパイロット)/i) ||
         hasActionableKeyword(cleanPrompt, /\b(build|create|make)\s+me\s+(an?\s+)?(app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b/i) ||
         hasActionableKeyword(cleanPrompt, /\bi\s+want\s+a\s+/i) ||
         hasActionableKeyword(cleanPrompt, /\bi\s+want\s+an\s+/i) ||
@@ -1186,7 +1189,7 @@ async function main() {
     // Ultrapilot keywords removed — routed to team which is now explicit-only (/team).
 
     // Ultrawork keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ultrawork|ulw|uw)\b|(울트라워크)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ultrawork|ulw|uw)\b|(울트라워크)|(ウルトラワーク)/i)) {
       matches.push({ name: 'ultrawork', args: '' });
     }
 
@@ -1199,7 +1202,7 @@ async function main() {
     }
 
     // Ralplan keyword
-    if (hasActionableRalplanKeyword(cleanPrompt, /\b(ralplan)\b|(랄플랜)/i)) {
+    if (hasActionableRalplanKeyword(cleanPrompt, /\b(ralplan)\b|(랄플랜)|(ラルプラン)/i)) {
       matches.push({ name: 'ralplan', args: '' });
     }
 
@@ -1233,7 +1236,7 @@ async function main() {
     }
 
     // Ultrathink keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ultrathink|think hard|think deeply)\b|(울트라씽크)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ultrathink|think hard|think deeply)\b|(울트라씽크)|(ウルトラシンク)/i)) {
       matches.push({ name: 'ultrathink', args: '' });
     }
 

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -583,4 +583,63 @@ diff --git a/a b/b
     expect(context).toContain('[MAGIC KEYWORD: AUTOPILOT]');
     expect(existsSync(autopilotStatePath)).toBe(true);
   });
+
+  // Japanese full-width katakana variants must fire on the deployed runtime
+  // hook (scripts/keyword-detector.mjs), not just the TS source. Mirrors the
+  // existing Korean positive controls above and guards the standalone copy
+  // against drift from src/hooks/keyword-detector/index.ts.
+  it('activates ralph for "ラルフ 起動" katakana invocation', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ralph-katakana-'));
+    const sessionId = 'session-katakana-ralph';
+    const output = runKeywordDetector('ラルフ 起動', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
+  });
+
+  it('activates ultrawork for "ウルトラワークで並列実行して" katakana invocation', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ultrawork-katakana-'));
+    const sessionId = 'session-katakana-ultrawork';
+    const output = runKeywordDetector('ウルトラワークで並列実行して', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: ULTRAWORK]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json'))).toBe(true);
+  });
+
+  it('activates ralplan for bare "ラルプラン" katakana invocation', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ralplan-katakana-'));
+    const sessionId = 'session-katakana-ralplan';
+    const output = runKeywordDetector('ラルプラン', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: RALPLAN]');
+    expect(existsSync(getRalplanStatePath(cwd, sessionId))).toBe(true);
+  });
+
+  it('does not activate ralph for "ラルフローレンのシャツ" (Ralph Lauren exclusion)', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ralph-lauren-'));
+    const sessionId = 'session-katakana-ralph-lauren';
+    const output = runKeywordDetector('ラルフローレンのシャツ', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(false);
+  });
+
+  it('does not activate ralph for Japanese complaint "ラルフ、また失敗した"', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-ralph-jp-complaint-'));
+    const sessionId = 'session-katakana-ralph-complaint';
+    const output = runKeywordDetector('ラルフ、また失敗した', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(false);
+  });
 });

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -2128,6 +2128,124 @@ This article argues that fake popularity signals damage trust in open source.`;
     });
   });
 
+  // Japanese full-width katakana variants mirror the existing Korean (Hangul)
+  // alternates in KEYWORD_PATTERNS exactly: raw match, no \b word boundary
+  // (ASCII-only), negative lookahead for the Ralph Lauren collision. Half-width
+  // katakana (ﾗﾙﾌ) is intentionally unsupported — full-width only, no NFKC.
+  describe('Japanese katakana triggers', () => {
+    it('should detect "ラルフ 起動" as ralph', () => {
+      const result = detectKeywordsWithType('ラルフ 起動');
+      const match = result.find((r) => r.type === 'ralph');
+      expect(match).toBeDefined();
+    });
+
+    it('should detect "オートパイロットで実装して" as autopilot', () => {
+      const result = detectKeywordsWithType('オートパイロットで実装して');
+      const match = result.find((r) => r.type === 'autopilot');
+      expect(match).toBeDefined();
+    });
+
+    it('should detect "ウルトラワークで並列実行して" as ultrawork', () => {
+      const result = detectKeywordsWithType('ウルトラワークで並列実行して');
+      const match = result.find((r) => r.type === 'ultrawork');
+      expect(match).toBeDefined();
+    });
+
+    it('should detect "ウルトラシンクで設計して" as ultrathink', () => {
+      const result = detectKeywordsWithType('ウルトラシンクで設計して');
+      const match = result.find((r) => r.type === 'ultrathink');
+      expect(match).toBeDefined();
+    });
+
+    // ralplan routes through the explicit-invocation gate. A bare keyword at
+    // position 0 has an empty prefix, which counts as a direct invocation —
+    // identical to bare Korean "랄플랜" (see the Korean basic-matching block).
+    it('should detect bare "ラルプラン" as ralplan (parity with bare "랄플랜")', () => {
+      const result = detectKeywordsWithType('ラルプラン');
+      const match = result.find((r) => r.type === 'ralplan');
+      expect(match).toBeDefined();
+    });
+
+    it('should NOT detect "ラルフローレンのシャツ" as ralph (Ralph Lauren)', () => {
+      const result = detectKeywordsWithType('ラルフローレンのシャツ');
+      const match = result.find((r) => r.type === 'ralph');
+      expect(match).toBeUndefined();
+    });
+
+    it('should NOT detect "ラルフ・ローレンについて" as ralph (nakaguro Ralph Lauren)', () => {
+      const result = detectKeywordsWithType('ラルフ・ローレンについて');
+      const match = result.find((r) => r.type === 'ralph');
+      expect(match).toBeUndefined();
+    });
+
+    it('should NOT detect informational "ラルフ とは？ 使い方を教えて"', () => {
+      const result = detectKeywordsWithType('ラルフ とは？ 使い方を教えて');
+      expect(result).toEqual([]);
+    });
+
+    // Japanese diagnostic/complaint prompts must not fire execution modes,
+    // mirroring the Korean 자꾸/계속 suppression.
+    it('should NOT detect ralph for complaint "ラルフ、また失敗した"', () => {
+      const result = detectKeywordsWithType('ラルフ、また失敗した');
+      expect(result.find((r) => r.type === 'ralph')).toBeUndefined();
+    });
+
+    it('should NOT detect ralph for complaint "ラルフが何度も再実行されて困る"', () => {
+      const result = detectKeywordsWithType('ラルフが何度も再実行されて困る');
+      expect(result.find((r) => r.type === 'ralph')).toBeUndefined();
+    });
+
+    // P2 removed for Korean parity — Korean does not suppress adverb-less complaints either.
+    // See follow-up: language-agnostic topic/subject-particle complaint pattern.
+    it('should now activate ultrawork for adverb-less "ウルトラワークがループしてる" (P2 removed, Korean parity)', () => {
+      const result = detectKeywordsWithType('ウルトラワークがループしてる');
+      expect(result.find((r) => r.type === 'ultrawork')).toBeDefined();
+    });
+
+    // P2 removed for Korean parity — Korean does not suppress adverb-less complaints either.
+    // See follow-up: language-agnostic topic/subject-particle complaint pattern.
+    it('should now activate ralph for adverb-less "ラルフは失敗しやすい" (P2 removed, Korean parity)', () => {
+      const result = detectKeywordsWithType('ラルフは失敗しやすい');
+      expect(result.find((r) => r.type === 'ralph')).toBeDefined();
+    });
+
+    // Regression guard: legitimate activations must still fire.
+    it('should STILL detect ralph for "ラルフ 起動" (regression)', () => {
+      const result = detectKeywordsWithType('ラルフ 起動');
+      expect(result.find((r) => r.type === 'ralph')).toBeDefined();
+    });
+
+    it('should STILL detect ralph for "ラルフで認証バグを直して" (regression)', () => {
+      const result = detectKeywordsWithType('ラルフで認証バグを直して');
+      expect(result.find((r) => r.type === 'ralph')).toBeDefined();
+    });
+
+    // Work-request still activates (representative guard; the P2 escape was removed for Korean parity).
+    it('should STILL detect ralph for work-request "ラルフは無限ループ検出機能を実装して"', () => {
+      const result = detectKeywordsWithType('ラルフは無限ループ検出機能を実装して');
+      expect(result.find((r) => r.type === 'ralph')).toBeDefined();
+    });
+
+    // Half-width katakana is unsupported by design (full-width only, no NFKC).
+    it('should NOT detect half-width "ﾗﾙﾌ 起動" as ralph (unsupported boundary)', () => {
+      const result = detectKeywordsWithType('ﾗﾙﾌ 起動');
+      const match = result.find((r) => r.type === 'ralph');
+      expect(match).toBeUndefined();
+    });
+
+    it('should NOT detect "私たちのチームはリリースした" as team (common word)', () => {
+      const result = detectKeywordsWithType('私たちのチームはリリースした');
+      const match = result.find((r) => r.type === 'team');
+      expect(match).toBeUndefined();
+    });
+
+    it('should NOT detect "チームで作業" as team (common word)', () => {
+      const result = detectKeywordsWithType('チームで作業');
+      const match = result.find((r) => r.type === 'team');
+      expect(match).toBeUndefined();
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Intent-pattern guards (spec h) — file paths, code fences, and backticks
   // must NOT trigger keyword detection

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -43,17 +43,17 @@ export interface DetectedKeyword {
  */
 const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   cancel: /\b(cancelomc|stopomc)\b/i,
-  ralph: /\b(ralph)\b(?!-)|(랄프)(?!로렌)/i,
-  autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|(오토파일럿)/i,
-  ultrawork: /\b(ultrawork|ulw)\b|(울트라워크)/i,
+  ralph: /\b(ralph)\b(?!-)|(랄프)(?!로렌)|(ラルフ)(?!・?ローレン)/i,
+  autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|(오토파일럿)|(オートパイロット)/i,
+  ultrawork: /\b(ultrawork|ulw)\b|(울트라워크)|(ウルトラワーク)/i,
   // Team keyword detection disabled — team mode is now explicit-only via /team skill.
   // This prevents infinite spawning when Claude workers receive prompts containing "team".
   team: /(?!x)x/,  // never-match placeholder (type system requires the key)
-  ralplan: /\b(ralplan)\b|(랄플랜)/i,
+  ralplan: /\b(ralplan)\b|(랄플랜)|(ラルプラン)/i,
   tdd: /\b(tdd)\b|\btest\s+first\b|(테스트\s?퍼스트)/i,
   'code-review': /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i,
   'security-review': /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i,
-  ultrathink: /\b(ultrathink)\b|(울트라씽크)/i,
+  ultrathink: /\b(ultrathink)\b|(울트라씽크)|(ウルトラシンク)/i,
   deepsearch: /\b(deepsearch)\b|\bsearch\s+the\s+codebase\b|\bfind\s+in\s+(the\s+)?codebase\b|(딥\s?서치)/i,
   analyze: /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)/i,
   'deep-interview': /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)/i,
@@ -493,6 +493,9 @@ function hasDiagnosticIntentNearKeyword(context: string, keyword: string): boole
     new RegExp(`\\b${escaped}\\b[^\\n]{0,48}\\b(?:keeps?\\s+(?:looping|re-?running)|has\\s+(?:a\\s+)?(?:bug|issue|problem|error)|is\\s+(?:stuck|broken|failing)|loop(?:ing)?)\\b`, 'i'),
     new RegExp(`\\b(?:bug|issue|problem|error)\\b[^\\n]{0,16}\\b(?:with|in)\\s+\\b${escaped}\\b`, 'i'),
     new RegExp(`${escaped}.{0,14}(?:자꾸|계속).{0,14}(?:재실행|반복|루프|멈추)`, 'u'),
+    // Japanese: repeated-failure complaint — direct mirror of the Korean 자꾸/계속 line above
+    // (frequency adverb + problem verb). No P2 subject-particle pattern / no work-request escape: Korean parity.
+    new RegExp(`${escaped}[^\\n]{0,16}(?:また|何度も|ずっと|頻繁|繰り返|いつも)[^\\n]{0,16}(?:失敗|エラー|ループ|止ま|落ち|再実行|動かな|フリーズ|壊れ|クラッシュ|こけ|暴走|無限)`, 'u'),
   ];
 
   return patterns.some((pattern) => pattern.test(context));
@@ -500,13 +503,13 @@ function hasDiagnosticIntentNearKeyword(context: string, keyword: string): boole
 
 function isRalphUltraworkMetaOrBanterContext(context: string, keywordText: string): boolean {
   const normalizedKeyword = keywordText.toLowerCase().replace(/\s+/g, '');
-  if (!['ralph', '랄프', 'ultrawork', 'ulw', 'uw', '울트라워크'].includes(normalizedKeyword)) {
+  if (!['ralph', '랄프', 'ラルフ', 'ultrawork', 'ulw', 'uw', '울트라워크', 'ウルトラワーク'].includes(normalizedKeyword)) {
     return false;
   }
 
-  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프'
-    ? ['랄프']
-    : ['울트라워크'];
+  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프' || normalizedKeyword === 'ラルフ'
+    ? ['랄프', 'ラルフ']
+    : ['울트라워크', 'ウルトラワーク'];
   const currentKeywordPattern = currentKeywordAliases.join('|');
   const imperativeVerbPattern = '켜|켜줘|실행|시작|돌려|돌려줘|써|써줘|사용해|진행해';
   const koreanImperativePatterns = [

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -541,6 +541,9 @@ function hasDiagnosticIntentNearKeyword(context, keyword) {
     new RegExp(`\\b${escaped}\\b[^\\n]{0,48}\\b(?:keeps?\\s+(?:looping|re-?running)|has\\s+(?:a\\s+)?(?:bug|issue|problem|error)|is\\s+(?:stuck|broken|failing)|loop(?:ing)?)\\b`, 'i'),
     new RegExp(`\\b(?:bug|issue|problem|error)\\b[^\\n]{0,16}\\b(?:with|in)\\s+\\b${escaped}\\b`, 'i'),
     new RegExp(`${escaped}.{0,14}(?:자꾸|계속).{0,14}(?:재실행|반복|루프|멈추)`, 'u'),
+    // Japanese: repeated-failure complaint — direct mirror of the Korean 자꾸/계속 line above
+    // (frequency adverb + problem verb). No P2 subject-particle pattern / no work-request escape: Korean parity.
+    new RegExp(`${escaped}[^\\n]{0,16}(?:また|何度も|ずっと|頻繁|繰り返|いつも)[^\\n]{0,16}(?:失敗|エラー|ループ|止ま|落ち|再実行|動かな|フリーズ|壊れ|クラッシュ|こけ|暴走|無限)`, 'u'),
   ];
 
   return patterns.some((pattern) => pattern.test(context));
@@ -548,13 +551,13 @@ function hasDiagnosticIntentNearKeyword(context, keyword) {
 
 function isRalphUltraworkMetaOrBanterContext(context, keywordText) {
   const normalizedKeyword = (keywordText || '').toLowerCase().replace(/\s+/g, '');
-  if (!['ralph', '랄프', 'ultrawork', 'ulw', 'uw', '울트라워크'].includes(normalizedKeyword)) {
+  if (!['ralph', '랄프', 'ラルフ', 'ultrawork', 'ulw', 'uw', '울트라워크', 'ウルトラワーク'].includes(normalizedKeyword)) {
     return false;
   }
 
-  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프'
-    ? ['랄프']
-    : ['울트라워크'];
+  const currentKeywordAliases = normalizedKeyword === 'ralph' || normalizedKeyword === '랄프' || normalizedKeyword === 'ラルフ'
+    ? ['랄프', 'ラルフ']
+    : ['울트라워크', 'ウルトラワーク'];
   const currentKeywordPattern = currentKeywordAliases.join('|');
   const imperativeVerbPattern = '켜|켜줘|실행|시작|돌려|돌려줘|써|써줘|사용해|진행해';
   const koreanImperativePatterns = [
@@ -952,12 +955,12 @@ async function main() {
     }
 
     // Ralph keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ralph)\b|(랄프)(?!로렌)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ralph)\b|(랄프)(?!로렌)|(ラルフ)(?!・?ローレン)/i)) {
       matches.push({ name: 'ralph', args: '' });
     }
 
     // Autopilot keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|(오토파일럿)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|(오토파일럿)|(オートパイロット)/i)) {
       matches.push({ name: 'autopilot', args: '' });
     }
 
@@ -965,7 +968,7 @@ async function main() {
     // This prevents infinite spawning when Claude workers receive prompts containing "team".
 
     // Ultrawork keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ultrawork|ulw)\b|(울트라워크)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ultrawork|ulw)\b|(울트라워크)|(ウルトラワーク)/i)) {
       matches.push({ name: 'ultrawork', args: '' });
     }
 
@@ -976,7 +979,7 @@ async function main() {
     }
 
     // Ralplan keyword
-    if (hasActionableRalplanKeyword(cleanPrompt, /\b(ralplan)\b|(랄플랜)/i)) {
+    if (hasActionableRalplanKeyword(cleanPrompt, /\b(ralplan)\b|(랄플랜)|(ラルプラン)/i)) {
       matches.push({ name: 'ralplan', args: '' });
     }
 
@@ -1017,7 +1020,7 @@ async function main() {
     }
 
     // Ultrathink keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(ultrathink)\b|(울트라씽크)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ultrathink)\b|(울트라씽크)|(ウルトラシンク)/i)) {
       matches.push({ name: 'ultrathink', args: '' });
     }
 


### PR DESCRIPTION
## Summary

Adds Japanese full-width **katakana** variants to the keyword detector, mirroring the existing Korean (Hangul) support, so that Japanese users can trigger OMC modes in their native script.

New katakana alternations (parallel to the existing `(랄프)` / `(오토파일럿)` etc.):

| keyword | katakana |
|---|---|
| ralph | `ラルフ` (with `(?!・?ローレン)` Ralph-Lauren exclusion, mirroring Korean `(?!로렌)`) |
| autopilot | `オートパイロット` |
| ultrawork | `ウルトラワーク` |
| ralplan | `ラルプラン` |
| ultrathink | `ウルトラシンク` |

## Design: Korean parity (deliberately simple)

Diagnostic-complaint suppression is kept at **exactly the Korean level** — a single frequency-adverb complaint regex folded into the shared `patterns` array. There is **no** broader subject-particle pattern and **no** work-request escape gate. This makes the Japanese diagnostic path structurally identical to Korean (one complaint regex in the shared array, no language-special early-return).

Intentional behavior (same as Korean): a complaint **with** a frequency adverb (`ラルフ、また失敗した`) is suppressed; an **adverb-less** complaint (`ラルフは失敗しやすい`) activates the mode — Korean behaves identically since it requires `자꾸/계속`.

## Triple-parity

Applied byte-identically across the three hand-maintained sources:
- `src/hooks/keyword-detector/index.ts` (unit-tested module)
- `scripts/keyword-detector.mjs` (runtime hook)
- `templates/hooks/keyword-detector.mjs` (installed template)

Build artifacts (`dist/`, `bridge/cli.cjs`) are **not** included — per repo convention they are regenerated only in release commits.

## Tests

- New unit tests for katakana activation, Ralph-Lauren / nakaguro exclusion, informational-query suppression, and half-width rejection.
- New e2e tests in `keyword-detector-script.test.ts` exercising the deployed standalone hook.
- Two adverb-less complaint tests assert activation (documenting the intentional Korean-parity behavior); now-vacuous work-request regression tests collapse to one representative guard.
- Full `keyword-detector` suite: **422 passing** locally.

## Notes

- Half-width katakana (`ﾗﾙﾌ`) is intentionally unsupported (full-width only, no NFKC normalization).
- The Ralph Lauren exclusion `(?!・?ローレン)` is load-bearing — without it, mentioning the fashion brand would falsely fire ralph mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)