### PR TITLE
fix(hooks): suppress verify-deliverables SubagentStop reinjection (#3233)

### DIFF
--- a/scripts/verify-deliverables.mjs
+++ b/scripts/verify-deliverables.mjs
@@ -11,13 +11,15 @@
  *   1. .omc/deliverables.json (project-specific overrides)
  *   2. ${CLAUDE_PLUGIN_ROOT}/templates/deliverables.json (OMC defaults)
  *
- * This hook is ADVISORY (non-blocking). It returns additionalContext warnings
- * when deliverables are missing, but never prevents the agent from stopping.
+ * This hook is ADVISORY (non-blocking) and never prevents the agent from
+ * stopping. Because it runs on SubagentStop, it does NOT emit
+ * hookSpecificOutput.additionalContext: that context would be reinjected into
+ * the finishing subagent (the regression fixed in #3209 / #3233). It always
+ * suppresses its own output.
  *
  * Hook output:
- *   - { continue: true, hookSpecificOutput: { additionalContext: "warning" } }
- *     when deliverables are missing
- *   - { continue: true, suppressOutput: true } when all checks pass or on error
+ *   - { continue: true, suppressOutput: true } in all cases (deliverables
+ *     missing, all checks pass, or on error)
  */
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
@@ -216,19 +218,12 @@ async function main() {
       return;
     }
 
-    // Build advisory warning
-    const warnings = issues.map(i => `  - ${i.path}: ${i.reason}`).join('\n');
-    const message = `[OMC] Deliverable verification for stage "${stage}":\n` +
-      `${issues.length} issue(s) found:\n${warnings}\n` +
-      `These deliverables may be expected by the next stage.`;
-
-    console.log(JSON.stringify({
-      continue: true,
-      hookSpecificOutput: {
-        hookEventName: 'SubagentStop',
-        additionalContext: message,
-      },
-    }));
+    // Deliverables are missing or incomplete. Do NOT emit
+    // hookSpecificOutput.additionalContext here: this hook runs on
+    // SubagentStop, and additionalContext would be reinjected into the
+    // finishing subagent's context (the regression fixed in #3209 for
+    // subagent-tracker). Suppress output and let the agent stop instead.
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   } catch {
     // On any error, allow the agent to stop (never block on hook failure)
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/src/__tests__/verify-deliverables-subagent-stop.test.mjs
+++ b/src/__tests__/verify-deliverables-subagent-stop.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for scripts/verify-deliverables.mjs (issue #3233).
+ *
+ * verify-deliverables.mjs runs on the SubagentStop hook event. Previously, when
+ * required deliverables were missing it returned
+ * { continue: true, hookSpecificOutput: { additionalContext: "..." } }, which
+ * Claude Code reinjects into the finishing subagent's context — the same loop
+ * that #3209 fixed for subagent-tracker. The hook must instead always suppress
+ * its own output: { continue: true, suppressOutput: true } with no
+ * additionalContext / hookSpecificOutput.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import process from 'node:process';
+
+const SCRIPT_PATH = join(process.cwd(), 'scripts', 'verify-deliverables.mjs');
+
+function runHook(input) {
+  // Strip CLAUDE_PLUGIN_ROOT / OMC_STATE_DIR so resolveOmcStateRoot uses the
+  // inline fallback (<cwd>/.omc) and reads the fixtures written below.
+  const env = { ...process.env, NODE_ENV: 'test' };
+  delete env.CLAUDE_PLUGIN_ROOT;
+  delete env.OMC_STATE_DIR;
+  const stdout = execFileSync('node', [SCRIPT_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    timeout: 5000,
+    env,
+  });
+  return JSON.parse(stdout.trim());
+}
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'verify-deliverables-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeFixtures(dir, sessionId, { stage = 'team-plan', files = ['DESIGN.md'], minSize = 10 } = {}) {
+  const omcRoot = join(dir, '.omc');
+  mkdirSync(omcRoot, { recursive: true });
+  writeFileSync(
+    join(omcRoot, 'deliverables.json'),
+    JSON.stringify({ [stage]: { files, minSize } }),
+  );
+  const sessionDir = join(omcRoot, 'state', 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, 'team-state.json'),
+    JSON.stringify({ current_phase: stage }),
+  );
+}
+
+describe('verify-deliverables SubagentStop output (issue #3233)', () => {
+  it('suppresses output without additionalContext when deliverables are missing', () => {
+    withTempDir((dir) => {
+      const sessionId = 'sess-missing';
+      writeFixtures(dir, sessionId);
+      // Note: DESIGN.md is intentionally NOT created → missing deliverable.
+
+      const result = runHook({
+        hook_event_name: 'SubagentStop',
+        cwd: dir,
+        session_id: sessionId,
+      });
+
+      expect(result).toEqual({ continue: true, suppressOutput: true });
+      expect(result.hookSpecificOutput).toBeUndefined();
+      expect(JSON.stringify(result)).not.toContain('additionalContext');
+    });
+  });
+
+  it('suppresses output when deliverables are present (control)', () => {
+    withTempDir((dir) => {
+      const sessionId = 'sess-present';
+      writeFixtures(dir, sessionId);
+      writeFileSync(
+        join(dir, 'DESIGN.md'),
+        '# Design\n\nThis document satisfies the minimum size requirement.\n',
+      );
+
+      const result = runHook({
+        hook_event_name: 'SubagentStop',
+        cwd: dir,
+        session_id: sessionId,
+      });
+
+      expect(result).toEqual({ continue: true, suppressOutput: true });
+      expect(result.hookSpecificOutput).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/verify-deliverables.mjs` runs solely on the **SubagentStop** hook event (`hooks/hooks.json`). When required deliverables were missing it returned:

```json
{ "continue": true, "hookSpecificOutput": { "hookEventName": "SubagentStop", "additionalContext": "[OMC] Deliverable verification ..." } }
```

Claude Code reinjects `additionalContext` into the **finishing subagent's** context — the exact reinjection loop fixed for `subagent-tracker` in #3209 (commit 7e69072). `verify-deliverables` was never updated, so it kept reintroducing the regression on missing deliverables.

This change makes the hook always emit `{ continue: true, suppressOutput: true }` on the missing/incomplete path, matching the all-pass and error paths. The hook stays advisory and non-blocking; present-deliverable behavior is unchanged. Since the hook is SubagentStop-only, no non-SubagentStop contract is affected.

## Changes

- `scripts/verify-deliverables.mjs`: replace the missing-deliverable `additionalContext` branch with `{ continue: true, suppressOutput: true }`; update header docstring.
- `src/__tests__/verify-deliverables-subagent-stop.test.mjs`: new regression test.

## Tests

```
npx vitest run src/__tests__/verify-deliverables-subagent-stop.test.mjs
# Test Files  1 passed (1) · Tests  2 passed (2)
```

- **missing deliverables** → asserts output equals `{ continue: true, suppressOutput: true }`, `hookSpecificOutput` is undefined, and the payload contains no `additionalContext`.
- **present deliverables (control)** → stays suppressed.

Verified the missing-deliverable test fails against the pre-fix script and passes after the fix.

Fixes #3233.