### PR TITLE
fix(installer): route shell setup through shared merge; EOL-only normalization + structural marker parser

### DIFF
--- a/scripts/generate-legacy-template-manifest.mjs
+++ b/scripts/generate-legacy-template-manifest.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Regenerate (or verify) the legacy pre-marker CLAUDE.md template manifest from
+ * upstream git history. History-dependent maintenance/CI helper — the shipped
+ * detector reads only the checked-in constants, so this never runs at install
+ * time.
+ *
+ * Usage:
+ *   node scripts/generate-legacy-template-manifest.mjs           # write manifest
+ *   node scripts/generate-legacy-template-manifest.mjs --check   # exit 1 if stale
+ *
+ * A "legacy template" is any revision of docs/CLAUDE.md that predates the OMC
+ * marker mechanism (i.e. contains no `<!-- OMC:START -->`). Normalization is
+ * EOL-only (CRLF/CR -> LF, drop a single trailing newline) to match
+ * normalizeTemplateLines() in src/installer/claude-md-merge.ts.
+ */
+
+import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const MANIFEST_PATH = join(
+  REPO_ROOT,
+  'src',
+  'installer',
+  '__tests__',
+  'fixtures',
+  'legacy-template-manifest.json',
+);
+const OMC_START_MARKER = '<!-- OMC:START -->';
+
+function run(command) {
+  return execSync(command, { cwd: REPO_ROOT, maxBuffer: 1 << 28 }).toString();
+}
+
+function normalizeTemplateLines(text) {
+  const lines = text.replace(/\r\n?/g, '\n').split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+function sha256Hex(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function generate() {
+  const commits = run('git log --all --format=%H -- docs/CLAUDE.md').trim().split('\n').filter(Boolean);
+  const blobs = new Set();
+  for (const commit of commits) {
+    try {
+      const blob = run(`git rev-parse ${commit}:docs/CLAUDE.md`).trim();
+      if (blob) blobs.add(blob);
+    } catch {
+      // Path may not exist at that revision; ignore.
+    }
+  }
+
+  const bySha = new Map();
+  for (const blob of blobs) {
+    const content = run(`git cat-file -p ${blob}`);
+    if (content.includes(OMC_START_MARKER)) continue; // markerless (pre-marker) only
+    const lines = normalizeTemplateLines(content);
+    const sha256 = sha256Hex(lines.join('\n'));
+    if (!bySha.has(sha256)) {
+      bySha.set(sha256, {
+        blob: blob.slice(0, 12),
+        lineCount: lines.length,
+        sha256,
+        heading: lines[0],
+        markerAbsence: true,
+      });
+    }
+  }
+
+  return [...bySha.values()].sort((a, b) => a.lineCount - b.lineCount || a.sha256.localeCompare(b.sha256));
+}
+
+const manifest = generate();
+const serialized = `${JSON.stringify(manifest, null, 2)}\n`;
+
+if (process.argv.includes('--check')) {
+  const current = readFileSync(MANIFEST_PATH, 'utf-8');
+  if (current !== serialized) {
+    process.stderr.write(
+      'Legacy template manifest is stale. Run: node scripts/generate-legacy-template-manifest.mjs\n',
+    );
+    process.exit(1);
+  }
+  process.stdout.write(`Legacy template manifest is up to date (${manifest.length} entries).\n`);
+} else {
+  writeFileSync(MANIFEST_PATH, serialized);
+  process.stdout.write(`Wrote ${manifest.length} entries to ${MANIFEST_PATH}\n`);
+}

--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -221,6 +221,41 @@ write_wrapped_omc_file() {
   } > "$destination"
 }
 
+# Merge OMC content into a CLAUDE.md file through the shared TypeScript merge
+# (src/installer/claude-md-merge.ts, built to dist/cli/commands/merge-claude-md.js).
+# This is the single source of truth shared with the `install()` code path: it
+# removes complete OMC blocks, strips residual legacy pre-marker guides by exact
+# historical match, preserves real user content, and fails safe on malformed
+# markers. Fails loudly if the built entry or node is unavailable so setup never
+# silently falls back to a non-cleanup merge.
+run_shared_merge() {
+  local destination="$1"
+  mkdir -p "$(dirname "$destination")"
+
+  local merge_entry="${OMC_CLAUDE_MD_MERGE_ENTRY:-${ACTIVE_PLUGIN_ROOT}/dist/cli/commands/merge-claude-md.js}"
+  if [ ! -f "$merge_entry" ]; then
+    echo "ERROR: Shared CLAUDE.md merge entry not found: $merge_entry" >&2
+    echo "Rebuild OMC ('npm run build') or reinstall the plugin, then retry." >&2
+    return 1
+  fi
+
+  set -- "$merge_entry" --target "$destination" --source "$TEMP_OMC"
+  if [ -n "${NEW_OMC_VERSION:-}" ]; then
+    set -- "$@" --version "$NEW_OMC_VERSION"
+  fi
+
+  if [ -n "${OMC_NODE_BIN:-}" ]; then
+    "$OMC_NODE_BIN" "$@"
+  elif command -v node >/dev/null 2>&1; then
+    node "$@"
+  elif [ -f "${SCRIPT_DIR}/find-node.sh" ]; then
+    sh "${SCRIPT_DIR}/find-node.sh" "$@"
+  else
+    echo "ERROR: node binary not found; cannot merge CLAUDE.md." >&2
+    return 1
+  fi
+}
+
 ensure_managed_companion_import() {
   local target_path="$1"
   local companion_name="$2"
@@ -288,46 +323,21 @@ if grep -q '<!-- OMC:START -->' "$TEMP_OMC"; then
   mv "${TEMP_OMC}.clean" "$TEMP_OMC"
 fi
 
+# Version to stamp in the merged file, taken from the canonical source content.
+NEW_OMC_VERSION=$(grep -m1 'OMC:VERSION:' "$TEMP_OMC" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
+
 if [ ! -f "$TARGET_PATH" ]; then
-  # Fresh install: wrap in markers
-  write_wrapped_omc_file "$TARGET_PATH"
+  # Fresh install via the shared merge (single source of truth with install()).
+  run_shared_merge "$TARGET_PATH"
   rm -f "$TEMP_OMC"
   echo "Installed CLAUDE.md (fresh)"
 else
   # Merge: preserve user content outside OMC markers
   if grep -q '<!-- OMC:START -->' "$TARGET_PATH"; then
-    # Has markers: remove ALL complete OMC blocks, preserve only real user text
-    # Use perl -0 for a global multiline regex replace (portable across GNU/BSD environments)
-    perl -0pe 's/^<!-- OMC:START -->\R[\s\S]*?^<!-- OMC:END -->(?:\R)?//msg; s/^<!-- User customizations(?: \([^)]+\))? -->\R?//mg; s/\A(?:[ \t]*\R)+//; s/(?:\R[ \t]*)+\z//;' \
-      "$TARGET_PATH" > "${TARGET_PATH}.preserved"
-
-    if grep -Eq '^<!-- OMC:(START|END) -->$' "${TARGET_PATH}.preserved"; then
-      # Corrupted/unmatched markers remain: preserve the whole original file for manual recovery
-      OLD_CONTENT=$(cat "$TARGET_PATH")
-      {
-        echo '<!-- OMC:START -->'
-        cat "$TEMP_OMC"
-        echo '<!-- OMC:END -->'
-        echo ""
-        echo "<!-- User customizations (recovered from corrupted markers) -->"
-        printf '%s\n' "$OLD_CONTENT"
-      } > "${TARGET_PATH}.tmp"
-    else
-      PRESERVED_CONTENT=$(cat "${TARGET_PATH}.preserved")
-      {
-        echo '<!-- OMC:START -->'
-        cat "$TEMP_OMC"
-        echo '<!-- OMC:END -->'
-        if printf '%s' "$PRESERVED_CONTENT" | grep -q '[^[:space:]]'; then
-          echo ""
-          echo "<!-- User customizations -->"
-          printf '%s\n' "$PRESERVED_CONTENT"
-        fi
-      } > "${TARGET_PATH}.tmp"
-    fi
-
-    mv "${TARGET_PATH}.tmp" "$TARGET_PATH"
-    rm -f "${TARGET_PATH}.preserved"
+    # Existing markers: the shared merge removes complete OMC blocks, strips any
+    # residual legacy pre-marker guide, preserves real user content, and falls
+    # back to safe recovery on malformed markers.
+    run_shared_merge "$TARGET_PATH"
     echo "Updated OMC section (user customizations preserved)"
   elif [ "$MODE" = "global" ] && [ "$INSTALL_STYLE" = "preserve" ]; then
     COMPANION_TARGET_PATH="$CONFIG_DIR/$COMPANION_FILENAME"
@@ -337,27 +347,19 @@ else
       cp "$COMPANION_TARGET_PATH" "${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"
       echo "Backed up existing companion CLAUDE.md to ${COMPANION_TARGET_PATH}.backup.${BACKUP_DATE}"
     fi
-    write_wrapped_omc_file "$COMPANION_TARGET_PATH"
+    run_shared_merge "$COMPANION_TARGET_PATH"
     ensure_managed_companion_import "$TARGET_PATH" "$COMPANION_FILENAME"
     VALIDATION_PATH="$COMPANION_TARGET_PATH"
     echo "Installed OMC companion file and preserved existing CLAUDE.md"
   else
-    # No markers: wrap new content in markers, append old content as user section
-    # Strip any preserve-mode import block left by a prior preserve install
+    # No markers: strip any preserve-mode import block left by a prior preserve
+    # install, then let the shared merge wrap new content and migrate the old
+    # content (removing any residual legacy pre-marker guide in the process).
     if grep -Fq "$OMC_IMPORT_START" "$TARGET_PATH"; then
       perl -0pe 's/^<!-- OMC:IMPORT:START -->\R[\s\S]*?^<!-- OMC:IMPORT:END -->(?:\R)?//msg' "$TARGET_PATH" > "${TARGET_PATH}.importless"
       mv "${TARGET_PATH}.importless" "$TARGET_PATH"
     fi
-    OLD_CONTENT=$(cat "$TARGET_PATH")
-    {
-      echo '<!-- OMC:START -->'
-      cat "$TEMP_OMC"
-      echo '<!-- OMC:END -->'
-      echo ""
-      echo "<!-- User customizations (migrated from previous CLAUDE.md) -->"
-      printf '%s\n' "$OLD_CONTENT"
-    } > "${TARGET_PATH}.tmp"
-    mv "${TARGET_PATH}.tmp" "$TARGET_PATH"
+    run_shared_merge "$TARGET_PATH"
     echo "Migrated existing CLAUDE.md (added OMC markers, preserved old content)"
   fi
   rm -f "$TEMP_OMC"

--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -578,6 +578,77 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
     const status = checkClaudeMdStatus();
     expect(status).toBeNull();
   });
+
+  // A block carrying legacy fingerprints (used inside and outside markers).
+  const legacyBody = [
+    '# oh-my-claudecode - Intelligent Multi-Agent Orchestration',
+    'You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**',
+    '',
+    '## PART 1: CORE PROTOCOL (CRITICAL)',
+    '',
+    "The difference? You don't NEED them anymore. Everything auto-activates."
+  ].join('\n');
+
+  it('(d) does not flag fingerprints that live only inside a valid marker block', () => {
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE.md'),
+      `<!-- OMC:START -->\n${legacyBody}\n<!-- OMC:END -->\n`
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasMarkers).toBe(true);
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(false);
+    expect(status!.hasMalformedMarkers).toBe(false);
+  });
+
+  it('flags legacy content that lives outside the marker block', () => {
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE.md'),
+      `<!-- OMC:START -->\n# OMC Config\n<!-- OMC:END -->\n\n<!-- User customizations -->\n${legacyBody}\n`
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(true);
+  });
+
+  it('(blocker 3) detects legacy content hidden behind malformed nested markers', () => {
+    // Adversarial: START / current / START / legacy guide / END. The nested START
+    // makes the structure malformed, so the legacy guide is NOT treated as safely
+    // inside a block and must be reported (plus a malformed-markers warning).
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE.md'),
+      [
+        '<!-- OMC:START -->',
+        '# Current marker-wrapped instructions',
+        '<!-- OMC:START -->',
+        legacyBody,
+        '<!-- OMC:END -->',
+        ''
+      ].join('\n')
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasMalformedMarkers).toBe(true);
+    expect(status!.hasMarkers).toBe(false); // not a healthy marker file
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(true);
+  });
+
+  it('(blocker 4) aggregates legacy content across companions regardless of order', () => {
+    // Clean companion sorts first; legacy content lives in a later companion.
+    writeFileSync(join(TEST_CLAUDE_DIR, 'CLAUDE.md'), '# My clean base config\nSee CLAUDE-a.md\n');
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE-a.md'),
+      '<!-- OMC:START -->\n# OMC Config\n<!-- OMC:END -->\n'
+    );
+    writeFileSync(
+      join(TEST_CLAUDE_DIR, 'CLAUDE-z.md'),
+      `<!-- OMC:START -->\n# OMC Config\n<!-- OMC:END -->\n\n<!-- User customizations -->\n${legacyBody}\n`
+    );
+    const status = checkClaudeMdStatus();
+    expect(status).not.toBeNull();
+    expect(status!.hasMarkers).toBe(true);
+    expect(status!.hasLegacyUnmarkedOmcContent).toBe(true);
+  });
 });
 
 describe('doctor-conflicts: legacy skills collision check (issue #1101)', () => {

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import {
   copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
@@ -12,12 +13,38 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { buildSync } from 'esbuild';
 
 const REPO_ROOT = join(__dirname, '..', '..');
 const SETUP_SCRIPT = join(REPO_ROOT, 'scripts', 'setup-claude-md.sh');
 const CONFIG_DIR_HELPER = join(REPO_ROOT, 'scripts', 'lib', 'config-dir.sh');
+const MERGE_ENTRY_SOURCE = join(REPO_ROOT, 'src', 'cli', 'commands', 'merge-claude-md.ts');
 
 const tempRoots: string[] = [];
+
+// The shell setup path delegates its CLAUDE.md merge to the built
+// dist/cli/commands/merge-claude-md.js. Bundle that entry once (it only depends
+// on node:crypto) so the shell tests exercise the real delegation hermetically,
+// without needing a full `npm run build`.
+//
+// Fixtures with a full plugin layout (createPluginFixture) get the bundle in
+// their own dist/ so the shell resolves it the production way. Minimal fixtures
+// (e.g. the stale-plugin-root resolution tests) point at it via the
+// OMC_CLAUDE_MD_MERGE_ENTRY env override, set here for the whole file.
+let mergeEntryBundle = '';
+let mergeEntryPath = '';
+beforeAll(() => {
+  mergeEntryPath = join(mkdtempSync(join(tmpdir(), 'omc-merge-entry-')), 'merge-claude-md.js');
+  buildSync({
+    entryPoints: [MERGE_ENTRY_SOURCE],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: mergeEntryPath,
+  });
+  mergeEntryBundle = readFileSync(mergeEntryPath, 'utf-8');
+  process.env.OMC_CLAUDE_MD_MERGE_ENTRY = mergeEntryPath;
+});
 
 function createPluginFixture(claudeMdContent: string) {
   const root = mkdtempSync(join(tmpdir(), 'omc-setup-claude-md-'));
@@ -30,11 +57,14 @@ function createPluginFixture(claudeMdContent: string) {
   mkdirSync(join(pluginRoot, 'scripts', 'lib'), { recursive: true });
   mkdirSync(join(pluginRoot, 'docs'), { recursive: true });
   mkdirSync(join(pluginRoot, 'skills', 'omc-reference'), { recursive: true });
+  mkdirSync(join(pluginRoot, 'dist', 'cli', 'commands'), { recursive: true });
   mkdirSync(projectRoot, { recursive: true });
   mkdirSync(homeRoot, { recursive: true });
 
   copyFileSync(SETUP_SCRIPT, join(pluginRoot, 'scripts', 'setup-claude-md.sh'));
   copyFileSync(CONFIG_DIR_HELPER, join(pluginRoot, 'scripts', 'lib', 'config-dir.sh'));
+  // Provide the shared merge entry the shell delegates to (same path as a real install).
+  writeFileSync(join(pluginRoot, 'dist', 'cli', 'commands', 'merge-claude-md.js'), mergeEntryBundle);
   writeFileSync(join(pluginRoot, 'docs', 'CLAUDE.md'), claudeMdContent);
   writeFileSync(join(pluginRoot, 'skills', 'omc-reference', 'SKILL.md'), `---
 name: omc-reference
@@ -568,7 +598,9 @@ Use the real docs file.
     const baseClaude = readFileSync(join(configDir, 'CLAUDE.md'), 'utf-8');
     expect(baseClaude).toContain('<!-- OMC:START -->');
     expect(baseClaude).toContain('<!-- OMC:END -->');
-    expect(baseClaude).toContain('<!-- User customizations (migrated from previous CLAUDE.md) -->');
+    // The shell now routes through the shared TS merge, which preserves user
+    // content under the unified "<!-- User customizations -->" header.
+    expect(baseClaude).toContain('<!-- User customizations -->');
     expect(baseClaude).toContain('# User CLAUDE');
     expect(existsSync(join(configDir, 'CLAUDE-omc.md'))).toBe(false);
   });
@@ -1117,5 +1149,79 @@ describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
     const installed = readFileSync(join(projectRoot, '.claude', 'CLAUDE.md'), 'utf-8');
     expect(installed).toContain('<!-- OMC:VERSION:4.9.0 -->');
     expect(installed).not.toContain('<!-- OMC:VERSION:4.8.2 -->');
+  });
+});
+
+describe('setup-claude-md.sh legacy pre-marker guide cleanup (shell path)', () => {
+  const CANONICAL = [
+    '<!-- OMC:START -->',
+    '<!-- OMC:VERSION:9.9.9 -->',
+    '',
+    '# Canonical CLAUDE',
+    'Current short guide.',
+    '<!-- OMC:END -->',
+    '',
+  ].join('\n');
+  const LEGACY_GUIDE_583 = readFileSync(
+    join(REPO_ROOT, 'src', 'installer', '__tests__', 'fixtures', 'legacy-guide-583.md'),
+    'utf-8',
+  ).replace(/\n+$/, '');
+  const CONDUCTOR = 'You are a CONDUCTOR, not a performer';
+
+  function runGlobalSetup(fixture: ReturnType<typeof createPluginFixture>, configDir: string) {
+    // Drop the env override so the shell resolves the merge entry the production
+    // way: ${ACTIVE_PLUGIN_ROOT}/dist/cli/commands/merge-claude-md.js.
+    const env: NodeJS.ProcessEnv = { ...process.env, HOME: fixture.homeRoot, CLAUDE_CONFIG_DIR: configDir };
+    delete env.OMC_CLAUDE_MD_MERGE_ENTRY;
+    return spawnSync('bash', [fixture.scriptPath, 'global', 'overwrite'], {
+      cwd: fixture.projectRoot,
+      env,
+      encoding: 'utf-8',
+    });
+  }
+
+  it('removes the 583-line legacy guide from a MARKED existing CLAUDE.md and shrinks the file', () => {
+    const fixture = createPluginFixture(CANONICAL);
+    const configDir = join(fixture.homeRoot, 'profile-marked');
+    mkdirSync(configDir, { recursive: true });
+    const targetPath = join(configDir, 'CLAUDE.md');
+    // Current marker block + legacy guide preserved as user customizations + a real user include.
+    const bloated =
+      '<!-- OMC:START -->\n<!-- OMC:VERSION:0.0.1 -->\n# Old OMC\n<!-- OMC:END -->\n\n' +
+      `<!-- User customizations -->\n${LEGACY_GUIDE_583}\n\n@USER.md\n`;
+    writeFileSync(targetPath, bloated);
+    const bytesBefore = readFileSync(targetPath, 'utf-8').length;
+
+    const result = runGlobalSetup(fixture, configDir);
+    expect(result.status).toBe(0);
+
+    const updated = readFileSync(targetPath, 'utf-8');
+    expect(updated.length).toBeLessThan(bytesBefore); // shrinks, never grows
+    expect(updated).not.toContain(CONDUCTOR);
+    expect(updated).toContain('@USER.md'); // real user content preserved
+    expect(updated).toContain('<!-- OMC:VERSION:9.9.9 -->');
+    // A timestamped backup of the original is written before overwrite.
+    const backups = readdirSync(configDir).filter(name => name.startsWith('CLAUDE.md.backup.'));
+    expect(backups.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('removes the 583-line legacy guide from an UNMARKED existing CLAUDE.md and shrinks the file', () => {
+    const fixture = createPluginFixture(CANONICAL);
+    const configDir = join(fixture.homeRoot, 'profile-unmarked');
+    mkdirSync(configDir, { recursive: true });
+    const targetPath = join(configDir, 'CLAUDE.md');
+    // The whole file is the raw pre-marker guide plus a real user include.
+    writeFileSync(targetPath, `${LEGACY_GUIDE_583}\n\n@USER.md\n`);
+    const bytesBefore = readFileSync(targetPath, 'utf-8').length;
+
+    const result = runGlobalSetup(fixture, configDir);
+    expect(result.status).toBe(0);
+
+    const updated = readFileSync(targetPath, 'utf-8');
+    expect(updated.length).toBeLessThan(bytesBefore);
+    expect(updated).not.toContain(CONDUCTOR);
+    expect(updated).toContain('@USER.md');
+    expect(updated).toContain('<!-- OMC:START -->'); // markers added
+    expect(updated).toContain('<!-- OMC:VERSION:9.9.9 -->');
   });
 });

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -6,7 +6,7 @@
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
-import { isOmcHook } from '../../installer/index.js';
+import { isOmcHook, hasLegacyUnmarkedOmcContent, parseOmcMarkerStructure } from '../../installer/index.js';
 import { colors } from '../utils/formatting.js';
 import { getSkillsDir, listBuiltinSkillNames } from '../../features/builtin-skills/skills.js';
 import { inspectUnifiedMcpRegistrySync } from '../../installer/mcp-registry.js';
@@ -25,7 +25,7 @@ export interface WorkspaceMarkerStatus {
 
 export interface ConflictReport {
   hookConflicts: { event: string; command: string; isOmc: boolean }[];
-  claudeMdStatus: { hasMarkers: boolean; hasUserContent: boolean; path: string; companionFile?: string } | null;
+  claudeMdStatus: { hasMarkers: boolean; hasUserContent: boolean; hasLegacyUnmarkedOmcContent: boolean; hasMalformedMarkers: boolean; path: string; companionFile?: string } | null;
   legacySkills: { name: string; path: string }[];
   envFlags: { disableOmc: boolean; skipHooks: string[] };
   configIssues: { unknownFields: string[] };
@@ -159,29 +159,49 @@ export function checkWindowsUnsafePluginHooks(): ConflictReport['windowsUnsafePl
   return unsafe;
 }
 
+interface FileMarkerStatus {
+  hasMarkers: boolean;
+  hasUserContent: boolean;
+  hasLegacyUnmarkedOmcContent: boolean;
+  hasMalformedMarkers: boolean;
+}
+
 /**
- * Check a single file for OMC markers.
- * Returns { hasMarkers, hasUserContent } or null on error.
+ * Check a single file for OMC markers using the same structural, line-anchored
+ * parser as the mutation path (never unanchored substring `includes`). Markers
+ * are "present" only when they form well-formed, non-nested, ordered pairs;
+ * malformed structure is surfaced separately and treated as unhealthy.
  */
-function checkFileForOmcMarkers(filePath: string): { hasMarkers: boolean; hasUserContent: boolean } | null {
+function checkFileForOmcMarkers(filePath: string): FileMarkerStatus | null {
   if (!existsSync(filePath)) return null;
   try {
     const content = readFileSync(filePath, 'utf-8');
-    const hasStartMarker = content.includes('<!-- OMC:START -->');
-    const hasEndMarker = content.includes('<!-- OMC:END -->');
-    const hasMarkers = hasStartMarker && hasEndMarker;
+    const structure = parseOmcMarkerStructure(content);
+    const hasMalformedMarkers = !structure.wellFormed;
+    const hasMarkers = structure.wellFormed && structure.blocks.length > 0;
 
-    let hasUserContent = false;
+    let hasUserContent: boolean;
     if (hasMarkers) {
-      const startIdx = content.indexOf('<!-- OMC:START -->');
-      const endIdx = content.indexOf('<!-- OMC:END -->');
-      const beforeMarker = content.substring(0, startIdx).trim();
-      const afterMarker = content.substring(endIdx + '<!-- OMC:END -->'.length).trim();
-      hasUserContent = beforeMarker.length > 0 || afterMarker.length > 0;
+      const lines = content.replace(/\r\n?/g, '\n').split('\n');
+      const insideBlock = new Array<boolean>(lines.length).fill(false);
+      for (const block of structure.blocks) {
+        for (let i = block.start; i <= block.end; i += 1) {
+          insideBlock[i] = true;
+        }
+      }
+      hasUserContent = lines.filter((_line, index) => !insideBlock[index]).join('\n').trim().length > 0;
     } else {
       hasUserContent = content.trim().length > 0;
     }
-    return { hasMarkers, hasUserContent };
+
+    // Legacy detection is scoped to content outside complete marker blocks, so
+    // fingerprints inside a valid current block do not false-positive.
+    return {
+      hasMarkers,
+      hasUserContent,
+      hasLegacyUnmarkedOmcContent: hasLegacyUnmarkedOmcContent(content),
+      hasMalformedMarkers,
+    };
   } catch {
     return null;
   }
@@ -216,50 +236,52 @@ export function checkClaudeMdStatus(): ConflictReport['claudeMdStatus'] {
   }
 
   try {
-    // Check the main CLAUDE.md first
+    // Check the main CLAUDE.md first.
     const mainResult = checkFileForOmcMarkers(claudeMdPath);
     if (!mainResult) return null;
 
-    if (mainResult.hasMarkers) {
-      return {
-        hasMarkers: true,
-        hasUserContent: mainResult.hasUserContent,
-        path: claudeMdPath
-      };
-    }
-
-    // No markers in main file - check companion files (file-split pattern)
-    const companions = findCompanionClaudeMdFiles(configDir);
-    for (const companionPath of companions) {
-      const companionResult = checkFileForOmcMarkers(companionPath);
-      if (companionResult?.hasMarkers) {
-        return {
-          hasMarkers: true,
-          hasUserContent: mainResult.hasUserContent,
-          path: claudeMdPath,
-          companionFile: companionPath
-        };
-      }
-    }
-
-    // No markers in main or companions - check if CLAUDE.md references a companion
+    // Gather every companion file: those present on disk (file-split pattern) and
+    // any referenced by the main file. Legacy/malformed content can live in any
+    // of them, so we scan all before reporting rather than returning on the
+    // first marked one.
     const content = readFileSync(claudeMdPath, 'utf-8');
+    const companionPaths = new Set<string>(findCompanionClaudeMdFiles(configDir));
     const companionRefPattern = /CLAUDE-[^\s)]+\.md/i;
     const refMatch = content.match(companionRefPattern);
-    if (refMatch) {
-      // CLAUDE.md references a companion file but it doesn't have markers yet
-      return {
-        hasMarkers: false,
-        hasUserContent: mainResult.hasUserContent,
-        path: claudeMdPath,
-        companionFile: join(configDir, refMatch[0])
-      };
+    const referencedCompanion = refMatch ? join(configDir, refMatch[0]) : undefined;
+    if (referencedCompanion) {
+      companionPaths.add(referencedCompanion);
     }
 
+    const companions = [...companionPaths].map(path => ({
+      path,
+      result: checkFileForOmcMarkers(path),
+    }));
+
+    // Aggregate legacy/malformed signals across the main file and all companions.
+    let hasLegacyUnmarkedOmcContentAggregate = mainResult.hasLegacyUnmarkedOmcContent;
+    let hasMalformedMarkersAggregate = mainResult.hasMalformedMarkers;
+    for (const companion of companions) {
+      if (!companion.result) continue;
+      hasLegacyUnmarkedOmcContentAggregate ||= companion.result.hasLegacyUnmarkedOmcContent;
+      hasMalformedMarkersAggregate ||= companion.result.hasMalformedMarkers;
+    }
+
+    // Pick the companion file to surface: prefer the first companion that
+    // actually carries markers, else the referenced one (if any).
+    const markedCompanion = companions.find(companion => companion.result?.hasMarkers);
+    const companionFile = mainResult.hasMarkers
+      ? undefined
+      : markedCompanion?.path ?? referencedCompanion;
+    const hasMarkers = mainResult.hasMarkers || Boolean(markedCompanion);
+
     return {
-      hasMarkers: false,
+      hasMarkers,
       hasUserContent: mainResult.hasUserContent,
-      path: claudeMdPath
+      hasLegacyUnmarkedOmcContent: hasLegacyUnmarkedOmcContentAggregate,
+      hasMalformedMarkers: hasMalformedMarkersAggregate,
+      path: claudeMdPath,
+      ...(companionFile ? { companionFile } : {}),
     };
   } catch (_error) {
     return null;
@@ -558,7 +580,9 @@ export function runConflictCheck(): ConflictReport {
     mcpRegistrySync.claudeMissing.length > 0 ||
     mcpRegistrySync.claudeMismatched.length > 0 ||
     mcpRegistrySync.codexMissing.length > 0 ||
-    mcpRegistrySync.codexMismatched.length > 0;
+    mcpRegistrySync.codexMismatched.length > 0 ||
+    (claudeMdStatus?.hasLegacyUnmarkedOmcContent ?? false) || // Residual pre-marker OMC guide outside markers
+    (claudeMdStatus?.hasMalformedMarkers ?? false); // Malformed/nested OMC markers (fail safe, needs manual repair)
     // Note: Missing OMC markers is informational (normal for fresh install), not a conflict
     // Note: workspaceMarker.precedenceConflict is a WARN, not a hard conflict
 
@@ -628,6 +652,17 @@ export function formatReport(report: ConflictReport, json: boolean): string {
       if (report.claudeMdStatus.hasUserContent) {
         lines.push(`  ${colors.blue('ℹ')} User content present - will be preserved`);
       }
+    }
+    if (report.claudeMdStatus.hasMalformedMarkers) {
+      lines.push(`  ${colors.yellow('⚠')} Malformed OMC markers detected (unmatched or nested START/END)`);
+      lines.push(`    ${colors.gray('Setup will fail safe and preserve the whole file for manual recovery.')}`);
+      lines.push(`    ${colors.gray('Fix the markers by hand, then re-run /oh-my-claudecode:omc-setup.')}`);
+    }
+    if (report.claudeMdStatus.hasLegacyUnmarkedOmcContent) {
+      lines.push(`  ${colors.yellow('⚠')} Legacy pre-marker OMC guide detected outside markers`);
+      lines.push(`    ${colors.gray('This duplicates the current OMC instructions and inflates every session.')}`);
+      lines.push(`    ${colors.gray('Re-run /oh-my-claudecode:omc-setup to strip exact historical copies')}`);
+      lines.push(`    ${colors.gray('(a timestamped CLAUDE.md backup is written first); review any leftover by hand.')}`);
     }
     lines.push(`  ${colors.gray(`Path: ${report.claudeMdStatus.path}`)}`);
     lines.push('');

--- a/src/cli/commands/merge-claude-md.ts
+++ b/src/cli/commands/merge-claude-md.ts
@@ -1,0 +1,74 @@
+/**
+ * Internal CLI entry: merge OMC content into a CLAUDE.md file using the shared,
+ * cleanup-capable {@link mergeClaudeMd}. `scripts/setup-claude-md.sh` invokes
+ * this so the shell setup path and the TypeScript installer share one merge
+ * implementation (including legacy pre-marker guide removal).
+ *
+ * Usage:
+ *   node dist/cli/commands/merge-claude-md.js --target <path> --source <path> [--version <v>]
+ *
+ * Reads the existing target (if present) and the canonical OMC source, writes the
+ * merged result back to target, and exits non-zero on error so the caller can
+ * fail safe instead of writing a half-merged file.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { mergeClaudeMd } from '../../installer/claude-md-merge.js';
+
+interface MergeArgs {
+  target?: string;
+  source?: string;
+  version?: string;
+}
+
+export function parseMergeArgs(argv: string[]): MergeArgs {
+  const args: MergeArgs = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === '--target') {
+      args.target = value;
+      i += 1;
+    } else if (flag === '--source') {
+      args.source = value;
+      i += 1;
+    } else if (flag === '--version') {
+      args.version = value;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+/** Perform the merge; returns the path written. Throws on invalid input. */
+export function runMergeClaudeMd(args: MergeArgs): string {
+  if (!args.target || !args.source) {
+    throw new Error('merge-claude-md requires --target <path> and --source <path>');
+  }
+  if (!existsSync(args.source)) {
+    throw new Error(`merge-claude-md source not found: ${args.source}`);
+  }
+
+  const existingContent = existsSync(args.target) ? readFileSync(args.target, 'utf-8') : null;
+  const omcContent = readFileSync(args.source, 'utf-8');
+  const merged = mergeClaudeMd(existingContent, omcContent, args.version);
+  writeFileSync(args.target, merged);
+  return args.target;
+}
+
+function main(): void {
+  try {
+    const args = parseMergeArgs(process.argv.slice(2));
+    runMergeClaudeMd(args);
+  } catch (error) {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exit(1);
+  }
+}
+
+// Run when invoked directly (not when imported by tests). Match the entry file
+// by basename across build formats (.js/.cjs/.mjs) and the TS source.
+const invokedPath = process.argv[1] ? process.argv[1].replace(/\\/g, '/') : '';
+if (/\/merge-claude-md\.(?:js|cjs|mjs|ts)$/.test(invokedPath)) {
+  main();
+}

--- a/src/installer/__tests__/claude-md-merge.test.ts
+++ b/src/installer/__tests__/claude-md-merge.test.ts
@@ -3,13 +3,22 @@
  * Tests merge-based CLAUDE.md updates with markers and backups
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
-import { mergeClaudeMd } from '../index.js';
+import { mergeClaudeMd, hasLegacyUnmarkedOmcContent, hasLegacyTemplateMatch } from '../index.js';
 
 const START_MARKER = '<!-- OMC:START -->';
 const END_MARKER = '<!-- OMC:END -->';
 const USER_CUSTOMIZATIONS = '<!-- User customizations -->';
 const USER_CUSTOMIZATIONS_RECOVERED = '<!-- User customizations (recovered from corrupted markers) -->';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const readLegacyGuide = (name: string): string =>
+  readFileSync(join(FIXTURES_DIR, name), 'utf-8').replace(/\n+$/, '');
+const LEGACY_HEADING = '# oh-my-claudecode - Intelligent Multi-Agent Orchestration';
+const CONDUCTOR = 'You are a CONDUCTOR, not a performer';
 
 describe('mergeClaudeMd', () => {
   const omcContent = '# OMC Configuration\n\nThis is the OMC content.';
@@ -377,6 +386,156 @@ Second user note`;
 
       expect((result.match(/<!-- User customizations/g) || []).length).toBe(1);
       expect(result).toContain(`${USER_CUSTOMIZATIONS}\nFirst user note\n\nSecond user note`);
+    });
+  });
+
+  describe('legacy unmarked OMC guide removal (exact historical templates)', () => {
+    const guide292 = readLegacyGuide('legacy-guide-292.md');
+    const guide583 = readLegacyGuide('legacy-guide-583.md');
+
+    const buildUpgraded = (body: string): string =>
+      `${START_MARKER}\n${omcContent}\n${END_MARKER}\n\n${USER_CUSTOMIZATIONS}\n${body}`;
+
+    it('fully removes the 583-line historical guide, keeping user content', () => {
+      const existing = buildUpgraded(`${guide583}\n\n@RTK.md`);
+      const result = mergeClaudeMd(existing, omcContent, '4.15.0');
+
+      expect(result).not.toContain(CONDUCTOR);
+      expect(result).not.toContain(LEGACY_HEADING);
+      expect(result).not.toContain('## PART 3: COMPLETE REFERENCE');
+      expect(result).not.toContain(guide583.split('\n').at(-1)!);
+      expect(result).toContain('@RTK.md');
+      expect(result).toContain(omcContent);
+      expect(result).toContain('<!-- OMC:VERSION:4.15.0 -->');
+      expect(result.length).toBeLessThan(existing.length / 2);
+    });
+
+    it('preserves user notes that merely quote two fingerprints (no false-positive span)', () => {
+      const body = [
+        'My orchestration playbook:',
+        `- I love the line "${CONDUCTOR}".`,
+        'KEEP-MIDDLE-USER-NOTE',
+        '- and remember "PART 1: CORE PROTOCOL" from the old guide.'
+      ].join('\n');
+      const result = mergeClaudeMd(buildUpgraded(body), omcContent);
+
+      expect(result).toContain('KEEP-MIDDLE-USER-NOTE');
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('PART 1: CORE PROTOCOL');
+    });
+
+    it('preserves user notes with reversed fingerprint order and the shared heading above', () => {
+      const body = [
+        LEGACY_HEADING,
+        '- quoting "PART 1: CORE PROTOCOL" first,',
+        'KEEP-MIDDLE-USER-NOTE',
+        `- then "${CONDUCTOR}".`
+      ].join('\n');
+      const result = mergeClaudeMd(buildUpgraded(body), omcContent);
+
+      expect(result).toContain('KEEP-MIDDLE-USER-NOTE');
+      expect(result).toContain(LEGACY_HEADING);
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('PART 1: CORE PROTOCOL');
+    });
+
+    it('removes two complete legacy blocks without spanning the user note between them', () => {
+      const body = `${guide292}\n\nMIDDLE-USER-NOTE\n\n${guide583}\n\n@RTK.md`;
+      const result = mergeClaudeMd(buildUpgraded(body), omcContent);
+
+      expect(result).not.toContain(CONDUCTOR);
+      expect(result).not.toContain(LEGACY_HEADING);
+      expect(result).toContain('MIDDLE-USER-NOTE');
+      expect(result).toContain('@RTK.md');
+    });
+
+    it('removes the 292-line historical guide and its CRLF variant', () => {
+      const existing = buildUpgraded(`${guide292}\n\n@RTK.md`);
+
+      const lf = mergeClaudeMd(existing, omcContent);
+      expect(lf).not.toContain(CONDUCTOR);
+      expect(lf).toContain('@RTK.md');
+
+      const crlf = mergeClaudeMd(existing.replace(/\n/g, '\r\n'), omcContent);
+      expect(crlf).not.toContain(CONDUCTOR);
+      expect(crlf).toContain('@RTK.md');
+    });
+
+    it('(blocker 2) preserves a guide edited with Markdown hard-break trailing spaces', () => {
+      // Adding two trailing spaces to a nonblank line changes the user's bytes;
+      // EOL-only normalization must NOT treat it as a verbatim generated block.
+      const edited = guide292.replace(
+        'You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**',
+        'You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**  '
+      );
+      const result = mergeClaudeMd(buildUpgraded(`${edited}\n\n@RTK.md`), omcContent);
+
+      expect(result).toContain(CONDUCTOR); // preserved, not stripped
+      expect(result).toContain('@RTK.md');
+      expect(hasLegacyTemplateMatch(edited)).toBe(false);
+    });
+
+    it('(blocker 2) preserves a guide edited with a trailing tab', () => {
+      const edited = guide292.replace('## PART 1: CORE PROTOCOL (CRITICAL)', '## PART 1: CORE PROTOCOL (CRITICAL)\t');
+      const result = mergeClaudeMd(buildUpgraded(`${edited}\n\n@RTK.md`), omcContent);
+
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('@RTK.md');
+      expect(hasLegacyTemplateMatch(edited)).toBe(false);
+    });
+
+    it('shrinks a bloated file and is idempotent (never grows)', () => {
+      const existing = buildUpgraded(`${guide583}\n\n@RTK.md`);
+      const first = mergeClaudeMd(existing, omcContent, '4.15.0');
+      expect(first.length).toBeLessThan(existing.length);
+
+      const second = mergeClaudeMd(first, omcContent, '4.15.0');
+      expect(second.length).toBeLessThanOrEqual(first.length);
+      expect(second).toContain('@RTK.md');
+      expect(second).not.toContain(CONDUCTOR);
+    });
+
+    it('fails closed on a near-miss variant (fingerprints present but no exact match)', () => {
+      const mutated = guide292.replace(CONDUCTOR, `${CONDUCTOR}\nMY-EXTRA-USER-LINE`);
+      const result = mergeClaudeMd(buildUpgraded(`${mutated}\n\n@RTK.md`), omcContent);
+
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('@RTK.md');
+      expect(hasLegacyUnmarkedOmcContent(mutated)).toBe(true);
+      expect(hasLegacyTemplateMatch(mutated)).toBe(false);
+    });
+
+    it('exposes detection helpers scoped to content outside markers', () => {
+      expect(hasLegacyTemplateMatch(guide583)).toBe(true);
+      expect(hasLegacyUnmarkedOmcContent(guide292)).toBe(true);
+      expect(hasLegacyUnmarkedOmcContent('just my own notes')).toBe(false);
+
+      const insideMarkersOnly = `${START_MARKER}\n${guide292}\n${END_MARKER}\n`;
+      expect(hasLegacyUnmarkedOmcContent(insideMarkersOnly)).toBe(false);
+    });
+  });
+
+  describe('(blocker 3) malformed marker structure fails safe', () => {
+    const guide292 = readLegacyGuide('legacy-guide-292.md');
+
+    it('does not strip anything when markers are nested (START/current/START/legacy/END)', () => {
+      const existing = [
+        START_MARKER,
+        '# Current marker-wrapped instructions',
+        START_MARKER,
+        guide292,
+        END_MARKER,
+        ''
+      ].join('\n');
+      const result = mergeClaudeMd(existing, omcContent, '4.15.0');
+
+      // Fail safe: preserve the whole original under the recovered header rather
+      // than deleting around the malformed markers.
+      expect(result).toContain(USER_CUSTOMIZATIONS_RECOVERED);
+      expect(result).toContain(CONDUCTOR);
+      expect(result).toContain('# Current marker-wrapped instructions');
+      expect((result.match(/<!-- OMC:START -->/g) || []).length).toBe(1);
+      expect((result.match(/<!-- OMC:END -->/g) || []).length).toBe(1);
     });
   });
 });

