### PR TITLE
fix(hooks): encode dots and the drive colon in worktree transcript resolution

### DIFF
--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -20,10 +20,11 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, basename } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
+import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
 const THRESHOLD = parseInt(process.env.OMC_CONTEXT_GUARD_THRESHOLD || '75', 10);
@@ -122,13 +123,12 @@ function resolveTranscriptPath(transcriptPath, cwd) {
     const worktreeTop = runGitRevParse(['--show-toplevel'], effectiveCwd);
 
     if (mainRepoRoot !== worktreeTop) {
-      const lastSep = transcriptPath.lastIndexOf('/');
-      const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
+      const sessionFile = basename(transcriptPath);
       if (sessionFile) {
         const configDir = getClaudeConfigDir();
         const projectsDir = join(configDir, 'projects');
         if (existsSync(projectsDir)) {
-          const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
+          const encodedMain = encodeProjectPath(mainRepoRoot);
           const resolvedPath = join(projectsDir, encodedMain, sessionFile);
           try {
             if (existsSync(resolvedPath)) return resolvedPath;

--- a/scripts/lib/encode-project-path.mjs
+++ b/scripts/lib/encode-project-path.mjs
@@ -1,0 +1,23 @@
+/**
+ * Claude Code project-directory name encoding (hook-runtime mirror).
+ *
+ * Mirror of `src/utils/encode-project-path.ts` — keep the two in sync. The TS
+ * helper is the source of truth; this `.mjs` copy exists because the hook
+ * runtime loads raw scripts and cannot import the compiled `dist/` util.
+ *
+ * Claude Code stores a project's transcripts under
+ * `~/.claude/projects/<encoded>` where `<encoded>` is the project's absolute
+ * path with path separators, dots, and the Windows drive colon all replaced
+ * by `-`. For example:
+ *
+ *   POSIX:    /home/me/proj      -> -home-me-proj
+ *   POSIX:    /home/me/my.proj   -> -home-me-my-proj
+ *   Windows:  C:\Users\me\proj   -> C--Users-me-proj
+ *
+ * Dropping the dot or the drive colon produces a name that never matches the
+ * real directory, so any lookup keyed on the encoded name (e.g. worktree
+ * transcript resolution) silently finds nothing.
+ */
+export function encodeProjectPath(projectPath) {
+  return projectPath.replace(/[/\\.:]/g, '-');
+}

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -14,6 +14,7 @@ import { basename, join, dirname, resolve } from 'path';
 import { homedir, tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
+import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
 import { readStdin } from './lib/stdin.mjs';
 
@@ -397,7 +398,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       if (sessionFile) {
         const projectsDir = join(getClaudeConfigDir(), 'projects');
         if (existsSync(projectsDir)) {
-          const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
+          const encodedMain = encodeProjectPath(mainRepoRoot);
           const resolvedPath = join(projectsDir, encodedMain, sessionFile);
           if (existsSync(resolvedPath)) return resolvedPath;
         }

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -8,11 +8,12 @@
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'fs';
 import { createHash } from 'crypto';
-import { dirname, join, resolve } from 'path';
+import { dirname, join, resolve, basename } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
+import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { evaluateAgentHeavyPreflight } from './lib/pre-tool-enforcer-preflight.mjs';
 import { evaluateForceAgentDelegation } from './lib/force-agent-delegation-preflight.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
@@ -527,13 +528,12 @@ function resolveTranscriptPath(transcriptPath, cwd) {
     }).trim();
 
     if (mainRepoRoot !== worktreeTop) {
-      const lastSep = transcriptPath.lastIndexOf('/');
-      const sessionFile = lastSep !== -1 ? transcriptPath.substring(lastSep + 1) : '';
+      const sessionFile = basename(transcriptPath);
       if (sessionFile) {
         const configDir = getClaudeConfigDir();
         const projectsDir = join(configDir, 'projects');
         if (existsSync(projectsDir)) {
-          const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
+          const encodedMain = encodeProjectPath(mainRepoRoot);
           const resolvedPath = join(projectsDir, encodedMain, sessionFile);
           try {
             if (existsSync(resolvedPath)) return resolvedPath;

--- a/src/__tests__/encode-project-path-mjs-mirror.test.mjs
+++ b/src/__tests__/encode-project-path-mjs-mirror.test.mjs
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { encodeProjectPath as mjsEncode } from '../../scripts/lib/encode-project-path.mjs';
+import { encodeProjectPath as tsEncode } from '../utils/encode-project-path.js';
+
+// The hook runtime (context-guard-stop / pre-tool-enforcer / post-tool-verifier)
+// can't import the compiled TS util, so it uses this .mjs mirror. Before the
+// mirror existed the three hooks inlined `replace(/[/\\]/g, '-')`, which dropped
+// dots and the Windows drive colon — so native-git-worktree transcript
+// resolution looked under the wrong ~/.claude/projects/<dir> and silently found
+// nothing (any repo whose path contains a dot, cross-platform; all repos on Windows).
+describe('encode-project-path.mjs (hook-runtime mirror)', () => {
+  it('folds path separators, dots, and the Windows drive colon', () => {
+    // Literal-string assertions, so they run and guard on any OS.
+    expect(mjsEncode('C:\\Users\\me\\my.app')).toBe('C--Users-me-my-app');
+    expect(mjsEncode('/home/me/my.service')).toBe('-home-me-my-service');
+    expect(mjsEncode('/home/me/proj')).toBe('-home-me-proj');
+  });
+
+  it('stays in sync with the canonical TS encoder (src/utils/encode-project-path.ts)', () => {
+    for (const p of ['C:\\Users\\me\\my.app', '/home/me/my.service', 'D:\\a.b\\c', '/x/y/z']) {
+      expect(mjsEncode(p)).toBe(tsEncode(p));
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Three hook-runtime scripts resolve a Claude Code transcript path for native git worktrees by encoding the main repo root into its `~/.claude/projects/<dir>` name. Each one inlined:

```js
const encodedMain = mainRepoRoot.replace(/[/\\]/g, '-');
```

That replaces only path separators. Claude Code also folds **dots** and the **Windows drive colon** to `-`, so the encoded name never matches the real directory and resolution silently returns the unresolved (non-existent) path:

- any repo whose path contains a dot (`.config`, `.claude/worktrees`, `app.v2`), on every OS
- every repo on Windows: `C:\Users\me\proj` encodes to `C:-Users-me-proj` instead of the real `C--Users-me-proj`

`context-guard-stop.mjs` and `pre-tool-enforcer.mjs` additionally extracted the session filename with `transcriptPath.lastIndexOf('/')`, which returns `-1` on a Windows backslash path, so resolution there bailed before it reached the encoder.

This is the same root cause as #2291 (fixed in `src/lib/worktree-paths.ts` and `src/features/session-history-search/index.ts`). The hook runtime keeps its own copies of the encoder that the #2291 and #3276 fixes never reached.

## Evidence

The canonical encoder is `src/utils/encode-project-path.ts`: `replace(/[/\\.:]/g, '-')`, added in #3276. The hook copies used `replace(/[/\\]/g, '-')`. Output divergence:

```
/home/me/my.service    hook: -home-me-my.service    canonical: -home-me-my-service
C:\Users\me\my.app     hook: C:-Users-me-my.app     canonical: C--Users-me-my-app
```

`C--Users-...` is the real on-disk directory name (verified against `~/.claude/projects` on Windows; #2291 documents that Claude Code replaces dots).

## Fix

- Add `scripts/lib/encode-project-path.mjs`, a hook-runtime mirror of the canonical TS encoder, following the existing `scripts/lib/config-dir.{mjs,cjs,sh}` mirror convention.
- `context-guard-stop.mjs`, `pre-tool-enforcer.mjs`, `post-tool-verifier.mjs`: use the shared encoder instead of the inline regex.
- `context-guard-stop.mjs`, `pre-tool-enforcer.mjs`: extract the session filename with `basename()`, matching what `post-tool-verifier.mjs` already did, so resolution works on Windows backslash paths.

## Tests

- `src/__tests__/encode-project-path-mjs-mirror.test.mjs`: literal-string regression covering dots and the drive colon (runs and guards on any OS), plus a parity assertion against the canonical TS encoder so the mirror cannot drift.
- `context-guard-stop`, `post-tool-verifier`, and the new mirror test pass locally. `pre-tool-enforcer.test.ts` has 4 failures unrelated to this change (model-advisory throttling) that are identical on a clean `dev` checkout.
- `tsc --noEmit` clean; `eslint src` reports 0 errors.

## Scope notes

Encoder and session-filename extraction only. The three hooks still carry near-duplicate copies of the whole native-worktree resolver; de-duplicating those into one shared helper is a reasonable follow-up, left out here to keep the change minimal.
