### PR TITLE
fix(keyword-detector): exempt quoted spans from activation-intent checks

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -556,6 +556,24 @@ function isWithinQuotedSpan(text, position) {
   return false;
 }
 
+// Bounds of the specific quoted span containing `position`, or null if none.
+// Used to scope the execution-directive check for the quote exemption to
+// this keyword's own quote — not the generic ±80-char context window, which
+// can otherwise pick up an unrelated genuine command elsewhere in the same
+// message and wrongly neutralize the exemption for a keyword that is purely
+// quoted as an example.
+function findQuotedSpanBounds(text, position) {
+  for (const match of text.matchAll(QUOTED_SPAN_PATTERN)) {
+    if (match.index === undefined) continue;
+    const start = match.index;
+    const end = start + match[0].length;
+    if (position >= start && position < end) {
+      return { start, end };
+    }
+  }
+  return null;
+}
+
 function stripQuotedSpans(text) {
   return text.replace(QUOTED_SPAN_PATTERN, ' ');
 }
@@ -676,8 +694,22 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   // `"ralph" fix the auth bug`) is still a genuine request stylistically
   // wrapped in quotes, so the exemption only applies when no execution
   // directive is present.
-  if (keywordInsideQuotes && !hasExecutionDirective) {
-    return true;
+  //
+  // The directive check here is scoped to this keyword's own quoted span
+  // (±28 chars around the span's bounds), not the generic ±80-char context
+  // window used elsewhere in this function. Otherwise an unrelated genuine
+  // command elsewhere in the same message could wrongly neutralize the
+  // exemption for a keyword that is purely quoted as an example.
+  if (keywordInsideQuotes) {
+    const span = findQuotedSpanBounds(text, position);
+    const hasExecutionDirectiveNearQuote = span
+      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
+          text.slice(Math.max(0, span.start - 28), Math.min(text.length, span.end + 28)),
+        )
+      : hasExecutionDirective;
+    if (!hasExecutionDirectiveNearQuote) {
+      return true;
+    }
   }
 
   if (keywordText) {

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -690,33 +690,39 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   // A keyword occurrence inside a quoted span is usually reported/example
   // text, not a command directed at the assistant — e.g. an example sentence
   // like `"use autopilot"` inside a paragraph discussing that exact phrasing.
-  // But a quoted keyword paired with a nearby execution directive (e.g.
-  // `"ralph" fix the auth bug`) is still a genuine request stylistically
-  // wrapped in quotes, so the exemption only applies when no execution
-  // directive is present.
+  // But a quoted keyword paired with a nearby execution directive OR
+  // activation verb (e.g. `"ralph" fix the auth bug`, or `run "ralph" on
+  // this issue`) is still a genuine request stylistically wrapped in quotes,
+  // so the exemption only applies when neither is present.
   //
-  // The directive check here is scoped to text immediately OUTSIDE this
-  // keyword's own quoted span (±28 chars before/after the span's bounds),
-  // not the generic ±80-char context window used elsewhere in this function,
-  // and NOT the quote's own interior. Two failure modes this avoids:
+  // This check is scoped to text immediately OUTSIDE this keyword's own
+  // quoted span (±28 chars before/after the span's bounds), not the generic
+  // ±80-char context window used elsewhere in this function, and NOT the
+  // quote's own interior. Three failure modes this avoids:
   // - Scoping to the wide window: an unrelated genuine command elsewhere in
   //   the same message could sit inside it and wrongly neutralize the
   //   exemption for a keyword that is purely quoted as an example.
-  // - Scoping to (or including) the quote's own interior: a directive word
-  //   used INSIDE the quoted text itself — extremely common in narrated
-  //   examples and bug reports, e.g. `"please fix autopilot" they said` —
-  //   would make the quote self-report as directive-bearing and defeat the
-  //   exemption for exactly the reported-speech case it exists to catch.
+  // - Scoping to (or including) the quote's own interior: a directive or
+  //   activation word used INSIDE the quoted text itself — extremely common
+  //   in narrated examples and bug reports, e.g. `"please fix autopilot"
+  //   they said` or `"...told it to use autopilot..."` — would make the
+  //   quote self-report as command-bearing and defeat the exemption for
+  //   exactly the reported-speech case it exists to catch.
+  // - Checking only execution-directive verbs (fix/debug/...) and not
+  //   activation verbs (use/run/start/...): genuine commands stylistically
+  //   quoting just the mode name, e.g. `run "ralph" on this issue` or
+  //   `use "autopilot" on this task`, would be wrongly suppressed even
+  //   though they activated before this exemption existed.
   if (keywordInsideQuotes) {
     const span = findQuotedSpanBounds(text, position);
-    const hasExecutionDirectiveNearQuote = span
-      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
+    const hasGenuineCommandNearQuote = span
+      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build|use|run|start|enable|activate|invoke|trigger|launch)\b/i.test(
           text.slice(Math.max(0, span.start - 28), span.start) +
             ' ' +
             text.slice(span.end, Math.min(text.length, span.end + 28)),
         )
       : hasExecutionDirective;
-    if (!hasExecutionDirectiveNearQuote) {
+    if (!hasGenuineCommandNearQuote) {
       return true;
     }
   }

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -667,6 +667,18 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   const line = text.slice(lineBounds.start, lineBounds.end);
   const questionOutsideQuotes = stripQuotedSpans(text);
   const keywordInsideQuotes = isWithinQuotedSpan(text, position);
+  const hasExecutionDirective = /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(context);
+
+  // A keyword occurrence inside a quoted span is usually reported/example
+  // text, not a command directed at the assistant — e.g. an example sentence
+  // like `"use autopilot"` inside a paragraph discussing that exact phrasing.
+  // But a quoted keyword paired with a nearby execution directive (e.g.
+  // `"ralph" fix the auth bug`) is still a genuine request stylistically
+  // wrapped in quotes, so the exemption only applies when no execution
+  // directive is present.
+  if (keywordInsideQuotes && !hasExecutionDirective) {
+    return true;
+  }
 
   if (keywordText) {
     if (hasActivationIntentNearKeyword(context, keywordText)) {

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -695,16 +695,25 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   // wrapped in quotes, so the exemption only applies when no execution
   // directive is present.
   //
-  // The directive check here is scoped to this keyword's own quoted span
-  // (±28 chars around the span's bounds), not the generic ±80-char context
-  // window used elsewhere in this function. Otherwise an unrelated genuine
-  // command elsewhere in the same message could wrongly neutralize the
-  // exemption for a keyword that is purely quoted as an example.
+  // The directive check here is scoped to text immediately OUTSIDE this
+  // keyword's own quoted span (±28 chars before/after the span's bounds),
+  // not the generic ±80-char context window used elsewhere in this function,
+  // and NOT the quote's own interior. Two failure modes this avoids:
+  // - Scoping to the wide window: an unrelated genuine command elsewhere in
+  //   the same message could sit inside it and wrongly neutralize the
+  //   exemption for a keyword that is purely quoted as an example.
+  // - Scoping to (or including) the quote's own interior: a directive word
+  //   used INSIDE the quoted text itself — extremely common in narrated
+  //   examples and bug reports, e.g. `"please fix autopilot" they said` —
+  //   would make the quote self-report as directive-bearing and defeat the
+  //   exemption for exactly the reported-speech case it exists to catch.
   if (keywordInsideQuotes) {
     const span = findQuotedSpanBounds(text, position);
     const hasExecutionDirectiveNearQuote = span
       ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
-          text.slice(Math.max(0, span.start - 28), Math.min(text.length, span.end + 28)),
+          text.slice(Math.max(0, span.start - 28), span.start) +
+            ' ' +
+            text.slice(span.end, Math.min(text.length, span.end + 28)),
         )
       : hasExecutionDirective;
     if (!hasExecutionDirectiveNearQuote) {

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -769,6 +769,43 @@ diff --git a/a b/b
     expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(false);
   });
 
+  // Regression (issue #3380, QA round 3): the execution-directive check must
+  // NOT include the quoted text's own interior — only text immediately
+  // outside the quote's boundaries. Otherwise a directive word used INSIDE a
+  // narrated/reported quote (extremely common: "she said 'fix X'") makes the
+  // quote self-report as directive-bearing and defeats the exemption for
+  // exactly the reported-speech case issue #3380 exists to catch.
+  it('does not activate autopilot when the execution directive is INSIDE the quoted text itself', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-inside-quote-directive-'));
+    const sessionId = 'session-inside-quote-directive-3380';
+    const output = runKeywordDetector(
+      'The old ticket said "please fix autopilot" and closed without action.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
+  });
+
+  it('does not activate autopilot for a narrated quote containing a directive, while still detecting an unrelated genuine command', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-inside-quote-mixed-'));
+    const sessionId = 'session-inside-quote-mixed-3380';
+    const output = runKeywordDetector(
+      'The FAQ says "please fix autopilot" is a common typo people made in 2023. Separately, ralph the test suite until it passes.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
+  });
+
   // Japanese full-width katakana variants must fire on the deployed runtime
   // hook (scripts/keyword-detector.mjs), not just the TS source. Mirrors the
   // existing Korean positive controls above and guards the standalone copy

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -664,6 +664,39 @@ diff --git a/a b/b
     expect(existsSync(autopilotStatePath)).toBe(true);
   });
 
