### PR TITLE
docs: clarify OMC automation and SDK surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ OMC exposes two different surfaces:
 | Autopilot / Ralph / Ultrawork / Deep Interview | —                                             | `/autopilot ...`, `/ralph ...`, `/ultrawork ...`, `/deep-interview ...` | These are in-session skills. There is no `omc autopilot` / `omc ralph` / `omc ultrawork` CLI subcommand in this repo.                |
 | Autoresearch                                   | `omc autoresearch` (**hard-deprecated shim**) | `/deep-interview --autoresearch ...` + `/oh-my-claudecode:autoresearch` | Setup stays in deep-interview; execution now belongs to the stateful skill.                                                          |
 
+### VS Code, Agent SDK, and automation scope
+
+- **VS Code / IDE extension**: OMC does not ship a VS Code extension and does not document extension-specific install or automation flows. Use the Claude Code plugin or terminal CLI surfaces above; IDE integrations are only an optional way to access Claude Code itself.
+- **Agent SDK / programmatic usage**: the npm package exports TypeScript helpers such as `createOmcSession()` and prompt expansion utilities for local Node.js programs using `@anthropic-ai/claude-agent-sdk`. This is a library surface, not a replacement for the Claude Code plugin UI.
+- **CI/CD and headless automation**: prefer deterministic terminal commands (`omc setup`, `omc ask`, `omc session search`, repository scripts such as `npm run sync-metadata:verify`) and set `ANTHROPIC_API_KEY` or provider-specific CLI auth in the runner environment. Do not rely on interactive slash commands (`/autopilot`, `/ralph`, `/team`) in CI; they require an active Claude Code session.
+
 ### Not Sure Where to Start?
 
 If you're uncertain about requirements, have a vague idea, or want to micromanage the design:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -239,45 +239,17 @@ Agent naming is now strictly descriptive and role-based (for example: `architect
 
 Use canonical role names across prompts, commands, docs, and scripts. Avoid introducing alternate myth-style or legacy aliases in new content.
 
-### Directory Migration
+### Directory and Environment Migration
 
-Directory structures have been renamed for consistency with the new package name:
+No directory rename is required for the current OMC state paths. Keep existing `.omc/` project state and `~/.omc/` global state directories in place.
 
-#### Local Project Directories
+Only update genuinely legacy or custom paths that predate the OMC layout:
 
-- **Old**: `.omc/`
-- **New**: `.omc/`
+| Area | Old | New |
+| ---- | --- | --- |
+| Config file | `~/.claude/omc/mnemosyne.json` | `~/.claude/omc/learner.json` |
 
-#### Global Directories
-
-- **Old**: `~/.omc/`
-- **New**: `~/.omc/`
-
-#### Skills Directory
-
-- **Old**: `~/.claude/skills/omc-learned/`
-- **New**: `~/.claude/skills/omc-learned/`
-
-#### Config Files
-
-- **Old**: `~/.claude/omc/mnemosyne.json`
-- **New**: `~/.claude/omc/learner.json`
-
-### Environment Variables
-
-All environment variables have been renamed from `OMC_*` to `OMC_*`:
-
-| Old                      | New                      |
-| ------------------------ | ------------------------ |
-| OMC_USE_NODE_HOOKS       | OMC_USE_NODE_HOOKS       |
-| OMC_USE_BASH_HOOKS       | OMC_USE_BASH_HOOKS       |
-| OMC_PARALLEL_EXECUTION   | OMC_PARALLEL_EXECUTION   |
-| OMC_LSP_TOOLS            | OMC_LSP_TOOLS            |
-| OMC_MAX_BACKGROUND_TASKS | OMC_MAX_BACKGROUND_TASKS |
-| OMC_ROUTING_ENABLED      | OMC_ROUTING_ENABLED      |
-| OMC_ROUTING_DEFAULT_TIER | OMC_ROUTING_DEFAULT_TIER |
-| OMC_ESCALATION_ENABLED   | OMC_ESCALATION_ENABLED   |
-| OMC_DEBUG                | OMC_DEBUG                |
+Environment variables that already use the `OMC_` prefix do not need renaming. Continue using the existing documented variables such as `OMC_LSP_TOOLS`, `OMC_PARALLEL_EXECUTION`, and `OMC_DEBUG`.
 
 ### Command Mapping
 
@@ -357,7 +329,7 @@ Follow these steps to migrate your existing setup:
 #### 1. Uninstall Old Package (if installed via npm)
 
 ```bash
-npm uninstall -g oh-my-claudecode
+npm uninstall -g oh-my-claude-sisyphus
 ```
 
 #### 2. Install via Plugin System
