### PR TITLE
fix(session-search): fix Windows worktree transcript resolution + converge the encoder

### DIFF
--- a/src/__tests__/resolve-transcript-path.test.ts
+++ b/src/__tests__/resolve-transcript-path.test.ts
@@ -15,6 +15,7 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { resolveTranscriptPath } from '../lib/worktree-paths.js';
+import { encodeProjectPath } from '../utils/encode-project-path.js';
 
 describe('resolveTranscriptPath', () => {
   let tempDir: string;
@@ -120,6 +121,39 @@ describe('resolveTranscriptPath', () => {
     expect(resolveTranscriptPath(normalPath)).toBe(normalPath);
   });
 
+  it('resolves via a .claude/worktrees CWD using the OS-native separator (Strategy 2)', () => {
+    // Regression: the worktree marker and the session-filename extraction must
+    // be separator-agnostic. On Windows the CWD arrives with `\`, so a
+    // hard-coded `.claude/worktrees/` marker (and lastIndexOf('/')) never
+    // matched and Strategy 2 was dead. Uses join() so the CWD carries whatever
+    // separator the host OS produces, exercising the fix on that OS.
+    const origClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    const fakeClaudeDir = join(tempDir, 'fake-claude');
+    process.env.CLAUDE_CONFIG_DIR = fakeClaudeDir;
+    try {
+      const projectRoot = join(tempDir, 'myproject');
+      const realDir = join(fakeClaudeDir, 'projects', encodeProjectPath(projectRoot));
+      mkdirSync(realDir, { recursive: true });
+      const realTranscript = join(realDir, 'sess.jsonl');
+      writeFileSync(realTranscript, '{}');
+
+      // CWD inside a Claude internal worktree (separator is OS-native here).
+      const worktreeCwd = join(projectRoot, '.claude', 'worktrees', 'wt');
+      // Worktree-encoded transcript path that does not exist and does NOT carry
+      // the `--claude-worktrees-` substring, so Strategy 1 is skipped and the
+      // CWD-based Strategy 2 is what resolves it.
+      const worktreePath = join(fakeClaudeDir, 'projects', '-missing-worktree-dir', 'sess.jsonl');
+
+      expect(resolveTranscriptPath(worktreePath, worktreeCwd)).toBe(realTranscript);
+    } finally {
+      if (origClaudeConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = origClaudeConfigDir;
+      }
+    }
+  });
+
   // --- Native git worktree tests (issue #1191) ---
 
   describe('native git worktree fallback', () => {
@@ -156,7 +190,7 @@ describe('resolveTranscriptPath', () => {
       // Simulate ~/.claude/projects/ with a transcript at the main repo's encoded path
       fakeClaudeDir = join(tempDir, 'fake-claude');
       process.env.CLAUDE_CONFIG_DIR = fakeClaudeDir;
-      const encodedMain = mainRepoDir.replace(/[/\\.]/g, '-');
+      const encodedMain = encodeProjectPath(mainRepoDir);
       const projectDir = join(fakeClaudeDir, 'projects', encodedMain);
       mkdirSync(projectDir, { recursive: true });
       writeFileSync(join(projectDir, 'session-abc.jsonl'), '{}');
@@ -183,18 +217,18 @@ describe('resolveTranscriptPath', () => {
 
     it('resolves transcript path from native git worktree to main repo (issue #1191)', () => {
       // The worktree-encoded transcript path (does not exist)
-      const encodedWorktree = worktreeDir.replace(/[/\\.]/g, '-');
+      const encodedWorktree = encodeProjectPath(worktreeDir);
       const worktreePath = join(fakeClaudeDir, 'projects', encodedWorktree, 'session-abc.jsonl');
 
       const resolved = resolveTranscriptPath(worktreePath, worktreeDir);
-      const encodedMain = mainRepoDir.replace(/[/\\.]/g, '-');
+      const encodedMain = encodeProjectPath(mainRepoDir);
       const expectedPath = join(fakeClaudeDir, 'projects', encodedMain, 'session-abc.jsonl');
 
       expect(resolved).toBe(expectedPath);
     });
 
     it('does not alter path when CWD is the main repo (not a worktree)', () => {
-      const encodedMain = mainRepoDir.replace(/[/\\.]/g, '-');
+      const encodedMain = encodeProjectPath(mainRepoDir);
       const mainPath = join(fakeClaudeDir, 'projects', encodedMain, 'session-abc.jsonl');
 
       // Path exists and CWD is the main repo — should return as-is
@@ -203,7 +237,7 @@ describe('resolveTranscriptPath', () => {
     });
 
     it('returns original path when main repo transcript also missing', () => {
-      const encodedWorktree = worktreeDir.replace(/[/\\.]/g, '-');
+      const encodedWorktree = encodeProjectPath(worktreeDir);
       // Use a session file that doesn't exist at the main repo path either
       const worktreePath = join(fakeClaudeDir, 'projects', encodedWorktree, 'nonexistent.jsonl');
 

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -6,10 +6,7 @@ import {
   formatSessionSearchReport,
   sessionSearchCommand,
 } from '../commands/session-search.js';
-
-function encodeProjectPath(projectPath: string): string {
-  return projectPath.replace(/[/\\.]/g, '-');
-}
+import { encodeProjectPath } from '../../utils/encode-project-path.js';
 
 function writeTranscript(filePath: string, entries: Array<Record<string, unknown>>): void {
   mkdirSync(join(filePath, '..'), { recursive: true });

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -9,6 +9,7 @@ import {
   getOmcRoot,
 } from '../../lib/worktree-paths.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
+import { encodeProjectPath } from '../../utils/encode-project-path.js';
 import type {
   SessionHistoryMatch,
   SessionHistorySearchOptions,
@@ -64,16 +65,6 @@ function parseSinceSpec(since?: string): number | undefined {
 
   const parsed = Date.parse(trimmed);
   return Number.isNaN(parsed) ? undefined : parsed;
-}
-
-function encodeProjectPath(projectPath: string): string {
-  // Mirror Claude Code's project-dir naming. On Windows an absolute path carries a
-  // drive colon (e.g. C:\Users\x) and Claude Code stores transcripts under
-  // ~/.claude/projects/C--Users-x — i.e. the colon is replaced with "-" just like
-  // the separators. Omitting ":" here produced "C:-Users-x", which never matches the
-  // real directory, so "current"-scope search discovered zero project transcripts on
-  // Windows. POSIX paths contain no colon, so this is a no-op there.
-  return projectPath.replace(/[/\\.:]/g, '-');
 }
 
 function getMainRepoRoot(projectRoot: string): string | null {

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -15,6 +15,7 @@ import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFi
 import { homedir, tmpdir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
+import { encodeProjectPath } from '../utils/encode-project-path.js';
 
 /**
  * Workspace marker filename. A directory containing this file is treated as
@@ -939,29 +940,29 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
   }
 
   // Strategy 2: Use CWD to detect worktree and reconstruct the path.
-  // When the CWD contains `/.claude/worktrees/`, we can derive the main
-  // project root and look for the transcript there.
+  // When the CWD contains `<sep>.claude<sep>worktrees<sep>`, we can derive the
+  // main project root and look for the transcript there. The marker is
+  // normalized so it matches the OS-native separator — on Windows the CWD uses
+  // `\`, so a hard-coded `/.claude/worktrees/` would never match.
   const effectiveCwd = cwd || process.cwd();
-  const worktreeMarker = '.claude/worktrees/';
-  const markerIdx = effectiveCwd.indexOf(worktreeMarker);
+  const normalizedCwd = normalize(effectiveCwd);
+  const worktreeMarker = normalize('/.claude/worktrees/');
+  const markerIdx = normalizedCwd.indexOf(worktreeMarker);
   if (markerIdx !== -1) {
-    // Adjust index to exclude the preceding path separator
-    const mainProjectRoot = effectiveCwd.substring(
-      0,
-      markerIdx > 0 && effectiveCwd[markerIdx - 1] === sep ? markerIdx - 1 : markerIdx,
-    );
+    // The marker includes its leading separator, so everything before it is
+    // the main project root.
+    const mainProjectRoot = normalizedCwd.substring(0, markerIdx);
 
-    // Extract session filename from the original path
-    const lastSep = transcriptPath.lastIndexOf('/');
-    const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
+    // Extract the session filename. basename handles both separators on
+    // Windows (transcript_path arrives with `\`) and `/` on POSIX.
+    const sessionFile = basename(transcriptPath);
     if (sessionFile) {
       // The projects directory is under the Claude config dir
       const projectsDir = join(getClaudeConfigDir(), 'projects');
 
       if (existsSync(projectsDir)) {
-        // Encode the main project root the same way Claude Code does:
-        // replace path separators with `-`, replace dots with `-`.
-        const encodedMain = mainProjectRoot.replace(/[/\\.]/g, '-');
+        // Encode the main project root the same way Claude Code does.
+        const encodedMain = encodeProjectPath(mainProjectRoot);
         const resolvedPath = join(projectsDir, encodedMain, sessionFile);
         if (existsSync(resolvedPath)) return resolvedPath;
       }
@@ -998,12 +999,12 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
     }).trim();
 
     if (mainRepoRoot !== worktreeTop) {
-      const lastSep = transcriptPath.lastIndexOf('/');
-      const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
+      // basename handles `\` (Windows transcript_path) and `/` (POSIX).
+      const sessionFile = basename(transcriptPath);
       if (sessionFile) {
         const projectsDir = join(getClaudeConfigDir(), 'projects');
         if (existsSync(projectsDir)) {
-          const encodedMain = mainRepoRoot.replace(/[/\\.]/g, '-');
+          const encodedMain = encodeProjectPath(mainRepoRoot);
           const resolvedPath = join(projectsDir, encodedMain, sessionFile);
           if (existsSync(resolvedPath)) return resolvedPath;
         }

--- a/src/utils/__tests__/encode-project-path.test.ts
+++ b/src/utils/__tests__/encode-project-path.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { encodeProjectPath } from '../encode-project-path.js';
+
+describe('encodeProjectPath', () => {
+  it('encodes a Windows drive path the way Claude Code names its project dir', () => {
+    // Regression: the drive colon must be replaced with "-" so the encoded
+    // directory matches Claude Code's actual project dir
+    // (e.g. ~/.claude/projects/C--Users-me-proj). Before the colon was added to
+    // the character class this returned "C:-Users-me-proj", which never matched
+    // on Windows. Asserts on a literal string, so it runs and guards on any OS.
+    expect(encodeProjectPath('C:\\Users\\me\\proj')).toBe('C--Users-me-proj');
+  });
+
+  it('encodes a POSIX path (colon replacement is a no-op there)', () => {
+    expect(encodeProjectPath('/home/me/proj')).toBe('-home-me-proj');
+  });
+
+  it('replaces dots so paths with dotted segments still match', () => {
+    expect(encodeProjectPath('/home/me/my.proj')).toBe('-home-me-my-proj');
+  });
+});

--- a/src/utils/encode-project-path.ts
+++ b/src/utils/encode-project-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Claude Code project-directory name encoding.
+ *
+ * Claude Code stores a project's transcripts under
+ * `~/.claude/projects/<encoded>` where `<encoded>` is the project's absolute
+ * path with path separators, dots, and the Windows drive colon all replaced
+ * by `-`. For example:
+ *
+ *   POSIX:    /home/me/proj      -> -home-me-proj
+ *   Windows:  C:\Users\me\proj   -> C--Users-me-proj
+ *
+ * The drive colon matters: omitting `:` produces `C:-Users-me-proj`, which
+ * never matches the real directory, so any lookup keyed on the encoded name
+ * finds zero transcripts on Windows. POSIX paths contain no colon, so the
+ * colon replacement is a no-op there.
+ *
+ * This is the single source of truth for that encoding. Both the session
+ * history search (`features/session-history-search`) and the worktree
+ * transcript resolver (`lib/worktree-paths`) must encode identically — keeping
+ * the rule in one place prevents the two from drifting apart (the drive-colon
+ * fix originally landed only in session-history-search; see PR #3274).
+ */
+export function encodeProjectPath(projectPath: string): string {
+  return projectPath.replace(/[/\\.:]/g, '-');
+}


### PR DESCRIPTION
## Problem

On Windows, `resolveTranscriptPath` (`src/lib/worktree-paths.ts`) never resolved
worktree-mismatched transcripts back to the real project transcript. Two
separate POSIX-path assumptions combined to break it:

**1. Drive-colon encoding divergence.** The encoder that reproduces Claude
Code's `~/.claude/projects/<dir>` name was duplicated, and the `worktree-paths`
copy still omitted the drive colon:

```
mainRepoRoot.replace(/[/\\.]/g, '-')   // C:\Users\me\proj → C:-Users-me-proj
```

Claude Code's real dir is `C--Users-me-proj` (colon → `-`), so the encoded name
never matched. This is exactly the divergence the #3274 merge review flagged:

> The drive-colon divergence still exists in the worktree transcript resolver
> (`src/lib/worktree-paths.ts` ~lines 964 and 1006) ... worth a follow-up to
> converge on a shared encoder.

**2. Separator handling.** Even with the colon fixed, both resolution
strategies bailed out before the encoder was reached:

- Strategy 2 used a hard-coded marker `'.claude/worktrees/'` and
  `effectiveCwd.indexOf(...)` — the Windows CWD uses `\`, so this returned `-1`.
- Strategy 3 (and Strategy 2) extracted the session filename with
  `transcriptPath.lastIndexOf('/')` — also `-1` on a backslash path.

I verified from a real hook payload on Windows that Claude Code passes
`transcript_path` with backslashes:

```
"transcript_path":"C:\\Users\\me\\.claude\\projects\\C--Users-me\\<id>.jsonl"
```

So the colon fix alone was inert on Windows — the separator handling had to be
fixed too for it to do anything.

## Fix

- **One shared encoder.** New `src/utils/encode-project-path.ts` is the single
  source of truth; `session-history-search` and `worktree-paths` both import it,
  as do the previously-duplicated test encoders. They can no longer drift.
- **Separator-agnostic resolution.** The worktree marker is now `normalize()`d
  (mirroring `session-history-search`'s already-correct `getClaudeWorktreeParent`),
  and the session filename is extracted with `basename()`, which handles `\` on
  Windows and `/` on POSIX.

Net of the dedup, this is a small change; the encoder convergence alone is a
code reduction.

## Tests

- New `src/utils/__tests__/encode-project-path.test.ts` — platform-independent
  assertions (`C:\Users\me\proj` → `C--Users-me-proj`, POSIX no-op, dot
  replacement). Runs and guards on Linux CI.
- New Strategy 2 regression test in `resolve-transcript-path.test.ts` that
  drives resolution through a `.claude/worktrees/` CWD using the OS-native
  separator, so it exercises the fix on whatever OS runs it.
- The full `resolveTranscriptPath` suite (incl. #1094 Strategy 2 and #1191
  native git worktree) now passes on **Windows** as well as Linux. Converging
  the duplicated test encoders also fixed their pre-existing Windows-only `mkdir`
  crashes (they built `C:-...` directories, an illegal name on Windows).
- `npx tsc --noEmit` passes. Touched-area suites green on Windows; CI runs on
  Linux where the suite was already green.

## Out of scope (separate follow-up)

The encoder still does not map spaces / other special characters the way Claude
Code does — the #3274 review noted this as its own non-blocking follow-up, and I
could not reproduce the space behavior locally, so I left it out rather than
guess.
