### PR TITLE
feat(workflows): integrate Claude Code native dynamic workflows

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -54,6 +54,7 @@
     "./skills/verify/",
     "./skills/visual-verdict/",
     "./skills/wiki/",
+    "./skills/workflow/",
     "./skills/writer-memory/"
   ],
   "mcpServers": "./.mcp.json",

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -44,6 +44,10 @@ Never self-approve in the same active context; use `code-reviewer` or `verifier`
 Before concluding: zero pending tasks, tests passing, verifier evidence collected.
 </execution_protocols>
 
+<dynamic_workflows>
+Claude Code native dynamic workflows are an optional execution backend (opt-in via `workflows.enabled`). When a stage is too big for one conversation — a codebase-wide audit, a large migration, cross-checked research — and workflows are available on the Claude lane, delegate THAT stage to a workflow via a natural-language "use a dynamic workflow" request; do not hand-author the script. One stage per workflow. Do not nest inside an active ultrawork/team run. Workflows use meaningfully more tokens, take no mid-run input, resume only within the same Claude Code session, and stop from `/workflows` (not `/cancel`). If workflows are disabled, the Claude Code version is too old, the run is headless without opt-in, or the lane is codex/gemini, continue with OMC orchestration. See `docs/WORKFLOW-INTEGRATION.md`.
+</dynamic_workflows>
+
 <hooks_and_context>
 Hooks inject `<system-reminder>` tags. Key patterns: `hook success: Success` (proceed), `[MAGIC KEYWORD: ...]` (invoke skill), `The boulder never stops` (ralph/ultrawork active).
 Persistence: `<remember>` (7 days), `<remember priority>` (permanent).

