### PR TITLE
Fix source hook manifest direct-node portability

### DIFF
--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -26,6 +26,8 @@ const SETTINGS_FILE = join(CLAUDE_DIR, 'settings.json');
 // nvm/fnm users whose non-interactive hook shells do not include node on PATH
 // (issue #892).
 const nodeBin = process.execPath || 'node';
+const isPublishedPluginCache = !existsSync(join(__dirname, '..', '.git'));
+
 
 console.log('[OMC] Running post-install setup...');
 
@@ -105,12 +107,13 @@ try {
   console.log('[OMC] Warning: Could not configure settings.json:', e.message);
 }
 
-// Patch hooks.json to keep plugin-provided hook commands safe for the
-// platform that is installing the plugin cache. Claude Code's plugin loader
-// reads hooks/hooks.json directly, so the shipped manifest remains native
-// Windows-spawnable (direct node -> run.cjs, no sh/find-node). During setup on
-// Unix/macOS, repair the cached manifest back to the find-node.sh bootstrap so
-// nvm/fnm users whose non-interactive hook PATH lacks node keep working.
+// Patch packaged plugin-cache hooks.json to keep plugin-provided hook commands
+// safe for the platform that is installing the plugin cache. Claude Code's
+// plugin loader reads hooks/hooks.json directly, so the source manifest remains
+// native Windows-spawnable (direct node -> run.cjs, no sh/find-node). During
+// setup from a published plugin cache on Unix/macOS, repair the cached manifest
+// back to the find-node.sh bootstrap so nvm/fnm users whose non-interactive hook
+// PATH lacks node keep working.
 //
 // Keep stale cache self-healing for older manifests that used sh/find-node, an
 // accidentally baked absolute node path, or the Windows-safe direct node form.
@@ -123,8 +126,8 @@ try {
 //
 // Fixes issues #909, #899, #892, #869, #3121.
 try {
-  const hooksJsonPath = join(__dirname, '..', 'hooks', 'hooks.json');
-  if (existsSync(hooksJsonPath)) {
+  const hooksJsonPath = isPublishedPluginCache ? join(__dirname, '..', 'hooks', 'hooks.json') : null;
+  if (hooksJsonPath && existsSync(hooksJsonPath)) {
     const data = JSON.parse(readFileSync(hooksJsonPath, 'utf-8'));
     const patched = normalizeHooksDataForPlatform(data);
 

--- a/src/__tests__/plugin-setup-deps.test.ts
+++ b/src/__tests__/plugin-setup-deps.test.ts
@@ -233,6 +233,33 @@ describe('plugin-setup.mjs hook command portability', () => {
     }
   });
 
+  it('does not rewrite the source hooks manifest when run from a repository checkout', () => {
+    const hooksJsonPath = join(PACKAGE_ROOT, 'hooks', 'hooks.json');
+    const before = readFileSync(hooksJsonPath, 'utf-8');
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-plugin-setup-source-hooks-'));
+
+    try {
+      const configDir = join(tempRoot, 'claude');
+      const fakeHome = join(tempRoot, 'home');
+      mkdirSync(configDir, { recursive: true });
+      mkdirSync(fakeHome, { recursive: true });
+
+      execFileSync(process.execPath, [PLUGIN_SETUP_PATH], {
+        cwd: PACKAGE_ROOT,
+        env: {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: configDir,
+          HOME: fakeHome,
+        },
+        stdio: 'pipe',
+      });
+
+      expect(readFileSync(hooksJsonPath, 'utf-8')).toBe(before);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('normalizes current sh find-node commands to node run.cjs on Windows', () => {
     const current =
       'sh "$CLAUDE_PLUGIN_ROOT"/scripts/find-node.sh "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs';


### PR DESCRIPTION
## Summary
- keep `scripts/plugin-setup.mjs` from rewriting the repository source `hooks/hooks.json` during checkout-based setup/test runs
- preserve packaged plugin-cache runtime normalization so Unix/macOS installs can still use `find-node.sh` while the shipped source manifest remains direct `node ... run.cjs`
- add regression coverage that plugin setup does not mutate the source hook manifest

## CI failure
Fixes dev CI run 26929808491 failure in `src/__tests__/setup-contracts-regression.test.ts` Contract 9: `hooks/hooks.json` portability.

## Verification
- `npm ci`
- `npx vitest run src/__tests__/setup-contracts-regression.test.ts src/__tests__/hooks-command-escaping.test.ts src/__tests__/npm-package-hook-surface.test.ts src/__tests__/plugin-setup-deps.test.ts src/__tests__/repair-plugin-cache-script.test.ts` — 5 files / 58 tests passed
- `npm run lint` — exited 0, existing warnings only
- `npx tsc --noEmit` — passed
