### PR TITLE
Add deterministic capabilities lockfile preflight

### DIFF
--- a/src/cli/commands/__tests__/capabilities.test.ts
+++ b/src/cli/commands/__tests__/capabilities.test.ts
@@ -7,6 +7,7 @@ import {
   capabilitiesCheckCommand,
   capabilitiesLockCommand,
   runDeterministicCapabilityFixtures,
+  skillNameFromSkillFilePath,
   type CapabilitiesLockfile,
 } from '../capabilities.js';
 
@@ -67,6 +68,32 @@ describe('capabilities lock/check', () => {
     expect(results.find((result) => result.kind === 'required_args')).toMatchObject({ ok: true, outcome: 'pass' });
     expect(results.find((result) => result.kind === 'no_hallucinated_tool')).toMatchObject({ ok: true, outcome: 'pass' });
     expect(results.find((result) => result.kind === 'tool_restraint')).toMatchObject({ ok: true, outcome: 'pass' });
+  });
+
+  it('fails check when the locked surface body is mutated without updating the digest', async () => {
+    await withTempCwd(async (cwd) => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const lockfilePath = join(cwd, 'capabilities.lock.json');
+      const lockfile = buildCapabilitiesLockfile();
+      lockfile.surface.schemaVersion = 'tampered';
+      await writeFile(lockfilePath, `${JSON.stringify(lockfile, null, 2)}\n`);
+
+      const exitCode = await capabilitiesCheckCommand({ json: true, lockfile: lockfilePath });
+
+      expect(exitCode).toBe(1);
+      const report = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+      expect(report.ok).toBe(false);
+      expect(report.failures).toContainEqual(expect.objectContaining({
+        code: 'lockfile_surface_digest_mismatch',
+        expected: lockfile.surfaceDigest,
+        actual: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }));
+    });
+  });
+
+  it('extracts skill names from win32-style SKILL.md paths without leaking parent paths', () => {
+    expect(skillNameFromSkillFilePath('C:\\repo\\skills\\deep-interview\\SKILL.md')).toBe('deep-interview');
+    expect(skillNameFromSkillFilePath('C:\\repo\\skills\\nested.skill\\SKILL.md')).toBe('nested.skill');
   });
 
   it('fails check when the locked deterministic surface digest regresses', async () => {

--- a/src/cli/commands/__tests__/capabilities.test.ts
+++ b/src/cli/commands/__tests__/capabilities.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  buildCapabilitiesLockfile,
+  capabilitiesCheckCommand,
+  capabilitiesLockCommand,
+  runDeterministicCapabilityFixtures,
+  type CapabilitiesLockfile,
+} from '../capabilities.js';
+
+async function withTempCwd<T>(fn: (cwd: string) => Promise<T>): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), 'omc-capabilities-'));
+  const originalCwd = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await fn(cwd);
+  } finally {
+    process.chdir(originalCwd);
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('capabilities lock/check', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+  });
+
+  it('writes a deterministic lockfile and checks it successfully', async () => {
+    await withTempCwd(async (cwd) => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const lockfile = join(cwd, 'capabilities.lock.json');
+
+      await expect(capabilitiesLockCommand({ json: true, lockfile })).resolves.toBe(0);
+      await expect(capabilitiesCheckCommand({ json: true, lockfile })).resolves.toBe(0);
+
+      const written = JSON.parse(await readFile(lockfile, 'utf-8')) as CapabilitiesLockfile;
+      expect(written.schemaVersion).toBe('1.0');
+      expect(written.surfaceDigest).toMatch(/^[a-f0-9]{64}$/);
+      expect(written.surface.contract).toMatchObject({
+        runner: 'deterministic-local',
+        liveProbeCompatible: true,
+      });
+      expect(written.fixtureResults.every((result) => result.ok)).toBe(true);
+      expect(logSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('returns a machine-readable failure for a missing lockfile', async () => {
+    await withTempCwd(async (cwd) => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const exitCode = await capabilitiesCheckCommand({ json: true, lockfile: join(cwd, 'missing.json') });
+
+      expect(exitCode).toBe(1);
+      const report = JSON.parse(String(logSpy.mock.calls[0]?.[0]));
+      expect(report.ok).toBe(false);
+      expect(report.failures[0].code).toBe('lockfile_missing');
+    });
+  });
+
+  it('checks required-arg, hallucinated-tool, and no-tool restraint fixtures', () => {
+    const lockfile = buildCapabilitiesLockfile();
+    const results = runDeterministicCapabilityFixtures(lockfile.fixtures, lockfile.surface);
+
+    expect(results.find((result) => result.kind === 'required_args')).toMatchObject({ ok: true, outcome: 'pass' });
+    expect(results.find((result) => result.kind === 'no_hallucinated_tool')).toMatchObject({ ok: true, outcome: 'pass' });
+    expect(results.find((result) => result.kind === 'tool_restraint')).toMatchObject({ ok: true, outcome: 'pass' });
+  });
+
+  it('fails check when the locked deterministic surface digest regresses', async () => {
+    await withTempCwd(async (cwd) => {
+      vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const lockfilePath = join(cwd, 'capabilities.lock.json');
+      const lockfile = buildCapabilitiesLockfile();
+      lockfile.surfaceDigest = '0'.repeat(64);
+      await writeFile(lockfilePath, `${JSON.stringify(lockfile, null, 2)}\n`);
+
+      const exitCode = await capabilitiesCheckCommand({ lockfile: lockfilePath });
+
+      expect(exitCode).toBe(1);
+      expect(errorSpy.mock.calls.flat().join('\n')).toContain('surface_digest_mismatch');
+    });
+  });
+});

--- a/src/cli/commands/capabilities.ts
+++ b/src/cli/commands/capabilities.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { z } from 'zod';
 import { allCustomTools, toSdkToolFormat } from '../../tools/index.js';
 import { getAgentDefinitions } from '../../agents/definitions.js';
@@ -162,6 +162,11 @@ function readSkillTitle(markdown: string): string | null {
   const heading = markdown.split('\n').find((line) => line.startsWith('# '));
   return heading ? heading.slice(2).trim() : null;
 }
+export function skillNameFromSkillFilePath(skillFilePath: string): string {
+  const normalizedPath = skillFilePath.replace(/\\/g, '/');
+  return basename(dirname(normalizedPath)) || skillFilePath;
+}
+
 function normalizeToolSchema(schema: unknown): z.ZodRawShape {
   return schema instanceof z.ZodObject ? schema.shape : schema as z.ZodRawShape;
 }
@@ -197,7 +202,7 @@ export function collectCapabilitySurface(root = packageRoot()): CapabilitySurfac
     .map((path) => {
       const markdown = readFileSync(path, 'utf-8');
       return {
-        name: path.split('/').at(-2) ?? path,
+        name: skillNameFromSkillFilePath(path),
         digest: sha256(markdown),
         title: readSkillTitle(markdown),
       };
@@ -374,6 +379,16 @@ export function checkCapabilitiesLockfile(lockfilePath: string): CapabilitiesChe
   const surfaceDigest = digestCapabilitySurface(surface);
   const fixtureResults = runDeterministicCapabilityFixtures(locked.fixtures, surface);
   const failures: CapabilitiesCheckFailure[] = [];
+  const lockedSurfaceDigest = digestCapabilitySurface(locked.surface);
+
+  if (lockedSurfaceDigest !== locked.surfaceDigest) {
+    failures.push({
+      code: 'lockfile_surface_digest_mismatch',
+      message: 'Locked capability surface body digest differs from the recorded lockfile digest.',
+      expected: locked.surfaceDigest,
+      actual: lockedSurfaceDigest,
+    });
+  }
 
   if (surfaceDigest !== locked.surfaceDigest) {
     failures.push({

--- a/src/cli/commands/capabilities.ts
+++ b/src/cli/commands/capabilities.ts
@@ -1,0 +1,475 @@
+import { createHash } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { z } from 'zod';
+import { allCustomTools, toSdkToolFormat } from '../../tools/index.js';
+import { getAgentDefinitions } from '../../agents/definitions.js';
+
+export const CAPABILITIES_LOCK_SCHEMA_VERSION = '1.0';
+export const DEFAULT_CAPABILITIES_LOCKFILE = 'omc-capabilities.lock.json';
+
+type FixtureKind =
+  | 'tool_selection'
+  | 'arg_validity'
+  | 'required_args'
+  | 'structured_output'
+  | 'no_hallucinated_tool'
+  | 'tool_restraint';
+
+type FixtureExpectedOutcome = 'pass' | 'fail';
+
+export interface CapabilityFixture {
+  id: string;
+  kind: FixtureKind;
+  description: string;
+  expectedOutcome: FixtureExpectedOutcome;
+  toolName?: string;
+  args?: Record<string, unknown>;
+  expectedToolName?: string;
+}
+
+export interface CapabilityFixtureResult {
+  id: string;
+  kind: FixtureKind;
+  ok: boolean;
+  outcome: FixtureExpectedOutcome;
+  message: string;
+}
+
+interface CapabilityToolSurface {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required: string[];
+  };
+}
+
+interface CapabilityAgentSurface {
+  name: string;
+  description: string;
+  tools: string[] | null;
+  disallowedTools: string[];
+  model: string | null;
+  defaultModel: string | null;
+}
+
+interface CapabilitySkillSurface {
+  name: string;
+  digest: string;
+  title: string | null;
+}
+
+interface CapabilitySurface {
+  schemaVersion: string;
+  generatedBy: 'omc capabilities';
+  contract: {
+    runner: 'deterministic-local';
+    liveProbeCompatible: true;
+    fixtureKinds: FixtureKind[];
+  };
+  tools: CapabilityToolSurface[];
+  agents: CapabilityAgentSurface[];
+  skills: CapabilitySkillSurface[];
+}
+
+export interface CapabilitiesLockfile {
+  schemaVersion: string;
+  generatedBy: 'omc capabilities lock';
+  surfaceDigest: string;
+  surface: CapabilitySurface;
+  fixtures: CapabilityFixture[];
+  fixtureResults: CapabilityFixtureResult[];
+}
+
+interface CapabilitiesCheckFailure {
+  code: string;
+  message: string;
+  expected?: unknown;
+  actual?: unknown;
+}
+
+export interface CapabilitiesCheckReport {
+  ok: boolean;
+  lockfile: string;
+  surfaceDigest: string;
+  lockedSurfaceDigest: string;
+  failures: CapabilitiesCheckFailure[];
+  fixtureResults: CapabilityFixtureResult[];
+}
+
+interface CapabilityCommandOptions {
+  json?: boolean;
+  lockfile?: string;
+}
+
+const FIXTURE_KINDS: FixtureKind[] = [
+  'tool_selection',
+  'arg_validity',
+  'required_args',
+  'structured_output',
+  'no_hallucinated_tool',
+  'tool_restraint',
+];
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJson(value), null, 2);
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, entry]) => [key, sortJson(entry)]),
+    );
+  }
+  return value;
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function resolveLockfilePath(lockfile?: string): string {
+  return resolve(process.cwd(), lockfile ?? DEFAULT_CAPABILITIES_LOCKFILE);
+}
+
+function packageRoot(): string {
+  if (typeof __dirname !== 'undefined' && __dirname) {
+    const fromSrc = resolve(__dirname, '..', '..', '..');
+    const fromDist = resolve(__dirname, '..', '..');
+    if (existsSync(join(fromSrc, 'package.json'))) return fromSrc;
+    if (existsSync(join(fromDist, 'package.json'))) return fromDist;
+  }
+  return process.cwd();
+}
+
+function listSkillFiles(root: string): string[] {
+  const skillsDir = join(root, 'skills');
+  if (!existsSync(skillsDir)) return [];
+  const names = readdirSync(skillsDir).sort((a, b) => a.localeCompare(b));
+  return names
+    .map((name) => join(skillsDir, name, 'SKILL.md'))
+    .filter((path) => existsSync(path) && statSync(path).isFile());
+}
+
+function readSkillTitle(markdown: string): string | null {
+  const heading = markdown.split('\n').find((line) => line.startsWith('# '));
+  return heading ? heading.slice(2).trim() : null;
+}
+function normalizeToolSchema(schema: unknown): z.ZodRawShape {
+  return schema instanceof z.ZodObject ? schema.shape : schema as z.ZodRawShape;
+}
+
+
+export function collectCapabilitySurface(root = packageRoot()): CapabilitySurface {
+  const tools = allCustomTools
+    .map((tool) => ({ ...tool, schema: normalizeToolSchema(tool.schema) }))
+    .map((tool) => toSdkToolFormat(tool))
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: {
+        ...tool.inputSchema,
+        required: [...tool.inputSchema.required].sort((a, b) => a.localeCompare(b)),
+        properties: sortJson(tool.inputSchema.properties) as Record<string, unknown>,
+      },
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const agents = Object.entries(getAgentDefinitions({ config: {} }))
+    .map(([name, agent]) => ({
+      name,
+      description: agent.description,
+      tools: agent.tools ? [...agent.tools].sort((a, b) => a.localeCompare(b)) : null,
+      disallowedTools: [...(agent.disallowedTools ?? [])].sort((a, b) => a.localeCompare(b)),
+      model: agent.model ?? null,
+      defaultModel: agent.defaultModel ?? null,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const skills = listSkillFiles(root)
+    .map((path) => {
+      const markdown = readFileSync(path, 'utf-8');
+      return {
+        name: path.split('/').at(-2) ?? path,
+        digest: sha256(markdown),
+        title: readSkillTitle(markdown),
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    schemaVersion: CAPABILITIES_LOCK_SCHEMA_VERSION,
+    generatedBy: 'omc capabilities',
+    contract: {
+      runner: 'deterministic-local',
+      liveProbeCompatible: true,
+      fixtureKinds: FIXTURE_KINDS,
+    },
+    tools,
+    agents,
+    skills,
+  };
+}
+
+export function digestCapabilitySurface(surface: CapabilitySurface): string {
+  return sha256(stableStringify(surface));
+}
+
+function findRequiredArgTool(): CapabilityToolSurface | undefined {
+  return collectCapabilitySurface().tools.find((tool) => tool.inputSchema.required.length > 0);
+}
+function supportsSimpleStringFixture(tool: CapabilityToolSurface): boolean {
+  return tool.inputSchema.required.length > 0 && tool.inputSchema.required.every((name) => {
+    const property = tool.inputSchema.properties[name] as { type?: unknown; enum?: unknown } | undefined;
+    return property?.type === 'string' && property.enum === undefined;
+  });
+}
+
+
+export function defaultCapabilityFixtures(surface = collectCapabilitySurface()): CapabilityFixture[] {
+  const requiredArgTool = surface.tools.find(supportsSimpleStringFixture) ?? surface.tools.find((tool) => tool.inputSchema.required.length > 0);
+  const selectedTool = requiredArgTool ?? surface.tools[0];
+  const validArgs = Object.fromEntries((requiredArgTool?.inputSchema.required ?? []).map((name) => [name, 'fixture-value']));
+
+  return [
+    {
+      id: 'deterministic-tool-selection',
+      kind: 'tool_selection',
+      description: 'A known tool requested by name resolves to the declared tool surface.',
+      expectedOutcome: 'pass',
+      toolName: selectedTool?.name,
+      expectedToolName: selectedTool?.name,
+    },
+    {
+      id: 'deterministic-arg-validity',
+      kind: 'arg_validity',
+      description: 'A deterministic fixture with required args validates against the tool schema.',
+      expectedOutcome: 'pass',
+      toolName: requiredArgTool?.name,
+      args: validArgs,
+    },
+    {
+      id: 'deterministic-required-args',
+      kind: 'required_args',
+      description: 'A deterministic fixture omitting required args is rejected by the tool schema.',
+      expectedOutcome: 'pass',
+      toolName: requiredArgTool?.name,
+      args: {},
+    },
+    {
+      id: 'deterministic-structured-output',
+      kind: 'structured_output',
+      description: 'Fixture results keep a stable machine-readable result envelope.',
+      expectedOutcome: 'pass',
+    },
+    {
+      id: 'deterministic-no-hallucinated-tool',
+      kind: 'no_hallucinated_tool',
+      description: 'A requested tool that is absent from the surface is rejected.',
+      expectedOutcome: 'pass',
+      toolName: 'omc_nonexistent_hallucinated_tool',
+    },
+    {
+      id: 'deterministic-tool-restraint',
+      kind: 'tool_restraint',
+      description: 'A no-tool fixture does not select any tool.',
+      expectedOutcome: 'pass',
+    },
+  ];
+}
+
+function validateToolArgs(toolName: string | undefined, args: Record<string, unknown> | undefined): { ok: boolean; message: string } {
+  if (!toolName) {
+    return { ok: false, message: 'fixture did not name a tool' };
+  }
+  const tool = allCustomTools.find((candidate) => candidate.name === toolName);
+  if (!tool) {
+    return { ok: false, message: `tool not found: ${toolName}` };
+  }
+  const result = z.object(normalizeToolSchema(tool.schema)).safeParse(args ?? {});
+  if (result.success) {
+    return { ok: true, message: 'args valid' };
+  }
+  return { ok: false, message: result.error.issues.map((issue) => issue.path.join('.') || issue.message).join('; ') };
+}
+
+export function runDeterministicCapabilityFixtures(
+  fixtures: CapabilityFixture[],
+  surface = collectCapabilitySurface(),
+): CapabilityFixtureResult[] {
+  const toolNames = new Set(surface.tools.map((tool) => tool.name));
+
+  return fixtures.map((fixture) => {
+    let condition = false;
+    let message = 'fixture kind not implemented';
+
+    if (fixture.kind === 'tool_selection') {
+      condition = !!fixture.toolName && toolNames.has(fixture.toolName) && fixture.toolName === fixture.expectedToolName;
+      message = condition ? `selected ${fixture.toolName}` : `could not select ${fixture.toolName ?? '<missing>'}`;
+    } else if (fixture.kind === 'arg_validity') {
+      const validation = validateToolArgs(fixture.toolName, fixture.args);
+      condition = validation.ok;
+      message = validation.message;
+    } else if (fixture.kind === 'required_args') {
+      const tool = surface.tools.find((candidate) => candidate.name === fixture.toolName);
+      const validation = validateToolArgs(fixture.toolName, fixture.args);
+      condition = !!tool && tool.inputSchema.required.length > 0 && !validation.ok;
+      message = condition ? 'missing required args rejected' : `missing required args were not rejected: ${validation.message}`;
+    } else if (fixture.kind === 'structured_output') {
+      condition = true;
+      message = 'structured fixture envelope emitted';
+    } else if (fixture.kind === 'no_hallucinated_tool') {
+      condition = !fixture.toolName || !toolNames.has(fixture.toolName);
+      message = condition ? `rejected absent tool ${fixture.toolName ?? '<none>'}` : `accepted unexpected tool ${fixture.toolName}`;
+    } else if (fixture.kind === 'tool_restraint') {
+      condition = !fixture.toolName;
+      message = condition ? 'no tool selected' : `unexpected tool selected: ${fixture.toolName}`;
+    }
+
+    const ok = fixture.expectedOutcome === 'pass' ? condition : !condition;
+    return {
+      id: fixture.id,
+      kind: fixture.kind,
+      ok,
+      outcome: ok ? 'pass' : 'fail',
+      message,
+    };
+  });
+}
+
+export function buildCapabilitiesLockfile(): CapabilitiesLockfile {
+  const surface = collectCapabilitySurface();
+  const fixtures = defaultCapabilityFixtures(surface);
+  return {
+    schemaVersion: CAPABILITIES_LOCK_SCHEMA_VERSION,
+    generatedBy: 'omc capabilities lock',
+    surfaceDigest: digestCapabilitySurface(surface),
+    surface,
+    fixtures,
+    fixtureResults: runDeterministicCapabilityFixtures(fixtures, surface),
+  };
+}
+
+function parseLockfile(path: string): CapabilitiesLockfile {
+  const parsed = JSON.parse(readFileSync(path, 'utf-8')) as CapabilitiesLockfile;
+  if (parsed.schemaVersion !== CAPABILITIES_LOCK_SCHEMA_VERSION) {
+    throw new Error(`unsupported capabilities lockfile schema: ${parsed.schemaVersion ?? '<missing>'}`);
+  }
+  if (!Array.isArray(parsed.fixtures) || !Array.isArray(parsed.fixtureResults)) {
+    throw new Error('invalid capabilities lockfile: missing fixtures or fixtureResults');
+  }
+  return parsed;
+}
+
+export function checkCapabilitiesLockfile(lockfilePath: string): CapabilitiesCheckReport {
+  const locked = parseLockfile(lockfilePath);
+  const surface = collectCapabilitySurface();
+  const surfaceDigest = digestCapabilitySurface(surface);
+  const fixtureResults = runDeterministicCapabilityFixtures(locked.fixtures, surface);
+  const failures: CapabilitiesCheckFailure[] = [];
+
+  if (surfaceDigest !== locked.surfaceDigest) {
+    failures.push({
+      code: 'surface_digest_mismatch',
+      message: 'Current deterministic tool/skill/capability surface digest differs from lockfile.',
+      expected: locked.surfaceDigest,
+      actual: surfaceDigest,
+    });
+  }
+
+  const lockedResultById = new Map(locked.fixtureResults.map((result) => [result.id, result]));
+  for (const result of fixtureResults) {
+    const expected = lockedResultById.get(result.id);
+    if (!expected) {
+      failures.push({
+        code: 'fixture_result_missing_from_lockfile',
+        message: `Fixture ${result.id} is not recorded in the lockfile.`,
+        actual: result,
+      });
+      continue;
+    }
+    if (!result.ok || result.outcome !== expected.outcome || result.ok !== expected.ok) {
+      failures.push({
+        code: 'fixture_result_mismatch',
+        message: `Fixture ${result.id} result changed or failed.`,
+        expected,
+        actual: result,
+      });
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    lockfile: lockfilePath,
+    surfaceDigest,
+    lockedSurfaceDigest: locked.surfaceDigest,
+    failures,
+    fixtureResults,
+  };
+}
+
+function printLockSummary(lockfilePath: string, lockfile: CapabilitiesLockfile, json?: boolean): void {
+  if (json) {
+    console.log(stableStringify({ ok: true, lockfile: lockfilePath, surfaceDigest: lockfile.surfaceDigest, fixtureResults: lockfile.fixtureResults }));
+    return;
+  }
+  console.log(`Capabilities lockfile written: ${lockfilePath}`);
+  console.log(`Surface digest: ${lockfile.surfaceDigest}`);
+  console.log(`Fixtures: ${lockfile.fixtureResults.filter((result) => result.ok).length}/${lockfile.fixtureResults.length} passed`);
+}
+
+function printCheckReport(report: CapabilitiesCheckReport, json?: boolean): void {
+  if (json) {
+    console.log(stableStringify(report));
+    return;
+  }
+  if (report.ok) {
+    console.log(`Capabilities check passed: ${report.lockfile}`);
+    console.log(`Surface digest: ${report.surfaceDigest}`);
+    console.log(`Fixtures: ${report.fixtureResults.filter((result) => result.ok).length}/${report.fixtureResults.length} passed`);
+    return;
+  }
+  console.error(`Capabilities check failed: ${report.lockfile}`);
+  for (const failure of report.failures) {
+    console.error(`- ${failure.code}: ${failure.message}`);
+  }
+}
+
+export async function capabilitiesLockCommand(options: CapabilityCommandOptions): Promise<number> {
+  const lockfilePath = resolveLockfilePath(options.lockfile);
+  const lockfile = buildCapabilitiesLockfile();
+  mkdirSync(dirname(lockfilePath), { recursive: true });
+  writeFileSync(lockfilePath, `${stableStringify(lockfile)}\n`);
+  printLockSummary(lockfilePath, lockfile, options.json);
+  return lockfile.fixtureResults.every((result) => result.ok) ? 0 : 1;
+}
+
+export async function capabilitiesCheckCommand(options: CapabilityCommandOptions): Promise<number> {
+  const lockfilePath = resolveLockfilePath(options.lockfile);
+  if (!existsSync(lockfilePath)) {
+    const report: CapabilitiesCheckReport = {
+      ok: false,
+      lockfile: lockfilePath,
+      surfaceDigest: digestCapabilitySurface(collectCapabilitySurface()),
+      lockedSurfaceDigest: '',
+      failures: [{ code: 'lockfile_missing', message: `Capabilities lockfile not found: ${lockfilePath}` }],
+      fixtureResults: [],
+    };
+    printCheckReport(report, options.json);
+    return 1;
+  }
+  const report = checkCapabilitiesLockfile(lockfilePath);
+  printCheckReport(report, options.json);
+  return report.ok ? 0 : 1;
+}
+
+export function __capabilitiesTestOnly(): { requiredArgTool?: string } {
+  return { requiredArgTool: findRequiredArgTool()?.name };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ import {
 } from './commands/wait.js';
 import { doctorConflictsCommand } from './commands/doctor-conflicts.js';
 import { doctorTeamRoutingCommand } from './commands/doctor-team-routing.js';
+import { capabilitiesCheckCommand, capabilitiesLockCommand } from './commands/capabilities.js';
 import { sessionSearchCommand } from './commands/session-search.js';
 import { sessionFrictionReportCommand } from './commands/session-friction-report.js';
 import { teamCommand } from './commands/team.js';
@@ -1189,6 +1190,38 @@ sessionCmd
       json: options.json,
       workingDirectory: process.cwd(),
     });
+  });
+
+/**
+ * Capabilities command - deterministic tool/skill/capability lockfile preflight
+ */
+const capabilitiesCmd = program
+  .command('capabilities')
+  .description('Create or verify deterministic tool/skill/capability lockfiles')
+  .addHelpText('after', `
+Examples:
+  $ omc capabilities lock
+  $ omc capabilities lock --json --lockfile .omc/capabilities.lock.json
+  $ omc capabilities check --json`);
+
+capabilitiesCmd
+  .command('lock')
+  .description('Write the current deterministic tool/skill/capability lockfile')
+  .option('--json', 'Output as JSON')
+  .option('--lockfile <path>', 'Lockfile path (default: omc-capabilities.lock.json)')
+  .action(async (options) => {
+    const exitCode = await capabilitiesLockCommand(options);
+    process.exit(exitCode);
+  });
+
+capabilitiesCmd
+  .command('check')
+  .description('Check current deterministic tool/skill/capability surface against a lockfile')
+  .option('--json', 'Output as JSON')
+  .option('--lockfile <path>', 'Lockfile path (default: omc-capabilities.lock.json)')
+  .action(async (options) => {
+    const exitCode = await capabilitiesCheckCommand(options);
+    process.exit(exitCode);
   });
 
 /**


### PR DESCRIPTION
Closes #3439

## Summary
- add `omc capabilities lock/check` for deterministic tool/skill/capability surface preflight
- record a stable surface digest and live-probe-compatible fixture contract/results
- validate tool selection, arg validity, missing required args, structured output, hallucinated tools, and no-tool restraint deterministically

## Validation
- `npm test -- src/cli/commands/__tests__/capabilities.test.ts src/cli/__tests__/cli-boot.test.ts` — 8 passed
- `npx tsc --noEmit` — passed
- `npm run lint` — passed with 19 pre-existing warnings, 0 errors
- `npm run build` — passed
- `node bridge/cli.cjs capabilities lock --json --lockfile /tmp/omc-capabilities-test.lock.json && node bridge/cli.cjs capabilities check --json --lockfile /tmp/omc-capabilities-test.lock.json` — passed
- `node bridge/cli.cjs capabilities lock --lockfile` — exits 1 with missing option argument

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
