### PR TITLE
Fix Claude Code native team guidance

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -33,7 +33,7 @@ explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (son
 <tools>
 External AI: `/team N:executor "task"`, `omc team N:codex|gemini "..."`, `omc ask <claude|codex|gemini>`, `/ccg`
 OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
-Teams: `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
+Teams: Claude Code implicit agent team via Agent/Task `name`; OMC tmux/CLI workers via `/team` or `omc team`; task tracking via TodoWrite/TaskList/TaskGet/TaskUpdate when available
 Notepad: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
 Project Memory: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
 Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, etc.), AST (`ast_grep_search`, `ast_grep_replace`), `python_repl`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (son
 <tools>
 External AI: `/team N:executor "task"`, `omc team N:codex|gemini "..."`, `omc ask <claude|codex|gemini>`, `/ccg`
 OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
-Teams: `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
+Teams: Claude Code implicit agent team via Agent/Task `name`; OMC tmux/CLI workers via `/team` or `omc team`; task tracking via TodoWrite/TaskList/TaskGet/TaskUpdate when available
 Notepad: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
 Project Memory: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
 Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, etc.), AST (`ast_grep_search`, `ast_grep_replace`), `python_repl`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ explore (haiku), analyst (opus), planner (opus), architect (opus), debugger (son
 <tools>
 External AI: `/team N:executor "task"`, `omc team N:codex|gemini "..."`, `omc ask <claude|codex|gemini>`, `/ccg`
 OMC State: `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
-Teams: Claude Code implicit agent team via Agent/Task `name`; OMC tmux/CLI workers via `/team` or `omc team`; task tracking via TodoWrite/TaskList/TaskGet/TaskUpdate when available
+Teams: Claude Code implicit agent team via Agent/Task `name`; OMC tmux/CLI workers via `/team` or `omc team`; task tracking via TodoWrite or the available task-list surface
 Notepad: `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`
 Project Memory: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
 Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, etc.), AST (`ast_grep_search`, `ast_grep_replace`), `python_repl`

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -158,7 +158,7 @@ Once a workspace is anchored, multiple Claude Code sessions in different sub-rep
 
 **Only the `team` skill writes to `.omc/handoffs/`.** All other code that reads the directory does so read-only. This is enforced by the lint test `tests/lint/handoffs-writers.test.ts`, which scans `src/**` and `templates/**` and fails if any file outside `src/team/` or `src/hooks/team-pipeline/` references `handoffs/` as a write target.
 
-- Handoff files survive `TeamDelete` and session cancellation intentionally — they are post-mortem artifacts.
+- Handoff files survive team cancellation and OMC state cleanup intentionally — they are post-mortem artifacts. Claude Code 2.1.178+ has no `TeamDelete`.
 - Do **not** session-scope `.omc/handoffs/` unless the `team` skill explicitly evolves to per-session inboxes (tracked as a follow-up in the ADR).
 
 #### Branded path types (`ReadPath` / `WritePath`)

--- a/scripts/cleanup-orphans.mjs
+++ b/scripts/cleanup-orphans.mjs
@@ -1,30 +1,27 @@
 #!/usr/bin/env node
 
 /**
- * OMC Orphan Agent Cleanup
+ * OMC Stale Worker Cleanup
  *
- * Detects and terminates orphan agent processes — agents whose team
- * config has been deleted (via TeamDelete) but whose OS processes
- * are still running. This happens when TeamDelete fires before all
- * teammates confirm shutdown.
+ * Detects and terminates stale OMC tmux/CLI worker processes that still
+ * carry team identity after the team cancellation path has completed. This is
+ * a post-cancellation cleanup tool; Claude Code 2.1.178+ has no native
+ * TeamDelete or per-team config to use as an orphan signal.
  *
  * Usage:
  *   node cleanup-orphans.mjs [--team-name <name>] [--dry-run]
  *
- * When --team-name is provided, only checks for orphans from that team.
- * When omitted, scans for ALL orphan claude agent processes.
+ * When --team-name is provided, only checks stale workers from that team.
+ * When omitted, scans for ALL matching OMC worker processes.
  *
- * --dry-run: Report orphans without killing them.
+ * --dry-run: Report matching workers without killing them.
  *
  * Exit codes:
- *   0 - Success (orphans cleaned or none found)
+ *   0 - Success (workers cleaned or none found)
  *   1 - Error during cleanup
  */
 
-import { existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { join } from 'node:path';
-import { getClaudeConfigDir } from './lib/config-dir.mjs';
 
 const args = process.argv.slice(2);
 const teamNameIdx = args.indexOf('--team-name');
@@ -40,16 +37,16 @@ if (rawTeamName && !teamName) {
 }
 
 /**
- * Find claude agent processes that match team patterns.
+ * Find OMC tmux/CLI worker processes that match team patterns.
  * Cross-platform: uses ps on Unix, tasklist on Windows.
  */
 function findOrphanProcesses(filterTeam) {
-  const orphans = [];
+  const workers = [];
 
   try {
     if (process.platform === 'win32') {
       const output = getWindowsProcessListOutput();
-      if (!output) return orphans;
+      if (!output) return workers;
 
       for (const line of output.split('\n')) {
         if (line.includes('--team-name') || line.includes('team_name')) {
@@ -61,7 +58,7 @@ function findOrphanProcesses(filterTeam) {
 
             const pidMatch = line.match(/,(\d+)\s*$/);
             if (pidMatch) {
-              orphans.push({ pid: parseInt(pidMatch[1], 10), team: procTeam, cmd: line.trim() });
+              workers.push({ pid: parseInt(pidMatch[1], 10), team: procTeam, cmd: line.trim() });
             }
           }
         }
@@ -71,10 +68,10 @@ function findOrphanProcesses(filterTeam) {
       const output = execSync('ps aux', { encoding: 'utf-8', timeout: 10000 });
 
       for (const line of output.split('\n')) {
-        // Match OMC agent processes with team context (exclude bare 'node' to avoid over-matching)
+        // Match OMC worker processes with team context (exclude bare 'node' to avoid over-matching).
         if ((line.includes('claude') || line.includes('codex') || line.includes('gemini') || line.includes('omc') || line.includes('oh-my-claude'))) {
           // Restrict team name match to valid slug characters.
-          // Support both native TeamDelete-style args and tmux worker env assignments.
+          // Support both legacy args and tmux worker env assignments.
           const match =
             line.match(/--team-name[=\s]+([\w][\w-]{0,63})/i)
             || line.match(/team_name[=:]\s*"?([\w][\w-]{0,63})"?/i)
@@ -87,17 +84,17 @@ function findOrphanProcesses(filterTeam) {
             const parts = line.trim().split(/\s+/);
             const pid = parseInt(parts[1], 10);
             if (pid && pid !== process.pid && pid !== process.ppid) {
-              orphans.push({ pid, team: procTeam, cmd: '(redacted)' });
+              workers.push({ pid, team: procTeam, cmd: '(redacted)' });
             }
           }
         }
       }
     }
   } catch {
-    // ps/wmic failed — can't detect orphans
+    // ps/wmic failed — can't detect stale workers
   }
 
-  return orphans;
+  return workers;
 }
 
 function getWindowsProcessListOutput() {
@@ -120,14 +117,6 @@ function getWindowsProcessListOutput() {
   }
 }
 
-/**
- * Check if a team's config still exists (i.e., team is still active).
- */
-function teamConfigExists(name) {
-  const configDir = getClaudeConfigDir();
-  const configPath = join(configDir, 'teams', name, 'config.json');
-  return existsSync(configPath);
-}
 
 /**
  * Kill a process.
@@ -160,7 +149,7 @@ function killProcess(pid) {
       // Schedule a best-effort SIGKILL escalation after 5s.
       // .unref() ensures this pending timer does not keep the Node event
       // loop alive — without it, main() would appear to "hang" for 5s per
-      // orphan after printing the JSON result.
+      // stale worker after printing the JSON result.
       setTimeout(() => {
         try {
           process.kill(pid, 0); // Check if still running
@@ -181,51 +170,41 @@ function main() {
 
   if (processes.length === 0) {
     console.log(JSON.stringify({
-      orphans: 0,
+      cleaned: 0,
       message: teamName
-        ? `No orphan processes found for team "${teamName}".`
-        : 'No orphan agent processes found.',
+        ? `No stale OMC worker processes found for team "${teamName}".`
+        : 'No stale OMC worker processes found.',
     }));
     process.exit(0);
   }
 
-  // Filter to actual orphans: processes whose team config no longer exists
-  const orphans = processes.filter(p => !teamConfigExists(p.team));
-
-  if (orphans.length === 0) {
-    console.log(JSON.stringify({
-      orphans: 0,
-      message: `Found ${processes.length} team process(es) but all have active team configs.`,
-    }));
-    process.exit(0);
-  }
 
   const results = [];
 
-  for (const orphan of orphans) {
+  for (const worker of processes) {
     if (dryRun) {
-      results.push({ pid: orphan.pid, team: orphan.team, action: 'would_kill' });
-      console.error(`[dry-run] Would kill PID ${orphan.pid} (team: ${orphan.team})`);
+      results.push({ pid: worker.pid, team: worker.team, action: 'would_kill' });
+      console.error(`[dry-run] Would kill PID ${worker.pid} (team: ${worker.team})`);
     } else {
-      const killed = killProcess(orphan.pid);
-      results.push({ pid: orphan.pid, team: orphan.team, action: killed ? 'killed' : 'failed' });
-      console.error(`[cleanup] ${killed ? 'Killed' : 'Failed to kill'} PID ${orphan.pid} (team: ${orphan.team})`);
+      const killed = killProcess(worker.pid);
+      results.push({ pid: worker.pid, team: worker.team, action: killed ? 'killed' : 'failed' });
+      console.error(`[cleanup] ${killed ? 'Killed' : 'Failed to kill'} PID ${worker.pid} (team: ${worker.team})`);
     }
   }
 
   console.log(JSON.stringify({
-    orphans: orphans.length,
+    cleaned: processes.length,
     dryRun,
     results,
     message: dryRun
-      ? `Found ${orphans.length} orphan(s). Re-run without --dry-run to clean up.`
-      : `Cleaned up ${results.filter(r => r.action === 'killed').length}/${orphans.length} orphan(s).`,
+      ? `Found ${processes.length} stale worker(s). Re-run without --dry-run to clean up.`
+      : `Cleaned up ${results.filter(r => r.action === 'killed').length}/${processes.length} stale worker(s).`,
   }));
 
   // Exit explicitly so we don't depend on timer/handle lifetime to end the
   // process. The SIGKILL escalation timers scheduled in killProcess() are
   // .unref()ed and therefore do not block exit; this line makes the intent
-  // symmetric with the earlier no-orphan return paths (which already call
+  // symmetric with the earlier no-worker return paths (which already call
   // process.exit(0)).
   process.exit(0);
 }

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -928,18 +928,19 @@ function generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId) {
   const bg = toolInput.run_in_background ? ' [BACKGROUND]' : '';
   const tracking = getAgentTrackingInfo(stateDir);
 
-  // Team-routing enforcement (issue #1006):
-  // When team state is active and Task is called WITHOUT team_name,
-  // inject a redirect message to use team agents instead of subagents.
+  // Team-routing guidance:
+  // Claude Code 2.1.178+ removed TeamCreate/TeamDelete. When OMC team state is
+  // active, teammates should be spawned into the session's implicit agent team by
+  // giving each Agent/Task call a distinct name. team_name is ignored by native
+  // Claude Code and should only be treated as legacy metadata.
   const teamState = getActiveTeamState(stateDir, sessionId);
-  if (teamState && !toolInput.team_name) {
+  if (teamState && !toolInput.name) {
     const teamName = teamState.team_name || teamState.teamName || 'team';
-    return `[TEAM ROUTING REQUIRED] Team "${teamName}" is active but you are spawning a regular subagent ` +
-      `without team_name. You MUST use TeamCreate first (if not already created), then spawn teammates with ` +
-      `Task(team_name="${teamName}", name="worker-N", subagent_type="${agentType}"). ` +
-      `Do NOT use Task without team_name during an active team session. ` +
-      `If TeamCreate is not available in your tools, tell the user to verify ` +
-      'CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is set in [$CLAUDE_CONFIG_DIR|~/.claude]/settings.json. Restart Claude Code.';
+    return `[TEAM ROUTING REQUIRED] Team "${teamName}" is active but you are spawning an unnamed subagent. ` +
+      `Claude Code 2.1.178+ uses one implicit team per session when ` +
+      `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is enabled; TeamCreate and TeamDelete are removed. ` +
+      `Spawn teammates directly with Agent/Task name="worker-N" and subagent_type="${agentType}". ` +
+      `Do NOT rely on team_name for routing; native Claude Code accepts it only as ignored legacy metadata.`;
   }
 
   if (QUIET_LEVEL >= 2) return '';

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -26,7 +26,7 @@ Automatically detects which mode is active and cancels it:
 - **Swarm**: Stops coordinated agent swarm, releases claimed tasks
 - **Ultrapilot**: Stops parallel autopilot workers
 - **Pipeline**: Stops sequential agent pipeline
-- **Team**: Sends shutdown_request to all teammates, waits for responses/timeouts, clears OMC team state, clears linked ralph if present. Claude Code 2.1.178+ has no TeamDelete.
+- **Team**: Requests shutdown from all teammates through the active team/conversation surface, waits for responses/timeouts, clears OMC team state, clears linked ralph if present. Claude Code 2.1.178+ has no TeamDelete.
 - **Team+Ralph (linked)**: Cancels team first (graceful shutdown), then clears ralph state. Cancelling ralph when linked also cancels team first.
 
 ## Usage
@@ -213,7 +213,7 @@ state_read(mode="team")
 For the active OMC team state:
   1. Read team_name and worker labels from OMC state/handoffs/task bookkeeping
   2. For each active teammate:
-     a. Send shutdown_request via SendMessage
+     a. Ask or notify the named teammate through the active conversation/team messaging surface
      b. Wait up to 15 seconds for shutdown_response
      c. If response received: mark member acknowledged
      d. If timeout: mark member as unresponsive, continue to next
@@ -266,7 +266,7 @@ Team "{team_name}" cancelled:
 **Implementation note:** The cancel skill is executed by the LLM, not as a bash script. When you detect an active team:
 1. Read `state_read(mode="team")` to find the active OMC team
 2. Identify active named teammates from state, handoffs, or task bookkeeping
-3. For each teammate, call `SendMessage(type: "shutdown_request", recipient: member-name, content: "Cancelling")`
+3. For each teammate, ask or notify the named teammate through the active conversation/team messaging surface
 4. Wait briefly for shutdown responses (15s per member timeout)
 5. Record unresponsive teammates after a reconciliation wait
 6. Clear team state: `state_clear(mode="team", session_id)`

--- a/skills/cancel/SKILL.md
+++ b/skills/cancel/SKILL.md
@@ -26,7 +26,7 @@ Automatically detects which mode is active and cancels it:
 - **Swarm**: Stops coordinated agent swarm, releases claimed tasks
 - **Ultrapilot**: Stops parallel autopilot workers
 - **Pipeline**: Stops sequential agent pipeline
-- **Team**: Sends shutdown_request to all teammates, waits for responses, calls TeamDelete, clears linked ralph if present
+- **Team**: Sends shutdown_request to all teammates, waits for responses/timeouts, clears OMC team state, clears linked ralph if present. Claude Code 2.1.178+ has no TeamDelete.
 - **Team+Ralph (linked)**: Cancels team first (graceful shutdown), then clears ralph state. Cancelling ralph when linked also cancels team first.
 
 ## Usage
@@ -197,25 +197,25 @@ Use force mode to clear every session plus legacy artifacts via `state_clear`. D
 
 ### 3B. Smart Cancellation (default)
 
-#### If Team Active (Claude Code native)
+#### If Team Active (Claude Code implicit team)
 
-Teams are detected by checking for config files in `${CLAUDE_CONFIG_DIR:-~/.claude}/teams/`:
+Teams are detected through OMC team state, not removed Claude Code `~/.claude/teams` config directories:
 
 ```bash
-# Check for active teams
-TEAM_CONFIGS=$(find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/teams -name config.json -maxdepth 2 2>/dev/null)
+# Check for active OMC team state
+state_read(mode="team")
 ```
 
 **Two-pass cancellation protocol:**
 
 **Pass 1: Graceful Shutdown**
 ```
-For each team found in ${CLAUDE_CONFIG_DIR:-~/.claude}/teams/:
-  1. Read config.json to get team_name and members list
-  2. For each non-lead member:
+For the active OMC team state:
+  1. Read team_name and worker labels from OMC state/handoffs/task bookkeeping
+  2. For each active teammate:
      a. Send shutdown_request via SendMessage
      b. Wait up to 15 seconds for shutdown_response
-     c. If response received: member terminates and is auto-removed
+     c. If response received: mark member acknowledged
      d. If timeout: mark member as unresponsive, continue to next
   3. Log: "Graceful pass: X/Y members responded"
 ```
@@ -223,36 +223,31 @@ For each team found in ${CLAUDE_CONFIG_DIR:-~/.claude}/teams/:
 **Pass 2: Reconciliation**
 ```
 After graceful pass:
-  1. Re-read config.json to check remaining members
-  2. If only lead remains (or config is empty): proceed to TeamDelete
-  3. If unresponsive members remain:
-     a. Wait 5 more seconds (they may still be processing)
-     b. Re-read config.json again
-     c. If still stuck: attempt TeamDelete anyway
-     d. If TeamDelete fails: report manual cleanup path
+  1. Wait 5 more seconds for unresponsive teammates that may still be processing
+  2. Record any remaining unresponsive teammates in the cancellation report
+  3. Do not call TeamDelete; Claude Code 2.1.178+ removed per-team native cleanup
 ```
 
-**TeamDelete + Cleanup:**
+**OMC State Cleanup:**
 ```
-  1. Call TeamDelete() — removes ~/.claude/teams/{name}/ and ~/.claude/tasks/{name}/
-  2. Clear team state: state_clear(mode="team")
-  3. Check for linked ralph: state_read(mode="ralph") — if linked_team is true:
+  1. Clear team state: state_clear(mode="team")
+  2. Check for linked ralph: state_read(mode="ralph") — if linked_team is true:
      a. Clear ralph state: state_clear(mode="ralph")
      b. Clear linked ultrawork if present: state_clear(mode="ultrawork")
-  4. Run orphan scan (see below)
-  5. Emit structured cancel report
+  3. Run OMC tmux/CLI orphan scan only for legacy `omc team` / `/omc-teams` workers (see below)
+  4. Emit structured cancel report
 ```
 
 **Orphan Detection (Post-Cleanup):**
 
-After TeamDelete, verify no agent processes remain:
+For legacy OMC tmux/CLI worker runs, verify no worker processes remain:
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-orphans.mjs" --team-name "{team_name}"
 ```
 
 The orphan scanner:
-1. Checks `ps aux` (Unix) or `tasklist` (Windows) for processes with `--team-name` matching the deleted team
-2. For each orphan whose team config no longer exists: sends SIGTERM, waits 5s, sends SIGKILL if still alive
+1. Checks `ps aux` (Unix) or `tasklist` (Windows) for OMC worker processes with `--team-name` matching the cleaned-up team
+2. Sends SIGTERM, waits 5s, sends SIGKILL if still alive
 3. Reports cleanup results as JSON
 
 Use `--dry-run` to inspect without killing. The scanner is safe to run multiple times.
@@ -263,20 +258,19 @@ Team "{team_name}" cancelled:
   - Members signaled: N
   - Responses received: M
   - Unresponsive: K (list names if any)
-  - TeamDelete: success/failed
+  - OMC state cleared: yes/no
   - Manual cleanup needed: yes/no
-    Path: ~/.claude/teams/{name}/ and ~/.claude/tasks/{name}/
+    Path: OMC team state / tmux worker processes, if any
 ```
 
 **Implementation note:** The cancel skill is executed by the LLM, not as a bash script. When you detect an active team:
-1. Read `${CLAUDE_CONFIG_DIR:-~/.claude}/teams/*/config.json` to find active teams
-2. If multiple teams exist, cancel oldest first (by `createdAt`)
-3. For each non-lead member, call `SendMessage(type: "shutdown_request", recipient: member-name, content: "Cancelling")`
+1. Read `state_read(mode="team")` to find the active OMC team
+2. Identify active named teammates from state, handoffs, or task bookkeeping
+3. For each teammate, call `SendMessage(type: "shutdown_request", recipient: member-name, content: "Cancelling")`
 4. Wait briefly for shutdown responses (15s per member timeout)
-5. Re-read config.json to check for remaining members (reconciliation pass)
-6. Call `TeamDelete()` to clean up
-7. Clear team state: `state_clear(mode="team", session_id)`
-8. Report structured summary to user
+5. Record unresponsive teammates after a reconciliation wait
+6. Clear team state: `state_clear(mode="team", session_id)`
+7. Report structured summary to user
 
 #### If Autopilot Active
 

--- a/skills/omc-reference/SKILL.md
+++ b/skills/omc-reference/SKILL.md
@@ -49,8 +49,10 @@ Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
 ### OMC state
 - `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
 
-### Team runtime
-- `TeamCreate`, `TeamDelete`, `SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`
+### Team orchestration
+- Claude Code 2.1.178+ uses one implicit agent team per session. Spawn teammates directly with Agent/Task using distinct `name` values; do not call removed `TeamCreate`/`TeamDelete` tools or rely on `team_name` for native routing.
+- Use TodoWrite or the available task-list surface for tracking only. Task-list tools do not create native teams.
+- Legacy OMC tmux/CLI teams are separate: use `/team` or `omc team` plus OMC state/API commands for external worker runs.
 
 ### Notepad
 - `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -211,7 +211,7 @@ If beads or beads-rust is detected, use AskUserQuestion:
 **Question:** "Which task management tool should I use for tracking work?"
 
 **Options:**
-1. **Built-in Tasks (default)** - Use Claude Code's native TaskCreate/TodoWrite. Tasks are session-only.
+1. **Built-in Tasks (default)** - Use Claude Code's native TodoWrite or available task-list surface. Tasks are session-only.
 2. **Beads (bd)** - Git-backed persistent tasks. Survives across sessions. [Only if detected]
 3. **Beads-Rust (br)** - Lightweight Rust port of beads. [Only if detected]
 

--- a/skills/omc-setup/phases/04-welcome.md
+++ b/skills/omc-setup/phases/04-welcome.md
@@ -42,7 +42,7 @@ TEAMS:
 Spawn coordinated agents with shared task lists and real-time messaging:
 - /oh-my-claudecode:team 3:executor "fix all TypeScript errors"
 - /oh-my-claudecode:team 5:debugger "fix build errors in src/"
-Teams use Claude Code native tools (TeamCreate/SendMessage/TaskCreate).
+Teams use Claude Code's implicit agent team (spawn teammates directly with distinct `name` values; no TeamCreate/TeamDelete in Claude Code 2.1.178+).
 
 MCP SERVERS:
 Run /oh-my-claudecode:mcp-setup to add tools like web search, GitHub, etc.
@@ -86,7 +86,7 @@ MAGIC KEYWORDS (power-user shortcuts):
 TEAMS (NEW!):
 Spawn coordinated agents with shared task lists and real-time messaging:
 - /oh-my-claudecode:team 3:executor "fix all TypeScript errors"
-- Uses Claude Code native tools (TeamCreate/SendMessage/TaskCreate)
+- Uses Claude Code's implicit agent team (spawn teammates directly with distinct `name` values; no TeamCreate/TeamDelete in Claude Code 2.1.178+)
 
 HUD STATUSLINE:
 The status bar now shows OMC state. Restart Claude Code to see it.

--- a/skills/omc-teams/SKILL.md
+++ b/skills/omc-teams/SKILL.md
@@ -190,9 +190,9 @@ If encountered, switch to `omc team ...` CLI commands.
 
 ## Relationship to `/team`
 
-| Aspect       | `/team`                                   | `/omc-teams`                                         |
-| ------------ | ----------------------------------------- | ---------------------------------------------------- |
-| Worker type  | Claude Code native team agents            | claude / codex / gemini CLI processes in tmux        |
-| Invocation   | `TeamCreate` / `Task` / `SendMessage`     | `omc team [N:agent]` + `status` + `shutdown` + `api` |
-| Coordination | Native team messaging and staged pipeline | tmux worker runtime + CLI API state files            |
-| Use when     | You want Claude-native team orchestration | You want external CLI worker execution               |
+| Aspect       | `/team`                                                       | `/omc-teams`                                         |
+| ------------ | ------------------------------------------------------------- | ---------------------------------------------------- |
+| Worker type  | Claude Code implicit agent-team teammates                     | claude / codex / gemini CLI processes in tmux        |
+| Invocation   | Agent/Task spawn with distinct `name` values; no TeamCreate/TeamDelete in Claude Code 2.1.178+ | `omc team [N:agent]` + `status` + `shutdown` + `api` |
+| Coordination | Native implicit-team messaging and staged pipeline            | tmux worker runtime + CLI API state files            |
+| Use when     | You want Claude-native in-session agent orchestration         | You want external CLI worker execution               |

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team
-description: N coordinated agents on shared task list using Claude Code native teams
+description: N coordinated agents on shared task list using Claude Code implicit agent teams
 argument-hint: "[N:agent-type] [ralph] <task description>"
 aliases: []
 level: 4
@@ -8,7 +8,7 @@ level: 4
 
 # Team Skill
 
-Spawn N coordinated agents working on a shared task list using Claude Code's native team tools. Replaces the legacy `/swarm` skill (SQLite-based) with built-in team management, inter-agent messaging, and task dependencies -- no external dependencies required.
+Spawn N coordinated agents working on a shared task list using Claude Code's implicit agent team. Claude Code 2.1.178+ removed native `TeamCreate`/`TeamDelete`; with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, each session has one implicit team and teammates are spawned directly with the Agent/Task tool using distinct `name` values. This skill still preserves OMC's legacy tmux/CLI worker orchestration where documented (`omc team` / `/omc-teams`).
 
 The `swarm` compatibility alias was removed in #1131.
 
@@ -50,19 +50,19 @@ User: "/team 3:executor fix all TypeScript errors"
               v
       [TEAM ORCHESTRATOR (Lead)]
               |
-              +-- TeamCreate("fix-ts-errors")
-              |       -> lead becomes team-lead@fix-ts-errors
+              +-- Use the session's implicit Claude Code team
+              |       -> no TeamCreate call; lead remains current session
               |
               +-- Analyze & decompose task into subtasks
               |       -> explore/architect produces subtask list
               |
-              +-- TaskCreate x N (one per subtask)
-              |       -> tasks #1, #2, #3 with dependencies
+              +-- Create task list entries from the implementation plan
+              |       -> TODO/task entries #1, #2, #3 with dependencies
               |
               +-- TaskUpdate x N (pre-assign owners)
               |       -> task #1 owner=worker-1, etc.
               |
-              +-- Task(team_name="fix-ts-errors", name="worker-1") x 3
+              +-- Task(name="worker-1") x 3
               |       -> spawns teammates into the team
               |
               +-- Monitor loop
@@ -73,22 +73,17 @@ User: "/team 3:executor fix all TypeScript errors"
               +-- Completion
                       -> SendMessage(shutdown_request) to each teammate
                       <- SendMessage(shutdown_response, approve: true)
-                      -> TeamDelete("fix-ts-errors")
+                      -> clear OMC team state (no TeamDelete call)
                       -> rm .omc/state/team-state.json
 ```
 
-**Storage layout (managed by Claude Code):**
+**Native Claude Code team model (2.1.178+):**
 
 ```
-~/.claude/
-  teams/fix-ts-errors/
-    config.json          # Team metadata + members array
-  tasks/fix-ts-errors/
-    .lock                # File lock for concurrent access
-    1.json               # Subtask #1
-    2.json               # Subtask #2 (may be internal)
-    3.json               # Subtask #3
-    ...
+- No per-team ~/.claude/teams/<name>/ directory is created by this skill.
+- No TeamCreate/TeamDelete calls are available.
+- `team_name` is accepted by native Claude Code only as ignored legacy metadata; do not rely on it for routing.
+- Spawn teammates directly via Agent/Task with `name="worker-N"`.
 ```
 
 ## Goal Workflow Relationship
@@ -131,7 +126,7 @@ Each pipeline stage uses **specialized agents** -- not just executors. The lead 
   - Agents: `analyst` extracts requirements, optionally `critic`.
   - Exit: acceptance criteria and boundaries are explicit.
 - **team-exec**
-  - Entry: `TeamCreate`, `TaskCreate`, assignment, and worker spawn are complete.
+  - Entry: task list assignment and worker spawn are complete.
   - Agents: workers spawned as the appropriate specialist type per subtask (see routing table).
   - Exit: execution tasks reach terminal state for the current pass.
 - **team-verify**
@@ -177,7 +172,7 @@ The lead writes handoffs to `.omc/handoffs/<stage-name>.md`.
 
 1. **Lead reads previous handoff BEFORE spawning next stage's agents.** The handoff content is included in the next stage's agent spawn prompts, ensuring agents start with full context.
 2. **Handoffs accumulate.** The verify stage can read all prior handoffs (plan → prd → exec) for full decision history.
-3. **On team cancellation, handoffs survive** in `.omc/handoffs/` for session resume. They are not deleted by `TeamDelete`.
+3. **On team cancellation, handoffs survive** in `.omc/handoffs/` for session resume. They are not deleted by native Claude Code team cleanup; no `TeamDelete` call exists in Claude Code 2.1.178+.
 4. **Handoffs are lightweight.** 10-20 lines max. They capture decisions and rationale, not full specifications (those live in deliverable files like DESIGN.md).
 
 #### Example
@@ -226,28 +221,11 @@ Use `explore` or `architect` (via MCP or agent) to analyze the codebase and brea
 - Each subtask needs a concise `subject` and detailed `description`
 - Identify dependencies between subtasks (e.g., "shared types must be fixed before consumers")
 
-### Phase 3: Create Team
+### Phase 3: Initialize Team State
 
-Call `TeamCreate` with a slug derived from the task:
+Use the session's implicit Claude Code team. Do **not** call `TeamCreate`; Claude Code 2.1.178+ removed that tool and automatically gives the session one implicit team when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is enabled.
 
-```json
-{
-  "team_name": "fix-ts-errors",
-  "description": "Fix all TypeScript errors across the project"
-}
-```
-
-**Response:**
-
-```json
-{
-  "team_name": "fix-ts-errors",
-  "team_file_path": "~/.claude/teams/fix-ts-errors/config.json",
-  "lead_agent_id": "team-lead@fix-ts-errors"
-}
-```
-
-The current session becomes the team lead (`team-lead@fix-ts-errors`).
+Derive a slug such as `fix-ts-errors` for OMC state, prompt labels, handoffs, and human-readable reporting only. Native Claude Code may accept `team_name` as legacy metadata, but it is ignored for routing.
 
 Write OMC state using the `state_write` MCP tool for proper session-scoped persistence:
 
@@ -272,7 +250,7 @@ state_write(mode="team", active=true, current_phase="team-plan", state={
 | ---------------- | ------- | --------------------------------------------------------------------------------------- |
 | `active`         | boolean | Whether team mode is active                                                             |
 | `current_phase`  | string  | Current pipeline stage: `team-plan`, `team-prd`, `team-exec`, `team-verify`, `team-fix` |
-| `team_name`      | string  | Slug name for the team                                                                  |
+| `team_name`      | string  | OMC slug for state, handoffs, and reporting; ignored by native Claude Code routing |
 | `agent_count`    | number  | Number of worker agents                                                                 |
 | `agent_types`    | string  | Comma-separated agent types used in team-exec                                           |
 | `task`           | string  | Original task description                                                               |
@@ -299,10 +277,10 @@ If `active=true` and `current_phase` is non-terminal, resume from the last incom
 
 ### Phase 4: Create Tasks
 
-Call `TaskCreate` for each subtask. Set dependencies with `TaskUpdate` using `addBlockedBy`.
+Create task list entries for each subtask using the active TodoWrite/task-list surface. If Claude Code exposes `TaskCreate`/`TaskUpdate` task-list tools, they may be used for task tracking only; they do not create native teams.
 
 ```json
-// TaskCreate for subtask 1
+// Task-list entry for subtask 1
 {
   "subject": "Fix type errors in src/auth/",
   "description": "Fix all TypeScript errors in src/auth/login.ts, src/auth/session.ts, and src/auth/types.ts. Run tsc --noEmit to verify.",
@@ -347,12 +325,11 @@ For tasks with dependencies, use `TaskUpdate` after creation:
 
 ### Phase 5: Spawn Teammates
 
-Spawn N teammates using `Task` with `team_name` and `name` parameters. Each teammate gets the team worker preamble (see below) plus their specific assignment.
+Spawn N teammates directly using the Agent/Task tool with distinct `name` values. Each teammate gets the team worker preamble (see below) plus their specific assignment. Do **not** call `TeamCreate`, and do **not** rely on `team_name`; Claude Code 2.1.178+ ignores it for native routing.
 
 ```json
 {
   "subagent_type": "oh-my-claudecode:executor",
-  "team_name": "fix-ts-errors",
   "name": "worker-1",
   "prompt": "<worker-preamble + assigned tasks>"
 }
@@ -362,15 +339,14 @@ Spawn N teammates using `Task` with `team_name` and `name` parameters. Each team
 
 ```json
 {
-  "agent_id": "worker-1@fix-ts-errors",
-  "name": "worker-1",
-  "team_name": "fix-ts-errors"
+  "agent_id": "worker-1",
+  "name": "worker-1"
 }
 ```
 
 **Side effects:**
 
-- Teammate added to `config.json` members array
+- Teammate is spawned into the session's implicit Claude Code team
 - An **internal task** is auto-created (with `metadata._internal: true`) tracking the agent lifecycle
 - Internal tasks appear in `TaskList` output -- filter them when counting real tasks
 
@@ -443,18 +419,7 @@ When all real tasks (non-internal) are completed or failed:
    }
    ```
 3. **Await responses** -- Each teammate responds with `shutdown_response(approve: true)` and terminates
-4. **Delete team** -- Call `TeamDelete` to clean up:
-   ```json
-   { "team_name": "fix-ts-errors" }
-   ```
-   Response:
-   ```json
-   {
-     "success": true,
-     "message": "Cleaned up directories and worktrees for team \"fix-ts-errors\"",
-     "team_name": "fix-ts-errors"
-   }
-   ```
+4. **Clean up native team state** -- Claude Code 2.1.178+ has no `TeamDelete`; after teammates acknowledge shutdown, clear OMC state and any local task bookkeeping.
 5. **Clean OMC state** -- Remove `.omc/state/team-state.json`
 6. **Report summary** -- Present results to the user
 
@@ -463,7 +428,7 @@ When all real tasks (non-internal) are completed or failed:
 When spawning teammates, include this preamble in the prompt to establish the work protocol. Adapt it per teammate with their specific task assignments.
 
 ```
-You are a TEAM WORKER in team "{team_name}". Your name is "{worker_name}".
+You are a TEAM WORKER in OMC team "{team_name}". Your name is "{worker_name}".
 You report to the team lead ("team-lead").
 You are not the leader and must not perform leader orchestration actions.
 
@@ -554,7 +519,7 @@ This addendum must preserve the core rule: **worker = executor only, never leade
 
 ### Shutdown Protocol (BLOCKING)
 
-**CRITICAL: Steps must execute in exact order. Never call TeamDelete before shutdown is confirmed.**
+**CRITICAL: Steps must execute in exact order. Never clear OMC team state before shutdown is confirmed or timed out.**
 
 **Step 1: Verify completion**
 
@@ -590,29 +555,23 @@ Call TaskList — verify all real tasks (non-internal) are completed or failed.
 }
 ```
 
-After approval:
+After approval, the teammate terminates or stops accepting new work. Claude Code 2.1.178+ does not expose per-team config membership or TeamDelete cleanup; track acknowledgements in OMC state/reporting instead.
 
-- Teammate process terminates
-- Teammate auto-removed from `config.json` members array
-- Internal task for that teammate completes
+**Step 4: Clear OMC team state — only after ALL teammates confirmed or timed out**
 
-**Step 4: TeamDelete — only after ALL teammates confirmed or timed out**
+Claude Code 2.1.178+ has no `TeamDelete`. Clear OMC team state and local task bookkeeping after the blocking shutdown pass completes.
 
-```json
-{ "team_name": "fix-ts-errors" }
-```
+**Step 5: Orphan scan for OMC tmux/CLI workers only**
 
-**Step 5: Orphan scan**
-
-Check for agent processes that survived TeamDelete:
+For legacy OMC tmux/CLI worker runs (`omc team` / `/omc-teams`), check for worker processes that survived cleanup:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/cleanup-orphans.mjs" --team-name fix-ts-errors
 ```
 
-This scans for processes matching the team name whose config no longer exists, and terminates them (SIGTERM → 5s wait → SIGKILL). Supports `--dry-run` for inspection.
+This scans for OMC worker processes matching the team name and terminates stale orphans (SIGTERM → 5s wait → SIGKILL). Supports `--dry-run` for inspection.
 
-**Shutdown sequence is BLOCKING:** Do not proceed to TeamDelete until all teammates have either:
+**Shutdown sequence is BLOCKING:** Do not clear OMC team state until all teammates have either:
 
 - Confirmed shutdown (`shutdown_response` with `approve: true`), OR
 - Timed out (30s with no response)
@@ -773,10 +732,9 @@ This approach complements the existing `SendMessage`-based communication by prov
 
 ### Teammate Crashes
 
-1. Internal task for that teammate will show unexpected status
-2. Teammate disappears from `config.json` members
-3. Lead reassigns orphaned tasks to remaining workers
-4. If needed, spawn a replacement teammate with `Task(team_name, name)`
+1. Internal tracking for that teammate will show unexpected status
+2. Lead reassigns orphaned tasks to remaining workers
+3. If needed, spawn a replacement teammate with `Task(name="worker-N", subagent_type="...")`
 
 ## Team + Ralph Composition
 
@@ -833,46 +791,44 @@ See Cancellation section below for details.
 
 ## Idempotent Recovery
 
-If the lead crashes mid-run, the team skill should detect existing state and resume:
+If the lead crashes mid-run, the team skill should detect existing OMC state and resume:
 
-1. Check `${CLAUDE_CONFIG_DIR:-~/.claude}/teams/` for teams matching the task slug
-2. If found, read `config.json` to discover active members
-3. Resume monitor mode instead of creating a duplicate team
-4. Call `TaskList` to determine current progress
-5. Continue from the monitoring phase
+1. Read `state_read(mode="team")` for the active OMC team slug, phase, and worker labels
+2. Use OMC handoffs and task-list/TodoWrite state to determine current progress
+3. Resume monitor mode instead of spawning duplicate teammates
+4. Continue from the last recorded stage
 
-This prevents duplicate teams and allows graceful recovery from lead failures.
+This prevents duplicate worker spawns and allows graceful recovery from lead failures.
 
 ## Comparison: Team vs Legacy Swarm
 
-| Aspect                  | Team (Native)                                                      | Swarm (Legacy SQLite)                  |
-| ----------------------- | ------------------------------------------------------------------ | -------------------------------------- |
-| **Storage**             | JSON files in `~/.claude/teams/` and `~/.claude/tasks/`            | SQLite in `.omc/state/swarm.db`        |
-| **Dependencies**        | `better-sqlite3` not needed                                        | Requires `better-sqlite3` npm package  |
-| **Task claiming**       | `TaskUpdate(owner + in_progress)` -- lead pre-assigns              | SQLite IMMEDIATE transaction -- atomic |
+| Aspect                  | Team (Native Claude Code 2.1.178+)                              | Swarm (Legacy SQLite)                  |
+| ----------------------- | ---------------------------------------------------------------- | -------------------------------------- |
+| **Storage**             | OMC state/handoffs plus Claude Code's current task-list surface   | SQLite in `.omc/state/swarm.db`        |
+| **Dependencies**        | `better-sqlite3` not needed                                      | Requires `better-sqlite3` npm package  |
+| **Task claiming**       | Lead pre-assigns named workers through task-list/TodoWrite state  | SQLite IMMEDIATE transaction -- atomic |
 | **Race conditions**     | Possible if two agents claim same task (mitigate by pre-assigning) | None (SQLite transactions)             |
-| **Communication**       | `SendMessage` (DM, broadcast, shutdown)                            | None (fire-and-forget agents)          |
-| **Task dependencies**   | Built-in `blocks` / `blockedBy` arrays                             | Not supported                          |
-| **Heartbeat**           | Automatic idle notifications from Claude Code                      | Manual heartbeat table + polling       |
-| **Shutdown**            | Graceful request/response protocol                                 | Signal-based termination               |
-| **Agent lifecycle**     | Auto-tracked via internal tasks + config members                   | Manual tracking via heartbeat table    |
-| **Progress visibility** | `TaskList` shows live status with owner                            | SQL queries on tasks table             |
-| **Conflict prevention** | Owner field (lead-assigned)                                        | Lease-based claiming with timeout      |
-| **Crash recovery**      | Lead detects via missing messages, reassigns                       | Auto-release after 5-min lease timeout |
-| **State cleanup**       | `TeamDelete` removes everything                                    | Manual `rm` of SQLite database         |
+| **Communication**       | Native implicit-team messages / conversation turns                | None (fire-and-forget agents)          |
+| **Task dependencies**   | Lead-managed dependencies in task-list/TodoWrite state            | Not supported                          |
+| **Heartbeat**           | Lead detects via missing messages/status                          | Manual heartbeat table + polling       |
+| **Shutdown**            | Graceful request/response protocol plus OMC state clear           | Signal-based termination               |
+| **Agent lifecycle**     | Tracked by named Agent/Task spawns and OMC state                  | Manual tracking via heartbeat table    |
+| **Progress visibility** | Task list/TodoWrite state with named worker ownership             | SQL queries on tasks table             |
+| **Conflict prevention** | Owner labels (lead-assigned)                                      | Lease-based claiming with timeout      |
+| **Crash recovery**      | Lead detects via missing messages, reassigns                      | Auto-release after 5-min lease timeout |
+| **State cleanup**       | Clear OMC team state after teammate shutdown                      | Manual `rm` of SQLite database         |
 
-**When to use Team over Swarm:** Always prefer `/team` for new work. It uses Claude Code's built-in infrastructure, requires no external dependencies, supports inter-agent communication, and has task dependency management.
+**When to use Team over Swarm:** Always prefer `/team` for new native Claude Code work. It uses Claude Code's implicit agent team, requires no external dependencies, supports inter-agent coordination, and has task dependency management.
 
 ## Cancellation
 
 The `/oh-my-claudecode:cancel` skill handles team cleanup:
 
 1. Read team state via `state_read(mode="team")` to get `team_name` and `linked_ralph`
-2. Send `shutdown_request` to all active teammates (from `config.json` members)
+2. Send `shutdown_request` to all active named teammates
 3. Wait for `shutdown_response` from each (15s timeout per member)
-4. Call `TeamDelete` to remove team and task directories
-5. Clear state via `state_clear(mode="team")`
-6. If `linked_ralph` is true, also clear ralph: `state_clear(mode="ralph")`
+4. Clear state via `state_clear(mode="team")`
+5. If `linked_ralph` is true, also clear ralph: `state_clear(mode="ralph")`
 
 ### Linked Mode Cancellation (Team + Ralph)
 
@@ -882,7 +838,7 @@ When team is linked to ralph, cancellation follows dependency order:
 - **Cancel triggered from Team context:** Clear Team state, then mark Ralph as cancelled. Ralph's stop hook will detect the missing team and stop iterating.
 - **Force cancel (`--force`):** Clears both `team` and `ralph` state unconditionally via `state_clear`.
 
-If teammates are unresponsive, `TeamDelete` may fail. In that case, the cancel skill should wait briefly and retry, or inform the user to manually clean up `~/.claude/teams/{team_name}/` and `~/.claude/tasks/{team_name}/`.
+If teammates are unresponsive, record the timeout, avoid spawning more work, and clear OMC state only after the shutdown wait completes or the user force-cancels.
 
 ## Runtime V2 (Event-Driven)
 
@@ -1006,10 +962,7 @@ An empty `team.roleRouting` preserves pre-patch behavior: every worker is Claude
 
 On successful completion:
 
-1. `TeamDelete` handles all Claude Code state:
-   - Removes `~/.claude/teams/{team_name}/` (config)
-   - Removes `~/.claude/tasks/{team_name}/` (all task files + lock)
-2. OMC state cleanup via MCP tools:
+1. Native Claude Code 2.1.178+ has no per-team `TeamDelete` cleanup. After shutdown is confirmed or timed out, clear OMC state via MCP tools:
    ```
    state_clear(mode="team")
    ```
@@ -1017,9 +970,10 @@ On successful completion:
    ```
    state_clear(mode="ralph")
    ```
-3. Or run `/oh-my-claudecode:cancel` which handles all cleanup automatically.
+2. For legacy OMC tmux/CLI workers, run the documented `omc team shutdown` / cleanup path.
+3. Or run `/oh-my-claudecode:cancel` which handles OMC state cleanup automatically.
 
-**IMPORTANT:** Call `TeamDelete` only AFTER all teammates have been shut down. `TeamDelete` will fail if active members (besides the lead) still exist in the config.
+**IMPORTANT:** Clear OMC team state only AFTER all teammates have been shut down or timed out.
 
 ## Git Worktree Integration
 
@@ -1056,19 +1010,19 @@ MCP workers can operate in isolated git worktrees to prevent file conflicts betw
 
 ## Gotchas
 
-1. **Internal tasks pollute TaskList** -- When a teammate is spawned, the system auto-creates an internal task with `metadata._internal: true`. These appear in `TaskList` output. Filter them when counting real task progress. The subject of an internal task is the teammate's name.
+1. **Internal/lifecycle task entries may pollute TaskList** -- If Claude Code reports internal lifecycle entries for spawned teammates, filter them when counting real task progress. The subject of an internal task is often the teammate's name.
 
-2. **No atomic claiming** -- Unlike SQLite swarm, there is no transactional guarantee on `TaskUpdate`. Two teammates could race to claim the same task. **Mitigation:** The lead should pre-assign owners via `TaskUpdate(taskId, owner)` before spawning teammates. Teammates should only work on tasks assigned to them.
+2. **No atomic claiming** -- Unlike SQLite swarm, native task-list/TodoWrite state does not provide transactional claiming. Two teammates could race to claim the same task. **Mitigation:** The lead should pre-assign owners before spawning teammates. Teammates should only work on tasks assigned to them.
 
-3. **Task IDs are strings** -- IDs are auto-incrementing strings ("1", "2", "3"), not integers. Always pass string values to `taskId` fields.
+3. **Task IDs are strings when exposed by task-list tools** -- IDs may be auto-incrementing strings ("1", "2", "3"), not integers. Always pass string values to `taskId` fields when using task-list tools.
 
-4. **TeamDelete requires empty team** -- All teammates must be shut down before calling `TeamDelete`. The lead (the only remaining member) is excluded from this check.
+4. **No TeamDelete cleanup** -- Claude Code 2.1.178+ removed `TeamDelete`; use shutdown messages plus OMC state cleanup.
 
 5. **Messages are auto-delivered** -- Teammate messages arrive to the lead as new conversation turns. No polling or inbox-checking is needed for inbound messages. However, if the lead is mid-turn (processing), messages queue and deliver when the turn ends.
 
-6. **Teammate prompt stored in config** -- The full prompt text is stored in `config.json` members array. Do not put secrets or sensitive data in teammate prompts.
+6. **Do not put secrets in teammate prompts** -- Prompts can be retained in logs, state, or conversation history. Keep credentials and sensitive data out of teammate prompts.
 
-7. **Members auto-removed on shutdown** -- After a teammate approves shutdown and terminates, it is automatically removed from `config.json`. Do not re-read config expecting to find shut-down teammates.
+7. **Shutdown acknowledgements are state/reporting events** -- After a teammate approves shutdown and terminates, track that acknowledgement in OMC state/reporting. Do not expect a Claude Code team membership config to update.
 
 8. **shutdown_response needs request_id** -- The teammate must extract the `request_id` from the incoming shutdown request JSON and pass it back. The format is `shutdown-{timestamp}@{worker-name}`. Fabricating this ID will cause the shutdown to fail silently.
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -59,20 +59,20 @@ User: "/team 3:executor fix all TypeScript errors"
               +-- Create task list entries from the implementation plan
               |       -> TODO/task entries #1, #2, #3 with dependencies
               |
-              +-- TaskUpdate x N (pre-assign owners)
+              +-- Update task-list entries (pre-assign owners)
               |       -> task #1 owner=worker-1, etc.
               |
               +-- Task(name="worker-1") x 3
               |       -> spawns teammates into the team
               |
               +-- Monitor loop
-              |       <- SendMessage from teammates (auto-delivered)
-              |       -> TaskList polling for progress
-              |       -> SendMessage to unblock/coordinate
+              |       <- teammate messages (auto-delivered by the active team surface)
+              |       -> task-list/TodoWrite review for progress
+              |       -> message teammates through the active team surface to unblock/coordinate
               |
               +-- Completion
-                      -> SendMessage(shutdown_request) to each teammate
-                      <- SendMessage(shutdown_response, approve: true)
+                      -> request shutdown from each teammate through the active team surface
+                      <- shutdown acknowledgement from teammates
                       -> clear OMC team state (no TeamDelete call)
                       -> rm .omc/state/team-state.json
 ```
@@ -277,7 +277,7 @@ If `active=true` and `current_phase` is non-terminal, resume from the last incom
 
 ### Phase 4: Create Tasks
 
-Create task list entries for each subtask using the active TodoWrite/task-list surface. If Claude Code exposes `TaskCreate`/`TaskUpdate` task-list tools, they may be used for task tracking only; they do not create native teams.
+Create task list entries for each subtask using TodoWrite or the active task-list surface. Task-list tools are for tracking only; they do not create native teams.
 
 ```json
 // Task-list entry for subtask 1
@@ -303,7 +303,7 @@ Create task list entries for each subtask using the active TodoWrite/task-list s
 }
 ```
 
-For tasks with dependencies, use `TaskUpdate` after creation:
+For tasks with dependencies, update the active task-list entries after creation:
 
 ```json
 // Task #3 depends on task #1 (shared types must be fixed first)
@@ -348,7 +348,7 @@ Spawn N teammates directly using the Agent/Task tool with distinct `name` values
 
 - Teammate is spawned into the session's implicit Claude Code team
 - An **internal task** is auto-created (with `metadata._internal: true`) tracking the agent lifecycle
-- Internal tasks appear in `TaskList` output -- filter them when counting real tasks
+- Internal tasks may appear in task-list output -- filter them when counting real tasks
 
 **IMPORTANT:** Spawn all teammates in parallel (they are background agents). Do NOT wait for one to finish before spawning the next.
 
@@ -356,9 +356,9 @@ Spawn N teammates directly using the Agent/Task tool with distinct `name` values
 
 The lead orchestrator monitors progress through two channels:
 
-1. **Inbound messages** -- Teammates send `SendMessage` to `team-lead` when they complete tasks or need help. These arrive automatically as new conversation turns (no polling needed).
+1. **Inbound messages** -- Teammates message `team-lead` when they complete tasks or need help. These arrive through the active team/conversation surface.
 
-2. **TaskList polling** -- Periodically call `TaskList` to check overall progress:
+2. **Task-list polling/review** -- Periodically check TodoWrite or the active task-list surface for overall progress:
    ```
    #1 [completed] Fix type errors in src/auth/ (worker-1)
    #3 [in_progress] Fix type errors in src/api/ (worker-2)
@@ -368,8 +368,8 @@ The lead orchestrator monitors progress through two channels:
 
 **Coordination actions the lead can take:**
 
-- **Unblock a teammate:** Send a `message` with guidance or missing context
-- **Reassign work:** If a teammate finishes early, use `TaskUpdate` to assign pending tasks to them and notify via `SendMessage`
+- **Unblock a teammate:** Send a message with guidance or missing context through the active team surface
+- **Reassign work:** If a teammate finishes early, update the task-list entry to assign pending work to them and notify through the active team surface
 - **Handle failures:** If a teammate reports failure, reassign the task or spawn a replacement
 
 #### Task Watchdog Policy
@@ -409,8 +409,8 @@ This enables:
 
 When all real tasks (non-internal) are completed or failed:
 
-1. **Verify results** -- Check that all subtasks are marked `completed` via `TaskList`
-2. **Shutdown teammates** -- Send `shutdown_request` to each active teammate:
+1. **Verify results** -- Check that all real tasks (non-internal) are marked `completed` in TodoWrite or the active task-list surface
+2. **Shutdown teammates** -- Send `shutdown_request` to each active teammate through the active team surface:
    ```json
    {
      "type": "shutdown_request",
@@ -434,9 +434,9 @@ You are not the leader and must not perform leader orchestration actions.
 
 == WORK PROTOCOL ==
 
-1. CLAIM: Call TaskList to see your assigned tasks (owner = "{worker_name}").
+1. CLAIM: Check TodoWrite or the active task-list surface for tasks assigned to you (owner = "{worker_name}").
    Pick the first task with status "pending" that is assigned to you.
-   Call TaskUpdate to set status "in_progress":
+   Mark it `in_progress` using the active task-list surface:
    {"taskId": "ID", "status": "in_progress", "owner": "{worker_name}"}
 
 2. WORK: Execute the task using your tools (Read, Write, Edit, Bash).
@@ -445,11 +445,11 @@ You are not the leader and must not perform leader orchestration actions.
 3. COMPLETE: When done, mark the task completed:
    {"taskId": "ID", "status": "completed"}
 
-4. REPORT: Notify the lead via SendMessage:
+4. REPORT: Notify the lead through the active team/conversation surface:
    {"type": "message", "recipient": "team-lead", "content": "Completed task #ID: <summary of what was done>", "summary": "Task #ID complete"}
 
-5. NEXT: Check TaskList for more assigned tasks. If you have more pending tasks, go to step 1.
-   If no more tasks are assigned to you, notify the lead:
+5. NEXT: Check TodoWrite or the active task-list surface for more assigned tasks. If you have more pending tasks, go to step 1.
+   If no more tasks are assigned to you, notify the lead through the active team/conversation surface:
    {"type": "message", "recipient": "team-lead", "content": "All assigned tasks complete. Standing by.", "summary": "All tasks done, standing by"}
 
 6. SHUTDOWN: When you receive a shutdown_request, respond with:
@@ -457,7 +457,7 @@ You are not the leader and must not perform leader orchestration actions.
 
 == BLOCKED TASKS ==
 If a task has blockedBy dependencies, skip it until those tasks are completed.
-Check TaskList periodically to see if blockers have been resolved.
+Check TodoWrite or the active task-list surface periodically to see if blockers have been resolved.
 
 == ERRORS ==
 If you cannot complete a task, report the failure to the lead:
@@ -469,15 +469,15 @@ Do NOT mark the task as completed. Leave it in_progress so the lead can reassign
 - NEVER run tmux pane/session orchestration commands (for example `tmux split-window`, `tmux new-session`)
 - NEVER run team spawning/orchestration skills or commands (for example `$team`, `$ultrawork`, `$autopilot`, `$ralph`, `omc team ...`, `omx team ...`)
 - ALWAYS use absolute file paths
-- ALWAYS report progress via SendMessage to "team-lead"
-- Use SendMessage with type "message" only -- never "broadcast"
+- ALWAYS report progress to "team-lead" through the active team/conversation surface
+- Use direct team/conversation messages with type "message" only -- never "broadcast"
 ```
 
 ### Agent-Type Prompt Injection (Worker-Specific Addendum)
 
 When composing teammate prompts, append a short addendum based on worker type:
 
-- `claude_worker`: Emphasize strict TaskList/TaskUpdate/SendMessage loop and no orchestration commands.
+- `claude_worker`: Emphasize strict TodoWrite/task-list updates, active team/conversation messages, and no orchestration commands.
 - `codex_worker`: Emphasize CLI API lifecycle (`omc team api ... --json`) and explicit failure ACKs with stderr.
 - `gemini_worker`: Emphasize bounded file ownership and milestone ACKs after each completed sub-step.
 
@@ -524,7 +524,7 @@ This addendum must preserve the core rule: **worker = executor only, never leade
 **Step 1: Verify completion**
 
 ```
-Call TaskList — verify all real tasks (non-internal) are completed or failed.
+Verify via TodoWrite or the active task-list surface — all real tasks (non-internal) are completed or failed.
 ```
 
 **Step 2: Request shutdown from each teammate**
@@ -605,7 +605,7 @@ Tmux CLI workers run in dedicated tmux panes with filesystem access. They are **
 **Key difference from Claude teammates:**
 
 - CLI workers operate via tmux, not Claude Code's tool system
-- They cannot use TaskList/TaskUpdate/SendMessage (no team awareness)
+- They cannot use Claude Code's native task-list or team messaging surfaces
 - They run as one-shot autonomous jobs, not persistent teammates
 - The lead manages their lifecycle (spawn, monitor, collect results)
 
@@ -620,7 +620,7 @@ Tmux CLI workers run in dedicated tmux panes with filesystem access. They are **
 | UI/frontend implementation       | designer Claude agent          | Design expertise, framework idioms                  |
 | Large-scale documentation        | writer Claude agent            | Writing expertise + large context for consistency   |
 | Build/test iteration loops       | Claude teammate                | Needs Bash tool + iterative fix cycles              |
-| Tasks needing team coordination  | Claude teammate                | Needs SendMessage for status updates                |
+| Tasks needing team coordination  | Claude teammate                | Needs team/conversation status updates              |
 
 ### Example: Hybrid Team with CLI Workers
 
@@ -649,7 +649,7 @@ This is especially useful when the task scope is unclear and benefits from exter
 
 ## Monitor Enhancement: Outbox Auto-Ingestion
 
-The lead can proactively ingest outbox messages from CLI workers using the outbox reader utilities, enabling event-driven monitoring without relying solely on `SendMessage` delivery.
+The lead can proactively ingest outbox messages from CLI workers using the outbox reader utilities, enabling event-driven monitoring alongside native team/conversation delivery.
 
 ### Outbox Reader Functions
 
@@ -705,30 +705,30 @@ if (status.taskSummary.pending === 0 && status.taskSummary.inProgress === 0) {
 | `shutdown_ack`  | Worker acknowledged shutdown -- safe to remove from team                                    |
 | `heartbeat`     | Update liveness tracking (redundant with heartbeat files but useful for latency monitoring) |
 
-This approach complements the existing `SendMessage`-based communication by providing a pull-based mechanism for MCP workers that cannot use Claude Code's team messaging tools.
+This approach complements native team/conversation messaging by providing a pull-based mechanism for MCP workers that cannot use Claude Code's team messaging tools.
 
 ## Error Handling
 
 ### Teammate Fails a Task
 
-1. Teammate sends `SendMessage` to lead reporting the failure
+1. Teammate reports the failure to the lead through the active team/conversation surface
 2. Lead decides: retry (reassign same task to same or different worker) or skip
-3. To reassign: `TaskUpdate` to set new owner, then `SendMessage` to the new owner
+3. To reassign: update the active task-list entry with the new owner, then message the new owner through the active team surface
 
 ### Teammate Gets Stuck (No Messages)
 
-1. Lead detects via `TaskList` -- task stuck in `in_progress` for too long
-2. Lead sends `SendMessage` to the teammate asking for status
+1. Lead detects via TodoWrite or the active task-list surface -- task stuck in `in_progress` for too long
+2. Lead messages the teammate asking for status through the active team surface
 3. If no response, consider the teammate dead
-4. Reassign the task to another worker via `TaskUpdate`
+4. Reassign the task to another worker through the active task-list surface
 
 ### Dependency Blocked
 
 1. If a blocking task fails, the lead must decide whether to:
    - Retry the blocker
-   - Remove the dependency (`TaskUpdate` with modified blockedBy)
+   - Remove the dependency by updating the active task-list entry's `blockedBy` metadata
    - Skip the blocked task entirely
-2. Communicate decisions to affected teammates via `SendMessage`
+2. Communicate decisions to affected teammates through the active team surface
 
 ### Teammate Crashes
 
@@ -825,7 +825,7 @@ This prevents duplicate worker spawns and allows graceful recovery from lead fai
 The `/oh-my-claudecode:cancel` skill handles team cleanup:
 
 1. Read team state via `state_read(mode="team")` to get `team_name` and `linked_ralph`
-2. Send `shutdown_request` to all active named teammates
+2. Request shutdown from all active named teammates through the active team surface
 3. Wait for `shutdown_response` from each (15s timeout per member)
 4. Clear state via `state_clear(mode="team")`
 5. If `linked_ralph` is true, also clear ralph: `state_clear(mode="ralph")`
@@ -880,7 +880,7 @@ Optional settings live in `.claude/omc.jsonc` (project) or `~/.config/claude-omc
 
 - **ops.maxAgents** - Maximum teammates (default: 20)
 - **ops.defaultAgentType** - CLI provider when a `/team` invocation does not specify one (`claude` | `codex` | `gemini` | `grok` | `cursor`, default: `claude`)
-- **ops.monitorIntervalMs** - How often to poll `TaskList` (default: 30s)
+- **ops.monitorIntervalMs** - How often to review TodoWrite or the active task-list surface (default: 30s)
 - **ops.shutdownTimeoutMs** - How long to wait for shutdown responses (default: 15s)
 
 > **Note:** Team members do not have a hardcoded model default. Each teammate is a separate Claude Code session that inherits the user's configured model. Since teammates can spawn their own subagents, the session model acts as the orchestration layer while subagents can use any model tier.
@@ -948,7 +948,7 @@ Precedence: `OMC_TEAM_ROLE_OVERRIDES` > `.claude/omc.jsonc` (project) > `~/.conf
 
 ### Fallback when a CLI is missing
 
-If the CLI for a configured provider is absent from `PATH` at spawn time, `buildLaunchArgs()` throws, the team lead emits a visible `SendMessage` warning, and the runtime falls back to a deterministic Claude assignment pre-computed by `buildResolvedRoutingSnapshot` (same tier + same agent, `provider: "claude"`). Fallback is loud by design — silent fallback is a test failure. Probe provider availability with `omc doctor --team-routing`.
+If the CLI for a configured provider is absent from `PATH` at spawn time, `buildLaunchArgs()` throws, the team lead emits a visible team/conversation warning, and the runtime falls back to a deterministic Claude assignment pre-computed by `buildResolvedRoutingSnapshot` (same tier + same agent, `provider: "claude"`). Fallback is loud by design — silent fallback is a test failure. Probe provider availability with `omc doctor --team-routing`.
 
 ### Stickiness — resolved once, reused everywhere
 
@@ -1010,7 +1010,7 @@ MCP workers can operate in isolated git worktrees to prevent file conflicts betw
 
 ## Gotchas
 
-1. **Internal/lifecycle task entries may pollute TaskList** -- If Claude Code reports internal lifecycle entries for spawned teammates, filter them when counting real task progress. The subject of an internal task is often the teammate's name.
+1. **Internal/lifecycle task entries may pollute task-list output** -- If Claude Code reports internal lifecycle entries for spawned teammates, filter them when counting real task progress. The subject of an internal task is often the teammate's name.
 
 2. **No atomic claiming** -- Unlike SQLite swarm, native task-list/TodoWrite state does not provide transactional claiming. Two teammates could race to claim the same task. **Mitigation:** The lead should pre-assign owners before spawning teammates. Teammates should only work on tasks assigned to them.
 
@@ -1030,7 +1030,7 @@ MCP workers can operate in isolated git worktrees to prevent file conflicts betw
 
 10. **Broadcast is expensive** -- Each broadcast sends a separate message to every teammate. Use `message` (DM) by default. Only broadcast for truly team-wide critical alerts.
 
-11. **CLI workers are one-shot, not persistent** -- Tmux CLI workers have full filesystem access and CAN make code changes. However, they run as autonomous one-shot jobs -- they cannot use TaskList/TaskUpdate/SendMessage. The lead must manage their lifecycle: write prompt_file, spawn CLI worker, read output_file, mark task complete. They don't participate in team communication like Claude teammates do.
+11. **CLI workers are one-shot, not persistent** -- Tmux CLI workers have full filesystem access and CAN make code changes. However, they run as autonomous one-shot jobs -- they cannot use Claude Code's native task-list or team messaging surfaces. The lead must manage their lifecycle: write prompt_file, spawn CLI worker, read output_file, mark task complete. They don't participate in team communication like Claude teammates do.
 
 ## Parallel session caveats
 

--- a/src/__tests__/cleanup-orphans-unref.test.ts
+++ b/src/__tests__/cleanup-orphans-unref.test.ts
@@ -39,6 +39,18 @@ describe('scripts/cleanup-orphans.mjs — SIGKILL escalation timer must not bloc
     expect(src).toMatch(pattern);
   });
 
+  it('does not use removed native team config as an orphan signal', () => {
+    expect(src).not.toContain('teamConfigExists');
+    expect(src).not.toContain('getClaudeConfigDir');
+    expect(src).not.toContain("teams', name, 'config.json");
+  });
+
+  it('frames output around stale workers instead of deleted TeamDelete configs', () => {
+    expect(src).toContain('No stale OMC worker processes found');
+    expect(src).toContain('stale worker(s)');
+    expect(src).not.toContain('active team configs');
+  });
+
   it('main() ends with an explicit process.exit(0)', () => {
     // The last line of main() before the closing brace must be process.exit(0);
     // We check that the success-path JSON print is followed by process.exit(0)

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -317,7 +317,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
 
   // === Team-routing enforcement tests (issue #1006) ===
 
-  it('injects team-routing redirect when Task called without team_name during active team session', () => {
+  it('injects team-routing redirect when Task called without teammate name during active team session', () => {
     const sessionId = 'session-1006';
     writeJson(
       join(tempDir, '.omc', 'state', 'sessions', sessionId, 'team-state.json'),
@@ -343,10 +343,13 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(output.continue).toBe(true);
     expect(hookSpecificOutput.additionalContext).toContain('TEAM ROUTING REQUIRED');
     expect(hookSpecificOutput.additionalContext).toContain('fix-ts-errors');
-    expect(hookSpecificOutput.additionalContext).toContain('team_name=');
+    expect(hookSpecificOutput.additionalContext).toContain('name="worker-N"');
+    expect(hookSpecificOutput.additionalContext).toContain('TeamCreate and TeamDelete are removed');
+    expect(hookSpecificOutput.additionalContext).toContain('team_name for routing');
+    expect(hookSpecificOutput.additionalContext).toContain('ignored legacy metadata');
   });
 
-  it('does NOT inject team-routing redirect when Task called WITH team_name', () => {
+  it('does NOT inject team-routing redirect when Task called WITH teammate name', () => {
     const sessionId = 'session-1006b';
     writeJson(
       join(tempDir, '.omc', 'state', 'sessions', sessionId, 'team-state.json'),
@@ -361,7 +364,6 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
       tool_name: 'Task',
       toolInput: {
         subagent_type: 'oh-my-claudecode:executor',
-        team_name: 'fix-ts-errors',
         name: 'worker-1',
         description: 'Fix type errors',
         prompt: 'Fix all type errors in src/auth/',

--- a/src/hooks/autopilot/__tests__/pipeline.test.ts
+++ b/src/hooks/autopilot/__tests__/pipeline.test.ts
@@ -131,7 +131,11 @@ describe('Stage Adapters', () => {
         config: { ...DEFAULT_PIPELINE_CONFIG, execution: 'team' },
       });
       expect(prompt).toContain('Team Mode');
-      expect(prompt).toContain('TeamCreate');
+      expect(prompt).toContain('implicit agent team');
+      expect(prompt).toContain('name="worker-1"');
+      expect(prompt).not.toContain('with TeamCreate');
+      expect(prompt).not.toContain('TaskCreate');
+      expect(prompt).not.toContain('Task with `team_name`');
       expect(prompt).toContain(EXECUTION_COMPLETION_SIGNAL);
       expect(prompt).toContain('short execution summary under 100 words');
     });
@@ -519,7 +523,7 @@ describe('autopilot team CLI worker configuration', () => {
     expect(prompt).not.toContain('test-engineer` with');
   });
 
-  it('keeps native TeamCreate guidance for Claude-only team execution', () => {
+  it('uses implicit-team guidance for Claude-only team execution', () => {
     const prompt = executionAdapter.getPrompt({
       idea: 'test',
       directory: '/tmp',
@@ -530,8 +534,12 @@ describe('autopilot team CLI worker configuration', () => {
       },
     });
 
-    expect(prompt).toContain('TeamCreate');
-    expect(prompt).toContain('team_name');
+    expect(prompt).toContain('implicit team');
+    expect(prompt).toContain('name="worker-1"');
+    expect(prompt).toContain('ignored legacy metadata');
+    expect(prompt).not.toContain('with TeamCreate');
+    expect(prompt).not.toContain('TaskCreate');
+    expect(prompt).not.toContain('Task with `team_name`');
     expect(prompt).not.toContain('CLI Team Runtime Required');
   });
 });

--- a/src/hooks/autopilot/adapters/execution-adapter.ts
+++ b/src/hooks/autopilot/adapters/execution-adapter.ts
@@ -91,7 +91,7 @@ export const executionAdapter: PipelineStageAdapter = {
     if (isTeam) {
       const teamRuntimeGuidance = useCliTeamRuntime
         ? getCliTeamRuntimeGuidance(requestedAgentTypes, planPath)
-        : `Use the Team orchestrator to execute tasks in parallel:`;
+        : `Use Claude Code's implicit agent team to execute tasks in parallel:`;
       return `## PIPELINE STAGE: EXECUTION (Team Mode)
 
 Execute the implementation plan using multi-worker team execution.
@@ -108,10 +108,10 @@ ${useCliTeamRuntime ? `1. **Launch CLI executor workers** with \`omc team\` or \
 2. **Decompose executor-style implementation tasks** from the implementation plan and pass them to CLI workers.
 3. **Monitor tmux/team output** and integrate completed implementation changes.
 4. **Keep review/critic/security/verdict work native**; do not assign those roles to Cursor/CLI workers.
-5. **Coordinate** dependencies between tasks.` : `1. **Create team** with TeamCreate
-2. **Create tasks** from the implementation plan using TaskCreate
-3. **Spawn executor teammates** using Task with \`team_name\` parameter
-4. **Monitor progress** as teammates complete tasks
+5. **Coordinate** dependencies between tasks.` : `1. **Use the implicit team** provided by Claude Code when \`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1\` is enabled; do not call removed \`TeamCreate\`/\`TeamDelete\` tools.
+2. **Track work in TodoWrite or the active task list** from the implementation plan.
+3. **Spawn executor teammates directly** with the Agent/Task tool using distinct \`name\` values (for example, \`name="worker-1"\`). Do not rely on \`team_name\`; Claude Code 2.1.178+ accepts it only as ignored legacy metadata.
+4. **Monitor progress** as teammates complete tasks.
 5. **Coordinate** dependencies between tasks.`}
 
 ### Output Contract


### PR DESCRIPTION
## Summary
- Update autopilot team execution prompts for Claude Code 2.1.178+ implicit-team behavior.
- Replace stale native TeamCreate/TeamDelete/team_name routing guidance in team/cancel/setup docs.
- Keep legacy OMC tmux/CLI team semantics distinct and preserve omc team / /omc-teams behavior.

Fixes #3301.

## Verification
- npm ci
- npm run test:run -- src/hooks/autopilot/__tests__/pipeline.test.ts src/__tests__/pre-tool-enforcer.test.ts
- npx tsc --noEmit

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*