### PR TITLE
Fix compact plugin skill shim path guidance

### DIFF
--- a/src/__tests__/plugin-skill-budget.test.ts
+++ b/src/__tests__/plugin-skill-budget.test.ts
@@ -82,7 +82,10 @@ describe('plugin skill context budget gate (issues #2943, #2986)', () => {
         const source = readFileSync(join(SKILLS_DIR, skillDir, 'SKILL.md'), 'utf-8');
 
         expect(Buffer.byteLength(shim), `${skillDir} compact shim size`).toBeLessThan(COMPACT_PLUGIN_SKILL_PER_FILE_BUDGET_BYTES);
-        expect(shim, `${skillDir} shim should point to archived body`).toContain(`../../skill-bodies/${skillDir}/SKILL.md`);
+        expect(shim, `${skillDir} shim should prefer plugin root archived body`).toContain(`\${CLAUDE_PLUGIN_ROOT}/skill-bodies/${skillDir}/SKILL.md`);
+        expect(shim, `${skillDir} shim should retain relative fallback metadata`).toContain(`../../skill-bodies/${skillDir}/SKILL.md`);
+        expect(shim, `${skillDir} shim fallback should be directory-relative`).toContain('relative to the directory containing this SKILL.md file, not relative to the SKILL.md file path itself');
+        expect(shim, `${skillDir} shim should not contain ambiguous path wording`).not.toContain('relative to this SKILL.md file');
         expect(shim, `${skillDir} shim should expose runtime body override`).toContain('omc-full-body:');
         expect(archived, `${skillDir} full skill body should be preserved`).toBe(source);
       }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1313,11 +1313,12 @@ function renderCompactPluginSkillShim(skillDirName: string, content: string): st
     ?? `Invoke the ${skillDirName} OMC skill.`;
   const description = normalizeCompactSkillDescription(rawDescription);
   const fullBodyRelPath = `../../${PLUGIN_FULL_SKILL_BODIES_DIR}/${skillDirName}/SKILL.md`;
+  const fullBodyPluginRootPath = `\${CLAUDE_PLUGIN_ROOT}/${PLUGIN_FULL_SKILL_BODIES_DIR}/${skillDirName}/SKILL.md`;
 
   frontmatter = upsertYamlStringField(frontmatter, 'description', description);
   frontmatter = upsertYamlStringField(frontmatter, 'omc-full-body', fullBodyRelPath);
 
-  return `---\n${frontmatter.trim()}\n---\n\n${PLUGIN_COMPACT_SKILL_SHIM_MARKER}\n\n# ${skillDirName}\n\nThis is a compact Claude Code plugin registry shim. It keeps startup skill descriptions small while preserving the full OMC skill body for on-demand invocation.\n\nWhen this skill is invoked, read and follow the full bundled instructions from:\n\n\`${fullBodyRelPath}\`\n\nResolve that path relative to this SKILL.md file. If needed, locate the active plugin root via \`CLAUDE_PLUGIN_ROOT\` or \`OMC_PLUGIN_ROOT\` and open \`${PLUGIN_FULL_SKILL_BODIES_DIR}/${skillDirName}/SKILL.md\`.\n`;
+  return `---\n${frontmatter.trim()}\n---\n\n${PLUGIN_COMPACT_SKILL_SHIM_MARKER}\n\n# ${skillDirName}\n\nThis is a compact Claude Code plugin registry shim. It keeps startup skill descriptions small while preserving the full OMC skill body for on-demand invocation.\n\nWhen this skill is invoked, read and follow the full bundled instructions from the active plugin root path:\n\n\`${fullBodyPluginRootPath}\`\n\nIf \`CLAUDE_PLUGIN_ROOT\` is unavailable, resolve \`${fullBodyRelPath}\` relative to the directory containing this SKILL.md file, not relative to the SKILL.md file path itself.\n`;
 }
 
 export function compactPluginSkillPayload(targetRoot: string): { compacted: number; totalBytes: number; errors: string[] } {


### PR DESCRIPTION
## Summary
- Make compact plugin skill shims lead with `${CLAUDE_PLUGIN_ROOT}/skill-bodies/<name>/SKILL.md`
- Keep the relative fallback but clarify it is relative to the directory containing the shim `SKILL.md`
- Add focused assertions covering the unambiguous wording and path behavior

Closes #3198

## Verification
- `npm ci`
- `npm run test:run src/__tests__/plugin-skill-budget.test.ts`