### PR TITLE
Fix project memory command harvest

### DIFF
--- a/src/hooks/project-memory/__tests__/detector.test.ts
+++ b/src/hooks/project-memory/__tests__/detector.test.ts
@@ -186,6 +186,32 @@ pytest = "^7.4.0"
     });
   });
 
+  describe('Makefile build detection', () => {
+    it('does not infer build or test commands from unrelated targets', async () => {
+      await fs.writeFile(
+        path.join(tempDir, 'Makefile'),
+        ['install:', '\t./scripts/install.sh', 'clean:', '\trm -rf tmp'].join('\n')
+      );
+
+      const memory = await detectProjectEnvironment(tempDir);
+
+      expect(memory.build.buildCommand).toBeNull();
+      expect(memory.build.testCommand).toBeNull();
+    });
+
+    it('detects explicit build and test targets', async () => {
+      await fs.writeFile(
+        path.join(tempDir, 'Makefile'),
+        ['build:', '\tnpm run build', 'test lint:', '\tnpm test'].join('\n')
+      );
+
+      const memory = await detectProjectEnvironment(tempDir);
+
+      expect(memory.build.buildCommand).toBe('make build');
+      expect(memory.build.testCommand).toBe('make test');
+    });
+  });
+
   describe('Empty project', () => {
     it('should return minimal memory for empty project', async () => {
       const memory = await detectProjectEnvironment(tempDir);

--- a/src/hooks/project-memory/__tests__/integration.test.ts
+++ b/src/hooks/project-memory/__tests__/integration.test.ts
@@ -11,7 +11,7 @@ import {
   registerProjectMemoryContext,
   clearProjectMemorySession,
 } from "../index.js";
-import { loadProjectMemory, getMemoryPath } from "../storage.js";
+import { loadProjectMemory, saveProjectMemory, getMemoryPath } from "../storage.js";
 import { learnFromToolOutput } from "../learner.js";
 
 describe("Project Memory Integration", () => {
@@ -427,7 +427,7 @@ describe("Project Memory Integration", () => {
   });
 
   describe("End-to-end PostToolUse learning flow", () => {
-    it("should learn build command from Bash execution", async () => {
+    it("should not learn build or test commands from Bash execution history", async () => {
       const packageJson = { name: "test", scripts: {} };
       await fs.writeFile(
         path.join(tempDir, "package.json"),
@@ -439,6 +439,7 @@ describe("Project Memory Integration", () => {
 
       let memory = await loadProjectMemory(tempDir);
       expect(memory?.build.buildCommand).toBeNull();
+      expect(memory?.build.testCommand).toBeNull();
 
       await learnFromToolOutput(
         "Bash",
@@ -446,9 +447,26 @@ describe("Project Memory Integration", () => {
         "",
         tempDir,
       );
+      await learnFromToolOutput("Bash", { command: "npm test" }, "", tempDir);
 
       memory = await loadProjectMemory(tempDir);
-      expect(memory?.build.buildCommand).toBe("npm run build");
+      expect(memory?.build.buildCommand).toBeNull();
+      expect(memory?.build.testCommand).toBeNull();
+
+      memory!.build.buildCommand = "trusted build";
+      memory!.build.testCommand = "trusted test";
+      await saveProjectMemory(tempDir, memory!);
+
+      await learnFromToolOutput(
+        "Bash",
+        { command: "npm run build && npm test" },
+        "",
+        tempDir,
+      );
+
+      memory = await loadProjectMemory(tempDir);
+      expect(memory?.build.buildCommand).toBe("trusted build");
+      expect(memory?.build.testCommand).toBe("trusted test");
     });
 
     it("should learn environment hints from command output", async () => {

--- a/src/hooks/project-memory/__tests__/learner.test.ts
+++ b/src/hooks/project-memory/__tests__/learner.test.ts
@@ -50,24 +50,45 @@ describe('Project Memory Learner', () => {
       expect(updated?.build.buildCommand).toBeNull();
     });
 
-    it('should detect and store build commands', async () => {
+    it.each([
+      ['simple build command', 'pnpm build'],
+      ['simple test command', 'cargo test'],
+      ['arbitrary transcript with build/test substrings', 'echo "build passed; test next"'],
+      ['heredoc containing build/test substrings', 'cat <<EOF\nbuildCommand=pnpm build\ntestCommand=pnpm test\nEOF'],
+      ['copy command with build substring', 'cp build/output.js dist/output.js'],
+      ['remove command with test substring', 'rm -rf test-results'],
+      ['absolute worktree path command', '/tmp/worktrees/project/scripts/build-and-test.sh'],
+      ['compound pipeline command', 'git diff --name-only | xargs pnpm test -- --runInBand'],
+      ['echo separator command', 'echo "--- build ---" && echo "--- test ---"'],
+    ])('should not learn build/test commands from Bash PostToolUse commands: %s', async (_name, command) => {
       const memory = createBasicMemory();
+      memory.build.buildCommand = 'trusted build';
+      memory.build.testCommand = 'trusted test';
       await saveProjectMemory(tempDir, memory);
 
-      await learnFromToolOutput('Bash', { command: 'pnpm build' }, '', tempDir);
+      await learnFromToolOutput('Bash', { command }, 'Node.js v20.10.0', tempDir);
 
       const updated = await loadProjectMemory(tempDir);
-      expect(updated?.build.buildCommand).toBe('pnpm build');
+      expect(updated?.build.buildCommand).toBe('trusted build');
+      expect(updated?.build.testCommand).toBe('trusted test');
+      expect(updated?.customNotes.some(note => note.content === 'Node.js v20.10.0')).toBe(true);
     });
 
-    it('should detect and store test commands', async () => {
+    it.each([
+      ['heredoc', 'cat <<EOF\nnpm run build\nnpm test\nEOF'],
+      ['cp/rm', 'cp build.log /tmp/build.log && rm -rf test-output'],
+      ['absolute worktree path', '/tmp/worktrees/demo/build-test'],
+      ['compound pipeline', 'echo build | tee /tmp/log | xargs echo test'],
+      ['echo separators', 'echo "===== build/test ====="'],
+    ])('should not populate empty build/test commands from Bash command shape: %s', async (_name, command) => {
       const memory = createBasicMemory();
       await saveProjectMemory(tempDir, memory);
 
-      await learnFromToolOutput('Bash', { command: 'cargo test' }, '', tempDir);
+      await learnFromToolOutput('Bash', { command }, '', tempDir);
 
       const updated = await loadProjectMemory(tempDir);
-      expect(updated?.build.testCommand).toBe('cargo test');
+      expect(updated?.build.buildCommand).toBeNull();
+      expect(updated?.build.testCommand).toBeNull();
     });
 
     it('should extract Node.js version from output', async () => {
@@ -81,6 +102,18 @@ describe('Project Memory Learner', () => {
       expect(updated?.customNotes).toHaveLength(1);
       expect(updated?.customNotes[0].category).toBe('runtime');
       expect(updated?.customNotes[0].content).toContain('Node.js');
+    });
+
+    it('should extract Bash output hints even when command input is missing', async () => {
+      const memory = createBasicMemory();
+      await saveProjectMemory(tempDir, memory);
+
+      await learnFromToolOutput('Bash', {}, 'Python 3.11.5', tempDir);
+
+      const updated = await loadProjectMemory(tempDir);
+      expect(updated?.build.buildCommand).toBeNull();
+      expect(updated?.build.testCommand).toBeNull();
+      expect(updated?.customNotes[0].content).toBe('Python 3.11.5');
     });
 
     it('should extract Python version from output', async () => {

--- a/src/hooks/project-memory/detector.ts
+++ b/src/hooks/project-memory/detector.ts
@@ -186,9 +186,11 @@ async function detectBuildInfo(projectRoot: string): Promise<BuildInfo> {
   }
 
   // Check Makefile
-  if (await fileExists(path.join(projectRoot, 'Makefile'))) {
-    if (!buildCommand) buildCommand = 'make build';
-    if (!testCommand) testCommand = 'make test';
+  const makefilePath = path.join(projectRoot, 'Makefile');
+  if (await fileExists(makefilePath)) {
+    const makeTargets = await detectMakefileTargets(makefilePath);
+    if (!buildCommand && makeTargets.has('build')) buildCommand = 'make build';
+    if (!testCommand && makeTargets.has('test')) testCommand = 'make test';
   }
 
   // Check pyproject.toml
@@ -370,6 +372,35 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Helper: Detect explicit Makefile targets.
+ */
+async function detectMakefileTargets(filePath: string): Promise<Set<string>> {
+  const targets = new Set<string>();
+
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    for (const line of content.split(/\r?\n/)) {
+      if (!line.trim() || line.startsWith('\t') || line.trimStart().startsWith('#')) {
+        continue;
+      }
+
+      const match = line.match(/^([^:=#\s][^:=#]*?)\s*:(?![=:])/);
+      if (!match) {
+        continue;
+      }
+
+      for (const target of match[1].trim().split(/\s+/)) {
+        if (target) targets.add(target);
+      }
+    }
+  } catch (_error) {
+    // Skip unreadable Makefiles
+  }
+
+  return targets;
 }
 
 /**

--- a/src/hooks/project-memory/learner.ts
+++ b/src/hooks/project-memory/learner.ts
@@ -4,7 +4,6 @@
  */
 
 import { loadProjectMemory, saveProjectMemory, withProjectMemoryLock } from './storage.js';
-import { BUILD_COMMAND_PATTERNS, TEST_COMMAND_PATTERNS } from './constants.js';
 import { CustomNote } from './types.js';
 import { trackAccess } from './hot-path-tracker.js';
 import { detectDirectivesFromMessage, addDirective } from './directive-detector.js';
@@ -87,7 +86,7 @@ export async function learnFromToolOutput(
         }
       }
 
-      // Learn from Bash commands
+      // Learn environment hints from Bash output without trusting commands as durable build/test facts
       if (toolName !== 'Bash') {
         if (updated) {
           await saveProjectMemory(projectRoot, memory);
@@ -95,29 +94,7 @@ export async function learnFromToolOutput(
         return;
       }
 
-      const command = toolInput?.command || '';
-      if (!command) {
-        return;
-      }
-
       try {
-
-        // Detect and store build commands
-        if (isBuildCommand(command)) {
-          if (!memory.build.buildCommand || memory.build.buildCommand !== command) {
-            memory.build.buildCommand = command;
-            updated = true;
-          }
-        }
-
-        // Detect and store test commands
-        if (isTestCommand(command)) {
-          if (!memory.build.testCommand || memory.build.testCommand !== command) {
-            memory.build.testCommand = command;
-            updated = true;
-          }
-        }
-
         // Extract environment hints from output
         const hints = extractEnvironmentHints(toolOutput);
         if (hints.length > 0) {
@@ -151,19 +128,6 @@ export async function learnFromToolOutput(
   });
 }
 
-/**
- * Check if command is a build command
- */
-function isBuildCommand(command: string): boolean {
-  return BUILD_COMMAND_PATTERNS.some(pattern => pattern.test(command));
-}
-
-/**
- * Check if command is a test command
- */
-function isTestCommand(command: string): boolean {
-  return TEST_COMMAND_PATTERNS.some(pattern => pattern.test(command));
-}
 
 /**
  * Extract environment hints from tool output

--- a/src/hooks/wiki/__tests__/session-hooks.test.ts
+++ b/src/hooks/wiki/__tests__/session-hooks.test.ts
@@ -83,7 +83,7 @@ describe('feedProjectMemory (environment.md)', () => {
       lastScanned: '2026-01-01T00:00:00.000Z',
       techStack: {
         languages: [{ name: 'Java' }, { name: 'Kotlin' }],
-        frameworks: ['Spring'],
+        frameworks: [{ name: 'Spring' }, { name: 'Quarkus' }],
         packageManager: 'gradle',
       },
     });
@@ -93,6 +93,7 @@ describe('feedProjectMemory (environment.md)', () => {
     const env = readPage(tempDir, 'environment.md');
     expect(env).not.toBeNull();
     expect(env!.content).toContain('**Languages:** Java, Kotlin');
+    expect(env!.content).toContain('**Frameworks:** Spring, Quarkus');
     expect(env!.content).not.toContain('[object Object]');
   });
 
@@ -107,6 +108,19 @@ describe('feedProjectMemory (environment.md)', () => {
 
     const env = readPage(tempDir, 'environment.md');
     expect(env!.content).toContain('**Languages:** TypeScript, Go');
+  });
+
+  it('renders plain-string frameworks too', () => {
+    ensureWikiDir(tempDir);
+    writeProjectMemory({
+      lastScanned: '2026-01-01T00:00:00.000Z',
+      techStack: { frameworks: ['React', 'Express'] },
+    });
+
+    onSessionStart({ cwd: tempDir });
+
+    const env = readPage(tempDir, 'environment.md');
+    expect(env!.content).toContain('**Frameworks:** React, Express');
   });
 
   it('updates environment.md when project-memory is newer', () => {

--- a/src/hooks/wiki/session-hooks.ts
+++ b/src/hooks/wiki/session-hooks.ts
@@ -222,7 +222,13 @@ function feedProjectMemory(root: string): void {
           .join(', ');
         if (names) lines.push(`**Languages:** ${names}`);
       }
-      if (ts.frameworks?.length) lines.push(`**Frameworks:** ${ts.frameworks.join(', ')}`);
+      if (ts.frameworks?.length) {
+        const names = ts.frameworks
+          .map((f: any) => (typeof f === 'string' ? f : f?.name))
+          .filter(Boolean)
+          .join(', ');
+        if (names) lines.push(`**Frameworks:** ${names}`);
+      }
       if (ts.packageManager) lines.push(`**Package Manager:** ${ts.packageManager}`);
       if (ts.runtime) lines.push(`**Runtime:** ${ts.runtime}`);
       lines.push('');


### PR DESCRIPTION
Closes #3425

## Summary
- Stop PostToolUse Bash observations from writing durable project-memory build/test commands; trusted repo detection remains the source for those fields.
- Keep Bash output environment hint learning intact.
- Render framework objects by name in generated wiki environment.md instead of `[object Object]`.
- Add focused regressions for command-harvest prevention and framework rendering.

## Validation
- `npm test -- --run src/hooks/project-memory/__tests__/learner.test.ts src/hooks/project-memory/__tests__/detector.test.ts src/hooks/wiki/__tests__/session-hooks.test.ts`
- `npm run build`
- `git diff --check`
- `git diff --name-only origin/dev HEAD -- dist/ bridge/` produced no files before commit

No generated `dist/` or `bridge/` artifacts are included.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*