--- a/src/installer/__tests__/claude-md-target-resolution.test.ts
+++ b/src/installer/__tests__/claude-md-target-resolution.test.ts
@@ -80,6 +80,34 @@ describe('install() CLAUDE.md target resolution', () => {
     expect(backups).toHaveLength(1);
   });
 
+  it('shrinks a CLAUDE.md bloated with a legacy pre-marker guide (does not grow)', async () => {
+    const configClaudePath = join(testClaudeDir, 'CLAUDE.md');
+    const legacyGuide = readFileSync(
+      new URL('./fixtures/legacy-guide-583.md', import.meta.url),
+      'utf-8',
+    ).replace(/\n+$/, '');
+
+    // Pre-marker upgrade artifact: current marker block, the 583-line legacy guide
+    // preserved as "user customizations", plus a real user include to keep.
+    const bloated =
+      '<!-- OMC:START -->\n<!-- OMC:VERSION:0.0.1 -->\n# Old OMC\n<!-- OMC:END -->\n\n' +
+      `<!-- User customizations -->\n${legacyGuide}\n\n@USER.md\n`;
+    writeFileSync(configClaudePath, bloated);
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true, skipHud: true });
+
+    const updated = readFileSync(configClaudePath, 'utf-8');
+
+    expect(result.success).toBe(true);
+    expect(updated.length).toBeLessThan(bloated.length); // shrinks, never grows
+    expect(updated).not.toContain('You are a CONDUCTOR, not a performer');
+    expect(updated).toContain('@USER.md'); // real user content preserved
+
+    const backups = readdirSync(testClaudeDir).filter(name => name.startsWith('CLAUDE.md.backup.'));
+    expect(backups).toHaveLength(1); // original safely backed up before overwrite
+  });
+
   it('preserves project-scoped behavior by skipping global CLAUDE.md writes', async () => {
     process.env.CLAUDE_PLUGIN_ROOT = join(tempRoot, 'project', '.claude', 'plugins', 'oh-my-claudecode');
     writeFileSync(join(testHomeDir, 'CLAUDE.md'), '# Home CLAUDE\nkeep me\n');

--- a/src/installer/__tests__/fixtures/legacy-guide-292.md
+++ b/src/installer/__tests__/fixtures/legacy-guide-292.md
@@ -1,0 +1,292 @@
+# oh-my-claudecode - Intelligent Multi-Agent Orchestration
+
+You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**
+
+---
+
+## PART 1: CORE PROTOCOL (CRITICAL)
+
+### DELEGATION-FIRST PHILOSOPHY
+
+**Your job is to ORCHESTRATE specialists, not to do work yourself.**
+
+```
+RULE 1: ALWAYS delegate substantive work to specialized agents
+RULE 2: ALWAYS invoke appropriate skills for recognized patterns
+RULE 3: NEVER do code changes directly - delegate to executor
+RULE 4: NEVER complete without Architect verification
+```
+
+### What You Do vs. Delegate
+
+| Action | YOU Do Directly | DELEGATE to Agent |
+|--------|-----------------|-------------------|
+| Read files for context | Yes | - |
+| Quick status checks | Yes | - |
+| Create/update todos | Yes | - |
+| Communicate with user | Yes | - |
+| Answer simple questions | Yes | - |
+| **Single-line code change** | NEVER | executor-low |
+| **Multi-file changes** | NEVER | executor / executor-high |
+| **Complex debugging** | NEVER | architect |
+| **UI/frontend work** | NEVER | designer |
+| **Documentation** | NEVER | writer |
+| **Deep analysis** | NEVER | architect / analyst |
+| **Codebase exploration** | NEVER | explore / explore-medium |
+| **Research tasks** | NEVER | researcher |
+| **Visual analysis** | NEVER | vision |
+
+### Mandatory Skill Invocation
+
+When you detect these patterns, you MUST invoke the corresponding skill:
+
+| Pattern Detected | MUST Invoke Skill |
+|------------------|-------------------|
+| Broad/vague request | `planner` (after explore for context) |
+| "don't stop", "must complete", "ralph" | `ralph` |
+| "fast", "parallel", "ulw", "ultrawork" | `ultrawork` |
+| "plan this", "plan the" | `plan` or `planner` |
+| "ralplan" keyword | `ralplan` |
+| UI/component/styling work | `frontend-ui-ux` (silent) |
+| Git/commit work | `git-master` (silent) |
+| "analyze", "debug", "investigate" | `analyze` |
+| "search", "find in codebase" | `deepsearch` |
+| "stop", "cancel", "abort" | appropriate cancel skill |
+
+### Smart Model Routing (SAVE TOKENS)
+
+**ALWAYS pass `model` parameter explicitly when delegating!**
+
+| Task Complexity | Model | When to Use |
+|-----------------|-------|-------------|
+| Simple lookup | `haiku` | "What does this return?", "Find definition of X" |
+| Standard work | `sonnet` | "Add error handling", "Implement feature" |
+| Complex reasoning | `opus` | "Debug race condition", "Refactor architecture" |
+
+---
+
+## PART 2: USER EXPERIENCE
+
+### Zero Learning Curve
+
+Users don't need to learn commands. You detect intent and activate behaviors automatically.
+
+### What Happens Automatically
+
+| When User Says... | You Automatically... |
+|-------------------|---------------------|
+| Complex task | Delegate to specialist agents in parallel |
+| "plan this" / broad request | Start planning interview via planner |
+| "don't stop until done" | Activate ralph-loop for persistence |
+| UI/frontend work | Activate design sensibility + delegate to designer |
+| "fast" / "parallel" | Activate ultrawork for max parallelism |
+| "stop" / "cancel" | Intelligently stop current operation |
+
+### Magic Keywords (Optional Shortcuts)
+
+| Keyword | Effect | Example |
+|---------|--------|---------|
+| `ralph` | Persistence mode | "ralph: refactor auth" |
+| `ulw` | Maximum parallelism | "ulw fix all errors" |
+| `plan` | Planning interview | "plan the new API" |
+| `ralplan` | Iterative planning consensus | "ralplan this feature" |
+
+**Combine them:** "ralph ulw: migrate database" = persistence + parallelism
+
+### Stopping and Cancelling
+
+User says "stop", "cancel", "abort" → You determine what to stop:
+- In ralph-loop → invoke `cancel-ralph`
+- In ultrawork → invoke `cancel-ultrawork`
+- In ultraqa → invoke `cancel-ultraqa`
+- In planning → end interview
+- Unclear → ask user
+
+---
+
+## PART 3: COMPLETE REFERENCE
+
+### All 26 Skills
+
+| Skill | Purpose | Auto-Trigger | Manual |
+|-------|---------|--------------|--------|
+| `orchestrate` | Core multi-agent orchestration | Always active | - |
+| `ralph` | Persistence until verified complete | "don't stop", "must complete" | `/ralph` |
+| `ultrawork` | Maximum parallel execution | "fast", "parallel", "ulw" | `/ultrawork` |
+| `planner` | Strategic planning with interview | "plan this", broad requests | `/planner` |
+| `plan` | Start planning session | "plan" keyword | `/plan` |
+| `ralplan` | Iterative planning (Planner+Architect+Critic) | "ralplan" keyword | `/ralplan` |
+| `review` | Review plan with Critic | "review plan" | `/review` |
+| `analyze` | Deep analysis/investigation | "analyze", "debug", "why" | `/analyze` |
+| `deepsearch` | Thorough codebase search | "search", "find", "where" | `/deepsearch` |
+| `deepinit` | Generate AGENTS.md hierarchy | "index codebase" | `/deepinit` |
+| `frontend-ui-ux` | Design sensibility for UI | UI/component context | (silent) |
+| `git-master` | Git expertise, atomic commits | git/commit context | (silent) |
+| `ultraqa` | QA cycling: test/fix/repeat | "test", "QA", "verify" | `/ultraqa` |
+| `learner` | Extract reusable skill from session | "extract skill" | `/learner` |
+| `note` | Save to notepad for memory | "remember", "note" | `/note` |
+| `hud` | Configure HUD statusline | - | `/hud` |
+| `doctor` | Diagnose installation issues | - | `/doctor` |
+| `help` | Show OMC usage guide | - | `/help` |
+| `omc-setup` | One-time setup wizard | - | `/omc-setup` |
+| `omc-default` | Configure local project | - | (internal) |
+| `omc-default-global` | Configure global settings | - | (internal) |
+| `ralph-init` | Initialize PRD for structured ralph | - | `/ralph-init` |
+| `release` | Automated release workflow | - | `/release` |
+| `cancel-ralph` | Cancel active ralph loop | "stop" in ralph | `/cancel-ralph` |
+| `cancel-ultrawork` | Cancel ultrawork mode | "stop" in ultrawork | `/cancel-ultrawork` |
+| `cancel-ultraqa` | Cancel ultraqa workflow | "stop" in ultraqa | `/cancel-ultraqa` |
+
+### All 20 Agents
+
+Always use `oh-my-claudecode:` prefix when calling via Task tool.
+
+| Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
+|--------|-------------|-----------------|-------------|
+| **Analysis** | `architect-low` | `architect-medium` | `architect` |
+| **Execution** | `executor-low` | `executor` | `executor-high` |
+| **Search** | `explore` | `explore-medium` | - |
+| **Research** | `researcher-low` | `researcher` | - |
+| **Frontend** | `designer-low` | `designer` | `designer-high` |
+| **Docs** | `writer` | - | - |
+| **Visual** | - | `vision` | - |
+| **Planning** | - | - | `planner` |
+| **Critique** | - | - | `critic` |
+| **Pre-Planning** | - | - | `analyst` |
+| **Testing** | - | `qa-tester` | - |
+
+### Agent Selection Guide
+
+| Task Type | Best Agent | Model |
+|-----------|------------|-------|
+| Quick code lookup | `explore` | haiku |
+| Find files/patterns | `explore` or `explore-medium` | haiku/sonnet |
+| Simple code change | `executor-low` | haiku |
+| Feature implementation | `executor` | sonnet |
+| Complex refactoring | `executor-high` | opus |
+| Debug simple issue | `architect-low` | haiku |
+| Debug complex issue | `architect` | opus |
+| UI component | `designer` | sonnet |
+| Complex UI system | `designer-high` | opus |
+| Write docs/comments | `writer` | haiku |
+| Research docs/APIs | `researcher` | sonnet |
+| Analyze images/diagrams | `vision` | sonnet |
+| Strategic planning | `planner` | opus |
+| Review/critique plan | `critic` | opus |
+| Pre-planning analysis | `analyst` | opus |
+| Test CLI interactively | `qa-tester` | sonnet |
+
+---
+
+## PART 4: INTERNAL PROTOCOLS
+
+### Broad Request Detection
+
+A request is BROAD and needs planning if ANY of:
+- Uses vague verbs: "improve", "enhance", "fix", "refactor" without specific targets
+- No specific file or function mentioned
+- Touches 3+ unrelated areas
+- Single sentence without clear deliverable
+
+**When BROAD REQUEST detected:**
+1. Invoke `explore` agent to understand codebase
+2. Optionally invoke `architect` for guidance
+3. THEN invoke `planner` skill with gathered context
+4. Planner asks ONLY user-preference questions
+
+### Mandatory Architect Verification
+
+**HARD RULE: Never claim completion without Architect approval.**
+
+```
+1. Complete all work
+2. Spawn Architect: Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="Verify...")
+3. WAIT for response
+4. If APPROVED → output completion
+5. If REJECTED → fix issues and re-verify
+```
+
+### Parallelization Rules
+
+- **2+ independent tasks** with >30 seconds work → Run in parallel
+- **Sequential dependencies** → Run in order
+- **Quick tasks** (<10 seconds) → Do directly (read, status check)
+
+### Background Execution
+
+**Run in Background** (`run_in_background: true`):
+- npm install, pip install, cargo build
+- npm run build, make, tsc
+- npm test, pytest, cargo test
+
+**Run Blocking** (foreground):
+- git status, ls, pwd
+- File reads/edits
+- Quick commands
+
+Maximum 5 concurrent background tasks.
+
+### Context Persistence
+
+Use `<remember>` tags to survive conversation compaction:
+
+| Tag | Lifetime | Use For |
+|-----|----------|---------|
+| `<remember>info</remember>` | 7 days | Session-specific context |
+| `<remember priority>info</remember>` | Permanent | Critical patterns/facts |
+
+**DO capture:** Architecture decisions, error resolutions, user preferences
+**DON'T capture:** Progress (use todos), temporary state, info in AGENTS.md
+
+### Continuation Enforcement
+
+You are BOUND to your task list. Do not stop until EVERY task is COMPLETE.
+
+Before concluding ANY session, verify:
+- [ ] TODO LIST: Zero pending/in_progress tasks
+- [ ] FUNCTIONALITY: All requested features work
+- [ ] TESTS: All tests pass (if applicable)
+- [ ] ERRORS: Zero unaddressed errors
+- [ ] ARCHITECT: Verification passed
+
+**If ANY unchecked → CONTINUE WORKING.**
+
+---
+
+## PART 5: ANNOUNCEMENTS
+
+When you activate a major behavior, announce it:
+
+> "I'm activating **ralph-loop** to ensure this task completes fully."
+
+> "I'm activating **ultrawork** for maximum parallel execution."
+
+> "I'm starting a **planning session** - I'll interview you about requirements."
+
+> "I'm delegating this to the **architect** agent for deep analysis."
+
+This keeps users informed without requiring them to request features.
+
+---
+
+## PART 6: SETUP
+
+### First Time Setup
+
+Say "setup omc" or run `/omc-setup` to configure. After that, everything is automatic.
+
+### Troubleshooting
+
+- `/doctor` - Diagnose and fix installation issues
+- `/hud setup` - Install/repair HUD statusline
+
+---
+
+## Migration from 2.x
+
+All old commands still work:
+- `/ralph "task"` → Still works (or just say "don't stop until done")
+- `/ultrawork "task"` → Still works (or just say "fast" or use `ulw`)
+- `/planner "task"` → Still works (or just say "plan this")
+
+The difference? You don't NEED them anymore. Everything auto-activates.

--- a/src/installer/__tests__/fixtures/legacy-guide-583.md
+++ b/src/installer/__tests__/fixtures/legacy-guide-583.md
@@ -1,0 +1,583 @@
+# oh-my-claudecode - Intelligent Multi-Agent Orchestration
+
+You are enhanced with multi-agent capabilities. **You are a CONDUCTOR, not a performer.**
+
+## Table of Contents
+- [Quick Start](#quick-start-for-new-users)
+- [Part 1: Core Protocol](#part-1-core-protocol-critical)
+- [Part 2: User Experience](#part-2-user-experience)
+- [Part 3: Complete Reference](#part-3-complete-reference)
+- [Part 4: New Features](#part-4-new-features-v31---v34)
+- [Part 5: Internal Protocols](#part-5-internal-protocols)
+- [Part 6: Announcements](#part-6-announcements)
+- [Part 7: Setup](#part-7-setup)
+
+---
+
+## Quick Start for New Users
+
+**Just say what you want to build:**
+- "I want a REST API for managing tasks"
+- "Build me a React dashboard with charts"
+- "Create a CLI tool that processes CSV files"
+
+Autopilot activates automatically and handles the rest. No commands needed.
+
+---
+
+## PART 1: CORE PROTOCOL (CRITICAL)
+
+### DELEGATION-FIRST PHILOSOPHY
+
+**Your job is to ORCHESTRATE specialists, not to do work yourself.**
+
+```
+RULE 1: ALWAYS delegate substantive work to specialized agents
+RULE 2: ALWAYS invoke appropriate skills for recognized patterns
+RULE 3: NEVER do code changes directly - delegate to executor
+RULE 4: NEVER complete without Architect verification
+```
+
+### What You Do vs. Delegate
+
+| Action | YOU Do Directly | DELEGATE to Agent |
+|--------|-----------------|-------------------|
+| Read files for context | Yes | - |
+| Quick status checks | Yes | - |
+| Create/update todos | Yes | - |
+| Communicate with user | Yes | - |
+| Answer simple questions | Yes | - |
+| **Single-line code change** | NEVER | executor-low |
+| **Multi-file changes** | NEVER | executor / executor-high |
+| **Complex debugging** | NEVER | architect |
+| **UI/frontend work** | NEVER | designer |
+| **Documentation** | NEVER | writer |
+| **Deep analysis** | NEVER | architect / analyst |
+| **Codebase exploration** | NEVER | explore / explore-medium / explore-high |
+| **Research tasks** | NEVER | researcher |
+| **Data analysis** | NEVER | scientist / scientist-high |
+| **Visual analysis** | NEVER | vision |
+
+### Mandatory Skill Invocation
+
+When you detect these patterns, you MUST invoke the corresponding skill:
+
+| Pattern Detected | MUST Invoke Skill |
+|------------------|-------------------|
+| "autopilot", "build me", "I want a" | `autopilot` |
+| Broad/vague request | `planner` (after explore for context) |
+| "don't stop", "must complete", "ralph" | `ralph` |
+| "ulw", "ultrawork" | `ultrawork` (explicit, always) |
+| "eco", "ecomode", "efficient", "save-tokens", "budget" | `ecomode` (explicit, always) |
+| "fast", "parallel" (no explicit mode keyword) | Check `defaultExecutionMode` config → route to default (ultrawork if unset) |
+| "ultrapilot", "parallel build", "swarm build" | `ultrapilot` |
+| "swarm", "coordinated agents" | `swarm` |
+| "pipeline", "chain agents" | `pipeline` |
+| "plan this", "plan the" | `plan` or `planner` |
+| "ralplan" keyword | `ralplan` |
+| UI/component/styling work | `frontend-ui-ux` (silent) |
+| Git/commit work | `git-master` (silent) |
+| "analyze", "debug", "investigate" | `analyze` |
+| "search", "find in codebase" | `deepsearch` |
+| "research", "analyze data", "statistics" | `research` |
+| "tdd", "test first", "red green" | `tdd` |
+| "setup mcp", "configure mcp" | `mcp-setup` |
+| "stop", "cancel", "abort" | `cancel` (unified) |
+
+**Keyword Conflict Resolution:**
+- Explicit mode keywords (`ulw`, `ultrawork`, `eco`, `ecomode`) ALWAYS override defaults
+- If BOTH explicit keywords present (e.g., "ulw eco fix errors"), **ecomode wins** (more token-restrictive)
+- Generic keywords (`fast`, `parallel`) respect config file default
+
+### Smart Model Routing (SAVE TOKENS)
+
+**ALWAYS pass `model` parameter explicitly when delegating!**
+
+| Task Complexity | Model | When to Use |
+|-----------------|-------|-------------|
+| Simple lookup | `haiku` | "What does this return?", "Find definition of X" |
+| Standard work | `sonnet` | "Add error handling", "Implement feature" |
+| Complex reasoning | `opus` | "Debug race condition", "Refactor architecture" |
+
+### Default Execution Mode Preference
+
+When user says "parallel" or "fast" WITHOUT an explicit mode keyword:
+
+1. **Check for explicit mode keywords first:**
+   - "ulw", "ultrawork" → activate `ultrawork` immediately
+   - "eco", "ecomode", "efficient", "save-tokens", "budget" → activate `ecomode` immediately
+
+2. **If no explicit keyword, read config file:**
+   ```bash
+   CONFIG_FILE="$HOME/.claude/.omc-config.json"
+   if [[ -f "$CONFIG_FILE" ]]; then
+     DEFAULT_MODE=$(cat "$CONFIG_FILE" | jq -r '.defaultExecutionMode // "ultrawork"')
+   else
+     DEFAULT_MODE="ultrawork"
+   fi
+   ```
+
+3. **Activate the resolved mode:**
+   - If `"ultrawork"` → activate `ultrawork` skill
+   - If `"ecomode"` → activate `ecomode` skill
+
+**Conflict Resolution Priority:**
+| Priority | Condition | Result |
+|----------|-----------|--------|
+| 1 (highest) | Both explicit keywords present | `ecomode` wins (more restrictive) |
+| 2 | Single explicit keyword | That mode wins |
+| 3 | Generic "fast"/"parallel" only | Read from config |
+| 4 (lowest) | No config file | Default to `ultrawork` |
+
+Users set their preference via `/oh-my-claudecode:omc-setup`.
+
+### Path-Based Write Rules
+
+Direct file writes are enforced via path patterns:
+
+**Allowed Paths (Direct Write OK):**
+| Path | Allowed For |
+|------|-------------|
+| `~/.claude/**` | System configuration |
+| `.omc/**` | OMC state and config |
+| `.claude/**` | Local Claude config |
+| `CLAUDE.md` | User instructions |
+| `AGENTS.md` | AI documentation |
+
+**Warned Paths (Should Delegate):**
+| Extension | Type |
+|-----------|------|
+| `.ts`, `.tsx`, `.js`, `.jsx` | JavaScript/TypeScript |
+| `.py` | Python |
+| `.go`, `.rs`, `.java` | Compiled languages |
+| `.c`, `.cpp`, `.h` | C/C++ |
+| `.svelte`, `.vue` | Frontend frameworks |
+
+**How to Delegate Source File Changes:**
+```
+Task(subagent_type="oh-my-claudecode:executor",
+     model="sonnet",
+     prompt="Edit src/file.ts to add validation...")
+```
+
+This is **soft enforcement** (warnings only). Audit log at `.omc/logs/delegation-audit.jsonl`.
+
+---
+
+## PART 2: USER EXPERIENCE
+
+### Autopilot: The Default Experience
+
+**Autopilot** is the flagship feature and recommended starting point for new users. It provides fully autonomous execution from high-level idea to working, tested code.
+
+When you detect phrases like "autopilot", "build me", or "I want a", activate autopilot mode. This engages:
+- Automatic planning and requirements gathering
+- Parallel execution with multiple specialized agents
+- Continuous verification and testing
+- Self-correction until completion
+- No manual intervention required
+
+Autopilot combines the best of ralph (persistence), ultrawork (parallelism), and planner (strategic thinking) into a single streamlined experience.
+
+### Zero Learning Curve
+
+Users don't need to learn commands. You detect intent and activate behaviors automatically.
+
+### What Happens Automatically
+
+| When User Says... | You Automatically... |
+|-------------------|---------------------|
+| "autopilot", "build me", "I want a" | Activate autopilot for full autonomous execution |
+| Complex task | Delegate to specialist agents in parallel |
+| "plan this" / broad request | Start planning interview via planner |
+| "don't stop until done" | Activate ralph-loop for persistence |
+| UI/frontend work | Activate design sensibility + delegate to designer |
+| "fast" / "parallel" | Activate default execution mode (ultrawork or ecomode per config) |
+| "stop" / "cancel" | Intelligently stop current operation |
+
+### Magic Keywords (Optional Shortcuts)
+
+| Keyword | Effect | Example |
+|---------|--------|---------|
+| `autopilot` | Full autonomous execution | "autopilot: build a todo app" |
+| `ralph` | Persistence mode | "ralph: refactor auth" |
+| `ulw` | Maximum parallelism | "ulw fix all errors" |
+| `plan` | Planning interview | "plan the new API" |
+| `ralplan` | Iterative planning consensus | "ralplan this feature" |
+| `eco` | Token-efficient parallelism | "eco fix all errors" |
+
+**Combine them:** "ralph ulw: migrate database" = persistence + parallelism
+
+### Stopping and Cancelling
+
+User says "stop", "cancel", "abort" → Invoke unified `cancel` skill (automatically detects active mode):
+- Detects and cancels: autopilot, ultrapilot, ralph, ultrawork, ultraqa, swarm, pipeline
+- In planning → end interview
+- Unclear → ask user
+
+---
+
+## PART 3: COMPLETE REFERENCE
+
+### All Skills
+
+| Skill | Purpose | Auto-Trigger | Manual |
+|-------|---------|--------------|--------|
+| `autopilot` | Full autonomous execution from idea to working code | "autopilot", "build me", "I want a" | `/oh-my-claudecode:autopilot` |
+| `orchestrate` | Core multi-agent orchestration | Always active | - |
+| `ralph` | Persistence until verified complete | "don't stop", "must complete" | `/oh-my-claudecode:ralph` |
+| `ultrawork` | Maximum parallel execution | "ulw", "ultrawork" (also "fast"/"parallel" per config) | `/oh-my-claudecode:ultrawork` |
+| `planner` | Strategic planning WITH interview workflow | "plan this", broad requests | `/oh-my-claudecode:planner` |
+| `plan` | Quick planning session (no interview) | "plan" keyword | `/oh-my-claudecode:plan` |
+| `ralplan` | Iterative planning (Planner+Architect+Critic) | "ralplan" keyword | `/oh-my-claudecode:ralplan` |
+| `review` | Review plan with Critic | "review plan" | `/oh-my-claudecode:review` |
+| `analyze` | Deep analysis/investigation | "analyze", "debug", "why" | `/oh-my-claudecode:analyze` |
+| `deepsearch` | Thorough codebase search | "search", "find", "where" | `/oh-my-claudecode:deepsearch` |
+| `deepinit` | Generate AGENTS.md hierarchy | "index codebase" | `/oh-my-claudecode:deepinit` |
+| `frontend-ui-ux` | Design sensibility for UI | UI/component context | (silent) |
+| `git-master` | Git expertise, atomic commits | git/commit context | (silent) |
+| `ultraqa` | QA cycling: test/fix/repeat | "test", "QA", "verify" | `/oh-my-claudecode:ultraqa` |
+| `learner` | Extract reusable skill from session | "extract skill" | `/oh-my-claudecode:learner` |
+| `note` | Save to notepad for memory | "remember", "note" | `/oh-my-claudecode:note` |
+| `hud` | Configure HUD statusline | - | `/oh-my-claudecode:hud` |
+| `doctor` | Diagnose installation issues | - | `/oh-my-claudecode:doctor` |
+| `help` | Show OMC usage guide | - | `/oh-my-claudecode:help` |
+| `omc-setup` | One-time setup wizard | - | `/oh-my-claudecode:omc-setup` |
+| `omc-default` | Configure local project | - | (internal) |
+| `omc-default-global` | Configure global settings | - | (internal) |
+| `ralph-init` | Initialize PRD for structured ralph | - | `/oh-my-claudecode:ralph-init` |
+| `release` | Automated release workflow | - | `/oh-my-claudecode:release` |
+| `ultrapilot` | Parallel autopilot (3-5x faster) | "ultrapilot", "parallel build", "swarm build" | `/oh-my-claudecode:ultrapilot` |
+| `swarm` | N coordinated agents with task claiming | "swarm N agents" | `/oh-my-claudecode:swarm` |
+| `pipeline` | Sequential agent chaining | "pipeline", "chain" | `/oh-my-claudecode:pipeline` |
+| `cancel` | Unified cancellation for all modes | "stop", "cancel" | `/oh-my-claudecode:cancel` |
+| `cancel-autopilot` | Cancel active autopilot (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-autopilot` |
+| `cancel-ralph` | Cancel ralph loop (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ralph` |
+| `cancel-ultrawork` | Cancel ultrawork (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ultrawork` |
+| `cancel-ultraqa` | Cancel ultraqa (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ultraqa` |
+| `ecomode` | Token-efficient parallel execution | "eco", "efficient", "budget" | `/oh-my-claudecode:ecomode` |
+| `cancel-ecomode` | Cancel ecomode (deprecated - use `cancel`) | - | `/oh-my-claudecode:cancel-ecomode` |
+| `research` | Parallel scientist orchestration | "research", "analyze data", "statistics" | `/oh-my-claudecode:research` |
+| `tdd` | TDD enforcement: test-first development | "tdd", "test first" | `/oh-my-claudecode:tdd` |
+| `mcp-setup` | Configure MCP servers for extended capabilities | "setup mcp", "configure mcp" | `/oh-my-claudecode:mcp-setup` |
+
+### All 32 Agents
+
+Always use `oh-my-claudecode:` prefix when calling via Task tool.
+
+| Domain | LOW (Haiku) | MEDIUM (Sonnet) | HIGH (Opus) |
+|--------|-------------|-----------------|-------------|
+| **Analysis** | `architect-low` | `architect-medium` | `architect` |
+| **Execution** | `executor-low` | `executor` | `executor-high` |
+| **Search** | `explore` | `explore-medium` | `explore-high` |
+| **Research** | `researcher-low` | `researcher` | - |
+| **Frontend** | `designer-low` | `designer` | `designer-high` |
+| **Docs** | `writer` | - | - |
+| **Visual** | - | `vision` | - |
+| **Planning** | - | - | `planner` |
+| **Critique** | - | - | `critic` |
+| **Pre-Planning** | - | - | `analyst` |
+| **Testing** | - | `qa-tester` | `qa-tester-high` |
+| **Security** | `security-reviewer-low` | - | `security-reviewer` |
+| **Build** | `build-fixer-low` | `build-fixer` | - |
+| **TDD** | `tdd-guide-low` | `tdd-guide` | - |
+| **Code Review** | `code-reviewer-low` | - | `code-reviewer` |
+| **Data Science** | `scientist-low` | `scientist` | `scientist-high` |
+
+### Agent Selection Guide
+
+| Task Type | Best Agent | Model |
+|-----------|------------|-------|
+| Quick code lookup | `explore` | haiku |
+| Find files/patterns | `explore` or `explore-medium` | haiku/sonnet |
+| Complex architectural search | `explore-high` | opus |
+| Simple code change | `executor-low` | haiku |
+| Feature implementation | `executor` | sonnet |
+| Complex refactoring | `executor-high` | opus |
+| Debug simple issue | `architect-low` | haiku |
+| Debug complex issue | `architect` | opus |
+| UI component | `designer` | sonnet |
+| Complex UI system | `designer-high` | opus |
+| Write docs/comments | `writer` | haiku |
+| Research docs/APIs | `researcher` | sonnet |
+| Analyze images/diagrams | `vision` | sonnet |
+| Strategic planning | `planner` | opus |
+| Review/critique plan | `critic` | opus |
+| Pre-planning analysis | `analyst` | opus |
+| Test CLI interactively | `qa-tester` | sonnet |
+| Security review | `security-reviewer` | opus |
+| Quick security scan | `security-reviewer-low` | haiku |
+| Fix build errors | `build-fixer` | sonnet |
+| Simple build fix | `build-fixer-low` | haiku |
+| TDD workflow | `tdd-guide` | sonnet |
+| Quick test suggestions | `tdd-guide-low` | haiku |
+| Code review | `code-reviewer` | opus |
+| Quick code check | `code-reviewer-low` | haiku |
+| Data analysis/stats | `scientist` | sonnet |
+| Quick data inspection | `scientist-low` | haiku |
+| Complex ML/hypothesis | `scientist-high` | opus |
+
+---
+
+## PART 4: NEW FEATURES (v3.1 - v3.4)
+
+### Notepad Wisdom System
+
+Plan-scoped wisdom capture for learnings, decisions, issues, and problems.
+
+**Location:** `.omc/notepads/{plan-name}/`
+
+| File | Purpose |
+|------|---------|
+| `learnings.md` | Technical discoveries and patterns |
+| `decisions.md` | Architectural and design decisions |
+| `issues.md` | Known issues and workarounds |
+| `problems.md` | Blockers and challenges |
+
+**API:** `initPlanNotepad()`, `addLearning()`, `addDecision()`, `addIssue()`, `addProblem()`, `getWisdomSummary()`, `readPlanWisdom()`
+
+### Delegation Categories
+
+Semantic task categorization that auto-maps to model tier, temperature, and thinking budget.
+
+| Category | Tier | Temperature | Thinking | Use For |
+|----------|------|-------------|----------|---------|
+| `visual-engineering` | HIGH | 0.7 | high | UI/UX, frontend, design systems |
+| `ultrabrain` | HIGH | 0.3 | max | Complex reasoning, architecture, deep debugging |
+| `artistry` | MEDIUM | 0.9 | medium | Creative solutions, brainstorming |
+| `quick` | LOW | 0.1 | low | Simple lookups, basic operations |
+| `writing` | MEDIUM | 0.5 | medium | Documentation, technical writing |
+
+**Auto-detection:** Categories detect from prompt keywords automatically.
+
+### Directory Diagnostics Tool
+
+Project-level type checking via `lsp_diagnostics_directory` tool.
+
+**Strategies:**
+- `auto` (default) - Auto-selects best strategy, prefers tsc when tsconfig.json exists
+- `tsc` - Fast, uses TypeScript compiler
+- `lsp` - Fallback, iterates files via Language Server
+
+**Usage:** Check entire project for errors before commits or after refactoring.
+
+### Session Resume
+
+Background agents can be resumed with full context via `resume-session` tool.
+
+### Ultrapilot (v3.4)
+
+Parallel autopilot with up to 5 concurrent workers for 3-5x faster execution.
+
+**Trigger:** "ultrapilot", "parallel build", "swarm build"
+
+**How it works:**
+1. Task decomposition engine breaks complex tasks into parallelizable subtasks
+2. File ownership coordinator assigns non-overlapping file sets to workers
+3. Workers execute in parallel, coordinator manages shared files
+4. Results integrated with conflict detection
+
+**Best for:** Multi-component systems, fullstack apps, large refactoring
+
+**State files:**
+- `.omc/state/ultrapilot-state.json` - Session state
+- `.omc/state/ultrapilot-ownership.json` - File ownership
+
+### Swarm (v3.4)
+
+N coordinated agents with atomic task claiming from shared pool.
+
+**Usage:** `/swarm 5:executor "fix all TypeScript errors"`
+
+**Features:**
+- Shared task list with pending/claimed/done status
+- 5-minute timeout per task with auto-release
+- Clean completion when all tasks done
+
+### Pipeline (v3.4)
+
+Sequential agent chaining with data passing between stages.
+
+**Built-in Presets:**
+| Preset | Stages |
+|--------|--------|
+| `review` | explore → architect → critic → executor |
+| `implement` | planner → executor → tdd-guide |
+| `debug` | explore → architect → build-fixer |
+| `research` | parallel(researcher, explore) → architect → writer |
+| `refactor` | explore → architect-medium → executor-high → qa-tester |
+| `security` | explore → security-reviewer → executor → security-reviewer-low |
+
+**Custom pipelines:** `/pipeline explore:haiku -> architect:opus -> executor:sonnet`
+
+### Unified Cancel (v3.4)
+
+Smart cancellation that auto-detects active mode.
+
+**Usage:** `/cancel` or just say "stop", "cancel", "abort"
+
+Auto-detects and cancels: autopilot, ultrapilot, ralph, ultrawork, ultraqa, ecomode, swarm, pipeline
+Use `--force` or `--all` to clear ALL states.
+
+### Verification Module (v3.4)
+
+Reusable verification protocol for workflows.
+
+**Standard Checks:** BUILD, TEST, LINT, FUNCTIONALITY, ARCHITECT, TODO, ERROR_FREE
+
+**Evidence validation:** 5-minute freshness detection, pass/fail tracking
+
+### State Management (v3.4)
+
+Standardized state file locations.
+
+**Standard paths:**
+- Local: `.omc/state/{name}.json`
+- Global: `~/.omc/state/{name}.json`
+
+Legacy locations auto-migrated on read.
+
+---
+
+## PART 5: INTERNAL PROTOCOLS
+
+### Broad Request Detection
+
+A request is BROAD and needs planning if ANY of:
+- Uses vague verbs: "improve", "enhance", "fix", "refactor" without specific targets
+- No specific file or function mentioned
+- Touches 3+ unrelated areas
+- Single sentence without clear deliverable
+
+**When BROAD REQUEST detected:**
+1. Invoke `explore` agent to understand codebase
+2. Optionally invoke `architect` for guidance
+3. THEN invoke `planner` skill with gathered context
+4. Planner asks ONLY user-preference questions
+
+### AskUserQuestion in Planning
+
+When in planning/interview mode, use the `AskUserQuestion` tool for preference questions instead of plain text. This provides a clickable UI for faster user responses.
+
+**Applies to**: Planner agent, plan skill, planning interviews
+**Question types**: Preference, Requirement, Scope, Constraint, Risk tolerance
+
+### Mandatory Architect Verification
+
+**HARD RULE: Never claim completion without Architect approval.**
+
+```
+1. Complete all work
+2. Spawn Architect: Task(subagent_type="oh-my-claudecode:architect", model="opus", prompt="Verify...")
+3. WAIT for response
+4. If APPROVED → output completion
+5. If REJECTED → fix issues and re-verify
+```
+
+### Verification-Before-Completion Protocol
+
+**Iron Law:** NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+
+Before ANY agent says "done", "fixed", or "complete":
+
+| Step | Action |
+|------|--------|
+| 1 | IDENTIFY: What command proves this claim? |
+| 2 | RUN: Execute verification command |
+| 3 | READ: Check output - did it pass? |
+| 4 | CLAIM: Make claim WITH evidence |
+
+**Red Flags (agent must STOP and verify):**
+- Using "should", "probably", "seems to"
+- Expressing satisfaction before verification
+- Claiming completion without fresh test/build run
+
+**Evidence Types:**
+| Claim | Required Evidence |
+|-------|-------------------|
+| "Fixed" | Test showing it passes now |
+| "Implemented" | lsp_diagnostics clean + build pass |
+| "Refactored" | All tests still pass |
+| "Debugged" | Root cause identified with file:line |
+
+### Parallelization Rules
+
+- **2+ independent tasks** with >30 seconds work → Run in parallel
+- **Sequential dependencies** → Run in order
+- **Quick tasks** (<10 seconds) → Do directly (read, status check)
+
+### Background Execution
+
+**Run in Background** (`run_in_background: true`):
+- npm install, pip install, cargo build
+- npm run build, make, tsc
+- npm test, pytest, cargo test
+
+**Run Blocking** (foreground):
+- git status, ls, pwd
+- File reads/edits
+- Quick commands
+
+Maximum 5 concurrent background tasks.
+
+### Context Persistence
+
+Use `<remember>` tags to survive conversation compaction:
+
+| Tag | Lifetime | Use For |
+|-----|----------|---------|
+| `<remember>info</remember>` | 7 days | Session-specific context |
+| `<remember priority>info</remember>` | Permanent | Critical patterns/facts |
+
+**DO capture:** Architecture decisions, error resolutions, user preferences
+**DON'T capture:** Progress (use todos), temporary state, info in AGENTS.md
+
+### Continuation Enforcement
+
+You are BOUND to your task list. Do not stop until EVERY task is COMPLETE.
+
+Before concluding ANY session, verify:
+- [ ] TODO LIST: Zero pending/in_progress tasks
+- [ ] FUNCTIONALITY: All requested features work
+- [ ] TESTS: All tests pass (if applicable)
+- [ ] ERRORS: Zero unaddressed errors
+- [ ] ARCHITECT: Verification passed
+
+**If ANY unchecked → CONTINUE WORKING.**
+
+---
+
+## PART 6: ANNOUNCEMENTS
+
+When you activate a major behavior, announce it:
+
+> "I'm activating **autopilot** for full autonomous execution from idea to working code."
+
+> "I'm activating **ralph-loop** to ensure this task completes fully."
+
+> "I'm activating **ultrawork** for maximum parallel execution."
+
+> "I'm starting a **planning session** - I'll interview you about requirements."
+
+> "I'm delegating this to the **architect** agent for deep analysis."
+
+This keeps users informed without requiring them to request features.
+
+---
+
+## PART 7: SETUP
+
+### First Time Setup
+
+Say "setup omc" or run `/oh-my-claudecode:omc-setup` to configure. After that, everything is automatic.
+
+### Troubleshooting
+
+- `/oh-my-claudecode:doctor` - Diagnose and fix installation issues
+- `/oh-my-claudecode:hud setup` - Install/repair HUD statusline
+
+---
+
+## Migration
+
+For migration guides from earlier versions, see [MIGRATION.md](./MIGRATION.md).

--- a/src/installer/__tests__/fixtures/legacy-template-manifest.json
+++ b/src/installer/__tests__/fixtures/legacy-template-manifest.json
@@ -1,0 +1,205 @@
+[
+  {
+    "blob": "df2cf2ed833e",
+    "lineCount": 168,
+    "sha256": "e63ed430c326b64f6673ff1aa2c523ded6432864a05ad96597e930d060fbecb7",
+    "heading": "# Sisyphus Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "30932adbdce0",
+    "lineCount": 220,
+    "sha256": "8953ef9807e8062480f5ea4a3f5831439ce15067f31a95dc95d0d2270b052c27",
+    "heading": "# Sisyphus Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "e96516c9b67b",
+    "lineCount": 222,
+    "sha256": "97629f1df4008d3d9add680342c6291df1d8305618ac5591173814dceeeb1722",
+    "heading": "# Sisyphus Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "1e5adf8fc013",
+    "lineCount": 281,
+    "sha256": "00e5c79ec3357a05ed1fbcb6dccf93e573f938bd6720e5e866afe0a33aa981f6",
+    "heading": "# OMC Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "3a564f00865a",
+    "lineCount": 281,
+    "sha256": "d5bc088810c29163d524936c7c82473d248c4e208647a778a1df593bddb59744",
+    "heading": "# OMC Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "97b83b327b74",
+    "lineCount": 292,
+    "sha256": "549e113b71738e73798096ac4be763a609b92c23fdc936680f20099aed28fa1a",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "173a9c8d542d",
+    "lineCount": 292,
+    "sha256": "570d03a21582707615690f3987139f401a74ce04307f94238550c2491b99f4e3",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "62706f8b0e5e",
+    "lineCount": 296,
+    "sha256": "e0d60a7612c32838058ac874d6e1aaf0922842571ab3c01ba9d0db84e18dbe9d",
+    "heading": "# Sisyphus Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "466569ea4877",
+    "lineCount": 304,
+    "sha256": "5e06d427b9681b1af6e48c53e61b93a5abfc2eb873a9fbd50a1fa583bd24f88d",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "26a56e555af3",
+    "lineCount": 304,
+    "sha256": "f79797777234b0b2321ac1346a096a216064d6e34a0659de9b13aea12f998783",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "60f219084886",
+    "lineCount": 386,
+    "sha256": "730ef988aa6f0c6e7e40224f38531ddf96245f9c4d24b93052bb6d86dc168679",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "294d68014791",
+    "lineCount": 388,
+    "sha256": "70763267fcd0ea35ed5c8eef64cead25ffcdf8c6008c50efd51f9aeaf4525887",
+    "heading": "# Sisyphus Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "95112588b50b",
+    "lineCount": 395,
+    "sha256": "9d317963b8f84231205a1ed4f6744b2fe2b0aeb7833fcddcbe5362b763fdebf7",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "6f005ea35251",
+    "lineCount": 411,
+    "sha256": "80df71c2efa0e1171b1004ff5cbc1ad098f34b23e9c658a2574f544e8aa66452",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "9f90998867fb",
+    "lineCount": 417,
+    "sha256": "abc8fbcc16cd44cd3bc6916124414b1789eb3eeec1720a0029125bd471e46efc",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "7e600225d358",
+    "lineCount": 424,
+    "sha256": "e3b2c65e66d8169e3dd942bff432e5f419cb41e197ecc4d68812e0a964cb0719",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "c01f0039651c",
+    "lineCount": 429,
+    "sha256": "e1f45622c042d007abba9421b9f2c75df1f5eadc0d17a7366e44192b94b22d64",
+    "heading": "# Sisyphus Multi-Agent System",
+    "markerAbsence": true
+  },
+  {
+    "blob": "091f7a4d3313",
+    "lineCount": 431,
+    "sha256": "38be02ee6ee1a4e368f9a5134614bf2ca58faca722ebf451bc4cdfe4f94aeb93",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "36eb3effcfac",
+    "lineCount": 457,
+    "sha256": "0d9234c7026540097d23a4f159f2ee49ba472060b9aee7cf1decb0c3c86fa6e1",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "4903c785e15e",
+    "lineCount": 457,
+    "sha256": "479bcbfc4d04e3e353846e2ca9cc85866b67097b690adedc568636d4143585ff",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "dc02bf379845",
+    "lineCount": 534,
+    "sha256": "6469fc2e3b41ec9d9c1000ac8c143b59f9776967fe1d832c1be4d1d4c6e8d926",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "9b19d53d59f3",
+    "lineCount": 576,
+    "sha256": "03ab36b0d233a19195d892ad43e2033ac12b28a44e629196d05345d70069f28b",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "7d38a2de5a03",
+    "lineCount": 576,
+    "sha256": "df301c7263291356005300f4a3175aa806693525d6f2245434bb173141196d54",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "afbf9cb29227",
+    "lineCount": 583,
+    "sha256": "b0b06eac1cf3ba557f91acc4b93ed2b4ea0ec133a49f84a4d07361f2b9d08c21",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "f2346c49597d",
+    "lineCount": 659,
+    "sha256": "ef1eed15aa9e80372516615a402a28762cc1f611bb0fb3c7d59e74994cb65e3e",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "c75cd527a6fd",
+    "lineCount": 680,
+    "sha256": "4ec039bd333c3ad6aecd16c7206731e97e6963e54a138a97379710261d9bdfa8",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "020424a846f5",
+    "lineCount": 680,
+    "sha256": "c2b6f253f146bbdf80e469751312fea9aecd6900c0d570369d3c285dfdd7f34b",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "b66ec4a761bc",
+    "lineCount": 718,
+    "sha256": "ad7c487773fd21de53dfdeaf40667f7ce37a3979efcaae347b8e30ea2b6525aa",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  },
+  {
+    "blob": "b1e5de1548f3",
+    "lineCount": 720,
+    "sha256": "b1bdafcd18b420d6c75c497e5b339ac1114787abb32bee70a418949c0b0580b5",
+    "heading": "# oh-my-claudecode - Intelligent Multi-Agent Orchestration",
+    "markerAbsence": true
+  }
+]

--- a/src/installer/__tests__/legacy-template-manifest.test.ts
+++ b/src/installer/__tests__/legacy-template-manifest.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Anti-drift guard for the legacy pre-marker template corpus (blocker 5).
+ *
+ * These checks are history-independent: they compare the shipped code constant
+ * against the checked-in provenance manifest and the fixtures, so an accidental
+ * edit to the signatures (or a normalization change) fails CI without needing a
+ * git checkout. `scripts/generate-legacy-template-manifest.mjs --check`
+ * additionally validates the manifest against git history in CI.
+ */
+
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { LEGACY_TEMPLATE_SIGNATURES, normalizeTemplateLines } from '../index.js';
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+interface ManifestEntry {
+  blob: string;
+  lineCount: number;
+  sha256: string;
+  heading: string;
+  markerAbsence: boolean;
+}
+
+const manifest: ManifestEntry[] = JSON.parse(
+  readFileSync(join(FIXTURES_DIR, 'legacy-template-manifest.json'), 'utf-8'),
+);
+
+const KNOWN_HEADINGS = new Set([
+  '# oh-my-claudecode - Intelligent Multi-Agent Orchestration',
+  '# OMC Multi-Agent System',
+  '# Sisyphus Multi-Agent System',
+]);
+
+const sha256Hex = (value: string): string => createHash('sha256').update(value).digest('hex');
+const key = (entry: { lineCount: number; sha256: string }): string => `${entry.lineCount}:${entry.sha256}`;
+
+describe('legacy template manifest ↔ code constant', () => {
+  it('the code constant matches the checked-in manifest exactly', () => {
+    const codeKeys = LEGACY_TEMPLATE_SIGNATURES.map(key).sort();
+    const manifestKeys = manifest.map(key).sort();
+    expect(codeKeys).toEqual(manifestKeys);
+    expect(LEGACY_TEMPLATE_SIGNATURES).toHaveLength(manifest.length);
+  });
+
+  it('every manifest entry is a markerless template with a known heading and valid sha', () => {
+    for (const entry of manifest) {
+      expect(entry.markerAbsence).toBe(true);
+      expect(KNOWN_HEADINGS.has(entry.heading)).toBe(true);
+      expect(entry.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(entry.lineCount).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate signatures', () => {
+    const keys = manifest.map(key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('the shipped fixtures normalize to signatures present in the manifest', () => {
+    for (const [name, lineCount] of [
+      ['legacy-guide-292.md', 292],
+      ['legacy-guide-583.md', 583],
+    ] as const) {
+      const lines = normalizeTemplateLines(readFileSync(join(FIXTURES_DIR, name), 'utf-8'));
+      expect(lines).toHaveLength(lineCount);
+      const sha256 = sha256Hex(lines.join('\n'));
+      expect(manifest.some(entry => entry.sha256 === sha256 && entry.lineCount === lineCount)).toBe(true);
+      expect(LEGACY_TEMPLATE_SIGNATURES.some(sig => sig.sha256 === sha256)).toBe(true);
+    }
+  });
+});

--- a/src/installer/claude-md-merge.ts
+++ b/src/installer/claude-md-merge.ts
@@ -1,0 +1,386 @@
+/**
+ * Shared CLAUDE.md merge + legacy pre-marker guide cleanup.
+ *
+ * This is the single source of truth for merging OMC content into a user's
+ * CLAUDE.md. Both the TypeScript installer (`install()`) and the shell setup
+ * path (`scripts/setup-claude-md.sh`, via the `merge-claude-md` CLI entry)
+ * route through {@link mergeClaudeMd} so the cleanup behavior cannot diverge.
+ *
+ * The module depends only on `node:crypto` so it bundles standalone for the CLI
+ * entry the shell invokes.
+ */
+
+import { createHash } from 'node:crypto';
+
+export const OMC_START_MARKER = '<!-- OMC:START -->';
+export const OMC_END_MARKER = '<!-- OMC:END -->';
+const USER_CUSTOMIZATIONS = '<!-- User customizations -->';
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Find a marker that appears at the start of a line (line-anchored).
+ * This prevents matching markers inside code blocks.
+ */
+function findLineAnchoredMarker(content: string, marker: string, fromEnd = false): number {
+  const regex = new RegExp(`^${escapeRegex(marker)}$`, 'gm');
+  if (fromEnd) {
+    let lastIndex = -1;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+      lastIndex = match.index;
+    }
+    return lastIndex;
+  }
+  const match = regex.exec(content);
+  return match ? match.index : -1;
+}
+
+function createLineAnchoredMarkerRegex(marker: string, flags = 'gm'): RegExp {
+  return new RegExp(`^${escapeRegex(marker)}$`, flags);
+}
+
+function stripGeneratedUserCustomizationHeaders(content: string): string {
+  return content.replace(/^<!-- User customizations(?: \([^)]+\))? -->\r?\n?/gm, '');
+}
+
+function trimClaudeUserContent(content: string): string {
+  if (content.trim().length === 0) {
+    return '';
+  }
+  return content
+    .replace(/^(?:[ \t]*\r?\n)+/, '')
+    .replace(/(?:\r?\n[ \t]*)+$/, '')
+    .replace(/(?:\r?\n){3,}/g, '\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Structural OMC marker parser (shared by mutation and diagnostic paths)
+// ---------------------------------------------------------------------------
+
+export interface OmcMarkerStructure {
+  /** Well-formed, non-nested START..END pairs in document order (line indices). */
+  blocks: Array<{ start: number; end: number }>;
+  /** Structural problems: 'nested-start', 'unmatched-end', 'unmatched-start'. */
+  anomalies: string[];
+  /** True when there are no structural anomalies at all. */
+  wellFormed: boolean;
+}
+
+/**
+ * Parse OMC markers structurally using whole-line anchoring (never substring
+ * `includes`). Validates ordering, pairing and nesting so that both the merge
+ * and the doctor diagnostic agree on what a "complete block" is and can fail
+ * safe on malformed input.
+ */
+export function parseOmcMarkerStructure(content: string): OmcMarkerStructure {
+  const lines = content.replace(/\r\n?/g, '\n').split('\n');
+  const blocks: Array<{ start: number; end: number }> = [];
+  const anomalies: string[] = [];
+  let openStart = -1;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line === OMC_START_MARKER) {
+      if (openStart !== -1) {
+        anomalies.push('nested-start');
+      } else {
+        openStart = i;
+      }
+    } else if (line === OMC_END_MARKER) {
+      if (openStart === -1) {
+        anomalies.push('unmatched-end');
+      } else {
+        blocks.push({ start: openStart, end: i });
+        openStart = -1;
+      }
+    }
+  }
+
+  if (openStart !== -1) {
+    anomalies.push('unmatched-start');
+  }
+
+  return { blocks, anomalies, wellFormed: anomalies.length === 0 };
+}
+
+/**
+ * Return the content that lives OUTSIDE complete, well-formed OMC marker blocks.
+ * Fails safe: on any structural anomaly, nothing is considered "safely inside" a
+ * block and the full content is returned (so legacy scans still see hidden
+ * content and mutation paths do not delete around malformed markers).
+ */
+export function contentOutsideCompleteOmcBlocks(content: string): string {
+  const structure = parseOmcMarkerStructure(content);
+  if (!structure.wellFormed || structure.blocks.length === 0) {
+    return content;
+  }
+
+  const lines = content.replace(/\r\n?/g, '\n').split('\n');
+  const removed = new Array<boolean>(lines.length).fill(false);
+  for (const block of structure.blocks) {
+    for (let i = block.start; i <= block.end; i += 1) {
+      removed[i] = true;
+    }
+  }
+  return lines.filter((_line, index) => !removed[index]).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Legacy pre-marker guide detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Distinctive phrases that appear only in the legacy long-form ("CONDUCTOR")
+ * OMC guide and never in the current marker-wrapped template. Used only as a
+ * coarse doctor heuristic (which warns for manual review); the installer's
+ * strip path relies on exact template matching, not these.
+ */
+const LEGACY_OMC_FINGERPRINTS = [
+  'You are a CONDUCTOR, not a performer',
+  'PART 1: CORE PROTOCOL',
+  'DELEGATION-FIRST PHILOSOPHY',
+  "The difference? You don't NEED them anymore. Everything auto-activates.",
+] as const;
+
+const LEGACY_OMC_FINGERPRINT_THRESHOLD = 2;
+
+/** Count how many distinct legacy OMC fingerprints appear in `content`. */
+export function countLegacyOmcFingerprints(content: string): number {
+  return LEGACY_OMC_FINGERPRINTS.reduce(
+    (count, fingerprint) => (content.includes(fingerprint) ? count + 1 : count),
+    0
+  );
+}
+
+/**
+ * Opening headings used across the pre-marker eras of the shipped template.
+ * A legacy guide always begins with one of these, so they gate the exact-match
+ * scan and mark candidate block starts.
+ */
+const LEGACY_TEMPLATE_HEADINGS = [
+  '# oh-my-claudecode - Intelligent Multi-Agent Orchestration',
+  '# OMC Multi-Agent System',
+  '# Sisyphus Multi-Agent System',
+] as const;
+
+export interface LegacyTemplateSignature {
+  /** Number of {@link normalizeTemplateLines}-normalized lines in the template. */
+  lineCount: number;
+  /** SHA-256 of the normalized template lines joined by "\n". */
+  sha256: string;
+}
+
+/**
+ * Fingerprints of every pre-marker `docs/CLAUDE.md` revision in upstream git
+ * history (all markerless blobs; the marker mechanism was introduced later).
+ * The pre-marker installer wrote one of these guides verbatim into the user's
+ * CLAUDE.md, so an exact match against a preserved region is a structural proof
+ * that the region is a stale generated guide rather than user-authored text.
+ *
+ * Normalization is EOL-only (see {@link normalizeTemplateLines}): CRLF/CR -> LF
+ * and a single trailing newline dropped. No whitespace is stripped, so any
+ * user edit (e.g. Markdown hard-break trailing spaces) makes the region differ
+ * from every template and be preserved.
+ *
+ * This list is kept in sync with the checked-in provenance manifest
+ * `src/installer/__tests__/fixtures/legacy-template-manifest.json`; a test
+ * asserts they match, and `scripts/generate-legacy-template-manifest.mjs`
+ * regenerates both from git history.
+ */
+export const LEGACY_TEMPLATE_SIGNATURES: readonly LegacyTemplateSignature[] = [
+  { lineCount: 168, sha256: "e63ed430c326b64f6673ff1aa2c523ded6432864a05ad96597e930d060fbecb7" }, // df2cf2ed833e "# Sisyphus Multi-Agent System"
+  { lineCount: 220, sha256: "8953ef9807e8062480f5ea4a3f5831439ce15067f31a95dc95d0d2270b052c27" }, // 30932adbdce0 "# Sisyphus Multi-Agent System"
+  { lineCount: 222, sha256: "97629f1df4008d3d9add680342c6291df1d8305618ac5591173814dceeeb1722" }, // e96516c9b67b "# Sisyphus Multi-Agent System"
+  { lineCount: 281, sha256: "00e5c79ec3357a05ed1fbcb6dccf93e573f938bd6720e5e866afe0a33aa981f6" }, // 1e5adf8fc013 "# OMC Multi-Agent System"
+  { lineCount: 281, sha256: "d5bc088810c29163d524936c7c82473d248c4e208647a778a1df593bddb59744" }, // 3a564f00865a "# OMC Multi-Agent System"
+  { lineCount: 292, sha256: "549e113b71738e73798096ac4be763a609b92c23fdc936680f20099aed28fa1a" }, // 97b83b327b74 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 292, sha256: "570d03a21582707615690f3987139f401a74ce04307f94238550c2491b99f4e3" }, // 173a9c8d542d "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 296, sha256: "e0d60a7612c32838058ac874d6e1aaf0922842571ab3c01ba9d0db84e18dbe9d" }, // 62706f8b0e5e "# Sisyphus Multi-Agent System"
+  { lineCount: 304, sha256: "5e06d427b9681b1af6e48c53e61b93a5abfc2eb873a9fbd50a1fa583bd24f88d" }, // 466569ea4877 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 304, sha256: "f79797777234b0b2321ac1346a096a216064d6e34a0659de9b13aea12f998783" }, // 26a56e555af3 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 386, sha256: "730ef988aa6f0c6e7e40224f38531ddf96245f9c4d24b93052bb6d86dc168679" }, // 60f219084886 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 388, sha256: "70763267fcd0ea35ed5c8eef64cead25ffcdf8c6008c50efd51f9aeaf4525887" }, // 294d68014791 "# Sisyphus Multi-Agent System"
+  { lineCount: 395, sha256: "9d317963b8f84231205a1ed4f6744b2fe2b0aeb7833fcddcbe5362b763fdebf7" }, // 95112588b50b "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 411, sha256: "80df71c2efa0e1171b1004ff5cbc1ad098f34b23e9c658a2574f544e8aa66452" }, // 6f005ea35251 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 417, sha256: "abc8fbcc16cd44cd3bc6916124414b1789eb3eeec1720a0029125bd471e46efc" }, // 9f90998867fb "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 424, sha256: "e3b2c65e66d8169e3dd942bff432e5f419cb41e197ecc4d68812e0a964cb0719" }, // 7e600225d358 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 429, sha256: "e1f45622c042d007abba9421b9f2c75df1f5eadc0d17a7366e44192b94b22d64" }, // c01f0039651c "# Sisyphus Multi-Agent System"
+  { lineCount: 431, sha256: "38be02ee6ee1a4e368f9a5134614bf2ca58faca722ebf451bc4cdfe4f94aeb93" }, // 091f7a4d3313 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 457, sha256: "0d9234c7026540097d23a4f159f2ee49ba472060b9aee7cf1decb0c3c86fa6e1" }, // 36eb3effcfac "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 457, sha256: "479bcbfc4d04e3e353846e2ca9cc85866b67097b690adedc568636d4143585ff" }, // 4903c785e15e "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 534, sha256: "6469fc2e3b41ec9d9c1000ac8c143b59f9776967fe1d832c1be4d1d4c6e8d926" }, // dc02bf379845 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 576, sha256: "03ab36b0d233a19195d892ad43e2033ac12b28a44e629196d05345d70069f28b" }, // 9b19d53d59f3 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 576, sha256: "df301c7263291356005300f4a3175aa806693525d6f2245434bb173141196d54" }, // 7d38a2de5a03 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 583, sha256: "b0b06eac1cf3ba557f91acc4b93ed2b4ea0ec133a49f84a4d07361f2b9d08c21" }, // afbf9cb29227 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 659, sha256: "ef1eed15aa9e80372516615a402a28762cc1f611bb0fb3c7d59e74994cb65e3e" }, // f2346c49597d "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 680, sha256: "4ec039bd333c3ad6aecd16c7206731e97e6963e54a138a97379710261d9bdfa8" }, // c75cd527a6fd "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 680, sha256: "c2b6f253f146bbdf80e469751312fea9aecd6900c0d570369d3c285dfdd7f34b" }, // 020424a846f5 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 718, sha256: "ad7c487773fd21de53dfdeaf40667f7ce37a3979efcaae347b8e30ea2b6525aa" }, // b66ec4a761bc "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+  { lineCount: 720, sha256: "b1bdafcd18b420d6c75c497e5b339ac1114787abb32bee70a418949c0b0580b5" }, // b1e5de1548f3 "# oh-my-claudecode - Intelligent Multi-Agent Orchestration"
+];
+
+const LEGACY_TEMPLATE_HASHES: ReadonlySet<string> = new Set(
+  LEGACY_TEMPLATE_SIGNATURES.map(signature => signature.sha256)
+);
+
+/** Distinct template lengths, longest first (prefer the largest proven block). */
+const LEGACY_TEMPLATE_LENGTHS: readonly number[] = [
+  ...new Set(LEGACY_TEMPLATE_SIGNATURES.map(signature => signature.lineCount)),
+].sort((a, b) => b - a);
+
+/**
+ * Split `content` into template-comparison lines. Normalization is EOL-only:
+ * CRLF/CR are converted to LF and a single trailing newline is dropped. No
+ * whitespace within or around lines is altered, so only a byte-identical
+ * (modulo EOL) region can match a historical template.
+ */
+export function normalizeTemplateLines(content: string): string[] {
+  const lines = content.replace(/\r\n?/g, '\n').split('\n');
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/** True when `content` contains a region that exactly matches a known template. */
+export function hasLegacyTemplateMatch(content: string): boolean {
+  return stripLegacyUnmarkedOmcContent(content) !== content;
+}
+
+/**
+ * Detect residual legacy pre-marker OMC guidance living OUTSIDE complete,
+ * well-formed OMC marker blocks. Used by the doctor diagnostic to warn for
+ * manual review. Intentionally broader than the installer's strip: it also
+ * flags fingerprinted near-miss variants that exact matching leaves in place.
+ */
+export function hasLegacyUnmarkedOmcContent(content: string): boolean {
+  const outsideMarkers = contentOutsideCompleteOmcBlocks(content);
+  return (
+    countLegacyOmcFingerprints(outsideMarkers) >= LEGACY_OMC_FINGERPRINT_THRESHOLD ||
+    hasLegacyTemplateMatch(outsideMarkers)
+  );
+}
+
+/**
+ * Remove residual legacy (pre-marker) OMC guides from `content`.
+ *
+ * Removal is proof-based and fails closed: a region is removed only when a
+ * contiguous run of lines, starting at a known template heading, matches a
+ * recorded historical template byte-for-byte (modulo EOL). Each proven block
+ * is removed independently; content between or around blocks is never spanned.
+ * Anything that does not match exactly is left untouched.
+ */
+function stripLegacyUnmarkedOmcContent(content: string): string {
+  if (!LEGACY_TEMPLATE_HEADINGS.some(heading => content.includes(heading))) {
+    return content;
+  }
+
+  const physicalLines = content.replace(/\r\n?/g, '\n').split('\n');
+  const total = physicalLines.length;
+  const headingSet: ReadonlySet<string> = new Set(LEGACY_TEMPLATE_HEADINGS);
+  const removed = new Array<boolean>(total).fill(false);
+  let matchedAny = false;
+
+  for (let start = 0; start < total; ) {
+    if (!headingSet.has(physicalLines[start])) {
+      start += 1;
+      continue;
+    }
+
+    let matchedLength = 0;
+    for (const length of LEGACY_TEMPLATE_LENGTHS) {
+      if (start + length > total) {
+        continue;
+      }
+      const window = physicalLines.slice(start, start + length).join('\n');
+      if (LEGACY_TEMPLATE_HASHES.has(sha256Hex(window))) {
+        matchedLength = length;
+        break;
+      }
+    }
+
+    if (matchedLength > 0) {
+      for (let k = start; k < start + matchedLength; k += 1) {
+        removed[k] = true;
+      }
+      matchedAny = true;
+      start += matchedLength;
+    } else {
+      start += 1;
+    }
+  }
+
+  if (!matchedAny) {
+    return content;
+  }
+  return physicalLines.filter((_line, index) => !removed[index]).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge OMC content into an existing CLAUDE.md using markers.
+ * @param existingContent - Existing CLAUDE.md content (null if file doesn't exist)
+ * @param omcContent - Canonical OMC content to inject (markers optional)
+ * @param version - Version string to stamp in the OMC:VERSION marker
+ */
+export function mergeClaudeMd(existingContent: string | null, omcContent: string, version?: string): string {
+  const START_MARKER = OMC_START_MARKER;
+  const END_MARKER = OMC_END_MARKER;
+  const markerStartRegex = createLineAnchoredMarkerRegex(START_MARKER);
+  const markerEndRegex = createLineAnchoredMarkerRegex(END_MARKER);
+
+  // Idempotency guard: strip markers from omcContent if already present
+  // (docs/CLAUDE.md ships with markers).
+  let cleanOmcContent = omcContent;
+  const omcStartIdx = findLineAnchoredMarker(omcContent, START_MARKER);
+  const omcEndIdx = findLineAnchoredMarker(omcContent, END_MARKER, true);
+  if (omcStartIdx !== -1 && omcEndIdx !== -1 && omcStartIdx < omcEndIdx) {
+    cleanOmcContent = omcContent.substring(omcStartIdx + START_MARKER.length, omcEndIdx).trim();
+  }
+
+  // Strip any existing version marker from content and inject current version.
+  cleanOmcContent = cleanOmcContent.replace(/<!-- OMC:VERSION:[^\s]*? -->\n?/, '');
+  const versionMarker = version ? `<!-- OMC:VERSION:${version} -->\n` : '';
+
+  // Case 1: No existing content - wrap omcContent in markers.
+  if (!existingContent) {
+    return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n`;
+  }
+
+  const structure = parseOmcMarkerStructure(existingContent);
+
+  // Case 2: Malformed marker structure (unmatched/nested markers). Fail safe:
+  // do not strip anything; preserve the whole original file for manual recovery.
+  if (!structure.wellFormed) {
+    const recoveredContent = existingContent
+      .replace(markerStartRegex, '')
+      .replace(markerEndRegex, '')
+      .trim();
+    return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n\n<!-- User customizations (recovered from corrupted markers) -->\n${recoveredContent}`;
+  }
+
+  // Remove complete OMC blocks, then remove residual legacy pre-marker guides,
+  // then preserve whatever real user content remains.
+  const strippedExistingContent = contentOutsideCompleteOmcBlocks(existingContent);
+  const cleanedExistingContent = stripLegacyUnmarkedOmcContent(strippedExistingContent);
+  const preservedUserContent = trimClaudeUserContent(
+    stripGeneratedUserCustomizationHeaders(cleanedExistingContent)
+  );
+
+  if (!preservedUserContent) {
+    return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n`;
+  }
+
+  // Case 3: Preserve only user-authored content that lives outside OMC markers.
+  return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n\n${USER_CUSTOMIZATIONS}\n${preservedUserContent}`;
+}

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -29,6 +29,22 @@ import { OMC_CONFIG_FILE_REL } from '../lib/paths.js';
 import { buildHudWrapper } from '../lib/hud-wrapper-template.js';
 import { getOmcRoot } from '../lib/worktree-paths.js';
 import { syncOmcLearnedUserSkillsForClaudeCode } from '../utils/user-skill-compat.js';
+import { mergeClaudeMd } from './claude-md-merge.js';
+
+// Re-export the shared CLAUDE.md merge + legacy cleanup API so existing importers
+// (doctor diagnostics, tests, the merge-claude-md CLI) keep a single entry point.
+export { mergeClaudeMd };
+export {
+  hasLegacyUnmarkedOmcContent,
+  hasLegacyTemplateMatch,
+  countLegacyOmcFingerprints,
+  parseOmcMarkerStructure,
+  contentOutsideCompleteOmcBlocks,
+  normalizeTemplateLines,
+  LEGACY_TEMPLATE_SIGNATURES,
+  type LegacyTemplateSignature,
+  type OmcMarkerStructure,
+} from './claude-md-merge.js';
 
 /** Claude Code configuration directory */
 export const CLAUDE_CONFIG_DIR = getClaudeConfigDir();
@@ -151,38 +167,6 @@ function getNewestInstalledVersionHint(): string | null {
   );
 }
 
-/**
- * Find a marker that appears at the start of a line (line-anchored).
- * This prevents matching markers inside code blocks.
- * @param content - The content to search in
- * @param marker - The marker string to find
- * @param fromEnd - If true, finds the LAST occurrence instead of first
- * @returns The index of the marker, or -1 if not found
- */
-function findLineAnchoredMarker(content: string, marker: string, fromEnd: boolean = false): number {
-  // Escape special regex characters in marker
-  const escapedMarker = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const regex = new RegExp(`^${escapedMarker}$`, 'gm');
-
-  if (fromEnd) {
-    // Find the last occurrence
-    let lastIndex = -1;
-    let match;
-    while ((match = regex.exec(content)) !== null) {
-      lastIndex = match.index;
-    }
-    return lastIndex;
-  } else {
-    // Find the first occurrence
-    const match = regex.exec(content);
-    return match ? match.index : -1;
-  }
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function normalizePath(value: string): string {
   return value.replace(/\\/g, '/').replace(/\/+$/, '');
 }
@@ -236,28 +220,6 @@ function buildStatusLineCommand(
   }
 
   return `node ${quoteShellArg(normalizedHudScriptPath)}`;
-}
-
-function createLineAnchoredMarkerRegex(marker: string, flags: string = 'gm'): RegExp {
-  return new RegExp(`^${escapeRegex(marker)}$`, flags);
-}
-
-function stripGeneratedUserCustomizationHeaders(content: string): string {
-  return content.replace(
-    /^<!-- User customizations(?: \([^)]+\))? -->\r?\n?/gm,
-    ''
-  );
-}
-
-function trimClaudeUserContent(content: string): string {
-  if (content.trim().length === 0) {
-    return '';
-  }
-
-  return content
-    .replace(/^(?:[ \t]*\r?\n)+/, '')
-    .replace(/(?:\r?\n[ \t]*)+$/, '')
-    .replace(/(?:\r?\n){3,}/g, '\n\n');
 }
 
 /** Installation result */
@@ -1987,72 +1949,6 @@ export function syncPersistedSetupVersion(options?: {
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify({ ...config, setupVersion: normalizedVersion }, null, 2));
   return true;
-}
-
-/**
- * Merge OMC content into existing CLAUDE.md using markers
- * @param existingContent - Existing CLAUDE.md content (null if file doesn't exist)
- * @param omcContent - New OMC content to inject
- * @returns Merged content with markers
- */
-export function mergeClaudeMd(existingContent: string | null, omcContent: string, version?: string): string {
-  const START_MARKER = '<!-- OMC:START -->';
-  const END_MARKER = '<!-- OMC:END -->';
-  const USER_CUSTOMIZATIONS = '<!-- User customizations -->';
-  const OMC_BLOCK_PATTERN = new RegExp(
-    `^${escapeRegex(START_MARKER)}\\r?\\n[\\s\\S]*?^${escapeRegex(END_MARKER)}(?:\\r?\\n)?`,
-    'gm'
-  );
-  const markerStartRegex = createLineAnchoredMarkerRegex(START_MARKER);
-  const markerEndRegex = createLineAnchoredMarkerRegex(END_MARKER);
-
-  // Idempotency guard: strip markers from omcContent if already present
-  // This handles the case where docs/CLAUDE.md ships with markers
-  let cleanOmcContent = omcContent;
-  const omcStartIdx = findLineAnchoredMarker(omcContent, START_MARKER);
-  const omcEndIdx = findLineAnchoredMarker(omcContent, END_MARKER, true);
-  if (omcStartIdx !== -1 && omcEndIdx !== -1 && omcStartIdx < omcEndIdx) {
-    // Extract content between markers, trimming any surrounding whitespace
-    cleanOmcContent = omcContent
-      .substring(omcStartIdx + START_MARKER.length, omcEndIdx)
-      .trim();
-  }
-
-  // Strip any existing version marker from content and inject current version
-  cleanOmcContent = cleanOmcContent.replace(/<!-- OMC:VERSION:[^\s]*? -->\n?/, '');
-  const versionMarker = version ? `<!-- OMC:VERSION:${version} -->\n` : '';
-
-  // Case 1: No existing content - wrap omcContent in markers
-  if (!existingContent) {
-    return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n`;
-  }
-
-  const strippedExistingContent = existingContent.replace(OMC_BLOCK_PATTERN, '');
-  const hasResidualStartMarker = markerStartRegex.test(strippedExistingContent);
-  const hasResidualEndMarker = markerEndRegex.test(strippedExistingContent);
-
-  // Case 2: Corrupted markers (unmatched markers remain after removing complete blocks)
-  if (hasResidualStartMarker || hasResidualEndMarker) {
-    // Handle corrupted state - backup will be created by caller
-    // Strip unmatched OMC markers from recovered content to prevent unbounded
-    // growth on repeated calls (each call would re-detect corruption and append again)
-    const recoveredContent = strippedExistingContent
-      .replace(markerStartRegex, '')
-      .replace(markerEndRegex, '')
-      .trim();
-    return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n\n<!-- User customizations (recovered from corrupted markers) -->\n${recoveredContent}`;
-  }
-
-  const preservedUserContent = trimClaudeUserContent(
-    stripGeneratedUserCustomizationHeaders(strippedExistingContent)
-  );
-
-  if (!preservedUserContent) {
-    return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n`;
-  }
-
-  // Case 3: Preserve only user-authored content that lives outside OMC markers
-  return `${START_MARKER}\n${versionMarker}${cleanOmcContent}\n${END_MARKER}\n\n${USER_CUSTOMIZATIONS}\n${preservedUserContent}`;
 }
 
 /**


### PR DESCRIPTION
Addresses #3442; follow-up to #3443/#3444 per @Yeachan-Heo's review.

Every blocking finding from the #3444 review is addressed below.

## 1 (P1) — the advertised remediation now executes the cleanup

The merge logic is extracted into `src/installer/claude-md-merge.ts` as the single source of truth and exposed via a small `merge-claude-md` CLI entry (`src/cli/commands/merge-claude-md.ts`, built to `dist/cli/commands/merge-claude-md.js`). `scripts/setup-claude-md.sh` — what `/oh-my-claudecode:omc-setup` runs — now **delegates its CLAUDE.md merge to that entry** instead of its own bash/perl merger. So the slash setup path strips legacy guides exactly like `install()`.

It fails loudly (aborts, backup intact) if the built entry or node is missing, rather than silently falling back to a non-cleanup merge. New shell-path regressions start from both a **marked** and an **unmarked** 583-line guide and assert the file shrinks, the guide is gone, and `@USER.md` survives.

## 2 (P1) — EOL-only normalization (no more deleting edited bytes)

`normalizeTemplateLines()` now normalizes **only** line endings (CRLF/CR → LF, drop one trailing newline) — no trailing-whitespace stripping. A guide edited with Markdown hard-break trailing spaces (or a tab) no longer hashes to a historical template and is preserved. The 29 signatures were recomputed under this rule (line counts unchanged; the historical blobs happen to carry no trailing whitespace, so the fixtures still match). Regressions cover both the hard-break-spaces and trailing-tab cases.

## 3 (P2) — one structural, line-anchored marker parser

`parseOmcMarkerStructure()` validates ordering, pairing and nesting using whole-line anchoring (never substring `includes`), and is shared by both the mutation path and doctor. Malformed structure **fails safe**: `mergeClaudeMd` preserves the whole file under the recovered-content header, and doctor reports `hasMalformedMarkers` + still flags any legacy content. The adversarial `START / current / START / exact legacy guide / END` is now detected (both a merge regression and a doctor regression).

## 4 (P2) — companion aggregation

`checkClaudeMdStatus()` no longer returns on the first marked companion or when the main file has markers. It scans the main file and **every** present/referenced companion and ORs their legacy/malformed results. Regression: clean `CLAUDE-a.md` first, legacy content in `CLAUDE-z.md` → reported.

## 5 (P2) — manifest anti-drift

`src/installer/__tests__/fixtures/legacy-template-manifest.json` records `{blob, lineCount, sha256, heading, markerAbsence}` for all 29 markerless revisions. A **history-independent** test (`legacy-template-manifest.test.ts`) asserts the shipped code constant matches the manifest and that the fixtures normalize into it. `scripts/generate-legacy-template-manifest.mjs [--check]` regenerates/verifies the manifest from git history for CI/maintenance.

## Retained v2 behavior

Exact-match removal, fail-closed on near-misses, multi-block removal without spanning, fingerprints-inside-markers not flagged, the `install()` smoke (file shrinks, backup written, `@USER.md`/`@RTK.md` preserved) — all still covered.

## Verification

Focused installer/doctor/setup suites: 112/112 pass (incl. all new blocker regressions). `npx tsc --noEmit` clean. `npm run lint` 0 errors (19 pre-existing warnings, none in changed files). `npm run build` succeeds and emits `dist/cli/commands/merge-claude-md.js`; a manual run of the real built entry removes the 583-line guide (23,148 → 113 bytes) and preserves `@USER.md`. `scripts/generate-legacy-template-manifest.mjs --check` passes.

Full `npm run test:run`: 10,178 passed / 8 skipped / 4 failed — the 4 failures are the known parallel-load flakes (`runtime-watchdog-retry`, `session-end-timeout`, `standalone-hook-reconcile`, shared-`/tmp` state), all of which pass in isolation and are unrelated to this change (the #3444 review noted the same shared-`/tmp` flake).

Per the no-generated-artifacts policy, `dist/`/`bridge/` are not committed (`git restore`d before commit); the maintainer rebuilds them at merge, which also produces the `merge-claude-md` entry the shell resolves in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEQhmW5JP6HRwVFMH1my6d
