### PR TITLE
Expose Cursor executor workers for autopilot team mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Enable Claude Code native teams in `~/.claude/settings.json`:
 omc team 2:codex "review auth module for security issues"
 omc team 2:gemini "redesign UI components for accessibility"
 omc team 1:claude "implement the payment flow"
+omc team 1:cursor "implement the payment flow"
 omc team status auth-review
 omc team shutdown auth-review
 ```
@@ -178,10 +179,24 @@ For mixed Codex + Gemini work in one command, use the **`/ccg`** skill (routes v
 | `omc team N:codex "..."`  | N Codex CLI panes        | Code review, security analysis, architecture |
 | `omc team N:gemini "..."` | N Gemini CLI panes       | UI/UX design, docs, large-context tasks      |
 | `omc team N:grok "..."`   | N Grok Build CLI panes   | Code review, analysis cross-check            |
+| `omc team N:cursor "..."` | N Cursor agent panes     | Executor-style implementation tasks          |
 | `omc team N:claude "..."` | N Claude CLI panes       | General tasks via Claude CLI in tmux         |
 | `/ccg`                    | /ask codex + /ask gemini | Tri-model advisor synthesis                  |
 
-Workers spawn on-demand and die when their task completes — no idle resource usage. Requires `codex` / `gemini` CLIs installed and an active tmux session.
+Workers spawn on-demand and die when their task completes — no idle resource usage. Requires the selected CLI (`codex`, `gemini`, `grok`, or `cursor-agent`) installed/authenticated and an active tmux session.
+
+Autopilot can prefer Cursor executor workers during team execution via `.claude/omc.jsonc`:
+
+```jsonc
+{
+  "autopilot": {
+    "execution": "team",
+    "team": { "agentTypes": ["cursor"] }
+  }
+}
+```
+
+This config makes the autopilot execution stage use `omc team 1:cursor "..."` or `/omc-teams 1:cursor "..."` for executor-style implementation work. Reviewer, critic, security-review, validation verdict, and final approval roles remain native Claude/OMC reviewer roles; Cursor requires an installed/authenticated `cursor-agent`.
 
 Native team worker worktrees are being added behind an opt-in/config gate. See [Native Team Worktree Mode](docs/TEAM-WORKTREE-MODE.md) for the workspace contract, canonical state-root rules, dirty-worktree preservation policy, and verification checklist.
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -736,7 +736,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `omc-plan`                | Planning workflow (`/plan` safe alias; bundled directory ID is `plan`) | `/oh-my-claudecode:plan`                    |
 | `omc-reference`           | Detailed OMC agent/tools/team/commit reference skill             | Auto-loaded reference only                  |
 | `omc-setup`               | One-time setup wizard                                            | `/oh-my-claudecode:omc-setup`               |
-| `omc-teams`               | Spawn `claude`/`codex`/`gemini` tmux workers for parallel execution | `/oh-my-claudecode:omc-teams`             |
+| `omc-teams`               | Spawn `claude`/`codex`/`gemini`/`grok`/`cursor` tmux workers for parallel execution | `/oh-my-claudecode:omc-teams`             |
 | `project-session-manager` | Manage isolated dev environments (git worktrees + tmux)          | `/oh-my-claudecode:project-session-manager` |
 | `psm` | **Deprecated** compatibility alias for `project-session-manager` | `/oh-my-claudecode:psm` |
 | `ralph`                   | Persistence loop until verified completion                       | `/oh-my-claudecode:ralph`                   |
@@ -775,7 +775,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:omc-doctor`                           | Diagnose and fix installation issues                                                          |
 | `/oh-my-claudecode:plan <description>`                   | Start planning session (supports consensus structured deliberation)                           |
 | `/oh-my-claudecode:omc-setup`                            | One-time setup wizard                                                                         |
-| `/oh-my-claudecode:omc-teams <N>:<agent> <task>`         | Spawn `claude`/`codex`/`gemini` tmux workers for legacy parallel execution                    |
+| `/oh-my-claudecode:omc-teams <N>:<agent> <task>`         | Spawn `claude`/`codex`/`gemini`/`grok`/`cursor` tmux workers for legacy parallel execution                    |
 | `/oh-my-claudecode:project-session-manager <arguments>`  | Manage isolated dev environments with git worktrees + tmux                                    |
 | `/oh-my-claudecode:psm <arguments>`                      | Deprecated alias for project session manager                                                  |
 | `/oh-my-claudecode:ralph <task>`                         | Self-referential loop until task completion (`--critic=architect \| critic \| codex`)       |

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -140,10 +140,39 @@ Optional settings in `.claude/omc.jsonc` (project) or `~/.config/claude-omc/conf
     "pauseAfterExpansion": false,
     "pauseAfterPlanning": false,
     "skipQa": false,
-    "skipValidation": false
+    "skipValidation": false,
+    "execution": "solo"
   }
 }
 ```
+
+To run autopilot implementation through the tmux CLI team runtime and prefer Cursor executor workers:
+
+```jsonc
+{
+  "autopilot": {
+    "execution": "team",
+    "team": { "agentTypes": ["cursor"] }
+  }
+}
+```
+
+With that config, the execution stage must launch executor-style work through:
+
+```sh
+omc team 1:cursor "<implementation task>"
+```
+
+or the Claude Code slash compatibility surface:
+
+```text
+/omc-teams 1:cursor "<implementation task>"
+```
+
+Limitations:
+- Cursor workers are executor-style only: implementation, file edits, build/test fixes, and other plan execution tasks.
+- Keep reviewer, critic, security-review, validation verdict, and final approval roles on native Claude/OMC reviewer agents unless explicit safe support is added later.
+- Cursor requires the `cursor-agent` CLI to be installed and authenticated. If `cursor-agent` is unavailable, report that setup requirement instead of silently falling back to Claude-only execution.
 
 ## Resume
 

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: omc-teams
-description: CLI-team runtime for claude, codex, or gemini workers in tmux panes when you need process-based parallel execution
+description: CLI-team runtime for claude, codex, gemini, grok, or cursor workers in tmux panes when you need process-based parallel execution
 aliases: []
 level: 4
 ---
 
 # OMC Teams Skill
 
-Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, and `gemini` agent types.
+Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Supports `claude`, `codex`, `gemini`, `grok`, and `cursor` agent types. Cursor workers are executor-style only.
 
 `/omc-teams` is a legacy compatibility skill for the CLI-first runtime: use `omc team ...` commands (not deprecated MCP runtime tools).
 
@@ -17,12 +17,14 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 /oh-my-claudecode:omc-teams N:claude "task description"
 /oh-my-claudecode:omc-teams N:codex "task description"
 /oh-my-claudecode:omc-teams N:gemini "task description"
