### PR TITLE
Design hook-backed workflow drift enforcement

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,10 +1,10 @@
 # Hooks System
 
-> OMC's 20 hooks intercept Claude Code lifecycle events to enable magic keywords, context injection, and quality enforcement.
+> OMC's 21 hooks intercept Claude Code lifecycle events to enable magic keywords, context injection, and quality enforcement.
 
 ## What Are Hooks?
 
-Hooks are scripts that execute automatically in response to Claude Code lifecycle events. oh-my-claudecode extends Claude Code's default behavior with 20 hooks.
+Hooks are scripts that execute automatically in response to Claude Code lifecycle events. oh-my-claudecode extends Claude Code's default behavior with 21 hooks.
 
 When a user submits a prompt, a tool runs, or a session starts/ends, hooks fire automatically to inject additional context, activate modes, and manage state.
 
@@ -68,6 +68,7 @@ Handle code quality, permissions, and subagent tracking.
 | permission-handler | Handles permission requests and validation |
 | subagent-tracker | Tracks subagent spawn and completion |
 | code-simplifier | Auto-simplifies recently modified files on Stop (opt-in) |
+| workflow-drift-guard | Blocks only deterministic Stop-hook workflow drift: structured-question drift and fake completion with changed-code TODO/stub/skipped-test blockers |
 
 ## Disabling Hooks
 
@@ -193,6 +194,7 @@ Fires when Claude finishes a response.
 | Script | Role | Timeout |
 |--------|------|---------|
 | `context-guard-stop.mjs` | Monitors context usage | 5s |
+| `workflow-drift-guard.mjs` | Blocks narrow structured-question and fake-completion drift | 3s |
 | `persistent-mode.cjs` | Maintains active mode state (ralph, ultrawork, etc.) | 10s |
 | `code-simplifier.mjs` | Auto-simplifies modified files (opt-in) | 5s |
 
