### PR TITLE
fix(installer): remove legacy pre-marker OMC guides by exact historical match

### DIFF
--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -578,6 +578,52 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
     const status = checkClaudeMdStatus();
     expect(status).toBeNull();
   });
+
+  // A block carrying legacy fingerprints. Used both inside and outside markers.
+  const legacyBody = [
+    '# oh-my-claudecode - Intelligent Multi-Agent Orchestration',
+    'You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**',
+    '',
+    '## PART 1: CORE PROTOCOL (CRITICAL)',
+    '',
+    "The difference? You don't NEED them anymore. Everything auto-activates."
+  ].join('\n');
+
+  it('(d) does not flag fingerprints that live only inside a valid marker block', () => {
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE.md'),
+      `<!-- OMC:START -->\n${legacyBody}\n<!-- OMC:END -->\n`
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasMarkers).toBe(true);
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(false);
+  });
+
+  it('flags legacy content that lives outside the marker block', () => {
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE.md'),
+      `<!-- OMC:START -->\n# OMC Config\n<!-- OMC:END -->\n\n<!-- User customizations -->\n${legacyBody}\n`
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(true);
+  });
+
+  it('(e) reports legacy content living in the companion file, not only the main file', () => {
+    // Main file has no markers and no legacy content; companion holds the markers
+    // and the residual legacy guide outside them.
+    writeFileSync(join(TEST_CLAUDE_DIR, 'CLAUDE.md'), '# My clean config\nSee CLAUDE-omc.md\n');
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE-omc.md'),
+      `<!-- OMC:START -->\n# OMC Config\n<!-- OMC:END -->\n\n<!-- User customizations -->\n${legacyBody}\n`
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasMarkers).toBe(true);
+    expect(status!.companionFile).toContain('CLAUDE-omc.md');
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(true);
+  });
 });
 
 describe('doctor-conflicts: legacy skills collision check (issue #1101)', () => {

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -6,7 +6,7 @@
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
-import { isOmcHook } from '../../installer/index.js';
+import { isOmcHook, hasLegacyUnmarkedOmcContent } from '../../installer/index.js';
 import { colors } from '../utils/formatting.js';
 import { getSkillsDir, listBuiltinSkillNames } from '../../features/builtin-skills/skills.js';
 import { inspectUnifiedMcpRegistrySync } from '../../installer/mcp-registry.js';
@@ -25,7 +25,7 @@ export interface WorkspaceMarkerStatus {
 
 export interface ConflictReport {
   hookConflicts: { event: string; command: string; isOmc: boolean }[];
-  claudeMdStatus: { hasMarkers: boolean; hasUserContent: boolean; path: string; companionFile?: string } | null;
+  claudeMdStatus: { hasMarkers: boolean; hasUserContent: boolean; hasLegacyUnmarkedOmcContent: boolean; path: string; companionFile?: string } | null;
   legacySkills: { name: string; path: string }[];
   envFlags: { disableOmc: boolean; skipHooks: string[] };
   configIssues: { unknownFields: string[] };
@@ -161,9 +161,11 @@ export function checkWindowsUnsafePluginHooks(): ConflictReport['windowsUnsafePl
 
 /**
  * Check a single file for OMC markers.
- * Returns { hasMarkers, hasUserContent } or null on error.
+ * Returns { hasMarkers, hasUserContent, hasLegacyUnmarkedOmcContent } or null on error.
  */
-function checkFileForOmcMarkers(filePath: string): { hasMarkers: boolean; hasUserContent: boolean } | null {
+function checkFileForOmcMarkers(
+  filePath: string
+): { hasMarkers: boolean; hasUserContent: boolean; hasLegacyUnmarkedOmcContent: boolean } | null {
   if (!existsSync(filePath)) return null;
   try {
     const content = readFileSync(filePath, 'utf-8');
@@ -181,7 +183,9 @@ function checkFileForOmcMarkers(filePath: string): { hasMarkers: boolean; hasUse
     } else {
       hasUserContent = content.trim().length > 0;
     }
-    return { hasMarkers, hasUserContent };
+    // Only content OUTSIDE complete OMC marker blocks counts as legacy; fingerprints
+    // inside a valid current block are expected and must not be flagged.
+    return { hasMarkers, hasUserContent, hasLegacyUnmarkedOmcContent: hasLegacyUnmarkedOmcContent(content) };
   } catch {
     return null;
   }
@@ -224,6 +228,7 @@ export function checkClaudeMdStatus(): ConflictReport['claudeMdStatus'] {
       return {
         hasMarkers: true,
         hasUserContent: mainResult.hasUserContent,
+        hasLegacyUnmarkedOmcContent: mainResult.hasLegacyUnmarkedOmcContent,
         path: claudeMdPath
       };
     }
@@ -236,6 +241,9 @@ export function checkClaudeMdStatus(): ConflictReport['claudeMdStatus'] {
         return {
           hasMarkers: true,
           hasUserContent: mainResult.hasUserContent,
+          // Legacy content may live in either the main file or the companion.
+          hasLegacyUnmarkedOmcContent:
+            mainResult.hasLegacyUnmarkedOmcContent || companionResult.hasLegacyUnmarkedOmcContent,
           path: claudeMdPath,
           companionFile: companionPath
         };
@@ -251,6 +259,7 @@ export function checkClaudeMdStatus(): ConflictReport['claudeMdStatus'] {
       return {
         hasMarkers: false,
         hasUserContent: mainResult.hasUserContent,
+        hasLegacyUnmarkedOmcContent: mainResult.hasLegacyUnmarkedOmcContent,
         path: claudeMdPath,
         companionFile: join(configDir, refMatch[0])
       };
@@ -259,6 +268,7 @@ export function checkClaudeMdStatus(): ConflictReport['claudeMdStatus'] {
     return {
       hasMarkers: false,
       hasUserContent: mainResult.hasUserContent,
+      hasLegacyUnmarkedOmcContent: mainResult.hasLegacyUnmarkedOmcContent,
       path: claudeMdPath
     };
   } catch (_error) {
@@ -558,7 +568,8 @@ export function runConflictCheck(): ConflictReport {
     mcpRegistrySync.claudeMissing.length > 0 ||
     mcpRegistrySync.claudeMismatched.length > 0 ||
     mcpRegistrySync.codexMissing.length > 0 ||
-    mcpRegistrySync.codexMismatched.length > 0;
+    mcpRegistrySync.codexMismatched.length > 0 ||
+    (claudeMdStatus?.hasLegacyUnmarkedOmcContent ?? false); // Residual pre-marker OMC guide outside markers
     // Note: Missing OMC markers is informational (normal for fresh install), not a conflict
     // Note: workspaceMarker.precedenceConflict is a WARN, not a hard conflict
 
@@ -628,6 +639,12 @@ export function formatReport(report: ConflictReport, json: boolean): string {
       if (report.claudeMdStatus.hasUserContent) {
         lines.push(`  ${colors.blue('ℹ')} User content present - will be preserved`);
       }
+    }
+    if (report.claudeMdStatus.hasLegacyUnmarkedOmcContent) {
+      lines.push(`  ${colors.yellow('⚠')} Legacy pre-marker OMC guide detected outside markers`);
+      lines.push(`    ${colors.gray('This duplicates the current OMC instructions and inflates every session.')}`);
+      lines.push(`    ${colors.gray('Re-run /oh-my-claudecode:omc-setup to strip exact historical copies')}`);
+      lines.push(`    ${colors.gray('(a timestamped CLAUDE.md backup is written first); review any leftover by hand.')}`);
     }
     lines.push(`  ${colors.gray(`Path: ${report.claudeMdStatus.path}`)}`);
     lines.push('');

--- a/src/installer/__tests__/claude-md-merge.test.ts
+++ b/src/installer/__tests__/claude-md-merge.test.ts
@@ -3,13 +3,22 @@
  * Tests merge-based CLAUDE.md updates with markers and backups
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
-import { mergeClaudeMd } from '../index.js';
+import { mergeClaudeMd, hasLegacyUnmarkedOmcContent, hasLegacyTemplateMatch } from '../index.js';
 
 const START_MARKER = '<!-- OMC:START -->';
 const END_MARKER = '<!-- OMC:END -->';
 const USER_CUSTOMIZATIONS = '<!-- User customizations -->';
 const USER_CUSTOMIZATIONS_RECOVERED = '<!-- User customizations (recovered from corrupted markers) -->';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const readLegacyGuide = (name: string): string =>
+  readFileSync(join(FIXTURES_DIR, name), 'utf-8').replace(/\n+$/, '');
+const LEGACY_HEADING = '# oh-my-claudecode - Intelligent Multi-Agent Orchestration';
+const CONDUCTOR = 'You are a CONDUCTOR, not a performer';
 
 describe('mergeClaudeMd', () => {
   const omcContent = '# OMC Configuration\n\nThis is the OMC content.';
@@ -377,6 +386,117 @@ Second user note`;
 
       expect((result.match(/<!-- User customizations/g) || []).length).toBe(1);
       expect(result).toContain(`${USER_CUSTOMIZATIONS}\nFirst user note\n\nSecond user note`);
+    });
+  });
+
+  describe('legacy unmarked OMC guide removal (exact historical templates)', () => {
+    const guide292 = readLegacyGuide('legacy-guide-292.md');
+    const guide583 = readLegacyGuide('legacy-guide-583.md');
+
+    // Simulate an upgraded CLAUDE.md: current marker block on top, then one or
+    // more legacy guides plus real user content preserved under customizations.
+    const buildUpgraded = (body: string): string =>
+      `${START_MARKER}\n${omcContent}\n${END_MARKER}\n\n${USER_CUSTOMIZATIONS}\n${body}`;
+
+    it('(a) fully removes the 583-line historical guide, keeping user content', () => {
+      const existing = buildUpgraded(`${guide583}\n\n@RTK.md`);
+      const result = mergeClaudeMd(existing, omcContent, '4.15.0');
+
+      expect(result).not.toContain(CONDUCTOR);
+      expect(result).not.toContain(LEGACY_HEADING);
+      expect(result).not.toContain('## PART 3: COMPLETE REFERENCE');
+      // The guide's final line must be gone (end-boundary proof, not fingerprint).
+      expect(result).not.toContain(guide583.split('\n').at(-1)!);
+      expect(result).toContain('@RTK.md');
+      expect(result).toContain(omcContent);
+      expect(result).toContain('<!-- OMC:VERSION:4.15.0 -->');
+      expect(result.length).toBeLessThan(existing.length / 2);
+    });
+
+    it('(b) preserves user notes that merely quote two fingerprints (no false-positive span)', () => {
+      const body = [
+        'My orchestration playbook:',
+        `- I love the line "${CONDUCTOR}".`,
+        'KEEP-MIDDLE-USER-NOTE',
+        '- and remember "PART 1: CORE PROTOCOL" from the old guide.'
+      ].join('\n');
+      const result = mergeClaudeMd(buildUpgraded(body), omcContent);
+
+      expect(result).toContain('KEEP-MIDDLE-USER-NOTE');
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('PART 1: CORE PROTOCOL');
+    });
+
+    it('(b) preserves user notes with reversed fingerprint order and the shared heading above', () => {
+      const body = [
+        LEGACY_HEADING,
+        '- quoting "PART 1: CORE PROTOCOL" first,',
+        'KEEP-MIDDLE-USER-NOTE',
+        `- then "${CONDUCTOR}".`
+      ].join('\n');
+      const result = mergeClaudeMd(buildUpgraded(body), omcContent);
+
+      expect(result).toContain('KEEP-MIDDLE-USER-NOTE');
+      expect(result).toContain(LEGACY_HEADING);
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('PART 1: CORE PROTOCOL');
+    });
+
+    it('(c) removes two complete legacy blocks without spanning the user note between them', () => {
+      const body = `${guide292}\n\nMIDDLE-USER-NOTE\n\n${guide583}\n\n@RTK.md`;
+      const result = mergeClaudeMd(buildUpgraded(body), omcContent);
+
+      expect(result).not.toContain(CONDUCTOR); // both blocks gone
+      expect(result).not.toContain(LEGACY_HEADING);
+      expect(result).toContain('MIDDLE-USER-NOTE'); // content between blocks preserved
+      expect(result).toContain('@RTK.md');
+    });
+
+    it('(f) removes the 292-line historical guide (v1 scenario) and its CRLF variant', () => {
+      const existing = buildUpgraded(`${guide292}\n\n@RTK.md`);
+
+      const lf = mergeClaudeMd(existing, omcContent);
+      expect(lf).not.toContain(CONDUCTOR);
+      expect(lf).toContain('@RTK.md');
+
+      const crlf = mergeClaudeMd(existing.replace(/\n/g, '\r\n'), omcContent);
+      expect(crlf).not.toContain(CONDUCTOR);
+      expect(crlf).toContain('@RTK.md');
+    });
+
+    it('(g) shrinks a bloated file and is idempotent (never grows)', () => {
+      const existing = buildUpgraded(`${guide583}\n\n@RTK.md`);
+      const first = mergeClaudeMd(existing, omcContent, '4.15.0');
+      expect(first.length).toBeLessThan(existing.length);
+
+      // Re-running the merge on its own output must not regrow the file.
+      const second = mergeClaudeMd(first, omcContent, '4.15.0');
+      expect(second.length).toBeLessThanOrEqual(first.length);
+      expect(second).toContain('@RTK.md');
+      expect(second).not.toContain(CONDUCTOR);
+    });
+
+    it('fails closed on a near-miss variant (fingerprints present but no exact template match)', () => {
+      // A guide with an extra line inserted no longer matches any historical
+      // template and must be preserved verbatim rather than partially deleted.
+      const mutated = guide292.replace(CONDUCTOR, `${CONDUCTOR}\nMY-EXTRA-USER-LINE`);
+      const result = mergeClaudeMd(buildUpgraded(`${mutated}\n\n@RTK.md`), omcContent);
+
+      expect(result).toContain(CONDUCTOR); // preserved, not stripped
+      expect(result).toContain('@RTK.md');
+      // But the doctor heuristic still flags it for manual review.
+      expect(hasLegacyUnmarkedOmcContent(mutated)).toBe(true);
+      expect(hasLegacyTemplateMatch(mutated)).toBe(false);
+    });
+
+    it('exposes detection helpers scoped to content outside markers', () => {
+      expect(hasLegacyTemplateMatch(guide583)).toBe(true);
+      expect(hasLegacyUnmarkedOmcContent(guide292)).toBe(true);
+      expect(hasLegacyUnmarkedOmcContent('just my own notes')).toBe(false);
+
+      // Fingerprints living only inside a valid marker block are not flagged.
+      const insideMarkersOnly = `${START_MARKER}\n${guide292}\n${END_MARKER}\n`;
+      expect(hasLegacyUnmarkedOmcContent(insideMarkersOnly)).toBe(false);
     });
   });
 });

--- a/src/installer/__tests__/claude-md-target-resolution.test.ts
+++ b/src/installer/__tests__/claude-md-target-resolution.test.ts
@@ -80,6 +80,35 @@ describe('install() CLAUDE.md target resolution', () => {
     expect(backups).toHaveLength(1);
   });
 
+  it('shrinks a CLAUDE.md bloated with a legacy pre-marker guide (does not grow)', async () => {
+    const configClaudePath = join(testClaudeDir, 'CLAUDE.md');
+    const legacyGuide = readFileSync(
+      new URL('./fixtures/legacy-guide-583.md', import.meta.url),
+      'utf-8',
+    ).replace(/\n+$/, '');
+
+    // Simulate a pre-marker upgrade artifact: current marker block on top, the
+    // 583-line legacy guide preserved as "user customizations", plus a real
+    // user include that must survive.
+    const bloated =
+      '<!-- OMC:START -->\n<!-- OMC:VERSION:0.0.1 -->\n# Old OMC\n<!-- OMC:END -->\n\n' +
+      `<!-- User customizations -->\n${legacyGuide}\n\n@RTK.md\n`;
+    writeFileSync(configClaudePath, bloated);
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true, skipHud: true });
+
+    const updated = readFileSync(configClaudePath, 'utf-8');
+
+    expect(result.success).toBe(true);
+    expect(updated.length).toBeLessThan(bloated.length); // shrinks, never grows
+    expect(updated).not.toContain('You are a CONDUCTOR, not a performer');
+    expect(updated).toContain('@RTK.md'); // real user content preserved
+
+    const backups = readdirSync(testClaudeDir).filter(name => name.startsWith('CLAUDE.md.backup.'));
+    expect(backups).toHaveLength(1); // original safely backed up before overwrite
+  });
+
   it('preserves project-scoped behavior by skipping global CLAUDE.md writes', async () => {
     process.env.CLAUDE_PLUGIN_ROOT = join(tempRoot, 'project', '.claude', 'plugins', 'oh-my-claudecode');
     writeFileSync(join(testHomeDir, 'CLAUDE.md'), '# Home CLAUDE\nkeep me\n');

--- a/src/installer/__tests__/fixtures/legacy-guide-292.md
+++ b/src/installer/__tests__/fixtures/legacy-guide-292.md
@@ -1,0 +1,292 @@
+# oh-my-claudecode - Intelligent Multi-Agent Orchestration
+
+You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**
+
+---
+
+## PART 1: CORE PROTOCOL (CRITICAL)
+
+### DELEGATION-FIRST PHILOSOPHY
+
+**Your job is to ORCHESTRATE specialists, not to do work yourself.**
+
+```
+RULE 1: ALWAYS delegate substantive work to specialized agents
+RULE 2: ALWAYS invoke appropriate skills for recognized patterns
+RULE 3: NEVER do code changes directly - delegate to executor
+RULE 4: NEVER complete without Architect verification
+```
+
+### What You Do vs. Delegate
+
+| Action | YOU Do Directly | DELEGATE to Agent |
+|--------|-----------------|-------------------|
+| Read files for context | Yes | - |
+| Quick status checks | Yes | - |
+| Create/update todos | Yes | - |
+| Communicate with user | Yes | - |
+| Answer simple questions | Yes | - |
+| **Single-line code change** | NEVER | executor-low |
+| **Multi-file changes** | NEVER | executor / executor-high |
+| **Complex debugging** | NEVER | architect |
+| **UI/frontend work** | NEVER | designer |
+| **Documentation** | NEVER | writer |
+| **Deep analysis** | NEVER | architect / analyst |
+| **Codebase exploration** | NEVER | explore / explore-medium |
+| **Research tasks** | NEVER | researcher |
+| **Visual analysis** | NEVER | vision |
+
+### Mandatory Skill Invocation
+
+When you detect these patterns, you MUST invoke the corresponding skill:
+
+| Pattern Detected | MUST Invoke Skill |
+|------------------|-------------------|
+| Broad/vague request | `planner` (after explore for context) |
+| "don't stop", "must complete", "ralph" | `ralph` |
+| "fast", "parallel", "ulw", "ultrawork" | `ultrawork` |
+| "plan this", "plan the" | `plan` or `planner` |
+| "ralplan" keyword | `ralplan` |
+| UI/component/styling work | `frontend-ui-ux` (silent) |
+| Git/commit work | `git-master` (silent) |
+| "analyze", "debug", "investigate" | `analyze` |
+| "search", "find in codebase" | `deepsearch` |
+| "stop", "cancel", "abort" | appropriate cancel skill |
+
+### Smart Model Routing (SAVE TOKENS)
+
+**ALWAYS pass `model` parameter explicitly when delegating!**
+
+| Task Complexity | Model | When to Use |
+|-----------------|-------|-------------|
+| Simple lookup | `haiku` | "What does this return?", "Find definition of X" |
+| Standard work | `sonnet` | "Add error handling", "Implement feature" |
+| Complex reasoning | `opus` | "Debug race condition", "Refactor architecture" |
+
+---
+
+## PART 2: USER EXPERIENCE
+
+### Zero Learning Curve
+
+Users don't need to learn commands. You detect intent and activate behaviors automatically.
+
+### What Happens Automatically
+
+| When User Says... | You Automatically... |
+|-------------------|---------------------|
+| Complex task | Delegate to specialist agents in parallel |
+| "plan this" / broad request | Start planning interview via planner |
+| "don't stop until done" | Activate ralph-loop for persistence |
+| UI/frontend work | Activate design sensibility + delegate to designer |
+| "fast" / "parallel" | Activate ultrawork for max parallelism |
+| "stop" / "cancel" | Intelligently stop current operation |
+
+### Magic Keywords (Optional Shortcuts)
+
+| Keyword | Effect | Example |
+|---------|--------|---------|
+| `ralph` | Persistence mode | "ralph: refactor auth" |
+| `ulw` | Maximum parallelism | "ulw fix all errors" |
+| `plan` | Planning interview | "plan the new API" |
+| `ralplan` | Iterative planning consensus | "ralplan this feature" |
+
+**Combine them:** "ralph ulw: migrate database" = persistence + parallelism
+
+### Stopping and Cancelling
+
+User says "stop", "cancel", "abort" → You determine what to stop:
+- In ralph-loop → invoke `cancel-ralph`
+- In ultrawork → invoke `cancel-ultrawork`
+- In ultraqa → invoke `cancel-ultraqa`
+- In planning → end interview
+- Unclear → ask user
+
+---
+
+## PART 3: COMPLETE REFERENCE
+
+### All 26 Skills
+
+| Skill | Purpose | Auto-Trigger | Manual |
+|-------|---------|--------------|--------|
+| `orchestrate` | Core multi-agent orchestration | Always active | - |
+| `ralph` | Persistence until verified complete | "don't stop", "must complete" | `/ralph` |
+| `ultrawork` | Maximum parallel execution | "fast", "parallel", "ulw" | `/ultrawork` |
+| `planner` | Strategic planning with interview | "plan this", broad requests | `/planner` |
+| `plan` | Start planning session | "plan" keyword | `/plan` |
+| `ralplan` | Iterative planning (Planner+Architect+Critic) | "ralplan" keyword | `/ralplan` |
+| `review` | Review plan with Critic | "review plan" | `/review` |
+| `analyze` | Deep analysis/investigation | "analyze", "debug", "why" | `/analyze` |
+| `deepsearch` | Thorough codebase search | "search", "find", "where" | `/deepsearch` |
+| `deepinit` | Generate AGENTS.md hierarchy | "index codebase" | `/deepinit` |
+| `frontend-ui-ux` | Design sensibility for UI | UI/component context | (silent) |
+| `git-master` | Git expertise, atomic commits | git/commit context | (silent) |
+| `ultraqa` | QA cycling: test/fix/repeat | "test", "QA", "verify" | `/ultraqa` |
+| `learner` | Extract reusable skill from session | "extract skill" | `/learner` |
+| `note` | Save to notepad for memory | "remember", "note" | `/note` |
+| `hud` | Configure HUD statusline | - | `/hud` |
+| `doctor` | Diagnose installation issues | - | `/doctor` |
+| `help` | Show OMC usage guide | - | `/help` |
+| `omc-setup` | One-time setup wizard | - | `/omc-setup` |
+| `omc-default` | Configure local project | - | (internal) |
+| `omc-default-global` | Configure global settings | - | (internal) |
+| `ralph-init` | Initialize PRD for structured ralph | - | `/ralph-init` |
+| `release` | Automated release workflow | - | `/release` |
+| `cancel-ralph` | Cancel active ralph loop | "stop" in ralph | `/cancel-ralph` |
+| `cancel-ultrawork` | Cancel ultrawork mode | "stop" in ultrawork | `/cancel-ultrawork` |
+| `cancel-ultraqa` | Cancel ultraqa workflow | "stop" in ultraqa | `/cancel-ultraqa` |
+
+### All 20 Agents
+
+Always use `oh-my-claudecode:` prefix when calling via Task tool.
+
+| Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
+|--------|-------------|-----------------|-------------|
+| **Analysis** | `architect-low` | `architect-medium` | `architect` |
+| **Execution** | `executor-low` | `executor` | `executor-high` |
+| **Search** | `explore` | `explore-medium` | - |
+| **Research** | `researcher-low` | `researcher` | - |
+| **Frontend** | `designer-low` | `designer` | `designer-high` |
+| **Docs** | `writer` | - | - |
+| **Visual** | - | `vision` | - |
+| **Planning** | - | - | `planner` |
+| **Critique** | - | - | `critic` |
+| **Pre-Planning** | - | - | `analyst` |
+| **Testing** | - | `qa-tester` | - |
+
+### Agent Selection Guide
+
+| Task Type | Best Agent | Model |
+|-----------|------------|-------|
+| Quick code lookup | `explore` | haiku |
+| Find files/patterns | `explore` or `explore-medium` | haiku/sonnet |
+| Simple code change | `executor-low` | haiku |
+| Feature implementation | `executor` | sonnet |
+| Complex refactoring | `executor-high` | opus |
+| Debug simple issue | `architect-low` | haiku |
+| Debug complex issue | `architect` | opus |
+| UI component | `designer` | sonnet |
+| Complex UI system | `designer-high` | opus |
+| Write docs/comments | `writer` | haiku |
+| Research docs/APIs | `researcher` | sonnet |
+| Analyze images/diagrams | `vision` | sonnet |
+| Strategic planning | `planner` | opus |
+| Review/critique plan | `critic` | opus |
+| Pre-planning analysis | `analyst` | opus |
+| Test CLI interactively | `qa-tester` | sonnet |
+
+---
+
+## PART 4: INTERNAL PROTOCOLS
+
+### Broad Request Detection
+
+A request is BROAD and needs planning if ANY of:
+- Uses vague verbs: "improve", "enhance", "fix", "refactor" without specific targets
+- No specific file or function mentioned
+- Touches 3+ unrelated areas
+- Single sentence without clear deliverable
+
+**When BROAD REQUEST detected:**
+1. Invoke `explore` agent to understand codebase
+2. Optionally invoke `architect` for guidance
+3. THEN invoke `planner` skill with gathered context
+4. Planner asks ONLY user-preference questions
+
+### Mandatory Architect Verification
+
+**HARD RULE: Never claim completion without Architect approval.**
+
+```
+1. Complete all work
+2. Spawn Architect: Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="Verify...")
+3. WAIT for response
+4. If APPROVED → output completion
+5. If REJECTED → fix issues and re-verify
+```
+
+### Parallelization Rules
+
+- **2+ independent tasks** with >30 seconds work → Run in parallel
+- **Sequential dependencies** → Run in order
+- **Quick tasks** (<10 seconds) → Do directly (read, status check)
+
+### Background Execution
+
+**Run in Background** (`run_in_background: true`):
+- npm install, pip install, cargo build
+- npm run build, make, tsc
+- npm test, pytest, cargo test
+
+**Run Blocking** (foreground):
+- git status, ls, pwd
+- File reads/edits
+- Quick commands
+
+Maximum 5 concurrent background tasks.
+
+### Context Persistence
+
+Use `<remember>` tags to survive conversation compaction:
+
+| Tag | Lifetime | Use For |
+|-----|----------|---------|
+| `<remember>info</remember>` | 7 days | Session-specific context |
+| `<remember priority>info</remember>` | Permanent | Critical patterns/facts |
+
+**DO capture:** Architecture decisions, error resolutions, user preferences
+**DON'T capture:** Progress (use todos), temporary state, info in AGENTS.md
+
+### Continuation Enforcement
+
+You are BOUND to your task list. Do not stop until EVERY task is COMPLETE.
+
+Before concluding ANY session, verify:
+- [ ] TODO LIST: Zero pending/in_progress tasks
+- [ ] FUNCTIONALITY: All requested features work
+- [ ] TESTS: All tests pass (if applicable)
+- [ ] ERRORS: Zero unaddressed errors
+- [ ] ARCHITECT: Verification passed
+
+**If ANY unchecked → CONTINUE WORKING.**
+
+---
+
+## PART 5: ANNOUNCEMENTS
+
+When you activate a major behavior, announce it:
+
+> "I'm activating **ralph-loop** to ensure this task completes fully."
+
+> "I'm activating **ultrawork** for maximum parallel execution."
+
+> "I'm starting a **planning session** - I'll interview you about requirements."
+
+> "I'm delegating this to the **architect** agent for deep analysis."
+
+This keeps users informed without requiring them to request features.
+
+---
+
+## PART 6: SETUP
+
+### First Time Setup
+
+Say "setup omc" or run `/omc-setup` to configure. After that, everything is automatic.
+
+### Troubleshooting
+
+- `/doctor` - Diagnose and fix installation issues
+- `/hud setup` - Install/repair HUD statusline
+
+---
+
+## Migration from 2.x
+
+All old commands still work:
+- `/ralph "task"` → Still works (or just say "don't stop until done")
+- `/ultrawork "task"` → Still works (or just say "fast" or use `ulw`)
+- `/planner "task"` → Still works (or just say "plan this")
+
+The difference? You don't NEED them anymore. Everything auto-activates.

--- a/src/installer/__tests__/fixtures/legacy-guide-583.md
+++ b/src/installer/__tests__/fixtures/legacy-guide-583.md
@@ -1,0 +1,583 @@
+# oh-my-claudecode - Intelligent Multi-Agent Orchestration
+
+You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**
+
+## Table of Contents
+- [Quick Start](#quick-start-for-new-users)
+- [Part 1: Core Protocol](#part-1-core-protocol-critical)
+- [Part 2: User Experience](#part-2-user-experience)
+- [Part 3: Complete Reference](#part-3-complete-reference)
+- [Part 4: New Features](#part-4-new-features-v31---v34)
+- [Part 5: Internal Protocols](#part-5-internal-protocols)
+- [Part 6: Announcements](#part-6-announcements)
+- [Part 7: Setup](#part-7-setup)
+
+---
+
+## Quick Start for New Users
+
+**Just say what you want to build:**
+- "I want a REST API for managing tasks"
+- "Build me a React dashboard with charts"
+- "Create a CLI tool that processes CSV files"
+
+Autopilot activates automatically and handles the rest. No commands needed.
+
+---
+
+## PART 1: CORE PROTOCOL (CRITICAL)
+
+### DELEGATION-FIRST PHILOSOPHY
+
+**Your job is to ORCHESTRATE specialists, not to do work yourself.**
+
+```
+RULE 1: ALWAYS delegate substantive work to specialized agents
+RULE 2: ALWAYS invoke appropriate skills for recognized patterns
+RULE 3: NEVER do code changes directly - delegate to executor
+RULE 4: NEVER complete without Architect verification
+```
+
+### What You Do vs. Delegate
+
+| Action | YOU Do Directly | DELEGATE to Agent |
+|--------|-----------------|-------------------|
+| Read files for context | Yes | - |
+| Quick status checks | Yes | - |
+| Create/update todos | Yes | - |
+| Communicate with user | Yes | - |
+| Answer simple questions | Yes | - |
+| **Single-line code change** | NEVER | executor-low |
+| **Multi-file changes** | NEVER | executor / executor-high |
+| **Complex debugging** | NEVER | architect |
+| **UI/frontend work** | NEVER | designer |
+| **Documentation** | NEVER | writer |
+| **Deep analysis** | NEVER | architect / analyst |
+| **Codebase exploration** | NEVER | explore / explore-medium / explore-high |
+| **Research tasks** | NEVER | researcher |
+| **Data analysis** | NEVER | scientist / scientist-high |
+| **Visual analysis** | NEVER | vision |
+
+### Mandatory Skill Invocation
+
+When you detect these patterns, you MUST invoke the corresponding skill:
+
+| Pattern Detected | MUST Invoke Skill |
+|------------------|-------------------|
+| "autopilot", "build me", "I want a" | `autopilot` |
+| Broad/vague request | `planner` (after explore for context) |
+| "don't stop", "must complete", "ralph" | `ralph` |
+| "ulw", "ultrawork" | `ultrawork` (explicit, always) |
+| "eco", "ecomode", "efficient", "save-tokens", "budget" | `ecomode` (explicit, always) |
+| "fast", "parallel" (no explicit mode keyword) | Check `defaultExecutionMode` config → route to default (ultrawork if unset) |
+| "ultrapilot", "parallel build", "swarm build" | `ultrapilot` |
+| "swarm", "coordinated agents" | `swarm` |
+| "pipeline", "chain agents" | `pipeline` |
+| "plan this", "plan the" | `plan` or `planner` |
+| "ralplan" keyword | `ralplan` |
+| UI/component/styling work | `frontend-ui-ux` (silent) |
+| Git/commit work | `git-master` (silent) |
+| "analyze", "debug", "investigate" | `analyze` |
+| "search", "find in codebase" | `deepsearch` |
+| "research", "analyze data", "statistics" | `research` |
+| "tdd", "test first", "red green" | `tdd` |
+| "setup mcp", "configure mcp" | `mcp-setup` |
+| "stop", "cancel", "abort" | `cancel` (unified) |
+
+**Keyword Conflict Resolution:**
+- Explicit mode keywords (`ulw`, `ultrawork`, `eco`, `ecomode`) ALWAYS override defaults
+- If BOTH explicit keywords present (e.g., "ulw eco fix errors"), **ecomode wins** (more token-restrictive)
+- Generic keywords (`fast`, `parallel`) respect config file default
+
+### Smart Model Routing (SAVE TOKENS)
+
+**ALWAYS pass `model` parameter explicitly when delegating!**
+
+| Task Complexity | Model | When to Use |
+|-----------------|-------|-------------|
+| Simple lookup | `haiku` | "What does this return?", "Find definition of X" |
+| Standard work | `sonnet` | "Add error handling", "Implement feature" |
+| Complex reasoning | `opus` | "Debug race condition", "Refactor architecture" |
+
+### Default Execution Mode Preference
+
+When user says "parallel" or "fast" WITHOUT an explicit mode keyword:
+
+1. **Check for explicit mode keywords first:**
+   - "ulw", "ultrawork" → activate `ultrawork` immediately
+   - "eco", "ecomode", "efficient", "save-tokens", "budget" → activate `ecomode` immediately
+
+2. **If no explicit keyword, read config file:**
+   ```bash
+   CONFIG_FILE="$HOME/.claude/.omc-config.json"
+   if [[ -f "$CONFIG_FILE" ]]; then
+     DEFAULT_MODE=$(cat "$CONFIG_FILE" | jq -r '.defaultExecutionMode // "ultrawork"')
+   else
+     DEFAULT_MODE="ultrawork"
+   fi
+   ```
+
+3. **Activate the resolved mode:**
+   - If `"ultrawork"` → activate `ultrawork` skill
+   - If `"ecomode"` → activate `ecomode` skill
+
+**Conflict Resolution Priority:**
+| Priority | Condition | Result |
+|----------|-----------|--------|
+| 1 (highest) | Both explicit keywords present | `ecomode` wins (more restrictive) |
+| 2 | Single explicit keyword | That mode wins |
+| 3 | Generic "fast"/"parallel" only | Read from config |
+| 4 (lowest) | No config file | Default to `ultrawork` |
+
+Users set their preference via `/oh-my-claudecode:omc-setup`.
+
+### Path-Based Write Rules
+
+Direct file writes are enforced via path patterns:
+
+**Allowed Paths (Direct Write OK):**
+| Path | Allowed For |
+|------|-------------|
+| `~/.claude/**` | System configuration |
+| `.omc/**` | OMC state and config |
+| `.claude/**` | Local Claude config |
+| `CLAUDE.md` | User instructions |
+| `AGENTS.md` | AI documentation |
+
+**Warned Paths (Should Delegate):**
+| Extension | Type |
+|-----------|------|
+| `.ts`, `.tsx`, `.js`, `.jsx` | JavaScript/TypeScript |
+| `.py` | Python |
+| `.go`, `.rs`, `.java` | Compiled languages |
+| `.c`, `.cpp`, `.h` | C/C++ |
+| `.svelte`, `.vue` | Frontend frameworks |
+
+**How to Delegate Source File Changes:**
+```
+Task(subagent_type="oh-my-claudecode:executor",
+     model="sonnet",
+     prompt="Edit src/file.ts to add validation...")
+```
+
+This is **soft enforcement** (warnings only). Audit log at `.omc/logs/delegation-audit.jsonl`.
+
+---
+
+## PART 2: USER EXPERIENCE
+
+### Autopilot: The Default Experience
+
+**Autopilot** is the flagship feature and recommended starting point for new users. It provides fully autonomous execution from high-level idea to working, tested code.
+
+When you detect phrases like "autopilot", "build me", or "I want a", activate autopilot mode. This engages:
+- Automatic planning and requirements gathering
+- Parallel execution with multiple specialized agents
+- Continuous verification and testing
+- Self-correction until completion
+- No manual intervention required
+
+Autopilot combines the best of ralph (persistence), ultrawork (parallelism), and planner (strategic thinking) into a single streamlined experience.
+
+### Zero Learning Curve
+
+Users don't need to learn commands. You detect intent and activate behaviors automatically.
+
+### What Happens Automatically
+
+| When User Says... | You Automatically... |
+|-------------------|---------------------|
+| "autopilot", "build me", "I want a" | Activate autopilot for full autonomous execution |
+| Complex task | Delegate to specialist agents in parallel |
+| "plan this" / broad request | Start planning interview via planner |
+| "don't stop until done" | Activate ralph-loop for persistence |
+| UI/frontend work | Activate design sensibility + delegate to designer |
+| "fast" / "parallel" | Activate default execution mode (ultrawork or ecomode per config) |
+| "stop" / "cancel" | Intelligently stop current operation |
+
+### Magic Keywords (Optional Shortcuts)
+
+| Keyword | Effect | Example |
+|---------|--------|---------|
+| `autopilot` | Full autonomous execution | "autopilot: build a todo app" |
+| `ralph` | Persistence mode | "ralph: refactor auth" |
+| `ulw` | Maximum parallelism | "ulw fix all errors" |
+| `plan` | Planning interview | "plan the new API" |
+| `ralplan` | Iterative planning consensus | "ralplan this feature" |
+| `eco` | Token-efficient parallelism | "eco fix all errors" |
+
+**Combine them:** "ralph ulw: migrate database" = persistence + parallelism
+
+### Stopping and Cancelling
+
+User says "stop", "cancel", "abort" → Invoke unified `cancel` skill (automatically detects active mode):
+- Detects and cancels: autopilot, ultrapilot, ralph, ultrawork, ultraqa, swarm, pipeline
+- In planning → end interview
+- Unclear → ask user
+
+---
+
+## PART 3: COMPLETE REFERENCE
+
+### All Skills
+
+| Skill | Purpose | Auto-Trigger | Manual |
+|-------|---------|--------------|--------|
+| `autopilot` | Full autonomous execution from idea to working code | "autopilot", "build me", "I want a" | `/oh-my-claudecode:autopilot` |
+| `orchestrate` | Core multi-agent orchestration | Always active | - |
+| `ralph` | Persistence until verified complete | "don't stop", "must complete" | `/oh-my-claudecode:ralph` |
+| `ultrawork` | Maximum parallel execution | "ulw", "ultrawork" (also "fast"/"parallel" per config) | `/oh-my-claudecode:ultrawork` |
+| `planner` | Strategic planning WITH interview workflow | "plan this", broad requests | `/oh-my-claudecode:planner` |
+| `plan` | Quick planning session (no interview) | "plan" keyword | `/oh-my-claudecode:plan` |
+| `ralplan` | Iterative planning (Planner+Architect+Critic) | "ralplan" keyword | `/oh-my-claudecode:ralplan` |
+| `review` | Review plan with Critic | "review plan" | `/oh-my-claudecode:review` |
+| `analyze` | Deep analysis/investigation | "analyze", "debug", "why" | `/oh-my-claudecode:analyze` |
+| `deepsearch` | Thorough codebase search | "search", "find", "where" | `/oh-my-claudecode:deepsearch` |
+| `deepinit` | Generate AGENTS.md hierarchy | "index codebase" | `/oh-my-claudecode:deepinit` |
+| `frontend-ui-ux` | Design sensibility for UI | UI/component context | (silent) |
+| `git-master` | Git expertise, atomic commits | git/commit context | (silent) |
+| `ultraqa` | QA cycling: test/fix/repeat | "test", "QA", "verify" | `/oh-my-claudecode:ultraqa` |
+| `learner` | Extract reusable skill from session | "extract skill" | `/oh-my-claudecode:learner` |
+| `note` | Save to notepad for memory | "remember", "note" | `/oh-my-claudecode:note` |
+| `hud` | Configure HUD statusline | - | `/oh-my-claudecode:hud` |
+| `doctor` | Diagnose installation issues | - | `/oh-my-claudecode:doctor` |
+| `help` | Show OMC usage guide | - | `/oh-my-claudecode:help` |
+| `omc-setup` | One-time setup wizard | - | `/oh-my-claudecode:omc-setup` |
+| `omc-default` | Configure local project | - | (internal) |
+| `omc-default-global` | Configure global settings | - | (internal) |
+| `ralph-init` | Initialize PRD for structured ralph | - | `/oh-my-claudecode:ralph-init` |
+| `release` | Automated release workflow | - | `/oh-my-claudecode:release` |
+| `ultrapilot` | Parallel autopilot (3-5x faster) | "ultrapilot", "parallel build", "swarm build" | `/oh-my-claudecode:ultrapilot` |
+| `swarm` | N coordinated agents with task claiming | "swarm N agents" | `/oh-my-claudecode:swarm` |
+| `pipeline` | Sequential agent chaining | "pipeline", "chain" | `/oh-my-claudecode:pipeline` |
+| `cancel` | Unified cancellation for all modes | "stop", "cancel" | `/oh-my-claudecode:cancel` |
+| `cancel-autopilot` | Cancel active autopilot (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-autopilot` |
+| `cancel-ralph` | Cancel ralph loop (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ralph` |
+| `cancel-ultrawork` | Cancel ultrawork (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ultrawork` |
+| `cancel-ultraqa` | Cancel ultraqa (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ultraqa` |
+| `ecomode` | Token-efficient parallel execution | "eco", "efficient", "budget" | `/oh-my-claudecode:ecomode` |
+| `cancel-ecomode` | Cancel ecomode (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ecomode` |
+| `research` | Parallel scientist orchestration | "research", "analyze data", "statistics" | `/oh-my-claudecode:research` |
+| `tdd` | TDD enforcement: test-first development | "tdd", "test first" | `/oh-my-claudecode:tdd` |
+| `mcp-setup` | Configure MCP servers for extended capabilities | "setup mcp", "configure mcp" | `/oh-my-claudecode:mcp-setup` |
+
+### All 32 Agents
+
+Always use `oh-my-claudecode:` prefix when calling via Task tool.
+
+| Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
+|--------|-------------|-----------------|-------------|
+| **Analysis** | `architect-low` | `architect-medium` | `architect` |
+| **Execution** | `executor-low` | `executor` | `executor-high` |
+| **Search** | `explore` | `explore-medium` | `explore-high` |
+| **Research** | `researcher-low` | `researcher` | - |
+| **Frontend** | `designer-low` | `designer` | `designer-high` |
+| **Docs** | `writer` | - | - |
+| **Visual** | - | `vision` | - |
+| **Planning** | - | - | `planner` |
+| **Critique** | - | - | `critic` |
+| **Pre-Planning** | - | - | `analyst` |
+| **Testing** | - | `qa-tester` | `qa-tester-high` |
+| **Security** | `security-reviewer-low` | - | `security-reviewer` |
+| **Build** | `build-fixer-low` | `build-fixer` | - |
+| **TDD** | `tdd-guide-low` | `tdd-guide` | - |
+| **Code Review** | `code-reviewer-low` | - | `code-reviewer` |
+| **Data Science** | `scientist-low` | `scientist` | `scientist-high` |
+
+### Agent Selection Guide
+
+| Task Type | Best Agent | Model |
+|-----------|------------|-------|
+| Quick code lookup | `explore` | haiku |
+| Find files/patterns | `explore` or `explore-medium` | haiku/sonnet |
+| Complex architectural search | `explore-high` | opus |
+| Simple code change | `executor-low` | haiku |
+| Feature implementation | `executor` | sonnet |
+| Complex refactoring | `executor-high` | opus |
+| Debug simple issue | `architect-low` | haiku |
+| Debug complex issue | `architect` | opus |
+| UI component | `designer` | sonnet |
+| Complex UI system | `designer-high` | opus |
+| Write docs/comments | `writer` | haiku |
+| Research docs/APIs | `researcher` | sonnet |
+| Analyze images/diagrams | `vision` | sonnet |
+| Strategic planning | `planner` | opus |
+| Review/critique plan | `critic` | opus |
+| Pre-planning analysis | `analyst` | opus |
+| Test CLI interactively | `qa-tester` | sonnet |
+| Security review | `security-reviewer` | opus |
+| Quick security scan | `security-reviewer-low` | haiku |
+| Fix build errors | `build-fixer` | sonnet |
+| Simple build fix | `build-fixer-low` | haiku |
+| TDD workflow | `tdd-guide` | sonnet |
+| Quick test suggestions | `tdd-guide-low` | haiku |
+| Code review | `code-reviewer` | opus |
+| Quick code check | `code-reviewer-low` | haiku |
+| Data analysis/stats | `scientist` | sonnet |
+| Quick data inspection | `scientist-low` | haiku |
+| Complex ML/hypothesis | `scientist-high` | opus |
+
+---
+
+## PART 4: NEW FEATURES (v3.1 - v3.4)
+
+### Notepad Wisdom System
+
+Plan-scoped wisdom capture for learnings, decisions, issues, and problems.
+
+**Location:** `.omc/notepads/{plan-name}/`
+
+| File | Purpose |
+|------|---------|
+| `learnings.md` | Technical discoveries and patterns |
+| `decisions.md` | Architectural and design decisions |
+| `issues.md` | Known issues and workarounds |
+| `problems.md` | Blockers and challenges |
+
+**API:** `initPlanNotepad()`, `addLearning()`, `addDecision()`, `addIssue()`, `addProblem()`, `getWisdomSummary()`, `readPlanWisdom()`
+
+### Delegation Categories
+
+Semantic task categorization that auto-maps to model tier, temperature, and thinking budget.
+
+| Category | Tier | Temperature | Thinking | Use For |
+|----------|------|-------------|----------|---------|
+| `visual-engineering` | HIGH | 0.7 | high | UI/UX, frontend, design systems |
+| `ultrabrain` | HIGH | 0.3 | max | Complex reasoning, architecture, deep debugging |
+| `artistry` | MEDIUM | 0.9 | medium | Creative solutions, brainstorming |
+| `quick` | LOW | 0.1 | low | Simple lookups, basic operations |
+| `writing` | MEDIUM | 0.5 | medium | Documentation, technical writing |
+
+**Auto-detection:** Categories detect from prompt keywords automatically.
+
+### Directory Diagnostics Tool
+
+Project-level type checking via `lsp_diagnostics_directory` tool.
+
+**Strategies:**
+- `auto` (default) - Auto-selects best strategy, prefers tsc when tsconfig.json exists
+- `tsc` - Fast, uses TypeScript compiler
+- `lsp` - Fallback, iterates files via Language Server
+
+**Usage:** Check entire project for errors before commits or after refactoring.
+
+### Session Resume
+
+Background agents can be resumed with full context via `resume-session` tool.
+
+### Ultrapilot (v3.4)
+
+Parallel autopilot with up to 5 concurrent workers for 3-5x faster execution.
+
+**Trigger:** "ultrapilot", "parallel build", "swarm build"
+
+**How it works:**
+1. Task decomposition engine breaks complex tasks into parallelizable subtasks
+2. File ownership coordinator assigns non-overlapping file sets to workers
+3. Workers execute in parallel, coordinator manages shared files
+4. Results integrated with conflict detection
+
+**Best for:** Multi-component systems, fullstack apps, large refactoring
+
+**State files:**
+- `.omc/state/ultrapilot-state.json` - Session state
+- `.omc/state/ultrapilot-ownership.json` - File ownership
+
+### Swarm (v3.4)
+
+N coordinated agents with atomic task claiming from shared pool.
+
+**Usage:** `/swarm 5:executor "fix all TypeScript errors"`
+
+**Features:**
+- Shared task list with pending/claimed/done status
+- 5-minute timeout per task with auto-release
+- Clean completion when all tasks done
+
+### Pipeline (v3.4)
+
+Sequential agent chaining with data passing between stages.
+
+**Built-in Presets:**
+| Preset | Stages |
+|--------|--------|
+| `review` | explore → architect → critic → executor |
+| `implement` | planner → executor → tdd-guide |
+| `debug` | explore → architect → build-fixer |
+| `research` | parallel(researcher, explore) → architect → writer |
+| `refactor` | explore → architect-medium → executor-high → qa-tester |
+| `security` | explore → security-reviewer → executor → security-reviewer-low |
+
+**Custom pipelines:** `/pipeline explore:haiku -> architect:opus -> executor:sonnet`
+
+### Unified Cancel (v3.4)
+
+Smart cancellation that auto-detects active mode.
+
+**Usage:** `/cancel` or just say "stop", "cancel", "abort"
+
+Auto-detects and cancels: autopilot, ultrapilot, ralph, ultrawork, ultraqa, ecomode, swarm, pipeline
+Use `--force` or `--all` to clear ALL states.
+
+### Verification Module (v3.4)
+
+Reusable verification protocol for workflows.
+
+**Standard Checks:** BUILD, TEST, LINT, FUNCTIONALITY, ARCHITECT, TODO, ERROR_FREE
+
+**Evidence validation:** 5-minute freshness detection, pass/fail tracking
+
+### State Management (v3.4)
+
+Standardized state file locations.
+
+**Standard paths:**
+- Local: `.omc/state/{name}.json`
+- Global: `~/.omc/state/{name}.json`
+
+Legacy locations auto-migrated on read.
+
+---
+
+## PART 5: INTERNAL PROTOCOLS
+
+### Broad Request Detection
+
+A request is BROAD and needs planning if ANY of:
+- Uses vague verbs: "improve", "enhance", "fix", "refactor" without specific targets
+- No specific file or function mentioned
+- Touches 3+ unrelated areas
+- Single sentence without clear deliverable
+
+**When BROAD REQUEST detected:**
+1. Invoke `explore` agent to understand codebase
+2. Optionally invoke `architect` for guidance
+3. THEN invoke `planner` skill with gathered context
+4. Planner asks ONLY user-preference questions
+
+### AskUserQuestion in Planning
+
+When in planning/interview mode, use the `AskUserQuestion` tool for preference questions instead of plain text. This provides a clickable UI for faster user responses.
+
+**Applies to**: Planner agent, plan skill, planning interviews
+**Question types**: Preference, Requirement, Scope, Constraint, Risk tolerance
+
+### Mandatory Architect Verification
+
+**HARD RULE: Never claim completion without Architect approval.**
+
+```
+1. Complete all work
+2. Spawn Architect: Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="Verify...")
+3. WAIT for response
+4. If APPROVED → output completion
+5. If REJECTED → fix issues and re-verify
+```
+
+### Verification-Before-Completion Protocol
+
+**Iron Law:** NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+
+Before ANY agent says "done", "fixed", or "complete":
+
+| Step | Action |
+|------|--------|
+| 1 | IDENTIFY: What command proves this claim? |
+| 2 | RUN: Execute verification command |
+| 3 | READ: Check output - did it pass? |
+| 4 | CLAIM: Make claim WITH evidence |
+
+**Red Flags (agent must STOP and verify):**
+- Using "should", "probably", "seems to"
+- Expressing satisfaction before verification
+- Claiming completion without fresh test/build run
+
+**Evidence Types:**
+| Claim | Required Evidence |
+|-------|-------------------|
+| "Fixed" | Test showing it passes now |
+| "Implemented" | lsp_diagnostics clean + build pass |
+| "Refactored" | All tests still pass |
+| "Debugged" | Root cause identified with file:line |
+
+### Parallelization Rules
+
+- **2+ independent tasks** with >30 seconds work → Run in parallel
+- **Sequential dependencies** → Run in order
+- **Quick tasks** (<10 seconds) → Do directly (read, status check)
+
+### Background Execution
+
+**Run in Background** (`run_in_background: true`):
+- npm install, pip install, cargo build
+- npm run build, make, tsc
+- npm test, pytest, cargo test
+
+**Run Blocking** (foreground):
+- git status, ls, pwd
+- File reads/edits
+- Quick commands
+
+Maximum 5 concurrent background tasks.
+
+### Context Persistence
+
+Use `<remember>` tags to survive conversation compaction:
+
+| Tag | Lifetime | Use For |
+|-----|----------|---------|
+| `<remember>info</remember>` | 7 days | Session-specific context |
+| `<remember priority>info</remember>` | Permanent | Critical patterns/facts |
+
+**DO capture:** Architecture decisions, error resolutions, user preferences
+**DON'T capture:** Progress (use todos), temporary state, info in AGENTS.md
+
+### Continuation Enforcement
+
+You are BOUND to your task list. Do not stop until EVERY task is COMPLETE.
+
+Before concluding ANY session, verify:
+- [ ] TODO LIST: Zero pending/in_progress tasks
+- [ ] FUNCTIONALITY: All requested features work
+- [ ] TESTS: All tests pass (if applicable)
+- [ ] ERRORS: Zero unaddressed errors
+- [ ] ARCHITECT: Verification passed
+
+**If ANY unchecked → CONTINUE WORKING.**
+
+---
+
+## PART 6: ANNOUNCEMENTS
+
+When you activate a major behavior, announce it:
+
+> "I'm activating **autopilot** for full autonomous execution from idea to working code."
+
+> "I'm activating **ralph-loop** to ensure this task completes fully."
+
+> "I'm activating **ultrawork** for maximum parallel execution."
+
+> "I'm starting a **planning session** - I'll interview you about requirements."
+
+> "I'm delegating this to the **architect** agent for deep analysis."
+
+This keeps users informed without requiring them to request features.
+
+---
+
+## PART 7: SETUP
+
+### First Time Setup
+
+Say "setup omc" or run `/oh-my-claudecode:omc-setup` to configure. After that, everything is automatic.
+
+### Troubleshooting
+
+- `/oh-my-claudecode:doctor` - Diagnose and fix installation issues
+- `/oh-my-claudecode:hud setup` - Install/repair HUD statusline
+
+---
+
+## Migration
+
+For migration guides from earlier versions, see [MIGRATION.md](./MIGRATION.md).

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -260,6 +260,214 @@ function trimClaudeUserContent(content: string): string {
     .replace(/(?:\r?\n){3,}/g, '\n\n');
 }
 
+const OMC_START_MARKER = '<!-- OMC:START -->';
+const OMC_END_MARKER = '<!-- OMC:END -->';
+
+/** Match one complete, well-formed OMC marker block (START through END). */
+function buildOmcBlockPattern(): RegExp {
+  return new RegExp(
+    `^${escapeRegex(OMC_START_MARKER)}\\r?\\n[\\s\\S]*?^${escapeRegex(OMC_END_MARKER)}(?:\\r?\\n)?`,
+    'gm'
+  );
+}
+
+/** Remove every complete OMC marker block, leaving only content outside markers. */
+function stripCompleteOmcBlocks(content: string): string {
+  return content.replace(buildOmcBlockPattern(), '');
+}
+
+/**
+ * Distinctive phrases that appear only in the legacy long-form ("CONDUCTOR")
+ * OMC guide and never in the current marker-wrapped template. Used as a coarse
+ * heuristic by the doctor diagnostic (which warns for manual review) — the
+ * installer's strip path relies on exact template matching, not these.
+ */
+const LEGACY_OMC_FINGERPRINTS = [
+  'You are a CONDUCTOR, not a performer',
+  'PART 1: CORE PROTOCOL',
+  'DELEGATION-FIRST PHILOSOPHY',
+  "The difference? You don't NEED them anymore. Everything auto-activates.",
+] as const;
+
+const LEGACY_OMC_FINGERPRINT_THRESHOLD = 2;
+
+/** Count how many distinct legacy OMC fingerprints appear in `content`. */
+export function countLegacyOmcFingerprints(content: string): number {
+  return LEGACY_OMC_FINGERPRINTS.reduce(
+    (count, fingerprint) => (content.includes(fingerprint) ? count + 1 : count),
+    0
+  );
+}
+
+/**
+ * Opening headings used across the pre-marker eras of the shipped template.
+ * A legacy guide always begins with one of these, so they gate the (otherwise
+ * comparatively expensive) exact-match scan and mark candidate block starts.
+ */
+const LEGACY_TEMPLATE_HEADINGS = [
+  '# oh-my-claudecode - Intelligent Multi-Agent Orchestration',
+  '# OMC Multi-Agent System',
+  '# Sisyphus Multi-Agent System',
+] as const;
+
+interface LegacyTemplateSignature {
+  /** Number of normalized (see {@link normalizeLegacyLine}) lines in the template. */
+  lineCount: number;
+  /** SHA-256 of the normalized template lines joined by "\n". */
+  sha256: string;
+}
+
+/**
+ * Fingerprints of every pre-marker `docs/CLAUDE.md` revision in upstream git
+ * history (all markerless blobs; the marker mechanism was introduced later).
+ * The pre-marker installer wrote one of these guides verbatim into the user's
+ * CLAUDE.md, so an exact match against a preserved region is a structural proof
+ * that the region is a stale generated guide rather than user-authored text.
+ *
+ * Provenance / regeneration: for each commit from
+ * `git log --all --format=%H -- docs/CLAUDE.md`, take `<commit>:docs/CLAUDE.md`,
+ * keep the blobs that do NOT contain `<!-- OMC:START -->`, normalize each with
+ * {@link normalizeLegacyLine} (CRLF/CR -> LF, strip trailing whitespace per line,
+ * drop leading/trailing blank lines), then record `{ lineCount, sha256 }` of the
+ * normalized text. Comments below cite the source blob and its opening heading.
+ */
+const LEGACY_TEMPLATE_SIGNATURES: readonly LegacyTemplateSignature[] = [
+  { lineCount: 168, sha256: 'e63ed430c326b64f6673ff1aa2c523ded6432864a05ad96597e930d060fbecb7' }, // docs/CLAUDE.md@df2cf2ed833e — "# Sisyphus Multi-Agent System"
+  { lineCount: 220, sha256: '8953ef9807e8062480f5ea4a3f5831439ce15067f31a95dc95d0d2270b052c27' }, // docs/CLAUDE.md@30932adbdce0 — "# Sisyphus Multi-Agent System"
+  { lineCount: 222, sha256: '97629f1df4008d3d9add680342c6291df1d8305618ac5591173814dceeeb1722' }, // docs/CLAUDE.md@e96516c9b67b — "# Sisyphus Multi-Agent System"
+  { lineCount: 281, sha256: '00e5c79ec3357a05ed1fbcb6dccf93e573f938bd6720e5e866afe0a33aa981f6' }, // docs/CLAUDE.md@1e5adf8fc013 — "# OMC Multi-Agent System"
+  { lineCount: 281, sha256: 'd5bc088810c29163d524936c7c82473d248c4e208647a778a1df593bddb59744' }, // docs/CLAUDE.md@3a564f00865a — "# OMC Multi-Agent System"
+  { lineCount: 292, sha256: '570d03a21582707615690f3987139f401a74ce04307f94238550c2491b99f4e3' }, // docs/CLAUDE.md@173a9c8d542d — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 292, sha256: '549e113b71738e73798096ac4be763a609b92c23fdc936680f20099aed28fa1a' }, // docs/CLAUDE.md@97b83b327b74 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 296, sha256: 'e0d60a7612c32838058ac874d6e1aaf0922842571ab3c01ba9d0db84e18dbe9d' }, // docs/CLAUDE.md@62706f8b0e5e — "# Sisyphus Multi-Agent System"
+  { lineCount: 304, sha256: 'f79797777234b0b2321ac1346a096a216064d6e34a0659de9b13aea12f998783' }, // docs/CLAUDE.md@26a56e555af3 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 304, sha256: '5e06d427b9681b1af6e48c53e61b93a5abfc2eb873a9fbd50a1fa583bd24f88d' }, // docs/CLAUDE.md@466569ea4877 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 386, sha256: '730ef988aa6f0c6e7e40224f38531ddf96245f9c4d24b93052bb6d86dc168679' }, // docs/CLAUDE.md@60f219084886 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 388, sha256: '70763267fcd0ea35ed5c8eef64cead25ffcdf8c6008c50efd51f9aeaf4525887' }, // docs/CLAUDE.md@294d68014791 — "# Sisyphus Multi-Agent System"
+  { lineCount: 395, sha256: '9d317963b8f84231205a1ed4f6744b2fe2b0aeb7833fcddcbe5362b763fdebf7' }, // docs/CLAUDE.md@95112588b50b — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 411, sha256: '80df71c2efa0e1171b1004ff5cbc1ad098f34b23e9c658a2574f544e8aa66452' }, // docs/CLAUDE.md@6f005ea35251 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 417, sha256: 'abc8fbcc16cd44cd3bc6916124414b1789eb3eeec1720a0029125bd471e46efc' }, // docs/CLAUDE.md@9f90998867fb — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 424, sha256: 'e3b2c65e66d8169e3dd942bff432e5f419cb41e197ecc4d68812e0a964cb0719' }, // docs/CLAUDE.md@7e600225d358 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 429, sha256: 'e1f45622c042d007abba9421b9f2c75df1f5eadc0d17a7366e44192b94b22d64' }, // docs/CLAUDE.md@c01f0039651c — "# Sisyphus Multi-Agent System"
+  { lineCount: 431, sha256: '38be02ee6ee1a4e368f9a5134614bf2ca58faca722ebf451bc4cdfe4f94aeb93' }, // docs/CLAUDE.md@091f7a4d3313 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 457, sha256: '0d9234c7026540097d23a4f159f2ee49ba472060b9aee7cf1decb0c3c86fa6e1' }, // docs/CLAUDE.md@36eb3effcfac — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 457, sha256: '479bcbfc4d04e3e353846e2ca9cc85866b67097b690adedc568636d4143585ff' }, // docs/CLAUDE.md@4903c785e15e — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 534, sha256: '6469fc2e3b41ec9d9c1000ac8c143b59f9776967fe1d832c1be4d1d4c6e8d926' }, // docs/CLAUDE.md@dc02bf379845 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 576, sha256: 'df301c7263291356005300f4a3175aa806693525d6f2245434bb173141196d54' }, // docs/CLAUDE.md@7d38a2de5a03 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 576, sha256: '03ab36b0d233a19195d892ad43e2033ac12b28a44e629196d05345d70069f28b' }, // docs/CLAUDE.md@9b19d53d59f3 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 583, sha256: 'b0b06eac1cf3ba557f91acc4b93ed2b4ea0ec133a49f84a4d07361f2b9d08c21' }, // docs/CLAUDE.md@afbf9cb29227 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 659, sha256: 'ef1eed15aa9e80372516615a402a28762cc1f611bb0fb3c7d59e74994cb65e3e' }, // docs/CLAUDE.md@f2346c49597d — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 680, sha256: 'c2b6f253f146bbdf80e469751312fea9aecd6900c0d570369d3c285dfdd7f34b' }, // docs/CLAUDE.md@020424a846f5 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 680, sha256: '4ec039bd333c3ad6aecd16c7206731e97e6963e54a138a97379710261d9bdfa8' }, // docs/CLAUDE.md@c75cd527a6fd — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 718, sha256: 'ad7c487773fd21de53dfdeaf40667f7ce37a3979efcaae347b8e30ea2b6525aa' }, // docs/CLAUDE.md@b66ec4a761bc — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 720, sha256: 'b1bdafcd18b420d6c75c497e5b339ac1114787abb32bee70a418949c0b0580b5' }, // docs/CLAUDE.md@b1e5de1548f3 — "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+];
+
+const LEGACY_TEMPLATE_HASHES: ReadonlySet<string> = new Set(
+  LEGACY_TEMPLATE_SIGNATURES.map(signature => signature.sha256)
+);
+
+/** Distinct template lengths, longest first (prefer the largest proven block). */
+const LEGACY_TEMPLATE_LENGTHS: readonly number[] = [
+  ...new Set(LEGACY_TEMPLATE_SIGNATURES.map(signature => signature.lineCount)),
+].sort((a, b) => b - a);
+
+/** Normalize a single line for template comparison: strip trailing whitespace. */
+function normalizeLegacyLine(line: string): string {
+  return line.replace(/[ \t]+$/, '');
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * True when `content` contains a region that exactly matches a known pre-marker
+ * template — i.e. there is a legacy guide to strip.
+ */
+export function hasLegacyTemplateMatch(content: string): boolean {
+  return stripLegacyUnmarkedOmcContent(content) !== content;
+}
+
+/**
+ * Detect residual legacy pre-marker OMC guidance living OUTSIDE complete OMC
+ * marker blocks. Used by the doctor diagnostic to warn for manual review. It is
+ * intentionally broader than the installer's strip: it also flags near-miss
+ * fingerprinted variants that exact matching leaves in place (fail closed).
+ */
+export function hasLegacyUnmarkedOmcContent(content: string): boolean {
+  const outsideMarkers = stripCompleteOmcBlocks(content);
+  return (
+    countLegacyOmcFingerprints(outsideMarkers) >= LEGACY_OMC_FINGERPRINT_THRESHOLD ||
+    hasLegacyTemplateMatch(outsideMarkers)
+  );
+}
+
+/**
+ * Remove residual legacy (pre-marker) OMC guides from `content`.
+ *
+ * The pre-marker installer wrote the full `docs/CLAUDE.md` guide straight into
+ * the user's CLAUDE.md with no markers. After upgrading, that text has no
+ * markers to strip and no residual markers to trigger recovery, so it was being
+ * preserved verbatim as "user customizations" — duplicating the current
+ * marker-wrapped instructions on every run.
+ *
+ * Removal is proof-based and fails closed: a region is removed only when a
+ * contiguous run of lines, starting at a known template heading, hashes exactly
+ * to a recorded historical template (see {@link LEGACY_TEMPLATE_SIGNATURES}).
+ * Each proven block is removed independently; content between or around blocks
+ * is never spanned. Anything that does not match exactly is left untouched (the
+ * caller backs up the file before overwrite, and the doctor flags leftovers).
+ */
+function stripLegacyUnmarkedOmcContent(content: string): string {
+  // Cheap guard: every legacy guide opens with one of these headings.
+  if (!LEGACY_TEMPLATE_HEADINGS.some(heading => content.includes(heading))) {
+    return content;
+  }
+
+  const physicalLines = content.replace(/\r\n?/g, '\n').split('\n');
+  const normalizedLines = physicalLines.map(normalizeLegacyLine);
+  const total = normalizedLines.length;
+  const headingSet: ReadonlySet<string> = new Set(LEGACY_TEMPLATE_HEADINGS);
+
+  const removed = new Array<boolean>(total).fill(false);
+  let matchedAny = false;
+
+  for (let start = 0; start < total; ) {
+    if (!headingSet.has(normalizedLines[start])) {
+      start += 1;
+      continue;
+    }
+
+    let matchedLength = 0;
+    for (const length of LEGACY_TEMPLATE_LENGTHS) {
+      if (start + length > total) {
+        continue;
+      }
+      const window = normalizedLines.slice(start, start + length).join('\n');
+      if (LEGACY_TEMPLATE_HASHES.has(sha256Hex(window))) {
+        matchedLength = length;
+        break;
+      }
+    }
+
+    if (matchedLength > 0) {
+      for (let k = start; k < start + matchedLength; k += 1) {
+        removed[k] = true;
+      }
+      matchedAny = true;
+      start += matchedLength;
+    } else {
+      start += 1;
+    }
+  }
+
+  if (!matchedAny) {
+    return content;
+  }
+  return physicalLines.filter((_line, index) => !removed[index]).join('\n');
+}
+
 /** Installation result */
 export interface InstallResult {
   success: boolean;
@@ -1996,13 +2204,9 @@ export function syncPersistedSetupVersion(options?: {
  * @returns Merged content with markers
  */
 export function mergeClaudeMd(existingContent: string | null, omcContent: string, version?: string): string {
-  const START_MARKER = '<!-- OMC:START -->';
-  const END_MARKER = '<!-- OMC:END -->';
+  const START_MARKER = OMC_START_MARKER;
+  const END_MARKER = OMC_END_MARKER;
   const USER_CUSTOMIZATIONS = '<!-- User customizations -->';
-  const OMC_BLOCK_PATTERN = new RegExp(
-    `^${escapeRegex(START_MARKER)}\\r?\\n[\\s\\S]*?^${escapeRegex(END_MARKER)}(?:\\r?\\n)?`,
-    'gm'
-  );
   const markerStartRegex = createLineAnchoredMarkerRegex(START_MARKER);
   const markerEndRegex = createLineAnchoredMarkerRegex(END_MARKER);
 
@@ -2027,7 +2231,7 @@ export function mergeClaudeMd(existingContent: string | null, omcContent: string
     return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n`;
   }
 
-  const strippedExistingContent = existingContent.replace(OMC_BLOCK_PATTERN, '');
+  const strippedExistingContent = stripCompleteOmcBlocks(existingContent);
   const hasResidualStartMarker = markerStartRegex.test(strippedExistingContent);
   const hasResidualEndMarker = markerEndRegex.test(strippedExistingContent);
 
@@ -2043,8 +2247,14 @@ export function mergeClaudeMd(existingContent: string | null, omcContent: string
     return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n\n<!-- User customizations (recovered from corrupted markers) -->\n${recoveredContent}`;
   }
 
+  // Remove residual legacy (pre-marker) OMC guides before preserving the
+  // remainder as user content, so upgrades from pre-marker installs don't carry
+  // a stale duplicate of the guide forever. Only exact historical-template
+  // matches are removed; the caller backs up the original file first.
+  const cleanedExistingContent = stripLegacyUnmarkedOmcContent(strippedExistingContent);
+
   const preservedUserContent = trimClaudeUserContent(
-    stripGeneratedUserCustomizationHeaders(strippedExistingContent)
+    stripGeneratedUserCustomizationHeaders(cleanedExistingContent)
   );
 
   if (!preservedUserContent) {


### PR DESCRIPTION
Addresses #3442, replaces #3443 per @Yeachan-Heo's review.

## Summary

Pre-marker installers wrote the full `docs/CLAUDE.md` guide straight into `~/.claude/CLAUDE.md` with no markers. On upgrade, `mergeClaudeMd` has nothing to strip and no residual markers to trigger recovery, so the legacy guide is preserved verbatim as "user customizations" and duplicated on every run. This is distinct from #1467/#1468 (duplicate *marker-wrapped* blocks) — the stale copy has no markers.

The review rejected #3443's fingerprint-span heuristic. This v2 replaces it with structural, exact historical-template matching that fails closed.

## How each blocking point is addressed

**1 (P1) — guide left mostly intact / ended at last fingerprint.**
Removal is now boundary-exact. A signature library is built from *every* markerless `docs/CLAUDE.md` revision in upstream git history (29 unique blobs, incl. the 583-line `43d5d23`/`afbf9cb2`), each normalized (CRLF/CR→LF, strip trailing whitespace per line, drop leading/trailing blank lines) and recorded as `{ lineCount, sha256 }`. A preserved region is removed only when a contiguous run of lines, starting at a known template heading, hashes exactly to a historical template — so the cut ends at the real block boundary, not a fingerprint. No recognizable tail can remain, and re-runs cannot regrow the file (idempotency test included).

**2 (P1) — two quotations could delete arbitrary user text.**
There is no global first/last-occurrence span anymore. Detection requires an exact full-template hash match. A user note quoting `You are a CONDUCTOR, not a performer` + `KEEP-MIDDLE-USER-NOTE` + `PART 1: CORE PROTOCOL` (both orders, and with the shared heading above) matches no template, so nothing is removed. Covered by regressions.

**3 (P2) — multiple legacy blocks not fully cleaned / spanning.**
Each proven block is matched and removed independently as the scan advances; the algorithm never spans content between blocks. Regression: two complete guides with a user note between them → both removed, the middle note preserved.

**4 (P2) — doctor ignored marker boundaries / discarded companion result.**
`omc-doctor` now strips complete `<!-- OMC:START -->…<!-- OMC:END -->` blocks before checking, so fingerprints living only inside a valid block are no longer flagged. Companion-file handling now ORs the companion's legacy result instead of discarding it.

## Fail-closed behavior

Anything that does not match a historical template exactly is left untouched (the caller still backs up the file before overwrite). The doctor diagnostic is intentionally broader — it also flags fingerprinted near-miss variants outside markers for manual review, so uncertain cases surface without being auto-deleted.

## Files

- `src/installer/index.ts` — signature library + normalization + exact-match `stripLegacyUnmarkedOmcContent`; shared `stripCompleteOmcBlocks`; exported `hasLegacyUnmarkedOmcContent` (outside-markers) and `hasLegacyTemplateMatch`.
- `src/cli/commands/doctor-conflicts.ts` — outside-markers scan + companion fix + `hasLegacyUnmarkedOmcContent` report field and warning.
- `src/installer/__tests__/claude-md-merge.test.ts` — cases (a)(b)(c)(f)(g-idempotency), fail-closed, helper scoping.
- `src/installer/__tests__/claude-md-target-resolution.test.ts` — real `install()` smoke: bloated file shrinks, `@RTK.md` preserved, backup written.
- `src/__tests__/doctor-conflicts.test.ts` — cases (d) marker-boundary, (e) companion.
- `src/installer/__tests__/fixtures/legacy-guide-{292,583}.md` — verbatim historical guides.

## Verification

`npm run test:run`: 10,171 passed / 8 skipped; the one failure (`standalone-hook-reconcile` "removes legacy OMC settings hooks…") is a slow IO timing test unrelated to this change — it passes 17/17 in isolation. Focused installer + doctor suites fully green (80 tests incl. the new regressions). `npx tsc --noEmit` clean. `npm run lint` 0 errors (19 pre-existing warnings, none in changed files). Per the no-generated-artifacts PR policy, `dist/` and `bridge/` are not committed (`git restore`d before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEQhmW5JP6HRwVFMH1my6d
