### PR TITLE
Fix configurable magic keyword triggers

### DIFF
--- a/src/features/__tests__/magic-keywords.test.ts
+++ b/src/features/__tests__/magic-keywords.test.ts
@@ -21,3 +21,31 @@ describe('magic-keywords ultrawork integration', () => {
     expect(result).not.toContain('<output_verbosity_spec>');
   });
 });
+
+describe('magic keyword custom triggers', () => {
+  it('applies search enhancement when only a custom search trigger is configured', () => {
+    const processPrompt = createMagicKeywordProcessor({ search: ['deep-scan'] });
+
+    const result = processPrompt('deep-scan src/hooks');
+
+    expect(result).toContain('[search-mode]');
+  });
+
+  it('applies analyze enhancement when only a custom analyze trigger is configured', () => {
+    const processPrompt = createMagicKeywordProcessor({ analyze: ['audit-this'] });
+
+    const result = processPrompt('audit-this deterministic modules');
+
+    expect(result).toContain('[analyze-mode]');
+  });
+
+  it('removes custom ultrathink triggers from the enhanced prompt', () => {
+    const processPrompt = createMagicKeywordProcessor({ ultrathink: ['ponder deeply'] });
+
+    const result = processPrompt('ponder deeply edge cases');
+
+    expect(result).toContain('[ULTRATHINK MODE - EXTENDED REASONING ACTIVATED]');
+    expect(result).toContain('edge cases');
+    expect(result).not.toContain('ponder deeply edge cases');
+  });
+});