+/oh-my-claudecode:omc-teams N:grok "task description"
+/oh-my-claudecode:omc-teams N:cursor "implementation task description"
 ```
 
 ### Parameters
 
 - **N** - Number of CLI workers (1-10)
-- **agent-type** - `claude` (Claude CLI), `codex` (OpenAI Codex CLI), or `gemini` (Google Gemini CLI)
+- **agent-type** - `claude` (Claude CLI), `codex` (OpenAI Codex CLI), `gemini` (Google Gemini CLI), `grok` (xAI Grok CLI), or `cursor` (Cursor agent CLI; executor-style tasks only)
 - **task** - Task description to distribute across all workers
 
 ### Examples
@@ -31,6 +33,8 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 /omc-teams 2:claude "implement auth module with tests"
 /omc-teams 2:codex "review the auth module for security issues"
 /omc-teams 3:gemini "redesign UI components for accessibility"
+/omc-teams 1:grok "prototype an implementation approach"
+/omc-teams 1:cursor "apply the implementation plan"
 ```
 
 ## Requirements
@@ -40,6 +44,8 @@ Spawn N CLI worker processes in tmux panes to execute tasks in parallel. Support
 - **claude** CLI: `npm install -g @anthropic-ai/claude-code`
 - **codex** CLI: `npm install -g @openai/codex`
 - **gemini** CLI: `npm install -g @google/gemini-cli`
+- **grok** CLI: install and authenticate the Grok CLI used by your environment
+- **cursor** CLI: install and authenticate `cursor-agent`; if unavailable, report this setup requirement instead of silently falling back to Claude-only execution
 
 ## Workflow
 
@@ -66,12 +72,13 @@ tmux display-message -p '#S'
 Extract:
 
 - `N` — worker count (1–10)
-- `agent-type` — `claude|codex|gemini`
+- `agent-type` — `claude|codex|gemini|grok|cursor`
 - `task` — task description
 
 Validate before decomposing or running anything:
 
-- Reject unsupported agent types up front. `/omc-teams` only supports **`claude`**, **`codex`**, and **`gemini`**.
+- Reject unsupported agent types up front. `/omc-teams` only supports **`claude`**, **`codex`**, **`gemini`**, **`grok`**, and **`cursor`**.
+- Treat Cursor workers as executor-style only. Accept `N:cursor` and `N:cursor:executor`; reject or reframe reviewer, critic, security-reviewer, verdict, or final-approval work onto native Claude/OMC reviewer agents.
 - If the user asks for an unsupported type such as `expert`, explain that `/omc-teams` launches external CLI workers only.
 - For native Claude Code team agents/roles, direct them to **`/oh-my-claudecode:team`** instead.
 
@@ -94,7 +101,7 @@ working directory before launch:
   plan after `--cwd` changes the launch directory.
 - Include the explicit repo paths or repo names in the task text and subtasks.
 - Do not anchor the launch cwd to only the repo containing `.omc/plans/...` when
-  target repos are siblings; that strands `codex`, `claude`, and `gemini` workers in
+  target repos are siblings; that strands `codex`, `claude`, `gemini`, `grok`, and `cursor` workers in
   the plan repo instead of the implementation workspace.
 - If no safe shared workspace root can be identified, do not launch `/omc-teams`.
   Report the single-cwd constraint and ask for, or derive from evidence, the intended
