### PR TITLE
docs(providers): note Gemini CLI free-tier shutdown, recommend agy

### DIFF
--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -52,6 +52,7 @@ cursor-agent --version
   any installer before running it). Verify: `agy --version`
   > **Platform note:** `omc ask antigravity` is supported on macOS/Linux. On Windows it is guarded with a clear error, because `agy --print` takes the prompt as an argv value (it cannot read stdin) and has known upstream Windows `-p` limitations; use `omc ask gemini` on Windows.
 - **Gemini CLI** remains supported for enterprise/API-key use cases.
+  > **Note:** As of 2026-06-18, Google discontinued the Gemini CLI's free/personal tier (free, AI Pro, and Ultra accounts). For free usage, use Antigravity (`agy`) instead. Gemini remains fully supported via a paid Gemini API key or Gemini Code Assist Standard/Enterprise. ([announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/))
 
 ## Artifacts
 

--- a/skills/omc-setup/phases/03-integrations.md
+++ b/skills/omc-setup/phases/03-integrations.md
@@ -148,6 +148,8 @@ Use AskUserQuestion with multiple questions:
 3. **gemini** - Use Gemini CLI workers by default when installed (enterprise/API-key tier)
 4. **antigravity** - Use Antigravity CLI (`agy`) workers by default when installed; Google's successor to the Gemini CLI (install per the [official instructions](https://antigravity.google))
 
+> **Note:** As of 2026-06-18, Google discontinued the Gemini CLI's free/personal tier (free, AI Pro, and Ultra accounts). For free usage, choose **antigravity** (`agy`) instead. Gemini remains fully supported via a paid Gemini API key or Gemini Code Assist Standard/Enterprise. ([announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/))
+
 Store the team configuration in `~/.claude/.omc-config.json`:
 
 ```bash


### PR DESCRIPTION
## What

Adds a short, factual user-facing notice to two setup/advisor docs explaining that Google discontinued the Gemini CLI's **free/personal** tier (free, AI Pro, and Ultra personal accounts) as of **2026-06-18**, and recommending Antigravity (`agy`) for free usage.

Source: [Transitioning Gemini CLI to Antigravity CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) (announced 2026-05-19, effective 2026-06-18).

## Why

The repo already supports both `gemini` and `antigravity` (`agy`) providers. New users who pick `gemini` expecting free personal-account access will hit an auth wall with no in-docs explanation. This adds a one-line pointer so free-tier users know to choose `agy`.

## Scope

- **Docs-only**, non-breaking. No provider logic, types, routing, or keyword-detector changes.
- Gemini is **not** deprecated or removed — the notice explicitly states it remains fully supported via a paid Gemini API key or Gemini Code Assist Standard/Enterprise.

## Files changed

- `skills/ask/SKILL.md` — note appended to the existing Gemini CLI requirements bullet.
- `skills/omc-setup/phases/03-integrations.md` — note added after the team provider options list.

## Verification

- `npm run build` — passed
- `npm run lint` — passed (0 errors)
- `npm run test:run` — passed (the only 2 failures were pre-existing environmentally-flaky timing/perf tests unrelated to these docs; both pass on isolated rerun)
- No `dist/` or `bridge/` artifacts committed.
