### PR TITLE
docs: clarify psmux Windows team caveats

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -147,7 +147,7 @@ This loads agents, skills, and commands directly from your checkout without copy
 | Linux | Claude Code Plugin | Bash (.sh) |
 | Windows | WSL2 recommended | Node.js (.mjs) |
 
-> ℹ️ **Note:** Native Windows support is experimental. For tmux-backed Team workers, OMC checks for a tmux-compatible binary first; native [psmux](https://github.com/psmux/psmux) is supported, and WSL2 remains the fallback when no compatible tmux is available.
+> ℹ️ **Note:** Native Windows support is experimental. For tmux-backed Team workers, OMC checks for a tmux-compatible binary first; native [psmux](https://github.com/psmux/psmux) is supported for PowerShell 7+ users who want visible Claude Code teammate panes in interactive team workflows. WSL2 remains the fallback when no compatible tmux is available or native Windows behavior is insufficient. psmux does not force worktree agents, non-interactive/print-mode agents, or model-selected in-process agents into visible panes.
 
 ### Updates
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1008,7 +1008,7 @@ stopomc
 
 > **Note**: Bash hooks are fully portable across macOS and Linux (no GNU-specific dependencies).
 
-> **Windows**: Native Windows (win32) support is experimental. Features that launch tmux-backed worker panes require a tmux-compatible binary. OMC supports native [psmux](https://github.com/psmux/psmux) when available and recommends WSL2 as the fallback when no compatible `tmux` command is installed. Native Windows issues may have limited support.
+> **Windows**: Native Windows (win32) support is experimental. Features that launch tmux-backed worker panes require a tmux-compatible binary. OMC supports native [psmux](https://github.com/psmux/psmux) for PowerShell 7+ users who want visible Claude Code teammate panes in interactive team workflows, and recommends WSL2 as the fallback when no compatible `tmux` command is installed or native Windows behavior is insufficient. psmux does not force worktree agents, non-interactive/print-mode agents, or model-selected in-process agents into visible panes. Native Windows issues may have limited support.
 
 > **Advanced**: Set `OMC_USE_NODE_HOOKS=1` to use Node.js hooks on macOS/Linux.
 


### PR DESCRIPTION
## Summary
- Clarifies native Windows psmux guidance for PowerShell 7+ users who want visible Claude Code teammate panes in interactive team workflows.
- Preserves WSL2 fallback wording when no compatible tmux command is installed or native Windows behavior is insufficient.
- Adds explicit caveats that psmux does not force worktree agents, non-interactive/print-mode agents, or model-selected in-process agents into visible panes.

## Verification
- Targeted psmux/reference search across README.md, docs/GETTING-STARTED.md, and docs/REFERENCE.md
- `npm run compose-docs`
- `git diff --check`
- Architect review: CLEAR / APPROVE
- Executor QA/red-team: passed

Closes #3311

*[repo owner's gaebal-gajae (clawdbot) 🦞]*