+  // Regression (issue #3380): a keyword quoted inside reported/example text
+  // (e.g. an example sentence like `"use autopilot"` embedded in prose
+  // discussing that exact phrasing) must not activate. This guards the
+  // deployed scripts/keyword-detector.mjs against drift from
+  // src/hooks/keyword-detector/index.ts, since this exact false positive was
+  // fixed in the TS source but initially missed in this standalone copy.
+  it('does not activate autopilot for a keyword quoted inside reported speech', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-span-'));
+    const sessionId = 'session-quoted-span-3380';
+    const output = runKeywordDetector(
+      'Your last message contained "I thought if I told it to use autopilot, it would just continue..." — that\'s reported speech about a hypothetical.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+    const autopilotStatePath = join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(autopilotStatePath)).toBe(false);
+  });
+
+  it('still activates ralph when quoted for emphasis alongside an execution directive (issue #3380 regression guard)', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-directive-'));
+    const sessionId = 'session-quoted-directive-3380';
+    const output = runKeywordDetector('"ralph" fix the auth bug', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
+  });
+
   // Japanese full-width katakana variants must fire on the deployed runtime
   // hook (scripts/keyword-detector.mjs), not just the TS source. Mirrors the
   // existing Korean positive controls above and guards the standalone copy

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -697,6 +697,78 @@ diff --git a/a b/b
     expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
   });
 
