### PR TITLE
Fix standalone hook lib deployment

### DIFF
--- a/src/__tests__/npm-package-hook-surface.test.ts
+++ b/src/__tests__/npm-package-hook-surface.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, normalize, relative } from 'node:path';
 
 const PACKAGE_ROOT = process.cwd();
@@ -187,6 +187,14 @@ function getPackedFiles(): Set<string> {
   return packedFilesCache;
 }
 
+function listTemplateHookLibFiles(): string[] {
+  const templatesLibDir = join(PACKAGE_ROOT, 'templates', 'hooks', 'lib');
+  return readdirSync(templatesLibDir)
+    .filter(filename => statSync(join(templatesLibDir, filename)).isFile())
+    .map(filename => `templates/hooks/lib/${filename}`)
+    .sort();
+}
+
 describe('npm package hook surface regression', () => {
   it('does not explicitly reference the auto-loaded standard hooks manifest from plugin.json', () => {
     const pluginJson = JSON.parse(readFileSync(PLUGIN_JSON_PATH, 'utf-8')) as PluginJson;
@@ -228,6 +236,15 @@ describe('npm package hook surface regression', () => {
     expect([...requiredFiles].sort()).not.toHaveLength(0);
 
     const missing = [...requiredFiles].filter(file => !packedFiles.has(file)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('packs the complete templates/hooks/lib payload for standalone hook installs', () => {
+    const packedFiles = getPackedFiles();
+    const hookLibFiles = listTemplateHookLibFiles();
+
+    expect(hookLibFiles).not.toHaveLength(0);
+    const missing = hookLibFiles.filter(file => !packedFiles.has(file));
     expect(missing).toEqual([]);
   });
 });

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -49,6 +49,13 @@ function shippedStandaloneHookPayload(filename: string, location: 'hooks' | 'hoo
     return readFileSync(join(process.cwd(), 'scripts', 'lib', filename), 'utf-8');
   }
   return readFileSync(join(process.cwd(), 'templates', 'hooks', 'lib', filename), 'utf-8');
+}
+
+function listTemplateHookLibPayload(): string[] {
+  const templatesLibDir = join(process.cwd(), 'templates', 'hooks', 'lib');
+  return readdirSync(templatesLibDir)
+    .filter(filename => statSync(join(templatesLibDir, filename)).isFile())
+    .sort();
 }
 
 describe('install() standalone hook reconciliation', () => {
@@ -122,6 +129,29 @@ describe('install() standalone hook reconciliation', () => {
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');
+  });
+
+  it('mirrors the complete standalone templates/hooks/lib payload', async () => {
+    const templatesLibDir = join(process.cwd(), 'templates', 'hooks', 'lib');
+    const futureHelper = `future-helper-${process.pid}.mjs`;
+    const futureHelperPath = join(templatesLibDir, futureHelper);
+
+    writeFileSync(futureHelperPath, 'export const futureHelper = true;\n');
+    try {
+      const { install } = await loadInstaller();
+      const result = install({
+        force: true,
+        skipClaudeCheck: true,
+      });
+
+      expect(result.success).toBe(true);
+      for (const filename of listTemplateHookLibPayload()) {
+        expect(existsSync(join(testClaudeDir, 'hooks', 'lib', filename)), filename).toBe(true);
+      }
+      expect(readFileSync(join(testClaudeDir, 'hooks', 'lib', futureHelper), 'utf-8')).toBe('export const futureHelper = true;\n');
+    } finally {
+      rmSync(futureHelperPath, { force: true });
+    }
   });
 
   it('installs standalone hooks with all runtime helper imports', async () => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -354,14 +354,29 @@ const OMC_HOOK_FILENAMES = new Set([
   'workflow-drift-guard.mjs',
 ]);
 
-const OMC_HOOK_HELPER_FILENAMES = new Set([
-  'atomic-write.mjs',
-  'config-dir.mjs',
-  'config-dir.sh',
-  'model-routing-override-message.mjs',
-  'state-root.mjs',
-  'stdin.mjs',
-]);
+function listTemplateHookLibFilenames(): Set<string> {
+  const templatesLibDir = join(getPackageDir(), 'templates', 'hooks', 'lib');
+  const filenames = new Set<string>();
+
+  try {
+    for (const filename of readdirSync(templatesLibDir)) {
+      if (statSync(join(templatesLibDir, filename)).isFile()) {
+        filenames.add(filename);
+      }
+    }
+  } catch {
+    // Missing/unreadable templates are handled by the copy path when setup runs.
+  }
+
+  return filenames;
+}
+
+function listStandaloneHookLibPayloadFilenames(): Set<string> {
+  const filenames = listTemplateHookLibFilenames();
+  filenames.add('config-dir.mjs');
+  filenames.add('config-dir.sh');
+  return filenames;
+}
 
 const OMC_HOOK_EXTRA_FILENAMES = new Set([
   'find-node.sh',
@@ -386,7 +401,7 @@ function getShippedStandaloneHookPayloadPath(filename: string, location: 'hooks'
     return null;
   }
 
-  if (!OMC_HOOK_HELPER_FILENAMES.has(filename)) {
+  if (!listStandaloneHookLibPayloadFilenames().has(filename)) {
     return null;
   }
   if (filename === 'config-dir.mjs' || filename === 'config-dir.sh') {
@@ -538,7 +553,7 @@ function pruneLegacyStandaloneHookScripts(log: (msg: string) => void): void {
   const hooksLibDir = join(HOOKS_DIR, 'lib');
   if (existsSync(hooksLibDir)) {
     for (const filename of readdirSync(hooksLibDir)) {
-      if (!OMC_HOOK_HELPER_FILENAMES.has(filename)) {
+      if (!listStandaloneHookLibPayloadFilenames().has(filename)) {
         continue;
       }
 
@@ -752,11 +767,15 @@ function ensureStandaloneHookScripts(log: (msg: string) => void): void {
     }
 
     for (const filename of readdirSync(templatesLibDir)) {
-      if (!filename.endsWith('.mjs') || filename === 'config-dir.mjs') {
+      const sourcePath = join(templatesLibDir, filename);
+      try {
+        if (!statSync(sourcePath).isFile()) {
+          continue;
+        }
+      } catch {
         continue;
       }
 
-      const sourcePath = join(templatesLibDir, filename);
       const targetPath = join(hooksLibDir, filename);
       copyFileSync(sourcePath, targetPath);
       if (!isWindows()) {


### PR DESCRIPTION
## Summary
- Mirror every regular file from `templates/hooks/lib/` into standalone `~/.claude/hooks/lib` during hook deployment/update instead of relying on a hard-coded helper allow-list.
- Preserve existing standalone hook settings/path behavior and canonical `scripts/lib/config-dir.*` handling.
- Add regressions for future hook lib helpers, deployed hook import resolution, and npm package/tarball inclusion of `templates/hooks/lib/*`.

Fixes #3383

## Validation
- `npx vitest run src/installer/__tests__/standalone-hook-reconcile.test.ts src/installer/__tests__/hook-templates.test.ts` — pass (25 tests)
- `npx vitest run src/__tests__/npm-package-hook-surface.test.ts` — pass (5 tests)
- `npx tsc --noEmit` — pass
- `npm run lint` — pass with pre-existing warnings only

— gaebal-gajae (clawdbot) 🦞