### PR TITLE
feat(hud): usage hint for API-key users when built-in usage unavailable (#3277)

### DIFF
--- a/src/__tests__/hud/rate-limits-error.test.ts
+++ b/src/__tests__/hud/rate-limits-error.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { renderRateLimitsError } from '../../hud/elements/limits.js';
+import { renderRateLimitsError, renderApiKeyUsageHint } from '../../hud/elements/limits.js';
 import type { UsageResult } from '../../hud/types.js';
 
 describe('renderRateLimitsError', () => {
@@ -95,5 +95,37 @@ describe('renderRateLimitsError', () => {
     };
     const result = renderRateLimitsError(usageResult);
     expect(result).toBeNull();
+  });
+});
+
+describe('renderApiKeyUsageHint (Issue #3277)', () => {
+  const noCreds: UsageResult = { rateLimits: null, error: 'no_credentials' };
+
+  it('shows a custom-provider hint for API-key users with no built-in usage', () => {
+    const result = renderApiKeyUsageHint(noCreds, true, false);
+    expect(result).toContain('omcHud.rateLimitsProvider');
+    expect(result).toContain('\x1b[2m'); // Dim ANSI code (unobtrusive)
+  });
+
+  it('returns null when not in API-key mode (OAuth users unaffected)', () => {
+    expect(renderApiKeyUsageHint(noCreds, false, false)).toBeNull();
+  });
+
+  it('returns null when a custom rate limits provider is already configured', () => {
+    expect(renderApiKeyUsageHint(noCreds, true, true)).toBeNull();
+  });
+
+  it('returns null when the error is not no_credentials', () => {
+    expect(renderApiKeyUsageHint({ rateLimits: null, error: 'network' }, true, false)).toBeNull();
+    expect(renderApiKeyUsageHint({ rateLimits: null, error: 'auth' }, true, false)).toBeNull();
+  });
+
+  it('returns null when usage data is present (no error)', () => {
+    const ok: UsageResult = { rateLimits: { fiveHourPercent: 10, weeklyPercent: 5 } };
+    expect(renderApiKeyUsageHint(ok, true, false)).toBeNull();
+  });
+
+  it('returns null when result is null', () => {
+    expect(renderApiKeyUsageHint(null, true, false)).toBeNull();
   });
 });

--- a/src/__tests__/hud/render-rate-limits-priority.test.ts
+++ b/src/__tests__/hud/render-rate-limits-priority.test.ts
@@ -381,4 +381,47 @@ describe('render: rate limits display priority', () => {
     expect(output).not.toContain('[API');
     expect(output).not.toContain('%');
   });
+
+  it('shows a custom-provider usage hint for API-key users with no_credentials (Issue #3277)', async () => {
+    const context = makeContext({
+      apiKeyMode: true,
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'no_credentials',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).toContain('omcHud.rateLimitsProvider');
+    expect(output).not.toContain('[API');
+  });
+
+  it('does not show the usage hint when a custom rate limits provider is configured', async () => {
+    const context = makeContext({
+      apiKeyMode: true,
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'no_credentials',
+      },
+    });
+
+    const output = await render(
+      context,
+      makeConfig({ rateLimitsProvider: { type: 'custom', command: 'echo {}' } }),
+    );
+    expect(output).not.toContain('omcHud.rateLimitsProvider');
+  });
+
+  it('does not show the usage hint for non-API-key users (OAuth path)', async () => {
+    const context = makeContext({
+      apiKeyMode: false,
+      rateLimitsResult: {
+        rateLimits: null,
+        error: 'no_credentials',
+      },
+    });
+
+    const output = await render(context, makeConfig());
+    expect(output).not.toContain('omcHud.rateLimitsProvider');
+  });
 });

--- a/src/hud/elements/limits.ts
+++ b/src/hud/elements/limits.ts
@@ -314,6 +314,31 @@ export function renderRateLimitsError(result: UsageResult | null): string | null
   return `${YELLOW}[API err]${RESET}`;
 }
 
+/**
+ * Render a usage hint for Anthropic API-key users.
+ *
+ * Built-in usage/rate-limit data is only available for OAuth subscribers
+ * (and z.ai/MiniMax tokens). Plain Anthropic API-key users get a
+ * 'no_credentials' result, which would otherwise render nothing, leaving
+ * them with no explanation for the missing usage display. Anthropic does
+ * not expose a usage endpoint for regular x-api-key callers (only the
+ * org-scoped Admin API, which needs a separate admin key), so we point
+ * users at the custom rateLimitsProvider hook (#794) instead.
+ *
+ * Returns null unless the user is in API-key mode, the built-in fetch
+ * failed with 'no_credentials', and no custom provider is configured.
+ */
+export function renderApiKeyUsageHint(
+  result: UsageResult | null,
+  apiKeyMode: boolean,
+  hasCustomProvider: boolean,
+): string | null {
+  if (!apiKeyMode) return null;
+  if (hasCustomProvider) return null;
+  if (result?.error !== 'no_credentials') return null;
+  return `${DIM}[usage: set omcHud.rateLimitsProvider]${RESET}`;
+}
+
 // ============================================================================
 // Custom provider bucket rendering
 // ============================================================================

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -489,6 +489,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       apiKeySource: config.elements.apiKeySource
         ? detectApiKeySource(cwd)
         : null,
