### PR TITLE
fix(perf): widen CI envelope for subagent-lock benchmark (#3352)

### DIFF
--- a/tests/perf/subagent-lock.bench.ts
+++ b/tests/perf/subagent-lock.bench.ts
@@ -2,9 +2,11 @@
  * Benchmark: subagent-tracking RMW latency under no contention.
  *
  * Measures per-update wall time for sequential updates. Local Linux keeps the
- * strict p99 <= 8ms guard; CI runners use repeated samples and a wider p99
+ * strict p99 <= 8ms guard; CI runners use repeated samples and a wider p50/p99
  * envelope so an isolated scheduler/filesystem stall does not fail dev, while
- * still catching sustained lock slowdowns and hangs.
+ * still catching sustained lock slowdowns and hangs (median-p50, median-p99,
+ * and max-p99 ceilings). GitHub-hosted runners routinely sustain ~23-31ms p50
+ * / ~30-32ms p99 on a healthy path, so the CI ceilings sit above that band.
  */
 
 import { describe, it, expect, afterEach } from "vitest";
@@ -22,9 +24,13 @@ const N = 100;
 const WARMUP_RUNS = 1;
 const MEASURED_RUNS = 5;
 const LOCAL_P99_LIMIT_MS = 8;
-const CI_MEDIAN_P50_LIMIT_MS = 8;
+// CI ceilings sit above the GitHub-hosted runner steady-state band (p50
+// ~23-31ms, p99 ~30-32ms) so healthy runs pass, while still catching sustained
+// slowdowns/hangs via the median-p50, median-p99, and max-p99 guards. The
+// strict 8ms target is kept for LOCAL runs only (LOCAL_P99_LIMIT_MS). See #3352.
+const CI_MEDIAN_P50_LIMIT_MS = 40;
 const CI_MEDIAN_P99_LIMIT_MS = 25;
-const CI_MEDIAN_P99_JITTER_MARGIN_MS = 5;
+const CI_MEDIAN_P99_JITTER_MARGIN_MS = 20;
 const CI_MAX_P99_LIMIT_MS = 100;
 const isCi = process.env.CI === "true" || process.env.CI === "1";
 


### PR DESCRIPTION
Fixes #3352.

## Problem

`CI / Test` fails on `tests/perf/subagent-lock.bench.ts` for PRs that do not touch the benchmark (e.g. #3350), blocking unrelated work:

```
AssertionError: expected 23.576250000000073 to be less than or equal to 8
  ❯ tests/perf/subagent-lock.bench.ts:152:27
```

The file documents the intent that **CI uses a wider envelope** than local's strict 8ms (header + the comment at the assertion), but the **p50** CI ceiling was never widened — it was left at the strict local `8`, while GitHub-hosted runners routinely sustain ~23–31ms p50 / ~30–32ms p99 on a healthy path. The `medianP99` band (30ms) was also marginally exceeded in the same runs.

## Change

Raise the CI ceilings above the observed steady-state band; the strict 8ms target stays for **local** runs only, and the 100ms max-p99 hang guard is unchanged:

```diff
-const CI_MEDIAN_P50_LIMIT_MS = 8;
+const CI_MEDIAN_P50_LIMIT_MS = 40;   // was the strict local value, never widened
-const CI_MEDIAN_P99_JITTER_MARGIN_MS = 5;
+const CI_MEDIAN_P99_JITTER_MARGIN_MS = 20;  // median-p99 band 30ms -> 45ms
```

Sustained slowdowns/hangs are still caught by the median-p50 (40ms), median-p99 (45ms), and max-p99 (100ms) guards, plus the informational <30s hang sanity check.

## Verification

- `npm run lint` clean.
- Diff is the single bench file — no source/runtime change.
- The hard assertion is `it.runIf(process.platform === "linux")`, so it is skipped on the macOS dev box; the ceilings are calibrated against the Linux CI medians reported in #3352 (and reproduced ~30.5ms p50 by reviewers on their machines), all comfortably under the new 40/45ms ceilings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)