### PR TITLE
fix(windows): hide console window for git execSync calls

### DIFF
--- a/src/hud/elements/multi-repo.ts
+++ b/src/hud/elements/multi-repo.ts
@@ -75,6 +75,7 @@ function isGitRepo(dir: string): boolean {
       timeout: 1000,
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+      windowsHide: true,
     });
     return true;
   } catch {

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -156,6 +156,7 @@ function resolveSuperprojectRoot(cwd: string): string | null {
         cwd: probeCwd,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
         timeout: 5000,
       }).trim();
     } catch {
@@ -215,6 +216,7 @@ export function getGitTopLevel(cwd?: string): string | null {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       timeout: 5000,
     }).trim();
 
@@ -448,6 +450,7 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
       cwd: root,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     source = remoteUrl || root;
   } catch {
@@ -466,6 +469,7 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
       cwd: root,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       timeout: 5000,
     }).trim();
     // Only resolve when --git-common-dir points to a .git directory.
@@ -1107,6 +1111,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
@@ -1124,6 +1129,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     if (mainRepoRoot !== worktreeTop) {
@@ -1226,6 +1232,7 @@ function getGitCommonDir(cwd: string): string | null {
       cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       timeout: 5000,
     }).trim();
     return realpathSync(commonDir);


### PR DESCRIPTION
## Summary

On Windows, every `git rev-parse`/`git remote`/`git rev-parse --show-toplevel` call in `src/lib/worktree-paths.ts` and the one in `src/hud/elements/multi-repo.ts` uses `execSync(..., { stdio: ['pipe','pipe','pipe'] })` without `windowsHide: true`. Since the child process gets piped stdio instead of an inherited console, Windows allocates it a brand-new console window - which flashes visibly on screen for the fraction of a second the command runs, then disappears.

This is very noticeable because `worktree-paths.ts` is on the hot path for `SessionEnd` hooks (worktree/project-identifier resolution) and the HUD status line (`multi-repo.ts`'s 30s-cached repo check), so users see multiple console flashes whenever a session ends or the status line refreshes after cache expiry.

Confirmed root cause via Procmon on Windows 11: captured the exact `cmd.exe` process-create events correlating 1:1 with these `execSync` call sites during a Claude Code session close.

## Change

Adds `windowsHide: true` to all 8 affected `execSync` calls (7 in `worktree-paths.ts`, 1 in `multi-repo.ts`). This is a standard Node.js `child_process` option - a no-op on non-Windows platforms, and on Windows it suppresses the window without changing any other behavior (stdout/stderr are still piped and captured exactly as before).

No logic changes.

## Test plan

- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/lib/worktree-paths.ts src/hud/elements/multi-repo.ts` - clean
- [x] `npx vitest run src/lib/__tests__/worktree-paths.test.ts` - 88 passed, 1 skipped (pre-existing skip, unrelated)
- [x] Verified via Procmon on Windows 11 that the corresponding `cmd.exe` process-create events disappear once `windowsHide: true` is applied to the compiled output