### PR TITLE
Fix installer agent cleanup ownership tracking

### DIFF
--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -90,6 +90,39 @@ describe('cleanupStaleAgents', () => {
     expect(readFileSync(join(agentsDir, '.omc-managed.json'), 'utf-8')).not.toContain('removed-agent.md');
   });
 
+  it('ignores unsafe manifest filenames instead of deleting outside the agents directory', async () => {
+    vi.resetModules();
+    const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(join(tempDir, 'victim.md'), '# do not delete\n');
+    writeFileSync(join(agentsDir, '.omc-managed.json'), JSON.stringify({
+      version: 1,
+      files: {
+        '../victim.md': { source: 'builtin' },
+      },
+    }));
+
+    const removed = cleanup(log);
+
+    expect(removed).toEqual([]);
+    expect(existsSync(join(tempDir, 'victim.md'))).toBe(true);
+    expect(readFileSync(join(agentsDir, '.omc-managed.json'), 'utf-8')).not.toContain('../victim.md');
+  });
+
+  it('removes stale pre-manifest legacy OMC agent files from known historical names', async () => {
+    vi.resetModules();
+    const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    mkdirSync(agentsDir, { recursive: true });
+    createAgentFile(agentsDir, 'tdd-guide.md', 'tdd-guide');
+
+    const removed = cleanup(log);
+
+    expect(removed).toContain('tdd-guide.md');
+    expect(existsSync(join(agentsDir, 'tdd-guide.md'))).toBe(false);
+  });
+
   it('preserves agent files that are in the current package', async () => {
     vi.resetModules();
     const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
@@ -507,17 +540,17 @@ describe('prunePluginDuplicateAgents', () => {
     expect(existsSync(join(agentsDir, 'architect.md'))).toBe(true);
   });
 
-  it('preserves user-authored agents with standard Claude Code frontmatter', async () => {
+  it('prunes pre-manifest plugin duplicate agents even when content drifted', async () => {
     vi.resetModules();
     const { prunePluginDuplicateAgents: prune, AGENTS_DIR: agentsDir } = await import('../index.js');
 
     mkdirSync(agentsDir, { recursive: true });
-    createAgentFile(agentsDir, 'architect.md', 'architect');
+    writeFileSync(join(agentsDir, 'architect.md'), `---\nname: architect\ndescription: Locally drifted old OMC copy\nmodel: claude-sonnet-4-6\n---\n\n# architect\nDrifted content.\n`);
 
     const removed = prune(log);
 
-    expect(removed).not.toContain('architect.md');
-    expect(existsSync(join(agentsDir, 'architect.md'))).toBe(true);
+    expect(removed).toContain('architect.md');
+    expect(existsSync(join(agentsDir, 'architect.md'))).toBe(false);
   });
 
   it('does not remove agents not in the current package', async () => {

--- a/src/installer/__tests__/stale-cleanup.test.ts
+++ b/src/installer/__tests__/stale-cleanup.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync, symlinkSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -44,6 +44,10 @@ function createManagedSkillMarker(dir: string, skillName: string): void {
   writeFileSync(join(dir, skillName, '.omc-managed'), 'omc-managed\n');
 }
 
+function createManagedAgentManifest(dir: string, files: Record<string, { source: 'builtin' }>): void {
+  writeFileSync(join(dir, '.omc-managed.json'), `${JSON.stringify({ version: 1, files }, null, 2)}\n`);
+}
+
 // ── Stale Agent Cleanup ──────────────────────────────────────────────────────
 
 describe('cleanupStaleAgents', () => {
@@ -67,20 +71,23 @@ describe('cleanupStaleAgents', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('removes agent files that have OMC frontmatter but are no longer in the package', async () => {
+  it('removes manifest-tracked agent files that are no longer in the package', async () => {
     // Re-import with fresh CLAUDE_CONFIG_DIR
     vi.resetModules();
     const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
 
     mkdirSync(agentsDir, { recursive: true });
 
-    // Create a fake "stale" agent that looks like OMC-created but isn't in current package
     createAgentFile(agentsDir, 'removed-agent.md', 'removed-agent');
+    createManagedAgentManifest(agentsDir, {
+      'removed-agent.md': { source: 'builtin' },
+    });
 
     const removed = cleanup(log);
 
     expect(removed).toContain('removed-agent.md');
     expect(existsSync(join(agentsDir, 'removed-agent.md'))).toBe(false);
+    expect(readFileSync(join(agentsDir, '.omc-managed.json'), 'utf-8')).not.toContain('removed-agent.md');
   });
 
   it('preserves agent files that are in the current package', async () => {
@@ -106,6 +113,19 @@ describe('cleanupStaleAgents', () => {
 
     // User-created file with no frontmatter
     createUserFile(agentsDir, 'my-custom-agent.md');
+
+    const removed = cleanup(log);
+
+    expect(removed).not.toContain('my-custom-agent.md');
+    expect(existsSync(join(agentsDir, 'my-custom-agent.md'))).toBe(true);
+  });
+
+  it('preserves user-authored agents with standard Claude Code frontmatter when unmanaged', async () => {
+    vi.resetModules();
+    const { cleanupStaleAgents: cleanup, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    mkdirSync(agentsDir, { recursive: true });
+    createAgentFile(agentsDir, 'my-custom-agent.md', 'my-custom-agent');
 
     const removed = cleanup(log);
 
@@ -463,11 +483,15 @@ describe('prunePluginDuplicateAgents', () => {
 
     mkdirSync(agentsDir, { recursive: true });
     createAgentFile(agentsDir, 'architect.md', 'architect');
+    createManagedAgentManifest(agentsDir, {
+      'architect.md': { source: 'builtin' },
+    });
 
     const removed = prune(log);
 
     expect(removed).toContain('architect.md');
     expect(existsSync(join(agentsDir, 'architect.md'))).toBe(false);
+    expect(readFileSync(join(agentsDir, '.omc-managed.json'), 'utf-8')).not.toContain('architect.md');
   });
 
   it('preserves user-created agents without OMC frontmatter', async () => {
@@ -476,6 +500,19 @@ describe('prunePluginDuplicateAgents', () => {
 
     mkdirSync(agentsDir, { recursive: true });
     createUserFile(agentsDir, 'architect.md');
+
+    const removed = prune(log);
+
+    expect(removed).not.toContain('architect.md');
+    expect(existsSync(join(agentsDir, 'architect.md'))).toBe(true);
+  });
+
+  it('preserves user-authored agents with standard Claude Code frontmatter', async () => {
+    vi.resetModules();
+    const { prunePluginDuplicateAgents: prune, AGENTS_DIR: agentsDir } = await import('../index.js');
+
+    mkdirSync(agentsDir, { recursive: true });
+    createAgentFile(agentsDir, 'architect.md', 'architect');
 
     const removed = prune(log);
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -9,7 +9,7 @@
  */
 
 import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, chmodSync, readdirSync, cpSync, unlinkSync, rmSync, realpathSync, statSync } from 'fs';
-import { join, dirname, resolve, isAbsolute } from 'path';
+import { basename, join, dirname, resolve, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
@@ -42,6 +42,18 @@ const OMC_MANAGED_SKILL_MARKER = '.omc-managed';
 const OMC_MANAGED_AGENT_MANIFEST = '.omc-managed.json';
 const PLUGIN_FULL_SKILL_BODIES_DIR = 'skill-bodies';
 const PLUGIN_COMPACT_SKILL_SHIM_MARKER = '<!-- OMC:COMPACT-PLUGIN-SKILL -->';
+const LEGACY_OMC_AGENT_FILES = new Set([
+  'api-reviewer.md',
+  'build-fixer.md',
+  'deep-executor.md',
+  'dependency-expert.md',
+  'harsh-critic.md',
+  'performance-reviewer.md',
+  'quality-reviewer.md',
+  'quality-strategist.md',
+  'researcher.md',
+  'tdd-guide.md',
+]);
 
 type ManagedAgentManifestEntry =
   | { source: 'builtin' }
@@ -91,6 +103,19 @@ function getManagedAgentManifestPath(agentsDir: string = currentAgentsDir()): st
   return join(agentsDir, OMC_MANAGED_AGENT_MANIFEST);
 }
 
+function isSafeAgentManifestFilename(filename: string): boolean {
+  return filename === basename(filename) && /^[a-z0-9-]+\.md$/i.test(filename);
+}
+
+function getSafeAgentFilePath(agentsDir: string, filename: string): string | undefined {
+  if (!isSafeAgentManifestFilename(filename)) return undefined;
+  const resolvedAgentsDir = resolve(agentsDir);
+  const resolvedPath = resolve(agentsDir, filename);
+  const rel = relative(resolvedAgentsDir, resolvedPath);
+  if (rel.startsWith('..') || isAbsolute(rel)) return undefined;
+  return resolvedPath;
+}
+
 function isManagedAgentManifestEntry(value: unknown): value is ManagedAgentManifestEntry {
   if (!value || typeof value !== 'object') return false;
   const entry = value as Record<string, unknown>;
@@ -133,10 +158,25 @@ function writeManagedAgentManifest(manifest: ManagedAgentManifest, agentsDir: st
   const sortedManifest: ManagedAgentManifest = { version: 1, files: {} };
 
   for (const filename of filenames) {
+    if (!isSafeAgentManifestFilename(filename)) continue;
     sortedManifest.files[filename] = manifest.files[filename];
   }
 
   writeFileSync(getManagedAgentManifestPath(agentsDir), `${JSON.stringify(sortedManifest, null, 2)}\n`);
+}
+
+function getLegacyOmcAgentFileSet(currentAgentFiles: Set<string>): Set<string> {
+  return new Set([...currentAgentFiles, ...LEGACY_OMC_AGENT_FILES]);
+}
+
+function hasMatchingAgentNameFrontmatter(content: string, filename: string): boolean {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) {
+    return false;
+  }
+
+  const expectedName = filename.replace(/\.md$/i, '');
+  const match = content.match(/^name:\s*['"]?([^'"\r\n]+)['"]?\s*$/m);
+  return match?.[1]?.trim() === expectedName;
 }
 
 function currentSkillsDir(): string {
@@ -789,21 +829,27 @@ export function cleanupStaleAgents(log: (msg: string) => void): string[] {
   const agentsDir = currentAgentsDir();
   if (!existsSync(agentsDir)) return [];
 
-  const currentAgentFiles = new Set(
-    Object.keys(loadAgentDefinitions()),
-  );
+  const currentAgentFiles = new Set(Object.keys(loadAgentDefinitions()));
+  const legacyOmcAgentFiles = getLegacyOmcAgentFileSet(currentAgentFiles);
   const manifest = readManagedAgentManifest(agentsDir);
   let manifestChanged = false;
 
   const removed: string[] = [];
   for (const [file, entry] of Object.entries(manifest.files)) {
+    const filepath = getSafeAgentFilePath(agentsDir, file);
+    if (!filepath) {
+      delete manifest.files[file];
+      manifestChanged = true;
+      log(`  Ignored unsafe managed agent manifest entry: ${file}`);
+      continue;
+    }
+
     const sourceExists = entry.source === 'builtin'
       ? currentAgentFiles.has(file)
       : existsSync(entry.sourcePath);
 
     if (sourceExists) continue;
 
-    const filepath = join(agentsDir, file);
     try {
       if (existsSync(filepath)) {
         unlinkSync(filepath);
@@ -817,6 +863,26 @@ export function cleanupStaleAgents(log: (msg: string) => void): string[] {
 
     delete manifest.files[file];
     manifestChanged = true;
+  }
+
+  for (const file of readdirSync(agentsDir)) {
+    if (currentAgentFiles.has(file)) continue;
+    if (!legacyOmcAgentFiles.has(file)) continue;
+    if (manifest.files[file]) continue;
+
+    const filepath = getSafeAgentFilePath(agentsDir, file);
+    if (!filepath) continue;
+
+    try {
+      const content = readFileSync(filepath, 'utf-8');
+      if (!hasMatchingAgentNameFrontmatter(content, file)) continue;
+
+      unlinkSync(filepath);
+      removed.push(file);
+      log(`  Removed stale legacy agent: ${file}`);
+    } catch {
+      // Skip files that can't be read or removed.
+    }
   }
 
   if (manifestChanged) {
@@ -841,6 +907,7 @@ export function prunePluginDuplicateAgents(log: (msg: string) => void): string[]
 
   const currentAgentDefinitions = loadAgentDefinitions();
   const currentAgentFiles = new Set(Object.keys(currentAgentDefinitions));
+  const legacyOmcAgentFiles = getLegacyOmcAgentFileSet(currentAgentFiles);
   const manifest = readManagedAgentManifest(agentsDir);
   let manifestChanged = false;
 
@@ -851,14 +918,18 @@ export function prunePluginDuplicateAgents(log: (msg: string) => void): string[]
     // Only prune agents whose name matches a current package agent
     if (!currentAgentFiles.has(file)) continue;
 
-    const filepath = join(agentsDir, file);
+    const filepath = getSafeAgentFilePath(agentsDir, file);
+    if (!filepath) continue;
+
     try {
       const content = readFileSync(filepath, 'utf-8');
-      if (manifest.files[file] || content === currentAgentDefinitions[file]) {
+      const isManifestManaged = manifest.files[file] !== undefined;
+      const isLegacyOmcStandalone = legacyOmcAgentFiles.has(file) && hasMatchingAgentNameFrontmatter(content, file);
+      if (isManifestManaged || content === currentAgentDefinitions[file] || isLegacyOmcStandalone) {
         unlinkSync(filepath);
         removed.push(file);
         log(`  Pruned plugin-duplicate agent: ${file}`);
-        if (manifest.files[file]) {
+        if (isManifestManaged) {
           delete manifest.files[file];
           manifestChanged = true;
         }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -39,8 +39,18 @@ export const HUD_DIR = join(CLAUDE_CONFIG_DIR, 'hud');
 export const SETTINGS_FILE = join(CLAUDE_CONFIG_DIR, 'settings.json');
 export const VERSION_FILE = join(CLAUDE_CONFIG_DIR, '.omc-version.json');
 const OMC_MANAGED_SKILL_MARKER = '.omc-managed';
+const OMC_MANAGED_AGENT_MANIFEST = '.omc-managed.json';
 const PLUGIN_FULL_SKILL_BODIES_DIR = 'skill-bodies';
 const PLUGIN_COMPACT_SKILL_SHIM_MARKER = '<!-- OMC:COMPACT-PLUGIN-SKILL -->';
+
+type ManagedAgentManifestEntry =
+  | { source: 'builtin' }
+  | { source: 'custom'; sourcePath: string };
+
+interface ManagedAgentManifest {
+  version: 1;
+  files: Record<string, ManagedAgentManifestEntry>;
+}
 
 /**
  * Core commands - DISABLED for v3.0+
@@ -75,6 +85,58 @@ const SKININTHEGAMEBROS_ONLY_SKILLS = new Set([
 
 function currentAgentsDir(): string {
   return join(getClaudeConfigDir(), 'agents');
+}
+
+function getManagedAgentManifestPath(agentsDir: string = currentAgentsDir()): string {
+  return join(agentsDir, OMC_MANAGED_AGENT_MANIFEST);
+}
+
+function isManagedAgentManifestEntry(value: unknown): value is ManagedAgentManifestEntry {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Record<string, unknown>;
+  if (entry.source === 'builtin') return true;
+  return entry.source === 'custom' && typeof entry.sourcePath === 'string';
+}
+
+function readManagedAgentManifest(agentsDir: string = currentAgentsDir()): ManagedAgentManifest {
+  const manifestPath = getManagedAgentManifestPath(agentsDir);
+  if (!existsSync(manifestPath)) {
+    return { version: 1, files: {} };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return { version: 1, files: {} };
+    }
+
+    const rawFiles = (parsed as { files?: unknown }).files;
+    if (!rawFiles || typeof rawFiles !== 'object' || Array.isArray(rawFiles)) {
+      return { version: 1, files: {} };
+    }
+
+    const files: Record<string, ManagedAgentManifestEntry> = {};
+    for (const [filename, entry] of Object.entries(rawFiles)) {
+      if (filename.endsWith('.md') && isManagedAgentManifestEntry(entry)) {
+        files[filename] = entry;
+      }
+    }
+
+    return { version: 1, files };
+  } catch {
+    return { version: 1, files: {} };
+  }
+}
+
+function writeManagedAgentManifest(manifest: ManagedAgentManifest, agentsDir: string = currentAgentsDir()): void {
+  const filenames = Object.keys(manifest.files).sort((a, b) => a.localeCompare(b));
+  const sortedManifest: ManagedAgentManifest = { version: 1, files: {} };
+
+  for (const filename of filenames) {
+    sortedManifest.files[filename] = manifest.files[filename];
+  }
+
+  writeFileSync(getManagedAgentManifestPath(agentsDir), `${JSON.stringify(sortedManifest, null, 2)}\n`);
 }
 
 function currentSkillsDir(): string {
@@ -719,14 +781,9 @@ function mergeHookGroups(
  * Remove stale OMC-created agent files from the config agents directory.
  *
  * When OMC drops an agent definition in a new version, the old .md file
- * lingers in ~/.claude/agents/. This function compares the installed files
- * against the current package's agent definitions and removes any that:
- *   1. Are .md files (OMC agent naming convention)
- *   2. Were previously shipped by OMC (match the frontmatter `name:` pattern)
- *   3. No longer exist in the current package's agents/ directory
- *
- * User-created files (those whose filename does not match any historically
- * known OMC agent) are preserved.
+ * lingers in ~/.claude/agents/. Ownership is tracked explicitly in
+ * .omc-managed.json so standard Claude Code agent files authored by users are
+ * never treated as OMC-owned based on frontmatter shape alone.
  */
 export function cleanupStaleAgents(log: (msg: string) => void): string[] {
   const agentsDir = currentAgentsDir();
@@ -735,25 +792,35 @@ export function cleanupStaleAgents(log: (msg: string) => void): string[] {
   const currentAgentFiles = new Set(
     Object.keys(loadAgentDefinitions()),
   );
+  const manifest = readManagedAgentManifest(agentsDir);
+  let manifestChanged = false;
 
   const removed: string[] = [];
-  for (const file of readdirSync(agentsDir)) {
-    if (!file.endsWith('.md')) continue;
-    if (file === 'AGENTS.md') continue;
-    if (currentAgentFiles.has(file)) continue;
+  for (const [file, entry] of Object.entries(manifest.files)) {
+    const sourceExists = entry.source === 'builtin'
+      ? currentAgentFiles.has(file)
+      : existsSync(entry.sourcePath);
 
-    // Check if this looks like an OMC-created agent (kebab-case .md with frontmatter)
+    if (sourceExists) continue;
+
     const filepath = join(agentsDir, file);
     try {
-      const content = readFileSync(filepath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      if (existsSync(filepath)) {
         unlinkSync(filepath);
         removed.push(file);
         log(`  Removed stale agent: ${file}`);
       }
     } catch {
-      // Skip files that can't be read
+      // Skip files that can't be removed.
+      continue;
     }
+
+    delete manifest.files[file];
+    manifestChanged = true;
+  }
+
+  if (manifestChanged) {
+    writeManagedAgentManifest(manifest, agentsDir);
   }
 
   return removed;
@@ -764,16 +831,18 @@ export function cleanupStaleAgents(log: (msg: string) => void): string[] {
  *
  * When the plugin is the canonical agent source, standalone copies in
  * ~/.claude/agents/ from a prior `omc setup` cause agent definitions to
- * appear twice. Removes standalone copies with OMC frontmatter whose
- * filename matches a current package agent.
+ * appear twice. Removes standalone copies only when OMC ownership is recorded
+ * in the managed manifest or when the file content exactly matches the current
+ * packaged agent definition.
  */
 export function prunePluginDuplicateAgents(log: (msg: string) => void): string[] {
   const agentsDir = currentAgentsDir();
   if (!existsSync(agentsDir)) return [];
 
-  const currentAgentFiles = new Set(
-    Object.keys(loadAgentDefinitions()),
-  );
+  const currentAgentDefinitions = loadAgentDefinitions();
+  const currentAgentFiles = new Set(Object.keys(currentAgentDefinitions));
+  const manifest = readManagedAgentManifest(agentsDir);
+  let manifestChanged = false;
 
   const removed: string[] = [];
   for (const file of readdirSync(agentsDir)) {
@@ -785,14 +854,22 @@ export function prunePluginDuplicateAgents(log: (msg: string) => void): string[]
     const filepath = join(agentsDir, file);
     try {
       const content = readFileSync(filepath, 'utf-8');
-      if (content.startsWith('---\n') && /^name:\s+\S+/m.test(content)) {
+      if (manifest.files[file] || content === currentAgentDefinitions[file]) {
         unlinkSync(filepath);
         removed.push(file);
         log(`  Pruned plugin-duplicate agent: ${file}`);
+        if (manifest.files[file]) {
+          delete manifest.files[file];
+          manifestChanged = true;
+        }
       }
     } catch {
       // Skip files that can't be read
     }
+  }
+
+  if (manifestChanged) {
+    writeManagedAgentManifest(manifest, agentsDir);
   }
 
   return removed;
@@ -2001,15 +2078,33 @@ export function install(options: InstallOptions = {}): InstallResult {
       // Install agents
       if (shouldInstallLegacyAgents) {
         log('Installing agent definitions...');
-        for (const [filename, content] of Object.entries(loadAgentDefinitions())) {
+        const agentDefinitions = loadAgentDefinitions();
+        const agentManifest = readManagedAgentManifest(AGENTS_DIR);
+        let agentManifestChanged = false;
+
+        for (const [filename, content] of Object.entries(agentDefinitions)) {
           const filepath = join(AGENTS_DIR, filename);
           if (existsSync(filepath) && !options.force) {
             log(`  Skipping ${filename} (already exists)`);
+            try {
+              if (readFileSync(filepath, 'utf-8') === content && !agentManifest.files[filename]) {
+                agentManifest.files[filename] = { source: 'builtin' };
+                agentManifestChanged = true;
+              }
+            } catch {
+              // Ignore unreadable files; they remain user-managed.
+            }
           } else {
             writeFileSync(filepath, content);
+            agentManifest.files[filename] = { source: 'builtin' };
+            agentManifestChanged = true;
             result.installedAgents.push(filename);
             log(`  Installed ${filename}`);
           }
+        }
+
+        if (agentManifestChanged) {
+          writeManagedAgentManifest(agentManifest, AGENTS_DIR);
         }
       } else {
         log('Skipping legacy agent file installation (plugin-provided agents are available)');


### PR DESCRIPTION
## Summary

- Track installer-managed agent files in `~/.claude/agents/.omc-managed.json`
- Harden manifest cleanup so malformed path-like keys cannot delete files outside `AGENTS_DIR`
- Preserve unmanaged user-authored custom agents instead of treating all `name:` frontmatter as OMC-owned
- Add a pre-manifest cleanup path for known legacy OMC standalone agents, including prompt-drift plugin duplicates
- Add regression coverage for manifest path escape, stale historical agents, and pre-manifest duplicate pruning

## Why

The old cleanup heuristic treated standard Claude Code agent frontmatter as proof of OMC ownership, which could delete user-authored agents. The first manifest-based version fixed that but missed path hardening and migration behavior for existing pre-manifest installs. This update keeps explicit ownership as the primary signal while adding a narrow legacy allowlist for previously shipped OMC agent filenames.

## Validation

- `npm test -- src/installer/__tests__/stale-cleanup.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/installer/index.ts src/installer/__tests__/stale-cleanup.test.ts`