### PR TITLE
fix(wiki): create environment.md via dedicated reserved-safe write path (#3219)

### DIFF
--- a/src/hooks/wiki/__tests__/reserved-file-guard.test.ts
+++ b/src/hooks/wiki/__tests__/reserved-file-guard.test.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import { writePageUnsafe, ensureWikiDir, withWikiLock } from '../storage.js';
 import { WIKI_SCHEMA_VERSION } from '../types.js';
 import type { WikiPage } from '../types.js';
+import { writeEnvironmentUnsafe, readPage } from '../storage.js';
 
 function makePage(filename: string): WikiPage {
   return {
@@ -46,5 +47,17 @@ describe('writePageUnsafe reserved file guard', () => {
     expect(() => {
       withWikiLock(tempDir, () => writePageUnsafe(tempDir, makePage('auth.md')));
     }).not.toThrow();
+  });
+  it('should throw when writing to environment.md via writePageUnsafe', () => {
+    expect(() => {
+      withWikiLock(tempDir, () => writePageUnsafe(tempDir, makePage('environment.md')));
+    }).toThrow('Cannot write to reserved wiki file');
+  });
+
+  it('writeEnvironmentUnsafe bypasses the reserved guard for environment.md', () => {
+    expect(() => {
+      withWikiLock(tempDir, () => writeEnvironmentUnsafe(tempDir, makePage('environment.md')));
+    }).not.toThrow();
+    expect(readPage(tempDir, 'environment.md')?.frontmatter.title).toBe('Test');
   });
 });

--- a/src/hooks/wiki/__tests__/session-hooks.test.ts
+++ b/src/hooks/wiki/__tests__/session-hooks.test.ts
@@ -8,7 +8,8 @@ import fsp from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { ensureWikiDir } from '../storage.js';
-import { onSessionEnd } from '../session-hooks.js';
+import { onSessionEnd, onSessionStart } from '../session-hooks.js';
+import { getWikiDir, readPage } from '../storage.js';
 
 describe('Wiki Session Hooks', () => {
   let tempDir: string;
@@ -46,5 +47,85 @@ describe('Wiki Session Hooks', () => {
     const wikiEntries = fs.readdirSync(wikiDir);
     expect(wikiEntries.filter(entry => entry.startsWith('session-log-'))).toHaveLength(0);
     expect(fs.existsSync(path.join(wikiDir, 'log.md'))).toBe(false);
+  });
+});
+
+describe('feedProjectMemory (environment.md)', () => {
+  let tempDir: string;
+  let configDir: string;
+  let originalClaudeConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-pm-'));
+    configDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-pm-config-'));
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    await fsp.rm(configDir, { recursive: true, force: true });
+  });
+
+  function writeProjectMemory(memory: Record<string, unknown>): void {
+    const omcRoot = path.dirname(getWikiDir(tempDir));
+    fs.writeFileSync(path.join(omcRoot, 'project-memory.json'), JSON.stringify(memory));
+  }
+
+  it('creates environment.md from project-memory.json on session start', () => {
+    ensureWikiDir(tempDir);
+    writeProjectMemory({
+      lastScanned: '2026-01-01T00:00:00.000Z',
+      techStack: {
+        languages: [{ name: 'Java' }, { name: 'Kotlin' }],
+        frameworks: ['Spring'],
+        packageManager: 'gradle',
+      },
+    });
+
+    onSessionStart({ cwd: tempDir });
+
+    const env = readPage(tempDir, 'environment.md');
+    expect(env).not.toBeNull();
+    expect(env!.content).toContain('**Languages:** Java, Kotlin');
+    expect(env!.content).not.toContain('[object Object]');
+  });
+
+  it('renders plain-string languages too', () => {
+    ensureWikiDir(tempDir);
+    writeProjectMemory({
+      lastScanned: '2026-01-01T00:00:00.000Z',
+      techStack: { languages: ['TypeScript', 'Go'] },
+    });
+
+    onSessionStart({ cwd: tempDir });
+
+    const env = readPage(tempDir, 'environment.md');
+    expect(env!.content).toContain('**Languages:** TypeScript, Go');
+  });
+
+  it('updates environment.md when project-memory is newer', () => {
+    ensureWikiDir(tempDir);
+    writeProjectMemory({
+      lastScanned: '2026-01-01T00:00:00.000Z',
+      techStack: { languages: [{ name: 'Java' }] },
+    });
+    onSessionStart({ cwd: tempDir });
+    const first = readPage(tempDir, 'environment.md');
+    expect(first!.content).toContain('Java');
+
+    writeProjectMemory({
+      lastScanned: '2030-01-01T00:00:00.000Z',
+      techStack: { languages: [{ name: 'Rust' }] },
+    });
+    onSessionStart({ cwd: tempDir });
+    const second = readPage(tempDir, 'environment.md');
+    expect(second!.content).toContain('Rust');
+    expect(second!.frontmatter.created).toBe(first!.frontmatter.created);
   });
 });

