### PR TITLE
fix(team): exclude harness files from worktree auto-merge (#3224)

### DIFF
--- a/src/team/__tests__/merge-coordinator.test.ts
+++ b/src/team/__tests__/merge-coordinator.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
-import { checkMergeConflicts, mergeWorkerBranch, mergeAllWorkerBranches } from '../merge-coordinator.js';
+import { checkMergeConflicts, mergeWorkerBranch, mergeAllWorkerBranches, configureHarnessMergeAttributes, HARNESS_MERGE_PATHS } from '../merge-coordinator.js';
 import { createWorkerWorktree, cleanupTeamWorktrees } from '../git-worktree.js';
 
 describe('merge-coordinator', () => {
@@ -136,5 +136,103 @@ describe('merge-coordinator', () => {
       expect(results).toHaveLength(2);
       expect(results.every(r => r.success)).toBe(true);
     });
+  });
+});
+
+describe('harness-file auto-merge (#3224)', () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), 'harness-merge-test-'));
+    execFileSync('git', ['init'], { cwd: repoDir, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: repoDir, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repoDir, stdio: 'pipe' });
+    // Base tree with a tracked harness file (AGENTS.md) and a task file.
+    writeFileSync(join(repoDir, 'AGENTS.md'), 'base agents\n');
+    writeFileSync(join(repoDir, 'app.ts'), 'export const x = 1;\n');
+    execFileSync('git', ['add', '.'], { cwd: repoDir, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', 'Initial commit'], { cwd: repoDir, stdio: 'pipe' });
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  function mainBranch(): string {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: repoDir, encoding: 'utf-8', stdio: 'pipe',
+    }).trim();
+  }
+
+  function commitAll(cwd: string, message: string): void {
+    execFileSync('git', ['add', '-A'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', message], { cwd, stdio: 'pipe' });
+  }
+
+  it('configureHarnessMergeAttributes registers the driver and is idempotent', () => {
+    configureHarnessMergeAttributes(repoDir);
+    configureHarnessMergeAttributes(repoDir);
+
+    const driver = execFileSync('git', ['config', '--get', 'merge.ours.driver'], {
+      cwd: repoDir, encoding: 'utf-8', stdio: 'pipe',
+    }).trim();
+    expect(driver).toBe('true');
+
+    const commonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+      cwd: repoDir, encoding: 'utf-8', stdio: 'pipe',
+    }).trim();
+    const attrPath = join(repoDir, commonDir, 'info', 'attributes');
+    const lines = readFileSync(attrPath, 'utf-8').split('\n').filter((l) => l.trim());
+    for (const p of HARNESS_MERGE_PATHS) {
+      // Each harness path appears exactly once despite two calls.
+      expect(lines.filter((l) => l === `${p} merge=ours`)).toHaveLength(1);
+    }
+  });
+
+  it('auto-resolves AGENTS.md conflict so disjoint task work still merges', () => {
+    const main = mainBranch();
+
+    // Worker branch: per-worker AGENTS.md overlay + real disjoint work.
+    execFileSync('git', ['checkout', '-q', '-b', 'wkr'], { cwd: repoDir, stdio: 'pipe' });
+    writeFileSync(join(repoDir, 'AGENTS.md'), 'worker overlay\n');
+    writeFileSync(join(repoDir, 'feature.ts'), 'export const y = 2;\n');
+    commitAll(repoDir, 'worker change');
+
+    // Leader branch independently changed the same harness file (e.g. an
+    // earlier worker already merged its overlay).
+    execFileSync('git', ['checkout', '-q', main], { cwd: repoDir, stdio: 'pipe' });
+    writeFileSync(join(repoDir, 'AGENTS.md'), 'leader overlay\n');
+    commitAll(repoDir, 'leader change');
+
+    // Without the driver this is a hard AGENTS.md conflict.
+    expect(checkMergeConflicts('wkr', main, repoDir)).toContain('AGENTS.md');
+
+    configureHarnessMergeAttributes(repoDir);
+
+    const result = mergeWorkerBranch('wkr', main, repoDir);
+    expect(result.success).toBe(true);
+    expect(result.conflicts).toEqual([]);
+    // The real task work survived the merge.
+    expect(readFileSync(join(repoDir, 'feature.ts'), 'utf-8')).toContain('export const y = 2;');
+    // Harness file kept the leader-side ("ours") content.
+    expect(readFileSync(join(repoDir, 'AGENTS.md'), 'utf-8')).toBe('leader overlay\n');
+  });
+
+  it('still fails on genuine conflicts in task files', () => {
+    const main = mainBranch();
+
+    execFileSync('git', ['checkout', '-q', '-b', 'wkr2'], { cwd: repoDir, stdio: 'pipe' });
+    writeFileSync(join(repoDir, 'app.ts'), 'export const x = 100;\n');
+    commitAll(repoDir, 'worker task change');
+
+    execFileSync('git', ['checkout', '-q', main], { cwd: repoDir, stdio: 'pipe' });
+    writeFileSync(join(repoDir, 'app.ts'), 'export const x = 200;\n');
+    commitAll(repoDir, 'leader task change');
+
+    configureHarnessMergeAttributes(repoDir);
+
+    const result = mergeWorkerBranch('wkr2', main, repoDir);
+    expect(result.success).toBe(false);
+    expect(result.conflicts).toContain('app.ts');
   });
 });

