### PR TITLE
fix(team): launch single-worker prose teams and spawn cmux worker panes (#3267)

### DIFF
--- a/src/__tests__/runtime-task-orphan.test.ts
+++ b/src/__tests__/runtime-task-orphan.test.ts
@@ -35,6 +35,7 @@ vi.mock('../team/tmux-session.js', () => ({
   killTeamSession: vi.fn(),
   resolveSplitPaneWorkerPaneIds: vi.fn(() => []),
   waitForPaneReady: vi.fn(() => Promise.resolve(true)),
+  splitTeamWorkerPane: vi.fn(() => Promise.resolve(null)),
 }));
 
 vi.mock('../team/worker-bootstrap.js', () => ({

--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -322,6 +322,50 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     );
   });
 
+  it('does not reject a single explicit worker when prose contains "and"/commas (#3267)', () => {
+    const parsed = parseTeamArgs(['1:executor', 'Read plan.md and execute it then commit the result']);
+    expect(parsed.workerCount).toBe(1);
+    expect(parsed.explicitWorkerSpec).toBe(true);
+
+    const decomposition = splitTaskString(parsed.task);
+    // Free-form prose still parses as a conjunction heuristic...
+    expect(decomposition.strategy).toBe('conjunction');
+    expect(decomposition.subtasks.length).toBeGreaterThan(1);
+
+    const effective = resolveTeamFanoutLimit(
+      parsed.workerCount,
+      parsed.agentTypes[0],
+      parsed.explicitWorkerSpec ? parsed.workerCount : undefined,
+      decomposition,
+      parsed.noDecompose,
+    );
+    expect(effective).toBe(1);
+
+    // ...but a conjunction guess must NOT reject the explicit worker spec.
+    const tasks = buildTeamLaunchTasks(parsed, decomposition, effective);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].description).toBe(parsed.task);
+  });
+
+  it('gives every explicit worker the full prose instead of splitting on conjunctions (#3267)', () => {
+    const parsed = parseTeamArgs(['2:codex', 'review the parser and patch the runtime']);
+    const decomposition = splitTaskString(parsed.task);
+    expect(decomposition.strategy).toBe('conjunction');
+    expect(decomposition.subtasks).toHaveLength(2);
+
+    const effective = resolveTeamFanoutLimit(
+      parsed.workerCount,
+      parsed.agentTypes[0],
+      parsed.explicitWorkerSpec ? parsed.workerCount : undefined,
+      decomposition,
+      parsed.noDecompose,
+    );
+    expect(effective).toBe(2);
+
+    const tasks = buildTeamLaunchTasks(parsed, decomposition, effective);
+    expect(tasks.map((task) => task.description)).toEqual([parsed.task, parsed.task]);
+  });
+
   it('maps pre-authored numbered scopes to explicit workers when counts match', () => {
     const parsed = parseTeamArgs([
       '1:claude,2:codex',

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -516,9 +516,18 @@ export function buildTeamLaunchTasks(
   effectiveWorkerCount: number,
 ): TeamLaunchTask[] {
   const tasks: TeamLaunchTask[] = [];
+
+  // Numbered/bulleted lists are explicit pre-authored scopes the user typed out,
+  // so they must line up with an explicit worker count. A `conjunction` split is
+  // only a heuristic guess at parallelism inside free-form prose (e.g.
+  // "Read X and execute it then commit"), so it must never reject or reshape an
+  // explicit worker spec — every worker just receives the full launch text. (#3267)
+  const isPreauthoredScopeList = decomposition.strategy === 'numbered'
+    || decomposition.strategy === 'bulleted';
+
   if (parsed.explicitWorkerSpec
     && !parsed.noDecompose
-    && decomposition.strategy !== 'atomic'
+    && isPreauthoredScopeList
     && decomposition.subtasks.length > 1
     && decomposition.subtasks.length !== effectiveWorkerCount) {
     throw new Error(
@@ -529,7 +538,8 @@ export function buildTeamLaunchTasks(
   const canUseDecomposition = !parsed.noDecompose
     && decomposition.strategy !== 'atomic'
     && decomposition.subtasks.length > 1
-    && (!parsed.explicitWorkerSpec || decomposition.subtasks.length === effectiveWorkerCount);
+    && (!parsed.explicitWorkerSpec
+      || (isPreauthoredScopeList && decomposition.subtasks.length === effectiveWorkerCount));
 
   for (let i = 0; i < effectiveWorkerCount; i++) {
     const workerSpec = parsed.workerSpecs[i];

--- a/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
+++ b/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
@@ -38,6 +38,7 @@ vi.mock('../tmux-session.js', () => ({
   paneHasActiveTask: vi.fn(() => false),
   paneLooksReady: vi.fn(() => true),
   applyMainVerticalLayout: mocks.applyMainVerticalLayout,
+  splitTeamWorkerPane: vi.fn(async () => '%2'),
 }));
 
 vi.mock('../model-contract.js', () => ({

--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -101,7 +101,7 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
-import { createTeamSession, detectTeamMultiplexerContext } from '../tmux-session.js';
+import { createTeamSession, detectTeamMultiplexerContext, splitTeamWorkerPane } from '../tmux-session.js';
 
 describe('detectTeamMultiplexerContext', () => {
   afterEach(() => {
@@ -246,5 +246,51 @@ describe('createTeamSession context resolution', () => {
     expect(session.sessionName).toBe('omx:5');
     expect(session.workerPaneIds).toEqual(['%501']);
     expect(session.sessionMode).toBe('dedicated-window');
+  });
+});
+
+describe('splitTeamWorkerPane multiplexer routing (#3267)', () => {
+  beforeEach(() => {
+    mockedCalls.execFileArgs = [];
+    mockedCalls.splitCount = 0;
+    mockedCalls.newSplitStdouts = [];
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('creates a native cmux surface (not a tmux pane) for on-demand workers under cmux', async () => {
+    vi.stubEnv('TMUX', '');
+    vi.stubEnv('TMUX_PANE', '');
+    vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');
+    vi.stubEnv('CMUX_WORKSPACE_ID', 'workspace-1');
+
+    const paneId = await splitTeamWorkerPane('cmux-leader', 'right', '/tmp');
+
+    // A cmux surface id (UUID/token) — NOT a tmux "%N" pane id — so that
+    // spawnWorkerInPane()/waitForShellReady() short-circuit instead of polling
+    // tmux and timing out with worker_start_shell_not_ready.
+    expect(paneId).toBe('cmux-worker-1');
+    expect(paneId?.startsWith('%')).toBe(false);
+    expect(mockedCalls.execFileArgs).toContainEqual(
+      ['new-split', 'right', '--surface', 'cmux-leader', '--workspace', 'workspace-1'],
+    );
+    expect(mockedCalls.execFileArgs.some((args) => args[0] === 'split-window')).toBe(false);
+  });
+
+  it('falls back to a tmux split-window pane id when running under tmux', async () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1,1');
+    vi.stubEnv('TMUX_PANE', '%732');
+    vi.stubEnv('CMUX_SURFACE_ID', '');
+
+    const paneId = await splitTeamWorkerPane('%732', 'down', '/tmp');
+
+    expect(paneId).toBe('%501');
+    expect(mockedCalls.execFileArgs).toContainEqual(
+      expect.arrayContaining(['split-window', '-v', '-t', '%732']),
+    );
+    expect(mockedCalls.execFileArgs.some((args) => args[0] === 'new-split')).toBe(false);
   });
 });

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -64,7 +64,7 @@ import {
 } from './model-contract.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker, killTeamSession,
-  waitForPaneReady, paneHasActiveTask, paneLooksReady, applyMainVerticalLayout, getWorkerLiveness, captureTeamPane, sendTeamPaneKey, type WorkerPaneConfig, type WorkerPaneLiveness, type TeamSessionMode,
+  waitForPaneReady, paneHasActiveTask, paneLooksReady, applyMainVerticalLayout, getWorkerLiveness, captureTeamPane, sendTeamPaneKey, splitTeamWorkerPane, type WorkerPaneConfig, type WorkerPaneLiveness, type TeamSessionMode,
 } from './tmux-session.js';
 import {
   composeInitialInbox,
@@ -610,14 +610,9 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
   const splitTarget = opts.existingWorkerPaneIds.length === 0
     ? opts.leaderPaneId
     : opts.existingWorkerPaneIds[opts.existingWorkerPaneIds.length - 1];
-  const splitType = opts.existingWorkerPaneIds.length === 0 ? '-h' : '-v';
+  const splitDirection = opts.existingWorkerPaneIds.length === 0 ? 'right' : 'down';
 
-  const splitResult = await tmuxExecAsync([
-    'split-window', splitType, '-t', splitTarget,
-    '-d', '-P', '-F', '#{pane_id}',
-    '-c', opts.workerCwd ?? opts.cwd,
-  ]);
-  const paneId = splitResult.stdout.split('\n')[0]?.trim();
+  const paneId = await splitTeamWorkerPane(splitTarget, splitDirection, opts.workerCwd ?? opts.cwd);
   if (!paneId) {
     return { paneId: null, startupAssigned: false, startupFailureReason: 'pane_id_missing' };
   }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -7,7 +7,7 @@ import { buildWorkerArgv, resolveValidatedBinaryPath, getWorkerEnv as getModelWo
 import { validateTeamName } from './team-name.js';
 import {
   createTeamSession, spawnWorkerInPane, sendToWorker,
-  isWorkerAlive, killTeamSession, resolveSplitPaneWorkerPaneIds, waitForPaneReady, applyMainVerticalLayout, killTeamPane,
+  isWorkerAlive, killTeamSession, resolveSplitPaneWorkerPaneIds, waitForPaneReady, applyMainVerticalLayout, killTeamPane, splitTeamWorkerPane,
   type TeamSession, type WorkerPaneConfig,
 } from './tmux-session.js';
 import {
@@ -686,13 +686,8 @@ export async function spawnWorkerForTask(
   const splitTarget = runtime.workerPaneIds.length === 0
     ? runtime.leaderPaneId
     : runtime.workerPaneIds[runtime.workerPaneIds.length - 1];
-  const splitType = runtime.workerPaneIds.length === 0 ? '-h' : '-v';
-  const splitResult = await tmuxExecAsync([
-    'split-window', splitType, '-t', splitTarget,
-    '-d', '-P', '-F', '#{pane_id}',
-    '-c', runtime.cwd,
-  ]);
-  const paneId = splitResult.stdout.split('\n')[0]?.trim();
+  const splitDirection = runtime.workerPaneIds.length === 0 ? 'right' : 'down';
+  const paneId = await splitTeamWorkerPane(splitTarget, splitDirection, runtime.cwd);
   if (!paneId) {
     try {
       await resetTaskToPending(root, taskId, runtime.teamName, runtime.cwd);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -650,6 +650,33 @@ export function spawnBridgeInSession(
  * Layout: leader pane on the left, worker panes stacked vertically on the right.
  * IMPORTANT: Uses pane IDs (%N format) not pane indices for stable targeting.
  */
+/**
+ * Split a new worker pane off `splitTarget`, honoring the active multiplexer.
+ *
+ * Under cmux a worker MUST be a native cmux surface (UUID), not a tmux pane id
+ * (`%N`). Otherwise spawnWorkerInPane()/waitForShellReady() classify the worker
+ * as a tmux pane, poll tmux for shell readiness, and time out after 5s with
+ * `worker_start_shell_not_ready` — abandoning the worker's git worktree.
+ * createTeamSession() already branches this way for panes created up front; the
+ * on-demand worker spawns in both team runtimes must do the same. (#3267)
+ */
+export async function splitTeamWorkerPane(
+  splitTarget: string,
+  direction: 'right' | 'down',
+  cwd: string,
+): Promise<string | null> {
+  if (isCmuxContext()) {
+    return cmuxSplitSurface(splitTarget, direction, cwd);
+  }
+  const splitType = direction === 'right' ? '-h' : '-v';
+  const splitResult = await tmuxExecAsync([
+    'split-window', splitType, '-t', splitTarget,
+    '-d', '-P', '-F', '#{pane_id}',
+    '-c', cwd,
+  ]);
+  return splitResult.stdout.split('\n')[0]?.trim() || null;
+}
+
 export async function createTeamSession(
   teamName: string,
   workerCount: number,


### PR DESCRIPTION
## Summary

Fixes two CLI team-launcher defects reported in #3267, both reproduced by `omc team 1:executor "Read X and execute it then commit..."`. Native MCP `TeamCreate`/Agent teammates were unaffected because they create panes through the already cmux-aware `createTeamSession()`; only the on-demand CLI spawn paths were broken.

## Root causes (independently verified)

**1. Conjunction false-rejection — `src/cli/commands/team.ts`**

`buildTeamLaunchTasks()` threw `"Pre-authored task scope count (N) must match explicit worker count (M)"` for *any* non-atomic decomposition whose subtask count differed from an explicit worker count. But the `conjunction` strategy is only a heuristic that splits free-form prose on `" and "` / commas — `"Read X and execute it then commit"` becomes 2 "scopes", so a single explicit worker (`1:executor`) was wrongly rejected.

Only numbered/bulleted lists are genuine pre-authored scopes. The fix restricts both the scope-count rejection and explicit-spec decomposition to `numbered`/`bulleted` strategies; a conjunction never reshapes or rejects an explicit worker spec — every worker just receives the full launch text. This also honors the existing contract test *"does not reduce explicit worker specs to comma-derived subtask count"*.

**2. cmux shell-readiness timeout — `src/team/runtime-v2.ts` + `src/team/runtime.ts`**

`spawnV2Worker()` and `spawnWorkerForTask()` always created the worker pane via tmux `split-window`, even under cmux, yielding a `%N` tmux pane id. `spawnWorkerInPane()` / `waitForShellReady()` then classified the worker as a tmux pane, polled tmux for shell readiness, and timed out after 5000ms with `worker_start_shell_not_ready` — abandoning the worker's git worktree (the reported stale worktrees).

`createTeamSession()` already branched to `cmuxSplitSurface()` for panes created up front, but the on-demand spawns did not. The fix extracts a shared cmux-aware `splitTeamWorkerPane()` helper in `tmux-session.ts` and routes both runtime spawns through it, so a cmux worker gets a native surface id (UUID) — `isCmuxSurfaceTarget()` then short-circuits readiness and delivery uses `cmux send`.

## Tests

- `team.test.ts`: single explicit worker with `"and"`/comma prose is **not** rejected; multi-worker conjunction gives every worker the full prose (no split).
- `tmux-session.create-team.test.ts`: `splitTeamWorkerPane()` creates a native cmux surface under cmux (no `split-window`) and falls back to a tmux `%N` pane under tmux.
- Updated the two fully-mocked runtime suites (`runtime-v2.gemini-preflight`, `runtime-task-orphan`) to provide the new `splitTeamWorkerPane` export.

## Verification

- Targeted vitest suites (team CLI, tmux-session, runtime v1/v2 spawn paths): green.
- `tsc --noEmit`: clean.
- `eslint` on changed files: clean.

Closes #3267

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*