### PR TITLE
feat(keyword-detector): support keywordDetector.disabled config opt-out

### DIFF
--- a/docs/settings-schema.md
+++ b/docs/settings-schema.md
@@ -40,3 +40,30 @@ In the current OMC config surface, the same block is written as the top-level
 This remains a prompt-level workflow contract, not runtime enforcement. For the
 full interface, trust boundary, trigger stages, and residual risk, see
 [`company-context-interface.md`](./company-context-interface.md).
+
+## `keywordDetector.disabled`
+
+Opt out of auto-routing for specific keyword-detector skills without turning the
+whole hook off. The UserPromptSubmit keyword detector maps keywords such as
+`wiki`, `plan`, `research`, or `deepsearch` to skills; in a project with its own
+same-named skill this auto-routing can hijack the word and shadow the intended
+skill. List the skill names to suppress here.
+
+Read from the OMC config surface above, project `.claude/omc.jsonc` first, then
+user `~/.config/claude-omc/config.jsonc` (project takes precedence).
+
+```jsonc
+{
+  "keywordDetector": {
+    // skill keywords to stop auto-routing; "cancel" cannot be disabled
+    "disabled": ["wiki"]
+  }
+}
+```
+
+### Behavior
+
+- Omitted or empty array: no change, every keyword routes as before.
+- A listed skill is dropped before conflict resolution, so neither its magic-keyword invocation nor its mode-injection context is emitted.
+- `cancel` is never disableable, even if listed: it is the emergency stop for active modes.
+- To disable all keyword routing at once instead, set `OMC_SKIP_HOOKS=keyword-detector`.

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1168,6 +1168,116 @@ function isTeamEnabled() {
   }
 }
 
