### PR TITLE
Fix Claude 2.1 native team routing guidance

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -937,8 +937,7 @@ function generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId) {
   if (teamState && !toolInput.name) {
     const teamName = teamState.team_name || teamState.teamName || 'team';
     return `[TEAM ROUTING REQUIRED] Team "${teamName}" is active but you are spawning an unnamed subagent. ` +
-      `Claude Code 2.1.178+ uses one implicit team per session when ` +
-      `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is enabled; TeamCreate and TeamDelete are removed. ` +
+      `Claude Code 2.1.178+ uses the session's implicit native agent team; TeamCreate and TeamDelete are removed. ` +
       `Spawn teammates directly with Agent/Task name="worker-N" and subagent_type="${agentType}". ` +
       `Do NOT rely on team_name for routing; native Claude Code accepts it only as ignored legacy metadata.`;
   }

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -347,6 +347,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(hookSpecificOutput.additionalContext).toContain('TeamCreate and TeamDelete are removed');
     expect(hookSpecificOutput.additionalContext).toContain('team_name for routing');
     expect(hookSpecificOutput.additionalContext).toContain('ignored legacy metadata');
+    expect(hookSpecificOutput.additionalContext).not.toContain('CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS');
     expect(hookSpecificOutput.additionalContext).not.toContain('verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS');
     expect(hookSpecificOutput.additionalContext).not.toContain('Restart Claude Code');
 
@@ -412,6 +413,7 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(context).toContain('name="worker-N"');
     expect(context).toContain('TeamCreate and TeamDelete are removed');
     expect(context).not.toContain('verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS');
+    expect(context).not.toContain('CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS');
     expect(context).not.toContain('Restart Claude Code');
   });
 

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -347,6 +347,9 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     expect(hookSpecificOutput.additionalContext).toContain('TeamCreate and TeamDelete are removed');
     expect(hookSpecificOutput.additionalContext).toContain('team_name for routing');
     expect(hookSpecificOutput.additionalContext).toContain('ignored legacy metadata');
+    expect(hookSpecificOutput.additionalContext).not.toContain('verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS');
+    expect(hookSpecificOutput.additionalContext).not.toContain('Restart Claude Code');
+
   });
 
   it('does NOT inject team-routing redirect when Task called WITH teammate name', () => {
@@ -377,6 +380,84 @@ describe('pre-tool-enforcer fallback gating (issue #970)', () => {
     // Should be a normal spawn message, not a redirect
     expect(String(hookSpecificOutput.additionalContext)).not.toContain('TEAM ROUTING REQUIRED');
     expect(String(hookSpecificOutput.additionalContext)).toContain('Spawning agent');
+  });
+
+  it('injects team-routing redirect when Agent called without teammate name during active team session', () => {
+    const sessionId = 'session-3323-agent';
+    writeJson(
+      join(tempDir, '.omc', 'state', 'sessions', sessionId, 'team-state.json'),
+      {
+        active: true,
+        session_id: sessionId,
+        team_name: 'native-team-compat',
+      },
+    );
+
+    const output = runPreToolEnforcer({
+      tool_name: 'Agent',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'Fix type errors',
+        prompt: 'Fix all type errors in src/auth/',
+      },
+      cwd: tempDir,
+      session_id: sessionId,
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    const context = String(hookSpecificOutput.additionalContext);
+    expect(output.continue).toBe(true);
+    expect(context).toContain('TEAM ROUTING REQUIRED');
+    expect(context).toContain('native-team-compat');
+    expect(context).toContain('name="worker-N"');
+    expect(context).toContain('TeamCreate and TeamDelete are removed');
+    expect(context).not.toContain('verify CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS');
+    expect(context).not.toContain('Restart Claude Code');
+  });
+
+  it('does NOT inject team-routing redirect when Agent called WITH teammate name', () => {
+    const sessionId = 'session-3323-agent-named';
+    writeJson(
+      join(tempDir, '.omc', 'state', 'sessions', sessionId, 'team-state.json'),
+      {
+        active: true,
+        session_id: sessionId,
+        team_name: 'native-team-compat',
+      },
+    );
+
+    const output = runPreToolEnforcer({
+      tool_name: 'Agent',
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        name: 'worker-1',
+        description: 'Fix type errors',
+        prompt: 'Fix all type errors in src/auth/',
+      },
+      cwd: tempDir,
+      session_id: sessionId,
+    });
+
+    const hookSpecificOutput = output.hookSpecificOutput as Record<string, unknown>;
+    const context = String(hookSpecificOutput.additionalContext);
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('TEAM ROUTING REQUIRED');
+    expect(context).toContain('Spawning agent');
+  });
+
+  it('keeps team skill guidance on the Claude Code 2.1.x implicit team contract', () => {
+    const skillSource = readFileSync(join(process.cwd(), 'skills', 'team', 'SKILL.md'), 'utf-8');
+
+    expect(skillSource).toContain('implicit Claude Code team');
+    expect(skillSource).toContain('Agent/Task');
+    expect(skillSource).toContain('name="worker-N"');
+    expect(skillSource).toContain('Do **not** call `TeamCreate`');
+    expect(skillSource).toContain('no `TeamDelete`');
+    expect(skillSource.split('\n').filter((line) => /call\s+`?TeamCreate/i.test(line) && !/not.*call\s+`?TeamCreate/i.test(line))).toEqual([]);
+    expect(skillSource).not.toMatch(/TeamCreate\s*\(/);
+    expect(skillSource).not.toMatch(/TeamDelete\s*\(/);
+    expect(skillSource).not.toContain('If `TeamCreate` is not available');
+    expect(skillSource).not.toContain('Restart Claude Code');
   });
 
   it('does NOT inject team-routing redirect when no team state is active', () => {


### PR DESCRIPTION
## Summary
- remove stale experimental-flag wording from active team routing enforcement
- add regression coverage for unnamed Agent and Task spawns during active team sessions
- add a source contract test that keeps /team guidance on the Claude Code 2.1.x implicit team model

Fixes #3323

## Verification
- npm ci
- npm run test:run -- src/__tests__/pre-tool-enforcer.test.ts src/__tests__/context-safety.test.ts
- npm run lint (passes with existing warnings)
- npm run build:bridge

## Notes
- OWNER_CONFIRMATION_REQUIRED: this PR clarifies the public /team contract around Claude Code 2.1.x implicit native teams; no broad runtime rewrite included.
