### PR TITLE
fix(team): only stamp dispatch cooldowns on successful delivery (#3224)

### DIFF
--- a/src/hooks/__tests__/team-dispatch-cooldown.test.ts
+++ b/src/hooks/__tests__/team-dispatch-cooldown.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { drainPendingTeamDispatch, type InjectionResult } from '../team-dispatch-hook.js';
+import type { TeamDispatchRequest } from '../../team/dispatch-queue.js';
+
+// Regression coverage for the #3224 "dispatch gap": issue/trigger cooldowns
+// must only be stamped once a dispatch is actually delivered. Stamping on
+// failure (or before an unconfirmed retry) gated legitimate re-dispatch for
+// the cooldown window and stranded the worker.
+
+const TEAM = 'dispatch-cooldown-team';
+
+let root: string;
+let stateDir: string;
+let logsDir: string;
+let teamDir: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+function makeRequest(overrides: Partial<TeamDispatchRequest> = {}): TeamDispatchRequest {
+  const now = new Date().toISOString();
+  return {
+    request_id: `req-${Math.random().toString(16).slice(2, 10)}`,
+    kind: 'inbox',
+    team_name: TEAM,
+    to_worker: 'worker-1',
+    worker_index: 1,
+    pane_id: '%1',
+    trigger_message: 'work item',
+    transport_preference: 'hook_preferred_with_fallback',
+    fallback_allowed: true,
+    status: 'pending',
+    attempt_count: 0,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  } as TeamDispatchRequest;
+}
+
+async function writeRequests(requests: TeamDispatchRequest[]): Promise<void> {
+  await writeFile(join(teamDir, 'dispatch', 'requests.json'), JSON.stringify(requests, null, 2));
+}
+
+async function readRequests(): Promise<TeamDispatchRequest[]> {
+  return JSON.parse(await readFile(join(teamDir, 'dispatch', 'requests.json'), 'utf8'));
+}
+
+async function readIssueCooldownKeys(): Promise<string[]> {
+  try {
+    const parsed = JSON.parse(await readFile(join(teamDir, 'dispatch', 'issue-cooldown.json'), 'utf8'));
+    return Object.keys(parsed?.by_issue ?? {});
+  } catch {
+    return [];
+  }
+}
+
+async function drain(injector: (request: TeamDispatchRequest) => Promise<InjectionResult>) {
+  return drainPendingTeamDispatch({
+    cwd: root,
+    stateDir,
+    logsDir,
+    maxPerTick: 10,
+    injector: async (request) => injector(request as unknown as TeamDispatchRequest),
+  });
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'omc-dispatch-cooldown-'));
+  stateDir = join(root, 'state');
+  logsDir = join(root, 'logs');
+  teamDir = join(stateDir, 'team', TEAM);
+  await mkdir(join(teamDir, 'dispatch'), { recursive: true });
+  await writeFile(join(teamDir, 'config.json'), JSON.stringify({ tmux_session: 'sess' }));
+
+  savedEnv = { ...process.env };
+  delete process.env.OMC_TEAM_WORKER;
+  // Keep both cooldowns active and large so any stamped cooldown would gate.
+  process.env.OMC_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = '600000';
+  process.env.OMC_TEAM_DISPATCH_TRIGGER_COOLDOWN_MS = '600000';
+});
+
+afterEach(async () => {
+  process.env = savedEnv;
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('drainPendingTeamDispatch cooldown stamping', () => {
+  it('stamps the issue cooldown on a successful dispatch and dedups same-issue requests', async () => {
+    await writeRequests([
+      makeRequest({ request_id: 'a', trigger_message: 'Resolve ABC-100 now' }),
+      makeRequest({ request_id: 'b', trigger_message: 'Resolve ABC-100 again' }),
+    ]);
+
+    const calls: string[] = [];
+    const result = await drain(async (request) => {
+      calls.push(request.request_id);
+      return { ok: true, reason: 'tmux_injected' };
+    });
+
+    // First delivered, second gated by the freshly-stamped issue cooldown.
+    expect(calls).toEqual(['a']);
+    expect(result.processed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(await readIssueCooldownKeys()).toContain('ABC-100');
+
+    const requests = await readRequests();
+    expect(requests.find((r) => r.request_id === 'a')?.status).toBe('notified');
+    expect(requests.find((r) => r.request_id === 'b')?.status).toBe('pending');
+  });
+
+  it('does not stamp the issue cooldown when dispatch fails, so re-dispatch is not gated', async () => {
+    await writeRequests([
+      makeRequest({ request_id: 'a', trigger_message: 'Resolve ABC-200 now' }),
+      makeRequest({ request_id: 'b', trigger_message: 'Resolve ABC-200 again' }),
+    ]);
+
+    const calls: string[] = [];
+    const result = await drain(async (request) => {
+      calls.push(request.request_id);
+      return { ok: false, reason: 'missing_tmux_target' };
+    });
+
+    // The failed first request must NOT poison the issue: the second still
+    // reaches the injector instead of being skipped for the cooldown window.
+    expect(calls).toEqual(['a', 'b']);
+    expect(result.failed).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(await readIssueCooldownKeys()).not.toContain('ABC-200');
+  });
+
+  it('does not self-gate an unconfirmed dispatch awaiting retry', async () => {
+    await writeRequests([makeRequest({ request_id: 'a', trigger_message: 'Resolve ABC-300 now' })]);
+
+    let calls = 0;
+    const injector = async (): Promise<InjectionResult> => {
+      calls += 1;
+      return { ok: true, reason: 'tmux_send_keys_unconfirmed' };
+    };
+
+    const first = await drain(injector);
+    expect(calls).toBe(1);
+    expect(first.skipped).toBe(1);
+    // Still pending for retry and not gated by a stamped cooldown.
+    expect((await readRequests())[0]?.status).toBe('pending');
+    expect(await readIssueCooldownKeys()).not.toContain('ABC-300');
+
+    // Next tick must re-attempt the unconfirmed request rather than skip it.
+    const second = await drain(injector);
+    expect(calls).toBe(2);
+    expect(second.skipped).toBe(1);
+    expect((await readRequests())[0]?.status).toBe('pending');
+  });
+});

--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -655,17 +655,6 @@ export async function drainPendingTeamDispatch(options: {
         }
 
         const result = await injector(request, config, resolve(cwd));
-        if (issueKey && issueCooldownMs > 0) {
-          issueCooldownByIssue[issueKey] = Date.now();
-          mutated = true;
-        }
-        if (triggerKey && triggerCooldownMs > 0) {
-          triggerCooldownByKey[triggerKey] = {
-            at: Date.now(),
-            last_request_id: safeString(request.request_id).trim(),
-          };
-          mutated = true;
-        }
         const nowIso = new Date().toISOString();
         request.attempt_count = Number.isFinite(request.attempt_count) ? Math.max(0, request.attempt_count + 1) : 1;
         request.updated_at = nowIso;
@@ -706,6 +695,19 @@ export async function drainPendingTeamDispatch(options: {
           request.status = 'notified';
           request.notified_at = nowIso;
           request.last_reason = result.reason;
+          // Only stamp issue/trigger cooldowns once a dispatch is actually
+          // delivered. Stamping on failure (or before an unconfirmed retry)
+          // would gate legitimate re-dispatch for the cooldown window and
+          // strand the worker — the dispatch gap from #3224.
+          if (issueKey && issueCooldownMs > 0) {
+            issueCooldownByIssue[issueKey] = Date.now();
+          }
+          if (triggerKey && triggerCooldownMs > 0) {
+            triggerCooldownByKey[triggerKey] = {
+              at: Date.now(),
+              last_request_id: safeString(request.request_id).trim(),
+            };
+          }
           if (request.kind === 'mailbox' && request.message_id) {
             await updateMailboxNotified(stateDir, teamName, request.to_worker, request.message_id).catch(logMailboxSyncFailure);
           }


### PR DESCRIPTION
## Summary

Closes the **dispatch gap** item of #3224. The team dispatch drain
(`drainPendingTeamDispatch` in `src/hooks/team-dispatch-hook.ts`) stamped
the issue and trigger cooldowns **unconditionally**, immediately after
calling the injector and before branching on the result. Two failure modes
stranded workers:

- A **failed** injection (e.g. `missing_tmux_target` / busy pane) still
  stamped the 15-minute issue cooldown, so any re-enqueued dispatch with the
  same issue key was skipped for the whole window. The issue gate has no
  same-request escape (unlike the trigger gate).
- An **unconfirmed** dispatch awaiting retry (`tmux_send_keys_unconfirmed`,
  attempt < max) kept the request pending, but the just-stamped issue
  cooldown then gated its own retry on the next tick, delaying redelivery.

The fix stamps the issue/trigger cooldowns only once a dispatch actually
reaches the `notified` state. Failures and pending retries now flow through
immediately, while a successful dispatch still stamps the cooldown and
dedups same-issue requests.

## Changes
- `src/hooks/team-dispatch-hook.ts`: move cooldown stamping into the
  `notified` success branch.
- `src/hooks/__tests__/team-dispatch-cooldown.test.ts`: focused tests for
  (1) success stamps + same-issue dedup (no regression), (2) failure does
  not poison the issue, (3) unconfirmed retry is not self-gated. The two
  fix tests fail on the pre-fix source; the no-regression test passes both.

## Verification
- `vitest run` focused suite: 3 passed.
- Adjacent suites `runtime-v2.dispatch` + `api-interop.dispatch`: 28 passed.
- `tsc --noEmit`: clean. `eslint` on changed files: clean.

## Scope
Addresses only the dispatch-gap item from #3224. The parser (#3225) and
harness auto-merge (#3226) items are already merged.

Relates to #3224.