### PR TITLE
fix(hooks): honor agents.<name>.model for native Task/Agent calls (#3242)

### DIFF
--- a/scripts/lib/agent-model-config.mjs
+++ b/scripts/lib/agent-model-config.mjs
@@ -1,0 +1,145 @@
+/**
+ * Per-agent model resolution for the registered PreToolUse hook.
+ *
+ * Reads `agents.<name>.model` from the OMC user/project config (the same
+ * JSONC files src/config/loader.ts loads) so native Task/Agent subagent
+ * calls honor the user's per-agent model override instead of falling back
+ * to the static `agents/*.md` frontmatter (issue #3242).
+ *
+ * Inlined (no dist/ import) so the hook stays build-independent, mirroring
+ * the rest of scripts/pre-tool-enforcer.mjs.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// Mirrors src/utils/paths.ts:getConfigDir
+function getConfigDir() {
+  if (process.platform === 'win32') {
+    return process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
+  }
+  return process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+}
+
+// Mirrors src/config/loader.ts:getConfigPaths
+function getConfigPaths(cwd) {
+  return {
+    user: join(getConfigDir(), 'claude-omc', 'config.jsonc'),
+    project: join(cwd || process.cwd(), '.claude', 'omc.jsonc'),
+  };
+}
+
+// Mirrors src/utils/jsonc.ts:stripJsoncComments
+export function stripJsoncComments(content) {
+  let result = '';
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] === '/' && content[i + 1] === '/') {
+      while (i < content.length && content[i] !== '\n') i++;
+      continue;
+    }
+    if (content[i] === '/' && content[i + 1] === '*') {
+      i += 2;
+      while (i < content.length && !(content[i] === '*' && content[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (content[i] === '"') {
+      result += content[i];
+      i++;
+      while (i < content.length && content[i] !== '"') {
+        if (content[i] === '\\') {
+          result += content[i];
+          i++;
+          if (i < content.length) {
+            result += content[i];
+            i++;
+          }
+          continue;
+        }
+        result += content[i];
+        i++;
+      }
+      if (i < content.length) {
+        result += content[i];
+        i++;
+      }
+      continue;
+    }
+    result += content[i];
+    i++;
+  }
+  return result;
+}
+
+function loadJsoncFile(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(stripJsoncComments(readFileSync(path, 'utf-8')));
+  } catch {
+    return null;
+  }
+}
+
+// Mirrors src/agents/definitions.ts:AGENT_CONFIG_KEY_MAP
+const AGENT_CONFIG_KEY_MAP = {
+  explore: 'explore',
+  analyst: 'analyst',
+  planner: 'planner',
+  architect: 'architect',
+  debugger: 'debugger',
+  executor: 'executor',
+  verifier: 'verifier',
+  'security-reviewer': 'securityReviewer',
+  'code-reviewer': 'codeReviewer',
+  'test-engineer': 'testEngineer',
+  designer: 'designer',
+  writer: 'writer',
+  'qa-tester': 'qaTester',
+  scientist: 'scientist',
+  tracer: 'tracer',
+  'git-master': 'gitMaster',
+  'code-simplifier': 'codeSimplifier',
+  critic: 'critic',
+  'document-specialist': 'documentSpecialist',
+};
+
+// Mirrors src/features/delegation-routing/types.ts:DEPRECATED_ROLE_ALIASES
+const DEPRECATED_ROLE_ALIASES = {
+  researcher: 'document-specialist',
+  'tdd-guide': 'test-engineer',
+  'api-reviewer': 'code-reviewer',
+  'performance-reviewer': 'code-reviewer',
+  'dependency-expert': 'document-specialist',
+  'quality-strategist': 'code-reviewer',
+  vision: 'document-specialist',
+  'quality-reviewer': 'code-reviewer',
+  'deep-executor': 'executor',
+  'build-fixer': 'debugger',
+  'harsh-critic': 'critic',
+  reviewer: 'code-reviewer',
+};
+
+/**
+ * Resolve the configured per-agent model for a subagent_type from config.jsonc.
+ * Returns the raw configured model string (e.g. "sonnet", "claude-opus-4-6"),
+ * or null when no per-agent override is configured. Project config takes
+ * precedence over user config, matching loadConfig()'s merge order.
+ */
+export function resolveConfiguredAgentModel(subagentType, cwd) {
+  const raw = (typeof subagentType === 'string' ? subagentType : '').replace(/^oh-my-claudecode:/, '');
+  if (!raw || !/^[a-zA-Z0-9_-]+$/.test(raw)) return null;
+  const canonical = DEPRECATED_ROLE_ALIASES[raw] ?? raw;
+  const key = AGENT_CONFIG_KEY_MAP[canonical];
+  if (!key) return null;
+
+  const paths = getConfigPaths(cwd);
+  // Project config takes precedence over user config (loadConfig merge order).
+  for (const path of [paths.project, paths.user]) {
+    const config = loadJsoncFile(path);
+    const model = config?.agents?.[key]?.model;
+    if (typeof model === 'string' && model.trim()) return model.trim();
+  }
+  return null;
+}

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -17,6 +17,7 @@ import { evaluateAgentHeavyPreflight } from './lib/pre-tool-enforcer-preflight.m
 import { evaluateForceAgentDelegation } from './lib/force-agent-delegation-preflight.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
 import { readStdin } from './lib/stdin.mjs';
+import { resolveConfiguredAgentModel } from './lib/agent-model-config.mjs';
 
 // Inlined from src/config/models.ts — avoids a dist/ import so the hook works
 // before a build and stays consistent with the TypeScript source.
@@ -1245,6 +1246,10 @@ async function main() {
 
     const modeActive = hasActiveMode(stateDir, sessionId);
 
+    // When set, replaces the Task/Agent tool input via hookSpecificOutput.updatedInput
+    // so a configured per-agent model (agents.<name>.model) is applied (issue #3242).
+    let updatedToolInput = null;
+
     // Force-inherit check: deny Task/Agent calls with invalid model param when forceInherit is
     // enabled (Bedrock, Vertex, CC Switch, etc.) - issues #1135, #1201, #1767, #1868
     //
@@ -1344,6 +1349,19 @@ async function main() {
         }
         // else: no model param and no [1m] on session model → normal forceInherit,
         // agents inherit the parent session's model cleanly.
+      } else if (!toolModel && toolInput.subagent_type) {
+        // Non-forceInherit: honor agents.<name>.model from config.jsonc for native
+        // Task/Agent calls without an explicit model param. Without this, Claude Code
+        // reads the static agents/*.md frontmatter and silently ignores the user's
+        // per-agent override (issue #3242). Inject the resolved tier alias via
+        // updatedInput so the spawned subagent runs on the configured model.
+        const configuredModel = resolveConfiguredAgentModel(toolInput.subagent_type, directory);
+        if (configuredModel && configuredModel !== 'inherit') {
+          const normalizedModel = normalizeToCcAlias(configuredModel);
+          if (normalizedModel) {
+            updatedToolInput = { ...toolInput, model: normalizedModel };
+          }
+        }
       }
     }
 
