### PR TITLE
feat(merge-readiness): core post-task explainability gate (standalone, review-hardened)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -31,6 +31,7 @@
     "./skills/hud/",
     "./skills/learner/",
     "./skills/local-build-reminder/",
+    "./skills/merge-readiness/",
     "./skills/mcp-setup/",
     "./skills/omc-doctor/",
     "./skills/omc-reference/",

--- a/skills/merge-readiness/SKILL.md
+++ b/skills/merge-readiness/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: merge-readiness
+aliases: understanding-gate
+description: "Post-task merge readiness gate with explanation artifact and human explainability quiz"
+argument-hint: "[--quick|--standard|--deep] [--from-diff|--from-artifacts] <change summary or artifact path>"
+---
+
+<Purpose>
+Merge Readiness is a post-task explainability gate. After implementation, tests, QA, and review evidence exist, it generates a human-readable explanation of the change, then asks the human targeted questions to verify they can explain why the change exists, what changed, what tradeoffs were made, what risks were considered, and how the team should understand it.
+</Purpose>
+
+<Use_When>
+- A task, PR, or change set is functionally complete and needs a final human-understanding check before merge readiness
+- Tests, QA, code review, security review, or other verification has already run, or missing evidence must be explicitly recorded
+- The user wants AI to explain the change and then quiz the human on whether they can explain it
+- You need a durable artifact showing why the team can trust and understand the change before asking for merge approval
+</Use_When>
+
+<Do_Not_Use_When>
+- Requirements are still unclear before implementation; use `/deep-interview`
+- The implementation is not done; use `/ralph`, `/team`, or `/autopilot`
+- Tests or QA have not run and the user expects this command to replace them
+- The user wants code review findings; use `/review` or the relevant review workflow
+</Do_Not_Use_When>
+
+<Why_This_Exists>
+Real delivery is not only code that works. Teams need to understand why a change exists, what changed, what was deliberately not done, which risks were considered, and what future maintainers should believe about the change. This workflow makes that understanding explicit before merge approval is requested. Passing this gate never means the change is approved or merged; it only means a human can explain it.
+</Why_This_Exists>
+
+<Depth_Profiles>
+- **Quick (`--quick`)**: small/local changes; correctness threshold `>= 0.70`; max 3 MCQs; required dimensions: why / change / risk
+- **Standard (`--standard`, default)**: normal feature/bugfix; correctness threshold `>= 0.80`; max 5 MCQs; required dimensions: why / change / tradeoff / risk / team
+- **Deep (`--deep`)**: high-risk, architectural, security, or cross-module changes; correctness threshold `>= 0.90`; max 8 MCQs (redundancy across all five dimensions)
+
+If no flag is provided, use **Standard**. Thresholds and round counts are canonical in `src/hooks/merge-readiness/mcq.ts` and must stay in sync with this file.
+</Depth_Profiles>
+
+<Execution_Policy>
+- This is a post-task command. Do not implement code inside this mode.
+- Gather repository and artifact evidence before asking the human for facts that can be discovered locally.
+- Generate the explanation doc + MCQs in one AI step, then present MCQs one-per-round.
+- The runtime (TS hook code) is the backbone: it owns validation, state, objective MCQ scoring, and the durable artifact. The AI owns content generation + MCQ presentation via AskUserQuestion.
+- Present each MCQ one-per-round via AskUserQuestion (deep-interview style). Record each selection via the runtime so it is scored objectively.
+- Ask about explainability, not implementation trivia.
+- Never ask the human to memorize line numbers, variable names, private helper names, or incidental implementation details.
+- Score is the objective correctness rate (correct answers / answered), not a keyword heuristic.
+- If the correctness rate is below threshold after all required MCQs are answered, mark result `paused` and do not claim merge readiness.
+- If key evidence is missing (no diff/change signal), mark result `blocked`.
+- Passing this gate does not approve merge, replace tests, replace review, replace security review, accept risk, or bypass maintainer approval.
+- Persist state for resume safety under `.omc/state/merge-readiness-state.json` (session-scoped under `.omc/state/sessions/<sessionId>/`). Do not write this file directly.
+- v1 is advisory: the runtime scores the quiz and writes a durable artifact, but does NOT block the Stop hook. Stop-hook enforcement and the git pre-merge hard gate are deferred to follow-up work.
+</Execution_Policy>
+
+<Steps>
+
+## Phase 0: Evidence Intake
+
+1. Parse `{{ARGUMENTS}}`, depth profile, source mode (`--from-diff|--from-artifacts`), and derive a task slug. `--from-pr` is unsupported; this workflow uses local evidence only.
+2. Collect available evidence:
+   - Local Git diff and commit range
+   - Changed files
+   - Test output
+   - QA output
+   - Review notes
+   - Security review notes when applicable
+   - `.omc/plans/`, `.omc/specs/`, `.omc/interviews/`, and relevant mode state artifacts
+3. Record missing evidence explicitly. Missing evidence is not hidden by a good explanation.
+
+## Phase 1: Initialize
+
+Call the `merge_readiness_start` tool with the change summary to seed state (the runtime parses the `--quick`/`--standard`/`--deep` profile from it; `--standard` is the default). State shape:
+
+```json
+{
+  "active": true,
+  "current_phase": "merge-readiness",
+  "phase": "artifact",
+  "profile": "standard",
+  "threshold": 0.80,
+  "max_rounds": 5,
+  "required_dimensions": ["why", "change", "tradeoff", "risk", "team"],
+  "questions": [],
+  "answers": [],
+  "awaiting_content": true,
+  "readiness_score": 0,
+  "result": "pending",
+  "artifact_path": ".omc/artifacts/merge-readiness/<timestamp>-<slug>.md"
+}
+```
+
+`awaiting_content` is true until the AI submits the generated doc + MCQs via `merge_readiness_set_content`.
+
+## Phase 2: Generate Explanation Doc + MCQs (AI content step)
+
+Generate, from the actual diff + evidence (not templates):
+
+1. A 5-section narrative: **Why**, **What Changed**, **Tradeoffs**, **Risks Considered**, **Team Understanding**.
+2. A set of MCQs (one correct option each, with `correctOptionId` + optional `rationale`):
+   - Up to the profile max rounds (quick 3 / standard 5 / deep 8)
+   - Distributed across the required dimensions
+   - Testing understanding of THIS change, not implementation trivia
+
+Submit them with `merge_readiness_set_content` (requires an active gate from `merge_readiness_start`; it errors if no gate is active). Do not write the state JSON or invoke internal runtime functions. Invalid content is rejected with recoverable validation errors. This writes the durable artifact under:
+
+`.omc/artifacts/merge-readiness/{timestamp}-{slug}.md`
+
+The artifact renders the five sections, evidence, quiz progress, readiness, and merge boundary. Correct answers and rationales remain hidden until the attempt is complete; cancellation or override reveals only answered questions.
+
+The Merge Boundary must say: "Passing means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk."
+
+## Phase 3: Human Quiz Loop (MCQ, one-per-round, deep-interview style)
+
+Present each MCQ one-per-round via AskUserQuestion with the option ids/text as choices, then record the human’s selection with the `merge_readiness_record_answer` tool (questionId + optionId). The runtime scores it objectively and either advances to the next question or finalizes the gate (pass / paused / blocked).
+
+Cover these dimensions before passing (quick = why/change/risk only):
+
+1. **why** - why this change was worth doing
+2. **change** - what behavior, workflow, interface, or maintenance model changed
+3. **tradeoff** - what was chosen, deferred, or rejected and why
+4. **risk** - which risks were considered and what remains risky
+5. **team** - how the team should understand and maintain this change
+
+Forbidden question types:
+
+- Function-name trivia
+- Line-number trivia
+- Variable-name recall
+- Private helper memorization
+- Any question whose answer does not help a reviewer explain the change
+
+## Phase 4: Score Readiness (runtime-owned, objective)
+
+The runtime computes:
+
+- `readiness_score` = correctness rate = (correct answers) / (answered answers), in [0, 1]
+- Per-dimension coverage = whether every required dimension has at least one answered MCQ
+
+Gate results:
+
+- `pass`: all required MCQs answered AND correctness rate >= threshold AND required dimensions covered
+- `paused`: all required MCQs answered but correctness rate below threshold (or required dimension uncovered)
+- `blocked`: missing minimal evidence (no diff/change signal)
+
+Thresholds: quick `0.70` / standard `0.80` / deep `0.90`.
+
+## Phase 5: Crystallize Result
+
+Update the artifact with:
+
+- Final readiness score
+- Dimension breakdown
+- Human answers
+- AI assessment
+- Result
+- Blocking or paused gap
+- Next step
+
+## Phase 6: Handoff
+
+If `pass`:
+- State that the change may proceed to human merge approval.
+- Do not merge.
+
+If `paused`:
+- State which explanation dimension is missing.
+- Recommend rereading or revising the report and rerunning `/merge-readiness`.
+
+If `blocked`:
+- State which evidence must be produced before rerunning.
+
+</Steps>
+
+<Tool_Usage>
+- Use repository search and local artifacts for evidence intake before asking the human for context.
+- Use structured user questioning when available.
+- Use `merge_readiness_start` to initialize the gate, `merge_readiness_set_content` to submit the report + MCQs, and `merge_readiness_record_answer` to record each selection. Use state read/status/clear only for `.omc/state/merge-readiness-state.json`; never use generic state write to submit quiz content. When clearing merge-readiness state with state_clear, always pass the current session_id - omitting it clears legacy plus every session and can erase concurrent quizzes.
+- Write reports under `.omc/artifacts/merge-readiness/`.
+</Tool_Usage>
+
+<Escalation_And_Stop_Conditions>
+- User says stop/cancel/abort -> persist current artifact and stop.
+- Missing diff or change evidence -> `blocked`.
+- Human cannot explain a required dimension -> `paused`.
+- Readiness threshold reached and mandatory gates satisfied -> `pass`.
+</Escalation_And_Stop_Conditions>
+
+<Final_Checklist>
+- [ ] Evidence intake completed
+- [ ] Missing evidence recorded
+- [ ] Explanation doc (5 sections) + MCQs submitted via merge_readiness_set_content
+- [ ] MCQs presented one-per-round via AskUserQuestion
+- [ ] Each answer correlated from marked AskUserQuestion output (objective scoring)
+- [ ] Questions avoided implementation trivia
+- [ ] Correctness rate calculated by the runtime
+- [ ] Result is `pass`, `paused`, `blocked`, `overridden`, or `cancelled`
+- [ ] Merge Boundary is explicit
+- [ ] No direct implementation or merge performed
+</Final_Checklist>
+
+<Advanced>
+## Recommended Delivery Pipeline
+
+```text
+/deep-interview
+  -> /omc-plan or /ralplan
+  -> /ralph, /team, or /autopilot
+  -> /ultraqa and review
+  -> /merge-readiness
+  -> human merge approval
+```
+
+## Autopilot Bridge
+
+Autopilot may call this workflow after QA/validation when configured:
+
+```jsonc
+{
+  "autopilot": {
+    "mergeReadiness": true
+  }
+}
+```
+
+`autopilot.understandingGate` is a deprecated compatibility alias for `autopilot.mergeReadiness`.
+</Advanced>
+
+Task: {{ARGUMENTS}}

