### PR TITLE
fix(ultragoal): recover the active /goal from the transcript on Claude Code

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -6,7 +6,7 @@
  * Cross-platform: Windows, macOS, Linux
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from 'fs';
 import { createHash } from 'crypto';
 import { dirname, join, resolve, basename } from 'path';
 import { homedir } from 'os';
@@ -716,7 +716,73 @@ function getExpectedUltragoalObjective(state, directory) {
   return '';
 }
 
-function extractClaudeGoalSnapshot(data) {
+// Upper bound on the transcript we are willing to read on every tool call.
+const MAX_TRANSCRIPT_BYTES = 25 * 1024 * 1024;
+// A canonical `/goal` local-command-stdout event, e.g.
+// `<local-command-stdout>Goal set: <objective></local-command-stdout>` or
+// `<local-command-stdout>Goal cleared</local-command-stdout>`.
+const GOAL_STDOUT_EVENT = /<local-command-stdout>\s*Goal (set:|cleared)([\s\S]*?)<\/local-command-stdout>/g;
+
+// Recover the active Claude `/goal` from the session transcript.
+//
+// Claude Code does not expose live `/goal` state to hooks (the PreToolUse payload
+// carries none of the goal fields read below), but every hook receives
+// `transcript_path`, where `/goal` set/clear are recorded as `/goal` local-command
+// stdout records. Reading only those lets the guard observe a goal the user actually
+// set instead of denying forever (issue #3341) — without trusting arbitrary text.
+//
+// Authorization boundary (PR review on #3465):
+// - the transcript must be the active session's own file (`<sessionId>.jsonl`);
+// - it must be a bounded regular file;
+// - only canonical user-role `/goal` local-command-stdout records count as evidence
+//   (malformed lines and ordinary message text are ignored);
+// - set/clear events are applied strictly in order, last-event-wins.
+function extractGoalFromTranscript(transcriptPath, sessionId) {
+  if (typeof transcriptPath !== 'string' || !transcriptPath) return null;
+  // Bind the transcript to the active session; Claude Code names it `<sessionId>.jsonl`.
+  // Without a verifiable session binding a foreign file cannot be trusted as evidence.
+  if (typeof sessionId !== 'string' || !sessionId) return null;
+  if (basename(transcriptPath).replace(/\.jsonl$/i, '') !== sessionId) return null;
+
+  let stat;
+  try {
+    stat = statSync(transcriptPath);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TRANSCRIPT_BYTES) return null;
+
+  let content;
+  try {
+    content = readFileSync(transcriptPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  let objective = '';
+  for (const line of content.split('\n')) {
+    if (!line || line.indexOf('local-command-stdout') === -1) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue; // a malformed line is not evidence
+    }
+    // Only trust canonical user-role `/goal` command-output records.
+    if (entry?.type !== 'user') continue;
+    const message = entry.message;
+    if (!message || message.role !== 'user' || typeof message.content !== 'string') continue;
+    const events = [...message.content.matchAll(GOAL_STDOUT_EVENT)];
+    if (events.length === 0) continue;
+    const last = events[events.length - 1]; // last event in this record wins
+    objective = last[1] === 'cleared' ? '' : last[2].trim();
+  }
+
+  if (!objective) return null;
+  return { objective, status: 'active' };
+}
+
+function extractClaudeGoalSnapshot(data, sessionId) {
   const candidates = [
     data.goal,
     data.claude_goal,
@@ -738,9 +804,20 @@ function extractClaudeGoalSnapshot(data) {
       }
     }
   }
-  return null;
+  // Runtime injected no goal field (the standard Claude Code case): fall back to the
+  // transcript, the only place a hook can observe an active `/goal`.
+  return extractGoalFromTranscript(data.transcript_path ?? data.transcriptPath, sessionId);
 }
 
+
+// A bootstrap/exit bypass must apply to one indivisible command only. Reject shell
+// chaining/expansion so a recognized token cannot smuggle other commands past the guard
+// (e.g. `omc ultragoal checkpoint ... && npm test`). See PR review on #3465.
+function isSingleShellCommand(command) {
+  return typeof command === 'string'
+    && command.trim().length > 0
+    && !/[\n\r;&|`]|\$\(|<\(|>\(/.test(command);
+}
 
 function isCancelSkillBootstrapTool(toolName, toolInput) {
   const skillName = extractSkillName(toolInput);
@@ -762,14 +839,16 @@ function isCancelSkillBootstrapTool(toolName, toolInput) {
 
   if (toolName !== 'Bash') return false;
   const command = typeof toolInput.command === 'string' ? toolInput.command : '';
-  return /(?:^|[;&|\s])(?:omc|oh-my-claudecode|gjc)\s+(?:state\s+(?:clear|read|write|list-active|get-status)|cancel)\b/.test(command);
+  if (!isSingleShellCommand(command)) return false;
+  return /^(?:omc|oh-my-claudecode|gjc)\s+(?:state\s+(?:clear|read|write|list-active|get-status)|cancel)\b/.test(command.trim());
 }
 
 function isUltragoalBootstrapTool(toolName, toolInput) {
   if (toolName === 'Skill' && extractSkillName(toolInput) === 'ultragoal') return true;
   if (toolName !== 'Bash') return false;
   const command = typeof toolInput.command === 'string' ? toolInput.command : '';
-  return /(?:^|[;&|\s])(?:omc|oh-my-claudecode)\s+ultragoal\s+(?:create(?:-goals)?|create-goals|complete(?:-goals)?|complete-goals|next|start-next|status)\b/.test(command);
+  if (!isSingleShellCommand(command)) return false;
+  return /^(?:omc|oh-my-claudecode)\s+ultragoal\s+(?:create(?:-goals)?|complete(?:-goals)?|next|start-next|status|checkpoint|record-review-blockers)\b/.test(command.trim());
 }
 
 function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, data) {
@@ -786,13 +865,19 @@ function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, dat
   if (isUltragoalTerminalState(state, directory)) return null;
 
   const expected = getExpectedUltragoalObjective(state, directory);
-  const actual = extractClaudeGoalSnapshot(data);
+  const actual = extractClaudeGoalSnapshot(data, sessionId);
   const actualObjective = normalizeText(actual?.objective);
   const expectedObjective = normalizeText(expected);
   const status = normalizePhase(actual?.status);
   const objectiveMatches = Boolean(actualObjective && expectedObjective && actualObjective === expectedObjective);
   const activeStatus = status === '' || status === 'active' || status === 'in_progress' || status === 'running';
 
+  // #3341: Claude Code does not expose live `/goal` state to a PreToolUse hook, so
+  // `actual` may be recovered from the session transcript (see extractGoalFromTranscript)
+  // in addition to the payload. Objective/status matching semantics are otherwise
+  // unchanged: an explicit or recovered goal must match the expected ultragoal objective
+  // (or the expected objective must be unseeded). Denying when no active goal is
+  // observable at all is preserved below, so the guard stays meaningful.
   if (!expectedObjective && actualObjective && activeStatus) return null;
   if (objectiveMatches && activeStatus) return null;
 

--- a/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
@@ -138,6 +138,173 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
     expect(result.hookSpecificOutput?.permissionDecisionReason).toContain('ALLOW_ULTRAGOAL_WITHOUT_GOAL=1');
   });
 
+  // Write a session-bound transcript (`<sessionId>.jsonl`) with the given record
+  // contents, mirroring how Claude Code records `/goal` local-command output.
+  function writeSessionTranscript(cwd: string, sessionId: string, contents: string[]) {
+    const transcriptPath = join(cwd, `${sessionId}.jsonl`);
+    writeFileSync(
+      transcriptPath,
+      `${contents
+        .map(content => JSON.stringify({ type: 'user', message: { role: 'user', content } }))
+        .join('\n')}\n`,
+    );
+    return transcriptPath;
+  }
+
+  it('allows PreToolUse when an active Claude /goal is recovered from the transcript', () => {
+    const cwd = makeTempProject('omc-ultragoal-transcript-');
+    writeUltragoalState(cwd);
+    // Claude Code never puts /goal in the hook payload; it is only recorded in the
+    // session transcript as a `/goal` local-command-stdout record. The guard must
+    // recover it there instead of denying every tool for the whole run (regression
+    // for #3341).
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      '<command-name>/goal</command-name>',
+      '<local-command-stdout>Goal set: Complete issue #3098 ultragoal persistence.</local-command-stdout>',
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('re-denies when the transcript shows the /goal was cleared', () => {
+    const cwd = makeTempProject('omc-ultragoal-transcript-cleared-');
+    writeUltragoalState(cwd);
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      '<local-command-stdout>Goal set: Complete issue #3098 ultragoal persistence.</local-command-stdout>',
+      '<local-command-stdout>Goal cleared</local-command-stdout>',
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('denies when the transcript is not the active session file (#3465 blocker 1)', () => {
+    const cwd = makeTempProject('omc-ultragoal-foreign-transcript-');
+    writeUltragoalState(cwd);
+    // A canonical-looking record, but in a file not bound to this session.
+    const foreignPath = join(cwd, 'not-the-session.jsonl');
+    writeFileSync(
+      foreignPath,
+      `${JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: '<local-command-stdout>Goal set: Complete issue #3098 ultragoal persistence.</local-command-stdout>' },
+      })}\n`,
+    );
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: foreignPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('denies when transcript prose merely quotes "Goal set:" outside a /goal record (#3465 blocker 1)', () => {
+    const cwd = makeTempProject('omc-ultragoal-prose-transcript-');
+    writeUltragoalState(cwd);
+    // Ordinary user message text (not a /goal local-command-stdout record) must not
+    // authorize tools, even in the session-bound file.
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      'Please investigate: Goal set: Complete issue #3098 ultragoal persistence.',
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('applies set/clear in order within one record, last-event-wins (#3465 blocker 2)', () => {
+    const cwd = makeTempProject('omc-ultragoal-record-order-');
+    writeUltragoalState(cwd);
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      '<local-command-stdout>Goal set: Complete issue #3098 ultragoal persistence.</local-command-stdout> then <local-command-stdout>Goal cleared</local-command-stdout>',
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('denies an explicit payload goal whose objective does not match the plan (#3465 blocker 3)', () => {
+    const cwd = makeTempProject('omc-ultragoal-payload-mismatch-');
+    writeUltragoalState(cwd);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      goal: { objective: 'Some entirely unrelated objective', status: 'active' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('allows single ultragoal checkpoint / record-review-blockers commands', () => {
+    const cwd = makeTempProject('omc-ultragoal-checkpoint-');
+    writeUltragoalState(cwd);
+
+    const checkpoint = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal checkpoint --goal-id G001 --status complete' },
+    });
+    const blockers = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal record-review-blockers --goal-id G001' },
+    });
+
+    expect(checkpoint.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    expect(blockers.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('does not let a checkpoint bypass smuggle a chained command (#3465 blocker 4)', () => {
+    const cwd = makeTempProject('omc-ultragoal-checkpoint-chain-');
+    writeUltragoalState(cwd);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal checkpoint --goal-id G001 --status complete && npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
   it('ignores stale ultragoal state in PreToolUse and Stop enforcement', () => {
     const cwd = makeTempProject('omc-ultragoal-stale-');
     writeUltragoalState(cwd, {


### PR DESCRIPTION
## Summary

Follow-up to #3343; fixes the still-live standalone-Claude-Code case of #3341. Supersedes #3465 (closed with `REQUEST_CHANGES`) — this revision resolves all four authorization-boundary blockers from that review and targets `dev`.

The ultragoal PreToolUse guard read the active Claude `/goal` only from hook-stdin fields (`data.goal` / `claude_goal` / `codex_goal` / …). **Claude Code never places `/goal` in the PreToolUse payload**, so `extractClaudeGoalSnapshot()` always returned `null` and the guard denied *every* tool for the whole run — regardless of whether `/goal` was set — bricking the session.

## Changes

- **Recover the goal from the session transcript**, the only place a hook can observe `/goal`. Evidence is strictly authenticated:
  - the transcript must be **the active session's own file** (`<sessionId>.jsonl`), a **bounded regular file**;
  - only **user-role `/goal` local-command-stdout records** count — arbitrary message prose and malformed lines are ignored;
  - set/clear events are applied **in order, last-event-wins** (within a record and across records).
- **Objective/status matching is unchanged.** An explicit *or* transcript-recovered goal must match the expected ultragoal objective (or expected must be unseeded); a mismatched payload goal is still denied. Exact reconciliation against the durable plan stays at `omc ultragoal checkpoint`.
- **Exempt only single `omc ultragoal checkpoint` / `record-review-blockers` commands** so a run can't block its own progress/exit, and **reject shell chaining/expansion** so a recognized token can't smuggle other commands (applied to the cancel/state bypass too).

## Addressing the #3465 review

1. **Foreign/untrusted transcript** → now requires `basename === <sessionId>.jsonl`, a regular bounded file, canonical user-role `/goal` stdout records only; malformed lines skipped.
2. **Set/clear ordering within one record** → `matchAll` + last-event-wins, no early `continue`.
3. **Objective matching removed for payloads** → the unconditional presence branch is gone; exact `objectiveMatches` (or unseeded-expected) restored for payload *and* transcript.
4. **Compound-command bypass** → `isSingleShellCommand()` rejects `;`, `&`, `|`, backtick, `$(`, `<(`, `>(`; bypass regexes anchored to the start of a single command.

## Verification

`NODE_OPTIONS` cleared:
- `npx vitest run src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts` → **19/19** (8 new, incl. a negative regression test for each reproducer above).
- `npx tsc --noEmit` → 0.
- `npm run build` → 0.

Manual hook trace: canonical session transcript → allow; foreign transcript → deny; non-stdout prose → deny; in-record set→clear → deny; payload mismatch → deny; `checkpoint … && npm test` → deny; no goal anywhere → deny (guard preserved).

## Gate

Opened after developer confirmation. Merge/issue closure still requires the review-gate.