### PR TITLE
fix(hooks): add async:true to SessionEnd hooks to prevent Windows shutdown cancellation

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -198,12 +198,14 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/session-end.mjs",
-            "timeout": 30
+            "timeout": 30,
+            "async": true
           },
           {
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/wiki-session-end.mjs",
-            "timeout": 30
+            "timeout": 30,
+            "async": true
           }
         ]
       }

--- a/src/__tests__/setup-contracts-regression.test.ts
+++ b/src/__tests__/setup-contracts-regression.test.ts
@@ -619,3 +619,59 @@ describe('OMC setup Ralph Ruby dependency guidance (issue #2969)', () => {
     expect(content).toContain('restart Claude Code');
   });
 });
+
+// ── Contract 11: SessionEnd hooks carry async:true (issue #3240) ─────────────
+// On Windows shutdown, synchronous SessionEnd hooks are killed before completion,
+// producing "Hook cancelled". async:true lets the runtime fire-and-forget them.
+
+describe('Contract 11: SessionEnd hooks are async (issue #3240)', () => {
+  const HOOKS_JSON_PATH = join(REPO_ROOT, 'hooks', 'hooks.json');
+
+  it('every SessionEnd hook entry has async:true', () => {
+    if (!existsSync(HOOKS_JSON_PATH)) return;
+
+    const hooksJson = JSON.parse(readFileSync(HOOKS_JSON_PATH, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ type: string; async?: boolean }> }>>;
+    };
+
+    const sessionEndGroups = hooksJson.hooks?.['SessionEnd'] ?? [];
+    expect(sessionEndGroups.length).toBeGreaterThan(0);
+
+    const violations: { command: string }[] = [];
+    for (const group of sessionEndGroups) {
+      for (const hook of group.hooks ?? []) {
+        if (hook.type === 'command' && hook.async !== true) {
+          violations.push({ command: (hook as { command?: string }).command ?? '(unknown)' });
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const details = violations.map(v => `  ${v.command}`).join('\n');
+      expect.fail(
+        `SessionEnd hook entries missing async:true (issue #3240 regression):\n${details}\n\n` +
+        `On Windows shutdown, synchronous SessionEnd hooks are killed before completion. ` +
+        `Add "async": true to every SessionEnd command hook.`,
+      );
+    }
+  });
+
+  it('non-SessionEnd hooks do not unconditionally carry async:true', () => {
+    if (!existsSync(HOOKS_JSON_PATH)) return;
+
+    const hooksJson = JSON.parse(readFileSync(HOOKS_JSON_PATH, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ type: string; async?: boolean }> }>>;
+    };
+
+    // Only SessionEnd should have async:true; verify at least one event type that
+    // is expected to be synchronous (Stop) is not accidentally marked async.
+    const stopGroups = hooksJson.hooks?.['Stop'] ?? [];
+    for (const group of stopGroups) {
+      for (const hook of group.hooks ?? []) {
+        if (hook.type === 'command') {
+          expect((hook as { async?: boolean }).async).not.toBe(true);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3240.

On Windows shutdown, synchronous `SessionEnd` hooks are killed by the Claude Code runtime before they complete, producing:

```
SessionEnd hook [...session-end.mjs] failed: Hook cancelled
```

### Root cause

`hooks/hooks.json` SessionEnd entries lacked `"async": true`. The runtime blocks on synchronous hooks during shutdown; when the process is terminated (e.g. `exit` / `Ctrl+C` on Windows), the hook subprocess is killed mid-run.

### Fix

Add `"async": true` to both SessionEnd command hooks (`session-end.mjs` and `wiki-session-end.mjs`). Fire-and-forget lets them complete their writes without being forcibly terminated during process teardown.

All other hook types remain synchronous — they rely on blocking behaviour for correctness (e.g. `Stop`, `PostToolUse`).

### Changes

- `hooks/hooks.json` — `async: true` on both SessionEnd entries
- `src/__tests__/setup-contracts-regression.test.ts` — Contract 11: asserts every SessionEnd command hook carries `async:true`; also asserts `Stop` hooks remain synchronous (regression guard)

### Tests

```
npx vitest run src/__tests__/setup-contracts-regression.test.ts
# 21 passed
npx vitest run src/__tests__/hooks-command-escaping.test.ts src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts src/__tests__/npm-package-hook-surface.test.ts
# 9 passed
npx tsc --noEmit  # clean
```

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*