### PR TITLE
test: cover Claude Code plugin MCP package surface

### DIFF
--- a/src/__tests__/npm-package-hook-surface.test.ts
+++ b/src/__tests__/npm-package-hook-surface.test.ts
@@ -6,6 +6,7 @@ import { dirname, join, normalize, relative } from 'node:path';
 const PACKAGE_ROOT = process.cwd();
 const HOOKS_JSON_PATH = join(PACKAGE_ROOT, 'hooks', 'hooks.json');
 const PLUGIN_JSON_PATH = join(PACKAGE_ROOT, '.claude-plugin', 'plugin.json');
+const MCP_JSON_PATH = join(PACKAGE_ROOT, '.mcp.json');
 const SCRIPTS_ROOT = join(PACKAGE_ROOT, 'scripts');
 
 type HookCommandConfig = {
@@ -28,6 +29,7 @@ type NpmPackDryRunResult = {
 
 type PluginJson = {
   hooks?: unknown;
+  mcpServers?: unknown;
 };
 
 function referencesStandardHooksManifest(value: unknown): boolean {
@@ -45,6 +47,62 @@ function referencesStandardHooksManifest(value: unknown): boolean {
   }
 
   return false;
+}
+
+function referencesRootMcpConfig(value: unknown): boolean {
+  if (typeof value === 'string') {
+    const normalized = value.replace(/\\/g, '/');
+    return normalized === './.mcp.json' || normalized === '.mcp.json';
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(referencesRootMcpConfig);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).some(referencesRootMcpConfig);
+  }
+
+  return false;
+}
+
+type McpServerConfig = {
+  command?: unknown;
+  args?: unknown;
+};
+
+type McpJson = {
+  mcpServers?: Record<string, McpServerConfig>;
+};
+
+function listPluginMcpRuntimeFiles(): string[] {
+  const pluginJson = JSON.parse(readFileSync(PLUGIN_JSON_PATH, 'utf-8')) as PluginJson;
+  expect(referencesRootMcpConfig(pluginJson.mcpServers)).toBe(true);
+
+  const mcpJson = JSON.parse(readFileSync(MCP_JSON_PATH, 'utf-8')) as McpJson;
+  const runtimeFiles = new Set<string>();
+
+  for (const server of Object.values(mcpJson.mcpServers ?? {})) {
+    expect(server.command).toBe('node');
+    expect(Array.isArray(server.args)).toBe(true);
+
+    if (!Array.isArray(server.args)) {
+      continue;
+    }
+
+    for (const arg of server.args) {
+      if (typeof arg !== 'string') {
+        continue;
+      }
+
+      const match = arg.match(/^\$\{CLAUDE_PLUGIN_ROOT\}\/(.+)$/);
+      if (match) {
+        runtimeFiles.add(match[1]);
+      }
+    }
+  }
+
+  return [...runtimeFiles].sort();
 }
 
 const LOCAL_IMPORT_RE = /(?:import\s+(?:[^'"()]+?\s+from\s+)?|import\s*\(|export\s+\*\s+from\s+|export\s+\{[^}]*\}\s+from\s+|require\s*\()\s*['"](\.[^'"]+)['"]/g;
@@ -144,6 +202,17 @@ describe('npm package hook surface regression', () => {
     expect(packedFiles.has('dist/hooks/skill-bridge.cjs')).toBe(true);
     expect(packedFiles.has('bridge/cli.cjs')).toBe(true);
     expect(packedFiles.has('.claude-plugin/plugin.json')).toBe(true);
+  });
+
+  it('packs the public plugin MCP config and referenced runtime files', () => {
+    const packedFiles = getPackedFiles();
+    const runtimeFiles = listPluginMcpRuntimeFiles();
+
+    expect(packedFiles.has('.mcp.json')).toBe(true);
+    expect(runtimeFiles).toEqual(['bridge/mcp-server.cjs']);
+
+    const missing = runtimeFiles.filter(file => !packedFiles.has(file));
+    expect(missing).toEqual([]);
   });
 
   it('packs hooks.json, hook entry scripts, and their local script dependencies', () => {


### PR DESCRIPTION
## Summary
- Adds focused deterministic coverage for the public Claude Code plugin MCP package surface.
- Verifies `.claude-plugin/plugin.json` advertises root `./.mcp.json`.
- Verifies root `.mcp.json` uses `${CLAUDE_PLUGIN_ROOT}` to reference `bridge/mcp-server.cjs`, and `npm pack --dry-run --json` includes both `.mcp.json` and that runtime file.

## Public evidence / gap
- Official Claude Code plugin docs describe plugin-root components including `.claude-plugin/plugin.json`, `hooks/hooks.json`, and root `.mcp.json`.
- Official MCP docs describe plugin-provided MCP servers and `${CLAUDE_PLUGIN_ROOT}` for bundled plugin files.
- OmC exposes this surface through `.claude-plugin/plugin.json`, `.mcp.json`, `bridge/mcp-server.cjs`, and `package.json.files`.
- Existing CI already ran Vitest and npm pack/install, but did not tie the plugin manifest's MCP pointer to the packed MCP runtime surface.

Closes #3309.

## Verification
- `npm test -- --run src/__tests__/npm-package-hook-surface.test.ts src/__tests__/mcp-default-config.test.ts`
- `npx tsc --noEmit`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*