### PR TITLE
fix(agents): make verifier agent read-only

### DIFF
--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -3,6 +3,7 @@ name: verifier
 description: Verification strategy, evidence-based completion checks, test adequacy
 model: sonnet
 level: 3
+disallowedTools: Write, Edit
 ---
 
 <Agent_Prompt>

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -467,7 +467,7 @@ describe('Installer Constants', () => {
     });
 
     it('should have read-only agents not include Edit/Write tools', () => {
-      const readOnlyAgents = ['architect.md', 'critic.md', 'analyst.md'];
+      const readOnlyAgents = ['architect.md', 'critic.md', 'analyst.md', 'verifier.md'];
 
       for (const agent of readOnlyAgents) {
         const content = AGENT_DEFINITIONS[agent];


### PR DESCRIPTION
## Summary

The `verifier` agent had `Write` and `Edit` in its toolset, unlike the other
analysis-only advisory agents (`architect`, `critic`, `code-reviewer`,
`security-reviewer`, `analyst`), which all declare `disallowedTools: Write, Edit`.
A verifier that can edit the artifact under test can make checks pass by changing
the code it is supposed to validate, undermining verification integrity.

## Change

- `agents/verifier.md` — add `disallowedTools: Write, Edit` to the frontmatter,
  matching the 8 sibling read-only agents (byte-identical line, position 6).
- `src/__tests__/installer.test.ts` — add `verifier.md` to the `readOnlyAgents`
  list in the "read-only agents not include Edit/Write tools" test, as a
  regression guard.

The source of truth for `disallowedTools` is the `agents/<name>.md` frontmatter,
parsed by `parseDisallowedTools` (`src/agents/utils.ts`). Both `verifier` and
`architect` rely on this md fallback rather than setting the field in TS
(`definitions.ts` uses `agentConfig.disallowedTools ?? parseDisallowedTools(name)`),
so a single frontmatter line is the complete and correct fix — no TS change is
needed, and adding one would create dual-SoT drift.

## Verification

Pre-commit verified: `vitest run src/__tests__/installer.test.ts` → 45 passed; `eslint src/__tests__/installer.test.ts` → clean; `tsc --noEmit` → clean.

- The read-only policy test now covers `verifier.md`.
- Parse equivalence: `verifier` and `architect` both resolve to
  `["Write", "Edit"]` under the exact `parseDisallowedTools` regex.
- Regression guard proven: against the pre-fix `verifier.md`, the test
  assertion fails (`disallowedMatch` is null); after the fix it passes.

Closes #3234