@@ -1421,19 +1439,34 @@ async function main() {
 
     if (toolName === 'Task' || toolName === 'Agent') {
       const toolInput = data.toolInput || data.tool_input || null;
-      message = generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId);
+      // Reflect any injected per-agent model (issue #3242) in the advisory label.
+      message = generateAgentSpawnMessage(updatedToolInput || toolInput, stateDir, todoStatus, sessionId);
     } else {
       message = generateMessage(toolName, todoStatus, modeActive);
     }
     message = combineHookMessages(slopWarning, message);
 
+    // Carry any per-agent model injection (issue #3242) even when the advisory
+    // message is empty or throttled, so the configured model is always applied.
+    const modelInjection = updatedToolInput
+      ? { hookSpecificOutput: { hookEventName: 'PreToolUse', updatedInput: updatedToolInput } }
+      : null;
+
     if (!message) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify(
+        modelInjection
+          ? { continue: true, suppressOutput: true, ...modelInjection }
+          : { continue: true, suppressOutput: true }
+      ));
       return;
     }
 
     if (!shouldEmitAdvisoryMessage(stateDir, sessionId, message)) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify(
+        modelInjection
+          ? { continue: true, suppressOutput: true, ...modelInjection }
+          : { continue: true, suppressOutput: true }
+      ));
       return;
     }
 
