### PR TITLE
Fix keyword detector informational occurrence scanning

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -620,6 +620,25 @@ function hasDirectInvocationPrefix(text, position) {
   return /^\s*(?:[$/!]\s*|force:\s*|oh-my-(?:claudecode|codex):\s*)?$/i.test(prefix);
 }
 
+function hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText) {
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
+  const context = text.slice(start, end);
+  const escaped = escapeRegExp((keywordText || '').trim());
+  if (!escaped) {
+    return false;
+  }
+
+  const conversationalInvocationPatterns = [
+    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
+  ];
+
+  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+}
+
 function hasExplicitInvocationContext(text, position, keywordLength, keywordText) {
   if (hasDirectInvocationPrefix(text, position)) {
     return true;
@@ -628,7 +647,11 @@ function hasExplicitInvocationContext(text, position, keywordLength, keywordText
   const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
   const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
   const context = text.slice(start, end);
-  return hasActivationIntentNearKeyword(context, keywordText);
+  if (hasActivationIntentNearKeyword(context, keywordText)) {
+    return true;
+  }
+
+  return hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText);
 }
 
 function hasDiagnosticIntentNearKeyword(context, keyword) {
@@ -729,6 +752,9 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
 
   if (keywordText) {
     if (hasActivationIntentNearKeyword(context, keywordText)) {
+      return false;
+    }
+    if (hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText)) {
       return false;
     }
     if (isRalphUltraworkMetaOrBanterContext(context, keywordText)) {

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -620,23 +620,21 @@ function hasDirectInvocationPrefix(text, position) {
   return /^\s*(?:[$/!]\s*|force:\s*|oh-my-(?:claudecode|codex):\s*)?$/i.test(prefix);
 }
 
-function hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText) {
-  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
-  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
-  const context = text.slice(start, end);
-  const escaped = escapeRegExp((keywordText || '').trim());
-  if (!escaped) {
+function hasConversationalInvocationNearKeyword(text, position, _keywordLength, _keywordText) {
+  if (isWithinQuotedSpan(text, position)) {
     return false;
   }
 
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const prefix = stripQuotedSpans(text.slice(start, position));
   const conversationalInvocationPatterns = [
-    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
+    /\bplease\s+$/i,
+    /\blet['’]?s\s+$/i,
+    /\bi\s+(?:want|need|would\s+like)\s+(?:a|an)\s+$/i,
+    /\b(?:can|could|would|will)\s+you\s+$/i,
   ];
 
-  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+  return conversationalInvocationPatterns.some((pattern) => pattern.test(prefix));
 }
 
 function hasExplicitInvocationContext(text, position, keywordLength, keywordText) {

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -719,6 +719,24 @@ diff --git a/a b/b
     expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
   });
 
+  // Regression (issue #3382): an informational/reference occurrence of a
+  // keyword earlier in the same prompt must not suppress a later directive
+  // occurrence of that same keyword.
+  it('activates ralph for a later directive after an earlier informational mention', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-info-then-directive-'));
+    const sessionId = 'session-info-then-directive-3382';
+    const output = runKeywordDetector(
+      'The old docs call ralph deprecated. Please ralph and fix the flaky tests.',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
+  });
+
   // Regression (issue #3380, repo-owner review bot finding against the round-1
   // fix commit): a bug-report/discussion prompt that describes fixing this
   // exact false positive, and happens to contain an execution-directive verb

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -737,6 +737,36 @@ diff --git a/a b/b
     expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
   });
 
+  it('does not activate ralph for an informational mention followed by a quoted please phrase', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-please-ralph-'));
+    const sessionId = 'session-quoted-please-ralph-3382';
+    const output = runKeywordDetector(
+      'The docs say ralph is triggered by the phrase "please ralph".',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: RALPH]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(false);
+  });
+
+  it('does not activate autopilot for an informational mention followed by a quoted please phrase', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-quoted-please-autopilot-'));
+    const sessionId = 'session-quoted-please-autopilot-3382';
+    const output = runKeywordDetector(
+      'The docs say autopilot is triggered by the phrase "please autopilot".',
+      cwd,
+      sessionId,
+    );
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: AUTOPILOT]');
+    expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'))).toBe(false);
+  });
+
   // Regression (issue #3380, repo-owner review bot finding against the round-1
   // fix commit): a bug-report/discussion prompt that describes fixing this
   // exact false positive, and happens to contain an execution-directive verb

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -410,6 +410,15 @@ Final draft.`);
         expect(ralphProblem.find((r) => r.type === 'ralph')).toBeDefined();
       });
 
+      it('should detect later directive occurrence after earlier informational same keyword mention', () => {
+        const result = detectKeywordsWithType(
+          'The old docs call ralph deprecated. Please ralph and fix the flaky tests.',
+        );
+        expect(result).toEqual([
+          expect.objectContaining({ type: 'ralph', keyword: 'ralph' }),
+        ]);
+      });
+
       it('should NOT detect "don\'t stop" phrase', () => {
         const result = detectKeywordsWithType("Don't stop until done");
         const ralphMatch = result.find((r) => r.type === 'ralph');

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -419,6 +419,20 @@ Final draft.`);
         ]);
       });
 