--- a/src/hooks/wiki/session-hooks.ts
+++ b/src/hooks/wiki/session-hooks.ts
@@ -19,6 +19,7 @@ import {
   listPages,
   withWikiLock,
   writePageUnsafe,
+  writeEnvironmentUnsafe,
   updateIndexUnsafe,
   appendLogUnsafe,
 } from './storage.js';
@@ -214,7 +215,13 @@ function feedProjectMemory(root: string): void {
 
     if (pm.techStack) {
       const ts = pm.techStack;
-      if (ts.languages?.length) lines.push(`**Languages:** ${ts.languages.join(', ')}`);
+      if (ts.languages?.length) {
+        const names = ts.languages
+          .map((l: any) => (typeof l === 'string' ? l : l?.name))
+          .filter(Boolean)
+          .join(', ');
+        if (names) lines.push(`**Languages:** ${names}`);
+      }
       if (ts.frameworks?.length) lines.push(`**Frameworks:** ${ts.frameworks.join(', ')}`);
       if (ts.packageManager) lines.push(`**Package Manager:** ${ts.packageManager}`);
       if (ts.runtime) lines.push(`**Runtime:** ${ts.runtime}`);
@@ -232,7 +239,7 @@ function feedProjectMemory(root: string): void {
     const now = new Date().toISOString();
 
     withWikiLock(root, () => {
-      writePageUnsafe(root, {
+      writeEnvironmentUnsafe(root, {
         filename: envSlug,
         frontmatter: {
           title: 'Project Environment',

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -340,6 +340,18 @@ export function appendLogUnsafe(root: string, entry: WikiLogEntry): void {
   atomicWriteFileSync(logPath, existing + logLine);
 }
 
+/**
+ * Write the reserved environment.md page. MUST be called inside withWikiLock.
+ *
+ * environment.md is a reserved file (excluded from index/listPages and
+ * rejected by writePageUnsafe), so project-memory feeding gets a dedicated
+ * write path — mirroring updateIndexUnsafe and appendLogUnsafe.
+ */
+export function writeEnvironmentUnsafe(root: string, page: WikiPage): void {
+  const wikiDir = ensureWikiDir(root);
+  atomicWriteFileSync(join(wikiDir, ENVIRONMENT_FILE), serializePage(page));
+}
+
 // ============================================================================
 // Safe Write Operations (acquire lock internally)
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #3219. `feedProjectMemory()` was supposed to auto-create `.omc/wiki/environment.md` from `project-memory.json` on session start, but it silently failed:

- `environment.md` is in `RESERVED_FILES`, and `writePageUnsafe()` throws on reserved filenames.
- `feedProjectMemory` called `writePageUnsafe`, hitting the guard.
- The best-effort `catch {}` swallowed the error, so `environment.md` was never written.

## Changes

- **storage.ts**: Add `writeEnvironmentUnsafe(root, page)` — a dedicated reserved-safe write path for `environment.md`, mirroring the existing `updateIndexUnsafe` / `appendLogUnsafe` pattern. The `RESERVED_FILES` guard in `writePageUnsafe` is unchanged, so general wiki page writes are still protected.
- **session-hooks.ts**: `feedProjectMemory` now writes via `writeEnvironmentUnsafe`.
- **session-hooks.ts**: Fix the languages formatting bug — `techStack.languages` is an array of objects (`[{name: "Java"}]`), so `.join(', ')` rendered `[object Object]`. Now maps to `name` (and tolerates plain-string entries) before joining.

## Tests

Added focused regression coverage:
- `reserved-file-guard.test.ts`: `writePageUnsafe` still throws for `environment.md`; `writeEnvironmentUnsafe` writes it successfully.
- `session-hooks.test.ts`: `environment.md` is created from `project-memory.json` on session start, languages render as names (object and string forms, no `[object Object]`), and the file is updated when project-memory is newer while preserving `created`.

## Verification

- `npx vitest run src/hooks/wiki/__tests__/reserved-file-guard.test.ts src/hooks/wiki/__tests__/session-hooks.test.ts` → 9 passed
- `npx tsc --noEmit` → exit 0
- `npm run build` → exit 0

Scope limited to #3219.