### PR TITLE
ci: move workflows to GitHub-hosted runners

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   label:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - name: Auto-label based on title/body
         uses: actions/github-script@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   lint-and-typecheck:
     name: Lint & Type Check
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,7 +40,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,7 +60,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     needs: [lint-and-typecheck, test]
     steps:
       - uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
 
   version-check:
     name: Version Consistency Check
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -150,7 +150,7 @@ jobs:
 
   npm-pack-test:
     name: npm pack + install test
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -178,7 +178,7 @@ jobs:
           echo "📦 Tarball: $TARBALL"
 
           # ENOTEMPTY hardening (mirrors .github/workflows/upgrade-test.yml):
-          # the global node_modules dir is reused across runs on self-hosted
+          # the global node_modules dir is reused across runs on GitHub-hosted
           # runners and inside the GitHub-hosted tool cache. A previously
           # interrupted `npm install -g` can leave the resolved package dir
           # and/or npm's staging temp dirs (`.oh-my-claude-sisyphus-*`) behind,

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
   cleanup-artifacts:
     name: Cleanup Old Artifacts
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - name: Delete old artifacts
         uses: actions/github-script@v7
@@ -48,7 +48,7 @@ jobs:
   cleanup-caches:
     name: Cleanup Old Caches
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - name: Cleanup caches
         uses: actions/github-script@v7

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   size-check:
     name: Size Check
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,7 +66,7 @@ jobs:
 
   base-branch-check:
     name: Base Branch Check
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     steps:
       - name: Require allowed base branch
         uses: actions/github-script@v7
@@ -92,7 +92,7 @@ jobs:
 
   draft-check:
     name: Draft PR Check
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     steps:
       - name: Check if PR is draft
         uses: actions/github-script@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     name: Create GitHub Release
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stale:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, gajae-layofflabs-2]
+    runs-on: ubuntu-latest
     steps:
       - name: Mark and close stale issues
         uses: actions/stale@v9

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   upgrade-test:
     name: omc update + session-start hook
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","gajae-layofflabs-2"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -44,7 +44,7 @@ jobs:
       # directly from repo-owned artifacts and therefore runs on push + PR.
 
       # ENOTEMPTY hardening: the toolcache global lib/node_modules dir is reused
-      # across runs on self-hosted runners (and inside the GitHub-hosted tool
+      # across runs on GitHub-hosted runners (and inside the GitHub-hosted tool
       # cache). A previously interrupted `npm install -g` can leave the resolved
       # scoped package dir and/or npm's staging temp dirs behind, so the next
       # install fails with
@@ -101,7 +101,7 @@ jobs:
       # Establishes the "old version" baseline before `omc update` is run.
       #
       # ENOTEMPTY hardening: the global node_modules dir is reused across runs on
-      # self-hosted runners (and within the GitHub-hosted tool cache). A
+      # GitHub-hosted runners (and within the GitHub-hosted tool cache). A
       # previously interrupted `npm install -g` can leave behind the resolved
       # package dir and/or npm's staging temp dirs (`.oh-my-claude-sisyphus-*`),
       # which makes the next install fail with


### PR DESCRIPTION
## Summary
- Move workflows off self-hosted runner labels and onto GitHub-hosted `ubuntu-latest`.
- Remove the PR-vs-internal split that routed trusted events to `gajae-layofflabs-2` / self-hosted labels.
- Update self-hosted prerequisite wording where touched so CI logs no longer point maintainers back to broken private runners.

## Context
Owner requested retiring the broken self-hosted runner path and moving required CI to GitHub Actions hosted runners across the managed repos.

## Verification
- Grepped changed workflow files for blocking `runs-on` self-hosted/custom runner labels after migration.
- YAML-only CI routing change; full GitHub Actions verification will run on this PR.