### PR TITLE
fix(subagent-tracker): distinguish unmatched stop telemetry (#3416)

### DIFF
--- a/src/__tests__/tools/trace-tools.test.ts
+++ b/src/__tests__/tools/trace-tools.test.ts
@@ -54,6 +54,20 @@ describe('trace-tools', () => {
       expect(text).toContain('Read');
     });
 
+    it('formats untracked synthetic agent stops distinctly', async () => {
+      appendReplayEvent(testDir, 'untracked-sess', {
+        agent: 'native-', event: 'agent_stop', agent_type: 'untracked-native-fork', success: true,
+        synthetic: true, telemetry_status: 'unmatched_stop', reason: 'SubagentStop arrived without a matching SubagentStart',
+      });
+
+      const result = await traceTimelineTool.handler({ sessionId: 'untracked-sess', workingDirectory: testDir });
+      const text = result.content[0].text;
+
+      expect(text).toContain('UNTRACKED_STOP');
+      expect(text).toContain('untracked-native-fork');
+      expect(text).not.toContain('completed (0.0s)');
+    });
+
     it('should format flow trace events in timeline', async () => {
       appendReplayEvent(testDir, 'flow-sess', { agent: 'system', event: 'hook_fire', hook: 'keyword-detector', hook_event: 'UserPromptSubmit' });
       appendReplayEvent(testDir, 'flow-sess', { agent: 'system', event: 'keyword_detected', keyword: 'ultrawork' });
@@ -125,6 +139,19 @@ describe('trace-tools', () => {
       expect(text).toContain('Total Events');
       expect(text).toContain('Agents');
       expect(text).toContain('1 spawned');
+    });
+
+    it('counts untracked synthetic agent stops separately from completions', async () => {
+      appendReplayEvent(testDir, 'untracked-sum', {
+        agent: 'native-', event: 'agent_stop', agent_type: 'untracked-native-fork', success: true,
+        synthetic: true, telemetry_status: 'unmatched_stop',
+      });
+
+      const result = await traceSummaryTool.handler({ sessionId: 'untracked-sum', workingDirectory: testDir });
+      const text = result.content[0].text;
+
+      expect(text).toContain('0 spawned, 0 completed, 0 failed, 1 untracked stop(s)');
+      expect(text).toContain('untracked-native-fork agent stop was untracked');
     });
 
     it('should show flow trace statistics', async () => {

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -25,6 +25,7 @@ import {
   type ToolUsageEntry,
 } from "../index.js";
 import { readMissionBoardState } from "../../../hud/mission-board.js";
+import { readReplayEvents } from "../session-replay.js";
 
 describe("subagent-tracker", () => {
   let testDir: string;
@@ -854,6 +855,18 @@ describe("subagent-tracker", () => {
       expect(state.agents.find((a) => a.agent_id === "stale-2")?.status).toBe("failed");
       const synthetic = state.agents.find((a) => a.agent_id === "native-fork-id");
       expect(synthetic?.status).toBe("completed");
+      expect(synthetic?.agent_type).toBe("untracked-native-fork");
+      expect(synthetic?.duration_ms).toBeUndefined();
+      expect(synthetic?.synthetic).toBe(true);
+      expect(synthetic?.telemetry_status).toBe("unmatched_stop");
+      expect(synthetic?.telemetry_note).toContain("without a matching SubagentStart");
+      const replayStop = readReplayEvents(testDir, "session-unmatched-ambiguous").find(
+        (event) => event.event === "agent_stop" && event.agent === "native-",
+      );
+      expect(replayStop?.agent_type).toBe("untracked-native-fork");
+      expect(replayStop?.duration_ms).toBeUndefined();
+      expect(replayStop?.synthetic).toBe(true);
+      expect(replayStop?.telemetry_status).toBe("unmatched_stop");
       expect(state.total_failed).toBe(2);
       expect(state.total_completed).toBe(1);
     });
@@ -890,6 +903,11 @@ describe("subagent-tracker", () => {
       expect(state.agents.find((a) => a.agent_id === "fresh-1")?.status).toBe("running");
       expect(state.agents.find((a) => a.agent_id === "fresh-2")?.status).toBe("running");
       expect(state.agents.find((a) => a.agent_id === "native-fork-id")?.status).toBe("completed");
+      const synthetic = state.agents.find((a) => a.agent_id === "native-fork-id");
+      expect(synthetic?.agent_type).toBe("untracked-native-fork");
+      expect(synthetic?.duration_ms).toBeUndefined();
+      expect(synthetic?.synthetic).toBe(true);
+      expect(synthetic?.telemetry_status).toBe("unmatched_stop");
       expect(state.total_completed).toBe(1);
       expect(state.total_failed).toBe(0);
     });

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -45,6 +45,9 @@ export interface SubagentInfo {
   tool_usage?: ToolUsageEntry[];
   token_usage?: TokenUsage;
   model?: string;
+  synthetic?: boolean;
+  telemetry_status?: "unmatched_stop";
+  telemetry_note?: string;
 }
 
 export interface ToolUsageEntry {
@@ -143,6 +146,9 @@ const MAX_COMPLETED_AGENTS = 100;
 const WRITE_DEBOUNCE_MS = 100;
 const MAX_FLUSH_RETRIES = 3;
 const FLUSH_RETRY_BASE_MS = 50;
+const UNTRACKED_NATIVE_FORK_AGENT_TYPE = "untracked-native-fork";
+const UNMATCHED_STOP_TELEMETRY_NOTE =
+  "SubagentStop arrived without a matching SubagentStart; native Agent/Task start telemetry was not observed.";
 
 // Lock options — short timeout for hot-path writes; stale detection generous
 // so healthy writers aren't mistakenly treated as abandoned.
@@ -797,19 +803,21 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
       } else if (input.agent_id) {
         // No exact or fallback match. Reap any stale running agents so unmatched
         // fork stops cannot accumulate "running" entries forever, then record
-        // this stop as a synthetic closed entry (create-and-close) so the event
-        // is not silently dropped.
+        // this stop as an explicitly synthetic closed entry. Avoid duration_ms: 0
+        // and agent_type: "unknown" because those look like real telemetry.
         reapStaleRunningAgents(state, nowIso);
 
         const synthetic: SubagentInfo = {
           agent_id: input.agent_id,
-          agent_type: input.agent_type || "unknown",
+          agent_type: input.agent_type || UNTRACKED_NATIVE_FORK_AGENT_TYPE,
           started_at: nowIso,
           parent_mode: detectParentMode(input.cwd),
           status: succeeded ? "completed" : "failed",
           completed_at: nowIso,
-          duration_ms: 0,
           output_summary: input.output ? input.output.substring(0, 500) : undefined,
+          synthetic: true,
+          telemetry_status: "unmatched_stop",
+          telemetry_note: UNMATCHED_STOP_TELEMETRY_NOTE,
         };
         state.agents.push(synthetic);
         agentIndex = state.agents.length - 1;
@@ -850,8 +858,10 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
         // Record to session replay JSONL for /trace
         // Fix: SDK doesn't populate agent_type in SubagentStop, so use tracked state
         try {
-          const agentType = stoppedAgent?.agent_type || input.agent_type || 'unknown';
-          recordAgentStop(input.cwd, input.session_id, input.agent_id, agentType, succeeded, stoppedAgent?.duration_ms);
+          const agentType = stoppedAgent?.agent_type || input.agent_type || UNTRACKED_NATIVE_FORK_AGENT_TYPE;
+          recordAgentStop(input.cwd, input.session_id, input.agent_id, agentType, succeeded, stoppedAgent?.duration_ms, stoppedAgent?.synthetic
+            ? { synthetic: true, telemetry_status: stoppedAgent.telemetry_status, reason: stoppedAgent.telemetry_note }
+            : undefined);
         } catch { /* best-effort */ }
 
         try {

--- a/src/hooks/subagent-tracker/session-replay.ts
+++ b/src/hooks/subagent-tracker/session-replay.ts
@@ -38,6 +38,8 @@ export interface ReplayEvent {
   task?: string;
   success?: boolean;
   reason?: string;
+  synthetic?: boolean;
+  telemetry_status?: "unmatched_stop";
   parent_mode?: string;
   model?: string;
   /** Hook name (e.g., "keyword-detector") */
@@ -75,6 +77,7 @@ export interface ReplaySummary {
   agents_spawned: number;
   agents_completed: number;
   agents_failed: number;
+  agents_untracked_stops?: number;
   tool_summary: Record<string, { count: number; total_ms: number; avg_ms: number; max_ms: number }>;
   bottlenecks: Array<{ tool: string; agent: string; avg_ms: number }>;
   timeline_range: { start: number; end: number };
@@ -191,6 +194,12 @@ export function recordAgentStart(
   });
 }
 
+export interface AgentStopReplayMetadata {
+  synthetic?: boolean;
+  telemetry_status?: "unmatched_stop";
+  reason?: string;
+}
+
 /**
  * Record agent stop event
  */
@@ -200,7 +209,8 @@ export function recordAgentStop(
   agentId: string,
   agentType: string,
   success: boolean,
-  durationMs?: number
+  durationMs?: number,
+  metadata?: AgentStopReplayMetadata
 ): void {
   appendReplayEvent(directory, sessionId, {
     agent: agentId.substring(0, 7),
@@ -208,6 +218,9 @@ export function recordAgentStop(
     event: 'agent_stop',
     success,
     duration_ms: durationMs,
+    synthetic: metadata?.synthetic,
+    telemetry_status: metadata?.telemetry_status,
+    reason: metadata?.reason,
   });
 }
 
@@ -368,6 +381,10 @@ export function getReplaySummary(directory: string, sessionId: string): ReplaySu
         }
         break;
       case 'agent_stop':
+        if (event.synthetic || event.telemetry_status === 'unmatched_stop') {
+          summary.agents_untracked_stops = (summary.agents_untracked_stops || 0) + 1;
+          break;
+        }
         if (event.success) summary.agents_completed++;
         else summary.agents_failed++;
         if (event.agent_type && event.duration_ms) {

--- a/src/tools/trace-tools.ts
+++ b/src/tools/trace-tools.ts
@@ -84,8 +84,13 @@ function formatTimelineEvent(event: ReplayEvent): string {
       if (event.model) detail += ` (${event.model})`;
       break;
     case 'agent_stop':
-      detail = `[${event.agent}] ${event.agent_type || 'unknown'} ${event.success ? 'completed' : 'FAILED'}`;
-      if (event.duration_ms) detail += ` (${(event.duration_ms / 1000).toFixed(1)}s)`;
+      if (event.synthetic || event.telemetry_status === 'unmatched_stop') {
+        detail = `[${event.agent}] ${event.agent_type || 'untracked-native-fork'} UNTRACKED_STOP`;
+        if (event.reason) detail += ` - ${event.reason}`;
+      } else {
+        detail = `[${event.agent}] ${event.agent_type || 'unknown'} ${event.success ? 'completed' : 'FAILED'}`;
+        if (event.duration_ms) detail += ` (${(event.duration_ms / 1000).toFixed(1)}s)`;
+      }
       break;
     case 'tool_start':
       detail = `[${event.agent}] ${event.tool} started`;
@@ -195,6 +200,10 @@ function buildExecutionFlow(events: ReplayEvent[]): string[] {
       }
       case 'agent_stop': {
         const type = event.agent_type || 'unknown';
+        if (event.synthetic || event.telemetry_status === 'unmatched_stop') {
+          flow.push(`${type} agent stop was untracked (${event.agent})`);
+          break;
+        }
         const status = event.success ? 'completed' : 'FAILED';
         const dur = event.duration_ms ? ` ${(event.duration_ms / 1000).toFixed(1)}s` : '';
         flow.push(`${type} agent ${status} (${event.agent}${dur})`);
@@ -337,7 +346,7 @@ export const traceSummaryTool: ToolDefinition<{
         `### Overview`,
         `- **Duration:** ${summary.duration_seconds.toFixed(1)}s`,
         `- **Total Events:** ${summary.total_events}`,
-        `- **Agents:** ${summary.agents_spawned} spawned, ${summary.agents_completed} completed, ${summary.agents_failed} failed`,
+        `- **Agents:** ${summary.agents_spawned} spawned, ${summary.agents_completed} completed, ${summary.agents_failed} failed${summary.agents_untracked_stops ? `, ${summary.agents_untracked_stops} untracked stop(s)` : ''}`,
         '',
       ];
 


### PR DESCRIPTION
## Summary
- Marks create-and-close unmatched `SubagentStop` records as synthetic with `telemetry_status: "unmatched_stop"` and a clear telemetry note.
- Uses `agent_type: "untracked-native-fork"` instead of `"unknown"` and omits fake `duration_ms: 0` so these records cannot look like normal successful zero-duration completions.
- Propagates synthetic metadata into session replay and trace output; trace summaries count untracked stops separately from completed agents.
- Adds regression coverage for tracker fallback records and trace consumers.

## Verification
- `npm test -- src/hooks/subagent-tracker/__tests__/index.test.ts src/__tests__/tools/trace-tools.test.ts` — 57 passed
- `npx tsc --noEmit`
- `npx eslint src/hooks/subagent-tracker/index.ts src/hooks/subagent-tracker/session-replay.ts src/tools/trace-tools.ts src/hooks/subagent-tracker/__tests__/index.test.ts src/__tests__/tools/trace-tools.test.ts`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*