### PR TITLE
fix(project-memory): normalize hot-path separators for Windows scope affinity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           src/__tests__/session-history-search.test.ts
           src/cli/__tests__/session-search.test.ts
           src/lib/__tests__/worktree-paths.test.ts
+          src/hooks/project-memory/__tests__/hot-path-tracker.test.ts
 
   build:
     name: Build

--- a/src/hooks/project-memory/__tests__/hot-path-tracker.test.ts
+++ b/src/hooks/project-memory/__tests__/hot-path-tracker.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the Hot Path Tracker scope-affinity ranking.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getTopHotPaths, trackAccess } from "../hot-path-tracker.js";
+import { HotPath, ProjectMemoryContext } from "../types.js";
+
+const NOW = Date.parse("2026-03-24T15:00:00Z");
+
+function hotPath(path: string, accessCount: number): HotPath {
+  return { path, accessCount, lastAccessed: NOW, type: "file" };
+}
+
+describe("getTopHotPaths scope affinity", () => {
+  it("boosts a hot path inside the working scope when stored with Windows separators", () => {
+    // trackAccess() stores hp.path from path.relative(), which returns backslash
+    // separators on Windows (e.g. "src\\app\\index.ts"), while normalizeScopePath()
+    // converts the working directory to forward slashes. Before the fix the two
+    // never matched on Windows, so scope affinity scored 0 and the in-scope file
+    // lost to a more-accessed out-of-scope file. Asserts on literal strings, so it
+    // runs and guards on every OS (the separator normalization is a no-op on POSIX).
+    const inScope = hotPath("src\\app\\index.ts", 3); // fewer accesses...
+    const outOfScope = hotPath("docs\\guide.md", 5); // ...but more accesses
+
+    const context: ProjectMemoryContext = {
+      workingDirectory: "src/app",
+      now: NOW,
+    };
+
+    const top = getTopHotPaths([outOfScope, inScope], 10, context);
+
+    // With scope affinity working, the in-scope file outranks the more-accessed
+    // out-of-scope file. Before the fix both scored 0 affinity, so the
+    // out-of-scope file (higher access count) ranked first.
+    expect(top[0].path).toBe("src\\app\\index.ts");
+  });
+
+  it("ranks identically whether the in-scope path uses POSIX or Windows separators", () => {
+    const posix = getTopHotPaths(
+      [hotPath("docs/guide.md", 5), hotPath("src/app/index.ts", 3)],
+      10,
+      { workingDirectory: "src/app", now: NOW },
+    );
+    const windows = getTopHotPaths(
+      [hotPath("docs\\guide.md", 5), hotPath("src\\app\\index.ts", 3)],
+      10,
+      { workingDirectory: "src/app", now: NOW },
+    );
+
+    expect(posix[0].path).toBe("src/app/index.ts");
+    expect(windows[0].path).toBe("src\\app\\index.ts");
+  });
+});
+
+describe("trackAccess separator normalization", () => {
+  it("stores hot paths with forward slashes when given Windows separators", () => {
+    // A relative path with backslashes (as produced by path.relative() on
+    // Windows) must be stored with forward slashes so the persisted data and
+    // the scope-affinity comparison stay consistent across operating systems.
+    // The input is not absolute, so this takes the same branch on every OS and
+    // asserts deterministically.
+    const result = trackAccess([], "src\\app\\index.ts", "/repo", "file");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe("src/app/index.ts");
+  });
+});