--- a/docs/WORKFLOW-INTEGRATION.md
+++ b/docs/WORKFLOW-INTEGRATION.md
@@ -1,0 +1,128 @@
+# Dynamic Workflows Integration
+
+> How OMC integrates with Claude Code **native dynamic workflows** (research preview).
+> Reference: https://code.claude.com/docs/en/workflows
+
+## Design
+
+OMC stays the **orchestrator** ("conductor"). When a single stage is too large for one
+conversation to coordinate — a codebase-wide audit, a large migration, cross-checked research —
+OMC may hand **that one stage** down to a Claude Code dynamic workflow as an execution backend,
+then fold the single coordinated result back into its own pipeline.
+
+This is **opt-in, capability-detected, and always-fallback**. It is never a hard dependency:
+when workflows are unavailable or disabled, OMC silently continues with its existing orchestration
+(ultrawork / team / ralph).
+
+OMC does **not** drive the workflow runtime programmatically and does **not** author workflow
+`.js` scripts. It triggers a workflow the supported way — a natural-language "use a dynamic
+workflow" request (optionally the `ultracode` keyword) — and lets Claude Code write the script.
+
+## Why not a deeper / hard integration
+
+Workflows and OMC both want to *hold the plan*. A workflow moves orchestration into a script the
+runtime runs in the background, with intermediate results kept out of Claude's context. That is
+fundamentally different from OMC's turn-by-turn delegation, and the two cannot share state,
+persistence, cancellation, or observability. The integration therefore picks one boundary
+(OMC-conductor delegates one stage down) instead of fusing the systems.
+
+## Configuration
+
+Add a `workflows` block to `.claude/omc.jsonc`:
+
+```jsonc
+{
+  "workflows": {
+    "enabled": false,        // master opt-in (default false)
+    "allowInHeadless": false, // allow under `claude -p` / SDK / bypass (default false)
+    "allowNesting": false,    // allow inside an active ultrawork/team run (default false)
+    "minScopeSignals": 1,     // heavy-scope signals required before routing
+    "triggerKeyword": null    // optional; default uses version-proof natural language
+  }
+}
+```
+
+### Environment overrides
+
+| Env var                          | Effect                                            |
+| -------------------------------- | ------------------------------------------------- |
+| `OMC_WORKFLOWS_ENABLED=true`     | Opt in to workflow routing                        |
+| `OMC_WORKFLOWS_ALLOW_HEADLESS=true` | Allow routing in non-interactive contexts      |
+
+### Claude Code disable surfaces (respected by capability detection)
+
+Any of these makes OMC treat workflows as unavailable and fall back:
+
+- `"disableWorkflows": true` in `~/.claude/settings.json` or managed settings
+- `CLAUDE_CODE_DISABLE_WORKFLOWS=1`
+- Claude Code older than `2.1.154`
+
+## Module surface (`src/features/workflows`)
+
+- `detectWorkflowCapability({ version, settingsDisabled, env })` → `WorkflowCapability`
+- `shouldRouteToWorkflow({ task, config, capability, activeModes, providerLane, headless })` → `WorkflowRouteDecision`
+- `resolveWorkflowsConfig(pluginConfig.workflows)` → resolved config (defaults: opt-in OFF)
+- `buildWorkflowInvocation(task, config)` → the conversational instruction to launch a workflow
+- `hasNativeWorkflowTrigger(prompt)` → true when the prompt already says `ultracode` / `workflow`
+- `countScopeSignals(task)` → heuristic heavy-scope score
+
+The decision fallback is **always** `omc-orchestration`.
+
+## Recommended CLAUDE.md block
+
+Add inside the OMC-managed region so the orchestrator knows the routing contract:
+
+```md
+<dynamic_workflows>
+When a stage is too big for one conversation (codebase-wide audit, large migration,
+cross-checked research) AND workflows are enabled+available on the Claude lane, delegate
+THAT stage to a Claude Code dynamic workflow via a natural-language "use a dynamic workflow"
+request — do not hand-author the script. One stage per workflow. Do not nest inside an active
+ultrawork/team run. Workflows use more tokens, take no mid-run input, resume only within the
+same session, and are stopped from /workflows (not /cancel). If workflows are disabled, too old,
+headless without opt-in, or on a codex/gemini lane, continue with OMC orchestration silently.
+</dynamic_workflows>
+```
+
+## Wiring status
+
+Done in this change:
+
+1. **Capability detection** — `detectWorkflowCapability` plus a live resolver
+   (`resolveLiveWorkflowCapability`) that reads the Claude Code version
+   (`CLAUDE_CODE_VERSION` / `claude --version`) and `disableWorkflows` from
+   `~/.claude/settings.json`, degrading gracefully to "unavailable".
+2. **Routing decision** — `shouldRouteToWorkflow` with the six gates and an
+   always-OMC fallback, plus config + `OMC_WORKFLOWS_*` env plumbing.
+3. **Keyword coexistence** — `src/hooks/keyword-detector` suppresses OMC's
+   auto-detected fan-out keywords (ultrawork/autopilot/ralph) when the prompt
+   already contains a native `ultracode` / `workflow` trigger. Explicit slash
+   invocations are preserved.
+4. **Skill + manifest** — the `workflow` skill is registered in
+   `.claude-plugin/plugin.json` (and shipped via the existing `skills` entry in
+   the npm `files` array).
+5. **Orchestrator guidance** — a `<dynamic_workflows>` block in the shipped
+   `docs/CLAUDE.md` tells the orchestrator when to delegate a stage down.
+
+Intentionally deferred (needs validation against a live Claude Code with
+workflows enabled):
+
+- **Team exec-stage hook.** Mapping the in-session team's heavy exec/audit stage
+  onto a workflow is delivered at the prompt/skill layer (the `workflow` skill +
+  `<dynamic_workflows>` block), which is the correct surface for the in-session
+  orchestrator. A programmatic hook is *not* added to `src/team/runtime-v2.ts`
+  on purpose: that runtime is the tmux CLI-worker path (the wrong surface for an
+  in-session feature), and a blind behavioral edit there is high-risk. Wire the
+  in-session team exec stage to `shouldRouteToWorkflow` once it can be validated
+  end-to-end.
+- **Recompose generated CLAUDE.md copies** (root `CLAUDE.md`, `.github/CLAUDE.md`)
+  if the project wants the block mirrored outside the installer's shipped source.
+
+## Edge cases (why a run may not use a workflow)
+
+Workflows disabled or Claude Code too old; headless/SDK/bypass without `allowInHeadless`
+(subagents auto-approve edits there); session exit mid-run (a workflow restarts fresh, it does not
+resume across sessions); OMC `/cancel` cannot stop a running workflow; OMC HUD/trackers cannot see
+inside a run; native `ultracode` colliding with OMC's `ultrawork`/`ulw`; codex/gemini lanes
+(Claude-only feature); the 16-concurrent / 1,000-total agent caps; and the meaningfully higher
+token cost.

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: workflow
+description: Delegate a single heavy, highly-parallel stage to a Claude Code native dynamic workflow while OMC stays the orchestrator
+argument-hint: "<heavy parallel task: codebase-wide audit, large migration, cross-checked research>"
+aliases: []
+level: 4
+---
+
+<Purpose>
+The workflow skill lets OMC hand ONE heavy, highly-parallel stage down to a Claude Code native dynamic workflow as an execution backend. OMC remains the conductor: it decides when a stage is workflow-shaped, launches the workflow the supported way, then folds the single coordinated result back into its own pipeline. This is an opt-in, capability-detected, always-fallback path — never a hard dependency.
+</Purpose>
+
+<Use_When>
+- The current stage is too large for one conversation to coordinate: a codebase-wide bug/security/dead-code sweep, a migration touching hundreds of files, a plan worth drafting from several independent angles, or research that must cross-check many sources.
+- Dynamic workflows are available (new-enough Claude Code, not disabled) AND `workflows.enabled` is true.
+- The work is on the Claude provider lane (not a codex/gemini lane).
+</Use_When>
+
+<Do_Not_Use_When>
+- `workflows.enabled` is false, workflows are disabled (org/managed settings, `disableWorkflows`, `CLAUDE_CODE_DISABLE_WORKFLOWS`), or Claude Code is older than 2.1.154 — fall back to OMC orchestration (ultrawork/team/ralph) silently.
+- An OMC fan-out mode (ultrawork/team/autopilot/ralph) is already active — do not nest a workflow inside it unless `workflows.allowNesting` is true. Nesting produces two competing orchestrators and runaway token use.
+- The task is small or sequential — keep it in OMC; a workflow's extra token cost is not justified.
+- The stage needs mid-run human sign-off — a workflow takes no mid-run input. Split into stage-per-workflow instead.
+- Running headless (`claude -p` / Agent SDK / bypass) unless `workflows.allowInHeadless` is true — workflow subagents auto-approve edits with no prompt in those contexts.
+- The lane is codex or gemini — dynamic workflows are Claude-only.
+</Do_Not_Use_When>
+
+<Why_This_Exists>
+OMC orchestrates turn-by-turn with results landing in the context window. A dynamic workflow moves the plan into a script the runtime executes in the background, keeping intermediate results out of context and applying repeatable adversarial-review patterns at a scale (dozens to hundreds of agents) a single pass cannot reach. For the right stage, delegating down to a workflow is stronger than OMC fanning out itself — but only for that stage, and only when it is safe and enabled.
+</Why_This_Exists>
+
+<Execution_Policy>
+- Decide first: confirm the stage is workflow-shaped and that workflows are enabled + available. If not, use OMC orchestration and do not mention workflows.
+- Launch the supported way: ask for a workflow in natural language (e.g. "Use a dynamic workflow to ..."), which Claude Code treats as the opt-in on every version. Do NOT hand-author a workflow `.js` script — let Claude Code's runtime write it. Optionally include the `ultracode` keyword on Claude Code 2.1.160+.
+- One stage per workflow. For multi-stage work needing sign-off between stages, run each stage as its own workflow and let OMC sequence them.
+- Pre-clear the tool allowlist for long unattended runs: shell/web/MCP calls not in the allowlist still prompt mid-run and will stall the run.
+- Mind the caps: the runtime allows up to 16 concurrent agents and 1,000 agents per run; do not assume unbounded parallelism.
+- Be explicit about cost: a workflow uses meaningfully more tokens than the same work in conversation. For a large target, suggest running on a small slice first.
+- Observability: OMC's HUD and subagent-tracker cannot see inside a running workflow. Track progress via the native `/workflows` view; treat the workflow's returned report as the stage result and verify it in a separate OMC pass.
+- Persistence + cancellation are the workflow's, not OMC's: a workflow resumes only within the same Claude Code session and is stopped from `/workflows` (not `/cancel` or OMC kill switches). Never assume an OMC ralph/persistent loop can resume a workflow across sessions.
+- Always-fallback: if anything blocks the workflow (disabled, wrong version, wrong lane, nested), continue with OMC orchestration without failing the task.
+</Execution_Policy>
+
+<Routing_Contract>
+OMC computes the decision in `src/features/workflows` (shouldRouteToWorkflow). The gates, in order: feature opted in → capability available → Claude lane → not nested in a fan-out mode → not headless (unless opted in) → task meets the scope-signal threshold. The fallback is always OMC orchestration. When the user's prompt already contains a native trigger (`ultracode` / `workflow`), OMC suppresses its own ultrawork/team auto-activation so the two systems do not both seize the task.
+</Routing_Contract>

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -355,6 +355,20 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     };
   }
 
+  // Dynamic Workflows integration from environment
+  if (process.env.OMC_WORKFLOWS_ENABLED !== undefined) {
+    config.workflows = {
+      ...config.workflows,
+      enabled: process.env.OMC_WORKFLOWS_ENABLED === "true",
+    };
+  }
+  if (process.env.OMC_WORKFLOWS_ALLOW_HEADLESS !== undefined) {
+    config.workflows = {
+      ...config.workflows,
+      allowInHeadless: process.env.OMC_WORKFLOWS_ALLOW_HEADLESS === "true",
+    };
+  }
+
   // External models configuration from environment
   const externalModelsDefaults: ExternalModelsConfig["defaults"] = {};
 

