### PR TITLE
Fix persistent-mode Stop hook watchdog

### DIFF
--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -25,25 +25,38 @@ import { spawn } from "child_process";
 import { join, dirname, resolve, normalize } from "path";
 import { homedir } from "os";
 import { fileURLToPath, pathToFileURL } from "url";
-import { getClaudeConfigDir } from "./lib/config-dir.mjs";
-import { resolveOmcStateRoot } from "./lib/state-root.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const SAFE_CONTINUE = { continue: true, suppressOutput: true };
-const DEFAULT_SAFETY_TIMEOUT_MS = 10000;
+const DEFAULT_SAFETY_TIMEOUT_MS = 8500;
+const SAFE_EXIT_FLUSH_TIMEOUT_MS = 100;
+
 
 function getSafetyTimeoutMs() {
   const parsed = Number.parseInt(process.env.OMC_PERSISTENT_MODE_TIMEOUT_MS || "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SAFETY_TIMEOUT_MS;
 }
 
-function writeSafeContinue() {
+function writeSafeContinue(onFlushed) {
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    if (onFlushed) onFlushed();
+  };
+
   try {
-    process.stdout.write(JSON.stringify(SAFE_CONTINUE) + "\n");
+    const ok = process.stdout.write(JSON.stringify(SAFE_CONTINUE) + "\n", finish);
+    if (!ok) {
+      process.stdout.once("drain", finish);
+    }
+    const timeout = setTimeout(finish, SAFE_EXIT_FLUSH_TIMEOUT_MS);
+    if (!onFlushed) timeout.unref?.();
   } catch {
     // If stdout is unavailable, exiting still prevents a wedged Stop hook.
+    finish();
   }
 }
 
@@ -56,7 +69,8 @@ function shouldSkipPersistentModeHook() {
   return (
     process.env.DISABLE_OMC === "1" ||
     process.env.DISABLE_OMC === "true" ||
-    skipHooks.includes("persistent-mode")
+    skipHooks.includes("persistent-mode") ||
+    skipHooks.includes("stop-continuation")
   );
 }
 
@@ -66,18 +80,27 @@ function forceSafeExit(message) {
   } catch {
     // Ignore stderr failures; the JSON decision is what matters.
   }
-  writeSafeContinue();
-  process.exit(0);
+  writeSafeContinue(() => process.exit(0));
 }
+
 
 const safetyTimeout = setTimeout(() => {
   forceSafeExit("[persistent-mode] Safety timeout reached, forcing exit");
 }, getSafetyTimeoutMs());
 
-// Dynamic import for the shared stdin module
+process.on("uncaughtException", (error) => {
+  forceSafeExit(`[persistent-mode] Uncaught exception: ${error?.message || error}`);
+});
+
+process.on("unhandledRejection", (error) => {
+  forceSafeExit(`[persistent-mode] Unhandled rejection: ${error?.message || error}`);
+});
+
+const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, "lib", "stdin.mjs")).href
 );
