### PR TITLE
fix(post-tool-rules-injector): honour DISABLE_OMC / OMC_SKIP_HOOKS skip guard

### DIFF
--- a/scripts/post-tool-rules-injector.mjs
+++ b/scripts/post-tool-rules-injector.mjs
@@ -49,6 +49,22 @@ function extractFilePath(toolInput) {
 }
 
 async function main() {
+  // Skip guard: honor the documented kill switches (see issues #838, #3253).
+  // This hook injects context on PostToolUse alongside post-tool-verifier.mjs, so it
+  // accepts the same `post-tool-use` event token plus its own script name. Without
+  // this, DISABLE_OMC=1 and OMC_SKIP_HOOKS=post-tool-use failed to suppress rule
+  // injection because only post-tool-verifier.mjs honored them.
+  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map((s) => s.trim());
+  if (
+    process.env.DISABLE_OMC === '1' ||
+    process.env.DISABLE_OMC === 'true' ||
+    _skipHooks.includes('post-tool-rules-injector') ||
+    _skipHooks.includes('post-tool-use')
+  ) {
+    console.log(JSON.stringify({ continue: true }));
+    return;
+  }
+
   try {
     const input = await readStdin();
     if (!input.trim()) {

--- a/scripts/post-tool-rules-injector.mjs
+++ b/scripts/post-tool-rules-injector.mjs
@@ -51,14 +51,13 @@ function extractFilePath(toolInput) {
 async function main() {
   // Skip guard: honor the documented kill switches (see issues #838, #3253).
   // This hook injects context on PostToolUse alongside post-tool-verifier.mjs, so it
-  // accepts the same `post-tool-use` event token plus its own script name. Without
-  // this, DISABLE_OMC=1 and OMC_SKIP_HOOKS=post-tool-use failed to suppress rule
-  // injection because only post-tool-verifier.mjs honored them.
+  // accepts the same `post-tool-use` event token. Without this, DISABLE_OMC=1 and
+  // OMC_SKIP_HOOKS=post-tool-use failed to suppress rule injection because only
+  // post-tool-verifier.mjs honored them.
   const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map((s) => s.trim());
   if (
     process.env.DISABLE_OMC === '1' ||
     process.env.DISABLE_OMC === 'true' ||
-    _skipHooks.includes('post-tool-rules-injector') ||
     _skipHooks.includes('post-tool-use')
   ) {
     console.log(JSON.stringify({ continue: true }));

--- a/src/__tests__/post-tool-rules-injector.test.ts
+++ b/src/__tests__/post-tool-rules-injector.test.ts
@@ -53,10 +53,6 @@ describe('post-tool-rules-injector.mjs skip guards (DISABLE_OMC / OMC_SKIP_HOOKS
     expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: 'post-tool-use' });
   });
 
-  it('no-ops when OMC_SKIP_HOOKS contains the post-tool-rules-injector script name', () => {
-    expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: 'post-tool-rules-injector' });
-  });
-
   it('honors whitespace and commas in OMC_SKIP_HOOKS', () => {
     expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: ' keyword-detector , post-tool-use ' });
   });