@@ -224,6 +226,17 @@ Detects magic keywords in user prompts and invokes the corresponding skill.
 - **Safety**: Disabled inside team workers to prevent infinite spawning
 
 See the [Magic Keywords](#magic-keywords) section for the full keyword list.
+
+
+#### workflow-drift-guard
+
+Blocks only deterministic recurring workflow drift at the Claude Code `Stop` lifecycle point. The boundary follows the official Claude Code [hooks reference](https://code.claude.com/docs/en/hooks): Stop hooks receive `last_assistant_message`, may return `decision: "block"` with a `reason`, and must account for `stop_hook_active` to avoid self-reinforcing loops. Plugin/Hookify installs follow the official Claude Code [plugins reference](https://code.claude.com/docs/en/plugins-reference): plugin hooks can live in `hooks/hooks.json` at the plugin root and respond to the same lifecycle events as user hooks.
+
+- **Event**: Stop
+- **Behavior**: Blocks when the final assistant message ends with a narrow preference/approval question that should be asked via structured `AskUserQuestion`; the reason tells Claude to use 2-4 options and keep `allowOther` enabled unless free-form input is unsafe.
+- **Fake completion guard**: Blocks only when the final assistant message claims completion and changed code adds deterministic blockers (`test.skip`/`.only`, placeholder TODOs, unimplemented throws, placeholder returns, or explicit stub/placeholder implementations).
+- **Allowed cases**: Free-form/`Other` question wording is allowed; TODO/stub markers are allowed while the assistant is not claiming completion; `stop_hook_active` fails open to avoid hook loops.
+- **Minimal safe boundary**: Worktree/session continuity remains SessionStart guidance plus existing mode-state restoration because a generic Stop hook cannot safely infer that the assistant is in the wrong branch or has lost context without overblocking valid work.
 
 #### persistent-mode
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -868,7 +868,7 @@ Key contract points:
 
 ## Hooks System
 
-OMC registers 20 hook scripts across 11 Claude Code lifecycle events. For detailed documentation, see [HOOKS.md](./HOOKS.md).
+OMC registers 21 hook scripts across 11 Claude Code lifecycle events. For detailed documentation, see [HOOKS.md](./HOOKS.md).
 
 ### Hooks by Lifecycle Event
 
@@ -883,7 +883,7 @@ OMC registers 20 hook scripts across 11 Claude Code lifecycle events. For detail
 | **SubagentStart**      | `subagent-tracker.mjs start`                                                                                      | 3s               |
 | **SubagentStop**       | `subagent-tracker.mjs stop`, `verify-deliverables.mjs`                                                            | 5s, 5s           |
 | **PreCompact**         | `pre-compact.mjs`, `project-memory-precompact.mjs`                                                                | 10s, 5s          |
-| **Stop**               | `context-guard-stop.mjs`, `persistent-mode.cjs`, `code-simplifier.mjs`                                            | 5s, 10s, 5s      |
+| **Stop**               | `context-guard-stop.mjs`, `workflow-drift-guard.mjs`, `persistent-mode.cjs`, `code-simplifier.mjs`                | 5s, 3s, 10s, 5s  |
 | **SessionEnd**         | `session-end.mjs`                                                                                                 | 30s              |
 
 > **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills** (activated via keyword-detector), not hooks. The `persistent-mode.cjs` hook enforces their continuation by blocking the Stop event.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -180,6 +180,11 @@
           },
           {
             "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/workflow-drift-guard.mjs",
+            "timeout": 3
+          },
+          {
+            "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/persistent-mode.mjs",
             "timeout": 10
           },

--- a/scripts/workflow-drift-guard.mjs
+++ b/scripts/workflow-drift-guard.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * OMC Workflow Drift Guard Stop hook.
+ *
+ * Boundary source: https://code.claude.com/docs/en/hooks documents Stop
+ * hooks with last_assistant_message and decision:"block";
+ * https://code.claude.com/docs/en/plugins-reference documents plugin
+ * hooks/hooks.json loading and the shared lifecycle events.
+ * This guard uses only deterministic Stop-hook signals and intentionally
+ * fails open for ambiguous/free-form cases.
+ */
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { extname, join } from 'path';
+const { readStdin } = await import(new URL('./lib/stdin.mjs', import.meta.url));
+
+const HOOK_NAME = 'workflow-drift-guard';
+const CODE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts', '.py', '.sh', '.bash', '.zsh', '.go', '.rs', '.java', '.kt', '.kts', '.swift', '.rb', '.php', '.cs', '.c', '.cc', '.cpp', '.h', '.hpp']);
+const COMPLETION_CLAIM_RE = /\b(?:done|complete[sd]?|finished|implemented|fixed|resolved|all set|ready\s+(?:for\s+(?:review|merge|release|qa|testing)|to\s+(?:merge|ship|release|submit)))\b/i;
+const QUESTION_END_RE = /\?\s*(?:[\])}"'`]*\s*)?$/;
+const STRUCTURED_CHOICE_RE = /\b(?:should i|would you like me to|do you want me to|which (?:option|approach|path)|choose|pick|select|approve|proceed)\b/i;
+const FREE_FORM_RE = /\b(?:free[- ]?form|other|provide(?: me)? (?:the )?exact|what exact|paste|send me|enter|type|tell me|describe|explain)\b/i;
+const BLOCKER_PATTERNS = [
+  { kind: 'skipped test', pattern: /\b(?:it|test|describe)\.skip\s*\(/i },
+  { kind: 'focused test', pattern: /\b(?:it|test|describe)\.only\s*\(/i },
+  { kind: 'placeholder TODO', pattern: /\bTODO\b(?:\([^)]*\))?\s*:?\s*(?:implement|fix|replace|stub|placeholder|later|follow[- ]?up|wire|add\b|fill)/i },
+  { kind: 'unimplemented throw', pattern: /throw\s+new\s+Error\s*\(\s*["'`](?:TODO|Not implemented|unimplemented|stub)/i },
+  { kind: 'placeholder return', pattern: /\breturn\s+(?:null|undefined)\s*;?\s*\/\/\s*(?:TODO|stub|placeholder|not implemented)/i },
+  { kind: 'placeholder implementation', pattern: /\b(?:stub|placeholder|not implemented|unimplemented)\s+(?:implementation|branch|path|test|coverage)\b/i },
+];
+
+function skippedByEnv() {
+  if (process.env.DISABLE_OMC === '1' || process.env.DISABLE_OMC === 'true') return true;
+  return (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim()).includes(HOOK_NAME);
+}
+
+function safeJsonParse(text) {
+  try { return JSON.parse(text || '{}'); } catch { return {}; }
+}
+
+function lastAssistantMessage(input) {
+  for (const key of ['last_assistant_message', 'lastAssistantMessage', 'message', 'output', 'response', 'text']) {
+    const value = input?.[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
+}
+
+function isCodePath(path) {
+  return CODE_EXTENSIONS.has(extname(path).toLowerCase());
+}
+
+function git(cwd, args) {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 });
+  } catch { return ''; }
+}
+
+function changedCodePaths(cwd) {
+  const names = new Set();
+  for (const line of git(cwd, ['diff', '--name-only', 'HEAD', '--']).split('\n')) {
+    const path = line.trim();
+    if (path && isCodePath(path)) names.add(path);
+  }
+  for (const line of git(cwd, ['ls-files', '--others', '--exclude-standard']).split('\n')) {
+    const path = line.trim();
+    if (path && isCodePath(path)) names.add(path);
+  }
+  return [...names];
+}
+
+function addedLinesForPath(cwd, path) {
+  const diff = git(cwd, ['diff', '--unified=0', 'HEAD', '--', path]);
+  if (diff) {
+    const added = [];
+    let newLine = 0;
+    for (const line of diff.split('\n')) {
+      const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunk) {
+        newLine = Number.parseInt(hunk[1], 10);
+        continue;
+      }
+      if (line.startsWith('+++') || line.startsWith('---') || newLine === 0) continue;
+      if (line.startsWith('+')) {
+        added.push({ lineNumber: newLine, text: line.slice(1) });
+        newLine += 1;
+      } else if (!line.startsWith('-')) {
+        newLine += 1;
+      }
+    }
+    return added;
+  }
+  const fullPath = join(cwd, path);
+  if (!existsSync(fullPath)) return [];
+  try {
+    return readFileSync(fullPath, 'utf8')
+      .split('\n')
+      .map((text, index) => ({ lineNumber: index + 1, text }));
+  } catch { return []; }
+}
+
+function stripQuotedAndRegexLiterals(line) {
+  let result = '';
+  let quote = '';
+  let escaped = false;
+  let inRegex = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const prev = line[index - 1] || '';
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = '';
+      }
+      result += ' ';
+      continue;
+    }
+    if (inRegex) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '/') {
+        inRegex = false;
+      }
+      result += ' ';
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      result += ' ';
+      continue;
+    }
+    if (char === '/' && prev !== '/' && prev !== '*' && /[=(:,\[]/.test(prev.trim() || '=')) {
+      inRegex = true;
+      result += ' ';
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+function blockerScanText(text) {
+  const stripped = stripQuotedAndRegexLiterals(text);
+  const commentIndex = stripped.indexOf('//');
+  if (commentIndex >= 0) return stripped.slice(commentIndex);
+  return stripped;
+}
+
+function findCompletionBlockers(cwd) {
+  const blockers = [];
+  for (const path of changedCodePaths(cwd)) {
+    const lines = addedLinesForPath(cwd, path);
+    lines.forEach(({ lineNumber, text }) => {
+      const scanText = blockerScanText(text);
+      for (const { kind, pattern } of BLOCKER_PATTERNS) {
+        if (pattern.test(scanText)) {
+          blockers.push({ path, line: lineNumber, kind, text: text.trim().slice(0, 160) });
+          break;
+        }
+      }
+    });
+  }
+  return blockers.slice(0, 8);
+}
+
+function shouldBlockProseQuestion(message) {
+  if (!QUESTION_END_RE.test(message)) return false;
+  if (!STRUCTURED_CHOICE_RE.test(message)) return false;
+  if (FREE_FORM_RE.test(message)) return false;
+  return true;
+}
+
+function makeBlock(reason) {
+  return { decision: 'block', reason };
+}
+
+async function main() {
+  if (skippedByEnv()) {
+    console.log(JSON.stringify({ suppressOutput: true }));
+    return;
+  }
+  const input = safeJsonParse(await readStdin());
+  // Claude Code docs warn Stop hooks receive stop_hook_active while already
+  // continuing from a Stop hook; fail open to avoid self-reinforcing loops.
+  if (input.stop_hook_active === true || input.stopHookActive === true) {
+    console.log(JSON.stringify({ suppressOutput: true }));
+    return;
+  }
+
+  const message = lastAssistantMessage(input);
+  if (shouldBlockProseQuestion(message)) {
+    console.log(JSON.stringify(makeBlock('[WORKFLOW DRIFT GUARD] The final response ends with a preference/approval question that should be asked with structured AskUserQuestion. Continue by calling AskUserQuestion with 2-4 options and keep allowOther enabled unless free-form input is unsafe.')));
+    return;
+  }
+
+  const cwd = typeof input.cwd === 'string' ? input.cwd : (typeof input.directory === 'string' ? input.directory : process.cwd());
+  if (message && COMPLETION_CLAIM_RE.test(message)) {
+    const blockers = findCompletionBlockers(cwd);
+    if (blockers.length > 0) {
+      const details = blockers.map(b => `${b.path}:${b.line} ${b.kind} — ${b.text}`).join('\n');
+      console.log(JSON.stringify(makeBlock(`[WORKFLOW DRIFT GUARD] Completion was claimed while changed code still contains TODO/stub/skipped-test blockers. Resolve them or explicitly report the blocker instead of claiming completion.\n${details}`)));
+      return;
+    }
+  }
+
+  console.log(JSON.stringify({ suppressOutput: true }));
+}
+
+main().catch((error) => {
+  console.error(`[workflow-drift-guard] ${error instanceof Error ? error.message : String(error)}`);
+  console.log(JSON.stringify({ suppressOutput: true }));
+});

--- a/src/hooks/__tests__/workflow-drift-guard-script.test.ts
+++ b/src/hooks/__tests__/workflow-drift-guard-script.test.ts
@@ -1,0 +1,164 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = join(process.cwd(), 'scripts', 'workflow-drift-guard.mjs');
+
+function runGuard(input: Record<string, unknown>, env: Record<string, string> = {}) {
+  const output = execFileSync(process.execPath, [SCRIPT], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return JSON.parse(output) as { decision?: string; reason?: string; suppressOutput?: boolean };
+}
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'omc-workflow-drift-'));
+  execFileSync('git', ['init'], { cwd: dir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: dir });
+  writeFileSync(join(dir, 'index.ts'), 'export const ok = true;\n');
+  execFileSync('git', ['add', '.'], { cwd: dir });
+  execFileSync('git', ['commit', '-m', 'init'], { cwd: dir, stdio: 'ignore' });
+  return dir;
+}
+
+describe('workflow-drift-guard Stop hook', () => {
+
+  it('is registered only on the Stop hook event', () => {
+    const manifest = JSON.parse(readFileSync(join(process.cwd(), 'hooks', 'hooks.json'), 'utf8')) as {
+      hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+    };
+
+    const events = Object.entries(manifest.hooks)
+      .filter(([, groups]) => groups.some((group) => group.hooks?.some((hook) => hook.command?.includes('workflow-drift-guard.mjs'))))
+      .map(([event]) => event);
+
+    expect(events).toEqual(['Stop']);
+  });
+
+  it('blocks prose approval questions that should use AskUserQuestion', () => {
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'I found two viable paths. Which approach should I take?',
+      cwd: process.cwd(),
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('AskUserQuestion');
+    expect(result.reason).toContain('allowOther');
+  });
+
+  it('allows valid Other/free-form user input questions', () => {
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Please choose PostgreSQL, SQLite, or Other/free-form?',
+      cwd: process.cwd(),
+    });
+
+    expect(result.decision).toBeUndefined();
+    expect(result.suppressOutput).toBe(true);
+  });
+
+  it('blocks completion claims when changed code adds skipped tests', () => {
+    const cwd = makeRepo();
+    writeFileSync(join(cwd, 'index.test.ts'), "import { test } from 'vitest';\ntest.skip('covers the edge case', () => {});\n");
+
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Implemented and complete.',
+      cwd,
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('skipped test');
+    expect(result.reason).toContain('index.test.ts');
+  });
+
+
+
+  it('allows ready-to-continue wording while work is not being claimed complete', () => {
+    const cwd = makeRepo();
+    writeFileSync(join(cwd, 'index.ts'), 'export function next() {\n  // TODO: implement follow-up\n  return 1;\n}\n');
+
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'I am ready to continue after checking the next step.',
+      cwd,
+    });
+
+    expect(result.decision).toBeUndefined();
+    expect(result.suppressOutput).toBe(true);
+  });
+
+  it('reports real file line numbers for tracked-file blockers', () => {
+    const cwd = makeRepo();
+    writeFileSync(join(cwd, 'index.ts'), [
+      'export const ok = true;',
+      '',
+      'export function later() {',
+      '  const value = 1;',
+      '  return value;',
+      '  // TODO: implement blocker',
+      '}',
+    ].join('\n'));
+
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Implemented and complete.',
+      cwd,
+    });
+
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('index.ts:6');
+  });
+
+  it('allows TODO blockers while work is not being claimed complete', () => {
+    const cwd = makeRepo();
+    writeFileSync(join(cwd, 'index.ts'), 'export function next() {\n  // TODO: implement follow-up\n  return 1;\n}\n');
+
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'I found the next implementation step and will continue after checking tests.',
+      cwd,
+    });
+
+    expect(result.decision).toBeUndefined();
+    expect(result.suppressOutput).toBe(true);
+  });
+
+
+
+  it('allows detector and test fixture literals that mention blocker patterns', () => {
+    const cwd = makeRepo();
+    writeFileSync(join(cwd, 'fixtures.ts'), [
+      'const regex = /\\b(?:stub|placeholder|not implemented|unimplemented)\\b/i;',
+      'const sampleTodo = "// TODO: implement fixture";',
+      'const skippedTestFixture = "test.skip(\'covers fixture\', () => {})";',
+    ].join('\n'));
+
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Implemented and complete.',
+      cwd,
+    });
+
+    expect(result.decision).toBeUndefined();
+    expect(result.suppressOutput).toBe(true);
+  });
+
+  it('fails open when already continuing from a Stop hook', () => {
+    const result = runGuard({
+      hook_event_name: 'Stop',
+      stop_hook_active: true,
+      last_assistant_message: 'Complete, but which approach should I take?',
+      cwd: process.cwd(),
+    });
+
+    expect(result.decision).toBeUndefined();
+    expect(result.suppressOutput).toBe(true);
+  });
+});

