### PR TITLE
fix: persist refreshed OAuth tokens back to Keychain (#3238)

### DIFF
--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -1486,3 +1486,211 @@ describe('getUsage routing - minimax', () => {
     expect(written.data.fiveHourPercent).toBe(50);
   });
 });
+describe('writeBackCredentials — Keychain vs file refresh', () => {
+  const originalPlatform = process.platform;
+
+  beforeAll(() => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.readFileSync).mockReturnValue('{}');
+    vi.mocked(childProcess.execFileSync).mockImplementation(() => { throw new Error('mock: no keychain'); });
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+  });
+
+  it('writes refreshed token back to Keychain when source is keychain', async () => {
+    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    const execFileMock = vi.mocked(childProcess.execFileSync);
+    const httpsModule = await import('https') as unknown as { default: { request: ReturnType<typeof vi.fn> } };
+
+    // First call: read expired creds from keychain (username-scoped)
+    // Second call: token refresh HTTP (handled via httpsModule mock)
+    // Third call: read existing keychain entry for merge
+    // Fourth call: write updated creds back to keychain
+    let execCallCount = 0;
+    execFileMock.mockImplementation((_file, args) => {
+      const argsArr = args as string[];
+      execCallCount++;
+
+      if (argsArr.includes('find-generic-password') && argsArr.includes('-a')) {
+        // First read: return expired keychain creds
+        if (execCallCount === 1) {
+          return JSON.stringify({
+            claudeAiOauth: {
+              accessToken: 'expired-access-token',
+              refreshToken: 'valid-refresh-token',
+              expiresAt: oneHourAgo,
+            },
+          });
+        }
+        // Third call: re-read existing entry for merge before write
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'expired-access-token',
+            refreshToken: 'valid-refresh-token',
+            expiresAt: oneHourAgo,
+          },
+        });
+      }
+
+      if (argsArr.includes('add-generic-password')) {
+        // Write-back call: capture what was written
+        return '';
+      }
+
+      // service-only fallback: no entry
+      throw new Error('mock: no service-only entry');
+    });
+
+    // Token refresh returns new tokens
+    httpsModule.default.request.mockImplementationOnce((_options: unknown, callback: (res: EventEmitter & { statusCode?: number }) => void) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          expires_in: 3600,
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    // Usage API call
+    httpsModule.default.request.mockImplementationOnce((_options: unknown, callback: (res: EventEmitter & { statusCode?: number }) => void) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 30 },
+          seven_day: { utilization: 60 },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimits?.fiveHourPercent).toBe(30);
+
+    // Verify Keychain write-back was called with add-generic-password
+    const writeBackCall = execFileMock.mock.calls.find(
+      c => Array.isArray(c[1]) && (c[1] as string[]).includes('add-generic-password')
+    );
+    expect(writeBackCall).toBeTruthy();
+
+    const writeArgs = writeBackCall![1] as string[];
+    // Should use -U flag (update) to replace existing entry
+    expect(writeArgs).toContain('-U');
+
+    // The written JSON should contain the new tokens
+    const writtenJson = writeArgs[writeArgs.indexOf('-w') + 1];
+    const written = JSON.parse(writtenJson);
+    const inner = written.claudeAiOauth ?? written;
+    expect(inner.accessToken).toBe('new-access-token');
+    expect(inner.refreshToken).toBe('new-refresh-token');
+
+    // File credential store should NOT have been written
+    const fileWriteCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      c => String(c[0]).endsWith('.credentials.json')
+    );
+    expect(fileWriteCall).toBeUndefined();
+  });
+
+  it('writes refreshed token back to file when source is file, not to Keychain', async () => {
+    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    const execFileMock = vi.mocked(childProcess.execFileSync);
+    const mockedExistsSync = vi.mocked(fs.existsSync);
+    const mockedReadFileSync = vi.mocked(fs.readFileSync);
+    const httpsModule = await import('https') as unknown as { default: { request: ReturnType<typeof vi.fn> } };
+
+    // Keychain has no entry — only file credentials
+    execFileMock.mockImplementation(() => { throw new Error('mock: no keychain'); });
+
+    mockedExistsSync.mockImplementation((path) => String(path).endsWith('.credentials.json'));
+    mockedReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith('.credentials.json')) {
+        return JSON.stringify({
+          claudeAiOauth: {
+            accessToken: 'expired-file-token',
+            refreshToken: 'file-refresh-token',
+            expiresAt: oneHourAgo,
+          },
+        });
+      }
+      return '{}';
+    });
+
+    // Token refresh returns new tokens
+    httpsModule.default.request.mockImplementationOnce((_options: unknown, callback: (res: EventEmitter & { statusCode?: number }) => void) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          access_token: 'new-file-access-token',
+          refresh_token: 'new-file-refresh-token',
+          expires_in: 3600,
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    // Usage API call
+    httpsModule.default.request.mockImplementationOnce((_options: unknown, callback: (res: EventEmitter & { statusCode?: number }) => void) => {
+      const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void };
+      req.destroy = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+        res.statusCode = 200;
+        callback(res);
+        res.emit('data', JSON.stringify({
+          five_hour: { utilization: 20 },
+          seven_day: { utilization: 40 },
+        }));
+        res.emit('end');
+      };
+      return req;
+    });
+
+    const result = await getUsage();
+
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimits?.fiveHourPercent).toBe(20);
+
+    // File should have been written with new tokens
+    const fileWriteCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      c => String(c[0]).endsWith('.credentials.json.tmp.' + process.pid)
+    );
+    expect(fileWriteCall).toBeTruthy();
+    const written = JSON.parse(String(fileWriteCall![1]));
+    expect(written.claudeAiOauth.accessToken).toBe('new-file-access-token');
+    expect(written.claudeAiOauth.refreshToken).toBe('new-file-refresh-token');
+
+    // Keychain write-back should NOT have been called with add-generic-password
+    const keychainWriteCall = execFileMock.mock.calls.find(
+      c => Array.isArray(c[1]) && (c[1] as string[]).includes('add-generic-password')
+    );
+    expect(keychainWriteCall).toBeUndefined();
+  });
+});

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -69,6 +69,8 @@ interface OAuthCredentials {
   refreshToken?: string;
   /** Where the credentials were read from, needed for write-back */
   source?: 'keychain' | 'file';
+  /** Keychain account name used when reading (null = service-only lookup) */
+  keychainAccount?: string | null;
   /** Subscription type from OAuth credentials (e.g. 'enterprise') */
   subscriptionType?: string;
   /** Rate limit tier from OAuth credentials (e.g. 'default_claude_zero') */
@@ -466,6 +468,7 @@ function readKeychainCredential(serviceName: string, account?: string): OAuthCre
       expiresAt: creds.expiresAt,
       refreshToken: creds.refreshToken,
       source: 'keychain' as const,
+      keychainAccount: account ?? null,
       subscriptionType: creds.subscriptionType,
       rateLimitTier: creds.rateLimitTier,
     };
