### PR TITLE
fix(transcript): honor $TMPDIR in path validation; align worktree test encoding

### DIFF
--- a/src/__tests__/resolve-transcript-path.test.ts
+++ b/src/__tests__/resolve-transcript-path.test.ts
@@ -156,7 +156,7 @@ describe('resolveTranscriptPath', () => {
       // Simulate ~/.claude/projects/ with a transcript at the main repo's encoded path
       fakeClaudeDir = join(tempDir, 'fake-claude');
       process.env.CLAUDE_CONFIG_DIR = fakeClaudeDir;
-      const encodedMain = mainRepoDir.replace(/[/\\]/g, '-');
+      const encodedMain = mainRepoDir.replace(/[/\\.]/g, '-');
       const projectDir = join(fakeClaudeDir, 'projects', encodedMain);
       mkdirSync(projectDir, { recursive: true });
       writeFileSync(join(projectDir, 'session-abc.jsonl'), '{}');
@@ -183,18 +183,18 @@ describe('resolveTranscriptPath', () => {
 
     it('resolves transcript path from native git worktree to main repo (issue #1191)', () => {
       // The worktree-encoded transcript path (does not exist)
-      const encodedWorktree = worktreeDir.replace(/[/\\]/g, '-');
+      const encodedWorktree = worktreeDir.replace(/[/\\.]/g, '-');
       const worktreePath = join(fakeClaudeDir, 'projects', encodedWorktree, 'session-abc.jsonl');
 
       const resolved = resolveTranscriptPath(worktreePath, worktreeDir);
-      const encodedMain = mainRepoDir.replace(/[/\\]/g, '-');
+      const encodedMain = mainRepoDir.replace(/[/\\.]/g, '-');
       const expectedPath = join(fakeClaudeDir, 'projects', encodedMain, 'session-abc.jsonl');
 
       expect(resolved).toBe(expectedPath);
     });
 
     it('does not alter path when CWD is the main repo (not a worktree)', () => {
-      const encodedMain = mainRepoDir.replace(/[/\\]/g, '-');
+      const encodedMain = mainRepoDir.replace(/[/\\.]/g, '-');
       const mainPath = join(fakeClaudeDir, 'projects', encodedMain, 'session-abc.jsonl');
 
       // Path exists and CWD is the main repo — should return as-is
@@ -203,7 +203,7 @@ describe('resolveTranscriptPath', () => {
     });
 
     it('returns original path when main repo transcript also missing', () => {
-      const encodedWorktree = worktreeDir.replace(/[/\\]/g, '-');
+      const encodedWorktree = worktreeDir.replace(/[/\\.]/g, '-');
       // Use a session file that doesn't exist at the main repo path either
       const worktreePath = join(fakeClaudeDir, 'projects', encodedWorktree, 'nonexistent.jsonl');
 

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -12,7 +12,7 @@
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFileSync, unlinkSync } from 'fs';
-import { homedir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 
@@ -676,10 +676,11 @@ export function isValidTranscriptPath(transcriptPath: string): boolean {
   const normalized = normalize(expandedPath);
   const home = homedir();
 
-  // Allowed: [$CLAUDE_CONFIG_DIR|~/.claude], ~/.omc/..., /tmp/...
+  // Allowed: [$CLAUDE_CONFIG_DIR|~/.claude], ~/.omc/..., system temp dir
   const allowedPrefixes = [
     getClaudeConfigDir(),
     join(home, '.omc'),
+    tmpdir(), // honors $TMPDIR; covers /tmp and macOS /var/folders defaults
     '/tmp',
     '/var/folders', // macOS temp
   ];


### PR DESCRIPTION
## Summary
Release-dogfood (`npm run test:run`) on `dev` failed 4 tests, all rooted in transcript path handling that only worked when the OS temp dir was `/tmp` or `/var/folders`. The dogfood environment uses `TMPDIR=~/.openclaw/tmp`, exposing two real fragilities.

## Root cause & fixes
1. **`isValidTranscriptPath()` temp allowlist was hardcoded** to `/tmp` and `/var/folders`. With a custom `$TMPDIR`, legitimate transcript reads were rejected, so `extractPythonReplSessionIdsFromTranscript()` returned `[]`. This cascaded into 3 failures:
   - `python-repl-cleanup.test.ts`
   - `session-end-bridge-cleanup.test.ts`
   - `session-end-timeout.test.ts`

   Fix: add `os.tmpdir()` to the allowlist so the actually-configured temp dir is honored (still covers `/tmp` and macOS defaults).

2. **Native git worktree test (#1191) encoded project paths without dots** (`replace(/[/\\]/g, '-')`). Claude Code — and the codebase's canonical `encodeProjectPath` (`src/features/session-history-search/index.ts`) — replace dots too. A temp path containing a dot (`.openclaw`) exposed the mismatch. Fix: align the test's inline encoding to `replace(/[/\\.]/g, '-')`.

## Changed files
- `src/lib/worktree-paths.ts` — add `tmpdir()` import + allowlist entry
- `src/__tests__/resolve-transcript-path.test.ts` — match canonical dot encoding

## Verification (in dogfood env, `TMPDIR=~/.openclaw/tmp`)
- Targeted: 4 previously-failing tests now pass (21 tests across the 4 files)
- `npm run build` — clean
- `npm run test:run` — **9761 passed, 9 skipped, 0 failed**
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm pack --dry-run` — OK (4545 files, 5.6 MB)

No `dist/`/`bridge/` artifacts committed — `prepublishOnly` rebuilds them at publish time, and committed dist had unrelated pre-existing drift.