### PR TITLE
fix(ultragoal): recover the active /goal from the transcript on Claude Code

### DIFF
--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -6,7 +6,7 @@
  * Cross-platform: Windows, macOS, Linux
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'fs';
+import { closeSync, existsSync, fstatSync, lstatSync, mkdirSync, openSync, readFileSync, readSync, readdirSync, renameSync, writeFileSync } from 'fs';
 import { createHash } from 'crypto';
 import { dirname, join, resolve, basename } from 'path';
 import { homedir } from 'os';
@@ -716,7 +716,107 @@ function getExpectedUltragoalObjective(state, directory) {
   return '';
 }
 
-function extractClaudeGoalSnapshot(data) {
+// Upper bound on the transcript we are willing to read on every tool call.
+const MAX_TRANSCRIPT_BYTES = 25 * 1024 * 1024;
+// The authoritative `/goal` signal is the slash-command *invocation* record, not the
+// `<local-command-stdout>` display echo (which Claude Code also emits for ordinary
+// user-typed/pasted prompts, so display text is spoofable). A real record looks like
+// `<command-name>/goal</command-name> ... <command-args>OBJECTIVE</command-args>`.
+const GOAL_COMMAND_MARKER = /<command-name>\s*\/goal\s*<\/command-name>/;
+const GOAL_COMMAND_ARGS = /<command-args>([\s\S]*?)<\/command-args>/;
+// Any line that plausibly carries `/goal` state — intentionally broad (matches even
+// truncated markers) so a malformed goal-bearing record fails closed instead of
+// silently keeping a stale goal active.
+const GOAL_BEARING_HINT = /\/goal|Goal set|Goal cleared|local-command-stdout/;
+
+// Read a bounded regular file without following symlinks and without a stat->open race:
+// reject symlinks via lstat, then stat the open fd (fstat) and read through that same fd.
+function readBoundedTranscript(path) {
+  let linkStat;
+  try {
+    linkStat = lstatSync(path);
+  } catch {
+    return null;
+  }
+  if (linkStat.isSymbolicLink() || !linkStat.isFile()) return null;
+
+  let fd;
+  try {
+    fd = openSync(path, 'r');
+  } catch {
+    return null;
+  }
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TRANSCRIPT_BYTES) return null;
+    const buffer = Buffer.allocUnsafe(stat.size);
+    let read = 0;
+    while (read < stat.size) {
+      const n = readSync(fd, buffer, read, stat.size - read, read);
+      if (n <= 0) break;
+      read += n;
+    }
+    return buffer.toString('utf-8', 0, read);
+  } catch {
+    return null;
+  } finally {
+    try { closeSync(fd); } catch { /* ignore */ }
+  }
+}
+
+// Recover the active Claude `/goal` from the session transcript.
+//
+// Claude Code does not expose live `/goal` state to hooks (the PreToolUse payload
+// carries none of the goal fields read below), but every hook receives
+// `transcript_path`, where a `/goal` invocation is recorded as a command record.
+// Reading it lets the guard observe a goal the user actually set instead of denying
+// forever (issue #3341) — without trusting arbitrary transcript text.
+//
+// Authorization boundary (PR review on #3465/#3466):
+// - resolve worktree-encoded paths via the shared resolver, then require the file to be
+//   the active session's own transcript (`<sessionId>.jsonl`);
+// - read a bounded, non-symlink regular file through a stable fd;
+// - trust only command-originated `/goal` records (`<command-name>/goal</command-name>`),
+//   never `<local-command-stdout>` display text;
+// - apply set/clear strictly in order (last-event-wins) and fail closed if any
+//   goal-bearing record is malformed.
+function extractGoalFromTranscript(rawTranscriptPath, sessionId, cwd) {
+  if (typeof rawTranscriptPath !== 'string' || !rawTranscriptPath) return null;
+  if (typeof sessionId !== 'string' || !sessionId) return null;
+
+  const resolved = resolveTranscriptPath(rawTranscriptPath, cwd);
+  if (typeof resolved !== 'string' || !resolved) return null;
+  // Bind to the active session; Claude Code names the transcript `<sessionId>.jsonl`.
+  if (basename(resolved).replace(/\.jsonl$/i, '') !== sessionId) return null;
+
+  const content = readBoundedTranscript(resolved);
+  if (content === null) return null;
+
+  let objective = '';
+  for (const line of content.split('\n')) {
+    if (!line || !GOAL_BEARING_HINT.test(line)) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      return null; // fail closed: a malformed goal-bearing record invalidates recovery
+    }
+    if (entry?.type !== 'user') continue;
+    const message = entry.message;
+    if (!message || message.role !== 'user' || typeof message.content !== 'string') continue;
+    // Trust only command-originated `/goal` records, not display stdout text.
+    if (!GOAL_COMMAND_MARKER.test(message.content)) continue;
+    const argsMatch = message.content.match(GOAL_COMMAND_ARGS);
+    const args = argsMatch ? argsMatch[1].trim() : '';
+    // `/goal clear` (or empty args) clears; any other args are the objective.
+    objective = args === '' || args.toLowerCase() === 'clear' ? '' : args;
+  }
+
+  if (!objective) return null;
+  return { objective, status: 'active' };
+}
+
+function extractClaudeGoalSnapshot(data, sessionId, cwd) {
   const candidates = [
     data.goal,
     data.claude_goal,
@@ -738,9 +838,20 @@ function extractClaudeGoalSnapshot(data) {
       }
     }
   }
