### PR TITLE
fix: honor disabled tools in standalone MCP

### DIFF
--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -26031,13 +26031,15 @@ function uniqueSortedTargets(targets) {
     return bTime - aTime;
   });
 }
-function buildCurrentProjectTargets(projectRoot) {
+function buildCurrentProjectTargets(projectRoot, transcriptProjectRoots = [projectRoot]) {
   const claudeDir = getClaudeConfigDir();
-  const projectRoots = /* @__PURE__ */ new Set([projectRoot]);
-  const mainRepoRoot = getMainRepoRoot(projectRoot);
-  if (mainRepoRoot) projectRoots.add(mainRepoRoot);
-  const claudeWorktreeParent = getClaudeWorktreeParent(projectRoot);
-  if (claudeWorktreeParent) projectRoots.add(claudeWorktreeParent);
+  const projectRoots = new Set(transcriptProjectRoots);
+  for (const root of transcriptProjectRoots) {
+    const mainRepoRoot = getMainRepoRoot(root);
+    if (mainRepoRoot) projectRoots.add(mainRepoRoot);
+    const claudeWorktreeParent = getClaudeWorktreeParent(root);
+    if (claudeWorktreeParent) projectRoots.add(claudeWorktreeParent);
+  }
   const targets = [];
   for (const root of projectRoots) {
     const encodedDir = (0, import_path26.join)(claudeDir, "projects", encodeProjectPath(root));
@@ -26079,9 +26081,9 @@ function isWithinProject(projectPath, projectRoots) {
   if (!projectPath) {
     return false;
   }
-  const normalizedProjectPath = (0, import_path26.normalize)((0, import_path26.resolve)(projectPath));
+  const normalizedProjectPath = (0, import_path26.normalize)((0, import_path26.resolve)(projectPath)).replace(/\\/g, "/");
   return projectRoots.some((root) => {
-    const normalizedRoot = (0, import_path26.normalize)((0, import_path26.resolve)(root));
+    const normalizedRoot = (0, import_path26.normalize)((0, import_path26.resolve)(root)).replace(/\\/g, "/");
     return normalizedProjectPath === normalizedRoot || normalizedProjectPath.startsWith(`${normalizedRoot}/`);
   });
 }
@@ -26319,8 +26321,10 @@ async function searchSessionHistory(rawOptions) {
   const currentProjectRoot = resolveToWorktreeRoot(workingDirectory);
   const scopeMode = buildScopeMode(rawOptions.project);
   const projectFilter = scopeMode === "project" ? rawOptions.project : void 0;
-  const currentProjectRoots = [currentProjectRoot].concat(getMainRepoRoot(currentProjectRoot) ?? []).concat(getClaudeWorktreeParent(currentProjectRoot) ?? []).filter((value, index, arr) => Boolean(value) && arr.indexOf(value) === index);
-  const targets = scopeMode === "all" ? buildAllProjectTargets() : buildCurrentProjectTargets(currentProjectRoot);
+  const literalWorkingDirectory = rawOptions.workingDirectory ? (0, import_path26.resolve)(rawOptions.workingDirectory) : workingDirectory;
+  const currentProjectRoots = [currentProjectRoot, literalWorkingDirectory].concat(getMainRepoRoot(currentProjectRoot) ?? []).concat(getClaudeWorktreeParent(currentProjectRoot) ?? []).filter((value, index, arr) => Boolean(value) && arr.indexOf(value) === index);
+  const transcriptProjectRoots = currentProjectRoots.filter((root) => isWithinProject(root, [currentProjectRoot]));
+  const targets = scopeMode === "all" ? buildAllProjectTargets() : buildCurrentProjectTargets(currentProjectRoot, transcriptProjectRoots);
   const allMatches = [];
   for (const target of targets) {
     const fileMatches = await collectMatchesFromFile(target, {
@@ -28803,20 +28807,67 @@ Searched:
 };
 var skillsTools = [loadLocalTool, loadGlobalTool, listSkillsTool];
 
+// src/mcp/disable-tools.ts
+var DISABLE_TOOLS_GROUP_MAP = {
+  "lsp": TOOL_CATEGORIES.LSP,
+  "ast": TOOL_CATEGORIES.AST,
+  "python": TOOL_CATEGORIES.PYTHON,
+  "python-repl": TOOL_CATEGORIES.PYTHON,
+  "trace": TOOL_CATEGORIES.TRACE,
+  "state": TOOL_CATEGORIES.STATE,
+  "notepad": TOOL_CATEGORIES.NOTEPAD,
+  "memory": TOOL_CATEGORIES.MEMORY,
+  "project-memory": TOOL_CATEGORIES.MEMORY,
+  "skills": TOOL_CATEGORIES.SKILLS,
+  "interop": TOOL_CATEGORIES.INTEROP,
+  "codex": TOOL_CATEGORIES.CODEX,
+  "gemini": TOOL_CATEGORIES.GEMINI,
+  "antigravity": TOOL_CATEGORIES.ANTIGRAVITY,
+  "shared-memory": TOOL_CATEGORIES.SHARED_MEMORY,
+  "deepinit": TOOL_CATEGORIES.DEEPINIT,
+  "deepinit-manifest": TOOL_CATEGORIES.DEEPINIT,
+  "wiki": TOOL_CATEGORIES.WIKI
+};
+function parseDisabledGroups(envValue) {
+  const disabled = /* @__PURE__ */ new Set();
+  const value = envValue ?? process.env.OMC_DISABLE_TOOLS;
+  if (!value || !value.trim()) return disabled;
+  for (const name of value.split(",")) {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed) continue;
+    const category = DISABLE_TOOLS_GROUP_MAP[trimmed];
+    if (category !== void 0) {
+      disabled.add(category);
+    }
+  }
+  return disabled;
+}
+function tagCategory(tools, category) {
+  return tools.map((t) => ({ ...t, category }));
+}
+function filterDisabledTools(tools, envValue) {
+  const disabledGroups = parseDisabledGroups(envValue);
+  if (disabledGroups.size === 0) return tools;
+  return tools.filter((tool) => !tool.category || !disabledGroups.has(tool.category));
+}
+
 // src/mcp/tool-registry.ts
 var allTools = [
-  ...lspTools,
-  ...astTools,
-  pythonReplTool,
-  ...stateTools,
-  ...notepadTools,
-  ...memoryTools,
-  ...traceTools,
-  ...sharedMemoryTools,
-  deepinitManifestTool,
-  ...wikiTools,
-  ...skillsTools
+  ...tagCategory(lspTools, TOOL_CATEGORIES.LSP),
+  ...tagCategory(astTools, TOOL_CATEGORIES.AST),
+  { ...pythonReplTool, category: TOOL_CATEGORIES.PYTHON },
+  ...tagCategory(stateTools, TOOL_CATEGORIES.STATE),
+  ...tagCategory(notepadTools, TOOL_CATEGORIES.NOTEPAD),
+  ...tagCategory(memoryTools, TOOL_CATEGORIES.MEMORY),
+  ...tagCategory(traceTools, TOOL_CATEGORIES.TRACE),
+  ...tagCategory(sharedMemoryTools, TOOL_CATEGORIES.SHARED_MEMORY),
+  { ...deepinitManifestTool, category: TOOL_CATEGORIES.DEEPINIT },
+  ...tagCategory(wikiTools, TOOL_CATEGORIES.WIKI),
+  ...tagCategory(skillsTools, TOOL_CATEGORIES.SKILLS)
 ];
+function getEnabledTools(envValue) {
+  return filterDisabledTools(allTools, envValue);
+}
 function zodTypeToJsonSchema(zodType) {
   const result = {};
   if (!zodType || !zodType._def) {
@@ -28872,9 +28923,9 @@ function zodToJsonSchema2(schema) {
   }
   return { type: "object", properties, required: required2 };
 }
-function buildListToolsResponse() {
+function buildListToolsResponse(envValue) {
   return {
-    tools: allTools.map((tool) => ({
+    tools: getEnabledTools(envValue).map((tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: zodToJsonSchema2(tool.schema),
@@ -28896,10 +28947,11 @@ var server = new Server(
   }
 );
 server.setRequestHandler(ListToolsRequestSchema, async () => buildListToolsResponse());
+var getStandaloneTools = () => getEnabledTools();
 var setStandaloneCallToolRequestHandler = server.setRequestHandler.bind(server);
 setStandaloneCallToolRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-  const tool = allTools.find((t) => t.name === name);
+  const tool = getStandaloneTools().find((t) => t.name === name);
   if (!tool) {
     return {
       content: [{ type: "text", text: `Unknown tool: ${name}` }],

--- a/src/mcp/__tests__/standalone-listtools.test.ts
+++ b/src/mcp/__tests__/standalone-listtools.test.ts
@@ -21,12 +21,13 @@
  *   of scope here.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { buildListToolsResponse, allTools } from '../tool-registry.js';
 
 describe('standalone MCP server – ListTools E2E drift guard', () => {
-  // Call the same helper the live ListTools handler uses.
-  const { tools } = buildListToolsResponse();
+  // Call the same helper the live ListTools handler uses, with filtering disabled
+  // so the drift guard stays independent of the parent test process env.
+  const { tools } = buildListToolsResponse('');
   const names = tools.map((t) => t.name);
 
   // -------------------------------------------------------------------------
@@ -94,5 +95,44 @@ describe('standalone MCP server – ListTools E2E drift guard', () => {
   // -------------------------------------------------------------------------
   it('buildListToolsResponse returns one entry per registered tool', () => {
     expect(tools.length).toBe(allTools.length);
+  });
+});
+
+describe('standalone MCP server – OMC_DISABLE_TOOLS filtering', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.OMC_DISABLE_TOOLS;
+    delete process.env.OMC_DISABLE_TOOLS;
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) {
+      process.env.OMC_DISABLE_TOOLS = savedEnv;
+    } else {
+      delete process.env.OMC_DISABLE_TOOLS;
+    }
+  });
+
+  it('preserves the full ListTools surface when OMC_DISABLE_TOOLS is unset', () => {
+    const { tools } = buildListToolsResponse();
+    const names = tools.map((tool) => tool.name);
+
+    expect(tools.length).toBe(allTools.length);
+    expect(names).toContain('ast_grep_search');
+    expect(names).toContain('ast_grep_replace');
+  });
+
+  it('excludes AST tools from standalone ListTools when OMC_DISABLE_TOOLS=ast', () => {
+    process.env.OMC_DISABLE_TOOLS = 'ast';
+
+    const { tools } = buildListToolsResponse();
+    const names = tools.map((tool) => tool.name);
+
+    expect(names).not.toContain('ast_grep_search');
+    expect(names).not.toContain('ast_grep_replace');
+    expect(names).toContain('lsp_hover');
+    expect(names).toContain('python_repl');
+    expect(tools.length).toBe(allTools.length - 2);
   });
 });

--- a/src/mcp/disable-tools.ts
+++ b/src/mcp/disable-tools.ts
@@ -1,0 +1,72 @@
+import { TOOL_CATEGORIES, type ToolCategory } from '../constants/index.js';
+
+/**
+ * Map from user-facing OMC_DISABLE_TOOLS group names to ToolCategory values.
+ * Supports both canonical names and common aliases.
+ */
+export const DISABLE_TOOLS_GROUP_MAP: Record<string, ToolCategory> = {
+  'lsp': TOOL_CATEGORIES.LSP,
+  'ast': TOOL_CATEGORIES.AST,
+  'python': TOOL_CATEGORIES.PYTHON,
+  'python-repl': TOOL_CATEGORIES.PYTHON,
+  'trace': TOOL_CATEGORIES.TRACE,
+  'state': TOOL_CATEGORIES.STATE,
+  'notepad': TOOL_CATEGORIES.NOTEPAD,
+  'memory': TOOL_CATEGORIES.MEMORY,
+  'project-memory': TOOL_CATEGORIES.MEMORY,
+  'skills': TOOL_CATEGORIES.SKILLS,
+  'interop': TOOL_CATEGORIES.INTEROP,
+  'codex': TOOL_CATEGORIES.CODEX,
+  'gemini': TOOL_CATEGORIES.GEMINI,
+  'antigravity': TOOL_CATEGORIES.ANTIGRAVITY,
+  'shared-memory': TOOL_CATEGORIES.SHARED_MEMORY,
+  'deepinit': TOOL_CATEGORIES.DEEPINIT,
+  'deepinit-manifest': TOOL_CATEGORIES.DEEPINIT,
+  'wiki': TOOL_CATEGORIES.WIKI,
+};
+
+/**
+ * Parse OMC_DISABLE_TOOLS env var value into a Set of disabled ToolCategory values.
+ *
+ * Accepts a comma-separated list of group names (case-insensitive).
+ * Unknown names are silently ignored.
+ *
+ * @param envValue - The env var value to parse. Defaults to process.env.OMC_DISABLE_TOOLS.
+ * @returns Set of ToolCategory values that should be disabled.
+ *
+ * @example
+ * // OMC_DISABLE_TOOLS=lsp,python-repl,project-memory
+ * parseDisabledGroups(); // Set { 'lsp', 'python', 'memory' }
+ */
+export function parseDisabledGroups(envValue?: string): Set<ToolCategory> {
+  const disabled = new Set<ToolCategory>();
+  const value = envValue ?? process.env.OMC_DISABLE_TOOLS;
+  if (!value || !value.trim()) return disabled;
+
+  for (const name of value.split(',')) {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed) continue;
+    const category = DISABLE_TOOLS_GROUP_MAP[trimmed];
+    if (category !== undefined) {
+      disabled.add(category);
+    }
+  }
+  return disabled;
+}
+
+export function tagCategory<T extends { name: string }>(
+  tools: T[],
+  category: ToolCategory,
+): (T & { category: ToolCategory })[] {
+  return tools.map(t => ({ ...t, category }));
+}
+
+export function filterDisabledTools<T extends { category?: ToolCategory }>(
+  tools: T[],
+  envValue?: string,
+): T[] {
+  const disabledGroups = parseDisabledGroups(envValue);
+  if (disabledGroups.size === 0) return tools;
+
+  return tools.filter(tool => !tool.category || !disabledGroups.has(tool.category));
+}

--- a/src/mcp/omc-tools-server.ts
+++ b/src/mcp/omc-tools-server.ts
@@ -20,6 +20,8 @@ import { getInteropTools } from "../interop/mcp-bridge.js";
 import { deepinitManifestTool } from "../tools/deepinit-manifest.js";
 import { wikiTools } from "../tools/wiki-tools.js";
 import { TOOL_CATEGORIES, type ToolCategory } from "../constants/index.js";
+import { filterDisabledTools, tagCategory } from "./disable-tools.js";
+export { DISABLE_TOOLS_GROUP_MAP, parseDisabledGroups } from "./disable-tools.js";
 
 // Type for our tool definitions
 interface ToolDef {
@@ -30,64 +32,6 @@ interface ToolDef {
   handler: (args: unknown) => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }>;
 }
 
-// Tag each tool array with its category before aggregation
-function tagCategory<T extends { name: string }>(tools: T[], category: ToolCategory): (T & { category: ToolCategory })[] {
-  return tools.map(t => ({ ...t, category }));
-}
-
-/**
- * Map from user-facing OMC_DISABLE_TOOLS group names to ToolCategory values.
- * Supports both canonical names and common aliases.
- */
-export const DISABLE_TOOLS_GROUP_MAP: Record<string, ToolCategory> = {
-  'lsp': TOOL_CATEGORIES.LSP,
-  'ast': TOOL_CATEGORIES.AST,
-  'python': TOOL_CATEGORIES.PYTHON,
-  'python-repl': TOOL_CATEGORIES.PYTHON,
-  'trace': TOOL_CATEGORIES.TRACE,
-  'state': TOOL_CATEGORIES.STATE,
-  'notepad': TOOL_CATEGORIES.NOTEPAD,
-  'memory': TOOL_CATEGORIES.MEMORY,
-  'project-memory': TOOL_CATEGORIES.MEMORY,
-  'skills': TOOL_CATEGORIES.SKILLS,
-  'interop': TOOL_CATEGORIES.INTEROP,
-  'codex': TOOL_CATEGORIES.CODEX,
-  'gemini': TOOL_CATEGORIES.GEMINI,
-  'antigravity': TOOL_CATEGORIES.ANTIGRAVITY,
-  'shared-memory': TOOL_CATEGORIES.SHARED_MEMORY,
-  'deepinit': TOOL_CATEGORIES.DEEPINIT,
-  'deepinit-manifest': TOOL_CATEGORIES.DEEPINIT,
-  'wiki': TOOL_CATEGORIES.WIKI,
-};
-
-/**
- * Parse OMC_DISABLE_TOOLS env var value into a Set of disabled ToolCategory values.
- *
- * Accepts a comma-separated list of group names (case-insensitive).
- * Unknown names are silently ignored.
- *
- * @param envValue - The env var value to parse. Defaults to process.env.OMC_DISABLE_TOOLS.
- * @returns Set of ToolCategory values that should be disabled.
- *
- * @example
- * // OMC_DISABLE_TOOLS=lsp,python-repl,project-memory
- * parseDisabledGroups(); // Set { 'lsp', 'python', 'memory' }
- */
-export function parseDisabledGroups(envValue?: string): Set<ToolCategory> {
-  const disabled = new Set<ToolCategory>();
-  const value = envValue ?? process.env.OMC_DISABLE_TOOLS;
-  if (!value || !value.trim()) return disabled;
-
-  for (const name of value.split(',')) {
-    const trimmed = name.trim().toLowerCase();
-    if (!trimmed) continue;
-    const category = DISABLE_TOOLS_GROUP_MAP[trimmed];
-    if (category !== undefined) {
-      disabled.add(category);
-    }
-  }
-  return disabled;
-}
 
 // Aggregate all custom tools with category metadata (full list, unfiltered)
 const interopToolsEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
@@ -111,10 +55,7 @@ const allTools: ToolDef[] = [
 ];
 
 // Read OMC_DISABLE_TOOLS once at startup and filter tools accordingly
-const _startupDisabledGroups = parseDisabledGroups();
-const enabledTools: ToolDef[] = _startupDisabledGroups.size === 0
-  ? allTools
-  : allTools.filter(t => !t.category || !_startupDisabledGroups.has(t.category));
+const enabledTools: ToolDef[] = filterDisabledTools(allTools);
 
 // Convert to SDK tool format
 // The SDK's tool() expects a ZodRawShape directly (not wrapped in z.object())

--- a/src/mcp/standalone-server.ts
+++ b/src/mcp/standalone-server.ts
@@ -17,7 +17,7 @@ import {
 import type { CallToolRequest, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { registerStandaloneShutdownHandlers } from './standalone-shutdown.js';
 import { cleanupOwnedBridgeSessions } from '../tools/python-repl/bridge-manager.js';
-import { allTools, buildListToolsResponse } from './tool-registry.js';
+import { buildListToolsResponse, getEnabledTools } from './tool-registry.js';
 import { disconnectAll as disconnectAllLsp } from '../tools/lsp/index.js';
 
 type StandaloneCallToolHandler = (
@@ -44,6 +44,7 @@ const server = new Server(
 
 // List available tools — delegates to tool-registry so tests exercise the same path.
 server.setRequestHandler(ListToolsRequestSchema, async () => buildListToolsResponse());
+const getStandaloneTools = () => getEnabledTools();
 
 // Handle tool calls
 const setStandaloneCallToolRequestHandler =
@@ -52,7 +53,7 @@ const setStandaloneCallToolRequestHandler =
 setStandaloneCallToolRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
-  const tool = allTools.find(t => t.name === name);
+  const tool = getStandaloneTools().find(t => t.name === name);
   if (!tool) {
     return {
       content: [{ type: 'text', text: `Unknown tool: ${name}` }],

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -27,12 +27,15 @@ import { sharedMemoryTools } from '../tools/shared-memory-tools.js';
 import { deepinitManifestTool } from '../tools/deepinit-manifest.js';
 import { wikiTools } from '../tools/wiki-tools.js';
 import { skillsTools } from '../tools/skills-tools.js';
+import { TOOL_CATEGORIES, type ToolCategory } from '../constants/index.js';
+import { filterDisabledTools, tagCategory } from './disable-tools.js';
 import { z } from 'zod';
 
 /** Minimal tool definition shape shared across all tool families. */
 export interface ToolDef {
   name: string;
   description: string;
+  category?: ToolCategory;
   annotations?: {
     readOnlyHint?: boolean;
     destructiveHint?: boolean;
@@ -47,18 +50,23 @@ export interface ToolDef {
 
 /** All tools exposed by the standalone server, in registration order. */
 export const allTools: ToolDef[] = [
-  ...(lspTools as unknown as ToolDef[]),
-  ...(astTools as unknown as ToolDef[]),
-  pythonReplTool as unknown as ToolDef,
-  ...(stateTools as unknown as ToolDef[]),
-  ...(notepadTools as unknown as ToolDef[]),
-  ...(memoryTools as unknown as ToolDef[]),
-  ...(traceTools as unknown as ToolDef[]),
-  ...(sharedMemoryTools as unknown as ToolDef[]),
-  deepinitManifestTool as unknown as ToolDef,
-  ...(wikiTools as unknown as ToolDef[]),
-  ...(skillsTools as unknown as ToolDef[]),
+  ...tagCategory(lspTools as unknown as ToolDef[], TOOL_CATEGORIES.LSP),
+  ...tagCategory(astTools as unknown as ToolDef[], TOOL_CATEGORIES.AST),
+  { ...(pythonReplTool as unknown as ToolDef), category: TOOL_CATEGORIES.PYTHON },
+  ...tagCategory(stateTools as unknown as ToolDef[], TOOL_CATEGORIES.STATE),
+  ...tagCategory(notepadTools as unknown as ToolDef[], TOOL_CATEGORIES.NOTEPAD),
+  ...tagCategory(memoryTools as unknown as ToolDef[], TOOL_CATEGORIES.MEMORY),
+  ...tagCategory(traceTools as unknown as ToolDef[], TOOL_CATEGORIES.TRACE),
+  ...tagCategory(sharedMemoryTools as unknown as ToolDef[], TOOL_CATEGORIES.SHARED_MEMORY),
+  { ...(deepinitManifestTool as unknown as ToolDef), category: TOOL_CATEGORIES.DEEPINIT },
+  ...tagCategory(wikiTools as unknown as ToolDef[], TOOL_CATEGORIES.WIKI),
+  ...tagCategory(skillsTools as unknown as ToolDef[], TOOL_CATEGORIES.SKILLS),
 ];
+
+/** Tools currently enabled for standalone ListTools after OMC_DISABLE_TOOLS filtering. */
+export function getEnabledTools(envValue?: string): ToolDef[] {
+  return filterDisabledTools(allTools, envValue);
+}
 
 // ---------------------------------------------------------------------------
 // Zod → JSON Schema helpers (mirrors what the MCP server sends over the wire)
@@ -150,9 +158,9 @@ export interface ListToolsEntry {
  * Build the ListTools response payload exactly as standalone-server.ts sends it.
  * Tests call this directly to exercise the same code path as the live server.
  */
-export function buildListToolsResponse(): { tools: ListToolsEntry[] } {
+export function buildListToolsResponse(envValue?: string): { tools: ListToolsEntry[] } {
   return {
-    tools: allTools.map((tool) => ({
+    tools: getEnabledTools(envValue).map((tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: zodToJsonSchema(tool.schema),


### PR DESCRIPTION
Closes #3345.

## Summary
- moved OMC_DISABLE_TOOLS parsing/category filtering into shared MCP disable-tools helpers
- tagged standalone tool-registry entries with ToolCategory metadata and filtered standalone ListTools/CallTool via the shared helper
- added standalone ListTools regression coverage for OMC_DISABLE_TOOLS=ast and unset env behavior
- rebuilt and committed bridge/mcp-server.cjs because it is the standalone/plugin MCP bundle shipped by the package

## Verification
- npm test -- --run src/__tests__/disable-tools.test.ts src/mcp/__tests__/standalone-listtools.test.ts (44/44 passed)
- npm run build (passed)