### PR TITLE
feat(keyword-detector): Japanese keyword routing for 7 more skills + KO/JA docs

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -418,6 +418,12 @@ These keywords inject an inline mode message rather than invoking a skill.
 | `deepsearch`, `search the codebase`, `find in codebase` | Activates codebase-focused search mode |
 | `deep-analyze`, `deepanalyze` | Activates deep analysis mode |
 
+### Localized Triggers (Korean / Japanese)
+
+`keyword-detector.mjs` also recognizes Korean and Japanese aliases for these keywords (e.g. `랄프` / `ラルフ` → ralph, `코드 리뷰` / `コード レビュー` → code-review, `딥 분석` / `ディープ アナライズ` → analyze). Because Korean and Japanese have no ASCII word boundary, these aliases match by substring, so a localized alias inside a longer noun phrase still routes (e.g. `コードレビュー記事を要約して` → code-review).
+
+See [REFERENCE.md → Magic Keywords → Localized triggers](./REFERENCE.md#magic-keywords) for the full alias table and routing-behavior details (reviewer-suffix guard, informational suppression, and the known `違いを教えて` gap).
+
 ### Priority and Conflict Resolution
 
 When multiple keywords are detected simultaneously, they resolve by the following priority:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -914,6 +914,34 @@ Use these trigger phrases in natural language prompts to activate enhanced modes
 | `security review`, `review security`                                           | Security-focused review mode                                                                  |
 | `cancelomc`, `stopomc`                                                         | Unified cancellation                                                                          |
 
+### Localized triggers (Korean / Japanese)
+
+The keyword detector recognizes localized aliases in addition to the English trigger phrases above. Each alias maps to the same skill/mode as its English counterpart:
+
+| Keyword          | Korean      | Japanese           |
+| ---------------- | ----------- | ------------------ |
+| `ralph`          | 랄프        | ラルフ             |
+| `autopilot`      | 오토파일럿  | オートパイロット   |
+| `ultrawork`      | 울트라워크  | ウルトラワーク     |
+| `ralplan`        | 랄플랜      | ラルプラン         |
+| `ultrathink`     | 울트라씽크  | ウルトラシンク     |
+| `ccg`            | 씨씨지      | シーシージー       |
+| `deep-interview` | 딥인터뷰    | ディープインタビュー |
+| `tdd`            | 테스트 퍼스트 | テスト ファースト |
+| `code-review`    | 코드 리뷰   | コード レビュー    |
+| `security-review`| 보안 리뷰   | セキュリティ レビュー |
+| `deepsearch`     | 딥 서치     | ディープ サーチ    |
+| `analyze`        | 딥 분석     | ディープ アナライズ |
+
+`cancelomc` / `stopomc` have no localized alias (cancellation is matched only by the English tokens).
+
+#### Localized routing behavior
+
+- **Substring matching (aggressive routing).** Korean and Japanese have no ASCII word boundary, so localized aliases are matched as substrings rather than whole words. This is intentional: a localized alias embedded in a longer noun phrase still routes — e.g. `コードレビュー記事を要約して` ("summarize this code-review article") activates **code-review** mode. Prefer the English form, or phrase around the alias, if you do not want that behavior.
+- **Reviewer-suffix guard.** `code-review` / `security-review` use a negative lookahead so "reviewer"-style nouns do not trigger review mode: `(?!어)` blocks Korean 리뷰어, and `(?!ア)` blocks any Japanese レビューア… form (e.g. レビューアー).
+- **Informational suppression.** Help-style questions are suppressed and pass through without activating a mode — e.g. Korean `뭐야` / Japanese `とは` / `使い方` near an alias.
+- **Known gap.** The Japanese "difference" phrasing `違いを教えて` (e.g. `ディープサーチと普通の検索の違いを教えて`) is **not yet** covered by the informational guards, so it can still activate the mode. Tracked as a follow-up.
+
 ### Examples
 
 ```bash

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1197,7 +1197,7 @@ async function main() {
     // This prevents infinite spawning when Claude workers receive prompts containing "team".
 
     // CCG keywords (Claude-Codex-Gemini tri-model orchestration)
-    if (hasActionableKeyword(cleanPrompt, /\b(ccg|claude-codex-gemini)\b|(씨씨지)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ccg|claude-codex-gemini)\b|(씨씨지)|(シーシージー)/i)) {
       matches.push({ name: 'ccg', args: '' });
     }
 
@@ -1207,7 +1207,7 @@ async function main() {
     }
 
     // Deep interview keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)|(ディープインタビュー)/i)) {
       matches.push({ name: 'deep-interview', args: '' });
     }
 
@@ -1217,7 +1217,7 @@ async function main() {
     }
 
     // TDD keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(tdd)\b|(테스트\s?퍼스트)/i) ||
+    if (hasActionableKeyword(cleanPrompt, /\b(tdd)\b|(테스트\s?퍼스트)|(テスト\s?ファースト)/i) ||
         hasActionableKeyword(cleanPrompt, /\btest\s+first\b/i) ||
         hasActionableKeyword(cleanPrompt, /\bred\s+green\b/i)) {
       matches.push({ name: 'tdd', args: '' });
@@ -1225,13 +1225,13 @@ async function main() {
 
     // Code review keywords — skip when the prompt is echoed review-instruction text
     if (!isReviewSeedContext(cleanPrompt) &&
-        hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i)) {
+        hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)|(コード\s?レビュー)(?!ア)/i)) {
       matches.push({ name: 'code-review', args: '' });
     }
 
     // Security review keywords — skip when the prompt is echoed review-instruction text
     if (!isReviewSeedContext(cleanPrompt) &&
-        hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i)) {
+        hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)|(セキュリティ[ー]?\s?レビュー)(?!ア)/i)) {
       matches.push({ name: 'security-review', args: '' });
     }
 
@@ -1241,14 +1241,14 @@ async function main() {
     }
 
     // Deepsearch keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(deepsearch)\b|(딥\s?서치)/i) ||
+    if (hasActionableKeyword(cleanPrompt, /\b(deepsearch)\b|(딥\s?서치)|(ディープ\s?サーチ)/i) ||
         hasActionableKeyword(cleanPrompt, /\bsearch\s+(the\s+)?(codebase|code|files?|project)\b/i) ||
         hasActionableKeyword(cleanPrompt, /\bfind\s+(in\s+)?(codebase|code|all\s+files?)\b/i)) {
       matches.push({ name: 'deepsearch', args: '' });
     }
 
     // Analyze keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)|(ディープ\s?アナライズ)/i)) {
       matches.push({ name: 'analyze', args: '' });
     }
 

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -253,9 +253,12 @@ function sanitizeForKeywordDetection(text) {
     .replace(/^\s*>\s.*$/gm, '')
     .replace(/^\s*\|(?:[^|\n]*\|){2,}\s*$/gm, '')
     .replace(/^\s*\|?(?:\s*:?-{3,}:?\s*\|){1,}\s*$/gm, '')
-    // 4. Strip file paths: /foo/bar/baz or foo/bar/baz — uses lookbehind (Node.js supports it)
+    // 4. Strip file paths: /foo/bar/baz or foo/bar/baz — uses lookbehind (Node.js supports it).
+    // Path segments are Unicode-aware (\w.- plus the NON_LATIN_SCRIPT_PATTERN ranges) so CJK
+    // file names like docs/コードレビュー.md are stripped before keyword detection; otherwise a
+    // CJK alias inside a path would survive and falsely activate its mode.
     // The TypeScript version (index.ts) uses capture group + $1 replacement for broader compat
-    .replace(/(?<=^|[\s"'`(])(?:\/)?(?:[\w.-]+\/)+[\w.-]+/gm, '')
+    .replace(/(?<=^|[\s"'`(])(?:\/)?(?:[\w.\-　-鿿가-힯Ѐ-ӿ؀-ۿऀ-ॿ฀-๿က-႟]+\/)+[\w.\-　-鿿가-힯Ѐ-ӿ؀-ۿऀ-ॿ฀-๿က-႟]+/gm, '')
     // 5. Strip markdown code blocks (existing)
     .replace(/```[\s\S]*?```/g, '')
     // 6. Strip inline code (existing)

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -100,6 +100,17 @@ describe('keyword-detector.mjs mode-message dispatch', () => {
     expect(context).not.toContain(marker);
   });
 
+  it.each([
+    ['docs/コードレビュー.mdを読んで', '<code-review-mode>'],
+    ['src/セキュリティレビュー.ts を開いて', '<security-review-mode>'],
+    ['notes/ディープアナライズ.md を見て', '<analyze-mode>'],
+  ])('does not activate a mode for a CJK file path %s', (prompt, marker) => {
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).not.toContain(marker);
+  });
+
   it('still emits magic keyword invocation for true skills like ralplan', () => {
     const output = runKeywordDetector('ralplan fix issue #2053');
     const context = output.hookSpecificOutput?.additionalContext ?? '';

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -65,6 +65,41 @@ describe('keyword-detector.mjs mode-message dispatch', () => {
     expect(context).not.toContain('[MAGIC KEYWORD:');
   });
 
+  it.each([
+    ['テストファーストで実装して', '<tdd-mode>'],
+    ['テスト ファースト で実装して', '<tdd-mode>'],
+    ['コードレビューして', '<code-review-mode>'],
+    ['セキュリティレビューお願いします', '<security-review-mode>'],
+    ['ディープサーチでコードベースを探して', '<search-mode>'],
+    ['ディープアナライズして', '<analyze-mode>'],
+  ])('routes Japanese mode keyword %s to the context-injection path', (prompt, marker) => {
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain(marker);
+    expect(context).not.toContain('[MAGIC KEYWORD:');
+  });
+
+  it.each([
+    ['ディープインタビューしたい', '[MAGIC KEYWORD: DEEP-INTERVIEW]'],
+    ['シーシージーで実装して', '[MAGIC KEYWORD: CCG]'],
+  ])('emits magic keyword invocation for Japanese skill keyword %s', (prompt, marker) => {
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain(marker);
+  });
+
+  it.each([
+    ['コードレビューとは何ですか', '<code-review-mode>'],
+    ['テストファーストの使い方を教えて', '<tdd-mode>'],
+  ])('suppresses Japanese informational question %s', (prompt, marker) => {
+    const output = runKeywordDetector(prompt);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).not.toContain(marker);
+  });
+
   it('still emits magic keyword invocation for true skills like ralplan', () => {
     const output = runKeywordDetector('ralplan fix issue #2053');
     const context = output.hookSpecificOutput?.additionalContext ?? '';

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1977,6 +1977,104 @@ This article argues that fake popularity signals damage trust in open source.`;
       });
     });
 
+    describe('Japanese keyword detection (basic matching — KO parity)', () => {
+      it('should detect "コードレビュー" as code-review', () => {
+        const result = detectKeywordsWithType('コードレビューして');
+        const match = result.find((r) => r.type === 'code-review');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "コード レビュー" (spaced) as code-review', () => {
+        const result = detectKeywordsWithType('コード レビュー お願い');
+        const match = result.find((r) => r.type === 'code-review');
+        expect(match).toBeDefined();
+      });
+
+      it('should NOT detect "コードレビューアー募集" as code-review (reviewer false positive)', () => {
+        const result = detectKeywordsWithType('コードレビューアー募集');
+        const match = result.find((r) => r.type === 'code-review');
+        expect(match).toBeUndefined();
+      });
+
+      it('should detect "セキュリティレビュー" as security-review', () => {
+        const result = detectKeywordsWithType('セキュリティレビューして');
+        const match = result.find((r) => r.type === 'security-review');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "セキュリティーレビュー" (long vowel) as security-review', () => {
+        const result = detectKeywordsWithType('セキュリティーレビューして');
+        const match = result.find((r) => r.type === 'security-review');
+        expect(match).toBeDefined();
+      });
+
+      it('should NOT detect "セキュリティレビューアー募集" as security-review (reviewer false positive)', () => {
+        const result = detectKeywordsWithType('セキュリティレビューアー募集');
+        const match = result.find((r) => r.type === 'security-review');
+        expect(match).toBeUndefined();
+      });
+
+      it('should detect "ディープサーチ" as deepsearch', () => {
+        const result = detectKeywordsWithType('ディープサーチして');
+        const match = result.find((r) => r.type === 'deepsearch');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "ディープ サーチ" (spaced) as deepsearch', () => {
+        const result = detectKeywordsWithType('ディープ サーチ して');
+        const match = result.find((r) => r.type === 'deepsearch');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "ディープアナライズ" as analyze', () => {
+        const result = detectKeywordsWithType('ディープアナライズして');
+        const match = result.find((r) => r.type === 'analyze');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "ディープ アナライズ" (spaced) as analyze', () => {
+        const result = detectKeywordsWithType('ディープ アナライズ して');
+        const match = result.find((r) => r.type === 'analyze');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "ディープインタビュー" as deep-interview', () => {
+        const result = detectKeywordsWithType('ディープインタビューしたい');
+        const match = result.find((r) => r.type === 'deep-interview');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "シーシージー" as ccg', () => {
+        const result = detectKeywordsWithType('シーシージーで実装して');
+        const match = result.find((r) => r.type === 'ccg');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "テストファースト" as tdd', () => {
+        const result = detectKeywordsWithType('テストファーストで実装して');
+        const match = result.find((r) => r.type === 'tdd');
+        expect(match).toBeDefined();
+      });
+
+      it('should detect "テスト ファースト" (spaced) as tdd (KO \\s? parity)', () => {
+        const result = detectKeywordsWithType('テスト ファースト で実装して');
+        const match = result.find((r) => r.type === 'tdd');
+        expect(match).toBeDefined();
+      });
+
+      it('should NOT trigger code-review for informational "コードレビューとは何ですか"', () => {
+        const result = detectKeywordsWithType('コードレビューとは何ですか');
+        const match = result.find((r) => r.type === 'code-review');
+        expect(match).toBeUndefined();
+      });
+
+      it('should NOT trigger tdd for informational "テストファーストの使い方を教えて"', () => {
+        const result = detectKeywordsWithType('テストファーストの使い方を教えて');
+        const match = result.find((r) => r.type === 'tdd');
+        expect(match).toBeUndefined();
+      });
+    });
+
     describe('Regression — English keywords still work', () => {
       it('should detect "autopilot mode" as autopilot (unchanged)', () => {
         const result = detectKeywordsWithType('autopilot mode');

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -2075,6 +2075,43 @@ This article argues that fake popularity signals damage trust in open source.`;
       });
     });
 
+    describe('CJK file-path stripping (no false activation)', () => {
+      it('should NOT detect code-review for a Japanese file path "docs/コードレビュー.mdを読んで"', () => {
+        const result = detectKeywordsWithType('docs/コードレビュー.mdを読んで');
+        expect(result.find((r) => r.type === 'code-review')).toBeUndefined();
+      });
+
+      it('should NOT detect code-review for a leading-slash path "/docs/コードレビュー.md"', () => {
+        const result = detectKeywordsWithType('/docs/コードレビュー.md を確認して');
+        expect(result.find((r) => r.type === 'code-review')).toBeUndefined();
+      });
+
+      it('should NOT detect security-review for "src/セキュリティレビュー.ts"', () => {
+        const result = detectKeywordsWithType('src/セキュリティレビュー.ts を開いて');
+        expect(result.find((r) => r.type === 'security-review')).toBeUndefined();
+      });
+
+      it('should NOT detect deepsearch for "docs/ディープサーチ.md"', () => {
+        const result = detectKeywordsWithType('docs/ディープサーチ.md を読む');
+        expect(result.find((r) => r.type === 'deepsearch')).toBeUndefined();
+      });
+
+      it('should NOT detect analyze for "notes/ディープアナライズ.md"', () => {
+        const result = detectKeywordsWithType('notes/ディープアナライズ.md を見て');
+        expect(result.find((r) => r.type === 'analyze')).toBeUndefined();
+      });
+
+      it('control: bare "コードレビューして" (no path) STILL detects code-review', () => {
+        const result = detectKeywordsWithType('コードレビューして');
+        expect(result.find((r) => r.type === 'code-review')).toBeDefined();
+      });
+
+      it('control: bare "ディープアナライズして" (no path) STILL detects analyze', () => {
+        const result = detectKeywordsWithType('ディープアナライズして');
+        expect(result.find((r) => r.type === 'analyze')).toBeDefined();
+      });
+    });
+
     describe('Regression — English keywords still work', () => {
       it('should detect "autopilot mode" as autopilot (unchanged)', () => {
         const result = detectKeywordsWithType('autopilot mode');

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -50,14 +50,14 @@ const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   // This prevents infinite spawning when Claude workers receive prompts containing "team".
   team: /(?!x)x/,  // never-match placeholder (type system requires the key)
   ralplan: /\b(ralplan)\b|(랄플랜)|(ラルプラン)/i,
-  tdd: /\b(tdd)\b|\btest\s+first\b|(테스트\s?퍼스트)/i,
-  'code-review': /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i,
-  'security-review': /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i,
+  tdd: /\b(tdd)\b|\btest\s+first\b|(테스트\s?퍼스트)|(テスト\s?ファースト)/i,
+  'code-review': /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)|(コード\s?レビュー)(?!ア)/i,
+  'security-review': /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)|(セキュリティ[ー]?\s?レビュー)(?!ア)/i,
   ultrathink: /\b(ultrathink)\b|(울트라씽크)|(ウルトラシンク)/i,
-  deepsearch: /\b(deepsearch)\b|\bsearch\s+the\s+codebase\b|\bfind\s+in\s+(the\s+)?codebase\b|(딥\s?서치)/i,
-  analyze: /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)/i,
-  'deep-interview': /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)/i,
-  ccg: /\b(ccg|claude-codex-gemini)\b|(씨씨지)/i,
+  deepsearch: /\b(deepsearch)\b|\bsearch\s+the\s+codebase\b|\bfind\s+in\s+(the\s+)?codebase\b|(딥\s?서치)|(ディープ\s?サーチ)/i,
+  analyze: /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)|(ディープ\s?アナライズ)/i,
+  'deep-interview': /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)|(ディープインタビュー)/i,
+  ccg: /\b(ccg|claude-codex-gemini)\b|(씨씨지)|(シーシージー)/i,
   codex: /\b(ask|use|delegate\s+to)\s+(codex|gpt)\b/i,
   gemini: /\b(ask|use|delegate\s+to)\s+gemini\b/i
 };

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -323,6 +323,38 @@ export const NON_LATIN_SCRIPT_PATTERN =
   /[\u3000-\u9FFF\uAC00-\uD7AF\u0400-\u04FF\u0600-\u06FF\u0900-\u097F\u0E00-\u0E7F\u1000-\u109F]/u;
 
 /**
+ * Character class for a single file-path segment. Includes `\w.-` plus the same
+ * non-Latin script ranges as NON_LATIN_SCRIPT_PATTERN, so CJK/etc. file names
+ * (e.g. `docs/\u30B3\u30FC\u30C9\u30EC\u30D3\u30E5\u30FC.md`) are recognized as paths and stripped before
+ * keyword detection. Without this, a CJK alias embedded in a path survives
+ * sanitization and falsely activates its mode (path detection is ASCII-only
+ * with a bare `[\w.-]`). Building the path regex from this shared constant
+ * avoids the class drifting across its repeated uses below.
+ */
+const PATH_SEGMENT_CHARS =
+  '[\\w.\\-\\u3000-\\u9FFF\\uAC00-\\uD7AF\\u0400-\\u04FF\\u0600-\\u06FF\\u0900-\\u097F\\u0E00-\\u0E7F\\u1000-\\u109F]';
+
+/**
+ * File-path matcher used by sanitizeForKeywordDetection: leading `/`/`./` path,
+ * or a multi-segment `dir/file.ext`. Mirrors the prior ASCII regex but with
+ * Unicode-aware segments. The trailing `.\w+` extension stays ASCII.
+ */
+/* eslint-disable no-misleading-character-class -- Same script ranges as NON_LATIN_SCRIPT_PATTERN: intentional range set, not grapheme clusters */
+const FILE_PATH_PATTERN = new RegExp(
+  '(^|[\\s"\'`(])(?:\\.?\\/(?:' +
+    PATH_SEGMENT_CHARS +
+    '+\\/)*' +
+    PATH_SEGMENT_CHARS +
+    '+|(?:' +
+    PATH_SEGMENT_CHARS +
+    '+\\/)+' +
+    PATH_SEGMENT_CHARS +
+    '+\\.\\w+)',
+  'gm',
+);
+/* eslint-enable no-misleading-character-class */
+
+/**
 * Sanitize text for keyword detection by removing structural noise.
  * Strips XML tags, URLs, file paths, and code blocks.
  */
