### PR TITLE
feat(ask): make provider backend configurable via OMC_ASK_<PROVIDER>_BIN/_ARGS

### DIFF
--- a/scripts/lib/provider-overrides.mjs
+++ b/scripts/lib/provider-overrides.mjs
@@ -1,0 +1,80 @@
+/**
+ * Provider backend overrides for `omc ask` / `run-provider-advisor`.
+ *
+ * Lets a site repoint a single `ask` provider axis at a drop-in CLI through
+ * environment variables, without editing the hardcoded provider table.
+ *
+ * Motivating case: Google moved `@google/gemini-cli` access behind Antigravity,
+ * so accounts on the new tier get `IneligibleTier` from the `gemini` binary —
+ * which silently breaks the Gemini axis used by `omc ask gemini` and the `/ccg`
+ * tri-model orchestration. With these overrides the Gemini axis can be routed
+ * through Antigravity's `agy` CLI instead:
+ *
+ *   OMC_ASK_GEMINI_BIN=agy
+ *   OMC_ASK_GEMINI_ARGS=["--print","{{prompt}}","--dangerously-skip-permissions"]
+ *
+ * Both overrides are opt-in and per-provider. When unset, default behavior is
+ * unchanged (full backward compatibility).
+ */
+
+export const PROMPT_PLACEHOLDER = '{{prompt}}';
+
+function envKey(provider, suffix) {
+  return `OMC_ASK_${provider.toUpperCase()}_${suffix}`;
+}
+
+/**
+ * Resolve the binary for a provider, honoring an `OMC_ASK_<PROVIDER>_BIN`
+ * override. Falls back to `defaultBinary` when the override is unset or blank.
+ *
+ * @param {string} provider - canonical provider name (e.g. `gemini`).
+ * @param {string} defaultBinary - the built-in binary for this provider.
+ * @param {Record<string, string | undefined>} [env] - environment to read.
+ * @returns {string} the binary to spawn.
+ */
+export function resolveProviderBinary(provider, defaultBinary, env = process.env) {
+  const override = env[envKey(provider, 'BIN')];
+  if (typeof override === 'string' && override.trim()) {
+    return override.trim();
+  }
+  return defaultBinary;
+}
+
+/**
+ * Resolve an `OMC_ASK_<PROVIDER>_ARGS` override.
+ *
+ * The value is a JSON array of strings. Every occurrence of the literal
+ * `{{prompt}}` token (see {@link PROMPT_PLACEHOLDER}) is replaced with `prompt`.
+ * When no token is present, the caller should pipe the prompt over stdin
+ * instead (mirroring how `claude -p` reads the prompt from stdin).
+ *
+ * @param {string} provider - canonical provider name.
+ * @param {string} prompt - the prompt to substitute / pipe.
+ * @param {Record<string, string | undefined>} [env] - environment to read.
+ * @returns {{ args: string[], usesPromptPlaceholder: boolean } | null}
+ *   resolved args, or `null` when the override is unset (use default args).
+ * @throws {Error} when the value is not a JSON array of strings.
+ */
+export function resolveProviderArgsOverride(provider, prompt, env = process.env) {
+  const key = envKey(provider, 'ARGS');
+  const raw = env[key];
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${key} must be a JSON array of strings, e.g. ["--print","{{prompt}}"]. JSON parse failed: ${detail}`);
+  }
+
+  if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+    throw new Error(`${key} must be a JSON array of strings, e.g. ["--print","{{prompt}}"].`);
+  }
+
+  const usesPromptPlaceholder = parsed.some((item) => item.includes(PROMPT_PLACEHOLDER));
+  const args = parsed.map((item) => item.split(PROMPT_PLACEHOLDER).join(prompt));
+  return { args, usesPromptPlaceholder };
+}

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -4,7 +4,11 @@ import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import process from 'process';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
+import { resolveProviderBinary, resolveProviderArgsOverride } from './lib/provider-overrides.mjs';
 
+// Default binary per provider. Each entry can be repointed at a drop-in CLI via
+// `OMC_ASK_<PROVIDER>_BIN` (binary) and `OMC_ASK_<PROVIDER>_ARGS` (JSON args)
+// without code changes — see scripts/lib/provider-overrides.mjs.
 const PROVIDER_BINARIES = {
   claude: 'claude',
   codex: 'codex',
@@ -256,12 +260,19 @@ async function writeArtifact({ provider, originalTask, finalPrompt, rawOutput, e
 
 async function main() {
   const { provider, prompt } = parseArgs(process.argv.slice(2));
-  const binary = PROVIDER_BINARIES[provider];
+  const binary = resolveProviderBinary(provider, PROVIDER_BINARIES[provider]);
+  const argsOverride = resolveProviderArgsOverride(provider, prompt);
 
   ensureBinary(provider, binary);
 
-  const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt);
-  const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin });
+  // When OMC_ASK_<PROVIDER>_ARGS embeds the prompt via {{prompt}}, pass it as an
+  // arg; otherwise pipe it over stdin. With no override, keep default behavior.
+  const pipePromptViaStdin = argsOverride
+    ? !argsOverride.usesPromptPlaceholder
+    : shouldPipePromptViaStdin(provider, prompt);
+  const providerArgs = argsOverride
+    ? argsOverride.args
+    : buildProviderArgs(provider, prompt, { pipePromptViaStdin });
   const run = spawnSync(binary, providerArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -45,6 +45,24 @@ grok --version
 cursor-agent --version
 ```
 
+## Backend overrides (advanced)
+
+Any provider's local CLI can be repointed via environment variables, without code changes:
+
+| Variable | Effect |
+|----------|--------|
+| `OMC_ASK_<PROVIDER>_BIN` | Replace the provider's binary (e.g. `gemini` → `agy`). |
+| `OMC_ASK_<PROVIDER>_ARGS` | Replace its argument list. JSON array of strings; the literal `{{prompt}}` token is substituted with the prompt (omit it to pipe the prompt over stdin). |
+
+`<PROVIDER>` is the upper-cased provider name (`CLAUDE`, `CODEX`, `GEMINI`, `GROK`, `CURSOR`). When both are unset the built-in command is used, so default behavior is unchanged.
+
+Example — route the Gemini axis (and therefore `/ccg`) through Antigravity's `agy` CLI, e.g. after `@google/gemini-cli` access moves to Antigravity and the `gemini` binary returns `IneligibleTier`:
+
+```bash
+export OMC_ASK_GEMINI_BIN=agy
+export OMC_ASK_GEMINI_ARGS='["--print","{{prompt}}","--dangerously-skip-permissions"]'
+```
+
 ## Artifacts
 
 `omc ask` writes artifacts to:

--- a/skills/ccg/SKILL.md
+++ b/skills/ccg/SKILL.md
@@ -20,7 +20,7 @@ Use this when you want parallel external perspectives without launching tmux tea
 ## Requirements
 
 - **Codex CLI**: `npm install -g @openai/codex` (or `@openai/codex`)
-- **Gemini CLI**: `npm install -g @google/gemini-cli`
+- **Gemini CLI**: `npm install -g @google/gemini-cli` (the Gemini axis can also be repointed at another CLI such as Antigravity's `agy` via `OMC_ASK_GEMINI_BIN` / `OMC_ASK_GEMINI_ARGS` — see the `ask` skill's "Backend overrides")
 - `omc ask` command available
 - If either CLI is unavailable, continue with whichever provider is available and note the limitation
 

--- a/tests/scripts/provider-overrides.test.ts
+++ b/tests/scripts/provider-overrides.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the `omc ask` provider backend overrides
+ * (scripts/lib/provider-overrides.mjs).
+ *
+ * These overrides let a single provider axis be repointed at a drop-in CLI via
+ * `OMC_ASK_<PROVIDER>_BIN` / `OMC_ASK_<PROVIDER>_ARGS` — e.g. routing the Gemini
+ * axis through Antigravity's `agy` after `@google/gemini-cli` access moved tiers.
+ * Default (env-unset) behavior must remain unchanged.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PROMPT_PLACEHOLDER,
+  resolveProviderBinary,
+  resolveProviderArgsOverride,
+  // @ts-expect-error - plain ESM helper module, no type declarations
+} from '../../scripts/lib/provider-overrides.mjs';
+
+describe('resolveProviderBinary', () => {
+  it('returns the default binary when no override is set', () => {
+    expect(resolveProviderBinary('gemini', 'gemini', {})).toBe('gemini');
+  });
+
+  it('returns the override binary from OMC_ASK_<PROVIDER>_BIN', () => {
+    const env = { OMC_ASK_GEMINI_BIN: 'agy' };
+    expect(resolveProviderBinary('gemini', 'gemini', env)).toBe('agy');
+  });
+
+  it('trims surrounding whitespace in the override', () => {
+    const env = { OMC_ASK_GEMINI_BIN: '  agy  ' };
+    expect(resolveProviderBinary('gemini', 'gemini', env)).toBe('agy');
+  });
+
+  it('ignores a blank override and falls back to the default', () => {
+    const env = { OMC_ASK_GEMINI_BIN: '   ' };
+    expect(resolveProviderBinary('gemini', 'gemini', env)).toBe('gemini');
+  });
+
+  it('is scoped per provider (does not leak across providers)', () => {
+    const env = { OMC_ASK_GEMINI_BIN: 'agy' };
+    expect(resolveProviderBinary('codex', 'codex', env)).toBe('codex');
+  });
+});
+
+describe('resolveProviderArgsOverride', () => {
+  it('returns null when no override is set', () => {
+    expect(resolveProviderArgsOverride('gemini', 'hi', {})).toBeNull();
+  });
+
+  it('returns null for a blank override', () => {
+    expect(resolveProviderArgsOverride('gemini', 'hi', { OMC_ASK_GEMINI_ARGS: '   ' })).toBeNull();
+  });
+
+  it('substitutes {{prompt}} as a standalone arg and flags placeholder use', () => {
+    const env = {
+      OMC_ASK_GEMINI_ARGS: JSON.stringify(['--print', PROMPT_PLACEHOLDER, '--dangerously-skip-permissions']),
+    };
+    const result = resolveProviderArgsOverride('gemini', 'review this PR', env);
+    expect(result).toEqual({
+      args: ['--print', 'review this PR', '--dangerously-skip-permissions'],
+      usesPromptPlaceholder: true,
+    });
+  });
+
+  it('substitutes {{prompt}} embedded inside an arg', () => {
+    const env = { OMC_ASK_GEMINI_ARGS: JSON.stringify(['--prompt={{prompt}}']) };
+    const result = resolveProviderArgsOverride('gemini', 'hello', env);
+    expect(result?.args).toEqual(['--prompt=hello']);
+    expect(result?.usesPromptPlaceholder).toBe(true);
+  });
+
+  it('reports usesPromptPlaceholder=false when the prompt is not embedded (stdin path)', () => {
+    const env = { OMC_ASK_GEMINI_ARGS: JSON.stringify(['--print', '--dangerously-skip-permissions']) };
+    const result = resolveProviderArgsOverride('gemini', 'hello', env);
+    expect(result).toEqual({
+      args: ['--print', '--dangerously-skip-permissions'],
+      usesPromptPlaceholder: false,
+    });
+  });
+
+  it('preserves prompts that contain spaces and newlines as a single arg', () => {
+    const env = { OMC_ASK_GEMINI_ARGS: JSON.stringify(['--print', PROMPT_PLACEHOLDER]) };
+    const prompt = 'line one\nline two with spaces';
+    const result = resolveProviderArgsOverride('gemini', prompt, env);
+    expect(result?.args).toEqual(['--print', 'line one\nline two with spaces']);
+  });
+
+  it('throws a helpful error on invalid JSON', () => {
+    const env = { OMC_ASK_GEMINI_ARGS: 'not json' };
+    expect(() => resolveProviderArgsOverride('gemini', 'hi', env))
+      .toThrow(/OMC_ASK_GEMINI_ARGS must be a JSON array of strings/);
+  });
+
+  it('throws when the JSON is not an array', () => {
+    const env = { OMC_ASK_GEMINI_ARGS: JSON.stringify({ not: 'an array' }) };
+    expect(() => resolveProviderArgsOverride('gemini', 'hi', env))
+      .toThrow(/must be a JSON array of strings/);
+  });
+
+  it('throws when array elements are not all strings', () => {
+    const env = { OMC_ASK_GEMINI_ARGS: JSON.stringify(['--print', 42]) };
+    expect(() => resolveProviderArgsOverride('gemini', 'hi', env))
+      .toThrow(/must be a JSON array of strings/);
+  });
+
+  it('builds the full Antigravity (agy) gemini-axis command end to end', () => {
+    const env = {
+      OMC_ASK_GEMINI_BIN: 'agy',
+      OMC_ASK_GEMINI_ARGS: JSON.stringify(['--print', PROMPT_PLACEHOLDER, '--dangerously-skip-permissions']),
+    };
+    const binary = resolveProviderBinary('gemini', 'gemini', env);
+    const override = resolveProviderArgsOverride('gemini', 'summarize the diff', env);
+    expect(binary).toBe('agy');
+    expect([binary, ...(override?.args ?? [])]).toEqual([
+      'agy',
+      '--print',
+      'summarize the diff',
+      '--dangerously-skip-permissions',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #3321.

## What & why

The Gemini axis used by `omc ask gemini` — and the `/ccg` orchestration — is
hardcoded to the `@google/gemini-cli` `gemini` binary. After Google moved that
CLI's access behind **Antigravity**, accounts on the new tier get
`IneligibleTier`, which silently breaks the Gemini axis (Codex still runs, so
`/ccg` degrades to a single cross-check) with no way to redirect it without
editing source.

This adds opt-in, per-provider environment overrides so a provider's backend can
be repointed at a drop-in CLI (e.g. Antigravity's `agy`) without code changes.

## Changes

- **`scripts/lib/provider-overrides.mjs`** (new) — pure resolvers:
  - `OMC_ASK_<PROVIDER>_BIN` overrides the binary (`gemini` → `agy`)
  - `OMC_ASK_<PROVIDER>_ARGS` overrides the args (JSON array of strings; the
    `{{prompt}}` token is substituted with the prompt, or omitted → prompt is
    piped over stdin)
  - invalid JSON / non-string-array values throw a clear error
- **`scripts/run-provider-advisor.js`** — resolve binary/args through the helpers
  (unchanged path when the env vars are unset)
- **`tests/scripts/provider-overrides.test.ts`** (new) — 15 unit tests
- **`skills/ask/SKILL.md`**, **`skills/ccg/SKILL.md`** — document the override

## Usage (motivating case)

```bash
export OMC_ASK_GEMINI_BIN=agy
export OMC_ASK_GEMINI_ARGS='["--print","{{prompt}}","--dangerously-skip-permissions"]'
```

Then `omc ask gemini …` (and `/ccg`'s Gemini axis) run through `agy`. `agy`
defaults to a Gemini model via its own `settings.json`, so `--model` is optional;
pin a Gemini model in `_ARGS` to keep the axis on Gemini rather than agy's other
available models.

## Backward compatibility

With both env vars unset, behavior is identical to before — existing
`@google/gemini-cli` users are unaffected.

## Testing

- New unit suite: **15/15** pass
- Existing `src/cli/__tests__/ask.test.ts`: **32/32** pass (no regression)
- End-to-end: ran the advisor with the override against a real `agy` install and
  confirmed it routes through `agy` and writes the artifact
- `npm run lint` and `npm run build` pass. The full `npm run test:run` has a few
  pre-existing failures under `src/installer/__tests__/` that are unrelated to
  this change (reproduced on a clean `dev` checkout with this branch stashed).
