### PR TITLE
fix(persistent-mode): break stuck autopilot loops and stop amplifying benign command exits

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -1127,6 +1127,18 @@ async function main() {
 
     if (autopilot.state?.active && !isAwaitingConfirmation(autopilot.state) && !isStaleState(autopilot.state) && isSessionMatch(autopilot.state, sessionId)) {
       const phase = getAutopilotPhase(autopilot.state);
+      // Circuit breaker: a healthy autopilot always carries a real phase. A
+      // state still stuck in "unspecified" after several reinforcements is an
+      // orphaned / never-initialized run; self-deactivate instead of looping.
+      if (phase === "unspecified" && (autopilot.state.reinforcement_count || 0) >= 3) {
+        autopilot.state.active = false;
+        autopilot.state.phase = "complete";
+        autopilot.state.cleanup_reason = "auto-deactivated: stuck in unspecified phase";
+        autopilot.state.last_checked_at = new Date().toISOString();
+        try { writeJsonFile(autopilot.path, autopilot.state); } catch {}
+        console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+        return;
+      }
       if (phase !== "complete") {
         const newCount = (autopilot.state.reinforcement_count || 0) + 1;
         if (newCount <= 20) {

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -1137,6 +1137,21 @@ async function main() {
         : !autopilot.state.session_id || autopilot.state.session_id === sessionId;
       if (sessionMatches) {
         const phase = getAutopilotPhase(autopilot.state);
+        // Circuit breaker: a healthy autopilot always carries a real phase
+        // (expansion/planning/execution/qa/validation). A state still stuck in
+        // "unspecified" after several reinforcements is an orphaned / never-
+        // initialized run (e.g. a cwd vs project_path mismatch left the real
+        // state file unreachable, so completion was written elsewhere). Self-
+        // deactivate it instead of force-looping all the way to the cap of 20.
+        if (phase === "unspecified" && (autopilot.state.reinforcement_count || 0) >= 3) {
+          autopilot.state.active = false;
+          autopilot.state.phase = "complete";
+          autopilot.state.cleanup_reason = "auto-deactivated: stuck in unspecified phase";
+          autopilot.state.last_checked_at = new Date().toISOString();
+          try { writeJsonFile(autopilot.path, autopilot.state); } catch {}
+          console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+          return;
+        }
         if (phase !== "complete") {
           const newCount = (autopilot.state.reinforcement_count || 0) + 1;
           if (newCount <= 20) {

--- a/scripts/post-tool-use-failure.mjs
+++ b/scripts/post-tool-use-failure.mjs
@@ -80,6 +80,37 @@ function shouldSuppressFilesystemScanPermissionNoise(toolName, toolInput, error)
   return nonNoiseLines.length === 0;
 }
 
+// Suppress benign, non-actionable command outcomes that should never be
+// amplified into "[TOOL ERROR - RETRY REQUIRED]" by the Stop hook:
+//   - intentional process termination (pkill/kill)
+//   - git "not a repository" probes (e.g. `git -C / rev-parse`)
+//   - search/probe misses where a path simply does not exist
+// These are normal control-flow exits, not failures the agent must retry.
+function shouldSuppressBenignToolOutcome(toolName, toolInput, error) {
+  if (String(toolName || '').toLowerCase() !== 'bash') {
+    return false;
+  }
+  const command = getToolInputCommand(toolInput).trim();
+  const err = String(error || '');
+
+  if (/\b(?:pkill|kill)\b/.test(command)) {
+    return true;
+  }
+
+  if (/\bgit\b/.test(command) && /not a git repository/i.test(err)) {
+    return true;
+  }
+
+  if (
+    /\b(?:grep|rg|ugrep|find|ls|cat|stat|test)\b/.test(command) &&
+    /no such file or directory/i.test(err)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 // Validate that targetPath is contained within basePath (prevent path traversal)
 function isPathContained(targetPath, basePath) {
   const normalizedTarget = resolve(targetPath);
@@ -215,6 +246,11 @@ async function main() {
     }
 
     if (shouldSuppressFilesystemScanPermissionNoise(toolName, toolInput, error)) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    if (shouldSuppressBenignToolOutcome(toolName, toolInput, error)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -942,6 +942,18 @@ async function main() {
         : !autopilot.state.session_id || autopilot.state.session_id === sessionId;
       if (sessionMatches) {
         const phase = autopilot.state.phase || "unspecified";
+        // Circuit breaker: a healthy autopilot always carries a real phase. A
+        // state still stuck in "unspecified" after several reinforcements is an
+        // orphaned / never-initialized run; self-deactivate instead of looping.
+        if (phase === "unspecified" && (autopilot.state.reinforcement_count || 0) >= 3) {
+          autopilot.state.active = false;
+          autopilot.state.phase = "complete";
+          autopilot.state.cleanup_reason = "auto-deactivated: stuck in unspecified phase";
+          autopilot.state.last_checked_at = new Date().toISOString();
+          try { writeJsonFile(autopilot.path, autopilot.state); } catch {}
+          console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+          return;
+        }
         if (phase !== "complete") {
           const newCount = (autopilot.state.reinforcement_count || 0) + 1;
           if (newCount <= 20) {


### PR DESCRIPTION
## Problem

Two Stop-hook behaviors can force a session to loop indefinitely — burning tokens and re-running already-complete work. I hit this in a real autopilot run that kept being force-continued after the task was done.

### 1. Autopilot can get stuck in `phase: "unspecified"`
The Stop hook (`persistent-mode`) force-continues whenever an autopilot state is `active` and `phase !== "complete"`. A healthy autopilot always carries a real phase (`expansion`/`planning`/`execution`/`qa`/`validation`). But an **orphaned / never-initialized** state can sit in `"unspecified"` forever.

The trigger I observed: the agent's working directory differed from the autopilot's `project_path`, so its `/cancel` and `state_write` calls resolved to the *wrong* `.omc` tree and never deactivated the authoritative state file. The hook then reinforced every turn up to the cap of 20 — each turn re-emitting `[AUTOPILOT - Phase: unspecified] Autopilot not complete`.

### 2. Benign command exits are amplified into mandatory retries
Every non-zero Bash exit is written to `last-tool-error.json` and re-injected by the Stop hook as `[TOOL ERROR - RETRY REQUIRED]`. Normal control-flow exits get treated as failures the agent must retry:
- `pkill`/`kill` cleanup (exit 144)
- `git ... rev-parse` "not a git repository" probes (exit 128)
- `grep`/`find`/`ls` "No such file or directory" misses (exit 2)

## Fix

1. **Circuit breaker** (`scripts/persistent-mode.{mjs,cjs}`, `templates/hooks/persistent-mode.mjs`): if `phase === "unspecified"` after `>= 3` reinforcements, self-deactivate the state and allow the stop instead of looping. A correctly-running autopilot reaches a real phase well before the 3rd reinforcement, so this only fires for stuck/orphaned states.

2. **`shouldSuppressBenignToolOutcome()`** (`scripts/post-tool-use-failure.mjs`): skip recording the benign outcomes above. Genuine failures (build errors, etc.) are still captured and still nudge the agent.

## Verification
- Stuck `"unspecified"` state → stops and self-deactivates ✓
- Healthy `"execution"`-phase state → still blocks (no regression) ✓
- Benign `git`/`pkill`/`grep` exits → not recorded; real `npm run build` failure → still recorded ✓
- All touched scripts pass `node --check` ✓

## Note
`templates/hooks/post-tool-use-failure.mjs` is a divergent minimal copy lacking the `getToolInputCommand`/`shouldSuppress*` helpers, so the benign-suppression change is applied only to `scripts/`. Happy to extend it there too if that template is still shipped, and to add regression tests in the suite if you point me at the preferred harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