+      it('should NOT detect earlier informational ralph because a later quoted phrase says please ralph', () => {
+        const result = detectKeywordsWithType(
+          'The docs say ralph is triggered by the phrase "please ralph".',
+        );
+        expect(result.find((r) => r.type === 'ralph')).toBeUndefined();
+      });
+
+      it('should NOT detect earlier informational autopilot because a later quoted phrase says please autopilot', () => {
+        const result = detectKeywordsWithType(
+          'The docs say autopilot is triggered by the phrase "please autopilot".',
+        );
+        expect(result.find((r) => r.type === 'autopilot')).toBeUndefined();
+      });
+
       it('should NOT detect "don\'t stop" phrase', () => {
         const result = detectKeywordsWithType("Don't stop until done");
         const ralphMatch = result.find((r) => r.type === 'ralph');

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -515,6 +515,30 @@ function hasDirectInvocationPrefix(text: string, position: number): boolean {
   return /^\s*(?:[$/!]\s*|force:\s*|oh-my-(?:claudecode|codex):\s*)?$/i.test(prefix);
 }
 
+function hasConversationalInvocationNearKeyword(
+  text: string,
+  position: number,
+  keywordLength: number,
+  keywordText: string,
+): boolean {
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
+  const context = text.slice(start, end);
+  const escaped = escapeRegExp(keywordText.trim());
+  if (!escaped) {
+    return false;
+  }
+
+  const conversationalInvocationPatterns = [
+    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
+  ];
+
+  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+}
+
 function hasExplicitInvocationContext(
   text: string,
   position: number,
@@ -532,19 +556,7 @@ function hasExplicitInvocationContext(
     return true;
   }
 
-  const escaped = escapeRegExp(keywordText.trim());
-  if (!escaped) {
-    return false;
-  }
-
-  const conversationalInvocationPatterns = [
-    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
-  ];
-
-  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+  return hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText);
 }
 
 function hasDiagnosticIntentNearKeyword(context: string, keyword: string): boolean {
@@ -664,6 +676,10 @@ function isInformationalKeywordContext(text: string, position: number, keywordLe
     }
 
     if (hasActivationIntent) {
+      return false;
+    }
+
+    if (hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText)) {
       return false;
     }
 

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -518,25 +518,23 @@ function hasDirectInvocationPrefix(text: string, position: number): boolean {
 function hasConversationalInvocationNearKeyword(
   text: string,
   position: number,
-  keywordLength: number,
-  keywordText: string,
+  _keywordLength: number,
+  _keywordText: string,
 ): boolean {
-  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
-  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
-  const context = text.slice(start, end);
-  const escaped = escapeRegExp(keywordText.trim());
-  if (!escaped) {
+  if (isWithinQuotedSpan(text, position)) {
     return false;
   }
 
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const prefix = stripQuotedSpans(text.slice(start, position));
   const conversationalInvocationPatterns = [
-    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
+    /\bplease\s+$/i,
+    /\blet['’]?s\s+$/i,
+    /\bi\s+(?:want|need|would\s+like)\s+(?:a|an)\s+$/i,
+    /\b(?:can|could|would|will)\s+you\s+$/i,
   ];
 
-  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+  return conversationalInvocationPatterns.some((pattern) => pattern.test(prefix));
 }
 
 function hasExplicitInvocationContext(

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -546,6 +546,25 @@ function hasDirectInvocationPrefix(text, position) {
   return /^\s*(?:[$/!]\s*|force:\s*|oh-my-(?:claudecode|codex):\s*)?$/i.test(prefix);
 }
 
+function hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText) {
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
+  const context = text.slice(start, end);
+  const escaped = escapeRegExp((keywordText || '').trim());
+  if (!escaped) {
+    return false;
+  }
+
+  const conversationalInvocationPatterns = [
+    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
+    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
+  ];
+
+  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+}
+
 function hasExplicitInvocationContext(text, position, keywordLength, keywordText) {
   if (hasDirectInvocationPrefix(text, position)) {
     return true;
@@ -554,7 +573,11 @@ function hasExplicitInvocationContext(text, position, keywordLength, keywordText
   const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
   const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
   const context = text.slice(start, end);
-  return hasActivationIntentNearKeyword(context, keywordText);
+  if (hasActivationIntentNearKeyword(context, keywordText)) {
+    return true;
+  }
+
+  return hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText);
 }
 
 function hasDiagnosticIntentNearKeyword(context, keyword) {
@@ -655,6 +678,9 @@ function isInformationalKeywordContext(text, position, keywordLength, keywordTex
 
   if (keywordText) {
     if (hasActivationIntentNearKeyword(context, keywordText)) {
+      return false;
+    }
+    if (hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText)) {
       return false;
     }
     if (isRalphUltraworkMetaOrBanterContext(context, keywordText)) {

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -546,23 +546,21 @@ function hasDirectInvocationPrefix(text, position) {
   return /^\s*(?:[$/!]\s*|force:\s*|oh-my-(?:claudecode|codex):\s*)?$/i.test(prefix);
 }
 
-function hasConversationalInvocationNearKeyword(text, position, keywordLength, keywordText) {
-  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
-  const end = Math.min(text.length, position + keywordLength + INFORMATIONAL_CONTEXT_WINDOW);
-  const context = text.slice(start, end);
-  const escaped = escapeRegExp((keywordText || '').trim());
-  if (!escaped) {
+function hasConversationalInvocationNearKeyword(text, position, _keywordLength, _keywordText) {
+  if (isWithinQuotedSpan(text, position)) {
     return false;
   }
 
+  const start = Math.max(0, position - INFORMATIONAL_CONTEXT_WINDOW);
+  const prefix = stripQuotedSpans(text.slice(start, position));
   const conversationalInvocationPatterns = [
-    new RegExp(`\\bplease\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\blet['’]?s\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\bi\\s+(?:want|need|would\\s+like)\\s+(?:a|an)\\s+${escaped}\\b`, 'i'),
-    new RegExp(`\\b(?:can|could|would|will)\\s+you\\s+${escaped}\\b`, 'i'),
+    /\bplease\s+$/i,
+    /\blet['’]?s\s+$/i,
+    /\bi\s+(?:want|need|would\s+like)\s+(?:a|an)\s+$/i,
+    /\b(?:can|could|would|will)\s+you\s+$/i,
   ];
 
-  return conversationalInvocationPatterns.some((pattern) => pattern.test(context));
+  return conversationalInvocationPatterns.some((pattern) => pattern.test(prefix));
 }
 
 function hasExplicitInvocationContext(text, position, keywordLength, keywordText) {


### PR DESCRIPTION
## Summary
- evaluate conversational directive intent per keyword occurrence so an earlier informational/reference mention does not suppress a later actionable mention of the same keyword
- keep standalone runtime hook and hook template in sync with the TS detector
- add TS and deployed runtime regression coverage for issue #3382

Fixes #3382

## Validation
- npm ci
- npm run test:run src/hooks/keyword-detector/__tests__/index.test.ts src/__tests__/keyword-detector-script.test.ts
- node scripts/keyword-detector.mjs with the issue #3382 repro prompt
- npm run lint (passes with existing warnings only)
- npm run build
- npx tsc --noEmit

Signed-off-by: GJC <gjc@local>