--- a/src/features/magic-keywords.ts
+++ b/src/features/magic-keywords.ts
@@ -83,15 +83,6 @@ const searchEnhancement: MagicKeyword = {
   triggers: ['search', 'find', 'locate', 'lookup', 'explore', 'discover', 'scan', 'grep', 'query', 'browse', 'detect', 'trace', 'seek', 'track', 'pinpoint', 'hunt'],
   description: 'Maximizes search effort and thoroughness',
   action: (prompt: string) => {
-    // Multi-language search pattern
-    const searchPattern = /\b(search|find|locate|lookup|look\s*up|explore|discover|scan|grep|query|browse|detect|trace|seek|track|pinpoint|hunt)\b|where\s+is|show\s+me|list\s+all|검색|찾아|탐색|조회|스캔|서치|뒤져|찾기|어디|추적|탐지|찾아봐|찾아내|보여줘|목록|検索|探して|見つけて|サーチ|探索|スキャン|どこ|発見|捜索|見つけ出す|一覧|搜索|查找|寻找|查询|检索|定位|扫描|发现|在哪里|找出来|列出|tìm kiếm|tra cứu|định vị|quét|phát hiện|truy tìm|tìm ra|ở đâu|liệt kê/i;
-
-    const hasSearchCommand = searchPattern.test(removeCodeBlocks(prompt));
-
-    if (!hasSearchCommand) {
-      return prompt;
-    }
-
     return `${prompt}
 
 [search-mode]
@@ -111,15 +102,6 @@ const analyzeEnhancement: MagicKeyword = {
   triggers: ['analyze', 'analyse', 'investigate', 'examine', 'study', 'deep-dive', 'inspect', 'audit', 'evaluate', 'assess', 'review', 'diagnose', 'scrutinize', 'dissect', 'debug', 'comprehend', 'interpret', 'breakdown', 'understand'],
   description: 'Activates deep analysis and investigation mode',
   action: (prompt: string) => {
-    // Multi-language analyze pattern
-    const analyzePattern = /\b(analyze|analyse|investigate|examine|study|deep[\s-]?dive|inspect|audit|evaluate|assess|review|diagnose|scrutinize|dissect|debug|comprehend|interpret|breakdown|understand)\b|why\s+is|how\s+does|how\s+to|분석|조사|파악|연구|검토|진단|이해|설명|원인|이유|뜯어봐|따져봐|평가|해석|디버깅|디버그|어떻게|왜|살펴|分析|調査|解析|検討|研究|診断|理解|説明|検証|精査|究明|デバッグ|なぜ|どう|仕組み|调查|检查|剖析|深入|诊断|解释|调试|为什么|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|gỡ lỗi|tại sao/i;
-
-    const hasAnalyzeCommand = analyzePattern.test(removeCodeBlocks(prompt));
-
-    if (!hasAnalyzeCommand) {
-      return prompt;
-    }
-
     return `${prompt}
 
 [analyze-mode]
@@ -145,15 +127,7 @@ const ultrathinkEnhancement: MagicKeyword = {
   triggers: ['ultrathink', 'think', 'reason', 'ponder'],
   description: 'Activates extended thinking mode for deep reasoning',
   action: (prompt: string) => {
-    // Check if ultrathink-related triggers are present
-    const hasThinkCommand = /\b(ultrathink|think|reason|ponder)\b/i.test(removeCodeBlocks(prompt));
-
-    if (!hasThinkCommand) {
-      return prompt;
-    }
-
-    const cleanPrompt = removeTriggerWords(prompt, ['ultrathink', 'think', 'reason', 'ponder']);
-
+    const cleanPrompt = removeTriggerWords(prompt, ultrathinkEnhancement.triggers);
     return `[ULTRATHINK MODE - EXTENDED REASONING ACTIVATED]
 
 ${cleanPrompt}


### PR DESCRIPTION
## Summary
- Audited deterministic/skillized OMC surfaces for issue #3288.
- Fixed a low-risk config drift bug in `src/features/magic-keywords.ts`: custom `magicKeywords.search`, `magicKeywords.analyze`, and `magicKeywords.ultrathink` overrides now control the injected behavior instead of being re-checked against hardcoded default regexes/lists.
- Added focused tests for custom search, analyze, and ultrathink triggers.

## Audit inventory
| Module | Classification | Evidence / rationale |
| --- | --- | --- |
| `src/hooks/keyword-detector/index.ts` keyword priority, sanitizer, ralplan gate | KEEP | Safety-critical deterministic routing with broad regression coverage for false positives, explicit team slash handling, multilingual triggers, and gate ordering. |
| `src/hooks/persistent-mode/index.ts` stop bypasses | KEEP | Deterministic stop-loop escape hatches prevent deadlocks and are covered by cancel/rate-limit/auth/schedule/oversize tests. |
| `src/features/builtin-skills/skills.ts` native command denylist and deep-interview threshold default | KEEP | Denylist prevents shadowing Claude Code commands; deep-interview threshold already has project/profile config and tests. |
| `scripts/build-skill-bridge.mjs` output path/format | KEEP | Build artifact path and CJS format are installer/runtime contract, not a good config surface. |
| `src/features/magic-keywords.ts` custom trigger handling | SIMPLIFY | The action bodies re-checked hardcoded default regexes/lists after config matching; fixed in this PR. |
| `src/hooks/keyword-detector/ultrawork/*.ts` message wrappers | SIMPLIFY | Shared banner/wrapper text is duplicated across variants; safe follow-up if output remains byte-equivalent. |
| `src/tools/skills-tools.ts` unused sanitizer helper | SIMPLIFY | Unused security-looking helper/imports in a metadata listing tool; low-risk follow-up candidate. |
| `src/hooks/think-mode/switcher.ts` provider/model tables | MAKE_CONFIGURABLE | GPT/Gemini/provider budgets and capability patterns are embedded in hook code; should become a bounded registry if provider churn continues. |
| `src/hooks/persistent-mode/index.ts` breaker/stale thresholds | MAKE_CONFIGURABLE | Defaults are safety rails, but selected advanced thresholds could be bounded config knobs. |
| `src/utils/skill-resources.ts` resource listing cap | MAKE_CONFIGURABLE | Deterministic cap protects prompt budget but truncation is silent for resource-heavy skills. |
| `src/hooks/think-mode/detector.ts` multilingual trigger list | SPLIT_FOLLOWUP | Broad language terms need negative fixtures before tightening. |
| `src/hooks/keyword-detector/index.ts` canonical slash skill mirror | SPLIT_FOLLOWUP | Manual mirror may drift; shared constants require dependency-boundary design. |
| `src/features/builtin-skills/runtime-guidance.ts` provider guidance shape | SPLIT_FOLLOWUP | Availability type advertises more providers than rendered guidance uses. |
| `src/features/builtin-skills/skills.ts` `skillify` alias precedence special-case | SPLIT_FOLLOWUP | Directory-order exception is brittle but user-facing alias behavior needs a separate design/test pass. |

## Files inspected
- Issue #3288 body/comments, branch state, `package.json`, AGENTS guidance.
- `src/features/magic-keywords.ts`, `src/features/__tests__/magic-keywords.test.ts`, docs keyword config references.
- `src/hooks/keyword-detector/**`, `src/hooks/persistent-mode/**`, `src/hooks/think-mode/**` and related tests.
- `src/features/builtin-skills/**`, `src/tools/skills-tools.ts`, `src/utils/skill-resources.ts`, `src/utils/user-skill-compat.ts`, `scripts/build-skill-bridge.mjs`, related tests.
- `src/team/stage-router.ts`, `src/team/phase-controller.ts`, `src/team/role-router.ts`, `src/team/worker-canonicalization.ts`, `src/team/runtime-v2.ts`, `src/hooks/team-pipeline/**`, related tests/docs.

## Verification
- `npx vitest run src/features/__tests__/magic-keywords.test.ts`
- `npx eslint src/features/magic-keywords.ts src/features/__tests__/magic-keywords.test.ts`
- `npx tsc --noEmit`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
