### PR TITLE
fix(rules-injector): parse multi-line rule arrays authored with CRLF

### DIFF
--- a/src/hooks/rules-injector/parser.test.ts
+++ b/src/hooks/rules-injector/parser.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseRuleFrontmatter } from './parser.js';
+
+// Rule files authored on Windows use CRLF line endings. The frontmatter
+// delimiter regex tolerates `\r`, but the multi-line array branch matches
+// items with `/^\s+-\s*(.*)$/`, and JS `.`/`$` do not span a trailing `\r`.
+// Without normalising line endings, a `\r`-terminated `  - pattern` item
+// fails to match and the whole array collapses (globs -> ''), so the rule
+// silently applies to nothing.
+describe('parseRuleFrontmatter line endings', () => {
+  it('parses a multi-line globs array with CRLF line endings', () => {
+    const content = [
+      '---',
+      'globs:',
+      '  - "**/*.py"',
+      '  - "src/**/*.ts"',
+      'alwaysApply: false',
+      '---',
+      'body',
+    ].join('\r\n');
+
+    const { metadata } = parseRuleFrontmatter(content);
+
+    expect(metadata.globs).toEqual(['**/*.py', 'src/**/*.ts']);
+  });
+
+  it('matches the LF result for the same multi-line array', () => {
+    const lines = [
+      '---',
+      'globs:',
+      '  - "**/*.py"',
+      '  - "src/**/*.ts"',
+      '---',
+      'body',
+    ];
+
+    const lf = parseRuleFrontmatter(lines.join('\n'));
+    const crlf = parseRuleFrontmatter(lines.join('\r\n'));
+
+    expect(crlf.metadata).toEqual(lf.metadata);
+  });
+
+  it('parses a multi-line paths alias array with CRLF line endings', () => {
+    const content = [
+      '---',
+      'paths:',
+      '  - "*.md"',
+      '---',
+      'body',
+    ].join('\r\n');
+
+    const { metadata } = parseRuleFrontmatter(content);
+
+    expect(metadata.globs).toEqual(['*.md']);
+  });
+});

--- a/src/hooks/rules-injector/parser.ts
+++ b/src/hooks/rules-injector/parser.ts
@@ -41,7 +41,10 @@ export function parseRuleFrontmatter(content: string): RuleFrontmatterResult {
  * Parse YAML content without external library.
  */
 function parseYamlContent(yamlContent: string): RuleMetadata {
-  const lines = yamlContent.split('\n');
+  // Split on CRLF or LF so a trailing "\r" from a Windows-authored rule file
+  // never leaks into a line. The multi-line array matcher (/^\s+-\s*(.*)$/)
+  // stops at "\r", which would otherwise collapse a "  - pattern" list to ''.
+  const lines = yamlContent.split(/\r?\n/);
   const metadata: RuleMetadata = {};
 
   let i = 0;


### PR DESCRIPTION
## Problem

Rule files authored on Windows use CRLF line endings. A rule whose `globs:` (or the `paths:`/`applyTo:` alias) is written as a multi-line YAML list fails to parse on such files. Every pattern is dropped and the rule silently applies to nothing.

```
---
globs:
  - "**/*.py"
  - "src/**/*.ts"
---
```

With CRLF endings, `parseRuleFrontmatter` returns `globs: ''` instead of `['**/*.py', 'src/**/*.ts']`. `shouldApplyRule` then treats the empty value as "no patterns", so the rule never matches its target files. On Linux/macOS (LF) the same file parses correctly, so this is invisible to CI.

## Root cause

The frontmatter delimiter regex tolerates `\r` (`/^---\r?\n.../`), but `parseYamlContent` splits the body on `\n` only:

```ts
const lines = yamlContent.split('\n');
```

That leaves a trailing `\r` on every line. Single-line values survive because they get `.trim()`ed, but the multi-line array branch matches items with `/^\s+-\s*(.*)$/`, and JS `.` and `$` do not span `\r`, so `  - "**/*.py"\r` fails the match, the loop breaks, and the array collapses.

## Fix

Split on `/\r?\n/` so a trailing `\r` never leaks into a line. One line, at the split, covers every downstream consumer uniformly.

## Tests

Added `src/hooks/rules-injector/parser.test.ts`. The CRLF multi-line cases fail on the old code (`globs: ''`) and pass after the fix; an LF/CRLF equivalence assertion locks the two together. Verified red to green locally; targeted suite, typecheck, and eslint are green.

## Scope

- `.gitattributes` keeps shipped rule files LF, so this only affected user-authored rule files on Windows.
- Left `src/utils/frontmatter.ts` untouched: it has no multi-line array branch and its scalar path is already `\r`-safe via trims. Happy to normalise it too as a follow-up for consistency if you prefer.