+// Read the OMC JSONC config the way src/config/loader.ts does, inlined so the
+// standalone hook stays build-independent (mirrors scripts/lib/agent-model-config.mjs).
+function getOmcUserConfigDir() {
+  if (process.platform === 'win32') {
+    return process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
+  }
+  return process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+}
+
+// Mirrors src/utils/jsonc.ts:stripJsoncComments (strips comments AND trailing commas)
+function stripJsoncComments(content) {
+  return stripTrailingCommas(stripComments(content));
+}
+
+function stripComments(content) {
+  let result = '';
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] === '/' && content[i + 1] === '/') {
+      while (i < content.length && content[i] !== '\n') i++;
+      continue;
+    }
+    if (content[i] === '/' && content[i + 1] === '*') {
+      i += 2;
+      while (i < content.length && !(content[i] === '*' && content[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (content[i] === '"') {
+      result += content[i++];
+      while (i < content.length && content[i] !== '"') {
+        if (content[i] === '\\') {
+          result += content[i++];
+          if (i < content.length) result += content[i++];
+          continue;
+        }
+        result += content[i++];
+      }
+      if (i < content.length) result += content[i++];
+      continue;
+    }
+    result += content[i++];
+  }
+  return result;
+}
+
+// Mirrors src/utils/jsonc.ts:stripTrailingCommas (comma before a closing } or ]).
+function stripTrailingCommas(content) {
+  let result = '';
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] === '"') {
+      result += content[i++];
+      while (i < content.length && content[i] !== '"') {
+        if (content[i] === '\\') {
+          result += content[i++];
+          if (i < content.length) result += content[i++];
+          continue;
+        }
+        result += content[i++];
+      }
+      if (i < content.length) result += content[i++];
+      continue;
+    }
+    if (content[i] === ',') {
+      let j = i + 1;
+      while (j < content.length && /\s/.test(content[j])) j++;
+      if (content[j] === '}' || content[j] === ']') {
+        i++;
+        continue;
+      }
+    }
+    result += content[i++];
+  }
+  return result;
+}
+
+function loadJsoncConfig(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(stripJsoncComments(readFileSync(path, 'utf-8')));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Skills the user opted out of via `keywordDetector.disabled` in the OMC
+ * config: project `.claude/omc.jsonc` first, then user
+ * `~/.config/claude-omc/config.jsonc`, the same JSONC surface
+ * src/config/loader.ts reads. Empty when unset, so default behavior is
+ * unchanged. `cancel` is never disableable: it is the emergency stop.
+ * @param {string} directory project working directory
+ * @returns {Set<string>} disabled skill names (never includes 'cancel')
+ */
+function loadDisabledKeywords(directory) {
+  const configPaths = [
+    join(directory || process.cwd(), '.claude', 'omc.jsonc'),
+    join(getOmcUserConfigDir(), 'claude-omc', 'config.jsonc'),
+  ];
+  for (const configPath of configPaths) {
+    const config = loadJsoncConfig(configPath);
+    const disabled = config?.keywordDetector?.disabled;
+    if (Array.isArray(disabled)) {
+      return new Set(disabled.filter((name) => name !== 'cancel'));
+    }
+  }
+  return new Set();
+}
+
 /**
  * Create a compact skill invocation guide without inlining SKILL.md bodies.
  * Full skill text remains available by path, avoiding UserPromptSubmit token blowups.
@@ -1440,10 +1550,15 @@ async function main() {
       matches.push({ name: 'wiki', args: '' });
     }
 
-    // Deduplicate matches by keyword name before conflict resolution
+    // Drop user-disabled keywords, then dedupe before conflict resolution.
+    // This chokepoint covers both magic-keyword and mode-injection keywords.
+    const disabledKeywords = loadDisabledKeywords(directory);
     const seen = new Set();
     const uniqueMatches = [];
     for (const m of matches) {
+      if (disabledKeywords.has(m.name)) {
+        continue;
+      }
       if (!seen.has(m.name)) {
         seen.add(m.name);
         uniqueMatches.push(m);
@@ -1521,11 +1636,11 @@ async function main() {
       }
     }
 
-    // No matches - pass through.
+    // Nothing left to act on (no keywords, or all opted out) - pass through.
     // Keep this after approved follow-up handling so short post-ralplan
     // prompts like "team" can launch the approved execution path even
     // though generic team keyword auto-detection is disabled.
-    if (matches.length === 0) {
+    if (resolved.length === 0) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -1087,3 +1087,51 @@ diff --git a/a b/b
     expect(existsSync(join(cwd, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json'))).toBe(true);
   });
 });
+
+describe('keyword-detector.mjs keywordDetector.disabled opt-out', () => {
+  function makeCwdWithDisabled(disabled: string[]) {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-disabled-'));
+    mkdirSync(join(cwd, '.claude'), { recursive: true });
+    // Canonical JSONC shape: a comment and trailing commas, which parseJsonc supports.
+    const list = disabled.map((name) => `"${name}",`).join(' ');
+    writeFileSync(
+      join(cwd, '.claude', 'omc.jsonc'),
+      `{\n  // keyword-detector opt-out\n  "keywordDetector": { "disabled": [${list}] },\n}`,
+    );
+    return cwd;
+  }
+
+  it('activates wiki with no opt-out config (positive control)', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'keyword-detector-wiki-default-'));
+    const output = runKeywordDetector('wiki this auth finding', cwd);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).toContain('[MAGIC KEYWORD: WIKI]');
+  });
+
+  it('does not activate wiki when it is in keywordDetector.disabled', () => {
+    const cwd = makeCwdWithDisabled(['wiki']);
+    const output = runKeywordDetector('wiki this auth finding', cwd);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(output.continue).toBe(true);
+    expect(context).not.toContain('[MAGIC KEYWORD: WIKI]');
+  });
+
+  it('only disables the listed keyword, leaving others active', () => {
+    const cwd = makeCwdWithDisabled(['wiki']);
+    const output = runKeywordDetector('deepsearch the codebase for keyword dispatch', cwd);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain('<search-mode>');
+  });
+
+  it('never disables cancel even when listed (emergency stop protection)', () => {
+    const cwd = makeCwdWithDisabled(['cancel']);
+    const output = runKeywordDetector('cancelomc', cwd);
+    const context = output.hookSpecificOutput?.additionalContext ?? '';
+
+    expect(context).toContain('[MAGIC KEYWORD: CANCEL]');
+  });
+});

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -223,6 +223,51 @@ OMC Ultrawork = "특수부대 작전 반"
     const pluginRalphProblem = runKeywordHook(pluginPath, 'run ralph on parser state issue');
     expect(JSON.stringify(templateRalphProblem)).toContain('[MAGIC KEYWORD: RALPH]');
     expect(JSON.stringify(pluginRalphProblem)).toContain('[MAGIC KEYWORD: RALPH]');
+  });
+
+  it('honors keywordDetector.disabled from .claude/omc.jsonc in both packaged artifacts', () => {
+    const templatePath = join(packageRoot, 'templates', 'hooks', 'keyword-detector.mjs');
+    const pluginPath = join(packageRoot, 'scripts', 'keyword-detector.mjs');
+
+    // Isolate from any real user config at ~/.config/claude-omc/config.jsonc.
+    const emptyXdg = mkdtempSync(join(tmpdir(), 'keyword-hook-xdg-'));
+    const disabledDir = mkdtempSync(join(tmpdir(), 'keyword-hook-disabled-'));
+    const controlDir = mkdtempSync(join(tmpdir(), 'keyword-hook-control-'));
+
+    const runInDir = (scriptPath: string, prompt: string, dir: string) =>
+      JSON.parse(
+        execFileSync('node', [scriptPath], {
+          cwd: packageRoot,
+          env: { ...process.env, XDG_CONFIG_HOME: emptyXdg },
+          input: JSON.stringify({ prompt, cwd: dir, directory: dir }),
+          encoding: 'utf-8',
+        }),
+      ) as Record<string, unknown>;
+
+    try {
+      mkdirSync(join(disabledDir, '.claude'), { recursive: true });
+      // Canonical JSONC shape from the #3421 review: comment + trailing commas.
+      writeFileSync(
+        join(disabledDir, '.claude', 'omc.jsonc'),
+        '{\n  // disable tdd auto-routing\n  "keywordDetector": { "disabled": ["tdd",], },\n}',
+      );
+
+      for (const scriptPath of [templatePath, pluginPath]) {
+        // Opt-out is honored: the shipped hook does not route the disabled keyword.
+        expect(runInDir(scriptPath, 'tdd implement password validation', disabledDir)).toEqual({
+          continue: true,
+          suppressOutput: true,
+        });
+        // Control: without the opt-out the same prompt still routes.
+        expect(
+          JSON.stringify(runInDir(scriptPath, 'tdd implement password validation', controlDir)),
+        ).toContain('[TDD MODE ACTIVATED]');
+      }
+    } finally {
+      rmSync(emptyXdg, { recursive: true, force: true });
+      rmSync(disabledDir, { recursive: true, force: true });
+      rmSync(controlDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -102,6 +102,12 @@ export interface PluginConfig {
     onError?: "warn" | "silent" | "fail";
   };
 
+  // UserPromptSubmit keyword-detector opt-outs
+  keywordDetector?: {
+    // Skill keywords to stop auto-routing (e.g. "wiki"); "cancel" is never disabled.
+    disabled?: string[];
+  };
+
   // Permission settings
   permissions?: {
     allowBash?: boolean;

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -1086,6 +1086,116 @@ function isTeamEnabled() {
   } catch { return false; }
 }
 
+// Read the OMC JSONC config the way src/config/loader.ts does, inlined so the
+// standalone hook stays build-independent (mirrors scripts/lib/agent-model-config.mjs).
+function getOmcUserConfigDir() {
+  if (process.platform === 'win32') {
+    return process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
+  }
+  return process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+}
+
+// Mirrors src/utils/jsonc.ts:stripJsoncComments (strips comments AND trailing commas)
+function stripJsoncComments(content) {
+  return stripTrailingCommas(stripComments(content));
+}
+
+function stripComments(content) {
+  let result = '';
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] === '/' && content[i + 1] === '/') {
+      while (i < content.length && content[i] !== '\n') i++;
+      continue;
+    }
+    if (content[i] === '/' && content[i + 1] === '*') {
+      i += 2;
+      while (i < content.length && !(content[i] === '*' && content[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (content[i] === '"') {
+      result += content[i++];
+      while (i < content.length && content[i] !== '"') {
+        if (content[i] === '\\') {
+          result += content[i++];
+          if (i < content.length) result += content[i++];
+          continue;
+        }
+        result += content[i++];
+      }
+      if (i < content.length) result += content[i++];
+      continue;
+    }
+    result += content[i++];
+  }
+  return result;
+}
+
+// Mirrors src/utils/jsonc.ts:stripTrailingCommas (comma before a closing } or ]).
+function stripTrailingCommas(content) {
+  let result = '';
+  let i = 0;
+  while (i < content.length) {
+    if (content[i] === '"') {
+      result += content[i++];
+      while (i < content.length && content[i] !== '"') {
+        if (content[i] === '\\') {
+          result += content[i++];
+          if (i < content.length) result += content[i++];
+          continue;
+        }
+        result += content[i++];
+      }
+      if (i < content.length) result += content[i++];
+      continue;
+    }
+    if (content[i] === ',') {
+      let j = i + 1;
+      while (j < content.length && /\s/.test(content[j])) j++;
+      if (content[j] === '}' || content[j] === ']') {
+        i++;
+        continue;
+      }
+    }
+    result += content[i++];
+  }
+  return result;
+}
+
+function loadJsoncConfig(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(stripJsoncComments(readFileSync(path, 'utf-8')));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Skills the user opted out of via `keywordDetector.disabled` in the OMC
+ * config: project `.claude/omc.jsonc` first, then user
+ * `~/.config/claude-omc/config.jsonc`, the same JSONC surface
+ * src/config/loader.ts reads. Empty when unset, so default behavior is
+ * unchanged. `cancel` is never disableable: it is the emergency stop.
+ * @param {string} directory project working directory
+ * @returns {Set<string>} disabled skill names (never includes 'cancel')
+ */
+function loadDisabledKeywords(directory) {
+  const configPaths = [
+    join(directory || process.cwd(), '.claude', 'omc.jsonc'),
+    join(getOmcUserConfigDir(), 'claude-omc', 'config.jsonc'),
+  ];
+  for (const configPath of configPaths) {
+    const config = loadJsoncConfig(configPath);
+    const disabled = config?.keywordDetector?.disabled;
+    if (Array.isArray(disabled)) {
+      return new Set(disabled.filter((name) => name !== 'cancel'));
+    }
+  }
+  return new Set();
+}
+
 // Main
 async function main() {
   // Skip guard: check OMC_SKIP_HOOKS env var (see issue #838)
@@ -1222,8 +1332,14 @@ async function main() {
       matches.push({ name: 'analyze', args: '' });
     }
 
+    // Drop user-disabled keywords, then pass through if nothing is left.
+    const disabledKeywords = loadDisabledKeywords(directory);
+    const enabledMatches = disabledKeywords.size > 0
+      ? matches.filter((m) => !disabledKeywords.has(m.name))
+      : matches;
+
     // No matches - pass through
-    if (matches.length === 0) {
+    if (enabledMatches.length === 0) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
@@ -1231,7 +1347,7 @@ async function main() {
     // Deduplicate matches by keyword name before conflict resolution
     const seen = new Set();
     const uniqueMatches = [];
-    for (const m of matches) {
+    for (const m of enabledMatches) {
       if (!seen.has(m.name)) {
         seen.add(m.name);
         uniqueMatches.push(m);


### PR DESCRIPTION
Reopens the work from #3418 against `dev` with both blocking findings from that review fixed. (#3418 could not be reopened once closed, so this is a fresh PR from the same branch.)

## Problem

The UserPromptSubmit keyword detector maps bare keywords (`wiki`, `plan`, `research`, `deepsearch`, ...) to skills. In a project that ships its own same-named skill, this auto-routing hijacks the word and shadows the intended skill. The only escapes today are `OMC_SKIP_HOOKS=keyword-detector` (kills all routing) or editing the deployed script (lost on update). No supported per-keyword off switch.

## Change

Opt-out list in the OMC config, backward-compatible (empty default = current behavior):

```jsonc
{
  "keywordDetector": {
    // skill keywords to stop auto-routing; "cancel" cannot be disabled
    "disabled": ["wiki"]
  }
}
```

- `loadDisabledKeywords()` reads from the canonical OMC config surface, project `.claude/omc.jsonc` first then user `~/.config/claude-omc/config.jsonc`, JSONC-parsed, mirroring `src/config/loader.ts` (inlined the same way `scripts/lib/agent-model-config.mjs` does, so the hook stays build-independent).
- Applied to **both** shipped artifacts: the plugin script (`scripts/keyword-detector.mjs`) and the installer template (`templates/hooks/keyword-detector.mjs`), so new installs get the feature.
- Disabled keywords are dropped before conflict resolution; a fully opted-out prompt takes the same clean no-op path as a keyword-free one.
- `cancel` is never disableable (emergency stop for active modes).
- `keywordDetector.disabled` is added to the `PluginConfig` type.

## Addresses the #3418 review

1. **Template ignored the config.** Both copies now honor it. Repro from the review (`.claude/omc.jsonc` disabling `deepsearch`): both `templates/hooks/keyword-detector.mjs` and `scripts/keyword-detector.mjs` now return `{continue:true,suppressOutput:true}` instead of emitting `<search-mode>`.
2. **Config path mismatched the documented surface.** Now reads `.claude/omc.jsonc` / `~/.config/claude-omc/config.jsonc` (JSONC), matching `docs/settings-schema.md`. The doc section was corrected to the same surface.

## Testing

- `src/__tests__/keyword-detector-script.test.ts`: opt-out cases (positive control, disabled, other keywords unaffected, cancel protection).
- `src/installer/__tests__/hook-templates.test.ts`: new case runs both the template and the plugin script through a `.claude/omc.jsonc` opt-out (previously uncovered).
- Both suites green (90 + 12). `tsc --noEmit` clean.