--- a/src/hooks/project-memory/hot-path-tracker.ts
+++ b/src/hooks/project-memory/hot-path-tracker.ts
@@ -17,9 +17,13 @@ export function trackAccess(
   projectRoot: string,
   type: "file" | "directory",
 ): HotPath[] {
-  const relativePath = path.isAbsolute(filePath)
-    ? path.relative(projectRoot, filePath)
-    : filePath;
+  // path.relative() returns the platform separator (backslashes on Windows).
+  // Store hot paths with forward slashes so the persisted data, the rendered
+  // output, and the scope-affinity comparison are identical on every OS
+  // (a no-op on POSIX, where paths already use forward slashes).
+  const relativePath = (
+    path.isAbsolute(filePath) ? path.relative(projectRoot, filePath) : filePath
+  ).replace(/\\/g, "/");
 
   const normalizedHotPaths = ensureHotPathList(hotPaths);
 
@@ -135,19 +139,25 @@ function getScopeAffinityScore(
     return 0;
   }
 
-  if (hotPath === scopePath) {
+  // hotPath is stored from path.relative(), which uses the platform separator
+  // (backslashes on Windows), while scopePath is already normalized to forward
+  // slashes by normalizeScopePath(). Normalize the separators so the comparisons
+  // below match on every OS (a no-op on POSIX).
+  const normalizedHotPath = hotPath.replace(/\\/g, "/");
+
+  if (normalizedHotPath === scopePath) {
     return 400;
   }
 
-  if (hotPath.startsWith(`${scopePath}/`)) {
+  if (normalizedHotPath.startsWith(`${scopePath}/`)) {
     return 320;
   }
 
-  if (scopePath.startsWith(`${hotPath}/`)) {
+  if (scopePath.startsWith(`${normalizedHotPath}/`)) {
     return 220;
   }
 
-  const hotSegments = hotPath.split("/");
+  const hotSegments = normalizedHotPath.split("/");
   const scopeSegments = scopePath.split("/");
   let sharedSegments = 0;
 


### PR DESCRIPTION
## Problem

The project-memory hot-path tracker ranks frequently accessed files for the `[Hot Paths]` context block. On Windows, the scope-affinity signal that boosts files inside the current working directory is silently disabled, so the block is mis-ranked. POSIX is unaffected, which is why this stayed hidden from Linux and macOS CI.

## Root cause

`trackAccess()` stores each hot path from `path.relative(projectRoot, filePath)`, which returns the platform separator: backslashes on Windows (for example `agent\generate.py`). Every consumer then compares a hot path against `scopePath`, which `normalizeScopePath()` has already converted to forward slashes. On Windows the two separators never match, so `getScopeAffinityScore()` returns 0 for every hot path, including one directly inside the working directory.

Concretely, a hot path persisted as `agent\generate.py` is compared against scope `agent/generate.py`. `"agent\generate.py".startsWith("agent/")` is false, and `"agent\generate.py".split("/")` yields a single segment, so the path that should score 320 (inside scope) scores 0.

## Fix

Normalize separators to forward slashes in two places:

- `trackAccess()`, at storage, so persisted data, rendered output, and comparisons are consistent on every OS going forward.
- `getScopeAffinityScore()`, at comparison, so paths already persisted with backslashes on existing Windows installs score correctly until they are re-tracked or decay out.

Both are no-ops on POSIX, where paths already use forward slashes.

## Tests

- New `hot-path-tracker.test.ts`: the in-scope file outranks a more-accessed out-of-scope file when stored with Windows separators; POSIX and Windows inputs rank identically; `trackAccess()` stores forward slashes. All assert on literal strings, so they run on every OS.
- This also greens a pre-existing Windows failure in `learner.test.ts` ("should initialize hot paths when saved memory is missing hotPaths"), which asserted `src/index.ts` but got `src\index.ts` on Windows.
- Wired the new test into the `test-windows` job, per its note to keep the list in sync with the path-handling test files.

Verified locally: `npx tsc --noEmit`, `eslint`, and the full `project-memory` suite (65 tests) pass. No `dist/` or `bridge/` changes.

## Scope notes

After this change, re-accessing a path that was previously stored with backslashes creates a fresh forward-slash entry while the old entry lingers until it decays (50-path cap, weekly decay). Migrating already-persisted entries is out of scope and self-heals; noting it as a possible follow-up.
