### PR TITLE
feat(merge-readiness): core post-task explainability gate (standalone, review-hardened)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -31,6 +31,7 @@
     "./skills/hud/",
     "./skills/learner/",
     "./skills/local-build-reminder/",
+    "./skills/merge-readiness/",
     "./skills/mcp-setup/",
     "./skills/omc-doctor/",
     "./skills/omc-reference/",

--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -21089,6 +21089,7 @@ var OmcPaths = {
 var MAX_WORKTREE_CACHE_SIZE = 8;
 var worktreeCacheMap = /* @__PURE__ */ new Map();
 var toplevelCacheMap = /* @__PURE__ */ new Map();
+var superprojectCacheMap = /* @__PURE__ */ new Map();
 var workspaceCacheMap = /* @__PURE__ */ new Map();
 function findWorkspaceRoot(startDir) {
   if (process.env.OMC_DISABLE_MULTIREPO === "1") return null;
@@ -21144,9 +21145,24 @@ function readWorkspaceMarkerConfig(workspaceRoot) {
     return {};
   }
 }
+function isDefinitiveNonGitError(error2) {
+  if (!error2 || typeof error2 !== "object") return false;
+  const { status, stderr } = error2;
+  if (status !== 128) return false;
+  const output = typeof stderr === "string" ? stderr : Buffer.isBuffer(stderr) ? stderr.toString() : "";
+  return /not a git repository/i.test(output);
+}
 function resolveSuperprojectRoot(cwd) {
+  const cacheKey = (0, import_path11.resolve)(cwd);
+  if (superprojectCacheMap.has(cacheKey)) {
+    const cached2 = superprojectCacheMap.get(cacheKey) ?? null;
+    superprojectCacheMap.delete(cacheKey);
+    superprojectCacheMap.set(cacheKey, cached2);
+    return cached2;
+  }
   let anchor = null;
-  let probeCwd = cwd;
+  let probeCwd = cacheKey;
+  let completed = false;
   for (let depth = 0; depth < 32; depth++) {
     let superRoot;
     try {
@@ -21157,12 +21173,23 @@ function resolveSuperprojectRoot(cwd) {
         windowsHide: true,
         timeout: 5e3
       }).trim();
-    } catch {
+    } catch (error2) {
+      completed = depth === 0 && isDefinitiveNonGitError(error2);
       break;
     }
-    if (!superRoot) break;
+    if (!superRoot) {
+      completed = true;
+      break;
+    }
     anchor = superRoot;
     probeCwd = superRoot;
+  }
+  if (completed) {
+    if (superprojectCacheMap.size >= MAX_WORKTREE_CACHE_SIZE) {
+      const oldest = superprojectCacheMap.keys().next().value;
+      if (oldest !== void 0) superprojectCacheMap.delete(oldest);
+    }
+    superprojectCacheMap.set(cacheKey, anchor);
   }
   return anchor;
 }
@@ -23465,11 +23492,47 @@ function runGit(directory, args) {
     return { stdout: "", error: error2 };
   }
 }
