### PR TITLE
Fix native Windows psmux team worker launch

### DIFF
--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -9,13 +9,15 @@
  */
 
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { execFileSync, spawnSync } from 'child_process';
+import { exec, execFile, execFileSync, spawnSync } from 'child_process';
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   return {
     ...actual,
     execFileSync: vi.fn(),
+    exec: vi.fn(),
+    execFile: vi.fn(),
     spawnSync: vi.fn(),
   };
 });
@@ -31,12 +33,33 @@ import {
   tmuxExec,
   tmuxEnv,
   tmuxSpawn,
+  tmuxCmdAsync,
   wrapWithLoginShell,
   quoteShellArg,
   sanitizeTmuxToken,
 } from '../tmux-utils.js';
 
 const mockedExecFileSync = vi.mocked(execFileSync);
+const mockedExec = vi.mocked(exec);
+const mockedExecFile = vi.mocked(execFile);
+
+function mockExecFileAsync(stdout = '', stderr = ''): void {
+  type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+  mockedExecFile.mockImplementation(((_command: string, _args: readonly string[], _options: unknown, callback?: ExecFileCallback) => {
+    const cb = typeof _options === 'function' ? _options as ExecFileCallback : callback;
+    cb?.(null, stdout, stderr);
+    return {} as never;
+  }) as unknown as typeof execFile);
+}
+
+function mockExecAsync(stdout = '', stderr = ''): void {
+  type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+  mockedExec.mockImplementation(((_command: string, _options: unknown, callback?: ExecCallback) => {
+    const cb = typeof _options === 'function' ? _options as ExecCallback : callback;
+    cb?.(null, stdout, stderr);
+    return {} as never;
+  }) as unknown as typeof exec);
+}
 const mockedSpawnSync = vi.mocked(spawnSync);
 const baselinePlatform = process.platform;
 