--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-server.js';
 
 const interopEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
-const totalTools = interopEnabled ? 57 : 49;
-const withoutLsp = interopEnabled ? 45 : 37;
-const withoutAst = interopEnabled ? 55 : 47;
-const withoutPython = interopEnabled ? 56 : 48;
-const withoutSkills = interopEnabled ? 54 : 46;
+const totalTools = interopEnabled ? 60 : 52;
+const withoutLsp = interopEnabled ? 48 : 40;
+const withoutAst = interopEnabled ? 58 : 50;
+const withoutPython = interopEnabled ? 59 : 51;
+const withoutSkills = interopEnabled ? 57 : 49;
 
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (36 canonical + 3 aliases)', () => {
+    it('should return correct number of skills (37 canonical + 4 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 39 entries: 36 canonical skills + 3 deprecated aliases (cancel-ralph, learner, psm)
-      expect(skills).toHaveLength(39);
+      // 41 entries: 37 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
+      expect(skills).toHaveLength(41);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -139,6 +139,7 @@ describe('Builtin Skills', () => {
         'skillify',
         'learner',
         'local-build-reminder',
+        'merge-readiness',
         'mcp-setup',
         'omc-setup',
         'omc-teams',
@@ -161,6 +162,7 @@ describe('Builtin Skills', () => {
         'visual-verdict',
         'wiki',
         'writer-memory',
+        'understanding-gate',
       ];
 
       const actualSkillNames = skills.map((s) => s.name);
@@ -214,6 +216,29 @@ describe('Builtin Skills', () => {
       const skill = getBuiltinSkill('autopilot');
       expect(skill).toBeDefined();
       expect(skill?.name).toBe('autopilot');
+    });
+
+    it('documents merge-readiness as a standalone post-task slash workflow', () => {
+      const skill = getBuiltinSkill('merge-readiness');
+      const alias = getBuiltinSkill('understanding-gate');
+
+      expect(skill).toBeDefined();
+      expect(skill?.aliases).toContain('understanding-gate');
+      expect(alias).toBeDefined();
+      expect(alias?.aliasOf).toBe('merge-readiness');
+      expect(skill?.description).toContain('Post-task merge readiness gate');
+      expect(skill?.template).toContain('post-task explainability gate');
+      // v1 MCQ-based flow: AI generates a 5-section doc + MCQs, runtime scores objectively.
+      expect(skill?.template).toContain('Generate Explanation Doc + MCQs');
+      expect(skill?.template).toContain('Human Quiz Loop');
+      expect(skill?.template).toContain('**Why**');
+      expect(skill?.template).toContain('**What Changed**');
+      expect(skill?.template).toContain('**Tradeoffs**');
+      expect(skill?.template).toContain('**Risks Considered**');
+      expect(skill?.template).toContain('**Team Understanding**');
+      expect(skill?.template).toContain('Forbidden question types');
+      expect(skill?.template).toContain('Passing this gate does not approve merge');
+      expect(skill?.template).toContain('No direct implementation or merge performed');
     });
 
     it('should retrieve the ai-slop-cleaner skill by name', () => {
@@ -831,7 +856,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(36);
+      expect(names).toHaveLength(37);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -869,7 +894,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; cancel-ralph, psm, and learner aliases still exist
-      expect(names).toHaveLength(39);
+      expect(names).toHaveLength(41);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/hooks/merge-readiness/__tests__/runtime.test.ts
+++ b/src/hooks/merge-readiness/__tests__/runtime.test.ts
@@ -1,0 +1,384 @@
+import { execFileSync } from "child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkMergeReadiness,
+  createInitialMergeReadinessState,
+  readMergeReadinessState,
+  recordMergeReadinessMCQAnswer,
+  recordMergeReadinessAskUserQuestionResult,
+  overrideMergeReadiness,
+  setMergeReadinessContent,
+} from "../index.js";
+import type { MergeReadinessMCQQuestion } from "../mcq.js";
+
+function makeQuestion(
+  id: string,
+  dimension: "why" | "change" | "tradeoff" | "risk" | "team",
+  correctOptionId = "a",
+): MergeReadinessMCQQuestion {
+  return {
+    id,
+    dimension,
+    stem: `(${dimension}) Pick the correct explanation of this change.`,
+    options: [
+      { id: "a", text: "Correct understanding of the change." },
+      { id: "b", text: "A plausible but wrong explanation." },
+      { id: "c", text: "An unrelated statement." },
+      { id: "d", text: "Implementation trivia." },
+    ],
+    correctOptionId,
+  };
+}
+
+describe("merge-readiness runtime", () => {
+  let tempDir: string;
+  const sessionId = "merge-readiness-session";
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "omc-merge-readiness-"));
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "before\n");
+    execFileSync("git", ["add", "README.md"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["commit", "-m", "initial"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "after\n");
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates state, collects git evidence, writes an artifact, and awaits content", () => {
+    const state = createInitialMergeReadinessState(
+      tempDir,
+      "/merge-readiness --standard improve docs after review",
+      sessionId,
+    );
+
+    expect(state.active).toBe(true);
+    expect(state.current_phase).toBe("merge-readiness");
+    expect(state.awaiting_content).toBe(true);
+    expect(state.questions).toEqual([]);
+    expect(state.answers).toEqual([]);
+    expect(state.threshold).toBe(0.8);
+    expect(state.max_rounds).toBe(5);
+    expect(state.required_dimensions).toEqual(["why", "change", "tradeoff", "risk", "team"]);
+    expect(state.evidence.changedFiles).toContain("README.md");
+    expect(state.artifact_path).toBeTruthy();
+    expect(existsSync(state.artifact_path!)).toBe(true);
+    expect(readFileSync(state.artifact_path!, "utf-8")).toContain("# Merge Readiness Report");
+  });
+
+  it("uses quick profile thresholds (0.70 / 3 rounds / why-change-risk)", () => {
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    expect(state.profile).toBe("quick");
+    expect(state.threshold).toBe(0.7);
+    expect(state.max_rounds).toBe(3);
+    expect(state.required_dimensions).toEqual(["why", "change", "risk"]);
+  });
+
+  it("uses deep profile thresholds (0.90 / 8 rounds / all five dims)", () => {
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --deep risky change", sessionId);
+    expect(state.profile).toBe("deep");
+    expect(state.threshold).toBe(0.9);
+    expect(state.max_rounds).toBe(8);
+    expect(state.required_dimensions).toEqual(["why", "change", "tradeoff", "risk", "team"]);
+  });
+
+  it("setMergeReadinessContent writes doc + MCQs, clears awaiting_content, arms first MCQ", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --standard explain docs change", sessionId);
+    const questions: MergeReadinessMCQQuestion[] = [
+      makeQuestion("q1", "why"),
+      makeQuestion("q2", "change"),
+      makeQuestion("q3", "tradeoff"),
+      makeQuestion("q4", "risk"),
+      makeQuestion("q5", "team"),
+    ];
+    const state = setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why text",
+        whatChanged: "What changed text",
+        tradeoffs: "Tradeoff text",
+        risksConsidered: "Risk text",
+        teamUnderstanding: "Team text",
+        questions,
+      },
+      sessionId,
+    );
+
+    expect(state?.awaiting_content).toBe(false);
+    expect(state?.questions).toHaveLength(5);
+    expect(state?.why).toBe("Why text");
+    expect(state?.pending_question?.id).toBe("q1");
+    const artifact = readFileSync(state!.artifact_path!, "utf-8");
+    expect(artifact).toContain("## Why");
+    expect(artifact).toContain("Why text");
+    expect(artifact).toContain("## What Changed");
+    expect(artifact).toContain("## Tradeoffs");
+    expect(artifact).toContain("## Risks Considered");
+    expect(artifact).toContain("## Team Understanding");
+  });
+
+  it("passes when all required MCQs answered correctly (correctness rate >= threshold)", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --standard explain docs change", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [
+          makeQuestion("q1", "why"),
+          makeQuestion("q2", "change"),
+          makeQuestion("q3", "tradeoff"),
+          makeQuestion("q4", "risk"),
+          makeQuestion("q5", "team"),
+        ],
+      },
+      sessionId,
+    );
+
+    for (const id of ["q1", "q2", "q3", "q4", "q5"]) {
+      recordMergeReadinessMCQAnswer(tempDir, id, "a", sessionId);
+    }
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    expect(state?.active).toBe(false);
+    expect(state?.result).toBe("pass");
+    expect(state?.readiness_score).toBe(1);
+    expect(state?.completed_at).toBeTruthy();
+  });
+
+  it("pauses when all required MCQs answered but correctness rate below threshold", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --deep risky change", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [
+          makeQuestion("q1", "why"),
+          makeQuestion("q2", "change"),
+          makeQuestion("q3", "tradeoff"),
+          makeQuestion("q4", "risk"),
+          makeQuestion("q5", "team"),
+        ],
+      },
+      sessionId,
+    );
+
+    // Answer 2/5 correctly -> 0.4 < deep threshold 0.90 -> paused.
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q4", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q5", "b", sessionId);
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    expect(state?.active).toBe(true);
+    expect(state?.result).toBe("paused");
+    expect(state?.readiness_score).toBeCloseTo(0.4, 5);
+  });
+
+  it("blocks when minimal evidence is missing (no diff/change signal)", () => {
+    // Fresh git repo with no changes and no status.
+    const emptyDir = mkdtempSync(join(tmpdir(), "omc-merge-readiness-empty-"));
+    try {
+      execFileSync("git", ["init"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+
+      createInitialMergeReadinessState(emptyDir, "/merge-readiness --standard no changes here", sessionId);
+      setMergeReadinessContent(
+        emptyDir,
+        {
+          why: "Why",
+          whatChanged: "What",
+          tradeoffs: "Tradeoff",
+          risksConsidered: "Risk",
+          teamUnderstanding: "Team",
+          questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "tradeoff"), makeQuestion("q4", "risk"), makeQuestion("q5", "team")],
+        },
+        sessionId,
+      );
+
+      recordMergeReadinessMCQAnswer(emptyDir, "q1", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q2", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q3", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q4", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q5", "a", sessionId);
+
+      const state = readMergeReadinessState(emptyDir, sessionId);
+      expect(state?.result).toBe("blocked");
+      expect(state?.active).toBe(true);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("scores MCQ answers objectively (selectedOptionId === correctOptionId)", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [
+          makeQuestion("q1", "why", "a"),
+          makeQuestion("q2", "change", "b"),
+          makeQuestion("q3", "risk", "c"),
+        ],
+      },
+      sessionId,
+    );
+
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId); // correct
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId); // wrong (correct is b)
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    expect(state?.answers).toHaveLength(2);
+    expect(state?.answers[0].isCorrect).toBe(true);
+    expect(state?.answers[1].isCorrect).toBe(false);
+  });
+
+  it("blocks stop while awaiting content", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+
+    const result = await checkMergeReadiness(sessionId, tempDir, false);
+
+    expect(result?.shouldBlock).toBe(true);
+    expect(result?.message).toContain("[MERGE READINESS BLOCKED]");
+    expect(result?.message).toContain("awaiting");
+  });
+
+  it("blocks stop and shows the pending MCQ after content is set", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+      },
+      sessionId,
+    );
+
+    const result = await checkMergeReadiness(sessionId, tempDir, false);
+
+    expect(result?.shouldBlock).toBe(true);
+    expect(result?.message).toContain("[MERGE READINESS BLOCKED]");
+    expect(result?.message).toContain("[why]");
+    expect(result?.message).toContain("(1/3)");
+  });
+
+  it("releases stop after the gate passes", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+      },
+      sessionId,
+    );
+
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "a", sessionId);
+
+    const result = await checkMergeReadiness(sessionId, tempDir, false);
+    expect(result).toBeNull();
+  });
+
+  it("records the merge-boundary statement in the artifact", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --standard explain docs change", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [makeQuestion("q1", "why")],
+      },
+      sessionId,
+    );
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    const artifact = readFileSync(state!.artifact_path!, "utf-8");
+    expect(artifact).toContain("## Merge Boundary");
+    expect(artifact).toContain("Passing means the human can explain the change.");
+    expect(artifact).toContain("does not approve merge");
+  });
+
+  it("keeps invalid content recoverable and does not arm a dead-end quiz", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    const state = setMergeReadinessContent(tempDir, {
+      why: "", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why")],
+    }, sessionId);
+    expect(state?.awaiting_content).toBe(true);
+    expect(state?.pending_question).toBeUndefined();
+    expect(state?.validation_errors?.join(" ")).toContain("Narrative section 'why'");
+  });
+
+  it("does not reveal correct options before the quiz completes", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    const state = setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    const artifact = readFileSync(state!.artifact_path!, "utf-8");
+    expect(artifact).not.toContain("_(correct");
+    expect(artifact).not.toContain("Correct: yes");
+  });
+
+  it("requires an offered option and the active question before recording an answer", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "not-an-option", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.answers).toEqual([]);
+  });
+
+  it("releases the soft gate only through a reasoned override", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    expect(overrideMergeReadiness(tempDir, "", sessionId)?.result).toBe("pending");
+    expect(overrideMergeReadiness(tempDir, "Maintainer accepts the documented gap.", sessionId)?.result).toBe("overridden");
+    expect(await checkMergeReadiness(sessionId, tempDir, false)).toBeNull();
+  });
+
+  it("rejects ambiguous AskUserQuestion output instead of guessing an answer", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    recordMergeReadinessAskUserQuestionResult(tempDir, { question: "[MERGE READINESS:q1] choose" }, "selected [a] or [b]", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.answers).toEqual([]);
+  });
+});

