### PR TITLE
fix(session-search): strip drive colon so current-scope search finds transcripts on Windows

### DIFF
--- a/src/__tests__/session-history-search.test.ts
+++ b/src/__tests__/session-history-search.test.ts
@@ -3,13 +3,10 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { basename, join } from 'path';
 import {
+  encodeProjectPath,
   parseSinceSpec,
   searchSessionHistory,
 } from '../features/session-history-search/index.js';
-
-function encodeProjectPath(projectPath: string): string {
-  return projectPath.replace(/[/\\.]/g, '-');
-}
 
 function writeTranscript(filePath: string, entries: Array<Record<string, unknown>>): void {
   mkdirSync(join(filePath, '..'), { recursive: true });
@@ -153,6 +150,17 @@ describe('session history search', () => {
 
     expect(report.totalMatches).toBe(1);
     expect(report.results[0].sessionId).toBe('session-tilde');
+  });
+
+  it('encodes a Windows drive path the same way Claude Code names its project dir', () => {
+    // Regression: the drive colon must be replaced with "-" so the encoded directory
+    // matches Claude Code's actual project dir (e.g. ~/.claude/projects/C--Users-me-proj).
+    // Before the fix this returned "C:-Users-me-proj", which never matched on Windows and
+    // made current-scope search find zero project transcripts. Platform-independent: this
+    // asserts the encoding of a literal Windows-style string regardless of host OS.
+    expect(encodeProjectPath('C:\\Users\\me\\proj')).toBe('C--Users-me-proj');
+    // POSIX paths are unaffected (no colon to replace).
+    expect(encodeProjectPath('/home/me/proj')).toBe('-home-me-proj');
   });
 
   it('parses relative and absolute since values', () => {

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -67,7 +67,13 @@ function parseSinceSpec(since?: string): number | undefined {
 }
 
 function encodeProjectPath(projectPath: string): string {
-  return projectPath.replace(/[/\\.]/g, '-');
+  // Mirror Claude Code's project-dir naming. On Windows an absolute path carries a
+  // drive colon (e.g. C:\Users\x) and Claude Code stores transcripts under
+  // ~/.claude/projects/C--Users-x — i.e. the colon is replaced with "-" just like
+  // the separators. Omitting ":" here produced "C:-Users-x", which never matches the
+  // real directory, so "current"-scope search discovered zero project transcripts on
+  // Windows. POSIX paths contain no colon, so this is a no-op there.
+  return projectPath.replace(/[/\\.:]/g, '-');
 }
 
 function getMainRepoRoot(projectRoot: string): string | null {
@@ -560,7 +566,7 @@ export async function searchSessionHistory(
   };
 }
 
-export { parseSinceSpec };
+export { encodeProjectPath, parseSinceSpec };
 export type {
   SessionHistoryMatch,
   SessionHistorySearchOptions,


### PR DESCRIPTION
## Problem

On Windows, `session_search` in its default **`current`** scope returns zero matches even when the query term appears many times in the project's transcripts. `project="all"` and named (`project="<name>"`) scopes work, so the data, file discovery, and text extraction are all fine — only `current` scope is broken on Windows.

## Root cause

`encodeProjectPath` builds the `~/.claude/projects/<dir>` name that Claude Code uses to store a project's transcripts. On Windows an absolute path carries a drive colon (`C:\Users\x`). A colon is illegal in a directory name, so Claude Code replaces it with `-` along with the separators — the real directory is `C--Users-x`.

`encodeProjectPath` replaced separators and dots, but **not the colon**:

```
C:\Users\me\proj
  → encodeProjectPath: C:-Users-me-proj   ← what OMC looked for (never exists)
  → Claude Code's dir: C--Users-me-proj   ← where the transcripts actually are
```

The encoded directory never matched, so `current` scope discovered **zero project transcripts** on Windows. `project="all"` skips the per-project directory lookup, which is why it worked.

This is the same class of bug as **#2291** ("transcript resolution fails for paths containing dots") — which is exactly why `.` is already in the replaced character class. The drive colon was simply missed for Windows.

## Fix

Add `:` to the replaced character class:

```diff
-  return projectPath.replace(/[/\\.]/g, '-');
+  return projectPath.replace(/[/\\.:]/g, '-');
```

- No-op on POSIX (no colon in paths), so Linux CI behavior is unchanged.
- `encodeProjectPath` is now exported so the encoding can be unit-tested directly and deterministically across platforms.

## Tests

- Direct unit test: `encodeProjectPath('C:\\Users\\me\\proj') === 'C--Users-me-proj'`, plus a POSIX no-op assertion. Platform-independent (asserts the encoding of literal strings, so it fails on the old code and passes on the new code regardless of host OS).

## Verification

Verified on Windows 11 (Node 24) against a real `~/.claude/projects` directory: before the fix the encoded directory (`C:-Users-...`) did not exist on disk while the real one (`C--Users-...`) did, so `current` scope found no project transcripts; after the fix the encoded name matches the real directory. The full `session-history-search` test suite passes.

## Scope note

I originally also hardened `isWithinProject` to be case-insensitive (a separate, rarer drive-letter-case scenario). I dropped it from this PR to keep the change minimal and free of a POSIX case-sensitivity tradeoff — happy to file it separately if useful.
