### PR TITLE
fix(teleport): add windowsHide to git execSync calls

### DIFF
--- a/src/cli/commands/teleport.ts
+++ b/src/cli/commands/teleport.ts
@@ -329,8 +329,8 @@ function sanitize(str: string, maxLen: number = 30): string {
  */
 function getCurrentRepo(): { owner: string; repo: string; root: string; provider: ProviderName } | null {
   try {
-    const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8', timeout: 5000 }).trim();
-    const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8', timeout: 5000 }).trim();
+    const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8', timeout: 5000, windowsHide: true }).trim();
+    const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8', timeout: 5000, windowsHide: true }).trim();
     const parsed = parseRemoteUrl(remoteUrl);
     if (parsed) {
       return { owner: parsed.owner, repo: parsed.repo, root, provider: parsed.provider };
@@ -652,6 +652,7 @@ export async function teleportListCommand(options: { json?: boolean }): Promise<
       branch = execSync('git branch --show-current', {
         cwd: worktreePath,
         encoding: 'utf-8',
+        windowsHide: true,
       }).trim();
     } catch {
       // Ignore
@@ -720,6 +721,7 @@ export async function teleportRemoveCommand(
       const status = execSync('git status --porcelain', {
         cwd: worktreePath,
         encoding: 'utf-8',
+        windowsHide: true,
       });
 
       if (status.trim()) {
@@ -737,6 +739,7 @@ export async function teleportRemoveCommand(
     const gitDir = execSync('git rev-parse --git-dir', {
       cwd: worktreePath,
       encoding: 'utf-8',
+      windowsHide: true,
     }).trim();
 
     // A removable worktree reports a git-dir inside the main repo's .git/worktrees directory.


### PR DESCRIPTION
## Problem

The five git `execSync` calls in `teleport.ts` (`getCurrentRepo`,
`listWorktrees`, `removeWorktree`) run without `windowsHide: true`. Each
call flashes a console window on Windows. Because a single `omc teleport`
command invokes two or more of these in sequence, users see multiple
consecutive flashes per command.

## Fix

Add `windowsHide: true` to all five git `execSync` calls in `teleport.ts`.
No logic changes.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint src/cli/commands/teleport.ts` — clean

## Scope

One file, five option additions. Same fix class as #3445 and #3453,
applied to the teleport CLI command.