### PR TITLE
fix(team): validate N:agent:role specs instead of silently collapsing to claude (#3224)

### DIFF
--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -482,6 +482,42 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     expect(parsed.role).toBe('architect');
   });
 
+
+  it('fails loudly when N:agent:role uses an invalid agent type instead of collapsing to claude', () => {
+    expect(() => parseTeamArgs(['2:foo:architect', 'design auth'])).toThrow(
+      /Invalid agent type "foo" in worker spec/,
+    );
+  });
+
+  it('rejects invalid agent in a comma-separated three-segment spec', () => {
+    expect(() => parseTeamArgs(['1:codex:architect,1:foo:writer', 'do task'])).toThrow(
+      /Invalid agent type "foo" in worker spec/,
+    );
+  });
+
+  it('suggests the role-only shorthand in the invalid-agent error', () => {
+    expect(() => parseTeamArgs(['3:reviewer:executor', 'go'])).toThrow(
+      /use "3:executor"/,
+    );
+  });
+
+
+  it('fails loudly on a malformed worker spec instead of swallowing it into the task', () => {
+    expect(() => parseTeamArgs(['2:claude:executor:extra', 'go'])).toThrow(
+      /Invalid worker spec "2:claude:executor:extra"/,
+    );
+    expect(() => parseTeamArgs(['1:codex,bogus', 'go'])).toThrow(
+      /Invalid worker spec "1:codex,bogus"/,
+    );
+  });
+
+  it('does not misread a time-like task prefix as a worker spec', () => {
+    const parsed = parseTeamArgs(['12:00 standup notes']);
+    expect(parsed.workerCount).toBe(3);
+    expect(parsed.agentTypes).toEqual(['claude', 'claude', 'claude']);
+    expect(parsed.task).toBe('12:00 standup notes');
+  });
+
   it('supports --json and --new-window flags with comma-separated specs', () => {
     const parsed = parseTeamArgs(['1:codex,1:gemini', '--new-window', '--json', 'compare']);
     expect(parsed.workerCount).toBe(2);

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -355,6 +355,13 @@ function normalizeWorkerSpecSegment(match: RegExpMatchArray): NormalizedWorkerSp
   }
 
   if (explicitRole) {
+    if (!VALID_TEAM_CLI_AGENT_TYPES.has(token)) {
+      throw new Error(
+        `Invalid agent type "${token}" in worker spec "${match[0]}". ` +
+        `Expected one of: ${[...VALID_TEAM_CLI_AGENT_TYPES].join(', ')}. ` +
+        `For a role-only shorthand on the default agent, use "${count}:${explicitRole}".`,
+      );
+    }
     return { count, agentType: token, role: explicitRole };
   }
 
@@ -450,6 +457,17 @@ export function parseTeamArgs(tokens: string[], defaultAgentType: string = 'clau
       explicitWorkerSpec = true;
       filteredArgs.shift();
     }
+  }
+
+  // A token that clearly looks like a worker spec ("N:<word>...") but failed to
+  // fully parse must fail loudly rather than being silently swallowed into the
+  // task text, which would default the team to claude workers (see #3224).
+  if (!explicitWorkerSpec && /^\d+:[a-z]/i.test(first)) {
+    throw new Error(
+      `Invalid worker spec "${first}". Expected "N:agent-type[:role]" ` +
+      `(e.g. "3:codex" or "2:codex:architect"), optionally comma-separated ` +
+      `(e.g. "1:codex,1:gemini"). Agent type must be one of: ${[...VALID_TEAM_CLI_AGENT_TYPES].join(', ')}.`,
+    );
   }
 
   // Default: 3 workers with configured default agent type (falls back to claude)


### PR DESCRIPTION
## Summary

Scoped fix for **bug #4 of #3224**: `N:agent:role` worker specs silently collapsing every worker to `claude` instead of parsing or failing loudly.

Two silent-collapse paths existed in `parseTeamArgs` (`src/cli/commands/team.ts`):

1. **Unvalidated agent in the explicit-role form.** `normalizeWorkerSpecSegment` accepted `N:<agent>:<role>` without checking the agent segment. An invalid provider (e.g. `2:foo:architect`) passed straight through; downstream `resolveValidatedBinaryPath` then failed and the AC-8 fallback silently swapped the worker to the claude snapshot.
2. **Spec-shaped tokens swallowed into the task.** Any `N:...` token that failed the strict spec regex (e.g. a 4th segment `2:claude:executor:extra`, or a malformed comma segment `1:codex,bogus`) was not consumed and got merged into the task text, leaving the team on the default 3 claude workers.

## Changes

- Reject an invalid agent type in the three-segment form with a clear error that points users at the `N:role` shorthand when they actually meant a role.
- Fail loudly when a token that clearly looks like a worker spec (`N:<word>...`) fails to parse, instead of treating it as task text. The guard is anchored to `^\d+:[a-z]` so legitimate task prefixes like `12:00 standup notes` are unaffected.

## Tests

Added focused cases in `src/cli/commands/__tests__/team.test.ts`:
- invalid agent in single and comma three-segment specs fails loudly;
- the error suggests the role-only shorthand;
- malformed specs fail instead of being swallowed;
- time-like task prefixes are not misread as specs.

`vitest run src/cli src/team` → 1438 passed / 1 skipped. `tsc --noEmit` and `eslint` clean.

## Scope

This intentionally addresses only the parser/validation bug (#4). The other three issues in #3224 — dispatch not firing (`owner:null` / `0 in`), harness-file auto-merge conflicts, and terse/empty subagent finals — are larger runtime changes and are left for separate follow-up PRs.

Fixes part of #3224.
