### PR TITLE
feat(ask): agy (Antigravity CLI) support for gemini provider with gemini fallback

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -8,26 +8,58 @@ import { resolveOmcStateRoot } from './lib/state-root.mjs';
 const PROVIDER_BINARIES = {
   claude: 'claude',
   codex: 'codex',
-  gemini: 'gemini',
+  // gemini: dynamically resolved — `agy` (Antigravity CLI) takes precedence,
+  // falls back to `gemini` CLI when agy is not installed. See resolveGeminiBinary().
+  gemini: null,
   grok: 'grok',
   cursor: 'cursor-agent',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
 /**
- * Build CLI args for a given provider.
- * - claude: `claude -p <prompt>` (or `claude -p` reading the prompt from stdin)
- * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
- * - gemini: `gemini -p <prompt> --yolo`
- * - grok: `grok -p <prompt> --always-approve` (headless mode takes the prompt
- *   as an arg; grok's stdin is reserved for ACP JSON-RPC, never the prompt)
- * - cursor: `cursor-agent --print --force --trust --sandbox disabled <prompt>`
+ * Resolve the binary to use for the `gemini` provider.
+ *
+ * Google Antigravity CLI (`agy`) supersedes the legacy Gemini CLI (`gemini`).
+ * Both support a non-interactive print mode:
+ *   - agy:    `agy --print <prompt>`
+ *   - gemini: `gemini -p <prompt> --yolo`
+ *
+ * Resolution order: agy → gemini. If neither is available, returns 'agy' so
+ * ensureBinary() produces a clear installation error.
  */
-function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
+function resolveGeminiBinary(env) {
+  for (const bin of ['agy', 'gemini']) {
+    const probe = spawnSync(bin, ['--version'], {
+      stdio: 'ignore',
+      encoding: 'utf8',
+      env,
+      shell: SHOULD_USE_WINDOWS_SHELL,
+    });
+    if (!probe.error && probe.status === 0) return bin;
+  }
+  return 'agy';
+}
+
+/**
+ * Build CLI args for a given provider.
+ * - claude:  `claude -p <prompt>` (or `claude -p` reading the prompt from stdin)
+ * - codex:   `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
+ * - gemini/agy:    `agy --print <prompt>`  (Antigravity CLI, preferred)
+ * - gemini/gemini: `gemini -p <prompt> --yolo`  (legacy Gemini CLI, fallback)
+ * - grok:    `grok -p <prompt> --always-approve`
+ * - cursor:  `cursor-agent --print --force --trust --sandbox disabled <prompt>`
+ */
+function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false, resolvedBinary = null } = {}) {
   if (provider === 'codex') {
     return ['exec', '--dangerously-bypass-approvals-and-sandbox', pipePromptViaStdin ? '-' : prompt];
   }
   if (provider === 'gemini') {
+    if (resolvedBinary === 'agy') {
+      // agy --print always takes the prompt as a positional arg.
+      // Stdin prompt piping is not supported by agy's --print mode.
+      return ['--print', prompt];
+    }
+    // Legacy gemini CLI
     return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
   }
   if (provider === 'grok') {
@@ -44,7 +76,11 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
   return pipePromptViaStdin ? ['-p'] : ['-p', prompt];
 }
 
-function shouldPipePromptViaStdin(provider, prompt) {
+function shouldPipePromptViaStdin(provider, prompt, { resolvedBinary = null } = {}) {
+  if (provider === 'gemini' && resolvedBinary === 'agy') {
+    // agy --print does not support stdin prompt piping; always pass as arg.
+    return false;
+  }
   if (provider === 'codex' || provider === 'gemini') {
     if (typeof prompt === 'string' && (prompt.includes('\n') || prompt.length > 500)) {
       return true;
@@ -76,6 +112,7 @@ const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
   console.error('Usage: omc ask <claude|codex|gemini|grok|cursor> "<prompt>"');
+  console.error('       gemini provider uses agy (Antigravity CLI) when available, falls back to gemini CLI');
   console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|grok|cursor> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
@@ -256,16 +293,21 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
 
 async function main() {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
-  const binary = PROVIDER_BINARIES[provider];
+
+  // Resolve binary: gemini uses agy (preferred) or gemini CLI (fallback).
+  const providerEnv = buildProviderEnv(provider);
+  const binary = provider === 'gemini'
+    ? resolveGeminiBinary(providerEnv)
+    : PROVIDER_BINARIES[provider];
 
   ensureBinary(provider, binary);
 
-  const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt);
-  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin });
+  const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt, { resolvedBinary: binary });
+  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin, resolvedBinary: binary });
   const run = spawnSync(binary, providerArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
-    env: buildProviderEnv(provider),
+    env: providerEnv,
     shell: SHOULD_USE_WINDOWS_SHELL,
     ...(pipePromptViaStdin ? { input: prompt } : { stdio: ['ignore', 'pipe', 'pipe'] }),
   });

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -37,7 +37,7 @@ function resolveGeminiBinary(env) {
     });
     if (!probe.error && probe.status === 0) return bin;
   }