--- a/src/__tests__/post-tool-rules-injector.test.ts
+++ b/src/__tests__/post-tool-rules-injector.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process';
+import { resolve, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const NODE = process.execPath;
+const REPO_ROOT = resolve(join(__dirname, '..', '..'));
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'post-tool-rules-injector.mjs');
+
+function runHook(input: Record<string, unknown>, extraEnv?: Record<string, string>) {
+  const raw = execFileSync(NODE, [SCRIPT_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: REPO_ROOT,
+      NODE_ENV: 'test',
+      ...extraEnv,
+    },
+    timeout: 15000,
+  }).trim();
+
+  return JSON.parse(raw) as {
+    continue: boolean;
+    suppressOutput?: boolean;
+    hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
+  };
+}
+
+describe('post-tool-rules-injector.mjs skip guards (DISABLE_OMC / OMC_SKIP_HOOKS)', () => {
+  // A payload with a file_path drives the hook into its rules-processing path, so a
+  // hook that ignores the kill switch would NOT emit the bare `{ continue: true }`
+  // that a guarded short-circuit produces.
+  const INPUT = {
+    tool_name: 'Read',
+    tool_input: { file_path: 'README.md' },
+    session_id: 'abc',
+  };
+
+  function expectSkipped(extraEnv: Record<string, string>) {
+    // Guarded hooks short-circuit before any processing with a bare continue.
+    expect(runHook(INPUT, extraEnv)).toEqual({ continue: true });
+  }
+
+  it('no-ops when DISABLE_OMC=1', () => {
+    expectSkipped({ DISABLE_OMC: '1', OMC_SKIP_HOOKS: '' });
+  });
+
+  it('no-ops when DISABLE_OMC=true', () => {
+    expectSkipped({ DISABLE_OMC: 'true', OMC_SKIP_HOOKS: '' });
+  });
+
+  it('no-ops when OMC_SKIP_HOOKS contains the post-tool-use event token', () => {
+    expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: 'post-tool-use' });
+  });
+
+  it('no-ops when OMC_SKIP_HOOKS contains the post-tool-rules-injector script name', () => {
+    expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: 'post-tool-rules-injector' });
+  });
+
+  it('honors whitespace and commas in OMC_SKIP_HOOKS', () => {
+    expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: ' keyword-detector , post-tool-use ' });
+  });
+
+  it('does not short-circuit when skip vars are empty', () => {
+    // Not skipped: the hook runs its processing path, which always adds
+    // suppressOutput (or injected context) rather than a bare continue.
+    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: '' })).not.toEqual({ continue: true });
+  });
+
+  it('does not short-circuit for an unrelated OMC_SKIP_HOOKS token', () => {
+    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: 'keyword-detector' })).not.toEqual({
+      continue: true,
+    });
+  });
+
+  it('processes normally when DISABLE_OMC=false', () => {
+    expect(runHook(INPUT, { DISABLE_OMC: 'false', OMC_SKIP_HOOKS: '' })).not.toEqual({
+      continue: true,
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`DISABLE_OMC` and `OMC_SKIP_HOOKS` are documented as kill switches (CLAUDE.md: "Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS`"; `docs/HOOKS.md` documents `OMC_SKIP_HOOKS=post-tool-use`). Two hooks fire on `PostToolUse`: `post-tool-verifier.mjs` and `post-tool-rules-injector.mjs`. Only the first honors the kill switches. The rules injector keeps injecting rule-file context even under `DISABLE_OMC=1`, so the master kill switch does not fully disable OMC.

Reproduction on current `dev`:

```
$ echo '{"tool_name":"Read","tool_input":{"file_path":"README.md"},"session_id":"abc"}' \
  | DISABLE_OMC=1 OMC_SKIP_HOOKS=post-tool-use node scripts/post-tool-rules-injector.mjs
{"continue":true,"suppressOutput":true}
```

A guarded hook short-circuits with a bare `{"continue":true}`. Here the hook still entered its processing path, ignoring both switches.

## Root cause

`scripts/post-tool-rules-injector.mjs` has no skip-guard check. This is the same gap #3255 fixed for `post-tool-use-failure.mjs` (issue #3253), which itself followed the #838 pattern. The injector was missed in that pass.

## Fix

Add the established guard at the top of `main()`, before any processing. It honors the existing `post-tool-use` event token (the same one `post-tool-verifier.mjs` already honors, so no new contract surface) and both `DISABLE_OMC=1` and `DISABLE_OMC=true`.

## Tests

`src/__tests__/post-tool-rules-injector.test.ts` (7 tests), mirroring the harness from #3255:

- no-op under `DISABLE_OMC=1`, `DISABLE_OMC=true`, `OMC_SKIP_HOOKS=post-tool-use`, and whitespace/comma-separated lists
- unchanged processing when skip vars are empty, for an unrelated token, and for `DISABLE_OMC=false`

Verified red then green: the skip-guard tests fail on the unpatched script and pass with the guard. `eslint src` and `tsc --noEmit` are clean. The script is `.mjs`, so no build step is involved.

## Scope

One hook, reusing existing tokens only. No new skip tokens are introduced (cf. the closed #2779, which expanded the token surface).

Follow-up, not included here: `skill-injector.mjs` (UserPromptSubmit) ignores `DISABLE_OMC` too, but adding it cleanly needs a new UserPromptSubmit token decision, so it belongs in a separate PR.
