### PR TITLE
fix(tdd-mode): anchor tests to acceptance criteria instead of blind 'write tests first'

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -151,7 +151,7 @@ ANALYSIS MODE. Gather context before diving deep:
 
 const TDD_MESSAGE = `<tdd-mode>
 [TDD MODE ACTIVATED]
-Write or update tests first when practical, confirm they fail for the right reason, then implement the minimal fix and re-run verification.
+Do not write blind tests. First anchor to the task's acceptance criteria or spec (a SPEC/AC ledger, ticket, or the exact failing behavior you're fixing) and write the failing test that proves the specific requirement you're implementing right now — confirm it fails for the right reason, then implement the minimal fix and re-run verification. If no acceptance criteria or reproducible failing case exists yet, define that first before writing any test.
 </tdd-mode>
 
 ---

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -93,7 +93,7 @@ ANALYSIS MODE. Gather context before diving deep:
 
 const TDD_MESSAGE = `<tdd-mode>
 [TDD MODE ACTIVATED]
-Write or update tests first when practical, confirm they fail for the right reason, then implement the minimal fix and re-run verification.
+Do not write blind tests. First anchor to the task's acceptance criteria or spec (a SPEC/AC ledger, ticket, or the exact failing behavior you're fixing) and write the failing test that proves the specific requirement you're implementing right now — confirm it fails for the right reason, then implement the minimal fix and re-run verification. If no acceptance criteria or reproducible failing case exists yet, define that first before writing any test.
 </tdd-mode>
 
 ---


### PR DESCRIPTION
## What
Re-points the `<tdd-mode>` banner from context-free "write or update tests first" to guidance that anchors the agent to the task's acceptance criteria / spec / exact failing case before writing a test.

## Why
Naively prompting "do TDD" without which-tests-matter context is a documented backfire pattern: TDFlow (EACL 2026) hits 88.8% on SWE-Bench Lite **only when handed human-written tests** — writing the reproduction test is the bottleneck, not solving it. GraphRAG-guided TDD cut regressions ~70% *by feeding which-tests-matter context*; the same technique without context made results worse. The old banner produces test theater (arbitrary tests that pass but don't prove the requirement).

## Change
Both copies (`scripts/keyword-detector.mjs` and `templates/hooks/keyword-detector.mjs`) updated; `node --check` clean on both. Message stays generic (no project-specific paths) so it's correct across any repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)