+  // Regression (issue #3380, QA round 2): the execution-directive check that
+  // gates the quote exemption must be scoped to the specific quoted span, not
+  // the generic ±80-char context window shared with unrelated keywords in the
+  // same message — otherwise a genuine directive-bearing command elsewhere in
+  // the message wrongly neutralizes the exemption for a keyword that is
+  // purely quoted as an example.
+  it('does not activate the quoted keyword when an unrelated genuine command appears elsewhere in the message', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-mixed-message-'));
+    const sessionId = 'session-mixed-message-3380';
+    const output = runKeywordDetector(
+      'Docs say "use autopilot" as an example, but can you run ralph now to fix the deployment script?',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
+  });
+
+  // Regression (issue #3380, repo-owner review bot finding against the round-1
+  // fix commit): a bug-report/discussion prompt that describes fixing this
+  // exact false positive, and happens to contain an execution-directive verb
+  // near the quoted example, must not itself trigger the false positive it is
+  // describing.
+  it('does not activate autopilot when a bug-report prompt describes fixing the false positive itself', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-bugreport-fix-'));
+    const sessionId = 'session-bugreport-fix-3380';
+    const output = runKeywordDetector(
+      'Please fix the detector: it activates when the user writes "use autopilot" in a bug report.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
+  });
+
+  it('does not activate autopilot when asked to implement a regression test for the quoted phrase', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-implement-test-'));
+    const sessionId = 'session-implement-test-3380';
+    const output = runKeywordDetector(
+      'Implement a regression test for the sentence "use autopilot" so it no longer activates.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
+  });
+
+  it('does not activate ralph when asked to address a false positive describing the quoted phrase', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-address-fp-'));
+    const sessionId = 'session-address-fp-3380';
+    const output = runKeywordDetector(
+      'Please address this false positive: "run ralph on this" should be treated as docs text.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(false);
+  });
+
   // Japanese full-width katakana variants must fire on the deployed runtime
   // hook (scripts/keyword-detector.mjs), not just the TS source. Mirrors the
   // existing Korean positive controls above and guards the standalone copy

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -806,6 +806,46 @@ diff --git a/a b/b
     expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
   });
 
+  // Regression (issue #3380, repo-owner review bot finding against commit
+  // 0d6cf924): the near-quote command check must also recognize activation
+  // verbs (use/run/start/enable/activate/invoke/trigger/launch), not just
+  // execution-directive verbs (fix/debug/...) — otherwise a genuine command
+  // that quotes only the mode name for emphasis (e.g. `run "ralph" on this
+  // issue`) is wrongly suppressed, even though it activated before the
+  // quote-exemption existed.
+  it('still activates ralph when the mode name alone is quoted for emphasis after an activation verb', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-activation-verb-ralph-'));
+    const sessionId = 'session-quoted-activation-verb-ralph-3380';
+    const output = runKeywordDetector('run "ralph" on this issue', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
+  });
+
+  it('still activates autopilot when the mode name alone is quoted for emphasis after an activation verb', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-activation-verb-autopilot-'));
+    const sessionId = 'session-quoted-activation-verb-autopilot-3380';
+    const output = runKeywordDetector('use "autopilot" on this task', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(true);
+  });
+
+  it('still activates ultrawork when the mode name alone is quoted for emphasis after an activation verb', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-activation-verb-ultrawork-'));
+    const sessionId = 'session-quoted-activation-verb-ultrawork-3380';
+    const output = runKeywordDetector('start "ultrawork" on this repo', cwd, sessionId);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: ULTRAWORK]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json'))).toBe(true);
+  });
+
   // Japanese full-width katakana variants must fire on the deployed runtime
   // hook (scripts/keyword-detector.mjs), not just the TS source. Mirrors the
   // existing Korean positive controls above and guards the standalone copy

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1001,6 +1001,29 @@ This article argues that fake popularity signals damage trust in open source.`;
       });
     });
 
+    describe('quoted-span exemption (issue #3380)', () => {
+      it('should NOT detect autopilot inside a quoted example sentence', () => {
+        const text =
+          'Your last message contained "I thought if I told it to use autopilot, it would just continue..." — that\'s reported speech about a hypothetical.';
+        const result = detectKeywordsWithType(text);
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeUndefined();
+      });
+
+      it('should still detect autopilot when unquoted', () => {
+        const result = detectKeywordsWithType('use autopilot on this task');
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeDefined();
+      });
+
+      it('should NOT detect ralph inside a quoted example sentence', () => {
+        const text = 'The docs give "run ralph on this" as an example of an activating phrase.';
+        const result = detectKeywordsWithType(text);
+        const ralphMatch = result.find((r) => r.type === 'ralph');
+        expect(ralphMatch).toBeUndefined();
+      });
+    });
+
     describe('edge cases', () => {
       it('should handle empty input', () => {
         const result = detectKeywordsWithType('');

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1086,6 +1086,24 @@ This article argues that fake popularity signals damage trust in open source.`;
         expect(autopilotMatch).toBeUndefined();
         expect(ralphMatch).toBeDefined();
       });
