### PR TITLE
Clarify .omc state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ Wrap handler at server.py:42 in try/except ClientDisconnectedError...
 
 Project-scoped OMC-authored skills are stored in `.omc/skills/` and are intended to be committed when you want them shared. During slash/skill execution OMC also reads Claude Code workspace skills from `.claude/skills/` and compatibility skills from `.agents/skills/`, so existing workspace-local `SKILL.md` packages remain callable without copying them into user-global skills. If you create project-local skills inside a linked git worktree and do not commit them, they disappear when that worktree is removed.
 
+### `.omc/` state and git
+
+OMC writes runtime state, session data, plans, logs, handoffs, research notes, and local artifacts under `.omc/` by default. The repository `.gitignore` keeps that runtime data local with one intentional exception: `.omc/skills/**` remains committable for project-scoped skills you want to share with the team. Treat everything else under `.omc/` as local operational state that may contain prompts, transcripts, or machine-specific paths.
+
+For linked git worktrees, the default `.omc/` directory lives inside that worktree, so deleting the worktree deletes its local OMC state. Set `OMC_STATE_DIR` if you want state to survive worktree deletion, or add a `.omc-workspace` marker when several independent repos should share one parent-level state root. See [OMC state, gitignore, worktree, and workspace contract](docs/REFERENCE.md#omc-state-gitignore-worktree-and-workspace-contract).
+
 [Full feature list →](docs/REFERENCE.md)
 
 ### Multi-repo workspaces

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -55,7 +55,7 @@ Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
 </cancellation>
 
 <worktree_paths>
-State: `.omc/state/`, `.omc/state/sessions/{sessionId}/`, `.omc/notepad.md`, `.omc/project-memory.json`, `.omc/plans/`, `.omc/research/`, `.omc/logs/`
+State root: `.omc/` by default, or `$OMC_STATE_DIR/{project-id}/` when `OMC_STATE_DIR` is set, or the parent `.omc/` when a `.omc-workspace` marker anchors a multi-repo workspace. Runtime state includes `.omc/state/`, `.omc/state/sessions/{sessionId}/`, `.omc/notepad.md`, `.omc/project-memory.json`, `.omc/plans/`, `.omc/research/`, `.omc/logs/`, `.omc/artifacts/`, `.omc/handoffs/`, and `.omc/ultragoal/`. These are ignored operational artifacts by default; `.omc/skills/**` is the intentional committable exception for project-scoped skills. In linked git worktrees, local `.omc/` state is removed with the worktree unless centralized via `OMC_STATE_DIR`.
 </worktree_paths>
 
 ## Setup

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -135,6 +135,29 @@ This resolves to `~/.claude/omc/{project-identifier}/` where the project identif
 
 If both a legacy `{worktree}/.omc/` directory and a centralized directory exist, OMC logs a notice and uses the centralized directory. You can then migrate data from the legacy directory and remove it.
 
+#### OMC state, gitignore, worktree, and workspace contract
+
+OMC's project-local state root is `.omc/` unless `OMC_STATE_DIR` or `.omc-workspace` changes the root resolution described below. The default root contains runtime and audit artifacts such as:
+
+- `.omc/state/` and `.omc/state/sessions/{sessionId}/` — mode state, session-scoped state, replay markers, and recovery metadata.
+- `.omc/notepad.md` and `.omc/project-memory.json` — local session notes and project memory.
+- `.omc/plans/`, `.omc/research/`, `.omc/logs/`, `.omc/artifacts/`, `.omc/handoffs/`, and `.omc/ultragoal/` — generated plans, research outputs, logs, advisor artifacts, team handoffs, and ultragoal ledgers.
+- `.omc/team/` — opt-in native team worker worktrees when team worktree mode creates them.
+- `.omc/skills/` — the only project-local `.omc` subtree intended to be committed when the team wants to share OMC-authored skills.
+
+Git handling is intentionally conservative. The repository `.gitignore` keeps `.omc/` itself visible, ignores `.omc/*`, and then re-includes `.omc/skills/` plus `.omc/skills/**`. That means generated state stays untracked by default, while project skills can be reviewed and committed explicitly. Do not force-add runtime `.omc` files unless you are deliberately attaching a sanitized artifact to an issue or test fixture; runtime state can include prompts, transcripts, absolute paths, machine identifiers, and workflow history.
+
+Worktree behavior follows the resolved state root:
+
+- **Default single repo / monorepo**: `getOmcRoot()` uses the git toplevel, so every package below one git root shares `{repo}/.omc/`.
+- **Linked git worktrees**: without `OMC_STATE_DIR`, each linked worktree has its own `{worktree}/.omc/`; removing that worktree removes its local OMC state. Re-run setup from the worktree you are actively using so installed hooks and generated instructions match that checkout.
+- **Persistent state across worktree deletion**: set `OMC_STATE_DIR`; OMC writes to `$OMC_STATE_DIR/{project-id}/`, where the project id is stable across linked worktrees when a remote or primary git dir is available.
+- **Multi-repo workspace**: add `.omc-workspace` to a non-git parent when independent sibling repos should share `{parent}/.omc/`. This is for multi-repo workspaces, not ordinary monorepos.
+
+Plan persistence follows the same rule. Default generated plans under `.omc/plans/` are local operational artifacts and are ignored. If a plan should become durable project documentation, move it to a tracked docs path or configure `planOutput.directory` to a reviewed directory such as `docs/plans`; keep machine-local session state in `.omc/`.
+
+Cleanup rule of thumb: after OMC sessions are stopped, it is safe to delete ignored runtime subtrees such as `.omc/state/`, `.omc/logs/`, `.omc/artifacts/`, `.omc/research/`, or `.omc/ultragoal/` if you no longer need their recovery/audit history. Do not delete `.omc/skills/` unless you intend to remove project-scoped skills.
+
 #### Multi-repo workspaces with `.omc-workspace`
 
 When you have several independent git repos under one parent directory and the parent itself is **not** a git repo, OMC cannot infer a shared root via `git rev-parse --show-toplevel`. Each sub-repo would get its own isolated `.omc/`. To anchor a single `.omc/` at the parent, drop a `.omc-workspace` marker file there:

--- a/src/__tests__/omc-state-gitignore-contract.test.ts
+++ b/src/__tests__/omc-state-gitignore-contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+describe('.omc gitignore state contract', () => {
+  it('ignores runtime .omc state while allowing project skills to be committed intentionally', () => {
+    const gitignore = readFileSync(resolve(process.cwd(), '.gitignore'), 'utf-8')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    expect(gitignore).toEqual(expect.arrayContaining([
+      '!.omc/',
+      '.omc/*',
+      '!.omc/skills/',
+      '!.omc/skills/**',
+    ]));
+
+    expect(gitignore.indexOf('!.omc/')).toBeLessThan(gitignore.indexOf('.omc/*'));
+    expect(gitignore.indexOf('.omc/*')).toBeLessThan(gitignore.indexOf('!.omc/skills/'));
+    expect(gitignore.indexOf('!.omc/skills/')).toBeLessThan(gitignore.indexOf('!.omc/skills/**'));
+  });
+});


### PR DESCRIPTION
## Summary
- Document the `.omc/` runtime-state contract in README and REFERENCE.
- Clarify the `.gitignore` rule: runtime `.omc/*` stays local, while `.omc/skills/**` is the intentional committable exception.
- Clarify worktree, `OMC_STATE_DIR`, monorepo, `.omc-workspace`, plan persistence, and cleanup expectations.
- Add a regression test that locks the `.gitignore` ordering for the `.omc/skills/**` exception.

## Verification
- `npm test -- --run src/__tests__/omc-state-gitignore-contract.test.ts`
- `npm run lint -- src/__tests__/omc-state-gitignore-contract.test.ts` (passes with pre-existing repo warnings only)
- `git diff --check`
- `npm run compose-docs`

Closes #3313

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
