### PR TITLE
fix(team): normalize separators in bridge path validation for Windows

### DIFF
--- a/src/team/__tests__/bridge-entry.guardrails.test.ts
+++ b/src/team/__tests__/bridge-entry.guardrails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { validateConfigPath } from '../bridge-entry.js';
+import { validateConfigPath, isPathWithin } from '../bridge-entry.js';
 
 describe('bridge-entry workdir guardrails (source contract)', () => {
   const source = readFileSync(join(__dirname, '..', 'bridge-entry.ts'), 'utf-8');
@@ -13,7 +13,7 @@ describe('bridge-entry workdir guardrails (source contract)', () => {
 
   it('requires working directory to stay under home directory', () => {
     expect(source).toContain('realpathSync(workingDirectory)');
-    expect(source).toContain("resolved.startsWith(home + '/')");
+    expect(source).toContain('isPathWithin(resolved, home)');
   });
 
   it('requires working directory to be inside a git worktree', () => {
@@ -36,6 +36,35 @@ describe('validateConfigPath guardrails', () => {
 
   it('accepts trusted .omc path under home', () => {
     expect(validateConfigPath('/home/user/project/.omc/state/config.json', home, claudeConfigDir)).toBe(true);
+  });
+});
+
+describe('isPathWithin (cross-platform separator handling)', () => {
+  // Windows: resolve()/realpathSync() and homedir() return backslash paths.
+  // The home-prefix containment check must still match, otherwise the bridge
+  // daemon rejects its own config and working directory on Windows.
+  it('matches a Windows path under a Windows home dir', () => {
+    expect(isPathWithin('C:\\Users\\me\\proj\\.omc\\state\\cfg.json', 'C:\\Users\\me')).toBe(true);
+  });
+
+  it('matches the home dir itself (Windows)', () => {
+    expect(isPathWithin('C:\\Users\\me', 'C:\\Users\\me')).toBe(true);
+  });
+
+  it('rejects a Windows sibling that only shares a name prefix', () => {
+    // C:\Users\member must not be treated as under C:\Users\me
+    expect(isPathWithin('C:\\Users\\member\\x', 'C:\\Users\\me')).toBe(false);
+  });
+
+  it('rejects a Windows path outside the home dir', () => {
+    expect(isPathWithin('D:\\evil\\cfg.json', 'C:\\Users\\me')).toBe(false);
+  });
+
+  it('still works for POSIX paths', () => {
+    expect(isPathWithin('/home/user/proj/.omc/cfg.json', '/home/user')).toBe(true);
+    expect(isPathWithin('/home/user', '/home/user')).toBe(true);
+    expect(isPathWithin('/tmp/x', '/home/user')).toBe(false);
+    expect(isPathWithin('/home/username/x', '/home/user')).toBe(false);
   });
 });
 

--- a/src/team/__tests__/bridge-integration.test.ts
+++ b/src/team/__tests__/bridge-integration.test.ts
@@ -7,6 +7,7 @@ import { readTask, updateTask } from '../task-file-ops.js';
 import { checkShutdownSignal, writeShutdownSignal, appendOutbox } from '../inbox-outbox.js';
 import { writeHeartbeat, readHeartbeat } from '../heartbeat.js';
 import { sanitizeName } from '../tmux-session.js';
+import { isPathWithin } from '../bridge-entry.js';
 import { logAuditEvent, readAuditLog } from '../audit-log.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
@@ -307,7 +308,7 @@ describe('validateBridgeWorkingDirectory logic', () => {
     }
     const resolved = realpathSync(workingDirectory);
     const home = homedir();
-    if (!resolved.startsWith(home + '/') && resolved !== home) {
+    if (!isPathWithin(resolved, home)) {
       throw new Error(`workingDirectory is outside home directory: ${resolved}`);
     }
   }

--- a/src/team/bridge-entry.ts
+++ b/src/team/bridge-entry.ts
@@ -18,7 +18,21 @@ import { deleteHeartbeat } from './heartbeat.js';
 import { unregisterMcpWorker } from './team-registration.js';
 import { getWorktreeRoot } from '../lib/worktree-paths.js';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
+import { toForwardSlash } from '../utils/paths.js';
 import { sanitizeName } from './tmux-session.js';
+
+/**
+ * True when `candidate` (an absolute path) is `dir` itself or sits beneath it.
+ * The comparison is done on forward-slash form so that Windows backslash paths
+ * from resolve()/realpathSync() still match a homedir()/config-dir prefix —
+ * otherwise `C:\\Users\\me\\...`.startsWith(`C:\\Users\\me/`) is always false
+ * and every containment check below fails closed.
+ */
+export function isPathWithin(candidate: string, dir: string): boolean {
+  const c = toForwardSlash(candidate);
+  const d = toForwardSlash(dir);
+  return c === d || c.startsWith(d + '/');
+}
 
 /**
  * Validate that a config path is under the user's home directory
@@ -28,16 +42,15 @@ import { sanitizeName } from './tmux-session.js';
 export function validateConfigPath(configPath: string, homeDir: string, claudeConfigDir: string): boolean {
   // Resolve to canonical absolute path to defeat ".." traversal
   const resolved = resolve(configPath);
+  const resolvedFwd = toForwardSlash(resolved);
 
-  const isUnderHome = resolved.startsWith(homeDir + '/') || resolved === homeDir;
+  const isUnderHome = isPathWithin(resolved, homeDir);
   const normalizedConfigDir = resolve(claudeConfigDir);
   const normalizedOmcDir = resolve(homeDir, '.omc');
-  const hasOmcComponent = resolved.includes('/.omc/') || resolved.endsWith('/.omc');
+  const hasOmcComponent = resolvedFwd.includes('/.omc/') || resolvedFwd.endsWith('/.omc');
   const isTrustedSubpath =
-    resolved === normalizedConfigDir ||
-    resolved.startsWith(normalizedConfigDir + '/') ||
-    resolved === normalizedOmcDir ||
-    resolved.startsWith(normalizedOmcDir + '/') ||
+    isPathWithin(resolved, normalizedConfigDir) ||
+    isPathWithin(resolved, normalizedOmcDir) ||
     hasOmcComponent;
   if (!isUnderHome || !isTrustedSubpath) return false;
 
@@ -46,7 +59,7 @@ export function validateConfigPath(configPath: string, homeDir: string, claudeCo
   try {
     const parentDir = resolve(resolved, '..');
     const realParent = realpathSync(parentDir);
-    if (!realParent.startsWith(homeDir + '/') && realParent !== homeDir) {
+    if (!isPathWithin(realParent, homeDir)) {
       return false;
     }
   } catch {
@@ -77,7 +90,7 @@ function validateBridgeWorkingDirectory(workingDirectory: string): void {
   // Resolve symlinks and verify under homedir
   const resolved = realpathSync(workingDirectory);
   const home = homedir();
-  if (!resolved.startsWith(home + '/') && resolved !== home) {
+  if (!isPathWithin(resolved, home)) {
     throw new Error(`workingDirectory is outside home directory: ${resolved}`);
   }
 


### PR DESCRIPTION
## Problem

`omc team N:codex|gemini` cannot start on native Windows. The team bridge daemon refuses to launch, failing with either:

- `Config path must be under ~/ with ... or ~/.omc/ subpath: ...`, or
- `[bridge] Invalid workingDirectory: workingDirectory is outside home directory: ...`

even when the config and working directory are correctly placed under the user's home directory. Native Windows + psmux is a supported configuration for the team feature (`tmux-session.ts` has `isUnixLikeOnWindows()` and the install hint `Windows: winget install psmux`), and #3285 already showed users running `omc team` there.

## Root cause

`bridge-entry.ts` validates paths against the home directory with hardcoded forward slashes:

```ts
resolved.startsWith(homeDir + '/')      // validateConfigPath
resolved.includes('/.omc/')             // validateConfigPath
resolved.startsWith(home + '/')         // validateBridgeWorkingDirectory
```

On Windows, `path.resolve()` and `fs.realpathSync()` return backslash paths and `os.homedir()` is `C:\Users\me`, so:

```
'C:\\Users\\me\\proj\\.omc\\cfg.json'.startsWith('C:\\Users\\me/')  // => false
```

Every containment check fails closed: `isUnderHome`, `isTrustedSubpath`, and the symlink-parent guard all evaluate false, so `validateConfigPath` returns `false` and `validateBridgeWorkingDirectory` throws. The daemon exits before doing any work.

Reproduced on a real Windows host with the actual comparison logic:

```
home         : C:\Users\me
legit config : C:\Users\me\myproject\.omc\state\team-config.json
CURRENT  : {"isUnderHome":false,"hasOmcComponent":false,"isTrustedSubpath":false,"valid":false}
FIXED    : {"isUnderHome":true,"hasOmcComponent":true,"isTrustedSubpath":true,"valid":true}
```

## Fix

Converge the repeated containment checks into one `isPathWithin(candidate, dir)` helper that compares on forward-slash form, matching the `toForwardSlash` pattern already used in `utils/paths.ts` (`purgeStalePluginCacheVersions`). This is the same normalization approach as the prior Windows separator fixes #3357, #3359, and #3360.

Behaviour is byte-identical on POSIX, where the normalization is a no-op, and correct on Windows.

## Tests

- New cross-platform unit tests for `isPathWithin` using literal Windows and POSIX paths (sibling-prefix and out-of-tree negatives included). These run and pass on any CI OS.
- Updated the source-contract assertion in `bridge-entry.guardrails.test.ts` to the new contract.
- The replicated `validateBridgeWorkingDirectory` copy in `bridge-integration.test.ts` now routes through the shared `isPathWithin`, so it cannot drift from production again.

Baseline diff on Windows (same two test files):

| | base (`dev`) | this branch |
|---|---|---|
| failed | 3 | 2 |
| passed | 20 | 26 |

This branch flips the real Windows failure (`accepts a valid directory under home`) from FAIL to PASS and adds zero regressions. The two remaining failures are pre-existing on `dev`: they hardcode POSIX absolute paths (`/home/user/...`, `/etc`) that `resolve()`/`statSync` reinterpret on Windows, and they pass on the Linux CI runner. `tsc --noEmit` is clean.

## Scope

- Source-only; `bridge/team-bridge.cjs` (esbuild output) is left untouched.
- Out of scope: `autoresearch/runtime.ts` `allowedBootstrapDirtyPaths` has the same `startsWith(resolve(...) + '/')` pattern and is a reasonable follow-up, but only triggers with a non-empty `allowedDirtyPaths` list, so it is kept separate.