--- a/src/hooks/merge-readiness/__tests__/tool-flow.test.ts
+++ b/src/hooks/merge-readiness/__tests__/tool-flow.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stateTools } from "../../../tools/state-tools.js";
+
+function findTool(name: string): any {
+  const tool = stateTools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} not found`);
+  return tool;
+}
+function textOf(res: any): string {
+  return (res.content?.[0]?.text ?? "") as string;
+}
+
+describe("merge-readiness standalone tool flow", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "omc-mr-tools-"));
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.name", "T"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "before\n");
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "after\n");
+    // validateWorkingDirectory trusts process.cwd()'s git root, so chdir into
+    // tempDir so the tools operate on tempDir's git evidence (not the repo CWD,
+    // which is a clean checkout on CI and would yield "blocked").
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    if (originalCwd) process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("start -> set_content -> record_answer reaches pass", async () => {
+    const start = findTool("merge_readiness_start");
+    const setContent = findTool("merge_readiness_set_content");
+    const recordAnswer = findTool("merge_readiness_record_answer");
+    const session = "flow-session";
+
+    const startRes = await start.handler({ summary: "/merge-readiness --quick fix a bug", workingDirectory: tempDir, session_id: session });
+    expect(startRes.isError).toBeFalsy();
+    expect(textOf(startRes)).toContain("started");
+
+    const questions = [
+      { id: "q1", dimension: "why", stem: "why?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q2", dimension: "change", stem: "change?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q3", dimension: "risk", stem: "risk?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+    ];
+    const contentRes = await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions, workingDirectory: tempDir, session_id: session,
+    });
+    expect(contentRes.isError).toBeFalsy();
+    expect(textOf(contentRes)).toContain("accepted");
+
+    let last = "";
+    for (const q of questions) {
+      const res = await recordAnswer.handler({ questionId: q.id, optionId: "a", workingDirectory: tempDir, session_id: session });
+      last = textOf(res);
+    }
+    expect(last).toContain("pass");
+  });
+
+  it("set_content without start errors instead of silently succeeding", async () => {
+    const setContent = findTool("merge_readiness_set_content");
+    const res = await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [], workingDirectory: tempDir, session_id: "no-start-session",
+    });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("no active gate");
+  });
+});

--- a/src/hooks/merge-readiness/artifact.ts
+++ b/src/hooks/merge-readiness/artifact.ts
@@ -1,0 +1,302 @@
+import { join } from "path";
+import { getOmcRoot } from "../../lib/worktree-paths.js";
+import {
+  writeTextArtifact,
+  type ArtifactDescriptor,
+} from "../../shared/artifact-descriptor.js";
+import type {
+  MergeReadinessDimension,
+  MergeReadinessEvidence,
+  MergeReadinessMCQAnswer,
+  MergeReadinessMCQQuestion,
+  MergeReadinessResult,
+  MergeReadinessRound,
+} from "./types.js";
+
+export interface MergeReadinessQuestion {
+  question: string;
+  expectedAnswerFocus?: string;
+}
+
+export interface MergeReadinessArtifactInput {
+  slug: string;
+  why: string;
+  whatChanged: string;
+  tradeoffs: string;
+  risksConsidered: string;
+  teamUnderstanding: string;
+  questions: MergeReadinessQuestion[];
+  result: Exclude<MergeReadinessResult, "pending">;
+  createdAt?: string;
+}
+
+export interface RuntimeMergeReadinessArtifactInput {
+  slug: string;
+  changeSummary: string;
+  evidence: MergeReadinessEvidence;
+  /** @deprecated retained for backward-compatible callers; MCQ path uses questions/answers. */
+  rounds: MergeReadinessRound[];
+  result: MergeReadinessResult;
+  readinessScore: number;
+  dimensionScores: Partial<Record<MergeReadinessDimension, number>>;
+  createdAt?: string;
+  // AI-generated explanation narrative (5 sections).
+  why?: string;
+  whatChanged?: string;
+  tradeoffs?: string;
+  risksConsidered?: string;
+  teamUnderstanding?: string;
+  // Objective MCQ quiz.
+  questions?: MergeReadinessMCQQuestion[];
+  answers?: MergeReadinessMCQAnswer[];
+  /** Correctness threshold for the active profile, in [0, 1]. */
+  threshold?: number;
+  /** Required dimensions for the active profile. */
+  requiredDimensions?: MergeReadinessDimension[];
+  /** Next unanswered MCQ (shown by the Stop-hook when the gate is not yet passed). */
+  pendingQuestion?: MergeReadinessMCQQuestion;
+  overrideReason?: string;
+}
+
+export function getMergeReadinessArtifactPath(
+  directory: string,
+  slug: string,
+  createdAt: Date = new Date(),
+): string {
+  const timestamp = createdAt
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+  return join(
+    getOmcRoot(directory),
+    "artifacts",
+    "merge-readiness",
+    `${timestamp}-${slug}.md`,
+  );
+}
+
+export function formatMergeReadinessArtifact(
+  input: MergeReadinessArtifactInput,
+): string {
+  const questions = input.questions.length > 0
+    ? input.questions
+      .map((question, index) => {
+        const focus = question.expectedAnswerFocus
+          ? `\n   - Expected answer focus: ${question.expectedAnswerFocus}`
+          : "";
+        return `${index + 1}. ${question.question}${focus}`;
+      })
+      .join("\n")
+    : "_No questions recorded._";
+
+  return [
+    "# Merge Readiness Report",
+    "",
+    "## Why",
+    "",
+    input.why,
+    "",
+    "## What Changed",
+    "",
+    input.whatChanged,
+    "",
+    "## Tradeoffs",
+    "",
+    input.tradeoffs,
+    "",
+    "## Risks Considered",
+    "",
+    input.risksConsidered,
+    "",
+    "## Team Understanding",
+    "",
+    input.teamUnderstanding,
+    "",
+    "## Human Quiz",
+    "",
+    questions,
+    "",
+    "## Result",
+    "",
+    input.result,
+    "",
+    "Passing this gate means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk on behalf of maintainers.",
+    "",
+  ].join("\n");
+}
+
+const MERGE_BOUNDARY_STATEMENT =
+  "Passing means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk.";
+
+function renderMCQTranscript(
+  questions: MergeReadinessMCQQuestion[],
+  answers: MergeReadinessMCQAnswer[],
+  result: MergeReadinessResult,
+): string {
+  if (questions.length === 0) return "_No quiz questions recorded yet._";
+  const answersByQuestion = new Map(answers.map((a) => [a.questionId, a]));
+  const revealAll = result === "pass" || result === "paused";
+  const revealAnswered = result === "overridden" || result === "cancelled";
+  return questions
+    .map((question, index) => {
+      const answer = answersByQuestion.get(question.id);
+      const optionLines = question.options.map((option) => {
+        const marks: string[] = [];
+        if ((revealAll || (revealAnswered && answer)) && option.id === question.correctOptionId) marks.push("correct");
+        if (answer && option.id === answer.selectedOptionId) marks.push("selected");
+        const suffix = marks.length > 0 ? ` _(${marks.join(", ")})_` : "";
+        return `- [${option.id}] ${option.text}${suffix}`;
+      });
+      const isCorrectLine = answer && (revealAll || revealAnswered)
+        ? `Correct: ${answer.isCorrect ? "yes" : "no"}`
+        : "_Not answered yet._";
+      return [
+        `### ${index + 1}. [${question.dimension}] ${question.stem}`,
+        "",
+        ...optionLines,
+        "",
+        isCorrectLine,
+      ].join("\n");
+    })
+    .join("\n\n");
+}
+
+export function formatRuntimeMergeReadinessArtifact(
+  input: RuntimeMergeReadinessArtifactInput,
+): string {
+  const changedFiles = input.evidence.changedFiles.length > 0
+    ? input.evidence.changedFiles.map((file) => `- ${file}`).join("\n")
+    : "_No changed files detected._";
+  const artifacts = input.evidence.sourceArtifacts.length > 0
+    ? input.evidence.sourceArtifacts.map((file) => `- ${file}`).join("\n")
+    : "_No source artifacts found._";
+  const missing = input.evidence.missingEvidence.length > 0
+    ? input.evidence.missingEvidence.map((item) => `- ${item}`).join("\n")
+    : "_No missing evidence recorded._";
+  const questions = input.questions ?? [];
+  const answers = input.answers ?? [];
+  const mcqTranscript = renderMCQTranscript(questions, answers, input.result);
+  const dimensionCoverage = input.requiredDimensions && input.requiredDimensions.length > 0
+    ? input.requiredDimensions
+      .map((dim) => `- ${dim}: ${Math.round((input.dimensionScores[dim] ?? 0) * 100)}%`)
+      .join("\n")
+    : (Object.entries(input.dimensionScores)
+      .map(([dimension, score]) => `- ${dimension}: ${Math.round((score ?? 0) * 100)}%`)
+      .join("\n") || "_No scored dimensions yet._");
+  const thresholdPct = Math.round((input.threshold ?? 0) * 100);
+  const scorePct = Math.round(input.readinessScore * 100);
+  const pendingLine = input.pendingQuestion
+    ? `- [${input.pendingQuestion.dimension}] ${input.pendingQuestion.stem}`
+    : "_No pending question._";
+
+  return [
+    "# Merge Readiness Report",
+    "",
+    "## Why",
+    "",
+    input.why && input.why.trim().length > 0 ? input.why.trim() : "_Not yet generated._",
+    "",
+    "## What Changed",
+    "",
+    input.whatChanged && input.whatChanged.trim().length > 0 ? input.whatChanged.trim() : "_Not yet generated._",
+    "",
+    "## Tradeoffs",
+    "",
+    input.tradeoffs && input.tradeoffs.trim().length > 0 ? input.tradeoffs.trim() : "_Not yet generated._",
+    "",
+    "## Risks Considered",
+    "",
+    input.risksConsidered && input.risksConsidered.trim().length > 0 ? input.risksConsidered.trim() : "_Not yet generated._",
+    "",
+    "## Team Understanding",
+    "",
+    input.teamUnderstanding && input.teamUnderstanding.trim().length > 0 ? input.teamUnderstanding.trim() : "_Not yet generated._",
+    "",
+    "## Change Summary",
+    "",
+    input.changeSummary || "_No change summary provided._",
+    "",
+    "## Evidence Collected",
+    "",
+    "### Changed Files",
+    "",
+    changedFiles,
+    "",
+    "### Git Status",
+    "",
+    input.evidence.status || "_No git status output._",
+    "",
+    "### Diff Stat",
+    "",
+    input.evidence.diffStat || "_No diff stat output._",
+    "",
+    "### Source Artifacts",
+    "",
+    artifacts,
+    "",
+    "### Missing Evidence",
+    "",
+    missing,
+    "",
+    "## Human Explainability Quiz",
+    "",
+    "This quiz checks whether the human can explain the change. It does not replace tests, review, or maintainer approval.",
+    "",
+    mcqTranscript,
+    "",
+    "## Pending Question",
+    "",
+    pendingLine,
+    "",
+    "## Readiness",
+    "",
+    `Result: ${input.result}`,
+    input.overrideReason ? `\nOverride reason: ${input.overrideReason}` : "",
+    "",
+    `Correctness rate: ${scorePct}% / threshold ${thresholdPct}%`,
+    "",
+    "Dimension coverage:",
+    "",
+    dimensionCoverage,
+    "",
+    "## Merge Boundary",
+    "",
+    MERGE_BOUNDARY_STATEMENT,
+    "",
+  ].join("\n");
+}
+
+export function writeMergeReadinessArtifact(
+  directory: string,
+  input: MergeReadinessArtifactInput,
+): ArtifactDescriptor {
+  const createdAt = input.createdAt ? new Date(input.createdAt) : new Date();
+  return writeTextArtifact({
+    path: getMergeReadinessArtifactPath(directory, input.slug, createdAt),
+    content: formatMergeReadinessArtifact(input),
+    kind: "merge-readiness",
+    producer: { system: "omc", component: "merge-readiness" },
+    retention: "persistent",
+    createdAt: createdAt.toISOString(),
+  });
+}
+
+export function writeRuntimeMergeReadinessArtifact(
+  directory: string,
+  input: RuntimeMergeReadinessArtifactInput,
+  artifactPath?: string,
+): ArtifactDescriptor {
+  const createdAt = input.createdAt ? new Date(input.createdAt) : new Date();
+  return writeTextArtifact({
+    path: artifactPath ?? getMergeReadinessArtifactPath(directory, input.slug, createdAt),
+    content: formatRuntimeMergeReadinessArtifact(input),
+    kind: "merge-readiness",
+    producer: { system: "omc", component: "merge-readiness-runtime" },
+    retention: "persistent",
+    createdAt: createdAt.toISOString(),
+  });
+}
+
+export const getUnderstandingGateArtifactPath = getMergeReadinessArtifactPath;
+export const formatUnderstandingGateArtifact = formatMergeReadinessArtifact;
+export const writeUnderstandingGateArtifact = writeMergeReadinessArtifact;

