### PR TITLE
feat(ask): add -m/--model passthrough for `omc ask gemini`

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -13,6 +13,7 @@ export const ASK_USAGE = [
   '   or: omc ask <claude|codex|gemini|grok|cursor> --prompt "<prompt>"',
   '   or: omc ask <claude|codex|gemini|grok|cursor> --agent-prompt <role> "<prompt>"',
   '   or: omc ask <claude|codex|gemini|grok|cursor> --agent-prompt=<role> --prompt "<prompt>"',
+  '   or: omc ask gemini -m <model> -p "<prompt>"   (gemini only; pins GEMINI_MODEL, e.g. gemini-2.5-pro)',
 ].join('\n');
 
 const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'grok', 'cursor'] as const;
@@ -29,6 +30,7 @@ export interface ParsedAskArgs {
   provider: AskProvider;
   prompt: string;
   agentPromptRole?: string;
+  model?: string;
 }
 
 function askUsageError(reason: string): Error {
@@ -131,10 +133,30 @@ export function parseAskArgs(args: readonly string[]): ParsedAskArgs {
   }
 
   let agentPromptRole: string | undefined;
+  let modelOverride: string | undefined;
   let prompt = '';
 
   for (let i = 0; i < rest.length; i += 1) {
     const token = rest[i];
+    if (token === '-m' || token === '--model') {
+      const model = rest[i + 1]?.trim();
+      if (!model || model.startsWith('-')) {
+        throw askUsageError('Missing model after -m/--model.');
+      }
+      modelOverride = model;
+      i += 1;
+      continue;
+    }
+
+    if (token.startsWith('--model=') || token.startsWith('-m=')) {
+      const model = token.slice(token.indexOf('=') + 1).trim();
+      if (!model) {
+        throw askUsageError('Missing model after --model=.');
+      }
+      modelOverride = model;
+      continue;
+    }
+
     if (token === ASK_AGENT_PROMPT_FLAG) {
       const role = rest[i + 1]?.trim();
       if (!role || role.startsWith('-')) {
@@ -177,6 +199,7 @@ export function parseAskArgs(args: readonly string[]): ParsedAskArgs {
     provider: provider as AskProvider,
     prompt,
     ...(agentPromptRole ? { agentPromptRole } : {}),
+    ...(modelOverride ? { model: modelOverride } : {}),
   };
 }
 
@@ -241,6 +264,12 @@ export async function askCommand(args: string[]): Promise<void> {
       env: {
         ...process.env,
         [ASK_ORIGINAL_TASK_ENV]: parsed.prompt,
+        // -m/--model passthrough: the gemini CLI reads GEMINI_MODEL natively, so injecting it
+        // here propagates ask -> advisor -> gemini with no advisor change. Gemini-only for now
+        // (codex/claude/grok/cursor have their own model routing); the parser accepts it generically.
+        ...(parsed.model && parsed.provider === 'gemini'
+          ? { GEMINI_MODEL: parsed.model }
+          : {}),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     },


### PR DESCRIPTION
## What

Adds a `-m` / `--model` flag to `omc ask` so a gemini call can pin its model:

```
omc ask gemini -m gemini-2.5-pro -p "<prompt>"
```

## Why

The `gemini` CLI defaults to a Flash model, and `omc ask` had no way to override it. On a Gemini **Code Assist standard-tier (Pro)** account this means heavy `ask`/advisor delegation silently runs Flash — you pay for Pro but never use it. There was no per-call escape hatch short of exporting `GEMINI_MODEL` yourself.

## How

`ask.ts` parses `-m` / `--model` / `--model=<v>` and, for the `gemini` provider, injects `GEMINI_MODEL` into the advisor spawn env. The gemini CLI reads `GEMINI_MODEL` natively, so this propagates `ask → run-provider-advisor.js → gemini` with **no change to the advisor script**. Mirrors the existing `--model` handling in `cg.ts`.

- Parser accepts the flag generically; env injection is gemini-scoped for now (codex/claude/grok/cursor have their own model routing).
- Unknown flags before the prompt are unaffected; the flag must precede `-p`/`--prompt` (same convention as `--agent-prompt`).

## Testing

Verified end-to-end against a built runtime:
- `-m gemini-2.5-flash` → Flash (overrides the account default)
- no flag → account default (unchanged behavior)
- flag value does **not** leak into the stored prompt
- `tsc --noEmit` clean

Source-only change — `bridge/cli.cjs` is a build artifact; rebuild with `npm run build:cli`.