### PR TITLE
fix(agents): extend final-output contract to advisory agents

### DIFF
--- a/agents/analyst.md
+++ b/agents/analyst.md
@@ -78,6 +78,12 @@ disallowedTools: Write, Edit
     - [Prioritized list of things to clarify before planning]
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured Analyst Review above, including Missing Questions, Undefined Guardrails, Scope Risks, Unvalidated Assumptions, Missing Acceptance Criteria, Edge Cases, and Recommendations as applicable.
+    - Do not put the substantive analysis only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Market analysis: Evaluating "should we build this?" instead of "can we build this clearly?" Focus on implementability.
     - Vague findings: "The requirements are unclear." Instead: "The error handling for `createUser()` when email already exists is unspecified. Should it return 409 Conflict or silently update?"

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -108,6 +108,12 @@ level: 3
     - No new errors introduced: [confirmed]
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured Bug Report above, including Symptom, Root Cause, Reproduction, Fix, Verification, and References (and Build Error Resolution when applicable).
+    - Do not put the substantive diagnosis only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Symptom fixing: Adding null checks everywhere instead of asking "why is it null?" Find the root cause.
     - Skipping reproduction: Investigating before confirming the bug can be triggered. Reproduce first.

--- a/agents/tracer.md
+++ b/agents/tracer.md
@@ -133,6 +133,12 @@ level: 3
     [What is still unknown or weakly supported]
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured Trace Report above, including Observation, Hypothesis Table, Evidence For/Against, Current Best Explanation, Critical Unknown, and Discriminating Probe as applicable.
+    - Do not put the substantive trace only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Premature certainty: declaring a cause before examining competing explanations
     - Observation drift: rewriting the observed result to fit a favorite theory

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -84,6 +84,12 @@ level: 3
     [One sentence justification]
   </Output_Format>
 
+  <Final_Response_Contract>
+    - Your LAST assistant message is the deliverable surfaced to callers. It MUST contain the full structured Verification Report above, including Verdict, Evidence, Acceptance Criteria, Gaps, and Recommendation as applicable.
+    - Do not put the substantive verification only in earlier messages or tool commentary. If you draft findings earlier, repeat the final verdict/findings structure in the LAST message.
+    - Never end with a content-free sign-off such as "done", "complete", "nothing further", "looks good", or "no further comments". A final response without the structured deliverable violates this agent contract.
+  </Final_Response_Contract>
+
   <Failure_Modes_To_Avoid>
     - Trust without evidence: Approving because the implementer said "it works." Run the tests yourself.
     - Stale evidence: Using test output from 30 minutes ago that predates recent changes. Run fresh.

--- a/src/__tests__/advisory-agent-final-output-contract.test.ts
+++ b/src/__tests__/advisory-agent-final-output-contract.test.ts
@@ -3,7 +3,16 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { getAgentDefinitions } from '../agents/definitions.js';
 
-const advisoryAgents = ['architect', 'critic', 'code-reviewer', 'security-reviewer'] as const;
+const advisoryAgents = [
+  'architect',
+  'critic',
+  'code-reviewer',
+  'security-reviewer',
+  'verifier',
+  'analyst',
+  'tracer',
+  'debugger',
+] as const;
 
 const forbiddenSignoffPattern = /(?:done|complete|nothing further|looks good|no further comments)/i;
 
@@ -12,6 +21,10 @@ const requiredMarkers: Record<(typeof advisoryAgents)[number], string[]> = {
   critic: ['<Final_Response_Contract>', '**VERDICT:', '**Critical Findings**', '**Major Findings**', '**Verdict Justification**'],
   'code-reviewer': ['<Final_Response_Contract>', '## Code Review Summary', '### Issues', '### Recommendation'],
   'security-reviewer': ['<Final_Response_Contract>', '# Security Review Report', '**Risk Level:**', '## Security Checklist'],
+  verifier: ['<Final_Response_Contract>', '## Verification Report', '### Verdict', '### Evidence', '### Recommendation'],
+  analyst: ['<Final_Response_Contract>', '## Analyst Review', '### Scope Risks', '### Recommendations'],
+  tracer: ['<Final_Response_Contract>', '## Trace Report', '### Hypothesis Table', '### Discriminating Probe'],
+  debugger: ['<Final_Response_Contract>', '## Bug Report', '## References', '## Build Error Resolution'],
 };
 
 function agentPrompt(name: string): string {


### PR DESCRIPTION
## Summary

PR #3217 added a `<Final_Response_Contract>` section to 4 advisory agents
(architect, critic, code-reviewer, security-reviewer) so their structured
report lands in the final assistant message — the only block the Task tool
returns to the caller.

The same advisory / READ-ONLY pattern applies to **verifier, analyst, tracer,
and debugger**: each emits a multi-section report consumed by the caller.
Issue #3215 itself generalized the failure as "every such advisory agent loses
its deliverable the same way." This PR mirrors the shipped contract block into
those four agents.

## Changes

- Add `<Final_Response_Contract>` (verbatim #3217 pattern, with each agent's own
  Output_Format section list) to `verifier`, `analyst`, `tracer`, `debugger`.
- Extend `src/__tests__/advisory-agent-final-output-contract.test.ts` —
  the `advisoryAgents` array and `requiredMarkers` now cover all 8 advisory
  agents (16 tests). The registry-backed second test confirms each new agent's
  prompt flows through `getAgentDefinitions()`.

## Verification

- `npx vitest run src/__tests__/advisory-agent-final-output-contract.test.ts` → 16/16 pass
- `npx tsc --noEmit` → clean
- `npx eslint` (changed test file) → clean

The contract is prompt-text plus a regression test; live Task-spawn behavior was
not exercised in CI (same scope as #3217).

Pre-commit verified: npx vitest run (16/16 pass), npx tsc --noEmit (clean), npx eslint (clean)

Refs #3215
