### PR TITLE
Fix HUD solid teammate rendering

### DIFF
--- a/src/__tests__/hud-agents.test.ts
+++ b/src/__tests__/hud-agents.test.ts
@@ -238,6 +238,19 @@ describe('Agents Element', () => {
       expect(result).toContain('Analyzing code');
     });
 
+    it('should render named teammates distinctly from anonymous subagents', () => {
+      const teammate: ActiveAgent = {
+        ...createAgent('oh-my-claudecode:executor', 'sonnet'),
+        name: 'worker-1',
+        description: 'Implementing fix',
+      };
+      const result = renderAgentsByFormat([teammate], 'descriptions');
+
+      expect(result).toContain('◆');
+      expect(result).not.toContain('x:');
+      expect(result).toContain('Implementing fix');
+    });
+
     it('should route to tasks format', () => {
       const agentsWithDesc: ActiveAgent[] = [
         {
@@ -383,6 +396,23 @@ describe('Agents Element', () => {
       expect(result.detailLines[0]).toContain('└─');
       expect(result.detailLines[0]).toContain('A');
       expect(result.detailLines[0]).toContain('analyzing code');
+    });
+
+    it('should show named teammate identity in solid multiline view', () => {
+      const agents: ActiveAgent[] = [
+        {
+          ...createAgent('oh-my-claudecode:executor', 'sonnet'),
+          name: 'worker-1',
+          description: 'implementing teammate task',
+        },
+      ];
+      const result = renderAgentsMultiLine(agents);
+
+      expect(result.detailLines).toHaveLength(1);
+      expect(result.detailLines[0]).toContain('◆');
+      expect(result.detailLines[0]).toContain('tm:worker-1');
+      expect(result.detailLines[0]).not.toContain('exec');
+      expect(result.detailLines[0]).toContain('implementing teammate task');
     });
 
     it('should render multiple agents with correct tree characters', () => {

--- a/src/__tests__/hud-agents.test.ts
+++ b/src/__tests__/hud-agents.test.ts
@@ -248,6 +248,7 @@ describe('Agents Element', () => {
 
       expect(result).toContain('◆');
       expect(result).not.toContain('x:');
+      expect(result).toContain('tm:worker-1');
       expect(result).toContain('Implementing fix');
     });
 

--- a/src/__tests__/hud/transcript-agent-lifecycle.test.ts
+++ b/src/__tests__/hud/transcript-agent-lifecycle.test.ts
@@ -110,6 +110,35 @@ describe("HUD transcript — agent lifecycle", () => {
       expect(teammate?.description).toBe("Implement HUD fix");
     });
 
+    it("preserves native teammate names from proxied Agent calls", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_proxy_agent_001",
+                name: "proxy_Agent",
+                input: {
+                  name: "worker-2",
+                  subagent_type: "executor",
+                  description: "Review HUD fix",
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const teammate = result.agents.find((a) => a.id === "toolu_proxy_agent_001");
+      expect(teammate?.name).toBe("worker-2");
+      expect(teammate?.type).toBe("executor");
+      expect(teammate?.description).toBe("Review HUD fix");
+    });
+
     it("does NOT misclassify a foreground agent result as a background launch when the result text incidentally contains the phrase 'Async agent launched'", async () => {
       // This is the regression case. An Explore agent investigation report
       // quoted earlier background-launch notifications in its output. The

--- a/src/__tests__/hud/transcript-agent-lifecycle.test.ts
+++ b/src/__tests__/hud/transcript-agent-lifecycle.test.ts
@@ -81,6 +81,35 @@ describe("HUD transcript — agent lifecycle", () => {
       expect(fg?.status).toBe("completed");
     });
 
+    it("preserves native teammate names from named Task calls", async () => {
+      const transcriptPath = createTempTranscript([
+        {
+          timestamp: "2026-04-07T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_team_001",
+                name: "Task",
+                input: {
+                  name: "worker-1",
+                  subagent_type: "executor",
+                  description: "Implement HUD fix",
+                },
+              },
+            ],
+          },
+        },
+      ]);
+
+      const result = await parseTranscript(transcriptPath, { staleTaskThresholdMinutes: 10 ** 9 });
+      const teammate = result.agents.find((a) => a.id === "toolu_team_001");
+      expect(teammate?.name).toBe("worker-1");
+      expect(teammate?.type).toBe("executor");
+      expect(teammate?.description).toBe("Implement HUD fix");
+    });
+
     it("does NOT misclassify a foreground agent result as a background launch when the result text incidentally contains the phrase 'Async agent launched'", async () => {
       // This is the regression case. An Explore agent investigation report
       // quoted earlier background-launch notifications in its output. The

--- a/src/hud/elements/agents.ts
+++ b/src/hud/elements/agents.ts
@@ -417,12 +417,17 @@ export function renderAgentsWithDescriptions(agents: ActiveAgent[]): string | nu
   const entries = running.map((a) => {
     const code = getAgentDisplayMarker(a);
     const color = getAgentDisplayColor(a);
-    const desc = truncateDescription(a.description, getTeammateName(a) ? 30 : 25);
+    const teammateName = getTeammateName(a);
+    const displayName = getAgentDisplayName(a);
+    const desc = truncateDescription(a.description, teammateName ? 30 : 25);
+    const label = teammateName
+      ? `${displayName}${desc ? ` ${desc}` : ""}`
+      : desc;
     const durationMs = now - a.startTime.getTime();
     const duration = formatDuration(durationMs);
 
-    // Format: O:description or O:description(2m)
-    let entry = `${color}${code}${RESET}:${dim(desc)}`;
+    // Format: O:description or ◆:tm:worker-1 description(2m)
+    let entry = `${color}${code}${RESET}:${dim(label)}`;
     if (duration && duration !== '!') {
       entry += dim(duration);
     } else if (duration === '!') {

--- a/src/hud/elements/agents.ts
+++ b/src/hud/elements/agents.ts
@@ -376,6 +376,29 @@ function getShortAgentName(agentType: string): string {
 }
 
 /**
+ * Native Claude Code named agents are solid teammates, not anonymous subagents.
+ * Show their teammate name prominently so they do not collapse to the same HUD
+ * rendering as ordinary subagent calls that only have a role/type.
+ */
+function getTeammateName(agent: ActiveAgent): string | null {
+  const name = agent.name?.trim();
+  return name ? name : null;
+}
+
+function getAgentDisplayName(agent: ActiveAgent): string {
+  const teammateName = getTeammateName(agent);
+  return teammateName ? `tm:${teammateName}` : getShortAgentName(agent.type);
+}
+
+function getAgentDisplayMarker(agent: ActiveAgent): string {
+  return getTeammateName(agent) ? '◆' : getAgentCode(agent.type, agent.model);
+}
+
+function getAgentDisplayColor(agent: ActiveAgent): string {
+  return getTeammateName(agent) ? CYAN : getModelTierColor(agent.model);
+}
+
+/**
  * Render agents with descriptions - most informative format.
  * Shows what each agent is actually doing.
  *
@@ -392,9 +415,9 @@ export function renderAgentsWithDescriptions(agents: ActiveAgent[]): string | nu
 
   // Build agent entries with descriptions
   const entries = running.map((a) => {
-    const code = getAgentCode(a.type, a.model);
-    const color = getModelTierColor(a.model);
-    const desc = truncateDescription(a.description, 25);
+    const code = getAgentDisplayMarker(a);
+    const color = getAgentDisplayColor(a);
+    const desc = truncateDescription(a.description, getTeammateName(a) ? 30 : 25);
     const durationMs = now - a.startTime.getTime();
     const duration = formatDuration(durationMs);
 
@@ -430,8 +453,8 @@ export function renderAgentsDescOnly(agents: ActiveAgent[]): string | null {
 
   // Build descriptions
   const descriptions = running.map((a) => {
-    const color = getModelTierColor(a.model);
-    const shortName = getShortAgentName(a.type);
+    const color = getAgentDisplayColor(a);
+    const shortName = getAgentDisplayName(a);
     const desc = a.description ? truncateDescription(a.description, 20) : shortName;
     const durationMs = now - a.startTime.getTime();
     const duration = formatDuration(durationMs);
@@ -505,9 +528,9 @@ export function renderAgentsMultiLine(
     const isLast = index === displayCount - 1 && running.length <= maxLines;
     const prefix = isLast ? '└─' : '├─';
 
-    const code = getAgentCode(a.type, a.model);
-    const color = getModelTierColor(a.model);
-    const shortName = getShortAgentName(a.type).padEnd(12);
+    const code = getAgentDisplayMarker(a);
+    const color = getAgentDisplayColor(a);
+    const shortName = getAgentDisplayName(a).padEnd(12);
 
     const durationMs = now - a.startTime.getTime();
     const duration = formatDurationPadded(durationMs);

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -510,7 +510,12 @@ function processEntry(
     if (block.type === "tool_use" && block.id && block.name) {
       result.toolCallCount++;
       result.lastToolName = block.name;
-      if (block.name === "Task" || block.name === "proxy_Task" || block.name === "Agent") {
+      if (
+        block.name === "Task" ||
+        block.name === "proxy_Task" ||
+        block.name === "Agent" ||
+        block.name === "proxy_Agent"
+      ) {
         result.agentCallCount++;
         const input = block.input as TaskInput | undefined;
         const agentEntry: ActiveAgent = {

--- a/src/hud/transcript.ts
+++ b/src/hud/transcript.ts
@@ -517,6 +517,7 @@ function processEntry(
           id: block.id,
           type: input?.subagent_type ?? "unknown",
           model: input?.model,
+          name: input?.name,
           description: input?.description,
           status: "running",
           startTime: timestamp,
@@ -702,6 +703,7 @@ interface ContentBlock {
 interface TaskInput {
   subagent_type?: string;
   model?: string;
+  name?: string;
   description?: string;
 }
 

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -96,6 +96,8 @@ export interface ActiveAgent {
   id: string;
   type: string;
   model?: string;
+  /** Native Claude Code teammate name when spawned with Agent/Task name="..." */
+  name?: string;
   description?: string;
   status: 'running' | 'completed';
   startTime: Date;


### PR DESCRIPTION
Fixes #3337

## Summary
- Preserve native Agent/Task `name` values from transcripts as teammate identity.
- Render named teammates with a solid teammate marker and `tm:<name>` label in rich HUD views.
- Add regression coverage for parsing teammate names and rendering solid teammate view distinctly from subagent role rendering.

## Verification
- `npm ci`
- `npm run test:run -- src/__tests__/hud-agents.test.ts src/__tests__/hud/transcript-agent-lifecycle.test.ts`
- `npm run build`
- `npx tsc --noEmit`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*