--- a/templates/hooks/workflow-drift-guard.mjs
+++ b/templates/hooks/workflow-drift-guard.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * OMC Workflow Drift Guard Stop hook.
+ *
+ * Boundary source: https://code.claude.com/docs/en/hooks documents Stop
+ * hooks with last_assistant_message and decision:"block";
+ * https://code.claude.com/docs/en/plugins-reference documents plugin
+ * hooks/hooks.json loading and the shared lifecycle events.
+ * This guard uses only deterministic Stop-hook signals and intentionally
+ * fails open for ambiguous/free-form cases.
+ */
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { extname, join } from 'path';
+const { readStdin } = await import(new URL('./lib/stdin.mjs', import.meta.url));
+
+const HOOK_NAME = 'workflow-drift-guard';
+const CODE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.mts', '.cts', '.py', '.sh', '.bash', '.zsh', '.go', '.rs', '.java', '.kt', '.kts', '.swift', '.rb', '.php', '.cs', '.c', '.cc', '.cpp', '.h', '.hpp']);
+const COMPLETION_CLAIM_RE = /\b(?:done|complete[sd]?|finished|implemented|fixed|resolved|all set|ready\s+(?:for\s+(?:review|merge|release|qa|testing)|to\s+(?:merge|ship|release|submit)))\b/i;
+const QUESTION_END_RE = /\?\s*(?:[\])}"'`]*\s*)?$/;
+const STRUCTURED_CHOICE_RE = /\b(?:should i|would you like me to|do you want me to|which (?:option|approach|path)|choose|pick|select|approve|proceed)\b/i;
+const FREE_FORM_RE = /\b(?:free[- ]?form|other|provide(?: me)? (?:the )?exact|what exact|paste|send me|enter|type|tell me|describe|explain)\b/i;
+const BLOCKER_PATTERNS = [
+  { kind: 'skipped test', pattern: /\b(?:it|test|describe)\.skip\s*\(/i },
+  { kind: 'focused test', pattern: /\b(?:it|test|describe)\.only\s*\(/i },
+  { kind: 'placeholder TODO', pattern: /\bTODO\b(?:\([^)]*\))?\s*:?\s*(?:implement|fix|replace|stub|placeholder|later|follow[- ]?up|wire|add\b|fill)/i },
+  { kind: 'unimplemented throw', pattern: /throw\s+new\s+Error\s*\(\s*["'`](?:TODO|Not implemented|unimplemented|stub)/i },
+  { kind: 'placeholder return', pattern: /\breturn\s+(?:null|undefined)\s*;?\s*\/\/\s*(?:TODO|stub|placeholder|not implemented)/i },
+  { kind: 'placeholder implementation', pattern: /\b(?:stub|placeholder|not implemented|unimplemented)\s+(?:implementation|branch|path|test|coverage)\b/i },
+];
+
+function skippedByEnv() {
+  if (process.env.DISABLE_OMC === '1' || process.env.DISABLE_OMC === 'true') return true;
+  return (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim()).includes(HOOK_NAME);
+}
+
+function safeJsonParse(text) {
+  try { return JSON.parse(text || '{}'); } catch { return {}; }
+}
+
+function lastAssistantMessage(input) {
+  for (const key of ['last_assistant_message', 'lastAssistantMessage', 'message', 'output', 'response', 'text']) {
+    const value = input?.[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
+}
+
+function isCodePath(path) {
+  return CODE_EXTENSIONS.has(extname(path).toLowerCase());
+}
+
+function git(cwd, args) {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 });
+  } catch { return ''; }
+}
+
+function changedCodePaths(cwd) {
+  const names = new Set();
+  for (const line of git(cwd, ['diff', '--name-only', 'HEAD', '--']).split('\n')) {
+    const path = line.trim();
+    if (path && isCodePath(path)) names.add(path);
+  }
+  for (const line of git(cwd, ['ls-files', '--others', '--exclude-standard']).split('\n')) {
+    const path = line.trim();
+    if (path && isCodePath(path)) names.add(path);
+  }
+  return [...names];
+}
+
+function addedLinesForPath(cwd, path) {
+  const diff = git(cwd, ['diff', '--unified=0', 'HEAD', '--', path]);
+  if (diff) {
+    const added = [];
+    let newLine = 0;
+    for (const line of diff.split('\n')) {
+      const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunk) {
+        newLine = Number.parseInt(hunk[1], 10);
+        continue;
+      }
+      if (line.startsWith('+++') || line.startsWith('---') || newLine === 0) continue;
+      if (line.startsWith('+')) {
+        added.push({ lineNumber: newLine, text: line.slice(1) });
+        newLine += 1;
+      } else if (!line.startsWith('-')) {
+        newLine += 1;
+      }
+    }
+    return added;
+  }
+  const fullPath = join(cwd, path);
+  if (!existsSync(fullPath)) return [];
+  try {
+    return readFileSync(fullPath, 'utf8')
+      .split('\n')
+      .map((text, index) => ({ lineNumber: index + 1, text }));
+  } catch { return []; }
+}
+
+function stripQuotedAndRegexLiterals(line) {
+  let result = '';
+  let quote = '';
+  let escaped = false;
+  let inRegex = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const prev = line[index - 1] || '';
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = '';
+      }
+      result += ' ';
+      continue;
+    }
+    if (inRegex) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '/') {
+        inRegex = false;
+      }
+      result += ' ';
+      continue;
+    }
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      result += ' ';
+      continue;
+    }
+    if (char === '/' && prev !== '/' && prev !== '*' && /[=(:,\[]/.test(prev.trim() || '=')) {
+      inRegex = true;
+      result += ' ';
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+function blockerScanText(text) {
+  const stripped = stripQuotedAndRegexLiterals(text);
+  const commentIndex = stripped.indexOf('//');
+  if (commentIndex >= 0) return stripped.slice(commentIndex);
+  return stripped;
+}
+
+function findCompletionBlockers(cwd) {
+  const blockers = [];
+  for (const path of changedCodePaths(cwd)) {
+    const lines = addedLinesForPath(cwd, path);
+    lines.forEach(({ lineNumber, text }) => {
+      const scanText = blockerScanText(text);
+      for (const { kind, pattern } of BLOCKER_PATTERNS) {
+        if (pattern.test(scanText)) {
+          blockers.push({ path, line: lineNumber, kind, text: text.trim().slice(0, 160) });
+          break;
+        }
+      }
+    });
+  }
+  return blockers.slice(0, 8);
+}
+
+function shouldBlockProseQuestion(message) {
+  if (!QUESTION_END_RE.test(message)) return false;
+  if (!STRUCTURED_CHOICE_RE.test(message)) return false;
+  if (FREE_FORM_RE.test(message)) return false;
+  return true;
+}
+
+function makeBlock(reason) {
+  return { decision: 'block', reason };
+}
+
+async function main() {
+  if (skippedByEnv()) {
+    console.log(JSON.stringify({ suppressOutput: true }));
+    return;
+  }
+  const input = safeJsonParse(await readStdin());
+  // Claude Code docs warn Stop hooks receive stop_hook_active while already
+  // continuing from a Stop hook; fail open to avoid self-reinforcing loops.
+  if (input.stop_hook_active === true || input.stopHookActive === true) {
+    console.log(JSON.stringify({ suppressOutput: true }));
+    return;
+  }
+
+  const message = lastAssistantMessage(input);
+  if (shouldBlockProseQuestion(message)) {
+    console.log(JSON.stringify(makeBlock('[WORKFLOW DRIFT GUARD] The final response ends with a preference/approval question that should be asked with structured AskUserQuestion. Continue by calling AskUserQuestion with 2-4 options and keep allowOther enabled unless free-form input is unsafe.')));
+    return;
+  }
+
+  const cwd = typeof input.cwd === 'string' ? input.cwd : (typeof input.directory === 'string' ? input.directory : process.cwd());
+  if (message && COMPLETION_CLAIM_RE.test(message)) {
+    const blockers = findCompletionBlockers(cwd);
+    if (blockers.length > 0) {
+      const details = blockers.map(b => `${b.path}:${b.line} ${b.kind} — ${b.text}`).join('\n');
+      console.log(JSON.stringify(makeBlock(`[WORKFLOW DRIFT GUARD] Completion was claimed while changed code still contains TODO/stub/skipped-test blockers. Resolve them or explicitly report the blocker instead of claiming completion.\n${details}`)));
+      return;
+    }
+  }
+
+  console.log(JSON.stringify({ suppressOutput: true }));
+}
+
+main().catch((error) => {
+  console.error(`[workflow-drift-guard] ${error instanceof Error ? error.message : String(error)}`);
+  console.log(JSON.stringify({ suppressOutput: true }));
+});


### PR DESCRIPTION
## Summary

Closes #3318.

- Adds a narrow Stop-only `workflow-drift-guard.mjs` hook and installs it in `hooks/hooks.json`.
- Blocks deterministic recurring drift only: prose approval/preference questions that should use structured `AskUserQuestion`, and completion claims while changed code adds obvious TODO/stub/skipped/focused-test blockers.
- Documents the Claude Code hooks/plugin boundary and the intentionally safe fail-open cases.
- Adds deterministic guard coverage and keeps the packaged script/template copies in sync.

## Verification

- `npm test -- --run src/hooks/__tests__/workflow-drift-guard-script.test.ts src/installer/__tests__/hook-command-portability.test.ts src/__tests__/npm-package-hook-surface.test.ts src/__tests__/tier0-docs-consistency.test.ts` — 33 tests passed.
- `npm run build` — passed.
- `npm run lint` — passed with existing warnings only.
- `npm pack --dry-run --json` — confirmed `scripts/workflow-drift-guard.mjs`, `templates/hooks/workflow-drift-guard.mjs`, and `hooks/hooks.json` are packaged.
- `diff -u scripts/workflow-drift-guard.mjs templates/hooks/workflow-drift-guard.mjs` — clean.

## Safe boundary / risk notes

- The guard is Stop-only and deterministic; it does not attempt broad branch/context inference that could overblock valid work.
- `stop_hook_active` fails open to avoid self-reinforcing Stop-hook loops.
- Free-form/Other question wording remains allowed; the hook only blocks narrow structured-choice approval/preference questions.
- TODO/stub markers are allowed unless the assistant claims completion.
- Not live-tested inside an installed Claude Code plugin during this finalization pass; behavior is covered by script-level and packaging tests.