--- a/src/features/workflows/__tests__/environment.test.ts
+++ b/src/features/workflows/__tests__/environment.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { parseClaudeVersion, readClaudeCodeVersion } from '../environment.js';
+
+const ORIGINAL = process.env.CLAUDE_CODE_VERSION;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) {
+    delete process.env.CLAUDE_CODE_VERSION;
+  } else {
+    process.env.CLAUDE_CODE_VERSION = ORIGINAL;
+  }
+});
+
+describe('parseClaudeVersion', () => {
+  it('extracts a dotted version from varied CLI output', () => {
+    expect(parseClaudeVersion('2.1.160 (Claude Code)')).toBe('2.1.160');
+    expect(parseClaudeVersion('claude version v2.2.0\n')).toBe('2.2.0');
+  });
+
+  it('returns null when no version is present', () => {
+    expect(parseClaudeVersion('no version here')).toBeNull();
+    expect(parseClaudeVersion('')).toBeNull();
+  });
+});
+
+describe('readClaudeCodeVersion', () => {
+  it('prefers a parseable CLAUDE_CODE_VERSION env value without probing the CLI', () => {
+    process.env.CLAUDE_CODE_VERSION = '2.1.200';
+    expect(readClaudeCodeVersion()).toBe('2.1.200');
+  });
+});

--- a/src/features/workflows/__tests__/workflows.test.ts
+++ b/src/features/workflows/__tests__/workflows.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MIN_WORKFLOW_VERSION,
+  compareWorkflowVersions,
+  detectWorkflowCapability,
+  meetsMinimumVersion,
+  resolveDefaultTriggerKeyword,
+} from '../capability.js';
+import {
+  WORKFLOWS_DEFAULTS,
+  buildWorkflowInvocation,
+  countScopeSignals,
+  hasNativeWorkflowTrigger,
+  resolveWorkflowsConfig,
+  shouldRouteToWorkflow,
+} from '../routing.js';
+import type { WorkflowCapability } from '../types.js';
+
+const noEnv = () => undefined;
+
+const availableCapability: WorkflowCapability = {
+  available: true,
+  version: '2.2.0',
+  meetsMinVersion: true,
+  disabledBy: null,
+  reason: 'ok',
+};
+
+describe('compareWorkflowVersions', () => {
+  it('orders versions numerically, not lexically', () => {
+    expect(compareWorkflowVersions('2.1.154', '2.1.154')).toBe(0);
+    expect(compareWorkflowVersions('2.1.160', '2.1.154')).toBe(1);
+    expect(compareWorkflowVersions('2.1.99', '2.1.154')).toBe(-1); // lexical would be wrong
+    expect(compareWorkflowVersions('v2.2.0', '2.1.154')).toBe(1); // tolerates leading v
+  });
+});
+
+describe('meetsMinimumVersion', () => {
+  it('requires at least the minimum and rejects unknown', () => {
+    expect(meetsMinimumVersion(MIN_WORKFLOW_VERSION)).toBe(true);
+    expect(meetsMinimumVersion('2.1.155')).toBe(true);
+    expect(meetsMinimumVersion('2.1.100')).toBe(false);
+    expect(meetsMinimumVersion(null)).toBe(false);
+  });
+});
+
+describe('detectWorkflowCapability', () => {
+  it('is available on a new-enough version with nothing disabling it', () => {
+    const cap = detectWorkflowCapability({ version: '2.1.160', env: noEnv });
+    expect(cap.available).toBe(true);
+    expect(cap.disabledBy).toBeNull();
+  });
+
+  it('reports unavailable + reason for an old version', () => {
+    const cap = detectWorkflowCapability({ version: '2.1.100', env: noEnv });
+    expect(cap.available).toBe(false);
+    expect(cap.disabledBy).toBe('version');
+  });
+
+  it('reports unavailable when the env kill-switch is set (truthy variants)', () => {
+    for (const value of ['1', 'true', 'YES', 'on']) {
+      const cap = detectWorkflowCapability({
+        version: '2.2.0',
+        env: (n) => (n === 'CLAUDE_CODE_DISABLE_WORKFLOWS' ? value : undefined),
+      });
+      expect(cap.available).toBe(false);
+      expect(cap.disabledBy).toBe('env');
+    }
+  });
+
+  it('reports unavailable when settings disable workflows', () => {
+    const cap = detectWorkflowCapability({ version: '2.2.0', settingsDisabled: true, env: noEnv });
+    expect(cap.available).toBe(false);
+    expect(cap.disabledBy).toBe('settings');
+  });
+
+  it('prioritizes env over settings over version in the disabledBy reason', () => {
+    const cap = detectWorkflowCapability({
+      version: '2.1.100',
+      settingsDisabled: true,
+      env: (n) => (n === 'CLAUDE_CODE_DISABLE_WORKFLOWS' ? '1' : undefined),
+    });
+    expect(cap.disabledBy).toBe('env');
+  });
+
+  it('treats unknown version as not meeting the minimum', () => {
+    const cap = detectWorkflowCapability({ version: null, env: noEnv });
+    expect(cap.available).toBe(false);
+    expect(cap.meetsMinVersion).toBe(false);
+  });
+});
+
+describe('resolveDefaultTriggerKeyword', () => {
+  it('uses ultracode at/after the keyword version and workflow before it', () => {
+    expect(resolveDefaultTriggerKeyword('2.1.160')).toBe('ultracode');
+    expect(resolveDefaultTriggerKeyword('2.2.0')).toBe('ultracode');
+    expect(resolveDefaultTriggerKeyword('2.1.154')).toBe('workflow');
+    expect(resolveDefaultTriggerKeyword(null)).toBe('workflow');
+  });
+});
+
+describe('resolveWorkflowsConfig', () => {
+  it('defaults to opt-in OFF with conservative gates', () => {
+    expect(resolveWorkflowsConfig()).toEqual(WORKFLOWS_DEFAULTS);
+    expect(resolveWorkflowsConfig().enabled).toBe(false);
+  });
+
+  it('overlays provided fields over defaults', () => {
+    const resolved = resolveWorkflowsConfig({ enabled: true, minScopeSignals: 2 });
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.minScopeSignals).toBe(2);
+    expect(resolved.allowInHeadless).toBe(false);
+  });
+});
+
+describe('countScopeSignals', () => {
+  it('counts heavy-scope phrases and ignores fenced code', () => {
+    expect(countScopeSignals('fix a typo in the readme')).toBe(0);
+    expect(countScopeSignals('audit every endpoint across the whole codebase')).toBeGreaterThanOrEqual(2);
+    // signal words that appear only inside code should not count
+    expect(countScopeSignals('rename a var\n```\nmigrate() // audit\n```')).toBe(0);
+  });
+});
+
+describe('hasNativeWorkflowTrigger', () => {
+  it('detects ultracode / workflow keywords outside code', () => {
+    expect(hasNativeWorkflowTrigger('ultracode: audit the repo')).toBe(true);
+    expect(hasNativeWorkflowTrigger('please run a workflow for this')).toBe(true);
+    expect(hasNativeWorkflowTrigger('ultrawork the auth module')).toBe(false); // OMC keyword, not native
+    expect(hasNativeWorkflowTrigger('`workflow`')).toBe(false); // inside inline code
+  });
+});
+
+describe('buildWorkflowInvocation', () => {
+  it('produces a version-proof natural-language request by default', () => {
+    const inv = buildWorkflowInvocation('audit every endpoint', resolveWorkflowsConfig({ enabled: true }));
+    expect(inv).toContain('dynamic workflow');
+    expect(inv).toContain('audit every endpoint');
+    expect(inv.startsWith('ultracode:')).toBe(false);
+  });
+
+  it('prefixes a configured trigger keyword when set', () => {
+    const inv = buildWorkflowInvocation(
+      'audit every endpoint',
+      resolveWorkflowsConfig({ enabled: true, triggerKeyword: 'ultracode' }),
+    );
+    expect(inv.startsWith('ultracode:')).toBe(true);
+  });
+});
+
+describe('shouldRouteToWorkflow', () => {
+  const heavyTask = 'migrate every controller across the whole codebase to the new API';
+
+  it('does not route when the feature is opted out (default)', () => {
+    const decision = shouldRouteToWorkflow({
+      task: heavyTask,
+      config: resolveWorkflowsConfig(),
+      capability: availableCapability,
+    });
+    expect(decision.route).toBe(false);
+    expect(decision.fallback).toBe('omc-orchestration');
+  });
+
+  it('does not route when capability is unavailable, even if enabled', () => {
+    const decision = shouldRouteToWorkflow({
+      task: heavyTask,
+      config: resolveWorkflowsConfig({ enabled: true }),
+      capability: { ...availableCapability, available: false, reason: 'too old', disabledBy: 'version' },
+    });
+    expect(decision.route).toBe(false);
+    expect(decision.reason).toContain('unavailable');
+  });
+
+  it('does not route on a non-Claude provider lane', () => {
+    const decision = shouldRouteToWorkflow({
+      task: heavyTask,
+      config: resolveWorkflowsConfig({ enabled: true }),
+      capability: availableCapability,
+      providerLane: 'codex',
+    });
+    expect(decision.route).toBe(false);
+    expect(decision.reason).toContain('Claude-only');
+  });
+
+  it('refuses to nest inside an active fan-out mode unless allowNesting', () => {
+    const base = {
+      task: heavyTask,
+      capability: availableCapability,
+      activeModes: ['ultrawork'],
+    };
+    expect(
+      shouldRouteToWorkflow({ ...base, config: resolveWorkflowsConfig({ enabled: true }) }).route,
+    ).toBe(false);
+    expect(
+      shouldRouteToWorkflow({
+        ...base,
+        config: resolveWorkflowsConfig({ enabled: true, allowNesting: true }),
+      }).route,
+    ).toBe(true);
+  });
+
+  it('blocks headless runs unless allowInHeadless is set', () => {
+    const base = {
+      task: heavyTask,
+      capability: availableCapability,
+      headless: true,
+    };
+    expect(
+      shouldRouteToWorkflow({ ...base, config: resolveWorkflowsConfig({ enabled: true }) }).route,
+    ).toBe(false);
+    expect(
+      shouldRouteToWorkflow({
+        ...base,
+        config: resolveWorkflowsConfig({ enabled: true, allowInHeadless: true }),
+      }).route,
+    ).toBe(true);
+  });
+
+  it('keeps OMC orchestration for low-scope tasks', () => {
+    const decision = shouldRouteToWorkflow({
+      task: 'fix a typo in the README',
+      config: resolveWorkflowsConfig({ enabled: true }),
+      capability: availableCapability,
+    });
+    expect(decision.route).toBe(false);
+    expect(decision.reason).toContain('below threshold');
+  });
+
+  it('routes a heavy Claude-lane task when enabled, available, and not nested', () => {
+    const decision = shouldRouteToWorkflow({
+      task: heavyTask,
+      config: resolveWorkflowsConfig({ enabled: true }),
+      capability: availableCapability,
+    });
+    expect(decision.route).toBe(true);
+    expect(decision.invocation).toBeDefined();
+    expect(decision.invocation).toContain('dynamic workflow');
+  });
+
+  it('respects a higher minScopeSignals threshold', () => {
+    const decision = shouldRouteToWorkflow({
+      task: 'audit the service', // a single signal
+      config: resolveWorkflowsConfig({ enabled: true, minScopeSignals: 3 }),
+      capability: availableCapability,
+    });
+    expect(decision.route).toBe(false);
+  });
+});

