### PR TITLE
fix(persistent-mode): bound thinking-only continuation loops (#3280)

### DIFF
--- a/src/hooks/persistent-mode/__tests__/thinking-only-streak.test.ts
+++ b/src/hooks/persistent-mode/__tests__/thinking-only-streak.test.ts
@@ -45,6 +45,27 @@ function writeAssistantTurn(transcriptPath: string, content: ContentBlock[] | st
   );
 }
 
+type TranscriptRecord = { type: string; message: { role: string; content: unknown } };
+
+const userRecord = (content: unknown): TranscriptRecord => ({
+  type: 'user',
+  message: { role: 'user', content },
+});
+const assistantRecord = (content: unknown): TranscriptRecord => ({
+  type: 'assistant',
+  message: { role: 'assistant', content },
+});
+
+// Write an explicit list of transcript records (one JSON object per line) so a
+// test can model a multi-record assistant turn (e.g. tool_use, tool_result, then
+// trailing text) instead of the single-record turn writeAssistantTurn emits.
+function writeRecords(transcriptPath: string, records: TranscriptRecord[]): void {
+  writeFileSync(
+    transcriptPath,
+    records.map((record) => JSON.stringify(record)).join('\n') + '\n',
+  );
+}
+
 const THINKING_ONLY: ContentBlock[] = [
   { type: 'thinking', thinking: 'Let me reason about this some more before acting.' },
 ];