@@ -340,8 +372,9 @@ export function sanitizeForKeywordDetection(text: string): string {
   result = result.replace(/^\s*>\s.*$/gm, '');
   result = result.replace(/^\s*\|(?:[^|\n]*\|){2,}\s*$/gm, '');
   result = result.replace(/^\s*\|?(?:\s*:?-{3,}:?\s*\|){1,}\s*$/gm, '');
-  // Remove file paths — requires leading / or ./ or multi-segment dir/file.ext
-  result = result.replace(/(^|[\s"'`(])(?:\.?\/(?:[\w.-]+\/)*[\w.-]+|(?:[\w.-]+\/)+[\w.-]+\.\w+)/gm, '$1');
+  // Remove file paths — requires leading / or ./ or multi-segment dir/file.ext.
+  // Unicode-aware segments (FILE_PATH_PATTERN) so CJK file names are stripped too.
+  result = result.replace(FILE_PATH_PATTERN, '$1');
   // Remove code blocks (fenced and inline)
   result = removeCodeBlocks(result);
   return result;

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -974,7 +974,7 @@ async function main() {
 
 
     // CCG keywords (Claude-Codex-Gemini tri-model orchestration)
-    if (hasActionableKeyword(cleanPrompt, /\b(ccg|claude-codex-gemini)\b|(씨씨지)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(ccg|claude-codex-gemini)\b|(씨씨지)|(シーシージー)/i)) {
       matches.push({ name: 'ccg', args: '' });
     }
 
@@ -989,7 +989,7 @@ async function main() {
     // brand name as the first token is a deterministic command, not a
     // routing request. Natural-language mentions ("please use ouroboros
     // to clarify…") still match because the brand is mid-sentence.
-    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]interview|ouroboros)\b|(딥인터뷰)|(ディープインタビュー)/i)) {
       if (!/^\s*\/?(?:ouroboros|ooo)\b/i.test(cleanPrompt)) {
         matches.push({ name: 'deep-interview', args: '' });
       }
@@ -1001,7 +1001,7 @@ async function main() {
     }
 
     // TDD keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(tdd)\b|(테스트\s?퍼스트)/i) ||
+    if (hasActionableKeyword(cleanPrompt, /\b(tdd)\b|(테스트\s?퍼스트)|(テスト\s?ファースト)/i) ||
         hasActionableKeyword(cleanPrompt, /\btest\s+first\b/i) ||
         hasActionableKeyword(cleanPrompt, /\bred\s+green\b/i)) {
       matches.push({ name: 'tdd', args: '' });
@@ -1009,13 +1009,13 @@ async function main() {
 
     // Code review keywords — skip when the prompt is echoed review-instruction text
     if (!isReviewSeedContext(cleanPrompt) &&
-        hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)/i)) {
+        hasActionableKeyword(cleanPrompt, /\b(code\s+review|review\s+code)\b|(코드\s?리뷰)(?!어)|(コード\s?レビュー)(?!ア)/i)) {
       matches.push({ name: 'code-review', args: '' });
     }
 
     // Security review keywords — skip when the prompt is echoed review-instruction text
     if (!isReviewSeedContext(cleanPrompt) &&
-        hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)/i)) {
+        hasActionableKeyword(cleanPrompt, /\b(security\s+review|review\s+security)\b|(보안\s?리뷰)(?!어)|(セキュリティ[ー]?\s?レビュー)(?!ア)/i)) {
       matches.push({ name: 'security-review', args: '' });
     }
 
@@ -1025,14 +1025,14 @@ async function main() {
     }
 
     // Deepsearch keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(deepsearch)\b|(딥\s?서치)/i) ||
+    if (hasActionableKeyword(cleanPrompt, /\b(deepsearch)\b|(딥\s?서치)|(ディープ\s?サーチ)/i) ||
         hasActionableKeyword(cleanPrompt, /\bsearch\s+the\s+codebase\b/i) ||
         hasActionableKeyword(cleanPrompt, /\bfind\s+in\s+(the\s+)?codebase\b/i)) {
       matches.push({ name: 'deepsearch', args: '' });
     }
 
     // Analyze keywords
-    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)/i)) {
+    if (hasActionableKeyword(cleanPrompt, /\b(deep[\s-]?analyze|deepanalyze)\b|(딥\s?분석)|(ディープ\s?アナライズ)/i)) {
       matches.push({ name: 'analyze', args: '' });
     }
 

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -193,9 +193,12 @@ function sanitizeForKeywordDetection(text) {
     .replace(/^\s*>\s.*$/gm, '')
     .replace(/^\s*\|(?:[^|\n]*\|){2,}\s*$/gm, '')
     .replace(/^\s*\|?(?:\s*:?-{3,}:?\s*\|){1,}\s*$/gm, '')
-    // 4. Strip file paths: /foo/bar/baz or foo/bar/baz — uses lookbehind (Node.js supports it)
+    // 4. Strip file paths: /foo/bar/baz or foo/bar/baz — uses lookbehind (Node.js supports it).
+    // Path segments are Unicode-aware (\w.- plus the NON_LATIN_SCRIPT_PATTERN ranges) so CJK
+    // file names like docs/コードレビュー.md are stripped before keyword detection; otherwise a
+    // CJK alias inside a path would survive and falsely activate its mode.
     // The TypeScript version (index.ts) uses capture group + $1 replacement for broader compat
-    .replace(/(?<=^|[\s"'`(])(?:\/)?(?:[\w.-]+\/)+[\w.-]+/gm, '')
+    .replace(/(?<=^|[\s"'`(])(?:\/)?(?:[\w.\-　-鿿가-힯Ѐ-ӿ؀-ۿऀ-ॿ฀-๿က-႟]+\/)+[\w.\-　-鿿가-힯Ѐ-ӿ؀-ۿऀ-ॿ฀-๿က-႟]+/gm, '')
     // 5. Strip markdown code blocks (existing)
     .replace(/```[\s\S]*?```/g, '')
     // 6. Strip inline code (existing)


### PR DESCRIPTION
Supersedes #3212 (closed, head SHA was rewritten so it could not be reopened). This branch now addresses the documentation blocker from that review.

## Summary
Extends Japanese magic-keyword routing to the 7 skills that previously had Korean coverage but no Japanese (**ccg, deep-interview, tdd, code-review, security-review, deepsearch, analyze**), and — per the #3212 review — documents the localized triggers in the public reference.

## Commits
1. `feat(keyword-detector): extend Japanese keyword routing to 7 more skills` — adds JA katakana/kanji aliases to all three hand-maintained detector copies (`src/hooks/keyword-detector/index.ts`, `scripts/keyword-detector.mjs`, `templates/hooks/keyword-detector.mjs`) + unit and runtime-e2e tests. `dist/`/`bridge/` are gitignored build artifacts (regenerated at release), not committed.
2. `docs(keyword-detector): document KO/JA localized magic-keyword triggers` — **addresses the #3212 blocker** (`docs/AGENTS.md` requires REFERENCE.md updates for magic-keyword changes).

## Docs change (the #3212 blocker)
- `docs/REFERENCE.md` → new **"Localized triggers (Korean / Japanese)"** subsection: 12-keyword KO/JA alias table (verified against `KEYWORD_PATTERNS`) + a **Localized routing behavior** note.
- `docs/HOOKS.md` → consistent subsection pointing to REFERENCE.md (single-sourced to avoid cross-doc drift).
- The note explicitly documents the **intended aggressive substring routing** the reviewer asked about (CJK has no `\b`, so `コードレビュー記事を要約して` → code-review), the `(?!어)`/`(?!ア)` reviewer-suffix guard, informational suppression (`뭐야`/`とは`/`使い方`), and the **known `違いを教えて` gap** (tracked follow-up).

## Verification
- `tsc --noEmit` ✅, `eslint src` ✅ (0 errors), multirepo path-gate ✅.
- Detector suites green: `index.test.ts` + `keyword-detector-script.test.ts` → **440 passed** (incl. JA unit + runtime-e2e cases).
- Doc alias table cross-checked against `KEYWORD_PATTERNS` (parity verified by a separate reviewer pass).
- Caveat: full Node-20 CI lane not run locally (dev env is Node 26, where `better-sqlite3`'s native build blocks in-tree `npm ci`); CI (Node 20) is authoritative.

## Known follow-up (out of scope here)
Codex P2: the JA `違いを教えて` phrasing (e.g. `ディープサーチと普通の検索の違いを教えて`) is not yet suppressed by the informational guard — documented as a known gap; a code fix can follow in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)