### PR TITLE
Fix setup warning for third-party hooks

### DIFF
--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -412,14 +412,15 @@ if [ "$MODE" = "global" ]; then
   rm -f "$CONFIG_DIR/hooks/session-start.sh"
   echo "Legacy hooks cleaned"
 
-  # Check for manual hook entries in settings.json
+  # Check for manual legacy OMC hook entries in settings.json
   SETTINGS_FILE="$CONFIG_DIR/settings.json"
   if [ -f "$SETTINGS_FILE" ]; then
-    if jq -e '.hooks' "$SETTINGS_FILE" > /dev/null 2>&1; then
+    if jq -e 'any(.. | objects | .command? | strings; test("(^|[^[:alnum:]_-])(keyword-detector|stop-continuation|persistent-mode|session-start)(\\.(sh|mjs|cjs|js))?([^[:alnum:]_-]|$)"))' "$SETTINGS_FILE" > /dev/null 2>&1; then
       echo ""
-      echo "NOTE: Found legacy hooks in settings.json. These should be removed since"
-      echo "the plugin now provides hooks automatically. Remove the \"hooks\" section"
-      echo "from $SETTINGS_FILE to prevent duplicate hook execution."
+      echo "NOTE: Found legacy OMC hook entries in settings.json. These should be removed since"
+      echo "the plugin now provides OMC hooks automatically. Remove only the legacy OMC"
+      echo "hook entries from $SETTINGS_FILE to prevent duplicate hook execution;"
+      echo "third-party hook entries can remain."
     fi
   fi
 fi

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -413,6 +413,132 @@ Use the real docs file.
     expect(`${result.stdout}\n${result.stderr}`).toContain('Plugin verified');
   });
 
+  it('does not warn for third-party-only settings hooks', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({
+        plugins: ['oh-my-claudecode'],
+        hooks: {
+          Stop: [
+            {
+              matcher: '',
+              hooks: [{ type: 'command', command: 'node /opt/vendor/hooks/third-party-stop.js' }],
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain('legacy OMC hook entries');
+  });
+
+  it('warns when settings hooks reference a legacy OMC hook command', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({
+        plugins: ['oh-my-claudecode'],
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: '',
+              hooks: [{ type: 'command', command: '$HOME/.claude/hooks/keyword-detector.sh' }],
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain('legacy OMC hook entries');
+  });
+
+  it('does not advise deleting the whole hooks section when hooks are mixed', () => {
+    const fixture = createPluginFixture(`<!-- OMC:START -->
+<!-- OMC:VERSION:9.9.9 -->
+
+# Canonical CLAUDE
+Use the real docs file.
+<!-- OMC:END -->
+`);
+
+    const configDir = join(fixture.homeRoot, 'custom-profile');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({
+        plugins: ['oh-my-claudecode'],
+        hooks: {
+          Stop: [
+            {
+              matcher: '',
+              hooks: [
+                { type: 'command', command: 'node /opt/vendor/hooks/third-party-stop.js' },
+                { type: 'command', command: '$HOME/.claude/hooks/session-start.sh' },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = spawnSync('bash', [fixture.scriptPath, 'global'], {
+      cwd: fixture.projectRoot,
+      env: {
+        ...process.env,
+        HOME: fixture.homeRoot,
+        CLAUDE_CONFIG_DIR: configDir,
+      },
+      encoding: 'utf-8',
+    });
+
+    const output = `${result.stdout}\n${result.stderr}`;
+    expect(result.status).toBe(0);
+    expect(output).toContain('legacy OMC hook entries');
+    expect(output).not.toContain('Remove the "hooks" section');
+    expect(output).toContain('third-party hook entries can remain');
+  });
+
   it('overwrites an existing global CLAUDE.md by default when preserve mode is not requested', () => {
     const fixture = createPluginFixture(`<!-- OMC:START -->
 <!-- OMC:VERSION:9.9.9 -->


### PR DESCRIPTION
## Summary
- Narrow global setup settings.json hook warning to known legacy OMC hook commands only.
- Update warning text to tell users to remove only legacy OMC entries and leave third-party hooks alone.
- Add focused regressions for third-party-only, legacy-only, and mixed hook configurations.

Fixes #3388

## Verification
- `npx vitest run src/__tests__/setup-claude-md-script.test.ts`
- `bash -n scripts/setup-claude-md.sh`
- `npm run lint` (passes with existing warnings)
- `npm run build`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*