--- a/src/features/workflows/capability.ts
+++ b/src/features/workflows/capability.ts
@@ -1,0 +1,151 @@
+/**
+ * Dynamic Workflows Integration — Capability detection
+ *
+ * Pure, side-effect-free probing of whether Claude Code native dynamic
+ * workflows are usable. Callers pass the inputs (version string, an env getter,
+ * and whether settings disabled workflows) so this is trivially testable
+ * without touching disk or process.env.
+ *
+ * Disable surfaces (any one => unavailable), per the Claude Code docs:
+ *   - env `CLAUDE_CODE_DISABLE_WORKFLOWS` truthy
+ *   - `"disableWorkflows": true` in settings.json / managed settings
+ *   - Claude Code older than MIN_WORKFLOW_VERSION
+ */
+
+import type { WorkflowCapability } from './types.js';
+
+/** Minimum Claude Code version that ships dynamic workflows. */
+export const MIN_WORKFLOW_VERSION = '2.1.154';
+
+/**
+ * Version at/after which the `ultracode` literal keyword triggers a workflow.
+ * Before this, the literal keyword was `workflow`. Natural-language requests
+ * work in both, so this only matters if a caller insists on a keyword prefix.
+ */
+export const ULTRACODE_KEYWORD_VERSION = '2.1.160';
+
+type EnvGetter = (name: string) => string | undefined;
+
+const defaultEnvGetter: EnvGetter = (name) => process.env[name];
+
+/** Parse a dotted version ("2.1.154") into numeric parts; non-numeric => -1. */
+function parseVersionParts(version: string): number[] {
+  return version
+    .trim()
+    .replace(/^v/i, '')
+    .split('.')
+    .map((part) => {
+      const n = parseInt(part, 10);
+      return Number.isNaN(n) ? -1 : n;
+    });
+}
+
+/**
+ * Compare two dotted version strings.
+ * Returns 1 if a > b, -1 if a < b, 0 if equal. Unknown/garbage sorts low.
+ */
+export function compareWorkflowVersions(a: string, b: string): number {
+  const pa = parseVersionParts(a);
+  const pb = parseVersionParts(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i += 1) {
+    const va = pa[i] ?? 0;
+    const vb = pb[i] ?? 0;
+    if (va > vb) return 1;
+    if (va < vb) return -1;
+  }
+  return 0;
+}
+
+/** True when `version` is at least `minimum`. */
+export function meetsMinimumVersion(version: string | null, minimum = MIN_WORKFLOW_VERSION): boolean {
+  if (!version) return false;
+  return compareWorkflowVersions(version, minimum) >= 0;
+}
+
+/** Whether the env var should be read as "disabled". */
+function isEnvTruthy(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const v = value.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+export interface DetectWorkflowCapabilityOptions {
+  /** Detected Claude Code version, or null if it could not be determined. */
+  version?: string | null;
+  /** `disableWorkflows` value read from settings.json / managed settings. */
+  settingsDisabled?: boolean;
+  /** Override env access (defaults to process.env). */
+  env?: EnvGetter;
+  /** Minimum version to require (defaults to MIN_WORKFLOW_VERSION). */
+  minVersion?: string;
+}
+
+/**
+ * Probe whether dynamic workflows are usable. Order of precedence for the
+ * `disabledBy` reason: env, then settings, then version.
+ */
+export function detectWorkflowCapability(
+  options: DetectWorkflowCapabilityOptions = {},
+): WorkflowCapability {
+  const {
+    version = null,
+    settingsDisabled = false,
+    env = defaultEnvGetter,
+    minVersion = MIN_WORKFLOW_VERSION,
+  } = options;
+
+  const meetsMin = meetsMinimumVersion(version, minVersion);
+
+  if (isEnvTruthy(env('CLAUDE_CODE_DISABLE_WORKFLOWS'))) {
+    return {
+      available: false,
+      version,
+      meetsMinVersion: meetsMin,
+      disabledBy: 'env',
+      reason: 'Dynamic workflows disabled via CLAUDE_CODE_DISABLE_WORKFLOWS.',
+    };
+  }
+
+  if (settingsDisabled) {
+    return {
+      available: false,
+      version,
+      meetsMinVersion: meetsMin,
+      disabledBy: 'settings',
+      reason: 'Dynamic workflows disabled via settings ("disableWorkflows": true).',
+    };
+  }
+
+  if (!meetsMin) {
+    return {
+      available: false,
+      version,
+      meetsMinVersion: false,
+      disabledBy: 'version',
+      reason: version
+        ? `Claude Code ${version} is older than the minimum ${minVersion} required for workflows.`
+        : `Claude Code version unknown; workflows require ${minVersion} or later.`,
+    };
+  }
+
+  return {
+    available: true,
+    version,
+    meetsMinVersion: true,
+    disabledBy: null,
+    reason: `Dynamic workflows available (Claude Code ${version ?? 'unknown'}).`,
+  };
+}
+
+/**
+ * Whether the `ultracode` literal keyword is the right keyword for this
+ * version (vs the older `workflow` literal). Natural-language requests work on
+ * both, so prefer those unless a keyword prefix is explicitly configured.
+ */
+export function resolveDefaultTriggerKeyword(version: string | null): 'ultracode' | 'workflow' {
+  if (version && compareWorkflowVersions(version, ULTRACODE_KEYWORD_VERSION) >= 0) {
+    return 'ultracode';
+  }
+  return 'workflow';
+}

--- a/src/features/workflows/environment.ts
+++ b/src/features/workflows/environment.ts
@@ -1,0 +1,78 @@
+/**
+ * Dynamic Workflows Integration — Live environment resolution
+ *
+ * Best-effort reading of the live Claude Code version and disable settings,
+ * fed into detectWorkflowCapability. Every probe degrades gracefully: an
+ * unknown version or unreadable settings file yields a conservative
+ * "unavailable" result (capability detection treats an unknown version as not
+ * meeting the minimum), so OMC simply falls back to its own orchestration.
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { parseJsonc } from '../../utils/jsonc.js';
+import { detectWorkflowCapability } from './capability.js';
+import type { WorkflowCapability } from './types.js';
+
+/** Extract a dotted version (e.g. "2.1.160") from arbitrary CLI output. */
+export function parseClaudeVersion(output: string): string | null {
+  const match = output.match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Best-effort read of the installed Claude Code version.
+ * Order: `CLAUDE_CODE_VERSION` env, then `claude --version`. Returns null on
+ * any failure (missing binary, timeout, unparseable output).
+ */
+export function readClaudeCodeVersion(): string | null {
+  const fromEnv = process.env.CLAUDE_CODE_VERSION;
+  if (fromEnv) {
+    const parsed = parseClaudeVersion(fromEnv);
+    if (parsed) return parsed;
+  }
+  try {
+    const output = String(
+      execFileSync('claude', ['--version'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+    );
+    return parseClaudeVersion(output);
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort read of `disableWorkflows` from ~/.claude/settings.json. */
+export function readWorkflowsDisabledSetting(): boolean {
+  try {
+    const settingsPath = join(getClaudeConfigDir(), 'settings.json');
+    const raw = readFileSync(settingsPath, 'utf-8');
+    const parsed = parseJsonc(raw) as { disableWorkflows?: unknown } | null;
+    return parsed?.disableWorkflows === true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ResolveLiveCapabilityOptions {
+  /** Skip the `claude --version` CLI probe (e.g. in tests or hot paths). */
+  skipVersionProbe?: boolean;
+}
+
+/**
+ * Resolve the workflow capability from the live environment. Convenience
+ * wrapper combining the version + settings probes with detectWorkflowCapability.
+ */
+export function resolveLiveWorkflowCapability(
+  options: ResolveLiveCapabilityOptions = {},
+): WorkflowCapability {
+  const version = options.skipVersionProbe ? null : readClaudeCodeVersion();
+  const settingsDisabled = readWorkflowsDisabledSetting();
+  return detectWorkflowCapability({ version, settingsDisabled });
+}

--- a/src/features/workflows/index.ts
+++ b/src/features/workflows/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Dynamic Workflows Integration
+ *
+ * Opt-in, capability-detected, always-fallback routing of heavy parallel stages
+ * to Claude Code native dynamic workflows. OMC remains the orchestrator.
+ *
+ * See docs/WORKFLOW-INTEGRATION.md and skills/workflow/SKILL.md.
+ */
+
+export type {
+  ProviderLane,
+  WorkflowDisabledBy,
+  WorkflowsConfig,
+  ResolvedWorkflowsConfig,
+  WorkflowCapability,
+  WorkflowRouteInput,
+  WorkflowRouteDecision,
+} from './types.js';
+
+export {
+  MIN_WORKFLOW_VERSION,
+  ULTRACODE_KEYWORD_VERSION,
+  compareWorkflowVersions,
+  meetsMinimumVersion,
+  detectWorkflowCapability,
+  resolveDefaultTriggerKeyword,
+  type DetectWorkflowCapabilityOptions,
+} from './capability.js';
+
+export {
+  WORKFLOWS_DEFAULTS,
+  countScopeSignals,
+  resolveWorkflowsConfig,
+  hasNativeWorkflowTrigger,
+  buildWorkflowInvocation,
+  shouldRouteToWorkflow,
+} from './routing.js';
+
+export {
+  parseClaudeVersion,
+  readClaudeCodeVersion,
+  readWorkflowsDisabledSetting,
+  resolveLiveWorkflowCapability,
+  type ResolveLiveCapabilityOptions,
+} from './environment.js';

--- a/src/features/workflows/routing.ts
+++ b/src/features/workflows/routing.ts
@@ -1,0 +1,180 @@
+/**
+ * Dynamic Workflows Integration — Routing
+ *
+ * Decides whether OMC should hand the current heavy stage down to a Claude Code
+ * native dynamic workflow, and if so, builds the (supported, conversational)
+ * invocation to surface to Claude. Every path that does NOT route falls back to
+ * OMC's existing orchestration — workflows are never a hard dependency.
+ *
+ * Gate order (any failing gate => keep OMC orchestration):
+ *   1. Feature opted in (config.enabled)
+ *   2. Capability available (new-enough Claude Code, not disabled)
+ *   3. Claude provider lane (workflows are Claude-only; codex/gemini excluded)
+ *   4. Not nested inside an active OMC fan-out mode (unless allowNesting)
+ *   5. Not headless, OR headless explicitly allowed (acceptEdits safety gate)
+ *   6. Task is heavy/parallel enough (>= minScopeSignals scope signals)
+ */
+
+import type {
+  ResolvedWorkflowsConfig,
+  WorkflowRouteDecision,
+  WorkflowRouteInput,
+  WorkflowsConfig,
+} from './types.js';
+
+/** Resolved defaults: opt-in OFF, conservative safety gates. */
+export const WORKFLOWS_DEFAULTS: ResolvedWorkflowsConfig = {
+  enabled: false,
+  allowInHeadless: false,
+  allowNesting: false,
+  minScopeSignals: 1,
+  triggerKeyword: undefined,
+};
+
+/** OMC fan-out modes that already own parallel orchestration. */
+const FANOUT_MODES = ['ultrawork', 'ulw', 'team', 'autopilot', 'ralph'];
+
+/**
+ * Signals that a task is large/parallel enough to be worth a workflow's extra
+ * token cost. Kept deliberately conservative — borderline tasks stay in OMC.
+ */
+const SCOPE_SIGNAL_PATTERNS: RegExp[] = [
+  /\bevery\b/i,
+  /\ball (?:the )?(?:files|endpoints|modules|routes|tests|callers|usages)\b/i,
+  /\bentire\b/i,
+  /\b(?:whole|across the (?:whole |entire )?)(?:codebase|repo|repository|service|project)\b/i,
+  /\b(?:codebase|repo|repository)-wide\b/i,
+  /\bhundreds of\b/i,
+  /\bthousands of\b/i,
+  /\b\d{2,}\s+files\b/i,
+  /\bmigrat(?:e|ion|ing)\b/i,
+  /\baudit\b/i,
+  /\bsweep\b/i,
+  /\bport(?:ing)?\s+(?:from|to)\b/i,
+  /\bdeprecat(?:e|ion|ing)\b/i,
+];
+
+const CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
+const INLINE_CODE_PATTERN = /`[^`]+`/g;
+
+function stripCode(text: string): string {
+  return text.replace(CODE_BLOCK_PATTERN, '').replace(INLINE_CODE_PATTERN, '');
+}
+
+/** Count how many distinct scope signals appear in a task description. */
+export function countScopeSignals(task: string): number {
+  const clean = stripCode(task);
+  let count = 0;
+  for (const pattern of SCOPE_SIGNAL_PATTERNS) {
+    if (pattern.test(clean)) count += 1;
+  }
+  return count;
+}
+
+/** Merge a partial WorkflowsConfig (from omc.jsonc / env) over the defaults. */
+export function resolveWorkflowsConfig(config?: WorkflowsConfig): ResolvedWorkflowsConfig {
+  return {
+    enabled: config?.enabled ?? WORKFLOWS_DEFAULTS.enabled,
+    allowInHeadless: config?.allowInHeadless ?? WORKFLOWS_DEFAULTS.allowInHeadless,
+    allowNesting: config?.allowNesting ?? WORKFLOWS_DEFAULTS.allowNesting,
+    minScopeSignals: config?.minScopeSignals ?? WORKFLOWS_DEFAULTS.minScopeSignals,
+    triggerKeyword: config?.triggerKeyword ?? WORKFLOWS_DEFAULTS.triggerKeyword,
+  };
+}
+
+const NATIVE_WORKFLOW_TRIGGERS = ['ultracode', 'workflow'];
+
+/**
+ * Whether the user's prompt already contains a native workflow trigger
+ * (`ultracode` / `workflow`). OMC's keyword detector should call this and
+ * SUPPRESS its own ultrawork/team auto-activation when true, so the two
+ * systems don't both try to take over the same task.
+ */
+export function hasNativeWorkflowTrigger(prompt: string): boolean {
+  const clean = stripCode(prompt);
+  return NATIVE_WORKFLOW_TRIGGERS.some((trigger) =>
+    new RegExp(`\\b${trigger}\\b`, 'i').test(clean),
+  );
+}
+
+/**
+ * Build the conversational instruction OMC surfaces to Claude to launch a
+ * native workflow. Defaults to a version-proof natural-language request
+ * (treated as the same opt-in on every Claude Code version). If a
+ * triggerKeyword is configured, it is prefixed.
+ */
+export function buildWorkflowInvocation(task: string, config: ResolvedWorkflowsConfig): string {
+  const base = `Use a Claude Code dynamic workflow to handle this end-to-end: ${task.trim()}`;
+  if (config.triggerKeyword) {
+    return `${config.triggerKeyword}: ${base}`;
+  }
+  return base;
+}
+
+/**
+ * Decide whether to route the current stage to a native dynamic workflow.
+ * Fallback is ALWAYS OMC orchestration.
+ */
+export function shouldRouteToWorkflow(input: WorkflowRouteInput): WorkflowRouteDecision {
+  const { task, config, capability } = input;
+  const providerLane = input.providerLane ?? 'claude';
+  const activeModes = input.activeModes ?? [];
+  const headless = input.headless ?? false;
+
+  const noRoute = (reason: string): WorkflowRouteDecision => ({
+    route: false,
+    reason,
+    fallback: 'omc-orchestration',
+  });
+
+  // 1. Opt-in
+  if (!config.enabled) {
+    return noRoute('Workflow routing is opt-in and not enabled (workflows.enabled=false).');
+  }
+
+  // 2. Capability
+  if (!capability.available) {
+    return noRoute(`Workflows unavailable: ${capability.reason}`);
+  }
+
+  // 3. Claude-only
+  if (providerLane !== 'claude') {
+    return noRoute(`Dynamic workflows are Claude-only; current lane is "${providerLane}".`);
+  }
+
+  // 4. No nesting inside an active fan-out mode
+  if (!config.allowNesting) {
+    const nested = activeModes
+      .map((m) => m.toLowerCase())
+      .find((m) => FANOUT_MODES.includes(m));
+    if (nested) {
+      return noRoute(
+        `Refusing to nest a workflow inside active OMC mode "${nested}" (set workflows.allowNesting=true to override).`,
+      );
+    }
+  }
+
+  // 5. Headless safety gate (workflow subagents auto-approve edits with no prompt)
+  if (headless && !config.allowInHeadless) {
+    return noRoute(
+      'Headless/SDK/bypass context: workflow subagents auto-approve edits with no prompt; ' +
+        'set workflows.allowInHeadless=true to opt in.',
+    );
+  }
+
+  // 6. Heavy/parallel enough to be worth the cost
+  const signals = countScopeSignals(task);
+  if (signals < config.minScopeSignals) {
+    return noRoute(
+      `Task scope below threshold (${signals} < ${config.minScopeSignals} scope signals); ` +
+        'keeping OMC orchestration.',
+    );
+  }
+
+  return {
+    route: true,
+    reason: `Routing to a dynamic workflow (${signals} scope signal(s), capability OK).`,
+    fallback: 'omc-orchestration',
+    invocation: buildWorkflowInvocation(task, config),
+  };
+}

--- a/src/features/workflows/types.ts
+++ b/src/features/workflows/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Dynamic Workflows Integration — Types
+ *
+ * OMC stays the orchestrator ("conductor") and may hand a single heavy,
+ * highly-parallel stage *down* to a Claude Code native dynamic workflow as one
+ * execution backend. This is an OPT-IN, CAPABILITY-DETECTED, ALWAYS-FALLBACK
+ * path — never a hard dependency.
+ *
+ * Workflows are a Claude Code feature (research preview). OMC cannot drive the
+ * workflow runtime programmatically; it triggers a workflow the supported way
+ * (a natural-language "use a dynamic workflow" request, the `ultracode`
+ * keyword, or a saved `/command`) and lets Claude Code author the script.
+ *
+ * Docs: https://code.claude.com/docs/en/workflows
+ */
+
+/** Provider lane the current task is running under. Workflows are Claude-only. */
+export type ProviderLane = 'claude' | 'codex' | 'gemini';
+
+/** Why workflows are unavailable, if they are. */
+export type WorkflowDisabledBy = 'env' | 'settings' | 'version' | null;
+
+/**
+ * User-facing config block. Lives under `workflows` in `.claude/omc.jsonc`
+ * (and via `OMC_WORKFLOWS_*` env vars). All fields optional; see
+ * WORKFLOWS_DEFAULTS for the resolved defaults.
+ */
+export interface WorkflowsConfig {
+  /** Master opt-in. Default: false. OMC never routes to workflows unless true. */
+  enabled?: boolean;
+  /**
+   * Allow routing while OMC runs non-interactively (`claude -p`, Agent SDK,
+   * bypass-permissions). Off by default because workflow subagents run in
+   * acceptEdits mode with no approval prompt in those contexts. Default: false.
+   */
+  allowInHeadless?: boolean;
+  /**
+   * Allow a workflow to be launched while an OMC fan-out mode (ultrawork/team)
+   * is already active. Off by default to prevent nested orchestration /
+   * runaway token use. Default: false.
+   */
+  allowNesting?: boolean;
+  /**
+   * How many heavy-scope signals a task must contain before OMC routes it to a
+   * workflow (e.g. "every", "across the whole codebase", "migrate", "audit").
+   * Default: 1.
+   */
+  minScopeSignals?: number;
+  /**
+   * Optional explicit trigger keyword to prefix the invocation with
+   * (e.g. 'ultracode'). When unset, OMC uses a version-proof natural-language
+   * request, which Claude Code treats as the same opt-in on every version.
+   */
+  triggerKeyword?: string;
+}
+
+/** WorkflowsConfig with every field resolved. */
+export type ResolvedWorkflowsConfig = Required<Omit<WorkflowsConfig, 'triggerKeyword'>> &
+  Pick<WorkflowsConfig, 'triggerKeyword'>;
+
+/** Result of probing whether dynamic workflows are usable in this environment. */
+export interface WorkflowCapability {
+  /** True only when a new-enough Claude Code is present and not disabled. */
+  available: boolean;
+  /** Detected Claude Code version string, or null if unknown. */
+  version: string | null;
+  /** Whether `version` satisfies the minimum required by the feature. */
+  meetsMinVersion: boolean;
+  /** What turned workflows off, if anything. */
+  disabledBy: WorkflowDisabledBy;
+  /** Human-readable explanation (surfaced in logs / HUD). */
+  reason: string;
+}
+
+/** Inputs to the routing decision. */
+export interface WorkflowRouteInput {
+  /** The task / stage description OMC is about to execute. */
+  task: string;
+  /** Resolved workflows config. */
+  config: ResolvedWorkflowsConfig;
+  /** Capability probe result. */
+  capability: WorkflowCapability;
+  /** OMC modes already active this turn (e.g. ['ultrawork'], ['team']). */
+  activeModes?: string[];
+  /** Provider lane for the current work. Defaults to 'claude'. */
+  providerLane?: ProviderLane;
+  /** True under `claude -p` / Agent SDK / bypass-permissions. */
+  headless?: boolean;
+}
+
+/** Outcome of the routing decision. Fallback is ALWAYS OMC orchestration. */
+export interface WorkflowRouteDecision {
+  /** True => surface `invocation` to Claude; false => keep OMC orchestration. */
+  route: boolean;
+  /** Why this decision was made. */
+  reason: string;
+  /** The lane OMC falls back to when not routing. */
+  fallback: 'omc-orchestration';
+  /** Prompt to trigger a native workflow. Present only when route === true. */
+  invocation?: string;
+}

--- a/src/hooks/keyword-detector/__tests__/native-workflow-suppression.test.ts
+++ b/src/hooks/keyword-detector/__tests__/native-workflow-suppression.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAllKeywords } from '../index.js';
+
+describe('native workflow trigger suppresses OMC fan-out keywords', () => {
+  it('keeps ultrawork when there is no native workflow trigger', () => {
+    expect(getAllKeywords('ultrawork fix all the errors')).toContain('ultrawork');
+  });
+
+  it('suppresses auto-detected ultrawork when a native "workflow" trigger is present', () => {
+    const keywords = getAllKeywords('ultrawork fix all the errors, use a workflow');
+    expect(keywords).not.toContain('ultrawork');
+  });
+
+  it('suppresses auto-detected ultrawork when the "ultracode" trigger is present', () => {
+    const keywords = getAllKeywords('ultrawork the refactor with ultracode');
+    expect(keywords).not.toContain('ultrawork');
+  });
+
+  it('preserves an explicit /ultrawork slash invocation even with a native trigger', () => {
+    const keywords = getAllKeywords('/oh-my-claudecode:ultrawork do it, maybe a workflow too');
+    expect(keywords).toContain('ultrawork');
+  });
+});

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -13,6 +13,7 @@ import {
   type TaskSizeResult,
   type TaskSizeThresholds,
 } from '../task-size-detector/index.js';
+import { hasNativeWorkflowTrigger } from '../../features/workflows/routing.js';
 
 export type KeywordType =
   | 'cancel'      // Priority 1
@@ -37,6 +38,18 @@ export interface DetectedKeyword {
   keyword: string;
   position: number;
 }
+
+/**
+ * OMC fan-out keywords that OMC suppresses (when auto-detected) if the user has
+ * explicitly invoked a Claude Code native dynamic workflow (`ultracode` /
+ * `workflow`). This prevents two orchestrators from both seizing the task.
+ * Explicit slash invocations (e.g. `/ultrawork`) are preserved.
+ */
+const FANOUT_KEYWORDS_SUPPRESSED_BY_NATIVE_WORKFLOW = new Set<KeywordType>([
+  'ultrawork',
+  'autopilot',
+  'ralph',
+]);
 
 /**
  * Keyword patterns for each mode
@@ -676,6 +689,18 @@ export function detectKeywordsWithType(
         type,
       });
     }
+  }
+
+  // If the user explicitly invoked a Claude Code native workflow (the
+  // `ultracode` / `workflow` trigger), suppress OMC's auto-detected fan-out
+  // keywords so the two orchestrators don't both seize the task. Explicit
+  // slash invocations (e.g. `/ultrawork`) are a deliberate choice and kept.
+  if (detected.length > 0 && hasNativeWorkflowTrigger(text)) {
+    return detected.filter(
+      (entry) =>
+        entry.type === explicitSlashType ||
+        !FANOUT_KEYWORDS_SUPPRESSED_BY_NATIVE_WORKFLOW.has(entry.type),
+    );
   }
 
   return detected;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -130,6 +130,22 @@ export interface PluginConfig {
     simplificationKeywords?: string[];
   };
 
+  // Dynamic Workflows integration (Claude Code native workflows).
+  // Opt-in, capability-detected, always-fallback routing of heavy parallel
+  // stages to native workflows. See src/features/workflows.
+  workflows?: {
+    /** Master opt-in. Default false; OMC never routes to workflows unless true. Env: OMC_WORKFLOWS_ENABLED */
+    enabled?: boolean;
+    /** Allow routing under `claude -p` / Agent SDK / bypass (acceptEdits auto-approve). Default false. Env: OMC_WORKFLOWS_ALLOW_HEADLESS */
+    allowInHeadless?: boolean;
+    /** Allow launching a workflow while an OMC fan-out mode (ultrawork/team) is active. Default false. */
+    allowNesting?: boolean;
+    /** Heavy-scope signals required before routing to a workflow. Default 1. */
+    minScopeSignals?: number;
+    /** Optional explicit trigger keyword (e.g. 'ultracode'); default uses version-proof natural language. */
+    triggerKeyword?: string;
+  };
+
   // External models configuration (Codex, Gemini)
   externalModels?: ExternalModelsConfig;
 


### PR DESCRIPTION
# PR: Integrate Claude Code native dynamic workflows (opt-in)

## Summary

Adds an **opt-in, capability-detected, always-fallback** path that lets OMC hand a single
heavy, highly-parallel stage *down* to a Claude Code [native dynamic workflow](https://code.claude.com/docs/en/workflows)
while OMC stays the orchestrator. Workflows are never a hard dependency — when they are
unavailable, disabled, on a non-Claude lane, nested inside a fan-out mode, or running headless
without explicit opt-in, OMC falls back to its existing orchestration (ultrawork / team / ralph).

## Why one boundary, not a fusion

Workflows and OMC both want to *hold the plan*: a workflow moves orchestration into a script the
runtime runs in the background, with intermediate results kept out of Claude's context — the
opposite of OMC's turn-by-turn, in-context delegation. They cannot share state, persistence,
cancellation, or observability, so this picks one clean boundary (OMC-conductor delegates one
heavy stage down) instead of fusing the two systems.

## What's included

- **`src/features/workflows/`** — capability detection (`detectWorkflowCapability`: Claude Code
  version + `disableWorkflows` settings/env), the six-gate routing decision
  (`shouldRouteToWorkflow`, fallback always OMC), a live environment resolver
  (`resolveLiveWorkflowCapability`), the version-proof invocation builder, and the native-trigger
  predicate (`hasNativeWorkflowTrigger`). Fully unit-tested.
- **`src/hooks/keyword-detector`** — suppresses OMC's *auto-detected* fan-out keywords
  (ultrawork / autopilot / ralph) when the prompt already contains a native `ultracode` /
  `workflow` trigger, so the two orchestrators don't both seize the task. Explicit slash
  invocations (e.g. `/ultrawork`) are preserved.
- **`skills/workflow/SKILL.md`** + **`.claude-plugin/plugin.json`** — registers the `workflow`
  skill (the in-session routing contract + guardrails).
- **`docs/CLAUDE.md`** — a `<dynamic_workflows>` orchestrator-guidance block (shipped source the
  installer injects).
- **`docs/WORKFLOW-INTEGRATION.md`** — design, config keys, env vars, edge cases, and wiring status.
- **`PluginConfig.workflows`** + `OMC_WORKFLOWS_ENABLED` / `OMC_WORKFLOWS_ALLOW_HEADLESS` env
  overrides. Default opt-in is **off**.

## Test plan

- `npx tsc --noEmit` — 0 errors across the project.
- `npx vitest run src/features/workflows src/hooks/keyword-detector` — 381 passed (new unit tests
  for capability/routing/environment + native-trigger suppression, plus the full existing
  keyword-detector suite with no regressions).
- `npx eslint` on all changed files — clean.

## Risk / scope

- Additive and behind a default-off flag; existing behavior is unchanged unless `workflows.enabled`
  is set and a workflow-capable Claude Code is present.
- The keyword-detector change is the only edit to existing runtime logic; it is conservative
  (only suppresses auto-detected fan-out keywords in the presence of an explicit native trigger)
  and covered by tests.

## Intentionally deferred (needs live validation)

- **In-session team exec-stage hook.** Delivered at the prompt/skill layer (the `workflow` skill +
  `<dynamic_workflows>` block), which is the correct surface for the in-session orchestrator. A
  programmatic hook is **not** added to `src/team/runtime-v2.ts` on purpose — that runtime is the
  tmux CLI-worker path (the wrong surface for an in-session feature) and a blind behavioral edit
  there is high-risk. Wire the in-session team exec stage to `shouldRouteToWorkflow` once it can be
  validated end-to-end against a live Claude Code with workflows enabled.
- Behavior against a live workflow runtime is unverified here (the dev sandbox cannot run it). The
  design degrades to OMC fallback whenever capability detection is uncertain.

---

## How to submit this PR

This branch/commit was prepared as a patch (`0001-feat-workflows-dynamic-workflows-integration.patch`).

```bash
# 1. From a clean clone of your fork, on an up-to-date main:
git checkout -b feat/dynamic-workflows-integration

# 2. Apply the commit (preserves message + trailers):
git am 0001-feat-workflows-dynamic-workflows-integration.patch
#    (or, if you prefer a plain apply: git apply 0001-*.patch && git add -A && git commit)

# 3. Push to your fork:
git push -u origin feat/dynamic-workflows-integration

# 4. Open the PR (GitHub CLI):
gh pr create \
  --base main \
  --title "feat(workflows): integrate Claude Code native dynamic workflows" \
  --body-file PR_DESCRIPTION.md
```

If you don't have push access to `Yeachan-Heo/oh-my-claudecode`, fork it first and push the branch
to your fork, then open the PR against the upstream `main` (see the project's CONTRIBUTING.md for
the full fork flow).