@@ -325,6 +348,48 @@ describe('tmux command execution parity on Windows', () => {
     );
 
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+  it('uses argv execution for tmux format args on native Windows instead of POSIX shell quoting', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+    mockedSpawnSync.mockClear();
+    mockedExecFile.mockClear();
+    mockedExec.mockClear();
+    mockedSpawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: 'C:\\Program Files\\psmux\\tmux.cmd\r\n',
+      stderr: '',
+      pid: 0,
+      output: [],
+      signal: null,
+    } as ReturnType<typeof spawnSync>);
+    mockExecFileAsync('42\n');
+
+    await tmuxCmdAsync(['display-message', '-p', '#{window_width}']);
+
+    expect(mockedExec).not.toHaveBeenCalled();
+    expect(mockedExecFile).toHaveBeenLastCalledWith(
+      'C:\\Windows\\System32\\cmd.exe',
+      ['/d', '/s', '/c', '"C:\\Program Files\\psmux\\tmux.cmd" display-message -p #{window_width}'],
+      expect.objectContaining({ encoding: 'utf-8' }),
+      expect.any(Function),
+    );
+  });
+
+  it('keeps POSIX shell quoting for tmux format args outside native Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    mockedExec.mockClear();
+    mockedExecFile.mockClear();
+    mockExecAsync('42\n');
+
+    await tmuxCmdAsync(['display-message', '-p', '#{window_width}']);
+
+    expect(mockedExecFile).not.toHaveBeenCalled();
+    expect(mockedExec).toHaveBeenLastCalledWith(
+      "tmux 'display-message' '-p' '#{window_width}'",
+      expect.objectContaining({ encoding: 'utf-8' }),
+      expect.any(Function),
+    );
   });
 });
 

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -133,7 +133,7 @@ export async function tmuxCmdAsync(
   args: string[],
   opts?: TmuxExecOptions & { timeout?: number },
 ): Promise<{ stdout: string; stderr: string }> {
-  if (args.some(a => a.includes('#{'))) {
+  if (args.some(a => a.includes('#{')) && !isNativeWindowsShell()) {
     const escaped = args.map(a => "'" + a.replace(/'/g, "'\\''") + "'").join(' ');
     return tmuxShellAsync(escaped, opts);
   }

--- a/src/team/__tests__/tmux-session.create-team.test.ts
+++ b/src/team/__tests__/tmux-session.create-team.test.ts
@@ -12,37 +12,38 @@ vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
   const runMockExec = (args: string[]): { stdout: string; stderr: string } => {
     mockedCalls.execFileArgs.push(args);
+    const tmuxArgs = args[0]?.toLowerCase().endsWith('cmd.exe') ? args.slice(1) : args;
 
-    if (args[0] === 'new-session') {
+    if (tmuxArgs[0] === 'new-session') {
       return { stdout: 'omc-team-race-team-detached:0 %91\n', stderr: '' };
     }
 
-    if (args[0] === 'new-window') {
+    if (tmuxArgs[0] === 'new-window') {
       return { stdout: 'omx:5 %99\n', stderr: '' };
     }
 
-    if (args[0] === 'display-message' && args.includes('#S:#I #{pane_id}')) {
+    if (tmuxArgs[0] === 'display-message' && tmuxArgs.includes('#S:#I #{pane_id}')) {
       return { stdout: 'fallback:2 %42\n', stderr: '' };
     }
 
-    if (args[0] === 'display-message' && args.includes('#S:#I')) {
+    if (tmuxArgs[0] === 'display-message' && tmuxArgs.includes('#S:#I')) {
       return { stdout: 'omx:4\n', stderr: '' };
     }
 
-    if (args[0] === 'display-message' && args.includes('#{window_width}')) {
+    if (tmuxArgs[0] === 'display-message' && tmuxArgs.includes('#{window_width}')) {
       return { stdout: '160\n', stderr: '' };
     }
 
-    if (args[0] === 'display-message' && args.includes('#{pane_dead} #{pane_current_command}')) {
+    if (tmuxArgs[0] === 'display-message' && tmuxArgs.includes('#{pane_dead} #{pane_current_command}')) {
       return { stdout: '0 zsh\n', stderr: '' };
     }
 
-    if (args[0] === 'split-window') {
+    if (tmuxArgs[0] === 'split-window') {
       mockedCalls.splitCount += 1;
       return { stdout: `%50${mockedCalls.splitCount}\n`, stderr: '' };
     }
 
-    if (args[0] === 'new-split') {
+    if (tmuxArgs[0] === 'new-split') {
       mockedCalls.splitCount += 1;
       return {
         stdout: mockedCalls.newSplitStdouts.shift() ?? `cmux-worker-${mockedCalls.splitCount}\n`,
@@ -246,6 +247,47 @@ describe('createTeamSession context resolution', () => {
     expect(session.sessionName).toBe('omx:5');
     expect(session.workerPaneIds).toEqual(['%501']);
     expect(session.sessionMode).toBe('dedicated-window');
+  });
+  it('launches native Windows psmux detached team sessions with explicit cmd shell', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('TMUX', '');
+    vi.stubEnv('TMUX_PANE', '');
+    vi.stubEnv('CMUX_SURFACE_ID', '');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    await createTeamSession('race-team', 0, 'C:\\repo');
+
+    const detachedCreateCall = mockedCalls.execFileArgs.find((args) => args.includes('new-session') && args.includes('-d') && args.includes('-P'));
+    expect(detachedCreateCall).toEqual(expect.arrayContaining(['new-session', '-d', '-P', '-F', '#S:0 #{pane_id}', '-s', expect.any(String), '-c', 'C:\\repo', 'C:\\Windows\\System32\\cmd.exe']));
+  });
+
+  it('launches native Windows psmux worker splits with explicit cmd shell', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1,1');
+    vi.stubEnv('TMUX_PANE', '%732');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    await createTeamSession('race-team', 1, 'C:\\repo');
+
+    const firstSplitCall = mockedCalls.execFileArgs.find((args) => args.includes('split-window'));
+    expect(firstSplitCall).toEqual(expect.arrayContaining(['split-window', '-h', '-t', '%732', '-d', '-P', '-F', '#{pane_id}', '-c', 'C:\\repo', 'C:\\Windows\\System32\\cmd.exe']));
+  });
+
+  it('keeps MSYS psmux team panes on POSIX shell defaults', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,1,1');
+    vi.stubEnv('TMUX_PANE', '%732');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('MSYSTEM', 'MINGW64');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    await createTeamSession('race-team', 1, '/c/repo');
+
+    const firstSplitCall = mockedCalls.execFileArgs.find((args) => args[0] === 'split-window');
+    expect(firstSplitCall).toEqual(expect.arrayContaining(['split-window', '-h', '-t', '%732']));
+    expect(firstSplitCall).not.toContain('C:\\Windows\\System32\\cmd.exe');
   });
 });
 

--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -7,6 +7,7 @@ const mockedCalls = vi.hoisted(() => ({
   paneStatus: '0 zsh\n',
   echoOnLiteralSend: true,
   wrapLiteralCapture: false,
+  insertWrapSpaces: false,
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -40,7 +41,7 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
       mockedCalls.tmuxArgs.push(args);
       if (args[0] === 'capture-pane') {
         const stdout = args.includes('-J')
-          ? mockedCalls.paneCapture.replace(/\n/g, '')
+          ? mockedCalls.paneCapture.replace(/\n/g, mockedCalls.insertWrapSpaces ? ' ' : '')
           : mockedCalls.paneCapture;
         return { stdout, stderr: '' };
       }
@@ -72,6 +73,7 @@ describe('spawnWorkerInPane', () => {
     mockedCalls.paneStatus = '0 zsh\n';
     mockedCalls.echoOnLiteralSend = true;
     mockedCalls.wrapLiteralCapture = false;
+    mockedCalls.insertWrapSpaces = false;
     vi.unstubAllEnvs();
   });
 
@@ -177,6 +179,28 @@ describe('spawnWorkerInPane', () => {
 
   it('verifies wrapped worker start commands with joined tmux capture before Enter', async () => {
     mockedCalls.wrapLiteralCapture = true;
+
+    await spawnWorkerInPane('session:0', '%2', {
+      teamName: 'safe-team',
+      workerName: 'worker-1',
+      envVars: {
+        OMC_TEAM_NAME: 'safe-team',
+        OMC_TEAM_WORKER: 'safe-team/worker-1',
+        OMC_TEAM_LONG_VALUE: 'x'.repeat(160),
+      },
+      launchBinary: 'codex',
+      launchArgs: ['--full-auto', '--model', 'gpt-5.5', '--reasoning-effort', 'high'],
+      cwd: '/tmp',
+    });
+
+    expect(mockedCalls.tmuxArgs).toContainEqual(['capture-pane', '-J', '-t', '%2', '-p', '-S', '-80']);
+    const enterSend = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys' && args.at(-1) === 'Enter');
+    expect(enterSend).toBeDefined();
+  });
+
+  it('tolerates psmux capture-pane join spaces inserted at wrap boundaries before Enter', async () => {
+    mockedCalls.wrapLiteralCapture = true;
+    mockedCalls.insertWrapSpaces = true;
 
     await spawnWorkerInPane('session:0', '%2', {
       teamName: 'safe-team',

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -131,7 +131,7 @@ describe('buildWorkerStartCommand', () => {
     })).not.toThrow();
   });
 
-  it('uses PowerShell syntax for native Windows psmux worker panes', () => {
+  it('uses cmd.exe syntax for native Windows psmux worker start commands', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
     vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
@@ -146,15 +146,13 @@ describe('buildWorkerStartCommand', () => {
     });
 
     expect(cmd).toBe(
-      "$env:OMC_TEAM_WORKER='team/worker-1'; " +
-      "& 'C:\\Users\\tester\\AppData\\Local\\Programs\\claude\\claude.exe' '--agent-id' 'worker-1'"
+      'C:\\Windows\\System32\\cmd.exe /d /s /c "set "OMC_TEAM_WORKER=team/worker-1" && ' +
+      '"C:\\Users\\tester\\AppData\\Local\\Programs\\claude\\claude.exe" "--agent-id" "worker-1""'
     );
-    expect(cmd).not.toContain('cmd.exe');
-    expect(cmd).not.toContain('/d /s /c');
-    expect(cmd).not.toContain('set "');
+    expect(cmd).not.toContain('$env:OMC_TEAM_WORKER');
   });
 
-  it('escapes psmux PowerShell env vars and quoted launch args without cmd.exe set syntax', () => {
+  it('escapes psmux cmd.exe env vars and quoted launch args without PowerShell syntax', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
     vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
@@ -176,14 +174,13 @@ describe('buildWorkerStartCommand', () => {
       cwd: 'C:\\repo'
     });
 
-    expect(cmd).toContain("$env:OMC_TEAM_WORKER='team name/worker ''one'''");
-    expect(cmd).toContain("$env:OMC_TEAM_STATE_ROOT='C:\\Users\\Test User\\AppData\\Local\\omc state'");
-    expect(cmd).toContain("$env:CLAUDE_CODE_USE_BEDROCK='value with spaces & [brackets] \"quotes\"'");
-    expect(cmd).toContain("& 'C:\\Program Files\\Claude Code\\claude.exe' '--model' 'sonnet \"quoted\"' '--label=worker ''one'''");
-    expect(cmd).not.toContain('cmd.exe');
-    expect(cmd).not.toContain('/d /s /c');
-    expect(cmd).not.toContain('set "');
+    expect(cmd).toContain('set "OMC_TEAM_WORKER=team name/worker \'one\'"');
+    expect(cmd).toContain('set "OMC_TEAM_STATE_ROOT=C:\\Users\\Test User\\AppData\\Local\\omc state"');
+    expect(cmd).toContain('set "CLAUDE_CODE_USE_BEDROCK=value with spaces & [brackets] ""quotes"""');
+    expect(cmd).toContain('"C:\\Program Files\\Claude Code\\claude.exe" "--model" "sonnet ""quoted""" "--label=worker \'one\'"');
+    expect(cmd).not.toContain('$env:OMC_TEAM_WORKER');
   });
+
 
   it('keeps cmd.exe worker startup syntax for native Windows without psmux', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -181,6 +181,49 @@ describe('buildWorkerStartCommand', () => {
     expect(cmd).not.toContain('$env:OMC_TEAM_WORKER');
   });
 
+  it('escapes literal percent signs in native Windows cmd env values and launch args', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: {
+        OMC_TEAM_WORKER: 'team/worker-1',
+        OMC_TOKEN: 'literal%USERPROFILE%token%25',
+      },
+      launchBinary: 'C:\\Program Files\\Claude Code\\claude.exe',
+      launchArgs: ['--label', '100% ready %USERPROFILE%', '--token=abc%25'],
+      cwd: 'C:\\repo'
+    });
+
+    expect(cmd).toContain('set "OMC_TOKEN=literal%%USERPROFILE%%token%%25"');
+    expect(cmd).toContain('"100%% ready %%USERPROFILE%%"');
+    expect(cmd).toContain('"--token=abc%%25"');
+    expect(cmd).not.toContain('literal%USERPROFILE%token%25');
+  });
+
+  it('does not cmd-escape percent signs on MSYS Windows worker startup', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
+    vi.stubEnv('MSYSTEM', 'MINGW64');
+    vi.stubEnv('SHELL', '/usr/bin/bash');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    const cmd = buildWorkerStartCommand({
+      teamName: 't',
+      workerName: 'w',
+      envVars: { OMC_TOKEN: 'literal%USERPROFILE%token%25' },
+      launchBinary: '/c/Program Files/Git/bin/bash.exe',
+      launchArgs: ['--label=100% ready'],
+      cwd: '/c/repo'
+    });
+
+    expect(cmd).toContain("OMC_TOKEN='literal%USERPROFILE%token%25'");
+    expect(cmd).toContain("'--label=100% ready'");
+    expect(cmd).not.toContain('%%USERPROFILE%%');
+  });
+
 
   it('keeps cmd.exe worker startup syntax for native Windows without psmux', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -353,7 +353,7 @@ function workerPaneShellCommand(): string[] {
 }
 
 function escapeForCmdSet(value: string): string {
-  return value.replace(/"/g, '""');
+  return value.replace(/(["%])/g, '$1$1');
 }
 
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -330,9 +330,14 @@ async function waitForShellReady(paneId: string, opts: WaitForShellReadyOptions 
 async function verifyWorkerStartCommandDelivered(paneId: string, startCmd: string): Promise<boolean> {
   if (isCmuxSurfaceTarget(paneId)) return true;
   const expected = normalizeTmuxCapture(startCmd);
+  const compactExpected = normalizeTmuxCaptureForDelivery(startCmd);
   for (let attempt = 1; attempt <= 5; attempt++) {
     const captured = await capturePaneAsync(paneId, { joinWrappedLines: true });
-    if (normalizeTmuxCapture(captured).includes(expected)) {
+    const normalizedCaptured = normalizeTmuxCapture(captured);
+    if (normalizedCaptured.includes(expected)) {
+      return true;
+    }
+    if (compactExpected.length > 0 && normalizeTmuxCaptureForDelivery(captured).includes(compactExpected)) {
       return true;
     }
     await sleep(50);
@@ -340,21 +345,17 @@ async function verifyWorkerStartCommandDelivered(paneId: string, startCmd: strin
   return false;
 }
 
+function workerPaneShellCommand(): string[] {
+  if (process.platform === 'win32' && !isUnixLikeOnWindows()) {
+    return [getDefaultShell()];
+  }
+  return [];
+}
+
 function escapeForCmdSet(value: string): string {
   return value.replace(/"/g, '""');
 }
 
-function escapeForPowerShellSingleQuotedString(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-function isNativeWindowsPsmuxPowerShellPane(): boolean {
-  // psmux sets PSMUX_SESSION in panes. Native psmux defaults to PowerShell,
-  // while MSYS/Git Bash psmux panes still need the POSIX branch below.
-  return process.platform === 'win32' &&
-    !isUnixLikeOnWindows() &&
-    !!process.env.PSMUX_SESSION;
-}
 
 function shellNameFromPath(shellPath: string): string {
   const shellName = basename(shellPath.replace(/\\/g, '/'));
@@ -411,18 +412,6 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
   const launchWords = getLaunchWords(config);
   const shouldSourceRc = process.env.OMC_TEAM_NO_RC !== '1';
 
-  if (isNativeWindowsPsmuxPowerShellPane()) {
-    const envStatements = Object.entries(config.envVars)
-      .map(([k, v]) => {
-        assertSafeEnvKey(k);
-        return `$env:${k}=${escapeForPowerShellSingleQuotedString(v)}`;
-      });
-    const launch = [
-      '&',
-      ...launchWords.map(escapeForPowerShellSingleQuotedString),
-    ].join(' ');
-    return [...envStatements, launch].join('; ');
-  }
 
   if (process.platform === 'win32' && !isUnixLikeOnWindows()) {
     const envPrefix = Object.entries(config.envVars)
@@ -564,6 +553,7 @@ export function createSession(teamName: string, workerName: string, workingDirec
   if (workingDirectory) {
     args.push('-c', workingDirectory);
   }
+  args.push(...workerPaneShellCommand());
   tmuxExec(args, { stripTmux: true, stdio: 'pipe', timeout: 5000 });
   try {
     configureTmuxClipboardForSession(name, { stripTmux: true, stdio: 'pipe', timeout: 5000 });
@@ -673,6 +663,7 @@ export async function splitTeamWorkerPane(
     'split-window', splitType, '-t', splitTarget,
     '-d', '-P', '-F', '#{pane_id}',
     '-c', cwd,
+    ...workerPaneShellCommand(),
   ]);
   return splitResult.stdout.split('\n')[0]?.trim() || null;
 }
@@ -715,6 +706,7 @@ export async function createTeamSession(
       'new-session', '-d', '-P', '-F', '#S:0 #{pane_id}',
       '-s', detachedSessionName,
       '-c', cwd,
+      ...workerPaneShellCommand(),
     ], { stripTmux: true });
     const detachedLine = detachedResult.stdout.trim();
     const detachedMatch = detachedLine.match(/^(\S+)\s+(%\d+)$/);
@@ -811,6 +803,7 @@ export async function createTeamSession(
       'split-window', splitType, '-t', splitTarget,
       '-d', '-P', '-F', '#{pane_id}',
       '-c', cwd,
+      ...workerPaneShellCommand(),
     ]);
     const paneId = splitResult.stdout.split('\n')[0]?.trim();
     if (paneId) {
@@ -928,6 +921,10 @@ export async function spawnWorkerInPane(
 
 function normalizeTmuxCapture(value: string): string {
   return value.replace(/\r/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeTmuxCaptureForDelivery(value: string): string {
+  return value.replace(/\r/g, '').replace(/\s+/g, '');
 }
 
 async function capturePaneAsync(paneId: string, opts: { joinWrappedLines?: boolean } = {}): Promise<string> {


### PR DESCRIPTION
## Summary
- Route tmux format-arg commands through argv/execFile on native Windows so psmux does not receive POSIX single-quoted tmux subcommands.
- Launch native Windows team tmux/psmux worker panes with an explicit cmd shell instead of relying on psmux default PowerShell, while leaving MSYS/Git Bash and Unix behavior unchanged.
- Make worker start-command delivery verification tolerate psmux capture-pane wrap-boundary spaces without blindly passing missing commands.

Fixes #3285.

## Verification
- `git diff --check`
- `npm run test:run -- src/cli/__tests__/tmux-utils.test.ts src/team/__tests__/tmux-session.test.ts src/team/__tests__/tmux-session.spawn.test.ts src/team/__tests__/tmux-session.create-team.test.ts`
- `npm run build`

## Notes
- Native Windows behavior is covered with mocked platform/env/tmux utilities; no real Windows host was available in this Linux worktree.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*