### PR TITLE
fix(model-routing): stop halving the indented code-block count

### DIFF
--- a/src/__tests__/model-routing.test.ts
+++ b/src/__tests__/model-routing.test.ts
@@ -62,6 +62,18 @@ describe('Signal Extraction', () => {
       expect(signals.codeBlockCount).toBe(2);
     });
 
+    it('should count a single indented code block', () => {
+      const prompt = 'Here is code:\n    const x = 1;\n    return x;\ndone';
+      const signals = extractLexicalSignals(prompt);
+      expect(signals.codeBlockCount).toBe(1);
+    });
+
+    it('should count two separate indented code blocks', () => {
+      const prompt = 'First:\n    const a = 1;\n\nSecond:\n    const b = 2;';
+      const signals = extractLexicalSignals(prompt);
+      expect(signals.codeBlockCount).toBe(2);
+    });
+
     it('should detect architecture keywords', () => {
       const signals = extractLexicalSignals('We need to refactor the architecture');
       expect(signals.hasArchitectureKeywords).toBe(true);

--- a/src/features/model-routing/signals.ts
+++ b/src/features/model-routing/signals.ts
@@ -107,8 +107,10 @@ function countFilePaths(prompt: string): number {
  */
 function countCodeBlocks(prompt: string): number {
   const fencedBlocks = (prompt.match(/```[\s\S]*?```/g) || []).length;
+  // The indented-block regex coalesces each contiguous run of indented lines
+  // into a single match, so `indentedBlocks` is already the block count.
   const indentedBlocks = (prompt.match(/(?:^|\n)(?:\s{4}|\t)[^\n]+(?:\n(?:\s{4}|\t)[^\n]+)*/g) || []).length;
-  return fencedBlocks + Math.floor(indentedBlocks / 2);
+  return fencedBlocks + indentedBlocks;
 }
 
 /**


### PR DESCRIPTION
## Problem

`countCodeBlocks()` in `src/features/model-routing/signals.ts` computes:

```ts
return fencedBlocks + Math.floor(indentedBlocks / 2);
```

The indented-block regex `(?:^|\n)(?:\s{4}|\t)[^\n]+(?:\n(?:\s{4}|\t)[^\n]+)*` already coalesces each **contiguous run** of indented lines into a single match — so `indentedBlocks` is already the block count. The `Math.floor(.../ 2)` then throws half of it away.

| Prompt | `indentedBlocks` | returned (before) | correct |
|---|---|---|---|
| one indented code block, no fences | 1 | **0** | 1 |
| two separate indented blocks | 2 | **1** | 2 |
| two fenced blocks (existing test) | 0 | 2 | 2 ✓ |

So a function named `countCodeBlocks` returns **0** for a prompt containing one indented code block.

## Impact

The sole consumer is the `signals.codeBlockCount > 0` gate in `scorer.ts`, which adds a lexical-complexity weight. For the "exactly one indented block, zero fenced" case the +1 signal is silently lost, which can nudge a borderline routing score one model tier too low. Low severity, but a clear correctness defect.

## Fix

Drop the divisor so indented blocks count 1:1, matching the fenced path. One-line change plus a clarifying comment.

## Tests

Added two regression tests (one- and two-indented-block prompts). Verified they **fail on the old code** and **pass with the fix**; the existing fenced-block test is unaffected.

```
Test Files  1 passed (1)
     Tests  97 passed (97)
```

`npm run lint` and `tsc --noEmit` are clean. No `dist/`/`bridge/` artifacts in the diff.