### PR TITLE
fix: respect home path boundary in HUD cwd

### DIFF
--- a/src/__tests__/hud/cwd.test.ts
+++ b/src/__tests__/hud/cwd.test.ts
@@ -34,6 +34,12 @@ describe('renderCwd', () => {
       expect(result).toContain('~');
     });
 
+    it('does not collapse a sibling prefix under the home directory name', () => {
+      const result = renderCwd('/Users/testuser2/workspace/project', 'relative');
+      expect(result).toContain('/Users/testuser2/workspace/project');
+      expect(result).not.toContain('~2');
+    });
+
     it('preserves paths outside home directory', () => {
       const result = renderCwd('/tmp/some/path', 'relative');
       expect(result).toContain('/tmp/some/path');
@@ -107,6 +113,12 @@ describe('renderCwd', () => {
       const result = renderCwd('C:/Users/testuser', 'relative');
       expect(result).toContain('~');
       expect(result).not.toContain('C:');
+    });
+
+    it('does not collapse a sibling prefix under the Windows home directory name', () => {
+      const result = renderCwd('C:/Users/testuser2/workspace/project', 'relative');
+      expect(result).toContain('C:/Users/testuser2/workspace/project');
+      expect(result).not.toContain('~2');
     });
 
     it('preserves a path outside home', () => {

--- a/src/hud/elements/cwd.ts
+++ b/src/hud/elements/cwd.ts
@@ -54,13 +54,18 @@ export function renderCwd(
     case 'relative': {
       // cwd reaches here from `git rev-parse --show-toplevel` (via
       // resolveToWorktreeRoot), which emits forward slashes even on Windows,
-      // while homedir() emits backslashes. Compare on normalized separators so
-      // the prefix check matches, as pathToFileUrl() already does above.
+      // while homedir() emits backslashes. Compare on normalized separators,
+      // but only abbreviate when cwd is exactly home or crosses a real path
+      // boundary so sibling prefixes like /Users/testuser2 do not fold to ~2.
       const home = homedir().replace(/\\/g, '/');
       const normalizedCwd = cwd.replace(/\\/g, '/');
-      displayPath = normalizedCwd.startsWith(home)
-        ? '~' + normalizedCwd.slice(home.length)
-        : cwd;
+      if (normalizedCwd === home) {
+        displayPath = '~';
+      } else if (normalizedCwd.startsWith(`${home}/`)) {
+        displayPath = '~' + normalizedCwd.slice(home.length);
+      } else {
+        displayPath = cwd;
+      }
       break;
     }
     case 'absolute':


### PR DESCRIPTION
## Summary
- Follow-up to #3359: keep Windows separator normalization for HUD cwd rendering while only abbreviating to `~` when cwd is exactly home or a true descendant.
- Prevent sibling prefixes like `/Users/testuser2` and `C:/Users/testuser2` from rendering as `~2/...`.
- Add focused POSIX and Windows-style regression coverage.

## Verification
- `npm ci`
- `npm run test:run -- src/__tests__/hud/cwd.test.ts`
- `npm run build`

Do not merge automatically; this is the #3359 boundary follow-up.