### PR TITLE
feat(lsp): launch native TypeScript 7 LSP for typescript-go projects

### DIFF
--- a/src/tools/lsp/__tests__/servers-typescript-native.test.ts
+++ b/src/tools/lsp/__tests__/servers-typescript-native.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getServerForFile, resolveTypescriptServer } from '../servers.js';
+
+// Builds a fake project tree with a node_modules/typescript install.
+function makeProject(kind: 'native' | 'classic'): string {
+  const root = mkdtempSync(join(tmpdir(), 'omc-ts-'));
+  const tsDir = join(root, 'node_modules', 'typescript');
+  mkdirSync(join(tsDir, 'lib'), { recursive: true });
+  mkdirSync(join(tsDir, 'bin'), { recursive: true });
+  writeFileSync(join(tsDir, 'package.json'), '{"name":"typescript"}');
+  writeFileSync(join(tsDir, 'bin', 'tsc'), '#!/usr/bin/env node\n');
+  // Classic (<=6) ships lib/tsserver.js; native (7+/typescript-go) does not.
+  if (kind === 'classic') writeFileSync(join(tsDir, 'lib', 'tsserver.js'), '');
+  return root;
+}
+
+describe('resolveTypescriptServer', () => {
+  let nativeRoot: string;
+  let classicRoot: string;
+
+  beforeAll(() => {
+    nativeRoot = makeProject('native');
+    classicRoot = makeProject('classic');
+  });
+
+  afterAll(() => {
+    rmSync(nativeRoot, { recursive: true, force: true });
+    rmSync(classicRoot, { recursive: true, force: true });
+  });
+
+  it('launches the native tsc LSP for a TypeScript 7 (typescript-go) project', () => {
+    const config = resolveTypescriptServer(join(nativeRoot, 'src', 'index.ts'));
+    expect(config.command).toBe(process.execPath);
+    expect(config.args).toEqual([
+      join(nativeRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+      '--lsp',
+      '--stdio',
+    ]);
+  });
+
+  it('uses typescript-language-server for a classic (<=6) project', () => {
+    const config = resolveTypescriptServer(join(classicRoot, 'src', 'index.ts'));
+    expect(config.command).toBe('typescript-language-server');
+    expect(config.args).toEqual(['--stdio']);
+  });
+
+  it('falls back to typescript-language-server when no local typescript is found', () => {
+    const config = resolveTypescriptServer(join(tmpdir(), 'no-such-project', 'index.ts'));
+    expect(config.command).toBe('typescript-language-server');
+  });
+
+  it('getServerForFile routes .ts through the native resolver', () => {
+    const config = getServerForFile(join(nativeRoot, 'a.ts'));
+    expect(config?.name).toBe('TypeScript Native LSP (typescript-go)');
+  });
+});

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -7,7 +7,7 @@
 
 import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
-import { extname, isAbsolute } from 'path';
+import { dirname, extname, isAbsolute, join, resolve } from 'path';
 
 export interface LspServerConfig {
   name: string;
@@ -177,14 +177,57 @@ export function commandExists(command: string): boolean {
 }
 
 /**
+ * Walk up from a file to find its project-local `node_modules/typescript` install.
+ */
+function findLocalTypescriptDir(filePath: string): string | null {
+  let dir = dirname(resolve(filePath));
+  // ponytail: plain parent walk to the filesystem root; no symlink-cycle guard needed.
+  for (;;) {
+    const tsDir = join(dir, 'node_modules', 'typescript');
+    if (existsSync(join(tsDir, 'package.json'))) return tsDir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Resolve the correct TypeScript language server for a file.
+ *
+ * TypeScript 7+ (the native `typescript-go` build) ships no `lib/tsserver.js`, so
+ * `typescript-language-server` — a wrapper around the classic tsserver protocol — can't
+ * drive it. It silently falls back to an unrelated global TypeScript (or fails outright),
+ * so OMC's LSP tools return nothing useful. TS7 instead exposes an LSP directly via
+ * `tsc --lsp --stdio`. When the project's TypeScript is a native build, launch that; the
+ * JS shim (`typescript/bin/tsc`) is run through `node` so it works cross-platform.
+ */
+export function resolveTypescriptServer(filePath: string): LspServerConfig {
+  const tsDir = findLocalTypescriptDir(filePath);
+  if (tsDir) {
+    const hasClassicTsserver = existsSync(join(tsDir, 'lib', 'tsserver.js'));
+    const nativeBin = join(tsDir, 'bin', 'tsc');
+    if (!hasClassicTsserver && existsSync(nativeBin)) {
+      return {
+        name: 'TypeScript Native LSP (typescript-go)',
+        command: process.execPath,
+        args: [nativeBin, '--lsp', '--stdio'],
+        extensions: LSP_SERVERS.typescript.extensions,
+        installHint: LSP_SERVERS.typescript.installHint
+      };
+    }
+  }
+  return LSP_SERVERS.typescript;
+}
+
+/**
  * Get the LSP server config for a file based on its extension
  */
 export function getServerForFile(filePath: string): LspServerConfig | null {
   const ext = extname(filePath).toLowerCase();
 
-  for (const [_, config] of Object.entries(LSP_SERVERS)) {
+  for (const [key, config] of Object.entries(LSP_SERVERS)) {
     if (config.extensions.includes(ext)) {
-      return config;
+      return key === 'typescript' ? resolveTypescriptServer(filePath) : config;
     }
   }
 


### PR DESCRIPTION
## What & why

OMC's LSP tools provide no usable TypeScript features on **TypeScript 7 (typescript-go)** projects.

`servers.ts` hardcodes `typescript-language-server` for `.ts`, but that server is a wrapper around the classic **tsserver protocol** and needs `typescript/lib/tsserver.js`. TypeScript 7 (the native typescript-go build) ships **no `tsserver.js`** — only `tsc`. So on a TS7 project the wrapper can't attach to the project's compiler and instead:

- **silently falls back** to an unrelated global classic TypeScript (e.g. `typescript@6.x`), serving stale/wrong results while reporting success, or
- **hard-fails** with `Could not find a valid TypeScript installation`.

TypeScript 7's language server is the native binary itself, invoked as `tsc --lsp --stdio`.

Fixes #3403.

## Change

- Add `resolveTypescriptServer(filePath)`: walks up to the project-local `node_modules/typescript`. If it's a **native build** (present, but no `lib/tsserver.js`) with a `bin/tsc`, launch `node <typescript/bin/tsc> --lsp --stdio`. Otherwise fall back to `typescript-language-server` for classic (≤6) projects.
- Route the `typescript` entry in `getServerForFile` through the resolver.

### Design notes

- **Detection is behavioral, not a version-string parse:** it keys on the absence of `lib/tsserver.js` — the exact condition under which the classic wrapper fails. This also covers future native releases without changes.
- **Cross-platform:** the JS shim (`typescript/bin/tsc`) is run through `node` (`process.execPath`) rather than the `node_modules/.bin/tsc` symlink, avoiding the Windows `.cmd` wrapper problem (cf. #569).
- **Project-relative resolution:** Bun nests the platform binary under `node_modules/.bun/...`; resolving from the file's project (not PATH) handles npm, pnpm, and bun layouts.

## Testing

- New `servers-typescript-native.test.ts` (4 cases): native project → `node bin/tsc --lsp --stdio`; classic project → `typescript-language-server`; no local TS → fallback; `getServerForFile` routing.
- `tsc --noEmit` clean, `eslint` clean, full LSP suite passes (43 tests).
- **End-to-end against a real TS 7.0.1-rc project:** `getServerForFile` resolves to `node .../node_modules/typescript/bin/tsc --lsp --stdio`, and that invocation was confirmed to answer an LSP `initialize` handshake (`serverInfo: { name: "typescript-go" }`).

**Not tested:** Windows spawn (verified on macOS arm64 only).

https://claude.ai/code/session_01JpDPAFpT6mDwEDURhvMmbN