--- a/src/hooks/merge-readiness/index.ts
+++ b/src/hooks/merge-readiness/index.ts
@@ -1,0 +1,3 @@
+export * from "./artifact.js";
+export * from "./runtime.js";
+export * from "./types.js";

--- a/src/hooks/merge-readiness/mcq.ts
+++ b/src/hooks/merge-readiness/mcq.ts
@@ -1,0 +1,134 @@
+/**
+ * Merge Readiness MCQ module.
+ *
+ * Objective multiple-choice scoring for the post-task explainability gate.
+ * The runtime uses these pure helpers to judge human answers without semantic
+ * guessing: an MCQ has exactly one correct option, and code checks equality.
+ *
+ * Depth profiles (v1, unified with skills/merge-readiness/SKILL.md):
+ *   quick    -> threshold 0.70, max 3 MCQs, dims: why/change/risk
+ *   standard -> threshold 0.80, max 5 MCQs, dims: why/change/tradeoff/risk/team
+ *   deep     -> threshold 0.90, max 8 MCQs (redundancy across dims)
+ *
+ * "max rounds" == total MCQs presented. The AI distributes MCQs across the
+ * required dimensions (with redundancy for deep) up to that count.
+ */
+
+export type MergeReadinessDimension =
+  | "why"
+  | "change"
+  | "tradeoff"
+  | "risk"
+  | "team";
+
+export type MergeReadinessProfile = "quick" | "standard" | "deep";
+
+export const MERGE_READINESS_DIMENSIONS: readonly MergeReadinessDimension[] = [
+  "why",
+  "change",
+  "tradeoff",
+  "risk",
+  "team",
+] as const;
+
+/**
+ * Readiness thresholds per depth profile, expressed as a required correctness
+ * rate over the answered MCQs.
+ */
+export const MERGE_READINESS_THRESHOLDS: Readonly<
+  Record<MergeReadinessProfile, number>
+> = {
+  quick: 0.7,
+  standard: 0.8,
+  deep: 0.9,
+};
+
+/** Total MCQs presented per profile (the "max rounds" cap). */
+export const MERGE_READINESS_MAX_ROUNDS: Readonly<
+  Record<MergeReadinessProfile, number>
+> = {
+  quick: 3,
+  standard: 5,
+  deep: 8,
+};
+
+export interface MergeReadinessMCQOption {
+  id: string;
+  text: string;
+}
+
+export interface MergeReadinessMCQQuestion {
+  id: string;
+  dimension: MergeReadinessDimension;
+  stem: string;
+  options: MergeReadinessMCQOption[];
+  /** Option id that is objectively correct. */
+  correctOptionId: string;
+  /** Why the correct option is right / what understanding it verifies. */
+  rationale?: string;
+}
+
+export interface MergeReadinessMCQAnswer {
+  questionId: string;
+  selectedOptionId: string;
+  isCorrect: boolean;
+  answeredAt?: string;
+}
+
+export function profileThreshold(profile: MergeReadinessProfile): number {
+  return MERGE_READINESS_THRESHOLDS[profile] ?? MERGE_READINESS_THRESHOLDS.standard;
+}
+
+export function profileMaxRounds(profile: MergeReadinessProfile): number {
+  return MERGE_READINESS_MAX_ROUNDS[profile] ?? MERGE_READINESS_MAX_ROUNDS.standard;
+}
+
+/**
+ * Dimensions that must be covered before the gate can pass.
+ * Quick is a lighter gate (why/change/risk); standard and deep cover all five.
+ */
+export function requiredDimensionsForProfile(
+  profile: MergeReadinessProfile,
+): MergeReadinessDimension[] {
+  if (profile === "quick") return ["why", "change", "risk"];
+  return [...MERGE_READINESS_DIMENSIONS];
+}
+
+/** Objective check: does the selected option match the correct one? */
+export function scoreMCQResponse(
+  question: MergeReadinessMCQQuestion,
+  selectedOptionId: string,
+): boolean {
+  return selectedOptionId === question.correctOptionId;
+}
+
+/** Correctness rate over answered MCQs, in [0, 1]. Empty -> 0. */
+export function computeCorrectnessRate(
+  answers: MergeReadinessMCQAnswer[],
+): number {
+  if (answers.length === 0) return 0;
+  const correct = answers.filter((a) => a.isCorrect).length;
+  return correct / answers.length;
+}
+
+export function isCorrectnessPass(rate: number, threshold: number): boolean {
+  return rate >= threshold;
+}
+
+/**
+ * Whether every required dimension has at least one answered MCQ.
+ * The gate does not pass until required coverage exists, even if the rate
+ * is high, so a human cannot skip a dimension they cannot explain.
+ */
+export function hasRequiredDimensionCoverage(
+  answers: MergeReadinessMCQAnswer[],
+  questions: MergeReadinessMCQQuestion[],
+  requiredDimensions: MergeReadinessDimension[],
+): boolean {
+  const answeredDimensions = new Set(
+    answers
+      .map((answer) => questions.find((q) => q.id === answer.questionId)?.dimension)
+      .filter((d): d is MergeReadinessDimension => Boolean(d)),
+  );
+  return requiredDimensions.every((dimension) => answeredDimensions.has(dimension));
+}