@@ -1441,7 +1474,8 @@ async function main() {
       continue: true,
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
-        additionalContext: message
+        additionalContext: message,
+        ...(updatedToolInput ? { updatedInput: updatedToolInput } : {})
       }
     }, null, 2));
   } catch (error) {

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2151,3 +2151,115 @@ describe('pre-tool-enforcer force-agent-delegation enforcement', () => {
     expect(String(hookOutput.permissionDecisionReason)).toContain('Investigation budget');
   });
 });
+
+describe('pre-tool-enforcer agents.<name>.model injection (issue #3242)', () => {
+  let tempDir: string;
+  let xdgConfigHome: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pre-tool-enforcer-agent-model-'));
+    xdgConfigHome = join(tempDir, 'xdg-config');
+    mkdirSync(join(xdgConfigHome, 'claude-omc'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeUserConfig(jsonc: string): void {
+    writeFileSync(join(xdgConfigHome, 'claude-omc', 'config.jsonc'), jsonc);
+  }
+
+  function writeProjectConfig(jsonc: string): void {
+    const dir = join(tempDir, '.claude');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'omc.jsonc'), jsonc);
+  }
+
+  function run(input: Record<string, unknown>, env: Record<string, string> = {}): Record<string, unknown> {
+    return runPreToolEnforcerWithEnv(
+      { cwd: tempDir, ...input },
+      { XDG_CONFIG_HOME: xdgConfigHome, OMC_ROUTING_FORCE_INHERIT: 'false', ...env },
+    );
+  }
+
+  function updatedModel(output: Record<string, unknown>): unknown {
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown> | undefined;
+    const updatedInput = hookOutput?.updatedInput as Record<string, unknown> | undefined;
+    return updatedInput?.model;
+  }
+
+  it('injects configured model via updatedInput for native Task calls without a model param', () => {
+    writeUserConfig('{ "agents": { "explore": { "model": "sonnet" } } }');
+    const output = run({
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:explore', prompt: 'x', description: 'find files' },
+      session_id: 'session-3242-inject',
+    });
+    expect(updatedModel(output)).toBe('sonnet');
+  });
+
+  it('does not inject when no per-agent override is configured', () => {
+    writeUserConfig('{ "agents": {} }');
+    const output = run({
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:architect', prompt: 'x', description: 'design' },
+      session_id: 'session-3242-noop',
+    });
+    expect(updatedModel(output)).toBeUndefined();
+  });
+
+  it('preserves an explicit model param and does not inject', () => {
+    writeUserConfig('{ "agents": { "explore": { "model": "sonnet" } } }');
+    const output = run({
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:explore', model: 'opus', prompt: 'x', description: 'd' },
+      session_id: 'session-3242-explicit',
+    });
+    expect(updatedModel(output)).toBeUndefined();
+  });
+
+  it('normalizes full Claude model IDs to a CC tier alias', () => {
+    writeUserConfig('{ "agents": { "executor": { "model": "claude-opus-4-6" } } }');
+    const output = run({
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:executor', prompt: 'x', description: 'd' },
+      session_id: 'session-3242-normalize',
+    });
+    expect(updatedModel(output)).toBe('opus');
+  });
+
+  it('lets project config override user config', () => {
+    writeUserConfig('{ "agents": { "explore": { "model": "haiku" } } }');
+    writeProjectConfig('{ "agents": { "explore": { "model": "sonnet" } } }');
+    const output = run({
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:explore', prompt: 'x', description: 'd' },
+      session_id: 'session-3242-precedence',
+    });
+    expect(updatedModel(output)).toBe('sonnet');
+  });
+
+  it('resolves deprecated subagent aliases to the canonical config key', () => {
+    writeUserConfig('{ "agents": { "codeReviewer": { "model": "opus" } } }');
+    const output = run({
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:reviewer', prompt: 'x', description: 'd' },
+      session_id: 'session-3242-alias',
+    });
+    expect(updatedModel(output)).toBe('opus');
+  });
+
+  it('does not inject under forceInherit even when an override is configured', () => {
+    writeUserConfig('{ "agents": { "explore": { "model": "sonnet" } } }');
+    const output = run(
+      {
+        tool_name: 'Task',
+        toolInput: { subagent_type: 'oh-my-claudecode:explore', prompt: 'x', description: 'd' },
+        session_id: 'session-3242-force-inherit',
+      },
+      { OMC_ROUTING_FORCE_INHERIT: 'true' },
+    );
+    expect(updatedModel(output)).toBeUndefined();
+  });
+});

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2262,4 +2262,29 @@ describe('pre-tool-enforcer agents.<name>.model injection (issue #3242)', () => 
     );
     expect(updatedModel(output)).toBeUndefined();
   });