@@ -127,6 +148,84 @@ describe('thinking-only streak guard (issue #3280)', () => {
       const t2 = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
       expect(t2.shouldBlock).toBe(true);
       expect(t2.mode).toBe('ralph');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resets the streak when a productive turn ends in trailing text after tool_use', async () => {
+    const sessionId = 'streak-reset-trailing-text';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+
+    try {
+      // Two thinking-only turns: streak climbs to 2.
+      writeAssistantTurn(transcriptPath, THINKING_ONLY);
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+
+      // A productive turn whose FINAL assistant record is plain text: the
+      // tool_use lives in an earlier record, with its tool_result in between.
+      // The whole-turn classifier must still see the progress and reset.
+      writeRecords(transcriptPath, [
+        userRecord('do the task'),
+        assistantRecord([
+          { type: 'thinking', thinking: 'I will run a command.' },
+          { type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } },
+        ]),
+        userRecord([{ type: 'tool_result', tool_use_id: 'tu-1', content: 'a\nb' }]),
+        assistantRecord([{ type: 'text', text: 'Done — listed the directory.' }]),
+      ]);
+      const afterTool = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(afterTool.shouldBlock).toBe(true);
+      expect(afterTool.mode).toBe('ralph');
+
+      // Streak restarted from zero, so two more thinking-only turns still block
+      // rather than bailing out on the second one.
+      writeAssistantTurn(transcriptPath, THINKING_ONLY);
+      const t1 = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(t1.shouldBlock).toBe(true);
+      expect(t1.mode).toBe('ralph');
+
+      const t2 = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(t2.shouldBlock).toBe(true);
+      expect(t2.mode).toBe('ralph');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('classifies only the most recent turn (a prior turn\'s tool_use never leaks across the user boundary)', async () => {
+    const sessionId = 'streak-turn-boundary';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+
+    try {
+      // A completed productive turn, then a fresh continuation prompt that
+      // begins the most-recent (thinking-only) turn. Classification must stop at
+      // the continuation boundary and not reach back into the productive turn.
+      writeRecords(transcriptPath, [
+        userRecord('do the task'),
+        assistantRecord([
+          { type: 'thinking', thinking: 'running a tool' },
+          { type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } },
+        ]),
+        userRecord([{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok' }]),
+        assistantRecord([{ type: 'text', text: 'finished the productive turn' }]),
+        userRecord('continue'),
+        assistantRecord(THINKING_ONLY),
+      ]);
+
+      // Same transcript each call: only the trailing thinking-only turn counts,
+      // so the streak climbs and bails on the third stop.
+      const first = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(first.shouldBlock).toBe(true);
+      const second = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(second.shouldBlock).toBe(true);
+      const third = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(third.shouldBlock).toBe(false);
+      expect(third.mode).toBe('none');
+      expect(third.message).toContain('NO TOOL PROGRESS');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/hooks/persistent-mode/__tests__/thinking-only-streak.test.ts
+++ b/src/hooks/persistent-mode/__tests__/thinking-only-streak.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+import type { StopContext } from '../../todo-continuation/index.js';
+
+// Active-mode worktree so a Stop would normally block (and could loop). We use
+// Ralph because it is the simplest always-reinforcing persistent mode.
+function makeRalphWorktree(sessionId: string): string {
+  const tempDir = mkdtempSync(join(tmpdir(), 'thinking-only-streak-'));
+  execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+  const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, 'ralph-state.json'),
+    JSON.stringify(
+      {
+        active: true,
+        iteration: 1,
+        max_iterations: 10,
+        started_at: new Date().toISOString(),
+        prompt: 'Finish the task',
+        session_id: sessionId,
+        project_path: tempDir,
+        linked_ultrawork: false,
+      },
+      null,
+      2,
+    ),
+  );
+  return tempDir;
+}
+
+type ContentBlock = { type: string; [key: string]: unknown };
+
+function writeAssistantTurn(transcriptPath: string, content: ContentBlock[] | string): void {
+  writeFileSync(
+    transcriptPath,
+    [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'do the task' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content } }),
+    ].join('\n') + '\n',
+  );
+}
+
+const THINKING_ONLY: ContentBlock[] = [
+  { type: 'thinking', thinking: 'Let me reason about this some more before acting.' },
+];
+const TOOL_USE: ContentBlock[] = [
+  { type: 'thinking', thinking: 'Now I will run a command.' },
+  { type: 'tool_use', id: 'tu-1', name: 'Bash', input: { command: 'ls' } },
+];
+
+function ctx(transcriptPath?: string): StopContext {
+  return { stop_reason: 'end_turn', ...(transcriptPath ? { transcript_path: transcriptPath } : {}) };
+}
+
+describe('thinking-only streak guard (issue #3280)', () => {
+  it('increments the streak and bails out after 3 consecutive thinking-only turns', async () => {
+    const sessionId = 'streak-bailout';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeAssistantTurn(transcriptPath, THINKING_ONLY);
+
+    try {
+      const first = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(first.shouldBlock).toBe(true);
+      expect(first.mode).toBe('ralph');
+
+      const second = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(second.shouldBlock).toBe(true);
+      expect(second.mode).toBe('ralph');
+
+      const third = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(third.shouldBlock).toBe(false);
+      expect(third.mode).toBe('none');
+      expect(third.message).toContain('NO TOOL PROGRESS');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('counts redacted_thinking turns toward the streak', async () => {
+    const sessionId = 'streak-redacted';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeAssistantTurn(transcriptPath, [{ type: 'redacted_thinking', data: 'opaque' }]);
+
+    try {
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      const third = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(third.shouldBlock).toBe(false);
+      expect(third.mode).toBe('none');
+      expect(third.message).toContain('NO TOOL PROGRESS');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resets the streak when a turn includes tool_use', async () => {
+    const sessionId = 'streak-reset-tooluse';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+
+    try {
+      // Two thinking-only turns: streak climbs to 2.
+      writeAssistantTurn(transcriptPath, THINKING_ONLY);
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+
+      // A tool_use turn resets the streak and keeps enforcing.
+      writeAssistantTurn(transcriptPath, TOOL_USE);
+      const afterTool = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(afterTool.shouldBlock).toBe(true);
+      expect(afterTool.mode).toBe('ralph');
+
+      // Two more thinking-only turns would have bailed without the reset, but
+      // the streak restarts from zero, so both still block.
+      writeAssistantTurn(transcriptPath, THINKING_ONLY);
+      const t1 = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(t1.shouldBlock).toBe(true);
+      expect(t1.mode).toBe('ralph');
+
+      const t2 = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(t2.shouldBlock).toBe(true);
+      expect(t2.mode).toBe('ralph');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('clears the streak after bail-out so the next thinking-only turn blocks again', async () => {
+    const sessionId = 'streak-cleanup';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeAssistantTurn(transcriptPath, THINKING_ONLY);
+
+    try {
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      const bail = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(bail.shouldBlock).toBe(false);
+
+      // Streak was cleared on bail-out: the immediate next thinking-only stop
+      // re-enters enforcement at streak 1 rather than bailing again.
+      const afterBail = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+      expect(afterBail.shouldBlock).toBe(true);
+      expect(afterBail.mode).toBe('ralph');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails open (keeps enforcing) when no transcript path is provided', async () => {
+    const sessionId = 'streak-no-transcript';
+    const tempDir = makeRalphWorktree(sessionId);
+
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        const result = await checkPersistentModes(sessionId, tempDir, ctx());
+        expect(result.shouldBlock).toBe(true);
+        expect(result.mode).toBe('ralph');
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails open when the transcript file does not exist', async () => {
+    const sessionId = 'streak-missing-file';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'does-not-exist.jsonl');
+
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        const result = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+        expect(result.shouldBlock).toBe(true);
+        expect(result.mode).toBe('ralph');
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails open on a malformed/unparseable transcript', async () => {
+    const sessionId = 'streak-malformed';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeFileSync(transcriptPath, '{ this is : not valid json at all\n');
+
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        const result = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+        expect(result.shouldBlock).toBe(true);
+        expect(result.mode).toBe('ralph');
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a text-only turn as indeterminate (no streak, keeps enforcing)', async () => {
+    const sessionId = 'streak-text-only';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeAssistantTurn(transcriptPath, [{ type: 'text', text: 'Here is the answer.' }]);
+
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        const result = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+        expect(result.shouldBlock).toBe(true);
+        expect(result.mode).toBe('ralph');
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats string transcript content as indeterminate (no streak, keeps enforcing)', async () => {
+    const sessionId = 'streak-string-content';
+    const tempDir = makeRalphWorktree(sessionId);
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeAssistantTurn(transcriptPath, 'plain string assistant response');
+
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        const result = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+        expect(result.shouldBlock).toBe(true);
+        expect(result.mode).toBe('ralph');
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never bails out when no persistent mode is active (guard is a no-op)', async () => {
+    const sessionId = 'streak-no-mode';
+    const tempDir = mkdtempSync(join(tmpdir(), 'thinking-only-streak-nomode-'));
+    execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeAssistantTurn(transcriptPath, THINKING_ONLY);
+
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        const result = await checkPersistentModes(sessionId, tempDir, ctx(transcriptPath));
+        expect(result.shouldBlock).toBe(false);
+        expect(result.mode).toBe('none');
+        // Plain idle stop, not the streak bail-out message.
+        expect(result.message).toBe('');
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -1294,6 +1294,147 @@ function writeStopBreaker(directory: string, name: string, count: number, sessio
 }
 
 // ---------------------------------------------------------------------------
+// Thinking-only streak guard (issue #3280)
+//
+// A persistent mode (ralph/autopilot/team/ralplan/ultrawork/…) re-injects a
+// continuation prompt on every Stop while the mode is active. If the agent
+// answers each continuation with only thinking blocks and never a tool_use,
+// no work happens but tokens keep burning. Bound that failure: count
+// consecutive thinking-only assistant turns and release the stop once the
+// streak hits a conservative threshold. Any tool_use turn resets the streak,
+// and every read/parse path fails open (keep enforcing) so a flaky transcript
+// never short-circuits a healthy persistent mode.
+// ---------------------------------------------------------------------------
+
+const THINKING_ONLY_STREAK_BREAKER = 'thinking-only-streak';
+const THINKING_ONLY_STREAK_MAX = 3;
+const THINKING_ONLY_STREAK_TTL_MS = 5 * 60 * 1000; // 5 min
+const THINKING_ONLY_STREAK_BAILOUT_MESSAGE =
+  `[PERSISTENT MODE PAUSED - NO TOOL PROGRESS] The last ${THINKING_ONLY_STREAK_MAX} assistant turns ` +
+  'produced only thinking with no tool calls, so the persistent-mode stop guard is releasing this ' +
+  'stop to avoid an infinite loop. Resume manually with a concrete next action (run a tool/command) ' +
+  'or /cancel the active mode.';
+
+type ThinkingOnlyClassification = 'tool_use' | 'thinking_only' | 'indeterminate';
+
+/**
+ * Classify the last assistant turn in a transcript as making tool progress,
+ * being thinking-only, or indeterminate. Reads only the bounded transcript
+ * tail (never the whole file) and treats any unreadable/ambiguous shape as
+ * indeterminate so callers fail open.
+ */
+function classifyLastAssistantTurn(transcriptPath: string): ThinkingOnlyClassification {
+  let lines: string[];
+  try {
+    lines = readTranscriptTailLines(transcriptPath);
+  } catch {
+    return 'indeterminate';
+  }
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]?.trim();
+    if (!line) continue;
+
+    let parsed: { type?: string; message?: { role?: string; content?: unknown } };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // Skip non-JSON/truncated lines and keep scanning backward.
+      continue;
+    }
+
+    const isAssistant =
+      parsed?.type === 'assistant' || parsed?.message?.role === 'assistant';
+    if (!isAssistant) continue;
+
+    const content = parsed.message?.content;
+    if (!Array.isArray(content)) {
+      // String or missing content carries no thinking/tool_use structure.
+      return 'indeterminate';
+    }
+
+    let hasThinking = false;
+    let hasToolUse = false;
+    for (const block of content) {
+      const blockType = (block as { type?: unknown } | null)?.type;
+      if (blockType === 'tool_use') {
+        hasToolUse = true;
+      } else if (blockType === 'thinking' || blockType === 'redacted_thinking') {
+        hasThinking = true;
+      }
+    }
+
+    if (hasToolUse) return 'tool_use';
+    if (hasThinking) return 'thinking_only';
+    return 'indeterminate';
+  }
+
+  return 'indeterminate';
+}
+
+/**
+ * Bound persistent-mode continuation loops that make no tool progress.
+ *
+ * Only acts when a mode would otherwise block the stop. A tool_use turn resets
+ * the streak; a thinking-only turn increments it and, once it reaches
+ * THINKING_ONLY_STREAK_MAX, releases the stop (and clears the counter) instead
+ * of re-injecting another continuation prompt. Indeterminate/unreadable
+ * transcripts leave the streak untouched and keep the original blocking result.
+ */
+function applyThinkingOnlyStreakGuard(
+  result: PersistentModeResult,
+  workingDir: string,
+  sessionId?: string,
+  stopContext?: StopContext,
+): PersistentModeResult {
+  // Non-blocking results already let the session stop — no loop to bound.
+  if (!result.shouldBlock) return result;
+
+  const transcriptPath = stopContext?.transcript_path ?? stopContext?.transcriptPath;
+  if (!transcriptPath || !existsSync(transcriptPath)) {
+    return result; // fail open: cannot classify without a transcript
+  }
+
+  let classification: ThinkingOnlyClassification;
+  try {
+    classification = classifyLastAssistantTurn(transcriptPath);
+  } catch {
+    return result; // fail open on any unexpected read/parse error
+  }
+
+  if (classification === 'tool_use') {
+    // Real progress — reset the streak and keep enforcing.
+    writeStopBreaker(workingDir, THINKING_ONLY_STREAK_BREAKER, 0, sessionId);
+    return result;
+  }
+
+  if (classification === 'indeterminate') {
+    // Cannot confirm a thinking-only stall — keep enforcing, leave streak as is.
+    return result;
+  }
+
+  const streak = readStopBreaker(
+    workingDir,
+    THINKING_ONLY_STREAK_BREAKER,
+    sessionId,
+    THINKING_ONLY_STREAK_TTL_MS,
+  ) + 1;
+
+  if (streak >= THINKING_ONLY_STREAK_MAX) {
+    // Bail out: release the stop and clear the counter for a clean restart.
+    writeStopBreaker(workingDir, THINKING_ONLY_STREAK_BREAKER, 0, sessionId);
+    return {
+      shouldBlock: false,
+      message: THINKING_ONLY_STREAK_BAILOUT_MESSAGE,
+      mode: 'none',
+    };
+  }
+
+  writeStopBreaker(workingDir, THINKING_ONLY_STREAK_BREAKER, streak, sessionId);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Team Pipeline enforcement (standalone team mode)
 // ---------------------------------------------------------------------------
 
@@ -1868,10 +2009,30 @@ ${TODO_CONTINUATION_PROMPT}
 }
 
 /**
- * Main persistent mode checker
- * Checks all persistent modes in priority order and returns appropriate action
+ * Main persistent mode checker.
+ * Resolves which mode (if any) should block, then applies the thinking-only
+ * streak guard so an active mode cannot loop forever re-injecting continuation
+ * prompts while the agent only emits thinking blocks and never tool_use (#3280).
  */
 export async function checkPersistentModes(
+  sessionId?: string,
+  directory?: string,
+  stopContext?: StopContext  // NEW: from todo-continuation types
+): Promise<PersistentModeResult> {
+  const result = await resolvePersistentModeBlock(sessionId, directory, stopContext);
+  return applyThinkingOnlyStreakGuard(
+    result,
+    resolveToWorktreeRoot(directory),
+    sessionId,
+    stopContext,
+  );
+}
+
+/**
+ * Resolve which persistent mode (if any) should block this stop event.
+ * Checks all persistent modes in priority order and returns appropriate action.
+ */
+async function resolvePersistentModeBlock(
   sessionId?: string,
   directory?: string,
   stopContext?: StopContext  // NEW: from todo-continuation types

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -1318,10 +1318,27 @@ const THINKING_ONLY_STREAK_BAILOUT_MESSAGE =
 type ThinkingOnlyClassification = 'tool_use' | 'thinking_only' | 'indeterminate';
 
 /**
- * Classify the last assistant turn in a transcript as making tool progress,
- * being thinking-only, or indeterminate. Reads only the bounded transcript
- * tail (never the whole file) and treats any unreadable/ambiguous shape as
- * indeterminate so callers fail open.
+ * Does a user-role transcript record carry a tool_result block? A tool_result
+ * only exists because the assistant invoked a tool earlier in the same turn, so
+ * its presence proves the most recent assistant turn made tool progress.
+ */
+function userRecordHasToolResult(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some(
+    (block) => (block as { type?: unknown } | null)?.type === 'tool_result',
+  );
+}
+
+/**
+ * Classify the most recent assistant *turn* in a transcript as making tool
+ * progress, being thinking-only, or indeterminate. A turn spans every assistant
+ * record (and interleaved tool_result records) back to the preceding real user
+ * message, so a productive turn whose final record is plain text — tool_use
+ * earlier, trailing text before stop — still classifies as tool_use rather than
+ * leaking through as indeterminate.
+ *
+ * Reads only the bounded transcript tail (never the whole file) and treats any
+ * unreadable/ambiguous shape as indeterminate so callers fail open.
  */
 function classifyLastAssistantTurn(transcriptPath: string): ThinkingOnlyClassification {
   let lines: string[];
@@ -1330,6 +1347,9 @@ function classifyLastAssistantTurn(transcriptPath: string): ThinkingOnlyClassifi
   } catch {
     return 'indeterminate';
   }
+
+  let sawAssistant = false;
+  let hasThinking = false;
 
   for (let index = lines.length - 1; index >= 0; index -= 1) {
     const line = lines[index]?.trim();
@@ -1343,33 +1363,43 @@ function classifyLastAssistantTurn(transcriptPath: string): ThinkingOnlyClassifi
       continue;
     }
 
-    const isAssistant =
-      parsed?.type === 'assistant' || parsed?.message?.role === 'assistant';
-    if (!isAssistant) continue;
-
-    const content = parsed.message?.content;
-    if (!Array.isArray(content)) {
-      // String or missing content carries no thinking/tool_use structure.
-      return 'indeterminate';
-    }
-
-    let hasThinking = false;
-    let hasToolUse = false;
-    for (const block of content) {
-      const blockType = (block as { type?: unknown } | null)?.type;
-      if (blockType === 'tool_use') {
-        hasToolUse = true;
-      } else if (blockType === 'thinking' || blockType === 'redacted_thinking') {
-        hasThinking = true;
+    const role = parsed?.message?.role;
+    const isAssistant = parsed?.type === 'assistant' || role === 'assistant';
+    if (isAssistant) {
+      sawAssistant = true;
+      const content = parsed.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          const blockType = (block as { type?: unknown } | null)?.type;
+          if (blockType === 'tool_use') {
+            // Any tool_use anywhere in the most recent turn is real progress.
+            return 'tool_use';
+          }
+          if (blockType === 'thinking' || blockType === 'redacted_thinking') {
+            hasThinking = true;
+          }
+        }
       }
+      // Non-array (string/missing) content carries no structured block; keep
+      // scanning the rest of the turn rather than bailing out early.
+      continue;
     }
 
-    if (hasToolUse) return 'tool_use';
-    if (hasThinking) return 'thinking_only';
-    return 'indeterminate';
+    const isUser = parsed?.type === 'user' || role === 'user';
+    if (isUser) {
+      // A tool_result confirms the turn invoked a tool, so it made progress.
+      if (userRecordHasToolResult(parsed.message?.content)) {
+        return 'tool_use';
+      }
+      // A real user message marks the start of the most recent assistant turn.
+      break;
+    }
+
+    // Other record types (system/summary/…) are turn-neutral; keep scanning.
   }
 
-  return 'indeterminate';
+  if (!sawAssistant) return 'indeterminate';
+  return hasThinking ? 'thinking_only' : 'indeterminate';
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #3280 — persistent mode / Stop hook can enter an infinite token-burning loop when assistant turns contain only thinking blocks and no `tool_use` blocks.

When a persistent mode (ralph / autopilot / team / ralplan / ultrawork) is active, the Stop hook re-injects a continuation prompt on every stop. If the agent answers each continuation with only thinking blocks and never a `tool_use`, no work happens but tokens keep burning indefinitely.

## Change

Adds a **bounded thinking-only streak guard** wrapped around the existing mode-priority resolution in `checkPersistentModes`:

- **Classify** the last assistant turn from a **bounded transcript tail** (reuses `readTranscriptTailLines`, never loads the whole transcript): `tool_use`, `thinking_only`, or `indeterminate`.
- **Persist** a per-session streak counter in the existing stop-breaker state (`<session>/thinking-only-streak-stop-breaker.json`), reusing `read/writeStopBreaker` — TTL'd JSON only, no secrets or raw logs.
- **Reset** the streak on any `tool_use` turn (real progress).
- **Bail out** after **3 consecutive** thinking-only turns: release the stop and clear the counter instead of re-injecting another continuation prompt.
- **Fail open everywhere**: missing / unreadable / ambiguous transcripts keep the original blocking behavior, so a healthy persistent mode is never short-circuited. The guard only acts when a mode would otherwise block.

The change is intentionally narrow — no changes to unrelated persistent/team/swarm semantics, and all existing bypass precedences (context-limit, rate-limit, user-abort, etc.) are untouched.

## Tests

New suite `src/hooks/persistent-mode/__tests__/thinking-only-streak.test.ts` covers:

- streak increment + bail-out after 3 thinking-only turns
- `redacted_thinking` counts toward the streak
- reset on `tool_use`
- post-bail-out cleanup (next thinking-only turn re-enters at streak 1)
- fail-open: no transcript path / missing file / malformed transcript
- indeterminate: text-only turn and string content keep enforcing
- guard is a no-op when no persistent mode is active

## Validation

- `npx vitest run` on the new suite + persistent-mode + bridge suites: **497 passed**
- `npx tsc --noEmit`: clean
- `npx eslint` on changed files: clean

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
