### PR TITLE
test(hud): cover z.ai Anthropic endpoint routing

### DIFF
--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -58,6 +58,7 @@ describe('isZaiHost', () => {
   it('accepts subdomains of z.ai', () => {
     expect(isZaiHost('https://api.z.ai')).toBe(true);
     expect(isZaiHost('https://api.z.ai/v1/messages')).toBe(true);
+    expect(isZaiHost('https://api.z.ai/api/anthropic')).toBe(true);
     expect(isZaiHost('https://foo.bar.z.ai')).toBe(true);
   });
 
@@ -778,8 +779,8 @@ describe('getUsage routing', () => {
     expect(result.rateLimits!.sonnetWeeklyResetsAt).toBeInstanceOf(Date);
   });
 
-  it('routes to z.ai when ANTHROPIC_BASE_URL is z.ai host', async () => {
-    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/v1';
+  it('routes z.ai Anthropic Messages endpoint to the quota API', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://api.z.ai/api/anthropic';
     process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
 
     // https.request mock not wired, so fetchUsageFromZai resolves to null (network error)


### PR DESCRIPTION
## Summary
- Add a z.ai host fixture for the official Anthropic Messages endpoint: `https://api.z.ai/api/anthropic`.
- Update the HUD routing regression test to use that endpoint and assert it still polls `/api/monitor/usage/quota/limit`.
- Test-only; no runtime behavior or provider-support surface change.

Context: Z.AI documents this endpoint for Claude Code in its GLM Coding Plan setup: https://docs.z.ai/devpack/quick-start

## Verification
- `npm test -- --run src/__tests__/hud/usage-api.test.ts` -> 61 passed
- `npx eslint src/__tests__/hud/usage-api.test.ts --max-warnings=0`
- `npx tsc --noEmit`

Note: local install/test used Node 24.14.0 because the machine default Node 26 is outside better-sqlite3's supported engine range.