+
+  it('still injects the configured model when the advisory message is throttled (suppressOutput)', () => {
+    writeUserConfig('{ "agents": { "explore": { "model": "sonnet" } } }');
+    const input = {
+      tool_name: 'Task',
+      toolInput: { subagent_type: 'oh-my-claudecode:explore', prompt: 'x', description: 'find files' },
+      session_id: 'session-3242-throttle',
+    };
+    // Pin the throttle clock so the second identical call lands inside the cooldown
+    // window and is advisory-throttled.
+    const throttleEnv = {
+      OMC_PRE_TOOL_ADVISORY_COOLDOWN_MS: '5000',
+      OMC_PRE_TOOL_ADVISORY_NOW_MS: '1000',
+    };
+
+    const first = run(input, throttleEnv);
+    const throttled = run(input, throttleEnv);
+
+    // First call: advisory emitted alongside the injection.
+    expect(updatedModel(first)).toBe('sonnet');
+    // Second identical call: advisory suppressed, but the model injection MUST survive.
+    expect(throttled.suppressOutput).toBe(true);
+    expect(throttled.hookSpecificOutput).toBeDefined();
+    expect(updatedModel(throttled)).toBe('sonnet');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #3242. Per-agent model overrides (`agents.<name>.model` in `~/.config/claude-omc/config.jsonc`) were silently ignored for subagents spawned via Claude Code's native `Task`/`Agent` tool.

The resolution logic (`enforceModel()` in `src/features/delegation-enforcer.ts`) was only reachable through `src/hooks/bridge.ts`, which is **not** the registered hook. The actually-registered PreToolUse hook (`scripts/pre-tool-enforcer.mjs`) only denied calls or injected advisory text — it never rewrote the `model` param. So Claude Code fell back to the static `model:` in `agents/*.md` frontmatter and ignored the user's config.

## Change (Option A from the issue)

Wire per-agent model resolution into the registered hook:

- New `scripts/lib/agent-model-config.mjs` resolves `agents.<name>.model` from the user (`claude-omc/config.jsonc`) and project (`.claude/omc.jsonc`) configs. It mirrors `src` for config-dir resolution, JSONC comment stripping, the `AGENT_CONFIG_KEY_MAP`, and deprecated role aliases. Project config takes precedence over user config (matching `loadConfig()` merge order).
- In `scripts/pre-tool-enforcer.mjs`, for `Task`/`Agent` calls **without** an explicit `model` param when `forceInherit` is **off**, the resolved model is normalized to a CC tier alias and injected via `hookSpecificOutput.updatedInput` (the documented PreToolUse mechanism for rewriting tool input). The spawn-message label now reflects the injected model instead of always reading `(inherit)`.

### Contract preservation
- `forceInherit` path: unchanged (override is intentionally ignored).
- Explicit `model` param: preserved, no injection.
- No per-agent override configured: no injection (CC keeps reading the static frontmatter default).

## Tests

Added a focused describe block to `src/__tests__/pre-tool-enforcer.test.ts` covering: injection for a configured agent, no-op when unconfigured, explicit-model preservation, full-ID normalization, project-over-user precedence, deprecated-alias resolution, and forceInherit suppression.

Verification (focused):
- `pre-tool-enforcer.test.ts` `-t 3242`: 7 passed
- `pre-tool-enforcer`, `delegation-enforcer`, `bedrock-model-routing`, `bedrock-lm-suffix-hook`, `routing-force-inherit`: 206 passed
