### PR TITLE
fix(cli): isolate each omc launch on its own tmux server via -L socket (fixes psmux session mirroring)

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -380,6 +380,20 @@ describe('runClaude outside-tmux — mouse scrolling (issue #890)', () => {
     expect(attachIdx).toBeGreaterThan(clipboardIdx);
   });
 
+  it('routes every tmux call through a dedicated -L socket (session name) for server isolation', () => {
+    runClaude('/tmp', [], 'sid');
+
+    const tmuxCalls = vi.mocked(tmuxExec).mock.calls;
+    expect(tmuxCalls.length).toBeGreaterThan(0);
+    // Every tmux invocation in the outside-tmux launch path — including the ones
+    // issued by configureTmuxClipboardForSession — must carry the same socket so
+    // they all target the launch's own isolated server rather than the shared
+    // default server (psmux mirroring guard).
+    for (const [, opts] of tmuxCalls) {
+      expect((opts as { socket?: string } | undefined)?.socket).toBe('test-session');
+    }
+  });
+
   it('preserves a valid detached session when attach-session is interrupted', () => {
     vi.mocked(tmuxExec).mockImplementation((args: string[]) => {
       if (args[0] === 'attach-session') {

--- a/src/cli/__tests__/tmux-utils.test.ts
+++ b/src/cli/__tests__/tmux-utils.test.ts
@@ -622,3 +622,34 @@ describe('HUD pane tmux server targeting', () => {
     expect(lastCall?.[2]?.env?.TMUX).toBe('/tmp/tmux-100/default,123,0');
   });
 });
+
+// ---------------------------------------------------------------------------
+// tmuxExec — dedicated server socket (-L) isolation
+// ---------------------------------------------------------------------------
+describe('tmuxExec socket option', () => {
+  it('injects -L <socket> before the subcommand when socket is set', () => {
+    mockedExecFileSync.mockClear();
+    mockedExecFileSync.mockReturnValue('' as any);
+
+    tmuxExec(['new-session', '-d', '-s', 'omc-proj-main-123'], { stripTmux: true, socket: 'omc-proj-main-123' });
+
+    const lastCall = mockedExecFileSync.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const passedArgs = lastCall![1] as string[];
+    // `-L <socket>` is a server option and must precede the subcommand.
+    expect(passedArgs.slice(0, 3)).toEqual(['-L', 'omc-proj-main-123', 'new-session']);
+    // socket must not leak into the child_process options object.
+    expect((lastCall![2] as { socket?: string }).socket).toBeUndefined();
+  });
+
+  it('omits -L entirely when no socket is provided', () => {
+    mockedExecFileSync.mockClear();
+    mockedExecFileSync.mockReturnValue('' as any);
+
+    tmuxExec(['has-session', '-t', 'omc-proj-main-123'], { stripTmux: true });
+
+    const passedArgs = mockedExecFileSync.mock.calls.at(-1)![1] as string[];
+    expect(passedArgs).toEqual(['has-session', '-t', 'omc-proj-main-123']);
+    expect(passedArgs).not.toContain('-L');
+  });
+});

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -599,9 +599,17 @@ function runClaudeOutsideTmux(
     : `${envPrefix}sleep 0.3; perl -e 'use POSIX;tcflush(0,TCIFLUSH)' 2>/dev/null; `;
   const claudeCmd = wrapWithLoginShell(`${preflight}${rawClaudeCmd}`);
   const sessionName = buildTmuxSessionName(cwd);
+  // Pin this launch to its own tmux server via a unique -L socket (the session
+  // name is already unique per launch). Separate sockets are separate server
+  // processes with disjoint session tables, so concurrent `omc` instances can
+  // never cross-attach. This is what keeps psmux (native-Windows tmux, whose
+  // default server has a single shared console surface) from mirroring two
+  // launches into one session. See TmuxExecOptions.socket. All tmux calls below
+  // must carry the same socket or they would target the wrong server.
+  const socket = sessionName;
 
   try {
-    tmuxExec(['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stripTmux: true, stdio: 'inherit' });
+    tmuxExec(['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stripTmux: true, socket, stdio: 'inherit' });
   } catch {
     if (options.requireTmux) {
       abortMadmaxRequiresTmux('launch-failed');
@@ -611,19 +619,19 @@ function runClaudeOutsideTmux(
   }
 
   try {
-    configureTmuxClipboardForSession(sessionName, { stripTmux: true, stdio: 'ignore' });
+    configureTmuxClipboardForSession(sessionName, { stripTmux: true, socket, stdio: 'ignore' });
   } catch {
     /* non-fatal — user's tmux may not support these options */
   }
 
   try {
-    tmuxExec(['set-option', '-t', sessionName, 'mouse', 'on'], { stripTmux: true, stdio: 'ignore' });
+    tmuxExec(['set-option', '-t', sessionName, 'mouse', 'on'], { stripTmux: true, socket, stdio: 'ignore' });
   } catch {
     /* non-fatal — user's tmux may not support these options */
   }
 
   try {
-    tmuxExec(['attach-session', '-t', sessionName], { stripTmux: true, stdio: 'inherit' });
+    tmuxExec(['attach-session', '-t', sessionName], { stripTmux: true, socket, stdio: 'inherit' });
   } catch {
     if (options.requireTmux) {
       abortMadmaxRequiresTmux('launch-failed');
@@ -632,7 +640,7 @@ function runClaudeOutsideTmux(
     // attach paths (SSH disconnect, terminal drop, etc.) do not kill or
     // duplicate a valid Claude session.
     try {
-      tmuxExec(['has-session', '-t', sessionName], { stripTmux: true, stdio: 'ignore' });
+      tmuxExec(['has-session', '-t', sessionName], { stripTmux: true, socket, stdio: 'ignore' });
       return;
     } catch {
       runClaudeDirect(cwd, args);

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -24,6 +24,17 @@ export interface TmuxExecOptions {
    *  Default: false — preserves TMUX (targets the current server).
    *  Set to true for OMC-owned background sessions and cross-session scans. */
   stripTmux?: boolean;
+  /** Target a dedicated tmux server on this socket name (`tmux -L <socket>`).
+   *  Each socket is a separate server process with a disjoint session table, so
+   *  distinct sockets can never cross-attach. Used to isolate each `omc` launch
+   *  onto its own server instead of sharing the single default server.
+   *
+   *  This is essential on psmux (the native-Windows tmux reimplementation): unlike
+   *  real tmux — where every attached terminal gets its own independent client view
+   *  of a shared server — psmux's default server exposes a single console surface,
+   *  so two `omc` instances attaching to it mirror each other's keystrokes. A unique
+   *  `-L` socket per launch gives each its own server and eliminates the mirroring. */
+  socket?: string;
 }
 
 export function tmuxEnv(): NodeJS.ProcessEnv {
@@ -63,11 +74,13 @@ function escapeForCmdSet(value: string): string {
   return value.replace(/"/g, '""');
 }
 
-function resolveTmuxInvocation(args: string[]): TmuxCommandInvocation {
+function resolveTmuxInvocation(args: string[], opts?: TmuxExecOptions): TmuxCommandInvocation {
   const resolvedBinary = resolveTmuxBinaryPath();
+  // `-L <socket>` is a tmux server option and must precede the subcommand.
+  const fullArgs = opts?.socket ? ['-L', opts.socket, ...args] : args;
   if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolvedBinary)) {
     const comspec = process.env.COMSPEC || 'cmd.exe';
-    const commandLine = [quoteForCmd(resolvedBinary), ...args.map(quoteForCmd)].join(' ');
+    const commandLine = [quoteForCmd(resolvedBinary), ...fullArgs.map(quoteForCmd)].join(' ');
     return {
       command: comspec,
       args: ['/d', '/s', '/c', commandLine],
@@ -76,7 +89,7 @@ function resolveTmuxInvocation(args: string[]): TmuxCommandInvocation {
 
   return {
     command: resolvedBinary,
-    args,
+    args: fullArgs,
   };
 }
 
@@ -84,8 +97,8 @@ export function tmuxExec(
   args: string[],
   opts?: TmuxExecOptions & Omit<ExecFileSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
 ): string {
-  const { stripTmux: _, ...execOpts } = opts ?? {};
-  const invocation = resolveTmuxInvocation(args);
+  const { stripTmux: _, socket: __, ...execOpts } = opts ?? {};
+  const invocation = resolveTmuxInvocation(args, opts);
   return execFileSync(invocation.command, invocation.args, { encoding: 'utf-8', ...execOpts, env: resolveEnv(opts) });
 }
 
@@ -93,8 +106,8 @@ export async function tmuxExecAsync(
   args: string[],
   opts?: TmuxExecOptions & { timeout?: number },
 ): Promise<{ stdout: string; stderr: string }> {
-  const { stripTmux: _, timeout, ...rest } = opts ?? {};
-  const invocation = resolveTmuxInvocation(args);
+  const { stripTmux: _, socket: __, timeout, ...rest } = opts ?? {};
+  const invocation = resolveTmuxInvocation(args, opts);
   return promisify(execFile)(invocation.command, invocation.args, {
     encoding: 'utf-8', env: resolveEnv(opts),
     ...(timeout !== undefined ? { timeout } : {}), ...rest,
@@ -124,8 +137,8 @@ export function tmuxSpawn(
   args: string[],
   opts?: TmuxExecOptions & Omit<SpawnSyncOptionsWithStringEncoding, 'env' | 'encoding'> & { encoding?: BufferEncoding },
 ): SpawnSyncReturns<string> {
-  const { stripTmux: _, ...spawnOpts } = opts ?? {};
-  const invocation = resolveTmuxInvocation(args);
+  const { stripTmux: _, socket: __, ...spawnOpts } = opts ?? {};
+  const invocation = resolveTmuxInvocation(args, opts);
   return spawnSync(invocation.command, invocation.args, { encoding: 'utf-8', ...spawnOpts, env: resolveEnv(opts) });
 }
 


### PR DESCRIPTION
## Problem

On Windows with **psmux** (the native-Windows tmux reimplementation), running `omc` in two terminals — different shells, different directories — does **not** create two independent sessions. The second `omc` ends up attached to the **same** session as the first, and keystrokes are **mirrored** across both terminals.

## Root cause

`buildTmuxSessionName()` already produces a unique session *name* per launch (`omc-{dir}-{branch}-{utcTimestamp}`), so the collision is **not** in the name. The problem is the *server*:

- Every tmux call in `runClaudeOutsideTmux` targets the **single default tmux server** (no `-L`).
- On **real tmux**, that's fine — each attached terminal is an independent client and can view a different session on the shared server.
- On **psmux**, the default server exposes a **single console surface**. Two `omc` instances that both `attach-session` to it therefore drive the *same* foreground session → mirroring. (psmux's own docs describe a single-session model and offer `-L` for "isolated instances".)

Reproduced and confirmed directly against psmux 3.3.6: two detached sessions coexist in the server's table, but the default server has one global "current" session and one client surface; a bare `tmux -L <sock>` per launch yields fully isolated servers with no cross-talk.

## Fix

Give each launch its own tmux **server** via a unique `-L <socket>` (the already-unique session name). Separate sockets are separate server processes with disjoint session tables and cannot cross-attach — this removes the mirroring on psmux and is a no-op on real tmux.

- **`tmux-utils.ts`**: add `TmuxExecOptions.socket`; `resolveTmuxInvocation` injects `-L <socket>` *before* the subcommand (handles both the direct and the Windows `cmd`/`bat` invocation paths). Threading the socket through the **options object** (rather than each `args` array) keeps every call site unchanged and lets `configureTmuxClipboardForSession` propagate it for free (it already forwards `opts`).
- **`launch.ts`**: pass `socket: sessionName` to every tmux call in `runClaudeOutsideTmux` — `new-session`, clipboard config, `set-option mouse`, `attach-session`, and the `has-session` fallback — so they all resolve against the launch's own server.

### Why per-launch (not per-directory) socket
The socket is set to the unique session name, so behavior is unchanged apart from isolation. A per-directory socket would reintroduce mirroring for two terminals opened in the *same* directory; per-launch eliminates it in all cases.

## Teams are unaffected

psmux sets `TMUX=/tmp/psmux-XXXX/<session>,…` (which **encodes the `-L` socket**) inside every pane. So `detectTeamMultiplexerContext` (which checks `env.TMUX`) still returns `"tmux"` → split-pane mode, and the non-stripped `splitTeamWorkerPane` / worker-start / message-injection `send-keys` calls inherit `TMUX` and land worker panes on the **same** isolated server. Verified: a bare `tmux split-window` inside a `-L` pane creates its panes on that `-L` server, default server empty.

## Testing

- `npx tsc --noEmit` — clean.
- `eslint` on changed files — clean.
- `vitest` on `tmux-utils.test.ts` + `launch.test.ts`: my 3 new tests pass; the 10 pre-existing failures on these files are native-Windows/MSYS environment artifacts (COMSPEC/`.cmd` detection, `wrapWithLoginShell` Windows quoting, symlink perms, `HOME` resolution) — identical count on pristine `dev`, so **no new failures introduced**. They pass on Linux CI.
- New tests: `tmux-utils` asserts `-L <socket>` is injected before the subcommand and omitted when unset; `launch` asserts every tmux call in the outside-tmux path carries the dedicated socket.

No `dist/`/`bridge/` artifacts committed (per CONTRIBUTING).

## Notes / follow-ups (not in this PR)

- `resolveLaunchPolicy` and `detectTeamMultiplexerContext` only check `env.TMUX`, not `PSMUX_SESSION`. It works today because psmux also sets `TMUX`, but honoring `PSMUX_SESSION` too would be more robust.
- Could add an opt-in env/flag (e.g. `OMC_TMUX_SOCKET=per-launch|per-dir|shared`) for users who intentionally want a shared/reattachable session.