+
+      it('should still detect ralph when the mode name alone is quoted for emphasis after an activation verb', () => {
+        const result = detectKeywordsWithType('run "ralph" on this issue');
+        const ralphMatch = result.find((r) => r.type === 'ralph');
+        expect(ralphMatch).toBeDefined();
+      });
+
+      it('should still detect autopilot when the mode name alone is quoted for emphasis after an activation verb', () => {
+        const result = detectKeywordsWithType('use "autopilot" on this task');
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeDefined();
+      });
+
+      it('should still detect ultrawork when the mode name alone is quoted for emphasis after an activation verb', () => {
+        const result = detectKeywordsWithType('start "ultrawork" on this repo');
+        const ultraworkMatch = result.find((r) => r.type === 'ultrawork');
+        expect(ultraworkMatch).toBeDefined();
+      });
     });
 
     describe('edge cases', () => {

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1034,6 +1034,40 @@ This article argues that fake popularity signals damage trust in open source.`;
         const autopilotMatch = result.find((r) => r.type === 'autopilot');
         expect(autopilotMatch).toBeDefined();
       });
+
+      it('should NOT detect the quoted keyword when an unrelated genuine command with a directive appears elsewhere in the same message', () => {
+        const result = detectKeywordsWithType(
+          'Docs say "use autopilot" as an example, but can you run ralph now to fix the deployment script?',
+        );
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        const ralphMatch = result.find((r) => r.type === 'ralph');
+        expect(autopilotMatch).toBeUndefined();
+        expect(ralphMatch).toBeDefined();
+      });
+
+      it('should NOT detect autopilot when a bug-report prompt describes fixing the false positive itself', () => {
+        const result = detectKeywordsWithType(
+          'Please fix the detector: it activates when the user writes "use autopilot" in a bug report.',
+        );
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeUndefined();
+      });
+
+      it('should NOT detect autopilot when asked to implement a regression test for the quoted phrase', () => {
+        const result = detectKeywordsWithType(
+          'Implement a regression test for the sentence "use autopilot" so it no longer activates.',
+        );
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeUndefined();
+      });
+
+      it('should NOT detect ralph when asked to address a false positive describing the quoted phrase', () => {
+        const result = detectKeywordsWithType(
+          'Please address this false positive: "run ralph on this" should be treated as docs text.',
+        );
+        const ralphMatch = result.find((r) => r.type === 'ralph');
+        expect(ralphMatch).toBeUndefined();
+      });
     });
 
     describe('edge cases', () => {

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1068,6 +1068,24 @@ This article argues that fake popularity signals damage trust in open source.`;
         const ralphMatch = result.find((r) => r.type === 'ralph');
         expect(ralphMatch).toBeUndefined();
       });