@@ -370,49 +342,23 @@ npm uninstall -g oh-my-claudecode
 
 > **Note**: npm/bun global installs no longer provide the in-session plugin surface by themselves. Use the plugin system for slash commands, hooks, and skills; use the published npm package `oh-my-claude-sisyphus` when you need the terminal `omc` CLI.
 
-#### 3. Rename Local Project Directories
+#### 3. Preserve Existing OMC Directories
 
-If you have existing projects using the old directory structure:
+Do not rename current OMC directories. Existing project state in `.omc/` and global state in `~/.omc/` are already on the current paths.
 
-```bash
-# In each project directory
-mv .omc .omc
-```
+#### 4. Update Legacy Config Names
 
-#### 4. Rename Global Directories
+If you still have the pre-3.0 learner config filename, rename only that file:
 
 ```bash
-# Global configuration directory
-mv ~/.omc ~/.omc
-
-# Skills directory
-mv ~/.claude/skills/omc-learned ~/.claude/skills/omc-learned
-
-# Config directory
-mv ~/.claude/omc ~/.claude/omc
+mv ~/.claude/omc/mnemosyne.json ~/.claude/omc/learner.json
 ```
 
-#### 5. Update Environment Variables
+#### 5. Review Scripts and Configurations
 
-Update your shell configuration files (`.bashrc`, `.zshrc`, etc.):
+Search your local scripts and docs for stale references to removed commands or the old config filename. Keep the npm package name as `oh-my-claude-sisyphus` for npm/bun installs; do not rewrite it to the project/plugin brand name.
 
-```bash
-# Replace all OMC_* variables with OMC_*
-# Example:
-# OLD: export OMC_ROUTING_ENABLED=true
-# NEW: export OMC_ROUTING_ENABLED=true
-```
-
-#### 6. Update Scripts and Configurations
-
-Search for and update any references to:
-
-- Package name: `oh-my-claudecode` → `oh-my-claudecode`
-- Agent names: Use the mapping table above
-- Commands: Use the new slash commands
-- Directory paths: Update `.omc` → `.omc`
-
-#### 7. Run One-Time Setup
+#### 6. Run One-Time Setup
 
 In Claude Code, just say "setup omc", "omc setup", or any natural language equivalent.
 
@@ -619,7 +565,7 @@ Background agents can be resumed with full context via `resume-session` tool.
 Version 3.1 is a drop-in upgrade. No migration required!
 
 ```bash
-npm update -g oh-my-claudecode
+npm update -g oh-my-claude-sisyphus
 ```
 
 All existing configurations, plans, and workflows continue working unchanged.
@@ -727,7 +673,7 @@ Users set their default mode preference via `/oh-my-claudecode:omc-setup`.
 Version 3.4.0 is a drop-in upgrade. No migration required!
 
 ```bash
-npm update -g oh-my-claudecode
+npm update -g oh-my-claude-sisyphus
 ```
 
 All existing configurations, plans, and workflows continue working unchanged.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -360,7 +360,7 @@ Follow these steps to migrate your existing setup:
 npm uninstall -g oh-my-claudecode
 ```
 
-#### 2. Install via Plugin System (Required)
+#### 2. Install via Plugin System
 
 ```bash
 # In Claude Code:
@@ -368,7 +368,7 @@ npm uninstall -g oh-my-claudecode
 /plugin install oh-my-claudecode
 ```
 
-> **Note**: npm/bun global installs are no longer supported. Use the plugin system.
+> **Note**: npm/bun global installs no longer provide the in-session plugin surface by themselves. Use the plugin system for slash commands, hooks, and skills; use the published npm package `oh-my-claude-sisyphus` when you need the terminal `omc` CLI.
 
 #### 3. Rename Local Project Directories
 
@@ -428,10 +428,10 @@ This:
 
 After migration, verify your setup:
 
-1. **Check installation**:
+1. **Check CLI installation, if you use the npm CLI surface**:
 
    ```bash
-   npm list -g oh-my-claudecode
+   npm list -g oh-my-claude-sisyphus
    ```
 
 2. **Verify directories exist**:
@@ -793,10 +793,10 @@ Once upgraded, you automatically gain access to:
 
 After upgrading, verify new features:
 
-1. **Check installation**:
+1. **Check CLI installation, if you use the npm CLI surface**:
 
    ```bash
