### PR TITLE
Fix advisory agent final output contracts

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -98,6 +98,12 @@ disallowedTools: Write, Edit
     - `path/to/other.ts:108` - [what it shows]
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured output above, including Summary, Analysis, Root Cause, Recommendations, Trade-offs, and References as applicable.
+    - Do not put the substantive review only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Armchair analysis: Giving advice without reading the code first. Always open files and cite line numbers.
     - Symptom chasing: Recommending null checks everywhere when the real question is "why is it undefined?" Always find root cause.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -153,6 +153,12 @@ disallowedTools: Write, Edit
     APPROVE / REQUEST CHANGES / COMMENT
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured code review above, including Code Review Summary, severity counts, Issues, Open Questions when any, Positive Observations, and Recommendation.
+    - Do not put the substantive review only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Style-first review: Nitpicking formatting while missing a SQL injection vulnerability. Always check security before style.
     - Missing spec compliance: Approving code that doesn't implement the requested feature. Always verify spec match first.

--- a/agents/critic.md
+++ b/agents/critic.md
@@ -226,6 +226,12 @@ disallowedTools: Write, Edit
     - Deliberate Additions (if required): [Pass/Fail + reason]
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured verdict above, beginning with **VERDICT:** and including findings, gaps, justification, open questions, and the ralplan summary row when applicable.
+    - Do not put the substantive critique only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Rubber-stamping: Approving work without reading referenced files. Always verify file references exist and contain what the plan claims.
     - Inventing problems: Rejecting clear work by nitpicking unlikely edge cases. If the work is actionable, say ACCEPT.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -162,6 +162,12 @@ disallowedTools: Write, Edit
     - [ ] Dependencies audited
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured security report above, including Scope, Risk Level, Summary, issue sections, and Security Checklist.
+    - Do not put the substantive security review only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Surface-level scan: Only checking for console.log while missing SQL injection. Follow the full OWASP checklist.
     - Flat prioritization: Listing all findings as "HIGH." Differentiate by severity x exploitability x blast radius.

--- a/src/__tests__/advisory-agent-final-output-contract.test.ts
+++ b/src/__tests__/advisory-agent-final-output-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { getAgentDefinitions } from '../agents/definitions.js';
+
+const advisoryAgents = ['architect', 'critic', 'code-reviewer', 'security-reviewer'] as const;
+
+const forbiddenSignoffPattern = /(?:done|complete|nothing further|looks good|no further comments)/i;
+
+const requiredMarkers: Record<(typeof advisoryAgents)[number], string[]> = {
+  architect: ['<Final_Response_Contract>', '## Summary', '## Analysis', '## Recommendations', '## References'],
+  critic: ['<Final_Response_Contract>', '**VERDICT:', '**Critical Findings**', '**Major Findings**', '**Verdict Justification**'],
+  'code-reviewer': ['<Final_Response_Contract>', '## Code Review Summary', '### Issues', '### Recommendation'],
+  'security-reviewer': ['<Final_Response_Contract>', '# Security Review Report', '**Risk Level:**', '## Security Checklist'],
+};
+
+function agentPrompt(name: string): string {
+  return readFileSync(join(process.cwd(), 'agents', `${name}.md`), 'utf-8');
+}
+
+describe('advisory agent final output contract', () => {
+  test.each(advisoryAgents)('%s prompt requires substantive final response', (agentName) => {
+    const prompt = agentPrompt(agentName);
+
+    for (const marker of requiredMarkers[agentName]) {
+      expect(prompt, `${agentName} prompt should include ${marker}`).toContain(marker);
+    }
+
+    expect(prompt, `${agentName} must explain final message is the Task deliverable`).toMatch(
+      /LAST assistant message is the deliverable surfaced to callers/i,
+    );
+    expect(prompt, `${agentName} must forbid content-free sign-offs`).toMatch(forbiddenSignoffPattern);
+    expect(prompt, `${agentName} must require repeating earlier findings in final response`).toMatch(
+      /repeat the final verdict\/findings structure in the LAST message/i,
+    );
+  });
+
+  test.each(advisoryAgents)('%s registry prompt includes final response contract', (agentName) => {
+    const agents = getAgentDefinitions();
+    const prompt = agents[agentName]?.prompt ?? '';
+
+    expect(prompt).toContain('<Final_Response_Contract>');
+    expect(prompt).toMatch(/LAST assistant message is the deliverable surfaced to callers/i);
+    expect(prompt).toMatch(forbiddenSignoffPattern);
+  });
+});


### PR DESCRIPTION
## Summary
- Add explicit final-response contracts to architect, critic, code-reviewer, and security-reviewer prompts.
- Add regression coverage ensuring advisory agent prompts and registry definitions require substantive, self-contained final outputs for Task callers.

## Tests
- npm test -- advisory-agent-final-output-contract (8 tests)
- npm test -- agent-registry (12 tests)
- npm run lint
- npx tsc --noEmit

Closes #3215