### PR TITLE
fix(tmux): strip PSMUX_SESSION in tmuxEnv for detached session creation (#3265)

### DIFF
--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -29,6 +29,7 @@ import {
   listHudWatchPaneIdsInCurrentWindow,
   resolveLaunchPolicy,
   tmuxExec,
+  tmuxEnv,
   tmuxSpawn,
   wrapWithLoginShell,
   quoteShellArg,
@@ -180,6 +181,57 @@ describe('isClaudeAvailable', () => {
     });
 
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tmuxEnv — psmux detached-session env stripping (issue #3265)
+// ---------------------------------------------------------------------------
+describe('tmuxEnv', () => {
+  it('strips PSMUX_SESSION so psmux does not block detached new-session -d', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-0/default,1,0');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+
+    const env = tmuxEnv();
+
+    expect(env.TMUX).toBeUndefined();
+    expect(env.PSMUX_SESSION).toBeUndefined();
+  });
+
+  it('preserves unrelated env vars', () => {
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('CLAUDE_CONFIG_DIR', '/tmp/cfg');
+
+    const env = tmuxEnv();
+
+    expect(env.CLAUDE_CONFIG_DIR).toBe('/tmp/cfg');
+    expect(env.PSMUX_SESSION).toBeUndefined();
+  });
+
+  it('passes a PSMUX_SESSION-free env to execFile for detached creation (stripTmux: true)', () => {
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    mockedExecFileSync.mockClear();
+    mockedExecFileSync.mockReturnValue('' as any);
+
+    tmuxExec(['new-session', '-d', '-s', 'omc-detached'], { stripTmux: true });
+
+    const lastCall = mockedExecFileSync.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const passedEnv = (lastCall![2] as { env?: NodeJS.ProcessEnv }).env;
+    expect(passedEnv?.PSMUX_SESSION).toBeUndefined();
+  });
+
+  it('leaves PSMUX_SESSION intact when stripTmux is not set (in-session split path)', () => {
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    mockedExecFileSync.mockClear();
+    mockedExecFileSync.mockReturnValue('' as any);
+
+    tmuxExec(['split-window', '-h']);
+
+    const lastCall = mockedExecFileSync.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const passedEnv = (lastCall![2] as { env?: NodeJS.ProcessEnv }).env;
+    expect(passedEnv?.PSMUX_SESSION).toBe('psmux-session-1');
   });
 });
 

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -27,7 +27,11 @@ export interface TmuxExecOptions {
 }
 
 export function tmuxEnv(): NodeJS.ProcessEnv {
-  const { TMUX: _, ...env } = process.env;
+  // Strip both TMUX (real tmux) and PSMUX_SESSION (psmux's drop-in tmux on
+  // native Windows). psmux gates `new-session -d` nesting on PSMUX_SESSION,
+  // not TMUX, so dropping only TMUX leaves psmux silently no-op'ing detached
+  // session creation. See issue #3265.
+  const { TMUX: _, PSMUX_SESSION: __, ...env } = process.env;
   return env;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3265.

On native Windows where `tmux` is provided by [psmux](https://github.com/psmux/psmux), OMC's detached-session path (`new-session -d`) silently no-ops when run from inside an existing psmux session. psmux gates nesting on **`PSMUX_SESSION`** (not `TMUX`), so `tmuxEnv()` stripping only `TMUX` did nothing for psmux — the session was never created yet the command returned exit `0`, causing later `has-session`/`send-keys` calls to fail with `no server running on session '<name>'`.

## Change

- `src/cli/tmux-utils.ts`: strip `PSMUX_SESSION` alongside `TMUX` in `tmuxEnv()`.

This only affects call sites that opt into `stripTmux: true` (the detached-creation paths — `createTmuxSession()` and the detached team-topology fallback). The in-session split path does **not** set `stripTmux`, so it continues to target the ambient session and is unchanged. This matches psmux's own guidance (`unset PSMUX_SESSION to force`).

Audited detached-creation call sites: all `new-session -d` invocations (`src/cli/autoresearch-guided.ts`, `src/cli/launch.ts`, `src/team/tmux-session.ts`) already pass `stripTmux: true`, so the fix takes effect for every detached path.

## Tests

Added a focused `tmuxEnv` regression suite in `src/cli/__tests__/tmux-utils.test.ts`:
- strips `PSMUX_SESSION` (and `TMUX`)
- preserves unrelated env vars
- passes a `PSMUX_SESSION`-free env to `execFile` for `stripTmux: true` detached creation
- leaves `PSMUX_SESSION` intact when `stripTmux` is unset (in-session split path)

```
npx vitest run src/cli/__tests__/tmux-utils.test.ts
 Test Files  1 passed (1)
      Tests  45 passed (45)
```