+const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, "lib", "state-root.mjs")).href);
 
 function readJsonFile(path) {
   try {
@@ -1597,14 +1620,6 @@ async function main() {
     writeSafeContinue();
   }
 }
-
-process.on("uncaughtException", (error) => {
-  forceSafeExit(`[persistent-mode] Uncaught exception: ${error?.message || error}`);
-});
-
-process.on("unhandledRejection", (error) => {
-  forceSafeExit(`[persistent-mode] Unhandled rejection: ${error?.message || error}`);
-});
 
 main().finally(() => {
   clearTimeout(safetyTimeout);

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -31,6 +31,49 @@ import { resolveOmcStateRoot } from "./lib/state-root.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const SAFE_CONTINUE = { continue: true, suppressOutput: true };
+const DEFAULT_SAFETY_TIMEOUT_MS = 10000;
+
+function getSafetyTimeoutMs() {
+  const parsed = Number.parseInt(process.env.OMC_PERSISTENT_MODE_TIMEOUT_MS || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SAFETY_TIMEOUT_MS;
+}
+
+function writeSafeContinue() {
+  try {
+    process.stdout.write(JSON.stringify(SAFE_CONTINUE) + "\n");
+  } catch {
+    // If stdout is unavailable, exiting still prevents a wedged Stop hook.
+  }
+}
+
+function shouldSkipPersistentModeHook() {
+  const skipHooks = (process.env.OMC_SKIP_HOOKS || "")
+    .split(",")
+    .map((hook) => hook.trim())
+    .filter(Boolean);
+
+  return (
+    process.env.DISABLE_OMC === "1" ||
+    process.env.DISABLE_OMC === "true" ||
+    skipHooks.includes("persistent-mode")
+  );
+}
+
+function forceSafeExit(message) {
+  try {
+    if (message) process.stderr.write(message + "\n");
+  } catch {
+    // Ignore stderr failures; the JSON decision is what matters.
+  }
+  writeSafeContinue();
+  process.exit(0);
+}
+
+const safetyTimeout = setTimeout(() => {
+  forceSafeExit("[persistent-mode] Safety timeout reached, forcing exit");
+}, getSafetyTimeoutMs());
+
 // Dynamic import for the shared stdin module
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, "lib", "stdin.mjs")).href
@@ -962,11 +1005,19 @@ function isScheduledWakeupStop(data) {
 
 async function main() {
   try {
+    if (shouldSkipPersistentModeHook()) {
+      writeSafeContinue();
+      return;
+    }
+
     const input = await readStdin();
     let data = {};
     try {
       data = JSON.parse(input);
-    } catch {}
+    } catch {
+      writeSafeContinue();
+      return;
+    }
 
     // Claude Code sets stop_hook_active when a Stop hook is already running.
     // Never emit another decision:block in that re-entrant path: doing so trips
@@ -1538,9 +1589,23 @@ async function main() {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
   } catch (error) {
     // On any error, allow stop rather than blocking forever
-    console.error(`[persistent-mode] Error: ${error.message}`);
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    try {
+      process.stderr.write(`[persistent-mode] Error: ${error?.message || error}\n`);
+    } catch {
+      // Ignore stderr errors - we just need to return valid JSON
+    }
+    writeSafeContinue();
   }
 }
 
-main();
+process.on("uncaughtException", (error) => {
+  forceSafeExit(`[persistent-mode] Uncaught exception: ${error?.message || error}`);
+});
+
+process.on("unhandledRejection", (error) => {
+  forceSafeExit(`[persistent-mode] Unhandled rejection: ${error?.message || error}`);
+});
+
+main().finally(() => {
+  clearTimeout(safetyTimeout);
+});

--- a/src/hooks/persistent-mode/__tests__/error-handling.test.ts
+++ b/src/hooks/persistent-mode/__tests__/error-handling.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { spawn } from 'child_process';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const TEMPLATE_HOOK_PATH = join(__dirname, '../../../../templates/hooks/persistent-mode.mjs');
@@ -59,6 +60,7 @@ describe('persistent-mode hook error handling (issue #319)', () => {
     const skipEnvs: Array<Record<string, string>> = [
       { DISABLE_OMC: '1' },
       { OMC_SKIP_HOOKS: 'other,persistent-mode' },
+      { OMC_SKIP_HOOKS: 'other,stop-continuation' },
     ];
     for (const hookPath of [TEMPLATE_HOOK_PATH, SCRIPT_HOOK_PATH]) {
       for (const env of skipEnvs) {
@@ -75,6 +77,32 @@ describe('persistent-mode hook error handling (issue #319)', () => {
       }
     }
   });
+
+  it('keeps the default safety timeout below the shipped Stop hook wrapper kill', () => {
+    const manifest = JSON.parse(readFileSync(join(__dirname, '../../../../hooks/hooks.json'), 'utf-8'));
+    const stopHook = manifest.hooks.Stop[0].hooks.find((hook: { command?: string }) =>
+      hook.command?.includes('/scripts/persistent-mode.mjs'),
+    );
+    expect(stopHook?.timeout).toBe(10);
+
+    const wrapperKillMs = stopHook.timeout * 1000 - 500;
+    for (const hookPath of [TEMPLATE_HOOK_PATH, SCRIPT_HOOK_PATH]) {
+      expect(readDefaultSafetyTimeoutMs(hookPath)).toBeLessThan(wrapperKillMs);
+    }
+  });
+
+  it('registers watchdog handlers before top-level awaited dynamic imports', () => {
+    for (const hookPath of [TEMPLATE_HOOK_PATH, SCRIPT_HOOK_PATH]) {
+      const source = readFileSync(hookPath, 'utf-8');
+      const timeoutIndex = source.indexOf('const safetyTimeout = setTimeout');
+      const handlerIndex = source.indexOf('process.on("uncaughtException"');
+      const dynamicImportIndex = source.indexOf('await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs"))');
+
+      expect(timeoutIndex).toBeGreaterThan(-1);
+      expect(handlerIndex).toBeGreaterThan(timeoutIndex);
+      expect(dynamicImportIndex).toBeGreaterThan(handlerIndex);
+    }
+  });
 });
 
 interface HookResult {
@@ -83,6 +111,13 @@ interface HookResult {
   exitCode: number | null;
   timedOut: boolean;
   duration: number;
+}
+
+function readDefaultSafetyTimeoutMs(hookPath: string): number {
+  const source = readFileSync(hookPath, 'utf-8');
+  const match = source.match(/const DEFAULT_SAFETY_TIMEOUT_MS = (\d+);/);
+  if (!match) throw new Error(`Missing DEFAULT_SAFETY_TIMEOUT_MS in ${hookPath}`);
+  return Number(match[1]);
 }
 
 function runHook(

--- a/src/hooks/persistent-mode/__tests__/error-handling.test.ts
+++ b/src/hooks/persistent-mode/__tests__/error-handling.test.ts
@@ -7,7 +7,8 @@ import { describe, it, expect } from 'vitest';
 import { spawn } from 'child_process';
 import { join } from 'path';
 
-const HOOK_PATH = join(__dirname, '../../../../templates/hooks/persistent-mode.mjs');
+const TEMPLATE_HOOK_PATH = join(__dirname, '../../../../templates/hooks/persistent-mode.mjs');
+const SCRIPT_HOOK_PATH = join(__dirname, '../../../../scripts/persistent-mode.mjs');
 const TIMEOUT_MS = 3000;
 
 describe('persistent-mode hook error handling (issue #319)', () => {
@@ -25,15 +26,54 @@ describe('persistent-mode hook error handling (issue #319)', () => {
   });
 
   it('should return continue:true on invalid JSON without hanging', async () => {
-    const result = await runHook('invalid json{{{');
-    expect(result.output).toContain('continue');
-    expect(result.timedOut).toBe(false);
+    for (const hookPath of [TEMPLATE_HOOK_PATH, SCRIPT_HOOK_PATH]) {
+      const result = await runHook('invalid json{{{', { hookPath });
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.output)).toEqual({ continue: true, suppressOutput: true });
+    }
   });
 
   it('should complete within timeout even on errors', async () => {
     const result = await runHook('{"malformed": }');
     expect(result.timedOut).toBe(false);
     expect(result.duration).toBeLessThan(TIMEOUT_MS);
+  });
+
+  it('bounds execution when stdin stays open', async () => {
+    for (const hookPath of [TEMPLATE_HOOK_PATH, SCRIPT_HOOK_PATH]) {
+      const result = await runHook('{"cwd":"."}', {
+        hookPath,
+        closeStdin: false,
+        env: { OMC_PERSISTENT_MODE_TIMEOUT_MS: '250' },
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.duration).toBeLessThan(TIMEOUT_MS);
+      expect(JSON.parse(result.output)).toEqual({ continue: true, suppressOutput: true });
+    }
+  });
+
+  it('honors persistent-mode environment skip before reading stdin', async () => {
+    const skipEnvs: Array<Record<string, string>> = [
+      { DISABLE_OMC: '1' },
+      { OMC_SKIP_HOOKS: 'other,persistent-mode' },
+    ];
+    for (const hookPath of [TEMPLATE_HOOK_PATH, SCRIPT_HOOK_PATH]) {
+      for (const env of skipEnvs) {
+        const result = await runHook('{"cwd":"."}', {
+          hookPath,
+          closeStdin: false,
+          env,
+        });
+
+        expect(result.timedOut).toBe(false);
+        expect(result.exitCode).toBe(0);
+        expect(result.duration).toBeLessThan(1000);
+        expect(JSON.parse(result.output)).toEqual({ continue: true, suppressOutput: true });
+      }
+    }
   });
 });
 
@@ -45,10 +85,21 @@ interface HookResult {
   duration: number;
 }
 
-function runHook(input: string, closeImmediately = false): Promise<HookResult> {
+function runHook(
+  input: string,
+  options: boolean | { hookPath?: string; closeStdin?: boolean; env?: Record<string, string> } = {},
+): Promise<HookResult> {
+  const normalized = typeof options === 'boolean'
+    ? { closeStdin: options }
+    : options;
+  const hookPath = normalized.hookPath ?? TEMPLATE_HOOK_PATH;
+  const closeStdin = normalized.closeStdin ?? true;
+
   return new Promise((resolve) => {
     const startTime = Date.now();
-    const proc = spawn('node', [HOOK_PATH]);
+    const proc = spawn('node', [hookPath], {
+      env: { ...process.env, ...normalized.env },
+    });
 
     let stdout = '';
     let stderr = '';
@@ -80,10 +131,10 @@ function runHook(input: string, closeImmediately = false): Promise<HookResult> {
       });
     });
 
-    if (closeImmediately) {
-      proc.stdin.end();
-    } else {
+    if (input) {
       proc.stdin.write(input);
+    }
+    if (closeStdin) {
       proc.stdin.end();
     }
   });

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -31,6 +31,49 @@ const { readStdin } = await import(
 );
 const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
+const SAFE_CONTINUE = { continue: true, suppressOutput: true };
+const DEFAULT_SAFETY_TIMEOUT_MS = 10000;
+
+function getSafetyTimeoutMs() {
+  const parsed = Number.parseInt(process.env.OMC_PERSISTENT_MODE_TIMEOUT_MS || "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SAFETY_TIMEOUT_MS;
+}
+
+function writeSafeContinue() {
+  try {
+    process.stdout.write(JSON.stringify(SAFE_CONTINUE) + "\n");
+  } catch {
+    // If stdout is unavailable, exiting still prevents a wedged Stop hook.
+  }
+}
+
+function shouldSkipPersistentModeHook() {
+  const skipHooks = (process.env.OMC_SKIP_HOOKS || "")
+    .split(",")
+    .map((hook) => hook.trim())
+    .filter(Boolean);
+
+  return (
+    process.env.DISABLE_OMC === "1" ||
+    process.env.DISABLE_OMC === "true" ||
+    skipHooks.includes("persistent-mode")
+  );
+}
+
+function forceSafeExit(message) {
+  try {
+    if (message) process.stderr.write(message + "\n");
+  } catch {
+    // Ignore stderr failures; the JSON decision is what matters.
+  }
+  writeSafeContinue();
+  process.exit(0);
+}
+
+const safetyTimeout = setTimeout(() => {
+  forceSafeExit("[persistent-mode] Safety timeout reached, forcing exit");
+}, getSafetyTimeoutMs());
+
 function readJsonFile(path) {
   try {
     if (!existsSync(path)) return null;
@@ -764,13 +807,18 @@ function isScheduledWakeupStop(data) {
 
 async function main() {
   try {
+    if (shouldSkipPersistentModeHook()) {
+      writeSafeContinue();
+      return;
+    }
+
     const input = await readStdin();
     let data = {};
     try {
       data = JSON.parse(input);
     } catch {
       // Invalid JSON - allow stop to prevent hanging
-      process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + "\n");
+      writeSafeContinue();
       return;
     }
 
@@ -1300,13 +1348,7 @@ async function main() {
     } catch {
       // Ignore stderr errors - we just need to return valid JSON
     }
-    try {
-      process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + "\n");
-    } catch {
-      // If stdout write fails, the hook will timeout and Claude Code will proceed
-      // This is better than hanging forever
-      process.exit(0);
-    }
+    writeSafeContinue();
   }
 }
 
@@ -1319,11 +1361,7 @@ process.on("uncaughtException", (error) => {
   } catch {
     // Ignore
   }
-  try {
-    process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + "\n");
-  } catch {
-    // If we can't write, just exit
-  }
+  writeSafeContinue();
   process.exit(0);
 });
 
@@ -1335,31 +1373,10 @@ process.on("unhandledRejection", (error) => {
   } catch {
     // Ignore
   }
-  try {
-    process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + "\n");
-  } catch {
-    // If we can't write, just exit
-  }
+  writeSafeContinue();
   process.exit(0);
 });
 
-// Safety timeout: if hook doesn't complete in 10 seconds, force exit
-// This prevents infinite hangs from any unforeseen issues
-const safetyTimeout = setTimeout(() => {
-  try {
-    process.stderr.write(
-      "[persistent-mode] Safety timeout reached, forcing exit\n",
-    );
-  } catch {
-    // Ignore
-  }
-  try {
-    process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + "\n");
-  } catch {
-    // If we can't write, just exit
-  }
-  process.exit(0);
-}, 10000);
 
 main().finally(() => {
   clearTimeout(safetyTimeout);

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -23,27 +23,35 @@ import { fileURLToPath, pathToFileURL } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
-
-// Dynamic import for the shared stdin module
-const { readStdin } = await import(
-  pathToFileURL(join(__dirname, "lib", "stdin.mjs")).href
-);
-const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
 
 const SAFE_CONTINUE = { continue: true, suppressOutput: true };
-const DEFAULT_SAFETY_TIMEOUT_MS = 10000;
+const DEFAULT_SAFETY_TIMEOUT_MS = 8500;
+const SAFE_EXIT_FLUSH_TIMEOUT_MS = 100;
+
 
 function getSafetyTimeoutMs() {
   const parsed = Number.parseInt(process.env.OMC_PERSISTENT_MODE_TIMEOUT_MS || "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SAFETY_TIMEOUT_MS;
 }
 
-function writeSafeContinue() {
+function writeSafeContinue(onFlushed) {
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    if (onFlushed) onFlushed();
+  };
+
   try {
-    process.stdout.write(JSON.stringify(SAFE_CONTINUE) + "\n");
+    const ok = process.stdout.write(JSON.stringify(SAFE_CONTINUE) + "\n", finish);
+    if (!ok) {
+      process.stdout.once("drain", finish);
+    }
+    const timeout = setTimeout(finish, SAFE_EXIT_FLUSH_TIMEOUT_MS);
+    if (!onFlushed) timeout.unref?.();
   } catch {
     // If stdout is unavailable, exiting still prevents a wedged Stop hook.
+    finish();
   }
 }
 
@@ -56,7 +64,8 @@ function shouldSkipPersistentModeHook() {
   return (
     process.env.DISABLE_OMC === "1" ||
     process.env.DISABLE_OMC === "true" ||
-    skipHooks.includes("persistent-mode")
+    skipHooks.includes("persistent-mode") ||
+    skipHooks.includes("stop-continuation")
   );
 }
 
@@ -66,13 +75,26 @@ function forceSafeExit(message) {
   } catch {
     // Ignore stderr failures; the JSON decision is what matters.
   }
-  writeSafeContinue();
-  process.exit(0);
+  writeSafeContinue(() => process.exit(0));
 }
 
 const safetyTimeout = setTimeout(() => {
   forceSafeExit("[persistent-mode] Safety timeout reached, forcing exit");
 }, getSafetyTimeoutMs());
+
+process.on("uncaughtException", (error) => {
+  forceSafeExit(`[persistent-mode] Uncaught exception: ${error?.message || error}`);
+});
+
+process.on("unhandledRejection", (error) => {
+  forceSafeExit(`[persistent-mode] Unhandled rejection: ${error?.message || error}`);
+});
+
+const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, "lib", "stdin.mjs")).href
+);
+const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, "lib", "state-root.mjs")).href);
 
 function readJsonFile(path) {
   try {
@@ -1351,31 +1373,6 @@ async function main() {
     writeSafeContinue();
   }
 }
-
-// Global error handlers to prevent hook from hanging on uncaught errors (issue #319)
-process.on("uncaughtException", (error) => {
-  try {
-    process.stderr.write(
-      `[persistent-mode] Uncaught exception: ${error?.message || error}\n`,
-    );
-  } catch {
-    // Ignore
-  }
-  writeSafeContinue();
-  process.exit(0);
-});
-
-process.on("unhandledRejection", (error) => {
-  try {
-    process.stderr.write(
-      `[persistent-mode] Unhandled rejection: ${error?.message || error}\n`,
-    );
-  } catch {
-    // Ignore
-  }
-  writeSafeContinue();
-  process.exit(0);
-});
 
 
 main().finally(() => {


### PR DESCRIPTION
Fixes #3433

## Summary
- Add a safety watchdog to persistent-mode Stop hooks so open stdin cannot hang indefinitely.
- Return a valid safe-continue JSON response for skip, malformed stdin, timeout, and uncaught error paths.
- Cover both script and template hook entrypoints with focused regression tests and keep required generated test output.

## Verification
- npm test -- --run src/hooks/persistent-mode/__tests__/error-handling.test.ts
- npm run build
- node -e "JSON.parse(require('fs').readFileSync('dist/hooks/persistent-mode/__tests__/error-handling.test.js.map','utf8')); console.log('map ok')"
- git diff --check

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*