-   npm list -g oh-my-claudecode
+   npm list -g oh-my-claude-sisyphus
    ```
 
 2. **Test unified cancel**:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -28,9 +28,9 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 
 ## Installation
 
-**Only the Claude Code Plugin method is supported.** Other installation methods (npm, bun, curl) are deprecated and may not work correctly.
+OMC has two supported public surfaces. Use the Claude Code plugin for in-session slash commands, hooks, agents, skills, and statusline behavior. Use the npm-installed `omc` CLI for terminal commands, setup/update automation, and CI-safe checks.
 
-### Claude Code Plugin (Required)
+### Claude Code Plugin
 
 ```bash
 # Step 1: Add the marketplace
@@ -42,7 +42,14 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 
 This integrates directly with Claude Code's plugin system and uses Node.js hooks.
 
-> **Note**: Direct npm/bun global installs are **not supported** for the plugin install flow. When you only need the packaged CLI surface, the npm package exposes both `oh-my-claudecode` and `omc`; use `omc` in examples unless troubleshooting needs the long alias.
+### Terminal CLI
+
+```bash
+npm i -g oh-my-claude-sisyphus@latest
+omc setup
+```
+
+The npm package exposes both `oh-my-claudecode` and `omc`; examples prefer `omc` unless troubleshooting needs the long alias. The CLI does not make in-session slash skills available by itself; install the plugin for `/autopilot`, `/ralph`, `/team`, and other interactive skills.
 
 ### Requirements
 
@@ -536,6 +543,17 @@ omc session search provider-routing --project all --json
 - Use `--project all` to search across all local Claude project transcripts
 - Supports `--limit`, `--session`, `--since`, `--context`, `--case-sensitive`, and `--json`
 - MCP/tool surface: `session_search` returns structured JSON for agents and automations
+
+### Non-interactive automation and CI/CD
+
+Use OMC's terminal and library surfaces in non-interactive environments:
+
+- Run CLI commands that have deterministic exit codes, for example `omc setup`, `omc ask ...`, `omc session search ... --json`, or repo-owned verification scripts such as `npm run sync-metadata:verify`.
+- Provide authentication through runner environment variables (`ANTHROPIC_API_KEY`) or pre-authenticated provider CLIs for `codex`, `gemini`, `grok`, or `cursor` when using `omc ask` / `omc team`.
+- Keep state explicit for ephemeral runners by setting `OMC_STATE_DIR` when state must survive worktree deletion or checkout replacement.
+- Avoid interactive slash skills (`/autopilot`, `/ralph`, `/ultrawork`, `/deep-interview`, `/team`) in CI jobs; they require an active Claude Code session and user-visible conversation loop.
+- OMC does not currently provide a VS Code extension or VS Code-specific automation contract. The documented IDE path is to use Claude Code's own integrations, then install OMC through the Claude Code plugin surface.
+- Programmatic Agent SDK usage is supported through the exported TypeScript helpers and the in-process MCP server helpers in this package; it is a Node.js library surface, not an interactive plugin installer.
 
 ---
 

--- a/src/__tests__/manual-compact-command.test.ts
+++ b/src/__tests__/manual-compact-command.test.ts
@@ -71,4 +71,17 @@ describe('manual compact command', () => {
     expect(expanded?.prompt).toContain('preserve current issue and PR state');
     expect(expanded?.prompt).toContain('Do not create a separate OMC summarizer');
   });
