### PR TITLE
feat(ask): agy (Antigravity CLI) support for gemini provider with fallback

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -8,26 +8,58 @@ import { resolveOmcStateRoot } from './lib/state-root.mjs';
 const PROVIDER_BINARIES = {
   claude: 'claude',
   codex: 'codex',
-  gemini: 'gemini',
+  // gemini: dynamically resolved — `agy` (Antigravity CLI) takes precedence,
+  // falls back to `gemini` CLI when agy is not installed. See resolveGeminiBinary().
+  gemini: null,
   grok: 'grok',
   cursor: 'cursor-agent',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
 /**
- * Build CLI args for a given provider.
- * - claude: `claude -p <prompt>` (or `claude -p` reading the prompt from stdin)
- * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
- * - gemini: `gemini -p <prompt> --yolo`
- * - grok: `grok -p <prompt> --always-approve` (headless mode takes the prompt
- *   as an arg; grok's stdin is reserved for ACP JSON-RPC, never the prompt)
- * - cursor: `cursor-agent --print --force --trust --sandbox disabled <prompt>`
+ * Resolve the binary to use for the `gemini` provider.
+ *
+ * Google Antigravity CLI (`agy`) supersedes the legacy Gemini CLI (`gemini`).
+ * Both support a non-interactive print mode:
+ *   - agy:    `agy --print <prompt>`
+ *   - gemini: `gemini -p <prompt> --yolo`
+ *
+ * Resolution order: agy → gemini. If neither is available, returns 'agy' so
+ * ensureBinary() produces a clear installation error.
  */
-function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
+function resolveGeminiBinary(env) {
+  for (const bin of ['agy', 'gemini']) {
+    const probe = spawnSync(bin, ['--version'], {
+      stdio: 'ignore',
+      encoding: 'utf8',
+      env,
+      shell: SHOULD_USE_WINDOWS_SHELL,
+    });
+    if (!probe.error && probe.status === 0) return bin;
+  }
+  return 'agy';
+}
+
+/**
+ * Build CLI args for a given provider.
+ * - claude:  `claude -p <prompt>` (or `claude -p` reading the prompt from stdin)
+ * - codex:   `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
+ * - gemini/agy:    `agy --print <prompt>`  (Antigravity CLI, preferred)
+ * - gemini/gemini: `gemini -p <prompt> --yolo`  (legacy Gemini CLI, fallback)
+ * - grok:    `grok -p <prompt> --always-approve`
+ * - cursor:  `cursor-agent --print --force --trust --sandbox disabled <prompt>`
+ */
+function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false, resolvedBinary = null } = {}) {
   if (provider === 'codex') {
     return ['exec', '--dangerously-bypass-approvals-and-sandbox', pipePromptViaStdin ? '-' : prompt];
   }
   if (provider === 'gemini') {
+    if (resolvedBinary === 'agy') {
+      // agy --print always takes the prompt as a positional arg.
+      // Stdin prompt piping is not supported by agy's --print mode.
+      return ['--print', prompt];
+    }
+    // Legacy gemini CLI
     return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
   }
   if (provider === 'grok') {
@@ -44,7 +76,11 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
   return pipePromptViaStdin ? ['-p'] : ['-p', prompt];
 }
 
-function shouldPipePromptViaStdin(provider, prompt) {
+function shouldPipePromptViaStdin(provider, prompt, { resolvedBinary = null } = {}) {
+  if (provider === 'gemini' && resolvedBinary === 'agy') {
+    // agy --print does not support stdin prompt piping; always pass as arg.
+    return false;
+  }
   if (provider === 'codex' || provider === 'gemini') {
     if (typeof prompt === 'string' && (prompt.includes('\n') || prompt.length > 500)) {
       return true;
@@ -76,6 +112,7 @@ const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
   console.error('Usage: omc ask <claude|codex|gemini|grok|cursor> "<prompt>"');
+  console.error('       gemini provider uses agy (Antigravity CLI) when available, falls back to gemini CLI');
   console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|grok|cursor> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
@@ -256,16 +293,21 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
 
 async function main() {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
-  const binary = PROVIDER_BINARIES[provider];
+
+  // Resolve binary: gemini uses agy (preferred) or gemini CLI (fallback).
+  const providerEnv = buildProviderEnv(provider);
+  const binary = provider === 'gemini'
+    ? resolveGeminiBinary(providerEnv)
+    : PROVIDER_BINARIES[provider];
 
   ensureBinary(provider, binary);
 
-  const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt);
-  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin });
+  const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt, { resolvedBinary: binary });
+  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin, resolvedBinary: binary });
   const run = spawnSync(binary, providerArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
-    env: buildProviderEnv(provider),
+    env: providerEnv,
     shell: SHOULD_USE_WINDOWS_SHELL,
     ...(pipePromptViaStdin ? { input: prompt } : { stdio: ['ignore', 'pipe', 'pipe'] }),
   });


### PR DESCRIPTION
## Summary

Google Antigravity CLI (\`agy\`) is the successor to the legacy \`gemini\` CLI. This PR adds \`agy\` support to \`omc ask gemini\` with automatic fallback to the legacy \`gemini\` binary when \`agy\` is not installed.

- \`resolveGeminiBinary()\`: resolves \`agy\` → \`gemini\` in order, returns first available
- \`agy\` uses \`--print <prompt>\` (Antigravity's non-interactive mode)
- Legacy \`gemini\` continues to use \`-p <prompt> --yolo\` unchanged
- \`shouldPipePromptViaStdin\`: returns \`false\` when \`agy\` is resolved (stdin not supported in \`--print\` mode)
- \`main()\`: resolves binary once, passes \`resolvedBinary\` through to arg builders

## Motivation

Antigravity CLI (\`agy --print\`) replaces \`gemini -p --yolo\` as Google's recommended non-interactive AI CLI. Users who have migrated to \`agy\` would otherwise lose CCG / \`omc ask gemini\` functionality.

## Behavior

| Environment | Binary used | Args |
|-------------|-------------|------|
| \`agy\` installed | \`agy\` | \`--print <prompt>\` |
| Only \`gemini\` installed | \`gemini\` | \`-p <prompt> --yolo\` |
| Neither installed | \`agy\` (fails with clear error) | — |

## No breaking change

Existing \`gemini\` CLI users are fully unaffected. The CCG skill and \`omc ask gemini\` continue to work with whichever binary is available.

## Test plan

- [x] Build passes (\`npm run build\`)
- [x] Lint passes: 0 errors, 19 pre-existing warnings (\`npm run lint\`)
- [x] Full test suite: 9738 passed, 82 failed — all failures are pre-existing in \`dev\` branch (python-repl sandbox, worktree e2e, tmux-dependent tests). Tests directly related to our change (\`src/hooks/keyword-detector\`, advisor scripts): **413/413 PASS**.
- [x] Manual: \`omc ask gemini "..."\` routes to \`agy --print\` when \`agy\` is installed
- [x] Manual: falls back to \`gemini -p --yolo\` when only legacy CLI is available