### PR TITLE
Fix inline TUI worker start verification

### DIFF
--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -11,6 +11,7 @@ const mockedCalls = vi.hoisted(() => ({
   enterSubmitsCommand: true,
   submitClearsAfterCaptures: 0,
   delayedSubmitCapturesRemaining: null as number | null,
+  paneStatusAfterEnter: null as string | null,
   delayedSubmitReplacement: '',
   cmuxFailOnce: [] as string[],
   cmuxFailures: [] as Array<{ command: string; message: string }>,
@@ -102,6 +103,9 @@ vi.mock('../../cli/tmux-utils.js', async (importOriginal) => {
           mockedCalls.paneCapture = replacement;
         }
       }
+      if (args[0] === 'send-keys' && args.at(-1) === 'Enter' && mockedCalls.paneStatusAfterEnter !== null) {
+        mockedCalls.paneStatus = mockedCalls.paneStatusAfterEnter;
+      }
       return { stdout: '', stderr: '' };
     }),
     tmuxCmdAsync: vi.fn(async (args: string[]) => {
@@ -133,6 +137,7 @@ describe('spawnWorkerInPane', () => {
     mockedCalls.submitClearsAfterCaptures = 0;
     mockedCalls.delayedSubmitCapturesRemaining = null;
     mockedCalls.delayedSubmitReplacement = '';
+    mockedCalls.paneStatusAfterEnter = null;
   });
 
   it('uses argv-style launch with literal tmux send-keys', async () => {
@@ -444,6 +449,43 @@ describe('spawnWorkerInPane', () => {
     );
     expect(submitVerificationCaptures.length).toBeGreaterThan(5);
     vi.useRealTimers();
+  });
+
+  it('accepts inline TUI worker submission when process leaves the ready shell but command remains in scrollback', async () => {
+    mockedCalls.enterSubmitsCommand = false;
+    mockedCalls.paneStatusAfterEnter = '0 codex\n';
+
+    await expect(spawnWorkerInPane('session:0', '%2', {
+      teamName: 'safe-team',
+      workerName: 'worker-1',
+      envVars: {
+        OMC_TEAM_NAME: 'safe-team',
+        OMC_TEAM_WORKER: 'safe-team/worker-1',
+      },
+      launchBinary: 'codex',
+      launchArgs: ['--full-auto'],
+      cwd: '/tmp',
+    })).resolves.toBeUndefined();
+  });
+
+  it('does not accept inline TUI worker submission when the pane is dead', async () => {
+    mockedCalls.enterSubmitsCommand = false;
+    mockedCalls.paneStatusAfterEnter = '1 codex\n';
+    vi.stubEnv('OMC_TEAM_START_SUBMIT_TIMEOUT_MS', '200');
+
+    await expect(
+      spawnWorkerInPane('session:0', '%2', {
+        teamName: 'safe-team',
+        workerName: 'worker-1',
+        envVars: {
+          OMC_TEAM_NAME: 'safe-team',
+          OMC_TEAM_WORKER: 'safe-team/worker-1',
+        },
+        launchBinary: 'codex',
+        launchArgs: ['--full-auto'],
+        cwd: '/tmp',
+      })
+    ).rejects.toThrow(/worker_start_submit_unverified:worker-1:%2:/);
   });
 
   it('fails loudly when a single Cursor worker start command remains unsubmitted after Enter', async () => {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -385,6 +385,25 @@ function paneCurrentCommandLooksReady(command: string): boolean {
     || ['cmd', 'powershell', 'pwsh', 'nu', 'elvish'].includes(normalized);
 }
 
+async function getPaneCurrentCommandStatus(paneId: string): Promise<{ dead: boolean; command: string } | null> {
+  try {
+    const result = await tmuxCmdAsync([
+      'display-message', '-p', '-t', paneId,
+      '#{pane_dead} #{pane_current_command}',
+    ], { timeout: 1000 });
+    const status = result.stdout.trim();
+    const [dead, ...commandParts] = status.split(/\s+/);
+    return { dead: dead === '1', command: commandParts.join(' ') };
+  } catch {
+    return null;
+  }
+}
+
+function paneCurrentCommandLooksSubmitted(command: string): boolean {
+  return command.length > 0 && !paneCurrentCommandLooksReady(command);
+}
+
+
 export interface WaitForShellReadyOptions {
   timeoutMs?: number;
   pollIntervalMs?: number;
@@ -403,20 +422,13 @@ async function waitForShellReady(paneId: string, opts: WaitForShellReadyOptions 
   const deadline = Date.now() + timeoutMs;
   let lastStatus = '';
   while (Date.now() < deadline) {
-    try {
-      const result = await tmuxCmdAsync([
-        'display-message', '-p', '-t', paneId,
-        '#{pane_dead} #{pane_current_command}',
-      ], { timeout: 1000 });
-      lastStatus = result.stdout.trim();
-      const [dead, ...commandParts] = lastStatus.split(/\s+/);
-      if (dead === '1') return false;
-      const currentCommand = commandParts.join(' ');
-      if (currentCommand && paneCurrentCommandLooksReady(currentCommand)) {
+    const status = await getPaneCurrentCommandStatus(paneId);
+    if (status) {
+      lastStatus = `${status.dead ? '1' : '0'} ${status.command}`.trim();
+      if (status.dead) return false;
+      if (paneCurrentCommandLooksReady(status.command)) {
         return true;
       }
-    } catch (error) {
-      lastStatus = error instanceof Error ? error.message : String(error);
     }
     await sleep(pollIntervalMs);
   }
@@ -482,6 +494,13 @@ async function verifyWorkerStartCommandSubmitted(
     const commandStillBuffered = normalizedCaptured.includes(expected)
       || (compactExpected.length > 0 && normalizeTmuxCaptureForDelivery(captured).includes(compactExpected));
     if (!commandStillBuffered) {
+      return true;
+    }
+    const status = await getPaneCurrentCommandStatus(paneId);
+    if (status?.dead) {
+      return false;
+    }
+    if (status && paneCurrentCommandLooksSubmitted(status.command)) {
       return true;
     }
     const remainingMs = deadline - Date.now();


### PR DESCRIPTION
Fixes #3436

## Summary
- Treat inline TUI worker startup as submitted when the pane is alive and foreground command has left the ready shell.
- Keep dead panes and shell/ready commands from counting as successful submission.
- Add focused coverage for inline TUI foreground-command and dead-pane cases.

## Validation
- node --check bridge/cli.cjs
- node --check bridge/team.js
- npm test -- src/team/__tests__/tmux-session.spawn.test.ts

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*