### PR TITLE
fix(resolve-node): add windowsHide to node binary resolution execSync

### DIFF
--- a/src/__tests__/resolve-node.test.ts
+++ b/src/__tests__/resolve-node.test.ts
@@ -112,7 +112,7 @@ describe('resolveNodeBinary', () => {
     });
 
     expect(resolveNodeBinary()).toBe('/opt/homebrew/bin/node');
-    expect(mockedExecSync).toHaveBeenCalledWith('which node', { encoding: 'utf-8', stdio: 'pipe' });
+    expect(mockedExecSync).toHaveBeenCalledWith('which node', { encoding: 'utf-8', stdio: 'pipe', windowsHide: true });
   });
 
   it('prefers PATH node over a CI-only hostedtoolcache process.execPath', () => {

--- a/src/utils/resolve-node.ts
+++ b/src/utils/resolve-node.ts
@@ -49,7 +49,7 @@ export function resolveNodeBinary(): string {
   // symlink (for example /opt/homebrew/bin/node instead of a Cellar version).
   try {
     const cmd = process.platform === 'win32' ? 'where node' : 'which node';
-    const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' })
+    const result = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', windowsHide: true })
       .trim()
       .split('\n')[0]
       .trim();


### PR DESCRIPTION
## Problem

`resolveNodeBinary()` calls `execSync` to run `where node` (Windows) or `which node` (POSIX) without `windowsHide: true`. On Windows, each call briefly allocates a visible console window — a flicker that's especially noticeable because this runs during setup.

## Root cause

`child_process.execSync` on Windows allocates a console window for the spawned process unless `windowsHide: true` is passed. The option is a no-op on POSIX, so it's safe to add unconditionally.

## Fix

Added `windowsHide: true` to the single `execSync` call in `resolveNodeBinary()` (`src/utils/resolve-node.ts:52`).

Updated the exact-match assertion in `src/__tests__/resolve-node.test.ts` to reflect the new options object.

## Baseline

Two pre-existing Windows-specific test failures were confirmed against the base commit (the test asserts `which node` but Windows calls `where node`; the nvm fallback returns early on Windows). The branch adds zero new failures.

Constraint: windowsHide is not available on Node < 10.1; OMC requires Node 20+
Confidence: high
Scope-risk: narrow
Not-tested: Windows with Node not on PATH (nvm/fnm path — separate code path, early-return)