### PR TITLE
Fix SubagentStop tracker output loop

### DIFF
--- a/scripts/subagent-tracker.mjs
+++ b/scripts/subagent-tracker.mjs
@@ -3,8 +3,27 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 import { readStdin } from './lib/stdin.mjs';
 
+function shouldSkipSubagentTracker(action) {
+  if (process.env.DISABLE_OMC === '1' || process.env.DISABLE_OMC === 'true') {
+    return true;
+  }
+
+  const skipHooks = (process.env.OMC_SKIP_HOOKS || '')
+    .split(',')
+    .map((hook) => hook.trim())
+    .filter(Boolean);
+  const hookName = action === 'start' ? 'subagent-start' : action === 'stop' ? 'subagent-stop' : 'subagent-tracker';
+
+  return skipHooks.includes(hookName) || skipHooks.includes('subagent-tracker');
+}
+
 async function main() {
   const action = process.argv[2]; // 'start' or 'stop'
+
+  if (shouldSkipSubagentTracker(action)) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
 
   // Read stdin (timeout-protected, see issue #240/#459)
   const input = await readStdin();

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import {
   getStaleAgents,
   getTrackingStats,
   processSubagentStart,
+  processSubagentStop,
   readTrackingState,
   writeTrackingState,
   recordToolUsageWithTiming,
@@ -663,6 +664,48 @@ describe("subagent-tracker", () => {
       const entries = require("fs").readdirSync(sessionsDir) as string[];
       expect(entries.filter((name) => name.startsWith("pid-"))).toHaveLength(0);
       expect(entries).toContain("parent-uuid-xyz");
+    });
+
+  });
+
+  describe("processSubagentStop", () => {
+    it("updates tracking state without injecting additional context into the stopping subagent", () => {
+      const startInput = {
+        session_id: "session-stop-output",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "worker-stop-output",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "Return a detailed final report",
+        model: "claude-sonnet-4-6",
+      };
+
+      processSubagentStart(startInput);
+      flushPendingWrites();
+
+      const output = processSubagentStop({
+        session_id: "session-stop-output",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "worker-stop-output",
+        agent_type: "oh-my-claudecode:executor",
+        output: "Detailed final report with implementation evidence.",
+      });
+      flushPendingWrites();
+
+      expect(output.continue).toBe(true);
+      expect(output.suppressOutput).toBe(true);
+      expect(output.hookSpecificOutput).toBeUndefined();
+
+      const state = readTrackingState(testDir, "session-stop-output");
+      const agent = state.agents.find((item) => item.agent_id === "worker-stop-output");
+      expect(agent?.status).toBe("completed");
+      expect(agent?.output_summary).toBe("Detailed final report with implementation evidence.");
+      expect(state.total_completed).toBe(1);
     });
   });
 

--- a/src/hooks/subagent-tracker/__tests__/script-skip.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/script-skip.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const scriptPath = resolve(process.cwd(), "scripts/subagent-tracker.mjs");
+
+function runTrackerWithSkip(action: "start" | "stop", skipHooks: string): unknown {
+  const stdout = execFileSync(process.execPath, [scriptPath, action], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      OMC_SKIP_HOOKS: skipHooks,
+    },
+    input: "",
+    encoding: "utf8",
+  });
+
+  return JSON.parse(stdout.trim());
+}
+
+describe("subagent-tracker script skip guard", () => {
+  it("honors the subagent-stop skip token before reading or importing hook logic", () => {
+    expect(runTrackerWithSkip("stop", "keyword-detector, subagent-stop")).toEqual({
+      continue: true,
+      suppressOutput: true,
+    });
+  });
+
+  it("honors the umbrella subagent-tracker skip token", () => {
+    expect(runTrackerWithSkip("start", "subagent-tracker")).toEqual({
+      continue: true,
+      suppressOutput: true,
+    });
+  });
+});

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -118,6 +118,7 @@ export interface HookOutput {
     agent_count?: number;
     stale_agents?: string[];
   };
+  suppressOutput?: boolean;
 }
 
 export interface AgentIntervention {
@@ -774,18 +775,9 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
           at: agentIndex !== -1 ? state.agents[agentIndex]?.completed_at : new Date().toISOString(),
         }, sessionId);
       } catch { /* best-effort */ }
-
-      const runningCount = state.agents.filter(
-        (a) => a.status === "running",
-      ).length;
-
       return {
         continue: true,
-        hookSpecificOutput: {
-          hookEventName: "SubagentStop",
-          additionalContext: `Agent ${input.agent_type} ${succeeded ? "completed" : "failed"} (${input.agent_id})`,
-          agent_count: runningCount,
-        },
+        suppressOutput: true,
       };
     }, LOCK_OPTS);
   } catch {


### PR DESCRIPTION
## Summary
- stop emitting SubagentStop `hookSpecificOutput.additionalContext` from `subagent-tracker`, while preserving tracking state and mission/replay side effects
- add direct `OMC_SKIP_HOOKS` parity for `scripts/subagent-tracker.mjs` using `subagent-stop`, `subagent-start`, and umbrella `subagent-tracker` tokens
- add focused regression tests for the SubagentStop output contract and skip guard behavior

## Verification
- `npm run test:run -- src/hooks/subagent-tracker/__tests__/index.test.ts src/hooks/subagent-tracker/__tests__/script-skip.test.ts`
- `npm run build`

Closes #3203