### PR TITLE
feat(ask): add --effort flag to control codex reasoning effort

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -13,17 +13,36 @@ const PROVIDER_BINARIES = {
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
+const ASK_REASONING_EFFORT_ENV = 'OMC_ASK_REASONING_EFFORT';
+// Codex `model_reasoning_effort` levels. Also an injection allowlist, since the
+// value is interpolated into a `-c model_reasoning_effort=<level>` arg.
+const VALID_REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high', 'xhigh']);
+
+function resolveReasoningEffort(env = process.env) {
+  const raw = env[ASK_REASONING_EFFORT_ENV];
+  if (!raw) {
+    return null;
+  }
+  const level = raw.trim().toLowerCase();
+  return VALID_REASONING_EFFORTS.has(level) ? level : null;
+}
+
 /**
  * Build CLI args for a given provider.
  * - claude: `claude -p <prompt>`
- * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
+ * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox [-c model_reasoning_effort=<level>] <prompt>`
  * - gemini: `gemini -p <prompt> --yolo`
  * - grok: `grok -p <prompt> --always-approve` (headless mode takes the prompt
  *   as an arg; grok's stdin is reserved for ACP JSON-RPC, never the prompt)
  */
-function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
+function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false, reasoningEffort = null } = {}) {
   if (provider === 'codex') {
-    return ['exec', '--dangerously-bypass-approvals-and-sandbox', pipePromptViaStdin ? '-' : prompt];
+    const args = ['exec', '--dangerously-bypass-approvals-and-sandbox'];
+    if (reasoningEffort) {
+      args.push('-c', `model_reasoning_effort=${reasoningEffort}`);
+    }
+    args.push(pipePromptViaStdin ? '-' : prompt);
+    return args;
   }
   if (provider === 'gemini') {
     return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
@@ -53,6 +72,7 @@ const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
   console.error('Usage: omc ask <claude|codex|gemini|grok> "<prompt>"');
+  console.error('Codex reasoning effort: set OMC_ASK_REASONING_EFFORT=<minimal|low|medium|high|xhigh> (via `omc ask codex --effort <level>`)');
   console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|grok> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
@@ -238,7 +258,8 @@ async function main() {
   ensureBinary(provider, binary);
 
   const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt);
-  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin });
+  const reasoningEffort = resolveReasoningEffort();
+  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin, reasoningEffort });
   const run = spawnSync(binary, providerArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -108,6 +108,7 @@ function writeAdvisorStub(dir: string): string {
       '  prompt: process.argv[3],',
       '  originalTask: process.env.OMC_ASK_ORIGINAL_TASK ?? null,',
       '  passthrough: process.env.ASK_WRAPPER_TOKEN ?? null,',
+      '  reasoningEffort: process.env.OMC_ASK_REASONING_EFFORT ?? null,',
       '};',
       'process.stdout.write(JSON.stringify(payload));',
       'if (process.env.ASK_STUB_STDERR) process.stderr.write(process.env.ASK_STUB_STDERR);',
@@ -293,6 +294,33 @@ describe('parseAskArgs', () => {
   it('rejects unsupported provider matrix', () => {
     expect(() => parseAskArgs(['openai', 'hi'])).toThrow(/Invalid provider/i);
   });
+
+  it('parses --effort flag and equals syntax (case-insensitive)', () => {
+    expect(parseAskArgs(['codex', '--effort', 'xhigh', 'review', 'this'])).toEqual({
+      provider: 'codex',
+      prompt: 'review this',
+      reasoningEffort: 'xhigh',
+    });
+
+    expect(parseAskArgs(['codex', '--effort=HIGH', '--prompt', 'audit it'])).toEqual({
+      provider: 'codex',
+      prompt: 'audit it',
+      reasoningEffort: 'high',
+    });
+
+    expect(parseAskArgs(['codex', '--agent-prompt', 'critic', '--effort', 'xhigh', '--prompt', 'judge'])).toEqual({
+      provider: 'codex',
+      prompt: 'judge',
+      agentPromptRole: 'critic',
+      reasoningEffort: 'xhigh',
+    });
+  });
+
+  it('rejects invalid or missing --effort levels', () => {
+    expect(() => parseAskArgs(['codex', '--effort', 'turbo', 'go'])).toThrow(/Invalid --effort/i);
+    expect(() => parseAskArgs(['codex', '--effort=', 'go'])).toThrow(/Missing level after --effort/i);
+    expect(() => parseAskArgs(['codex', '--effort', '--prompt', 'go'])).toThrow(/Missing level after --effort/i);
+  });
 });
 
 describe('omc ask command', () => {
@@ -316,6 +344,7 @@ describe('omc ask command', () => {
         prompt: 'hello world',
         originalTask: 'hello world',
         passthrough: null,
+        reasoningEffort: null,
       });
     } finally {
       rmSync(wd, { recursive: true, force: true });
@@ -370,6 +399,7 @@ describe('omc ask command', () => {
         prompt: 'cli nested codex prompt',
         originalTask: 'cli nested codex prompt',
         passthrough: null,
+        reasoningEffort: null,
       });
     } finally {
       rmSync(wd, { recursive: true, force: true });
@@ -426,6 +456,28 @@ describe('omc ask command', () => {
       expect(payload.originalTask).toBe('ship feature');
       expect(payload.prompt).toContain('ROLE HEADER');
       expect(payload.prompt).toContain('ship feature');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('forwards --effort to the advisor as OMC_ASK_REASONING_EFFORT', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-effort-forward-'));
+    try {
+      const stubPath = writeAdvisorStub(wd);
+      const result = runCli(
+        ['ask', 'codex', '--effort', 'xhigh', '--prompt', 'judge the plan'],
+        wd,
+        { OMC_ASK_ADVISOR_SCRIPT: stubPath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.provider).toBe('codex');
+      expect(payload.prompt).toBe('judge the plan');
+      expect(payload.reasoningEffort).toBe('xhigh');
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }
@@ -594,6 +646,74 @@ describe('run-provider-advisor script contract', () => {
       expect(artifact).toContain('CODEX_OK');
       expect(artifact).not.toContain('RUST_LEAK');
       expect(artifact).not.toContain('trace');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('injects -c model_reasoning_effort=<level> for codex when OMC_ASK_REASONING_EFFORT is set', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-effort-args-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['codex', '--prompt', 'short prompt'],
+        wd,
+        {
+          SPAWN_CAPTURE_PATH: capturePath,
+          OMC_ASK_REASONING_EFFORT: 'xhigh',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+      }>;
+
+      const launch = calls.find((c) => c.args[0] === 'exec');
+      expect(launch).toBeDefined();
+      expect(launch!.args).toEqual([
+        'exec',
+        '--dangerously-bypass-approvals-and-sandbox',
+        '-c',
+        'model_reasoning_effort=xhigh',
+        'short prompt',
+      ]);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores an invalid OMC_ASK_REASONING_EFFORT instead of injecting it', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-effort-invalid-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['codex', '--prompt', 'short prompt'],
+        wd,
+        {
+          SPAWN_CAPTURE_PATH: capturePath,
+          OMC_ASK_REASONING_EFFORT: 'turbo; rm -rf /',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+      }>;
+
+      const launch = calls.find((c) => c.args[0] === 'exec');
+      expect(launch).toBeDefined();
+      expect(launch!.args).toEqual(['exec', '--dangerously-bypass-approvals-and-sandbox', 'short prompt']);
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -13,6 +13,7 @@ export const ASK_USAGE = [
   '   or: omc ask <claude|codex|gemini|grok> --prompt "<prompt>"',
   '   or: omc ask <claude|codex|gemini|grok> --agent-prompt <role> "<prompt>"',
   '   or: omc ask <claude|codex|gemini|grok> --agent-prompt=<role> --prompt "<prompt>"',
+  '   or: omc ask codex --effort <minimal|low|medium|high|xhigh> "<prompt>"',
 ].join('\n');
 
 const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'grok'] as const;
@@ -20,15 +21,22 @@ export type AskProvider = (typeof ASK_PROVIDERS)[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 
 const ASK_AGENT_PROMPT_FLAG = '--agent-prompt';
+const ASK_EFFORT_FLAG = '--effort';
 const SAFE_ROLE_PATTERN = /^[a-z][a-z0-9-]*$/;
+// Codex `model_reasoning_effort` levels. Doubles as an injection allowlist:
+// the value is interpolated into a `-c model_reasoning_effort=<level>` arg.
+const VALID_REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+const VALID_REASONING_EFFORT_SET = new Set<string>(VALID_REASONING_EFFORTS);
 const ASK_ADVISOR_SCRIPT_ENV = 'OMC_ASK_ADVISOR_SCRIPT';
 const ASK_ADVISOR_SCRIPT_ENV_ALIAS = 'OMX_ASK_ADVISOR_SCRIPT';
 const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
+const ASK_REASONING_EFFORT_ENV = 'OMC_ASK_REASONING_EFFORT';
 
 export interface ParsedAskArgs {
   provider: AskProvider;
   prompt: string;
   agentPromptRole?: string;
+  reasoningEffort?: string;
 }
 
 function askUsageError(reason: string): Error {
@@ -37,6 +45,16 @@ function askUsageError(reason: string): Error {
 
 function warnDeprecatedAlias(alias: string, canonical: string): void {
   process.stderr.write(`[ask] DEPRECATED: ${alias} is deprecated; use ${canonical} instead.\n`);
+}
+
+function normalizeReasoningEffort(raw: string): string {
+  const level = raw.trim().toLowerCase();
+  if (!VALID_REASONING_EFFORT_SET.has(level)) {
+    throw askUsageError(
+      `Invalid --effort "${raw}". Expected one of: ${VALID_REASONING_EFFORTS.join(', ')}.`,
+    );
+  }
+  return level;
 }
 
 function getPackageRoot(): string {
@@ -131,6 +149,7 @@ export function parseAskArgs(args: readonly string[]): ParsedAskArgs {
   }
 
   let agentPromptRole: string | undefined;
+  let reasoningEffort: string | undefined;
   let prompt = '';
 
   for (let i = 0; i < rest.length; i += 1) {
@@ -151,6 +170,25 @@ export function parseAskArgs(args: readonly string[]): ParsedAskArgs {
         throw askUsageError('Missing role after --agent-prompt=');
       }
       agentPromptRole = role;
+      continue;
+    }
+
+    if (token === ASK_EFFORT_FLAG) {
+      const level = rest[i + 1]?.trim();
+      if (!level || level.startsWith('-')) {
+        throw askUsageError('Missing level after --effort.');
+      }
+      reasoningEffort = normalizeReasoningEffort(level);
+      i += 1;
+      continue;
+    }
+
+    if (token.startsWith(`${ASK_EFFORT_FLAG}=`)) {
+      const level = token.slice(`${ASK_EFFORT_FLAG}=`.length).trim();
+      if (!level) {
+        throw askUsageError('Missing level after --effort=');
+      }
+      reasoningEffort = normalizeReasoningEffort(level);
       continue;
     }
 
@@ -177,6 +215,7 @@ export function parseAskArgs(args: readonly string[]): ParsedAskArgs {
     provider: provider as AskProvider,
     prompt,
     ...(agentPromptRole ? { agentPromptRole } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
   };
 }
 
@@ -241,6 +280,7 @@ export async function askCommand(args: string[]): Promise<void> {
       env: {
         ...process.env,
         [ASK_ORIGINAL_TASK_ENV]: parsed.prompt,
+        ...(parsed.reasoningEffort ? { [ASK_REASONING_EFFORT_ENV]: parsed.reasoningEffort } : {}),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     },


### PR DESCRIPTION
Fixes #3244

## What this does

Adds an `--effort <minimal|low|medium|high|xhigh>` flag to `omc ask` so callers can control Codex's reasoning effort per invocation:

```
omc ask codex --effort xhigh --agent-prompt critic "<prompt>"
```

When set, the advisor injects `-c model_reasoning_effort=<level>` into the `codex exec` argv. Without the flag, behavior is unchanged.

## Why

#627 added a per-call `reasoning_effort` parameter to the old `ask_codex` MCP tool, but #1442 (unify into `/ask`) routed everything through the `omc ask` CLI / `run-provider-advisor.js` path, which had no effort passthrough. So per-call effort regressed for the current `/ask` flow.

This matters for `--critic codex` / `--architect codex` passes: OMC's own runtime guidance tells the model to use `omc ask codex --agent-prompt <role> "<prompt>"` for those, and they're exactly the passes that want `xhigh`. With no way to express effort, the only way to guarantee `xhigh` was to bypass `omc ask` and hand-build `codex exec -c model_reasoning_effort=xhigh ...` — the drift #1806 set out to prevent (and it loses the `.omc/` ask artifact). This closes that gap.

## Implementation

- **`src/cli/ask.ts`** — parse `--effort <level>` and `--effort=<level>`; validate against an allowlist (`minimal|low|medium|high|xhigh`); forward to the advisor via the `OMC_ASK_REASONING_EFFORT` env var (same pattern as the existing `OMC_ASK_ORIGINAL_TASK` handoff).
- **`scripts/run-provider-advisor.js`** — read `OMC_ASK_REASONING_EFFORT`, re-validate against the same allowlist (defense-in-depth / injection protection since the value is interpolated into the `-c` arg), and for `codex` inject `-c model_reasoning_effort=<level>` ahead of the prompt. Non-codex providers ignore it.

The allowlist is the injection guard: an unrecognized value (including anything with shell metacharacters) is dropped rather than passed to `codex`.

## Tests

Added to `src/cli/__tests__/ask.test.ts`:
- `parseAskArgs` — flag + `=` syntax, case-insensitivity, combined with `--agent-prompt`, and rejection of invalid/missing levels.
- End-to-end — `omc ask codex --effort xhigh` forwards `OMC_ASK_REASONING_EFFORT` to the advisor.
- Advisor contract — codex launch args become `exec --dangerously-bypass-approvals-and-sandbox -c model_reasoning_effort=xhigh <prompt>` when the env is set, and an invalid value (e.g. `turbo; rm -rf /`) is **not** injected.

`npm run test:run`, `npm run lint`, and `tsc --noEmit` all pass. Per repo convention (cf. #3218), only source files are committed; `dist/`/`bridge/` build artifacts are left to the build/release pipeline.

## Notes / out of scope

`omc ask codex` always runs with `--dangerously-bypass-approvals-and-sandbox`, which is broader than a read-only critic pass needs. That's a separate concern from effort and not touched here.
