### PR TITLE
Fix session search from subdirectory cwd

### DIFF
--- a/src/__tests__/session-history-search.test.ts
+++ b/src/__tests__/session-history-search.test.ts
@@ -14,6 +14,10 @@ function writeTranscript(filePath: string, entries: Array<Record<string, unknown
   writeFileSync(filePath, entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n', 'utf-8');
 }
 
+function normalizePathForAssert(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
 describe('session history search', () => {
   const repoRoot = process.cwd();
   const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
@@ -117,10 +121,16 @@ describe('session history search', () => {
     });
 
     expect(report.scope.mode).toBe('current');
-    expect(report.scope.workingDirectory).toBe(repoRoot);
+    expect(report.scope.workingDirectory).toBeDefined();
+    const workingDirectory = report.scope.workingDirectory!;
+    expect(normalizePathForAssert(workingDirectory)).toBe(normalizePathForAssert(repoRoot));
     expect(report.totalMatches).toBe(1);
-    expect(report.results[0].sessionId).toBe('session-subdir');
-    expect(report.results[0].projectPath).toBe(subdirCwd);
+    expect(report.results[0]).toBeDefined();
+    const result = report.results[0]!;
+    expect(result.sessionId).toBe('session-subdir');
+    expect(result.projectPath).toBeDefined();
+    const resultProjectPath = result.projectPath!;
+    expect(normalizePathForAssert(resultProjectPath)).toBe(normalizePathForAssert(subdirCwd));
   });
 
   it('supports since and session filters', async () => {

--- a/src/__tests__/session-history-search.test.ts
+++ b/src/__tests__/session-history-search.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { basename, join } from 'path';
 import {
+  __testingIsWithinProject,
   encodeProjectPath,
   parseSinceSpec,
   searchSessionHistory,
@@ -96,6 +97,32 @@ describe('session history search', () => {
     expect(report.results[0].sourcePath).toContain('session-current.jsonl');
   });
 
+  it('searches transcripts stored under the literal subdirectory cwd project dir', async () => {
+    const subdirCwd = join(repoRoot, 'src');
+    const subdirProjectDir = join(claudeDir, 'projects', encodeProjectPath(subdirCwd));
+
+    writeTranscript(join(subdirProjectDir, 'session-subdir.jsonl'), [
+      {
+        sessionId: 'session-subdir',
+        cwd: subdirCwd,
+        type: 'assistant',
+        timestamp: '2026-03-11T10:00:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'subdirectory cwd transcript sentinel' }] },
+      },
+    ]);
+
+    const report = await searchSessionHistory({
+      query: 'subdirectory cwd transcript sentinel',
+      workingDirectory: subdirCwd,
+    });
+
+    expect(report.scope.mode).toBe('current');
+    expect(report.scope.workingDirectory).toBe(repoRoot);
+    expect(report.totalMatches).toBe(1);
+    expect(report.results[0].sessionId).toBe('session-subdir');
+    expect(report.results[0].projectPath).toBe(subdirCwd);
+  });
+
   it('supports since and session filters', async () => {
     const recentOnly = await searchSessionHistory({
       query: 'provider routing',
@@ -161,6 +188,11 @@ describe('session history search', () => {
     expect(encodeProjectPath('C:\\Users\\me\\proj')).toBe('C--Users-me-proj');
     // POSIX paths are unaffected (no colon to replace).
     expect(encodeProjectPath('/home/me/proj')).toBe('-home-me-proj');
+  });
+
+  it('keeps Windows-style subdirectory paths within their project root', () => {
+    expect(__testingIsWithinProject('C:\\Users\\me\\repo\\packages\\api', ['C:\\Users\\me\\repo'])).toBe(true);
+    expect(__testingIsWithinProject('C:\\Users\\me\\repo-other', ['C:\\Users\\me\\repo'])).toBe(false);
   });
 
   it('parses relative and absolute since values', () => {

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -138,13 +138,15 @@ function uniqueSortedTargets(targets: SearchTarget[]): SearchTarget[] {
     });
 }
 
-function buildCurrentProjectTargets(projectRoot: string): SearchTarget[] {
+function buildCurrentProjectTargets(projectRoot: string, transcriptProjectRoots: string[] = [projectRoot]): SearchTarget[] {
   const claudeDir = getClaudeConfigDir();
-  const projectRoots = new Set<string>([projectRoot]);
-  const mainRepoRoot = getMainRepoRoot(projectRoot);
-  if (mainRepoRoot) projectRoots.add(mainRepoRoot);
-  const claudeWorktreeParent = getClaudeWorktreeParent(projectRoot);
-  if (claudeWorktreeParent) projectRoots.add(claudeWorktreeParent);
+  const projectRoots = new Set<string>(transcriptProjectRoots);
+  for (const root of transcriptProjectRoots) {
+    const mainRepoRoot = getMainRepoRoot(root);
+    if (mainRepoRoot) projectRoots.add(mainRepoRoot);
+    const claudeWorktreeParent = getClaudeWorktreeParent(root);
+    if (claudeWorktreeParent) projectRoots.add(claudeWorktreeParent);
+  }
 
   const targets: SearchTarget[] = [];
 
@@ -198,9 +200,9 @@ function isWithinProject(projectPath: string | undefined, projectRoots: string[]
     return false;
   }
 
-  const normalizedProjectPath = normalize(resolve(projectPath));
+  const normalizedProjectPath = normalize(resolve(projectPath)).replace(/\\/g, '/');
   return projectRoots.some((root) => {
-    const normalizedRoot = normalize(resolve(root));
+    const normalizedRoot = normalize(resolve(root)).replace(/\\/g, '/');
     return normalizedProjectPath === normalizedRoot || normalizedProjectPath.startsWith(`${normalizedRoot}/`);
   });
 }
@@ -511,15 +513,18 @@ export async function searchSessionHistory(
   const currentProjectRoot = resolveToWorktreeRoot(workingDirectory);
   const scopeMode = buildScopeMode(rawOptions.project);
   const projectFilter = scopeMode === 'project' ? rawOptions.project : undefined;
+  const literalWorkingDirectory = rawOptions.workingDirectory ? resolve(rawOptions.workingDirectory) : workingDirectory;
 
-  const currentProjectRoots = [currentProjectRoot]
+  const currentProjectRoots = [currentProjectRoot, literalWorkingDirectory]
     .concat(getMainRepoRoot(currentProjectRoot) ?? [])
     .concat(getClaudeWorktreeParent(currentProjectRoot) ?? [])
     .filter((value, index, arr): value is string => Boolean(value) && arr.indexOf(value) === index);
 
+  const transcriptProjectRoots = currentProjectRoots.filter((root) => isWithinProject(root, [currentProjectRoot]));
+
   const targets = scopeMode === 'all'
     ? buildAllProjectTargets()
-    : buildCurrentProjectTargets(currentProjectRoot);
+    : buildCurrentProjectTargets(currentProjectRoot, transcriptProjectRoots);
 
   const allMatches: SessionHistoryMatch[] = [];
   for (const target of targets) {
@@ -557,7 +562,7 @@ export async function searchSessionHistory(
   };
 }
 
-export { encodeProjectPath, parseSinceSpec };
+export { encodeProjectPath, isWithinProject as __testingIsWithinProject, parseSinceSpec };
 export type {
   SessionHistoryMatch,
   SessionHistorySearchOptions,


### PR DESCRIPTION
Fixes session search when Claude transcripts are stored under the literal subdirectory cwd project directory, so searches launched from a subdirectory can discover those transcript files.

Also fixes project containment checks to be Windows separator-safe, preventing sibling paths such as `repo-other` from matching `repo` while preserving nested subdirectory matches.

Verification:
- `npm run test:run -- session-history-search` passed (8 tests)
- LSP diagnostics OK

Fixes #3334

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
