### PR TITLE
feat(team): add GitHub Copilot CLI as a team worker and ask provider

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -206,7 +206,7 @@ function isExplicitRalplanSlashInvocation(prompt) {
 }
 
 function isExplicitAskSlashInvocation(prompt) {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|antigravity|agy|grok|cursor)\b/i.test(prompt);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|antigravity|agy|grok|cursor|copilot)\b/i.test(prompt);
 }
 
 // Sanitize text to prevent false positives from code blocks, XML tags, URLs, and file paths

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -12,6 +12,7 @@ const PROVIDER_BINARIES = {
   antigravity: 'agy',
   grok: 'grok',
   cursor: 'cursor-agent',
+  copilot: 'copilot',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
@@ -50,6 +51,9 @@ const ANTIGRAVITY_TIMEOUT_MS = (() => {
  * - grok: `grok -p <prompt> --always-approve` (headless mode takes the prompt
  *   as an arg; grok's stdin is reserved for ACP JSON-RPC, never the prompt)
  * - cursor: `cursor-agent --print --force --trust --sandbox disabled <prompt>`
+ * - copilot: `copilot -p <prompt> -s --allow-all-tools --no-ask-user` (GitHub
+ *   Copilot CLI one-shot; `-s` prints only the final answer, --allow-all-tools and
+ *   --no-ask-user keep it non-interactive; prompt is the `-p` value, never stdin)
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
@@ -75,6 +79,14 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
     // Cursor Agent's print mode takes the prompt as a positional arg. Keep stdin
     // closed so it cannot interpret advisor prompt bytes as interactive input.
     return ['--print', '--force', '--trust', '--sandbox', 'disabled', prompt];
+  }
+  if (provider === 'copilot') {
+    // GitHub Copilot CLI one-shot: `-p <prompt>` runs non-interactively and exits;
+    // `-s` prints only the final answer (clean stdout for the advisor artifact);
+    // --allow-all-tools and --no-ask-user keep it autonomous so it never blocks on
+    // a permission or ask_user prompt. Prompt is the `-p` value, never stdin.
+    // Verified on GitHub Copilot CLI 1.0.65.
+    return ['-p', prompt, '-s', '--allow-all-tools', '--no-ask-user'];
   }
   // claude: `claude -p` reads the prompt from stdin when no prompt arg is given.
   return pipePromptViaStdin ? ['-p'] : ['-p', prompt];
@@ -106,8 +118,8 @@ function shouldPipePromptViaStdin(provider, prompt) {
     return prompt.includes('\n') || prompt.length > 500 || /^\s*-/.test(prompt);
   }
 
-  // grok (ACP stdin), cursor-agent (interactive stdin), and any other provider
-  // never pipe the prompt.
+  // grok (ACP stdin), cursor-agent (interactive stdin), copilot (prompt is the
+  // `-p` arg value), and any other provider never pipe the prompt.
   return false;
 }
 
@@ -115,8 +127,8 @@ const ASK_ORIGINAL_TASK_ENV = 'OMC_ASK_ORIGINAL_TASK';
 const ASK_ORIGINAL_TASK_ENV_ALIAS = 'OMX_ASK_ORIGINAL_TASK';
 
 function usage() {
-  console.error('Usage: omc ask <claude|codex|gemini|antigravity|grok|cursor> "<prompt>"');
-  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|antigravity|grok|cursor> <prompt...>');
+  console.error('Usage: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> "<prompt>"');
+  console.error('Legacy direct usage: node scripts/run-provider-advisor.js <claude|codex|gemini|antigravity|grok|cursor|copilot> <prompt...>');
   console.error('                 or: node scripts/run-provider-advisor.js claude --print "<prompt>"');
   console.error('                 or: node scripts/run-provider-advisor.js gemini --prompt "<prompt>"');
 }

--- a/src/__tests__/runtime-guidance-plan-ralph.test.ts
+++ b/src/__tests__/runtime-guidance-plan-ralph.test.ts
@@ -8,6 +8,7 @@ const availability = vi.hoisted(() => ({
   cursor: false,
   grok: false,
   antigravity: false,
+  copilot: false,
 }));
 
 vi.mock('../team/model-contract.js', () => ({

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -296,6 +296,8 @@ describe('parseAskArgs', () => {
     expect(parseAskArgs(['grok', '-p', 'brainstorm'])).toEqual({ provider: 'grok', prompt: 'brainstorm' });
     expect(parseAskArgs(['cursor', 'review', 'this'])).toEqual({ provider: 'cursor', prompt: 'review this' });
     expect(parseAskArgs(['cursor', '-p', 'brainstorm'])).toEqual({ provider: 'cursor', prompt: 'brainstorm' });
+    expect(parseAskArgs(['copilot', 'review', 'this'])).toEqual({ provider: 'copilot', prompt: 'review this' });
+    expect(parseAskArgs(['copilot', '-p', 'brainstorm'])).toEqual({ provider: 'copilot', prompt: 'brainstorm' });
   });
 
   it('supports --agent-prompt flag and equals syntax', () => {
@@ -693,6 +695,47 @@ describe('run-provider-advisor script contract', () => {
         '--sandbox',
         'disabled',
         'review this\nand that',
+      ]);
+      expect(launch!.options.input ?? null).toBeNull();
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('launches copilot as `copilot -p <prompt> -s --allow-all-tools --no-ask-user` and never pipes stdin', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-copilot-args-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      // Copilot's headless `-p` takes the prompt as its arg value; stdin is not used
+      // for the prompt, so it must stay closed even for multiline prompts.
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['copilot', '--prompt', 'review this\nand that'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { input: string | null };
+      }>;
+
+      // version probe + launch, both via the `copilot` binary
+      expect(calls).toHaveLength(2);
+      const launch = calls.find((c) => !c.args.includes('--version'));
+      expect(launch).toBeDefined();
+      expect(launch!.command).toBe('copilot');
+      expect(launch!.args).toEqual([
+        '-p',
+        'review this\nand that',
+        '-s',
+        '--allow-all-tools',
+        '--no-ask-user',
       ]);
       expect(launch!.options.input ?? null).toBeNull();
     } finally {

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -7,15 +7,15 @@ import { fileURLToPath } from 'url';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
 export const ASK_USAGE = [
-  'Usage: omc ask <claude|codex|gemini|antigravity|grok|cursor> <question or task>',
-  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor> -p "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor> --print "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor> --prompt "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor> --agent-prompt <role> "<prompt>"',
-  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor> --agent-prompt=<role> --prompt "<prompt>"',
+  'Usage: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> <question or task>',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> -p "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> --print "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> --prompt "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> --agent-prompt <role> "<prompt>"',
+  '   or: omc ask <claude|codex|gemini|antigravity|grok|cursor|copilot> --agent-prompt=<role> --prompt "<prompt>"',
 ].join('\n');
 
-const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'antigravity', 'grok', 'cursor'] as const;
+const ASK_PROVIDERS = ['claude', 'codex', 'gemini', 'antigravity', 'grok', 'cursor', 'copilot'] as const;
 export type AskProvider = (typeof ASK_PROVIDERS)[number];
 const ASK_PROVIDER_SET = new Set<string>(ASK_PROVIDERS);
 

--- a/src/cli/commands/doctor-team-routing.ts
+++ b/src/cli/commands/doctor-team-routing.ts
@@ -27,6 +27,7 @@ const PROVIDER_BINARY: Record<TeamRoleProvider, string> = {
   grok: 'grok',
   cursor: 'cursor-agent',
   antigravity: 'agy',
+  copilot: 'copilot',
 };
 
 function probeProvider(provider: TeamRoleProvider): ProviderProbe {
@@ -64,7 +65,7 @@ function collectConfiguredProviders(): Set<TeamRoleProvider> {
   const roleRouting = cfg.team?.roleRouting ?? {};
   for (const spec of Object.values(roleRouting)) {
     const provider = spec?.provider as TeamRoleProvider | undefined;
-    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'grok' || provider === 'cursor' || provider === 'antigravity') {
+    if (provider === 'claude' || provider === 'codex' || provider === 'gemini' || provider === 'grok' || provider === 'cursor' || provider === 'antigravity' || provider === 'copilot') {
       providers.add(provider);
     }
   }

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -26,7 +26,7 @@ import { getOmcRoot } from '../../lib/worktree-paths.js';
 const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
-const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity']);
+const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity', 'copilot']);
 const CURSOR_ALLOWED_TEAM_ROLES = new Set(['executor']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
@@ -44,6 +44,7 @@ Examples:
   omc team 1:codex,1:gemini "compare approaches"
   omc team 1:cursor:executor "apply the implementation"
   omc team 1:antigravity:executor "apply the implementation"
+  omc team 1:copilot:executor "apply the implementation"
   omc team 2:codex "review auth flow" --new-window
   omc team status fix-failing-tests
   omc team shutdown fix-failing-tests

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -16,7 +16,7 @@ import { readApprovedExecutionLaunchHintOutcome } from '../planning/artifacts.js
 import { getOmcRoot } from '../lib/worktree-paths.js';
 
 const JOB_ID_PATTERN = /^omc-[a-z0-9]{1,16}$/;
-const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'grok', 'antigravity']);
+const VALID_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'cursor', 'grok', 'antigravity', 'copilot']);
 const SUBCOMMANDS = new Set(['start', 'status', 'wait', 'cleanup', 'resume', 'shutdown', 'api', 'help', '--help', '-h']);
 
 const SUPPORTED_API_OPERATIONS = new Set([
@@ -794,7 +794,7 @@ export async function teamCleanupCommand(
 
 export const TEAM_USAGE = `
 Usage:
-  omc team start --agent <claude|codex|gemini|cursor|grok|antigravity>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--auto-merge] [--json]
+  omc team start --agent <claude|codex|gemini|cursor|grok|antigravity|copilot>[,<agent>...] --task "<task>" [--count N] [--name TEAM] [--cwd DIR] [--new-window] [--auto-merge] [--json]
   omc team status <job_id|team_name> [--json] [--cwd DIR]
   omc team wait <job_id> [--timeout-ms MS] [--json]
   omc team cleanup <job_id> [--grace-ms MS] [--json]

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -402,6 +402,14 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     externalModelsDefaults.antigravityModel = process.env.OMC_ANTIGRAVITY_DEFAULT_MODEL;
   }
 
+  if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL) {
+    externalModelsDefaults.copilotModel =
+      process.env.OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL;
+  } else if (process.env.OMC_COPILOT_DEFAULT_MODEL) {
+    // Legacy fallback
+    externalModelsDefaults.copilotModel = process.env.OMC_COPILOT_DEFAULT_MODEL;
+  }
+
   const externalModelsFallback: ExternalModelsConfig["fallbackPolicy"] = {
     onModelFailure: "provider_chain",
   };
@@ -498,8 +506,8 @@ function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
 const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
 const CURSOR_EXECUTOR_TEAM_ROLE_SET = new Set<string>(CURSOR_EXECUTOR_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
-// /team CLI workers — codex/gemini/grok/cursor here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
-const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "grok", "cursor", "antigravity"]);
+// /team CLI workers: codex/gemini/grok/cursor/copilot here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
+const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "grok", "cursor", "antigravity", "copilot"]);
 const TEAM_ROLE_TIERS = new Set(["HIGH", "MEDIUM", "LOW"]);
 
 export function validateTeamConfig(config: PluginConfig): void {
@@ -1091,6 +1099,10 @@ export function generateConfigSchema(): object {
                 default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.antigravityModel,
                 description: "Default Antigravity model",
               },
+              copilotModel: {
+                type: "string",
+                description: "Default GitHub Copilot CLI model (omit to let Copilot pick automatically)",
+              },
             },
           },
           rolePreferences: {
@@ -1217,7 +1229,7 @@ export function generateConfigSchema(): object {
                 type: "array",
                 items: {
                   type: "string",
-                  enum: ["claude", "codex", "gemini", "grok", "cursor", "antigravity"],
+                  enum: ["claude", "codex", "gemini", "grok", "cursor", "antigravity", "copilot"],
                 },
                 description:
                   "Preferred CLI worker types for executor-style autopilot team execution tasks",
@@ -1236,7 +1248,7 @@ export function generateConfigSchema(): object {
               maxAgents: { type: "integer", minimum: 1 },
               defaultAgentType: {
                 type: "string",
-                enum: ["claude", "codex", "gemini", "grok", "cursor", "antigravity"],
+                enum: ["claude", "codex", "gemini", "grok", "cursor", "antigravity", "copilot"],
                 default: "claude",
               },
               monitorIntervalMs: { type: "integer", minimum: 1 },
@@ -1250,7 +1262,7 @@ export function generateConfigSchema(): object {
             additionalProperties: {
               type: "object",
               properties: {
-                provider: { type: "string", enum: ["claude", "codex", "gemini", "grok", "cursor", "antigravity"] },
+                provider: { type: "string", enum: ["claude", "codex", "gemini", "grok", "cursor", "antigravity", "copilot"] },
                 model: { type: "string" },
                 agent: { type: "string" },
               },

--- a/src/features/builtin-skills/runtime-guidance.ts
+++ b/src/features/builtin-skills/runtime-guidance.ts
@@ -6,6 +6,7 @@ export interface SkillRuntimeAvailability {
   gemini: boolean;
   grok: boolean;
   antigravity: boolean;
+  copilot: boolean;
 }
 
 export function detectSkillRuntimeAvailability(
@@ -24,6 +25,7 @@ export function detectSkillRuntimeAvailability(
     gemini: safeDetect('gemini'),
     grok: safeDetect('grok'),
     antigravity: safeDetect('antigravity'),
+    copilot: safeDetect('copilot'),
   };
 }
 

--- a/src/hooks/__tests__/bridge-routing.test.ts
+++ b/src/hooks/__tests__/bridge-routing.test.ts
@@ -905,6 +905,27 @@ $ ultrawork search the codebase`,
       }
     });
 
+    it('does not arm ralplan state for keywords inside delegated /ask copilot prompts', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-ask-copilot-'));
+      try {
+        execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+        const sessionId = 'ask-copilot-session';
+
+        const result = await processHook('keyword-detector', {
+          sessionId,
+          prompt: '/ask copilot 지금까지 논의한걸 ralplan으로 계획서 작성해줘',
+          directory: tempDir,
+        });
+
+        expect(result.continue).toBe(true);
+        expect(result.message).toBeUndefined();
+        expect((result as unknown as Record<string, unknown>).hookSpecificOutput).toBeUndefined();
+        expect(existsSync(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'ralplan-state.json'))).toBe(false);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('activates ralplan state when Skill tool invokes plan in consensus mode', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'bridge-routing-plan-consensus-skill-'));
       try {

--- a/src/hooks/autopilot/adapters/execution-adapter.ts
+++ b/src/hooks/autopilot/adapters/execution-adapter.ts
@@ -16,7 +16,7 @@ import { resolveAutopilotPlanPath } from "../../../config/plan-output.js";
 
 export const EXECUTION_COMPLETION_SIGNAL = "PIPELINE_EXECUTION_COMPLETE";
 
-const CLI_TEAM_AGENT_TYPES = new Set(["codex", "gemini", "grok", "cursor", "antigravity"]);
+const CLI_TEAM_AGENT_TYPES = new Set(["codex", "gemini", "grok", "cursor", "antigravity", "copilot"]);
 
 function uniqueRequestedAgentTypes(
   agentTypes: readonly string[] | undefined,

--- a/src/hooks/autopilot/pipeline-types.ts
+++ b/src/hooks/autopilot/pipeline-types.ts
@@ -54,7 +54,8 @@ export type AutopilotTeamAgentType =
   | "gemini"
   | "grok"
   | "cursor"
-  | "antigravity";
+  | "antigravity"
+  | "copilot";
 
 /** Team execution options for autopilot execution=team. */
 export interface AutopilotTeamConfig {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1246,7 +1246,7 @@ function getPromptText(input: HookInput): string {
 }
 
 function isExplicitAskSlashInvocation(promptText: string): boolean {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|antigravity|agy|grok|cursor)\b/i.test(promptText);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|antigravity|agy|grok|cursor|copilot)\b/i.test(promptText);
 }
 
 function activateRalplanStartupState(directory: string, sessionId?: string): void {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -338,6 +338,7 @@ export interface ExternalModelsDefaults {
   geminiModel?: string;
   grokModel?: string;
   antigravityModel?: string;
+  copilotModel?: string;
 }
 
 /**
@@ -462,7 +463,7 @@ export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
 export const CURSOR_EXECUTOR_TEAM_ROLES = ["executor"] as const;
 
 /** Provider for /team role routing. */
-export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity';
+export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity' | 'copilot';
 
 /** Tier name accepted in role-assignment `model` field. */
 export type TeamRoleTier = 'HIGH' | 'MEDIUM' | 'LOW';

--- a/src/team/__tests__/cli-detection.test.ts
+++ b/src/team/__tests__/cli-detection.test.ts
@@ -51,4 +51,17 @@ describe('cli-detection', () => {
     expect(mockSpawnSync).toHaveBeenCalledWith('agy', ['--version'], expect.objectContaining({ timeout: 5000 }));
     mockSpawnSync.mockRestore();
   });
+
+  it('detectAllClis probes the copilot binary', () => {
+    const mockSpawnSync = vi.mocked(spawnSync);
+    // Make every probe report not-found so we exercise the copilot version probe.
+    mockSpawnSync.mockReturnValue({ status: 1, stdout: '', stderr: '', pid: 0, output: [], signal: null } as any);
+
+    const result = detectAllClis();
+
+    expect(result).toHaveProperty('copilot');
+    expect(result.copilot).toEqual({ available: false });
+    expect(mockSpawnSync).toHaveBeenCalledWith('copilot', ['--version'], expect.objectContaining({ timeout: 5000 }));
+    mockSpawnSync.mockRestore();
+  });
 });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -179,6 +179,16 @@ describe('model-contract', () => {
       expect(c.installInstructions).toContain('antigravity.google');
       expect(c.installInstructions).not.toContain('| bash');
     });
+    it('returns contract for copilot', () => {
+      const c = getContract('copilot');
+      expect(c.agentType).toBe('copilot');
+      expect(c.binary).toBe('copilot');
+      expect(c.supportsPromptMode).toBe(true);
+      expect(c.promptModeFlag).toBe('-p');
+      // Points to the official npm install command, not a raw pipe-to-shell command.
+      expect(c.installInstructions).toContain('@github/copilot');
+      expect(c.installInstructions).not.toContain('| bash');
+    });
     it('throws for unknown agent type', () => {
       expect(() => getContract('unknown' as any)).toThrow('Unknown agent type');
     });
@@ -191,6 +201,7 @@ describe('model-contract', () => {
         // Other prompt-mode providers stay supported on Windows.
         expect(isHeadlessSupportedOnPlatform('gemini', 'win32')).toBe(true);
         expect(isHeadlessSupportedOnPlatform('grok', 'win32')).toBe(true);
+        expect(isHeadlessSupportedOnPlatform('copilot', 'win32')).toBe(true);
       });
 
       it('getPromptModeArgs throws for an antigravity team worker on Windows', () => {
@@ -266,6 +277,24 @@ describe('model-contract', () => {
         const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
         clearSecurityConfigCache();
         expect(() => getContract('grok')).toThrow('blocked by security policy');
+      } finally {
+        if (origSecurity === undefined) {
+          delete process.env.OMC_SECURITY;
+        } else {
+          process.env.OMC_SECURITY = origSecurity;
+        }
+        const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
+        clearSecurityConfigCache();
+      }
+    });
+
+    it('blocks copilot when external LLM is disabled', async () => {
+      const origSecurity = process.env.OMC_SECURITY;
+      process.env.OMC_SECURITY = 'strict';
+      try {
+        const { clearSecurityConfigCache } = await import('../../lib/security-config.js');
+        clearSecurityConfigCache();
+        expect(() => getContract('copilot')).toThrow('blocked by security policy');
       } finally {
         if (origSecurity === undefined) {
           delete process.env.OMC_SECURITY;
@@ -369,6 +398,21 @@ describe('model-contract', () => {
 
       const withModel = buildLaunchArgs('grok', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'grok-4-fast' });
       expect(withModel).toEqual(['--always-approve', '--model', 'grok-4-fast']);
+    });
+    it('copilot leads with -s --allow-all-tools --no-ask-user (no -p; appended later by getPromptModeArgs) and appends --model <m> when given', () => {
+      const noModel = buildLaunchArgs('copilot', { teamName: 't', workerName: 'w', cwd: '/tmp' });
+      expect(noModel).toEqual(['-s', '--allow-all-tools', '--no-ask-user']);
+      expect(noModel).not.toContain('--model');
+      // -p is NOT in buildLaunchArgs: copilot's -p takes the prompt as its value and
+      // is appended (with the instruction) by getPromptModeArgs.
+      expect(noModel).not.toContain('-p');
+
+      const withModel = buildLaunchArgs('copilot', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'claude-sonnet-4.5' });
+      expect(withModel).toEqual(['-s', '--allow-all-tools', '--no-ask-user', '--model', 'claude-sonnet-4.5']);
+    });
+    it('copilot appends extraFlags after the model flag', () => {
+      const args = buildLaunchArgs('copilot', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'm', extraFlags: ['--add-dir', '/work'] });
+      expect(args).toEqual(['-s', '--allow-all-tools', '--no-ask-user', '--model', 'm', '--add-dir', '/work']);
     });
     it('passes model flag when specified', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4' });
@@ -608,6 +652,13 @@ describe('model-contract', () => {
       expect(c.promptModeFlag).toBe('-p');
     });
 
+    it('copilot supports prompt mode', () => {
+      expect(isPromptModeAgent('copilot')).toBe(true);
+      const c = getContract('copilot');
+      expect(c.supportsPromptMode).toBe(true);
+      expect(c.promptModeFlag).toBe('-p');
+    });
+
     it('getPromptModeArgs returns flag + instruction for antigravity', () => {
       const args = getPromptModeArgs('antigravity', 'Read inbox');
       expect(args).toEqual(['-p', 'Read inbox']);
@@ -615,6 +666,11 @@ describe('model-contract', () => {
 
     it('getPromptModeArgs returns flag + instruction for grok', () => {
       const args = getPromptModeArgs('grok', 'Read inbox');
+      expect(args).toEqual(['-p', 'Read inbox']);
+    });
+
+    it('getPromptModeArgs returns flag + instruction for copilot', () => {
+      const args = getPromptModeArgs('copilot', 'Read inbox');
       expect(args).toEqual(['-p', 'Read inbox']);
     });
 

--- a/src/team/__tests__/runtime-prompt-mode.test.ts
+++ b/src/team/__tests__/runtime-prompt-mode.test.ts
@@ -110,7 +110,7 @@ vi.mock('child_process', async (importOriginal) => {
 
 import { spawnWorkerForTask, type TeamRuntime } from '../runtime.js';
 
-function makeRuntime(cwd: string, agentType: 'gemini' | 'codex' | 'claude' | 'grok' | 'antigravity'): TeamRuntime {
+function makeRuntime(cwd: string, agentType: 'gemini' | 'codex' | 'claude' | 'grok' | 'antigravity' | 'copilot'): TeamRuntime {
   return {
     teamName: 'test-team',
     sessionName: 'test-session:0',
@@ -361,6 +361,8 @@ describe('spawnWorkerForTask – model passthrough from environment variables', 
     delete process.env.OMC_GROK_DEFAULT_MODEL;
     delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_ANTIGRAVITY_MODEL;
     delete process.env.OMC_ANTIGRAVITY_DEFAULT_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL;
+    delete process.env.OMC_COPILOT_DEFAULT_MODEL;
     delete process.env.ANTHROPIC_MODEL;
     delete process.env.CLAUDE_MODEL;
     delete process.env.ANTHROPIC_BASE_URL;
@@ -556,6 +558,67 @@ describe('spawnWorkerForTask – model passthrough from environment variables', 
     //  model-env allowlist, exactly as they would for any non-claude worker —
     //  that is pane startup env, not the grok model selection.)
     expect(launchCmd).toContain("'--always-approve'");
+    expect(launchCmd).not.toContain("'--model'");
+    expect(launchCmd).not.toContain("'--model' 'us.anthropic.claude-sonnet-4-6-v1:0'");
+  });
+
+  it('copilot worker passes model from OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL', async () => {
+    process.env.OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL = 'gpt-5.4';
+    const runtime = makeRuntime(cwd, 'copilot');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    expect(launchCmd).toContain("'--allow-all-tools'");
+    expect(launchCmd).toContain("'--no-ask-user'");
+    expect(launchCmd).toContain("'--model'");
+    expect(launchCmd).toContain("'gpt-5.4'");
+  });
+
+  it('copilot worker falls back to OMC_COPILOT_DEFAULT_MODEL', async () => {
+    process.env.OMC_COPILOT_DEFAULT_MODEL = 'claude-sonnet-4.5';
+    const runtime = makeRuntime(cwd, 'copilot');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    expect(launchCmd).toContain("'--model'");
+    expect(launchCmd).toContain("'claude-sonnet-4.5'");
+  });
+
+  it('direct copilot worker does not fall through to a Claude/Bedrock model', async () => {
+    // A DIRECT copilot launch must resolve its model only from copilot env vars.
+    // Even with Bedrock/Claude model env present, copilot must NOT receive any
+    // --model flag (its copilot env vars are unset here) and must NOT pick up a
+    // Claude/Bedrock model id via resolveClaudeWorkerModel().
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    process.env.ANTHROPIC_MODEL = 'us.anthropic.claude-sonnet-4-6-v1:0';
+    process.env.CLAUDE_CODE_BEDROCK_SONNET_MODEL = 'us.anthropic.claude-sonnet-4-6-v1:0';
+    process.env.OMC_MODEL_MEDIUM = 'us.anthropic.claude-sonnet-4-6-v1:0';
+    const runtime = makeRuntime(cwd, 'copilot');
+
+    await spawnWorkerForTask(runtime, 'worker-1', 0);
+
+    const launchCall = tmuxCalls.args.find(
+      args => args[0] === 'send-keys' && args.includes('-l')
+    );
+    expect(launchCall).toBeDefined();
+    const launchCmd = launchCall![launchCall!.length - 1];
+
+    // copilot env vars unset → no --model flag at all. The copilot branch returns
+    // undefined and never falls through to resolveClaudeWorkerModel(), so the
+    // Claude/Bedrock model id is never passed as a `--model` CLI argument.
+    expect(launchCmd).toContain("'--allow-all-tools'");
     expect(launchCmd).not.toContain("'--model'");
     expect(launchCmd).not.toContain("'--model' 'us.anthropic.claude-sonnet-4-6-v1:0'");
   });

--- a/src/team/__tests__/stage-router.test.ts
+++ b/src/team/__tests__/stage-router.test.ts
@@ -113,6 +113,29 @@ describe('stage-router resolveRoleAssignment', () => {
       expect(out.agent).toBe('critic');
     });
 
+    it('respects provider=copilot and resolves to empty model (no Claude fallthrough) when omitted', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { 'code-reviewer': { provider: 'copilot' } } },
+      };
+      const out = resolveRoleAssignment('code-reviewer', cfg);
+      expect(out.provider).toBe('copilot');
+      // copilot has no builtin default model and none configured → resolves to ''
+      // (Copilot's own `auto` picks the model), NOT a Claude tier model id.
+      expect(out.model).toBe('');
+      expect(out.model).not.toBe(CLAUDE_FAMILY_DEFAULTS.OPUS);
+      expect(out.agent).toBe('codeReviewer');
+    });
+
+    it('respects provider=copilot with explicit model passthrough', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { critic: { provider: 'copilot', model: 'claude-sonnet-4.5' } } },
+      };
+      const out = resolveRoleAssignment('critic', cfg);
+      expect(out.provider).toBe('copilot');
+      expect(out.model).toBe('claude-sonnet-4.5');
+      expect(out.agent).toBe('critic');
+    });
+
     it('respects provider=cursor and resolves to empty model (cursor-agent owns model selection)', () => {
       const cfg: PluginConfig = {
         team: { roleRouting: { executor: { provider: 'cursor' } } },
@@ -142,6 +165,16 @@ describe('stage-router resolveRoleAssignment', () => {
       const out = resolveRoleAssignment('code-reviewer', cfg);
       expect(out.provider).toBe('grok');
       expect(out.model).toBe('grok-code-fast-1');
+    });
+
+    it('copilot resolves configured externalModels.defaults.copilotModel when model omitted', () => {
+      const cfg: PluginConfig = {
+        externalModels: { defaults: { copilotModel: 'gpt-5.4' } },
+        team: { roleRouting: { 'code-reviewer': { provider: 'copilot' } } },
+      };
+      const out = resolveRoleAssignment('code-reviewer', cfg);
+      expect(out.provider).toBe('copilot');
+      expect(out.model).toBe('gpt-5.4');
     });
 
     it('tier name on grok provider falls back to provider default (tiers are claude-centric)', () => {

--- a/src/team/capabilities.ts
+++ b/src/team/capabilities.ts
@@ -21,6 +21,7 @@ const DEFAULT_CAPABILITIES: Record<WorkerBackend, WorkerCapability[]> = {
   'tmux-cursor': ['code-edit', 'refactoring', 'general'],
   'tmux-grok': ['code-edit', 'code-review', 'refactoring', 'general'],
   'tmux-antigravity': ['ui-design', 'documentation', 'research', 'code-edit'],
+  'tmux-copilot': ['code-edit', 'code-review', 'refactoring', 'general'],
 };
 
 /**

--- a/src/team/cli-detection.ts
+++ b/src/team/cli-detection.ts
@@ -38,5 +38,6 @@ export function detectAllClis(): Record<string, CliInfo> {
     cursor: detectCli('cursor-agent'),
     grok: detectCli('grok'),
     antigravity: detectCli('agy'),
+    copilot: detectCli('copilot'),
   };
 }

--- a/src/team/cli-worker-contract.ts
+++ b/src/team/cli-worker-contract.ts
@@ -50,8 +50,8 @@ const VALID_SEVERITIES: ReadonlySet<string> = new Set(['critical', 'major', 'min
 
 /**
  * Returns true when a role + provider pair requires the verdict-output contract.
- * External providers (codex/gemini/grok) on reviewer-style roles need it; Claude
- * teammates speak through the team messaging API directly.
+ * External providers (codex/gemini/grok/copilot) on reviewer-style roles need it;
+ * Claude teammates speak through the team messaging API directly.
  */
 export function shouldInjectContract(
   role: CanonicalTeamRole | null | undefined,

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -5,7 +5,7 @@ import { normalizeToCcAlias } from '../features/delegation-enforcer.js';
 import { isBedrock, isVertexAI, isProviderSpecificModelId } from '../config/models.js';
 import { isExternalLLMDisabled } from '../lib/security-config.js';
 
-export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'grok' | 'antigravity';
+export type CliAgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'grok' | 'antigravity' | 'copilot';
 
 export interface CliAgentContract {
   agentType: CliAgentType;
@@ -304,6 +304,27 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       return rawOutput.trim();
     },
   },
+  copilot: {
+    agentType: 'copilot',
+    binary: 'copilot',
+    installInstructions: 'Install GitHub Copilot CLI: npm install -g @github/copilot',
+    supportsPromptMode: true,
+    promptModeFlag: '-p',
+    buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
+      // GitHub Copilot CLI one-shot worker. `-p <instruction>` is appended later by
+      // getPromptModeArgs (like grok/gemini), so buildLaunchArgs returns only the
+      // leading flags: `-s` prints only the agent's final answer (clean stdout for
+      // parsing), and `--allow-all-tools` + `--no-ask-user` keep the run autonomous
+      // so it never blocks on a permission or ask_user prompt. Verified against
+      // GitHub Copilot CLI 1.0.65.
+      const args = ['-s', '--allow-all-tools', '--no-ask-user'];
+      if (model) args.push('--model', model);
+      return [...args, ...extraFlags];
+    },
+    parseOutput(rawOutput: string): string {
+      return rawOutput.trim();
+    },
+  },
 };
 
 export function getContract(agentType: CliAgentType): CliAgentContract {
@@ -432,6 +453,8 @@ const WORKER_MODEL_ENV_ALLOWLIST = [
   'OMC_GROK_DEFAULT_MODEL',
   'OMC_EXTERNAL_MODELS_DEFAULT_ANTIGRAVITY_MODEL',
   'OMC_ANTIGRAVITY_DEFAULT_MODEL',
+  'OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL',
+  'OMC_COPILOT_DEFAULT_MODEL',
 ] as const;
 
 export function getWorkerEnv(

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -729,6 +729,11 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
         || process.env.OMC_GROK_DEFAULT_MODEL
         || undefined;
     }
+    if (opts.agentType === 'copilot') {
+      return process.env.OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL
+        || process.env.OMC_COPILOT_DEFAULT_MODEL
+        || undefined;
+    }
     if (opts.agentType === 'cursor') {
       return undefined;
     }

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -751,6 +751,11 @@ export async function spawnWorkerForTask(
         || process.env.OMC_GROK_DEFAULT_MODEL
         || undefined;
     }
+    if (agentType === 'copilot') {
+      return process.env.OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL
+        || process.env.OMC_COPILOT_DEFAULT_MODEL
+        || undefined;
+    }
     if (agentType === 'cursor') {
       return undefined;
     }
@@ -946,7 +951,7 @@ export async function shutdownTeam(
   // Polling for ACK files on CLI worker teams wastes the full timeoutMs on every shutdown.
   // Detect CLI worker teams by checking if all agent types are known CLI types, and skip
   // ACK polling — the tmux kill below handles process cleanup instead.
-  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity']);
+  const CLI_AGENT_TYPES = new Set<string>(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity', 'copilot']);
   const agentTypes: string[] = configData?.agentTypes ?? [];
   const isCliWorkerTeam = agentTypes.length > 0 && agentTypes.every(t => CLI_AGENT_TYPES.has(t));
 

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -55,7 +55,7 @@ import {
 // ── Environment gate ──────────────────────────────────────────────────────────
 
 const OMC_TEAM_SCALING_ENABLED_ENV = 'OMC_TEAM_SCALING_ENABLED';
-const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity']);
+const CLI_AGENT_TYPES = new Set<CliAgentType>(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity', 'copilot']);
 
 export function isScalingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[OMC_TEAM_SCALING_ENABLED_ENV];

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -133,7 +133,7 @@ function resolveClaudeModel(
  * an explicit non-tier model ID is passed through.
  */
 function resolveExternalModel(
-  provider: 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity',
+  provider: 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity' | 'copilot',
   raw: string | undefined,
   cfg: PluginConfig,
 ): string {
@@ -146,6 +146,11 @@ function resolveExternalModel(
   }
   if (provider === 'grok') {
     return defaults?.grokModel ?? '';
+  }
+  if (provider === 'copilot') {
+    // Empty string lets the Copilot CLI pick its own model (`--model` omitted,
+    // i.e. Copilot's `auto`). An explicit non-tier model ID is honored above.
+    return defaults?.copilotModel ?? '';
   }
   if (provider === 'cursor') {
     return '';

--- a/src/team/team-status.ts
+++ b/src/team/team-status.ts
@@ -59,7 +59,7 @@ function peekRecentOutboxMessages(
 
 export interface WorkerStatus {
   workerName: string;
-  provider: 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity';
+  provider: 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity' | 'copilot';
   heartbeat: HeartbeatData | null;
   isAlive: boolean;
   currentTask: TaskFile | null;
@@ -133,7 +133,7 @@ export function getTeamStatus(
     };
 
     const currentTask = workerTasks.find(t => t.status === 'in_progress') || null;
-    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity';
+    const provider = w.agentType.replace(/^(?:mcp|tmux)-/, '') as 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity' | 'copilot';
 
     return {
       workerName: w.name,

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -103,7 +103,7 @@ export interface McpWorkerMember {
 export interface HeartbeatData {
   workerName: string;
   teamName: string;
-  provider: 'codex' | 'gemini' | 'claude' | 'cursor' | 'grok' | 'antigravity';
+  provider: 'codex' | 'gemini' | 'claude' | 'cursor' | 'grok' | 'antigravity' | 'copilot';
   pid: number;
   lastPollAt: string;       // ISO timestamp of last poll cycle
   currentTaskId?: string;   // task being executed, if any
@@ -138,7 +138,7 @@ export interface TaskFailureSidecar {
 }
 
 /** Worker backend type */
-export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-cursor' | 'tmux-grok' | 'tmux-antigravity';
+export type WorkerBackend = 'claude-native' | 'mcp-codex' | 'mcp-gemini' | 'tmux-claude' | 'tmux-codex' | 'tmux-gemini' | 'tmux-cursor' | 'tmux-grok' | 'tmux-antigravity' | 'tmux-copilot';
 
 /** Worker capability tag */
 export type WorkerCapability =
@@ -278,7 +278,7 @@ export interface WorkerInfo {
   name: string;
   index: number;
   role: string;
-  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'grok' | 'antigravity';
+  worker_cli?: 'codex' | 'claude' | 'gemini' | 'cursor' | 'grok' | 'antigravity' | 'copilot';
   assigned_tasks: string[];
   pid?: number;
   pane_id?: string;

--- a/src/team/worker-bootstrap.ts
+++ b/src/team/worker-bootstrap.ts
@@ -116,6 +116,13 @@ function agentTypeGuidance(agentType: CliAgentType): string {
         '- Keep commit-sized changes scoped to assigned files only; no broad refactors.',
         `- CRITICAL: You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done. Do not exit without transitioning the task status.`,
       ].join('\n');
+    case 'copilot':
+      return [
+        '### Agent-Type Guidance (copilot)',
+        `- Prefer short, explicit \`${teamApiCommand} ... --json\` commands and parse outputs before next step.`,
+        '- If a command fails, report the exact stderr to leader-fixed before retrying.',
+        `- You MUST run \`${claimTaskCommand}\` before starting work and \`${transitionTaskStatusCommand}\` when done.`,
+      ].join('\n');
     case 'claude':
     default:
       return [

--- a/src/team/worker-commit-cadence.ts
+++ b/src/team/worker-commit-cadence.ts
@@ -24,7 +24,7 @@ export interface WorkerCadenceContext {
   teamName: string;
   workerName: string;
   worktreePath: string;
-  agentType: 'claude' | 'codex' | 'gemini' | 'cursor' | 'grok' | 'antigravity';
+  agentType: 'claude' | 'codex' | 'gemini' | 'cursor' | 'grok' | 'antigravity' | 'copilot';
   enabled: boolean;
 }
 

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -146,7 +146,7 @@ function extractPrompt(input) {
 }
 
 function isExplicitAskSlashInvocation(prompt) {
-  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|grok)\b/i.test(prompt);
+  return /^\s*\/(?:oh-my-claudecode:)?ask\s+(?:claude|codex|gemini|grok|copilot)\b/i.test(prompt);
 }
 
 // Sanitize text to prevent false positives from code blocks, XML tags, URLs, and file paths


### PR DESCRIPTION
Adds `copilot` as a tmux CLI team worker (`omc team N:copilot`) and ask provider (`omc ask copilot`), mirroring the existing grok/antigravity prompt-mode backends field for field.

## What this is (and is not)

This registers Copilot as an orchestrated CLI backend agent. It is separate from the existing Copilot model-provider awareness (the think-mode `github-copilot` proxy resolution in `src/hooks/think-mode/switcher.ts`, and the `.github/copilot-instructions.md` rules convention in `src/hooks/rules-injector`), both of which are left unchanged.

## Contract

`copilot -p <prompt> -s --allow-all-tools --no-ask-user [--model <m>]`, verified against GitHub Copilot CLI 1.0.65. `-s` yields clean stdout; `--allow-all-tools` plus `--no-ask-user` keep runs autonomous. Prompt mode `-p` is appended by `getPromptModeArgs` like grok/gemini.

## Wired across

model-contract (`CliAgentType` plus the contract plus the worker model-env allowlist), model resolution (stage-router `resolveExternalModel` plus runtime/runtime-v2 `modelForAgent`, with `OMC_EXTERNAL_MODELS_DEFAULT_COPILOT_MODEL` / `OMC_COPILOT_DEFAULT_MODEL`), provider lists and enums (ask, scaling, types, config/loader team enums plus `externalModels.copilotModel`, cli/team, cli/commands/team, doctor-team-routing, cli-detection, capabilities, team-status, worker-bootstrap, worker-commit-cadence, runtime-guidance, autopilot pipeline-types plus execution-adapter), the provider advisor (`run-provider-advisor.js`), and the `/ask` suppression regex in all three copies.

## Scope

Team plus ask only, matching grok. Not a delegation-routing or external-model-default provider; MCP-daemon worker paths remain codex/gemini-only. Session resume, JSONL output parsing, and `--acp` are intentionally deferred (no existing backend uses them).

## Testing (on this machine)

- Typecheck clean (`tsc --noEmit`), lint clean (`eslint src`), full `npm run build` green (generated `dist/`/`bridge/` artifacts intentionally not committed).
- Added copilot mirrors of existing backend tests (contract, buildLaunchArgs, prompt mode, security gating, cli-detection, ask parse plus advisor launch args, role routing, direct-launch model resolution, `/ask` suppression). All touched-scope suites pass (1893 passed across the changed directories; 299 across the 7 modified test files).
- Live smoke test against the real Copilot CLI 1.0.65: `node scripts/run-provider-advisor.js copilot -p "..."` returns the real Copilot output (exit 0), and a direct one-shot `copilot -p "..." -s --allow-all-tools --no-ask-user` returns the expected token.

This targets the `dev` branch per CONTRIBUTING.md.
