### PR TITLE
Add user-extensible agent registry

### DIFF
--- a/src/__tests__/agent-registry.test.ts
+++ b/src/__tests__/agent-registry.test.ts
@@ -1,8 +1,12 @@
-import { beforeEach, afterEach, describe, test, expect } from 'vitest';
+import { beforeEach, afterEach, describe, test, expect, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
 import { getAgentDefinitions } from '../agents/definitions.js';
+import { loadAgentPrompt } from '../agents/utils.js';
+import { loadConfig } from '../config/loader.js';
+import { createOmcSession } from '../index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,20 +27,29 @@ const MODEL_ENV_KEYS = [
   'OMC_MODEL_MEDIUM',
   'OMC_MODEL_LOW',
   'OMC_ROUTING_FORCE_INHERIT',
+  'XDG_CONFIG_HOME',
 ] as const;
 
 describe('Agent Registry Validation', () => {
   let savedEnv: Record<string, string | undefined>;
+  let originalCwd: string;
+  let tempDir: string;
 
   beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'omc-agent-registry-'));
+    process.chdir(tempDir);
+
     savedEnv = {};
     for (const key of MODEL_ENV_KEYS) {
       savedEnv[key] = process.env[key];
       delete process.env[key];
     }
+    process.env.XDG_CONFIG_HOME = path.join(tempDir, 'config');
   });
 
   afterEach(() => {
+    process.chdir(originalCwd);
     for (const key of MODEL_ENV_KEYS) {
       if (savedEnv[key] === undefined) {
         delete process.env[key];
@@ -44,6 +57,7 @@ describe('Agent Registry Validation', () => {
         process.env[key] = savedEnv[key];
       }
     }
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
   test('agent count matches documentation', () => {
     const agentsDir = path.join(__dirname, '../../agents');
@@ -209,5 +223,225 @@ describe('Agent Registry Validation', () => {
       const content = fs.readFileSync(path.join(agentsDir, `${name}.ts`), 'utf-8');
       expect(content, `Hardcoded prompt found in ${name}.ts`).not.toMatch(/const\s+\w+_PROMPT\s*=\s*`/);
     }
+  });
+
+  test('discovers project custom agents with Claude Code frontmatter and omc metadata', () => {
+    const customAgentsDir = path.join(tempDir, '.omc', 'agents');
+    fs.mkdirSync(customAgentsDir, { recursive: true });
+    fs.writeFileSync(path.join(customAgentsDir, 'proto-reviewer.md'), `---
+name: proto-reviewer
+description: Reviews protobuf schema changes (Sonnet)
+model: sonnet
+disallowedTools: Write, Edit
+omc:
+  category: reviewer
+  cost: CHEAP
+  promptAlias: proto
+  triggers:
+    - domain: protobuf schemas
+      trigger: ".proto files added or modified"
+  useWhen:
+    - "Schema review before merge"
+  avoidWhen:
+    - "General code review"
+---
+
+<Agent_Prompt>
+Review protobuf compatibility.
+</Agent_Prompt>
+`);
+
+    const agents = getAgentDefinitions();
+
+    expect(agents['proto-reviewer']).toMatchObject({
+      name: 'proto-reviewer',
+      description: 'Reviews protobuf schema changes (Sonnet)',
+      model: 'sonnet',
+      defaultModel: 'sonnet',
+      disallowedTools: ['Write', 'Edit'],
+    });
+    expect(agents['proto-reviewer']?.prompt).toContain('Review protobuf compatibility.');
+    expect(agents['proto-reviewer']?.metadata).toMatchObject({
+      category: 'reviewer',
+      cost: 'CHEAP',
+      promptAlias: 'proto',
+      triggers: [{ domain: 'protobuf schemas', trigger: '.proto files added or modified' }],
+      useWhen: ['Schema review before merge'],
+      avoidWhen: ['General code review'],
+    });
+  });
+
+  test('project custom agents override user custom agents with the same name', () => {
+    const userAgentsDir = path.join(process.env.XDG_CONFIG_HOME!, 'claude-omc', 'agents');
+    const projectAgentsDir = path.join(tempDir, '.omc', 'agents');
+    fs.mkdirSync(userAgentsDir, { recursive: true });
+    fs.mkdirSync(projectAgentsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(userAgentsDir, 'domain-agent.md'), `---
+name: domain-agent
+description: User version
+---
+
+user prompt
+`);
+    fs.writeFileSync(path.join(projectAgentsDir, 'domain-agent.md'), `---
+name: domain-agent
+description: Project version
+---
+
+project prompt
+`);
+
+    const agents = getAgentDefinitions();
+
+    expect(agents['domain-agent']?.description).toBe('Project version');
+    expect(agents['domain-agent']?.prompt).toBe('project prompt');
+  });
+
+  test('rejects custom agents that collide with built-ins by default', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const customAgentsDir = path.join(tempDir, '.omc', 'agents');
+    fs.mkdirSync(customAgentsDir, { recursive: true });
+    fs.writeFileSync(path.join(customAgentsDir, 'executor.md'), `---
+name: executor
+description: Replacement executor
+---
+
+custom executor prompt
+`);
+
+    const agents = getAgentDefinitions();
+
+    expect(agents.executor?.description).not.toBe('Replacement executor');
+    expect(agents.executor?.prompt).not.toBe('custom executor prompt');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('collides with a built-in agent'));
+    warn.mockRestore();
+  });
+
+  test('team.roleRouting accepts discovered custom agent names', () => {
+    const customAgentsDir = path.join(tempDir, '.omc', 'agents');
+    const claudeDir = path.join(tempDir, '.claude');
+    fs.mkdirSync(customAgentsDir, { recursive: true });
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(customAgentsDir, 'proto-reviewer.md'), `---
+name: proto-reviewer
+description: Reviews protobuf schema changes
+---
+
+Review protobuf compatibility.
+`);
+    fs.writeFileSync(path.join(claudeDir, 'omc.jsonc'), JSON.stringify({
+      team: {
+        roleRouting: {
+          'code-reviewer': { agent: 'proto-reviewer' },
+        },
+      },
+    }));
+
+    expect(() => loadConfig()).not.toThrow();
+    expect(loadConfig().team?.roleRouting?.['code-reviewer']?.agent).toBe('proto-reviewer');
+  });
+
+  test('team.roleRouting accepts built-in registry names in addition to config keys', () => {
+    const claudeDir = path.join(tempDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, 'omc.jsonc'), JSON.stringify({
+      team: {
+        roleRouting: {
+          critic: { agent: 'code-reviewer' },
+        },
+      },
+    }));
+
+    expect(() => loadConfig()).not.toThrow();
+    expect(loadConfig().team?.roleRouting?.critic?.agent).toBe('code-reviewer');
+  });
+
+  test('scans extra customAgents.dirs relative to the project root', () => {
+    const extraDir = path.join(tempDir, 'team-agents');
+    fs.mkdirSync(extraDir, { recursive: true });
+    fs.writeFileSync(path.join(extraDir, 'release-checker.md'), `---
+name: release-checker
+description: Reviews release readiness
+---
+
+Check release notes and versioning.
+`);
+
+    const agents = getAgentDefinitions({
+      config: {
+        customAgents: {
+          enabled: true,
+          dirs: ['./team-agents'],
+        },
+      },
+    });
+
+    expect(agents['release-checker']?.description).toBe('Reviews release readiness');
+  });
+
+  test('allows custom agents to override built-ins only with omc.overrideBuiltin', () => {
+    const customAgentsDir = path.join(tempDir, '.omc', 'agents');
+    fs.mkdirSync(customAgentsDir, { recursive: true });
+    fs.writeFileSync(path.join(customAgentsDir, 'executor.md'), `---
+name: executor
+description: Project executor override
+omc:
+  overrideBuiltin: true
+---
+
+project executor prompt
+`);
+
+    const agents = getAgentDefinitions();
+
+    expect(agents.executor?.description).toBe('Project executor override');
+    expect(agents.executor?.prompt).toBe('project executor prompt');
+  });
+
+  test('loadAgentPrompt can read custom agent prompts from project source dir', () => {
+    const customAgentsDir = path.join(tempDir, '.omc', 'agents');
+    fs.mkdirSync(customAgentsDir, { recursive: true });
+    fs.writeFileSync(path.join(customAgentsDir, 'schema-critic.md'), `---
+name: schema-critic
+description: Reviews schema changes
+---
+
+Review schemas from the custom source directory.
+`);
+
+    expect(loadAgentPrompt('schema-critic')).toBe('Review schemas from the custom source directory.');
+  });
+
+  test('adds custom agents with metadata to generated orchestrator prompt sections', () => {
+    const customAgentsDir = path.join(tempDir, '.omc', 'agents');
+    fs.mkdirSync(customAgentsDir, { recursive: true });
+    fs.writeFileSync(path.join(customAgentsDir, 'schema-critic.md'), `---
+name: schema-critic
+description: Reviews schema changes
+omc:
+  category: reviewer
+  cost: CHEAP
+  promptAlias: schema
+  triggers:
+    - domain: database schemas
+      trigger: "schema files changed"
+  useWhen:
+    - "Schema compatibility review"
+  avoidWhen:
+    - "General implementation"
+---
+
+Review schemas from the custom source directory.
+`);
+
+    const session = createOmcSession();
+    const systemPrompt = session.queryOptions.options.systemPrompt;
+
+    expect(systemPrompt).toContain('## Custom Subagents');
+    expect(systemPrompt).toContain('**schema-critic**');
+    expect(systemPrompt).toContain('| schema | CHEAP | database schemas: schema files changed |');
+    expect(systemPrompt).toContain('**database schemas** → schema: schema files changed');
+    expect(systemPrompt).toContain('### schema-critic Use/Avoid Guidance');
   });
 });

--- a/src/agents/custom-registry.ts
+++ b/src/agents/custom-registry.ts
@@ -1,0 +1,409 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { basename, join, resolve } from 'path';
+
+import type { PluginConfig } from '../shared/types.js';
+import { getConfigDir } from '../utils/paths.js';
+import type {
+  AgentCategory,
+  AgentConfig,
+  AgentCost,
+  AgentPromptMetadata,
+  DelegationTrigger,
+} from './types.js';
+
+const SAFE_AGENT_NAME = /^[a-z0-9-]+$/i;
+const AGENT_CATEGORIES = new Set<AgentCategory>([
+  'exploration',
+  'specialist',
+  'advisor',
+  'utility',
+  'orchestration',
+  'planner',
+  'reviewer',
+]);
+const AGENT_COSTS = new Set<AgentCost>(['FREE', 'CHEAP', 'EXPENSIVE']);
+const DEFAULT_MAX_CUSTOM_AGENTS = 20;
+
+type FrontmatterValue = string | string[] | Array<string | Record<string, string>> | Record<string, unknown>;
+type FrontmatterObject = Record<string, FrontmatterValue>;
+
+export interface CustomAgentDiscoveryResult {
+  agents: Record<string, AgentConfig>;
+  warnings: string[];
+}
+
+export function getCustomAgentDirs(config?: PluginConfig, cwd: string = process.cwd()): string[] {
+  const customConfig = config?.customAgents;
+  if (customConfig?.enabled === false) {
+    return [];
+  }
+
+  const dirs = [
+    join(getConfigDir(), 'claude-omc', 'agents'),
+    ...(customConfig?.dirs ?? []).map(dir => resolve(cwd, dir)),
+    join(cwd, '.omc', 'agents'),
+  ];
+
+  return [...new Set(dirs.map(dir => resolve(dir)))];
+}
+
+export function discoverCustomAgents(
+  config?: PluginConfig,
+  options?: {
+    builtInNames?: Iterable<string>;
+    cwd?: string;
+    maxAgents?: number;
+  },
+): CustomAgentDiscoveryResult {
+  const cwd = options?.cwd ?? process.cwd();
+  const builtInNames = new Set(options?.builtInNames ?? []);
+  const maxAgents = options?.maxAgents ?? config?.customAgents?.maxAgents ?? DEFAULT_MAX_CUSTOM_AGENTS;
+  const warnings: string[] = [];
+  const agents: Record<string, AgentConfig> = {};
+  let acceptedCount = 0;
+
+  for (const dir of getCustomAgentDirs(config, cwd)) {
+    if (!existsSync(dir)) continue;
+
+    let files: string[];
+    try {
+      files = readdirSync(dir)
+        .filter(file => file.endsWith('.md') && file !== 'AGENTS.md')
+        .sort((a, b) => a.localeCompare(b));
+    } catch (error) {
+      warnings.push(`Could not scan custom agents directory ${dir}: ${formatError(error)}`);
+      continue;
+    }
+
+    for (const file of files) {
+      if (acceptedCount >= maxAgents) {
+        warnings.push(`Skipping ${join(dir, file)}: customAgents.maxAgents limit (${maxAgents}) reached`);
+        continue;
+      }
+
+      const filePath = join(dir, file);
+      const parsed = parseCustomAgentFile(filePath);
+      if (!parsed.agent) {
+        warnings.push(...parsed.warnings);
+        continue;
+      }
+
+      const overrideBuiltin = parsed.overrideBuiltin === true;
+      if (builtInNames.has(parsed.agent.name) && !overrideBuiltin) {
+        warnings.push(`Skipping ${filePath}: custom agent "${parsed.agent.name}" collides with a built-in agent`);
+        continue;
+      }
+
+      const isReplacement = agents[parsed.agent.name] !== undefined;
+      agents[parsed.agent.name] = parsed.agent;
+      warnings.push(...parsed.warnings);
+      if (!isReplacement) acceptedCount++;
+    }
+  }
+
+  return { agents, warnings };
+}
+
+export function getDiscoveredCustomAgentNames(config?: PluginConfig): string[] {
+  return Object.keys(discoverCustomAgents(config).agents);
+}
+
+export function loadCustomAgentPrompt(agentName: string, config?: PluginConfig): string | undefined {
+  if (!SAFE_AGENT_NAME.test(agentName)) {
+    return undefined;
+  }
+
+  for (const dir of getCustomAgentDirs(config).reverse()) {
+    const filePath = join(dir, `${agentName}.md`);
+    if (!existsSync(filePath)) continue;
+    const parsed = parseCustomAgentFile(filePath);
+    if (parsed.agent?.name === agentName) {
+      return parsed.agent.prompt;
+    }
+  }
+
+  return undefined;
+}
+
+function parseCustomAgentFile(filePath: string): {
+  agent?: AgentConfig;
+  overrideBuiltin?: boolean;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  let content: string;
+
+  try {
+    if (!statSync(filePath).isFile()) {
+      return { warnings: [`Skipping ${filePath}: not a regular file`] };
+    }
+    content = readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    return { warnings: [`Skipping ${filePath}: ${formatError(error)}`] };
+  }
+
+  const { frontmatter, body } = parseFrontmatterObject(content);
+  const fallbackName = basename(filePath, '.md');
+  const name = asString(frontmatter.name) || fallbackName;
+  const description = asString(frontmatter.description);
+  const metadata = parseOmcMetadata(frontmatter.omc, warnings, filePath);
+
+  const agent: AgentConfig = {
+    name,
+    description: description ?? '',
+    prompt: body.trim(),
+    model: asString(frontmatter.model),
+    defaultModel: asString(frontmatter.defaultModel) ?? asString(frontmatter.model),
+    tools: asStringList(frontmatter.tools),
+    disallowedTools: asStringList(frontmatter.disallowedTools),
+    metadata,
+  };
+
+  if (!SAFE_AGENT_NAME.test(agent.name)) {
+    warnings.push(`Skipping ${filePath}: invalid custom agent name "${agent.name}"`);
+    return { warnings };
+  }
+
+  const validationErrors = validateParsedAgentConfig(agent);
+  if (validationErrors.length > 0) {
+    warnings.push(`Skipping ${filePath}: ${validationErrors.join('; ')}`);
+    return { warnings };
+  }
+
+  const omc = isRecord(frontmatter.omc) ? frontmatter.omc : undefined;
+  return {
+    agent,
+    overrideBuiltin: asBoolean(omc?.overrideBuiltin),
+    warnings,
+  };
+}
+
+function validateParsedAgentConfig(config: AgentConfig): string[] {
+  const errors: string[] = [];
+  if (!config.name) errors.push('Agent name is required');
+  if (!config.description) errors.push('Agent description is required');
+  if (!config.prompt) errors.push('Agent prompt is required');
+  return errors;
+}
+
+function parseFrontmatterObject(content: string): { frontmatter: FrontmatterObject; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) {
+    return { frontmatter: {}, body: content };
+  }
+
+  return {
+    frontmatter: parseYamlSubset(match[1]),
+    body: match[2],
+  };
+}
+
+function parseYamlSubset(yaml: string): FrontmatterObject {
+  const root: FrontmatterObject = {};
+  const lines = yaml.replace(/\t/g, '  ').split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index++) {
+    const rawLine = lines[index];
+    if (!rawLine.trim() || rawLine.trimStart().startsWith('#')) continue;
+    if (/^\s/.test(rawLine)) continue;
+
+    const separator = rawLine.indexOf(':');
+    if (separator === -1) continue;
+    const key = rawLine.slice(0, separator).trim();
+    const rawValue = rawLine.slice(separator + 1).trim();
+
+    if (rawValue) {
+      root[key] = parseScalarOrInlineList(rawValue);
+      continue;
+    }
+
+    const block = collectIndentedBlock(lines, index + 1);
+    if (block.lines.length === 0) {
+      root[key] = '';
+      continue;
+    }
+
+    root[key] = parseIndentedBlock(block.lines);
+    index = block.endIndex - 1;
+  }
+
+  return root;
+}
+
+function collectIndentedBlock(lines: string[], startIndex: number): { lines: string[]; endIndex: number } {
+  const block: string[] = [];
+  let index = startIndex;
+  for (; index < lines.length; index++) {
+    const line = lines[index];
+    if (!line.trim()) {
+      block.push(line);
+      continue;
+    }
+    if (!/^\s/.test(line)) break;
+    block.push(line.replace(/^\s{2}/, ''));
+  }
+  return { lines: block, endIndex: index };
+}
+
+function parseIndentedBlock(lines: string[]): FrontmatterValue {
+  const meaningful = lines.filter(line => line.trim().length > 0);
+  if (meaningful[0]?.trimStart().startsWith('- ')) {
+    return parseYamlList(meaningful);
+  }
+
+  const record: Record<string, unknown> = {};
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (!line.trim() || /^\s/.test(line)) continue;
+    const separator = line.indexOf(':');
+    if (separator === -1) continue;
+
+    const key = line.slice(0, separator).trim();
+    const rawValue = line.slice(separator + 1).trim();
+    if (rawValue) {
+      record[key] = parseScalarOrInlineList(rawValue);
+      continue;
+    }
+
+    const block = collectIndentedBlock(lines, index + 1);
+    record[key] = parseIndentedBlock(block.lines);
+    index = block.endIndex - 1;
+  }
+  return record;
+}
+
+function parseYamlList(lines: string[]): Array<string | Record<string, string>> {
+  const items: Array<string | Record<string, string>> = [];
+  for (let index = 0; index < lines.length; index++) {
+    const trimmed = lines[index].trimStart();
+    if (!trimmed.startsWith('- ')) continue;
+    const value = trimmed.slice(2).trim();
+
+    if (!value.includes(':')) {
+      items.push(stripOptionalQuotes(value));
+      continue;
+    }
+
+    const item: Record<string, string> = {};
+    const firstSeparator = value.indexOf(':');
+    item[value.slice(0, firstSeparator).trim()] = stripOptionalQuotes(value.slice(firstSeparator + 1));
+
+    for (let next = index + 1; next < lines.length; next++) {
+      const continuation = lines[next];
+      if (!/^\s{2,}\S/.test(continuation)) break;
+      const separator = continuation.indexOf(':');
+      if (separator !== -1) {
+        item[continuation.slice(0, separator).trim()] = stripOptionalQuotes(continuation.slice(separator + 1));
+        index = next;
+      }
+    }
+
+    items.push(item);
+  }
+  return items;
+}
+
+function parseScalarOrInlineList(value: string): string | string[] {
+  const trimmed = stripOptionalQuotes(value);
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(',').map(item => stripOptionalQuotes(item)).filter(Boolean);
+  }
+  if (trimmed.includes(',') && /^[A-Za-z0-9_, -]+$/.test(trimmed)) {
+    return trimmed.split(',').map(item => stripOptionalQuotes(item)).filter(Boolean);
+  }
+  return trimmed;
+}
+
+function parseOmcMetadata(value: FrontmatterValue | undefined, warnings: string[], filePath: string): AgentPromptMetadata | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    warnings.push(`Ignoring omc metadata in ${filePath}: expected an object`);
+    return undefined;
+  }
+
+  const category = asString(value.category);
+  const cost = asString(value.cost);
+  const hasPromptMetadata = category !== undefined ||
+    cost !== undefined ||
+    value.promptAlias !== undefined ||
+    value.triggers !== undefined ||
+    value.useWhen !== undefined ||
+    value.avoidWhen !== undefined ||
+    value.promptDescription !== undefined ||
+    value.tools !== undefined;
+  if (!hasPromptMetadata) {
+    return undefined;
+  }
+
+  if (!category || !AGENT_CATEGORIES.has(category as AgentCategory)) {
+    warnings.push(`Ignoring omc metadata in ${filePath}: invalid category "${String(category)}"`);
+    return undefined;
+  }
+  if (!cost || !AGENT_COSTS.has(cost as AgentCost)) {
+    warnings.push(`Ignoring omc metadata in ${filePath}: invalid cost "${String(cost)}"`);
+    return undefined;
+  }
+
+  return {
+    category: category as AgentCategory,
+    cost: cost as AgentCost,
+    promptAlias: asString(value.promptAlias),
+    triggers: parseTriggers(value.triggers).slice(0, 3),
+    useWhen: asStringList(value.useWhen),
+    avoidWhen: asStringList(value.avoidWhen),
+    promptDescription: asString(value.promptDescription),
+    tools: asStringList(value.tools),
+  };
+}
+
+function parseTriggers(value: unknown): DelegationTrigger[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap(item => {
+    if (!isRecord(item)) return [];
+    const domain = asString(item.domain);
+    const trigger = asString(item.trigger);
+    return domain && trigger ? [{ domain, trigger }] : [];
+  });
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asStringList(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const items = value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+    return items.length > 0 ? items : undefined;
+  }
+  const single = asString(value);
+  return single ? [single] : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return undefined;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stripOptionalQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/agents/definitions.ts
+++ b/src/agents/definitions.ts
@@ -8,11 +8,13 @@
  * 4. omcSystemPrompt for the main orchestrator
  */
 
-import type { AgentConfig, PluginConfig } from '../shared/types.js';
+import type { PluginConfig } from '../shared/types.js';
+import type { AgentConfig } from './types.js';
 import { loadAgentPrompt, parseDisallowedTools } from './utils.js';
 import { loadConfig } from '../config/loader.js';
 import { resolveInheritedModelFromEnv } from '../config/models.js';
 import { appendSkininthegamebrosGuidance } from './skininthegamebros-guidance.js';
+import { discoverCustomAgents } from './custom-registry.js';
 
 // Re-export base agents from individual files (rebranded names)
 export { architectAgent } from './architect.js';
@@ -177,40 +179,8 @@ function getConfiguredAgentModel(name: string, config: PluginConfig): string | u
   return key ? config.agents?.[key]?.model : undefined;
 }
 
-// ============================================================
-// AGENT REGISTRY
-// ============================================================
-
-/**
- * Agent Role Disambiguation
- *
- * HIGH-tier review/planning agents have distinct, non-overlapping roles:
- *
- * | Agent | Role | What They Do | What They Don't Do |
- * |-------|------|--------------|-------------------|
- * | architect | code-analysis | Analyze code, debug, verify | Requirements, plan creation, plan review |
- * | analyst | requirements-analysis | Find requirement gaps | Code analysis, planning, plan review |
- * | planner | plan-creation | Create work plans | Requirements, code analysis, plan review |
- * | critic | plan-review | Review plan quality | Requirements, code analysis, plan creation |
- *
- * Workflow: explore → analyst → planner → critic → executor → architect (verify)
- */
-
-/**
- * Get all agent definitions as a record for use with Claude Agent SDK
- */
-export function getAgentDefinitions(options?: {
-  overrides?: Partial<Record<string, Partial<AgentConfig>>>;
-  config?: PluginConfig;
-}): Record<string, {
-  description: string;
-  prompt: string;
-  tools?: string[];
-  disallowedTools?: string[];
-  model?: string;
-  defaultModel?: string;
-}> {
-  const agents: Record<string, AgentConfig> = {
+function getBuiltInAgentDefinitions(): Record<string, AgentConfig> {
+  return {
     // ============================================================
     // BUILD/ANALYSIS LANE
     // ============================================================
@@ -250,21 +220,63 @@ export function getAgentDefinitions(options?: {
     // ============================================================
     'document-specialist': documentSpecialistAgent
   };
+}
 
+export const BUILT_IN_AGENT_NAMES = Object.keys(getBuiltInAgentDefinitions()).sort((a, b) => a.localeCompare(b));
+
+// ============================================================
+// AGENT REGISTRY
+// ============================================================
+
+/**
+ * Agent Role Disambiguation
+ *
+ * HIGH-tier review/planning agents have distinct, non-overlapping roles:
+ *
+ * | Agent | Role | What They Do | What They Don't Do |
+ * |-------|------|--------------|-------------------|
+ * | architect | code-analysis | Analyze code, debug, verify | Requirements, plan creation, plan review |
+ * | analyst | requirements-analysis | Find requirement gaps | Code analysis, planning, plan review |
+ * | planner | plan-creation | Create work plans | Requirements, code analysis, plan review |
+ * | critic | plan-review | Review plan quality | Requirements, code analysis, plan creation |
+ *
+ * Workflow: explore → analyst → planner → critic → executor → architect (verify)
+ */
+
+/**
+ * Get all agent definitions as a record for use with Claude Agent SDK
+ */
+export function getAgentDefinitions(options?: {
+  overrides?: Partial<Record<string, Partial<AgentConfig>>>;
+  config?: PluginConfig;
+}): Record<string, AgentConfig> {
   const resolvedConfig = options?.config ?? loadConfig();
+  const builtInAgents = getBuiltInAgentDefinitions();
+  const discovered = discoverCustomAgents(resolvedConfig, {
+    builtInNames: Object.keys(builtInAgents),
+  });
+  for (const warning of discovered.warnings) {
+    console.warn(`[custom-agents] ${warning}`);
+  }
+  const agents: Record<string, AgentConfig> = {
+    ...builtInAgents,
+    ...discovered.agents,
+  };
   const inheritModel = resolvedConfig.routing?.forceInherit
     ? resolveInheritedModelFromEnv()
     : undefined;
-  const result: Record<string, { description: string; prompt: string; tools?: string[]; disallowedTools?: string[]; model?: string; defaultModel?: string }> = {};
+  const result: Record<string, AgentConfig> = {};
 
   for (const [name, agentConfig] of Object.entries(agents)) {
     const override = options?.overrides?.[name];
     const configuredModel = getConfiguredAgentModel(name, resolvedConfig);
-    const disallowedTools = agentConfig.disallowedTools ?? parseDisallowedTools(name);
+    const isBuiltInAgent = builtInAgents[name] !== undefined;
+    const disallowedTools = agentConfig.disallowedTools ?? (isBuiltInAgent ? parseDisallowedTools(name) : undefined);
     const resolvedModel = override?.model ?? inheritModel ?? configuredModel ?? agentConfig.model;
     const resolvedDefaultModel = override?.defaultModel ?? agentConfig.defaultModel;
 
     result[name] = {
+      name,
       description: override?.description ?? agentConfig.description,
       prompt: appendSkininthegamebrosGuidance(
         override?.prompt ?? agentConfig.prompt,
@@ -274,6 +286,7 @@ export function getAgentDefinitions(options?: {
       disallowedTools,
       model: resolvedModel,
       defaultModel: resolvedDefaultModel,
+      metadata: override?.metadata ?? agentConfig.metadata,
     };
   }
 

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -10,6 +10,7 @@
 import { readFileSync } from 'fs';
 import { join, dirname, basename, resolve, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
+import { loadCustomAgentPrompt } from './custom-registry.js';
 
 import type {
   AgentConfig,
@@ -118,6 +119,11 @@ export function loadAgentPrompt(agentName: string): string {
     const content = readFileSync(agentPath, 'utf-8');
     return stripFrontmatter(content);
   } catch (error) {
+    const customPrompt = loadCustomAgentPrompt(agentName);
+    if (customPrompt) {
+      return customPrompt;
+    }
+
     // Don't leak internal paths in error messages
     const message = error instanceof Error && error.message.includes('Invalid agent name')
       ? error.message

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -17,8 +17,10 @@ import type {
 } from "../shared/types.js";
 import {
   CANONICAL_TEAM_ROLES,
+  KNOWN_AGENT_REGISTRY_NAMES,
   KNOWN_AGENT_NAMES,
 } from "../shared/types.js";
+import { getDiscoveredCustomAgentNames } from "../agents/custom-registry.js";
 import { getConfigDir } from "../utils/paths.js";
 import { parseJsonc } from "../utils/jsonc.js";
 import {
@@ -165,6 +167,11 @@ export function buildDefaultConfig(): PluginConfig {
     team: {
       ops: {},
       roleRouting: {},
+    },
+    customAgents: {
+      enabled: true,
+      dirs: [],
+      maxAgents: 20,
     },
     planOutput: {
       directory: ".omc/plans",
@@ -518,6 +525,11 @@ export function validateTeamConfig(config: PluginConfig): void {
 
   const roleRouting = team.roleRouting as Record<string, unknown> | undefined;
   if (!roleRouting || typeof roleRouting !== "object") return;
+  const allowedAgentNames = new Set<string>([
+    ...KNOWN_AGENT_NAME_SET,
+    ...KNOWN_AGENT_REGISTRY_NAMES,
+    ...getDiscoveredCustomAgentNames(config),
+  ]);
 
   for (const [rawRoleKey, rawSpec] of Object.entries(roleRouting)) {
     const normalized = normalizeDelegationRole(rawRoleKey);
@@ -566,9 +578,9 @@ export function validateTeamConfig(config: PluginConfig): void {
     }
 
     if (spec.agent !== undefined) {
-      if (typeof spec.agent !== "string" || !KNOWN_AGENT_NAME_SET.has(spec.agent)) {
+      if (typeof spec.agent !== "string" || !allowedAgentNames.has(spec.agent)) {
         throw new Error(
-          `[OMC] team.roleRouting.${rawRoleKey}.agent: unknown agent "${String(spec.agent)}". Allowed: ${[...KNOWN_AGENT_NAME_SET].join(", ")}`,
+          `[OMC] team.roleRouting.${rawRoleKey}.agent: unknown agent "${String(spec.agent)}". Allowed: ${[...allowedAgentNames].join(", ")}`,
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@
  */
 
 import { loadConfig, findContextFiles, loadContextFromFiles } from './config/loader.js';
-import { getAgentDefinitions, omcSystemPrompt } from './agents/definitions.js';
+import { BUILT_IN_AGENT_NAMES, getAgentDefinitions, omcSystemPrompt } from './agents/definitions.js';
+import { buildDelegationTable, buildKeyTriggersSection, buildUseAvoidSection, getAvailableAgents } from './agents/utils.js';
+import type { AgentConfig } from './agents/types.js';
 import { getDefaultMcpServers, toSdkMcpFormat } from './mcp/servers.js';
 import { omcToolsServer, getOmcToolNames } from './mcp/omc-tools-server.js';
 import { createMagicKeywordProcessor, detectMagicKeywords } from './features/magic-keywords.js';
@@ -299,6 +301,7 @@ export function createOmcSession(options?: OmcOptions): OmcSession {
 
   // Get agent definitions
   const agents = getAgentDefinitions({ config });
+  systemPrompt += buildCustomAgentSystemPromptAddition(agents);
 
   // Build MCP servers configuration
   const externalMcpServers = getDefaultMcpServers({
@@ -402,4 +405,39 @@ export function getOmcSystemPrompt(options?: {
   }
 
   return prompt;
+}
+
+function buildCustomAgentSystemPromptAddition(agents: Record<string, AgentConfig>): string {
+  const builtIns = new Set(BUILT_IN_AGENT_NAMES);
+  const customAgents = Object.fromEntries(
+    Object.entries(agents).filter(([name]) => !builtIns.has(name)),
+  );
+  const customAgentList = Object.values(customAgents);
+
+  if (customAgentList.length === 0) {
+    return '';
+  }
+
+  const sections: string[] = [
+    '## Custom Subagents',
+    '',
+    ...customAgentList.map(agent => `- **${agent.name}**${agent.model ? ` (${agent.model})` : ''}: ${agent.description}`),
+  ];
+
+  const availableAgents = getAvailableAgents(customAgents);
+  const delegationTable = buildDelegationTable(availableAgents);
+  if (delegationTable) sections.push('', delegationTable);
+
+  const keyTriggers = buildKeyTriggersSection(availableAgents);
+  if (keyTriggers) sections.push('', keyTriggers);
+
+  for (const agent of customAgentList) {
+    if (!agent.metadata) continue;
+    const useAvoid = buildUseAvoidSection(agent.metadata);
+    if (useAvoid) {
+      sections.push('', `### ${agent.name} Use/Avoid Guidance`, '', useAvoid);
+    }
+  }
+
+  return `\n\n${sections.join('\n')}`;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,6 +41,16 @@ export interface PluginConfig {
     documentSpecialist?: { model?: string };
   };
 
+  // User-extensible agent registry
+  customAgents?: {
+    /** Enable discovery from user/project custom agent directories. Defaults to true. */
+    enabled?: boolean;
+    /** Extra directories to scan. Relative paths resolve from the current project root. */
+    dirs?: string[];
+    /** Maximum number of custom agents to merge into the runtime registry. Defaults to 20. */
+    maxAgents?: number;
+  };
+
   // Feature toggles
   features?: {
     parallelExecution?: boolean;
@@ -446,12 +456,35 @@ export const KNOWN_AGENT_NAMES = [
 
 export type KnownAgentName = typeof KNOWN_AGENT_NAMES[number];
 
+/** Runtime subagent names registered with Claude Code. */
+export const KNOWN_AGENT_REGISTRY_NAMES = [
+  'explore',
+  'analyst',
+  'planner',
+  'architect',
+  'debugger',
+  'executor',
+  'verifier',
+  'security-reviewer',
+  'code-reviewer',
+  'test-engineer',
+  'designer',
+  'writer',
+  'qa-tester',
+  'scientist',
+  'tracer',
+  'git-master',
+  'code-simplifier',
+  'critic',
+  'document-specialist',
+] as const;
+
 /** User-facing per-role spec in `team.roleRouting`. */
 export interface TeamRoleAssignmentSpec {
   provider?: TeamRoleProvider;
   /** Tier name ('HIGH' | 'MEDIUM' | 'LOW') or explicit model ID. */
   model?: TeamRoleTier | string;
-  agent?: KnownAgentName;
+  agent?: string;
 }
 
 /** Orchestrator is pinned to claude; only `model` is user-configurable. */
@@ -484,5 +517,5 @@ export interface RoleAssignment {
   provider: TeamRoleProvider;
   /** Resolved model ID (tier names expanded to explicit model strings). */
   model: string;
-  agent: KnownAgentName;
+  agent: string;
 }

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -13,7 +13,6 @@
 
 import type {
   CanonicalTeamRole,
-  KnownAgentName,
   PluginConfig,
   RoleAssignment,
   TeamRoleAssignmentSpec,
@@ -27,8 +26,8 @@ import {
   getDefaultTierModels,
 } from '../config/models.js';
 
-/** Map canonical team role → KnownAgentName key (matches PluginConfig.agents.*). */
-const ROLE_TO_AGENT: Record<CanonicalTeamRole, KnownAgentName> = {
+/** Map canonical team role → built-in agent key. */
+const ROLE_TO_AGENT: Record<CanonicalTeamRole, string> = {
   orchestrator: 'omc',
   planner: 'planner',
   analyst: 'analyst',
@@ -184,7 +183,7 @@ export function resolveRoleAssignment(
   const model = provider === 'claude'
     ? resolveClaudeModel(canonical, spec?.model, cfg)
     : resolveExternalModel(provider, spec?.model, cfg);
-  const agent: KnownAgentName = spec?.agent ?? ROLE_TO_AGENT[canonical];
+  const agent = spec?.agent ?? ROLE_TO_AGENT[canonical];
 
   return { provider, model, agent };
 }


### PR DESCRIPTION
## Summary

- Discover custom agent markdown files from `~/.config/claude-omc/agents/`, configured `customAgents.dirs`, and project `.omc/agents/`
- Parse standard Claude Code frontmatter plus optional `omc:` routing metadata into the existing agent registry shape
- Merge custom agents into `getAgentDefinitions()` with deterministic precedence and built-in collision protection, including explicit `omc.overrideBuiltin` opt-in
- Surface custom agents in generated orchestrator prompt sections, delegation triggers, and use/avoid guidance
- Allow `team.roleRouting.*.agent` to reference discovered custom agents at config validation time
- Let `loadAgentPrompt()` resolve custom agent prompt bodies from source directories for direct runtime prompt loading

## Notes

This PR focuses on opening the registry data source while keeping the existing registry/prompt/routing pipeline. It does not include installer sync into `~/.claude/agents/`; that should be paired with the manifest-based cleanup fix separately so user-authored Claude Code agents are never deleted by ownership heuristics.

## Validation

- `npm test -- src/__tests__/agent-registry.test.ts src/__tests__/delegation-enforcer.test.ts src/config/__tests__/loader.test.ts src/team/__tests__/stage-router.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/agents/custom-registry.ts src/agents/definitions.ts src/agents/utils.ts src/config/loader.ts src/team/stage-router.ts src/index.ts src/shared/types.ts src/__tests__/agent-registry.test.ts`
- `npm test`