@@ -111,14 +118,14 @@ state_write(mode="team", current_phase="team-exec", active=true)
 Start workers via CLI:
 
 ```bash
-omc team <N>:<claude|codex|gemini> "<task>"
+omc team <N>:<claude|codex|gemini|grok|cursor> "<task>"
 ```
 
 For the multi-repo case resolved in Phase 2.5, launch from the shared workspace root
 with the existing `--cwd` contract and keep the plan reference absolute:
 
 ```bash
-omc team <N>:<claude|codex|gemini> "<task with absolute plan path and explicit repo paths>" --cwd <workspace-root>
+omc team <N>:<claude|codex|gemini|grok|cursor> "<task with absolute plan path and explicit repo paths>" --cwd <workspace-root>
 ```
 
 Team name defaults to a slug from the task text (example: `review-auth-flow`).

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -792,9 +792,11 @@ describe('Builtin Skills', () => {
     it('should document allowed omc-teams agent types and native team fallback', () => {
       const skill = getBuiltinSkill('omc-teams');
       expect(skill).toBeDefined();
-      expect(skill?.template).toContain('/omc-teams` only supports **`claude`**, **`codex`**, and **`gemini`**');
+      expect(skill?.template).toContain('/omc-teams` only supports **`claude`**, **`codex`**, **`gemini`**, **`grok`**, and **`cursor`**');
       expect(skill?.template).toContain('unsupported type such as `expert`');
       expect(skill?.template).toContain('/oh-my-claudecode:team');
+      expect(skill?.template).toContain('Cursor workers as executor-style only');
+      expect(skill?.template).toContain('cursor-agent');
     });
 
     it('should preserve the multi-repo omc-teams cwd and plan-path contract', () => {

--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -511,6 +511,15 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     expect(parsed.task).toBe('compare edits');
   });
 
+  it('rejects cursor with non-executor explicit roles', () => {
+    expect(() => parseTeamArgs(['1:cursor:architect', 'design auth'])).toThrow(
+      /Cursor workers are executor-style only/,
+    );
+    expect(() => parseTeamArgs(['1:cursor:security-reviewer', 'review auth'])).toThrow(
+      /Cursor workers are executor-style only/,
+    );
+  });
+
   it('defaults to 3 claude workers when no spec is given', () => {
     const parsed = parseTeamArgs(['run all tests']);
     expect(parsed.workerCount).toBe(3);

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -27,6 +27,7 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
 const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'grok', 'cursor']);
+const CURSOR_ALLOWED_TEAM_ROLES = new Set(['executor']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
 const TEAM_HELP = `
@@ -59,6 +60,8 @@ Auto-merge (v2-only):
 
 Roles (optional): architect, executor, planner, analyst, critic, debugger, verifier,
   code-reviewer, security-reviewer, test-engineer, designer, writer, scientist
+
+Cursor workers are executor-style only; use 1:cursor or 1:cursor:executor, not reviewer/critic/security/verdict roles.
 `;
 
 const TEAM_API_HELP = `
@@ -361,6 +364,12 @@ function normalizeWorkerSpecSegment(match: RegExpMatchArray): NormalizedWorkerSp
         `Invalid agent type "${token}" in worker spec "${match[0]}". ` +
         `Expected one of: ${[...VALID_TEAM_CLI_AGENT_TYPES].join(', ')}. ` +
         `For a role-only shorthand on the default agent, use "${count}:${explicitRole}".`,
+      );
+    }
+    if (token === 'cursor' && !CURSOR_ALLOWED_TEAM_ROLES.has(explicitRole)) {
+      throw new Error(
+        `Invalid Cursor worker role "${explicitRole}" in worker spec "${match[0]}". ` +
+        `Cursor workers are executor-style only; use "${count}:cursor" or "${count}:cursor:executor".`,
       );
     }
     return { count, agentType: token, role: explicitRole };

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -462,7 +462,7 @@ describe("team.roleRouting (Option E)", () => {
     }
   });
 
-  it("accepts cursor as team defaultAgentType and roleRouting provider", () => {
+  it("accepts cursor as team defaultAgentType and executor roleRouting provider", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "omc-team-routing-cursor-"));
     try {
       const claudeDir = join(tempDir, ".claude");
@@ -482,6 +482,30 @@ describe("team.roleRouting (Option E)", () => {
       const config = loadConfig();
       expect(config.team?.ops?.defaultAgentType).toBe("cursor");
       expect(config.team?.roleRouting?.executor).toEqual({ provider: "cursor" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+
+
+  it("rejects cursor for non-executor team roleRouting providers", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-team-routing-cursor-reviewer-"));
+    try {
+      const claudeDir = join(tempDir, ".claude");
+      require("node:fs").mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, "omc.jsonc"),
+        JSON.stringify({
+          team: {
+            roleRouting: {
+              "code-reviewer": { provider: "cursor" },
+            },
+          },
+        }),
+      );
+      process.chdir(tempDir);
+      expect(() => loadConfig()).toThrow(/cursor is only supported for executor-style roles/);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -700,5 +724,62 @@ describe("delegation routing deprecation warnings", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("loadConfig() — autopilot team worker config", () => {
+  const originalCwd = process.cwd();
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "omc-autopilot-config-"));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads autopilot.execution=team with Cursor team agentTypes", () => {
+    require("node:fs").mkdirSync(join(tempDir, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tempDir, ".claude", "omc.jsonc"),
+      `{
+        "autopilot": {
+          "execution": "team",
+          "team": { "agentTypes": ["cursor"] }
+        }
+      }`,
+    );
+
+    const config = loadConfig();
+
+    expect(config.autopilot?.execution).toBe("team");
+    expect(config.autopilot?.team?.agentTypes).toEqual(["cursor"]);
+  });
+
+  it("rejects unsupported autopilot team agentTypes", () => {
+    require("node:fs").mkdirSync(join(tempDir, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tempDir, ".claude", "omc.jsonc"),
+      `{
+        "autopilot": {
+          "execution": "team",
+          "team": { "agentTypes": ["security-review"] }
+        }
+      }`,
+    );
+
+    expect(() => loadConfig()).toThrow(/autopilot\.team\.agentTypes/);
+  });
+
+  it("advertises autopilot.team.agentTypes in generated config schema", () => {
+    const schema = generateConfigSchema() as {
+      properties?: Record<string, { properties?: Record<string, unknown> }>;
+    };
+
+    expect(schema.properties?.autopilot).toBeDefined();
+    expect(schema.properties?.autopilot?.properties?.team).toBeDefined();
   });
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -17,6 +17,7 @@ import type {
 } from "../shared/types.js";
 import {
   CANONICAL_TEAM_ROLES,
+  CURSOR_EXECUTOR_TEAM_ROLES,
   KNOWN_AGENT_NAMES,
 } from "../shared/types.js";
 import { getConfigDir } from "../utils/paths.js";
@@ -165,6 +166,9 @@ export function buildDefaultConfig(): PluginConfig {
     team: {
       ops: {},
       roleRouting: {},
+    },
+    autopilot: {
+      execution: "solo",
     },
     planOutput: {
       directory: ".omc/plans",
@@ -483,6 +487,7 @@ function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
  * Throws a descriptive error naming offending key + allowed values.
  */
 const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
+const CURSOR_EXECUTOR_TEAM_ROLE_SET = new Set<string>(CURSOR_EXECUTOR_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
 // /team CLI workers — codex/gemini/grok/cursor here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
 const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "grok", "cursor"]);
@@ -557,6 +562,11 @@ export function validateTeamConfig(config: PluginConfig): void {
           `[OMC] team.roleRouting.${rawRoleKey}.provider: invalid value "${String(spec.provider)}". Allowed: ${[...TEAM_ROLE_PROVIDERS].join(", ")}`,
         );
       }
+      if (spec.provider === "cursor" && !CURSOR_EXECUTOR_TEAM_ROLE_SET.has(normalized)) {
+        throw new Error(
+          `[OMC] team.roleRouting.${rawRoleKey}.provider: cursor is only supported for executor-style roles (${[...CURSOR_EXECUTOR_TEAM_ROLE_SET].join(", ")})`,
+        );
+      }
     }
 
     if (spec.model !== undefined && !isValidModelValue(spec.model)) {
@@ -569,6 +579,64 @@ export function validateTeamConfig(config: PluginConfig): void {
       if (typeof spec.agent !== "string" || !KNOWN_AGENT_NAME_SET.has(spec.agent)) {
         throw new Error(
           `[OMC] team.roleRouting.${rawRoleKey}.agent: unknown agent "${String(spec.agent)}". Allowed: ${[...KNOWN_AGENT_NAME_SET].join(", ")}`,
+        );
+      }
+    }
+  }
+}
+
+const AUTOPILOT_EXECUTION_BACKENDS = new Set(["team", "solo"]);
+const AUTOPILOT_PLANNING_MODES = new Set(["ralplan", "direct"]);
+const AUTOPILOT_TEAM_AGENT_TYPES = new Set([
+  "claude",
+  "codex",
+  "gemini",
+  "grok",
+  "cursor",
+]);
+
+export function validateAutopilotConfig(config: PluginConfig): void {
+  const autopilot = (config as Record<string, unknown>).autopilot as
+    | Record<string, unknown>
+    | undefined;
+  if (!autopilot || typeof autopilot !== "object") return;
+
+  if (
+    autopilot.execution !== undefined &&
+    (typeof autopilot.execution !== "string" ||
+      !AUTOPILOT_EXECUTION_BACKENDS.has(autopilot.execution))
+  ) {
+    throw new Error(
+      `[OMC] autopilot.execution: invalid value "${String(autopilot.execution)}". Allowed: ${[...AUTOPILOT_EXECUTION_BACKENDS].join(", ")}`,
+    );
+  }
+
+  if (
+    autopilot.planning !== undefined &&
+    autopilot.planning !== false &&
+    (typeof autopilot.planning !== "string" ||
+      !AUTOPILOT_PLANNING_MODES.has(autopilot.planning))
+  ) {
+    throw new Error(
+      `[OMC] autopilot.planning: invalid value "${String(autopilot.planning)}". Allowed: ralplan, direct, false`,
+    );
+  }
+
+  const team = autopilot.team as Record<string, unknown> | undefined;
+  if (!team || typeof team !== "object") return;
+
+  if (team.agentTypes !== undefined) {
+    if (!Array.isArray(team.agentTypes)) {
+      throw new Error("[OMC] autopilot.team.agentTypes: must be an array");
+    }
+
+    for (const agentType of team.agentTypes) {
+      if (
+        typeof agentType !== "string" ||
+        !AUTOPILOT_TEAM_AGENT_TYPES.has(agentType)
+      ) {
+        throw new Error(
+          `[OMC] autopilot.team.agentTypes: invalid value "${String(agentType)}". Allowed: ${[...AUTOPILOT_TEAM_AGENT_TYPES].join(", ")}`,
         );
       }
     }
@@ -647,6 +715,7 @@ export function loadConfig(): PluginConfig {
   // Validate /team role routing post-merge. Throws on invalid shape,
   // walking the parsed object so deepMerge bypasses surface here.
   validateTeamConfig(config);
+  validateAutopilotConfig(config);
 
   return config;
 }
@@ -1092,6 +1161,52 @@ export function generateConfigSchema(): object {
                 fallback: { type: "array", items: { type: "string" } },
               },
               required: ["provider", "tool"],
+            },
+          },
+        },
+      },
+      autopilot: {
+        type: "object",
+        description: "/autopilot pipeline and team execution configuration",
+        properties: {
+          planning: {
+            anyOf: [
+              { type: "string", enum: ["ralplan", "direct"] },
+              { type: "boolean", enum: [false] },
+            ],
+            default: "ralplan",
+          },
+          execution: {
+            type: "string",
+            enum: ["team", "solo"],
+            default: "solo",
+          },
+          verification: {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  engine: { type: "string", enum: ["ralph"] },
+                  maxIterations: { type: "integer", minimum: 1 },
+                },
+                required: ["engine", "maxIterations"],
+              },
+              { type: "boolean", enum: [false] },
+            ],
+          },
+          qa: { type: "boolean", default: true },
+          team: {
+            type: "object",
+            properties: {
+              agentTypes: {
+                type: "array",
+                items: {
+                  type: "string",
+                  enum: ["claude", "codex", "gemini", "grok", "cursor"],
+                },
+                description:
+                  "Preferred CLI worker types for executor-style autopilot team execution tasks",
+              },
             },
           },
         },

--- a/src/hooks/autopilot/__tests__/pipeline.test.ts
+++ b/src/hooks/autopilot/__tests__/pipeline.test.ts
@@ -473,3 +473,65 @@ describe('Pipeline Orchestrator (with state)', () => {
     });
   });
 });
+
+describe('autopilot team CLI worker configuration', () => {
+  it('preserves requested Cursor worker types in pipeline config', () => {
+    const config = resolvePipelineConfig({
+      execution: 'team',
+      team: { agentTypes: ['cursor'] },
+    });
+
+    expect(config.execution).toBe('team');
+    expect(config.team?.agentTypes).toEqual(['cursor']);
+  });
+
+  it('does not imply team execution from team agentTypes alone', () => {
+    const config = resolvePipelineConfig({
+      team: { agentTypes: ['cursor'] },
+    });
+
+    expect(config.execution).toBe('solo');
+    expect(config.team?.agentTypes).toEqual(['cursor']);
+  });
+
+  it('instructs team execution to use omc team for Cursor executor workers', () => {
+    const prompt = executionAdapter.getPrompt({
+      idea: 'test',
+      directory: '/tmp',
+      planPath: '.omc/plans/autopilot-impl.md',
+      config: {
+        ...DEFAULT_PIPELINE_CONFIG,
+        execution: 'team',
+        team: { agentTypes: ['cursor'] },
+      },
+    });
+
+    expect(prompt).toContain('CLI Team Runtime Required');
+    expect(prompt).toContain('omc team 1:cursor');
+    expect(prompt).toContain('/omc-teams 1:cursor');
+    expect(prompt).toContain('executor-style only');
+    expect(prompt).toContain('reviewer, critic, security-review, validation verdict');
+    expect(prompt).toContain('cursor-agent');
+    expect(prompt).toContain('installed and authenticated');
+    expect(prompt).not.toContain('TeamCreate');
+    expect(prompt).not.toContain('team_name');
+    expect(prompt).not.toContain('debugger` with');
+    expect(prompt).not.toContain('test-engineer` with');
+  });
+
+  it('keeps native TeamCreate guidance for Claude-only team execution', () => {
+    const prompt = executionAdapter.getPrompt({
+      idea: 'test',
+      directory: '/tmp',
+      config: {
+        ...DEFAULT_PIPELINE_CONFIG,
+        execution: 'team',
+        team: { agentTypes: ['claude'] },
+      },
+    });
+
+    expect(prompt).toContain('TeamCreate');
+    expect(prompt).toContain('team_name');
+    expect(prompt).not.toContain('CLI Team Runtime Required');
+  });
+});

