### PR TITLE
fix(external-context): spawn facet agents on opus to survive subagent message-loss bug

### DIFF
--- a/skills/external-context/SKILL.md
+++ b/skills/external-context/SKILL.md
@@ -44,15 +44,17 @@ Given a query, decompose into 2-5 independent search facets:
 
 ### Step 2: Parallel Agent Invocation
 
-Fire independent facets in parallel via Task tool:
+Fire independent facets in parallel via Task tool. **Always spawn the facet agents with `model="opus"`** (see note below):
 
 ```
-Task(subagent_type="oh-my-claudecode:document-specialist", model="sonnet", prompt="Search for: <facet 1 description>. Use WebSearch and WebFetch to find official documentation and examples. Cite all sources with URLs.")
+Task(subagent_type="oh-my-claudecode:document-specialist", model="opus", prompt="Search for: <facet 1 description>. Use WebSearch and WebFetch to find official documentation and examples. Cite all sources with URLs.")
 
-Task(subagent_type="oh-my-claudecode:document-specialist", model="sonnet", prompt="Search for: <facet 2 description>. Use WebSearch and WebFetch to find official documentation and examples. Cite all sources with URLs.")
+Task(subagent_type="oh-my-claudecode:document-specialist", model="opus", prompt="Search for: <facet 2 description>. Use WebSearch and WebFetch to find official documentation and examples. Cite all sources with URLs.")
 ```
 
 Maximum 5 parallel document-specialist agents.
+
+> **Why opus (not sonnet):** this skill's whole value is the facet agents' *free-form research reports* coming back to the orchestrator. Current Claude Code has a subagent bug where a non-opus subagent's final free-form message is frequently lost and replaced by a degenerate idle/wrap-up line (e.g. `"Standing by."`, `"Acknowledged."`, `"(awaiting input)"`), so the report never reaches the caller — which silently breaks this skill. Opus is effectively immune; in controlled testing opus returned the cited report 48/48 while sonnet/haiku lost it in the large majority of free-form runs. Spawn facets on opus until the upstream bug is fixed (anthropics/claude-code#47936).
 
 ### Step 3: Synthesis Output Format
 


### PR DESCRIPTION
## What

Spawn the `external-context` facet agents (`document-specialist`) with `model="opus"` instead of `model="sonnet"`, and document why.

## Why

`/external-context` fans out 2–5 `document-specialist` agents and its entire value is their **free-form research reports** returning to the orchestrator for synthesis. Current Claude Code has a subagent bug where a **non-opus** subagent's final free-form message is frequently lost and replaced by a degenerate idle/wrap-up line — so the report never reaches the caller and the skill silently produces nothing (the orchestrator then tends to misattribute it, e.g. "can't retrieve the subagent report").

Observed degenerate captures in place of the real report: `"(Standing by.)"`, `"Acknowledged."`, `"Subagent task concluded."`, `"(대기 중)"`, empty string.

## Evidence (~126 controlled runs)

Marker-probe sweep (PASS = the subagent's intended final message actually reaches the parent):

| model | no-tool (short) | no-tool (long) | one web search | forced structured output |
|---|---|---|---|---|
| **opus** | 8/8 | 8/8 | 8/8 | 8/8 |
| sonnet | 1/8 | 0/8 | 6/8 | 8/8 |
| haiku | 0/8 | 0/8 | 2/8 | 8/8 |

Real-usage sweep — actual `document-specialist` doing web research (report a version + cite URL):

| model | cited report surfaced |
|---|---|
| **opus** | **8/8** |
| sonnet | **0/8** |

Opus is effectively immune (48/48 across both sweeps). Structured output is immune across all tiers, but `document-specialist` returns free-form prose so that workaround doesn't apply here — hence opus.

Upstream bug: anthropics/claude-code#47936 (I added the model-tier + structured-output data there).

## Scope

- Change is limited to `skills/external-context/SKILL.md` (the two facet-spawn examples + a `model="opus"` directive + a rationale note).
- Intentionally **not** changing `document-specialist`'s frontmatter default, to avoid raising cost for other callers that don't depend on free-form return surfacing.
- `.md`-only change; no build required.

## Note for reviewers

Other skills/flows that pin web-research agents to sonnet and depend on their free-form return may have the same latent issue; out of scope for this PR but worth a sweep.