--- a/src/hooks/merge-readiness/runtime.ts
+++ b/src/hooks/merge-readiness/runtime.ts
@@ -1,0 +1,696 @@
+import { execFileSync } from "child_process";
+import { existsSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import { readModeState, writeModeState } from "../../lib/mode-state-io.js";
+import { getOmcRoot, resolveToWorktreeRoot } from "../../lib/worktree-paths.js";
+import { writeRuntimeMergeReadinessArtifact } from "./artifact.js";
+import {
+  computeCorrectnessRate,
+  hasRequiredDimensionCoverage,
+  isCorrectnessPass,
+  profileMaxRounds,
+  profileThreshold,
+  requiredDimensionsForProfile,
+  scoreMCQResponse,
+  type MergeReadinessMCQAnswer,
+  type MergeReadinessMCQQuestion,
+} from "./mcq.js";
+import type {
+  MergeReadinessDimension,
+  MergeReadinessEvidence,
+  MergeReadinessProfile,
+  MergeReadinessPromptResult,
+  MergeReadinessResult,
+  MergeReadinessState,
+} from "./types.js";
+
+const MODE = "merge-readiness";
+
+export function parseMergeReadinessProfile(promptText: string): MergeReadinessProfile {
+  if (/\B--deep\b/i.test(promptText)) return "deep";
+  if (/\B--quick\b/i.test(promptText)) return "quick";
+  return "standard";
+}
+
+export function slugifyMergeReadiness(input: string): string {
+  const slug = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return slug || "change";
+}
+
+function runGit(directory: string, args: string[]): { stdout: string; error?: string } {
+  try {
+    const stdout = execFileSync("git", args, {
+      cwd: directory,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      timeout: 10000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout: stdout.trim() };
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { status?: number; stderr?: string };
+    const timedOut = err?.code === "ETIMEDOUT" || /timed out/i.test(String(err?.message || ""));
+    const stderr = typeof err?.stderr === "string" ? err.stderr.trim().slice(0, 200) : "";
+    const exit = err?.status;
+    const error = timedOut
+      ? `git ${args[0]} timed out (>10s)`
+      : `git ${args[0]} failed (exit ${exit ?? "?"})${stderr ? ": " + stderr : ""}`;
+    return { stdout: "", error };
+  }
+}
+
+function listArtifactFiles(directory: string): string[] {
+  const root = getOmcRoot(directory);
+  const candidates = ["plans", "artifacts", "logs"]
+    .map((segment) => join(root, segment))
+    .filter((path) => existsSync(path));
+  const found: string[] = [];
+  for (const candidate of candidates) {
+    const stack = [candidate];
+    while (stack.length > 0 && found.length < 40) {
+      const current = stack.pop();
+      if (!current) continue;
+      try {
+        const entries = readdirSync(current, { withFileTypes: true });
+        for (const entry of entries) {
+          const full = join(current, entry.name);
+          if (entry.isDirectory()) {
+            stack.push(full);
+          } else if (entry.isFile() && /\.(md|json|txt|log)$/i.test(entry.name)) {
+            const relativePath = relative(root, full).replace(/\\/g, "/");
+            if (!relativePath.startsWith("artifacts/merge-readiness/") && !relativePath.includes("merge-readiness-state")) {
+              found.push(relativePath);
+            }
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return found.sort();
+}
+
+export function collectMergeReadinessEvidence(directory: string, baseRef?: string): MergeReadinessEvidence {
+  const worktree = resolveToWorktreeRoot(directory);
+  const gitErrors: string[] = [];
+  const git = (args: string[]): string => {
+    const r = runGit(worktree, args);
+    if (r.error) gitErrors.push(r.error);
+    return r.stdout;
+  };
+  const changedFiles = git(["diff", "--name-only", "HEAD"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const stagedFiles = git(["diff", "--cached", "--name-only"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const untrackedFiles = git(["ls-files", "--others", "--exclude-standard"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const resolvedBase = baseRef || git(["rev-parse", "--abbrev-ref", "@{upstream}"]) || git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+  const committedBase = resolvedBase ? git(["merge-base", resolvedBase, "HEAD"]) : "";
+  const committedFiles = /^[0-9a-f]{7,40}$/.test(committedBase || "")
+    ? git(["diff", "--name-only", committedBase + "...HEAD"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+    : [];
+  const allChangedFiles = Array.from(new Set([...changedFiles, ...stagedFiles, ...untrackedFiles, ...committedFiles])).sort();
+  const status = git(["status", "--short"]);
+  const diffStat = git(["diff", "--stat", "HEAD"]) || (committedBase ? git(["diff", "--stat", committedBase + "...HEAD"]) : "") || git(["diff", "--cached", "--stat"]);
+  const sourceArtifacts = listArtifactFiles(worktree);
+  const evidenceText = sourceArtifacts.join("\n").toLowerCase();
+  const testEvidence = sourceArtifacts.filter((file) => /test|spec|qa|verify|validation/i.test(file));
+  const reviewEvidence = sourceArtifacts.filter((file) => /review|risk|security|readiness|verdict/i.test(file));
+  const missingEvidence: string[] = [];
+  if (allChangedFiles.length === 0 && !status) {
+    missingEvidence.push("No changed files or git status evidence were detected.");
+  }
+  if (!diffStat) {
+    missingEvidence.push("No diff stat was detected for the current worktree.");
+  }
+  if (!/test|spec|qa|verify|validation/.test(evidenceText)) {
+    missingEvidence.push("No test or verification artifact was detected under .omc.");
+  }
+  if (!/review|risk|security|verdict/.test(evidenceText)) {
+    missingEvidence.push("No review or risk artifact was detected under .omc.");
+  }
+  for (const gerr of gitErrors) missingEvidence.push(gerr);
+  return { changedFiles: allChangedFiles, status, diffStat, sourceArtifacts, testEvidence, reviewEvidence, missingEvidence };
+}
+
+function extractChangeSummary(promptText: string): string {
+  return promptText
+    .replace(/^\s*\/(?:oh-my-claudecode:|omc:)?merge-readiness\b/i, "")
+    .replace(/\B--(?:quick|standard|deep|from-diff|from-artifacts)\b/gi, "")
+    .trim();
+}
+
+/** True when the collected evidence lacks the minimal diff/change signal needed to quiz on. */
+function hasMinimalEvidence(evidence: MergeReadinessEvidence): boolean {
+  return evidence.changedFiles.length > 0 || Boolean(evidence.status) || Boolean(evidence.diffStat) || evidence.sourceArtifacts.length > 0;
+}
+
+/** Pick the next unanswered MCQ from state.questions, preferring required dimensions first. */
+function pickNextQuestion(state: MergeReadinessState): MergeReadinessMCQQuestion | undefined {
+  if (state.questions.length === 0) return undefined;
+  const answered = new Set(state.answers.map((a) => a.questionId));
+  const unanswered = state.questions.filter((q) => !answered.has(q.id));
+  if (unanswered.length === 0) return undefined;
+  // Prefer required dimensions, then any remaining unanswered question.
+  const requiredSet = new Set(state.required_dimensions);
+  const requiredNext = unanswered.find((q) => requiredSet.has(q.dimension));
+  return requiredNext ?? unanswered[0];
+}
+
+/**
+ * Recompute correctness rate + per-dimension coverage from recorded MCQ answers.
+ * The readiness score is the objective correctness rate (not a heuristic).
+ */
+function recomputeReadiness(state: MergeReadinessState): void {
+  const scores: Partial<Record<MergeReadinessDimension, number>> = {};
+  for (const dimension of state.required_dimensions) {
+    const dimensionAnswers = state.answers.filter((a) => {
+      const question = state.questions.find((q) => q.id === a.questionId);
+      return question?.dimension === dimension;
+    });
+    if (dimensionAnswers.length > 0) {
+      const correct = dimensionAnswers.filter((a) => a.isCorrect).length;
+      scores[dimension] = correct / dimensionAnswers.length;
+    }
+  }
+  state.dimension_scores = scores;
+  state.readiness_score = computeCorrectnessRate(state.answers);
+}
+
+function allRequiredAnswered(state: MergeReadinessState): boolean {
+  if (state.questions.length === 0) return false;
+  const answered = new Set(state.answers.map((a) => a.questionId));
+  // Every required dimension must have at least one answered MCQ.
+  const answeredDimensions = new Set(
+    state.answers
+      .map((a) => state.questions.find((q) => q.id === a.questionId)?.dimension)
+      .filter((d): d is MergeReadinessDimension => Boolean(d)),
+  );
+  const coverageOk = state.required_dimensions.every((d) => answeredDimensions.has(d));
+  // And every generated question should be answered (no half-finished quiz),
+  // unless the profile max rounds caps the count below questions.length.
+  const cap = Math.min(state.questions.length, state.max_rounds);
+  const answeredInRange = state.answers.filter((a) => answered.has(a.questionId)).length;
+  return coverageOk && answeredInRange >= cap;
+}
+
+/**
+ * Finalize the gate result from recorded answers + evidence.
+ *   pass    = all required answered, correctness rate >= threshold, required dims covered -> active=false (release)
+ *   paused  = all required answered but correctness rate below threshold -> stays active (Stop-hook keeps blocking until re-run + pass)
+ *   blocked = missing minimal evidence (no diff/change signal) -> stays active
+ * The Stop-hook blocks on any result !== "pass"; only pass deactivates the gate.
+ */
+function finalizeIfReady(state: MergeReadinessState, now: string): void {
+  recomputeReadiness(state);
+
+  if (!hasMinimalEvidence(state.evidence)) {
+    state.phase = "complete";
+    state.result = "blocked";
+    state.completed_at = now;
+    delete state.pending_question;
+    return;
+  }
+
+  if (!allRequiredAnswered(state)) {
+    // Quiz not finished yet; keep the gate active and pending.
+    return;
+  }
+
+  const rate = state.readiness_score;
+  const coverageOk = hasRequiredDimensionCoverage(
+    state.answers,
+    state.questions,
+    state.required_dimensions,
+  );
+
+  if (isCorrectnessPass(rate, state.threshold) && coverageOk) {
+    state.active = false;
+    state.phase = "complete";
+    state.result = "pass";
+    state.completed_at = now;
+    delete state.pending_question;
+    return;
+  }
+
+  // All required answered but below threshold or missing coverage: paused.
+  // Keep active=true so the Stop-hook keeps blocking until the operator
+  // re-runs /merge-readiness and passes.
+  state.phase = "complete";
+  state.result = "paused";
+  state.completed_at = now;
+  delete state.pending_question;
+}
+
+export function readMergeReadinessState(directory: string, sessionId?: string): MergeReadinessState | null {
+  return readModeState<MergeReadinessState>(MODE, directory, sessionId) ?? null;
+}
+
+export function writeMergeReadinessState(
+  directory: string,
+  state: MergeReadinessState,
+  sessionId?: string,
+): void {
+  writeModeState(MODE, state as unknown as Record<string, unknown>, directory, sessionId);
+}
+
+function writeArtifactForState(directory: string, state: MergeReadinessState): void {
+  // Artifact paths are derived from trusted state fields. Never reuse a persisted
+  // path, which could be tampered with or resolve through a symlink.
+  const safeArtifactPath = undefined;
+  const descriptor = writeRuntimeMergeReadinessArtifact(
+    directory,
+    {
+      slug: state.slug,
+      changeSummary: state.change_summary,
+      evidence: state.evidence,
+      rounds: state.rounds,
+      result: state.result,
+      readinessScore: state.readiness_score,
+      dimensionScores: state.dimension_scores,
+      createdAt: state.started_at,
+      why: state.why,
+      whatChanged: state.whatChanged,
+      tradeoffs: state.tradeoffs,
+      risksConsidered: state.risksConsidered,
+      teamUnderstanding: state.teamUnderstanding,
+      questions: state.questions,
+      answers: state.answers,
+      threshold: state.threshold,
+      requiredDimensions: state.required_dimensions,
+      pendingQuestion: state.pending_question,
+      overrideReason: state.override_reason,
+    },
+    safeArtifactPath,
+  );
+  state.artifact_path = descriptor.path;
+}
+
+/**
+ * Seed initial merge-readiness state. Called by the bridge on `/merge-readiness`
+ * and by the autopilot adapter's onEnter. Collects evidence, picks the profile
+ * threshold/maxRounds/required dims from mcq.ts, and marks the state as
+ * awaiting AI-generated content (doc + MCQs).
+ */
+export function createInitialMergeReadinessState(
+  directory: string,
+  promptText: string,
+  sessionId?: string,
+  baseRef?: string,
+): MergeReadinessState {
+  const now = new Date().toISOString();
+  const profile = parseMergeReadinessProfile(promptText);
+  const changeSummary = extractChangeSummary(promptText);
+  const unsupportedFromPr = /\B--from-pr\b/i.test(promptText);
+  const evidence = collectMergeReadinessEvidence(directory, baseRef);
+  const missingEvidence = unsupportedFromPr || !hasMinimalEvidence(evidence);
+  const state: MergeReadinessState = {
+    active: true,
+    session_id: sessionId,
+    current_phase: MODE,
+    phase: "artifact",
+    profile,
+    threshold: profileThreshold(profile),
+    max_rounds: profileMaxRounds(profile),
+    required_dimensions: requiredDimensionsForProfile(profile),
+    rounds: [],
+    questions: [],
+    answers: [],
+    awaiting_content: !unsupportedFromPr,
+    evidence,
+    readiness_score: 0,
+    dimension_scores: {},
+    result: missingEvidence ? "blocked" : "pending",
+    why: "",
+    whatChanged: "",
+    tradeoffs: "",
+    risksConsidered: "",
+    teamUnderstanding: "",
+    started_at: now,
+    updated_at: now,
+    change_summary: changeSummary,
+    slug: slugifyMergeReadiness(changeSummary || "merge-readiness"),
+  };
+  if (missingEvidence) {
+    state.validation_errors = unsupportedFromPr
+      ? ["--from-pr is unsupported: merge-readiness uses local git and .omc evidence only."]
+      : ["No minimal change evidence (diff/status/artifacts) detected; produce the change before running /merge-readiness."];
+  }
+  writeArtifactForState(directory, state);
+  writeMergeReadinessState(directory, state, sessionId);
+  return state;
+}
+
+/**
+ * AI writes the generated explanation doc (5 sections) + MCQs into state.
+ * Called after the AI has read the evidence and produced narrative + questions.
+ * Each question must carry correctOptionId so the runtime can score objectively.
+ */
+export function setMergeReadinessContent(
+  directory: string,
+  content: {
+    why: string;
+    whatChanged: string;
+    tradeoffs: string;
+    risksConsidered: string;
+    teamUnderstanding: string;
+    questions: MergeReadinessMCQQuestion[];
+  },
+  sessionId?: string,
+): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  const now = new Date().toISOString();
+  const errors = validateMergeReadinessContent(content, state);
+  if (errors.length > 0) {
+    state.validation_errors = errors;
+    state.awaiting_content = true;
+    state.phase = "artifact";
+    state.answers = [];
+    state.readiness_score = 0;
+    state.dimension_scores = {};
+    state.result = "pending";
+    delete state.pending_question;
+    delete state.completed_at;
+    delete state.override_reason;
+    state.updated_at = now;
+    writeArtifactForState(workingDir, state);
+    writeMergeReadinessState(workingDir, state, sessionId);
+    return state;
+  }
+  state.why = content.why.trim();
+  state.whatChanged = content.whatChanged.trim();
+  state.tradeoffs = content.tradeoffs.trim();
+  state.risksConsidered = content.risksConsidered.trim();
+  state.teamUnderstanding = content.teamUnderstanding.trim();
+  // Cap generated questions at the profile max rounds.
+  state.questions = content.questions.slice(0, state.max_rounds);
+  // Re-submitted content starts a fresh quiz: clear prior answers, score, and terminal result.
+  state.answers = [];
+  state.readiness_score = 0;
+  state.dimension_scores = {};
+  state.result = "pending";
+  delete state.completed_at;
+  delete state.override_reason;
+  delete state.validation_errors;
+  state.awaiting_content = false;
+  state.phase = "questioning";
+  state.updated_at = now;
+  state.pending_question = pickNextQuestion(state);
+  writeArtifactForState(workingDir, state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+/**
+ * Record one MCQ answer (objective scoring via scoreMCQResponse), append it,
+ * and finalize the gate if all required questions are answered.
+ */
+export function recordMergeReadinessMCQAnswer(
+  directory: string,
+  questionId: string,
+  selectedOptionId: string,
+  sessionId?: string,
+): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  if (state.awaiting_content || state.phase !== "questioning") return null;
+  const question = state.questions.find((q) => q.id === questionId);
+  if (!question || state.pending_question?.id !== questionId) return null;
+  const normalizedOptionId = selectedOptionId.trim();
+  if (!question.options.some((option) => option.id === normalizedOptionId)) return null;
+  const now = new Date().toISOString();
+  const isCorrect = scoreMCQResponse(question, normalizedOptionId);
+  // Replace any prior answer to the same question (idempotent re-answer).
+  const filtered = state.answers.filter((a) => a.questionId !== questionId);
+  const answer: MergeReadinessMCQAnswer = {
+    questionId,
+    selectedOptionId: normalizedOptionId,
+    isCorrect,
+    answeredAt: now,
+  };
+  state.answers = [...filtered, answer];
+  state.updated_at = now;
+  delete state.pending_question;
+  finalizeIfReady(state, now);
+  if (state.active) {
+    state.pending_question = pickNextQuestion(state);
+  }
+  writeArtifactForState(workingDir, state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+/** Correlate only a marked native AskUserQuestion result to the current MCQ. */
+export function recordMergeReadinessAskUserQuestionResult(
+  directory: string,
+  toolInput: unknown,
+  toolOutput: unknown,
+  sessionId?: string,
+): MergeReadinessState | null {
+  const state = readMergeReadinessState(resolveToWorktreeRoot(directory), sessionId);
+  const pending = state?.pending_question;
+  if (!state?.active || !pending) return state ?? null;
+  const inputText = JSON.stringify(toolInput ?? "");
+  if (!inputText.includes(`[MERGE READINESS:${pending.id}]`)) return state;
+  const outputText = typeof toolOutput === "string" ? toolOutput : JSON.stringify(toolOutput ?? "");
+  const selected = pending.options.filter((option) =>
+    new RegExp(`(?:^|[\\s\\[\"'])${option.id.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}(?:$|[\\s\\]\"',:])`).test(outputText),
+  );
+  return selected.length === 1
+    ? recordMergeReadinessMCQAnswer(directory, pending.id, selected[0].id, sessionId)
+    : state;
+}
+
+export function validateMergeReadinessContent(
+  content: { why: string; whatChanged: string; tradeoffs: string; risksConsidered: string; teamUnderstanding: string; questions: MergeReadinessMCQQuestion[] },
+  state: Pick<MergeReadinessState, "required_dimensions" | "max_rounds">,
+): string[] {
+  const errors: string[] = [];
+  const sections: Array<[string, string]> = [["why", content.why], ["whatChanged", content.whatChanged], ["tradeoffs", content.tradeoffs], ["risksConsidered", content.risksConsidered], ["teamUnderstanding", content.teamUnderstanding]];
+  for (const [name, value] of sections) if (!value?.trim()) errors.push(`Narrative section '${name}' is required.`);
+  if (!Array.isArray(content.questions) || content.questions.length < state.required_dimensions.length) errors.push("Questions must cover every required dimension.");
+  if (content.questions.length > state.max_rounds) errors.push(`Questions exceed the ${state.max_rounds}-question profile limit.`);
+  const ids = new Set<string>();
+  const dimensions = new Set<MergeReadinessDimension>();
+  for (const question of content.questions ?? []) {
+    if (!question.id?.trim() || ids.has(question.id)) errors.push("Question ids must be non-empty and unique.");
+    ids.add(question.id);
+    dimensions.add(question.dimension);
+    if (!question.stem?.trim()) errors.push(`Question '${question.id}' needs a stem.`);
+    if (!Array.isArray(question.options) || question.options.length < 2) errors.push(`Question '${question.id}' needs at least two options.`);
+    const optionIds = new Set(question.options?.map((option) => option.id) ?? []);
+    if (optionIds.size !== (question.options?.length ?? 0) || [...optionIds].some((id) => !id?.trim())) errors.push(`Question '${question.id}' has invalid option ids.`);
+    if (!optionIds.has(question.correctOptionId)) errors.push(`Question '${question.id}' correctOptionId must identify an option.`);
+  }
+  for (const dimension of state.required_dimensions) if (!dimensions.has(dimension)) errors.push(`No question covers required dimension '${dimension}'.`);
+  return errors;
+}
+
+export function overrideMergeReadiness(directory: string, reason: string, sessionId?: string): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active || !reason.trim()) return state ?? null;
+  state.active = false;
+  state.phase = "complete";
+  state.result = "overridden";
+  state.override_reason = reason.trim();
+  state.completed_at = state.updated_at = new Date().toISOString();
+  delete state.pending_question;
+  writeArtifactForState(workingDir, state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+export function cancelMergeReadiness(directory: string, sessionId?: string): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  state.active = false;
+  state.phase = "complete";
+  state.result = "cancelled";
+  state.completed_at = state.updated_at = new Date().toISOString();
+  delete state.pending_question;
+  writeArtifactForState(workingDir, state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+export function formatMergeReadinessQuestionMessage(state: MergeReadinessState): string {
+  const artifactLine = state.artifact_path ? `Artifact: ${state.artifact_path}` : "Artifact: pending";
+  const scorePct = Math.round(state.readiness_score * 100);
+  const thresholdPct = Math.round(state.threshold * 100);
+
+  if (state.awaiting_content) {
+    return [
+      "[MERGE READINESS BLOCKED]",
+      "Do not merge yet. The runtime is awaiting the AI-generated explanation doc + MCQs.",
+      artifactLine,
+      `Profile: ${state.profile} | threshold ${thresholdPct}% | max rounds ${state.max_rounds}`,
+      `Required dimensions: ${state.required_dimensions.join(", ")}`,
+      "",
+      "AI step: call setMergeReadinessContent with the 5-section doc + up to " +
+        `${state.max_rounds} MCQs (each with correctOptionId), then present each MCQ ` +
+        "one-per-round via AskUserQuestion and record answers via recordMergeReadinessMCQAnswer.",
+    ].join("\n");
+  }
+
+  const pending = state.pending_question;
+  if (!pending) {
+    return `[MERGE READINESS] No pending question. Result: ${state.result}. Score: ${scorePct}% / threshold ${thresholdPct}%. ${artifactLine}`;
+  }
+
+  const answeredCount = state.answers.length;
+  const total = Math.min(state.questions.length || state.max_rounds, state.max_rounds);
+  const options = Array.isArray(pending.options)
+    ? pending.options.map((opt) => `  [${opt.id}] ${opt.text}`).join("\n")
+    : "";
+  const stem = pending.stem || (pending as { question?: string }).question || "";
+  const dimension = pending.dimension ?? "why";
+  return [
+    "[MERGE READINESS BLOCKED]",
+    "Do not merge yet. This post-task gate checks whether the human can explain the change.",
+    artifactLine,
+    `Score: ${scorePct}% / threshold ${thresholdPct}%`,
+    `Answered: ${answeredCount}/${total}`,
+    "",
+    `Question [${dimension}] (${answeredCount + 1}/${total}): ${stem}`,
+    options,
+  ].filter((line) => line.length > 0).join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Legacy prompt-as-answer fallback (standalone /merge-readiness text path).
+// Kept for backward compatibility; the AI-driven MCQ path (setMergeReadinessContent
+// + recordMergeReadinessMCQAnswer) is the canonical v1 path.
+// ---------------------------------------------------------------------------
+
+/** @deprecated heuristic scorer retained only for the legacy text fallback. */
+function scoreAnswer(answer: string): number {
+  const normalized = answer.trim().toLowerCase();
+  if (!normalized) return 0;
+  if (/(不知道|不清楚|说不出|答不出|not sure|don't know|do not know|unknown)/i.test(normalized)) {
+    return 0.1;
+  }
+  const lengthScore = normalized.length >= 140 ? 0.65 : normalized.length >= 70 ? 0.48 : normalized.length >= 30 ? 0.32 : 0.15;
+  const signalPatterns = [
+    /because|why|为了|因为|目标|原因/,
+    /change|changed|改了|变化|行为|影响/,
+    /risk|风险|tradeoff|取舍|alternative|替代|权衡/,
+    /test|review|verify|验证|测试|评审/,
+    /team|maintain|approve|团队|维护|批准|理解/,
+  ];
+  const signalScore = signalPatterns.reduce((sum, pattern) => sum + (pattern.test(normalized) ? 0.07 : 0), 0);
+  return Math.min(1, lengthScore + signalScore);
+}
+
+/**
+ * @deprecated Legacy text-answer recorder. Only routes to the old open-ended
+ * round shape when the state has no AI-generated MCQs yet. When MCQs exist,
+ * the AI-driven recordMergeReadinessMCQAnswer path is canonical.
+ */
+export function recordMergeReadinessAnswer(
+  directory: string,
+  answer: string,
+  sessionId?: string,
+): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  const now = new Date().toISOString();
+  const pendingRound = state.rounds.find((r) => !r.answer);
+  if (!pendingRound) return state;
+  const score = scoreAnswer(answer);
+  state.rounds = state.rounds.map((round) =>
+    round.round === pendingRound.round
+      ? { ...round, answer: answer.trim(), score, answered_at: now }
+      : round,
+  );
+  state.updated_at = now;
+  writeArtifactForState(workingDir, state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+export function isLikelyMergeReadinessAnswer(promptText: string): boolean {
+  const trimmed = promptText.trim();
+  if (!trimmed) return false;
+  if (/^\//.test(trimmed)) return false;
+  if (/^\$/.test(trimmed)) return false;
+  // Only treat as a fallback answer when no AI-generated MCQs are pending;
+  // the AI-driven path writes state directly and never hits this.
+  return true;
+}
+
+export function handleMergeReadinessPromptSubmit(
+  directory: string,
+  promptText: string,
+  sessionId?: string,
+): MergeReadinessPromptResult {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) {
+    return { handled: false };
+  }
+  const override = /^\/(?:oh-my-claudecode:|omc:)?merge-readiness\s+--override\s+(.+)$/i.exec(promptText.trim());
+  if (!override) return { handled: false };
+  const updated = overrideMergeReadiness(workingDir, override[1], sessionId);
+  if (!updated || updated.result !== "overridden") return { handled: false };
+  return {
+    handled: true,
+    message: formatMergeReadinessQuestionMessage(updated),
+  };
+}
+
+/**
+ * Stop-hook gate. Reads state; if active and not yet passed, blocks the session
+ * and injects the pending MCQ (or an awaiting-content nudge). Releases on pass.
+ */
+export async function checkMergeReadiness(
+  sessionId: string | undefined,
+  directory: string,
+  cancelInProgress: boolean,
+): Promise<{ shouldBlock: boolean; message: string; result: MergeReadinessResult } | null> {
+  if (cancelInProgress) return null;
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return null;
+  if (state.result === "pass") return null;
+
+  const now = new Date().toISOString();
+  state.updated_at = now;
+  if (!state.awaiting_content && !state.pending_question && state.result === "pending") {
+    state.pending_question = pickNextQuestion(state);
+    if (!state.pending_question) {
+      finalizeIfReady(state, now);
+    }
+  }
+  writeArtifactForState(workingDir, state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+
+  // finalizeIfReady (called above) may have deactivated the gate on pass/paused/
+  // blocked. When active=false the session is released; otherwise block.
+  if (!state.active) return null;
+  return {
+    shouldBlock: true,
+    message: formatMergeReadinessQuestionMessage(state),
+    result: state.result,
+  };
+}
+
+export function isMergeReadinessArtifactFresh(directory: string, state: MergeReadinessState): boolean {
+  if (!state.artifact_path || !existsSync(state.artifact_path)) return false;
+  try {
+    return statSync(state.artifact_path).mtimeMs >= new Date(state.started_at).getTime();
+  } catch {
+    return false;
+  }
+}
+
+// Re-export deprecated types for callers that still import them from runtime.
+export type { MergeReadinessRound } from "./types.js";

--- a/src/hooks/merge-readiness/types.ts
+++ b/src/hooks/merge-readiness/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Merge Readiness state, evidence, and result types.
+ *
+ * The v1 explainability gate is MCQ-driven: the AI generates an explanation
+ * document (5 narrative sections) plus a set of multiple-choice questions, the
+ * human answers them one per round (deep-interview style), and the runtime
+ * scores each answer objectively (selected option === correct option).
+ *
+ * Canonical dimension/profile/threshold definitions live in ./mcq.js and are
+ * re-exported here so existing imports from ./types.js keep compiling.
+ */
+
+export type {
+  MergeReadinessDimension,
+  MergeReadinessProfile,
+  MergeReadinessMCQOption,
+  MergeReadinessMCQQuestion,
+  MergeReadinessMCQAnswer,
+} from "./mcq.js";
+
+import type {
+  MergeReadinessDimension,
+  MergeReadinessProfile,
+  MergeReadinessMCQQuestion,
+  MergeReadinessMCQAnswer,
+} from "./mcq.js";
+
+export type MergeReadinessPhase = "evidence" | "artifact" | "questioning" | "complete";
+export type MergeReadinessResult = "pending" | "pass" | "paused" | "blocked" | "overridden" | "cancelled";
+
+export interface MergeReadinessEvidence {
+  changedFiles: string[];
+  status: string;
+  diffStat: string;
+  sourceArtifacts: string[];
+  testEvidence: string[];
+  reviewEvidence: string[];
+  missingEvidence: string[];
+}
+
+/**
+ * @deprecated v1 uses objective MCQ scoring (questions + answers). This open
+ * ended round shape is retained only for backward-compatible state files and
+ * the legacy prompt-as-answer fallback; new code should not populate it.
+ */
+export interface MergeReadinessRound {
+  round: number;
+  dimension: MergeReadinessDimension;
+  question: string;
+  answer?: string;
+  score?: number;
+  created_at: string;
+  answered_at?: string;
+}
+
+export interface MergeReadinessState {
+  active: boolean;
+  session_id?: string;
+  current_phase: "merge-readiness";
+  phase: MergeReadinessPhase;
+  profile: MergeReadinessProfile;
+  threshold: number;
+  max_rounds: number;
+  required_dimensions: MergeReadinessDimension[];
+  /** @deprecated retained for backward-compatible state files; MCQ path uses questions/answers. */
+  rounds: MergeReadinessRound[];
+  /** AI-generated MCQs for this change. Empty until the AI calls setMergeReadinessContent. */
+  questions: MergeReadinessMCQQuestion[];
+  /** Human MCQ answers recorded one per round. */
+  answers: MergeReadinessMCQAnswer[];
+  /** True until the AI writes the generated doc + MCQs into state. */
+  awaiting_content: boolean;
+  validation_errors?: string[];
+  /** Next unanswered MCQ the human should see (deep-interview one-per-round). */
+  pending_question?: MergeReadinessMCQQuestion;
+  evidence: MergeReadinessEvidence;
+  artifact_path?: string;
+  /** Correctness rate over answered MCQs, in [0, 1]. */
+  readiness_score: number;
+  dimension_scores: Partial<Record<MergeReadinessDimension, number>>;
+  result: MergeReadinessResult;
+  // AI-generated explanation narrative (5 sections). Populated by setMergeReadinessContent.
+  why: string;
+  whatChanged: string;
+  tradeoffs: string;
+  risksConsidered: string;
+  teamUnderstanding: string;
+  started_at: string;
+  updated_at: string;
+  completed_at?: string;
+  override_reason?: string;
+  change_summary: string;
+  slug: string;
+}
+
+export interface MergeReadinessPromptResult {
+  handled: boolean;
+  message?: string;
+}

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -89,6 +89,11 @@ const MODE_CONFIGS: Record<ExecutionMode, ModeConfig> = {
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.DEEP_INTERVIEW],
     activeProperty: "active",
   },
+  [MODE_NAMES.MERGE_READINESS]: {
+    name: "Merge Readiness",
+    stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.MERGE_READINESS],
+    activeProperty: "active",
+  },
   [MODE_NAMES.SELF_IMPROVE]: {
     name: "Self Improve",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.SELF_IMPROVE],

--- a/src/hooks/mode-registry/types.ts
+++ b/src/hooks/mode-registry/types.ts
@@ -12,6 +12,7 @@ export type ExecutionMode =
   | 'ultrawork'
   | 'ultraqa'
   | 'deep-interview'
+  | 'merge-readiness'
   | 'self-improve';
 
 export interface ModeConfig {

--- a/src/lib/mode-names.ts
+++ b/src/lib/mode-names.ts
@@ -16,6 +16,7 @@ export const MODE_NAMES = {
   ULTRAQA: 'ultraqa',
   RALPLAN: 'ralplan',
   DEEP_INTERVIEW: 'deep-interview',
+  MERGE_READINESS: 'merge-readiness',
   SELF_IMPROVE: 'self-improve',
 } as const;
 
@@ -45,6 +46,7 @@ export const ALL_MODE_NAMES: readonly ModeName[] = [
   MODE_NAMES.ULTRAQA,
   MODE_NAMES.RALPLAN,
   MODE_NAMES.DEEP_INTERVIEW,
+  MODE_NAMES.MERGE_READINESS,
   MODE_NAMES.SELF_IMPROVE,
 ] as const;
 
@@ -61,6 +63,7 @@ export const MODE_STATE_FILE_MAP: Readonly<Record<ModeName, string>> = {
   [MODE_NAMES.ULTRAQA]: 'ultraqa-state.json',
   [MODE_NAMES.RALPLAN]: 'ralplan-state.json',
   [MODE_NAMES.DEEP_INTERVIEW]: 'deep-interview-state.json',
+  [MODE_NAMES.MERGE_READINESS]: 'merge-readiness-state.json',
   [MODE_NAMES.SELF_IMPROVE]: 'self-improve-state.json',
 };
 
@@ -91,5 +94,6 @@ export const SESSION_METRICS_MODE_FILES: readonly { file: string; mode: string }
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK], mode: MODE_NAMES.ULTRAWORK },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN], mode: MODE_NAMES.RALPLAN },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.DEEP_INTERVIEW], mode: MODE_NAMES.DEEP_INTERVIEW },
+  { file: MODE_STATE_FILE_MAP[MODE_NAMES.MERGE_READINESS], mode: MODE_NAMES.MERGE_READINESS },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.SELF_IMPROVE], mode: MODE_NAMES.SELF_IMPROVE },
 ];

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -40,6 +40,7 @@ import {
   type ExecutionMode
 } from '../hooks/mode-registry/index.js';
 import { ToolDefinition } from './types.js';
+import { createInitialMergeReadinessState, setMergeReadinessContent, recordMergeReadinessMCQAnswer } from '../hooks/merge-readiness/runtime.js';
 
 // Canonical execution modes from mode-registry (deep-interview and self-improve
 // are first-class modes with dedicated MODE_CONFIGS entries; ralplan remains an
@@ -48,8 +49,16 @@ const EXECUTION_MODES: [string, ...string[]] = [
   'autopilot', 'autoresearch', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
 ];
 
-// Extended type for state tools - includes state-bearing modes outside mode-registry
+// merge-readiness is read/clear-eligible (state_read/status/clear + /cancel work) but NOT write-eligible.
 const STATE_TOOL_MODES: [string, ...string[]] = [
+  ...EXECUTION_MODES,
+  'ralplan',
+  'omc-teams',
+  'skill-active',
+  'merge-readiness'
+];
+// Modes that may be generically written via state_write. Excludes merge-readiness (runtime-owned).
+const STATE_WRITE_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
   'ralplan',
   'omc-teams',
@@ -731,7 +740,7 @@ export const stateReadTool: ToolDefinition<{
 // ============================================================================
 
 export const stateWriteTool: ToolDefinition<{
-  mode: z.ZodEnum<typeof STATE_TOOL_MODES>;
+  mode: z.ZodEnum<typeof STATE_WRITE_MODES>;
   active: z.ZodOptional<z.ZodBoolean>;
   iteration: z.ZodOptional<z.ZodNumber>;
   max_iterations: z.ZodOptional<z.ZodNumber>;
@@ -749,7 +758,7 @@ export const stateWriteTool: ToolDefinition<{
   description: 'Write/update state for a specific mode. Creates the state file and directories if they do not exist. Common fields (active, iteration, phase, etc.) can be set directly as parameters. Additional custom fields can be passed via the optional `state` parameter. Note: swarm uses SQLite and cannot be written via this tool.',
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   schema: {
-    mode: z.enum(STATE_TOOL_MODES).describe('The mode to write state for'),
+    mode: z.enum(STATE_WRITE_MODES).describe('The mode to write state for'),
     active: z.boolean().optional().describe('Whether the mode is currently active'),
     iteration: z.number().optional().describe('Current iteration number'),
     max_iterations: z.number().optional().describe('Maximum iterations allowed'),
@@ -1644,4 +1653,66 @@ export const stateTools = [
   stateClearTool,
   stateListActiveTool,
   stateGetStatusTool,
+  {
+    name: 'merge_readiness_start',
+    description: 'Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick/--standard/--deep; standard is default).',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      summary: z.string().max(2000),
+      baseRef: z.string().optional().describe("Base ref to diff committed changes against (e.g. origin/dev). Defaults to the branch upstream / origin/HEAD."),
+      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+    },
+    handler: async (args: { summary: string; workingDirectory?: string; session_id?: string; baseRef?: string }) => {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+      const state = createInitialMergeReadinessState(directory, args.summary, sessionId, args.baseRef);
+      const blocked = state.result === 'blocked';
+      return { content: [{ type: 'text' as const, text: blocked ? `Merge-readiness blocked: ${state.validation_errors?.join(' ') ?? 'missing evidence'}` : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.` }], ...(blocked ? { isError: true } : {}) };
+    },
+  } as ToolDefinition<any>,
+  {
+    name: 'merge_readiness_set_content',
+    description: 'Validate and submit the five-section merge-readiness report and objective MCQs. Requires an active gate (call merge_readiness_start first).',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      why: z.string().max(10000), whatChanged: z.string().max(10000), tradeoffs: z.string().max(10000), risksConsidered: z.string().max(10000), teamUnderstanding: z.string().max(10000),
+      questions: z.array(z.object({ id: z.string().max(100), dimension: z.enum(['why', 'change', 'tradeoff', 'risk', 'team']), stem: z.string().max(2000), options: z.array(z.object({ id: z.string().max(100), text: z.string().max(1000) })).max(8), correctOptionId: z.string().max(100), rationale: z.string().max(2000).optional() })).max(8),
+      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+    },
+    handler: async (args: { why: string; whatChanged: string; tradeoffs: string; risksConsidered: string; teamUnderstanding: string; questions: Array<any>; workingDirectory?: string; session_id?: string }) => {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+      const state = setMergeReadinessContent(directory, args, sessionId);
+      if (!state) {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness content rejected: no active gate. Call merge_readiness_start first.' }], isError: true };
+      }
+      const errors = state.validation_errors ?? [];
+      return { content: [{ type: 'text' as const, text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(' ')}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? 'none'}` }], ...(errors.length > 0 ? { isError: true } : {}) };
+    },
+  } as ToolDefinition<any>,
+  {
+    name: 'merge_readiness_record_answer',
+    description: 'Record the human-selected option for the current merge-readiness MCQ. Advances the gate; returns the next question or the final result plus readiness score.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      questionId: z.string().max(100),
+      optionId: z.string().max(100),
+      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+    },
+    handler: async (args: { questionId: string; optionId: string; workingDirectory?: string; session_id?: string }) => {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+      const state = recordMergeReadinessMCQAnswer(directory, args.questionId, args.optionId, sessionId);
+      if (!state) {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ.' }], isError: true };
+      }
+      const result = state.result;
+      const score = state.readiness_score;
+      const terminal = result === 'pass' || result === 'paused' || result === 'blocked' || result === 'overridden';
+      const text = terminal
+        ? `Merge-readiness ${result}. Readiness score: ${score}. ${result === 'pass' ? 'The change may proceed to human merge approval.' : result === 'paused' ? 'Explanation gap remains; reread the report and rerun /merge-readiness.' : result === 'blocked' ? 'Missing evidence; produce it before rerunning.' : 'Gate overridden; artifact preserves the record.'}`
+        : `Answer recorded. Next question: ${state.pending_question?.id ?? 'none'}. Answered: ${state.answers.length}/${state.questions.length}.`;
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  } as ToolDefinition<any>,
 ];


### PR DESCRIPTION
Fresh focused revision addressing the four 4th-round blockers posted on #3456, with all prior-round findings still fixed.

## 4th-round blockers (all addressed)

- **Artifact path safety**: \`writeTextArtifact\` now writes to a temp file then \`rename()\`s it into place - atomic, and \`rename\` does not follow a symlink at the target, so a tampered symlink at the predictable artifact path cannot redirect the write to another file.
- **Session isolation / clear semantics**: the three tools trim and treat empty \`session_id\`/\`CLAUDE_SESSION_ID\` as absent (\`||\` instead of \`??\`), so an empty \`CLAUDE_SESSION_ID\` no longer beats a valid \`OMC_SESSION_ID\`. SKILL.md notes \`state_clear\` on merge-readiness must pass the current \`session_id\` (omitting it clears legacy + every session and can erase concurrent quizzes).
- **Retry contracts**: \`merge_readiness_start\` and \`merge_readiness_record_answer\` are no longer marked idempotent (a retry reinitializes state / rejects after \`pending_question\` advances). \`set_content\` was already non-idempotent.
- **Empty-evidence behavior**: \`createInitialMergeReadinessState\` checks \`hasMinimalEvidence\` at init and sets \`result="blocked"\` (with a validation_error) when there is no diff/status/artifact evidence, instead of starting a meaningless pending quiz that only blocks at finalization.

## Prior rounds (still fixed)

Evidence base deterministic (\`baseRef\` > \`@{upstream}\` > \`origin/HEAD\`, no heuristic); \`--from-artifacts\` counts \`sourceArtifacts\`; \`runGit\` 10s timeout + error surfacing; SKILL.md advisory (no Stop-hook promise); read/clear-eligible but not \`state_write\`-able; removed from session-end cleanup; atomic invalid-replacement rejection; \`record_answer\` requires \`phase="questioning"\` and errors on invalid ids.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`src/hooks/merge-readiness/\` 19 passing; \`state-tools\`, \`omc-tools-server\` green (91 focused)
- [x] No \`dist/\`/\`bridge/\`; single clean commit on \`dev\`

v1 is advisory (soft gate tested, not wired to Stop hook). One pre-existing unrelated \`skills.test.ts\` failure (\`psm.sh\`) fails on \`dev\` already.