--- a/src/hooks/autopilot/adapters/execution-adapter.ts
+++ b/src/hooks/autopilot/adapters/execution-adapter.ts
@@ -16,6 +16,59 @@ import { resolveAutopilotPlanPath } from "../../../config/plan-output.js";
 
 export const EXECUTION_COMPLETION_SIGNAL = "PIPELINE_EXECUTION_COMPLETE";
 
+const CLI_TEAM_AGENT_TYPES = new Set(["codex", "gemini", "grok", "cursor"]);
+
+function uniqueRequestedAgentTypes(
+  agentTypes: readonly string[] | undefined,
+): string[] {
+  return [...new Set((agentTypes ?? []).filter(Boolean))];
+}
+
+function hasCliTeamAgentTypes(agentTypes: readonly string[]): boolean {
+  return agentTypes.some((agentType) => CLI_TEAM_AGENT_TYPES.has(agentType));
+}
+
+function formatCliTeamAgentSpec(agentTypes: readonly string[]): string {
+  const cliTypes = agentTypes.filter((agentType) =>
+    CLI_TEAM_AGENT_TYPES.has(agentType),
+  );
+  const preferred = cliTypes.length > 0 ? cliTypes[0] : "cursor";
+  return `1:${preferred}`;
+}
+
+function getCliTeamRuntimeGuidance(
+  agentTypes: readonly string[],
+  planPath: string,
+): string {
+  const requested = agentTypes.join(", ");
+  const agentSpec = formatCliTeamAgentSpec(agentTypes);
+  const cursorGuidance = agentTypes.includes("cursor")
+    ? `
+
+### Cursor Availability
+
+Before launching Cursor workers, verify \`cursor-agent\` is installed and authenticated. If it is unavailable, stop and report: install/authenticate \`cursor-agent\` for Cursor worker support. Do not silently fall back to Claude-only execution in a way that hides the missing Cursor dependency.`
+    : "";
+
+  return `### CLI Team Runtime Required
+
+Configured autopilot team worker types include CLI-backed workers: ${requested}. For executor-style implementation work, use the tmux CLI team runtime instead of in-process Claude-only Task subagents.
+
+Use one of these equivalent surfaces from the lead session:
+
+\`\`\`sh
+omc team ${agentSpec} "<implementation task from ${planPath}>"
+\`\`\`
+
+Or from Claude Code slash commands:
+
+\`\`\`text
+/omc-teams ${agentSpec} "<implementation task from ${planPath}>"
+\`\`\`
+
+Requested worker types: ${requested}. Keep these CLI workers executor-style only: implementation, file edits, build/test fixes, and other plan execution tasks. Keep reviewer, critic, security-review, validation verdict, and final approval roles on the native Claude/OMC reviewer agents unless this repository explicitly adds safe role support for that CLI worker type.${cursorGuidance}`;
+}
+
 export const executionAdapter: PipelineStageAdapter = {
   id: "execution",
   name: "Execution",
@@ -29,8 +82,16 @@ export const executionAdapter: PipelineStageAdapter = {
   getPrompt(context: PipelineContext): string {
     const planPath = context.planPath || resolveAutopilotPlanPath();
     const isTeam = context.config.execution === "team";
+    const requestedAgentTypes = uniqueRequestedAgentTypes(
+      context.config.team?.agentTypes,
+    );
+    const useCliTeamRuntime =
+      isTeam && hasCliTeamAgentTypes(requestedAgentTypes);
 
     if (isTeam) {
+      const teamRuntimeGuidance = useCliTeamRuntime
+        ? getCliTeamRuntimeGuidance(requestedAgentTypes, planPath)
+        : `Use the Team orchestrator to execute tasks in parallel:`;
       return `## PIPELINE STAGE: EXECUTION (Team Mode)
 
 Execute the implementation plan using multi-worker team execution.
@@ -41,13 +102,17 @@ Read the implementation plan at: \`${planPath}\`
 
 ### Team Execution
 
-Use the Team orchestrator to execute tasks in parallel:
+${teamRuntimeGuidance}
 
-1. **Create team** with TeamCreate
+${useCliTeamRuntime ? `1. **Launch CLI executor workers** with \`omc team\` or \`/omc-teams\` using the requested agent types.
+2. **Decompose executor-style implementation tasks** from the implementation plan and pass them to CLI workers.
+3. **Monitor tmux/team output** and integrate completed implementation changes.
+4. **Keep review/critic/security/verdict work native**; do not assign those roles to Cursor/CLI workers.
+5. **Coordinate** dependencies between tasks.` : `1. **Create team** with TeamCreate
 2. **Create tasks** from the implementation plan using TaskCreate
 3. **Spawn executor teammates** using Task with \`team_name\` parameter
 4. **Monitor progress** as teammates complete tasks
-5. **Coordinate** dependencies between tasks
+5. **Coordinate** dependencies between tasks.`}
 
 ### Output Contract
 
@@ -55,13 +120,13 @@ Every teammate response must stay concise: return ONLY a short execution summary
 
 ### Agent Selection
 
-Match agent types to task complexity:
+${useCliTeamRuntime ? `Use the requested CLI worker spec for executor-style implementation tasks only. Keep task prompts framed as implementation/build/test-fix work; do not ask Cursor/CLI workers to act as reviewers, critics, security reviewers, or final verdict agents.` : `Match agent types to task complexity:
 - Simple tasks (single file, config): \`executor\` with \`model="haiku"\`
 - Standard implementation: \`executor\` with \`model="sonnet"\`
 - Complex work (architecture, refactoring): \`executor\` with \`model="opus"\`
 - Build issues: \`debugger\` with \`model="sonnet"\`
 - Test creation: \`test-engineer\` with \`model="sonnet"\`
-- UI work: \`designer\` with \`model="sonnet"\`
+- UI work: \`designer\` with \`model="sonnet"\``}
 
 ### Progress Tracking
 

--- a/src/hooks/autopilot/pipeline-types.ts
+++ b/src/hooks/autopilot/pipeline-types.ts
@@ -47,6 +47,20 @@ export const STAGE_ORDER: readonly PipelineStageId[] = [
 /** Execution backend for the execution stage */
 export type ExecutionBackend = "team" | "solo";
 
+/** CLI-backed worker types supported by the tmux team runtime. */
+export type AutopilotTeamAgentType =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "grok"
+  | "cursor";
+
+/** Team execution options for autopilot execution=team. */
+export interface AutopilotTeamConfig {
+  /** Preferred CLI worker types for executor-style implementation tasks. */
+  agentTypes?: AutopilotTeamAgentType[];
+}
+
 /** Verification engine configuration */
 export interface VerificationConfig {
   /** Engine to use for verification (currently only 'ralph') */
@@ -80,6 +94,8 @@ export interface PipelineConfig {
   verification: VerificationConfig | false;
   /** Whether to run the QA stage (build/lint/test cycling) */
   qa: boolean;
+  /** Team execution options, only used when execution is 'team'. */
+  team?: AutopilotTeamConfig;
 }
 
 /** Default pipeline configuration (matches current autopilot behavior) */

--- a/src/hooks/autopilot/pipeline.ts
+++ b/src/hooks/autopilot/pipeline.ts
@@ -69,6 +69,9 @@ export function resolvePipelineConfig(
     if (userConfig.verification !== undefined)
       config.verification = userConfig.verification;
     if (userConfig.qa !== undefined) config.qa = userConfig.qa;
+    if (userConfig.team !== undefined) {
+      config.team = { ...(config.team ?? {}), ...userConfig.team };
+    }
   }
 
   return config;

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -73,6 +73,7 @@ import {
   resolveOpenQuestionsPlanPath,
 } from "../config/plan-output.js";
 import { formatAutopilotRuntimeInsight } from "./autopilot/runtime-insight.js";
+import type { AutopilotState } from "./autopilot/types.js";
 import {
   writeSkillActiveState,
   isCanonicalWorkflowSkill,
@@ -732,7 +733,13 @@ async function seedAutopilotStartupState(
   prompt: string,
   sessionId?: string,
 ): Promise<void> {
-  const { readAutopilotState, writeAutopilotState, DEFAULT_CONFIG } = await import("./autopilot/index.js");
+  const {
+    readAutopilotState,
+    writeAutopilotState,
+    DEFAULT_CONFIG,
+    resolvePipelineConfig,
+    buildPipelineTracking,
+  } = await import("./autopilot/index.js");
   const existingState = readAutopilotState(directory, sessionId);
   const existingAutopilotRecord = existingState as unknown as Record<string, unknown> | null;
 
@@ -743,58 +750,65 @@ async function seedAutopilotStartupState(
     return;
   }
 
+  const config = loadConfig();
   const now = new Date().toISOString();
-  const wrote = writeAutopilotState(
-    directory,
-    {
-      active: true,
-      phase: "expansion",
-      current_phase: "expansion",
-      iteration: 1,
-      max_iterations: DEFAULT_CONFIG.maxIterations ?? 10,
-      originalIdea: prompt,
-      expansion: {
-        analyst_complete: false,
-        architect_complete: false,
-        spec_path: null,
-        requirements_summary: "",
-        tech_stack: [],
-      },
-      planning: {
-        plan_path: null,
-        architect_iterations: 0,
-        approved: false,
-      },
-      execution: {
-        ralph_iterations: 0,
-        ultrawork_active: false,
-        tasks_completed: 0,
-        tasks_total: 0,
-        files_created: [],
-        files_modified: [],
-      },
-      qa: {
-        ultraqa_cycles: 0,
-        build_status: "pending",
-        lint_status: "pending",
-        test_status: "pending",
-      },
-      validation: {
-        architects_spawned: 0,
-        verdicts: [],
-        all_approved: false,
-        validation_rounds: 0,
-      },
-      started_at: now,
-      completed_at: null,
-      phase_durations: {},
-      total_agents_spawned: 0,
-      wisdom_entries: 0,
-      session_id: sessionId,
-      project_path: directory,
+  const state: AutopilotState = {
+    active: true,
+    phase: "expansion",
+    current_phase: "expansion",
+    iteration: 1,
+    max_iterations: DEFAULT_CONFIG.maxIterations ?? 10,
+    originalIdea: prompt,
+    expansion: {
+      analyst_complete: false,
+      architect_complete: false,
+      spec_path: null,
+      requirements_summary: "",
+      tech_stack: [],
     },
-    sessionId,
-  );
+    planning: {
+      plan_path: null,
+      architect_iterations: 0,
+      approved: false,
+    },
+    execution: {
+      ralph_iterations: 0,
+      ultrawork_active: false,
+      tasks_completed: 0,
+      tasks_total: 0,
+      files_created: [],
+      files_modified: [],
+    },
+    qa: {
+      ultraqa_cycles: 0,
+      build_status: "pending",
+      lint_status: "pending",
+      test_status: "pending",
+    },
+    validation: {
+      architects_spawned: 0,
+      verdicts: [],
+      all_approved: false,
+      validation_rounds: 0,
+    },
+    started_at: now,
+    completed_at: null,
+    phase_durations: {},
+    total_agents_spawned: 0,
+    wisdom_entries: 0,
+    session_id: sessionId,
+    project_path: directory,
+  };
+
+  const autopilotConfig = config.autopilot;
+  const shouldUsePipeline = autopilotConfig?.execution === "team";
+  if (shouldUsePipeline) {
+    const pipelineConfig = resolvePipelineConfig(autopilotConfig);
+    (state as unknown as Record<string, unknown>).pipeline =
+      buildPipelineTracking(pipelineConfig);
+  }
+
+  const wrote = writeAutopilotState(directory, state, sessionId);
   if (wrote) {
     markModeAwaitingConfirmation(directory, sessionId, "autopilot");
   }
@@ -2961,8 +2975,12 @@ async function processAutopilot(input: HookInput): Promise<HookOutput> {
   const directory = resolveToWorktreeRoot(input.directory);
 
   // Lazy-load autopilot module
-  const { readAutopilotState, getPhasePrompt } =
-    await import("./autopilot/index.js");
+  const {
+    readAutopilotState,
+    getPhasePrompt,
+    hasPipelineTracking,
+    generatePipelinePrompt,
+  } = await import("./autopilot/index.js");
 
   const state = readAutopilotState(directory, input.sessionId);
 
@@ -2970,8 +2988,22 @@ async function processAutopilot(input: HookInput): Promise<HookOutput> {
     return { continue: true };
   }
 
-  // Check phase and inject appropriate prompt
   const config = loadConfig();
+
+  if (hasPipelineTracking(state)) {
+    const pipelinePrompt = generatePipelinePrompt(directory, input.sessionId);
+    const runtimeInsight = formatAutopilotRuntimeInsight(directory, input.sessionId);
+    if (pipelinePrompt || runtimeInsight) {
+      const detailParts = [runtimeInsight, pipelinePrompt].filter(Boolean);
+      return {
+        continue: true,
+        message: `[AUTOPILOT - Pipeline]\n\n${detailParts.join("\n\n")}`,
+      };
+    }
+    return { continue: true };
+  }
+
+  // Check phase and inject appropriate prompt
   const context = {
     idea: state.originalIdea,
     specPath: state.expansion.spec_path || ".omc/autopilot/spec.md",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,6 +16,45 @@ export interface AgentConfig {
   defaultModel?: string;
 }
 
+export type AutopilotExecutionBackend = "team" | "solo";
+export type AutopilotPlanningMode = "ralplan" | "direct" | false;
+export type AutopilotTeamAgentType =
+  | "claude"
+  | "codex"
+  | "gemini"
+  | "grok"
+  | "cursor";
+
+export interface AutopilotConfigBlock {
+  /** Maximum total iterations across all phases. */
+  maxIterations?: number;
+  /** Maximum QA test-fix cycles. */
+  maxQaCycles?: number;
+  /** Maximum validation rounds before giving up. */
+  maxValidationRounds?: number;
+  /** Pause for user confirmation after expansion. */
+  pauseAfterExpansion?: boolean;
+  /** Pause for user confirmation after planning. */
+  pauseAfterPlanning?: boolean;
+  /** Skip QA phase entirely. */
+  skipQa?: boolean;
+  /** Skip validation phase entirely. */
+  skipValidation?: boolean;
+  /** Planning stage: 'ralplan' for consensus, 'direct' for simple planning, false to skip. */
+  planning?: AutopilotPlanningMode;
+  /** Execution backend: 'team' for multi-worker execution, 'solo' for current-session execution. */
+  execution?: AutopilotExecutionBackend;
+  /** Verification config, or false to skip verification. */
+  verification?: { engine: "ralph"; maxIterations: number } | false;
+  /** Whether to run QA build/lint/test cycling. */
+  qa?: boolean;
+  /** Team execution options used when execution is 'team'. */
+  team?: {
+    /** Preferred CLI worker types for executor-style implementation tasks. */
+    agentTypes?: AutopilotTeamAgentType[];
+  };
+}
+
 export interface PluginConfig {
   // Agent model overrides
   agents?: {
@@ -138,6 +177,9 @@ export interface PluginConfig {
 
   // /team role routing configuration (scoped to /team only; distinct from delegationRouting)
   team?: TeamConfigBlock;
+
+  // /autopilot pipeline and team execution configuration
+  autopilot?: AutopilotConfigBlock;
 
   // Plan output configuration (issue #1636)
   planOutput?: {
@@ -413,6 +455,9 @@ export const CANONICAL_TEAM_ROLES = [
 ] as const;
 
 export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
+
+/** Cursor team workers are currently supported only for executor-style tasks. */
+export const CURSOR_EXECUTOR_TEAM_ROLES = ["executor"] as const;
 
 /** Provider for /team role routing. */
 export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor';

--- a/src/team/__tests__/runtime-v2.cursor-routing.test.ts
+++ b/src/team/__tests__/runtime-v2.cursor-routing.test.ts
@@ -23,6 +23,28 @@ describe('runtime-v2 Cursor task assignment guard', () => {
     expect(assignment).toEqual({ agentType: 'cursor', model: '', role: 'executor' });
   });
 
+  it('keeps unowned cursor build-test-fix executor contexts on cursor', () => {
+    const cases = [
+      'fix failing tests',
+      'fix the build error',
+      'debug the failing test runner',
+      'refactor the parser implementation',
+      'verify tests after patching the build',
+    ];
+
+    for (const description of cases) {
+      const assignment = resolveTaskAssignment(
+        { subject: description, description },
+        resolvedRouting,
+        undefined,
+        binaries,
+        'cursor',
+      );
+
+      expect(assignment).toEqual({ agentType: 'cursor', model: '', role: 'executor' });
+    }
+  });
+
   it('keeps explicit cursor executor tasks on cursor', () => {
     const assignment = resolveTaskAssignment(
       { subject: 'Executor task', description: 'apply the implementation plan', role: 'executor' },

--- a/src/team/__tests__/runtime-v2.cursor-routing.test.ts
+++ b/src/team/__tests__/runtime-v2.cursor-routing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTaskAssignment } from '../runtime-v2.js';
+import { buildResolvedRoutingSnapshot } from '../stage-router.js';
+import type { CliAgentType } from '../model-contract.js';
+
+const resolvedRouting = buildResolvedRoutingSnapshot({});
+const binaries: Partial<Record<CliAgentType, string>> = {
+  claude: '/usr/bin/claude',
+  cursor: '/usr/bin/cursor-agent',
+};
+
+describe('runtime-v2 Cursor task assignment guard', () => {
+  it('keeps inferred executor-style implementation tasks on cursor', () => {
+    const assignment = resolveTaskAssignment(
+      { subject: 'Implement plan', description: 'apply the implementation plan', },
+      resolvedRouting,
+      undefined,
+      binaries,
+      'cursor',
+    );
+
+    expect(assignment).toEqual({ agentType: 'cursor', model: '', role: 'executor' });
+  });
+
+  it('keeps explicit cursor executor tasks on cursor', () => {
+    const assignment = resolveTaskAssignment(
+      { subject: 'Executor task', description: 'apply the implementation plan', role: 'executor' },
+      resolvedRouting,
+      undefined,
+      binaries,
+      'cursor',
+    );
+
+    expect(assignment).toEqual({ agentType: 'cursor', model: '', role: 'executor' });
+  });
+
+  it('rejects inferred review/security/verdict-style roles for cursor workers', () => {
+    const cases = [
+      { subject: 'Review auth', description: 'review the auth module for maintainability' },
+      { subject: 'Security review', description: 'review auth for vulnerabilities and injection issues' },
+      { subject: 'Validation verdict', description: 'verify tests and provide final verdict' },
+    ];
+
+    for (const task of cases) {
+      expect(() =>
+        resolveTaskAssignment(task, resolvedRouting, undefined, binaries, 'cursor'),
+      ).toThrow(/Cursor workers are executor-style only/);
+    }
+  });
+});

--- a/src/team/__tests__/stage-router.test.ts
+++ b/src/team/__tests__/stage-router.test.ts
@@ -124,6 +124,16 @@ describe('stage-router resolveRoleAssignment', () => {
       expect(out.agent).toBe('executor');
     });
 
+
+    it('rejects provider=cursor for reviewer/verdict roles', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { 'code-reviewer': { provider: 'cursor' } } },
+      };
+      expect(() => resolveRoleAssignment('code-reviewer', cfg)).toThrow(
+        /cursor is only supported for executor-style roles/,
+      );
+    });
+
     it('grok resolves configured externalModels.defaults.grokModel when model omitted', () => {
       const cfg: PluginConfig = {
         externalModels: { defaults: { grokModel: 'grok-code-fast-1' } },

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -88,7 +88,7 @@ import type { CanonicalTeamRole, PluginConfig, RoleAssignment, TeamRoleAssignmen
 import { CANONICAL_TEAM_ROLES, CURSOR_EXECUTOR_TEAM_ROLES } from '../shared/types.js';
 import { loadConfig } from '../config/loader.js';
 import { buildResolvedRoutingSnapshot, getRoleRoutingSpec } from './stage-router.js';
-import { routeTaskToRole } from './role-router.js';
+import { inferLaneIntent, routeTaskToRole, type LaneIntent } from './role-router.js';
 import { normalizeDelegationRole } from '../features/delegation-routing/types.js';
 import {
   cliWorkerOutputFilePath,
@@ -119,6 +119,24 @@ import {
 // ---------------------------------------------------------------------------
 
 const orchestratorByTeam = new Map<string, OrchestratorHandle>();
+const CURSOR_UNSUPPORTED_REVIEW_INTENT_RE =
+  /\b(?:review|audit|critic|critique|security|vulnerabilit|cve|owasp|xss|csrf|sqli|verdict|approval|approve|final\s+decision)\b/i;
+const CURSOR_EXECUTOR_CONTEXT_RE =
+  /\b(?:implement|implementation|apply|edit|patch|fix|build|ci|lint|compile|tsc|type.?check|test|tests|debug|troubleshoot|investigate|root.?cause|diagnos|refactor|clean\s*up|simplif)\b/i;
+const CURSOR_EXECUTOR_CONTEXT_INTENTS = new Set<LaneIntent>([
+  'implementation',
+  'build-fix',
+  'debug',
+  'cleanup',
+  'verification',
+]);
+
+function isCursorExecutorContextTask(task: { subject: string; description: string }): boolean {
+  const text = `${task.subject} ${task.description}`.trim();
+  if (!text || CURSOR_UNSUPPORTED_REVIEW_INTENT_RE.test(text)) return false;
+  if (!CURSOR_EXECUTOR_CONTEXT_RE.test(text)) return false;
+  return CURSOR_EXECUTOR_CONTEXT_INTENTS.has(inferLaneIntent(text));
+}
 const cadenceByTeam = new Map<string, { pollers: FallbackPollerHandle[]; contexts: WorkerCadenceContext[] }>();
 
 function registerTeamOrchestrator(teamName: string, handle: OrchestratorHandle): void {
@@ -297,8 +315,13 @@ export function resolveTaskAssignment(
     roleRoutingConfig as Record<string, TeamRoleAssignmentSpec | undefined> | undefined,
     canonical,
   );
-  if (fallbackAgent === 'cursor' && CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {
-    return { agentType: fallbackAgent, model: '', role: canonical };
+  if (fallbackAgent === 'cursor') {
+    if (CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {
+      return { agentType: fallbackAgent, model: '', role: canonical };
+    }
+    if (!hasExplicitRole && !hasConfigForRole && isCursorExecutorContextTask(task)) {
+      return { agentType: fallbackAgent, model: '', role: 'executor' };
+    }
   }
   if (!hasExplicitRole && !hasConfigForRole) {
     if (fallbackAgent === 'cursor' && !CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -85,7 +85,7 @@ import {
 import { formatOmcCliInvocation } from '../utils/omc-cli-rendering.js';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 import type { CanonicalTeamRole, PluginConfig, RoleAssignment, TeamRoleAssignmentSpec } from '../shared/types.js';
-import { CANONICAL_TEAM_ROLES } from '../shared/types.js';
+import { CANONICAL_TEAM_ROLES, CURSOR_EXECUTOR_TEAM_ROLES } from '../shared/types.js';
 import { loadConfig } from '../config/loader.js';
 import { buildResolvedRoutingSnapshot, getRoleRoutingSpec } from './stage-router.js';
 import { routeTaskToRole } from './role-router.js';
@@ -269,7 +269,7 @@ const MONITOR_SIGNAL_STALE_MS = 30_000;
  * Returns the primary assignment by default; callers swap to the Claude
  * fallback if the primary provider's CLI binary is missing at spawn time.
  */
-function resolveTaskAssignment(
+export function resolveTaskAssignment(
   task: { subject: string; description: string; role?: string },
   resolvedRouting: Record<CanonicalTeamRole, { primary: RoleAssignment; fallback: RoleAssignment }>,
   roleRoutingConfig: Partial<Record<CanonicalTeamRole, TeamRoleAssignmentSpec>> | undefined,
@@ -297,7 +297,15 @@ function resolveTaskAssignment(
     roleRoutingConfig as Record<string, TeamRoleAssignmentSpec | undefined> | undefined,
     canonical,
   );
+  if (fallbackAgent === 'cursor' && CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {
+    return { agentType: fallbackAgent, model: '', role: canonical };
+  }
   if (!hasExplicitRole && !hasConfigForRole) {
+    if (fallbackAgent === 'cursor' && !CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {
+      throw new Error(
+        `Cursor workers are executor-style only; inferred role "${canonical}" for task "${task.subject}" must run on a native Claude/OMC reviewer agent or another supported CLI worker.`,
+      );
+    }
     return { agentType: fallbackAgent, model: '', role: canonical };
   }
 

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -20,7 +20,7 @@ import type {
   TeamRoleProvider,
   TeamRoleTier,
 } from '../shared/types.js';
-import { CANONICAL_TEAM_ROLES } from '../shared/types.js';
+import { CANONICAL_TEAM_ROLES, CURSOR_EXECUTOR_TEAM_ROLES } from '../shared/types.js';
 import { normalizeDelegationRole } from '../features/delegation-routing/types.js';
 import {
   BUILTIN_EXTERNAL_MODEL_DEFAULTS,
@@ -66,6 +66,7 @@ const ROLE_DEFAULT_TIER: Record<CanonicalTeamRole, TeamRoleTier> = {
 };
 
 const TIER_SET: ReadonlySet<string> = new Set<TeamRoleTier>(['HIGH', 'MEDIUM', 'LOW']);
+const CURSOR_EXECUTOR_TEAM_ROLE_SET: ReadonlySet<string> = new Set(CURSOR_EXECUTOR_TEAM_ROLES);
 
 function isTier(value: string): value is TeamRoleTier {
   return TIER_SET.has(value);
@@ -180,6 +181,11 @@ export function resolveRoleAssignment(
   const provider: TeamRoleProvider = isOrchestrator
     ? 'claude'
     : (spec?.provider ?? 'claude');
+  if (provider === 'cursor' && !CURSOR_EXECUTOR_TEAM_ROLE_SET.has(canonical)) {
+    throw new Error(
+      `team.roleRouting.${canonical}.provider: cursor is only supported for executor-style roles (${[...CURSOR_EXECUTOR_TEAM_ROLE_SET].join(', ')})`,
+    );
+  }
 
   const model = provider === 'claude'
     ? resolveClaudeModel(canonical, spec?.model, cfg)


### PR DESCRIPTION
## Summary
- add `autopilot.execution = "team"` + `autopilot.team.agentTypes` config support for Cursor/CLI executor workers
- teach autopilot team execution prompts to use `omc team` / `/omc-teams` for CLI-backed workers instead of Claude-only Task subagents
- enforce Cursor as executor-style only across config validation, CLI parsing, stage routing, and runtime inferred-role assignment
- document Cursor worker setup/limitations, including `cursor-agent` install/auth requirements

## Verification
- `node` skill contract check for `skills/omc-teams/SKILL.md` passed
- `npx vitest run src/team/__tests__/runtime-v2.cursor-routing.test.ts src/cli/commands/__tests__/team.test.ts src/team/__tests__/cli-worker-contract.test.ts src/team/__tests__/stage-router.test.ts src/hooks/autopilot/__tests__/pipeline.test.ts src/config/__tests__/loader.test.ts` — 6 files, 188 tests passed
- `npx tsc --noEmit` — passed
- `git diff --check` — passed

## Notes
- Owner confirmation is recommended before merge because this changes user-facing `/autopilot` config and team-worker behavior.
- Full test suite/full build were skipped as broader than this focused config/prompt/runtime guard change.
- Full-file `src/__tests__/skills.test.ts` import was unstable in this environment; the changed `/omc-teams` skill contract was verified directly with a Node assertion.

Fixes #3283

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
