### PR TITLE
fix(learner): respect OMC_STATE_DIR in skill-sessions state path

### DIFF
--- a/src/__tests__/hooks/learner/bridge.test.ts
+++ b/src/__tests__/hooks/learner/bridge.test.ts
@@ -15,6 +15,7 @@ import {
   rmSync,
   existsSync,
   readFileSync,
+  readdirSync,
   symlinkSync,
 } from "fs";
 import { join } from "path";
@@ -513,6 +514,36 @@ Mixed trigger instructions`,
       expect(state.sessions["persist-test"].injectedPaths).toContain(
         "/path/to/persist.md",
       );
+    });
+
+    it("does not write project-local .omc when OMC_STATE_DIR is set", () => {
+      const centralizedDir = join(tmpdir(), `omc-state-dir-${Date.now()}`);
+      mkdirSync(centralizedDir, { recursive: true });
+      const previousOmcStateDir = process.env.OMC_STATE_DIR;
+      process.env.OMC_STATE_DIR = centralizedDir;
+      try {
+        markSkillsInjected(
+          "omc-state-dir-test",
+          ["/path/to/centralized.md"],
+          testProjectRoot,
+        );
+
+        // State must NOT land in the project-local .omc/
+        expect(existsSync(join(testProjectRoot, ".omc"))).toBe(false);
+
+        // State must land somewhere under the centralized dir
+        const found = readdirSync(centralizedDir, { recursive: true })
+          .map((f) => String(f))
+          .filter((f) => f.endsWith("skill-sessions.json"));
+        expect(found).toHaveLength(1);
+      } finally {
+        if (previousOmcStateDir === undefined) {
+          delete process.env.OMC_STATE_DIR;
+        } else {
+          process.env.OMC_STATE_DIR = previousOmcStateDir;
+        }
+        rmSync(centralizedDir, { recursive: true, force: true });
+      }
     });
 
     it("should not re-inject already injected skills", () => {

--- a/src/hooks/learner/bridge.ts
+++ b/src/hooks/learner/bridge.ts
@@ -18,7 +18,7 @@ import {
 } from "fs";
 import { join, dirname, basename } from "path";
 import { homedir } from "os";
-import { OmcPaths } from "../../lib/worktree-paths.js";
+import { OmcPaths, getOmcRoot } from "../../lib/worktree-paths.js";
 import { parseYamlMetadata } from "./parser.js";
 import { expandTriggers } from "./transliteration-map.js";
 
@@ -182,9 +182,6 @@ function summarizeSkillContent(content: string): string {
   return (firstUsefulLine || content.replace(/\s+/g, " ").trim()).slice(0, 240);
 }
 
-/** State file path */
-const STATE_FILE = `${OmcPaths.STATE}/skill-sessions.json`;
-
 // =============================================================================
 // Types
 // =============================================================================
@@ -242,7 +239,7 @@ interface SessionState {
  * Get state file path for a project.
  */
 function getStateFilePath(projectRoot: string): string {
-  return join(projectRoot, STATE_FILE);
+  return join(getOmcRoot(projectRoot), "state", "skill-sessions.json");
 }
 
 /**


### PR DESCRIPTION
## Current behavior

`src/hooks/learner/bridge.ts` hardcodes the `skill-sessions.json` path to `<project>/.omc/state/`, bypassing `getOmcRoot()`. Even with `OMC_STATE_DIR` set, the learner hook still writes state into the project's `.omc/` instead of the centralized `$OMC_STATE_DIR/{projectId}/` — the last entry point missed by #2533 (which centralized state-root resolution across `scripts/`); same class as #1126.

## Expected behavior

With `OMC_STATE_DIR` set, the learner hook's `skill-sessions.json` should land under `$OMC_STATE_DIR/{projectId}/state/` like every other hook, and must not create `.omc/` inside the project working tree.

## Fix

Route `getStateFilePath()` through `getOmcRoot()`:

```ts
function getStateFilePath(projectRoot: string): string {
  return join(getOmcRoot(projectRoot), "state", "skill-sessions.json");
}
```

The hardcoded `STATE_FILE` constant is removed (no other references); `getOmcRoot` is added to the existing `worktree-paths` import.

## Tests

Added a regression test: with `OMC_STATE_DIR` set, `markSkillsInjected()` writes under the centralized dir and does **not** create `<projectRoot>/.omc/`. Existing tests cover the default (unset) path.

```
✓ src/__tests__/hooks/learner/bridge.test.ts (24 tests)
```

`npm run lint` (0 errors), `tsc --noEmit`, `npm run test:run` (10076 passed), `npm run build` — all green.

## Notes

Source-only change. Compiled `dist/` / `bridge/*.cjs` artifacts are not included — rebuilt to verify, then `git restore`-ed before commit per CONTRIBUTING §6 (`Do NOT commit dist/ or bridge/`).