### PR TITLE
Fix plugin cache source realpath exclusion

### DIFF
--- a/src/installer/__tests__/plugin-cache-sync.test.ts
+++ b/src/installer/__tests__/plugin-cache-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 
 const ORIG_ENV = { ...process.env };
 
@@ -94,6 +94,53 @@ describe('syncInstalledPluginPayload', () => {
     expect(existsSync(join(cacheRoot, 'scripts', 'run.cjs'))).toBe(true);
     expect(existsSync(join(cacheRoot, 'commands', 'omc-setup.md'))).toBe(true);
     expect(JSON.parse(readFileSync(join(cacheRoot, 'package.json'), 'utf-8')).version).toBe('9.9.9-test');
+  });
+
+  it('excludes marketplace sources that canonicalize to an installed cache target', async () => {
+    const configDir = process.env.CLAUDE_CONFIG_DIR as string;
+    const cacheRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.12.0');
+    const samePhysicalSourceRoot = `${cacheRoot}/../${basename(cacheRoot)}`;
+    const sourceRoot = join(tempRoot, 'alternate-marketplace-source');
+
+    writePayloadTree(sourceRoot);
+    mkdirSync(join(cacheRoot, 'agents'), { recursive: true });
+    writeFileSync(join(cacheRoot, 'agents', 'executor.md'), '# stale executor\n');
+    mkdirSync(join(configDir, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'oh-my-claudecode@omc': [{ installPath: cacheRoot, version: '4.12.0' }],
+        },
+      }, null, 2),
+    );
+    writeFileSync(
+      join(configDir, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({
+        omc: {
+          installLocation: samePhysicalSourceRoot,
+          source: { source: 'directory', path: samePhysicalSourceRoot },
+        },
+        'oh-my-claudecode-local': {
+          installLocation: sourceRoot,
+          source: { source: 'directory', path: sourceRoot },
+        },
+      }, null, 2),
+    );
+
+    const installer = await freshInstaller();
+    const result = installer.syncInstalledPluginPayload();
+
+    expect(result.synced).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.sourceRoot).toBe(sourceRoot);
+    expect(result.sourceRoot).not.toBe(samePhysicalSourceRoot);
+    expect(existsSync(join(cacheRoot, 'package.json'))).toBe(true);
+    expect(JSON.parse(readFileSync(join(cacheRoot, 'package.json'), 'utf-8')).version).toBe('9.9.9-test');
+
+    const selfCopyResult = installer.copyPluginSyncPayload(samePhysicalSourceRoot, [cacheRoot]);
+    expect(selfCopyResult).toEqual({ synced: false, errors: [] });
   });
 
   it('repairs incomplete cache installs during setup before plugin-provided file detection runs', async () => {

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -1417,6 +1417,7 @@ function isCacheInstalledPluginRoot(root: string): boolean {
 
 function resolveBestPluginSyncSource(targetRoots: string[]): { sourceRoot: string | null; errors: string[] } {
   const excludedRoots = new Set(targetRoots.map(normalizePath));
+  const excludedCanonicalRoots = new Set(targetRoots.map(canonicalizeExistingPath));
   const seen = new Set<string>();
   const globalPackageRoot = getGlobalInstalledPackageRoot();
   const candidates = [
@@ -1435,7 +1436,14 @@ function resolveBestPluginSyncSource(targetRoots: string[]): { sourceRoot: strin
     if (seen.has(normalizedCandidate) || excludedRoots.has(normalizedCandidate) || !existsSync(candidate)) {
       continue;
     }
+
+    const canonicalCandidate = canonicalizeExistingPath(candidate);
+    if (seen.has(canonicalCandidate) || excludedCanonicalRoots.has(canonicalCandidate)) {
+      continue;
+    }
+
     seen.add(normalizedCandidate);
+    seen.add(canonicalCandidate);
 
     const sourceValidationErrors = validatePluginSyncPayload(candidate);
     if (sourceValidationErrors.length > 0) {
@@ -1576,8 +1584,12 @@ export function copyPluginSyncPayload(sourceRoot: string, targetRoots: string[])
 
   let synced = false;
   const errors: string[] = [];
+  const canonicalSourceRoot = canonicalizeExistingPath(sourceRoot);
 
   for (const targetRoot of targetRoots) {
+    if (canonicalizeExistingPath(targetRoot) === canonicalSourceRoot) {
+      continue;
+    }
     let copiedToTarget = false;
     let copiedSkills = false;
 


### PR DESCRIPTION
## Summary
- Exclude plugin sync source candidates whose canonical realpath matches an installed cache target root
- Add a self-copy guard in plugin payload copying to avoid src/dest EINVAL when paths alias the same directory
- Cover a directory marketplace path that resolves back to the installed cache target while another valid source is selected

Closes #3431

## Verification
- npm test -- src/installer/__tests__/plugin-cache-sync.test.ts --run
- npm run lint (passes with existing warnings)
- npm run build

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*