--- a/src/team/merge-coordinator.ts
+++ b/src/team/merge-coordinator.ts
@@ -9,6 +9,8 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 import { listTeamWorktrees } from './git-worktree.js';
 
 const BRANCH_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
@@ -22,6 +24,62 @@ export function validateBranchName(branch: string): void {
   if (!BRANCH_NAME_RE.test(branch)) {
     throw new Error(`Invalid branch name: "${branch}" — must match ${BRANCH_NAME_RE}`);
   }
+}
+
+/**
+ * Harness overlay files that OMC writes into every worker worktree
+ * (AGENTS.md and the .claude/ settings overlay). They are infrastructure,
+ * not task output, and differ per worker — so the auto-merge / auto-rebase
+ * fan-out collides on them (`UU AGENTS.md`) even when the actual task files
+ * are disjoint. See issue #3224.
+ */
+export const HARNESS_MERGE_PATHS = ['AGENTS.md', '.claude/**'] as const;
+
+/**
+ * Configure a trivial `merge=ours` driver for harness overlay files so the
+ * team auto-merge / auto-rebase never conflicts on infrastructure (#3224).
+ *
+ * Registers the built-in-style `ours` driver (`true` keeps the current
+ * version and exits 0) and writes `<path> merge=ours` lines into the repo's
+ * shared `info/attributes`. Both apply across every linked worktree because
+ * worktrees share the common git dir, so a single call from a team merge
+ * entry point covers the merger worktree and all worker worktrees.
+ *
+ * Idempotent: re-registers the driver (a no-op set) and only appends
+ * attribute lines that are not already present.
+ */
+export function configureHarnessMergeAttributes(repoRoot: string): void {
+  // Register the trivial "ours" merge driver. `true` always succeeds and
+  // leaves the current (HEAD-side) content in place.
+  execFileSync('git', ['config', 'merge.ours.driver', 'true'], {
+    cwd: repoRoot,
+    stdio: 'pipe',
+  });
+
+  const commonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  }).trim();
+  const resolvedCommonDir = isAbsolute(commonDir) ? commonDir : join(repoRoot, commonDir);
+  const infoDir = join(resolvedCommonDir, 'info');
+  mkdirSync(infoDir, { recursive: true });
+
+  const attrPath = join(infoDir, 'attributes');
+  let existing = '';
+  try {
+    existing = readFileSync(attrPath, 'utf-8');
+  } catch {
+    // No attributes file yet — start fresh.
+  }
+  const existingLines = new Set(existing.split('\n').map((l) => l.trim()));
+  const missing = HARNESS_MERGE_PATHS.map((p) => `${p} merge=ours`).filter(
+    (line) => !existingLines.has(line),
+  );
+  if (missing.length === 0) return;
+
+  const prefix = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';
+  appendFileSync(attrPath, `${prefix}${missing.join('\n')}\n`, 'utf-8');
 }
 
 export interface MergeResult {
@@ -181,6 +239,10 @@ export function mergeAllWorkerBranches(
   }).trim();
 
   validateBranchName(base);
