### PR TITLE
ci(npm-pack-test): harden global tarball install against ENOTEMPTY rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,13 +173,51 @@ jobs:
         run: |
           echo "📦 Creating tarball..."
           npm pack
-          
+
           TARBALL=$(ls -t oh-my-claude-sisyphus-*.tgz | head -1)
           echo "📦 Tarball: $TARBALL"
-          
+
+          # ENOTEMPTY hardening (mirrors .github/workflows/upgrade-test.yml):
+          # the global node_modules dir is reused across runs on self-hosted
+          # runners and inside the GitHub-hosted tool cache. A previously
+          # interrupted `npm install -g` can leave the resolved package dir
+          # and/or npm's staging temp dirs (`.oh-my-claude-sisyphus-*`) behind,
+          # so the next install fails with
+          #   npm ERR! ENOTEMPTY: directory not empty, rename
+          #     '.../oh-my-claude-sisyphus' -> '.../.oh-my-claude-sisyphus-XXXX'
+          # Remove any stale global package + npm staging dirs before
+          # installing, then retry a few times so a transient rename race does
+          # not fail the run. A persistent install failure still exits non-zero.
+          PKG=oh-my-claude-sisyphus
+          GLOBAL_ROOT="$(npm root -g)"
+
+          clean_stale_global_pkg() {
+            # `:?` guards against an empty GLOBAL_ROOT so we never rm -rf "/".
+            rm -rf "${GLOBAL_ROOT:?}/$PKG" 2>/dev/null || true
+            find "$GLOBAL_ROOT" -maxdepth 1 -name ".$PKG-*" -exec rm -rf {} + 2>/dev/null || true
+          }
+
           echo "📦 Testing global install from tarball..."
-          npm install -g ./$TARBALL
-          
+          clean_stale_global_pkg
+
+          ATTEMPTS=3
+          INSTALLED=false
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            echo "Installing $TARBALL globally (attempt $attempt/$ATTEMPTS)"
+            if npm install -g "./$TARBALL" --no-audit --no-fund; then
+              INSTALLED=true
+              break
+            fi
+            echo "Install attempt $attempt failed; cleaning stale global state and retrying."
+            clean_stale_global_pkg
+            sleep 2
+          done
+
+          if [ "$INSTALLED" != "true" ]; then
+            echo "❌ npm install -g ./$TARBALL failed after $ATTEMPTS attempts"
+            exit 1
+          fi
+
           echo "🔍 Checking omc command..."
           which omc
           


### PR DESCRIPTION
## Problem

The dev CI **`npm pack + install test`** job (workflow **CI**) fails at the
`npm pack test` step, right after packing the tarball at
`📦 Testing global install from tarball...`:

```
npm ERR! ENOTEMPTY: directory not empty, rename
  '/home/runner/work/_tool/node/20.20.2/x64/lib/node_modules/oh-my-claude-sisyphus'
  -> '/home/runner/work/_tool/node/20.20.2/x64/lib/node_modules/.oh-my-claude-sisyphus-...'
```

Failing run: https://github.com/Yeachan-Heo/oh-my-claudecode/actions/runs/27388007611

The step installed the freshly packed tarball with a bare
`npm install -g ./$TARBALL`. The global `node_modules` dir is reused across runs
on self-hosted runners and inside the GitHub-hosted tool cache, so a previously
interrupted global install can leave the resolved package dir and/or npm's
staging temp dirs (`.oh-my-claude-sisyphus-*`) behind. The next install then
fails the rename with `ENOTEMPTY`.

## Fix

Mirror the proven #3256 hardening from `.github/workflows/upgrade-test.yml` in
the CI npm pack/install smoke path:

- Resolve `GLOBAL_ROOT="$(npm root -g)"` and add a `clean_stale_global_pkg`
  helper that removes the resolved global package dir plus any leftover npm
  staging temp dirs (`.oh-my-claude-sisyphus-*`). The `${GLOBAL_ROOT:?}` guard
  prevents an accidental `rm -rf "/"`.
- Clean stale state before installing, then retry the global install up to 3
  times, cleaning between attempts so a transient rename race does not fail the
  run.
- A persistent install failure still exits non-zero — real failures are **not**
  masked. The existing `omc --version` / `omc --help` verification is unchanged,
  so the local tarball is still globally installed and verified.

Scope is limited to the `npm pack test` step in `.github/workflows/ci.yml`.
No product behavior changes.

## Verification

- `python3 yaml.safe_load` parses `.github/workflows/ci.yml` cleanly; step present.
- `bash -n` on the extracted embedded script: syntax OK.
- Simulated the cleanup + retry logic in isolation:
  - stale package dir + `.oh-my-claude-sisyphus-*` staging dir removed; unrelated package preserved.
  - flaky install (fails attempt 1, succeeds attempt 2) recovered → `INSTALLED=true`.
  - empty `GLOBAL_ROOT` rejected by `:?` guard (no `rm -rf "/"`).

## Acceptance criteria

1. ✅ CI npm pack + install test no longer fails on npm global ENOTEMPTY rename.
2. ✅ The local tarball is still globally installed and verified (`omc --version` / `--help`).
3. ✅ Lightweight validation of changed workflow syntax/behavior run (YAML parse, `bash -n`, logic simulation).
4. ✅ Commit + branch pushed + PR to dev.
