### PR TITLE
docs(release): clarify CLI and plugin install tracks

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -34,13 +34,18 @@ Maintenance release with **11 bug fixes** and **3 other changes** across **14 me
 
 ### Install / Update
 
+The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.
+
+**CLI / runtime:**
+
 ```bash
 npm install -g oh-my-claude-sisyphus@4.15.1
 ```
 
-Or reinstall the plugin:
-```bash
-claude /install-plugin oh-my-claudecode
+**Claude Code plugin:**
+
+```text
+/plugin marketplace update omc
 ```
 
 ## Contributors

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,7 +1,17 @@
 ## Install / Upgrade
 
+The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.
+
+**CLI / runtime:**
+
 ```bash
 npm i -g oh-my-claude-sisyphus@{{VERSION}}
+```
+
+**Claude Code plugin:**
+
+```text
+/plugin marketplace update omc
 ```
 
 > **Package naming note:** the repo, plugin, and commands are branded **oh-my-claudecode**, but the published npm package name remains [`oh-my-claude-sisyphus`](https://www.npmjs.com/package/oh-my-claude-sisyphus).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,19 @@ jobs:
             echo "## oh-my-claudecode v${VERSION}" > release-notes.md
             echo "" >> release-notes.md
             echo "### Install / Update" >> release-notes.md
+            echo "" >> release-notes.md
+            echo 'The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.' >> release-notes.md
+            echo "" >> release-notes.md
+            echo "**CLI / runtime:**" >> release-notes.md
+            echo "" >> release-notes.md
             echo '```bash' >> release-notes.md
             echo "npm install -g oh-my-claude-sisyphus@${VERSION}" >> release-notes.md
+            echo '```' >> release-notes.md
+            echo "" >> release-notes.md
+            echo "**Claude Code plugin:**" >> release-notes.md
+            echo "" >> release-notes.md
+            echo '```text' >> release-notes.md
+            echo "/plugin marketplace update omc" >> release-notes.md
             echo '```' >> release-notes.md
           fi
 

--- a/src/__tests__/release-generation.test.ts
+++ b/src/__tests__/release-generation.test.ts
@@ -123,7 +123,11 @@ describe('release generation', () => {
       'v4.10.1',
     );
 
+    expect(body).toContain('The npm CLI and the Claude Code marketplace/plugin are separate install tracks');
+    expect(body).toContain('if you have both installed, update both');
+    expect(body).toContain('CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI');
     expect(body).toContain('npm install -g oh-my-claude-sisyphus@4.10.2');
+    expect(body).toContain('/plugin marketplace update omc');
     expect(body).toContain('https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.10.1...v4.10.2');
     expect(body).toContain('@blue-int @DdangJin @Yeachan-Heo');
     expect(body.match(/## Contributors/g)).toHaveLength(1);

--- a/src/lib/release-generation.ts
+++ b/src/lib/release-generation.ts
@@ -247,10 +247,15 @@ export function generateReleaseBody(
   let body = changelog;
 
   body += `\n### Install / Update\n\n`;
+  body += 'The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.\n\n';
+  body += '**CLI / runtime:**\n\n';
   body += '```bash\n';
   body += `npm install -g oh-my-claude-sisyphus@${version}\n`;
   body += '```\n\n';
-  body += 'Or reinstall the plugin:\n```bash\nclaude /install-plugin oh-my-claudecode\n```\n';
+  body += '**Claude Code plugin:**\n\n';
+  body += '```text\n';
+  body += '/plugin marketplace update omc\n';
+  body += '```\n';
 
   if (prevTag) {
     body += `\n**Full Changelog**: ${repoUrl}/compare/${prevTag}...v${version}\n`;


### PR DESCRIPTION
## Summary
- Clarifies release install/update notes so the npm CLI/runtime and Claude Code plugin are separate install tracks, not either/or replacements.
- Notes that users with both tracks installed should update both to avoid drift.
- Documents that CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the npm-installed `omc` CLI.
- Updates the release workflow/generator and focused release-generation test expectations.

Closes #3361

## Verification
- `git diff --check`
- `npm run test:run -- src/__tests__/release-generation.test.ts` (7 tests passed)
