### PR TITLE
ci(guard): fail PRs that commit dist/ or bridge/ build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,31 @@ jobs:
           path: dist/
           retention-days: 7
 
+  no-committed-build-artifacts:
+    name: No Committed Build Artifacts
+    runs-on: ubuntu-latest
+    # PR-only: the maintainer regenerates dist/ and bridge/ in the merge/release
+    # commit, so pushes to dev/main legitimately change them. Contributors must not.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Reject committed dist/ or bridge/ changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD -- dist/ bridge/ || true)
+          if [ -n "$CHANGED" ]; then
+            echo "::error::This PR commits generated build artifacts. dist/ and bridge/ are produced by 'npm run build' and must NOT be committed — the maintainer regenerates them at merge/release. Run 'git restore dist/ bridge/' and recommit. See .github/CLAUDE.md."
+            echo "Offending files:"
+            echo "$CHANGED" | sed 's/^/  - /'
+            exit 1
+          fi
+          echo "✅ No committed dist/ or bridge/ changes."
+
   multirepo-paths-gate:
     name: Multi-repo Path Gate (AST-grep)
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,6 +246,18 @@ npm run build
 
 Runs the complete pipeline: `tsc` → esbuild bundles → docs composition → all bridge artifacts.
 
+### Do NOT commit `dist/` or `bridge/`
+
+`npm run build` regenerates `dist/` and `bridge/`. **These are build artifacts — do not commit them in your PR.** They are gitignored, but the `bridge/*.cjs` bundles are tracked in the repo, so a rebuild will show them as modified in your working tree. The maintainer regenerates them at merge/release; committing them in a contributor PR inflates the diff, causes merge conflicts, and obscures the real change.
+
+Before committing, restore them:
+
+```bash
+git restore dist/ bridge/
+```
+
+CI enforces this: the **No Committed Build Artifacts** check fails any PR whose diff touches `dist/` or `bridge/`. (Your source change still ships — `bridge/` is rebuilt from it when the maintainer merges.)
+
 ---
 
 ## 7. Running Tests & Lint


### PR DESCRIPTION
## Summary

`.github/CLAUDE.md` already states contributors must **never commit `dist/` or `bridge/`** (they're build artifacts; the maintainer regenerates them at merge/release). But nothing *enforced* it — and since CI rebuilds artifacts on a fresh checkout before testing, a stale or extra committed bundle passes every existing job. Only manual review catches it.

This adds enforcement + documents the rule in the main `CONTRIBUTING.md` (it was only in `.github/CLAUDE.md`).

## Changes

- **`.github/workflows/ci.yml`** — new `No Committed Build Artifacts` job. Diffs the PR against its base; fails if `dist/` or `bridge/` changed, with a `git restore dist/ bridge/` fix hint.
  - **PR-only** (`if: github.event_name == 'pull_request'`) so the maintainer's merge/release commits — which legitimately rebuild `bridge/` — are never blocked.
- **`CONTRIBUTING.md`** — a "Do NOT commit `dist/` or `bridge/`" callout under the build section explaining the gitignored-but-tracked trap and pointing at the new CI check.

## Why not a "bridge is current" byte-diff guard?

The first idea was a job that rebuilds and runs `git diff --exit-code -- bridge/` to ensure committed bridge matches source. Investigation showed that's the wrong model here: contributors don't commit bridge at all, so there's nothing to keep "current" in a PR — the maintainer rebuilds at merge. Enforcing the actual rule (*don't commit artifacts*) is simpler and needs no cross-environment reproducible-build guarantee.

## Verification

- `ci.yml` parses (validated with `yaml.safe_load`); job graph intact.
- Guard logic checked against real branches: flags a branch that committed `bridge/`, passes a source-only branch and a clean branch.
- This PR itself touches only `ci.yml` + `CONTRIBUTING.md` → the new check passes on itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)