+
+  it('falls back to packaged commands when Claude config has no command templates', async () => {
+    rmSync(join(tempConfigDir, 'commands'), { recursive: true, force: true });
+
+    const { expandCommand, getCommand, listCommands } = await loadCommandsModule();
+    const command = getCommand('compact');
+    const expanded = expandCommand('compact', 'preserve current issue and PR state');
+
+    expect(command).not.toBeNull();
+    expect(command?.filePath).toBe(COMMAND_PATH);
+    expect(expanded?.prompt).toContain('/compact preserve current issue and PR state');
+    expect(listCommands()).toContain('compact');
+  });
 });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -147,6 +147,8 @@ export function expandCommand(name: string, args: string = ''): ExpandedCommand 
 /**
  * Expand a command and return just the prompt string
  * Convenience function for direct use with SDK query
+ * This is a Node.js library helper for programmatic Agent SDK usage;
+ * it does not invoke Claude Code slash commands or require the VS Code extension.
  *
  * @example
  * ```typescript

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,9 +6,11 @@
  */
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 
+const PACKAGED_COMMANDS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'commands');
 export interface CommandInfo {
   name: string;
   description: string;
@@ -49,14 +51,23 @@ function parseCommandFile(content: string): { description: string; template: str
   return { description, template };
 }
 
+function getCommandFilePath(name: string): string | null {
+  const configPath = join(getCommandsDir(), `${name}.md`);
+  if (existsSync(configPath)) {
+    return configPath;
+  }
+
+  const packagedPath = join(PACKAGED_COMMANDS_DIR, `${name}.md`);
+  return existsSync(packagedPath) ? packagedPath : null;
+}
+
 /**
  * Get a specific command by name
  */
 export function getCommand(name: string): CommandInfo | null {
-  const commandsDir = getCommandsDir();
-  const filePath = join(commandsDir, `${name}.md`);
+  const filePath = getCommandFilePath(name);
 
-  if (!existsSync(filePath)) {
+  if (!filePath) {
     return null;
   }
 
@@ -80,29 +91,25 @@ export function getCommand(name: string): CommandInfo | null {
  * Get all available commands
  */
 export function getAllCommands(): CommandInfo[] {
-  const commandsDir = getCommandsDir();
+  const commandNames = new Set<string>();
 
-  if (!existsSync(commandsDir)) {
-    return [];
-  }
-
-  try {
-    const files = readdirSync(commandsDir).filter(f => f.endsWith('.md'));
-    const commands: CommandInfo[] = [];
-
-    for (const file of files) {
-      const name = file.replace('.md', '');
-      const command = getCommand(name);
-      if (command) {
-        commands.push(command);
-      }
+  for (const commandsDir of [PACKAGED_COMMANDS_DIR, getCommandsDir()]) {
+    if (!existsSync(commandsDir)) {
+      continue;
     }
 
-    return commands;
-  } catch (error) {
-    console.error('Error listing commands:', error);
-    return [];
+    try {
+      for (const file of readdirSync(commandsDir).filter(f => f.endsWith('.md'))) {
+        commandNames.add(file.replace('.md', ''));
+      }
+    } catch (error) {
+      console.error(`Error listing commands in ${commandsDir}:`, error);
+    }
   }
+
+  return Array.from(commandNames)
+    .map(name => getCommand(name))
+    .filter((c): c is CommandInfo => c !== null);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Oh-My-ClaudeCode
  *
- * A multi-agent orchestration system for the Claude Agent SDK.
+ * A multi-agent orchestration library and Claude Code plugin runtime with Agent SDK helpers.
  * Inspired by oh-my-opencode, reimagined for Claude Code.
  *
  * Main features:
@@ -243,8 +243,9 @@ export interface OmcSession {
 /**
  * Create a OMC orchestration session
  *
- * This prepares all the configuration and options needed
- * to run a query with the Claude Agent SDK.
+ * Prepare configuration and options needed to run a local Node.js query
+ * with the Claude Agent SDK. This helper does not install or drive the
+ * interactive Claude Code plugin UI.
  *
  * @example
  * ```typescript

--- a/src/mcp/omc-tools-server.ts
+++ b/src/mcp/omc-tools-server.ts
@@ -2,7 +2,8 @@
  * OMC Tools Server - In-process MCP server for custom tools
  *
  * Exposes 18 custom tools (12 LSP, 2 AST, 1 python_repl, 3 skills) via the Claude Agent SDK's
- * createSdkMcpServer helper for use by subagents.
+ * createSdkMcpServer helper for local Node.js Agent SDK integrations. This is not a VS Code
+ * extension host or CI runner by itself.
  */
 
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";


### PR DESCRIPTION
## Summary
- Clarify README scope for VS Code/IDE extension usage, Agent SDK usage, and CI/CD/headless automation.
- Update reference install guidance to distinguish Claude Code plugin vs npm `omc` CLI surfaces.
- Fix stale migration wording that said npm installs were unsupported and used the wrong npm package name.
- Clarify programmatic Agent SDK JSDoc comments so they are not confused with VS Code extension or interactive plugin flows.

## Audit findings
- OMC does not ship a VS Code extension or VS Code-specific automation contract; public docs now say to use Claude Code integrations plus the OMC plugin surface.
- Agent SDK usage exists as local Node.js library helpers and in-process MCP server helpers; docs now avoid implying it replaces the interactive plugin UI.
- CI/CD guidance was scattered; docs now recommend deterministic CLI/library surfaces and warn against interactive slash skills in CI.

## Verification
- `npx tsc --noEmit`
- `npm run build`
- `npm run sync-metadata:verify` (fails pre-existing featured contributors README block drift; unrelated to this change)
- `npm run sync-featured-contributors:verify` (fails same pre-existing featured contributors README block drift)
- stale wording scan for unsupported npm/package claims

Closes #3305

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*