@@ -766,11 +769,75 @@ function fetchUsageFromZai(): Promise<FetchResult<ZaiQuotaResponse>> {
 }
 
 /**
- * Persist refreshed credentials back to the file-based credential store.
- * Keychain write-back is not supported (read-only for HUD).
- * Updates only the claudeAiOauth fields, preserving other data.
+ * Persist refreshed credentials back to the Keychain.
+ * Reads the existing Keychain entry, merges the updated fields, and writes it back.
+ */
+function writeKeychainCredentials(creds: OAuthCredentials): void {
+  if (process.platform !== 'darwin') return;
+  try {
+    const serviceName = getKeychainServiceName();
+    const account = creds.keychainAccount ?? undefined;
+
+    // Read the existing Keychain entry to preserve any extra fields
+    const readArgs = account
+      ? ['find-generic-password', '-s', serviceName, '-a', account, '-w']
+      : ['find-generic-password', '-s', serviceName, '-w'];
+
+    let existing: Record<string, unknown> = {};
+    try {
+      const raw = execFileSync('/usr/bin/security', readArgs, {
+        encoding: 'utf-8',
+        timeout: 2000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      if (raw) existing = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      // If we can't read it, we'll write a fresh entry
+    }
+
+    // Merge into the correct structure
+    if (existing.claudeAiOauth && typeof existing.claudeAiOauth === 'object') {
+      const inner = existing.claudeAiOauth as Record<string, unknown>;
+      inner.accessToken = creds.accessToken;
+      if (creds.expiresAt != null) inner.expiresAt = creds.expiresAt;
+      if (creds.refreshToken) inner.refreshToken = creds.refreshToken;
+    } else {
+      // Flat structure or empty
+      (existing as Record<string, unknown>).accessToken = creds.accessToken;
+      if (creds.expiresAt != null) (existing as Record<string, unknown>).expiresAt = creds.expiresAt;
+      if (creds.refreshToken) (existing as Record<string, unknown>).refreshToken = creds.refreshToken;
+    }
+
+    const newJson = JSON.stringify(existing);
+    const writeArgs = account
+      ? ['add-generic-password', '-s', serviceName, '-a', account, '-w', newJson, '-U']
+      : ['add-generic-password', '-s', serviceName, '-w', newJson, '-U'];
+
+    execFileSync('/usr/bin/security', writeArgs, {
+      encoding: 'utf-8',
+      timeout: 2000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    // Silent failure - Keychain write-back is best-effort
+    if (process.env.OMC_DEBUG) {
+      console.error('[usage-api] Failed to write back refreshed credentials to Keychain');
+    }
+  }
+}
+
+/**
+ * Persist refreshed credentials back to the credential store.
+ * When the credentials originated from Keychain, writes back to Keychain.
+ * When they originated from file, updates ~/.claude/.credentials.json.
+ * Updates only the OAuth token fields, preserving other data.
  */
 function writeBackCredentials(creds: OAuthCredentials): void {
+  if (creds.source === 'keychain') {
+    writeKeychainCredentials(creds);
+    return;
+  }
+
   try {
     const credPath = join(getClaudeConfigDir(), '.credentials.json');
     if (!existsSync(credPath)) return;


### PR DESCRIPTION
## Problem

macOS Keychain-only Claude Code installs store OAuth credentials in Keychain. When the access token expires, `getUsage()` calls `refreshAccessToken`, receives a rotated token pair, then calls `writeBackCredentials`. That function immediately returned when `~/.claude/.credentials.json` was absent — the normal case for Keychain-only installs — silently discarding the new tokens and leaving Keychain with dead credentials.

## Root Cause

`writeBackCredentials` had no Keychain write-back path. The early-return guard `if (!existsSync(credPath)) return;` exited before any write when the file did not exist, regardless of credential source.

## Fix

1. **`OAuthCredentials.keychainAccount`** — new optional field that records which Keychain account slot was used (`string` for username-scoped, `null` for service-only). Set in `readKeychainCredential`.
2. **`writeKeychainCredentials`** — reads the existing Keychain entry, merges the new `accessToken`/`refreshToken`/`expiresAt` fields into the correct structure (nested `claudeAiOauth` or flat), and writes back with `security add-generic-password -U`. Silently no-ops on non-macOS and on security tool failures (best-effort, matching the file path behaviour).
3. **`writeBackCredentials`** — routes to `writeKeychainCredentials` when `source === 'keychain'`; file-sourced credential behavior is unchanged.

## Tests

Two new focused tests in `src/__tests__/hud/usage-api.test.ts` under *"writeBackCredentials — Keychain vs file refresh"*:

- **Keychain-sourced refresh** — expired Keychain creds → refresh succeeds → `add-generic-password -U` called with new tokens; `.credentials.json` not written.
- **File-sourced refresh** — no Keychain entry, file creds expired → refresh succeeds → `.credentials.json` written with new tokens; `add-generic-password` not called.

All 571 HUD tests pass. TypeScript: clean. ESLint: clean.

Closes #3238

---
*[repo owner's gaebal-gajae (clawdbot) 🦞]*