### PR TITLE
fix(persistent-mode): keep stop reinforcement quiet while a delegated subagent is running

### DIFF
--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -273,6 +273,11 @@ async function sendStopNotification(modeName, stateData, sessionId, directory) {
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
 const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
+// A delegated subagent counts as pending owned async work while its tracking
+// entry stays "running". Bound by 30 min so an orphaned entry (subagent killed
+// without SubagentStop) eventually releases the gate; over-suppression is the
+// benign direction (the agent stops cleanly instead of being nagged mid-work).
+const RUNNING_SUBAGENT_STALE_MS = 30 * 60 * 1000;
 
 // Stop breaker constants for first-class mode enforcement
 const TEAM_PIPELINE_STOP_BLOCKER_MAX = 20;
@@ -395,8 +400,25 @@ function hasPendingScheduledWakeup(stateDir, sessionId) {
   });
 }
 
+function hasRunningSubagent(stateDir) {
+  // subagent-tracking.json is per-directory (not session-scoped), written by the
+  // wired SubagentStart/SubagentStop hooks. A "running" entry means a delegated
+  // agent is still working, so persistent modes must not inject a "stalled"
+  // reinforcement while we wait for it (mirrors the background-task gate).
+  const tracking = readJsonFile(join(stateDir, "subagent-tracking.json"));
+  const agents = Array.isArray(tracking?.agents) ? tracking.agents : [];
+  return agents.some((agent) => {
+    if (agent?.status !== "running") return false;
+    return isFreshTimestamp(agent.started_at, RUNNING_SUBAGENT_STALE_MS);
+  });
+}
+
 function hasPendingOwnedAsyncWork(stateDir, sessionId) {
-  return hasPendingBackgroundTask(stateDir, sessionId) || hasPendingScheduledWakeup(stateDir, sessionId);
+  return (
+    hasPendingBackgroundTask(stateDir, sessionId) ||
+    hasRunningSubagent(stateDir) ||
+    hasPendingScheduledWakeup(stateDir, sessionId)
+  );
 }
 
 function normalizeTeamPhase(state) {

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -183,6 +183,11 @@ Do NOT skip this step. Do NOT move on without fixing the error.
  */
 const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
 const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
+// A delegated subagent counts as pending owned async work while its tracking
+// entry stays "running". Bound by 30 min so an orphaned entry (subagent killed
+// without SubagentStop) eventually releases the gate; over-suppression is the
+// benign direction (the agent stops cleanly instead of being nagged mid-work).
+const RUNNING_SUBAGENT_STALE_MS = 30 * 60 * 1000;
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 const TEAM_TERMINAL_PHASES = new Set([
   "completed",
@@ -286,8 +291,25 @@ function hasPendingScheduledWakeup(stateDir, sessionId) {
   });
 }
 
+function hasRunningSubagent(stateDir) {
+  // subagent-tracking.json is per-directory (not session-scoped), written by the
+  // wired SubagentStart/SubagentStop hooks. A "running" entry means a delegated
+  // agent is still working, so persistent modes must not inject a "stalled"
+  // reinforcement while we wait for it (mirrors the background-task gate).
+  const tracking = readJsonFile(join(stateDir, "subagent-tracking.json"));
+  const agents = Array.isArray(tracking?.agents) ? tracking.agents : [];
+  return agents.some((agent) => {
+    if (agent?.status !== "running") return false;
+    return isFreshTimestamp(agent.started_at, RUNNING_SUBAGENT_STALE_MS);
+  });
+}
+
 function hasPendingOwnedAsyncWork(stateDir, sessionId) {
-  return hasPendingBackgroundTask(stateDir, sessionId) || hasPendingScheduledWakeup(stateDir, sessionId);
+  return (
+    hasPendingBackgroundTask(stateDir, sessionId) ||
+    hasRunningSubagent(stateDir) ||
+    hasPendingScheduledWakeup(stateDir, sessionId)
+  );
 }
 
 function normalizeTeamPhase(state) {

--- a/src/cli/__tests__/session-search.test.ts
+++ b/src/cli/__tests__/session-search.test.ts
@@ -41,7 +41,9 @@ describe('session search cli command', () => {
   afterEach(() => {
     delete process.env.CLAUDE_CONFIG_DIR;
     delete process.env.OMC_STATE_DIR;
-    rmSync(tempRoot, { recursive: true, force: true });
+    // Windows can throw ENOTEMPTY on rmdir when handles/indexing linger;
+    // retry to avoid a flaky teardown failure in the Windows path suite.
+    rmSync(tempRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
   });
 
   it('prints JSON when requested', async () => {

--- a/src/hooks/persistent-mode/stop-hook-blocking.test.ts
+++ b/src/hooks/persistent-mode/stop-hook-blocking.test.ts
@@ -924,6 +924,45 @@ describe("Stop Hook Blocking Contract", () => {
       expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
     });
 
+    it("returns continue: true for active ralph with a running delegated subagent", () => {
+      const sessionId = "ralph-mjs-subagent-running";
+      writeActiveRalphState(tempDir, sessionId);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: "agent-mjs-running",
+          agent_type: "executor",
+          started_at: new Date().toISOString(),
+          parent_mode: "ralph",
+          status: "running",
+        },
+      ]);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
+    });
+
+    it("returns decision: block for active ralph when the only delegated subagent has completed", () => {
+      // Negative control: a completed (non-running) subagent must NOT suppress
+      // the boulder — only an in-flight one does. Proves the gate has teeth.
+      const sessionId = "ralph-mjs-subagent-done";
+      writeActiveRalphState(tempDir, sessionId);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: "agent-mjs-done",
+          agent_type: "executor",
+          started_at: new Date(Date.now() - 60_000).toISOString(),
+          completed_at: new Date().toISOString(),
+          parent_mode: "ralph",
+          status: "completed",
+        },
+      ]);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.decision).toBe("block");
+    });
+
     it("returns continue: true for tombstoned stale ralph state", () => {
       const sessionId = "ralph-mjs-tombstoned";
       const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
@@ -1814,6 +1853,45 @@ describe("Stop Hook Blocking Contract", () => {
         stop_reason: "ScheduleWakeup",
       });
       expect(output.continue).toBe(true);
+    });
+
+    it("returns continue: true for active ralph with a running delegated subagent", () => {
+      const sessionId = "ralph-cjs-subagent-running";
+      writeActiveRalphState(tempDir, sessionId);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: "agent-cjs-running",
+          agent_type: "executor",
+          started_at: new Date().toISOString(),
+          parent_mode: "ralph",
+          status: "running",
+        },
+      ]);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.continue).toBe(true);
+      expect(output.decision).toBeUndefined();
+      expect(String(output.reason || "")).not.toContain("[RALPH LOOP");
+    });
+
+    it("returns decision: block for active ralph when the only delegated subagent has completed", () => {
+      // Negative control: a completed (non-running) subagent must NOT suppress
+      // the boulder — only an in-flight one does. Proves the gate has teeth.
+      const sessionId = "ralph-cjs-subagent-done";
+      writeActiveRalphState(tempDir, sessionId);
+      writeSubagentTrackingState(tempDir, [
+        {
+          agent_id: "agent-cjs-done",
+          agent_type: "executor",
+          started_at: new Date(Date.now() - 60_000).toISOString(),
+          completed_at: new Date().toISOString(),
+          parent_mode: "ralph",
+          status: "completed",
+        },
+      ]);
+
+      const output = runScript({ directory: tempDir, sessionId });
+      expect(output.decision).toBe("block");
     });
 
     it("returns continue: true when skill state is active but delegated subagents are still running", () => {


### PR DESCRIPTION
## Problem

The Stop-hook continuation gate `hasPendingOwnedAsyncWork()` (in the wired runtime `scripts/persistent-mode.{mjs,cjs}`) only consulted:

- `hud-state.json` `backgroundTasks` — never populated for `Task`-tool subagents, only background Bash, and
- the scheduled-wakeup state.

So when `ultrawork`/`ralph` delegated to a background subagent, the runtime saw **no** pending async work and re-injected a `[ULTRAWORK]/[RALPH LOOP]` "keep going" reinforcement **while the subagent was still in-flight** — the orchestrator could not cleanly yield. A faux-complete todo made it worse, since only `/cancel` ends the loop.

The data needed to detect this already exists on disk: `subagent-tracking.json`, written by the wired `SubagentStart`/`SubagentStop` hooks. The gate just wasn't reading it.

## Fix

`hasPendingOwnedAsyncWork()` now also calls a new `hasRunningSubagent()` that reads `<.omc>/state/subagent-tracking.json` and treats a **fresh `running`** agent as pending owned async work — mirroring the existing background-task and scheduled-wakeup gates.

- New `RUNNING_SUBAGENT_STALE_MS` (30 min) bounds orphaned entries (subagent killed without `SubagentStop`). Over-suppression is the benign direction: the orchestrator stops cleanly instead of being nagged mid-work.
- Applied to **both** hand-maintained runtime copies (`.mjs` + `.cjs`).
- The richer TS path (`src/hooks/persistent-mode/index.ts`) already covers this via `getActiveAgentSnapshot` (with a deliberate fail-closed recency check on the ralplan branch), so it was intentionally **not** touched to avoid double-handling.

## Tests

Added execution-contract tests for both `.mjs` and `.cjs` in `stop-hook-blocking.test.ts`:

- **positive**: active ralph + running delegated subagent → `continue: true` (suppressed)
- **negative control**: active ralph + only a *completed* subagent → `decision: block` (proves the gate distinguishes running from done)

Verification:

- **RED proof**: removing the `hasRunningSubagent` call makes exactly the two positive tests fail; the negative controls stay green.
- Full `persistent-mode` suite: **327/327 green**.
- `tsc --noEmit`: **0 errors**.

## Known limitation (not addressed here — flagging for maintainers)

The `Workflow` tool's agents are tracked in a **separate, session-scoped state tree** (`<session>/subagents/workflows/wf_*/.omc/state/subagent-tracking.json`), not the project-level `.omc/state` that the Stop gate reads. A deterministic repro confirms that an active OMC mode + a running `Workflow` still nags, because the gate cannot see the nested workflow tracking (and short workflows may write no OMC tracking at all). This is a structurally different problem — covering it reliably needs a harness-level workflow signal, so it is intentionally out of scope for this PR. Happy to open a separate issue if useful.