+var EVIDENCE_MODE_STATE_FILES = /* @__PURE__ */ new Set([
+  MODE_STATE_FILE_MAP[MODE_NAMES.RALPH],
+  MODE_STATE_FILE_MAP[MODE_NAMES.AUTOPILOT],
+  MODE_STATE_FILE_MAP[MODE_NAMES.TEAM],
+  MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK],
+  MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAQA],
+  MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN],
+  MODE_STATE_FILE_MAP[MODE_NAMES.AUTORESEARCH]
+]);
+var NON_EVIDENCE_STATE_SUFFIXES = ["-stop-breaker.json", "-last-steer-at", "-continue-steer.lock"];
+function isNonEvidenceStateFile(name) {
+  return NON_EVIDENCE_STATE_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+function modeStateRecordsRun(filePath) {
+  try {
+    const raw = (0, import_fs14.readFileSync)(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      if (parsed.active === true) return true;
+      if (typeof parsed.iteration === "number" && parsed.iteration > 0) return true;
+      if (typeof parsed.started_at === "string" && parsed.started_at.length > 0) return true;
+      if (typeof parsed.phase === "string" && parsed.phase.length > 0 && parsed.phase !== "init") return true;
+    }
+  } catch {
+  }
+  return false;
+}
 function listArtifactFiles(directory) {
   const root = getOmcRoot(directory);
-  const candidates = ["plans", "artifacts", "logs", "specs", "interviews"].map((segment) => (0, import_path15.join)(root, segment)).filter((path13) => (0, import_fs14.existsSync)(path13));
+  const dirCandidates = ["plans", "artifacts", "logs", "specs", "interviews"].map((segment) => (0, import_path15.join)(root, segment)).filter((path13) => (0, import_fs14.existsSync)(path13));
   const found = [];
-  for (const candidate of candidates) {
+  const seen = /* @__PURE__ */ new Set();
+  const pushRelative = (full) => {
+    const relativePath = (0, import_path15.relative)(root, full).replace(/\\/g, "/");
+    if (relativePath.startsWith("artifacts/merge-readiness/")) return;
+    if (relativePath.includes("merge-readiness-state")) return;
+    if (seen.has(relativePath)) return;
+    seen.add(relativePath);
+    found.push(relativePath);
+  };
+  for (const candidate of dirCandidates) {
     const stack = [candidate];
     while (stack.length > 0 && found.length < 40) {
       const current = stack.pop();
@@ -23481,15 +23544,26 @@ function listArtifactFiles(directory) {
           if (entry.isDirectory()) {
             stack.push(full);
           } else if (entry.isFile() && /\.(md|json|txt|log)$/i.test(entry.name)) {
-            const relativePath = (0, import_path15.relative)(root, full).replace(/\\/g, "/");
-            if (!relativePath.startsWith("artifacts/merge-readiness/") && !relativePath.includes("merge-readiness-state")) {
-              found.push(relativePath);
-            }
+            pushRelative(full);
           }
         }
       } catch {
         continue;
       }
+    }
+  }
+  const stateDir = (0, import_path15.join)(root, "state");
+  if ((0, import_fs14.existsSync)(stateDir)) {
+    try {
+      for (const entry of (0, import_fs14.readdirSync)(stateDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+        if (isNonEvidenceStateFile(entry.name)) continue;
+        if (!EVIDENCE_MODE_STATE_FILES.has(entry.name)) continue;
+        const full = (0, import_path15.join)(stateDir, entry.name);
+        if (!modeStateRecordsRun(full)) continue;
+        pushRelative(full);
+      }
+    } catch {
     }
   }
   return found.sort();
@@ -23545,11 +23619,17 @@ function parseMergeReadinessSourceMode(promptText) {
   if (fromArtifacts) return { mode: "artifacts" };
   return {};
 }
+function hasModeStateArtifact(evidence) {
+  return evidence.sourceArtifacts.some((path13) => {
+    const name = path13.slice(path13.lastIndexOf("/") + 1);
+    return EVIDENCE_MODE_STATE_FILES.has(name);
+  });
+}
 function hasMinimalEvidenceForMode(evidence, mode) {
   const hasDiff = evidence.changedFiles.length > 0 || Boolean(evidence.diffStat);
+  const hasRelevantArtifact = evidence.testEvidence.length > 0 || evidence.reviewEvidence.length > 0 || hasModeStateArtifact(evidence);
   if (mode === "diff") return hasDiff;
-  if (mode === "artifacts") return evidence.sourceArtifacts.length > 0;
-  const hasRelevantArtifact = evidence.testEvidence.length > 0 || evidence.reviewEvidence.length > 0;
+  if (mode === "artifacts") return hasRelevantArtifact;
   return hasDiff || hasRelevantArtifact;
 }
 function pickNextQuestion(state) {
@@ -23624,6 +23704,20 @@ function readMergeReadinessState(directory, sessionId) {
 function writeMergeReadinessState(directory, state, sessionId) {
   return writeModeState(MODE, state, directory, sessionId);
 }
+function persistOrFailClosed(workingDir, state, sessionId) {
+  const persisted = writeMergeReadinessState(workingDir, state, sessionId);
+  if (persisted) return state;
+  state.active = true;
+  state.phase = "complete";
+  state.result = "blocked";
+  state.awaiting_content = false;
+  delete state.pending_question;
+  state.validation_errors = [
+    ...state.validation_errors ?? [],
+    "Merge-readiness state could not be persisted (invalid session id or state path). Resolve the session id and re-run merge_readiness_start."
+  ];
+  return persistOrFailClosed(workingDir, state, sessionId);
+}
 function createInitialMergeReadinessState(directory, promptText, sessionId, baseRef) {
   const now = (/* @__PURE__ */ new Date()).toISOString();
   const profile = parseMergeReadinessProfile(promptText);
@@ -23671,16 +23765,31 @@ function createInitialMergeReadinessState(directory, promptText, sessionId, base
     prior = null;
   }
   if (prior && prior.result !== "pending" && prior.completed_at) {
-    state.prior_attempts = [
-      ...prior.prior_attempts ?? [],
-      {
-        started_at: prior.started_at,
-        completed_at: prior.completed_at,
-        result: prior.result,
-        readiness_score: prior.readiness_score,
-        change_summary: prior.change_summary
+    const priorAttempt = {
+      profile: prior.profile,
+      threshold: prior.threshold,
+      max_rounds: prior.max_rounds,
+      required_dimensions: [...prior.required_dimensions],
+      change_summary: prior.change_summary,
+      slug: prior.slug,
+      started_at: prior.started_at,
+      completed_at: prior.completed_at,
+      result: prior.result,
+      override_reason: prior.override_reason,
+      readiness_score: prior.readiness_score,
+      dimension_scores: { ...prior.dimension_scores },
+      questions: prior.questions.map((q) => ({ ...q, options: q.options.map((o) => ({ ...o })) })),
+      answers: prior.answers.map((a) => ({ ...a })),
+      evidence_summary: {
+        changedFiles: [...prior.evidence.changedFiles],
+        source_mode: prior.source_mode,
+        missingEvidence: [...prior.evidence.missingEvidence],
+        sourceArtifactCount: prior.evidence.sourceArtifacts.length,
+        testEvidenceCount: prior.evidence.testEvidence.length,
+        reviewEvidenceCount: prior.evidence.reviewEvidence.length
       }
-    ];
+    };
+    state.prior_attempts = [...prior.prior_attempts ?? [], priorAttempt];
   }
   const persisted = writeMergeReadinessState(directory, state, sessionId);
   if (!persisted) {
@@ -23703,8 +23812,7 @@ function setMergeReadinessContent(directory, content, sessionId) {
       state.phase = "content";
     }
     state.updated_at = now;
-    writeMergeReadinessState(workingDir, state, sessionId);
-    return state;
+    return persistOrFailClosed(workingDir, state, sessionId);
   }
   const errors = validateMergeReadinessContent(content, state);
   if (errors.length > 0) {
@@ -23719,8 +23827,7 @@ function setMergeReadinessContent(directory, content, sessionId) {
     delete state.completed_at;
     delete state.override_reason;
     state.updated_at = now;
-    writeMergeReadinessState(workingDir, state, sessionId);
-    return state;
+    return persistOrFailClosed(workingDir, state, sessionId);
   }
   state.why = content.why.trim();
   state.whatChanged = content.whatChanged.trim();
@@ -23739,8 +23846,7 @@ function setMergeReadinessContent(directory, content, sessionId) {
   state.phase = "questioning";
   state.updated_at = now;
   state.pending_question = pickNextQuestion(state);
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 function recordMergeReadinessMCQAnswer(directory, questionId, selectedOptionId, sessionId) {
   const workingDir = resolveToWorktreeRoot(directory);
@@ -23769,8 +23875,7 @@ function recordMergeReadinessMCQAnswer(directory, questionId, selectedOptionId, 
   } else {
     delete state.pending_question;
   }
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 function validateMergeReadinessContent(content, state) {
   const errors = [];
@@ -23802,8 +23907,7 @@ function cancelMergeReadiness(directory, sessionId) {
   state.result = "cancelled";
   state.completed_at = state.updated_at = (/* @__PURE__ */ new Date()).toISOString();
   delete state.pending_question;
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 // src/hooks/merge-readiness/report.ts
@@ -23833,6 +23937,47 @@ function renderQuestions(questions, answers, result) {
 }
 function renderList(values, empty) {
   return values.length > 0 ? values.map((value) => `- ${value}`).join("\n") : empty;
+}
+function renderPriorAttempt(attempt, index) {
+  const header = [
+    `### Attempt ${index + 1}: ${attempt.result}`,
+    `- Profile: ${attempt.profile} | threshold ${Math.round(attempt.threshold * 100)}% | max rounds ${attempt.max_rounds}`,
+    `- Readiness score: ${Math.round(attempt.readiness_score * 100)}%`,
+    `- Change summary: ${attempt.change_summary || "_No change summary._"}`,
+    attempt.override_reason ? `- Override reason: ${attempt.override_reason}` : "",
+    attempt.started_at ? `- Started: ${attempt.started_at}` : "",
+    attempt.completed_at ? `- Completed: ${attempt.completed_at}` : ""
+  ].filter((line) => line.length > 0).join("\n");
+  const dimensions = attempt.required_dimensions.length > 0 ? attempt.required_dimensions.map((dimension) => `- ${dimension}: ${Math.round((attempt.dimension_scores[dimension] ?? 0) * 100)}%`).join("\n") : "_No required dimensions recorded._";
+  const qa = attempt.questions.length === 0 ? "_No quiz questions recorded._" : attempt.questions.map((question, qIndex) => {
+    const answer = attempt.answers.find((a) => a.questionId === question.id);
+    const options = question.options.map((option) => {
+      const marks = [];
+      if (option.id === question.correctOptionId) marks.push("correct");
+      if (answer?.selectedOptionId === option.id) marks.push("selected");
+      return `- [${option.id}] ${option.text}${marks.length > 0 ? ` _(${marks.join(", ")})_` : ""}`;
+    });
+    const correctness = answer ? `Correct: ${answer.isCorrect ? "yes" : "no"}` : "_Not answered._";
+    return [
+      `#### Q${qIndex + 1}. [${question.dimension}] ${question.stem}`,
+      "",
+      ...options,
+      "",
+      correctness
+    ].join("\n");
+  }).join("\n\n");
+  const evidence = attempt.evidence_summary;
+  const evidenceBlock = [
+    "#### Evidence Summary",
+    `- Changed files: ${evidence.changedFiles.length}`,
+    evidence.source_mode ? `- Source mode: ${evidence.source_mode}` : "",
+    `- Source artifacts: ${evidence.sourceArtifactCount}`,
+    `- Test artifacts: ${evidence.testEvidenceCount}`,
+    `- Review artifacts: ${evidence.reviewEvidenceCount}`,
+    evidence.missingEvidence.length > 0 ? `- Missing evidence:
+${evidence.missingEvidence.map((m) => `  - ${m}`).join("\n")}` : "- Missing evidence: none"
+  ].filter((line) => line.length > 0).join("\n");
+  return [header, "", "#### Dimension Coverage", "", dimensions, "", "#### Questions & Answers", "", qa, "", evidenceBlock].join("\n");
 }
 function formatMergeReadinessReport(state) {
   const revealAssessment = ["pass", "paused", "overridden", "cancelled"].includes(state.result);
@@ -23909,7 +24054,7 @@ function formatMergeReadinessReport(state) {
     dimensions || "_No scored dimensions yet._",
     "",
     "",
-    state.prior_attempts && state.prior_attempts.length > 0 ? ["## Prior Attempts", "", ...state.prior_attempts.map((a, i) => "- Attempt " + (i + 1) + ": " + a.result + " (score " + Math.round((a.readiness_score ?? 0) * 100) + "%)" + (a.change_summary ? " - " + a.change_summary : ""))].join("\n") : "",
+    state.prior_attempts && state.prior_attempts.length > 0 ? ["## Prior Attempts", "", ...state.prior_attempts.map((a, i) => renderPriorAttempt(a, i))].join("\n") : "",
     "",
     "## Merge Boundary",
     "",
@@ -25243,7 +25388,7 @@ var stateTools = [
   stateGetStatusTool,
   {
     name: "merge_readiness_start",
-    description: "Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick/--standard/--deep; standard is default).",
+    description: "Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick or --deep; standard is the default when neither flag is present).",
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     schema: {
       summary: external_exports.string().max(2e3),

--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -2994,7 +2994,7 @@ var require_compile = __commonJS({
       const schOrFunc = root.refs[ref];
       if (schOrFunc)
         return schOrFunc;
-      let _sch = resolve9.call(this, root, ref);
+      let _sch = resolve10.call(this, root, ref);
       if (_sch === void 0) {
         const schema = (_a = root.localRefs) === null || _a === void 0 ? void 0 : _a[ref];
         const { schemaId } = this.opts;
@@ -3021,7 +3021,7 @@ var require_compile = __commonJS({
     function sameSchemaEnv(s1, s2) {
       return s1.schema === s2.schema && s1.root === s2.root && s1.baseId === s2.baseId;
     }
-    function resolve9(root, ref) {
+    function resolve10(root, ref) {
       let sch;
       while (typeof (sch = this.refs[ref]) == "string")
         ref = sch;
@@ -3648,59 +3648,59 @@ var require_fast_uri = __commonJS({
         normalizeString(uri, options);
       } else if (typeof uri === "object") {
         uri = /** @type {T} */
-        parse7(serialize(uri, options), options);
+        parse8(serialize(uri, options), options);
       }
       return uri;
     }
-    function resolve9(baseURI, relativeURI, options) {
+    function resolve10(baseURI, relativeURI, options) {
       const schemelessOptions = options ? Object.assign({ scheme: "null" }, options) : { scheme: "null" };
-      const resolved = resolveComponent(parse7(baseURI, schemelessOptions), parse7(relativeURI, schemelessOptions), schemelessOptions, true);
+      const resolved = resolveComponent(parse8(baseURI, schemelessOptions), parse8(relativeURI, schemelessOptions), schemelessOptions, true);
       schemelessOptions.skipEscape = true;
       return serialize(resolved, schemelessOptions);
     }
-    function resolveComponent(base, relative7, options, skipNormalization) {
+    function resolveComponent(base, relative8, options, skipNormalization) {
       const target = {};
       if (!skipNormalization) {
-        base = parse7(serialize(base, options), options);
-        relative7 = parse7(serialize(relative7, options), options);
+        base = parse8(serialize(base, options), options);
+        relative8 = parse8(serialize(relative8, options), options);
       }
       options = options || {};
-      if (!options.tolerant && relative7.scheme) {
-        target.scheme = relative7.scheme;
-        target.userinfo = relative7.userinfo;
-        target.host = relative7.host;
-        target.port = relative7.port;
-        target.path = removeDotSegments(relative7.path || "");
-        target.query = relative7.query;
+      if (!options.tolerant && relative8.scheme) {
+        target.scheme = relative8.scheme;
+        target.userinfo = relative8.userinfo;
+        target.host = relative8.host;
+        target.port = relative8.port;
+        target.path = removeDotSegments(relative8.path || "");
+        target.query = relative8.query;
       } else {
-        if (relative7.userinfo !== void 0 || relative7.host !== void 0 || relative7.port !== void 0) {
-          target.userinfo = relative7.userinfo;
-          target.host = relative7.host;
-          target.port = relative7.port;
-          target.path = removeDotSegments(relative7.path || "");
-          target.query = relative7.query;
+        if (relative8.userinfo !== void 0 || relative8.host !== void 0 || relative8.port !== void 0) {
+          target.userinfo = relative8.userinfo;
+          target.host = relative8.host;
+          target.port = relative8.port;
+          target.path = removeDotSegments(relative8.path || "");
+          target.query = relative8.query;
         } else {
-          if (!relative7.path) {
+          if (!relative8.path) {
             target.path = base.path;
-            if (relative7.query !== void 0) {
-              target.query = relative7.query;
+            if (relative8.query !== void 0) {
+              target.query = relative8.query;
             } else {
               target.query = base.query;
             }
           } else {
-            if (relative7.path[0] === "/") {
-              target.path = removeDotSegments(relative7.path);
+            if (relative8.path[0] === "/") {
+              target.path = removeDotSegments(relative8.path);
             } else {
               if ((base.userinfo !== void 0 || base.host !== void 0 || base.port !== void 0) && !base.path) {
-                target.path = "/" + relative7.path;
+                target.path = "/" + relative8.path;
               } else if (!base.path) {
-                target.path = relative7.path;
+                target.path = relative8.path;
               } else {
-                target.path = base.path.slice(0, base.path.lastIndexOf("/") + 1) + relative7.path;
+                target.path = base.path.slice(0, base.path.lastIndexOf("/") + 1) + relative8.path;
               }
               target.path = removeDotSegments(target.path);
             }
-            target.query = relative7.query;
+            target.query = relative8.query;
           }
           target.userinfo = base.userinfo;
           target.host = base.host;
@@ -3708,7 +3708,7 @@ var require_fast_uri = __commonJS({
         }
         target.scheme = base.scheme;
       }
-      target.fragment = relative7.fragment;
+      target.fragment = relative8.fragment;
       return target;
     }
     function equal(uriA, uriB, options) {
@@ -3885,7 +3885,7 @@ var require_fast_uri = __commonJS({
       }
       return { parsed, malformedAuthorityOrPort };
     }
-    function parse7(uri, opts) {
+    function parse8(uri, opts) {
       return parseWithStatus(uri, opts).parsed;
     }
     function normalizeString(uri, opts) {
@@ -3910,11 +3910,11 @@ var require_fast_uri = __commonJS({
     var fastUri = {
       SCHEMES,
       normalize: normalize8,
-      resolve: resolve9,
+      resolve: resolve10,
       resolveComponent,
       equal,
       serialize,
-      parse: parse7
+      parse: parse8
     };
     module2.exports = fastUri;
     module2.exports.default = fastUri;
@@ -16761,7 +16761,7 @@ var Protocol = class {
           return;
         }
         const pollInterval = task2.pollInterval ?? this._options?.defaultTaskPollInterval ?? 1e3;
-        await new Promise((resolve9) => setTimeout(resolve9, pollInterval));
+        await new Promise((resolve10) => setTimeout(resolve10, pollInterval));
         options?.signal?.throwIfAborted();
       }
     } catch (error2) {
@@ -16778,7 +16778,7 @@ var Protocol = class {
    */
   request(request, resultSchema, options) {
     const { relatedRequestId, resumptionToken, onresumptiontoken, task, relatedTask } = options ?? {};
-    return new Promise((resolve9, reject) => {
+    return new Promise((resolve10, reject) => {
       const earlyReject = (error2) => {
         reject(error2);
       };
@@ -16856,7 +16856,7 @@ var Protocol = class {
           if (!parseResult.success) {
             reject(parseResult.error);
           } else {
-            resolve9(parseResult.data);
+            resolve10(parseResult.data);
           }
         } catch (error2) {
           reject(error2);
@@ -17117,12 +17117,12 @@ var Protocol = class {
       }
     } catch {
     }
-    return new Promise((resolve9, reject) => {
+    return new Promise((resolve10, reject) => {
       if (signal.aborted) {
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
         return;
       }
-      const timeoutId = setTimeout(resolve9, interval);
+      const timeoutId = setTimeout(resolve10, interval);
       signal.addEventListener("abort", () => {
         clearTimeout(timeoutId);
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
@@ -17851,12 +17851,12 @@ var StdioServerTransport = class {
     this.onclose?.();
   }
   send(message) {
-    return new Promise((resolve9) => {
+    return new Promise((resolve10) => {
       const json = serializeMessage(message);
       if (this._stdout.write(json)) {
-        resolve9();
+        resolve10();
       } else {
-        this._stdout.once("drain", resolve9);
+        this._stdout.once("drain", resolve10);
       }
     });
   }
@@ -18911,7 +18911,7 @@ async function removeFileIfExists(filePath) {
   }
 }
 function sleep(ms) {
-  return new Promise((resolve9) => setTimeout(resolve9, ms));
+  return new Promise((resolve10) => setTimeout(resolve10, ms));
 }
 
 // src/tools/lsp/client.ts
@@ -19186,14 +19186,75 @@ function runDocker(args) {
 var import_child_process5 = require("child_process");
 var import_fs5 = require("fs");
 var import_path6 = require("path");
+var TYPESCRIPT_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"];
+var TYPESCRIPT_CLASSIC_SERVER = {
+  name: "TypeScript Language Server",
+  command: "typescript-language-server",
+  args: ["--stdio"],
+  extensions: TYPESCRIPT_EXTENSIONS,
+  installHint: "npm install -g typescript-language-server typescript"
+};
+function getTypeScriptNativeBin(packageRoot) {
+  const packageNodeModules = (0, import_path6.dirname)(packageRoot);
+  const workspaceRoot = (0, import_path6.dirname)(packageNodeModules);
+  const executable = process.platform === "win32" ? "tsc.cmd" : "tsc";
+  return (0, import_path6.join)(workspaceRoot, "node_modules", ".bin", executable);
+}
+function findTypeScriptPackageRoot(workspaceRoot) {
+  let dir = (0, import_path6.resolve)(workspaceRoot);
+  while (true) {
+    const packageJsonPath = (0, import_path6.join)(dir, "node_modules", "typescript", "package.json");
+    if ((0, import_fs5.existsSync)(packageJsonPath)) {
+      return (0, import_path6.dirname)(packageJsonPath);
+    }
+    const parsed = (0, import_path6.parse)(dir);
+    if (parsed.root === dir) {
+      return null;
+    }
+    dir = (0, import_path6.dirname)(dir);
+  }
+}
+function readTypeScriptMajorVersion(packageRoot) {
+  try {
+    const packageJson = JSON.parse((0, import_fs5.readFileSync)((0, import_path6.join)(packageRoot, "package.json"), "utf8"));
+    if (typeof packageJson.version !== "string") {
+      return null;
+    }
+    const major = Number.parseInt(packageJson.version.split(".")[0] ?? "", 10);
+    return Number.isNaN(major) ? null : major;
+  } catch {
+    return null;
+  }
+}
+function shouldUseNativeTypeScriptServer(packageRoot) {
+  const majorVersion = readTypeScriptMajorVersion(packageRoot);
+  if (majorVersion !== null && majorVersion >= 7) {
+    return true;
+  }
+  if ((0, import_fs5.existsSync)((0, import_path6.join)(packageRoot, "lib", "getExePath.js"))) {
+    return true;
+  }
+  return !(0, import_fs5.existsSync)((0, import_path6.join)(packageRoot, "lib", "tsserver.js"));
+}
+function getTypeScriptServerForWorkspace(workspaceRoot) {
+  const packageRoot = findTypeScriptPackageRoot(workspaceRoot);
+  if (!packageRoot || !shouldUseNativeTypeScriptServer(packageRoot)) {
+    return TYPESCRIPT_CLASSIC_SERVER;
+  }
+  const localTsc = getTypeScriptNativeBin(packageRoot);
+  if (!(0, import_fs5.existsSync)(localTsc)) {
+    return TYPESCRIPT_CLASSIC_SERVER;
+  }
+  return {
+    name: "TypeScript 7 Native Language Server (typescript-go)",
+    command: localTsc,
+    args: ["--lsp", "--stdio"],
+    extensions: TYPESCRIPT_EXTENSIONS,
+    installHint: "Install TypeScript 7 locally so node_modules/.bin/tsc is available"
+  };
+}
 var LSP_SERVERS = {
-  typescript: {
-    name: "TypeScript Language Server",
-    command: "typescript-language-server",
-    args: ["--stdio"],
-    extensions: [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"],
-    installHint: "npm install -g typescript-language-server typescript"
-  },
+  typescript: TYPESCRIPT_CLASSIC_SERVER,
   python: {
     name: "Python Language Server (ty)",
     command: "ty",
@@ -19335,8 +19396,11 @@ function commandExists(command) {
   const result = (0, import_child_process5.spawnSync)(checkCommand, [command], { stdio: "ignore" });
   return result.status === 0;
 }
-function getServerForFile(filePath) {
+function getServerForFile(filePath, workspaceRoot) {
   const ext = (0, import_path6.extname)(filePath).toLowerCase();
+  if (TYPESCRIPT_EXTENSIONS.includes(ext) && workspaceRoot) {
+    return getTypeScriptServerForWorkspace(workspaceRoot);
+  }
   for (const [_, config2] of Object.entries(LSP_SERVERS)) {
     if (config2.extensions.includes(ext)) {
       return config2;
@@ -19407,7 +19471,7 @@ var LspClient = class _LspClient {
 Install with: ${this.serverConfig.installHint}`
       );
     }
-    return new Promise((resolve9, reject) => {
+    return new Promise((resolve10, reject) => {
       const command = this.devContainerContext ? "docker" : this.serverConfig.command;
       const args = this.devContainerContext ? ["exec", "-i", "-w", this.devContainerContext.containerWorkspaceRoot, this.devContainerContext.containerId, this.serverConfig.command, ...this.serverConfig.args] : this.serverConfig.args;
       this.process = (0, import_child_process6.spawn)(command, args, {
@@ -19434,7 +19498,7 @@ Install with: ${this.serverConfig.installHint}`
       });
       this.initialize().then(() => {
         this.initialized = true;
-        resolve9();
+        resolve10();
       }).catch(reject);
     });
   }
@@ -19578,13 +19642,13 @@ Install with: ${this.serverConfig.installHint}`
     const message = `Content-Length: ${Buffer.byteLength(content)}\r
 \r
 ${content}`;
-    return new Promise((resolve9, reject) => {
+    return new Promise((resolve10, reject) => {
       const timeoutHandle = setTimeout(() => {
         this.pendingRequests.delete(id);
         reject(new Error(`LSP request '${method}' timed out after ${effectiveTimeout}ms`));
       }, effectiveTimeout);
       this.pendingRequests.set(id, {
-        resolve: resolve9,
+        resolve: resolve10,
         reject,
         timeout: timeoutHandle
       });
@@ -19660,7 +19724,7 @@ ${content}`;
       }
     });
     this.openDocuments.add(hostUri);
-    await new Promise((resolve9) => setTimeout(resolve9, 100));
+    await new Promise((resolve10) => setTimeout(resolve10, 100));
   }
   /**
    * Close a document
@@ -19821,13 +19885,13 @@ ${content}`;
     if (this.diagnostics.has(uri)) {
       return Promise.resolve();
     }
-    return new Promise((resolve9) => {
+    return new Promise((resolve10) => {
       let resolved = false;
       const timer = setTimeout(() => {
         if (!resolved) {
           resolved = true;
           this.diagnosticWaiters.delete(uri);
-          resolve9();
+          resolve10();
         }
       }, timeoutMs);
       const existing = this.diagnosticWaiters.get(uri) || [];
@@ -19835,7 +19899,7 @@ ${content}`;
         if (!resolved) {
           resolved = true;
           clearTimeout(timer);
-          resolve9();
+          resolve10();
         }
       });
       this.diagnosticWaiters.set(uri, existing);
@@ -19971,11 +20035,11 @@ var LspClientManager = class {
    * Get or create a client for a file
    */
   async getClientForFile(filePath) {
-    const serverConfig = getServerForFile(filePath);
+    const workspaceRoot = this.findWorkspaceRoot(filePath);
+    const serverConfig = getServerForFile(filePath, workspaceRoot);
     if (!serverConfig) {
       return null;
     }
-    const workspaceRoot = this.findWorkspaceRoot(filePath);
     const devContainerContext = resolveDevContainerContext(workspaceRoot);
     const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? "host"}`;
     let client = this.clients.get(key);
@@ -19997,11 +20061,11 @@ var LspClientManager = class {
    * The lastUsed timestamp is refreshed on both entry and exit.
    */
   async runWithClientLease(filePath, fn) {
-    const serverConfig = getServerForFile(filePath);
+    const workspaceRoot = this.findWorkspaceRoot(filePath);
+    const serverConfig = getServerForFile(filePath, workspaceRoot);
     if (!serverConfig) {
       throw new Error(`No language server available for: ${filePath}`);
     }
-    const workspaceRoot = this.findWorkspaceRoot(filePath);
     const devContainerContext = resolveDevContainerContext(workspaceRoot);
     const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? "host"}`;
     let client = this.clients.get(key);
@@ -21090,6 +21154,7 @@ function resolveSuperprojectRoot(cwd) {
         cwd: probeCwd,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
         timeout: 5e3
       }).trim();
     } catch {
@@ -21118,6 +21183,7 @@ function getGitTopLevel(cwd) {
       cwd: effectiveCwd,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
       timeout: 5e3
     }).trim();
     if (toplevelCacheMap.size >= MAX_WORKTREE_CACHE_SIZE) {
@@ -21179,7 +21245,8 @@ function getProjectIdentifier(worktreeRoot) {
     const remoteUrl = (0, import_child_process8.execSync)("git remote get-url origin", {
       cwd: root,
       encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
     }).trim();
     source = remoteUrl || root;
   } catch {
@@ -21191,6 +21258,7 @@ function getProjectIdentifier(worktreeRoot) {
       cwd: root,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
       timeout: 5e3
     }).trim();
     const isGitDir = (0, import_path11.basename)(commonDir) === ".git";
@@ -21365,6 +21433,7 @@ function getGitCommonDir(cwd) {
       cwd,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
       timeout: 5e3
     }).trim();
     return (0, import_fs10.realpathSync)(commonDir);
@@ -22192,7 +22261,7 @@ var SessionLock = class {
   }
 };
 function sleep2(ms) {
-  return new Promise((resolve9) => setTimeout(resolve9, ms));
+  return new Promise((resolve10) => setTimeout(resolve10, ms));
 }
 
 // src/tools/python-repl/socket-client.ts
@@ -22222,7 +22291,7 @@ var JsonRpcError = class extends Error {
   }
 };
 async function sendSocketRequest(socketPath, method, params, timeout = 6e4) {
-  return new Promise((resolve9, reject) => {
+  return new Promise((resolve10, reject) => {
     const id = (0, import_crypto2.randomUUID)();
     const request = {
       jsonrpc: "2.0",
@@ -22312,7 +22381,7 @@ async function sendSocketRequest(socketPath, method, params, timeout = 6e4) {
           }
           if (!settled) {
             settled = true;
-            resolve9(response.result);
+            resolve10(response.result);
           }
         } catch (e) {
           if (!settled) {
@@ -22795,9 +22864,9 @@ var pythonReplTool = {
 };
 
 // src/tools/state-tools.ts
-var import_fs14 = require("fs");
+var import_fs15 = require("fs");
 var import_os4 = require("os");
-var import_path15 = require("path");
+var import_path16 = require("path");
 
 // src/lib/session-id.ts
 function readEnv() {
@@ -22900,6 +22969,13 @@ function resolveStateRoot(directory) {
   const baseDir = directory || process.cwd();
   return getGitTopLevel(baseDir) || baseDir;
 }
+function resolveFile(mode, directory, sessionId) {
+  const baseDir = resolveStateRoot(directory);
+  if (sessionId) {
+    return resolveSessionStatePath(mode, sessionId, baseDir);
+  }
+  return resolveStatePath(mode, baseDir);
+}
 function hasSessionEndSummary(baseDir, sessionId) {
   return (0, import_fs12.existsSync)((0, import_path13.join)(getOmcRoot(baseDir), "sessions", `${sessionId}.json`));
 }
@@ -22949,6 +23025,49 @@ function findCompletedSessionStateFiles(mode, directory, requesterSessionId) {
   }
   return [...matches];
 }
+function writeModeState(mode, state, directory, sessionId) {
+  try {
+    const baseDir = resolveStateRoot(directory);
+    if (sessionId) {
+      ensureSessionStateDir(sessionId, baseDir);
+    } else {
+      ensureOmcDir("state", baseDir);
+    }
+    const filePath = resolveFile(mode, directory, sessionId);
+    const ownerPid = typeof process.pid === "number" ? process.pid : void 0;
+    const envelope = {
+      ...state,
+      ...ownerPid !== void 0 && state.owner_pid === void 0 ? { owner_pid: ownerPid } : {},
+      _meta: {
+        written_at: (/* @__PURE__ */ new Date()).toISOString(),
+        mode,
+        ...sessionId ? { sessionId } : {},
+        ...ownerPid !== void 0 ? { ownerPid } : {}
+      }
+    };
+    atomicWriteJsonSync(filePath, envelope);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function readModeState(mode, directory, sessionId) {
+  const filePath = resolveFile(mode, directory, sessionId);
+  if (!(0, import_fs12.existsSync)(filePath)) {
+    return null;
+  }
+  try {
+    const content = (0, import_fs12.readFileSync)(filePath, "utf-8");
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed === "object" && "_meta" in parsed) {
+      const { _meta: _, ...rest } = parsed;
+      return rest;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
 
 // src/hooks/mode-registry/index.ts
 var import_fs13 = require("fs");
@@ -22964,6 +23083,7 @@ var MODE_NAMES = {
   ULTRAQA: "ultraqa",
   RALPLAN: "ralplan",
   DEEP_INTERVIEW: "deep-interview",
+  MERGE_READINESS: "merge-readiness",
   SELF_IMPROVE: "self-improve"
 };
 var ALL_MODE_NAMES = [
@@ -22975,6 +23095,7 @@ var ALL_MODE_NAMES = [
   MODE_NAMES.ULTRAQA,
   MODE_NAMES.RALPLAN,
   MODE_NAMES.DEEP_INTERVIEW,
+  MODE_NAMES.MERGE_READINESS,
   MODE_NAMES.SELF_IMPROVE
 ];
 var MODE_STATE_FILE_MAP = {
@@ -22986,6 +23107,7 @@ var MODE_STATE_FILE_MAP = {
   [MODE_NAMES.ULTRAQA]: "ultraqa-state.json",
   [MODE_NAMES.RALPLAN]: "ralplan-state.json",
   [MODE_NAMES.DEEP_INTERVIEW]: "deep-interview-state.json",
+  [MODE_NAMES.MERGE_READINESS]: "merge-readiness-state.json",
   [MODE_NAMES.SELF_IMPROVE]: "self-improve-state.json"
 };
 var SESSION_END_MODE_STATE_FILES = [
@@ -23007,6 +23129,7 @@ var SESSION_METRICS_MODE_FILES = [
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK], mode: MODE_NAMES.ULTRAWORK },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN], mode: MODE_NAMES.RALPLAN },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.DEEP_INTERVIEW], mode: MODE_NAMES.DEEP_INTERVIEW },
+  { file: MODE_STATE_FILE_MAP[MODE_NAMES.MERGE_READINESS], mode: MODE_NAMES.MERGE_READINESS },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.SELF_IMPROVE], mode: MODE_NAMES.SELF_IMPROVE }
 ];
 
@@ -23050,6 +23173,11 @@ var MODE_CONFIGS = {
   [MODE_NAMES.DEEP_INTERVIEW]: {
     name: "Deep Interview",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.DEEP_INTERVIEW],
+    activeProperty: "active"
+  },
+  [MODE_NAMES.MERGE_READINESS]: {
+    name: "Merge Readiness",
+    stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.MERGE_READINESS],
     activeProperty: "active"
   },
   [MODE_NAMES.SELF_IMPROVE]: {
@@ -23255,6 +23383,575 @@ function getActiveSessionsForMode(mode, cwd) {
   return sessionIds.filter((sid) => isJsonModeActive(cwd, mode, sid));
 }
 
+// src/hooks/merge-readiness/runtime.ts
+var import_child_process10 = require("child_process");
+var import_fs14 = require("fs");
+var import_path15 = require("path");
+
+// src/hooks/merge-readiness/mcq.ts
+var MERGE_READINESS_DIMENSIONS = [
+  "why",
+  "change",
+  "tradeoff",
+  "risk",
+  "team"
+];
+var MERGE_READINESS_THRESHOLDS = {
+  quick: 0.7,
+  standard: 0.8,
+  deep: 0.9
+};
+var MERGE_READINESS_MAX_ROUNDS = {
+  quick: 3,
+  standard: 5,
+  deep: 8
+};
+function profileThreshold(profile) {
+  return MERGE_READINESS_THRESHOLDS[profile] ?? MERGE_READINESS_THRESHOLDS.standard;
+}
+function profileMaxRounds(profile) {
+  return MERGE_READINESS_MAX_ROUNDS[profile] ?? MERGE_READINESS_MAX_ROUNDS.standard;
+}
+function requiredDimensionsForProfile(profile) {
+  if (profile === "quick") return ["why", "change", "risk"];
+  return [...MERGE_READINESS_DIMENSIONS];
+}
+function scoreMCQResponse(question, selectedOptionId) {
+  return selectedOptionId === question.correctOptionId;
+}
+function computeCorrectnessRate(answers) {
+  if (answers.length === 0) return 0;
+  const correct = answers.filter((a) => a.isCorrect).length;
+  return correct / answers.length;
+}
+function isCorrectnessPass(rate, threshold) {
+  return rate >= threshold;
+}
+function hasRequiredDimensionCoverage(answers, questions, requiredDimensions) {
+  const answeredDimensions = new Set(
+    answers.map((answer) => questions.find((q) => q.id === answer.questionId)?.dimension).filter((d) => Boolean(d))
+  );
+  return requiredDimensions.every((dimension) => answeredDimensions.has(dimension));
+}
+
+// src/hooks/merge-readiness/runtime.ts
+var MODE = "merge-readiness";
+function parseMergeReadinessProfile(promptText) {
+  if (/\B--deep\b/i.test(promptText)) return "deep";
+  if (/\B--quick\b/i.test(promptText)) return "quick";
+  return "standard";
+}
+function slugifyMergeReadiness(input) {
+  const slug = input.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 48);
+  return slug || "change";
+}
+function runGit(directory, args) {
+  try {
+    const stdout = (0, import_child_process10.execFileSync)("git", args, {
+      cwd: directory,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      timeout: 1e4,
+      maxBuffer: 10 * 1024 * 1024
+    });
+    return { stdout: stdout.trim() };
+  } catch (e) {
+    const err = e;
+    const timedOut = err?.code === "ETIMEDOUT" || /timed out/i.test(String(err?.message || ""));
+    const stderr = typeof err?.stderr === "string" ? err.stderr.trim().slice(0, 200) : "";
+    const exit = err?.status;
+    const error2 = timedOut ? `git ${args[0]} timed out (>10s)` : `git ${args[0]} failed (exit ${exit ?? "?"})${stderr ? ": " + stderr : ""}`;
+    return { stdout: "", error: error2 };
+  }
+}
+function listArtifactFiles(directory) {
+  const root = getOmcRoot(directory);
+  const candidates = ["plans", "artifacts", "logs", "specs", "interviews"].map((segment) => (0, import_path15.join)(root, segment)).filter((path13) => (0, import_fs14.existsSync)(path13));
+  const found = [];
+  for (const candidate of candidates) {
+    const stack = [candidate];
+    while (stack.length > 0 && found.length < 40) {
+      const current = stack.pop();
+      if (!current) continue;
+      try {
+        const entries = (0, import_fs14.readdirSync)(current, { withFileTypes: true });
+        for (const entry of entries) {
+          const full = (0, import_path15.join)(current, entry.name);
+          if (entry.isDirectory()) {
+            stack.push(full);
+          } else if (entry.isFile() && /\.(md|json|txt|log)$/i.test(entry.name)) {
+            const relativePath = (0, import_path15.relative)(root, full).replace(/\\/g, "/");
+            if (!relativePath.startsWith("artifacts/merge-readiness/") && !relativePath.includes("merge-readiness-state")) {
+              found.push(relativePath);
+            }
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return found.sort();
+}
+function collectMergeReadinessEvidence(directory, baseRef) {
+  const worktree = resolveToWorktreeRoot(directory);
+  const gitErrors = [];
+  const git = (args) => {
+    const r = runGit(worktree, args);
+    if (r.error) gitErrors.push(r.error);
+    return r.stdout;
+  };
+  const changedFiles = git(["diff", "--name-only", "HEAD"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const stagedFiles = git(["diff", "--cached", "--name-only"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const untrackedFiles = git(["ls-files", "--others", "--exclude-standard"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const resolvedBase = baseRef || git(["rev-parse", "--abbrev-ref", "@{upstream}"]) || git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+  const committedBase = resolvedBase ? git(["merge-base", resolvedBase, "HEAD"]) : "";
+  const committedFiles = /^[0-9a-f]{7,40}$/.test(committedBase || "") ? git(["diff", "--name-only", committedBase + "...HEAD"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean) : [];
+  const trackedChangedFiles = Array.from(/* @__PURE__ */ new Set([...changedFiles, ...stagedFiles, ...committedFiles])).sort();
+  const status = git(["status", "--short"]);
+  const diffStat = git(["diff", "--stat", "HEAD"]) || (committedBase ? git(["diff", "--stat", committedBase + "...HEAD"]) : "") || git(["diff", "--cached", "--stat"]);
+  const sourceArtifacts = listArtifactFiles(worktree);
+  const evidenceText = sourceArtifacts.join("\n").toLowerCase();
+  const testEvidence = sourceArtifacts.filter((file) => /test|spec|qa|verify|validation/i.test(file));
+  const reviewEvidence = sourceArtifacts.filter((file) => /review|risk|security|readiness|verdict/i.test(file));
+  const missingEvidence = [];
+  if (trackedChangedFiles.length === 0 && !status) {
+    missingEvidence.push("No changed files or git status evidence were detected.");
+  }
+  if (!diffStat) {
+    missingEvidence.push("No diff stat was detected for the current worktree.");
+  }
+  if (!/test|spec|qa|verify|validation/.test(evidenceText)) {
+    missingEvidence.push("No test or verification artifact was detected under .omc.");
+  }
+  if (!/review|risk|security|verdict/.test(evidenceText)) {
+    missingEvidence.push("No review or risk artifact was detected under .omc.");
+  }
+  for (const gerr of gitErrors) missingEvidence.push(gerr);
+  return { changedFiles: trackedChangedFiles, untrackedFiles, status, diffStat, sourceArtifacts, testEvidence, reviewEvidence, missingEvidence };
+}
+function extractChangeSummary(promptText) {
+  return promptText.replace(/^\s*\/(?:oh-my-claudecode:|omc:)?merge-readiness\b/i, "").replace(/\B--(?:quick|standard|deep|from-diff|from-artifacts)\b/gi, "").trim();
+}
+function hasMinimalEvidence(evidence) {
+  return evidence.changedFiles.length > 0 || Boolean(evidence.status) || Boolean(evidence.diffStat) || evidence.sourceArtifacts.length > 0;
+}
+function parseMergeReadinessSourceMode(promptText) {
+  const fromDiff = /(?:^|\s)--from-diff(?=\s|$)/i.test(promptText);
+  const fromArtifacts = /(?:^|\s)--from-artifacts(?=\s|$)/i.test(promptText);
+  if (fromDiff && fromArtifacts) return { error: "--from-diff and --from-artifacts cannot be used together." };
+  if (fromDiff) return { mode: "diff" };
+  if (fromArtifacts) return { mode: "artifacts" };
+  return {};
+}
+function hasMinimalEvidenceForMode(evidence, mode) {
+  const hasDiff = evidence.changedFiles.length > 0 || Boolean(evidence.diffStat);
+  if (mode === "diff") return hasDiff;
+  if (mode === "artifacts") return evidence.sourceArtifacts.length > 0;
+  const hasRelevantArtifact = evidence.testEvidence.length > 0 || evidence.reviewEvidence.length > 0;
+  return hasDiff || hasRelevantArtifact;
+}
+function pickNextQuestion(state) {
+  if (state.questions.length === 0) return void 0;
+  const answered = new Set(state.answers.map((a) => a.questionId));
+  const unanswered = state.questions.filter((q) => !answered.has(q.id));
+  if (unanswered.length === 0) return void 0;
+  const requiredSet = new Set(state.required_dimensions);
+  const requiredNext = unanswered.find((q) => requiredSet.has(q.dimension));
+  return requiredNext ?? unanswered[0];
+}
+function recomputeReadiness(state) {
+  const scores = {};
+  for (const dimension of state.required_dimensions) {
+    const dimensionAnswers = state.answers.filter((a) => {
+      const question = state.questions.find((q) => q.id === a.questionId);
+      return question?.dimension === dimension;
+    });
+    if (dimensionAnswers.length > 0) {
+      const correct = dimensionAnswers.filter((a) => a.isCorrect).length;
+      scores[dimension] = correct / dimensionAnswers.length;
+    }
+  }
+  state.dimension_scores = scores;
+  state.readiness_score = computeCorrectnessRate(state.answers);
+}
+function allRequiredAnswered(state) {
+  if (state.questions.length === 0) return false;
+  const answered = new Set(state.answers.map((a) => a.questionId));
+  const answeredDimensions = new Set(
+    state.answers.map((a) => state.questions.find((q) => q.id === a.questionId)?.dimension).filter((d) => Boolean(d))
+  );
+  const coverageOk = state.required_dimensions.every((d) => answeredDimensions.has(d));
+  const cap = Math.min(state.questions.length, state.max_rounds);
+  const answeredInRange = state.answers.filter((a) => answered.has(a.questionId)).length;
+  return coverageOk && answeredInRange >= cap;
+}
+function finalizeIfReady(state, now) {
+  recomputeReadiness(state);
+  if (!hasMinimalEvidence(state.evidence)) {
+    state.phase = "complete";
+    state.result = "blocked";
+    state.completed_at = now;
+    delete state.pending_question;
+    return;
+  }
+  if (!allRequiredAnswered(state)) {
+    return;
+  }
+  const rate = state.readiness_score;
+  const coverageOk = hasRequiredDimensionCoverage(
+    state.answers,
+    state.questions,
+    state.required_dimensions
+  );
+  if (isCorrectnessPass(rate, state.threshold) && coverageOk) {
+    state.active = false;
+    state.phase = "complete";
+    state.result = "pass";
+    state.completed_at = now;
+    delete state.pending_question;
+    return;
+  }
+  state.phase = "complete";
+  state.result = "paused";
+  state.completed_at = now;
+  delete state.pending_question;
+}
+function readMergeReadinessState(directory, sessionId) {
+  return readModeState(MODE, directory, sessionId) ?? null;
+}
+function writeMergeReadinessState(directory, state, sessionId) {
+  return writeModeState(MODE, state, directory, sessionId);
+}
+function createInitialMergeReadinessState(directory, promptText, sessionId, baseRef) {
+  const now = (/* @__PURE__ */ new Date()).toISOString();
+  const profile = parseMergeReadinessProfile(promptText);
+  const changeSummary = extractChangeSummary(promptText);
+  const unsupportedFromPr = /\B--from-pr\b/i.test(promptText);
+  const sourceModeResult = parseMergeReadinessSourceMode(promptText);
+  const sourceMode = sourceModeResult.mode;
+  const evidence = collectMergeReadinessEvidence(directory, baseRef);
+  const missingEvidence = unsupportedFromPr || Boolean(sourceModeResult.error) || !hasMinimalEvidenceForMode(evidence, sourceMode);
+  const state = {
+    active: true,
+    session_id: sessionId,
+    current_phase: MODE,
+    phase: "content",
+    profile,
+    threshold: profileThreshold(profile),
+    max_rounds: profileMaxRounds(profile),
+    required_dimensions: requiredDimensionsForProfile(profile),
+    rounds: [],
+    questions: [],
+    answers: [],
+    awaiting_content: !missingEvidence,
+    evidence,
+    readiness_score: 0,
+    dimension_scores: {},
+    result: missingEvidence ? "blocked" : "pending",
+    why: "",
+    whatChanged: "",
+    tradeoffs: "",
+    risksConsidered: "",
+    teamUnderstanding: "",
+    started_at: now,
+    updated_at: now,
+    change_summary: changeSummary,
+    slug: slugifyMergeReadiness(changeSummary || "merge-readiness"),
+    source_mode: sourceMode
+  };
+  if (missingEvidence) {
+    state.validation_errors = unsupportedFromPr ? ["--from-pr is unsupported: merge-readiness uses local git and .omc evidence only."] : sourceModeResult.error ? [sourceModeResult.error] : ["No minimal evidence for the selected source mode was detected; produce it before running /merge-readiness."];
+  }
+  let prior = null;
+  try {
+    prior = readMergeReadinessState(directory, sessionId);
+  } catch {
+    prior = null;
+  }
+  if (prior && prior.result !== "pending" && prior.completed_at) {
+    state.prior_attempts = [
+      ...prior.prior_attempts ?? [],
+      {
+        started_at: prior.started_at,
+        completed_at: prior.completed_at,
+        result: prior.result,
+        readiness_score: prior.readiness_score,
+        change_summary: prior.change_summary
+      }
+    ];
+  }
+  const persisted = writeMergeReadinessState(directory, state, sessionId);
+  if (!persisted) {
+    state.result = "blocked";
+    state.awaiting_content = false;
+    state.phase = "complete";
+    state.validation_errors = ["Merge-readiness state could not be persisted (invalid session id or state path). Resolve the session id and re-run merge_readiness_start."];
+  }
+  return state;
+}
+function setMergeReadinessContent(directory, content, sessionId) {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  const now = (/* @__PURE__ */ new Date()).toISOString();
+  if (state.result === "blocked" || state.result === "paused") {
+    state.validation_errors ??= [state.result === "blocked" ? "Blocked: no minimal evidence for the selected source mode. Produce it before submitting content." : "Paused: the quiz was not passed. Re-run merge_readiness_start to collect fresh evidence and retry; the prior attempt is retained in the audit history."];
+    if (state.result === "blocked") {
+      state.awaiting_content = true;
+      state.phase = "content";
+    }
+    state.updated_at = now;
+    writeMergeReadinessState(workingDir, state, sessionId);
+    return state;
+  }
+  const errors = validateMergeReadinessContent(content, state);
+  if (errors.length > 0) {
+    state.validation_errors = errors;
+    state.awaiting_content = true;
+    state.phase = "content";
+    state.answers = [];
+    state.readiness_score = 0;
+    state.dimension_scores = {};
+    state.result = "pending";
+    delete state.pending_question;
+    delete state.completed_at;
+    delete state.override_reason;
+    state.updated_at = now;
+    writeMergeReadinessState(workingDir, state, sessionId);
+    return state;
+  }
+  state.why = content.why.trim();
+  state.whatChanged = content.whatChanged.trim();
+  state.tradeoffs = content.tradeoffs.trim();
+  state.risksConsidered = content.risksConsidered.trim();
+  state.teamUnderstanding = content.teamUnderstanding.trim();
+  state.questions = content.questions.slice(0, state.max_rounds);
+  state.answers = [];
+  state.readiness_score = 0;
+  state.dimension_scores = {};
+  state.result = "pending";
+  delete state.completed_at;
+  delete state.override_reason;
+  delete state.validation_errors;
+  state.awaiting_content = false;
+  state.phase = "questioning";
+  state.updated_at = now;
+  state.pending_question = pickNextQuestion(state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+function recordMergeReadinessMCQAnswer(directory, questionId, selectedOptionId, sessionId) {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  if (state.awaiting_content || state.phase !== "questioning") return null;
+  const question = state.questions.find((q) => q.id === questionId);
+  if (!question || state.pending_question?.id !== questionId) return null;
+  const normalizedOptionId = selectedOptionId.trim();
+  if (!question.options.some((option) => option.id === normalizedOptionId)) return null;
+  const now = (/* @__PURE__ */ new Date()).toISOString();
+  const isCorrect = scoreMCQResponse(question, normalizedOptionId);
+  const filtered = state.answers.filter((a) => a.questionId !== questionId);
+  const answer = {
+    questionId,
+    selectedOptionId: normalizedOptionId,
+    isCorrect,
+    answeredAt: now
+  };
+  state.answers = [...filtered, answer];
+  state.updated_at = now;
+  delete state.pending_question;
+  finalizeIfReady(state, now);
+  if (state.active && state.phase === "questioning") {
+    state.pending_question = pickNextQuestion(state);
+  } else {
+    delete state.pending_question;
+  }
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+function validateMergeReadinessContent(content, state) {
+  const errors = [];
+  const sections = [["why", content.why], ["whatChanged", content.whatChanged], ["tradeoffs", content.tradeoffs], ["risksConsidered", content.risksConsidered], ["teamUnderstanding", content.teamUnderstanding]];
+  for (const [name, value] of sections) if (!value?.trim()) errors.push(`Narrative section '${name}' is required.`);
+  if (!Array.isArray(content.questions) || content.questions.length < state.required_dimensions.length) errors.push("Questions must cover every required dimension.");
+  if (content.questions.length > state.max_rounds) errors.push(`Questions exceed the ${state.max_rounds}-question profile limit.`);
+  const ids = /* @__PURE__ */ new Set();
+  const dimensions = /* @__PURE__ */ new Set();
+  for (const question of content.questions ?? []) {
+    if (!question.id?.trim() || ids.has(question.id)) errors.push("Question ids must be non-empty and unique.");
+    ids.add(question.id);
+    dimensions.add(question.dimension);
+    if (!question.stem?.trim()) errors.push(`Question '${question.id}' needs a stem.`);
+    if (!Array.isArray(question.options) || question.options.length < 2) errors.push(`Question '${question.id}' needs at least two options.`);
+    const optionIds = new Set(question.options?.map((option) => option.id) ?? []);
+    if (optionIds.size !== (question.options?.length ?? 0) || [...optionIds].some((id) => !id?.trim())) errors.push(`Question '${question.id}' has invalid option ids.`);
+    if (!optionIds.has(question.correctOptionId)) errors.push(`Question '${question.id}' correctOptionId must identify an option.`);
+  }
+  for (const dimension of state.required_dimensions) if (!dimensions.has(dimension)) errors.push(`No question covers required dimension '${dimension}'.`);
+  return errors;
+}
+function cancelMergeReadiness(directory, sessionId) {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  state.active = false;
+  state.phase = "complete";
+  state.result = "cancelled";
+  state.completed_at = state.updated_at = (/* @__PURE__ */ new Date()).toISOString();
+  delete state.pending_question;
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+// src/hooks/merge-readiness/report.ts
+var MERGE_BOUNDARY_STATEMENT = "Passing means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk.";
+function renderQuestions(questions, answers, result) {
+  if (questions.length === 0) return "_No quiz questions recorded yet._";
+  const answersByQuestion = new Map(answers.map((answer) => [answer.questionId, answer]));
+  const revealAll = result === "pass" || result === "paused";
+  const revealAnswered = result === "overridden" || result === "cancelled";
+  return questions.map((question, index) => {
+    const answer = answersByQuestion.get(question.id);
+    const options = question.options.map((option) => {
+      const marks = [];
+      if ((revealAll || revealAnswered && answer) && option.id === question.correctOptionId) marks.push("correct");
+      if (answer?.selectedOptionId === option.id) marks.push("selected");
+      return `- [${option.id}] ${option.text}${marks.length > 0 ? ` _(${marks.join(", ")})_` : ""}`;
+    });
+    const correctness = answer && (revealAll || revealAnswered) ? `Correct: ${answer.isCorrect ? "yes" : "no"}` : answer ? "_Answered; correctness hidden until completion._" : "_Not answered yet._";
+    return [
+      `### ${index + 1}. [${question.dimension}] ${question.stem}`,
+      "",
+      ...options,
+      "",
+      correctness
+    ].join("\n");
+  }).join("\n\n");
+}
+function renderList(values, empty) {
+  return values.length > 0 ? values.map((value) => `- ${value}`).join("\n") : empty;
+}
+function formatMergeReadinessReport(state) {
+  const revealAssessment = ["pass", "paused", "overridden", "cancelled"].includes(state.result);
+  const dimensions = revealAssessment ? state.required_dimensions.map((dimension) => `- ${dimension}: ${Math.round((state.dimension_scores[dimension] ?? 0) * 100)}%`).join("\n") : "_Available after the attempt completes._";
+  const pending = state.pending_question ? `- [${state.pending_question.dimension}] ${state.pending_question.stem}` : "_No pending question._";
+  return [
+    "# Merge Readiness Report",
+    "",
+    "## Why",
+    "",
+    state.why || "_Not yet generated._",
+    "",
+    "## What Changed",
+    "",
+    state.whatChanged || "_Not yet generated._",
+    "",
+    "## Tradeoffs",
+    "",
+    state.tradeoffs || "_Not yet generated._",
+    "",
+    "## Risks Considered",
+    "",
+    state.risksConsidered || "_Not yet generated._",
+    "",
+    "## Team Understanding",
+    "",
+    state.teamUnderstanding || "_Not yet generated._",
+    "",
+    "## Change Summary",
+    "",
+    state.change_summary || "_No change summary provided._",
+    "",
+    "## Evidence Collected",
+    "",
+    "### Changed Files",
+    "",
+    renderList(state.evidence.changedFiles, "_No changed files detected._"),
+    "",
+    "### Git Status",
+    "",
+    state.evidence.status || "_No git status output._",
+    "",
+    "### Diff Stat",
+    "",
+    state.evidence.diffStat || "_No diff stat output._",
+    "",
+    "### Source Artifacts",
+    "",
+    renderList(state.evidence.sourceArtifacts, "_No source artifacts found._"),
+    "",
+    "### Missing Evidence",
+    "",
+    renderList(state.evidence.missingEvidence, "_No missing evidence recorded._"),
+    "",
+    "## Human Explainability Quiz",
+    "",
+    "This quiz checks whether the human can explain the change. It does not replace tests, review, or maintainer approval.",
+    "",
+    renderQuestions(state.questions, state.answers, state.result),
+    "",
+    "## Pending Question",
+    "",
+    pending,
+    "",
+    "## Readiness",
+    "",
+    `Result: ${state.result}`,
+    state.override_reason ? `Override reason: ${state.override_reason}` : "",
+    "",
+    revealAssessment ? `Correctness rate: ${Math.round(state.readiness_score * 100)}% / threshold ${Math.round(state.threshold * 100)}%` : `Correctness rate: hidden until completion / threshold ${Math.round(state.threshold * 100)}%`,
+    "",
+    "Dimension coverage:",
+    "",
+    dimensions || "_No scored dimensions yet._",
+    "",
+    "",
+    state.prior_attempts && state.prior_attempts.length > 0 ? ["## Prior Attempts", "", ...state.prior_attempts.map((a, i) => "- Attempt " + (i + 1) + ": " + a.result + " (score " + Math.round((a.readiness_score ?? 0) * 100) + "%)" + (a.change_summary ? " - " + a.change_summary : ""))].join("\n") : "",
+    "",
+    "## Merge Boundary",
+    "",
+    MERGE_BOUNDARY_STATEMENT,
+    ""
+  ].filter((line, index, lines) => line !== "" || lines[index - 1] !== "").join("\n");
+}
+function redactQuestion(question) {
+  const redacted = { ...question };
+  delete redacted.correctOptionId;
+  delete redacted.rationale;
+  return redacted;
+}
+function redactMergeReadinessState(state) {
+  const revealAll = state.result === "pass" || state.result === "paused";
+  const revealAnswered = state.result === "overridden" || state.result === "cancelled";
+  const answeredQuestionIds = new Set(state.answers.map((answer) => answer.questionId));
+  const shouldRevealQuestion = (question) => revealAll || revealAnswered && answeredQuestionIds.has(question.id);
+  const redacted = {
+    ...state,
+    questions: state.questions.map((question) => shouldRevealQuestion(question) ? question : redactQuestion(question)),
+    pending_question: state.pending_question ? shouldRevealQuestion(state.pending_question) ? state.pending_question : redactQuestion(state.pending_question) : void 0,
+    answers: state.answers.map((answer) => {
+      if (revealAll || revealAnswered) return answer;
+      const publicAnswer = { ...answer };
+      delete publicAnswer.isCorrect;
+      return publicAnswer;
+    }),
+    rounds: state.rounds.map((round) => {
+      if (revealAll || revealAnswered) return round;
+      const publicRound = { ...round };
+      delete publicRound.score;
+      return publicRound;
+    })
+  };
+  if (!revealAll && !revealAnswered) {
+    delete redacted.readiness_score;
+    delete redacted.dimension_scores;
+  }
+  return redacted;
+}
+
 // src/tools/state-tools.ts
 var EXECUTION_MODES = [
   "autopilot",
@@ -23270,6 +23967,13 @@ var STATE_TOOL_MODES = [
   ...EXECUTION_MODES,
   "ralplan",
   "omc-teams",
+  "skill-active",
+  "merge-readiness"
+];
+var STATE_WRITE_MODES = [
+  ...EXECUTION_MODES,
+  "ralplan",
+  "omc-teams",
   "skill-active"
 ];
 var EXTRA_STATE_ONLY_MODES = ["ralplan", "omc-teams", "skill-active"];
@@ -23282,26 +23986,26 @@ function getStateFileName(mode) {
 }
 function readJsonRecord(filePath) {
   try {
-    return JSON.parse((0, import_fs14.readFileSync)(filePath, "utf-8"));
+    return JSON.parse((0, import_fs15.readFileSync)(filePath, "utf-8"));
   } catch {
     return null;
   }
 }
 function listSessionIdsUnderOmcRoot(omcRoot) {
-  const sessionsDir = (0, import_path15.join)(omcRoot, "state", "sessions");
-  if (!(0, import_fs14.existsSync)(sessionsDir)) {
+  const sessionsDir = (0, import_path16.join)(omcRoot, "state", "sessions");
+  if (!(0, import_fs15.existsSync)(sessionsDir)) {
     return [];
   }
   try {
-    return (0, import_fs14.readdirSync)(sessionsDir, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).filter((name) => /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(name));
+    return (0, import_fs15.readdirSync)(sessionsDir, { withFileTypes: true }).filter((entry) => entry.isDirectory()).map((entry) => entry.name).filter((name) => /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(name));
   } catch {
     return [];
   }
 }
 function getConvergedOmcRoots(root) {
   const roots = /* @__PURE__ */ new Set([getOmcRoot(root)]);
-  roots.add((0, import_path15.join)(root, OmcPaths.ROOT));
-  roots.add((0, import_path15.join)((0, import_os4.homedir)(), OmcPaths.ROOT));
+  roots.add((0, import_path16.join)(root, OmcPaths.ROOT));
+  roots.add((0, import_path16.join)((0, import_os4.homedir)(), OmcPaths.ROOT));
   return [...roots];
 }
 function getConvergedStateCandidates(mode, root, sessionId) {
@@ -23311,11 +24015,11 @@ function getConvergedStateCandidates(mode, root, sessionId) {
   const filename = getStateFileName(mode);
   const paths = /* @__PURE__ */ new Set();
   for (const omcRoot of getConvergedOmcRoots(root)) {
-    const stateDir = (0, import_path15.join)(omcRoot, "state");
+    const stateDir = (0, import_path16.join)(omcRoot, "state");
     if (sessionId) {
-      paths.add((0, import_path15.join)(stateDir, "sessions", sessionId, filename));
+      paths.add((0, import_path16.join)(stateDir, "sessions", sessionId, filename));
       for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-        const candidatePath = (0, import_path15.join)(stateDir, "sessions", sid, filename);
+        const candidatePath = (0, import_path16.join)(stateDir, "sessions", sid, filename);
         const raw = readJsonRecord(candidatePath);
         if (raw && getStateSessionOwner(raw) === sessionId) {
           paths.add(candidatePath);
@@ -23323,11 +24027,11 @@ function getConvergedStateCandidates(mode, root, sessionId) {
       }
     } else {
       for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-        paths.add((0, import_path15.join)(stateDir, "sessions", sid, filename));
+        paths.add((0, import_path16.join)(stateDir, "sessions", sid, filename));
       }
     }
-    paths.add((0, import_path15.join)(stateDir, filename));
-    paths.add((0, import_path15.join)(omcRoot, filename));
+    paths.add((0, import_path16.join)(stateDir, filename));
+    paths.add((0, import_path16.join)(omcRoot, filename));
   }
   return [...paths];
 }
@@ -23346,7 +24050,7 @@ function clearConvergedStateCandidates(mode, root, sessionId) {
   let hadFailure = false;
   const paths = getConvergedStateCandidates(mode, root, sessionId);
   for (const statePath of paths) {
-    if (!(0, import_fs14.existsSync)(statePath)) {
+    if (!(0, import_fs15.existsSync)(statePath)) {
       continue;
     }
     try {
@@ -23356,7 +24060,7 @@ function clearConvergedStateCandidates(mode, root, sessionId) {
           continue;
         }
       }
-      (0, import_fs14.unlinkSync)(statePath);
+      (0, import_fs15.unlinkSync)(statePath);
       cleared++;
     } catch {
       hadFailure = true;
@@ -23368,9 +24072,9 @@ function hasActiveConvergedState(mode, root, sessionId) {
   return getConvergedStateCandidates(mode, root, sessionId).some((statePath) => isConvergedCandidateActiveForSession(statePath, sessionId));
 }
 function readTeamNamesFromStateFile(statePath) {
-  if (!(0, import_fs14.existsSync)(statePath)) return [];
+  if (!(0, import_fs15.existsSync)(statePath)) return [];
   try {
-    const raw = JSON.parse((0, import_fs14.readFileSync)(statePath, "utf-8"));
+    const raw = JSON.parse((0, import_fs15.readFileSync)(statePath, "utf-8"));
     const teamName = typeof raw.team_name === "string" ? raw.team_name.trim() : typeof raw.teamName === "string" ? raw.teamName.trim() : "";
     return teamName ? [teamName] : [];
   } catch {
@@ -23378,10 +24082,10 @@ function readTeamNamesFromStateFile(statePath) {
   }
 }
 function pruneMissionBoardTeams(root, teamNames) {
-  const missionStatePath = (0, import_path15.join)(getOmcRoot(root), "state", "mission-state.json");
-  if (!(0, import_fs14.existsSync)(missionStatePath)) return 0;
+  const missionStatePath = (0, import_path16.join)(getOmcRoot(root), "state", "mission-state.json");
+  if (!(0, import_fs15.existsSync)(missionStatePath)) return 0;
   try {
-    const parsed = JSON.parse((0, import_fs14.readFileSync)(missionStatePath, "utf-8"));
+    const parsed = JSON.parse((0, import_fs15.readFileSync)(missionStatePath, "utf-8"));
     if (!Array.isArray(parsed.missions)) return 0;
     const shouldRemoveAll = teamNames == null;
     const teamNameSet = new Set(teamNames ?? []);
@@ -23393,7 +24097,7 @@ function pruneMissionBoardTeams(root, teamNames) {
     });
     const removed = parsed.missions.length - remainingMissions.length;
     if (removed > 0) {
-      (0, import_fs14.writeFileSync)(missionStatePath, JSON.stringify({
+      (0, import_fs15.writeFileSync)(missionStatePath, JSON.stringify({
         ...parsed,
         updatedAt: (/* @__PURE__ */ new Date()).toISOString(),
         missions: remainingMissions
@@ -23405,13 +24109,13 @@ function pruneMissionBoardTeams(root, teamNames) {
   }
 }
 function cleanupTeamRuntimeState(root, teamNames) {
-  const teamStateRoot = (0, import_path15.join)(getOmcRoot(root), "state", "team");
-  if (!(0, import_fs14.existsSync)(teamStateRoot)) return 0;
+  const teamStateRoot = (0, import_path16.join)(getOmcRoot(root), "state", "team");
+  if (!(0, import_fs15.existsSync)(teamStateRoot)) return 0;
   const shouldRemoveAll = teamNames == null;
   let removed = 0;
   if (shouldRemoveAll) {
     try {
-      (0, import_fs14.rmSync)(teamStateRoot, { recursive: true, force: true });
+      (0, import_fs15.rmSync)(teamStateRoot, { recursive: true, force: true });
       return 1;
     } catch {
       return 0;
@@ -23420,7 +24124,7 @@ function cleanupTeamRuntimeState(root, teamNames) {
   for (const teamName of teamNames ?? []) {
     if (!teamName) continue;
     try {
-      (0, import_fs14.rmSync)((0, import_path15.join)(teamStateRoot, teamName), { recursive: true, force: true });
+      (0, import_fs15.rmSync)((0, import_path16.join)(teamStateRoot, teamName), { recursive: true, force: true });
       removed += 1;
     } catch {
     }
@@ -23437,25 +24141,25 @@ function getLegacyStateFileCandidates(mode, root) {
   const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   const candidates = [
     getStatePath(mode, root),
-    (0, import_path15.join)(getOmcRoot(root), `${normalizedName}.json`)
+    (0, import_path16.join)(getOmcRoot(root), `${normalizedName}.json`)
   ];
   return [...new Set(candidates)];
 }
 function getWorkingDirectoryLocalOmcRoot(root) {
-  return (0, import_path15.join)(root, OmcPaths.ROOT);
+  return (0, import_path16.join)(root, OmcPaths.ROOT);
 }
 function shouldCheckWorkingDirectoryLocalState(root) {
   return getWorkingDirectoryLocalOmcRoot(root) !== getOmcRoot(root);
 }
 function getWorkingDirectoryLocalSessionStatePath(mode, root, sessionId) {
   const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
-  return (0, import_path15.join)(getWorkingDirectoryLocalOmcRoot(root), "state", "sessions", sessionId, `${normalizedName}.json`);
+  return (0, import_path16.join)(getWorkingDirectoryLocalOmcRoot(root), "state", "sessions", sessionId, `${normalizedName}.json`);
 }
 function getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root) {
   const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   return [
-    (0, import_path15.join)(getWorkingDirectoryLocalOmcRoot(root), "state", `${normalizedName}.json`),
-    (0, import_path15.join)(getWorkingDirectoryLocalOmcRoot(root), `${normalizedName}.json`)
+    (0, import_path16.join)(getWorkingDirectoryLocalOmcRoot(root), "state", `${normalizedName}.json`),
+    (0, import_path16.join)(getWorkingDirectoryLocalOmcRoot(root), `${normalizedName}.json`)
   ];
 }
 function getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId) {
@@ -23477,17 +24181,17 @@ function clearWorkingDirectoryLocalStateCandidates(mode, root, sessionId) {
   const paths = getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId);
   const localLegacyPaths = new Set(getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root));
   for (const statePath of paths) {
-    if (!(0, import_fs14.existsSync)(statePath)) {
+    if (!(0, import_fs15.existsSync)(statePath)) {
       continue;
     }
     try {
       if (sessionId && localLegacyPaths.has(statePath)) {
-        const raw = JSON.parse((0, import_fs14.readFileSync)(statePath, "utf-8"));
+        const raw = JSON.parse((0, import_fs15.readFileSync)(statePath, "utf-8"));
         if (!canClearStateForSession(raw, sessionId)) {
           continue;
         }
       }
-      (0, import_fs14.unlinkSync)(statePath);
+      (0, import_fs15.unlinkSync)(statePath);
       cleared++;
     } catch {
       hadFailure = true;
@@ -23499,17 +24203,17 @@ function clearLegacyStateCandidates(mode, root, sessionId) {
   let cleared = 0;
   let hadFailure = false;
   for (const legacyPath of getLegacyStateFileCandidates(mode, root)) {
-    if (!(0, import_fs14.existsSync)(legacyPath)) {
+    if (!(0, import_fs15.existsSync)(legacyPath)) {
       continue;
     }
     try {
       if (sessionId) {
-        const raw = JSON.parse((0, import_fs14.readFileSync)(legacyPath, "utf-8"));
+        const raw = JSON.parse((0, import_fs15.readFileSync)(legacyPath, "utf-8"));
         if (!canClearStateForSession(raw, sessionId)) {
           continue;
         }
       }
-      (0, import_fs14.unlinkSync)(legacyPath);
+      (0, import_fs15.unlinkSync)(legacyPath);
       cleared++;
     } catch {
       hadFailure = true;
@@ -23523,7 +24227,7 @@ function clearSessionOwnedStateCandidates(mode, root, sessionId) {
   const paths = findSessionOwnedStateFiles(mode, sessionId, root);
   for (const statePath of paths) {
     try {
-      (0, import_fs14.unlinkSync)(statePath);
+      (0, import_fs15.unlinkSync)(statePath);
       cleared++;
     } catch {
       hadFailure = true;
@@ -23537,7 +24241,7 @@ function clearCompletedSessionStateCandidates(mode, root, requesterSessionId) {
   const paths = findCompletedSessionStateFiles(mode, root, requesterSessionId);
   for (const statePath of paths) {
     try {
-      (0, import_fs14.unlinkSync)(statePath);
+      (0, import_fs15.unlinkSync)(statePath);
       cleared++;
     } catch {
       hadFailure = true;
@@ -23582,23 +24286,23 @@ function getModeRuntimeArtifactNames(mode) {
 function clearModeRuntimeArtifacts(mode, root, sessionId) {
   let cleared = 0;
   let hadFailure = false;
-  const stateRoot = (0, import_path15.join)(getOmcRoot(root), "state");
+  const stateRoot = (0, import_path16.join)(getOmcRoot(root), "state");
   const candidateDirs = /* @__PURE__ */ new Set([stateRoot]);
   if (sessionId) {
-    candidateDirs.add((0, import_path15.join)(stateRoot, "sessions", sessionId));
+    candidateDirs.add((0, import_path16.join)(stateRoot, "sessions", sessionId));
   } else {
     for (const sid of listSessionIds(root)) {
-      candidateDirs.add((0, import_path15.join)(stateRoot, "sessions", sid));
+      candidateDirs.add((0, import_path16.join)(stateRoot, "sessions", sid));
     }
   }
   for (const dir of candidateDirs) {
     for (const artifactName of getModeRuntimeArtifactNames(mode)) {
-      const artifactPath = (0, import_path15.join)(dir, artifactName);
-      if (!(0, import_fs14.existsSync)(artifactPath)) {
+      const artifactPath = (0, import_path16.join)(dir, artifactName);
+      if (!(0, import_fs15.existsSync)(artifactPath)) {
         continue;
       }
       try {
-        (0, import_fs14.unlinkSync)(artifactPath);
+        (0, import_fs15.unlinkSync)(artifactPath);
         cleared++;
       } catch {
         hadFailure = true;
@@ -23623,11 +24327,11 @@ function isSessionModeActive(mode, root, sessionId) {
     return isModeActive(mode, root, sessionId);
   }
   const statePath = resolveSessionStatePath(mode, sessionId, root);
-  if (!(0, import_fs14.existsSync)(statePath)) {
+  if (!(0, import_fs15.existsSync)(statePath)) {
     return false;
   }
   try {
-    const state = JSON.parse((0, import_fs14.readFileSync)(statePath, "utf-8"));
+    const state = JSON.parse((0, import_fs15.readFileSync)(statePath, "utf-8"));
     return state.active === true;
   } catch {
     return false;
@@ -23636,6 +24340,9 @@ function isSessionModeActive(mode, root, sessionId) {
 function findSingleOwningSessionForMode(mode, root, requesterSessionId) {
   const owningSessions = listSessionIds(root).filter((sid) => sid !== requesterSessionId && isSessionModeActive(mode, root, sid));
   return owningSessions.length === 1 ? owningSessions[0] : void 0;
+}
+function publicStateForMode(mode, state) {
+  return mode === "merge-readiness" ? redactMergeReadinessState(state) : state;
 }
 var stateReadTool = {
   name: "state_read",
@@ -23654,11 +24361,11 @@ var stateReadTool = {
       if (sessionId) {
         validateSessionId(sessionId);
         const statePath2 = MODE_CONFIGS[mode] ? getStateFilePath(root, mode, sessionId) : resolveSessionStatePath(mode, sessionId, root);
-        if (!(0, import_fs14.existsSync)(statePath2)) {
+        if (!(0, import_fs15.existsSync)(statePath2)) {
           const completedSessionPaths = findCompletedSessionStateFiles(mode, root, sessionId);
           if (completedSessionPaths.length > 0) {
             const orphanList = completedSessionPaths.map((orphanPath) => {
-              const sessionMarker = `${(0, import_path15.join)("state", "sessions")}/`;
+              const sessionMarker = `${(0, import_path16.join)("state", "sessions")}/`;
               const markerIndex = orphanPath.indexOf(sessionMarker);
               if (markerIndex === -1) return `- ${orphanPath}`;
               const rest = orphanPath.slice(markerIndex + sessionMarker.length);
@@ -23687,7 +24394,7 @@ Expected path: ${statePath2}`
             }]
           };
         }
-        const content = (0, import_fs14.readFileSync)(statePath2, "utf-8");
+        const content = (0, import_fs15.readFileSync)(statePath2, "utf-8");
         const state = JSON.parse(content);
         return {
           content: [{
@@ -23697,18 +24404,18 @@ Expected path: ${statePath2}`
 Path: ${statePath2}
 
 \`\`\`json
-${JSON.stringify(state, null, 2)}
+${JSON.stringify(publicStateForMode(mode, state), null, 2)}
 \`\`\``
           }]
         };
       }
       const statePath = getStatePath(mode, root);
-      const legacyExists = (0, import_fs14.existsSync)(statePath);
+      const legacyExists = (0, import_fs15.existsSync)(statePath);
       const sessionIds = listSessionIds(root);
       const activeSessions = [];
       for (const sid of sessionIds) {
         const sessionStatePath = MODE_CONFIGS[mode] ? getStateFilePath(root, mode, sid) : resolveSessionStatePath(mode, sid, root);
-        if ((0, import_fs14.existsSync)(sessionStatePath)) {
+        if ((0, import_fs15.existsSync)(sessionStatePath)) {
           activeSessions.push(sid);
         }
       }
@@ -23731,13 +24438,13 @@ Note: Reading from legacy/aggregate path (no session_id). This may include state
 `;
       if (legacyExists) {
         try {
-          const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+          const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
           const state = JSON.parse(content);
           output += `### Legacy Path (shared)
 Path: ${statePath}
 
 \`\`\`json
-${JSON.stringify(state, null, 2)}
+${JSON.stringify(publicStateForMode(mode, state), null, 2)}
 \`\`\`
 
 `;
@@ -23756,13 +24463,13 @@ Path: ${statePath}
         for (const sid of activeSessions) {
           const sessionStatePath = MODE_CONFIGS[mode] ? getStateFilePath(root, mode, sid) : resolveSessionStatePath(mode, sid, root);
           try {
-            const content = (0, import_fs14.readFileSync)(sessionStatePath, "utf-8");
+            const content = (0, import_fs15.readFileSync)(sessionStatePath, "utf-8");
             const state = JSON.parse(content);
             output += `**Session: ${sid}**
 Path: ${sessionStatePath}
 
 \`\`\`json
-${JSON.stringify(state, null, 2)}
+${JSON.stringify(publicStateForMode(mode, state), null, 2)}
 \`\`\`
 
 `;
@@ -23797,7 +24504,7 @@ var stateWriteTool = {
   description: "Write/update state for a specific mode. Creates the state file and directories if they do not exist. Common fields (active, iteration, phase, etc.) can be set directly as parameters. Additional custom fields can be passed via the optional `state` parameter. Note: swarm uses SQLite and cannot be written via this tool.",
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   schema: {
-    mode: external_exports.enum(STATE_TOOL_MODES).describe("The mode to write state for"),
+    mode: external_exports.enum(STATE_WRITE_MODES).describe("The mode to write state for"),
     active: external_exports.boolean().optional().describe("Whether the mode is currently active"),
     iteration: external_exports.number().optional().describe("Current iteration number"),
     max_iterations: external_exports.number().optional().describe("Maximum iterations allowed"),
@@ -23904,7 +24611,7 @@ ${JSON.stringify(stateWithMeta, null, 2)}
 };
 var stateClearTool = {
   name: "state_clear",
-  description: "Clear/delete state for a specific mode. Removes the state file and any associated marker files.",
+  description: "Clear/delete state for a specific mode. Removes the state file and any associated marker files. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).",
   annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
   schema: {
     mode: external_exports.enum(STATE_TOOL_MODES).describe("The mode to clear state for"),
@@ -23916,6 +24623,27 @@ var stateClearTool = {
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id;
+      if (mode === "merge-readiness") {
+        const cancelledSessions = [];
+        const cancelActiveSession = (targetSessionId) => {
+          const current = readMergeReadinessState(root, targetSessionId);
+          return current?.active === true && cancelMergeReadiness(root, targetSessionId)?.result === "cancelled";
+        };
+        if (sessionId) {
+          validateSessionId(sessionId);
+          if (cancelActiveSession(sessionId)) cancelledSessions.push(sessionId);
+        } else {
+          const callerSid = process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
+          if (callerSid && cancelActiveSession(callerSid)) cancelledSessions.push(callerSid);
+          if (cancelActiveSession()) cancelledSessions.push("legacy");
+        }
+        return {
+          content: [{
+            type: "text",
+            text: cancelledSessions.length > 0 ? `Cancelled merge-readiness gate(s) with durable state audit records: ${cancelledSessions.join(", ")}` : "No active merge-readiness gate found; existing state audit records were preserved."
+          }]
+        };
+      }
       const cleanedTeamNames = /* @__PURE__ */ new Set();
       const collectTeamNamesForCleanup = (statePath) => {
         if (mode !== "team") return;
@@ -24106,7 +24834,7 @@ var stateClearTool = {
           mode,
           source: "state_clear"
         };
-        const legacySignalPath = (0, import_path15.join)(getOmcRoot(root), "state", "cancel-signal-state.json");
+        const legacySignalPath = (0, import_path16.join)(getOmcRoot(root), "state", "cancel-signal-state.json");
         try {
           atomicWriteJsonSync(legacySignalPath, cancelSignalPayload);
         } catch {
@@ -24127,7 +24855,7 @@ var stateClearTool = {
       }
       if (MODE_CONFIGS[mode]) {
         const primaryLegacyStatePath = getStateFilePath(root, mode);
-        if ((0, import_fs14.existsSync)(primaryLegacyStatePath)) {
+        if ((0, import_fs15.existsSync)(primaryLegacyStatePath)) {
           if (clearModeState(mode, root)) {
             clearedCount++;
           } else {
@@ -24156,7 +24884,7 @@ var stateClearTool = {
         }
         if (MODE_CONFIGS[mode]) {
           const sessionStatePath = getStateFilePath(root, mode, sid);
-          if ((0, import_fs14.existsSync)(sessionStatePath)) {
+          if ((0, import_fs15.existsSync)(sessionStatePath)) {
             if (clearModeState(mode, root, sid)) {
               clearedCount++;
             } else {
@@ -24165,9 +24893,9 @@ var stateClearTool = {
           }
         } else {
           const statePath = resolveSessionStatePath(mode, sid, root);
-          if ((0, import_fs14.existsSync)(statePath)) {
+          if ((0, import_fs15.existsSync)(statePath)) {
             try {
-              (0, import_fs14.unlinkSync)(statePath);
+              (0, import_fs15.unlinkSync)(statePath);
               clearedCount++;
             } catch {
               errors.push(`session: ${sid}`);
@@ -24247,8 +24975,8 @@ var stateListActiveTool = {
         for (const mode of EXTRA_STATE_ONLY_MODES) {
           try {
             const statePath = resolveSessionStatePath(mode, sessionId, root);
-            if ((0, import_fs14.existsSync)(statePath)) {
-              const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+            if ((0, import_fs15.existsSync)(statePath)) {
+              const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
               const state = JSON.parse(content);
               if (state.active) {
                 activeModes.push(mode);
@@ -24286,9 +25014,9 @@ ${modeList}`
       const legacyActiveModes = [...getActiveModes(root)];
       for (const mode of EXTRA_STATE_ONLY_MODES) {
         const statePath = getStatePath(mode, root);
-        if ((0, import_fs14.existsSync)(statePath)) {
+        if ((0, import_fs15.existsSync)(statePath)) {
           try {
-            const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+            const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
             const state = JSON.parse(content);
             if (state.active) {
               legacyActiveModes.push(mode);
@@ -24314,8 +25042,8 @@ ${modeList}`
         for (const mode of EXTRA_STATE_ONLY_MODES) {
           try {
             const statePath = resolveSessionStatePath(mode, sid, root);
-            if ((0, import_fs14.existsSync)(statePath)) {
-              const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+            if ((0, import_fs15.existsSync)(statePath)) {
+              const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
               const state = JSON.parse(content);
               if (state.active) {
                 sessionActiveModes.push(mode);
@@ -24381,9 +25109,9 @@ var stateGetStatusTool = {
         if (sessionId) {
           validateSessionId(sessionId);
           const statePath = MODE_CONFIGS[mode] ? getStateFilePath(root, mode, sessionId) : resolveSessionStatePath(mode, sessionId, root);
-          const active = MODE_CONFIGS[mode] ? isModeActive(mode, root, sessionId) : (0, import_fs14.existsSync)(statePath) && (() => {
+          const active = MODE_CONFIGS[mode] ? isModeActive(mode, root, sessionId) : (0, import_fs15.existsSync)(statePath) && (() => {
             try {
-              const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+              const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
               const state = JSON.parse(content);
               return state.active === true;
             } catch {
@@ -24391,11 +25119,11 @@ var stateGetStatusTool = {
             }
           })();
           let statePreview = "No state file";
-          if ((0, import_fs14.existsSync)(statePath)) {
+          if ((0, import_fs15.existsSync)(statePath)) {
             try {
-              const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+              const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
               const state = JSON.parse(content);
-              statePreview = JSON.stringify(state, null, 2).slice(0, 500);
+              statePreview = JSON.stringify(publicStateForMode(mode, state), null, 2).slice(0, 500);
               if (statePreview.length >= 500) statePreview += "\n...(truncated)";
             } catch {
               statePreview = "Error reading state file";
@@ -24404,7 +25132,7 @@ var stateGetStatusTool = {
           lines2.push(`### Session: ${sessionId}`);
           lines2.push(`- **Active:** ${active ? "Yes" : "No"}`);
           lines2.push(`- **State Path:** ${statePath}`);
-          lines2.push(`- **Exists:** ${(0, import_fs14.existsSync)(statePath) ? "Yes" : "No"}`);
+          lines2.push(`- **Exists:** ${(0, import_fs15.existsSync)(statePath) ? "Yes" : "No"}`);
           lines2.push(`
 ### State Preview
 \`\`\`json
@@ -24418,9 +25146,9 @@ ${statePreview}
           };
         }
         const legacyPath = getStatePath(mode, root);
-        const legacyActive = MODE_CONFIGS[mode] ? isModeActive(mode, root) : (0, import_fs14.existsSync)(legacyPath) && (() => {
+        const legacyActive = MODE_CONFIGS[mode] ? isModeActive(mode, root) : (0, import_fs15.existsSync)(legacyPath) && (() => {
           try {
-            const content = (0, import_fs14.readFileSync)(legacyPath, "utf-8");
+            const content = (0, import_fs15.readFileSync)(legacyPath, "utf-8");
             const state = JSON.parse(content);
             return state.active === true;
           } catch {
@@ -24430,13 +25158,13 @@ ${statePreview}
         lines2.push(`### Legacy Path`);
         lines2.push(`- **Active:** ${legacyActive ? "Yes" : "No"}`);
         lines2.push(`- **State Path:** ${legacyPath}`);
-        lines2.push(`- **Exists:** ${(0, import_fs14.existsSync)(legacyPath) ? "Yes" : "No"}
+        lines2.push(`- **Exists:** ${(0, import_fs15.existsSync)(legacyPath) ? "Yes" : "No"}
 `);
         const activeSessions = MODE_CONFIGS[mode] ? getActiveSessionsForMode(mode, root) : listSessionIds(root).filter((sid) => {
           try {
             const sessionPath = resolveSessionStatePath(mode, sid, root);
-            if ((0, import_fs14.existsSync)(sessionPath)) {
-              const content = (0, import_fs14.readFileSync)(sessionPath, "utf-8");
+            if ((0, import_fs15.existsSync)(sessionPath)) {
+              const content = (0, import_fs15.readFileSync)(sessionPath, "utf-8");
               const state = JSON.parse(content);
               return state.active === true;
             }
@@ -24478,9 +25206,9 @@ No active sessions for this mode.`);
       for (const mode2 of EXTRA_STATE_ONLY_MODES) {
         const statePath = sessionId ? resolveSessionStatePath(mode2, sessionId, root) : getStatePath(mode2, root);
         let active = false;
-        if ((0, import_fs14.existsSync)(statePath)) {
+        if ((0, import_fs15.existsSync)(statePath)) {
           try {
-            const content = (0, import_fs14.readFileSync)(statePath, "utf-8");
+            const content = (0, import_fs15.readFileSync)(statePath, "utf-8");
             const state = JSON.parse(content);
             active = state.active === true;
           } catch {
@@ -24512,25 +25240,142 @@ var stateTools = [
   stateWriteTool,
   stateClearTool,
   stateListActiveTool,
-  stateGetStatusTool
+  stateGetStatusTool,
+  {
+    name: "merge_readiness_start",
+    description: "Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick/--standard/--deep; standard is default).",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      summary: external_exports.string().max(2e3),
+      baseRef: external_exports.string().max(200).regex(/^[A-Za-z0-9._\/@{}~^:-]+$/, "baseRef must be a valid git ref").refine((s) => !s.startsWith("-"), "baseRef must not start with '-'").optional().describe("Base ref to diff committed changes against (e.g. origin/dev, HEAD, HEAD~1, HEAD^). Defaults to the branch upstream / origin/HEAD."),
+      workingDirectory: external_exports.string().optional(),
+      session_id: external_exports.string().optional()
+    },
+    handler: async (args) => {
+      try {
+        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
+        const state = createInitialMergeReadinessState(directory, args.summary, sessionId, args.baseRef);
+        const blocked = state.result === "blocked";
+        return { content: [{ type: "text", text: blocked ? `Merge-readiness blocked: ${state.validation_errors?.join(" ") ?? "missing evidence"}` : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.` }], ...blocked ? { isError: true } : {} };
+      } catch (error2) {
+        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+      }
+    }
+  },
+  {
+    name: "merge_readiness_set_content",
+    description: "Validate and submit the five-section merge-readiness report and objective MCQs. Requires an active gate (call merge_readiness_start first).",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      why: external_exports.string().max(1e4),
+      whatChanged: external_exports.string().max(1e4),
+      tradeoffs: external_exports.string().max(1e4),
+      risksConsidered: external_exports.string().max(1e4),
+      teamUnderstanding: external_exports.string().max(1e4),
+      questions: external_exports.array(external_exports.object({ id: external_exports.string().max(100), dimension: external_exports.enum(["why", "change", "tradeoff", "risk", "team"]), stem: external_exports.string().max(2e3), options: external_exports.array(external_exports.object({ id: external_exports.string().max(100), text: external_exports.string().max(1e3) })).max(8), correctOptionId: external_exports.string().max(100), rationale: external_exports.string().max(2e3).optional() })).max(8),
+      workingDirectory: external_exports.string().optional(),
+      session_id: external_exports.string().optional()
+    },
+    handler: async (args) => {
+      try {
+        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
+        const state = setMergeReadinessContent(directory, args, sessionId);
+        if (!state) {
+          return { content: [{ type: "text", text: "Merge-readiness content rejected: no active gate. Call merge_readiness_start first." }], isError: true };
+        }
+        const errors = state.validation_errors ?? [];
+        return { content: [{ type: "text", text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(" ")}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? "none"}` }], ...errors.length > 0 ? { isError: true } : {} };
+      } catch (error2) {
+        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+      }
+    }
+  },
+  {
+    name: "merge_readiness_record_answer",
+    description: "Record the human-selected option for the current merge-readiness MCQ. Advances the gate; returns the next question or the final result plus readiness score.",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      questionId: external_exports.string().max(100),
+      optionId: external_exports.string().max(100),
+      workingDirectory: external_exports.string().optional(),
+      session_id: external_exports.string().optional()
+    },
+    handler: async (args) => {
+      try {
+        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
+        const state = recordMergeReadinessMCQAnswer(directory, args.questionId, args.optionId, sessionId);
+        if (!state) {
+          return { content: [{ type: "text", text: "Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ." }], isError: true };
+        }
+        const result = state.result;
+        const score = state.readiness_score;
+        const terminal = result === "pass" || result === "paused" || result === "blocked" || result === "overridden";
+        const text = terminal ? `Merge-readiness ${result}. Readiness score: ${score}. ${result === "pass" ? "The change may proceed to human merge approval." : result === "paused" ? "Explanation gap remains; reread the report and rerun /merge-readiness." : result === "blocked" ? "Missing evidence; produce it before rerunning." : "Gate overridden; terminal session state preserves the record."}` : `Answer recorded. Next question: ${state.pending_question?.id ?? "none"}. Answered: ${state.answers.length}/${state.questions.length}.`;
+        return { content: [{ type: "text", text }] };
+      } catch (error2) {
+        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+      }
+    }
+  },
+  {
+    name: "merge_readiness_report",
+    description: "Render the authoritative merge-readiness session state as a Markdown report without writing a file.",
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    schema: { workingDirectory: external_exports.string().optional(), session_id: external_exports.string().optional() },
+    handler: async (args) => {
+      try {
+        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
+        const state = readMergeReadinessState(directory, sessionId);
+        if (!state) {
+          return { content: [{ type: "text", text: "Merge-readiness report unavailable: no session state found." }], isError: true };
+        }
+        return { content: [{ type: "text", text: formatMergeReadinessReport(state) }] };
+      } catch (error2) {
+        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+      }
+    }
+  },
+  {
+    name: "merge_readiness_cancel",
+    description: "Cancel an active merge-readiness gate while preserving its terminal state audit record.",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    schema: { workingDirectory: external_exports.string().optional(), session_id: external_exports.string().optional() },
+    handler: async (args) => {
+      try {
+        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
+        const state = cancelMergeReadiness(directory, sessionId);
+        if (!state || state.result !== "cancelled") {
+          return { content: [{ type: "text", text: "Merge-readiness cancellation rejected: no active gate." }], isError: true };
+        }
+        return { content: [{ type: "text", text: "Merge-readiness cancelled. Terminal session state preserved as the audit record." }] };
+      } catch (error2) {
+        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+      }
+    }
+  }
 ];
 
 // src/hooks/notepad/index.ts
-var import_fs16 = require("fs");
-var import_path16 = require("path");
+var import_fs17 = require("fs");
+var import_path17 = require("path");
 
 // src/lib/file-lock.ts
-var import_fs15 = require("fs");
+var import_fs16 = require("fs");
 var path6 = __toESM(require("path"), 1);
 var DEFAULT_STALE_LOCK_MS = 3e4;
 var DEFAULT_RETRY_DELAY_MS = 50;
 function isLockStale(lockPath, staleLockMs) {
   try {
-    const stat = (0, import_fs15.statSync)(lockPath);
+    const stat = (0, import_fs16.statSync)(lockPath);
     const ageMs = Date.now() - stat.mtimeMs;
     if (ageMs < staleLockMs) return false;
     try {
-      const raw = (0, import_fs15.readFileSync)(lockPath, "utf-8");
+      const raw = (0, import_fs16.readFileSync)(lockPath, "utf-8");
       const payload = JSON.parse(raw);
       if (payload.pid && isProcessAlive(payload.pid)) return false;
     } catch {
@@ -24546,21 +25391,21 @@ function lockPathFor(filePath) {
 function tryAcquireSync(lockPath, staleLockMs) {
   ensureDirSync(path6.dirname(lockPath));
   try {
-    const fd = (0, import_fs15.openSync)(
+    const fd = (0, import_fs16.openSync)(
       lockPath,
-      import_fs15.constants.O_CREAT | import_fs15.constants.O_EXCL | import_fs15.constants.O_WRONLY,
+      import_fs16.constants.O_CREAT | import_fs16.constants.O_EXCL | import_fs16.constants.O_WRONLY,
       384
     );
     try {
       const payload = JSON.stringify({ pid: process.pid, timestamp: Date.now() });
-      (0, import_fs15.writeSync)(fd, payload, null, "utf-8");
+      (0, import_fs16.writeSync)(fd, payload, null, "utf-8");
     } catch (writeErr) {
       try {
-        (0, import_fs15.closeSync)(fd);
+        (0, import_fs16.closeSync)(fd);
       } catch {
       }
       try {
-        (0, import_fs15.unlinkSync)(lockPath);
+        (0, import_fs16.unlinkSync)(lockPath);
       } catch {
       }
       throw writeErr;
@@ -24570,25 +25415,25 @@ function tryAcquireSync(lockPath, staleLockMs) {
     if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
       if (isLockStale(lockPath, staleLockMs)) {
         try {
-          (0, import_fs15.unlinkSync)(lockPath);
+          (0, import_fs16.unlinkSync)(lockPath);
         } catch {
         }
         try {
-          const fd = (0, import_fs15.openSync)(
+          const fd = (0, import_fs16.openSync)(
             lockPath,
-            import_fs15.constants.O_CREAT | import_fs15.constants.O_EXCL | import_fs15.constants.O_WRONLY,
+            import_fs16.constants.O_CREAT | import_fs16.constants.O_EXCL | import_fs16.constants.O_WRONLY,
             384
           );
           try {
             const payload = JSON.stringify({ pid: process.pid, timestamp: Date.now() });
-            (0, import_fs15.writeSync)(fd, payload, null, "utf-8");
+            (0, import_fs16.writeSync)(fd, payload, null, "utf-8");
           } catch (writeErr) {
             try {
-              (0, import_fs15.closeSync)(fd);
+              (0, import_fs16.closeSync)(fd);
             } catch {
             }
             try {
-              (0, import_fs15.unlinkSync)(lockPath);
+              (0, import_fs16.unlinkSync)(lockPath);
             } catch {
             }
             throw writeErr;
@@ -24628,11 +25473,11 @@ function acquireFileLockSync(lockPath, opts) {
 }
 function releaseFileLockSync(handle) {
   try {
-    (0, import_fs15.closeSync)(handle.fd);
+    (0, import_fs16.closeSync)(handle.fd);
   } catch {
   }
   try {
-    (0, import_fs15.unlinkSync)(handle.path);
+    (0, import_fs16.unlinkSync)(handle.path);
   } catch {
   }
 }
@@ -24648,7 +25493,7 @@ function withFileLockSync(lockPath, fn, opts) {
   }
 }
 function sleep3(ms) {
-  return new Promise((resolve9) => setTimeout(resolve9, ms));
+  return new Promise((resolve10) => setTimeout(resolve10, ms));
 }
 async function acquireFileLock(lockPath, opts) {
   const staleLockMs = opts?.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
@@ -24706,19 +25551,19 @@ function getSectionRegexSet(header) {
   return SECTION_REGEXES[header] ?? createSectionRegexSet(header);
 }
 function getNotepadPath(directory) {
-  return (0, import_path16.join)(getOmcRoot(directory), NOTEPAD_FILENAME);
+  return (0, import_path17.join)(getOmcRoot(directory), NOTEPAD_FILENAME);
 }
 function initNotepad(directory) {
   const omcDir = getOmcRoot(directory);
-  if (!(0, import_fs16.existsSync)(omcDir)) {
+  if (!(0, import_fs17.existsSync)(omcDir)) {
     try {
-      (0, import_fs16.mkdirSync)(omcDir, { recursive: true });
+      (0, import_fs17.mkdirSync)(omcDir, { recursive: true });
     } catch {
       return false;
     }
   }
   const notepadPath = getNotepadPath(directory);
-  if ((0, import_fs16.existsSync)(notepadPath)) {
+  if ((0, import_fs17.existsSync)(notepadPath)) {
     return true;
   }
   const content = `# Notepad
@@ -24743,11 +25588,11 @@ ${MANUAL_HEADER}
 }
 function readNotepad(directory) {
   const notepadPath = getNotepadPath(directory);
-  if (!(0, import_fs16.existsSync)(notepadPath)) {
+  if (!(0, import_fs17.existsSync)(notepadPath)) {
     return null;
   }
   try {
-    return (0, import_fs16.readFileSync)(notepadPath, "utf-8");
+    return (0, import_fs17.readFileSync)(notepadPath, "utf-8");
   } catch {
     return null;
   }
@@ -24791,7 +25636,7 @@ function getManualSection(directory) {
   return extractSection(content, MANUAL_HEADER);
 }
 function setPriorityContext(directory, content, config2 = DEFAULT_CONFIG) {
-  if (!(0, import_fs16.existsSync)(getNotepadPath(directory))) {
+  if (!(0, import_fs17.existsSync)(getNotepadPath(directory))) {
     if (!initNotepad(directory)) {
       return { success: false };
     }
@@ -24799,7 +25644,7 @@ function setPriorityContext(directory, content, config2 = DEFAULT_CONFIG) {
   const notepadPath = getNotepadPath(directory);
   try {
     return withFileLockSync(lockPathFor(notepadPath), () => {
-      let notepadContent = (0, import_fs16.readFileSync)(notepadPath, "utf-8");
+      let notepadContent = (0, import_fs17.readFileSync)(notepadPath, "utf-8");
       const warning = content.length > config2.priorityMaxChars ? `Priority Context exceeds ${config2.priorityMaxChars} chars (${content.length} chars). Consider condensing.` : void 0;
       notepadContent = replaceSection(notepadContent, PRIORITY_HEADER, content);
       atomicWriteFileSync(notepadPath, notepadContent);
@@ -24810,7 +25655,7 @@ function setPriorityContext(directory, content, config2 = DEFAULT_CONFIG) {
   }
 }
 function addWorkingMemoryEntry(directory, content) {
-  if (!(0, import_fs16.existsSync)(getNotepadPath(directory))) {
+  if (!(0, import_fs17.existsSync)(getNotepadPath(directory))) {
     if (!initNotepad(directory)) {
       return false;
     }
@@ -24818,7 +25663,7 @@ function addWorkingMemoryEntry(directory, content) {
   const notepadPath = getNotepadPath(directory);
   try {
     return withFileLockSync(lockPathFor(notepadPath), () => {
-      let notepadContent = (0, import_fs16.readFileSync)(notepadPath, "utf-8");
+      let notepadContent = (0, import_fs17.readFileSync)(notepadPath, "utf-8");
       const currentMemory = extractSection(notepadContent, WORKING_MEMORY_HEADER) || "";
       const now = /* @__PURE__ */ new Date();
       const timestamp = now.toISOString().slice(0, 16).replace("T", " ");
@@ -24839,7 +25684,7 @@ ${content}
   }
 }
 function addManualEntry(directory, content) {
-  if (!(0, import_fs16.existsSync)(getNotepadPath(directory))) {
+  if (!(0, import_fs17.existsSync)(getNotepadPath(directory))) {
     if (!initNotepad(directory)) {
       return false;
     }
@@ -24847,7 +25692,7 @@ function addManualEntry(directory, content) {
   const notepadPath = getNotepadPath(directory);
   try {
     return withFileLockSync(lockPathFor(notepadPath), () => {
-      let notepadContent = (0, import_fs16.readFileSync)(notepadPath, "utf-8");
+      let notepadContent = (0, import_fs17.readFileSync)(notepadPath, "utf-8");
       const currentManual = extractSection(notepadContent, MANUAL_HEADER) || "";
       const now = /* @__PURE__ */ new Date();
       const timestamp = now.toISOString().slice(0, 16).replace("T", " ");
@@ -24865,12 +25710,12 @@ ${content}
 }
 function pruneOldEntries(directory, daysOld = DEFAULT_CONFIG.workingMemoryDays) {
   const notepadPath = getNotepadPath(directory);
-  if (!(0, import_fs16.existsSync)(notepadPath)) {
+  if (!(0, import_fs17.existsSync)(notepadPath)) {
     return { pruned: 0, remaining: 0 };
   }
   try {
     return withFileLockSync(lockPathFor(notepadPath), () => {
-      let notepadContent = (0, import_fs16.readFileSync)(notepadPath, "utf-8");
+      let notepadContent = (0, import_fs17.readFileSync)(notepadPath, "utf-8");
       const workingMemory = extractSection(notepadContent, WORKING_MEMORY_HEADER);
       if (!workingMemory) {
         return { pruned: 0, remaining: 0 };
@@ -24908,7 +25753,7 @@ ${entry.content}`).join("\n\n");
 }
 function getNotepadStats(directory) {
   const notepadPath = getNotepadPath(directory);
-  if (!(0, import_fs16.existsSync)(notepadPath)) {
+  if (!(0, import_fs17.existsSync)(notepadPath)) {
     return {
       exists: false,
       totalSize: 0,
@@ -24917,7 +25762,7 @@ function getNotepadStats(directory) {
       oldestEntry: null
     };
   }
-  const content = (0, import_fs16.readFileSync)(notepadPath, "utf-8");
+  const content = (0, import_fs17.readFileSync)(notepadPath, "utf-8");
   const priorityContext = extractSection(content, PRIORITY_HEADER) || "";
   const workingMemory = extractSection(content, WORKING_MEMORY_HEADER) || "";
   const wmMatches = workingMemory.match(
@@ -25230,7 +26075,7 @@ var notepadTools = [
 ];
 
 // src/hooks/project-memory/index.ts
-var import_path24 = __toESM(require("path"), 1);
+var import_path25 = __toESM(require("path"), 1);
 
 // src/features/context-injector/collector.ts
 var PRIORITY_ORDER = {
@@ -25340,18 +26185,18 @@ var ContextCollector = class {
 var contextCollector = new ContextCollector();
 
 // src/hooks/rules-injector/finder.ts
-var import_fs17 = require("fs");
-var import_path18 = require("path");
+var import_fs18 = require("fs");
+var import_path19 = require("path");
 
 // src/hooks/rules-injector/constants.ts
-var import_path17 = require("path");
+var import_path18 = require("path");
 var import_os5 = require("os");
-var OMC_STORAGE_DIR = (0, import_path17.join)((0, import_os5.homedir)(), ".omc");
-var RULES_INJECTOR_STORAGE = (0, import_path17.join)(OMC_STORAGE_DIR, "rules-injector");
+var OMC_STORAGE_DIR = (0, import_path18.join)((0, import_os5.homedir)(), ".omc");
+var RULES_INJECTOR_STORAGE = (0, import_path18.join)(OMC_STORAGE_DIR, "rules-injector");
 
 // src/hooks/project-memory/storage.ts
 var import_promises = __toESM(require("fs/promises"), 1);
-var import_path19 = __toESM(require("path"), 1);
+var import_path20 = __toESM(require("path"), 1);
 
 // src/hooks/project-memory/constants.ts
 var CACHE_EXPIRY_MS = 24 * 60 * 60 * 1e3;
@@ -25383,7 +26228,7 @@ async function loadProjectMemory(projectRoot) {
 }
 async function saveProjectMemory(projectRoot, memory) {
   const memoryPath = getMemoryPath(projectRoot);
-  const omcDir = import_path19.default.dirname(memoryPath);
+  const omcDir = import_path20.default.dirname(memoryPath);
   try {
     await import_promises.default.mkdir(omcDir, { recursive: true });
     await atomicWriteJson(memoryPath, memory);
@@ -25399,17 +26244,17 @@ async function withProjectMemoryLock(projectRoot, fn) {
 
 // src/hooks/project-memory/detector.ts
 var import_promises3 = __toESM(require("fs/promises"), 1);
-var import_path21 = __toESM(require("path"), 1);
+var import_path22 = __toESM(require("path"), 1);
 
 // src/hooks/project-memory/directory-mapper.ts
 var import_promises2 = __toESM(require("fs/promises"), 1);
-var import_path20 = __toESM(require("path"), 1);
+var import_path21 = __toESM(require("path"), 1);
 
 // src/hooks/project-memory/formatter.ts
-var import_path23 = __toESM(require("path"), 1);
+var import_path24 = __toESM(require("path"), 1);
 
 // src/hooks/project-memory/hot-path-tracker.ts
-var import_path22 = __toESM(require("path"), 1);
+var import_path23 = __toESM(require("path"), 1);
 
 // src/hooks/project-memory/directive-detector.ts
 function addDirective(directives, newDirective) {
@@ -25542,7 +26387,7 @@ function mergeArrays(fieldName, base, incoming) {
       return mergeScalarArray(base, incoming);
   }
 }
-function mergeByKey(base, incoming, keyFn, resolve9) {
+function mergeByKey(base, incoming, keyFn, resolve10) {
   const seen = /* @__PURE__ */ new Map();
   for (const item of base) {
     seen.set(keyFn(item), item);
@@ -25551,7 +26396,7 @@ function mergeByKey(base, incoming, keyFn, resolve9) {
     const key = keyFn(item);
     const existing = seen.get(key);
     if (existing) {
-      seen.set(key, resolve9(existing, item));
+      seen.set(key, resolve10(existing, item));
     } else {
       seen.set(key, item);
     }
@@ -25792,27 +26637,27 @@ var memoryTools = [
 ];
 
 // src/tools/trace-tools.ts
-var import_fs20 = require("fs");
-var import_path27 = require("path");
+var import_fs21 = require("fs");
+var import_path28 = require("path");
 
 // src/hooks/subagent-tracker/session-replay.ts
-var import_fs18 = require("fs");
-var import_path25 = require("path");
+var import_fs19 = require("fs");
+var import_path26 = require("path");
 var REPLAY_PREFIX = "agent-replay-";
 var MAX_REPLAY_SIZE_BYTES = 5 * 1024 * 1024;
 function getReplayFilePath(directory, sessionId) {
-  const stateDir = (0, import_path25.join)(getOmcRoot(directory), "state");
-  if (!(0, import_fs18.existsSync)(stateDir)) {
-    (0, import_fs18.mkdirSync)(stateDir, { recursive: true });
+  const stateDir = (0, import_path26.join)(getOmcRoot(directory), "state");
+  if (!(0, import_fs19.existsSync)(stateDir)) {
+    (0, import_fs19.mkdirSync)(stateDir, { recursive: true });
   }
   const safeId = sessionId.replace(/[^a-zA-Z0-9_-]/g, "_");
-  return (0, import_path25.join)(stateDir, `${REPLAY_PREFIX}${safeId}.jsonl`);
+  return (0, import_path26.join)(stateDir, `${REPLAY_PREFIX}${safeId}.jsonl`);
 }
 function readReplayEvents(directory, sessionId) {
   const filePath = getReplayFilePath(directory, sessionId);
-  if (!(0, import_fs18.existsSync)(filePath)) return [];
+  if (!(0, import_fs19.existsSync)(filePath)) return [];
   try {
-    const content = (0, import_fs18.readFileSync)(filePath, "utf-8");
+    const content = (0, import_fs19.readFileSync)(filePath, "utf-8");
     return content.split("\n").filter((line) => line.trim()).map((line) => {
       try {
         return JSON.parse(line);
@@ -25883,6 +26728,10 @@ function getReplaySummary(directory, sessionId) {
         }
         break;
       case "agent_stop":
+        if (event.synthetic || event.telemetry_status === "unmatched_stop") {
+          summary.agents_untracked_stops = (summary.agents_untracked_stops || 0) + 1;
+          break;
+        }
         if (event.success) summary.agents_completed++;
         else summary.agents_failed++;
         if (event.agent_type && event.duration_ms) {
@@ -25983,9 +26832,9 @@ function getReplaySummary(directory, sessionId) {
 }
 
 // src/features/session-history-search/index.ts
-var import_child_process10 = require("child_process");
-var import_fs19 = require("fs");
-var import_path26 = require("path");
+var import_child_process11 = require("child_process");
+var import_fs20 = require("fs");
+var import_path27 = require("path");
 var import_readline = require("readline");
 var DEFAULT_LIMIT = 10;
 var DEFAULT_CONTEXT_CHARS = 120;
@@ -26018,27 +26867,27 @@ function parseSinceSpec(since) {
 }
 function getMainRepoRoot(projectRoot) {
   try {
-    const gitCommonDir = (0, import_child_process10.execSync)("git rev-parse --git-common-dir", {
+    const gitCommonDir = (0, import_child_process11.execSync)("git rev-parse --git-common-dir", {
       cwd: projectRoot,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"]
     }).trim();
-    const absoluteCommonDir = (0, import_path26.resolve)(projectRoot, gitCommonDir);
-    const mainRepoRoot = (0, import_path26.dirname)(absoluteCommonDir);
+    const absoluteCommonDir = (0, import_path27.resolve)(projectRoot, gitCommonDir);
+    const mainRepoRoot = (0, import_path27.dirname)(absoluteCommonDir);
     return mainRepoRoot === projectRoot ? null : mainRepoRoot;
   } catch {
     return null;
   }
 }
 function getClaudeWorktreeParent(projectRoot) {
-  const marker = `${(0, import_path26.normalize)("/.claude/worktrees/")}`;
-  const normalizedRoot = (0, import_path26.normalize)(projectRoot);
+  const marker = `${(0, import_path27.normalize)("/.claude/worktrees/")}`;
+  const normalizedRoot = (0, import_path27.normalize)(projectRoot);
   const idx = normalizedRoot.indexOf(marker);
   if (idx === -1) return null;
   return normalizedRoot.slice(0, idx) || null;
 }
 function listJsonlFiles(rootDir) {
-  if (!(0, import_fs19.existsSync)(rootDir)) {
+  if (!(0, import_fs20.existsSync)(rootDir)) {
     return [];
   }
   const files = [];
@@ -26047,12 +26896,12 @@ function listJsonlFiles(rootDir) {
     const current = stack.pop();
     let entries;
     try {
-      entries = (0, import_fs19.readdirSync)(current, { withFileTypes: true });
+      entries = (0, import_fs20.readdirSync)(current, { withFileTypes: true });
     } catch {
       continue;
     }
     for (const entry of entries) {
-      const fullPath = (0, import_path26.join)(current, entry.name);
+      const fullPath = (0, import_path27.join)(current, entry.name);
       if (entry.isDirectory()) {
         stack.push(fullPath);
         continue;
@@ -26072,8 +26921,8 @@ function uniqueSortedTargets(targets) {
     seen.add(key);
     return true;
   }).sort((a, b) => {
-    const aTime = (0, import_fs19.existsSync)(a.filePath) ? (0, import_fs19.statSync)(a.filePath).mtimeMs : 0;
-    const bTime = (0, import_fs19.existsSync)(b.filePath) ? (0, import_fs19.statSync)(b.filePath).mtimeMs : 0;
+    const aTime = (0, import_fs20.existsSync)(a.filePath) ? (0, import_fs20.statSync)(a.filePath).mtimeMs : 0;
+    const bTime = (0, import_fs20.existsSync)(b.filePath) ? (0, import_fs20.statSync)(b.filePath).mtimeMs : 0;
     return bTime - aTime;
   });
 }
@@ -26088,22 +26937,22 @@ function buildCurrentProjectTargets(projectRoot, transcriptProjectRoots = [proje
   }
   const targets = [];
   for (const root of projectRoots) {
-    const encodedDir = (0, import_path26.join)(claudeDir, "projects", encodeProjectPath(root));
+    const encodedDir = (0, import_path27.join)(claudeDir, "projects", encodeProjectPath(root));
     for (const filePath of listJsonlFiles(encodedDir)) {
       targets.push({ filePath, sourceType: "project-transcript" });
     }
   }
-  const legacyTranscriptsDir = (0, import_path26.join)(claudeDir, "transcripts");
+  const legacyTranscriptsDir = (0, import_path27.join)(claudeDir, "transcripts");
   for (const filePath of listJsonlFiles(legacyTranscriptsDir)) {
     targets.push({ filePath, sourceType: "legacy-transcript" });
   }
   const omcRoot = getOmcRoot(projectRoot);
-  const sessionSummariesDir = (0, import_path26.join)(omcRoot, "sessions");
+  const sessionSummariesDir = (0, import_path27.join)(omcRoot, "sessions");
   for (const filePath of listJsonlFiles(sessionSummariesDir)) {
     targets.push({ filePath, sourceType: "omc-session-summary" });
   }
-  const replayDir = (0, import_path26.join)(omcRoot, "state");
-  if ((0, import_fs19.existsSync)(replayDir)) {
+  const replayDir = (0, import_path27.join)(omcRoot, "state");
+  if ((0, import_fs20.existsSync)(replayDir)) {
     for (const filePath of listJsonlFiles(replayDir)) {
       if (filePath.includes("agent-replay-") && filePath.endsWith(".jsonl")) {
         targets.push({ filePath, sourceType: "omc-session-replay" });
@@ -26115,10 +26964,10 @@ function buildCurrentProjectTargets(projectRoot, transcriptProjectRoots = [proje
 function buildAllProjectTargets() {
   const claudeDir = getClaudeConfigDir();
   const targets = [];
-  for (const filePath of listJsonlFiles((0, import_path26.join)(claudeDir, "projects"))) {
+  for (const filePath of listJsonlFiles((0, import_path27.join)(claudeDir, "projects"))) {
     targets.push({ filePath, sourceType: "project-transcript" });
   }
-  for (const filePath of listJsonlFiles((0, import_path26.join)(claudeDir, "transcripts"))) {
+  for (const filePath of listJsonlFiles((0, import_path27.join)(claudeDir, "transcripts"))) {
     targets.push({ filePath, sourceType: "legacy-transcript" });
   }
   return uniqueSortedTargets(targets);
@@ -26127,9 +26976,9 @@ function isWithinProject(projectPath, projectRoots) {
   if (!projectPath) {
     return false;
   }
-  const normalizedProjectPath = (0, import_path26.normalize)((0, import_path26.resolve)(projectPath)).replace(/\\/g, "/");
+  const normalizedProjectPath = (0, import_path27.normalize)((0, import_path27.resolve)(projectPath)).replace(/\\/g, "/");
   return projectRoots.some((root) => {
-    const normalizedRoot = (0, import_path26.normalize)((0, import_path26.resolve)(root)).replace(/\\/g, "/");
+    const normalizedRoot = (0, import_path27.normalize)((0, import_path27.resolve)(root)).replace(/\\/g, "/");
     return normalizedProjectPath === normalizedRoot || normalizedProjectPath.startsWith(`${normalizedRoot}/`);
   });
 }
@@ -26275,7 +27124,7 @@ function buildScopeMode(project) {
 }
 async function collectMatchesFromFile(target, options) {
   const matches = [];
-  const fileMtime = (0, import_fs19.existsSync)(target.filePath) ? (0, import_fs19.statSync)(target.filePath).mtimeMs : 0;
+  const fileMtime = (0, import_fs20.existsSync)(target.filePath) ? (0, import_fs20.statSync)(target.filePath).mtimeMs : 0;
   if (target.sourceType === "omc-session-summary" && target.filePath.endsWith(".json")) {
     try {
       const payload = JSON.parse(await import("fs/promises").then((fs8) => fs8.readFile(target.filePath, "utf-8")));
@@ -26307,7 +27156,7 @@ async function collectMatchesFromFile(target, options) {
     }
     return matches;
   }
-  const stream = (0, import_fs19.createReadStream)(target.filePath, { encoding: "utf-8" });
+  const stream = (0, import_fs20.createReadStream)(target.filePath, { encoding: "utf-8" });
   const reader = (0, import_readline.createInterface)({ input: stream, crlfDelay: Infinity });
   let line = 0;
   try {
@@ -26367,7 +27216,7 @@ async function searchSessionHistory(rawOptions) {
   const currentProjectRoot = resolveToWorktreeRoot(workingDirectory);
   const scopeMode = buildScopeMode(rawOptions.project);
   const projectFilter = scopeMode === "project" ? rawOptions.project : void 0;
-  const literalWorkingDirectory = rawOptions.workingDirectory ? (0, import_path26.resolve)(rawOptions.workingDirectory) : workingDirectory;
+  const literalWorkingDirectory = rawOptions.workingDirectory ? (0, import_path27.resolve)(rawOptions.workingDirectory) : workingDirectory;
   const currentProjectRoots = [currentProjectRoot, literalWorkingDirectory].concat(getMainRepoRoot(currentProjectRoot) ?? []).concat(getClaudeWorktreeParent(currentProjectRoot) ?? []).filter((value, index, arr) => Boolean(value) && arr.indexOf(value) === index);
   const transcriptProjectRoots = currentProjectRoots.filter((root) => isWithinProject(root, [currentProjectRoot]));
   const targets = scopeMode === "all" ? buildAllProjectTargets() : buildCurrentProjectTargets(currentProjectRoot, transcriptProjectRoots);
@@ -26446,12 +27295,12 @@ var sessionSearchTool = {
 // src/tools/trace-tools.ts
 var REPLAY_PREFIX2 = "agent-replay-";
 function findLatestSessionId(directory) {
-  const stateDir = (0, import_path27.join)(getOmcRoot(directory), "state");
+  const stateDir = (0, import_path28.join)(getOmcRoot(directory), "state");
   try {
-    const files = (0, import_fs20.readdirSync)(stateDir).filter((f) => f.startsWith(REPLAY_PREFIX2) && f.endsWith(".jsonl")).map((f) => ({
+    const files = (0, import_fs21.readdirSync)(stateDir).filter((f) => f.startsWith(REPLAY_PREFIX2) && f.endsWith(".jsonl")).map((f) => ({
       name: f,
       sessionId: f.slice(REPLAY_PREFIX2.length, -".jsonl".length),
-      mtime: (0, import_fs20.statSync)((0, import_path27.join)(stateDir, f)).mtimeMs
+      mtime: (0, import_fs21.statSync)((0, import_path28.join)(stateDir, f)).mtimeMs
     })).sort((a, b) => b.mtime - a.mtime);
     return files.length > 0 ? files[0].sessionId : null;
   } catch {
@@ -26487,8 +27336,13 @@ function formatTimelineEvent(event) {
       if (event.model) detail += ` (${event.model})`;
       break;
     case "agent_stop":
-      detail = `[${event.agent}] ${event.agent_type || "unknown"} ${event.success ? "completed" : "FAILED"}`;
-      if (event.duration_ms) detail += ` (${(event.duration_ms / 1e3).toFixed(1)}s)`;
+      if (event.synthetic || event.telemetry_status === "unmatched_stop") {
+        detail = `[${event.agent}] ${event.agent_type || "untracked-native-fork"} UNTRACKED_STOP`;
+        if (event.reason) detail += ` - ${event.reason}`;
+      } else {
+        detail = `[${event.agent}] ${event.agent_type || "unknown"} ${event.success ? "completed" : "FAILED"}`;
+        if (event.duration_ms) detail += ` (${(event.duration_ms / 1e3).toFixed(1)}s)`;
+      }
       break;
     case "tool_start":
       detail = `[${event.agent}] ${event.tool} started`;
@@ -26583,6 +27437,10 @@ function buildExecutionFlow(events) {
       }
       case "agent_stop": {
         const type = event.agent_type || "unknown";
+        if (event.synthetic || event.telemetry_status === "unmatched_stop") {
+          flow.push(`${type} agent stop was untracked (${event.agent})`);
+          break;
+        }
         const status = event.success ? "completed" : "FAILED";
         const dur = event.duration_ms ? ` ${(event.duration_ms / 1e3).toFixed(1)}s` : "";
         flow.push(`${type} agent ${status} (${event.agent}${dur})`);
@@ -26691,7 +27549,7 @@ No events recorded.`
         `### Overview`,
         `- **Duration:** ${summary.duration_seconds.toFixed(1)}s`,
         `- **Total Events:** ${summary.total_events}`,
-        `- **Agents:** ${summary.agents_spawned} spawned, ${summary.agents_completed} completed, ${summary.agents_failed} failed`,
+        `- **Agents:** ${summary.agents_spawned} spawned, ${summary.agents_completed} completed, ${summary.agents_failed} failed${summary.agents_untracked_stops ? `, ${summary.agents_untracked_stops} untracked stop(s)` : ""}`,
         ""
       ];
       if (summary.agent_breakdown && summary.agent_breakdown.length > 0) {
@@ -26795,14 +27653,14 @@ No events recorded.`
 var traceTools = [traceTimelineTool, traceSummaryTool, sessionSearchTool];
 
 // src/lib/shared-memory.ts
-var import_fs21 = require("fs");
-var import_path28 = require("path");
+var import_fs22 = require("fs");
+var import_path29 = require("path");
 var CONFIG_FILE_NAME = ".omc-config.json";
 function isSharedMemoryEnabled() {
   try {
-    const configPath = (0, import_path28.join)(getClaudeConfigDir(), CONFIG_FILE_NAME);
-    if (!(0, import_fs21.existsSync)(configPath)) return true;
-    const raw = JSON.parse((0, import_fs21.readFileSync)(configPath, "utf-8"));
+    const configPath = (0, import_path29.join)(getClaudeConfigDir(), CONFIG_FILE_NAME);
+    if (!(0, import_fs22.existsSync)(configPath)) return true;
+    const raw = JSON.parse((0, import_fs22.readFileSync)(configPath, "utf-8"));
     const enabled = raw?.agents?.sharedMemory?.enabled;
     if (typeof enabled === "boolean") return enabled;
     return true;
@@ -26836,16 +27694,16 @@ function validateKey(key) {
 function getNamespaceDir(namespace, worktreeRoot) {
   validateNamespace(namespace);
   const omcRoot = getOmcRoot(worktreeRoot);
-  return (0, import_path28.join)(omcRoot, SHARED_MEMORY_DIR, namespace);
+  return (0, import_path29.join)(omcRoot, SHARED_MEMORY_DIR, namespace);
 }
 function getEntryPath(namespace, key, worktreeRoot) {
   validateKey(key);
-  return (0, import_path28.join)(getNamespaceDir(namespace, worktreeRoot), `${key}.json`);
+  return (0, import_path29.join)(getNamespaceDir(namespace, worktreeRoot), `${key}.json`);
 }
 function ensureNamespaceDir(namespace, worktreeRoot) {
   const dir = getNamespaceDir(namespace, worktreeRoot);
-  if (!(0, import_fs21.existsSync)(dir)) {
-    (0, import_fs21.mkdirSync)(dir, { recursive: true });
+  if (!(0, import_fs22.existsSync)(dir)) {
+    (0, import_fs22.mkdirSync)(dir, { recursive: true });
   }
   return dir;
 }
@@ -26860,9 +27718,9 @@ function writeEntry(namespace, key, value, ttl, worktreeRoot) {
   const lockPath = filePath + ".lock";
   const doWrite = () => {
     let existingCreatedAt = now;
-    if ((0, import_fs21.existsSync)(filePath)) {
+    if ((0, import_fs22.existsSync)(filePath)) {
       try {
-        const existing = JSON.parse((0, import_fs21.readFileSync)(filePath, "utf-8"));
+        const existing = JSON.parse((0, import_fs22.readFileSync)(filePath, "utf-8"));
         existingCreatedAt = existing.createdAt || now;
       } catch {
       }
@@ -26879,11 +27737,11 @@ function writeEntry(namespace, key, value, ttl, worktreeRoot) {
       entry.expiresAt = new Date(Date.now() + ttl * 1e3).toISOString();
     }
     const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
-    (0, import_fs21.writeFileSync)(tmpPath, JSON.stringify(entry, null, 2), "utf-8");
-    (0, import_fs21.renameSync)(tmpPath, filePath);
+    (0, import_fs22.writeFileSync)(tmpPath, JSON.stringify(entry, null, 2), "utf-8");
+    (0, import_fs22.renameSync)(tmpPath, filePath);
     try {
       const legacyTmp = filePath + ".tmp";
-      if ((0, import_fs21.existsSync)(legacyTmp)) (0, import_fs21.unlinkSync)(legacyTmp);
+      if ((0, import_fs22.existsSync)(legacyTmp)) (0, import_fs22.unlinkSync)(legacyTmp);
     } catch {
     }
     return entry;
@@ -26898,12 +27756,12 @@ function readEntry(namespace, key, worktreeRoot) {
   validateNamespace(namespace);
   validateKey(key);
   const filePath = getEntryPath(namespace, key, worktreeRoot);
-  if (!(0, import_fs21.existsSync)(filePath)) return null;
+  if (!(0, import_fs22.existsSync)(filePath)) return null;
   try {
-    const entry = JSON.parse((0, import_fs21.readFileSync)(filePath, "utf-8"));
+    const entry = JSON.parse((0, import_fs22.readFileSync)(filePath, "utf-8"));
     if (isExpired(entry)) {
       try {
-        (0, import_fs21.unlinkSync)(filePath);
+        (0, import_fs22.unlinkSync)(filePath);
       } catch {
       }
       return null;
@@ -26916,14 +27774,14 @@ function readEntry(namespace, key, worktreeRoot) {
 function listEntries(namespace, worktreeRoot) {
   validateNamespace(namespace);
   const dir = getNamespaceDir(namespace, worktreeRoot);
-  if (!(0, import_fs21.existsSync)(dir)) return [];
+  if (!(0, import_fs22.existsSync)(dir)) return [];
   const items = [];
   try {
-    const files = (0, import_fs21.readdirSync)(dir).filter((f) => f.endsWith(".json"));
+    const files = (0, import_fs22.readdirSync)(dir).filter((f) => f.endsWith(".json"));
     for (const file of files) {
       try {
-        const filePath = (0, import_path28.join)(dir, file);
-        const entry = JSON.parse((0, import_fs21.readFileSync)(filePath, "utf-8"));
+        const filePath = (0, import_path29.join)(dir, file);
+        const entry = JSON.parse((0, import_fs22.readFileSync)(filePath, "utf-8"));
         if (!isExpired(entry)) {
           items.push({
             key: entry.key,
@@ -26942,9 +27800,9 @@ function deleteEntry(namespace, key, worktreeRoot) {
   validateNamespace(namespace);
   validateKey(key);
   const filePath = getEntryPath(namespace, key, worktreeRoot);
-  if (!(0, import_fs21.existsSync)(filePath)) return false;
+  if (!(0, import_fs22.existsSync)(filePath)) return false;
   try {
-    (0, import_fs21.unlinkSync)(filePath);
+    (0, import_fs22.unlinkSync)(filePath);
     return true;
   } catch {
     return false;
@@ -26952,15 +27810,15 @@ function deleteEntry(namespace, key, worktreeRoot) {
 }
 function cleanupExpired(namespace, worktreeRoot) {
   const omcRoot = getOmcRoot(worktreeRoot);
-  const sharedMemDir = (0, import_path28.join)(omcRoot, SHARED_MEMORY_DIR);
-  if (!(0, import_fs21.existsSync)(sharedMemDir)) return { removed: 0, namespaces: [] };
+  const sharedMemDir = (0, import_path29.join)(omcRoot, SHARED_MEMORY_DIR);
+  if (!(0, import_fs22.existsSync)(sharedMemDir)) return { removed: 0, namespaces: [] };
   const namespacesToClean = [];
   if (namespace) {
     validateNamespace(namespace);
     namespacesToClean.push(namespace);
   } else {
     try {
-      const entries = (0, import_fs21.readdirSync)(sharedMemDir, { withFileTypes: true });
+      const entries = (0, import_fs22.readdirSync)(sharedMemDir, { withFileTypes: true });
       for (const entry of entries) {
         if (entry.isDirectory()) {
           namespacesToClean.push(entry.name);
@@ -26973,17 +27831,17 @@ function cleanupExpired(namespace, worktreeRoot) {
   let removed = 0;
   const cleanedNamespaces = [];
   for (const ns of namespacesToClean) {
-    const nsDir = (0, import_path28.join)(sharedMemDir, ns);
-    if (!(0, import_fs21.existsSync)(nsDir)) continue;
+    const nsDir = (0, import_path29.join)(sharedMemDir, ns);
+    if (!(0, import_fs22.existsSync)(nsDir)) continue;
     let nsRemoved = 0;
     try {
-      const files = (0, import_fs21.readdirSync)(nsDir).filter((f) => f.endsWith(".json"));
+      const files = (0, import_fs22.readdirSync)(nsDir).filter((f) => f.endsWith(".json"));
       for (const file of files) {
         try {
-          const filePath = (0, import_path28.join)(nsDir, file);
-          const entry = JSON.parse((0, import_fs21.readFileSync)(filePath, "utf-8"));
+          const filePath = (0, import_path29.join)(nsDir, file);
+          const entry = JSON.parse((0, import_fs22.readFileSync)(filePath, "utf-8"));
           if (isExpired(entry)) {
-            (0, import_fs21.unlinkSync)(filePath);
+            (0, import_fs22.unlinkSync)(filePath);
             nsRemoved++;
           }
         } catch {
@@ -27000,10 +27858,10 @@ function cleanupExpired(namespace, worktreeRoot) {
 }
 function listNamespaces(worktreeRoot) {
   const omcRoot = getOmcRoot(worktreeRoot);
-  const sharedMemDir = (0, import_path28.join)(omcRoot, SHARED_MEMORY_DIR);
-  if (!(0, import_fs21.existsSync)(sharedMemDir)) return [];
+  const sharedMemDir = (0, import_path29.join)(omcRoot, SHARED_MEMORY_DIR);
+  if (!(0, import_fs22.existsSync)(sharedMemDir)) return [];
   try {
-    const entries = (0, import_fs21.readdirSync)(sharedMemDir, { withFileTypes: true });
+    const entries = (0, import_fs22.readdirSync)(sharedMemDir, { withFileTypes: true });
     return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
   } catch {
     return [];
@@ -27555,25 +28413,25 @@ var DEFAULT_WIKI_CONFIG = {
 };
 
 // src/hooks/wiki/storage.ts
-var import_fs22 = require("fs");
-var import_path29 = require("path");
+var import_fs23 = require("fs");
+var import_path30 = require("path");
 var WIKI_DIR = "wiki";
 var INDEX_FILE = "index.md";
 var LOG_FILE = "log.md";
 var ENVIRONMENT_FILE = "environment.md";
 var RESERVED_FILES = /* @__PURE__ */ new Set([INDEX_FILE, LOG_FILE, ENVIRONMENT_FILE]);
 function getWikiDir(root) {
-  return (0, import_path29.join)(getOmcRoot(root), WIKI_DIR);
+  return (0, import_path30.join)(getOmcRoot(root), WIKI_DIR);
 }
 function ensureWikiDir(root) {
   const wikiDir = getWikiDir(root);
-  if (!(0, import_fs22.existsSync)(wikiDir)) {
-    (0, import_fs22.mkdirSync)(wikiDir, { recursive: true });
+  if (!(0, import_fs23.existsSync)(wikiDir)) {
+    (0, import_fs23.mkdirSync)(wikiDir, { recursive: true });
   }
   const omcRoot = getOmcRoot(root);
-  const gitignorePath = (0, import_path29.join)(omcRoot, ".gitignore");
-  if ((0, import_fs22.existsSync)(gitignorePath)) {
-    const content = (0, import_fs22.readFileSync)(gitignorePath, "utf-8");
+  const gitignorePath = (0, import_path30.join)(omcRoot, ".gitignore");
+  if ((0, import_fs23.existsSync)(gitignorePath)) {
+    const content = (0, import_fs23.readFileSync)(gitignorePath, "utf-8");
     if (!content.includes("wiki/")) {
       atomicWriteFileSync(gitignorePath, content.trimEnd() + "\nwiki/\n");
     }
@@ -27584,7 +28442,7 @@ function ensureWikiDir(root) {
 }
 function withWikiLock(root, fn) {
   const wikiDir = ensureWikiDir(root);
-  const lockPath = lockPathFor((0, import_path29.join)(wikiDir, ".wiki-lock"));
+  const lockPath = lockPathFor((0, import_path30.join)(wikiDir, ".wiki-lock"));
   return withFileLockSync(lockPath, fn, { timeoutMs: 5e3, retryDelayMs: 50 });
 }
 function parseFrontmatter(raw) {
@@ -27666,9 +28524,9 @@ function safeWikiPath(wikiDir, filename) {
   if (filename.includes("/") || filename.includes("\\") || filename.includes("..")) {
     return null;
   }
-  const filePath = (0, import_path29.join)(wikiDir, filename);
-  const resolved = (0, import_path29.resolve)(filePath);
-  if (!resolved.startsWith((0, import_path29.resolve)(wikiDir) + import_path29.sep)) {
+  const filePath = (0, import_path30.join)(wikiDir, filename);
+  const resolved = (0, import_path30.resolve)(filePath);
+  if (!resolved.startsWith((0, import_path30.resolve)(wikiDir) + import_path30.sep)) {
     return null;
   }
   return filePath;
@@ -27677,9 +28535,9 @@ function readPage(root, filename) {
   const wikiDir = getWikiDir(root);
   const filePath = safeWikiPath(wikiDir, filename);
   if (!filePath) return null;
-  if (!(0, import_fs22.existsSync)(filePath)) return null;
+  if (!(0, import_fs23.existsSync)(filePath)) return null;
   try {
-    const raw = (0, import_fs22.readFileSync)(filePath, "utf-8");
+    const raw = (0, import_fs23.readFileSync)(filePath, "utf-8");
     const parsed = parseFrontmatter(raw);
     if (!parsed) return null;
     return {
@@ -27693,16 +28551,16 @@ function readPage(root, filename) {
 }
 function listPages(root) {
   const wikiDir = getWikiDir(root);
-  if (!(0, import_fs22.existsSync)(wikiDir)) return [];
-  return (0, import_fs22.readdirSync)(wikiDir).filter((f) => f.endsWith(".md") && !RESERVED_FILES.has(f)).sort();
+  if (!(0, import_fs23.existsSync)(wikiDir)) return [];
+  return (0, import_fs23.readdirSync)(wikiDir).filter((f) => f.endsWith(".md") && !RESERVED_FILES.has(f)).sort();
 }
 function readAllPages(root) {
   return listPages(root).map((f) => readPage(root, f)).filter((p) => p !== null);
 }
 function readIndex(root) {
-  const indexPath = (0, import_path29.join)(getWikiDir(root), INDEX_FILE);
-  if (!(0, import_fs22.existsSync)(indexPath)) return null;
-  return (0, import_fs22.readFileSync)(indexPath, "utf-8");
+  const indexPath = (0, import_path30.join)(getWikiDir(root), INDEX_FILE);
+  if (!(0, import_fs23.existsSync)(indexPath)) return null;
+  return (0, import_fs23.readFileSync)(indexPath, "utf-8");
 }
 function writePageUnsafe(root, page) {
   if (RESERVED_FILES.has(page.filename)) {
@@ -27717,8 +28575,8 @@ function deletePageUnsafe(root, filename) {
   const wikiDir = getWikiDir(root);
   const filePath = safeWikiPath(wikiDir, filename);
   if (!filePath) return false;
-  if (!(0, import_fs22.existsSync)(filePath)) return false;
-  (0, import_fs22.unlinkSync)(filePath);
+  if (!(0, import_fs23.existsSync)(filePath)) return false;
+  (0, import_fs23.unlinkSync)(filePath);
   return true;
 }
 function updateIndexUnsafe(root) {
@@ -27747,19 +28605,19 @@ function updateIndexUnsafe(root) {
     lines.push("");
   }
   const wikiDir = ensureWikiDir(root);
-  atomicWriteFileSync((0, import_path29.join)(wikiDir, INDEX_FILE), lines.join("\n"));
+  atomicWriteFileSync((0, import_path30.join)(wikiDir, INDEX_FILE), lines.join("\n"));
 }
 function appendLogUnsafe(root, entry) {
   const wikiDir = ensureWikiDir(root);
-  const logPath = (0, import_path29.join)(wikiDir, LOG_FILE);
+  const logPath = (0, import_path30.join)(wikiDir, LOG_FILE);
   const logLine = `## [${entry.timestamp}] ${entry.operation}
 - **Pages:** ${entry.pagesAffected.join(", ") || "none"}
 - **Summary:** ${entry.summary}
 
 `;
   let existing = "";
-  if ((0, import_fs22.existsSync)(logPath)) {
-    existing = (0, import_fs22.readFileSync)(logPath, "utf-8");
+  if ((0, import_fs23.existsSync)(logPath)) {
+    existing = (0, import_fs23.readFileSync)(logPath, "utf-8");
   } else {
     existing = "# Wiki Log\n\n";
   }
@@ -28430,37 +29288,37 @@ var wikiTools = [
 ];
 
 // src/tools/skills-tools.ts
-var import_path33 = require("path");
+var import_path34 = require("path");
 var import_os7 = require("os");
 
 // src/hooks/learner/loader.ts
-var import_fs24 = require("fs");
+var import_fs25 = require("fs");
 var import_crypto3 = require("crypto");
-var import_path32 = require("path");
+var import_path33 = require("path");
 
 // src/hooks/learner/finder.ts
-var import_fs23 = require("fs");
-var import_path31 = require("path");
+var import_fs24 = require("fs");
+var import_path32 = require("path");
 
 // src/hooks/learner/constants.ts
-var import_path30 = require("path");
+var import_path31 = require("path");
 var import_os6 = require("os");
-var USER_SKILLS_DIR = (0, import_path30.join)(getClaudeConfigDir(), "skills", "omc-learned");
-var GLOBAL_SKILLS_DIR = (0, import_path30.join)((0, import_os6.homedir)(), ".omc", "skills");
+var USER_SKILLS_DIR = (0, import_path31.join)(getClaudeConfigDir(), "skills", "omc-learned");
+var GLOBAL_SKILLS_DIR = (0, import_path31.join)((0, import_os6.homedir)(), ".omc", "skills");
 var PROJECT_SKILLS_SUBDIR = OmcPaths.SKILLS;
-var PROJECT_AGENT_SKILLS_SUBDIR = (0, import_path30.join)(".agents", "skills");
+var PROJECT_AGENT_SKILLS_SUBDIR = (0, import_path31.join)(".agents", "skills");
 var MAX_RECURSION_DEPTH = 10;
 var SKILL_EXTENSION = ".md";
 var DEBUG_ENABLED = process.env.OMC_DEBUG === "1";
 
 // src/hooks/learner/finder.ts
 function findSkillFilesRecursive(dir, results, depth = 0) {
-  if (!(0, import_fs23.existsSync)(dir)) return;
+  if (!(0, import_fs24.existsSync)(dir)) return;
   if (depth > MAX_RECURSION_DEPTH) return;
   try {
-    const entries = (0, import_fs23.readdirSync)(dir, { withFileTypes: true });
+    const entries = (0, import_fs24.readdirSync)(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = (0, import_path31.join)(dir, entry.name);
+      const fullPath = (0, import_path32.join)(dir, entry.name);
       if (entry.isDirectory()) {
         findSkillFilesRecursive(fullPath, results, depth + 1);
       } else if (entry.isFile() && entry.name.endsWith(SKILL_EXTENSION)) {
@@ -28475,15 +29333,15 @@ function findSkillFilesRecursive(dir, results, depth = 0) {
 }
 function safeRealpathSync(filePath) {
   try {
-    return (0, import_fs23.realpathSync)(filePath);
+    return (0, import_fs24.realpathSync)(filePath);
   } catch {
     return filePath;
   }
 }
 function isWithinBoundary(realPath, boundary) {
-  const normalizedReal = (0, import_path31.normalize)(realPath);
-  const normalizedBoundary = (0, import_path31.normalize)(safeRealpathSync(boundary));
-  return normalizedReal === normalizedBoundary || normalizedReal.startsWith(normalizedBoundary + import_path31.sep);
+  const normalizedReal = (0, import_path32.normalize)(realPath);
+  const normalizedBoundary = (0, import_path32.normalize)(safeRealpathSync(boundary));
+  return normalizedReal === normalizedBoundary || normalizedReal.startsWith(normalizedBoundary + import_path32.sep);
 }
 function findSkillFiles(projectRoot, options) {
   const candidates = [];
@@ -28491,8 +29349,8 @@ function findSkillFiles(projectRoot, options) {
   const scope = options?.scope ?? "all";
   if (projectRoot && (scope === "project" || scope === "all")) {
     const projectSkillDirs = [
-      (0, import_path31.join)(projectRoot, PROJECT_SKILLS_SUBDIR),
-      (0, import_path31.join)(projectRoot, PROJECT_AGENT_SKILLS_SUBDIR)
+      (0, import_path32.join)(projectRoot, PROJECT_SKILLS_SUBDIR),
+      (0, import_path32.join)(projectRoot, PROJECT_AGENT_SKILLS_SUBDIR)
     ];
     for (const projectSkillsDir of projectSkillDirs) {
       const projectFiles = [];
@@ -28701,7 +29559,7 @@ function loadAllSkills(projectRoot) {
   const seenIds = /* @__PURE__ */ new Map();
   for (const candidate of candidates) {
     try {
-      const rawContent = (0, import_fs24.readFileSync)(candidate.path, "utf-8");
+      const rawContent = (0, import_fs25.readFileSync)(candidate.path, "utf-8");
       const { metadata, content, valid, errors } = parseSkillFile(rawContent);
       if (!valid) {
         if (DEBUG_ENABLED) {
@@ -28710,7 +29568,7 @@ function loadAllSkills(projectRoot) {
         continue;
       }
       const skillId = metadata.id;
-      const relativePath = (0, import_path32.normalize)((0, import_path32.relative)(candidate.sourceDir, candidate.path));
+      const relativePath = (0, import_path33.normalize)((0, import_path33.relative)(candidate.sourceDir, candidate.path));
       const skill = {
         path: candidate.path,
         relativePath,
@@ -28736,13 +29594,13 @@ function loadAllSkills(projectRoot) {
 // src/tools/skills-tools.ts
 var ALLOWED_BOUNDARIES = [process.cwd(), (0, import_os7.homedir)()];
 function validateProjectRoot(input) {
-  const normalized = (0, import_path33.normalize)((0, import_path33.resolve)(input));
+  const normalized = (0, import_path34.normalize)((0, import_path34.resolve)(input));
   if (input.includes("..")) {
     throw new Error("Invalid project root: path traversal not allowed");
   }
   const isWithinAllowed = ALLOWED_BOUNDARIES.some((boundary) => {
-    const normalizedBoundary = (0, import_path33.normalize)(boundary);
-    return normalized === normalizedBoundary || normalized.startsWith(normalizedBoundary + import_path33.sep);
+    const normalizedBoundary = (0, import_path34.normalize)(boundary);
+    return normalized === normalizedBoundary || normalized.startsWith(normalizedBoundary + import_path34.sep);
   });
   if (!isWithinAllowed) {
     throw new Error("Invalid project root: path is outside allowed directories");

--- a/skills/merge-readiness/SKILL.md
+++ b/skills/merge-readiness/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: merge-readiness
+aliases: understanding-gate
+description: "Post-task merge readiness gate with a state-backed explanation report and human explainability quiz"
+argument-hint: "[--quick|--standard|--deep] [--from-diff|--from-artifacts] <change summary or artifact path>"
+---
+
+<Purpose>
+Merge Readiness is a post-task explainability gate. After implementation, tests, QA, and review evidence exist, it generates a human-readable explanation of the change, then asks the human targeted questions to verify they can explain why the change exists, what changed, what tradeoffs were made, what risks were considered, and how the team should understand it.
+</Purpose>
+
+<Use_When>
+- A task, PR, or change set is functionally complete and needs a final human-understanding check before merge readiness
+- Tests, QA, code review, security review, or other verification has already run, or missing evidence must be explicitly recorded
+- The user wants AI to explain the change and then quiz the human on whether they can explain it
+- You need a durable session audit record showing why the team can trust and understand the change before asking for merge approval
+</Use_When>
+
+<Do_Not_Use_When>
+- Requirements are still unclear before implementation; use `/deep-interview`
+- The implementation is not done; use `/ralph`, `/team`, or `/autopilot`
+- Tests or QA have not run and the user expects this command to replace them
+- The user wants code review findings; use `/review` or the relevant review workflow
+</Do_Not_Use_When>
+
+<Why_This_Exists>
+Real delivery is not only code that works. Teams need to understand why a change exists, what changed, what was deliberately not done, which risks were considered, and what future maintainers should believe about the change. This workflow makes that understanding explicit before merge approval is requested. Passing this gate never means the change is approved or merged; it only means a human can explain it.
+</Why_This_Exists>
+
+<Depth_Profiles>
+- **Quick (`--quick`)**: small/local changes; correctness threshold `>= 0.70`; max 3 MCQs; required dimensions: why / change / risk
+- **Standard (`--standard`, default)**: normal feature/bugfix; correctness threshold `>= 0.80`; max 5 MCQs; required dimensions: why / change / tradeoff / risk / team
+- **Deep (`--deep`)**: high-risk, architectural, security, or cross-module changes; correctness threshold `>= 0.90`; max 8 MCQs (redundancy across all five dimensions)
+
+If no flag is provided, use **Standard**. Thresholds and round counts are canonical in `src/hooks/merge-readiness/mcq.ts` and must stay in sync with this file.
+</Depth_Profiles>
+
+<Execution_Policy>
+- This is a post-task command. Do not implement code inside this mode.
+- Gather repository and artifact evidence before asking the human for facts that can be discovered locally.
+- Generate the explanation doc + MCQs in one AI step, then present MCQs one-per-round.
+- The runtime (TS hook code) is the backbone: it owns validation, authoritative session state, objective MCQ scoring, and report rendering. The AI owns content generation + MCQ presentation via AskUserQuestion.
+- Present each MCQ one-per-round via AskUserQuestion (deep-interview style). Record each selection via the runtime so it is scored objectively.
+- Ask about explainability, not implementation trivia.
+- Never ask the human to memorize line numbers, variable names, private helper names, or incidental implementation details.
+- Score is the objective correctness rate (correct answers / answered), not a keyword heuristic.
+- If the correctness rate is below threshold after all required MCQs are answered, mark result `paused` and do not claim merge readiness.
+- If key evidence is missing (no diff/change signal), mark result `blocked`.
+- Passing this gate does not approve merge, replace tests, replace review, replace security review, accept risk, or bypass maintainer approval.
+- Persist state for resume safety under `.omc/state/merge-readiness-state.json` (session-scoped under `.omc/state/sessions/<sessionId>/`). Do not write this file directly.
+- v1 is advisory: the gate logic (`checkMergeReadiness`) is not wired to the Stop hook, so an active gate does not block the session. It does not perform or approve a Git merge.
+</Execution_Policy>
+
+<Steps>
+
+## Phase 0: Evidence Intake
+
+1. Parse `{{ARGUMENTS}}`, depth profile, source mode (`--from-diff|--from-artifacts`), and derive a task slug. `--from-pr` is unsupported; this workflow uses local evidence only.
+2. Collect available evidence:
+   - Local Git diff and commit range
+   - Changed files
+   - Test output
+   - QA output
+   - Review notes
+   - Security review notes when applicable
+   - `.omc/plans/`, `.omc/specs/`, `.omc/interviews/`, and relevant mode state artifacts
+3. Record missing evidence explicitly. Missing evidence is not hidden by a good explanation.
+
+## Phase 1: Initialize
+
+Call the `merge_readiness_start` tool with the change summary to seed state (the runtime parses the `--quick`/`--standard`/`--deep` profile from it; `--standard` is the default). State shape:
+
+```json
+{
+  "active": true,
+  "current_phase": "merge-readiness",
+  "phase": "content",
+  "profile": "standard",
+  "threshold": 0.80,
+  "max_rounds": 5,
+  "required_dimensions": ["why", "change", "tradeoff", "risk", "team"],
+  "questions": [],
+  "answers": [],
+  "awaiting_content": true,
+  "readiness_score": 0,
+  "result": "pending"
+}
+```
+
+`awaiting_content` is true until the AI submits the generated doc + MCQs via `merge_readiness_set_content`.
+
+## Phase 2: Generate Explanation Doc + MCQs (AI content step)
+
+Generate, from the actual diff + evidence (not templates):
+
+1. A 5-section narrative: **Why**, **What Changed**, **Tradeoffs**, **Risks Considered**, **Team Understanding**.
+2. A set of MCQs (one correct option each, with `correctOptionId` + optional `rationale`):
+   - Up to the profile max rounds (quick 3 / standard 5 / deep 8)
+   - Distributed across the required dimensions
+   - Testing understanding of THIS change, not implementation trivia
+
+Submit them with `merge_readiness_set_content` (requires an active gate from `merge_readiness_start`; it errors if no gate is active). Do not write the state JSON or invoke internal runtime functions. Invalid content is rejected with recoverable validation errors. The validated content is persisted in the authoritative session state.
+
+Use `merge_readiness_report` to render the five sections, evidence, quiz progress, readiness, and merge boundary directly from state. It is read-only and does not create a file. Correct answers and rationales remain hidden until the attempt is complete; cancellation or override reveals only answered questions.
+
+The Merge Boundary must say: "Passing means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk."
+
+## Phase 3: Human Quiz Loop (MCQ, one-per-round, deep-interview style)
+
+Present each MCQ one-per-round via AskUserQuestion with the option ids/text as choices, then record the human’s selection with the `merge_readiness_record_answer` tool (questionId + optionId). The runtime scores it objectively and either advances to the next question or finalizes the gate (pass / paused / blocked).
+
+Cover these dimensions before passing (quick = why/change/risk only):
+
+1. **why** - why this change was worth doing
+2. **change** - what behavior, workflow, interface, or maintenance model changed
+3. **tradeoff** - what was chosen, deferred, or rejected and why
+4. **risk** - which risks were considered and what remains risky
+5. **team** - how the team should understand and maintain this change
+
+Forbidden question types:
+
+- Function-name trivia
+- Line-number trivia
+- Variable-name recall
+- Private helper memorization
+- Any question whose answer does not help a reviewer explain the change
+
+## Phase 4: Score Readiness (runtime-owned, objective)
+
+The runtime computes:
+
+- `readiness_score` = correctness rate = (correct answers) / (answered answers), in [0, 1]
+- Per-dimension coverage = whether every required dimension has at least one answered MCQ
+
+Gate results:
+
+- `pass`: all required MCQs answered AND correctness rate >= threshold AND required dimensions covered
+- `paused`: all required MCQs answered but correctness rate below threshold (or required dimension uncovered)
+- `blocked`: missing minimal evidence (no diff/change signal)
+
+Thresholds: quick `0.70` / standard `0.80` / deep `0.90`.
+
+## Phase 5: Crystallize Result
+
+Persist these fields in the terminal session state and inspect them with `merge_readiness_report`:
+
+- Final readiness score
+- Dimension breakdown
+- Human answers
+- AI assessment
+- Result
+- Blocking or paused gap
+- Next step
+
+## Phase 6: Handoff
+
+If `pass`:
+- State that the change may proceed to human merge approval.
+- Do not merge.
+
+If `paused`:
+- State which explanation dimension is missing.
+- Recommend rereading or revising the report and rerunning `/merge-readiness`.
+
+If `blocked`:
+- State which evidence must be produced before rerunning.
+
+</Steps>
+
+<Tool_Usage>
+- Use repository search and local artifacts for evidence intake before asking the human for context.
+- Use structured user questioning when available.
+- Use `merge_readiness_start` to initialize the gate, `merge_readiness_set_content` to submit the report + MCQs, `merge_readiness_record_answer` to record each selection, and `merge_readiness_report` to render the current audit record. Use state read/status/clear only for `.omc/state/merge-readiness-state.json`; never use generic state write to submit quiz content. `state_clear` routes merge-readiness through cancellation and preserves terminal state; pass the current session_id to avoid cancelling concurrent quizzes.
+</Tool_Usage>
+
+<Escalation_And_Stop_Conditions>
+- User says stop/cancel/abort -> persist terminal `cancelled` state and stop.
+- Missing diff or change evidence -> `blocked`.
+- Human cannot explain a required dimension -> `paused`.
+- Readiness threshold reached and mandatory gates satisfied -> `pass`.
+</Escalation_And_Stop_Conditions>
+
+<Final_Checklist>
+- [ ] Evidence intake completed
+- [ ] Missing evidence recorded
+- [ ] Explanation doc (5 sections) + MCQs submitted via merge_readiness_set_content
+- [ ] MCQs presented one-per-round via AskUserQuestion
+- [ ] Each answer correlated from marked AskUserQuestion output (objective scoring)
+- [ ] Questions avoided implementation trivia
+- [ ] Correctness rate calculated by the runtime
+- [ ] Result is `pass`, `paused`, `blocked`, `overridden`, or `cancelled`
+- [ ] Merge Boundary is explicit
+- [ ] No direct implementation or merge performed
+</Final_Checklist>
+
+<Advanced>
+## Recommended Delivery Pipeline
+
+```text
+/deep-interview
+  -> /omc-plan or /ralplan
+  -> /ralph, /team, or /autopilot
+  -> /ultraqa and review
+  -> /merge-readiness
+  -> human merge approval
+```
+
+## Autopilot Bridge
+
+Autopilot may call this workflow after QA/validation when configured:
+
+```jsonc
+{
+  "autopilot": {
+    "mergeReadiness": true
+  }
+}
+```
+
+`autopilot.understandingGate` is a deprecated compatibility alias for `autopilot.mergeReadiness`.
+</Advanced>
+
+Task: {{ARGUMENTS}}

--- a/skills/merge-readiness/SKILL.md
+++ b/skills/merge-readiness/SKILL.md
@@ -56,19 +56,17 @@ If no flag is provided, use **Standard**. Thresholds and round counts are canoni
 ## Phase 0: Evidence Intake
 
 1. Parse `{{ARGUMENTS}}`, depth profile, source mode (`--from-diff|--from-artifacts`), and derive a task slug. `--from-pr` is unsupported; this workflow uses local evidence only.
-2. Collect available evidence:
+2. Collect available evidence (the runtime detects artifacts by FILENAME heuristics; file CONTENTS are never parsed):
    - Local Git diff and commit range
    - Changed files
-   - Test output
-   - QA output
-   - Review notes
-   - Security review notes when applicable
-   - `.omc/plans/`, `.omc/specs/`, `.omc/interviews/`, and relevant mode state artifacts
+   - Test/QA/verification artifacts (filenames matching `test|spec|qa|verify|validation`)
+   - Review/risk/security/readiness/verdict artifacts (filenames matching `review|risk|security|readiness|verdict`)
+   - `.omc/plans/`, `.omc/specs/`, `.omc/interviews/`, `.omc/artifacts/`, `.omc/logs/`, and relevant mode state artifacts (canonical `{mode}-state.json` files under `.omc/state/` that record a real run)
 3. Record missing evidence explicitly. Missing evidence is not hidden by a good explanation.
 
 ## Phase 1: Initialize
 
-Call the `merge_readiness_start` tool with the change summary to seed state (the runtime parses the `--quick`/`--standard`/`--deep` profile from it; `--standard` is the default). State shape:
+Call the `merge_readiness_start` tool with the change summary to seed state (the runtime parses the `--quick`/`--deep` profile (`--standard` is the default when neither flag is present; it is not a parsed token)). State shape:
 
 ```json
 {

--- a/src/__tests__/omc-tools-server.test.ts
+++ b/src/__tests__/omc-tools-server.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { omcToolsServer, omcToolNames, getOmcToolNames } from '../mcp/omc-tools-server.js';
 
 const interopEnabled = process.env.OMC_INTEROP_TOOLS_ENABLED === '1';
-const totalTools = interopEnabled ? 57 : 49;
-const withoutLsp = interopEnabled ? 45 : 37;
-const withoutAst = interopEnabled ? 55 : 47;
-const withoutPython = interopEnabled ? 56 : 48;
-const withoutSkills = interopEnabled ? 54 : 46;
+const totalTools = interopEnabled ? 62 : 54;
+const withoutLsp = interopEnabled ? 50 : 42;
+const withoutAst = interopEnabled ? 60 : 52;
+const withoutPython = interopEnabled ? 61 : 53;
+const withoutSkills = interopEnabled ? 59 : 51;
 
 describe('omc-tools-server', () => {
   describe('omcToolNames', () => {

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (36 canonical + 3 aliases)', () => {
+    it('should return correct number of skills (37 canonical + 4 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 39 entries: 36 canonical skills + 3 deprecated aliases (cancel-ralph, learner, psm)
-      expect(skills).toHaveLength(39);
+      // 41 entries: 37 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
+      expect(skills).toHaveLength(41);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -139,6 +139,7 @@ describe('Builtin Skills', () => {
         'skillify',
         'learner',
         'local-build-reminder',
+        'merge-readiness',
         'mcp-setup',
         'omc-setup',
         'omc-teams',
@@ -161,6 +162,7 @@ describe('Builtin Skills', () => {
         'visual-verdict',
         'wiki',
         'writer-memory',
+        'understanding-gate',
       ];
 
       const actualSkillNames = skills.map((s) => s.name);
@@ -214,6 +216,29 @@ describe('Builtin Skills', () => {
       const skill = getBuiltinSkill('autopilot');
       expect(skill).toBeDefined();
       expect(skill?.name).toBe('autopilot');
+    });
+
+    it('documents merge-readiness as a standalone post-task slash workflow', () => {
+      const skill = getBuiltinSkill('merge-readiness');
+      const alias = getBuiltinSkill('understanding-gate');
+
+      expect(skill).toBeDefined();
+      expect(skill?.aliases).toContain('understanding-gate');
+      expect(alias).toBeDefined();
+      expect(alias?.aliasOf).toBe('merge-readiness');
+      expect(skill?.description).toContain('Post-task merge readiness gate');
+      expect(skill?.template).toContain('post-task explainability gate');
+      // v1 MCQ-based flow: AI generates a 5-section doc + MCQs, runtime scores objectively.
+      expect(skill?.template).toContain('Generate Explanation Doc + MCQs');
+      expect(skill?.template).toContain('Human Quiz Loop');
+      expect(skill?.template).toContain('**Why**');
+      expect(skill?.template).toContain('**What Changed**');
+      expect(skill?.template).toContain('**Tradeoffs**');
+      expect(skill?.template).toContain('**Risks Considered**');
+      expect(skill?.template).toContain('**Team Understanding**');
+      expect(skill?.template).toContain('Forbidden question types');
+      expect(skill?.template).toContain('Passing this gate does not approve merge');
+      expect(skill?.template).toContain('No direct implementation or merge performed');
     });
 
     it('should retrieve the ai-slop-cleaner skill by name', () => {
@@ -831,7 +856,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(36);
+      expect(names).toHaveLength(37);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -869,7 +894,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; cancel-ralph, psm, and learner aliases still exist
-      expect(names).toHaveLength(39);
+      expect(names).toHaveLength(41);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/hooks/merge-readiness/__tests__/runtime.test.ts
+++ b/src/hooks/merge-readiness/__tests__/runtime.test.ts
@@ -1,0 +1,508 @@
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  checkMergeReadiness,
+  cancelMergeReadiness,
+  createInitialMergeReadinessState,
+  readMergeReadinessState,
+  recordMergeReadinessMCQAnswer,
+  recordMergeReadinessAskUserQuestionResult,
+  overrideMergeReadiness,
+  setMergeReadinessContent,
+} from "../index.js";
+import type { MergeReadinessMCQQuestion } from "../mcq.js";
+
+function makeQuestion(
+  id: string,
+  dimension: "why" | "change" | "tradeoff" | "risk" | "team",
+  correctOptionId = "a",
+): MergeReadinessMCQQuestion {
+  return {
+    id,
+    dimension,
+    stem: `(${dimension}) Pick the correct explanation of this change.`,
+    options: [
+      { id: "a", text: "Correct understanding of the change." },
+      { id: "b", text: "A plausible but wrong explanation." },
+      { id: "c", text: "An unrelated statement." },
+      { id: "d", text: "Implementation trivia." },
+    ],
+    correctOptionId,
+  };
+}
+
+describe("merge-readiness runtime", () => {
+  let tempDir: string;
+  const sessionId = "merge-readiness-session";
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "omc-merge-readiness-"));
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.name", "Test User"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "before\n");
+    execFileSync("git", ["add", "README.md"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["commit", "-m", "initial"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "after\n");
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates the authoritative audit state without writing a report artifact", () => {
+    const state = createInitialMergeReadinessState(
+      tempDir,
+      "/merge-readiness --standard improve docs after review",
+      sessionId,
+    );
+
+    expect(state.active).toBe(true);
+    expect(state.current_phase).toBe("merge-readiness");
+    expect(state.phase).toBe("content");
+    expect(state.awaiting_content).toBe(true);
+    expect(state.questions).toEqual([]);
+    expect(state.answers).toEqual([]);
+    expect(state.threshold).toBe(0.8);
+    expect(state.max_rounds).toBe(5);
+    expect(state.required_dimensions).toEqual(["why", "change", "tradeoff", "risk", "team"]);
+    expect(state.evidence.changedFiles).toContain("README.md");
+    expect("artifact_path" in state).toBe(false);
+    expect(existsSync(join(tempDir, ".omc", "artifacts", "merge-readiness"))).toBe(false);
+    const persisted = readMergeReadinessState(tempDir, sessionId);
+    expect(persisted?.result).toBe("pending");
+    expect(persisted?.change_summary).toBe(state.change_summary);
+    expect(persisted?.evidence.changedFiles).toEqual(state.evidence.changedFiles);
+  });
+
+  it("uses quick profile thresholds (0.70 / 3 rounds / why-change-risk)", () => {
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    expect(state.profile).toBe("quick");
+    expect(state.threshold).toBe(0.7);
+    expect(state.max_rounds).toBe(3);
+    expect(state.required_dimensions).toEqual(["why", "change", "risk"]);
+  });
+
+  it("uses deep profile thresholds (0.90 / 8 rounds / all five dims)", () => {
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --deep risky change", sessionId);
+    expect(state.profile).toBe("deep");
+    expect(state.threshold).toBe(0.9);
+    expect(state.max_rounds).toBe(8);
+    expect(state.required_dimensions).toEqual(["why", "change", "tradeoff", "risk", "team"]);
+  });
+
+  it("setMergeReadinessContent persists doc + MCQs in state and arms first MCQ", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --standard explain docs change", sessionId);
+    const questions: MergeReadinessMCQQuestion[] = [
+      makeQuestion("q1", "why"),
+      makeQuestion("q2", "change"),
+      makeQuestion("q3", "tradeoff"),
+      makeQuestion("q4", "risk"),
+      makeQuestion("q5", "team"),
+    ];
+    const state = setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why text",
+        whatChanged: "What changed text",
+        tradeoffs: "Tradeoff text",
+        risksConsidered: "Risk text",
+        teamUnderstanding: "Team text",
+        questions,
+      },
+      sessionId,
+    );
+
+    expect(state?.awaiting_content).toBe(false);
+    expect(state?.questions).toHaveLength(5);
+    expect(state?.why).toBe("Why text");
+    expect(state?.pending_question?.id).toBe("q1");
+    expect(readMergeReadinessState(tempDir, sessionId)?.whatChanged).toBe("What changed text");
+    expect(existsSync(join(tempDir, ".omc", "artifacts", "merge-readiness"))).toBe(false);
+  });
+
+  it("passes when all required MCQs answered correctly (correctness rate >= threshold)", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --standard explain docs change", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [
+          makeQuestion("q1", "why"),
+          makeQuestion("q2", "change"),
+          makeQuestion("q3", "tradeoff"),
+          makeQuestion("q4", "risk"),
+          makeQuestion("q5", "team"),
+        ],
+      },
+      sessionId,
+    );
+
+    for (const id of ["q1", "q2", "q3", "q4", "q5"]) {
+      recordMergeReadinessMCQAnswer(tempDir, id, "a", sessionId);
+    }
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    expect(state?.active).toBe(false);
+    expect(state?.result).toBe("pass");
+    expect(state?.readiness_score).toBe(1);
+    expect(state?.completed_at).toBeTruthy();
+  });
+
+  it("pauses when all required MCQs answered but correctness rate below threshold", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --deep risky change", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [
+          makeQuestion("q1", "why"),
+          makeQuestion("q2", "change"),
+          makeQuestion("q3", "tradeoff"),
+          makeQuestion("q4", "risk"),
+          makeQuestion("q5", "team"),
+        ],
+      },
+      sessionId,
+    );
+
+    // Answer 2/5 correctly -> 0.4 < deep threshold 0.90 -> paused.
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q4", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q5", "b", sessionId);
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    expect(state?.active).toBe(true);
+    expect(state?.result).toBe("paused");
+    expect(state?.readiness_score).toBeCloseTo(0.4, 5);
+  });
+
+  it("rejects content that does not cover every required dimension (anti-gaming)", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", sessionId);
+    // quick requires why/change/risk; omit "change" so a high score cannot pass without coverage.
+    const state = setMergeReadinessContent(tempDir, {
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "why"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    expect(state?.validation_errors?.some((e) => e.includes("change"))).toBe(true);
+    expect(state?.phase).toBe("content");
+    expect(state?.result).toBe("pending");
+  });
+
+  it("does not start the gate on an unrelated artifact (fail-open fix)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-unrelated-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree (no diff) + an unrelated plans file: must block, not start pending.
+      mkdirSync(join(dir, ".omc", "plans"), { recursive: true });
+      writeFileSync(join(dir, ".omc", "plans", "unrelated.md"), "notes\n");
+      const state = createInitialMergeReadinessState(dir, "/merge-readiness --standard change", sessionId);
+      expect(state.result).toBe("blocked");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("starts the gate on a specs-only repo (scan scope fix)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-specs-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree + a specs file: specs is now scanned and matches the test-evidence regex.
+      mkdirSync(join(dir, ".omc", "specs"), { recursive: true });
+      writeFileSync(join(dir, ".omc", "specs", "design.md"), "spec for the change\n");
+      const state = createInitialMergeReadinessState(dir, "/merge-readiness --standard change", sessionId);
+      expect(state.result).toBe("pending");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves prior terminal attempts across re-start (audit history)", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    // Answer all wrong -> 0/3 = 0 < quick threshold 0.70 -> paused.
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "b", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.result).toBe("paused");
+    // Re-start should preserve the prior paused attempt in prior_attempts.
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick retry", sessionId);
+    expect(state.prior_attempts?.length).toBe(1);
+    expect(state.prior_attempts?.[0].result).toBe("paused");
+  });
+
+  it("fails closed when state cannot be persisted (invalid session id)", () => {
+    // tempDir has a diff, so without the persistence failure this would be pending.
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", "bad/session");
+    expect(state.result).toBe("blocked");
+    expect(state.validation_errors?.some((e) => e.includes("persisted"))).toBe(true);
+  });
+
+  it("blocked gate message directs to evidence, not content submission", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-blocked-msg-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree, no artifacts -> blocked.
+      createInitialMergeReadinessState(dir, "/merge-readiness --standard change", sessionId);
+      const result = await checkMergeReadiness(sessionId, dir, false);
+      expect(result?.message).toContain("Minimal evidence");
+      expect(result?.message).not.toContain("setMergeReadinessContent");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when minimal evidence is missing (no diff/change signal)", () => {
+    // Fresh git repo with no changes and no status.
+    const emptyDir = mkdtempSync(join(tmpdir(), "omc-merge-readiness-empty-"));
+    try {
+      execFileSync("git", ["init"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+
+      createInitialMergeReadinessState(emptyDir, "/merge-readiness --standard no changes here", sessionId);
+      setMergeReadinessContent(
+        emptyDir,
+        {
+          why: "Why",
+          whatChanged: "What",
+          tradeoffs: "Tradeoff",
+          risksConsidered: "Risk",
+          teamUnderstanding: "Team",
+          questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "tradeoff"), makeQuestion("q4", "risk"), makeQuestion("q5", "team")],
+        },
+        sessionId,
+      );
+
+      recordMergeReadinessMCQAnswer(emptyDir, "q1", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q2", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q3", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q4", "a", sessionId);
+      recordMergeReadinessMCQAnswer(emptyDir, "q5", "a", sessionId);
+
+      const state = readMergeReadinessState(emptyDir, sessionId);
+      expect(state?.result).toBe("blocked");
+      expect(state?.active).toBe(true);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses source flags exactly and rejects conflicting source modes", () => {
+    const lookalike = createInitialMergeReadinessState(tempDir, "/merge-readiness summary--from-diff", sessionId);
+    expect(lookalike.source_mode).toBeUndefined();
+    expect(lookalike.result).toBe("pending");
+
+    const conflicting = createInitialMergeReadinessState(
+      tempDir,
+      "/merge-readiness --from-diff --from-artifacts change",
+      "conflicting-source-session",
+    );
+    expect(conflicting.result).toBe("blocked");
+    expect(conflicting.validation_errors).toContain("--from-diff and --from-artifacts cannot be used together.");
+    expect(setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "tradeoff"), makeQuestion("q4", "risk"), makeQuestion("q5", "team")],
+    }, "conflicting-source-session")?.result).toBe("blocked");
+  });
+
+  it("does not accept untracked files as --from-diff evidence", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "omc-merge-readiness-untracked-"));
+    try {
+      execFileSync("git", ["init"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(emptyDir, "tracked.md"), "tracked\n");
+      execFileSync("git", ["add", "tracked.md"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "initial"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(emptyDir, "untracked.md"), "untracked\n");
+
+      const state = createInitialMergeReadinessState(emptyDir, "/merge-readiness --from-diff only untracked", sessionId);
+      expect(state.evidence.untrackedFiles).toEqual(["untracked.md"]);
+      expect(state.evidence.changedFiles).toEqual([]);
+      expect(state.result).toBe("blocked");
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cancels a blocked gate while retaining a terminal audit record", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "omc-merge-readiness-cancel-"));
+    try {
+      execFileSync("git", ["init"], { cwd: emptyDir, stdio: "ignore", windowsHide: true });
+      const state = createInitialMergeReadinessState(emptyDir, "/merge-readiness --from-diff no changes", sessionId);
+      expect(state.result).toBe("blocked");
+      const cancelled = cancelMergeReadiness(emptyDir, sessionId);
+      expect(cancelled?.result).toBe("cancelled");
+      expect(cancelled?.active).toBe(false);
+      expect(readMergeReadinessState(emptyDir, sessionId)?.result).toBe("cancelled");
+      expect("artifact_path" in cancelled!).toBe(false);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it("scores MCQ answers objectively (selectedOptionId === correctOptionId)", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [
+          makeQuestion("q1", "why", "a"),
+          makeQuestion("q2", "change", "b"),
+          makeQuestion("q3", "risk", "c"),
+        ],
+      },
+      sessionId,
+    );
+
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId); // correct
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId); // wrong (correct is b)
+
+    const state = readMergeReadinessState(tempDir, sessionId);
+    expect(state?.answers).toHaveLength(2);
+    expect(state?.answers[0].isCorrect).toBe(true);
+    expect(state?.answers[1].isCorrect).toBe(false);
+  });
+
+  it("blocks stop while awaiting content", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+
+    const result = await checkMergeReadiness(sessionId, tempDir, false);
+
+    expect(result?.shouldBlock).toBe(true);
+    expect(result?.message).toContain("[MERGE READINESS BLOCKED]");
+    expect(result?.message).toContain("awaiting");
+  });
+
+  it("blocks stop and shows the pending MCQ after content is set", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+      },
+      sessionId,
+    );
+
+    const result = await checkMergeReadiness(sessionId, tempDir, false);
+
+    expect(result?.shouldBlock).toBe(true);
+    expect(result?.message).toContain("[MERGE READINESS BLOCKED]");
+    expect(result?.message).toContain("[why]");
+    expect(result?.message).toContain("(1/3)");
+  });
+
+  it("releases stop after the gate passes", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(
+      tempDir,
+      {
+        why: "Why",
+        whatChanged: "What",
+        tradeoffs: "Tradeoff",
+        risksConsidered: "Risk",
+        teamUnderstanding: "Team",
+        questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+      },
+      sessionId,
+    );
+
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "a", sessionId);
+
+    const result = await checkMergeReadiness(sessionId, tempDir, false);
+    expect(result).toBeNull();
+  });
+
+  it("keeps invalid content recoverable and does not arm a dead-end quiz", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    const state = setMergeReadinessContent(tempDir, {
+      why: "", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why")],
+    }, sessionId);
+    expect(state?.awaiting_content).toBe(true);
+    expect(state?.pending_question).toBeUndefined();
+    expect(state?.validation_errors?.join(" ")).toContain("Narrative section 'why'");
+  });
+
+  it("keeps correct-option metadata only in the authoritative state before completion", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    const state = setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    expect(state?.result).toBe("pending");
+    expect(state?.answers).toEqual([]);
+  });
+
+  it("requires an offered option and the active question before recording an answer", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "not-an-option", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.answers).toEqual([]);
+  });
+
+  it("releases the soft gate only through a reasoned override", async () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    expect(overrideMergeReadiness(tempDir, "", sessionId)?.result).toBe("pending");
+    expect(overrideMergeReadiness(tempDir, "Maintainer accepts the documented gap.", sessionId)?.result).toBe("overridden");
+    expect(await checkMergeReadiness(sessionId, tempDir, false)).toBeNull();
+  });
+
+  it("rejects ambiguous AskUserQuestion output instead of guessing an answer", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick docs gate", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "Why", whatChanged: "What", tradeoffs: "Tradeoff", risksConsidered: "Risk", teamUnderstanding: "Team",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    recordMergeReadinessAskUserQuestionResult(tempDir, { question: "[MERGE READINESS:q1] choose" }, "selected [a] or [b]", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.answers).toEqual([]);
+  });
+});

--- a/src/hooks/merge-readiness/__tests__/runtime.test.ts
+++ b/src/hooks/merge-readiness/__tests__/runtime.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkMergeReadiness,
   cancelMergeReadiness,
@@ -14,6 +14,26 @@ import {
   setMergeReadinessContent,
 } from "../index.js";
 import type { MergeReadinessMCQQuestion } from "../mcq.js";
+
+// Forces writeModeState to return false (read-only FS / full-disk analog) so
+// persistOrFailClosed's fail-closed path is exercised without throwing. Other
+// tests are unaffected while failWrites stays false.
+const persistFail = vi.hoisted(() => ({ failWrites: false }));
+vi.mock("../../../lib/mode-state-io.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../lib/mode-state-io.js")>();
+  return {
+    ...actual,
+    writeModeState: (
+      mode: string,
+      state: Record<string, unknown>,
+      directory?: string,
+      sessionId?: string,
+    ) => {
+      if (persistFail.failWrites) return false;
+      return actual.writeModeState(mode, state, directory, sessionId);
+    },
+  };
+});
 
 function makeQuestion(
   id: string,
@@ -340,6 +360,32 @@ describe("merge-readiness runtime", () => {
     expect(() => cancelMergeReadiness(tempDir, "bad/session")).toThrow();
     // The valid gate is untouched: still a real pass under the good session.
     expect(readMergeReadinessState(tempDir, sessionId)?.result).toBe("pass");
+  });
+
+  it("fails closed without recursing when a mutator's write cannot land (read-only FS / full disk)", () => {
+    // Seed an active, non-blocked gate under a valid session: real writes succeed
+    // and reads still resolve the on-disk state, so the mutator reaches
+    // persistOrFailClosed rather than failing earlier on the read path.
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    // The next write fails the way writeModeState fails on a read-only FS / full
+    // disk: it returns false (does not throw). Previously persistOrFailClosed
+    // recursed with identical args here and overflowed the stack (RangeError),
+    // also appending a duplicate error per frame.
+    persistFail.failWrites = true;
+    try {
+      const state = overrideMergeReadiness(tempDir, "Maintainer override.", sessionId);
+      expect(state?.result).toBe("blocked");
+      expect(state?.active).toBe(true);
+      expect(state?.validation_errors?.some((e) => e.includes("persisted"))).toBe(true);
+      // The fail-closed error must appear exactly once - no unbounded recursion.
+      expect(state?.validation_errors?.filter((e) => e.includes("persisted"))).toHaveLength(1);
+    } finally {
+      persistFail.failWrites = false;
+    }
   });
 
   it("blocked gate message directs to evidence, not content submission", async () => {

--- a/src/hooks/merge-readiness/__tests__/runtime.test.ts
+++ b/src/hooks/merge-readiness/__tests__/runtime.test.ts
@@ -650,6 +650,33 @@ describe("merge-readiness runtime", () => {
     }
   });
 
+  it("scans later artifact roots after an earlier root fills its per-directory cap", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-perroot-cap-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree (no diff). plans/ has 45 unrelated files - more than the
+      // 40-per-root cap. specs/ has one valid test-evidence file. Previously the
+      // global 40-file cap was exhausted by plans/ and specs/ was never scanned,
+      // so --from-artifacts blocked despite valid evidence in a later root.
+      mkdirSync(join(dir, ".omc", "plans"), { recursive: true });
+      for (let i = 0; i < 45; i++) {
+        writeFileSync(join(dir, ".omc", "plans", `plan-${i}.md`), `plan notes ${i}\n`);
+      }
+      mkdirSync(join(dir, ".omc", "specs"), { recursive: true });
+      writeFileSync(join(dir, ".omc", "specs", "design.md"), "spec for the change\n");
+      const state = createInitialMergeReadinessState(dir, "/merge-readiness --from-artifacts change", sessionId);
+      expect(state.evidence.sourceArtifacts).toContain("specs/design.md");
+      expect(state.result).toBe("pending");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("counts an active ralph mode-state file as evidence", () => {
     const dir = mkdtempSync(join(tmpdir(), "omc-mr-ralph-state-"));
     try {

--- a/src/hooks/merge-readiness/__tests__/runtime.test.ts
+++ b/src/hooks/merge-readiness/__tests__/runtime.test.ts
@@ -257,11 +257,89 @@ describe("merge-readiness runtime", () => {
     expect(state.prior_attempts?.[0].result).toBe("paused");
   });
 
+  it("preserves a full prior-attempt audit record with questions, answers, and scores", () => {
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [
+        makeQuestion("q1", "why", "a"),
+        makeQuestion("q2", "change", "a"),
+        makeQuestion("q3", "risk", "a"),
+      ],
+    }, sessionId);
+    // Answer all wrong -> 0/3 = 0 < quick threshold 0.70 -> paused.
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "b", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.result).toBe("paused");
+
+    // First re-start: the prior paused attempt is captured in full.
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick retry", sessionId);
+    expect(state.prior_attempts?.length).toBe(1);
+    const prior = state.prior_attempts?.[0];
+    expect(prior).toBeDefined();
+    expect(prior?.result).toBe("paused");
+    expect(prior?.readiness_score).toBe(0);
+    // Full questions retained with correctOptionId (terminal, safe to reveal).
+    expect(prior?.questions).toHaveLength(3);
+    expect(prior?.questions.every((q) => typeof q.correctOptionId === "string")).toBe(true);
+    // Full answers retained with isCorrect=false (all wrong).
+    expect(prior?.answers).toHaveLength(3);
+    expect(prior?.answers.every((a) => a.isCorrect === false)).toBe(true);
+    // Dimension scores captured.
+    expect(prior?.dimension_scores).toBeDefined();
+    expect(Object.keys(prior?.dimension_scores ?? {}).length).toBeGreaterThan(0);
+    // Evidence summary captured.
+    expect(prior?.evidence_summary.sourceArtifactCount).toBeDefined();
+    expect(prior?.evidence_summary.testEvidenceCount).toBeDefined();
+
+    // Take the first re-start's gate to a terminal result so a second re-start
+    // can append (a pending gate is not captured as a prior attempt).
+    setMergeReadinessContent(tempDir, {
+      why: "w2", whatChanged: "wc2", tradeoffs: "t2", risksConsidered: "r2", teamUnderstanding: "tu2",
+      questions: [
+        makeQuestion("q1", "why", "a"),
+        makeQuestion("q2", "change", "a"),
+        makeQuestion("q3", "risk", "a"),
+      ],
+    }, sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "b", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "b", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.result).toBe("paused");
+
+    // Second re-start appends a second prior attempt (does not overwrite).
+    const state2 = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick retry2", sessionId);
+    expect(state2.prior_attempts?.length).toBe(2);
+  });
+
   it("fails closed when state cannot be persisted (invalid session id)", () => {
     // tempDir has a diff, so without the persistence failure this would be pending.
     const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", "bad/session");
     expect(state.result).toBe("blocked");
     expect(state.validation_errors?.some((e) => e.includes("persisted"))).toBe(true);
+  });
+
+  it("mutators never surface a phantom pass/override when the write cannot land", () => {
+    // Seed a valid, active, passing gate under a good session.
+    createInitialMergeReadinessState(tempDir, "/merge-readiness --quick change", sessionId);
+    setMergeReadinessContent(tempDir, {
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [makeQuestion("q1", "why"), makeQuestion("q2", "change"), makeQuestion("q3", "risk")],
+    }, sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q1", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q2", "a", sessionId);
+    recordMergeReadinessMCQAnswer(tempDir, "q3", "a", sessionId);
+    expect(readMergeReadinessState(tempDir, sessionId)?.result).toBe("pass");
+
+    // With an invalid session id, the mutator's read path throws (validateSessionId
+    // rejects path separators). The contract: the mutator must NOT return a
+    // phantom active=false/overridden/pass result when the write cannot land.
+    // It throws rather than silently producing a phantom release.
+    expect(() => overrideMergeReadiness(tempDir, "Maintainer override.", "bad/session")).toThrow();
+    expect(() => cancelMergeReadiness(tempDir, "bad/session")).toThrow();
+    // The valid gate is untouched: still a real pass under the good session.
+    expect(readMergeReadinessState(tempDir, sessionId)?.result).toBe("pass");
   });
 
   it("blocked gate message directs to evidence, not content submission", async () => {
@@ -504,5 +582,76 @@ describe("merge-readiness runtime", () => {
     }, sessionId);
     recordMergeReadinessAskUserQuestionResult(tempDir, { question: "[MERGE READINESS:q1] choose" }, "selected [a] or [b]", sessionId);
     expect(readMergeReadinessState(tempDir, sessionId)?.answers).toEqual([]);
+  });
+
+  it("does not start the gate on an unrelated artifact in --from-artifacts mode", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-artifacts-unrelated-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree (no diff) + an unrelated plans file under --from-artifacts:
+      // must block, since the artifact is neither a test nor a review artifact.
+      mkdirSync(join(dir, ".omc", "plans"), { recursive: true });
+      writeFileSync(join(dir, ".omc", "plans", "unrelated.md"), "notes\n");
+      const state = createInitialMergeReadinessState(dir, "/merge-readiness --from-artifacts change", sessionId);
+      expect(state.result).toBe("blocked");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("counts an active ralph mode-state file as evidence", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-ralph-state-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree, but an active ralph mode-state file records a real run.
+      mkdirSync(join(dir, ".omc", "state"), { recursive: true });
+      writeFileSync(
+        join(dir, ".omc", "state", "ralph-state.json"),
+        JSON.stringify({ active: true, iteration: 3, started_at: "2026-01-01T00:00:00.000Z", phase: "execute" }),
+      );
+      const state = createInitialMergeReadinessState(dir, "/merge-readiness --standard change", sessionId);
+      expect(state.evidence.sourceArtifacts).toContain("state/ralph-state.json");
+      expect(state.result).toBe("pending");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not count a stale/empty mode-state stub as evidence", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omc-mr-stale-state-"));
+    try {
+      execFileSync("git", ["init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      writeFileSync(join(dir, "README.md"), "x\n");
+      execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore", windowsHide: true });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore", windowsHide: true });
+      // Clean tree + a stale ralph-state stub (active:false, phase:init) and a
+      // bookkeeping ralph-stop-breaker.json: neither records a real run.
+      mkdirSync(join(dir, ".omc", "state"), { recursive: true });
+      writeFileSync(
+        join(dir, ".omc", "state", "ralph-state.json"),
+        JSON.stringify({ active: false, phase: "init" }),
+      );
+      writeFileSync(
+        join(dir, ".omc", "state", "ralph-stop-breaker.json"),
+        JSON.stringify({ active: true, iteration: 5 }),
+      );
+      const state = createInitialMergeReadinessState(dir, "/merge-readiness --standard change", sessionId);
+      expect(state.evidence.sourceArtifacts).toEqual([]);
+      expect(state.result).toBe("blocked");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/hooks/merge-readiness/__tests__/tool-flow.test.ts
+++ b/src/hooks/merge-readiness/__tests__/tool-flow.test.ts
@@ -190,6 +190,44 @@ describe("merge-readiness standalone tool flow", () => {
     expect(readMergeReadinessState(tempDir, session)?.result).toBe("paused");
   });
 
+  it("refuses to submit content on a terminal (pass) gate instead of false-accepting", async () => {
+    const start = findTool("merge_readiness_start");
+    const setContent = findTool("merge_readiness_set_content");
+    const recordAnswer = findTool("merge_readiness_record_answer");
+    const session = "terminal-session";
+
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: session });
+    const questions = [
+      { id: "q1", dimension: "why", stem: "why?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q2", dimension: "change", stem: "change?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q3", dimension: "risk", stem: "risk?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+    ];
+    await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions, workingDirectory: tempDir, session_id: session,
+    });
+    for (const q of questions) {
+      await recordAnswer.handler({ questionId: q.id, optionId: "a", workingDirectory: tempDir, session_id: session });
+    }
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("pass");
+    expect(readMergeReadinessState(tempDir, session)?.active).toBe(false);
+
+    // Gate is terminal (pass, active=false). setMergeReadinessContent returns the
+    // inactive state (non-null), so the handler MUST check state.active - not
+    // just null - or it false-accepts and arms a dead-end quiz on a resumed/
+    // passed session.
+    const resubmit = await setContent.handler({
+      why: "w2", whatChanged: "wc2", tradeoffs: "t2", risksConsidered: "r2", teamUnderstanding: "tu2",
+      questions, workingDirectory: tempDir, session_id: session,
+    });
+    expect(resubmit.isError).toBe(true);
+    expect(textOf(resubmit)).toContain("no active gate");
+    expect(textOf(resubmit)).not.toContain("accepted");
+    // The terminal pass state is untouched (no new quiz armed).
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("pass");
+    expect(readMergeReadinessState(tempDir, session)?.active).toBe(false);
+  });
+
   it("state_clear without session_id only cancels the caller's session", async () => {
     const start = findTool("merge_readiness_start");
     const clear = findTool("state_clear");

--- a/src/hooks/merge-readiness/__tests__/tool-flow.test.ts
+++ b/src/hooks/merge-readiness/__tests__/tool-flow.test.ts
@@ -1,0 +1,213 @@
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stateTools } from "../../../tools/state-tools.js";
+import { readMergeReadinessState, writeMergeReadinessState } from "../runtime.js";
+
+function findTool(name: string): any {
+  const tool = stateTools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool ${name} not found`);
+  return tool;
+}
+function textOf(res: any): string {
+  return (res.content?.[0]?.text ?? "") as string;
+}
+
+describe("merge-readiness standalone tool flow", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "omc-mr-tools-"));
+    execFileSync("git", ["init"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["config", "user.name", "T"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "before\n");
+    execFileSync("git", ["add", "."], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: tempDir, stdio: "ignore", windowsHide: true });
+    writeFileSync(join(tempDir, "README.md"), "after\n");
+    // validateWorkingDirectory trusts process.cwd()'s git root, so chdir into
+    // tempDir so the tools operate on tempDir's git evidence (not the repo CWD,
+    // which is a clean checkout on CI and would yield "blocked").
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    if (originalCwd) process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("start -> set_content -> record_answer reaches pass", async () => {
+    const start = findTool("merge_readiness_start");
+    const setContent = findTool("merge_readiness_set_content");
+    const recordAnswer = findTool("merge_readiness_record_answer");
+    const report = findTool("merge_readiness_report");
+    const stateRead = findTool("state_read");
+    const session = "flow-session";
+
+    const startRes = await start.handler({ summary: "/merge-readiness --quick fix a bug", workingDirectory: tempDir, session_id: session });
+    expect(startRes.isError).toBeFalsy();
+    expect(textOf(startRes)).toContain("started");
+
+    const questions = [
+      { id: "q1", dimension: "why", stem: "why?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a", rationale: "private rationale" },
+      { id: "q2", dimension: "change", stem: "change?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q3", dimension: "risk", stem: "risk?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+    ];
+    const contentRes = await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions, workingDirectory: tempDir, session_id: session,
+    });
+    expect(contentRes.isError).toBeFalsy();
+    expect(textOf(contentRes)).toContain("accepted");
+    const pendingReport = await report.handler({ workingDirectory: tempDir, session_id: session });
+    expect(textOf(pendingReport)).toContain("# Merge Readiness Report");
+    expect(textOf(pendingReport)).toContain("## Why");
+    expect(textOf(pendingReport)).toContain("## Merge Boundary");
+    expect(textOf(pendingReport)).not.toContain("_(correct");
+    expect(textOf(pendingReport)).toContain("hidden until completion");
+
+    const firstAnswer = await recordAnswer.handler({ questionId: "q1", optionId: "a", workingDirectory: tempDir, session_id: session });
+    expect(textOf(firstAnswer)).toContain("Answer recorded");
+    const internalState = readMergeReadinessState(tempDir, session)!;
+    internalState.rounds = [{
+      round: 1,
+      dimension: "why",
+      question: "legacy question",
+      answer: "legacy answer",
+      score: 1,
+      created_at: new Date().toISOString(),
+    }];
+    writeMergeReadinessState(tempDir, internalState, session);
+    const pendingState = await stateRead.handler({ mode: "merge-readiness", workingDirectory: tempDir, session_id: session });
+    expect(textOf(pendingState)).not.toContain("correctOptionId");
+    expect(textOf(pendingState)).not.toContain("private rationale");
+    expect(textOf(pendingState)).not.toContain("isCorrect");
+    expect(textOf(pendingState)).not.toContain("readiness_score");
+    expect(textOf(pendingState)).not.toContain('"score"');
+
+    let last = "";
+    for (const q of questions.slice(1)) {
+      const res = await recordAnswer.handler({ questionId: q.id, optionId: "a", workingDirectory: tempDir, session_id: session });
+      last = textOf(res);
+    }
+    expect(last).toContain("pass");
+    const finalReport = await report.handler({ workingDirectory: tempDir, session_id: session });
+    expect(textOf(finalReport)).toContain("Result: pass");
+    expect(textOf(finalReport)).toContain("_(correct, selected)");
+    const finalState = await stateRead.handler({ mode: "merge-readiness", workingDirectory: tempDir, session_id: session });
+    expect(textOf(finalState)).toContain("correctOptionId");
+    expect(textOf(finalState)).toContain("private rationale");
+  });
+
+  it("set_content without start errors instead of silently succeeding", async () => {
+    const setContent = findTool("merge_readiness_set_content");
+    const res = await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [], workingDirectory: tempDir, session_id: "no-start-session",
+    });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain("no active gate");
+  });
+
+  it("exposes cancellation and state_clear as durable audit-preserving operations", async () => {
+    const start = findTool("merge_readiness_start");
+    const cancel = findTool("merge_readiness_cancel");
+    const clear = findTool("state_clear");
+    const session = "cancel-session";
+
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: session });
+    const cancelResult = await cancel.handler({ workingDirectory: tempDir, session_id: session });
+    expect(textOf(cancelResult)).toContain("cancelled");
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("cancelled");
+
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: session });
+    const clearResult = await clear.handler({ mode: "merge-readiness", workingDirectory: tempDir, session_id: session });
+    expect(textOf(clearResult)).toContain("durable state audit records");
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("cancelled");
+    const repeatedClear = await clear.handler({ mode: "merge-readiness", workingDirectory: tempDir, session_id: session });
+    expect(textOf(repeatedClear)).toContain("No active merge-readiness gate found");
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("cancelled");
+  });
+
+  it("state_get_status does not leak correctOptionId/rationale while pending", async () => {
+    const start = findTool("merge_readiness_start");
+    const setContent = findTool("merge_readiness_set_content");
+    const getStatus = findTool("state_get_status");
+    const session = "leak-session";
+
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: session });
+    await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions: [
+        { id: "q1", dimension: "why", stem: "why?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a", rationale: "private rationale" },
+        { id: "q2", dimension: "change", stem: "change?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+        { id: "q3", dimension: "risk", stem: "risk?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      ],
+      workingDirectory: tempDir, session_id: session,
+    });
+
+    const status = await getStatus.handler({ mode: "merge-readiness", workingDirectory: tempDir, session_id: session });
+    const preview = textOf(status);
+    expect(preview).not.toContain("correctOptionId");
+    expect(preview).not.toContain("private rationale");
+    expect(preview).not.toContain("readiness_score");
+  });
+
+  it("refuses to re-submit content on a paused (failed-quiz) gate, preserving the audit record", async () => {
+    const start = findTool("merge_readiness_start");
+    const setContent = findTool("merge_readiness_set_content");
+    const recordAnswer = findTool("merge_readiness_record_answer");
+    const session = "paused-session";
+
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: session });
+    const questions = [
+      { id: "q1", dimension: "why", stem: "why?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q2", dimension: "change", stem: "change?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+      { id: "q3", dimension: "risk", stem: "risk?", options: [{ id: "a", text: "correct" }, { id: "b", text: "wrong" }], correctOptionId: "a" },
+    ];
+    await setContent.handler({
+      why: "w", whatChanged: "wc", tradeoffs: "t", risksConsidered: "r", teamUnderstanding: "tu",
+      questions, workingDirectory: tempDir, session_id: session,
+    });
+    // Answer all wrong -> 0/3 = 0 < quick threshold 0.70 -> paused.
+    for (const q of questions) {
+      await recordAnswer.handler({ questionId: q.id, optionId: "b", workingDirectory: tempDir, session_id: session });
+    }
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("paused");
+
+    // Re-submitting content on a paused gate must be refused: no fresh quiz
+    // without re-collecting evidence, and the failed attempt is preserved.
+    const resubmit = await setContent.handler({
+      why: "w2", whatChanged: "wc2", tradeoffs: "t2", risksConsidered: "r2", teamUnderstanding: "tu2",
+      questions, workingDirectory: tempDir, session_id: session,
+    });
+    expect(resubmit.isError).toBe(true);
+    expect(textOf(resubmit)).toContain("Paused");
+    expect(readMergeReadinessState(tempDir, session)?.result).toBe("paused");
+  });
+
+  it("state_clear without session_id only cancels the caller's session", async () => {
+    const start = findTool("merge_readiness_start");
+    const clear = findTool("state_clear");
+    // Start active gates in two distinct sessions.
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: "sess-A" });
+    await start.handler({ summary: "/merge-readiness --quick change", workingDirectory: tempDir, session_id: "sess-B" });
+    expect(readMergeReadinessState(tempDir, "sess-A")?.active).toBe(true);
+    expect(readMergeReadinessState(tempDir, "sess-B")?.active).toBe(true);
+    // Clear with no session_id, caller resolved from env = sess-A.
+    const prevSid = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = "sess-A";
+    try {
+      await clear.handler({ mode: "merge-readiness", workingDirectory: tempDir });
+    } finally {
+      if (prevSid === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = prevSid;
+    }
+    // sess-A cancelled, sess-B untouched (no cross-session clear).
+    expect(readMergeReadinessState(tempDir, "sess-A")?.result).toBe("cancelled");
+    expect(readMergeReadinessState(tempDir, "sess-B")?.active).toBe(true);
+  });
+});

--- a/src/hooks/merge-readiness/__tests__/win-cross-platform.test.ts
+++ b/src/hooks/merge-readiness/__tests__/win-cross-platform.test.ts
@@ -1,0 +1,185 @@
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { basename, isAbsolute, join, sep } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  collectMergeReadinessEvidence,
+  createInitialMergeReadinessState,
+  readMergeReadinessState,
+  slugifyMergeReadiness,
+} from "../index.js";
+import {
+  getOmcRoot,
+  resolveSessionStatePath,
+  resolveToWorktreeRoot,
+  validateSessionId,
+} from "../../../lib/worktree-paths.js";
+
+const isWin32 = process.platform === "win32";
+const BS = String.fromCharCode(92); // backslash, shell-safe
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: "ignore", windowsHide: true });
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-mr-win-"));
+  git(["init"], dir);
+  git(["config", "user.email", "t@e.com"], dir);
+  git(["config", "user.name", "T"], dir);
+  writeFileSync(join(dir, "README.md"), "before\n");
+  git(["add", "."], dir);
+  git(["commit", "-m", "init"], dir);
+  writeFileSync(join(dir, "README.md"), "after\n");
+  return dir;
+}
+
+describe("merge-readiness Windows cross-platform contract", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeRepo();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("resolves .omc root with the platform-native separator under a worktree", () => {
+    const omcRoot = getOmcRoot(tempDir);
+    expect(isAbsolute(omcRoot)).toBe(true);
+    // .omc root terminates with the native separator + ".omc" (backslash on win32,
+    // forward slash on POSIX) - proves path.join builds the path, not string concat.
+    expect(omcRoot.endsWith(sep + ".omc")).toBe(true);
+    // Worktree root prefix preserved verbatim (no accidental drive-letter drop on win32).
+    expect(omcRoot.startsWith(tempDir)).toBe(true);
+  });
+
+  it("constructs the session-scoped state path with native separators and validates the id", () => {
+    const sessionId = "win-session-123";
+    const statePath = resolveSessionStatePath("merge-readiness", sessionId, tempDir);
+    expect(statePath.includes(join("state", "sessions", sessionId))).toBe(true);
+    expect(statePath.endsWith(join(sessionId, "merge-readiness-state.json"))).toBe(true);
+    expect(statePath.includes(sep)).toBe(true);
+
+    // Path-traversal rejection is platform-agnostic: backslash OR forward-slash OR ".."
+    // must throw regardless of host OS (prevents .omc/state/sessions/../x writes).
+    expect(() => validateSessionId("bad/session")).toThrow();
+    expect(() => validateSessionId("bad" + sep + "session")).toThrow();
+    expect(() => validateSessionId("..escape")).toThrow();
+    expect(() => validateSessionId("ok_session-1")).not.toThrow();
+  });
+
+  it("resolves the worktree root from a subdirectory (not a subdirectory itself)", () => {
+    const sub = join(tempDir, "nested", "deep");
+    mkdirSync(sub, { recursive: true });
+    const root = resolveToWorktreeRoot(sub);
+    // Must climb to the git worktree root, never the nested subdir - prevents .omc
+    // from being created in a subdirectory on Windows drives (#576).
+    // On win32, git rev-parse --show-toplevel emits forward slashes AND expands 8.3
+    // short names (ADMINI~1 -> Administrator), while mkdtempSync keeps the short form.
+    // So string equality fails even for the same physical dir. Prove identity by:
+    // (a) both share the mkdtemp random basename (final path segment),
+    // (b) both share the same drive letter prefix on win32.
+    const rootBase = basename(root);
+    const tempBase = basename(tempDir);
+    expect(rootBase).toBe(tempBase);
+    if (isWin32) {
+      expect(root.charAt(1)).toBe(":"); // drive letter preserved
+      // Case-insensitive drive+path prefix match (Administrator vs ADMINI~1 short name).
+      const norm = (x: string) => x.toLowerCase().split("\\").join("/");
+      expect(norm(root).endsWith(norm(tempDir).split("/").slice(-2).join("/"))).toBe(true);
+    }
+    if (isWin32) {
+      // Drive-letter or UNC prefix must survive the climb on win32.
+      expect(/^[A-Za-z]:[\\/]/.test(root) || root.startsWith("\\\\")).toBe(true);
+    }
+  });
+
+  it("collects git evidence on the native platform (git exec resolves on win32)", () => {
+    // Concrete native-Windows evidence: execFileSync("git", ...) resolves git.exe
+    // through the OS PATH on win32 and returns the working-tree diff.
+    const evidence = collectMergeReadinessEvidence(tempDir);
+    expect(evidence.changedFiles).toContain("README.md");
+    // git emits forward-slash relative paths even on win32; no backslash leakage.
+    for (const f of evidence.changedFiles) {
+      expect(f.indexOf(BS)).toBe(-1);
+    }
+    // A fresh local repo has no upstream/remote, so git rev-parse @{upstream} and
+    // symbolic-ref refs/remotes/origin/HEAD legitimately exit 128 - the runtime must
+    // capture these as graceful missingEvidence strings, NOT crash. The core diff
+    // commands (diff/status/ls-files) succeed and populate changedFiles.
+    const gitGracefulFailures = evidence.missingEvidence.filter((m) => /git \w+ failed\s\(\(\d\)\)/i.test(m));
+    // The failures are surfaced as strings (not thrown), proving graceful capture on win32.
+    for (const f of gitGracefulFailures) {
+      expect(typeof f === "string" && f.includes("failed")).toBe(true);
+    }
+    // The healthy diff command(s) still succeeded - changedFiles is populated.
+    expect(evidence.changedFiles.length).toBeGreaterThan(0);
+  });
+
+  it("normalizes backslash artifact paths to forward slashes on win32 (listArtifactFiles contract)", () => {
+    mkdirSync(join(tempDir, ".omc", "specs"), { recursive: true });
+    writeFileSync(join(tempDir, ".omc", "specs", "design.md"), "spec for the change\n");
+    // Plant a merge-readiness artifact that must be EXCLUDED from source evidence.
+    mkdirSync(join(tempDir, ".omc", "artifacts", "merge-readiness"), { recursive: true });
+    writeFileSync(join(tempDir, ".omc", "artifacts", "merge-readiness", "self.md"), "self\n");
+
+    const evidence = collectMergeReadinessEvidence(tempDir);
+    expect(evidence.sourceArtifacts).toContain("specs/design.md");
+    // No backslashes survive into the persisted artifact list on win32.
+    expect(evidence.sourceArtifacts.every((f) => f.indexOf(BS) === -1)).toBe(true);
+    // Merge-readiness own artifacts are excluded (no self-reference in evidence).
+    expect(evidence.sourceArtifacts.every((f) => !f.includes("merge-readiness"))).toBe(true);
+    expect(evidence.testEvidence).toContain("specs/design.md");
+  });
+
+  it("persists session-scoped state readable via the same resolver (short-name tmpdir on win32)", () => {
+    // On win32, os.tmpdir() often returns an 8.3 short-name path (ADMINI~1). State
+    // written through that tempDir must read back through the same resolver, proving
+    // the path round-trips even when the drive prefix is a short name.
+    if (isWin32 && tmpdir().indexOf("~1") === -1) {
+      console.warn("[win-cross-platform] tmpdir is long-form; short-name round-trip not exercised on this host");
+    }
+    const sessionId = "win-persist-session";
+    const state = createInitialMergeReadinessState(tempDir, "/merge-readiness --standard win change", sessionId);
+    expect(state.result).toBe("pending");
+
+    const statePath = resolveSessionStatePath("merge-readiness", sessionId, tempDir);
+    expect(existsSync(statePath)).toBe(true);
+    const persisted = readMergeReadinessState(tempDir, sessionId);
+    expect(persisted?.session_id).toBe(sessionId);
+    expect(persisted?.evidence.changedFiles).toEqual(state.evidence.changedFiles);
+
+    const raw = JSON.parse(readFileSync(statePath, "utf-8")) as Record<string, unknown>;
+    expect(raw.session_id).toBe(sessionId);
+  });
+
+  it("slugifies change summaries identically across platforms (no separator leakage)", () => {
+    // slugifyMergeReadiness strips everything outside [a-z0-9], so drive letters /
+    // backslashes never leak into the slug on win32.
+    expect(slugifyMergeReadiness("Fix auth on Windows: D:\\path issue")).toBe("fix-auth-on-windows-d-path-issue");
+    expect(slugifyMergeReadiness("")).toBe("change");
+    expect(slugifyMergeReadiness("   ")).toBe("change");
+    const long = "a".repeat(120);
+    expect(slugifyMergeReadiness(long).length).toBe(48);
+    // CJK collapses to hyphens (non-[a-z0-9] stripped), trimmed; result stays in [a-z0-9-].
+    expect(slugifyMergeReadiness("修复 认证 问题")).toMatch(/^[a-z0-9-]*$/);
+  });
+
+  it("invokes git.exe successfully on win32 (no ETIMEDOUT / no exec spawn failure)", () => {
+    // Native-Windows evidence: execFileSync("git", args, {windowsHide:true})
+    // resolves git.exe from PATH on win32 and returns structured output. The proof
+    // is that collectMergeReadinessEvidence completes (no throw) and produces git
+    // stdout (changedFiles populated) rather than an ENOENT/ETIMEDOUT surface error.
+    const evidence = collectMergeReadinessEvidence(tempDir);
+    // No "timed out" entry => git exec did not hang on win32.
+    expect(evidence.missingEvidence.some((m) => /timed out/i.test(m))).toBe(false);
+    // No "git <cmd> failed (exit ?)" with an unknown exit (spawn/ENOENT) => git resolved.
+    const spawnFailures = evidence.missingEvidence.filter((m) => /failed \(exit \?\)\)/i.test(m) && !/\d\)/.test(m));
+    expect(spawnFailures).toEqual([]);
+    // The diff command ran: changedFiles is populated from git diff --name-only HEAD.
+    expect(evidence.changedFiles).toContain("README.md");
+  });
+});

--- a/src/hooks/merge-readiness/index.ts
+++ b/src/hooks/merge-readiness/index.ts
@@ -1,0 +1,3 @@
+export * from "./report.js";
+export * from "./runtime.js";
+export * from "./types.js";

--- a/src/hooks/merge-readiness/mcq.ts
+++ b/src/hooks/merge-readiness/mcq.ts
@@ -1,0 +1,134 @@
+/**
+ * Merge Readiness MCQ module.
+ *
+ * Objective multiple-choice scoring for the post-task explainability gate.
+ * The runtime uses these pure helpers to judge human answers without semantic
+ * guessing: an MCQ has exactly one correct option, and code checks equality.
+ *
+ * Depth profiles (v1, unified with skills/merge-readiness/SKILL.md):
+ *   quick    -> threshold 0.70, max 3 MCQs, dims: why/change/risk
+ *   standard -> threshold 0.80, max 5 MCQs, dims: why/change/tradeoff/risk/team
+ *   deep     -> threshold 0.90, max 8 MCQs (redundancy across dims)
+ *
+ * "max rounds" == total MCQs presented. The AI distributes MCQs across the
+ * required dimensions (with redundancy for deep) up to that count.
+ */
+
+export type MergeReadinessDimension =
+  | "why"
+  | "change"
+  | "tradeoff"
+  | "risk"
+  | "team";
+
+export type MergeReadinessProfile = "quick" | "standard" | "deep";
+
+export const MERGE_READINESS_DIMENSIONS: readonly MergeReadinessDimension[] = [
+  "why",
+  "change",
+  "tradeoff",
+  "risk",
+  "team",
+] as const;
+
+/**
+ * Readiness thresholds per depth profile, expressed as a required correctness
+ * rate over the answered MCQs.
+ */
+export const MERGE_READINESS_THRESHOLDS: Readonly<
+  Record<MergeReadinessProfile, number>
+> = {
+  quick: 0.7,
+  standard: 0.8,
+  deep: 0.9,
+};
+
+/** Total MCQs presented per profile (the "max rounds" cap). */
+export const MERGE_READINESS_MAX_ROUNDS: Readonly<
+  Record<MergeReadinessProfile, number>
+> = {
+  quick: 3,
+  standard: 5,
+  deep: 8,
+};
+
+export interface MergeReadinessMCQOption {
+  id: string;
+  text: string;
+}
+
+export interface MergeReadinessMCQQuestion {
+  id: string;
+  dimension: MergeReadinessDimension;
+  stem: string;
+  options: MergeReadinessMCQOption[];
+  /** Option id that is objectively correct. */
+  correctOptionId: string;
+  /** Why the correct option is right / what understanding it verifies. */
+  rationale?: string;
+}
+
+export interface MergeReadinessMCQAnswer {
+  questionId: string;
+  selectedOptionId: string;
+  isCorrect: boolean;
+  answeredAt?: string;
+}
+
+export function profileThreshold(profile: MergeReadinessProfile): number {
+  return MERGE_READINESS_THRESHOLDS[profile] ?? MERGE_READINESS_THRESHOLDS.standard;
+}
+
+export function profileMaxRounds(profile: MergeReadinessProfile): number {
+  return MERGE_READINESS_MAX_ROUNDS[profile] ?? MERGE_READINESS_MAX_ROUNDS.standard;
+}
+
+/**
+ * Dimensions that must be covered before the gate can pass.
+ * Quick is a lighter gate (why/change/risk); standard and deep cover all five.
+ */
+export function requiredDimensionsForProfile(
+  profile: MergeReadinessProfile,
+): MergeReadinessDimension[] {
+  if (profile === "quick") return ["why", "change", "risk"];
+  return [...MERGE_READINESS_DIMENSIONS];
+}
+
+/** Objective check: does the selected option match the correct one? */
+export function scoreMCQResponse(
+  question: MergeReadinessMCQQuestion,
+  selectedOptionId: string,
+): boolean {
+  return selectedOptionId === question.correctOptionId;
+}
+
+/** Correctness rate over answered MCQs, in [0, 1]. Empty -> 0. */
+export function computeCorrectnessRate(
+  answers: MergeReadinessMCQAnswer[],
+): number {
+  if (answers.length === 0) return 0;
+  const correct = answers.filter((a) => a.isCorrect).length;
+  return correct / answers.length;
+}
+
+export function isCorrectnessPass(rate: number, threshold: number): boolean {
+  return rate >= threshold;
+}
+
+/**
+ * Whether every required dimension has at least one answered MCQ.
+ * The gate does not pass until required coverage exists, even if the rate
+ * is high, so a human cannot skip a dimension they cannot explain.
+ */
+export function hasRequiredDimensionCoverage(
+  answers: MergeReadinessMCQAnswer[],
+  questions: MergeReadinessMCQQuestion[],
+  requiredDimensions: MergeReadinessDimension[],
+): boolean {
+  const answeredDimensions = new Set(
+    answers
+      .map((answer) => questions.find((q) => q.id === answer.questionId)?.dimension)
+      .filter((d): d is MergeReadinessDimension => Boolean(d)),
+  );
+  return requiredDimensions.every((dimension) => answeredDimensions.has(dimension));
+}

--- a/src/hooks/merge-readiness/report.ts
+++ b/src/hooks/merge-readiness/report.ts
@@ -1,4 +1,4 @@
-import type { MergeReadinessMCQAnswer, MergeReadinessMCQQuestion, MergeReadinessState } from "./types.js";
+import type { MergeReadinessAttempt, MergeReadinessMCQAnswer, MergeReadinessMCQQuestion, MergeReadinessState } from "./types.js";
 
 const MERGE_BOUNDARY_STATEMENT =
   "Passing means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk.";
@@ -38,6 +38,66 @@ function renderQuestions(
 
 function renderList(values: string[], empty: string): string {
   return values.length > 0 ? values.map((value) => `- ${value}`).join("\n") : empty;
+}
+
+/**
+ * Render a prior (terminal) attempt. Prior attempts are terminal by
+ * construction, so revealing correctOptionId/isCorrect is safe (not a
+ * redaction leak) and gives the operator a complete audit of past tries.
+ */
+function renderPriorAttempt(attempt: MergeReadinessAttempt, index: number): string {
+  const header = [
+    `### Attempt ${index + 1}: ${attempt.result}`,
+    `- Profile: ${attempt.profile} | threshold ${Math.round(attempt.threshold * 100)}% | max rounds ${attempt.max_rounds}`,
+    `- Readiness score: ${Math.round(attempt.readiness_score * 100)}%`,
+    `- Change summary: ${attempt.change_summary || "_No change summary._"}`,
+    attempt.override_reason ? `- Override reason: ${attempt.override_reason}` : "",
+    attempt.started_at ? `- Started: ${attempt.started_at}` : "",
+    attempt.completed_at ? `- Completed: ${attempt.completed_at}` : "",
+  ].filter((line) => line.length > 0).join("\n");
+
+  const dimensions = attempt.required_dimensions.length > 0
+    ? attempt.required_dimensions
+      .map((dimension) => `- ${dimension}: ${Math.round((attempt.dimension_scores[dimension] ?? 0) * 100)}%`)
+      .join("\n")
+    : "_No required dimensions recorded._";
+
+  const qa = attempt.questions.length === 0
+    ? "_No quiz questions recorded._"
+    : attempt.questions.map((question, qIndex) => {
+      const answer = attempt.answers.find((a) => a.questionId === question.id);
+      const options = question.options.map((option) => {
+        const marks: string[] = [];
+        if (option.id === question.correctOptionId) marks.push("correct");
+        if (answer?.selectedOptionId === option.id) marks.push("selected");
+        return `- [${option.id}] ${option.text}${marks.length > 0 ? ` _(${marks.join(", ")})_` : ""}`;
+      });
+      const correctness = answer
+        ? `Correct: ${answer.isCorrect ? "yes" : "no"}`
+        : "_Not answered._";
+      return [
+        `#### Q${qIndex + 1}. [${question.dimension}] ${question.stem}`,
+        "",
+        ...options,
+        "",
+        correctness,
+      ].join("\n");
+    }).join("\n\n");
+
+  const evidence = attempt.evidence_summary;
+  const evidenceBlock = [
+    "#### Evidence Summary",
+    `- Changed files: ${evidence.changedFiles.length}`,
+    evidence.source_mode ? `- Source mode: ${evidence.source_mode}` : "",
+    `- Source artifacts: ${evidence.sourceArtifactCount}`,
+    `- Test artifacts: ${evidence.testEvidenceCount}`,
+    `- Review artifacts: ${evidence.reviewEvidenceCount}`,
+    evidence.missingEvidence.length > 0
+      ? `- Missing evidence:\n${evidence.missingEvidence.map((m) => `  - ${m}`).join("\n")}`
+      : "- Missing evidence: none",
+  ].filter((line) => line.length > 0).join("\n");
+
+  return [header, "", "#### Dimension Coverage", "", dimensions, "", "#### Questions & Answers", "", qa, "", evidenceBlock].join("\n");
 }
 
 /** Render the authoritative session state as a report without filesystem side effects. */
@@ -97,7 +157,7 @@ export function formatMergeReadinessReport(state: MergeReadinessState): string {
     "",
     "",
     state.prior_attempts && state.prior_attempts.length > 0
-      ? ["## Prior Attempts", "", ...state.prior_attempts.map((a, i) => "- Attempt " + (i + 1) + ": " + a.result + " (score " + Math.round((a.readiness_score ?? 0) * 100) + "%)" + (a.change_summary ? " - " + a.change_summary : ""))].join("\n")
+      ? ["## Prior Attempts", "", ...state.prior_attempts.map((a, i) => renderPriorAttempt(a, i))].join("\n")
       : "",
     "",
     "## Merge Boundary", "", MERGE_BOUNDARY_STATEMENT,

--- a/src/hooks/merge-readiness/report.ts
+++ b/src/hooks/merge-readiness/report.ts
@@ -1,0 +1,148 @@
+import type { MergeReadinessMCQAnswer, MergeReadinessMCQQuestion, MergeReadinessState } from "./types.js";
+
+const MERGE_BOUNDARY_STATEMENT =
+  "Passing means the human can explain the change. It does not approve merge, replace tests, replace review, or accept risk.";
+
+function renderQuestions(
+  questions: MergeReadinessMCQQuestion[],
+  answers: MergeReadinessMCQAnswer[],
+  result: MergeReadinessState["result"],
+): string {
+  if (questions.length === 0) return "_No quiz questions recorded yet._";
+  const answersByQuestion = new Map(answers.map((answer) => [answer.questionId, answer]));
+  const revealAll = result === "pass" || result === "paused";
+  const revealAnswered = result === "overridden" || result === "cancelled";
+
+  return questions.map((question, index) => {
+    const answer = answersByQuestion.get(question.id);
+    const options = question.options.map((option) => {
+      const marks: string[] = [];
+      if ((revealAll || (revealAnswered && answer)) && option.id === question.correctOptionId) marks.push("correct");
+      if (answer?.selectedOptionId === option.id) marks.push("selected");
+      return `- [${option.id}] ${option.text}${marks.length > 0 ? ` _(${marks.join(", ")})_` : ""}`;
+    });
+    const correctness = answer && (revealAll || revealAnswered)
+      ? `Correct: ${answer.isCorrect ? "yes" : "no"}`
+      : answer
+        ? "_Answered; correctness hidden until completion._"
+        : "_Not answered yet._";
+    return [
+      `### ${index + 1}. [${question.dimension}] ${question.stem}`,
+      "",
+      ...options,
+      "",
+      correctness,
+    ].join("\n");
+  }).join("\n\n");
+}
+
+function renderList(values: string[], empty: string): string {
+  return values.length > 0 ? values.map((value) => `- ${value}`).join("\n") : empty;
+}
+
+/** Render the authoritative session state as a report without filesystem side effects. */
+export function formatMergeReadinessReport(state: MergeReadinessState): string {
+  const revealAssessment = ["pass", "paused", "overridden", "cancelled"].includes(state.result);
+  const dimensions = revealAssessment
+    ? state.required_dimensions
+      .map((dimension) => `- ${dimension}: ${Math.round((state.dimension_scores[dimension] ?? 0) * 100)}%`)
+      .join("\n")
+    : "_Available after the attempt completes._";
+  const pending = state.pending_question
+    ? `- [${state.pending_question.dimension}] ${state.pending_question.stem}`
+    : "_No pending question._";
+
+  return [
+    "# Merge Readiness Report",
+    "",
+    "## Why", "", state.why || "_Not yet generated._",
+    "",
+    "## What Changed", "", state.whatChanged || "_Not yet generated._",
+    "",
+    "## Tradeoffs", "", state.tradeoffs || "_Not yet generated._",
+    "",
+    "## Risks Considered", "", state.risksConsidered || "_Not yet generated._",
+    "",
+    "## Team Understanding", "", state.teamUnderstanding || "_Not yet generated._",
+    "",
+    "## Change Summary", "", state.change_summary || "_No change summary provided._",
+    "",
+    "## Evidence Collected", "",
+    "### Changed Files", "", renderList(state.evidence.changedFiles, "_No changed files detected._"),
+    "",
+    "### Git Status", "", state.evidence.status || "_No git status output._",
+    "",
+    "### Diff Stat", "", state.evidence.diffStat || "_No diff stat output._",
+    "",
+    "### Source Artifacts", "", renderList(state.evidence.sourceArtifacts, "_No source artifacts found._"),
+    "",
+    "### Missing Evidence", "", renderList(state.evidence.missingEvidence, "_No missing evidence recorded._"),
+    "",
+    "## Human Explainability Quiz", "",
+    "This quiz checks whether the human can explain the change. It does not replace tests, review, or maintainer approval.",
+    "",
+    renderQuestions(state.questions, state.answers, state.result),
+    "",
+    "## Pending Question", "", pending,
+    "",
+    "## Readiness", "",
+    `Result: ${state.result}`,
+    state.override_reason ? `Override reason: ${state.override_reason}` : "",
+    "",
+    revealAssessment
+      ? `Correctness rate: ${Math.round(state.readiness_score * 100)}% / threshold ${Math.round(state.threshold * 100)}%`
+      : `Correctness rate: hidden until completion / threshold ${Math.round(state.threshold * 100)}%`,
+    "",
+    "Dimension coverage:", "", dimensions || "_No scored dimensions yet._",
+    "",
+    "",
+    state.prior_attempts && state.prior_attempts.length > 0
+      ? ["## Prior Attempts", "", ...state.prior_attempts.map((a, i) => "- Attempt " + (i + 1) + ": " + a.result + " (score " + Math.round((a.readiness_score ?? 0) * 100) + "%)" + (a.change_summary ? " - " + a.change_summary : ""))].join("\n")
+      : "",
+    "",
+    "## Merge Boundary", "", MERGE_BOUNDARY_STATEMENT,
+    "",
+  ].filter((line, index, lines) => line !== "" || lines[index - 1] !== "").join("\n");
+}
+
+function redactQuestion(question: MergeReadinessMCQQuestion): Record<string, unknown> {
+  const redacted: Record<string, unknown> = { ...question };
+  delete redacted.correctOptionId;
+  delete redacted.rationale;
+  return redacted;
+}
+
+/** Remove answer keys and interim scoring from the public state_read surface. */
+export function redactMergeReadinessState(state: MergeReadinessState): Record<string, unknown> {
+  const revealAll = state.result === "pass" || state.result === "paused";
+  const revealAnswered = state.result === "overridden" || state.result === "cancelled";
+  const answeredQuestionIds = new Set(state.answers.map((answer) => answer.questionId));
+  const shouldRevealQuestion = (question: MergeReadinessMCQQuestion): boolean =>
+    revealAll || (revealAnswered && answeredQuestionIds.has(question.id));
+
+  const redacted: Record<string, unknown> = {
+    ...state,
+    questions: state.questions.map((question) => shouldRevealQuestion(question) ? question : redactQuestion(question)),
+    pending_question: state.pending_question
+      ? (shouldRevealQuestion(state.pending_question) ? state.pending_question : redactQuestion(state.pending_question))
+      : undefined,
+    answers: state.answers.map((answer) => {
+      if (revealAll || revealAnswered) return answer;
+      const publicAnswer: Record<string, unknown> = { ...answer };
+      delete publicAnswer.isCorrect;
+      return publicAnswer;
+    }),
+    rounds: state.rounds.map((round) => {
+      if (revealAll || revealAnswered) return round;
+      const publicRound: Record<string, unknown> = { ...round };
+      delete publicRound.score;
+      return publicRound;
+    }),
+  };
+
+  if (!revealAll && !revealAnswered) {
+    delete redacted.readiness_score;
+    delete redacted.dimension_scores;
+  }
+  return redacted;
+}

--- a/src/hooks/merge-readiness/runtime.ts
+++ b/src/hooks/merge-readiness/runtime.ts
@@ -1,0 +1,733 @@
+import { execFileSync } from "child_process";
+import { existsSync, readdirSync } from "fs";
+import { join, relative } from "path";
+import { readModeState, writeModeState } from "../../lib/mode-state-io.js";
+import { getOmcRoot, resolveToWorktreeRoot } from "../../lib/worktree-paths.js";
+import {
+  computeCorrectnessRate,
+  hasRequiredDimensionCoverage,
+  isCorrectnessPass,
+  profileMaxRounds,
+  profileThreshold,
+  requiredDimensionsForProfile,
+  scoreMCQResponse,
+  type MergeReadinessMCQAnswer,
+  type MergeReadinessMCQQuestion,
+} from "./mcq.js";
+import type {
+  MergeReadinessDimension,
+  MergeReadinessEvidence,
+  MergeReadinessProfile,
+  MergeReadinessPromptResult,
+  MergeReadinessResult,
+  MergeReadinessState,
+} from "./types.js";
+
+const MODE = "merge-readiness";
+
+export function parseMergeReadinessProfile(promptText: string): MergeReadinessProfile {
+  if (/\B--deep\b/i.test(promptText)) return "deep";
+  if (/\B--quick\b/i.test(promptText)) return "quick";
+  return "standard";
+}
+
+export function slugifyMergeReadiness(input: string): string {
+  const slug = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return slug || "change";
+}
+
+function runGit(directory: string, args: string[]): { stdout: string; error?: string } {
+  try {
+    const stdout = execFileSync("git", args, {
+      cwd: directory,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      timeout: 10000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout: stdout.trim() };
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException & { status?: number; stderr?: string };
+    const timedOut = err?.code === "ETIMEDOUT" || /timed out/i.test(String(err?.message || ""));
+    const stderr = typeof err?.stderr === "string" ? err.stderr.trim().slice(0, 200) : "";
+    const exit = err?.status;
+    const error = timedOut
+      ? `git ${args[0]} timed out (>10s)`
+      : `git ${args[0]} failed (exit ${exit ?? "?"})${stderr ? ": " + stderr : ""}`;
+    return { stdout: "", error };
+  }
+}
+
+function listArtifactFiles(directory: string): string[] {
+  const root = getOmcRoot(directory);
+  const candidates = ["plans", "artifacts", "logs", "specs", "interviews"]
+    .map((segment) => join(root, segment))
+    .filter((path) => existsSync(path));
+  const found: string[] = [];
+  for (const candidate of candidates) {
+    const stack = [candidate];
+    while (stack.length > 0 && found.length < 40) {
+      const current = stack.pop();
+      if (!current) continue;
+      try {
+        const entries = readdirSync(current, { withFileTypes: true });
+        for (const entry of entries) {
+          const full = join(current, entry.name);
+          if (entry.isDirectory()) {
+            stack.push(full);
+          } else if (entry.isFile() && /\.(md|json|txt|log)$/i.test(entry.name)) {
+            const relativePath = relative(root, full).replace(/\\/g, "/");
+            if (!relativePath.startsWith("artifacts/merge-readiness/") && !relativePath.includes("merge-readiness-state")) {
+              found.push(relativePath);
+            }
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return found.sort();
+}
+
+export function collectMergeReadinessEvidence(directory: string, baseRef?: string): MergeReadinessEvidence {
+  const worktree = resolveToWorktreeRoot(directory);
+  const gitErrors: string[] = [];
+  const git = (args: string[]): string => {
+    const r = runGit(worktree, args);
+    if (r.error) gitErrors.push(r.error);
+    return r.stdout;
+  };
+  const changedFiles = git(["diff", "--name-only", "HEAD"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const stagedFiles = git(["diff", "--cached", "--name-only"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const untrackedFiles = git(["ls-files", "--others", "--exclude-standard"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const resolvedBase = baseRef || git(["rev-parse", "--abbrev-ref", "@{upstream}"]) || git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
+  const committedBase = resolvedBase ? git(["merge-base", resolvedBase, "HEAD"]) : "";
+  const committedFiles = /^[0-9a-f]{7,40}$/.test(committedBase || "")
+    ? git(["diff", "--name-only", committedBase + "...HEAD"]).split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
+    : [];
+  const trackedChangedFiles = Array.from(new Set([...changedFiles, ...stagedFiles, ...committedFiles])).sort();
+  const status = git(["status", "--short"]);
+  const diffStat = git(["diff", "--stat", "HEAD"]) || (committedBase ? git(["diff", "--stat", committedBase + "...HEAD"]) : "") || git(["diff", "--cached", "--stat"]);
+  const sourceArtifacts = listArtifactFiles(worktree);
+  const evidenceText = sourceArtifacts.join("\n").toLowerCase();
+  const testEvidence = sourceArtifacts.filter((file) => /test|spec|qa|verify|validation/i.test(file));
+  const reviewEvidence = sourceArtifacts.filter((file) => /review|risk|security|readiness|verdict/i.test(file));
+  const missingEvidence: string[] = [];
+  if (trackedChangedFiles.length === 0 && !status) {
+    missingEvidence.push("No changed files or git status evidence were detected.");
+  }
+  if (!diffStat) {
+    missingEvidence.push("No diff stat was detected for the current worktree.");
+  }
+  if (!/test|spec|qa|verify|validation/.test(evidenceText)) {
+    missingEvidence.push("No test or verification artifact was detected under .omc.");
+  }
+  if (!/review|risk|security|verdict/.test(evidenceText)) {
+    missingEvidence.push("No review or risk artifact was detected under .omc.");
+  }
+  for (const gerr of gitErrors) missingEvidence.push(gerr);
+  return { changedFiles: trackedChangedFiles, untrackedFiles, status, diffStat, sourceArtifacts, testEvidence, reviewEvidence, missingEvidence };
+}
+
+function extractChangeSummary(promptText: string): string {
+  return promptText
+    .replace(/^\s*\/(?:oh-my-claudecode:|omc:)?merge-readiness\b/i, "")
+    .replace(/\B--(?:quick|standard|deep|from-diff|from-artifacts)\b/gi, "")
+    .trim();
+}
+
+/** True when the collected evidence lacks the minimal diff/change signal needed to quiz on. */
+function hasMinimalEvidence(evidence: MergeReadinessEvidence): boolean {
+  return evidence.changedFiles.length > 0 || Boolean(evidence.status) || Boolean(evidence.diffStat) || evidence.sourceArtifacts.length > 0;
+}
+
+function parseMergeReadinessSourceMode(promptText: string): { mode?: "diff" | "artifacts"; error?: string } {
+  const fromDiff = /(?:^|\s)--from-diff(?=\s|$)/i.test(promptText);
+  const fromArtifacts = /(?:^|\s)--from-artifacts(?=\s|$)/i.test(promptText);
+  if (fromDiff && fromArtifacts) return { error: "--from-diff and --from-artifacts cannot be used together." };
+  if (fromDiff) return { mode: "diff" };
+  if (fromArtifacts) return { mode: "artifacts" };
+  return {};
+}
+
+function hasMinimalEvidenceForMode(evidence: MergeReadinessEvidence, mode: "diff" | "artifacts" | undefined): boolean {
+  // Status and untracked files are not a diff: --from-diff requires Git to
+  // report a tracked working-tree, staged, or committed change.
+  const hasDiff = evidence.changedFiles.length > 0 || Boolean(evidence.diffStat);
+  if (mode === "diff") return hasDiff;
+  if (mode === "artifacts") return evidence.sourceArtifacts.length > 0;
+  // Default: an unrelated artifact (e.g. plans/notes.md) must not alone start
+  // the gate. Require a real diff or a test/review artifact, so the gate does
+  // not go pending on evidence that missingEvidence itself flags as absent.
+  const hasRelevantArtifact = evidence.testEvidence.length > 0 || evidence.reviewEvidence.length > 0;
+  return hasDiff || hasRelevantArtifact;
+}
+
+function pickNextQuestion(state: MergeReadinessState): MergeReadinessMCQQuestion | undefined {
+  if (state.questions.length === 0) return undefined;
+  const answered = new Set(state.answers.map((a) => a.questionId));
+  const unanswered = state.questions.filter((q) => !answered.has(q.id));
+  if (unanswered.length === 0) return undefined;
+  // Prefer required dimensions, then any remaining unanswered question.
+  const requiredSet = new Set(state.required_dimensions);
+  const requiredNext = unanswered.find((q) => requiredSet.has(q.dimension));
+  return requiredNext ?? unanswered[0];
+}
+
+/**
+ * Recompute correctness rate + per-dimension coverage from recorded MCQ answers.
+ * The readiness score is the objective correctness rate (not a heuristic).
+ */
+function recomputeReadiness(state: MergeReadinessState): void {
+  const scores: Partial<Record<MergeReadinessDimension, number>> = {};
+  for (const dimension of state.required_dimensions) {
+    const dimensionAnswers = state.answers.filter((a) => {
+      const question = state.questions.find((q) => q.id === a.questionId);
+      return question?.dimension === dimension;
+    });
+    if (dimensionAnswers.length > 0) {
+      const correct = dimensionAnswers.filter((a) => a.isCorrect).length;
+      scores[dimension] = correct / dimensionAnswers.length;
+    }
+  }
+  state.dimension_scores = scores;
+  state.readiness_score = computeCorrectnessRate(state.answers);
+}
+
+function allRequiredAnswered(state: MergeReadinessState): boolean {
+  if (state.questions.length === 0) return false;
+  const answered = new Set(state.answers.map((a) => a.questionId));
+  // Every required dimension must have at least one answered MCQ.
+  const answeredDimensions = new Set(
+    state.answers
+      .map((a) => state.questions.find((q) => q.id === a.questionId)?.dimension)
+      .filter((d): d is MergeReadinessDimension => Boolean(d)),
+  );
+  const coverageOk = state.required_dimensions.every((d) => answeredDimensions.has(d));
+  // And every generated question should be answered (no half-finished quiz),
+  // unless the profile max rounds caps the count below questions.length.
+  const cap = Math.min(state.questions.length, state.max_rounds);
+  const answeredInRange = state.answers.filter((a) => answered.has(a.questionId)).length;
+  return coverageOk && answeredInRange >= cap;
+}
+
+/**
+ * Finalize the gate result from recorded answers + evidence.
+ *   pass    = all required answered, correctness rate >= threshold, required dims covered -> active=false (release)
+ *   paused  = all required answered but correctness rate below threshold -> stays active (gate remains active until re-run + pass)
+ *   blocked = missing minimal evidence (no diff/change signal) -> stays active
+ * v1 is advisory: checkMergeReadiness is not wired to the Stop hook, so an active gate does not block the session; active gates remain active until pass/override/cancel.
+ */
+function finalizeIfReady(state: MergeReadinessState, now: string): void {
+  recomputeReadiness(state);
+
+  if (!hasMinimalEvidence(state.evidence)) {
+    state.phase = "complete";
+    state.result = "blocked";
+    state.completed_at = now;
+    delete state.pending_question;
+    return;
+  }
+
+  if (!allRequiredAnswered(state)) {
+    // Quiz not finished yet; keep the gate active and pending.
+    return;
+  }
+
+  const rate = state.readiness_score;
+  const coverageOk = hasRequiredDimensionCoverage(
+    state.answers,
+    state.questions,
+    state.required_dimensions,
+  );
+
+  if (isCorrectnessPass(rate, state.threshold) && coverageOk) {
+    state.active = false;
+    state.phase = "complete";
+    state.result = "pass";
+    state.completed_at = now;
+    delete state.pending_question;
+    return;
+  }
+
+  // All required answered but below threshold or missing coverage: paused.
+  // Keep active=true so the Stop-hook keeps blocking until the operator
+  // re-runs /merge-readiness and passes.
+  state.phase = "complete";
+  state.result = "paused";
+  state.completed_at = now;
+  delete state.pending_question;
+}
+
+export function readMergeReadinessState(directory: string, sessionId?: string): MergeReadinessState | null {
+  return readModeState<MergeReadinessState>(MODE, directory, sessionId) ?? null;
+}
+
+export function writeMergeReadinessState(
+  directory: string,
+  state: MergeReadinessState,
+  sessionId?: string,
+): boolean {
+  return writeModeState(MODE, state as unknown as Record<string, unknown>, directory, sessionId);
+}
+
+/**
+ * Seed initial merge-readiness state. Called by the bridge on `/merge-readiness`
+ * and by the autopilot adapter's onEnter. Collects evidence, picks the profile
+ * threshold/maxRounds/required dims from mcq.ts, and marks the state as
+ * awaiting AI-generated content (doc + MCQs).
+ */
+export function createInitialMergeReadinessState(
+  directory: string,
+  promptText: string,
+  sessionId?: string,
+  baseRef?: string,
+): MergeReadinessState {
+  const now = new Date().toISOString();
+  const profile = parseMergeReadinessProfile(promptText);
+  const changeSummary = extractChangeSummary(promptText);
+  const unsupportedFromPr = /\B--from-pr\b/i.test(promptText);
+  const sourceModeResult = parseMergeReadinessSourceMode(promptText);
+  const sourceMode = sourceModeResult.mode;
+  const evidence = collectMergeReadinessEvidence(directory, baseRef);
+  const missingEvidence = unsupportedFromPr || Boolean(sourceModeResult.error) || !hasMinimalEvidenceForMode(evidence, sourceMode);
+  const state: MergeReadinessState = {
+    active: true,
+    session_id: sessionId,
+    current_phase: MODE,
+    phase: "content",
+    profile,
+    threshold: profileThreshold(profile),
+    max_rounds: profileMaxRounds(profile),
+    required_dimensions: requiredDimensionsForProfile(profile),
+    rounds: [],
+    questions: [],
+    answers: [],
+    awaiting_content: !missingEvidence,
+    evidence,
+    readiness_score: 0,
+    dimension_scores: {},
+    result: missingEvidence ? "blocked" : "pending",
+    why: "",
+    whatChanged: "",
+    tradeoffs: "",
+    risksConsidered: "",
+    teamUnderstanding: "",
+    started_at: now,
+    updated_at: now,
+    change_summary: changeSummary,
+    slug: slugifyMergeReadiness(changeSummary || "merge-readiness"),
+    source_mode: sourceMode,
+  };
+  if (missingEvidence) {
+    state.validation_errors = unsupportedFromPr
+      ? ["--from-pr is unsupported: merge-readiness uses local git and .omc evidence only."]
+      : sourceModeResult.error
+        ? [sourceModeResult.error]
+        : ["No minimal evidence for the selected source mode was detected; produce it before running /merge-readiness."];
+  }
+  let prior: MergeReadinessState | null = null;
+  try {
+    prior = readMergeReadinessState(directory, sessionId);
+  } catch {
+    // An invalid session id throws on the read path (validateSessionId); treat
+    // as no prior attempt. The write below will fail-closed on the same id.
+    prior = null;
+  }
+  if (prior && prior.result !== "pending" && prior.completed_at) {
+    state.prior_attempts = [
+      ...(prior.prior_attempts ?? []),
+      {
+        started_at: prior.started_at,
+        completed_at: prior.completed_at,
+        result: prior.result,
+        readiness_score: prior.readiness_score,
+        change_summary: prior.change_summary,
+      },
+    ];
+  }
+  const persisted = writeMergeReadinessState(directory, state, sessionId);
+  if (!persisted) {
+    state.result = "blocked";
+    state.awaiting_content = false;
+    state.phase = "complete";
+    state.validation_errors = ["Merge-readiness state could not be persisted (invalid session id or state path). Resolve the session id and re-run merge_readiness_start."];
+  }
+  return state;
+}
+
+/**
+ * AI writes the generated explanation doc (5 sections) + MCQs into state.
+ * Called after the AI has read the evidence and produced narrative + questions.
+ * Each question must carry correctOptionId so the runtime can score objectively.
+ */
+export function setMergeReadinessContent(
+  directory: string,
+  content: {
+    why: string;
+    whatChanged: string;
+    tradeoffs: string;
+    risksConsidered: string;
+    teamUnderstanding: string;
+    questions: MergeReadinessMCQQuestion[];
+  },
+  sessionId?: string,
+): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  const now = new Date().toISOString();
+  // Do not re-arm blocked or paused states: a blocked state lacks minimal
+  // evidence, and a paused state failed the quiz. Both require a fresh
+  // merge_readiness_start (which re-collects evidence) rather than a content
+  // re-submit. The prior attempt is appended to prior_attempts on re-start, so
+  // the audit history is retained across retries.
+  if (state.result === "blocked" || state.result === "paused") {
+    state.validation_errors ??= [state.result === "blocked"
+      ? "Blocked: no minimal evidence for the selected source mode. Produce it before submitting content."
+      : "Paused: the quiz was not passed. Re-run merge_readiness_start to collect fresh evidence and retry; the prior attempt is retained in the audit history."];
+    if (state.result === "blocked") {
+      state.awaiting_content = true;
+      state.phase = "content";
+    }
+    state.updated_at = now;
+    writeMergeReadinessState(workingDir, state, sessionId);
+    return state;
+  }
+  const errors = validateMergeReadinessContent(content, state);
+  if (errors.length > 0) {
+    state.validation_errors = errors;
+    state.awaiting_content = true;
+    state.phase = "content";
+    state.answers = [];
+    state.readiness_score = 0;
+    state.dimension_scores = {};
+    state.result = "pending";
+    delete state.pending_question;
+    delete state.completed_at;
+    delete state.override_reason;
+    state.updated_at = now;
+    writeMergeReadinessState(workingDir, state, sessionId);
+    return state;
+  }
+  state.why = content.why.trim();
+  state.whatChanged = content.whatChanged.trim();
+  state.tradeoffs = content.tradeoffs.trim();
+  state.risksConsidered = content.risksConsidered.trim();
+  state.teamUnderstanding = content.teamUnderstanding.trim();
+  // Cap generated questions at the profile max rounds.
+  state.questions = content.questions.slice(0, state.max_rounds);
+  // Re-submitted content starts a fresh quiz: clear prior answers, score, and terminal result.
+  state.answers = [];
+  state.readiness_score = 0;
+  state.dimension_scores = {};
+  state.result = "pending";
+  delete state.completed_at;
+  delete state.override_reason;
+  delete state.validation_errors;
+  state.awaiting_content = false;
+  state.phase = "questioning";
+  state.updated_at = now;
+  state.pending_question = pickNextQuestion(state);
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+/**
+ * Record one MCQ answer (objective scoring via scoreMCQResponse), append it,
+ * and finalize the gate if all required questions are answered.
+ */
+export function recordMergeReadinessMCQAnswer(
+  directory: string,
+  questionId: string,
+  selectedOptionId: string,
+  sessionId?: string,
+): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  if (state.awaiting_content || state.phase !== "questioning") return null;
+  const question = state.questions.find((q) => q.id === questionId);
+  if (!question || state.pending_question?.id !== questionId) return null;
+  const normalizedOptionId = selectedOptionId.trim();
+  if (!question.options.some((option) => option.id === normalizedOptionId)) return null;
+  const now = new Date().toISOString();
+  const isCorrect = scoreMCQResponse(question, normalizedOptionId);
+  // Replace any prior answer to the same question (idempotent re-answer).
+  const filtered = state.answers.filter((a) => a.questionId !== questionId);
+  const answer: MergeReadinessMCQAnswer = {
+    questionId,
+    selectedOptionId: normalizedOptionId,
+    isCorrect,
+    answeredAt: now,
+  };
+  state.answers = [...filtered, answer];
+  state.updated_at = now;
+  delete state.pending_question;
+  finalizeIfReady(state, now);
+  if (state.active && state.phase === "questioning") {
+    state.pending_question = pickNextQuestion(state);
+  } else {
+    delete state.pending_question;
+  }
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+/** Correlate only a marked native AskUserQuestion result to the current MCQ. */
+export function recordMergeReadinessAskUserQuestionResult(
+  directory: string,
+  toolInput: unknown,
+  toolOutput: unknown,
+  sessionId?: string,
+): MergeReadinessState | null {
+  const state = readMergeReadinessState(resolveToWorktreeRoot(directory), sessionId);
+  const pending = state?.pending_question;
+  if (!state?.active || !pending) return state ?? null;
+  const inputText = JSON.stringify(toolInput ?? "");
+  if (!inputText.includes(`[MERGE READINESS:${pending.id}]`)) return state;
+  const outputText = typeof toolOutput === "string" ? toolOutput : JSON.stringify(toolOutput ?? "");
+  const selected = pending.options.filter((option) =>
+    new RegExp(`(?:^|[\\s\\[\"'])${option.id.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}(?:$|[\\s\\]\"',:])`).test(outputText),
+  );
+  return selected.length === 1
+    ? recordMergeReadinessMCQAnswer(directory, pending.id, selected[0].id, sessionId)
+    : state;
+}
+
+export function validateMergeReadinessContent(
+  content: { why: string; whatChanged: string; tradeoffs: string; risksConsidered: string; teamUnderstanding: string; questions: MergeReadinessMCQQuestion[] },
+  state: Pick<MergeReadinessState, "required_dimensions" | "max_rounds">,
+): string[] {
+  const errors: string[] = [];
+  const sections: Array<[string, string]> = [["why", content.why], ["whatChanged", content.whatChanged], ["tradeoffs", content.tradeoffs], ["risksConsidered", content.risksConsidered], ["teamUnderstanding", content.teamUnderstanding]];
+  for (const [name, value] of sections) if (!value?.trim()) errors.push(`Narrative section '${name}' is required.`);
+  if (!Array.isArray(content.questions) || content.questions.length < state.required_dimensions.length) errors.push("Questions must cover every required dimension.");
+  if (content.questions.length > state.max_rounds) errors.push(`Questions exceed the ${state.max_rounds}-question profile limit.`);
+  const ids = new Set<string>();
+  const dimensions = new Set<MergeReadinessDimension>();
+  for (const question of content.questions ?? []) {
+    if (!question.id?.trim() || ids.has(question.id)) errors.push("Question ids must be non-empty and unique.");
+    ids.add(question.id);
+    dimensions.add(question.dimension);
+    if (!question.stem?.trim()) errors.push(`Question '${question.id}' needs a stem.`);
+    if (!Array.isArray(question.options) || question.options.length < 2) errors.push(`Question '${question.id}' needs at least two options.`);
+    const optionIds = new Set(question.options?.map((option) => option.id) ?? []);
+    if (optionIds.size !== (question.options?.length ?? 0) || [...optionIds].some((id) => !id?.trim())) errors.push(`Question '${question.id}' has invalid option ids.`);
+    if (!optionIds.has(question.correctOptionId)) errors.push(`Question '${question.id}' correctOptionId must identify an option.`);
+  }
+  for (const dimension of state.required_dimensions) if (!dimensions.has(dimension)) errors.push(`No question covers required dimension '${dimension}'.`);
+  return errors;
+}
+
+export function overrideMergeReadiness(directory: string, reason: string, sessionId?: string): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active || !reason.trim()) return state ?? null;
+  if (state.result === "blocked") {
+    state.validation_errors ??= ["Blocked: resolve the validation errors before overriding."];
+    writeMergeReadinessState(workingDir, state, sessionId);
+    return state;
+  }
+  state.active = false;
+  state.phase = "complete";
+  state.result = "overridden";
+  state.override_reason = reason.trim();
+  state.completed_at = state.updated_at = new Date().toISOString();
+  delete state.pending_question;
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+export function cancelMergeReadiness(directory: string, sessionId?: string): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  state.active = false;
+  state.phase = "complete";
+  state.result = "cancelled";
+  state.completed_at = state.updated_at = new Date().toISOString();
+  delete state.pending_question;
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+export function formatMergeReadinessQuestionMessage(state: MergeReadinessState): string {
+  const scorePct = Math.round(state.readiness_score * 100);
+  const thresholdPct = Math.round(state.threshold * 100);
+  const scoreLine = state.result === "pending"
+    ? `Score: hidden until completion / threshold ${thresholdPct}%`
+    : `Score: ${scorePct}% / threshold ${thresholdPct}%`;
+
+  if (state.result === "blocked") {
+    return [
+      "[MERGE READINESS BLOCKED]",
+      "Do not merge yet. Minimal evidence for the change is missing.",
+      "Produce the diff/test/review evidence under .omc, then re-run /merge-readiness (merge_readiness_start).",
+      ...(state.validation_errors ?? []),
+    ].join("\n");
+  }
+
+  if (state.awaiting_content) {
+    return [
+      "[MERGE READINESS BLOCKED]",
+      "Do not merge yet. The runtime is awaiting the AI-generated explanation doc + MCQs.",
+      "Audit record: authoritative session state",
+      `Profile: ${state.profile} | threshold ${thresholdPct}% | max rounds ${state.max_rounds}`,
+      `Required dimensions: ${state.required_dimensions.join(", ")}`,
+      "",
+      "AI step: call setMergeReadinessContent with the 5-section doc + up to " +
+        `${state.max_rounds} MCQs (each with correctOptionId), then present each MCQ ` +
+        "one-per-round via AskUserQuestion and record answers via recordMergeReadinessMCQAnswer.",
+    ].join("\n");
+  }
+
+  const pending = state.pending_question;
+  if (!pending) {
+    return `[MERGE READINESS] No pending question. Result: ${state.result}. Score: ${scorePct}% / threshold ${thresholdPct}%. Audit record: authoritative session state.`;
+  }
+
+  const answeredCount = state.answers.length;
+  const total = Math.min(state.questions.length || state.max_rounds, state.max_rounds);
+  const options = Array.isArray(pending.options)
+    ? pending.options.map((opt) => `  [${opt.id}] ${opt.text}`).join("\n")
+    : "";
+  const stem = pending.stem || (pending as { question?: string }).question || "";
+  const dimension = pending.dimension ?? "why";
+  return [
+    "[MERGE READINESS BLOCKED]",
+    "Do not merge yet. This post-task gate checks whether the human can explain the change.",
+    "Audit record: authoritative session state",
+    scoreLine,
+    `Answered: ${answeredCount}/${total}`,
+    "",
+    `Question [${dimension}] (${answeredCount + 1}/${total}): ${stem}`,
+    options,
+  ].filter((line) => line.length > 0).join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Legacy prompt-as-answer fallback (standalone /merge-readiness text path).
+// Kept for backward compatibility; the AI-driven MCQ path (setMergeReadinessContent
+// + recordMergeReadinessMCQAnswer) is the canonical v1 path.
+// ---------------------------------------------------------------------------
+
+/** @deprecated heuristic scorer retained only for the legacy text fallback. */
+function scoreAnswer(answer: string): number {
+  const normalized = answer.trim().toLowerCase();
+  if (!normalized) return 0;
+  if (/(不知道|不清楚|说不出|答不出|not sure|don't know|do not know|unknown)/i.test(normalized)) {
+    return 0.1;
+  }
+  const lengthScore = normalized.length >= 140 ? 0.65 : normalized.length >= 70 ? 0.48 : normalized.length >= 30 ? 0.32 : 0.15;
+  const signalPatterns = [
+    /because|why|为了|因为|目标|原因/,
+    /change|changed|改了|变化|行为|影响/,
+    /risk|风险|tradeoff|取舍|alternative|替代|权衡/,
+    /test|review|verify|验证|测试|评审/,
+    /team|maintain|approve|团队|维护|批准|理解/,
+  ];
+  const signalScore = signalPatterns.reduce((sum, pattern) => sum + (pattern.test(normalized) ? 0.07 : 0), 0);
+  return Math.min(1, lengthScore + signalScore);
+}
+
+/**
+ * @deprecated Legacy text-answer recorder. Only routes to the old open-ended
+ * round shape when the state has no AI-generated MCQs yet. When MCQs exist,
+ * the AI-driven recordMergeReadinessMCQAnswer path is canonical.
+ */
+export function recordMergeReadinessAnswer(
+  directory: string,
+  answer: string,
+  sessionId?: string,
+): MergeReadinessState | null {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return state ?? null;
+  const now = new Date().toISOString();
+  const pendingRound = state.rounds.find((r) => !r.answer);
+  if (!pendingRound) return state;
+  const score = scoreAnswer(answer);
+  state.rounds = state.rounds.map((round) =>
+    round.round === pendingRound.round
+      ? { ...round, answer: answer.trim(), score, answered_at: now }
+      : round,
+  );
+  state.updated_at = now;
+  writeMergeReadinessState(workingDir, state, sessionId);
+  return state;
+}
+
+export function isLikelyMergeReadinessAnswer(promptText: string): boolean {
+  const trimmed = promptText.trim();
+  if (!trimmed) return false;
+  if (/^\//.test(trimmed)) return false;
+  if (/^\$/.test(trimmed)) return false;
+  // Only treat as a fallback answer when no AI-generated MCQs are pending;
+  // the AI-driven path writes state directly and never hits this.
+  return true;
+}
+
+export function handleMergeReadinessPromptSubmit(
+  directory: string,
+  promptText: string,
+  sessionId?: string,
+): MergeReadinessPromptResult {
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) {
+    return { handled: false };
+  }
+  const override = /^\/(?:oh-my-claudecode:|omc:)?merge-readiness\s+--override\s+(.+)$/i.exec(promptText.trim());
+  if (!override) return { handled: false };
+  const updated = overrideMergeReadiness(workingDir, override[1], sessionId);
+  if (!updated || updated.result !== "overridden") return { handled: false };
+  return {
+    handled: true,
+    message: formatMergeReadinessQuestionMessage(updated),
+  };
+}
+
+/**
+ * Stop-hook gate. Reads state; if active and not yet passed, blocks the session
+ * and injects the pending MCQ (or an awaiting-content nudge). Releases on pass.
+ */
+export async function checkMergeReadiness(
+  sessionId: string | undefined,
+  directory: string,
+  cancelInProgress: boolean,
+): Promise<{ shouldBlock: boolean; message: string; result: MergeReadinessResult } | null> {
+  if (cancelInProgress) return null;
+  const workingDir = resolveToWorktreeRoot(directory);
+  const state = readMergeReadinessState(workingDir, sessionId);
+  if (!state?.active) return null;
+  if (state.result === "pass") return null;
+
+  const now = new Date().toISOString();
+  state.updated_at = now;
+  if (!state.awaiting_content && !state.pending_question && state.result === "pending") {
+    state.pending_question = pickNextQuestion(state);
+    if (!state.pending_question) {
+      finalizeIfReady(state, now);
+    }
+  }
+  writeMergeReadinessState(workingDir, state, sessionId);
+
+  // finalizeIfReady (called above) may have deactivated the gate on pass/paused/
+  // blocked. When active=false the session is released; otherwise block.
+  if (!state.active) return null;
+  return {
+    shouldBlock: true,
+    message: formatMergeReadinessQuestionMessage(state),
+    result: state.result,
+  };
+}
+
+// Re-export deprecated types for callers that still import them from runtime.
+export type { MergeReadinessRound } from "./types.js";

--- a/src/hooks/merge-readiness/runtime.ts
+++ b/src/hooks/merge-readiness/runtime.ts
@@ -364,7 +364,15 @@ function persistOrFailClosed(workingDir: string, state: MergeReadinessState, ses
     ...(state.validation_errors ?? []),
     "Merge-readiness state could not be persisted (invalid session id or state path). Resolve the session id and re-run merge_readiness_start.",
   ];
-  return persistOrFailClosed(workingDir, state, sessionId);
+  // Return the fail-closed state directly. Do NOT recurse: re-invoking
+  // writeMergeReadinessState with the same session id/path will fail
+  // identically (read-only FS, full disk, EACCES), so the recursion would
+  // never terminate - it would also append a duplicate error per frame -
+  // and would overflow the stack instead of returning the intended blocked
+  // state. The on-disk state is unchanged here (the write above did not
+  // land), so the gate stays armed until the operator resolves the session
+  // id and re-runs merge_readiness_start.
+  return state;
 }
 
 /**

--- a/src/hooks/merge-readiness/runtime.ts
+++ b/src/hooks/merge-readiness/runtime.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from "child_process";
-import { existsSync, readdirSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { join, relative } from "path";
 import { readModeState, writeModeState } from "../../lib/mode-state-io.js";
+import { MODE_NAMES, MODE_STATE_FILE_MAP } from "../../lib/mode-names.js";
 import { getOmcRoot, resolveToWorktreeRoot } from "../../lib/worktree-paths.js";
 import {
   computeCorrectnessRate,
@@ -15,6 +16,7 @@ import {
   type MergeReadinessMCQQuestion,
 } from "./mcq.js";
 import type {
+  MergeReadinessAttempt,
   MergeReadinessDimension,
   MergeReadinessEvidence,
   MergeReadinessProfile,
@@ -63,13 +65,56 @@ function runGit(directory: string, args: string[]): { stdout: string; error?: st
   }
 }
 
+const EVIDENCE_MODE_STATE_FILES = new Set<string>([
+  MODE_STATE_FILE_MAP[MODE_NAMES.RALPH],
+  MODE_STATE_FILE_MAP[MODE_NAMES.AUTOPILOT],
+  MODE_STATE_FILE_MAP[MODE_NAMES.TEAM],
+  MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK],
+  MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAQA],
+  MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN],
+  MODE_STATE_FILE_MAP[MODE_NAMES.AUTORESEARCH],
+]);
+
+const NON_EVIDENCE_STATE_SUFFIXES = ["-stop-breaker.json", "-last-steer-at", "-continue-steer.lock"];
+
+function isNonEvidenceStateFile(name: string): boolean {
+  return NON_EVIDENCE_STATE_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
+function modeStateRecordsRun(filePath: string): boolean {
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (parsed && typeof parsed === "object") {
+      if (parsed.active === true) return true;
+      if (typeof parsed.iteration === "number" && parsed.iteration > 0) return true;
+      if (typeof parsed.started_at === "string" && parsed.started_at.length > 0) return true;
+      if (typeof parsed.phase === "string" && parsed.phase.length > 0 && parsed.phase !== "init") return true;
+    }
+  } catch {
+    // Unreadable/unparseable state is not evidence.
+  }
+  return false;
+}
+
 function listArtifactFiles(directory: string): string[] {
   const root = getOmcRoot(directory);
-  const candidates = ["plans", "artifacts", "logs", "specs", "interviews"]
+  const dirCandidates = ["plans", "artifacts", "logs", "specs", "interviews"]
     .map((segment) => join(root, segment))
     .filter((path) => existsSync(path));
   const found: string[] = [];
-  for (const candidate of candidates) {
+  const seen = new Set<string>();
+
+  const pushRelative = (full: string): void => {
+    const relativePath = relative(root, full).replace(/\\/g, "/");
+    if (relativePath.startsWith("artifacts/merge-readiness/")) return;
+    if (relativePath.includes("merge-readiness-state")) return;
+    if (seen.has(relativePath)) return;
+    seen.add(relativePath);
+    found.push(relativePath);
+  };
+
+  for (const candidate of dirCandidates) {
     const stack = [candidate];
     while (stack.length > 0 && found.length < 40) {
       const current = stack.pop();
@@ -81,10 +126,7 @@ function listArtifactFiles(directory: string): string[] {
           if (entry.isDirectory()) {
             stack.push(full);
           } else if (entry.isFile() && /\.(md|json|txt|log)$/i.test(entry.name)) {
-            const relativePath = relative(root, full).replace(/\\/g, "/");
-            if (!relativePath.startsWith("artifacts/merge-readiness/") && !relativePath.includes("merge-readiness-state")) {
-              found.push(relativePath);
-            }
+            pushRelative(full);
           }
         }
       } catch {
@@ -92,6 +134,26 @@ function listArtifactFiles(directory: string): string[] {
       }
     }
   }
+
+  // Scan .omc/state/ for canonical mode-state files that record a real run
+  // (the "relevant mode state artifacts" advertised in SKILL.md). Only the
+  // legacy/global state dir; session-scoped state belongs to other sessions.
+  const stateDir = join(root, "state");
+  if (existsSync(stateDir)) {
+    try {
+      for (const entry of readdirSync(stateDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+        if (isNonEvidenceStateFile(entry.name)) continue;
+        if (!EVIDENCE_MODE_STATE_FILES.has(entry.name)) continue;
+        const full = join(stateDir, entry.name);
+        if (!modeStateRecordsRun(full)) continue;
+        pushRelative(full);
+      }
+    } catch {
+      // Unreadable state dir: skip.
+    }
+  }
+
   return found.sort();
 }
 
@@ -156,16 +218,20 @@ function parseMergeReadinessSourceMode(promptText: string): { mode?: "diff" | "a
   return {};
 }
 
+function hasModeStateArtifact(evidence: MergeReadinessEvidence): boolean {
+  return evidence.sourceArtifacts.some((path) => {
+    const name = path.slice(path.lastIndexOf("/") + 1);
+    return EVIDENCE_MODE_STATE_FILES.has(name);
+  });
+}
+
 function hasMinimalEvidenceForMode(evidence: MergeReadinessEvidence, mode: "diff" | "artifacts" | undefined): boolean {
-  // Status and untracked files are not a diff: --from-diff requires Git to
-  // report a tracked working-tree, staged, or committed change.
   const hasDiff = evidence.changedFiles.length > 0 || Boolean(evidence.diffStat);
+  const hasRelevantArtifact = evidence.testEvidence.length > 0
+    || evidence.reviewEvidence.length > 0
+    || hasModeStateArtifact(evidence);
   if (mode === "diff") return hasDiff;
-  if (mode === "artifacts") return evidence.sourceArtifacts.length > 0;
-  // Default: an unrelated artifact (e.g. plans/notes.md) must not alone start
-  // the gate. Require a real diff or a test/review artifact, so the gate does
-  // not go pending on evidence that missingEvidence itself flags as absent.
-  const hasRelevantArtifact = evidence.testEvidence.length > 0 || evidence.reviewEvidence.length > 0;
+  if (mode === "artifacts") return hasRelevantArtifact;
   return hasDiff || hasRelevantArtifact;
 }
 
@@ -257,8 +323,10 @@ function finalizeIfReady(state: MergeReadinessState, now: string): void {
   }
 
   // All required answered but below threshold or missing coverage: paused.
-  // Keep active=true so the Stop-hook keeps blocking until the operator
-  // re-runs /merge-readiness and passes.
+  // Keep active=true so the gate stays armed until the operator re-runs
+  // /merge-readiness and passes. v1 is advisory: checkMergeReadiness is not
+  // wired to the Stop hook, so this does not block the session; the gate
+  // remains active until pass/override/cancel.
   state.phase = "complete";
   state.result = "paused";
   state.completed_at = now;
@@ -275,6 +343,28 @@ export function writeMergeReadinessState(
   sessionId?: string,
 ): boolean {
   return writeModeState(MODE, state as unknown as Record<string, unknown>, directory, sessionId);
+}
+
+/**
+ * Persist state and fail closed if the write cannot land (invalid session id
+ * or state path). Prevents phantom pass/override/cancel results from surfacing
+ * when the authoritative state file cannot be written. Mutators that would
+ * otherwise report a terminal release (active=false) instead force-block so the
+ * operator must resolve the session id and re-run.
+ */
+function persistOrFailClosed(workingDir: string, state: MergeReadinessState, sessionId: string | undefined): MergeReadinessState {
+  const persisted = writeMergeReadinessState(workingDir, state, sessionId);
+  if (persisted) return state;
+  state.active = true;
+  state.phase = "complete";
+  state.result = "blocked";
+  state.awaiting_content = false;
+  delete state.pending_question;
+  state.validation_errors = [
+    ...(state.validation_errors ?? []),
+    "Merge-readiness state could not be persisted (invalid session id or state path). Resolve the session id and re-run merge_readiness_start.",
+  ];
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 /**
@@ -341,16 +431,31 @@ export function createInitialMergeReadinessState(
     prior = null;
   }
   if (prior && prior.result !== "pending" && prior.completed_at) {
-    state.prior_attempts = [
-      ...(prior.prior_attempts ?? []),
-      {
-        started_at: prior.started_at,
-        completed_at: prior.completed_at,
-        result: prior.result,
-        readiness_score: prior.readiness_score,
-        change_summary: prior.change_summary,
+    const priorAttempt: MergeReadinessAttempt = {
+      profile: prior.profile,
+      threshold: prior.threshold,
+      max_rounds: prior.max_rounds,
+      required_dimensions: [...prior.required_dimensions],
+      change_summary: prior.change_summary,
+      slug: prior.slug,
+      started_at: prior.started_at,
+      completed_at: prior.completed_at,
+      result: prior.result,
+      override_reason: prior.override_reason,
+      readiness_score: prior.readiness_score,
+      dimension_scores: { ...prior.dimension_scores },
+      questions: prior.questions.map((q) => ({ ...q, options: q.options.map((o) => ({ ...o })) })),
+      answers: prior.answers.map((a) => ({ ...a })),
+      evidence_summary: {
+        changedFiles: [...prior.evidence.changedFiles],
+        source_mode: prior.source_mode,
+        missingEvidence: [...prior.evidence.missingEvidence],
+        sourceArtifactCount: prior.evidence.sourceArtifacts.length,
+        testEvidenceCount: prior.evidence.testEvidence.length,
+        reviewEvidenceCount: prior.evidence.reviewEvidence.length,
       },
-    ];
+    };
+    state.prior_attempts = [...(prior.prior_attempts ?? []), priorAttempt];
   }
   const persisted = writeMergeReadinessState(directory, state, sessionId);
   if (!persisted) {
@@ -397,8 +502,7 @@ export function setMergeReadinessContent(
       state.phase = "content";
     }
     state.updated_at = now;
-    writeMergeReadinessState(workingDir, state, sessionId);
-    return state;
+    return persistOrFailClosed(workingDir, state, sessionId);
   }
   const errors = validateMergeReadinessContent(content, state);
   if (errors.length > 0) {
@@ -413,8 +517,7 @@ export function setMergeReadinessContent(
     delete state.completed_at;
     delete state.override_reason;
     state.updated_at = now;
-    writeMergeReadinessState(workingDir, state, sessionId);
-    return state;
+    return persistOrFailClosed(workingDir, state, sessionId);
   }
   state.why = content.why.trim();
   state.whatChanged = content.whatChanged.trim();
@@ -435,8 +538,7 @@ export function setMergeReadinessContent(
   state.phase = "questioning";
   state.updated_at = now;
   state.pending_question = pickNextQuestion(state);
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 /**
@@ -476,8 +578,7 @@ export function recordMergeReadinessMCQAnswer(
   } else {
     delete state.pending_question;
   }
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 /** Correlate only a marked native AskUserQuestion result to the current MCQ. */
@@ -532,8 +633,7 @@ export function overrideMergeReadiness(directory: string, reason: string, sessio
   if (!state?.active || !reason.trim()) return state ?? null;
   if (state.result === "blocked") {
     state.validation_errors ??= ["Blocked: resolve the validation errors before overriding."];
-    writeMergeReadinessState(workingDir, state, sessionId);
-    return state;
+    return persistOrFailClosed(workingDir, state, sessionId);
   }
   state.active = false;
   state.phase = "complete";
@@ -541,8 +641,7 @@ export function overrideMergeReadiness(directory: string, reason: string, sessio
   state.override_reason = reason.trim();
   state.completed_at = state.updated_at = new Date().toISOString();
   delete state.pending_question;
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 export function cancelMergeReadiness(directory: string, sessionId?: string): MergeReadinessState | null {
@@ -554,8 +653,7 @@ export function cancelMergeReadiness(directory: string, sessionId?: string): Mer
   state.result = "cancelled";
   state.completed_at = state.updated_at = new Date().toISOString();
   delete state.pending_question;
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 export function formatMergeReadinessQuestionMessage(state: MergeReadinessState): string {
@@ -660,8 +758,7 @@ export function recordMergeReadinessAnswer(
       : round,
   );
   state.updated_at = now;
-  writeMergeReadinessState(workingDir, state, sessionId);
-  return state;
+  return persistOrFailClosed(workingDir, state, sessionId);
 }
 
 export function isLikelyMergeReadinessAnswer(promptText: string): boolean {
@@ -717,11 +814,23 @@ export async function checkMergeReadiness(
       finalizeIfReady(state, now);
     }
   }
-  writeMergeReadinessState(workingDir, state, sessionId);
+  const persisted = writeMergeReadinessState(workingDir, state, sessionId);
 
   // finalizeIfReady (called above) may have deactivated the gate on pass/paused/
   // blocked. When active=false the session is released; otherwise block.
-  if (!state.active) return null;
+  if (!state.active) {
+    // Fail-closed: if the write could not land (invalid session id/state path),
+    // do NOT release the gate on a phantom pass/paused/blocked result. Force a
+    // block so the operator resolves the session id and re-runs.
+    if (!persisted) {
+      return {
+        shouldBlock: true,
+        message: "Merge-readiness state could not be persisted (invalid session id or state path). Resolve the session id and re-run merge_readiness_start.",
+        result: "blocked",
+      };
+    }
+    return null;
+  }
   return {
     shouldBlock: true,
     message: formatMergeReadinessQuestionMessage(state),

--- a/src/hooks/merge-readiness/runtime.ts
+++ b/src/hooks/merge-readiness/runtime.ts
@@ -114,19 +114,27 @@ function listArtifactFiles(directory: string): string[] {
     found.push(relativePath);
   };
 
+  // Cap evidence per artifact root (not globally): a repo with many unrelated
+  // files under plans/ must not exhaust the cap before logs/specs/interviews
+  // are inspected, or valid test/review evidence in those later roots is missed
+  // and the gate blocks incorrectly on artifact-only / --from-artifacts runs.
+  const MAX_PER_ROOT = 40;
   for (const candidate of dirCandidates) {
     const stack = [candidate];
-    while (stack.length > 0 && found.length < 40) {
+    let perRoot = 0;
+    while (stack.length > 0 && perRoot < MAX_PER_ROOT) {
       const current = stack.pop();
       if (!current) continue;
       try {
         const entries = readdirSync(current, { withFileTypes: true });
         for (const entry of entries) {
+          if (perRoot >= MAX_PER_ROOT) break;
           const full = join(current, entry.name);
           if (entry.isDirectory()) {
             stack.push(full);
           } else if (entry.isFile() && /\.(md|json|txt|log)$/i.test(entry.name)) {
             pushRelative(full);
+            perRoot++;
           }
         }
       } catch {

--- a/src/hooks/merge-readiness/types.ts
+++ b/src/hooks/merge-readiness/types.ts
@@ -99,11 +99,28 @@ export interface MergeReadinessState {
 }
 
 export interface MergeReadinessAttempt {
+  profile: MergeReadinessProfile;
+  threshold: number;
+  max_rounds: number;
+  required_dimensions: MergeReadinessDimension[];
+  change_summary: string;
+  slug: string;
   started_at?: string;
   completed_at?: string;
   result: MergeReadinessResult;
+  override_reason?: string;
   readiness_score: number;
-  change_summary?: string;
+  dimension_scores: Partial<Record<MergeReadinessDimension, number>>;
+  questions: MergeReadinessMCQQuestion[];
+  answers: MergeReadinessMCQAnswer[];
+  evidence_summary: {
+    changedFiles: string[];
+    source_mode?: "diff" | "artifacts";
+    missingEvidence: string[];
+    sourceArtifactCount: number;
+    testEvidenceCount: number;
+    reviewEvidenceCount: number;
+  };
 }
 
 export interface MergeReadinessPromptResult {

--- a/src/hooks/merge-readiness/types.ts
+++ b/src/hooks/merge-readiness/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Merge Readiness state, evidence, and result types.
+ *
+ * The v1 explainability gate is MCQ-driven: the AI generates an explanation
+ * document (5 narrative sections) plus a set of multiple-choice questions, the
+ * human answers them one per round (deep-interview style), and the runtime
+ * scores each answer objectively (selected option === correct option).
+ *
+ * Canonical dimension/profile/threshold definitions live in ./mcq.js and are
+ * re-exported here so existing imports from ./types.js keep compiling.
+ */
+
+export type {
+  MergeReadinessDimension,
+  MergeReadinessProfile,
+  MergeReadinessMCQOption,
+  MergeReadinessMCQQuestion,
+  MergeReadinessMCQAnswer,
+} from "./mcq.js";
+
+import type {
+  MergeReadinessDimension,
+  MergeReadinessProfile,
+  MergeReadinessMCQQuestion,
+  MergeReadinessMCQAnswer,
+} from "./mcq.js";
+
+export type MergeReadinessPhase = "evidence" | "content" | "questioning" | "complete";
+export type MergeReadinessResult = "pending" | "pass" | "paused" | "blocked" | "overridden" | "cancelled";
+
+export interface MergeReadinessEvidence {
+  changedFiles: string[];
+  /** Untracked paths are context only; they are never proof for --from-diff. */
+  untrackedFiles?: string[];
+  status: string;
+  diffStat: string;
+  sourceArtifacts: string[];
+  testEvidence: string[];
+  reviewEvidence: string[];
+  missingEvidence: string[];
+}
+
+/**
+ * @deprecated v1 uses objective MCQ scoring (questions + answers). This open
+ * ended round shape is retained only for backward-compatible state files and
+ * the legacy prompt-as-answer fallback; new code should not populate it.
+ */
+export interface MergeReadinessRound {
+  round: number;
+  dimension: MergeReadinessDimension;
+  question: string;
+  answer?: string;
+  score?: number;
+  created_at: string;
+  answered_at?: string;
+}
+
+export interface MergeReadinessState {
+  active: boolean;
+  session_id?: string;
+  current_phase: "merge-readiness";
+  phase: MergeReadinessPhase;
+  profile: MergeReadinessProfile;
+  threshold: number;
+  max_rounds: number;
+  required_dimensions: MergeReadinessDimension[];
+  /** @deprecated retained for backward-compatible state files; MCQ path uses questions/answers. */
+  rounds: MergeReadinessRound[];
+  /** AI-generated MCQs for this change. Empty until the AI calls setMergeReadinessContent. */
+  questions: MergeReadinessMCQQuestion[];
+  /** Human MCQ answers recorded one per round. */
+  answers: MergeReadinessMCQAnswer[];
+  /** True until the AI writes the generated doc + MCQs into state. */
+  awaiting_content: boolean;
+  validation_errors?: string[];
+  /** Next unanswered MCQ the human should see (deep-interview one-per-round). */
+  pending_question?: MergeReadinessMCQQuestion;
+  evidence: MergeReadinessEvidence;
+  /** Correctness rate over answered MCQs, in [0, 1]. */
+  readiness_score: number;
+  dimension_scores: Partial<Record<MergeReadinessDimension, number>>;
+  result: MergeReadinessResult;
+  // AI-generated explanation narrative (5 sections). Populated by setMergeReadinessContent.
+  why: string;
+  whatChanged: string;
+  tradeoffs: string;
+  risksConsidered: string;
+  teamUnderstanding: string;
+  started_at: string;
+  updated_at: string;
+  completed_at?: string;
+  override_reason?: string;
+  change_summary: string;
+  slug: string;
+  /** Evidence source mode: --from-diff requires a diff; --from-artifacts accepts .omc artifacts. */
+  source_mode?: "diff" | "artifacts";
+  /** Summaries of prior terminal attempts on this session, preserved across re-starts. */
+  prior_attempts?: MergeReadinessAttempt[];
+}
+
+export interface MergeReadinessAttempt {
+  started_at?: string;
+  completed_at?: string;
+  result: MergeReadinessResult;
+  readiness_score: number;
+  change_summary?: string;
+}
+
+export interface MergeReadinessPromptResult {
+  handled: boolean;
+  message?: string;
+}

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -89,6 +89,11 @@ const MODE_CONFIGS: Record<ExecutionMode, ModeConfig> = {
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.DEEP_INTERVIEW],
     activeProperty: "active",
   },
+  [MODE_NAMES.MERGE_READINESS]: {
+    name: "Merge Readiness",
+    stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.MERGE_READINESS],
+    activeProperty: "active",
+  },
   [MODE_NAMES.SELF_IMPROVE]: {
     name: "Self Improve",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.SELF_IMPROVE],

--- a/src/hooks/mode-registry/types.ts
+++ b/src/hooks/mode-registry/types.ts
@@ -12,6 +12,7 @@ export type ExecutionMode =
   | 'ultrawork'
   | 'ultraqa'
   | 'deep-interview'
+  | 'merge-readiness'
   | 'self-improve';
 
 export interface ModeConfig {

--- a/src/lib/mode-names.ts
+++ b/src/lib/mode-names.ts
@@ -16,6 +16,7 @@ export const MODE_NAMES = {
   ULTRAQA: 'ultraqa',
   RALPLAN: 'ralplan',
   DEEP_INTERVIEW: 'deep-interview',
+  MERGE_READINESS: 'merge-readiness',
   SELF_IMPROVE: 'self-improve',
 } as const;
 
@@ -45,6 +46,7 @@ export const ALL_MODE_NAMES: readonly ModeName[] = [
   MODE_NAMES.ULTRAQA,
   MODE_NAMES.RALPLAN,
   MODE_NAMES.DEEP_INTERVIEW,
+  MODE_NAMES.MERGE_READINESS,
   MODE_NAMES.SELF_IMPROVE,
 ] as const;
 
@@ -61,6 +63,7 @@ export const MODE_STATE_FILE_MAP: Readonly<Record<ModeName, string>> = {
   [MODE_NAMES.ULTRAQA]: 'ultraqa-state.json',
   [MODE_NAMES.RALPLAN]: 'ralplan-state.json',
   [MODE_NAMES.DEEP_INTERVIEW]: 'deep-interview-state.json',
+  [MODE_NAMES.MERGE_READINESS]: 'merge-readiness-state.json',
   [MODE_NAMES.SELF_IMPROVE]: 'self-improve-state.json',
 };
 
@@ -91,5 +94,6 @@ export const SESSION_METRICS_MODE_FILES: readonly { file: string; mode: string }
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.ULTRAWORK], mode: MODE_NAMES.ULTRAWORK },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.RALPLAN], mode: MODE_NAMES.RALPLAN },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.DEEP_INTERVIEW], mode: MODE_NAMES.DEEP_INTERVIEW },
+  { file: MODE_STATE_FILE_MAP[MODE_NAMES.MERGE_READINESS], mode: MODE_NAMES.MERGE_READINESS },
   { file: MODE_STATE_FILE_MAP[MODE_NAMES.SELF_IMPROVE], mode: MODE_NAMES.SELF_IMPROVE },
 ];

--- a/src/shared/artifact-descriptor.ts
+++ b/src/shared/artifact-descriptor.ts
@@ -1,5 +1,5 @@
-import { createHash } from 'crypto';
-import { mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { createHash, randomBytes } from 'crypto';
+import { closeSync, constants, mkdirSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
 
 export const DEFAULT_INLINE_ARTIFACT_THRESHOLD_BYTES = 2048;
@@ -92,8 +92,23 @@ export function createArtifactDescriptorFromPath(
 
 export function writeTextArtifact(options: WriteTextArtifactOptions): ArtifactDescriptor {
   mkdirSync(dirname(options.path), { recursive: true });
-  writeFileSync(options.path, options.content, { encoding: 'utf-8', mode: 0o600 });
-
+  // Atomic replacement with an exclusive, unpredictable temp name: random suffix + O_EXCL prevents
+  // same-process concurrent writes and stale/precreated temp collisions from clobbering each other.
+  const tmp = `${options.path}.tmp-${process.pid}-${randomBytes(8).toString("hex")}`;
+  const fd = openSync(tmp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  try {
+    writeFileSync(fd, options.content, { encoding: "utf-8" });
+  } catch (e) {
+    try { closeSync(fd); unlinkSync(tmp); } catch { /* best-effort */ }
+    throw e;
+  }
+  closeSync(fd);
+  try {
+    renameSync(tmp, options.path);
+  } catch (e) {
+    try { unlinkSync(tmp); } catch { /* best-effort */ }
+    throw e;
+  }
   return createArtifactDescriptorFromPath(options.path, options);
 }
 

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -1691,7 +1691,7 @@ export const stateTools = [
   stateGetStatusTool,
   {
     name: 'merge_readiness_start',
-    description: 'Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick/--standard/--deep; standard is default).',
+    description: 'Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick or --deep; standard is the default when neither flag is present).',
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     schema: {
       summary: z.string().max(2000),

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -1724,8 +1724,8 @@ export const stateTools = [
       const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
       const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
       const state = setMergeReadinessContent(directory, args, sessionId);
-      if (!state) {
-        return { content: [{ type: 'text' as const, text: 'Merge-readiness content rejected: no active gate. Call merge_readiness_start first.' }], isError: true };
+      if (!state || !state.active) {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness content rejected: no active gate (the gate is missing or already terminal - pass/cancelled/overridden). Call merge_readiness_start first.' }], isError: true };
       }
       const errors = state.validation_errors ?? [];
       return { content: [{ type: 'text' as const, text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(' ')}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? 'none'}` }], ...(errors.length > 0 ? { isError: true } : {}) };

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -40,6 +40,8 @@ import {
   type ExecutionMode
 } from '../hooks/mode-registry/index.js';
 import { ToolDefinition } from './types.js';
+import { cancelMergeReadiness, createInitialMergeReadinessState, readMergeReadinessState, setMergeReadinessContent, recordMergeReadinessMCQAnswer } from '../hooks/merge-readiness/runtime.js';
+import { formatMergeReadinessReport, redactMergeReadinessState } from '../hooks/merge-readiness/report.js';
 
 // Canonical execution modes from mode-registry (deep-interview and self-improve
 // are first-class modes with dedicated MODE_CONFIGS entries; ralplan remains an
@@ -48,8 +50,16 @@ const EXECUTION_MODES: [string, ...string[]] = [
   'autopilot', 'autoresearch', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
 ];
 
-// Extended type for state tools - includes state-bearing modes outside mode-registry
+// merge-readiness is read/clear-eligible (state_read/status/clear + /cancel work) but NOT write-eligible.
 const STATE_TOOL_MODES: [string, ...string[]] = [
+  ...EXECUTION_MODES,
+  'ralplan',
+  'omc-teams',
+  'skill-active',
+  'merge-readiness'
+];
+// Modes that may be generically written via state_write. Excludes merge-readiness (runtime-owned).
+const STATE_WRITE_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
   'ralplan',
   'omc-teams',
@@ -581,6 +591,12 @@ function findSingleOwningSessionForMode(
   return owningSessions.length === 1 ? owningSessions[0] : undefined;
 }
 
+function publicStateForMode(mode: StateToolMode, state: unknown): unknown {
+  return mode === 'merge-readiness'
+    ? redactMergeReadinessState(state as Parameters<typeof redactMergeReadinessState>[0])
+    : state;
+}
+
 // ============================================================================
 // state_read - Read state for a mode
 // ============================================================================
@@ -647,7 +663,7 @@ export const stateReadTool: ToolDefinition<{
         return {
           content: [{
             type: 'text' as const,
-            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(state, null, 2)}\n\`\`\``
+            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\``
           }]
         };
       }
@@ -684,7 +700,7 @@ export const stateReadTool: ToolDefinition<{
         try {
           const content = readFileSync(statePath, 'utf-8');
           const state = JSON.parse(content);
-          output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(state, null, 2)}\n\`\`\`\n\n`;
+          output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\`\n\n`;
         } catch {
           output += `### Legacy Path (shared)\nPath: ${statePath}\n*Error reading state file*\n\n`;
         }
@@ -701,7 +717,7 @@ export const stateReadTool: ToolDefinition<{
           try {
             const content = readFileSync(sessionStatePath, 'utf-8');
             const state = JSON.parse(content);
-            output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(state, null, 2)}\n\`\`\`\n\n`;
+            output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\`\n\n`;
           } catch {
             output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n*Error reading state file*\n\n`;
           }
@@ -731,7 +747,7 @@ export const stateReadTool: ToolDefinition<{
 // ============================================================================
 
 export const stateWriteTool: ToolDefinition<{
-  mode: z.ZodEnum<typeof STATE_TOOL_MODES>;
+  mode: z.ZodEnum<typeof STATE_WRITE_MODES>;
   active: z.ZodOptional<z.ZodBoolean>;
   iteration: z.ZodOptional<z.ZodNumber>;
   max_iterations: z.ZodOptional<z.ZodNumber>;
@@ -749,7 +765,7 @@ export const stateWriteTool: ToolDefinition<{
   description: 'Write/update state for a specific mode. Creates the state file and directories if they do not exist. Common fields (active, iteration, phase, etc.) can be set directly as parameters. Additional custom fields can be passed via the optional `state` parameter. Note: swarm uses SQLite and cannot be written via this tool.',
   annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
   schema: {
-    mode: z.enum(STATE_TOOL_MODES).describe('The mode to write state for'),
+    mode: z.enum(STATE_WRITE_MODES).describe('The mode to write state for'),
     active: z.boolean().optional().describe('Whether the mode is currently active'),
     iteration: z.number().optional().describe('Current iteration number'),
     max_iterations: z.number().optional().describe('Maximum iterations allowed'),
@@ -877,7 +893,7 @@ export const stateClearTool: ToolDefinition<{
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
   name: 'state_clear',
-  description: 'Clear/delete state for a specific mode. Removes the state file and any associated marker files.',
+  description: 'Clear/delete state for a specific mode. Removes the state file and any associated marker files. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).',
   annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
   schema: {
     mode: z.enum(STATE_TOOL_MODES).describe('The mode to clear state for'),
@@ -890,6 +906,35 @@ export const stateClearTool: ToolDefinition<{
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
+
+      // Merge-readiness is an audit gate, so clearing it must leave a durable
+      // terminal result and report rather than deleting the evidence trail.
+      if (mode === 'merge-readiness') {
+        const cancelledSessions: string[] = [];
+        const cancelActiveSession = (targetSessionId?: string): boolean => {
+          const current = readMergeReadinessState(root, targetSessionId);
+          return current?.active === true && cancelMergeReadiness(root, targetSessionId)?.result === 'cancelled';
+        };
+        if (sessionId) {
+          validateSessionId(sessionId);
+          if (cancelActiveSession(sessionId)) cancelledSessions.push(sessionId);
+        } else {
+          // Omitting session_id must not cross session boundaries: only cancel
+          // the caller's own session (resolved from env) and legacy state,
+          // never other sessions' active gates.
+          const callerSid = (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+          if (callerSid && cancelActiveSession(callerSid)) cancelledSessions.push(callerSid);
+          if (cancelActiveSession()) cancelledSessions.push('legacy');
+        }
+        return {
+          content: [{
+            type: 'text' as const,
+            text: cancelledSessions.length > 0
+              ? `Cancelled merge-readiness gate(s) with durable state audit records: ${cancelledSessions.join(', ')}`
+              : 'No active merge-readiness gate found; existing state audit records were preserved.',
+          }],
+        };
+      }
       const cleanedTeamNames = new Set<string>();
 
       const collectTeamNamesForCleanup = (statePath: string): void => {
@@ -1505,7 +1550,7 @@ export const stateGetStatusTool: ToolDefinition<{
             try {
               const content = readFileSync(statePath, 'utf-8');
               const state = JSON.parse(content);
-              statePreview = JSON.stringify(state, null, 2).slice(0, 500);
+              statePreview = JSON.stringify(publicStateForMode(mode, state), null, 2).slice(0, 500);
               if (statePreview.length >= 500) statePreview += '\n...(truncated)';
             } catch {
               statePreview = 'Error reading state file';
@@ -1644,4 +1689,116 @@ export const stateTools = [
   stateClearTool,
   stateListActiveTool,
   stateGetStatusTool,
+  {
+    name: 'merge_readiness_start',
+    description: 'Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick/--standard/--deep; standard is default).',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      summary: z.string().max(2000),
+      baseRef: z.string().max(200).regex(/^[A-Za-z0-9._\/@{}~^:-]+$/, "baseRef must be a valid git ref").refine((s) => !s.startsWith("-"), "baseRef must not start with '-'").optional().describe("Base ref to diff committed changes against (e.g. origin/dev, HEAD, HEAD~1, HEAD^). Defaults to the branch upstream / origin/HEAD."),
+      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+    },
+    handler: async (args: { summary: string; workingDirectory?: string; session_id?: string; baseRef?: string }) => {
+      try {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+      const state = createInitialMergeReadinessState(directory, args.summary, sessionId, args.baseRef);
+      const blocked = state.result === 'blocked';
+      return { content: [{ type: 'text' as const, text: blocked ? `Merge-readiness blocked: ${state.validation_errors?.join(' ') ?? 'missing evidence'}` : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.` }], ...(blocked ? { isError: true } : {}) };
+      } catch (error) {
+        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    },
+  } as ToolDefinition<any>,
+  {
+    name: 'merge_readiness_set_content',
+    description: 'Validate and submit the five-section merge-readiness report and objective MCQs. Requires an active gate (call merge_readiness_start first).',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      why: z.string().max(10000), whatChanged: z.string().max(10000), tradeoffs: z.string().max(10000), risksConsidered: z.string().max(10000), teamUnderstanding: z.string().max(10000),
+      questions: z.array(z.object({ id: z.string().max(100), dimension: z.enum(['why', 'change', 'tradeoff', 'risk', 'team']), stem: z.string().max(2000), options: z.array(z.object({ id: z.string().max(100), text: z.string().max(1000) })).max(8), correctOptionId: z.string().max(100), rationale: z.string().max(2000).optional() })).max(8),
+      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+    },
+    handler: async (args: { why: string; whatChanged: string; tradeoffs: string; risksConsidered: string; teamUnderstanding: string; questions: Array<any>; workingDirectory?: string; session_id?: string }) => {
+      try {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+      const state = setMergeReadinessContent(directory, args, sessionId);
+      if (!state) {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness content rejected: no active gate. Call merge_readiness_start first.' }], isError: true };
+      }
+      const errors = state.validation_errors ?? [];
+      return { content: [{ type: 'text' as const, text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(' ')}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? 'none'}` }], ...(errors.length > 0 ? { isError: true } : {}) };
+      } catch (error) {
+        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    },
+  } as ToolDefinition<any>,
+  {
+    name: 'merge_readiness_record_answer',
+    description: 'Record the human-selected option for the current merge-readiness MCQ. Advances the gate; returns the next question or the final result plus readiness score.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    schema: {
+      questionId: z.string().max(100),
+      optionId: z.string().max(100),
+      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+    },
+    handler: async (args: { questionId: string; optionId: string; workingDirectory?: string; session_id?: string }) => {
+      try {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
+      const state = recordMergeReadinessMCQAnswer(directory, args.questionId, args.optionId, sessionId);
+      if (!state) {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ.' }], isError: true };
+      }
+      const result = state.result;
+      const score = state.readiness_score;
+      const terminal = result === 'pass' || result === 'paused' || result === 'blocked' || result === 'overridden';
+      const text = terminal
+        ? `Merge-readiness ${result}. Readiness score: ${score}. ${result === 'pass' ? 'The change may proceed to human merge approval.' : result === 'paused' ? 'Explanation gap remains; reread the report and rerun /merge-readiness.' : result === 'blocked' ? 'Missing evidence; produce it before rerunning.' : 'Gate overridden; terminal session state preserves the record.'}`
+        : `Answer recorded. Next question: ${state.pending_question?.id ?? 'none'}. Answered: ${state.answers.length}/${state.questions.length}.`;
+      return { content: [{ type: 'text' as const, text }] };
+      } catch (error) {
+        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    },
+  } as ToolDefinition<any>,
+  {
+    name: 'merge_readiness_report',
+    description: 'Render the authoritative merge-readiness session state as a Markdown report without writing a file.',
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    schema: { workingDirectory: z.string().optional(), session_id: z.string().optional() },
+    handler: async (args: { workingDirectory?: string; session_id?: string }) => {
+      try {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: 'cli' });
+      const state = readMergeReadinessState(directory, sessionId);
+      if (!state) {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness report unavailable: no session state found.' }], isError: true };
+      }
+      return { content: [{ type: 'text' as const, text: formatMergeReadinessReport(state) }] };
+      } catch (error) {
+        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    },
+  } as ToolDefinition<any>,
+  {
+    name: 'merge_readiness_cancel',
+    description: 'Cancel an active merge-readiness gate while preserving its terminal state audit record.',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    schema: { workingDirectory: z.string().optional(), session_id: z.string().optional() },
+    handler: async (args: { workingDirectory?: string; session_id?: string }) => {
+      try {
+      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: 'cli' });
+      const state = cancelMergeReadiness(directory, sessionId);
+      if (!state || state.result !== 'cancelled') {
+        return { content: [{ type: 'text' as const, text: 'Merge-readiness cancellation rejected: no active gate.' }], isError: true };
+      }
+      return { content: [{ type: 'text' as const, text: 'Merge-readiness cancelled. Terminal session state preserved as the audit record.' }] };
+      } catch (error) {
+        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    },
+  } as ToolDefinition<any>,
 ];


### PR DESCRIPTION
Fresh single-commit revision on the latest `dev` (a32217d6). Supersedes #3461. All review findings across rounds are addressed and test-verified.

## What
Post-task, pre-merge human explainability gate. Collects git/.omc evidence, requires a 5-section explanation, quizzes the operator via objective MCQs. v1 is advisory (gate logic exists; not wired to the Stop hook). Passing never approves merge, replaces tests/review, or accepts risk.

## Surface (17 files, +3486/-346)
- `skills/merge-readiness/SKILL.md` (advisory; no Stop-hook claim)
- `src/hooks/merge-readiness/`: runtime, report (pure render + redaction), mcq, types, index, tests
- `src/tools/state-tools.ts`: 5 tools (start/set_content/record_answer/report/cancel) + state_clear durable-cancel
- `src/lib/mode-names.ts`, `src/hooks/mode-registry/`: mode registration (read/clear-eligible, not state_write-able)
- `src/shared/artifact-descriptor.ts`: atomic-write hardening (random+O_EXCL+rename)
- `.claude-plugin/plugin.json`: skill registration
- `bridge/mcp-server.cjs`: hosted bundle with the 5 tools (so marketplace installs ship them)

## All prior review findings addressed
- Evidence: scans plans/artifacts/logs/specs/interviews; minimal-evidence requires a diff or a real test/review artifact (an unrelated file no longer starts the gate).
- Audit history: `prior_attempts[]` preserved across re-start.
- Persistence: `writeMergeReadinessState` checks the `writeModeState` boolean; init fails closed (blocked) when state cannot be persisted.
- Session isolation: `state_clear` without `session_id` only cancels the caller's session, not every session.
- Redaction: `state_read`/`state_get_status`/`report` hide `correctOptionId`, `rationale`, `isCorrect`, and interim scoring while pending.
- state_clear durable-cancel (no deletion); `--from-diff` requires a tracked diff; `baseRef` validated (no option injection).
- Source-mode parsing uses bounded regex (not substring).
- No merge-readiness-owned filesystem writer (removed); persistence delegates to shared mode-state IO.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `runtime.test.ts` (28, incl. 5 behavior tests: unrelated-artifact blocks, specs-only starts, prior_attempts preserved, fail-closed on invalid session, blocked-gate message)
- [x] `tool-flow.test.ts` (7, incl. no-cross-session state_clear)
- [x] `state-tools.test.ts` (58, no regression)
- [x] `omc-tools-server.test.ts` (14, tool count 54/62)
- [x] `git diff --check` clean; no `dist/` or unrelated drift in the diff
- [ ] CI (this PR)

A fail-closed test caught and fixed a real bug during verification: `readMergeReadinessState` threw on an invalid session id (validateSessionId), so the prior-attempt read is now wrapped in try/catch.