### PR TITLE
feat: /ultradebug — a stateful, resumable bug-fixing workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -49,6 +49,7 @@
     "./skills/skillify/",
     "./skills/team/",
     "./skills/trace/",
+    "./skills/ultradebug/",
     "./skills/ultraqa/",
     "./skills/ultrawork/",
     "./skills/ultragoal/",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,8 @@ Code Intel: LSP (`lsp_hover`, `lsp_goto_definition`, `lsp_find_references`, `lsp
 <skills>
 Invoke via `/oh-my-claudecode:<name>`. Trigger patterns auto-detect keywords.
 
-Workflow: `autopilot`, `ralph`, `ultrawork`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`, `self-improve`
-Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
+Workflow: `autopilot`, `ralph`, `ultrawork`, `ultradebug`, `team`, `ccg`, `ultraqa`, `omc-plan`, `ralplan`, `sciomc`, `external-context`, `deepinit`, `deep-interview`, `ai-slop-cleaner`, `self-improve`
+Keyword triggers: "autopilot"→autopilot, "ralph"→ralph, "ulw"→ultrawork, "ultradebug"→ultradebug, "ccg"→ccg, "ralplan"→ralplan, "deep interview"→deep-interview, "deslop"/"anti-slop"/cleanup+slop-smell→ai-slop-cleaner, "deep-analyze"→analysis mode, "tdd"→TDD mode, "deepsearch"→codebase search, "ultrathink"→deep reasoning, "cancelomc"→cancel. Team orchestration is explicit via `/team`.
 Utilities: `ask-codex`, `ask-gemini`, `cancel`, `note`, `learner`, `omc-setup`, `mcp-setup`, `hud`, `omc-doctor`, `omc-help`, `trace`, `release`, `project-session-manager`, `skill`, `writer-memory`, `ralph-init`, `configure-notifications`, `learn-about-omc` (`trace` is the evidence-driven tracing lane)
 Per-role `/team` routing: configure provider/model per canonical role (codex critic, gemini reviewer, etc.) in `.claude/omc.jsonc` under `team.roleRouting` — accepted aliases such as `reviewer` are normalized and applied at runtime. See `skills/team/SKILL.md#per-role-provider--model-routing`.
 </skills>

--- a/skills/ultradebug/SKILL.md
+++ b/skills/ultradebug/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: ultradebug
+description: Stateful, resumable bug-fixing loop - reproduce, hypothesize, fix, verify, driven to completion until the bug is gone
+argument-hint: "\"<bug>\" [--competing|--serial] [--effort=thorough|balanced|fast] [--no-verify] [--uat] | --resume [--session <id>]"
+level: 4
+---
+
+[ULTRADEBUG - ITERATION {{ITERATION}}/{{MAX}}]
+
+Your previous attempt did not output the completion promise `ULTRADEBUG_COMPLETE`.
+Continue the debug loop from the current session status.
+
+<Purpose>
+UltraDebug is a persistence loop that fixes ONE bug per session using the
+scientific method — reproduce → hypothesize → evidence → diagnose → fix → verify —
+and keeps iterating until the original reproduction passes and the suite is green,
+or the loop's bounds trip. State is persisted every phase transition, so the run
+survives interruption, compaction, and `--resume` across sessions.
+
+Design reference: `.omc/plans/ultradebug-design.md` (decisions D1–D7).
+</Purpose>
+
+<Use_When>
+- A specific bug needs fixing end-to-end, not just diagnosing.
+- The user says "ultradebug", "debug this", "fix this bug and verify it", "find and fix".
+- The fix may take several investigate→fix→verify cycles and must be verified, not assumed.
+</Use_When>
+
+<Do_Not_Use_When>
+- User only wants a diagnosis / root-cause opinion — delegate to the `debugger` or `tracer` agent, or use `/trace`.
+- User wants to diagnose the OMC session/repo state itself — use `/debug` (different skill).
+- User wants a general quality-gate cycle unrelated to a specific bug — use `/ultraqa`.
+- User wants a full idea→code pipeline — use `/autopilot`.
+</Do_Not_Use_When>
+
+<Driver>
+UltraDebug is driven by the OMC persistence engine (the "ralph engine", design §5A),
+NOT by Claude's native `/goal` (its evaluator only reads the transcript and cannot
+run tests — see D4). The Stop hook re-injects this continuation prompt every turn
+while the session's `active: true`, until either:
+- the loop prints the completion promise `ULTRADEBUG_COMPLETE`, or
+- `iteration >= max_iterations` (default 8), or
+- the thinking-only-streak guard trips (no tool progress).
+
+Completion promise contract: only print `ULTRADEBUG_COMPLETE` once session status is
+`complete` (the original repro passes AND `/ultraqa` returned PASS). Never print it
+to escape a hard iteration — report the blocker instead.
+
+Implementation note: full cross-turn autonomy requires the persistent-mode Stop
+hook to recognize an `ultradebug` mode (small follow-up in `src/hooks/persistent-mode`,
+mirroring `ralph`). Until then the loop runs in-context within a single turn and
+relies on `--resume` for continuation. This does not change the phases below.
+</Driver>
+
+<State>
+Per-session file: `.omc/state/sessions/{sessionId}/ultradebug-state.json` (schema: design §6).
+(The `state_write`/`state_read` tools normalize mode `ultradebug` to the canonical
+`ultradebug-state.json` filename — same convention as every other OMC mode.)
+Written via `state_write`, read via `state_read`. Key fields:
+`active`, `session_id`, `title`, `issue`, `status`, `path` (A|B), `effort`,
+`iteration`, `max_iterations`, `head_before`, `hypotheses[]` (confirmed AND rejected,
+each with `evidence_for`/`evidence_against`/`conclusion`), `root_cause`, `plan`,
+`changed_files[]`, `commit`, `verify{round,result,failures}`, `uat{round,checkpoints}`.
+
+Session id: `OMC_SESSION_ID` (CLI) or hook `data.session_id`.
+Hypothesis preservation is non-negotiable — keep every rejected hypothesis so
+`--resume` never re-investigates a dead end.
+</State>
+
+<Phases>
+
+**Phase 0 — Resolve session.**
+- `--resume` → load active session, else latest unresolved (announce which).
+- `--session <id>` → load that session; missing file → STOP with error.
+- Neither, and a bug description present → create a new session: parse the bug
+  (strip flags), capture `head_before = git rev-parse HEAD`, set `status=investigating`,
+  `iteration=1`, `max_iterations=8`, `effort` from `--effort` (default `balanced`, D5).
+- No description and no resume flag → STOP with usage.
+- On resume, dispatch on `status`: `investigating`→Phase 2, `fixing`→Phase 3,
+  `verifying`→Phase 4, `uat_pending`→Phase 5, `complete`→STOP (already done).
+
+**Phase 1 — Classify + route (D6).**
+- Ambiguity signals (2+ = ambiguous): intermittent/flaky/random/sporadic wording;
+  multiple plausible root-cause areas; generic/missing error; prior reverted fixes in `git log`.
+- `--competing` → Path A always. `--serial` → Path B always.
+- Else: Path A if ambiguous, Path B otherwise.
+- **Emit the routing decision + reason** so the 3-lane cost of Path A is visible.
+- Persist `path`.
+
+**Phase 2 — Investigate (read-only).**
+- **Path A (competing):** run `/trace` orchestration — 3 `tracer` lanes, deliberately
+  different hypotheses, evidence for/against, rebuttal, synthesis picks the winner.
+  (Dispatch backend = teams via `/trace` for v1, D3.)
+- **Path B (standard):** spawn one `debugger` agent (scientific method).
+- Model tier from `effort` (D5): thorough→opus, balanced→sonnet, fast→haiku.
+- Persist ALL hypotheses (confirmed + rejected) and `root_cause`.
+- Confident root cause → `status=fixing`, go to Phase 3.
+- No confident root cause → stay `investigating`; loop re-injects for the next
+  hypothesis (or `--resume`). Never fabricate a fix.
+
+**Phase 3 — Fix.**
+- Spawn `executor` (model per effort; opus for complex) with the root cause + minimal
+  fix. It applies the change and commits `fix({scope}): {desc}` using OMC's git-trailer
+  protocol (D7: `Constraint:`/`Rejected:`/`Confidence:`/`Scope-risk:`).
+- Persist `changed_files`, `commit`. Set `status=verifying`.
+
+**Phase 4 — Verify (always delegate, D1).**
+- Delegate to `/ultraqa` — never inline — with the goal scoped to the changed files
+  plus a repro of the original bug (default `--tests`). Read back its verdict.
+- PASS → `status=uat_pending` if `--uat`, else `status=complete`.
+- FAIL/exhausted → back to `status=investigating` with the failure context prepended
+  to the next investigation prompt; increment `iteration`; loop.
+- `--no-verify` → skip straight to `complete` after the fix (records `verify: skipped`).
+
+**Phase 5 — UAT (only with `--uat`).**
+- Generate 1–3 human-judgment checkpoints (does the original bug still reproduce?
+  visible regressions? fix correct from the user's view). Present each via `AskUserQuestion`.
+- All pass → `status=complete`. Any issue → `status=investigating` with the issue as
+  failure context; loop.
+
+**Phase 6 — Complete.**
+- Emit the result summary (mode + backend, issue, root cause, outcome, files, commit).
+- Print `ULTRADEBUG_COMPLETE`.
+- Delete `.omc/state/sessions/{sessionId}/ultradebug-state.json` (never leave `active:false`).
+
+</Phases>
+
+<Exit_Conditions>
+| Condition | Action |
+|---|---|
+| Repro passes + `/ultraqa` PASS (+ UAT if `--uat`) | `complete` → print `ULTRADEBUG_COMPLETE`, delete state |
+| `iteration >= max_iterations` | STOP: report the strongest hypothesis + evidence + remaining unknowns; keep state for `--resume` |
+| Same verify failure 3× | STOP early: surface the fundamental blocker; keep state |
+| No confident root cause | stay `investigating`; loop or STOP with `--resume` hint |
+| User `/oh-my-claudecode:cancel` | clear state, stop |
+</Exit_Conditions>
+
+<Rules>
+1. Author/review separation: investigators (`tracer`/`debugger`) are read-only; only
+   `executor` mutates and commits. Verification is a separate lane (`/ultraqa`).
+2. Never claim done without evidence in the transcript — `/ultraqa` PASS is the gate.
+3. Minimal fixes only: root cause, not symptom; add/adjust a regression test.
+4. Preserve every hypothesis (audit trail). Log the Path A routing choice + cost.
+5. One bug per session.
+</Rules>
+
+<Cancellation>
+`/oh-my-claudecode:cancel` clears ultradebug state. On `complete`, delete the session file.
+</Cancellation>

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (36 canonical + 3 aliases)', () => {
+    it('should return correct number of skills (37 canonical + 3 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 39 entries: 36 canonical skills + 3 deprecated aliases (cancel-ralph, learner, psm)
-      expect(skills).toHaveLength(39);
+      // 40 entries: 37 canonical skills + 3 deprecated aliases (cancel-ralph, learner, psm)
+      expect(skills).toHaveLength(40);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -155,6 +155,7 @@ describe('Builtin Skills', () => {
         'skill',
         'team',
         'trace',
+        'ultradebug',
         'ultraqa',
         'ultrawork',
         'ultragoal',
@@ -831,7 +832,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(36);
+      expect(names).toHaveLength(37);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -869,7 +870,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; cancel-ralph, psm, and learner aliases still exist
-      expect(names).toHaveLength(39);
+      expect(names).toHaveLength(40);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/hooks/persistent-mode/__tests__/ultradebug-loop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ultradebug-loop.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+import { checkPersistentModes } from '../index.js';
+
+/**
+ * UltraDebug persistent-mode driver tests. Mirrors the ralph hook tests: write a
+ * fake session state file (and, where completion is exercised, a fake JSONL
+ * transcript), then invoke checkPersistentModes() and assert on the result.
+ *
+ * Contract-sensitive: the continuation header `[ULTRADEBUG - ITERATION n/max]`
+ * and the promise string `ULTRADEBUG_COMPLETE` must stay byte-exact.
+ */
+describe('persistent-mode ultradebug driver', () => {
+  function setup(sessionId: string, state: Record<string, unknown>): { tempDir: string; stateDir: string } {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ultradebug-'));
+    execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+    const stateDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'ultradebug-state.json'),
+      JSON.stringify({ session_id: sessionId, project_path: tempDir, ...state }, null, 2),
+    );
+    return { tempDir, stateDir };
+  }
+
+  it('detects an active ultradebug session and re-injects the continuation prompt', async () => {
+    const sessionId = 'ud-detect';
+    const { tempDir, stateDir } = setup(sessionId, {
+      active: true,
+      iteration: 2,
+      max_iterations: 8,
+      status: 'investigating',
+      started_at: new Date().toISOString(),
+    });
+
+    try {
+      const result = await checkPersistentModes(sessionId, tempDir);
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe('ultradebug');
+      // iteration incremented 2 -> 3
+      expect(result.message).toContain('[ULTRADEBUG - ITERATION 3/8]');
+
+      const updated = JSON.parse(readFileSync(join(stateDir, 'ultradebug-state.json'), 'utf-8')) as {
+        iteration: number;
+      };
+      expect(updated.iteration).toBe(3);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('completes and clears state when an assistant turn prints ULTRADEBUG_COMPLETE', async () => {
+    const sessionId = 'ud-complete';
+    const { tempDir, stateDir } = setup(sessionId, {
+      active: true,
+      iteration: 3,
+      max_iterations: 8,
+      status: 'verifying',
+      started_at: new Date().toISOString(),
+    });
+
+    // Fake transcript: an assistant turn that printed the completion promise.
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'fix the bug' } }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'Repro passes, suite green. ULTRADEBUG_COMPLETE' }] },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    try {
+      const result = await checkPersistentModes(sessionId, tempDir, { transcript_path: transcriptPath });
+      expect(result.shouldBlock).toBe(false);
+      expect(result.message).toContain('[ULTRADEBUG COMPLETE]');
+      // Genuine completion deletes the session state file.
+      expect(existsSync(join(stateDir, 'ultradebug-state.json'))).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT complete when the promise only appears in the injected (user) prompt', async () => {
+    const sessionId = 'ud-nofalse';
+    const { tempDir, stateDir } = setup(sessionId, {
+      active: true,
+      iteration: 1,
+      max_iterations: 8,
+      status: 'investigating',
+      started_at: new Date().toISOString(),
+    });
+
+    // The continuation prompt (a user-role record) quotes the promise string.
+    // Scanning it must NOT trigger completion.
+    const transcriptPath = join(tempDir, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'did not output the completion promise `ULTRADEBUG_COMPLETE`' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: {} }] },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    try {
+      const result = await checkPersistentModes(sessionId, tempDir, { transcript_path: transcriptPath });
+      expect(result.shouldBlock).toBe(true);
+      expect(result.mode).toBe('ultradebug');
+      expect(result.message).toContain('[ULTRADEBUG - ITERATION 2/8]');
+      expect(existsSync(join(stateDir, 'ultradebug-state.json'))).toBe(true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('stops at max_iterations and keeps state (active:false) for --resume', async () => {
+    const sessionId = 'ud-max';
+    const { tempDir, stateDir } = setup(sessionId, {
+      active: true,
+      iteration: 8,
+      max_iterations: 8,
+      status: 'investigating',
+      started_at: new Date().toISOString(),
+    });
+
+    try {
+      const result = await checkPersistentModes(sessionId, tempDir);
+      // Unlike ralph, ultradebug stops (releases) at max_iterations.
+      expect(result.shouldBlock).toBe(false);
+      expect(result.message).toContain('[ULTRADEBUG - MAX ITERATIONS]');
+
+      // State is KEPT for --resume, marked inactive.
+      const statePath = join(stateDir, 'ultradebug-state.json');
+      expect(existsSync(statePath)).toBe(true);
+      const updated = JSON.parse(readFileSync(statePath, 'utf-8')) as { active: boolean; iteration: number };
+      expect(updated.active).toBe(false);
+      expect(updated.iteration).toBe(8);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does nothing when no ultradebug state exists', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ultradebug-none-'));
+    execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
+    try {
+      const result = await checkPersistentModes('ud-absent', tempDir);
+      expect(result.mode).not.toBe('ultradebug');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -47,6 +47,14 @@ import {
   clearVerificationState,
   type VerificationState,
 } from '../ralph/index.js';
+import {
+  readUltradebugState,
+  writeUltradebugState,
+  clearUltradebugState,
+  incrementUltradebugIteration,
+  detectUltradebugComplete,
+  buildUltradebugContinuationPrompt,
+} from '../ultradebug/index.js';
 import { checkIncompleteTodos, getNextPendingTodo, StopContext, isUserAbort, isContextLimitStop, isRateLimitStop, isExplicitCancelCommand, isAuthenticationError, isScheduledWakeupStop, isOversizeToolResultRedirectStop } from '../todo-continuation/index.js';
 import { TODO_CONTINUATION_PROMPT } from '../../installer/hooks.js';
 import {
@@ -74,7 +82,7 @@ export interface PersistentModeResult {
   /** Message to inject into context */
   message: string;
   /** Which mode triggered the block */
-  mode: 'ralph' | 'ultrawork' | 'todo-continuation' | 'autopilot' | 'autoresearch' | 'team' | 'ralplan' | 'none';
+  mode: 'ralph' | 'ultradebug' | 'ultrawork' | 'todo-continuation' | 'autopilot' | 'autoresearch' | 'team' | 'ralplan' | 'none';
   /** Additional metadata */
   metadata?: {
     todoCount?: number;
@@ -96,7 +104,7 @@ const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 const OVERSIZE_TOOL_RESULT_REDIRECT_STOP_MAX = 3;
 const OVERSIZE_TOOL_RESULT_REDIRECT_STOP_TTL_MS = 5 * 60 * 1000;
-const TERMINAL_WORKFLOW_SLOT_MODES = new Set(['autopilot', 'ralph', 'ralplan']);
+const TERMINAL_WORKFLOW_SLOT_MODES = new Set(['autopilot', 'ralph', 'ralplan', 'ultradebug']);
 const TERMINAL_WORKFLOW_PHASES = new Set([
   'complete',
   'completed',
@@ -1248,6 +1256,154 @@ ${newState.prompt ? `Original task: ${truncatePromptForEcho(newState.prompt)}` :
 }
 
 // ---------------------------------------------------------------------------
+// UltraDebug enforcement (ralph-engine driven, D4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan ONLY assistant-authored turns in the transcript tail for the ultradebug
+ * completion promise. The injected continuation prompt quotes the promise
+ * string, so scanning user-role records would false-positive — restrict to
+ * assistant text/thinking blocks. Fails closed (returns false) on any read or
+ * parse error so a flaky transcript never falsely completes the loop.
+ */
+function transcriptHasUltradebugPromise(transcriptPath: string): boolean {
+  let lines: string[];
+  try {
+    lines = readTranscriptTailLines(transcriptPath);
+  } catch {
+    return false;
+  }
+
+  for (const line of lines) {
+    const trimmed = line?.trim();
+    if (!trimmed) continue;
+
+    let parsed: { type?: string; message?: { role?: string; content?: unknown } };
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    const role = parsed?.message?.role;
+    const isAssistant = parsed?.type === 'assistant' || role === 'assistant';
+    if (!isAssistant) continue;
+
+    const text = extractTranscriptText(parsed.message?.content);
+    if (detectUltradebugComplete(text)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check UltraDebug loop state and decide whether to re-inject the debug
+ * continuation prompt. Mirrors checkRalphLoop's shape (state read, session
+ * isolation, hard-max auto-disable) but drives the scientific-method bug-fixing
+ * lifecycle instead of PRD stories. Termination follows SKILL.md
+ * <Exit_Conditions>:
+ *  - completion promise present in an assistant turn -> complete, clear state;
+ *  - iteration >= max_iterations -> stop, KEEP state (active:false) for --resume;
+ *  - hard max reached -> auto-disable, KEEP state for --resume;
+ *  - otherwise increment and re-inject.
+ * The thinking-only-streak guard is applied by the shared wrapper in
+ * checkPersistentModes(), so it is not re-implemented here.
+ */
+async function checkUltradebug(
+  sessionId?: string,
+  directory?: string,
+  cancelInProgress?: boolean,
+  stopContext?: StopContext,
+): Promise<PersistentModeResult | null> {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readUltradebugState(workingDir, sessionId);
+  const ultradebugStatePath = sessionId
+    ? resolveSessionStatePath('ultradebug', sessionId, workingDir)
+    : resolveStatePath('ultradebug', workingDir);
+
+  if (!state || !state.active || isStaleState(state)) {
+    return null;
+  }
+
+  // Session isolation (lenient form — see checkRalphLoop for rationale).
+  if (state.session_id && sessionId && state.session_id !== sessionId) {
+    return null;
+  }
+
+  if (isAwaitingConfirmation(state)) {
+    return null;
+  }
+
+  // Never re-arm internals while a cancel is in progress.
+  if (cancelInProgress) {
+    return { shouldBlock: false, message: '', mode: 'none' };
+  }
+
+  // Completion promise: only genuine when an assistant turn printed it. This is
+  // genuine completion, so clear state (idempotent with the skill's own delete).
+  const transcriptPath = stopContext?.transcript_path ?? stopContext?.transcriptPath;
+  if (transcriptPath && existsSync(transcriptPath) && transcriptHasUltradebugPromise(transcriptPath)) {
+    clearUltradebugState(workingDir, sessionId);
+    return {
+      shouldBlock: false,
+      message: `[ULTRADEBUG COMPLETE] Bug fixed and verified after ${state.iteration} iteration(s). Session state cleared.`,
+      mode: 'none',
+    };
+  }
+
+  // Hard max: independent of max_iterations so it cannot be bypassed by a large
+  // initial max. Auto-disable but KEEP state for --resume.
+  const hardMax = getHardMaxIterations();
+  if (hardMax > 0 && state.iteration >= hardMax) {
+    state.active = false;
+    if (!shouldWriteStateBack(ultradebugStatePath)) {
+      return { shouldBlock: false, message: '', mode: 'none' };
+    }
+    writeUltradebugState(workingDir, state, sessionId);
+    return {
+      shouldBlock: true,
+      message: `[ULTRADEBUG - HARD LIMIT] Reached hard max iterations (${hardMax}). Mode auto-disabled; state kept for --resume. Restart with /oh-my-claudecode:ultradebug --resume if needed.`,
+      mode: 'ultradebug',
+      metadata: { iteration: state.iteration, maxIterations: state.max_iterations },
+    };
+  }
+
+  // Max iterations: unlike ralph (which extends), ultradebug STOPS and keeps
+  // state for --resume (SKILL.md <Exit_Conditions>). Release the stop.
+  if (state.iteration >= state.max_iterations) {
+    state.active = false;
+    if (!shouldWriteStateBack(ultradebugStatePath)) {
+      return { shouldBlock: false, message: '', mode: 'none' };
+    }
+    writeUltradebugState(workingDir, state, sessionId);
+    return {
+      shouldBlock: false,
+      message: `[ULTRADEBUG - MAX ITERATIONS] Reached max iterations (${state.max_iterations}) without completion. Stopping; report the strongest hypothesis and remaining unknowns. State kept for /oh-my-claudecode:ultradebug --resume.`,
+      mode: 'ultradebug',
+      metadata: { iteration: state.iteration, maxIterations: state.max_iterations },
+    };
+  }
+
+  // Increment and re-inject the continuation prompt.
+  const newState = incrementUltradebugIteration(workingDir, sessionId);
+  if (!newState) {
+    return null;
+  }
+
+  return {
+    shouldBlock: true,
+    message: buildUltradebugContinuationPrompt(newState.iteration, newState.max_iterations),
+    mode: 'ultradebug',
+    metadata: {
+      iteration: newState.iteration,
+      maxIterations: newState.max_iterations,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Stop Breaker helpers (shared by team pipeline and ralplan)
 // ---------------------------------------------------------------------------
 
@@ -2291,6 +2447,17 @@ async function resolvePersistentModeBlock(
     if (ralphResult) return ralphResult;
     const autopilotResult = await runAutopilotPriority();
     if (autopilotResult) return autopilotResult;
+  }
+
+  // Priority 1.5: UltraDebug (stateful bug-fixing loop, ralph-engine driven, D4)
+  // Self-gates on its own session state; returns null when inactive so lower
+  // priorities still run. Suppressed while the ultradebug slot is tombstoned so
+  // a completed run does not re-arm until the tombstone TTL expires.
+  if (!tombstonedWorkflowModes.has('ultradebug')) {
+    const ultradebugResult = await checkUltradebug(sessionId, workingDir, cancelInProgress, stopContext);
+    if (ultradebugResult) {
+      return ultradebugResult;
+    }
   }
 
   // Priority 1.6: Autoresearch (stateful single-mission runtime)

--- a/src/hooks/ultradebug/index.ts
+++ b/src/hooks/ultradebug/index.ts
@@ -1,0 +1,168 @@
+/**
+ * UltraDebug Hook
+ *
+ * Stateful, resumable bug-fixing loop driven by the OMC persistence engine (the
+ * "ralph engine"). This module owns the per-session state I/O, iteration
+ * counting, the completion-promise contract, and the Stop-hook continuation
+ * prompt. The Stop-hook integration itself (checkUltradebug) lives in
+ * persistent-mode/index.ts and reuses these helpers, mirroring ralph.
+ *
+ * Design reference: `.omc/plans/ultradebug-design.md` (§5A, §6, §7, D1–D7).
+ * Driver contract: `skills/ultradebug/SKILL.md` <Driver>/<Exit_Conditions>.
+ */
+
+import {
+  writeModeState,
+  readModeState,
+  clearModeStateFile,
+} from "../../lib/mode-state-io.js";
+
+/**
+ * Completion promise. The loop prints this EXACT string only once the original
+ * repro passes and `/ultraqa` returned PASS. Contract tests grep for it — do
+ * not change without updating SKILL.md and the design doc.
+ */
+export const ULTRADEBUG_COMPLETE_PROMISE = "ULTRADEBUG_COMPLETE";
+
+/** Default iteration bound (SKILL.md DRIVER CONTRACT: max_iterations default 8). */
+export const ULTRADEBUG_DEFAULT_MAX_ITERATIONS = 8;
+
+export type UltradebugStatus =
+  | "investigating"
+  | "fixing"
+  | "verifying"
+  | "uat_pending"
+  | "complete";
+
+/**
+ * Per-session ultradebug state (design §6). Only the loop-control fields are
+ * typed explicitly; the skill also persists `path`, `effort`, `hypotheses[]`,
+ * `root_cause`, `plan`, `changed_files[]`, `commit`, `verify`, `uat`, and
+ * `head_before`. Those are preserved verbatim via the index signature — the
+ * driver never needs to read them.
+ */
+export interface UltradebugState {
+  /** Whether the loop is currently active. */
+  active: boolean;
+  /** Current iteration number. */
+  iteration: number;
+  /** Maximum iterations before the loop hard-stops (kept for --resume). */
+  max_iterations: number;
+  /** ISO timestamp when the session started. */
+  started_at: string;
+  /** Session id the loop is bound to. */
+  session_id?: string;
+  /** Project path for isolation. */
+  project_path?: string;
+  /** Current phase in the state machine (design §5). */
+  status?: UltradebugStatus;
+  /** One-line bug summary. */
+  title?: string;
+  /** Verbatim bug description. */
+  issue?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Read ultradebug session state from disk.
+ * Enforces the same lenient session-identity check ralph uses: reject only when
+ * BOTH the state file and the caller carry defined, differing session ids.
+ */
+export function readUltradebugState(
+  directory: string,
+  sessionId?: string,
+): UltradebugState | null {
+  const state = readModeState<UltradebugState>("ultradebug", directory, sessionId);
+
+  if (state && sessionId && state.session_id && state.session_id !== sessionId) {
+    return null;
+  }
+
+  return state;
+}
+
+/**
+ * Write ultradebug session state to disk.
+ */
+export function writeUltradebugState(
+  directory: string,
+  state: UltradebugState,
+  sessionId?: string,
+): boolean {
+  return writeModeState(
+    "ultradebug",
+    state as unknown as Record<string, unknown>,
+    directory,
+    sessionId,
+  );
+}
+
+/**
+ * Clear (delete) ultradebug session state. Used on genuine completion and by
+ * `/oh-my-claudecode:cancel`.
+ */
+export function clearUltradebugState(
+  directory: string,
+  sessionId?: string,
+): boolean {
+  return clearModeStateFile("ultradebug", directory, sessionId);
+}
+
+/**
+ * Increment the ultradebug iteration counter and persist it.
+ * Returns the updated state, or null when there is no active session.
+ */
+export function incrementUltradebugIteration(
+  directory: string,
+  sessionId?: string,
+): UltradebugState | null {
+  const state = readUltradebugState(directory, sessionId);
+
+  if (!state || !state.active) {
+    return null;
+  }
+
+  state.iteration += 1;
+
+  if (writeUltradebugState(directory, state, sessionId)) {
+    return state;
+  }
+
+  return null;
+}
+
+/**
+ * Does assistant-authored text carry the completion promise? The Stop-hook
+ * caller must scan ONLY assistant turns — the continuation prompt below quotes
+ * the promise string, so scanning injected (user-role) prompts would false-positive.
+ */
+export function detectUltradebugComplete(text: string): boolean {
+  return typeof text === "string" && text.includes(ULTRADEBUG_COMPLETE_PROMISE);
+}
+
+/**
+ * Build the Stop-hook continuation prompt. The `[ULTRADEBUG - ITERATION n/max]`
+ * header is the SKILL.md activation header and IS the continuation prompt —
+ * contract tests grep for it, so keep it byte-exact.
+ */
+export function buildUltradebugContinuationPrompt(
+  iteration: number,
+  maxIterations: number,
+): string {
+  return `<ultradebug-continuation>
+[ULTRADEBUG - ITERATION ${iteration}/${maxIterations}]
+
+Your previous attempt did not output the completion promise \`${ULTRADEBUG_COMPLETE_PROMISE}\`.
+Continue the debug loop from the current session status.
+
+CRITICAL INSTRUCTIONS:
+1. Resume from the persisted session status (investigate -> fix -> verify -> UAT).
+2. Preserve every hypothesis (confirmed AND rejected) so resume never re-investigates a dead end.
+3. Only print \`${ULTRADEBUG_COMPLETE_PROMISE}\` once the original repro passes AND /ultraqa returned PASS.
+4. Never print the promise to escape a hard iteration — report the blocker instead.
+</ultradebug-continuation>
+
+---
+
+`;
+}

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -52,10 +52,11 @@ const EXECUTION_MODES: [string, ...string[]] = [
 const STATE_TOOL_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
   'ralplan',
+  'ultradebug',
   'omc-teams',
   'skill-active'
 ];
-const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'skill-active'] as const;
+const EXTRA_STATE_ONLY_MODES = ['ralplan', 'ultradebug', 'omc-teams', 'skill-active'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
 const OWNER_SESSION_FALLBACK_MODES = new Set<StateToolMode>(['ralph']);


### PR DESCRIPTION
## What this is

`/ultradebug` — a stateful, resumable **bug-fixing** workflow: the debugging sibling to `/ultraqa`. One bug per session, and its distinguishing power is **competing-hypothesis investigation** — instead of one investigator it runs rival hypotheses in parallel (via `/trace`), weighs evidence for/against each, and lets a synthesis pick the winner. Then it fixes the root cause and drives investigate → fix → verify to completion, persisting state every transition so `--resume` never re-chases dead ends.

Filed originally as design issue #3396, which was (rightly) closed as a design surface rather than a bug. This PR is the requested focused path against `dev`, cut to the **smallest viable slice**: the competing spine only.

## Scoped to the minimal slice (this is competing-only)

v1 ships exactly the spine and nothing else:

> **investigate (competing: `/trace` → 3 rival `tracer` lanes + hypothesis audit trail) → fix (`executor`) → verify (delegates to `/ultraqa`) → state machine + `--resume`**

Deliberately **deferred** to follow-up PRs (present in the design doc, *not* in this diff): a serial single-investigator path + routing, `--effort` model tiers, an explicit UAT phase, and skip-verify. Dropping them shrinks the argument surface to just `"<bug>" | --resume [--session <id>]` and removes the entire routing-decision surface — no `--competing`/`--serial`, no auto-route logic. Competing is simply the behavior.

No new agent types — pure orchestration + state over agents OMC already ships.

## Compatibility boundaries (explicit, per maintainer request)

| Existing surface | Interaction | Guarantee |
|---|---|---|
| `/debug` | none | Untouched. `/debug` stays the session self-diagnostic; `/ultradebug` is a different name → **no collision**. |
| `/trace` | reused | Investigation dispatches `/trace` (3 `tracer` lanes). No change to `/trace` itself. |
| `/ultraqa` | reused | Verify **always delegates** to `/ultraqa`; never inlines a second cycle. `/ultraqa` unchanged. |
| persistent-mode | additive | New `ultradebug` mode mirrors `ralph`: reuses shared `mode-state-io`, iteration bounds, thinking-only guard. Priority slot added after ralph/autopilot, before autoresearch. Existing modes untouched. |

## What's in the diff (1 commit, 8 files)

- `skills/ultradebug/SKILL.md` — the workflow (phases 0–4, exit conditions, cancellation)
- `src/hooks/ultradebug/index.ts` — driver module (reuses ralph's `mode-state-io`)
- `src/hooks/persistent-mode/index.ts` — `ultradebug` mode wiring (the one new piece of infra)
- `src/tools/state-tools.ts` — `/cancel` support for the mode
- `.claude-plugin/plugin.json`, `CLAUDE.md` — registration
- `src/**/__tests__/ultradebug-loop.test.ts` + `skills.test.ts` — tests (skills-count contract updated)

Source-only — no `dist/`/`bridge/`. Follows the git-trailer commit protocol.

## Validation

Built and dogfooded end-to-end against a **real, recurring production Sentry bug** in a private repo (run via `claude --plugin-dir`): full lifecycle fired, competing lanes + `executor` spawned, `/ultraqa` verified, a real `fix(...)` commit landed, state self-cleaned on completion. `tsc --noEmit` clean, lint 0 errors, touched test areas green (56 tests).

## Status

Opened as **draft** — running PR-QA rounds before requesting review.

---

<details>
<summary><b>Full design document</b> — the complete design incl. the deferred surface (serial path, effort tiers, UAT), as the roadmap this v1 slice extends toward</summary>

# `/ultradebug` — Design Doc

Status: **Proposal** · Author: design pass · Sibling of `/ultraqa`

A stateful, resumable bug-fixing workflow for OMC. Takes a bug description,
drives investigate → fix → verify to completion, and survives interruption
because every phase transition is persisted.

> **VBW** (referenced throughout) = [`vibe-better-with-claude-code`](https://github.com/yidakee), a
> separate Claude Code plugin whose `debug` command inspired this design. OMC's
> `/ultradebug` is an independent reimplementation on OMC's own agents and state —
> it shares no VBW code. See Credits for attribution.

---

## 1. Motivation & the gap

OMC's workflow/execution lane has **no bug-fixing command**. The pieces all
exist as agents, but nothing stitches them into one lifecycle:

| Building block | Exists today | Role in a debug lifecycle |
|---|---|---|
| `tracer` agent + `/trace` | ✅ | Competing-hypothesis investigation (evidence for/against) |
| `debugger` agent | ✅ | Single scientific-method investigator |
| `executor` agent | ✅ | Applies + commits the fix |
| `architect` agent | ✅ | Failure diagnosis (used by ultraqa) |
| `verifier` / `ultraqa` | ✅ | Verify the fix, cycle on failure |
| **A resumable bug→fix→verify state machine** | ❌ | *This proposal* |

Note the naming trap: **`/debug` is already taken** — it's an OMC/session
*self-diagnostic* (`skills/debug/SKILL.md`, ~35 lines: inspect logs/traces/state,
recommend the smallest next fix, **does not fix code**). It is not a bug-fixing
workflow. Because we name this `/ultradebug`, there is **no collision** and
`/debug` stays exactly as-is.

The value ultradebug adds is not new agents — it's the **orchestration + state**:
a persisted state machine, `--resume`, a preserved hypothesis audit trail so
resume never re-investigates dead ends, and an inline verify/UAT chain.

## 2. Scope & non-goals

**In scope**
- One bug per session, driven end-to-end: investigate → fix → verify → (optional) UAT.
- Two investigation paths, auto-routed: competing hypotheses (hard/ambiguous) vs. single debugger (clear).
- Persistent, resumable session state with a hypothesis audit trail.
- Reuse of existing OMC agents — no new agent types.

**Non-goals**
- Not a QA runner. `/ultraqa` owns repeated quality-gate cycling; ultradebug
  *delegates* its verify lane to that pattern rather than reimplementing it.
- Not a self-diagnostic. `/debug` keeps that job.
- No VBW-style plumbing port (see §12).
- No todo/backlog integration in v1 (VBW's `<N>` selected-todo path is dropped).

## 3. Command surface

```
/oh-my-claudecode:ultradebug "<bug description>" [flags]
/oh-my-claudecode:ultradebug --resume [--session <id>]
```

| Flag | Meaning |
|---|---|
| `--competing` | Force Path A (competing hypotheses), overrides routing |
| `--serial` | Force Path B (single debugger), overrides routing |
| `--no-verify` | Stop after the fix commits; skip the verify lane |
| `--uat` | After verify passes, run human UAT checkpoints |
| `--resume` | Resume the active session, or latest unresolved |
| `--session <id>` | Resume a specific session |

**Guards**
- No description and no `--resume`/`--session` → STOP with usage.
- `--session <id>` with a missing session file → STOP with error.
- `--resume` with no resumable session → STOP, suggest starting one.

## 4. Routing (which investigator)

Mirror VBW's ambiguity classifier but map it onto OMC agents.

**Ambiguity signals (2+ = ambiguous):**
- Keywords: intermittent / sometimes / random / flaky / sporadic / nondeterministic / inconsistent.
- Multiple plausible root-cause areas.
- Generic or missing error text.
- Prior reverted fixes visible in `git log`.

**Decision:**
- `--competing` → Path A always. `--serial` → Path B always.
- Otherwise: **Path A** if ambiguous, else **Path B**.

| Path | Investigator | How |
|---|---|---|
| **A — Competing** | `/trace` orchestration (3 `tracer` lanes) | 3 deliberately different hypotheses, evidence for/against, rebuttal round, synthesis picks winner |
| **B — Standard** | single `debugger` agent | scientific method, one ranked-hypotheses pass |

Both investigators are **read-only** in OMC (neither commits). They produce a
root cause + minimal-fix recommendation. The fix is applied separately by
`executor` — this preserves OMC's author/review separation (CLAUDE.md:
"Keep authoring and review as separate passes").

**Backend is pluggable (methodology ≠ dispatch).** Path A's *methodology*
(a 3-hypothesis cohort + synthesis) is separate from its *dispatch backend*
(how the 3 lanes are spawned). v1 uses the only backend OMC has today —
**teams**, via `/trace`. OMC does **not** currently use the `Workflow` tool at
all; adding a Workflow dispatch backend is a **separate foundational effort**
(see §14). This design is deliberately backend-agnostic so that effort can slot
a workflow backend under Path A later without touching ultradebug's lifecycle,
state machine, or synthesis — only the spawn mechanism changes.

## 5. State machine

```
                 ┌─────────────┐
   start ───────▶│investigating│◀───────────────┐
                 └──────┬──────┘                 │
              root cause│found                    │verify/uat failed
                        ▼                         │(re-investigate with
                  ┌──────────┐                    │ failure context)
                  │ fixing   │ (executor applies) │
                  └────┬─────┘                    │
                       │commit                    │
                       ▼                          │
                 ┌───────────┐  fail              │
                 │ verifying │──────────────────▶─┤
                 └────┬──────┘                     │
                 pass │                            │
                      ▼                            │
              ┌───────────────┐                    │
              │  uat_pending  │ (only if --uat)    │
              └───────┬───────┘  issues ──────────▶┘
                 pass │  (else skip straight to complete)
                      ▼
                 ┌──────────┐
                 │ complete │  → delete session state
                 └──────────┘
```

States: `investigating`, `fixing`, `verifying`, `uat_pending`, `complete`.
Failure of verify/UAT loops back to `investigating` with the failure context
prepended to the next investigation prompt (VBW's re-investigation pattern).

`no_fix_yet` outcome: if investigation completes but no confident fix emerges,
stay in `investigating`. Under the ralph driver the loop re-injects and tries the
next hypothesis; on driver exhaustion (or cross-session), STOP with a `--resume`
hint — never fabricate a fix.

### 5A. Driving to completion — the ralph engine (Decided: D4)

The state machine above is the *loop body*. Something has to be the *driver* — the
thing that re-invokes the model and decides "not done, iterate." OMC has four
candidate drivers; they are not equal for this job.

| Driver | Re-invokes via | Termination | Real verification gate? | A skill can start it? |
|---|---|---|---|---|
| native `/goal` | built-in Stop hook, auto-restart | evaluator "met" / manual cap | ❌ Haiku reads **transcript only** | ❌ user-only |
| native `/loop` | ScheduleWakeup timer / self-pace | manual / condition | ❌ none | ⚠️ indirect |
| **OMC ralph** | "boulder" Stop-hook re-injection | `max_iterations` + thinking-only guard | ✅ reviewer/gate + evidence | ✅ state file |
| OMC autopilot | phase state-machine + Stop hook | phase cleanup / blocker | ✅ ultraqa + reviewers | ✅ state file |

**Decision (D4): drive ultradebug with the ralph engine only.** No native `/goal`
layer. Rationale:

- **`/goal`'s evaluator cannot verify.** It's a small fast model judging the
  *conversation*, not running tests — so "bug is fixed" evaluates true only if
  passing output already surfaced in the transcript, and otherwise hallucinates
  completion. That is precisely the shotgun-debugging / false-done failure the
  scientific method exists to prevent. (OMC's ralph & ultraqa already forbid
  trusting the `/goal` evaluator — same limitation, reached independently.)
- **`/goal` is user-only** — a skill can't set it; at most it prints handoff text.
- **`/goal` has no bounded termination** — loops until a manual cap.
- **ralph gives us exactly what's missing:** Stop-hook re-injection, bounded
  termination (`max_iterations` + the thinking-only-streak guard), and a real
  per-iteration verification gate. The scientific method contributes the piece
  ralph usually lacks — a *naturally measurable* exit condition (the repro test).

**How the layers compose:**
- **Body:** scientific method (Phase 2–5).
- **Driver:** a ralph-style Stop-hook loop re-injecting a debug continuation
  prompt each turn (e.g. "Continue: next hypothesis, or verify the fix. Signal
  `ULTRADEBUG_COMPLETE` when the original repro passes and the suite is green").
- **Gate:** delegate to `/ultraqa` (D1) for real test execution — the verification
  `/goal` structurally cannot do.
- **Exit condition:** "original repro no longer fails AND suite green" — objective,
  lands in the transcript, maps 1:1 onto the `complete` state.

**One-liner:** the scientific method is what makes autonomous pursuit *safe* — it
turns a vague "fix it" into a measurable, evidence-gated convergence loop. The
ralph engine supplies the safe pursuit; `/goal` is deliberately out of scope.

*(Not chosen, noted: because the exit condition is measurable and in-transcript,
debug is one of the few workflows where a native `/goal` handoff would actually
work. We are not adding it in v1, but the loop is designed so a `/goal` handoff
could layer on later without changing the body or the gate.)*

## 6. Session schema

Per-session file (supports concurrent debug sessions + audit trail), under the
canonical session-scoped path from CLAUDE.md's `worktree_paths`:

```
.omc/state/sessions/{sessionId}/ultradebug-state.json
```

```json
{
  "active": true,
  "session_id": "uuid",
  "title": "one-line bug summary",
  "issue": "verbatim bug description",
  "path": "A",
  "status": "verifying",
  "effort": "standard",
  "head_before": "abc1234",
  "hypotheses": [
    {
      "description": "race in sync handler",
      "status": "confirmed",
      "evidence_for": ["..."],
      "evidence_against": ["..."],
      "conclusion": "chosen: strongest evidence + reproduces"
    },
    {
      "description": "stale cache",
      "status": "rejected",
      "evidence_against": ["cache cleared, bug persists"],
      "conclusion": "ruled out — do not re-investigate on resume"
    }
  ],
  "root_cause": "…with file:line refs",
  "plan": "chosen minimal fix",
  "changed_files": ["src/sync.ts"],
  "commit": "def5678 fix(sync): guard concurrent flush",
  "verify": { "round": 1, "result": "fail", "failures": ["sync.test.ts: timeout"] },
  "uat": { "round": 0, "checkpoints": [] },
  "started_at": "2026-07-02T12:00:00Z"
}
```

Written via the `state_write` / `state_read` MCP tools (same as ultraqa/deep-dive).
`session_id` source follows OMC convention: `OMC_SESSION_ID` env in CLI,
`data.session_id` in hook contexts.

**Hypothesis preservation is non-negotiable** — every rejected hypothesis keeps
its `evidence_against`. This is the audit trail that lets `--resume` skip dead
ends. This is the single most valuable idea imported from VBW.

## 7. Workflow

**Phase 0 — Resolve session.** New (parse description → create session file, capture
`head_before = git rev-parse HEAD`) or resume (load file, jump to the phase named
by `status`). On resume from a failed verify/UAT, load failure context and route
back to investigation.

**Phase 1 — Classify + route** (§4). Persist `path` + `effort`.

**Phase 2 — Investigate.**
- Path A: run `/trace` orchestration → synthesized ranked hypotheses + winner.
- Path B: spawn `debugger`.
- Persist ALL hypotheses (confirmed + rejected) + `root_cause`. Set `status: fixing`.
- If no confident root cause → stay `investigating`, STOP with resume hint.

**Phase 3 — Fix.** Spawn `executor` with the root cause + recommended minimal fix;
it applies and commits `fix({scope}): {desc}`. Persist `changed_files` + `commit`.
Set `status: verifying`.

**Phase 4 — Verify.** **Always delegate to `/ultraqa`** (never inline) — even when
it's a single cycle. Ultradebug hands ultraqa the goal (default `--tests`, or the
scoped repro of the original bug) and reads back its verdict. Rationale (decided):
inlining would duplicate ultraqa's architect→executor cycle for the sake of one
level of indirection; the token/orchestration cost of delegating one cycle is not
worth a second copy of that loop. `/ultraqa` owns the verify machinery; ultradebug
owns the lifecycle around it. On pass → `uat_pending` (if `--uat`) or `complete`.
On exhaustion → back to `investigating` with failure context.

**Phase 5 — UAT (optional, `--uat`).** Generate 1–3 human-judgment checkpoints
("does the original bug still reproduce?", "any visible regressions?"), present
via `AskUserQuestion`. Issues → re-investigate; all pass → `complete`.

**Phase 6 — Complete.** Emit summary box, then **delete the session file**
(ultraqa's rule: never leave `active:false` stale state).

## 8. Agent orchestration map

| Phase | Agent(s) | Model | Mutates? |
|---|---|---|---|
| Investigate A | `/trace` → 3× `tracer` | sonnet | read-only |
| Investigate B | `debugger` | sonnet | read-only |
| Fix | `executor` | sonnet (opus for complex) | commits |
| Verify | **delegate to `/ultraqa`** (which runs `architect` + `executor`) | opus + sonnet | commits |
| UAT | orchestrator + `AskUserQuestion` | — | no |

No new agent types. `/ultradebug` is pure orchestration + state over what OMC
already ships. The whole map is driven by the ralph engine (§5A): a Stop-hook
re-injects the loop each turn until the `complete` exit condition holds or the
driver's bounds (`max_iterations` / thinking-only guard) trip.

## 9. Resume semantics

- `--resume` → active session, else latest unresolved (announce which was picked).
- `--session <id>` → that exact session.
- Resume dispatches on persisted `status`: `investigating` → Phase 2 (with prior
  hypotheses injected as "already ruled out — do not repeat"); `fixing` → Phase 3;
  `verifying` → Phase 4; `uat_pending` → Phase 5; `complete` → STOP (already done).
- Failure contexts (verify/UAT) are compiled from the session file and prepended
  to the next investigation prompt.

## 10. Cancellation & cleanup

- `/oh-my-claudecode:cancel` clears ultradebug state (same as other modes).
- On `complete`, delete `.omc/state/sessions/{sessionId}/ultradebug-state.json`.
- Never leave stale `active:false` files.

## 11. Registration

1. Create `skills/ultradebug/SKILL.md` (drafted — supersedes the Appendix A skeleton).
2. Add `"./skills/ultradebug/"` to `.claude-plugin/plugin.json` `skills` array (alphabetical).
3. Add `/ultradebug` to the skills lists in `CLAUDE.md` (root + global) under Workflow, and the keyword trigger table (`"ultradebug"→ultradebug`).
4. `marketplace.json` auto-picks up via `plugin.json`.
5. **Driver wiring (for full cross-turn autonomy):** teach the persistent-mode Stop
   hook an `ultradebug` mode, mirroring `ralph` — recognize the session state file,
   re-inject the continuation prompt with `{{ITERATION}}/{{MAX}}`, honor the
   `ULTRADEBUG_COMPLETE` promise + `max_iterations` + thinking-only guard. This is a
   TS change under `src/hooks/persistent-mode` → requires `npm run build`. Until wired,
   the skill runs the loop in-context and relies on `--resume` (functional, not autonomous).
6. Markdown-only steps (1–4) need no `dist/` rebuild; step 5 does.

## 12. What we deliberately drop from VBW

VBW's `commands/debug.md` is ~700 lines; ~500 are plumbing OMC already solves
differently. Dropped on purpose:

- **Plugin-root resolution** (the 1-line-of-hell `Plugin root` block) — OMC skills don't need it.
- **`.vbw-planning/` state + bash session scripts** — replaced by `.omc/state/` + `state_read`/`state_write`.
- **Selected-todo helpers** (`<N>` numeric pickup, `debug-start-selected-todo.sh`, STATE.md mutation) — no OMC todo backend in v1.
- **`<skill_activation>` / `<skill_no_activation>` XML blocks + `extract-skill-follow-up-files.sh`** — OMC agents already auto-select skills.
- **Accepted-exception / UAT-deviation semantics** — VBW backlog-specific.
- **TeamCreate/TeamDelete teardown gates + shutdown handshake** — `/trace` already encapsulates OMC's team orchestration.

Kept (the actual value): scientific-method protocol, competing-hypothesis
routing, **persistent resumable state machine**, **hypothesis-preservation audit
trail**, inline verify→UAT chaining with failure-context re-investigation.

Estimated size: **~150–200 lines** of SKILL.md, mostly wiring.

## 13. Decisions & open questions

**Decided**
- **D1 — Verify always delegates to `/ultraqa`** (never inline), even for a single
  cycle. One level of indirection beats a duplicated architect→executor loop. (§7 Phase 4)
- **D2 — Doc lives in `.omc/plans/`**, not `docs/`.

- **D3 — Path A dispatch backend = teams (`/trace`) for v1.** OMC has no `Workflow`
  tool usage today, so teams are the only available backend. A Workflow backend is
  a separate effort (§14), and §4's methodology/backend split keeps it drop-in
  later. This supersedes the earlier "teams vs Workflow" open question.
- **D4 — Completion driver = the ralph engine only; native `/goal` out of scope.**
  Full rationale in §5A. `/goal`'s evaluator reads the transcript only (can't
  verify), is user-only (a skill can't set it), and has no bounded termination.
  ralph gives Stop-hook re-injection + bounded termination + a real ultraqa gate.

- **D5 — Effort profiles via `--effort`, default `balanced`.** `thorough|balanced|fast`
  → `opus|sonnet|haiku` model routing for the investigator/fix agents (drop VBW's
  `turbo`; ralph's driver bounds already cover the "cheap and fast" case). Persisted
  as `effort` in the session file.
- **D6 — Path A auto-routes on ambiguity (§4), and logs the choice.** No mandatory
  `--competing`; the 3-lane cost is gated behind the ambiguity classifier, but the
  routing decision + reason is emitted to the user so the spend is visible. `--competing`
  / `--serial` remain manual overrides.
- **D7 — Fix commits follow OMC's git-trailer protocol.** `executor` gets the trailer
  template (`Constraint:` / `Rejected:` / `Confidence:` / `Scope-risk:`) so debug
  fixes carry the same decision context as the rest of the repo (CLAUDE.md commit_protocol).

**Open**
- None — all v1 decisions locked (D1–D7). Deferred: the Workflow-tool backend (§14),
  and a possible future `/goal` handoff layer (§5A).

## 14. Separate effort — Workflow-tool support in OMC

**Not required for ultradebug**, but ultradebug is the first natural consumer.
OMC today has **zero** `Workflow()` orchestration-tool usage — it dispatches only
via agents/teams (`Task`/`Agent`/`TeamCreate`). Adding a Workflow-tool executor
backend is its own foundational effort, and should be scoped as a separate issue.

Prior art to port (not copy) — the VBW `feat/workflows-executor-backend` branch,
which adds the Workflow tool as a **config-selectable dispatch backend, peer to
teams**:

- **Methodology / backend split** — the "competing cohort vs single" decision is
  orthogonal to "workflow vs team." A pure predicate answers only "workflow or
  fallback?"; existing team/agent routing is untouched when the answer is fallback.
- **Fail-safe resolver** (`resolve-executor.sh`) — picks `workflow` only when the
  runtime supports it (a detection probe) **and** fan-out ≥ 2; else `fallback`.
  Always exits 0 — a routing predicate must never break the caller.
- **Config peer** — `prefer_workflows` mirrors `prefer_teams` and is evaluated
  **before** it; `prefer_teams=never` removes only the *team* backend, so an
  eligible cohort still runs as a workflow rather than collapsing to a single lane.
- **Governance** — `workflow_max_workers` bounds fan-out; workers use the resolved
  per-agent model (no session-model or `ultracode` escalation).
- **Runtime-detect + register** (`detect-workflows-support.sh`,
  `workflow-worker-register.sh`) so dispatched workers count as active agents.

OMC translation sketch: an OMC `prefer_workflows` config key, an OMC resolver
predicate, and a Workflow script that `parallel()`s N `tracer`/reviewer agents +
a synthesis stage — usable by ultradebug Path A, `/trace`, `/ultraqa`, `/team`,
and any other fan-out lane. Reference contract: VBW `references/workflow-executor.md`.

---

## Appendix A — SKILL.md skeleton

```markdown
---
name: ultradebug
description: Stateful bug-fixing workflow - investigate, fix, verify, resume until the bug is dead
argument-hint: "\"<bug>\" [--competing|--serial] [--no-verify] [--uat] | --resume [--session <id>]"
level: 3
---

# UltraDebug Skill

[ULTRADEBUG ACTIVATED — STATEFUL BUG-FIXING LIFECYCLE]

## Overview
One bug per session, driven investigate → fix → verify → (optional) UAT,
persisted and resumable. Reuses tracer/debugger/executor/architect.

## Phase 0 — Resolve session   (new | --resume | --session)
## Phase 1 — Classify + route  (ambiguity → Path A/B)
## Phase 2 — Investigate       (/trace 3× tracer  OR  debugger)  → persist hypotheses
## Phase 3 — Fix               (executor applies + commits)      → persist commit
## Phase 4 — Verify            (delegate to /ultraqa — always, never inline)
## Phase 5 — UAT (--uat only)  (AskUserQuestion checkpoints)
## Phase 6 — Complete          (summary box → delete session state)

## State: .omc/state/sessions/{sessionId}/ultradebug-state.json  (schema §6)
## Cancellation: /oh-my-claudecode:cancel clears state
## Cleanup: delete session file on complete — never leave active:false
```

---

## Credits

This design is inspired by the **debug model in `vibe-better-with-claude-code`
(VBW)** — its scientific-method debugger, competing-hypotheses routing, and
persistent/resumable debug-session lifecycle are the conceptual seeds ported
(not copied) here.

- **VBW project** — Tiago Serôdio ([@yidakee](https://github.com/yidakee))
- **VBW `debug` command & `vbw-debugger` agent** — Derek Pearson, Tiago Serôdio,
  Shane McCarron, and VBW contributors
- **Workflow-tool executor backend** (§14 prior art) — VBW
  `feat/workflows-executor-backend` branch

OMC's `/ultradebug` reimplements these ideas natively on OMC's own agents
(`tracer`, `debugger`, `executor`, `architect`) and `.omc/state` — it shares no
VBW code. Any bugs in this adaptation are ours, not VBW's.

</details>

---

*Design-of-record originally filed as #3396. Inspired by the `debug` model in [`vibe-better-with-claude-code`](https://github.com/yidakee) (VBW) — independent reimplementation on OMC's own agents and `.omc/state`; shares no VBW code.*