-  return 'agy';
+  return null;
 }
 
 /**
@@ -245,7 +245,7 @@ function resolveOriginalTask(prompt) {
   return prompt;
 }
 
-async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, exitCode }) {
+async function writeArtifact({ provider, resolvedBinary, originalTask, finalPrompt, rawOutput, exitCode }) {
   const root = process.cwd();
   const artifactDir = join(await resolveOmcStateRoot(root), 'artifacts', 'ask');
   const slug = slugify(originalTask);
@@ -259,6 +259,7 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
     `# ${provider} advisor artifact`,
     '',
     `- Provider: ${provider}`,
+    `- Resolved binary: ${resolvedBinary || provider}`,
     `- Exit code: ${exitCode}`,
     `- Created at: ${new Date().toISOString()}`,
     '',
@@ -296,11 +297,20 @@ async function main() {
 
   // Resolve binary: gemini uses agy (preferred) or gemini CLI (fallback).
   const providerEnv = buildProviderEnv(provider);
-  const binary = provider === 'gemini'
-    ? resolveGeminiBinary(providerEnv)
-    : PROVIDER_BINARIES[provider];
-
-  ensureBinary(provider, binary);
+  let binary;
+  if (provider === 'gemini') {
+    // Resolution already probes each candidate; skip separate ensureBinary.
+    binary = resolveGeminiBinary(providerEnv);
+    if (!binary) {
+      console.error('[ask-gemini] Missing required CLI binary: agy or gemini');
+      console.error('[ask-gemini] Install Antigravity CLI: curl -fsSL https://antigravity.google/cli/install.sh | bash');
+      console.error('[ask-gemini] Or install legacy Gemini CLI: npm install -g @google/gemini-cli');
+      process.exit(1);
+    }
+  } else {
+    binary = PROVIDER_BINARIES[provider];
+    ensureBinary(provider, binary);
+  }
 
   const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt, { resolvedBinary: binary });
   const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin, resolvedBinary: binary });
@@ -319,6 +329,7 @@ async function main() {
 
   const artifactPath = await writeArtifact({
     provider,
+    resolvedBinary: binary,
     originalTask: resolveOriginalTask(prompt),
     finalPrompt: prompt,
     rawOutput,

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -123,6 +123,12 @@ function writeAdvisorStub(dir: string): string {
 function writeFakeProviderBinary(dir: string, provider: 'claude' | 'gemini'): string {
   const binDir = join(dir, 'bin');
   mkdirSync(binDir, { recursive: true });
+
+  // Write a failing agy stub so resolveGeminiBinary deterministically falls back
+  const agyPath = join(binDir, 'agy');
+  writeFileSync(agyPath, '#!/bin/sh\nexit 1\n', 'utf8');
+  chmodSync(agyPath, 0o755);
+
   const binPath = join(binDir, provider);
   writeFileSync(
     binPath,
@@ -145,6 +151,7 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
       "Object.defineProperty(process, 'platform', { value: 'win32' });",
       'const capturePath = process.env.SPAWN_CAPTURE_PATH;',
       "const mode = process.env.SPAWN_CAPTURE_MODE || 'success';",
+      "const agyMode = process.env.SPAWN_CAPTURE_AGY_MODE || 'absent';",
       'const calls = [];',
       'childProcess.spawnSync = (command, args = [], options = {}) => {',
       '  calls.push({',
@@ -165,6 +172,11 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
       '      },',
       '    },',
       '  });',
+      "  if (command === 'agy' && Array.isArray(args) && args[0] === '--version') {",
+      "    if (agyMode === 'absent') {",
+      "      return { status: 1, stdout: '', stderr: \"'agy' is not recognized\", pid: 0, output: [], signal: null };",
+      "    }",
+      "  }",
       "  if (mode === 'missing' && command === 'where') {",
       "    return { status: 1, stdout: '', stderr: '', pid: 0, output: [], signal: null };",
       '  }',
@@ -553,7 +565,10 @@ describe('run-provider-advisor script contract', () => {
         };
       }>;
 
-      expect(calls).toHaveLength(2);
+      // gemini: agy probe (fails) + gemini probe + gemini launch = 3 calls
+      // all other providers: version probe + launch = 2 calls
+      const expectedLength = provider === 'gemini' ? 3 : 2;
+      expect(calls).toHaveLength(expectedLength);
       for (const call of calls) {
         expect(call.options.env).toMatchObject({
           CLAUDECODE: null,
@@ -729,13 +744,19 @@ describe('run-provider-advisor script contract', () => {
         options: { shell: boolean; encoding: string | null; stdio: string | null; input: string | null };
       }>;
 
-      expect(calls).toHaveLength(2);
+      // agy probe (fails) + gemini probe + gemini launch = 3 calls
+      expect(calls).toHaveLength(3);
       expect(calls[0]).toMatchObject({
-        command: 'gemini',
+        command: 'agy',
         args: ['--version'],
         options: { shell: true, encoding: 'utf8', stdio: 'ignore', input: null },
       });
       expect(calls[1]).toMatchObject({
+        command: 'gemini',
+        args: ['--version'],
+        options: { shell: true, encoding: 'utf8', stdio: 'ignore', input: null },
+      });
+      expect(calls[2]).toMatchObject({
         command: 'gemini',
         args: ['--yolo'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'ship safely 你好' },
@@ -800,8 +821,9 @@ describe('run-provider-advisor script contract', () => {
         options: { shell: boolean; encoding: string | null; stdio: string | null; input: string | null };
       }>;
 
-      expect(calls).toHaveLength(2);
-      expect(calls[1]).toMatchObject({
+      // agy probe (fails) + gemini probe + gemini launch = 3 calls
+      expect(calls).toHaveLength(3);
+      expect(calls[2]).toMatchObject({
         command: 'gemini',
         args: ['--yolo'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: longPrompt },
@@ -1019,6 +1041,92 @@ describe('run-provider-advisor script contract', () => {
       // Provider spawn must close stdin to prevent hangs when parent stdin is a pipe
       expect(calls[1].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
       expect(calls[1].options.input).toBeNull();
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('launches agy with --print when agy is installed', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-agy-preferred-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['gemini', '--prompt', 'hello agy'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath, SPAWN_CAPTURE_AGY_MODE: 'present' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string; args: string[]; options: { input: string | null };
+      }>;
+
+      // agy probe + agy launch = 2 calls
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).toMatchObject({ command: 'agy', args: ['--version'] });
+      const launch = calls[1];
+      expect(launch.command).toBe('agy');
+      expect(launch.args).toEqual(['--print', 'hello agy']);
+      expect(launch.options.input).toBeNull();
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to gemini CLI when agy is absent (gemini provider)', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-gemini-fallback-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      // Windows prelude (platform=win32): agy absent by default, gemini found on fallback.
+      // On win32 the prompt is piped via stdin so args are ['--yolo'].
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['gemini', '--prompt', 'hello gemini'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string; args: string[]; options: { input: string | null };
+      }>;
+
+      // agy probe (fail) + gemini probe + gemini launch = 3 calls
+      expect(calls).toHaveLength(3);
+      expect(calls[0]).toMatchObject({ command: 'agy', args: ['--version'] });
+      expect(calls[1]).toMatchObject({ command: 'gemini', args: ['--version'] });
+      const launch = calls[2];
+      expect(launch.command).toBe('gemini');
+      // On win32 prompt is piped via stdin, so args are ['--yolo'] (no prompt arg)
+      expect(launch.args).toEqual(['--yolo']);
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('shows install guidance when neither agy nor gemini is installed', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-gemini-neither-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['gemini', '--prompt', 'install guidance'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath, SPAWN_CAPTURE_MODE: 'missing' },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Missing required CLI binary: agy or gemini');
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Adds `agy` (Google Antigravity CLI) as the preferred binary for the `gemini` provider slot, with automatic fallback to the legacy `gemini` CLI. Addresses all review blockers from #3262.

## Design

| Environment | Resolution | Spawns | CLI args |
|-------------|-----------|--------|----------|
| `agy` installed | `agy` wins | 1 probe + 1 launch = **2** | `agy --print <prompt>` |
| `agy` absent, `gemini` installed | `gemini` fallback | 2 probes + 1 launch = **3** | `gemini -p <prompt> --yolo` |
| Neither installed | Error exit | 2 probes | install guidance for both |

`resolveGeminiBinary()` returns `null` on failure. `main()` skips `ensureBinary` for the gemini provider — the resolution probes are the binary check. No double-probe.

## Changes

### `scripts/run-provider-advisor.js`
- `resolveGeminiBinary(env)`: probes `agy` → `gemini`, returns first found or `null`
- `main()`: gemini provider uses `resolveGeminiBinary`; skips `ensureBinary` entirely
- `buildProviderArgs`: `agy` → `['--print', prompt]`; legacy `gemini` → `['-p', prompt, '--yolo']` unchanged
- `shouldPipePromptViaStdin`: returns `false` for `agy` (stdin mode not confirmed for `--print`)
- `writeArtifact`: adds `Resolved binary` field for auditability
- Install guidance when neither binary is found

### `src/cli/__tests__/ask.test.ts`
- `writeSpawnSyncCapturePrelude`: `agy --version` fails by default (`SPAWN_CAPTURE_AGY_MODE=absent`); succeeds when `SPAWN_CAPTURE_AGY_MODE=present`
- `writeFakeProviderBinary`: always writes a failing `agy` stub for deterministic real-binary tests
- Existing gemini mock tests updated for 3-spawn contract (agy probe + gemini probe + gemini launch)
- **3 new focused tests**: agy preferred (2 spawns, `--print`), gemini fallback (3 spawns, `--yolo`), neither installed (exit 1 + install guidance)

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint: 0 errors, 19 pre-existing warnings
- [x] `src/cli/__tests__/ask.test.ts`: **35/35 PASS** (verified locally)
- [x] Full test suite: 9738 pass (18 pre-existing failures in `dev` branch unrelated to this change)
- [x] Manual: `omc ask gemini` routes to `agy --print` when `agy` installed
- [x] Manual: falls back to `gemini -p --yolo` when only legacy CLI available

## No breaking change

Existing `gemini` CLI users are fully unaffected when `agy` is not installed. The provider name `gemini` is preserved throughout.