+
+      it('should NOT detect autopilot when the execution directive is INSIDE the quoted text itself', () => {
+        const result = detectKeywordsWithType(
+          'The old ticket said "please fix autopilot" and closed without action.',
+        );
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeUndefined();
+      });
+
+      it('should NOT detect autopilot for a narrated quote containing a directive, while still detecting an unrelated genuine command', () => {
+        const result = detectKeywordsWithType(
+          'The FAQ says "please fix autopilot" is a common typo people made in 2023. Separately, ralph the test suite until it passes.',
+        );
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        const ralphMatch = result.find((r) => r.type === 'ralph');
+        expect(autopilotMatch).toBeUndefined();
+        expect(ralphMatch).toBeDefined();
+      });
     });
 
     describe('edge cases', () => {

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -1022,6 +1022,18 @@ This article argues that fake popularity signals damage trust in open source.`;
         const ralphMatch = result.find((r) => r.type === 'ralph');
         expect(ralphMatch).toBeUndefined();
       });
+
+      it('should still detect ralph when quoted for emphasis alongside an execution directive', () => {
+        const result = detectKeywordsWithType('"ralph" fix the auth bug');
+        const ralphMatch = result.find((r) => r.type === 'ralph');
+        expect(ralphMatch).toBeDefined();
+      });
+
+      it('should still detect autopilot when quoted for emphasis alongside an execution directive', () => {
+        const result = detectKeywordsWithType('"autopilot" implement the login page');
+        const autopilotMatch = result.find((r) => r.type === 'autopilot');
+        expect(autopilotMatch).toBeDefined();
+      });
     });
 
     describe('edge cases', () => {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -583,6 +583,14 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
   const questionOutsideQuotes = stripQuotedSpans(text);
   const keywordInsideQuotes = isWithinQuotedSpan(text, position);
 
+  // A keyword occurrence inside a quoted span is reported/example text, not a
+  // command directed at the assistant — e.g. an example sentence like
+  // `"use autopilot"` inside a paragraph discussing that exact phrasing.
+  // Short-circuit before any activation-intent checks so quoting always wins.
+  if (keywordInsideQuotes) {
+    return true;
+  }
+
   if (keywordText) {
     const hasActivationIntent = hasActivationIntentNearKeyword(context, keywordText);
     const hasExecutionDirective = /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(context);

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -614,17 +614,26 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
   // directive is present — checked before any other activation-intent logic
   // so quoting wins for reported speech but not for real commands.
   //
-  // The directive check here is scoped to this keyword's own quoted span
-  // (±28 chars around the span's bounds), not the generic ±80-char context
-  // window used elsewhere in this function. Otherwise an unrelated genuine
-  // command elsewhere in the same message (e.g. a second keyword issued as a
-  // real directive) could sit inside the wide window and wrongly neutralize
-  // the exemption for a keyword that is purely quoted as an example.
+  // The directive check here is scoped to text immediately OUTSIDE this
+  // keyword's own quoted span (±28 chars before/after the span's bounds),
+  // not the generic ±80-char context window used elsewhere in this function,
+  // and NOT the quote's own interior. Two failure modes this avoids:
+  // - Scoping to the wide window: an unrelated genuine command elsewhere in
+  //   the same message (e.g. a second keyword issued as a real directive)
+  //   could sit inside it and wrongly neutralize the exemption for a keyword
+  //   that is purely quoted as an example.
+  // - Scoping to (or including) the quote's own interior: a directive word
+  //   used INSIDE the quoted text itself — extremely common in narrated
+  //   examples and bug reports, e.g. `"please fix autopilot" they said` —
+  //   would make the quote self-report as directive-bearing and defeat the
+  //   exemption for exactly the reported-speech case it exists to catch.
   if (keywordInsideQuotes) {
     const span = findQuotedSpanBounds(text, position);
     const hasExecutionDirectiveNearQuote = span
       ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
-          text.slice(Math.max(0, span.start - 28), Math.min(text.length, span.end + 28)),
+          text.slice(Math.max(0, span.start - 28), span.start) +
+            ' ' +
+            text.slice(span.end, Math.min(text.length, span.end + 28)),
         )
       : hasExecutionDirective;
     if (!hasExecutionDirectiveNearQuote) {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -608,35 +608,42 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
   // A keyword occurrence inside a quoted span is usually reported/example
   // text, not a command directed at the assistant — e.g. an example sentence
   // like `"use autopilot"` inside a paragraph discussing that exact phrasing.
-  // But a quoted keyword paired with a nearby execution directive (e.g.
-  // `"ralph" fix the auth bug`) is still a genuine request stylistically
-  // wrapped in quotes, so the exemption only applies when no execution
-  // directive is present — checked before any other activation-intent logic
-  // so quoting wins for reported speech but not for real commands.
+  // But a quoted keyword paired with a nearby execution directive OR
+  // activation verb (e.g. `"ralph" fix the auth bug`, or `run "ralph" on
+  // this issue`) is still a genuine request stylistically wrapped in quotes,
+  // so the exemption only applies when neither is present — checked before
+  // any other activation-intent logic so quoting wins for reported speech
+  // but not for real commands.
   //
-  // The directive check here is scoped to text immediately OUTSIDE this
-  // keyword's own quoted span (±28 chars before/after the span's bounds),
-  // not the generic ±80-char context window used elsewhere in this function,
-  // and NOT the quote's own interior. Two failure modes this avoids:
+  // This check is scoped to text immediately OUTSIDE this keyword's own
+  // quoted span (±28 chars before/after the span's bounds), not the generic
+  // ±80-char context window used elsewhere in this function, and NOT the
+  // quote's own interior. Three failure modes this avoids:
   // - Scoping to the wide window: an unrelated genuine command elsewhere in
   //   the same message (e.g. a second keyword issued as a real directive)
   //   could sit inside it and wrongly neutralize the exemption for a keyword
   //   that is purely quoted as an example.
-  // - Scoping to (or including) the quote's own interior: a directive word
-  //   used INSIDE the quoted text itself — extremely common in narrated
-  //   examples and bug reports, e.g. `"please fix autopilot" they said` —
-  //   would make the quote self-report as directive-bearing and defeat the
-  //   exemption for exactly the reported-speech case it exists to catch.
+  // - Scoping to (or including) the quote's own interior: a directive or
+  //   activation word used INSIDE the quoted text itself — extremely common
+  //   in narrated examples and bug reports, e.g. `"please fix autopilot"
+  //   they said` or `"...told it to use autopilot..."` — would make the
+  //   quote self-report as command-bearing and defeat the exemption for
+  //   exactly the reported-speech case it exists to catch.
+  // - Checking only execution-directive verbs (fix/debug/...) and not
+  //   activation verbs (use/run/start/...): genuine commands stylistically
+  //   quoting just the mode name, e.g. `run "ralph" on this issue` or
+  //   `use "autopilot" on this task`, would be wrongly suppressed even
+  //   though they activated before this exemption existed.
   if (keywordInsideQuotes) {
     const span = findQuotedSpanBounds(text, position);
-    const hasExecutionDirectiveNearQuote = span
-      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
+    const hasGenuineCommandNearQuote = span
+      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build|use|run|start|enable|activate|invoke|trigger|launch)\b/i.test(
           text.slice(Math.max(0, span.start - 28), span.start) +
             ' ' +
             text.slice(span.end, Math.min(text.length, span.end + 28)),
         )
       : hasExecutionDirective;
-    if (!hasExecutionDirectiveNearQuote) {
+    if (!hasGenuineCommandNearQuote) {
       return true;
     }
   }

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -438,6 +438,27 @@ function isWithinQuotedSpan(text: string, position: number): boolean {
   return false;
 }
 
+/**
+ * Bounds of the specific quoted span containing `position`, or null if none.
+ * Used to scope the execution-directive check for the quote exemption to
+ * this keyword's own quote — not the generic ±80-char context window, which
+ * can otherwise pick up an unrelated genuine command elsewhere in the same
+ * message (e.g. a second keyword issued as a real directive) and wrongly
+ * neutralize the exemption for a keyword that is purely quoted as an
+ * example.
+ */
+function findQuotedSpanBounds(text: string, position: number): { start: number; end: number } | null {
+  for (const match of text.matchAll(QUOTED_SPAN_PATTERN)) {
+    if (match.index === undefined) continue;
+    const start = match.index;
+    const end = start + match[0].length;
+    if (position >= start && position < end) {
+      return { start, end };
+    }
+  }
+  return null;
+}
+
 function stripQuotedSpans(text: string): string {
   return text.replace(QUOTED_SPAN_PATTERN, ' ');
 }
@@ -592,8 +613,23 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
   // wrapped in quotes, so the exemption only applies when no execution
   // directive is present — checked before any other activation-intent logic
   // so quoting wins for reported speech but not for real commands.
-  if (keywordInsideQuotes && !hasExecutionDirective) {
-    return true;
+  //
+  // The directive check here is scoped to this keyword's own quoted span
+  // (±28 chars around the span's bounds), not the generic ±80-char context
+  // window used elsewhere in this function. Otherwise an unrelated genuine
+  // command elsewhere in the same message (e.g. a second keyword issued as a
+  // real directive) could sit inside the wide window and wrongly neutralize
+  // the exemption for a keyword that is purely quoted as an example.
+  if (keywordInsideQuotes) {
+    const span = findQuotedSpanBounds(text, position);
+    const hasExecutionDirectiveNearQuote = span
+      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
+          text.slice(Math.max(0, span.start - 28), Math.min(text.length, span.end + 28)),
+        )
+      : hasExecutionDirective;
+    if (!hasExecutionDirectiveNearQuote) {
+      return true;
+    }
   }
 
   if (keywordText) {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -582,18 +582,22 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
   const line = text.slice(lineBounds.start, lineBounds.end);
   const questionOutsideQuotes = stripQuotedSpans(text);
   const keywordInsideQuotes = isWithinQuotedSpan(text, position);
+  const hasExecutionDirective = /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(context);
 
-  // A keyword occurrence inside a quoted span is reported/example text, not a
-  // command directed at the assistant — e.g. an example sentence like
-  // `"use autopilot"` inside a paragraph discussing that exact phrasing.
-  // Short-circuit before any activation-intent checks so quoting always wins.
-  if (keywordInsideQuotes) {
+  // A keyword occurrence inside a quoted span is usually reported/example
+  // text, not a command directed at the assistant — e.g. an example sentence
+  // like `"use autopilot"` inside a paragraph discussing that exact phrasing.
+  // But a quoted keyword paired with a nearby execution directive (e.g.
+  // `"ralph" fix the auth bug`) is still a genuine request stylistically
+  // wrapped in quotes, so the exemption only applies when no execution
+  // directive is present — checked before any other activation-intent logic
+  // so quoting wins for reported speech but not for real commands.
+  if (keywordInsideQuotes && !hasExecutionDirective) {
     return true;
   }
 
   if (keywordText) {
     const hasActivationIntent = hasActivationIntentNearKeyword(context, keywordText);
-    const hasExecutionDirective = /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(context);
 
     // Explicit command + execution intent should remain actionable even if the
     // surrounding message also contains a help question.

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -621,16 +621,25 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   // wrapped in quotes, so the exemption only applies when no execution
   // directive is present.
   //
-  // The directive check here is scoped to this keyword's own quoted span
-  // (±28 chars around the span's bounds), not the generic ±80-char context
-  // window used elsewhere in this function. Otherwise an unrelated genuine
-  // command elsewhere in the same message could wrongly neutralize the
-  // exemption for a keyword that is purely quoted as an example.
+  // The directive check here is scoped to text immediately OUTSIDE this
+  // keyword's own quoted span (±28 chars before/after the span's bounds),
+  // not the generic ±80-char context window used elsewhere in this function,
+  // and NOT the quote's own interior. Two failure modes this avoids:
+  // - Scoping to the wide window: an unrelated genuine command elsewhere in
+  //   the same message could sit inside it and wrongly neutralize the
+  //   exemption for a keyword that is purely quoted as an example.
+  // - Scoping to (or including) the quote's own interior: a directive word
+  //   used INSIDE the quoted text itself — extremely common in narrated
+  //   examples and bug reports, e.g. `"please fix autopilot" they said` —
+  //   would make the quote self-report as directive-bearing and defeat the
+  //   exemption for exactly the reported-speech case it exists to catch.
   if (keywordInsideQuotes) {
     const span = findQuotedSpanBounds(text, position);
     const hasExecutionDirectiveNearQuote = span
       ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
-          text.slice(Math.max(0, span.start - 28), Math.min(text.length, span.end + 28)),
+          text.slice(Math.max(0, span.start - 28), span.start) +
+            ' ' +
+            text.slice(span.end, Math.min(text.length, span.end + 28)),
         )
       : hasExecutionDirective;
     if (!hasExecutionDirectiveNearQuote) {

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -482,6 +482,24 @@ function isWithinQuotedSpan(text, position) {
   return false;
 }
 
+// Bounds of the specific quoted span containing `position`, or null if none.
+// Used to scope the execution-directive check for the quote exemption to
+// this keyword's own quote — not the generic ±80-char context window, which
+// can otherwise pick up an unrelated genuine command elsewhere in the same
+// message and wrongly neutralize the exemption for a keyword that is purely
+// quoted as an example.
+function findQuotedSpanBounds(text, position) {
+  for (const match of text.matchAll(QUOTED_SPAN_PATTERN)) {
+    if (match.index === undefined) continue;
+    const start = match.index;
+    const end = start + match[0].length;
+    if (position >= start && position < end) {
+      return { start, end };
+    }
+  }
+  return null;
+}
+
 function stripQuotedSpans(text) {
   return text.replace(QUOTED_SPAN_PATTERN, ' ');
 }
@@ -602,8 +620,22 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   // `"ralph" fix the auth bug`) is still a genuine request stylistically
   // wrapped in quotes, so the exemption only applies when no execution
   // directive is present.
-  if (keywordInsideQuotes && !hasExecutionDirective) {
-    return true;
+  //
+  // The directive check here is scoped to this keyword's own quoted span
+  // (±28 chars around the span's bounds), not the generic ±80-char context
+  // window used elsewhere in this function. Otherwise an unrelated genuine
+  // command elsewhere in the same message could wrongly neutralize the
+  // exemption for a keyword that is purely quoted as an example.
+  if (keywordInsideQuotes) {
+    const span = findQuotedSpanBounds(text, position);
+    const hasExecutionDirectiveNearQuote = span
+      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
+          text.slice(Math.max(0, span.start - 28), Math.min(text.length, span.end + 28)),
+        )
+      : hasExecutionDirective;
+    if (!hasExecutionDirectiveNearQuote) {
+      return true;
+    }
   }
 
   if (keywordText) {

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -616,33 +616,39 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   // A keyword occurrence inside a quoted span is usually reported/example
   // text, not a command directed at the assistant — e.g. an example sentence
   // like `"use autopilot"` inside a paragraph discussing that exact phrasing.
-  // But a quoted keyword paired with a nearby execution directive (e.g.
-  // `"ralph" fix the auth bug`) is still a genuine request stylistically
-  // wrapped in quotes, so the exemption only applies when no execution
-  // directive is present.
+  // But a quoted keyword paired with a nearby execution directive OR
+  // activation verb (e.g. `"ralph" fix the auth bug`, or `run "ralph" on
+  // this issue`) is still a genuine request stylistically wrapped in quotes,
+  // so the exemption only applies when neither is present.
   //
-  // The directive check here is scoped to text immediately OUTSIDE this
-  // keyword's own quoted span (±28 chars before/after the span's bounds),
-  // not the generic ±80-char context window used elsewhere in this function,
-  // and NOT the quote's own interior. Two failure modes this avoids:
+  // This check is scoped to text immediately OUTSIDE this keyword's own
+  // quoted span (±28 chars before/after the span's bounds), not the generic
+  // ±80-char context window used elsewhere in this function, and NOT the
+  // quote's own interior. Three failure modes this avoids:
   // - Scoping to the wide window: an unrelated genuine command elsewhere in
   //   the same message could sit inside it and wrongly neutralize the
   //   exemption for a keyword that is purely quoted as an example.
-  // - Scoping to (or including) the quote's own interior: a directive word
-  //   used INSIDE the quoted text itself — extremely common in narrated
-  //   examples and bug reports, e.g. `"please fix autopilot" they said` —
-  //   would make the quote self-report as directive-bearing and defeat the
-  //   exemption for exactly the reported-speech case it exists to catch.
+  // - Scoping to (or including) the quote's own interior: a directive or
+  //   activation word used INSIDE the quoted text itself — extremely common
+  //   in narrated examples and bug reports, e.g. `"please fix autopilot"
+  //   they said` or `"...told it to use autopilot..."` — would make the
+  //   quote self-report as command-bearing and defeat the exemption for
+  //   exactly the reported-speech case it exists to catch.
+  // - Checking only execution-directive verbs (fix/debug/...) and not
+  //   activation verbs (use/run/start/...): genuine commands stylistically
+  //   quoting just the mode name, e.g. `run "ralph" on this issue` or
+  //   `use "autopilot" on this task`, would be wrongly suppressed even
+  //   though they activated before this exemption existed.
   if (keywordInsideQuotes) {
     const span = findQuotedSpanBounds(text, position);
-    const hasExecutionDirectiveNearQuote = span
-      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(
+    const hasGenuineCommandNearQuote = span
+      ? /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build|use|run|start|enable|activate|invoke|trigger|launch)\b/i.test(
           text.slice(Math.max(0, span.start - 28), span.start) +
             ' ' +
             text.slice(span.end, Math.min(text.length, span.end + 28)),
         )
       : hasExecutionDirective;
-    if (!hasExecutionDirectiveNearQuote) {
+    if (!hasGenuineCommandNearQuote) {
       return true;
     }
   }

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -593,6 +593,18 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
   const line = text.slice(lineBounds.start, lineBounds.end);
   const questionOutsideQuotes = stripQuotedSpans(text);
   const keywordInsideQuotes = isWithinQuotedSpan(text, position);
+  const hasExecutionDirective = /\b(?:fix|debug|investigate|resolve|handle|patch|address|implement|build)\b/i.test(context);
+
+  // A keyword occurrence inside a quoted span is usually reported/example
+  // text, not a command directed at the assistant — e.g. an example sentence
+  // like `"use autopilot"` inside a paragraph discussing that exact phrasing.
+  // But a quoted keyword paired with a nearby execution directive (e.g.
+  // `"ralph" fix the auth bug`) is still a genuine request stylistically
+  // wrapped in quotes, so the exemption only applies when no execution
+  // directive is present.
+  if (keywordInsideQuotes && !hasExecutionDirective) {
+    return true;
+  }
 
   if (keywordText) {
     if (hasActivationIntentNearKeyword(context, keywordText)) {


### PR DESCRIPTION
## Summary
- Fixes #3380: quoted keyword occurrences (e.g. an example sentence like `"use autopilot"` embedded in prose discussing that exact phrasing) were still treated as an actionable activation, silently writing `autopilot-state.json` with `active: true` and causing the `Stop` hook to later block completion demanding cancellation of a session that was never actually requested.
- Root cause: `isWithinQuotedSpan()` already existed and was wired into one narrow heuristic (question-follow-up-in-quotes), but the primary activation-intent gate in `isInformationalKeywordContext()` never consulted it.
- Fix: short-circuit to "informational" (non-activating) whenever the matched keyword falls inside a quoted span, before any activation/diagnostic-intent checks run.
- Scope: intentionally limited to this one precise, unambiguous case. A second, related gap (no guard for continuous-tense narration like "I've been running through autopilot") is called out in the issue but left for separate follow-up.

## Test plan
- [x] Added 3 regression tests in `src/hooks/keyword-detector/__tests__/index.test.ts` under a new `quoted-span exemption (issue #3380)` block
- [x] Verified new tests fail without the fix (reverted fix via `git stash`, confirmed 2/3 assertions fail) and pass with it
- [x] `npx vitest run src/hooks/keyword-detector/__tests__/index.test.ts` — 412/412 pass
- [x] `npx vitest run src/__tests__/keyword-detector-echo-guard.test.ts src/__tests__/keyword-detector-script.test.ts` — 70/70 pass, including the issue #3162 regression guard
- [x] `npm run lint` — 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `npm run build` — succeeds; `dist/`/`bridge/` restored before commit per CONTRIBUTING.md
- [x] Full `npm run test:run` — pre-existing failures in `runtime-v2.dispatch`, `runtime-prompt-mode` (tmux/cmux unavailable in this sandbox) and `mnemosyne/finder` (`CLAUDE_CONFIG_DIR` path) confirmed present on unmodified `dev` @ 694a9e7c via `git stash`; unrelated to this change

Marked as draft while running `/pr-qa` review before requesting maintainer review.