### PR TITLE
test: stabilize runtime cleanup CI specs

### DIFF
--- a/src/hooks/session-end/__tests__/team-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/team-cleanup.test.ts
@@ -136,7 +136,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       directory: tmpDir,
       sessionId,
       transcriptPath,
-      cleanupBudgetMs: 2000,
+      cleanupBudgetMs: 10000,
     });
 
     await waitForAssertion(() => {
@@ -147,7 +147,7 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       );
       expect(teamCleanupMocks.shutdownTeam).not.toHaveBeenCalled();
     });
-  });
+  }, 10000);
 
   it('force-shuts down a legacy runtime team referenced by the ending session', async () => {
     const sessionId = 'pid-1632-legacy';

--- a/src/team/__tests__/runtime-watchdog-retry.test.ts
+++ b/src/team/__tests__/runtime-watchdog-retry.test.ts
@@ -214,7 +214,7 @@ describe('watchdogCliWorkers dead-pane retry behavior', { timeout: 15000 }, () =
     });
 
     ({ watchdogCliWorkers } = await import('../runtime.js'));
-  });
+  }, 30000);
 
   afterEach(() => {
     vi.useRealTimers();


### PR DESCRIPTION
Stabilizes the two dev CI runtime cleanup specs that failed at ed29f0395.

- Extends the watchdog retry spec beforeEach timeout so CI import/mock setup cannot fail before the actual assertion runs.
- Extends the session-owned runtime-v2 cleanup spec timeout and cleanup budget to match the bounded cleanup worker maximum used by production.

Verification:
- npm run test:run -- src/team/__tests__/runtime-watchdog-retry.test.ts src/hooks/session-end/__tests__/team-cleanup.test.ts
- npm run test:run -- src/hooks/session-end/__tests__
- npm run test:run -- src/team/__tests__/runtime-watchdog-retry.test.ts src/team/__tests__/runtime.test.ts src/team/__tests__/runtime-done-recovery.test.ts src/team/__tests__/runtime-assign.test.ts
- npm run lint (0 errors, existing warnings only)
- npm run build
- npm run test:run