+
+  // Keep harness overlay files (AGENTS.md, .claude/**) from blocking the merge
+  // fan-out on infrastructure that has nothing to do with the task (#3224).
+  configureHarnessMergeAttributes(repoRoot);
 
   const results: MergeResult[] = [];
 

--- a/src/team/merge-orchestrator.ts
+++ b/src/team/merge-orchestrator.ts
@@ -64,7 +64,7 @@ import { getOmcRoot } from '../lib/worktree-paths.js';
 import { isRuntimeV2Enabled } from './runtime-flags.js';
 import { sanitizeName } from './tmux-session.js';
 import { listTeamWorktrees, getWorktreePath, getBranchName } from './git-worktree.js';
-import { checkMergeConflicts, mergeWorkerBranch, validateBranchName } from './merge-coordinator.js';
+import { checkMergeConflicts, mergeWorkerBranch, validateBranchName, configureHarnessMergeAttributes } from './merge-coordinator.js';
 import { appendToInbox } from './worker-bootstrap.js';
 import { appendToLeaderInbox, ensureLeaderInbox } from './leader-inbox.js';
 import {
@@ -360,6 +360,12 @@ export async function startMergeOrchestrator(
   // Bootstrap merger worktree + leader inbox.
   ensureMergerWorktree(config.repoRoot, mergerPath, config.leaderBranch);
   await ensureLeaderInbox(config.teamName, config.cwd);
+
+  // Stop harness overlay files (AGENTS.md, .claude/**) from blocking the
+  // auto-merge/auto-rebase fan-out on infrastructure unrelated to the task.
+  // Applies across the merger worktree and every worker worktree because they
+  // share the common git dir (#3224).
+  configureHarnessMergeAttributes(config.repoRoot);
 
   // Hydrate from persisted state if present (M6).
   const persistedPath = persistedStatePath(config.repoRoot, config.teamName);


### PR DESCRIPTION
## What

Fixes the **harness-file auto-merge conflict** bug from #3224 (bug #2): OMC writes a per-worker `AGENTS.md` overlay (and the `.claude/` settings overlay) into every worker worktree. The worker auto-commit cadence (`git add -A`) commits the tracked `AGENTS.md`, so the auto-merge / auto-rebase fan-out collides on it (`UU AGENTS.md`) even when the actual task files are disjoint — stalling/blocking workers.

## How

- Add `configureHarnessMergeAttributes(repoRoot)` to `merge-coordinator.ts`:
  - registers a trivial `merge=ours` driver (`git config merge.ours.driver true`), and
  - writes `AGENTS.md merge=ours` / `.claude/** merge=ours` into the repo's shared `info/attributes` (idempotent).
- Call it at both team-merge entry points: `startMergeOrchestrator` (v2) and `mergeAllWorkerBranches` (legacy). Because linked worktrees share the common git dir, one call covers the merger worktree **and** every worker worktree, so both `git merge --no-ff` (merger path) and `git rebase` (fan-out path) auto-resolve harness conflicts.

Harness conflicts resolve to the current/HEAD ("ours") side; **genuine task-file conflicts are unaffected**.

## Tests

`src/team/__tests__/merge-coordinator.test.ts` — 3 new real-git cases:
- `configureHarnessMergeAttributes` registers the driver and is idempotent.
- A divergent `AGENTS.md` no longer blocks the merge; disjoint task work survives and the harness file keeps the "ours" content.
- A real conflict in a task file (`app.ts`) still fails as expected.

Verification: focused suites pass (`merge-coordinator` 9, plus `merge-orchestrator` / `worker-commit-cadence` / `auto-merge-restart` 55), `tsc --noEmit` clean, `eslint` clean on changed files.

## Scope

Deliberately limited to the harness-file auto-merge bug. The remaining #3224 items are larger runtime changes left for separate PRs:
- **Dispatch doesn't fire** (`owner:null` / `0 in`) — leader→pane injection gap.
- **Terse/empty final messages** — leader/subagent finals vs `.output`.

The `N:agent:role` parser bug (#4) was already fixed in #3225 and is not touched here.

Closes part of #3224.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
