### PR TITLE
Fix HUD Sonnet 5 model version display

### DIFF
--- a/src/__tests__/hud/model.test.ts
+++ b/src/__tests__/hud/model.test.ts
@@ -25,6 +25,8 @@ describe('model element', () => {
     it('returns versioned name from model IDs', () => {
       expect(formatModelName('claude-opus-4-8-20260528', 'versioned')).toBe('Opus 4.8');
       expect(formatModelName('claude-sonnet-4-6-20260217', 'versioned')).toBe('Sonnet 4.6');
+      expect(formatModelName('claude-sonnet-5', 'versioned')).toBe('Sonnet 5');
+      expect(formatModelName('global.anthropic.claude-sonnet-5', 'versioned')).toBe('Sonnet 5');
       expect(formatModelName('claude-haiku-4-5-20251001', 'versioned')).toBe('Haiku 4.5');
     });
 

--- a/src/hud/elements/model.ts
+++ b/src/hud/elements/model.ts
@@ -15,11 +15,16 @@ import { DEFAULT_HUD_LABELS, type HudLabels, type ModelFormat } from '../types.j
  *       'claude-haiku-4-5-20251001' -> '4.5'
  *       'claude-3-5-sonnet-20241022' -> '3.5'
  *       'claude-3-opus-20240229' -> '3'
+ *       'claude-sonnet-5' -> '5'
  */
 function extractVersion(modelId: string): string | null {
   // Match hyphenated ID patterns like opus-4-6, sonnet-4-5, haiku-4-5
   const idMatch = modelId.match(/(?:opus|sonnet|haiku)-(\d+)-(\d+)/i);
   if (idMatch) return `${idMatch[1]}.${idMatch[2]}`;
+
+  // Match Claude family IDs with a single trailing numeric version like claude-sonnet-5
+  const singleSegmentIdMatch = modelId.match(/(?:^|[.-])claude-(?:opus|sonnet|haiku)-(\d+)$/i);
+  if (singleSegmentIdMatch) return singleSegmentIdMatch[1];
 
   // Match legacy raw ID patterns like claude-3-5-sonnet-20241022 and claude-3-opus-20240229
   const legacyIdMatch = modelId.match(/claude-(\d+)(?:-(\d+))?-(?:opus|sonnet|haiku)/i);


### PR DESCRIPTION
## Summary
- extract single trailing numeric Claude family versions such as `claude-sonnet-5`
- cover provider-prefixed Sonnet 5 model IDs in HUD model formatting tests
- preserve existing multi-segment, legacy, and display-name version handling

Fixes #3374

## Validation
- npm run test:run -- src/__tests__/hud/model.test.ts
- npm run build