### PR TITLE
fix: hide nested hook child processes on Windows

### DIFF
--- a/scripts/code-simplifier.mjs
+++ b/scripts/code-simplifier.mjs
@@ -51,6 +51,7 @@ function getModifiedFiles(cwd, extensions, maxFiles) {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     });
 
     return output

--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -84,6 +84,7 @@ function runGitRevParse(args, cwd) {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: GIT_PROBE_TIMEOUT_MS,
+    windowsHide: true,
   }).trim();
 }
 

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -84,6 +84,7 @@ function resolveOmcRoot(startDir) {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      windowsHide: true,
     }).trim();
     if (top) return join(top, '.omc');
   } catch {
@@ -384,6 +385,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     const mainRepoRoot = dirname(resolve(effectiveCwd, gitCommonDir));
@@ -391,6 +393,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     if (mainRepoRoot !== worktreeTop) {

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -481,6 +481,7 @@ function resolveOmcRoot(startDir) {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      windowsHide: true,
     }).trim();
     if (top) return join(top, '.omc');
   } catch {
@@ -516,6 +517,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
@@ -525,6 +527,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     if (mainRepoRoot !== worktreeTop) {

--- a/tests/lint/windows-hide-hooks.test.ts
+++ b/tests/lint/windows-hide-hooks.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+const RECURRING_HOOK_SCRIPTS = [
+  'scripts/pre-tool-enforcer.mjs',
+  'scripts/post-tool-verifier.mjs',
+  'scripts/context-guard-stop.mjs',
+  'scripts/code-simplifier.mjs',
+] as const;
+
+const CHILD_PROCESS_CALL = /\b(execSync|execFileSync|spawn|spawnSync)\s*\(\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{([\s\S]*?)\}\s*\)/g;
+const WINDOWS_HIDE_TRUE = /\bwindowsHide\s*:\s*true\b/;
+
+function toForwardSlash(path: string): string {
+  return path.split(sep).join('/');
+}
+
+describe('Windows hook child-process hardening', () => {
+  it('recurring hook scripts hide nested child_process calls on Windows', () => {
+    const violations: string[] = [];
+    const scannedCalls: string[] = [];
+
+    for (const script of RECURRING_HOOK_SCRIPTS) {
+      const absolutePath = join(REPO_ROOT, script);
+      const content = readFileSync(absolutePath, 'utf-8');
+      const linesBefore = (index: number) => content.slice(0, index).split('\n').length;
+
+      for (const match of content.matchAll(CHILD_PROCESS_CALL)) {
+        const callName = match[1];
+        const optionsBlock = match[2] ?? '';
+        const line = linesBefore(match.index ?? 0);
+        scannedCalls.push(`${script}:${callName}`);
+
+        if (!WINDOWS_HIDE_TRUE.test(optionsBlock)) {
+          violations.push(`${toForwardSlash(relative(REPO_ROOT, absolutePath))}:${line}: ${callName} missing windowsHide: true`);
+        }
+      }
+    }
+
+    expect(scannedCalls).toEqual([
+      'scripts/pre-tool-enforcer.mjs:execSync',
+      'scripts/pre-tool-enforcer.mjs:execSync',
+      'scripts/pre-tool-enforcer.mjs:execSync',
+      'scripts/post-tool-verifier.mjs:execSync',
+      'scripts/post-tool-verifier.mjs:execSync',
+      'scripts/post-tool-verifier.mjs:execSync',
+      'scripts/context-guard-stop.mjs:execSync',
+      'scripts/code-simplifier.mjs:execSync',
+    ]);
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `windowsHide: true` to nested `execSync` git probes in high-frequency PreToolUse/PostToolUse hook scripts.
- Add `windowsHide: true` to the listed Stop hook git probes in `context-guard-stop.mjs` and `code-simplifier.mjs`.
- Add a lint-style regression guard so these recurring hook scripts keep nested child_process calls hidden on Windows.

## Scope note
This is defensive Windows hardening for OMC nested hook child processes. It does not claim to resolve the reporter's corrected live popup loop, which was traced to Codex Desktop retrying a disconnected remote workspace.

Fixes #3379

## Validation
- `npm run test:run -- tests/lint/windows-hide-hooks.test.ts`
- `npm run lint` (0 errors; existing warnings only)
- `npx tsc --noEmit`
- `npx eslint tests/lint/windows-hide-hooks.test.ts`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --types node,vitest --esModuleInterop tests/lint/windows-hide-hooks.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*