### PR TITLE
fix(hooks): windowsHide + strip Bash-only shell syntax from hook git calls

### DIFF
--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -351,10 +351,11 @@ function globToRegex(glob: string): RegExp {
 
 function checkIfModified(pattern: string): boolean {
   try {
-    const output = execSync("git diff --name-only 2>/dev/null || true", {
+    const output = execSync("git diff --name-only", {
       timeout: 5000,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
     const regex = globToRegex(pattern);
     return output.split("\n").some((f) => regex.test(f.trim()));
@@ -365,10 +366,11 @@ function checkIfModified(pattern: string): boolean {
 
 function checkIfBranch(pattern: string): boolean {
   try {
-    const branch = execSync("git branch --show-current 2>/dev/null || true", {
+    const branch = execSync("git branch --show-current", {
       timeout: 5000,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     }).trim();
     return globToRegex(pattern).test(branch);
   } catch {

--- a/src/hooks/code-simplifier/index.ts
+++ b/src/hooks/code-simplifier/index.ts
@@ -84,6 +84,7 @@ export function getModifiedFiles(
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     });
 
     return output

--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -181,6 +181,7 @@ export function getGitDiffStats(directory: string): GitFileStat[] {
       cwd: directory,
       encoding: 'utf-8',
       timeout: 5000,
+      windowsHide: true,
     }).trim();
 
     if (!output) return [];
@@ -189,6 +190,7 @@ export function getGitDiffStats(directory: string): GitFileStat[] {
       cwd: directory,
       encoding: 'utf-8',
       timeout: 5000,
+      windowsHide: true,
     }).trim();
 
     const statusMap = new Map<string, 'modified' | 'added' | 'deleted'>();

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -303,6 +303,7 @@ export function createRalphLoopHook(directory: string): RalphLoopHook {
         cwd: directory,
         encoding: "utf-8",
         timeout: 5000,
+        windowsHide: true,
       }).trim();
     } catch {
       // Fallback outside git repos.

--- a/templates/hooks/code-simplifier.mjs
+++ b/templates/hooks/code-simplifier.mjs
@@ -58,6 +58,7 @@ function getModifiedFiles(cwd, extensions, maxFiles) {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     });
 
     return output

--- a/tests/lint/windows-hide-hooks.test.ts
+++ b/tests/lint/windows-hide-hooks.test.ts
@@ -9,6 +9,7 @@ const RECURRING_HOOK_SCRIPTS = [
   'scripts/post-tool-verifier.mjs',
   'scripts/context-guard-stop.mjs',
   'scripts/code-simplifier.mjs',
+  'templates/hooks/code-simplifier.mjs',
 ] as const;
 
 const CHILD_PROCESS_CALL = /\b(execSync|execFileSync|spawn|spawnSync)\s*\(\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{([\s\S]*?)\}\s*\)/g;
@@ -49,6 +50,7 @@ describe('Windows hook child-process hardening', () => {
       'scripts/post-tool-verifier.mjs:execSync',
       'scripts/context-guard-stop.mjs:execSync',
       'scripts/code-simplifier.mjs:execSync',
+      'templates/hooks/code-simplifier.mjs:execSync',
     ]);
     expect(violations).toEqual([]);
   });


### PR DESCRIPTION
## Problem

The four hook files that fire on every Claude Code tool event
(auto-slash-command, code-simplifier, omc-orchestrator, ralph) had git
`execSync` calls with no `windowsHide: true`. On Windows, each call spawns
a console window that flashes visibly for the duration of the subprocess.
Because hooks fire on every tool use, users see repeated flashes throughout
a session.

Two calls in `live-data.ts` also embedded Bash shell operators
(`2>/dev/null || true`). `execSync` uses `cmd.exe` on Windows, where
`2>/dev/null` redirects stderr to a literal file at `\dev\null` on the
current drive (creating a junk file), and `true` is not a cmd built-in
(throws, caught by the surrounding try/catch). Both operators are also
redundant on POSIX: `stdio: ['pipe','pipe','pipe']` already captures stderr
through Node's pipe, and the try/catch already handles non-zero git exit.

## Fix

- Strip `2>/dev/null || true` from the two `live-data.ts` git calls.
- Add `windowsHide: true` to all six git `execSync` calls across the four
  hook files.

`windowsHide` is a no-op on non-Windows platforms.

## Verification

- `npx vitest run src/__tests__/live-data.test.ts` — 40 passed
- `npx tsc --noEmit` — clean
- `npx eslint src/hooks/auto-slash-command/live-data.ts src/hooks/code-simplifier/index.ts src/hooks/omc-orchestrator/index.ts src/hooks/ralph/loop.ts` — clean

## Scope

Hook files only. Follows the same fix applied to `worktree-paths.ts` and
`multi-repo.ts` in #3445, extended to the remaining hot-path hook callers.