### PR TITLE
fix(team): verify Cursor worker start submission

### DIFF
--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -8,6 +8,7 @@ const mockedCalls = vi.hoisted(() => ({
   echoOnLiteralSend: true,
   wrapLiteralCapture: false,
   insertWrapSpaces: false,
+  enterSubmitsCommand: true,
 }));
 
 vi.mock('child_process', async (importOriginal) => {
@@ -51,6 +52,11 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
           ? `${literal.slice(0, 80)}\n${literal.slice(80)}`
           : literal;
       }
+      if (args[0] === 'send-keys' && args.at(-1) === 'Enter' && mockedCalls.enterSubmitsCommand) {
+        mockedCalls.paneCapture = mockedCalls.paneCapture.includes('cursor-agent')
+          ? 'cursor-agent ready\n'
+          : '';
+      }
       return { stdout: '', stderr: '' };
     }),
     tmuxCmdAsync: vi.fn(async (args: string[]) => {
@@ -75,6 +81,7 @@ describe('spawnWorkerInPane', () => {
     mockedCalls.wrapLiteralCapture = false;
     mockedCalls.insertWrapSpaces = false;
     vi.unstubAllEnvs();
+    mockedCalls.enterSubmitsCommand = true;
   });
 
   it('uses argv-style launch with literal tmux send-keys', async () => {
@@ -218,6 +225,40 @@ describe('spawnWorkerInPane', () => {
     expect(mockedCalls.tmuxArgs).toContainEqual(['capture-pane', '-J', '-t', '%2', '-p', '-S', '-80']);
     const enterSend = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys' && args.at(-1) === 'Enter');
     expect(enterSend).toBeDefined();
+  });
+
+  it('verifies a single Cursor worker start command submits after Enter', async () => {
+    await spawnWorkerInPane('session:0', '%2', {
+      teamName: 'safe-team',
+      workerName: 'worker-1',
+      envVars: {
+        OMC_TEAM_NAME: 'safe-team',
+        OMC_TEAM_WORKER: 'safe-team/worker-1',
+      },
+      launchBinary: 'cursor-agent',
+      cwd: '/tmp',
+    });
+
+    const enterSend = mockedCalls.tmuxArgs.find((args) => args[0] === 'send-keys' && args.at(-1) === 'Enter');
+    expect(enterSend).toBeDefined();
+    expect(mockedCalls.paneCapture).toBe('cursor-agent ready\n');
+  });
+
+  it('fails loudly when a single Cursor worker start command remains unsubmitted after Enter', async () => {
+    mockedCalls.enterSubmitsCommand = false;
+
+    await expect(
+      spawnWorkerInPane('session:0', '%2', {
+        teamName: 'safe-team',
+        workerName: 'worker-1',
+        envVars: {
+          OMC_TEAM_NAME: 'safe-team',
+          OMC_TEAM_WORKER: 'safe-team/worker-1',
+        },
+        launchBinary: 'cursor-agent',
+        cwd: '/tmp',
+      })
+    ).rejects.toThrow(/worker_start_submit_unverified:worker-1:%2:/);
   });
 
   it('fails before send-keys when the target pane shell never becomes ready', async () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -345,6 +345,23 @@ async function verifyWorkerStartCommandDelivered(paneId: string, startCmd: strin
   return false;
 }
 
+async function verifyWorkerStartCommandSubmitted(paneId: string, startCmd: string): Promise<boolean> {
+  if (isCmuxSurfaceTarget(paneId)) return true;
+  const expected = normalizeTmuxCapture(startCmd);
+  const compactExpected = normalizeTmuxCaptureForDelivery(startCmd);
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const captured = await capturePaneAsync(paneId, { joinWrappedLines: true });
+    const normalizedCaptured = normalizeTmuxCapture(captured);
+    const commandStillBuffered = normalizedCaptured.includes(expected)
+      || (compactExpected.length > 0 && normalizeTmuxCaptureForDelivery(captured).includes(compactExpected));
+    if (!commandStillBuffered) {
+      return true;
+    }
+    await sleep(50);
+  }
+  return false;
+}
+
 function workerPaneShellCommand(): string[] {
   if (process.platform === 'win32' && !isUnixLikeOnWindows()) {
     return [getDefaultShell()];
@@ -907,9 +924,18 @@ export async function spawnWorkerInPane(
   try {
     const enterResult = await tmuxExecAsync(['send-keys', '-t', paneId, 'Enter'], { timeout: 5000 });
     logWorkerSpawnDiagnostic(
-      `worker start submit sent session=${sessionName} pane=${paneId} ` +
+      `worker start submit key sent session=${sessionName} pane=${paneId} ` +
       `worker=${config.workerName} cmdSha=${fingerprint} sendStatus=0 stderr=${JSON.stringify(enterResult.stderr.trim())}`,
     );
+    const submitted = await verifyWorkerStartCommandSubmitted(paneId, startCmd);
+    if (!submitted) {
+      const reason = `worker_start_submit_unverified:${config.workerName}:${paneId}:${fingerprint}`;
+      logWorkerSpawnDiagnostic(
+        `worker start submit verification failed session=${sessionName} pane=${paneId} ` +
+        `worker=${config.workerName} cmdSha=${fingerprint} cmdPreview=${JSON.stringify(preview)}`,
+      );
+      throw new Error(reason);
+    }
   } catch (error) {
     logWorkerSpawnDiagnostic(
       `worker start submit failed session=${sessionName} pane=${paneId} ` +


### PR DESCRIPTION
## Summary
- Reconciles #3295 against the existing team startup path hardened by #3137 and dispatch-path fixes from #3224/#3227: the single Cursor slash command resolves to `commands/omc-teams.md` → `skills/omc-teams/SKILL.md` → `omc team 1:cursor ping` → `teamCommand` → `startTeamV2` → `spawnV2Worker` → `spawnWorkerInPane` with `launchBinary: cursor-agent`.
- Keeps the existing literal `tmux send-keys` delivery verification and adds submit verification after the `Enter` key, so a command that stays buffered/unsubmitted now fails loudly with `worker_start_submit_unverified:*` instead of waiting silently.
- Adds focused regression coverage for the single Cursor worker path: successful prompt submission and fail-loud unsubmitted behavior.

Fixes #3295

## Verification
- `npm test -- src/team/__tests__/tmux-session.spawn.test.ts`
- `npm test -- src/cli/commands/__tests__/team.test.ts src/team/__tests__/runtime-v2.cursor-routing.test.ts`
- `npm run build`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
