### PR TITLE
Fix MiniMax general plan HUD usage parsing

### DIFF
--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -1145,25 +1145,29 @@ describe('parseMinimaxResponse', () => {
     expect(parseMinimaxResponse(response)).toBeNull();
   });
 
-  it('returns null when no MiniMax-M* model exists', () => {
+  it('falls back to the first row when no MiniMax-M* or general model exists', () => {
     const response = {
       model_remains: [
         {
           model_name: 'speech-hd',
           current_interval_total_count: 100,
-          current_interval_usage_count: 50,
+          current_interval_usage_count: 75,
           start_time: Date.now(),
           end_time: Date.now() + 3600_000,
           remains_time: 3600_000,
           current_weekly_total_count: 700,
-          current_weekly_usage_count: 350,
+          current_weekly_usage_count: 525,
           weekly_start_time: Date.now(),
           weekly_end_time: Date.now() + 86400_000,
           weekly_remains_time: 86400_000,
         },
       ],
     };
-    expect(parseMinimaxResponse(response)).toBeNull();
+
+    const result = parseMinimaxResponse(response);
+    expect(result).not.toBeNull();
+    expect(result!.fiveHourPercent).toBe(25);
+    expect(result!.weeklyPercent).toBe(25);
   });
 
   it('parses MiniMax-M* remaining counts as used fiveHourPercent and weeklyPercent', () => {
@@ -1247,6 +1251,115 @@ describe('parseMinimaxResponse', () => {
     expect(result).not.toBeNull();
     expect(result!.fiveHourPercent).toBe(0);
     expect(result!.weeklyPercent).toBe(0);
+  });
+
+  it('uses direct remaining-percent fields as HUD used percentages', () => {
+    const response = {
+      model_remains: [
+        {
+          model_name: 'MiniMax-M1',
+          current_interval_total_count: 0,
+          current_interval_usage_count: 0,
+          current_interval_remaining_percent: 44,
+          start_time: Date.now(),
+          end_time: Date.now() + 3600_000,
+          remains_time: 3600_000,
+          current_weekly_total_count: 0,
+          current_weekly_usage_count: 0,
+          current_weekly_remaining_percent: 88,
+          weekly_start_time: Date.now(),
+          weekly_end_time: Date.now() + 86400_000,
+          weekly_remains_time: 86400_000,
+        },
+      ],
+    };
+
+    const result = parseMinimaxResponse(response);
+    expect(result).not.toBeNull();
+    expect(result!.fiveHourPercent).toBe(56);
+    expect(result!.weeklyPercent).toBe(12);
+  });
+
+  it('accepts a general plan row when no MiniMax-M* model exists', () => {
+    const response = {
+      model_remains: [
+        {
+          model_name: 'video',
+          current_interval_total_count: 5,
+          current_interval_usage_count: 5,
+          current_interval_remaining_percent: 100,
+          start_time: Date.now(),
+          end_time: Date.now() + 3600_000,
+          remains_time: 3600_000,
+          current_weekly_total_count: 5,
+          current_weekly_usage_count: 5,
+          current_weekly_remaining_percent: 100,
+          weekly_start_time: Date.now(),
+          weekly_end_time: Date.now() + 86400_000,
+          weekly_remains_time: 86400_000,
+        },
+        {
+          model_name: 'general',
+          current_interval_total_count: 0,
+          current_interval_usage_count: 0,
+          current_interval_remaining_percent: 44,
+          start_time: Date.now(),
+          end_time: Date.now() + 3600_000,
+          remains_time: 3600_000,
+          current_weekly_total_count: 0,
+          current_weekly_usage_count: 0,
+          current_weekly_remaining_percent: 88,
+          weekly_start_time: Date.now(),
+          weekly_end_time: Date.now() + 86400_000,
+          weekly_remains_time: 86400_000,
+        },
+      ],
+    };
+
+    const result = parseMinimaxResponse(response);
+    expect(result).not.toBeNull();
+    expect(result!.fiveHourPercent).toBe(56);
+    expect(result!.weeklyPercent).toBe(12);
+  });
+
+  it('preserves MiniMax-M* model preference over plan-style rows', () => {
+    const response = {
+      model_remains: [
+        {
+          model_name: 'general',
+          current_interval_total_count: 0,
+          current_interval_usage_count: 0,
+          current_interval_remaining_percent: 44,
+          start_time: Date.now(),
+          end_time: Date.now() + 3600_000,
+          remains_time: 3600_000,
+          current_weekly_total_count: 0,
+          current_weekly_usage_count: 0,
+          current_weekly_remaining_percent: 88,
+          weekly_start_time: Date.now(),
+          weekly_end_time: Date.now() + 86400_000,
+          weekly_remains_time: 86400_000,
+        },
+        {
+          model_name: 'MiniMax-M3',
+          current_interval_total_count: 100,
+          current_interval_usage_count: 75,
+          start_time: Date.now(),
+          end_time: Date.now() + 3600_000,
+          remains_time: 3600_000,
+          current_weekly_total_count: 200,
+          current_weekly_usage_count: 150,
+          weekly_start_time: Date.now(),
+          weekly_end_time: Date.now() + 86400_000,
+          weekly_remains_time: 86400_000,
+        },
+      ],
+    };
+
+    const result = parseMinimaxResponse(response);
+    expect(result).not.toBeNull();
+    expect(result!.fiveHourPercent).toBe(25);
+    expect(result!.weeklyPercent).toBe(25);
   });
 
   it('uses first MiniMax-M* model when multiple exist', () => {

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -182,9 +182,11 @@ interface MinimaxModelRemain {
   current_weekly_total_count: number;
   /** Remaining request count in the current weekly window */
   current_weekly_usage_count: number;
+  current_interval_remaining_percent?: number;
   weekly_start_time: number;
   weekly_end_time: number;
   weekly_remains_time: number;
+  current_weekly_remaining_percent?: number;
 }
 
 interface MinimaxCodingPlanResponse {
@@ -1197,25 +1199,31 @@ export function parseMinimaxResponse(response: MinimaxCodingPlanResponse): RateL
   const models = response.model_remains;
   if (!models || models.length === 0) return null;
 
-  // Find the primary coding model (first match, case-insensitive)
-  const codingModel = models.find(m => m.model_name.toLowerCase().startsWith('minimax-m'));
-  if (!codingModel) {
-    if (process.env.OMC_DEBUG) {
-      console.error('[usage-api] No MiniMax-M* model found in coding plan response');
-    }
-    return null;
-  }
+  // Prefer the primary coding model when present. MiniMax's billing API can
+  // return plan names like "general" instead of Claude-side MiniMax-M aliases.
+  const codingModel =
+    models.find(m => m.model_name.toLowerCase().startsWith('minimax-m')) ??
+    models.find(m => m.model_name.toLowerCase() === 'general') ??
+    models[0];
+  if (!codingModel) return null;
 
-  // MiniMax's "remains" endpoint reports remaining quota, not consumed quota.
-  // Convert remaining-count fields to used percentages for the HUD.
+  const percentFromRemaining = (remainingPercent: number | undefined): number | undefined => {
+    if (remainingPercent == null || !isFinite(remainingPercent)) return undefined;
+    return clamp(100 - remainingPercent);
+  };
+
+  // MiniMax's "remains" endpoint reports remaining quota. Prefer direct
+  // remaining-percent fields when present because plan-style rows can report
+  // total_count=0 while still exposing useful remaining quota percentages.
+  const directIntervalPercent = percentFromRemaining(codingModel.current_interval_remaining_percent);
   const intervalTotal = codingModel.current_interval_total_count;
   const intervalUsed = intervalTotal - codingModel.current_interval_usage_count;
-  const intervalPercent = intervalTotal > 0 ? (intervalUsed / intervalTotal) * 100 : 0;
+  const intervalPercent = directIntervalPercent ?? (intervalTotal > 0 ? (intervalUsed / intervalTotal) * 100 : 0);
 
-  // Calculate weekly usage percentage from remaining weekly quota
+  const directWeeklyPercent = percentFromRemaining(codingModel.current_weekly_remaining_percent);
   const weeklyTotal = codingModel.current_weekly_total_count;
   const weeklyUsed = weeklyTotal - codingModel.current_weekly_usage_count;
-  const weeklyPercent = weeklyTotal > 0 ? (weeklyUsed / weeklyTotal) * 100 : 0;
+  const weeklyPercent = directWeeklyPercent ?? (weeklyTotal > 0 ? (weeklyUsed / weeklyTotal) * 100 : 0);
 
   // Parse reset times from Unix ms timestamps
   const parseResetTime = (timestamp: number | undefined): Date | null => {


### PR DESCRIPTION
Fixes #3419.

## Summary
- Accept MiniMax billing rows named `general` when no `minimax-m*` row is present.
- Prefer direct MiniMax remaining-percent fields and convert them to HUD used percentages.
- Fall back to the first row when neither `minimax-m*` nor `general` exists instead of treating the successful response as an API error.
- Add focused parser coverage for MiniMax-M preservation, general-plan parsing, direct remaining percentages, and fallback behavior.

## Verification
- `npm test -- src/__tests__/hud/usage-api.test.ts --run`
- `npm run lint` (passes with existing warnings)
- `npm run build`

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*