### PR TITLE
docs: audit Claude Code changelog compatibility

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -147,7 +147,7 @@ This loads agents, skills, and commands directly from your checkout without copy
 | Linux | Claude Code Plugin | Bash (.sh) |
 | Windows | WSL2 recommended | Node.js (.mjs) |
 
-> ℹ️ **Note:** Native Windows support is experimental. OMC requires tmux, which is not available on native Windows. Use WSL2 instead.
+> ℹ️ **Note:** Native Windows support is experimental. For tmux-backed Team workers, OMC checks for a tmux-compatible binary first; native [psmux](https://github.com/psmux/psmux) is supported, and WSL2 remains the fallback when no compatible tmux is available.
 
 ### Updates
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -990,7 +990,7 @@ stopomc
 
 > **Note**: Bash hooks are fully portable across macOS and Linux (no GNU-specific dependencies).
 
-> **Windows**: Native Windows (win32) support is experimental. OMC requires tmux, which is not available on native Windows. **WSL2 is strongly recommended** for Windows users. See the [WSL2 installation guide](https://learn.microsoft.com/en-us/windows/wsl/install). Native Windows issues may have limited support.
+> **Windows**: Native Windows (win32) support is experimental. Features that launch tmux-backed worker panes require a tmux-compatible binary. OMC supports native [psmux](https://github.com/psmux/psmux) when available and recommends WSL2 as the fallback when no compatible `tmux` command is installed. Native Windows issues may have limited support.
 
 > **Advanced**: Set `OMC_USE_NODE_HOOKS=1` to use Node.js hooks on macOS/Linux.
 

--- a/src/installer/__tests__/hook-command-portability.test.ts
+++ b/src/installer/__tests__/hook-command-portability.test.ts
@@ -147,7 +147,7 @@ describe('Contract 7: hook command portability (#2084, #2348)', () => {
     }
   });
 
-  it('Windows default config: avoids CMD-only %USERPROFILE% and keeps portable bash-style expansion', async () => {
+  it('Windows default config: emits concrete hook paths without POSIX shell expansion', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     delete process.env.CLAUDE_CONFIG_DIR;
     vi.resetModules();
@@ -166,7 +166,8 @@ describe('Contract 7: hook command portability (#2084, #2348)', () => {
 
     expect(commands.length).toBeGreaterThan(0);
     for (const cmd of commands) {
-      expect(cmd).toContain('${CLAUDE_CONFIG_DIR:-$HOME/.claude}');
+      expect(cmd).toContain('/.claude/hooks/');
+      expect(cmd).not.toContain('${CLAUDE_CONFIG_DIR:-$HOME/.claude}');
       expect(cmd).not.toContain('%USERPROFILE%');
     }
   });

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -98,10 +98,6 @@ function quoteCommandPath(path: string): string {
 
 function buildHookCommand(filename: string): string {
   if (isWindows()) {
-    if (isDefaultClaudeConfigDir()) {
-      return `node "\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/${filename}"`;
-    }
-
     return `node ${quoteCommandPath(join(getClaudeConfigDir(), 'hooks', filename).replace(/\\/g, '/'))}`;
   }
 


### PR DESCRIPTION
## Summary
- Audited recent Claude Code changelog entries through 2.1.183 against OmC team/autopilot, hook, slash-command, provider/auth, session/worktree, and Windows/shell surfaces.
- Left the Claude Code 2.1.178 native `TeamCreate`/`TeamDelete` prompt cleanup to #3301 to avoid duplicate broad edits.
- Fixed the distinct high-confidence Windows compatibility drift: native Windows hook command generation now emits concrete hook paths instead of POSIX `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` expansion, and docs now match the existing psmux/tmux-compatible runtime behavior.
- Noted the broader session-root anchoring risk across `/cd` / worktree movement as follow-up-sized; this PR keeps the #3302 code fix scoped to the confirmed Windows hook breakage.

## Verification
- `npm run test:run -- src/installer/__tests__/hook-command-portability.test.ts src/__tests__/cli-win32-warning.test.ts src/__tests__/skills.test.ts`

Closes #3302. Cross-links #3301 for native team-tool removal follow-up.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*