### PR TITLE
fix(hud): render cwd as ~ and forward slashes on Windows

### DIFF
--- a/src/__tests__/hud/cwd.test.ts
+++ b/src/__tests__/hud/cwd.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { homedir } from 'node:os';
 import { renderCwd } from '../../hud/elements/cwd.js';
 
-// Mock os.homedir and path.basename
+// Mock os.homedir (controllable so Windows-style homes can be exercised too).
 vi.mock('node:os', () => ({
-  homedir: () => '/Users/testuser',
+  homedir: vi.fn(() => '/Users/testuser'),
 }));
 
 describe('renderCwd', () => {
@@ -81,6 +82,37 @@ describe('renderCwd', () => {
     it('applies dim styling', () => {
       const result = renderCwd('/Users/testuser/project');
       expect(result).toContain('\x1b[2m'); // dim escape code
+    });
+  });
+
+  // On Windows, the cwd handed to renderCwd comes from
+  // `git rev-parse --show-toplevel` (via resolveToWorktreeRoot), which emits
+  // forward slashes, while homedir() emits backslashes. A raw startsWith()
+  // misses, so the full absolute path leaks into the HUD instead of "~".
+  describe('relative format with backslash home (Windows)', () => {
+    beforeEach(() => {
+      vi.mocked(homedir).mockReturnValue('C:\\Users\\testuser');
+    });
+    afterEach(() => {
+      vi.mocked(homedir).mockReturnValue('/Users/testuser');
+    });
+
+    it('collapses a forward-slash cwd under a backslash home to ~', () => {
+      const result = renderCwd('C:/Users/testuser/workspace/project', 'relative');
+      expect(result).toContain('~/workspace/project');
+      expect(result).not.toContain('C:');
+    });
+
+    it('collapses the exact home directory to ~', () => {
+      const result = renderCwd('C:/Users/testuser', 'relative');
+      expect(result).toContain('~');
+      expect(result).not.toContain('C:');
+    });
+
+    it('preserves a path outside home', () => {
+      const result = renderCwd('D:/work/project', 'relative');
+      expect(result).toContain('D:/work/project');
+      expect(result).not.toContain('~');
     });
   });
 });

--- a/src/hud/elements/cwd.ts
+++ b/src/hud/elements/cwd.ts
@@ -6,7 +6,7 @@
  */
 
 import { homedir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname } from 'node:path';
 import { dim } from '../colors.js';
 import type { CwdFormat } from '../types.js';
 
@@ -52,9 +52,14 @@ export function renderCwd(
 
   switch (format) {
     case 'relative': {
-      const home = homedir();
-      displayPath = cwd.startsWith(home)
-        ? '~' + cwd.slice(home.length)
+      // cwd reaches here from `git rev-parse --show-toplevel` (via
+      // resolveToWorktreeRoot), which emits forward slashes even on Windows,
+      // while homedir() emits backslashes. Compare on normalized separators so
+      // the prefix check matches, as pathToFileUrl() already does above.
+      const home = homedir().replace(/\\/g, '/');
+      const normalizedCwd = cwd.replace(/\\/g, '/');
+      displayPath = normalizedCwd.startsWith(home)
+        ? '~' + normalizedCwd.slice(home.length)
         : cwd;
       break;
     }
@@ -66,7 +71,10 @@ export function renderCwd(
       // directory names like src/, test/, docs/, packages/core, apps/web.
       const parent = basename(dirname(cwd));
       const folder = basename(cwd);
-      displayPath = parent ? join(parent, folder) : folder;
+      // Join with a literal "/" rather than join(), whose win32 separator would
+      // render "parent\leaf" and break display consistency with the rest of the
+      // HUD (which uses forward slashes everywhere).
+      displayPath = parent ? `${parent}/${folder}` : folder;
       break;
     }
     default:


### PR DESCRIPTION
## Problem

With the HUD `cwd` element enabled, the **relative** format shows the full absolute path instead of `~/…` on Windows:

```
C:/Users/you/oh-my-claudecode        <- shown
~/oh-my-claudecode                   <- expected
```

The cwd handed to `renderCwd()` comes from `git rev-parse --show-toplevel` (via `resolveToWorktreeRoot`), which emits **forward slashes even on Windows**, while `homedir()` emits **backslashes**. The relative branch compared them with a raw `startsWith()`:

```ts
const home = homedir();              // C:\Users\you   (backslashes)
cwd.startsWith(home)                 // "C:/Users/you/...".startsWith("C:\Users\you") -> false
```

So the prefix never matches and the `~` collapse is skipped.

The **folder** format has the same bug class: `join(parent, folder)` uses the win32 separator, rendering `parent\leaf` instead of `parent/leaf`. The existing folder-format tests already assert forward slashes, so they were silently failing on native Windows. CI runs Linux, where `join` returns `/`, so it never surfaced.

## Root cause

`src/hud/elements/cwd.ts` mixed separator conventions: it compared a forward-slash cwd against a backslash `homedir()`, and built the folder display with `join()` (OS separator). `pathToFileUrl()` in the same file already normalizes backslashes for exactly this reason. The `relative` and `folder` branches just missed it.

## Fix

Normalize separators before the relative prefix check, and build the folder display with a literal `/`. Both are no-ops on POSIX.

```ts
// relative
const home = homedir().replace(/\\/g, '/');
const normalizedCwd = cwd.replace(/\\/g, '/');
displayPath = normalizedCwd.startsWith(home) ? '~' + normalizedCwd.slice(home.length) : cwd;

// folder
displayPath = parent ? `${parent}/${folder}` : folder;
```

## Tests

- Added `relative format with backslash home (Windows)` cases (mocked backslash `homedir()` + forward-slash cwd): collapses to `~/…`, handles exact home, preserves outside-home paths. These fail on the current code and pass with the fix.
- The three pre-existing `folder format` tests (which assert forward slashes) now pass on Windows.
- Baseline diff against the clean tree: `src/__tests__/hud/` goes from 24 failing to 21 failing; the 3 fixed are exactly the folder cases, and `cwd.test.ts` no longer appears in the failures. The remaining 21 are pre-existing and unrelated (usage-api timing, call-counts, state, and the `windows-platform` "emoji on current platform" case).
- `npm run build` and `tsc --noEmit` pass; eslint clean on both files.

## Scope

`renderCwd` only (display). No change to the absolute/default branches or to POSIX behavior. Drive-letter case folding is deliberately left out, since it is not an observed failure.

Refs #776 (Windows QA).