-  return null;
+  // Runtime injected no goal field (the standard Claude Code case): fall back to the
+  // transcript, the only place a hook can observe an active `/goal`.
+  return extractGoalFromTranscript(data.transcript_path ?? data.transcriptPath, sessionId, cwd);
 }
 
+
+// A bootstrap/exit bypass must apply to one indivisible command only. Reject shell
+// chaining/expansion so a recognized token cannot smuggle other commands past the guard
+// (e.g. `omc ultragoal checkpoint ... && npm test`). See PR review on #3465.
+function isSingleShellCommand(command) {
+  return typeof command === 'string'
+    && command.trim().length > 0
+    && !/[\n\r;&|`]|\$\(|<\(|>\(/.test(command);
+}
 
 function isCancelSkillBootstrapTool(toolName, toolInput) {
   const skillName = extractSkillName(toolInput);
@@ -762,14 +873,16 @@ function isCancelSkillBootstrapTool(toolName, toolInput) {
 
   if (toolName !== 'Bash') return false;
   const command = typeof toolInput.command === 'string' ? toolInput.command : '';
-  return /(?:^|[;&|\s])(?:omc|oh-my-claudecode|gjc)\s+(?:state\s+(?:clear|read|write|list-active|get-status)|cancel)\b/.test(command);
+  if (!isSingleShellCommand(command)) return false;
+  return /^(?:omc|oh-my-claudecode|gjc)\s+(?:state\s+(?:clear|read|write|list-active|get-status)|cancel)\b/.test(command.trim());
 }
 
 function isUltragoalBootstrapTool(toolName, toolInput) {
   if (toolName === 'Skill' && extractSkillName(toolInput) === 'ultragoal') return true;
   if (toolName !== 'Bash') return false;
   const command = typeof toolInput.command === 'string' ? toolInput.command : '';
-  return /(?:^|[;&|\s])(?:omc|oh-my-claudecode)\s+ultragoal\s+(?:create(?:-goals)?|create-goals|complete(?:-goals)?|complete-goals|next|start-next|status)\b/.test(command);
+  if (!isSingleShellCommand(command)) return false;
+  return /^(?:omc|oh-my-claudecode)\s+ultragoal\s+(?:create(?:-goals)?|complete(?:-goals)?|next|start-next|status|checkpoint|record-review-blockers)\b/.test(command.trim());
 }
 
 function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, data) {
@@ -786,13 +899,19 @@ function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, dat
   if (isUltragoalTerminalState(state, directory)) return null;
 
   const expected = getExpectedUltragoalObjective(state, directory);
-  const actual = extractClaudeGoalSnapshot(data);
+  const actual = extractClaudeGoalSnapshot(data, sessionId, directory);
   const actualObjective = normalizeText(actual?.objective);
   const expectedObjective = normalizeText(expected);
   const status = normalizePhase(actual?.status);
   const objectiveMatches = Boolean(actualObjective && expectedObjective && actualObjective === expectedObjective);
   const activeStatus = status === '' || status === 'active' || status === 'in_progress' || status === 'running';
 
+  // #3341: Claude Code does not expose live `/goal` state to a PreToolUse hook, so
+  // `actual` may be recovered from the session transcript (see extractGoalFromTranscript)
+  // in addition to the payload. Objective/status matching semantics are otherwise
+  // unchanged: an explicit or recovered goal must match the expected ultragoal objective
+  // (or the expected objective must be unseeded). Denying when no active goal is
+  // observable at all is preserved below, so the guard stays meaningful.
   if (!expectedObjective && actualObjective && activeStatus) return null;
   if (objectiveMatches && activeStatus) return null;
 

--- a/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -136,6 +136,234 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
 
     expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
     expect(result.hookSpecificOutput?.permissionDecisionReason).toContain('ALLOW_ULTRAGOAL_WITHOUT_GOAL=1');
+  });
+
+  // Write a session-bound transcript (`<sessionId>.jsonl`) with the given record
+  // contents, mirroring how Claude Code records `/goal` local-command output.
+  const PLAN_OBJECTIVE = 'Complete issue #3098 ultragoal persistence.';
+  // A canonical `/goal` slash-command invocation record content string.
+  function goalCommand(args: string) {
+    return `<command-name>/goal</command-name>\n<command-message>goal</command-message>\n<command-args>${args}</command-args>`;
+  }
+  function writeSessionTranscript(cwd: string, sessionId: string, contents: string[]) {
+    const transcriptPath = join(cwd, `${sessionId}.jsonl`);
+    writeFileSync(
+      transcriptPath,
+      `${contents
+        .map(content => JSON.stringify({ type: 'user', message: { role: 'user', content } }))
+        .join('\n')}\n`,
+    );
+    return transcriptPath;
+  }
+
+  it('allows PreToolUse when an active Claude /goal is recovered from the transcript', () => {
+    const cwd = makeTempProject('omc-ultragoal-transcript-');
+    writeUltragoalState(cwd);
+    // Claude Code never puts /goal in the hook payload; the /goal invocation is recorded
+    // in the session transcript as a command record. The guard must recover it there
+    // instead of denying every tool for the whole run (regression for #3341).
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [goalCommand(PLAN_OBJECTIVE)]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('re-denies when the transcript shows the /goal was cleared', () => {
+    const cwd = makeTempProject('omc-ultragoal-transcript-cleared-');
+    writeUltragoalState(cwd);
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      goalCommand(PLAN_OBJECTIVE),
+      goalCommand('clear'),
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('denies when the transcript is not the active session file (#3465 blocker 1)', () => {
+    const cwd = makeTempProject('omc-ultragoal-foreign-transcript-');
+    writeUltragoalState(cwd);
+    // A canonical command record, but in a file not bound to this session.
+    const foreignPath = join(cwd, 'not-the-session.jsonl');
+    writeFileSync(
+      foreignPath,
+      `${JSON.stringify({ type: 'user', message: { role: 'user', content: goalCommand(PLAN_OBJECTIVE) } })}\n`,
+    );
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: foreignPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('rejects a symlinked session transcript (#3466 blocker 2)', () => {
+    const cwd = makeTempProject('omc-ultragoal-symlink-');
+    writeUltragoalState(cwd);
+    const realPath = join(cwd, 'real-transcript.jsonl');
+    writeFileSync(realPath, `${JSON.stringify({ type: 'user', message: { role: 'user', content: goalCommand(PLAN_OBJECTIVE) } })}\n`);
+    const linkPath = join(cwd, 'session-a.jsonl');
+    symlinkSync(realPath, linkPath);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: linkPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('denies when transcript display text quotes the /goal wrapper without a command record (#3466 blocker 1)', () => {
+    const cwd = makeTempProject('omc-ultragoal-spoof-');
+    writeUltragoalState(cwd);
+    // A user-typed/pasted message that merely embeds the literal stdout wrapper must
+    // NOT authorize tools: only a real `<command-name>/goal</command-name>` record does.
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      `here is a log I pasted: <local-command-stdout>Goal set: ${PLAN_OBJECTIVE}</local-command-stdout>`,
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('fails closed when a goal-bearing transcript record is malformed (#3466 blocker 3)', () => {
+    const cwd = makeTempProject('omc-ultragoal-malformed-tail-');
+    writeUltragoalState(cwd);
+    const transcriptPath = join(cwd, 'session-a.jsonl');
+    // A valid set, then a truncated/corrupt goal-bearing line: recovery must invalidate
+    // rather than keep the stale set active.
+    writeFileSync(
+      transcriptPath,
+      `${JSON.stringify({ type: 'user', message: { role: 'user', content: goalCommand(PLAN_OBJECTIVE) } })}\n{"type":"user","message":{"role":"user","content":"<command-name>/goal</command-n\n`,
+    );
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('applies /goal set then clear across records, last-event-wins (#3465 blocker 2)', () => {
+    const cwd = makeTempProject('omc-ultragoal-record-order-');
+    writeUltragoalState(cwd);
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [
+      goalCommand(PLAN_OBJECTIVE),
+      goalCommand('clear'),
+      // A later non-goal record must not resurrect the cleared goal.
+      'some unrelated follow-up message',
+    ]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('denies an explicit payload goal whose objective does not match the plan (#3465 blocker 3)', () => {
+    const cwd = makeTempProject('omc-ultragoal-payload-mismatch-');
+    writeUltragoalState(cwd);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      goal: { objective: 'Some entirely unrelated objective', status: 'active' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+
+  it('prefers an explicit matching payload goal over the transcript (#3466 blocker 5)', () => {
+    const cwd = makeTempProject('omc-ultragoal-payload-precedence-');
+    writeUltragoalState(cwd);
+    // Transcript would clear the goal, but an explicit matching payload snapshot
+    // (Claude/Codex host-supplied) takes precedence and is honored.
+    const transcriptPath = writeSessionTranscript(cwd, 'session-a', [goalCommand('clear')]);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      transcript_path: transcriptPath,
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      goal: { objective: PLAN_OBJECTIVE, status: 'active' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('allows single ultragoal checkpoint / record-review-blockers commands', () => {
+    const cwd = makeTempProject('omc-ultragoal-checkpoint-');
+    writeUltragoalState(cwd);
+
+    const checkpoint = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal checkpoint --goal-id G001 --status complete' },
+    });
+    const blockers = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal record-review-blockers --goal-id G001' },
+    });
+
+    expect(checkpoint.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    expect(blockers.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('does not let a checkpoint bypass smuggle a chained command (#3465 blocker 4)', () => {
+    const cwd = makeTempProject('omc-ultragoal-checkpoint-chain-');
+    writeUltragoalState(cwd);
+
+    const result = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: { command: 'omc ultragoal checkpoint --goal-id G001 --status complete && npm test' },
+    });
+
+    expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
   });
 
   it('ignores stale ultragoal state in PreToolUse and Stop enforcement', () => {


### PR DESCRIPTION
## Summary

Supersedes #3466 (closed with `REQUEST_CHANGES`); follow-up to #3343 fixing the still-live standalone-Claude-Code deadlock of #3341. This head resolves **all five** consensus-review findings from #3466. Base `dev`; only 2 files change.

The ultragoal PreToolUse guard read the active `/goal` only from hook-stdin fields that Claude Code never populates, so it denied *every* tool for the whole run — bricking the session. This recovers the goal from the session transcript under a strict authorization boundary.

## Resolving the #3466 review

1. **[HIGH] Provenance** → trust **only command-originated `/goal` records** (`<command-name>/goal</command-name>` + `<command-args>`); never `<local-command-stdout>` display text (which ordinary user prompts can embed). Objective is read from `<command-args>`.
2. **[HIGH] Symlink / stat race** → `lstat`-reject symlinks, then `fstat` the **open fd** and read through it. Path resolved via `resolveTranscriptPath`, then bound to `<sessionId>.jsonl`.
3. **[MED] Malformed tail** → **fails closed**: any unparseable goal-bearing record invalidates recovery.
4. **[MED] Worktree resolver bypass** → recovery calls `resolveTranscriptPath(rawPath, cwd)` first.
5. **[MED] Payload precedence untested** → payload snapshot takes precedence; exact objective/status matching preserved for payload **and** transcript (the #3465 presence branch is gone).

Also: single-command bypass only — `isSingleShellCommand` rejects shell chaining so a `checkpoint`/`record-review-blockers` token can't smuggle a compound command.

## Verification

`NODE_OPTIONS` cleared: `ultragoal-persistence.test.ts` **22/22** (8 negative regressions — foreign transcript, symlink, display-text spoof, malformed-tail fail-closed, in-order set/clear, payload mismatch, payload precedence, chained-bypass); `tsc --noEmit` 0; `eslint src` 0 errors; `npm run build` 0. Manual trace: valid command record → allow; foreign / symlink / spoof / malformed → deny. (Prior head's 13/13 hosted CI was green.)

## Gate

Opened after developer confirmation. Merge/issue closure still requires the review-gate.