+      apiKeyMode: detectApiKeySource(cwd) !== null,
       subscriptionType: subscriptionInfo.subscriptionType,
       rateLimitTier: subscriptionInfo.rateLimitTier,
       profileName: process.env.CLAUDE_CONFIG_DIR

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -23,6 +23,7 @@ import {
   renderRateLimits,
   renderRateLimitsWithBar,
   renderRateLimitsError,
+  renderApiKeyUsageHint,
   renderCustomBuckets,
 } from "./elements/limits.js";
 import { renderPermission } from "./elements/permission.js";
@@ -351,7 +352,16 @@ export async function render(
       if (limits) rendered.set("rateLimits", limits);
     } else {
       const errorIndicator = renderRateLimitsError(context.rateLimitsResult);
-      if (errorIndicator) rendered.set("rateLimits", errorIndicator);
+      if (errorIndicator) {
+        rendered.set("rateLimits", errorIndicator);
+      } else {
+        const hint = renderApiKeyUsageHint(
+          context.rateLimitsResult,
+          context.apiKeyMode ?? false,
+          config.rateLimitsProvider?.type === "custom",
+        );
+        if (hint) rendered.set("rateLimits", hint);
+      }
     }
   }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -399,6 +399,9 @@ export interface HudRenderContext {
   /** API key source: 'project', 'global', or 'env' */
   apiKeySource: ApiKeySource | null;
 
+  /** True when an Anthropic API key is active (no OAuth subscription); used to surface a usage hint when built-in usage cannot be fetched */
+  apiKeyMode?: boolean;
+
   /** OAuth subscription type (e.g. 'enterprise'), null when unavailable */
   subscriptionType?: string | null;
 


### PR DESCRIPTION
## Summary

Closes #3277.

Anthropic **API-key (non-OAuth)** users previously got a *silent* HUD: the built-in usage fetch returns `no_credentials`, the error renderer intentionally renders nothing for that case, and so the rate-limit slot stayed blank — with no explanation for why usage was missing.

Per the issue's proposed path, I verified the API-key usage/billing surface first rather than assuming a safe endpoint exists. **Anthropic does not expose a usage/billing endpoint for plain `x-api-key` callers** (only the org-scoped Admin API, which requires a separate admin key). So instead of hardcoding an unsupported endpoint, this PR implements **issue step 3**: a narrow, unobtrusive HUD hint that points API-key users at the custom `rateLimitsProvider` hook (#794).

```
[usage: set omcHud.rateLimitsProvider]
```

## What changed

- **`src/hud/elements/limits.ts`** — new `renderApiKeyUsageHint(result, apiKeyMode, hasCustomProvider)`. Returns a dim (`\x1b[2m`) hint, or `null` unless all three conditions hold.
- **`src/hud/types.ts`** — added `apiKeyMode?: boolean` to `HudRenderContext`.
- **`src/hud/index.ts`** — populates `apiKeyMode` via the existing `detectApiKeySource(cwd)` (project / global / env key detection).
- **`src/hud/render.ts`** — renders the hint as a **fallback** only after `renderRateLimitsError()` produces no indicator.

## Guard conditions (the hint shows only when all are true)

1. An Anthropic API key is active (`apiKeyMode`).
2. The built-in fetch failed with `no_credentials` (not `network` / `auth` / `rate_limited`, and not when usage data is present).
3. No custom `rateLimitsProvider` is already configured.

## Acceptance criteria

- ✅ **No unsupported Anthropic billing endpoint** — zero new network calls; pure render-path hint.
- ✅ **API-key users no longer silently get no HUD explanation** when built-in usage cannot be fetched.
- ✅ **OAuth and existing providers unchanged** — OAuth subscribers, z.ai, and MiniMax paths are untouched; the hint is gated on `apiKeyMode` + `no_credentials` + no custom provider.
- ✅ **Tests cover the fallback/hint** — unit tests for `renderApiKeyUsageHint` and render-priority integration tests for the API-key path, the custom-provider suppression, and the OAuth (non-hint) path.

## Verification

- `npx tsc --noEmit` → clean (exit 0)
- `npm run lint` (eslint) on changed files → clean (exit 0)
- Focused tests:
  - `src/__tests__/hud/rate-limits-error.test.ts`
  - `src/__tests__/hud/render-rate-limits-priority.test.ts`
  - → **38 passed**
- Full HUD suite (`src/__tests__/hud`) → **705 passed** (no regressions)

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
