### PR TITLE
fix: validate direct team mailbox targets

### DIFF
--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -1,17 +1,40 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+const tmuxUtilsMocks = vi.hoisted(() => ({
+  tmuxExecAsync: vi.fn(async (_args: string[]) => ({ stdout: '', stderr: '' })),
+  tmuxCmdAsync: vi.fn(async (_args: string[]) => ({ stdout: '0\n', stderr: '' })),
+}));
+
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../cli/tmux-utils.js')>(),
+  tmuxExecAsync: tmuxUtilsMocks.tmuxExecAsync,
+  tmuxCmdAsync: tmuxUtilsMocks.tmuxCmdAsync,
+}));
+
+
 import { executeTeamApiOperation } from '../api-interop.js';
 import { listDispatchRequests } from '../dispatch-queue.js';
+
+function mockOwnedTmuxPanes(...paneIds: string[]): void {
+  tmuxUtilsMocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'list-panes') return { stdout: `${paneIds.join('\n')}\n`, stderr: '' };
+    if (args[0] === 'display-message') return { stdout: '0\n', stderr: '' };
+    if (args[0] === 'capture-pane') return { stdout: '❯\n', stderr: '' };
+    return { stdout: '', stderr: '' };
+  });
+}
 
 describe('team api dispatch-aware messaging', () => {
   let cwd: string;
   const teamName = 'dispatch-team';
 
   beforeEach(async () => {
+    tmuxUtilsMocks.tmuxExecAsync.mockReset().mockResolvedValue({ stdout: '', stderr: '' });
+    tmuxUtilsMocks.tmuxCmdAsync.mockReset().mockResolvedValue({ stdout: '0\n', stderr: '' });
     cwd = await mkdtemp(join(tmpdir(), 'omc-team-api-dispatch-'));
     const base = join(cwd, '.omc', 'state', 'team', teamName);
     await mkdir(join(base, 'tasks'), { recursive: true });
@@ -174,6 +197,65 @@ describe('team api dispatch-aware messaging', () => {
     expect(requests[0]?.message_id).toBe(messageId);
   });
 
+  it('notifies an exactly owned worker pane and commits both replay markers', async () => {
+    const configPath = join(cwd, '.omc', 'state', 'team', teamName, 'config.json');
+    const config = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
+    await writeFile(configPath, JSON.stringify({
+      ...config,
+      leader_pane_id: '%0',
+      workers: [{ name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [], pane_id: '%9' }],
+    }, null, 2));
+    mockOwnedTmuxPanes('%0', '%9');
+
+    const result = await executeTeamApiOperation('send-message', {
+      team_name: teamName,
+      from_worker: 'leader-fixed',
+      to_worker: 'worker-1',
+      body: 'Continue with the task',
+    }, cwd);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const outcome = result.data.notification_outcome as { reason?: string; request_id?: string; message_id?: string };
+    expect(outcome.reason).toBe('worker_pane_notified');
+    const mailbox = JSON.parse(await readFile(
+      join(cwd, '.omc', 'state', 'team', teamName, 'mailbox', 'worker-1.json'),
+      'utf8',
+    )) as { messages: Array<{ message_id: string; notified_at?: string }> };
+    expect(mailbox.messages.find((message) => message.message_id === outcome.message_id)?.notified_at).toEqual(expect.any(String));
+    const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'worker-1' });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ request_id: outcome.request_id, message_id: outcome.message_id, status: 'notified' });
+    expect(tmuxUtilsMocks.tmuxExecAsync.mock.calls.some(([args]) => args[0] === 'send-keys')).toBe(true);
+  });
+
+  it('notifies an exactly owned leader pane and commits both replay markers', async () => {
+    const configPath = join(cwd, '.omc', 'state', 'team', teamName, 'config.json');
+    const config = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
+    await writeFile(configPath, JSON.stringify({ ...config, leader_pane_id: '%0' }, null, 2));
+    mockOwnedTmuxPanes('%0');
+
+    const result = await executeTeamApiOperation('send-message', {
+      team_name: teamName,
+      from_worker: 'worker-1',
+      to_worker: 'leader-fixed',
+      body: 'Worker progress report',
+    }, cwd);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const outcome = result.data.notification_outcome as { reason?: string; request_id?: string; message_id?: string };
+    expect(outcome.reason).toBe('leader_pane_notified');
+    const mailbox = JSON.parse(await readFile(
+      join(cwd, '.omc', 'state', 'team', teamName, 'mailbox', 'leader-fixed.json'),
+      'utf8',
+    )) as { messages: Array<{ message_id: string; notified_at?: string }> };
+    expect(mailbox.messages.find((message) => message.message_id === outcome.message_id)?.notified_at).toEqual(expect.any(String));
+    const requests = await listDispatchRequests(teamName, cwd, { kind: 'mailbox', to_worker: 'leader-fixed' });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ request_id: outcome.request_id, message_id: outcome.message_id, status: 'notified' });
+  });
+
   it('uses the canonical worker pane when duplicate worker records exist', async () => {
     const configPath = join(cwd, '.omc', 'state', 'team', teamName, 'config.json');
     await writeFile(configPath, JSON.stringify({
@@ -208,5 +290,9 @@ describe('team api dispatch-aware messaging', () => {
     expect(requests[0]?.message_id).toBe(messageId);
     expect(requests[0]?.pane_id).toBe('%9');
     expect(['pending', 'notified']).toContain(requests[0]?.status);
+    expect(tmuxUtilsMocks.tmuxExecAsync).toHaveBeenCalledWith([
+      'list-panes', '-t', 'dispatch-session', '-F', '#{pane_id}',
+    ]);
+    expect(tmuxUtilsMocks.tmuxExecAsync.mock.calls.some(([args]) => args[0] === 'send-keys')).toBe(false);
   });
 });

--- a/src/team/__tests__/api-interop.dispatch.test.ts
+++ b/src/team/__tests__/api-interop.dispatch.test.ts
@@ -57,6 +57,19 @@ describe('team api dispatch-aware messaging', () => {
     await rm(cwd, { recursive: true, force: true });
   });
 
+  it('returns the top-level operation failure for an unknown broadcast team', async () => {
+    const result = await executeTeamApiOperation('broadcast', {
+      team_name: 'unknown-team',
+      from_worker: 'leader-fixed',
+      body: 'Unreachable broadcast',
+    }, cwd);
+
+    expect(result).toEqual({
+      ok: false,
+      operation: 'broadcast',
+      error: { code: 'operation_failed', message: 'Team unknown-team not found' },
+    });
+  });
   it('persists leader-fixed messages and leaves a durable pending dispatch request when the leader pane is absent', async () => {
     const result = await executeTeamApiOperation('send-message', {
       team_name: teamName,

--- a/src/team/__tests__/dispatch-queue.strict-read.test.ts
+++ b/src/team/__tests__/dispatch-queue.strict-read.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  patchPendingDispatchReason,
+  readDispatchRequest,
+  readDispatchRequestStrict,
+  type TeamDispatchRequest,
+} from '../dispatch-queue.js';
+
+const teamName = 'strict-team';
+const timestamp = '2026-07-13T00:00:00.000Z';
+
+function request(overrides: Partial<TeamDispatchRequest> = {}): TeamDispatchRequest {
+  return {
+    request_id: 'request-1',
+    kind: 'mailbox',
+    team_name: teamName,
+    to_worker: 'worker-1',
+    worker_index: 1,
+    pane_id: '%9',
+    trigger_message: 'Read the mailbox.',
+    message_id: 'message-1',
+    transport_preference: 'transport_direct',
+    fallback_allowed: true,
+    status: 'pending',
+    attempt_count: 0,
+    created_at: timestamp,
+    updated_at: timestamp,
+    ...overrides,
+  };
+}
+
+describe('readDispatchRequestStrict', () => {
+  let cwd: string;
+
+  async function writeStore(value: unknown): Promise<string> {
+    const path = join(cwd, '.omc', 'state', 'team', teamName, 'dispatch', 'requests.json');
+    await mkdir(join(cwd, '.omc', 'state', 'team', teamName, 'dispatch'), { recursive: true });
+    await writeFile(path, JSON.stringify(value, null, 2), 'utf8');
+    return path;
+  }
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-dispatch-strict-'));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('returns a fresh valid exact mailbox request', async () => {
+    const raw = { ...request(), extra_future_field: 'preserved' };
+    await writeStore([raw]);
+
+    const result = await readDispatchRequestStrict(teamName, 'request-1', cwd);
+
+    expect(result).toMatchObject({ kind: 'valid', request: request() });
+    if (result.kind === 'valid') {
+      expect(result.request).not.toBe(raw);
+      expect((result.request as unknown as Record<string, unknown>).extra_future_field).toBeUndefined();
+    }
+  });
+
+  it('distinguishes a missing store, malformed JSON, and non-array JSON', async () => {
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({ kind: 'store_missing' });
+
+    const path = await writeStore([]);
+    await writeFile(path, '{not json', 'utf8');
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_store', cause: 'json',
+    });
+
+    await writeStore({ request: request() });
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_store', cause: 'non_array',
+    });
+  });
+
+  it('fails closed for every malformed row and required field type', async () => {
+    await writeStore([null]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_row', rowIndex: 0, field: '$',
+    });
+
+    await writeStore([{ ...request(), fallback_allowed: 'true' }]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_row', rowIndex: 0, field: 'fallback_allowed',
+    });
+
+    await writeStore([{ ...request(), request_id: ' request-1 ' }]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_row', rowIndex: 0, field: 'request_id',
+    });
+
+    await writeStore([{ ...request(), worker_index: 1.5 }]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_row', rowIndex: 0, field: 'worker_index',
+    });
+  });
+
+  it('does not use compatibility team rewriting or status defaulting', async () => {
+    const legacyLike = { ...request(), team_name: 'foreign-team', status: 'not-a-status' };
+    await writeStore([legacyLike]);
+
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'team_mismatch', rowIndex: 0,
+    });
+    await expect(readDispatchRequest(teamName, 'request-1', cwd)).resolves.toMatchObject({
+      team_name: teamName,
+      status: 'pending',
+    });
+
+    await writeStore([{ ...request(), status: 'not-a-status' }]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'invalid_status', rowIndex: 0,
+    });
+  });
+
+  it('rejects invalid kinds and mailbox rows without a message ID', async () => {
+    await writeStore([{ ...request(), kind: 'unknown' }]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'invalid_kind', rowIndex: 0,
+    });
+
+    await writeStore([{ ...request(), message_id: undefined }]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'malformed_row', rowIndex: 0, field: 'message_id',
+    });
+
+    await writeStore([request({ kind: 'inbox', message_id: undefined })]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'invalid_kind', rowIndex: 0,
+    });
+  });
+
+  it('rejects duplicate target IDs, unrelated duplicate IDs, and missing targets', async () => {
+    await writeStore([request(), request({ updated_at: '2026-07-13T00:01:00.000Z' })]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'duplicate_request_id', requestId: 'request-1', rowIndexes: [0, 1],
+    });
+
+    await writeStore([
+      request(),
+      request({ request_id: 'other', message_id: 'message-2' }),
+      request({ request_id: 'other', message_id: 'message-3' }),
+    ]);
+    await expect(readDispatchRequestStrict(teamName, 'request-1', cwd)).resolves.toEqual({
+      kind: 'ambiguous_request', rowIndexes: [1, 2],
+    });
+
+    await writeStore([request()]);
+    await expect(readDispatchRequestStrict(teamName, 'missing-request', cwd)).resolves.toEqual({ kind: 'request_missing' });
+  });
+
+  it('patches only one current pending request and preserves delivery markers', async () => {
+    const path = await writeStore([request()]);
+
+    await expect(patchPendingDispatchReason(teamName, 'request-1', 'mailbox_target_foreign', cwd)).resolves.toMatchObject({
+      kind: 'patched',
+      request: { status: 'pending', last_reason: 'mailbox_target_foreign' },
+    });
+    const stored = JSON.parse(await readFile(path, 'utf8')) as TeamDispatchRequest[];
+    expect(stored[0]).toMatchObject({ status: 'pending', last_reason: 'mailbox_target_foreign' });
+    expect(stored[0]?.notified_at).toBeUndefined();
+    expect(stored[0]?.delivered_at).toBeUndefined();
+    expect(stored[0]?.failed_at).toBeUndefined();
+
+    await writeStore([request({ status: 'notified', notified_at: '2026-07-13T00:02:00.000Z' })]);
+    await expect(patchPendingDispatchReason(teamName, 'request-1', 'ignored', cwd)).resolves.toMatchObject({
+      kind: 'not_pending', request: { status: 'notified' },
+    });
+  });
+
+  it('does not mutate ambiguous or invalid stores just to record a reason', async () => {
+    const invalidPath = await writeStore([{ ...request(), attempt_count: -1 }]);
+    const invalidBefore = await readFile(invalidPath, 'utf8');
+    await expect(patchPendingDispatchReason(teamName, 'request-1', 'must-not-write', cwd)).resolves.toMatchObject({
+      kind: 'unsafe', read: { kind: 'malformed_row', field: 'attempt_count' },
+    });
+    await expect(readFile(invalidPath, 'utf8')).resolves.toBe(invalidBefore);
+
+    const duplicatePath = await writeStore([request(), request()]);
+    const duplicateBefore = await readFile(duplicatePath, 'utf8');
+    await expect(patchPendingDispatchReason(teamName, 'request-1', 'must-not-write', cwd)).resolves.toMatchObject({
+      kind: 'unsafe', read: { kind: 'duplicate_request_id' },
+    });
+    await expect(readFile(duplicatePath, 'utf8')).resolves.toBe(duplicateBefore);
+  });
+});

--- a/src/team/__tests__/mailbox-notification-guard.test.ts
+++ b/src/team/__tests__/mailbox-notification-guard.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  teamListMailbox,
+  teamReadCanonicalMailboxMessageStrict,
+  type StrictCanonicalMailboxMessageReadResult,
+} from '../team-ops.js';
+import type { TeamConfig, TeamDispatchRequest, TeamMailboxMessage } from '../types.js';
+import type { StrictDispatchReadResult } from '../dispatch-queue.js';
+import {
+  evaluateMailboxNotificationGuard,
+  mailboxNotificationSecurityTupleEquals,
+  readCurrentMailboxNotificationGuard,
+  type MailboxNotificationGuardInput,
+  type MailboxNotificationGuardState,
+  type MailboxTargetOwnership,
+} from '../mailbox-notification-guard.js';
+
+const teamName = 'dispatch-team';
+const timestamp = '2026-07-13T00:00:00.000Z';
+const input: MailboxNotificationGuardInput = {
+  teamName,
+  recipient: 'worker-1',
+  requestId: 'request-1',
+  messageId: 'message-1',
+  triggerMessage: 'Read your mailbox and report progress.',
+};
+
+function request(overrides: Partial<TeamDispatchRequest> = {}): TeamDispatchRequest {
+  return {
+    request_id: input.requestId,
+    kind: 'mailbox',
+    team_name: teamName,
+    to_worker: input.recipient,
+    worker_index: 1,
+    pane_id: '%9',
+    trigger_message: input.triggerMessage,
+    message_id: input.messageId,
+    transport_preference: 'transport_direct',
+    fallback_allowed: true,
+    status: 'pending',
+    attempt_count: 0,
+    created_at: timestamp,
+    updated_at: timestamp,
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<TeamMailboxMessage> = {}): TeamMailboxMessage {
+  return {
+    message_id: input.messageId,
+    from_worker: 'leader-fixed',
+    to_worker: input.recipient,
+    body: 'Continue.',
+    created_at: timestamp,
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<TeamConfig> = {}): TeamConfig {
+  return {
+    name: teamName,
+    task: 'dispatch',
+    agent_type: 'claude',
+    worker_launch_mode: 'interactive',
+    worker_count: 1,
+    max_workers: 20,
+    workers: [{ name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [], pane_id: '%9' }],
+    created_at: timestamp,
+    tmux_session: 'dispatch-session:0',
+    next_task_id: 2,
+    leader_pane_id: '%0',
+    hud_pane_id: null,
+    resize_hook_name: null,
+    resize_hook_target: null,
+    ...overrides,
+  };
+}
+
+function strictDispatch(value: TeamDispatchRequest = request()): StrictDispatchReadResult {
+  return { kind: 'valid', request: value };
+}
+
+function strictMailbox(value: TeamMailboxMessage = message()): StrictCanonicalMailboxMessageReadResult {
+  return { kind: 'valid', message: value };
+}
+
+function owned(): MailboxTargetOwnership {
+  return {
+    kind: 'owned',
+    provider: 'tmux',
+    providerTarget: 'dispatch-session:0',
+    paneId: '%9',
+  };
+}
+
+function validState(overrides: Partial<MailboxNotificationGuardState> = {}): MailboxNotificationGuardState {
+  return {
+    config: config(),
+    dispatch: strictDispatch(),
+    mailbox: strictMailbox(),
+    ownership: owned(),
+    ...overrides,
+  };
+}
+
+describe('teamReadCanonicalMailboxMessageStrict', () => {
+  let cwd: string;
+
+  async function writeMailbox(value: unknown, workerName = input.recipient): Promise<void> {
+    const path = join(cwd, '.omc', 'state', 'team', teamName, 'mailbox', `${workerName}.json`);
+    await mkdir(join(cwd, '.omc', 'state', 'team', teamName, 'mailbox'), { recursive: true });
+    await writeFile(path, JSON.stringify(value, null, 2), 'utf8');
+  }
+
+  async function writeRawMailbox(raw: string, workerName = input.recipient): Promise<void> {
+    const path = join(cwd, '.omc', 'state', 'team', teamName, 'mailbox', `${workerName}.json`);
+    await mkdir(join(cwd, '.omc', 'state', 'team', teamName, 'mailbox'), { recursive: true });
+    await writeFile(path, raw, 'utf8');
+  }
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-mailbox-strict-'));
+  });
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('never falls back to legacy JSONL while compatibility reads still do', async () => {
+    const legacyPath = join(cwd, '.omc', 'state', 'team', teamName, 'mailbox', 'worker-1.jsonl');
+    await mkdir(join(cwd, '.omc', 'state', 'team', teamName, 'mailbox'), { recursive: true });
+    await writeFile(legacyPath, `${JSON.stringify({
+      id: input.messageId,
+      from: 'leader-fixed',
+      to: input.recipient,
+      body: 'Continue.',
+      createdAt: timestamp,
+    })}\n`, 'utf8');
+
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'store_missing',
+    });
+    await expect(teamListMailbox(teamName, input.recipient, cwd)).resolves.toMatchObject([
+      { message_id: input.messageId, to_worker: input.recipient },
+    ]);
+  });
+
+  it('distinguishes malformed stores, owner mismatch, malformed messages, missing, and duplicates', async () => {
+    await writeRawMailbox('{not-json');
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'malformed_store', cause: 'json',
+    });
+
+    await writeMailbox({ worker: input.recipient, messages: {} });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'malformed_store', cause: 'messages_non_array',
+    });
+
+    await writeMailbox({ worker: 'other-worker', messages: [message()] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'wrong_owner',
+    });
+
+    await writeMailbox({ worker: input.recipient, messages: [{ ...message(), body: 42 } as unknown as TeamMailboxMessage] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'malformed_message', messageIndex: 0, field: 'body',
+    });
+
+    await writeMailbox({ worker: input.recipient, messages: [message({ message_id: 'other-message' })] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'message_missing',
+    });
+
+    await writeMailbox({ worker: input.recipient, messages: [message(), message()] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'duplicate_message_id', messageId: input.messageId, messageIndexes: [0, 1],
+    });
+  });
+
+  it('rejects recipient mismatch and replay, then returns a fresh exact canonical message', async () => {
+    await writeMailbox({ worker: input.recipient, messages: [message({ to_worker: 'worker-2' })] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toEqual({
+      kind: 'recipient_mismatch', messageIndex: 0,
+    });
+
+    await writeMailbox({ worker: input.recipient, messages: [message({ notified_at: '2026-07-13T00:01:00.000Z' })] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toMatchObject({
+      kind: 'replay_suppressed', marker: 'notified_at',
+    });
+
+    await writeMailbox({ worker: input.recipient, messages: [message()] });
+    await expect(teamReadCanonicalMailboxMessageStrict(teamName, input.recipient, input.messageId, cwd)).resolves.toMatchObject({
+      kind: 'valid', message: message(),
+    });
+  });
+});
+
+describe('mailbox notification guard', () => {
+  it('allows the deterministic canonical duplicate-worker target only when strict metadata agrees', () => {
+    const duplicateConfig = config({
+      workers: [
+        { name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [] },
+        { name: 'worker-1', index: 0, role: 'executor', assigned_tasks: [], pane_id: '%9' },
+      ],
+    });
+    const result = evaluateMailboxNotificationGuard(input, validState({ config: duplicateConfig }));
+
+    expect(result).toMatchObject({ kind: 'allow', target: { paneId: '%9', recipientRole: 'worker' } });
+
+    const mismatched = evaluateMailboxNotificationGuard(input, validState({
+      config: duplicateConfig,
+      dispatch: strictDispatch(request({ pane_id: '%foreign' })),
+    }));
+    expect(mismatched).toMatchObject({
+      kind: 'suppress', reason: 'mailbox_target_metadata_mismatch',
+    });
+  });
+
+  it('maps every strict evidence and provider failure to a stable pre-effect reason', () => {
+    expect(evaluateMailboxNotificationGuard(input, validState({ config: null }))).toMatchObject({
+      kind: 'suppress', reason: 'mailbox_team_unavailable',
+    });
+    expect(evaluateMailboxNotificationGuard(input, validState({ config: config({ name: 'other-team' }) }))).toMatchObject({
+      kind: 'suppress', reason: 'mailbox_team_identity_mismatch',
+    });
+    expect(evaluateMailboxNotificationGuard(input, validState({ config: config({ workers: [] }) }))).toMatchObject({
+      kind: 'suppress', reason: 'mailbox_target_missing',
+    });
+    expect(evaluateMailboxNotificationGuard(input, validState({
+      dispatch: { kind: 'malformed_row', rowIndex: 0, field: 'status' },
+    }))).toMatchObject({ kind: 'suppress', reason: 'mailbox_dispatch_store_invalid' });
+    expect(evaluateMailboxNotificationGuard(input, validState({
+      dispatch: { kind: 'duplicate_request_id', requestId: input.requestId, rowIndexes: [0, 1] },
+    }))).toMatchObject({ kind: 'suppress', reason: 'mailbox_request_ambiguous' });
+    expect(evaluateMailboxNotificationGuard(input, validState({
+      dispatch: strictDispatch(request({ status: 'notified' })),
+    }))).toMatchObject({ kind: 'suppress', reason: 'mailbox_request_not_pending' });
+    expect(evaluateMailboxNotificationGuard(input, validState({
+      dispatch: strictDispatch(request({ trigger_message: 'Different trigger.' })),
+    }))).toMatchObject({ kind: 'suppress', reason: 'mailbox_request_identity_mismatch' });
+    expect(evaluateMailboxNotificationGuard(input, validState({
+      mailbox: { kind: 'replay_suppressed', message: message({ notified_at: timestamp }), marker: 'notified_at' },
+    }))).toMatchObject({ kind: 'suppress', reason: 'mailbox_replay_suppressed' });
+    expect(evaluateMailboxNotificationGuard(input, validState({ ownership: { kind: 'foreign' } }))).toMatchObject({
+      kind: 'suppress', reason: 'mailbox_target_foreign',
+    });
+    expect(evaluateMailboxNotificationGuard(input, validState({ ownership: { kind: 'unavailable' } }))).toMatchObject({
+      kind: 'suppress', reason: 'mailbox_membership_unresolvable',
+    });
+  });
+
+  it('compares named security fields while ignoring diagnostic-only dispatch changes', () => {
+    const first = evaluateMailboxNotificationGuard(input, validState());
+    const diagnosticsOnly = evaluateMailboxNotificationGuard(input, validState({
+      dispatch: strictDispatch(request({
+        attempt_count: 3,
+        updated_at: '2026-07-13T00:03:00.000Z',
+        last_reason: 'mailbox_membership_unresolvable',
+      })),
+    }));
+    expect(first.kind).toBe('allow');
+    expect(diagnosticsOnly.kind).toBe('allow');
+    if (first.kind !== 'allow' || diagnosticsOnly.kind !== 'allow') return;
+    expect(mailboxNotificationSecurityTupleEquals(first.securityTuple, diagnosticsOnly.securityTuple)).toBe(true);
+    expect(mailboxNotificationSecurityTupleEquals(first.securityTuple, {
+      ...first.securityTuple,
+      requestTriggerMessage: 'Different trigger.',
+    })).toBe(false);
+
+    const changedSecurity = evaluateMailboxNotificationGuard(input, validState({
+      config: config({ tmux_session: 'other-session:0' }),
+      ownership: { kind: 'owned', provider: 'tmux', providerTarget: 'other-session:0', paneId: '%9' },
+    }));
+    expect(changedSecurity.kind).toBe('allow');
+    if (changedSecurity.kind !== 'allow') return;
+    expect(mailboxNotificationSecurityTupleEquals(first.securityTuple, changedSecurity.securityTuple)).toBe(false);
+  });
+
+  it('performs strict current reads and an injected ownership check with zero marker or pane effects', async () => {
+    const markMailbox = vi.fn();
+    const markDispatch = vi.fn();
+    const paneEffect = vi.fn();
+    const readConfig = vi.fn(async () => config());
+    const readStrictDispatchRequest = vi.fn(async () => strictDispatch());
+    const readStrictMailboxMessage = vi.fn(async () => strictMailbox());
+    const verifyProviderOwnership = vi.fn(async () => owned());
+
+    const result = await readCurrentMailboxNotificationGuard(input, '/unused', {
+      readConfig,
+      readStrictDispatchRequest,
+      readStrictMailboxMessage,
+      verifyProviderOwnership,
+    });
+
+    expect(result).toMatchObject({ kind: 'allow', target: { paneId: '%9' } });
+    expect(readStrictDispatchRequest).toHaveBeenCalledWith(teamName, input.requestId, '/unused');
+    expect(readStrictMailboxMessage).toHaveBeenCalledWith(teamName, input.recipient, input.messageId, '/unused');
+    expect(verifyProviderOwnership).toHaveBeenCalledWith(expect.objectContaining({ paneId: '%9' }));
+    expect(markMailbox).not.toHaveBeenCalled();
+    expect(markDispatch).not.toHaveBeenCalled();
+    expect(paneEffect).not.toHaveBeenCalled();
+  });
+});

--- a/src/team/__tests__/mcp-comm.mailbox-notification.test.ts
+++ b/src/team/__tests__/mcp-comm.mailbox-notification.test.ts
@@ -291,7 +291,7 @@ describe('direct mailbox notification orchestration', () => {
     const partialReplay = await runMailboxNotificationAttempt(partial.input, partial.dependencies);
 
     expect(partialOutcome.reason).toBe('notification_commit_mailbox_failed');
-    expect(partialReplay.reason).toBe('mailbox_replay_suppressed');
+    expect(partialReplay.reason).toBe('notification_commit_mailbox_failed');
     expect(partial.effect).toHaveBeenCalledTimes(1);
 
     const dual = harness();
@@ -303,6 +303,61 @@ describe('direct mailbox notification orchestration', () => {
     expect(dualOutcome.reason).toBe('notification_commit_uncertain');
     expect(dualReplay.reason).toBe('notification_commit_uncertain');
     expect(dual.effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles a worker commit missing its mailbox marker without reinvoking transport', async () => {
+    const state = harness();
+    state.dependencies.markMailbox = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockImplementation(async () => {
+        state.markMailbox(true);
+        return true;
+      });
+
+    const partial = await runMailboxNotificationAttempt(state.input, state.dependencies);
+    const reconciled = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(partial.reason).toBe('notification_commit_mailbox_failed');
+    expect(reconciled.reason).toBe('worker_pane_notified');
+    expect(state.effect).toHaveBeenCalledTimes(1);
+    expect(state.dependencies.markMailbox).toHaveBeenCalledTimes(2);
+    expect(state.dependencies.markDispatch).toHaveBeenCalledTimes(1);
+    expect(state.mailboxMarked).toBe(true);
+    expect(state.request.status).toBe('notified');
+  });
+
+  it('reconciles a leader commit missing its dispatch marker without reinvoking transport', async () => {
+    const state = harness(params({ recipient: 'leader-fixed' }));
+    const effect = vi.fn(async () => ({
+      kind: 'confirmed' as const,
+      transport: 'tmux_send_keys' as const,
+      reason: 'leader_pane_notified' as const,
+    }));
+    state.dependencies.invokeEffect = effect;
+    const markDispatch = state.dependencies.markDispatch;
+    let firstDispatch = true;
+    state.dependencies.markDispatch = vi.fn(async (
+      resolvedTeamName: string,
+      requestId: string,
+      resolvedCwd: string,
+    ) => {
+      if (firstDispatch) {
+        firstDispatch = false;
+        return null;
+      }
+      return markDispatch(resolvedTeamName, requestId, resolvedCwd);
+    });
+
+    const partial = await runMailboxNotificationAttempt(state.input, state.dependencies);
+    const reconciled = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(partial.reason).toBe('notification_commit_dispatch_failed');
+    expect(reconciled.reason).toBe('leader_pane_notified');
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(state.dependencies.markMailbox).toHaveBeenCalledTimes(1);
+    expect(state.dependencies.markDispatch).toHaveBeenCalledTimes(2);
+    expect(state.mailboxMarked).toBe(true);
+    expect(state.request.status).toBe('notified');
   });
 
   it('reconciles a tombstone through markers only and never invokes transport again', async () => {
@@ -385,6 +440,7 @@ describe('direct mailbox notification orchestration', () => {
     await mkdir(join(cwd, '.omc', 'state', 'team', 'dispatch-team'), { recursive: true });
 
     let nextMessage = 0;
+    const effects: string[] = [];
     const outcomes = await queueBroadcastMailboxMessage({
       teamName: 'dispatch-team',
       fromWorker: 'leader-fixed',
@@ -395,12 +451,18 @@ describe('direct mailbox notification orchestration', () => {
       body: 'broadcast body',
       cwd,
       triggerFor: (workerName) => `Read mailbox for ${workerName}.`,
-      notify: vi.fn(async () => ({ ok: true, transport: 'hook' as const, reason: 'queued_for_hook_dispatch' })),
+      notify: vi.fn(async () => {
+        effects.push('notify');
+        return { ok: true, transport: 'hook' as const, reason: 'queued_for_hook_dispatch' };
+      }),
       deps: {
-        sendDirectMessage: vi.fn(async (_teamName, _fromWorker, toWorker) => ({
-          message_id: `broadcast-${++nextMessage}`,
-          to_worker: nextMessage === 2 ? 'worker-foreign' : toWorker,
-        })),
+        sendDirectMessage: vi.fn(async (_teamName, _fromWorker, toWorker) => {
+          effects.push(`persist:${toWorker}`);
+          return {
+            message_id: `broadcast-${++nextMessage}`,
+            to_worker: nextMessage === 2 ? 'worker-foreign' : toWorker,
+          };
+        }),
         broadcastMessage: vi.fn(async () => []),
         markMessageNotified: vi.fn(async () => true),
       },
@@ -409,5 +471,36 @@ describe('direct mailbox notification orchestration', () => {
     expect(outcomes).toHaveLength(2);
     expect(outcomes[0]).toMatchObject({ to_worker: 'worker-1', reason: 'queued_for_hook_dispatch' });
     expect(outcomes[1]).toMatchObject({ to_worker: 'worker-2', reason: 'broadcast_recipient_diverged' });
+    expect(effects).toEqual(['persist:worker-1', 'persist:worker-2', 'notify']);
+  });
+
+  it('does not notify a broadcast when persisting the second recipient fails', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omc-mcp-broadcast-'));
+    temporaryDirectories.push(cwd);
+    await mkdir(join(cwd, '.omc', 'state', 'team', 'dispatch-team'), { recursive: true });
+    const notify = vi.fn(async () => ({ ok: true, transport: 'hook' as const, reason: 'queued_for_hook_dispatch' }));
+
+    await expect(queueBroadcastMailboxMessage({
+      teamName: 'dispatch-team',
+      fromWorker: 'leader-fixed',
+      recipients: [
+        { workerName: 'worker-1', workerIndex: 1, paneId: '%9' },
+        { workerName: 'worker-2', workerIndex: 2, paneId: '%10' },
+      ],
+      body: 'broadcast body',
+      cwd,
+      triggerFor: (workerName) => `Read mailbox for ${workerName}.`,
+      notify,
+      deps: {
+        sendDirectMessage: vi.fn(async (_teamName, _fromWorker, toWorker) => {
+          if (toWorker === 'worker-2') throw new Error('persist recipient 2 failed');
+          return { message_id: 'broadcast-1', to_worker: toWorker };
+        }),
+        broadcastMessage: vi.fn(async () => []),
+        markMessageNotified: vi.fn(async () => true),
+      },
+    })).rejects.toThrow('persist recipient 2 failed');
+
+    expect(notify).not.toHaveBeenCalled();
   });
 });

--- a/src/team/__tests__/mcp-comm.mailbox-notification.test.ts
+++ b/src/team/__tests__/mcp-comm.mailbox-notification.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  queueBroadcastMailboxMessage,
+  runMailboxNotificationAttempt,
+  type MailboxNotificationAttemptDependencies,
+  type MailboxNotificationAttemptParams,
+} from '../mcp-comm.js';
+import { TeamPaths } from '../state-paths.js';
+import type { TeamDispatchRequest } from '../dispatch-queue.js';
+import type {
+  MailboxNotificationGuardResult,
+  MailboxNotificationSecurityTuple,
+  MailboxNotificationTarget,
+} from '../mailbox-notification-guard.js';
+import type { TeamMailboxMessage } from '../types.js';
+
+let sequence = 0;
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+function params(overrides: Partial<MailboxNotificationAttemptParams> = {}): MailboxNotificationAttemptParams {
+  const id = ++sequence;
+  return {
+    teamName: 'dispatch-team',
+    recipient: 'worker-1',
+    requestId: `request-${id}`,
+    messageId: `message-${id}`,
+    triggerMessage: 'Read your mailbox and report progress.',
+    cwd: `/mailbox-notification-test-${id}`,
+    ...overrides,
+  };
+}
+
+function request(input: MailboxNotificationAttemptParams, overrides: Partial<TeamDispatchRequest> = {}): TeamDispatchRequest {
+  return {
+    request_id: input.requestId,
+    kind: 'mailbox',
+    team_name: input.teamName,
+    to_worker: input.recipient,
+    worker_index: 1,
+    pane_id: '%9',
+    trigger_message: input.triggerMessage,
+    message_id: input.messageId,
+    transport_preference: 'transport_direct',
+    fallback_allowed: true,
+    status: 'pending',
+    attempt_count: 0,
+    created_at: '2026-07-13T00:00:00.000Z',
+    updated_at: '2026-07-13T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function message(input: MailboxNotificationAttemptParams): TeamMailboxMessage {
+  return {
+    message_id: input.messageId,
+    from_worker: 'leader-fixed',
+    to_worker: input.recipient,
+    body: 'durable mailbox body',
+    created_at: '2026-07-13T00:00:00.000Z',
+  };
+}
+
+function target(input: MailboxNotificationAttemptParams): MailboxNotificationTarget {
+  return {
+    provider: 'tmux',
+    providerTarget: 'dispatch-session:0',
+    recipient: input.recipient,
+    recipientRole: 'worker',
+    paneId: '%9',
+    workerIndex: 1,
+  };
+}
+
+function tuple(input: MailboxNotificationAttemptParams, paneId = '%9'): MailboxNotificationSecurityTuple {
+  return {
+    configName: input.teamName,
+    configProviderTarget: 'dispatch-session:0',
+    recipient: input.recipient,
+    recipientRole: 'worker',
+    canonicalPaneId: paneId,
+    canonicalWorkerIndex: 1,
+    requestId: input.requestId,
+    requestKind: 'mailbox',
+    requestTeamName: input.teamName,
+    requestRecipient: input.recipient,
+    requestMessageId: input.messageId,
+    requestTriggerMessage: input.triggerMessage,
+    requestPaneId: paneId,
+    requestWorkerIndex: 1,
+    requestTransportPreference: 'transport_direct',
+    requestFallbackAllowed: true,
+    requestStatus: 'pending',
+    mailboxOwner: input.recipient,
+    mailboxMessageId: input.messageId,
+    mailboxRecipient: input.recipient,
+    provider: 'tmux',
+    providerTarget: 'dispatch-session:0',
+    providerPaneId: paneId,
+  };
+}
+
+function allow(input: MailboxNotificationAttemptParams, current: TeamDispatchRequest, paneId = '%9'): MailboxNotificationGuardResult {
+  return {
+    kind: 'allow',
+    target: { ...target(input), paneId },
+    request: { ...current, pane_id: paneId },
+    message: message(input),
+    securityTuple: tuple(input, paneId),
+  };
+}
+
+function suppress(current: TeamDispatchRequest, reason = 'mailbox_target_metadata_mismatch'): MailboxNotificationGuardResult {
+  return { kind: 'suppress', reason: reason as 'mailbox_target_metadata_mismatch', safePendingRequest: current };
+}
+
+function serialLock(): MailboxNotificationAttemptDependencies['withRequestLock'] {
+  const locks = new Map<string, Promise<void>>();
+  return async <T>(path: string, fn: () => Promise<T>): Promise<T> => {
+    const previous = locks.get(path) ?? Promise.resolve();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    locks.set(path, held);
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (locks.get(path) === held) locks.delete(path);
+    }
+  };
+}
+
+function harness(input = params(), overrides: Partial<MailboxNotificationAttemptDependencies> = {}) {
+  let current = request(input);
+  let mailboxMarked = false;
+  const effect = vi.fn(async () => ({
+    kind: 'confirmed' as const,
+    transport: 'tmux_send_keys' as const,
+    reason: 'worker_pane_notified' as const,
+  }));
+  const readGuard = vi.fn(async () => {
+    if (current.status !== 'pending' || mailboxMarked) {
+      return { kind: 'suppress', reason: 'mailbox_replay_suppressed' } as MailboxNotificationGuardResult;
+    }
+    return allow(input, current);
+  });
+  const dependencies: MailboxNotificationAttemptDependencies = {
+    readGuard,
+    readStrictDispatch: vi.fn(async () => ({ kind: 'valid' as const, request: { ...current } })),
+    readStrictMailbox: vi.fn(async () => mailboxMarked
+      ? { kind: 'replay_suppressed' as const, message: { ...message(input), notified_at: '2026-07-13T00:01:00.000Z' }, marker: 'notified_at' as const }
+      : { kind: 'valid' as const, message: message(input) }),
+    invokeEffect: effect,
+    markMailbox: vi.fn(async () => {
+      mailboxMarked = true;
+      return true;
+    }),
+    markDispatch: vi.fn(async () => {
+      current = { ...current, status: 'notified', notified_at: '2026-07-13T00:01:00.000Z' };
+      return current;
+    }),
+    patchPendingReason: vi.fn(async (_teamName, _requestId, reason) => {
+      current = { ...current, last_reason: reason };
+      return { kind: 'patched' };
+    }),
+    withRequestLock: serialLock(),
+    ...overrides,
+  };
+  return {
+    input,
+    dependencies,
+    effect,
+    readGuard,
+    get request() { return current; },
+    get mailboxMarked() { return mailboxMarked; },
+    markMailbox: (marked: boolean) => { mailboxMarked = marked; },
+  };
+}
+
+describe('direct mailbox notification orchestration', () => {
+  it('hashes the per-request lock name so opaque request text cannot traverse dispatch state', () => {
+    const lock = TeamPaths.mailboxNotificationLock('dispatch-team', '../foreign/request');
+    expect(lock).toMatch(/^\.omc\/state\/team\/dispatch-team\/dispatch\/\.mailbox-notification-[a-f0-9]{64}\.lock$/);
+    expect(lock).not.toContain('foreign');
+  });
+  it('serializes two waiters after mutation then false without a second transport effect', async () => {
+    const state = harness();
+    let mutations = 0;
+    state.dependencies.invokeEffect = vi.fn(async () => {
+      mutations += 1;
+      return {
+        kind: 'attempted_unconfirmed' as const,
+        transport: 'tmux_send_keys' as const,
+        reason: 'notification_delivery_uncertain' as const,
+        cause: 'returned_false' as const,
+      };
+    });
+
+    const [first, second] = await Promise.all([
+      runMailboxNotificationAttempt(state.input, state.dependencies),
+      runMailboxNotificationAttempt(state.input, state.dependencies),
+    ]);
+
+    expect(mutations).toBe(1);
+    expect(first.reason).toBe('notification_delivery_uncertain');
+    expect(second.reason).toBe('notification_delivery_uncertain');
+    expect(state.request.status).toBe('pending');
+    expect(state.mailboxMarked).toBe(false);
+  });
+
+  it('uses canonical lock identity for uncertainty across cwd path aliases', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'omc-mailbox-alias-'));
+    temporaryDirectories.push(root);
+    const actualCwd = join(root, 'actual');
+    const aliasCwd = join(root, 'alias');
+    await mkdir(join(actualCwd, '.omc', 'state', 'team', 'dispatch-team', 'dispatch'), { recursive: true });
+    await symlink(actualCwd, aliasCwd, 'dir');
+    const state = harness(params({ cwd: actualCwd }));
+    state.dependencies.invokeEffect = vi.fn(async () => ({
+      kind: 'attempted_unconfirmed' as const,
+      transport: 'tmux_send_keys' as const,
+      reason: 'notification_delivery_uncertain' as const,
+      cause: 'returned_false' as const,
+    }));
+
+    const first = await runMailboxNotificationAttempt(state.input, state.dependencies);
+    const second = await runMailboxNotificationAttempt({ ...state.input, cwd: aliasCwd }, state.dependencies);
+
+    expect(first.reason).toBe('notification_delivery_uncertain');
+    expect(second.reason).toBe('notification_delivery_uncertain');
+    expect(state.dependencies.invokeEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains delivery uncertainty when the invoked effect throws', async () => {
+    const state = harness();
+    state.dependencies.invokeEffect = vi.fn(async () => {
+      throw new Error('simulated pane mutation followed by throw');
+    });
+
+    const first = await runMailboxNotificationAttempt(state.input, state.dependencies);
+    const second = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(first.reason).toBe('notification_delivery_uncertain');
+    expect(second.reason).toBe('notification_delivery_uncertain');
+    expect(state.dependencies.invokeEffect).toHaveBeenCalledTimes(1);
+    expect(state.request.status).toBe('pending');
+  });
+
+  it('removes a tombstone for provable pre-effect suppression so a corrected retry may invoke once', async () => {
+    const state = harness();
+    state.dependencies.invokeEffect = vi.fn()
+      .mockResolvedValueOnce({ kind: 'not_attempted', reason: 'mailbox_target_missing' })
+      .mockResolvedValueOnce({ kind: 'confirmed', transport: 'tmux_send_keys', reason: 'worker_pane_notified' });
+
+    const first = await runMailboxNotificationAttempt(state.input, state.dependencies);
+    const second = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(first.reason).toBe('mailbox_target_missing');
+    expect(second.reason).toBe('worker_pane_notified');
+    expect(state.dependencies.invokeEffect).toHaveBeenCalledTimes(2);
+    expect(state.mailboxMarked).toBe(true);
+    expect(state.request.status).toBe('notified');
+  });
+
+  it('commits confirmed concurrent delivery exactly once and verifies both durable markers', async () => {
+    const state = harness();
+    const [first, second] = await Promise.all([
+      runMailboxNotificationAttempt(state.input, state.dependencies),
+      runMailboxNotificationAttempt(state.input, state.dependencies),
+    ]);
+
+    expect(first.reason).toBe('worker_pane_notified');
+    expect(second.reason).toBe('mailbox_replay_suppressed');
+    expect(state.effect).toHaveBeenCalledTimes(1);
+    expect(state.mailboxMarked).toBe(true);
+    expect(state.request.status).toBe('notified');
+  });
+
+  it('surfaces partial marker failures without retrying the pane effect and retains dual failures as commit uncertainty', async () => {
+    const partial = harness();
+    partial.dependencies.markMailbox = vi.fn(async () => false);
+    const partialOutcome = await runMailboxNotificationAttempt(partial.input, partial.dependencies);
+    const partialReplay = await runMailboxNotificationAttempt(partial.input, partial.dependencies);
+
+    expect(partialOutcome.reason).toBe('notification_commit_mailbox_failed');
+    expect(partialReplay.reason).toBe('mailbox_replay_suppressed');
+    expect(partial.effect).toHaveBeenCalledTimes(1);
+
+    const dual = harness();
+    dual.dependencies.markMailbox = vi.fn(async () => false);
+    dual.dependencies.markDispatch = vi.fn(async () => null);
+    const dualOutcome = await runMailboxNotificationAttempt(dual.input, dual.dependencies);
+    const dualReplay = await runMailboxNotificationAttempt(dual.input, dual.dependencies);
+
+    expect(dualOutcome.reason).toBe('notification_commit_uncertain');
+    expect(dualReplay.reason).toBe('notification_commit_uncertain');
+    expect(dual.effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles a tombstone through markers only and never invokes transport again', async () => {
+    const state = harness();
+    state.dependencies.invokeEffect = vi.fn(async () => ({
+      kind: 'attempted_unconfirmed' as const,
+      transport: 'tmux_send_keys' as const,
+      reason: 'notification_delivery_uncertain' as const,
+      cause: 'returned_false' as const,
+    }));
+
+    await runMailboxNotificationAttempt(state.input, state.dependencies);
+    state.markMailbox(true);
+    const reconciled = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(reconciled.reason).toBe('notification_commit_dispatch_failed');
+    expect(state.dependencies.invokeEffect).toHaveBeenCalledTimes(1);
+    expect(state.dependencies.markDispatch).not.toHaveBeenCalled();
+  });
+
+  it('suppresses final current-state or security-tuple changes before installing an effect tombstone', async () => {
+    const stateChange = harness();
+    stateChange.dependencies.readGuard = vi.fn()
+      .mockResolvedValueOnce(allow(stateChange.input, stateChange.request))
+      .mockResolvedValueOnce(suppress(stateChange.request));
+
+    const changedState = await runMailboxNotificationAttempt(stateChange.input, stateChange.dependencies);
+    expect(changedState.reason).toBe('mailbox_target_metadata_mismatch');
+    expect(stateChange.effect).not.toHaveBeenCalled();
+
+    const tupleChange = harness();
+    tupleChange.dependencies.readGuard = vi.fn()
+      .mockResolvedValueOnce(allow(tupleChange.input, tupleChange.request))
+      .mockResolvedValueOnce(allow(tupleChange.input, tupleChange.request, '%10'));
+
+    const changedTuple = await runMailboxNotificationAttempt(tupleChange.input, tupleChange.dependencies);
+    expect(changedTuple.reason).toBe('mailbox_security_tuple_changed');
+    expect(tupleChange.effect).not.toHaveBeenCalled();
+  });
+
+  it('surfaces pending-reason persistence failures without calling transport', async () => {
+    const state = harness();
+    state.dependencies.readGuard = vi.fn(async () => suppress(state.request, 'mailbox_target_metadata_mismatch'));
+    state.dependencies.patchPendingReason = vi.fn(async () => ({ kind: 'write_failed' }));
+
+    const outcome = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(outcome.reason).toBe('pending_reason_persist_failed');
+    expect(state.effect).not.toHaveBeenCalled();
+  });
+
+  it('does not recurse through the request lock while safely patching a pending reason', async () => {
+    const state = harness();
+    let lockDepth = 0;
+    let maximumLockDepth = 0;
+    state.dependencies.readGuard = vi.fn(async () => suppress(state.request, 'mailbox_target_metadata_mismatch'));
+    state.dependencies.withRequestLock = async <T>(_path: string, fn: () => Promise<T>): Promise<T> => {
+      lockDepth += 1;
+      maximumLockDepth = Math.max(maximumLockDepth, lockDepth);
+      try {
+        return await fn();
+      } finally {
+        lockDepth -= 1;
+      }
+    };
+    state.dependencies.patchPendingReason = vi.fn(async () => {
+      expect(lockDepth).toBe(1);
+      return { kind: 'patched' };
+    });
+
+    const outcome = await runMailboxNotificationAttempt(state.input, state.dependencies);
+
+    expect(outcome.reason).toBe('mailbox_target_metadata_mismatch');
+    expect(maximumLockDepth).toBe(1);
+  });
+
+  it('uses the broadcast recipient snapshot 1:1 and surfaces a persisted recipient divergence', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omc-mcp-broadcast-'));
+    temporaryDirectories.push(cwd);
+    await mkdir(join(cwd, '.omc', 'state', 'team', 'dispatch-team'), { recursive: true });
+
+    let nextMessage = 0;
+    const outcomes = await queueBroadcastMailboxMessage({
+      teamName: 'dispatch-team',
+      fromWorker: 'leader-fixed',
+      recipients: [
+        { workerName: 'worker-1', workerIndex: 1, paneId: '%9' },
+        { workerName: 'worker-2', workerIndex: 2, paneId: '%10' },
+      ],
+      body: 'broadcast body',
+      cwd,
+      triggerFor: (workerName) => `Read mailbox for ${workerName}.`,
+      notify: vi.fn(async () => ({ ok: true, transport: 'hook' as const, reason: 'queued_for_hook_dispatch' })),
+      deps: {
+        sendDirectMessage: vi.fn(async (_teamName, _fromWorker, toWorker) => ({
+          message_id: `broadcast-${++nextMessage}`,
+          to_worker: nextMessage === 2 ? 'worker-foreign' : toWorker,
+        })),
+        broadcastMessage: vi.fn(async () => []),
+        markMessageNotified: vi.fn(async () => true),
+      },
+    });
+
+    expect(outcomes).toHaveLength(2);
+    expect(outcomes[0]).toMatchObject({ to_worker: 'worker-1', reason: 'queued_for_hook_dispatch' });
+    expect(outcomes[1]).toMatchObject({ to_worker: 'worker-2', reason: 'broadcast_recipient_diverged' });
+  });
+});

--- a/src/team/__tests__/tmux-session.target-membership.test.ts
+++ b/src/team/__tests__/tmux-session.target-membership.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  invokeDirectMailboxEffect,
+  verifyTeamTargetOwnership,
+  type DirectMailboxEffectDependencies,
+  type MailboxTargetOwnershipDependencies,
+} from '../tmux-session.js';
+import type { MailboxNotificationTarget } from '../mailbox-notification-guard.js';
+
+function workerTarget(overrides: Partial<MailboxNotificationTarget> = {}): MailboxNotificationTarget {
+  return {
+    provider: 'tmux',
+    providerTarget: 'dispatch-session:workers',
+    recipient: 'worker-1',
+    recipientRole: 'worker',
+    paneId: '%9',
+    workerIndex: 1,
+    ...overrides,
+  };
+}
+
+function ownershipDependencies(
+  tmuxOutput: string = '',
+  cmuxOutputs: string[] = [],
+): MailboxTargetOwnershipDependencies & {
+  tmuxExec: ReturnType<typeof vi.fn>;
+  cmuxExec: ReturnType<typeof vi.fn>;
+} {
+  const outputs = [...cmuxOutputs];
+  return {
+    tmuxExec: vi.fn(async () => ({ stdout: tmuxOutput, stderr: '' })),
+    cmuxExec: vi.fn(async () => ({ stdout: outputs.shift() ?? '', stderr: '' })),
+  };
+}
+
+describe('direct mailbox target ownership', () => {
+  it('proves exact tmux target membership with the unchanged session window target', async () => {
+    const dependencies = ownershipDependencies('%2\n%9\n%9\n');
+
+    const result = await verifyTeamTargetOwnership(workerTarget(), dependencies);
+
+    expect(result).toEqual({
+      kind: 'owned',
+      provider: 'tmux',
+      providerTarget: 'dispatch-session:workers',
+      paneId: '%9',
+    });
+    expect(dependencies.tmuxExec).toHaveBeenCalledOnce();
+    expect(dependencies.tmuxExec).toHaveBeenCalledWith([
+      'list-panes', '-t', 'dispatch-session:workers', '-F', '#{pane_id}',
+    ]);
+    expect(dependencies.cmuxExec).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['', 'unavailable'],
+    ['%2\nnot-a-pane\n%9\n', 'unavailable'],
+    ['%2\n%3\n', 'foreign'],
+  ])('fails closed for tmux output %j', async (stdout, expectedKind) => {
+    const dependencies = ownershipDependencies(stdout);
+
+    const result = await verifyTeamTargetOwnership(workerTarget(), dependencies);
+
+    expect(result.kind).toBe(expectedKind);
+  });
+
+  it('rejects malformed tmux target metadata without executing a provider command', async () => {
+    const dependencies = ownershipDependencies('%9\n');
+
+    const result = await verifyTeamTargetOwnership(
+      workerTarget({ providerTarget: 'dispatch-session:workers:extra' }),
+      dependencies,
+    );
+
+    expect(result).toEqual({ kind: 'unavailable' });
+    expect(dependencies.tmuxExec).not.toHaveBeenCalled();
+  });
+
+  it('proves exact cmux workspace to pane to surface membership using read-only commands', async () => {
+    const dependencies = ownershipDependencies('', [
+      JSON.stringify({ panes: [{ id: 'pane-a' }, { id: 'pane-b' }] }),
+      JSON.stringify({ surfaces: [{ id: 'surface-other' }] }),
+      JSON.stringify({ surfaces: [{ id: 'surface-worker-1' }] }),
+    ]);
+    const target = workerTarget({
+      provider: 'cmux',
+      providerTarget: 'cmux:workspace-1',
+      paneId: 'surface-worker-1',
+    });
+
+    const result = await verifyTeamTargetOwnership(target, dependencies);
+
+    expect(result).toEqual({
+      kind: 'owned',
+      provider: 'cmux',
+      providerTarget: 'cmux:workspace-1',
+      paneId: 'surface-worker-1',
+    });
+    expect(dependencies.cmuxExec.mock.calls).toEqual([
+      [['--json', 'list-panes', '--workspace', 'workspace-1']],
+      [['--json', 'list-pane-surfaces', '--workspace', 'workspace-1', '--pane', 'pane-a']],
+      [['--json', 'list-pane-surfaces', '--workspace', 'workspace-1', '--pane', 'pane-b']],
+    ]);
+    expect(dependencies.tmuxExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tmux-shaped cmux surface before any provider query', async () => {
+    const dependencies = ownershipDependencies('', [
+      JSON.stringify({ panes: [{ id: 'pane-a' }] }),
+      JSON.stringify({ surfaces: [{ id: '%9' }] }),
+    ]);
+
+    const result = await verifyTeamTargetOwnership(workerTarget({
+      provider: 'cmux',
+      providerTarget: 'cmux:workspace-1',
+      paneId: '%9',
+    }), dependencies);
+
+    expect(result).toEqual({ kind: 'unavailable' });
+    expect(dependencies.tmuxExec).not.toHaveBeenCalled();
+    expect(dependencies.cmuxExec).not.toHaveBeenCalled();
+  });
+
+  it('rejects provider disagreement without querying either provider', async () => {
+    const dependencies = ownershipDependencies('%9\n');
+
+    const result = await verifyTeamTargetOwnership(
+      workerTarget({ provider: 'cmux', providerTarget: 'dispatch-session' }),
+      dependencies,
+    );
+
+    expect(result).toEqual({ kind: 'provider_mismatch' });
+    expect(dependencies.tmuxExec).not.toHaveBeenCalled();
+    expect(dependencies.cmuxExec).not.toHaveBeenCalled();
+  });
+});
+
+describe('direct mailbox effect adapter', () => {
+  function effectDependencies(
+    workerResult: boolean | Error,
+    leaderResult: boolean | Error = true,
+  ): DirectMailboxEffectDependencies & {
+    sendWorker: ReturnType<typeof vi.fn>;
+    sendLeader: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      sendWorker: vi.fn(async () => {
+        if (workerResult instanceof Error) throw workerResult;
+        return workerResult;
+      }),
+      sendLeader: vi.fn(async () => {
+        if (leaderResult instanceof Error) throw leaderResult;
+        return leaderResult;
+      }),
+    };
+  }
+
+  it('classifies a confirmed worker effect without changing the public boolean transport', async () => {
+    const dependencies = effectDependencies(true);
+
+    const result = await invokeDirectMailboxEffect(workerTarget(), 'mailbox trigger', dependencies);
+
+    expect(result).toEqual({
+      kind: 'confirmed',
+      transport: 'tmux_send_keys',
+      reason: 'worker_pane_notified',
+    });
+    expect(dependencies.sendWorker).toHaveBeenCalledOnce();
+    expect(dependencies.sendLeader).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [false, 'returned_false'],
+    [new Error('transport failed'), 'threw'],
+  ])('classifies an invoked but unconfirmed worker effect', async (workerResult, cause) => {
+    const dependencies = effectDependencies(workerResult);
+
+    const result = await invokeDirectMailboxEffect(workerTarget(), 'mailbox trigger', dependencies);
+
+    expect(result).toEqual({
+      kind: 'attempted_unconfirmed',
+      transport: 'tmux_send_keys',
+      reason: 'notification_delivery_uncertain',
+      cause,
+    });
+    expect(dependencies.sendWorker).toHaveBeenCalledOnce();
+  });
+
+  it('uses the leader adapter for a canonical leader target', async () => {
+    const dependencies = effectDependencies(true, true);
+    const target = workerTarget({ recipient: 'leader-fixed', recipientRole: 'leader', workerIndex: undefined });
+
+    const result = await invokeDirectMailboxEffect(target, 'mailbox trigger', dependencies);
+
+    expect(result).toMatchObject({ kind: 'confirmed', reason: 'leader_pane_notified' });
+    expect(dependencies.sendLeader).toHaveBeenCalledOnce();
+    expect(dependencies.sendWorker).not.toHaveBeenCalled();
+  });
+
+  it('does not route an owned cmux surface through tmux when cmux execution context is absent', async () => {
+    const previousSurface = process.env.CMUX_SURFACE_ID;
+    delete process.env.CMUX_SURFACE_ID;
+    const dependencies = effectDependencies(true, true);
+    const target = workerTarget({
+      provider: 'cmux',
+      providerTarget: 'cmux:workspace-1',
+      paneId: 'surface-worker-1',
+    });
+
+    try {
+      const result = await invokeDirectMailboxEffect(target, 'mailbox trigger', dependencies);
+
+      expect(result).toEqual({ kind: 'not_attempted', reason: 'mailbox_membership_unresolvable' });
+      expect(dependencies.sendWorker).not.toHaveBeenCalled();
+      expect(dependencies.sendLeader).not.toHaveBeenCalled();
+    } finally {
+      if (previousSurface === undefined) delete process.env.CMUX_SURFACE_ID;
+      else process.env.CMUX_SURFACE_ID = previousSurface;
+    }
+  });
+
+  it('returns not attempted for missing input without invoking either public transport', async () => {
+    const dependencies = effectDependencies(true);
+
+    const result = await invokeDirectMailboxEffect(workerTarget(), '', dependencies);
+
+    expect(result).toEqual({ kind: 'not_attempted', reason: 'mailbox_target_missing' });
+    expect(dependencies.sendWorker).not.toHaveBeenCalled();
+    expect(dependencies.sendLeader).not.toHaveBeenCalled();
+  });
+});

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -42,10 +42,22 @@ import {
   teamReadTaskApproval,
   teamWriteTaskApproval,
   teamPublishTaskRecoveryCheckpoint,
+  teamReadCanonicalMailboxMessageStrict,
   type TeamMonitorSnapshotState,
 } from './team-ops.js';
-import { queueBroadcastMailboxMessage, queueDirectMailboxMessage, type DispatchOutcome } from './mcp-comm.js';
-import { injectToLeaderPane, sendToWorker } from './tmux-session.js';
+import {
+  queueBroadcastMailboxMessage,
+  queueDirectMailboxMessage,
+  runMailboxNotificationAttempt,
+  type DispatchOutcome,
+} from './mcp-comm.js';
+import { verifyTeamTargetOwnership } from './tmux-session.js';
+import { readDispatchRequestStrict } from './dispatch-queue.js';
+import {
+  readCurrentMailboxNotificationGuard,
+  type MailboxNotificationGuardInput,
+  type MailboxNotificationGuardResult,
+} from './mailbox-notification-guard.js';
 import { listDispatchRequests, markDispatchRequestDelivered, markDispatchRequestNotified } from './dispatch-queue.js';
 import { generateMailboxTriggerMessage } from './worker-bootstrap.js';
 import { shutdownTeam } from './runtime.js';
@@ -445,56 +457,72 @@ export function buildLegacyTeamDeprecationHint(
 }
 
 
-const QUEUED_FOR_HOOK_DISPATCH_REASON = 'queued_for_hook_dispatch';
-const LEADER_PANE_MISSING_MAILBOX_PERSISTED_REASON = 'leader_pane_missing_mailbox_persisted';
 const WORKTREE_TRIGGER_STATE_ROOT = '$OMC_TEAM_STATE_ROOT';
 
 function resolveInstructionStateRoot(worktreePath?: string | null): string | undefined {
   return worktreePath ? WORKTREE_TRIGGER_STATE_ROOT : undefined;
 }
 
-function queuedForHookDispatch(): DispatchOutcome {
-  return {
-    ok: true,
-    transport: 'hook',
-    reason: QUEUED_FOR_HOOK_DISPATCH_REASON,
-  };
+function hasExactText(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value === value.trim();
 }
 
-async function notifyMailboxTarget(
-  teamName: string,
-  toWorker: string,
-  triggerMessage: string,
+/**
+ * Older leader mailbox requests did not always persist pane_id. The leader
+ * target is canonical config metadata, so rehydrate only that optional legacy
+ * field for the strict guard; every durable identity field remains exact.
+ */
+async function readMailboxGuardWithCanonicalLeaderTarget(
+  input: MailboxNotificationGuardInput,
   cwd: string,
-): Promise<DispatchOutcome> {
-  const config = await teamReadConfig(teamName, cwd);
-  if (!config) return queuedForHookDispatch();
+): Promise<MailboxNotificationGuardResult> {
+  let configPromise: ReturnType<typeof teamReadConfig> | undefined;
+  const readConfig = () => {
+    configPromise ??= teamReadConfig(input.teamName, cwd);
+    return configPromise;
+  };
+  return readCurrentMailboxNotificationGuard(input, cwd, {
+    readConfig,
+    readStrictDispatchRequest: async (teamName, requestId, requestCwd) => {
+      const [dispatch, config] = await Promise.all([
+        readDispatchRequestStrict(teamName, requestId, requestCwd),
+        readConfig(),
+      ]);
+      const canonicalLeaderPaneId = config?.leader_pane_id;
+      if (
+        dispatch.kind === 'valid'
+        && input.recipient === 'leader-fixed'
+        && dispatch.request.to_worker === 'leader-fixed'
+        && dispatch.request.pane_id === undefined
+        && hasExactText(canonicalLeaderPaneId)
+      ) {
+        return { kind: 'valid', request: { ...dispatch.request, pane_id: canonicalLeaderPaneId } };
+      }
+      return dispatch;
+    },
+    readStrictMailboxMessage: teamReadCanonicalMailboxMessageStrict,
+    verifyProviderOwnership: verifyTeamTargetOwnership,
+  });
+}
 
-  const sessionName = typeof config.tmux_session === 'string' ? config.tmux_session.trim() : '';
-  if (!sessionName) return queuedForHookDispatch();
-
-  if (toWorker === 'leader-fixed') {
-    const leaderPaneId = typeof config.leader_pane_id === 'string' ? config.leader_pane_id.trim() : '';
-    if (!leaderPaneId) {
-      return {
-        ok: true,
-        transport: 'mailbox',
-        reason: LEADER_PANE_MISSING_MAILBOX_PERSISTED_REASON,
-      };
-    }
-    const injected = await injectToLeaderPane(sessionName, leaderPaneId, triggerMessage);
-    return injected
-      ? { ok: true, transport: 'tmux_send_keys', reason: 'leader_pane_notified' }
-      : queuedForHookDispatch();
-  }
-
-  const workerPaneId = config.workers.find((worker) => worker.name === toWorker)?.pane_id?.trim();
-  if (!workerPaneId) return queuedForHookDispatch();
-
-  const notified = await sendToWorker(sessionName, workerPaneId, triggerMessage);
-  return notified
-    ? { ok: true, transport: 'tmux_send_keys', reason: 'worker_pane_notified' }
-    : queuedForHookDispatch();
+async function notifyMailboxTarget(params: {
+  teamName: string;
+  toWorker: string;
+  triggerMessage: string;
+  requestId: string;
+  messageId: string;
+  cwd: string;
+}): Promise<DispatchOutcome> {
+  return runMailboxNotificationAttempt({
+    teamName: params.teamName,
+    recipient: params.toWorker,
+    requestId: params.requestId,
+    messageId: params.messageId,
+    triggerMessage: params.triggerMessage,
+    cwd: params.cwd,
+  }, {
+    readGuard: readMailboxGuardWithCanonicalLeaderTarget,
+  });
 }
 
 function findWorkerDispatchTarget(
@@ -504,6 +532,9 @@ function findWorkerDispatchTarget(
 ): Promise<{ paneId?: string; workerIndex?: number; instructionStateRoot?: string }>
 {
   return teamReadConfig(teamName, cwd).then((config) => {
+    if (toWorker === 'leader-fixed') {
+      return { paneId: config?.leader_pane_id ?? undefined };
+    }
     const recipient = config?.workers.find((worker) => worker.name === toWorker);
     return {
       paneId: recipient?.pane_id,
@@ -714,7 +745,7 @@ export async function executeTeamApiOperation(
 
         let message: Awaited<ReturnType<typeof sendDirectMessage>> | null = null;
         const target = await findWorkerDispatchTarget(teamName, toWorker, cwd);
-        await queueDirectMailboxMessage({
+        const notificationOutcome = await queueDirectMailboxMessage({
           teamName,
           fromWorker,
           toWorker,
@@ -723,20 +754,26 @@ export async function executeTeamApiOperation(
           body,
           triggerMessage: generateMailboxTriggerMessage(teamName, toWorker, 1, target.instructionStateRoot),
           cwd,
-          notify: ({ workerName }, triggerMessage) => notifyMailboxTarget(teamName, workerName, triggerMessage, cwd),
+          notify: (_target, resolvedTriggerMessage, context) => notifyMailboxTarget({
+            teamName,
+            toWorker: context.request.to_worker,
+            triggerMessage: resolvedTriggerMessage,
+            requestId: context.request.request_id,
+            messageId: context.message_id ?? context.request.message_id ?? '',
+            cwd,
+          }),
           deps: {
             sendDirectMessage: async (resolvedTeamName, resolvedFromWorker, resolvedToWorker, resolvedBody, resolvedCwd) => {
               message = await sendDirectMessage(resolvedTeamName, resolvedFromWorker, resolvedToWorker, resolvedBody, resolvedCwd);
               return message;
             },
             broadcastMessage,
-            markMessageNotified: async (resolvedTeamName, workerName, messageId, resolvedCwd) => {
-              await markMessageNotified(resolvedTeamName, workerName, messageId, resolvedCwd);
-            },
+            markMessageNotified: (resolvedTeamName, workerName, messageId, resolvedCwd) =>
+              markMessageNotified(resolvedTeamName, workerName, messageId, resolvedCwd),
           },
         });
 
-        return { ok: true, operation, data: { message } };
+        return { ok: true, operation, data: { message, notification_outcome: notificationOutcome } };
       }
       case 'broadcast': {
         const teamName = String(args.team_name || '').trim();
@@ -746,7 +783,7 @@ export async function executeTeamApiOperation(
           return { ok: false, operation, error: { code: 'invalid_input', message: 'team_name, from_worker, body are required' } };
         }
 
-        let messages: Awaited<ReturnType<typeof broadcastMessage>> = [];
+        const messages: Awaited<ReturnType<typeof broadcastMessage>> = [];
         const config = await teamReadConfig(teamName, cwd);
         const recipients = (config?.workers ?? [])
           .filter((worker) => worker.name !== fromWorker)
@@ -757,7 +794,7 @@ export async function executeTeamApiOperation(
             instructionStateRoot: resolveInstructionStateRoot(worker.worktree_path),
           }));
 
-        await queueBroadcastMailboxMessage({
+        const notificationOutcomes = await queueBroadcastMailboxMessage({
           teamName,
           fromWorker,
           recipients,
@@ -769,20 +806,34 @@ export async function executeTeamApiOperation(
             1,
             recipients.find((recipient) => recipient.workerName === workerName)?.instructionStateRoot,
           ),
-          notify: ({ workerName }, triggerMessage) => notifyMailboxTarget(teamName, workerName, triggerMessage, cwd),
+          notify: (_target, resolvedTriggerMessage, context) => notifyMailboxTarget({
+            teamName,
+            toWorker: context.request.to_worker,
+            triggerMessage: resolvedTriggerMessage,
+            requestId: context.request.request_id,
+            messageId: context.message_id ?? context.request.message_id ?? '',
+            cwd,
+          }),
           deps: {
-            sendDirectMessage,
-            broadcastMessage: async (resolvedTeamName, resolvedFromWorker, resolvedBody, resolvedCwd) => {
-              messages = await broadcastMessage(resolvedTeamName, resolvedFromWorker, resolvedBody, resolvedCwd);
-              return messages;
+            sendDirectMessage: async (resolvedTeamName, resolvedFromWorker, resolvedToWorker, resolvedBody, resolvedCwd) => {
+              const message = await sendDirectMessage(
+                resolvedTeamName,
+                resolvedFromWorker,
+                resolvedToWorker,
+                resolvedBody,
+                resolvedCwd,
+              );
+              messages.push(message);
+              return message;
             },
-            markMessageNotified: async (resolvedTeamName, workerName, messageId, resolvedCwd) => {
-              await markMessageNotified(resolvedTeamName, workerName, messageId, resolvedCwd);
-            },
+            // queueBroadcastMailboxMessage persists from the recipient snapshot via sendDirectMessage.
+            broadcastMessage: async () => [],
+            markMessageNotified: (resolvedTeamName, workerName, messageId, resolvedCwd) =>
+              markMessageNotified(resolvedTeamName, workerName, messageId, resolvedCwd),
           },
         });
 
-        return { ok: true, operation, data: { count: messages.length, messages } };
+        return { ok: true, operation, data: { count: messages.length, messages, notification_outcomes: notificationOutcomes } };
       }
       case 'mailbox-list': {
         const teamName = String(args.team_name || '').trim();

--- a/src/team/api-interop.ts
+++ b/src/team/api-interop.ts
@@ -785,7 +785,8 @@ export async function executeTeamApiOperation(
 
         const messages: Awaited<ReturnType<typeof broadcastMessage>> = [];
         const config = await teamReadConfig(teamName, cwd);
-        const recipients = (config?.workers ?? [])
+        if (!config) throw new Error(`Team ${teamName} not found`);
+        const recipients = config.workers
           .filter((worker) => worker.name !== fromWorker)
           .map((worker) => ({
             workerName: worker.name,

--- a/src/team/dispatch-queue.ts
+++ b/src/team/dispatch-queue.ts
@@ -59,6 +59,30 @@ export interface TeamDispatchRequestInput {
   last_reason?: string;
 }
 
+/**
+ * Result of reading raw dispatch evidence for the mailbox authorization guard.
+ * This intentionally does not share the compatibility normalization path.
+ */
+export type StrictDispatchReadResult =
+  | { kind: 'valid'; request: TeamDispatchRequest }
+  | { kind: 'store_missing' }
+  | { kind: 'malformed_store'; cause: 'json' | 'non_array' }
+  | { kind: 'malformed_row'; rowIndex: number; field: string }
+  | { kind: 'team_mismatch'; rowIndex: number }
+  | { kind: 'invalid_kind'; rowIndex: number }
+  | { kind: 'invalid_status'; rowIndex: number }
+  | { kind: 'duplicate_request_id'; requestId: string; rowIndexes: number[] }
+  | { kind: 'request_missing' }
+  | { kind: 'ambiguous_request'; rowIndexes: number[] };
+
+/** A checked, non-transitioning diagnostic patch for a strict pending request. */
+export type PatchPendingDispatchReasonResult =
+  | { kind: 'patched'; request: TeamDispatchRequest }
+  | { kind: 'missing' }
+  | { kind: 'not_pending'; request: TeamDispatchRequest }
+  | { kind: 'unsafe'; read: Exclude<StrictDispatchReadResult, { kind: 'valid' | 'request_missing' }> }
+  | { kind: 'write_failed' };
+
 // ── Lock constants ─────────────────────────────────────────────────────────
 
 const OMC_DISPATCH_LOCK_TIMEOUT_ENV = 'OMC_TEAM_DISPATCH_LOCK_TIMEOUT_MS';
@@ -83,6 +107,27 @@ function isDispatchKind(value: unknown): value is TeamDispatchRequestKind {
 
 function isDispatchStatus(value: unknown): value is TeamDispatchRequestStatus {
   return value === 'pending' || value === 'notified' || value === 'delivered' || value === 'failed';
+}
+
+function isDispatchTransportPreference(value: unknown): value is TeamDispatchTransportPreference {
+  return value === 'hook_preferred_with_fallback' || value === 'transport_direct' || value === 'prompt_stdin';
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function isStrictText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '' && value === value.trim();
+}
+
+function isStrictTimestamp(value: unknown): value is string {
+  return isStrictText(value) && Number.isFinite(Date.parse(value));
+}
+
+function isStrictNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value) && value >= 0;
 }
 
 // ── Lock ───────────────────────────────────────────────────────────────────
@@ -220,6 +265,206 @@ export function normalizeDispatchRequest(
     failed_at: typeof raw.failed_at === 'string' && raw.failed_at !== '' ? raw.failed_at : undefined,
     last_reason: typeof raw.last_reason === 'string' && raw.last_reason !== '' ? raw.last_reason : undefined,
   };
+}
+
+type StrictDispatchStoreFailure = Exclude<
+  StrictDispatchReadResult,
+  { kind: 'valid' | 'duplicate_request_id' | 'request_missing' | 'ambiguous_request' }
+>;
+
+interface StrictValidatedDispatchStore {
+  kind: 'valid_store';
+  rawRows: Record<string, unknown>[];
+  requests: TeamDispatchRequest[];
+}
+
+type StrictDispatchStoreResult = StrictValidatedDispatchStore | StrictDispatchStoreFailure;
+
+type StrictDispatchLookupResult =
+  | { kind: 'valid'; request: TeamDispatchRequest; rowIndex: number }
+  | Exclude<StrictDispatchReadResult, { kind: 'valid' }>;
+
+function strictMalformedRow(rowIndex: number, field: string): StrictDispatchStoreFailure {
+  return { kind: 'malformed_row', rowIndex, field };
+}
+
+function materializeStrictDispatchRequest(raw: Record<string, unknown>): TeamDispatchRequest {
+  const request: TeamDispatchRequest = {
+    request_id: raw.request_id as string,
+    kind: raw.kind as TeamDispatchRequestKind,
+    team_name: raw.team_name as string,
+    to_worker: raw.to_worker as string,
+    trigger_message: raw.trigger_message as string,
+    transport_preference: raw.transport_preference as TeamDispatchTransportPreference,
+    fallback_allowed: raw.fallback_allowed as boolean,
+    status: raw.status as TeamDispatchRequestStatus,
+    attempt_count: raw.attempt_count as number,
+    created_at: raw.created_at as string,
+    updated_at: raw.updated_at as string,
+  };
+  if ('worker_index' in raw) request.worker_index = raw.worker_index as number;
+  if ('pane_id' in raw) request.pane_id = raw.pane_id as string;
+  if ('message_id' in raw) request.message_id = raw.message_id as string;
+  if ('inbox_correlation_key' in raw) request.inbox_correlation_key = raw.inbox_correlation_key as string;
+  if ('notified_at' in raw) request.notified_at = raw.notified_at as string;
+  if ('delivered_at' in raw) request.delivered_at = raw.delivered_at as string;
+  if ('failed_at' in raw) request.failed_at = raw.failed_at as string;
+  if ('last_reason' in raw) request.last_reason = raw.last_reason as string;
+  return request;
+}
+
+function validateStrictDispatchRow(
+  teamName: string,
+  raw: unknown,
+  rowIndex: number,
+): TeamDispatchRequest | StrictDispatchStoreFailure {
+  if (!isPlainRecord(raw)) return strictMalformedRow(rowIndex, '$');
+  if (!isStrictText(raw.request_id)) return strictMalformedRow(rowIndex, 'request_id');
+  if (typeof raw.team_name !== 'string' || raw.team_name === '') return strictMalformedRow(rowIndex, 'team_name');
+  if (raw.team_name !== teamName) return { kind: 'team_mismatch', rowIndex };
+  if (!isDispatchKind(raw.kind)) return { kind: 'invalid_kind', rowIndex };
+  if (!isStrictText(raw.to_worker)) return strictMalformedRow(rowIndex, 'to_worker');
+  if (!isStrictText(raw.trigger_message)) return strictMalformedRow(rowIndex, 'trigger_message');
+  if (!isDispatchTransportPreference(raw.transport_preference)) return strictMalformedRow(rowIndex, 'transport_preference');
+  if (typeof raw.fallback_allowed !== 'boolean') return strictMalformedRow(rowIndex, 'fallback_allowed');
+  if (!isDispatchStatus(raw.status)) return { kind: 'invalid_status', rowIndex };
+  if (!isStrictNonNegativeInteger(raw.attempt_count)) return strictMalformedRow(rowIndex, 'attempt_count');
+  if (!isStrictTimestamp(raw.created_at)) return strictMalformedRow(rowIndex, 'created_at');
+  if (!isStrictTimestamp(raw.updated_at)) return strictMalformedRow(rowIndex, 'updated_at');
+
+  if (raw.kind === 'mailbox' && !isStrictText(raw.message_id)) return strictMalformedRow(rowIndex, 'message_id');
+  if ('message_id' in raw && !isStrictText(raw.message_id)) return strictMalformedRow(rowIndex, 'message_id');
+  if ('worker_index' in raw && !isStrictNonNegativeInteger(raw.worker_index)) return strictMalformedRow(rowIndex, 'worker_index');
+  if ('pane_id' in raw && !isStrictText(raw.pane_id)) return strictMalformedRow(rowIndex, 'pane_id');
+  if ('inbox_correlation_key' in raw && !isStrictText(raw.inbox_correlation_key)) {
+    return strictMalformedRow(rowIndex, 'inbox_correlation_key');
+  }
+  if ('notified_at' in raw && !isStrictTimestamp(raw.notified_at)) return strictMalformedRow(rowIndex, 'notified_at');
+  if ('delivered_at' in raw && !isStrictTimestamp(raw.delivered_at)) return strictMalformedRow(rowIndex, 'delivered_at');
+  if ('failed_at' in raw && !isStrictTimestamp(raw.failed_at)) return strictMalformedRow(rowIndex, 'failed_at');
+  if ('last_reason' in raw && typeof raw.last_reason !== 'string') return strictMalformedRow(rowIndex, 'last_reason');
+
+  return materializeStrictDispatchRequest(raw);
+}
+
+async function readStrictDispatchStore(teamName: string, cwd: string): Promise<StrictDispatchStoreResult> {
+  const path = absPath(cwd, TeamPaths.dispatchRequests(teamName));
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'ENOENT'
+      ? { kind: 'store_missing' }
+      : { kind: 'malformed_store', cause: 'json' };
+  }
+  if (!Array.isArray(parsed)) return { kind: 'malformed_store', cause: 'non_array' };
+
+  const rawRows: Record<string, unknown>[] = [];
+  const requests: TeamDispatchRequest[] = [];
+  for (let rowIndex = 0; rowIndex < parsed.length; rowIndex += 1) {
+    const raw = parsed[rowIndex];
+    const validated = validateStrictDispatchRow(teamName, raw, rowIndex);
+    if (!('request_id' in validated)) return validated;
+    rawRows.push(raw as Record<string, unknown>);
+    requests.push(validated);
+  }
+  return { kind: 'valid_store', rawRows, requests };
+}
+
+function lookupStrictDispatchRequest(
+  store: StrictValidatedDispatchStore,
+  requestId: string,
+): StrictDispatchLookupResult {
+  const indexesByRequestId = new Map<string, number[]>();
+  for (const [rowIndex, request] of store.requests.entries()) {
+    const indexes = indexesByRequestId.get(request.request_id) ?? [];
+    indexes.push(rowIndex);
+    indexesByRequestId.set(request.request_id, indexes);
+  }
+
+  const requestedIndexes = indexesByRequestId.get(requestId) ?? [];
+  if (requestedIndexes.length > 1) {
+    return { kind: 'duplicate_request_id', requestId, rowIndexes: requestedIndexes };
+  }
+  const duplicateIndexes = [...indexesByRequestId.values()].filter((indexes) => indexes.length > 1).flat();
+  if (duplicateIndexes.length > 0) return { kind: 'ambiguous_request', rowIndexes: duplicateIndexes };
+  if (requestedIndexes.length === 0) return { kind: 'request_missing' };
+
+  const rowIndex = requestedIndexes[0]!;
+  const request = store.requests[rowIndex]!;
+  if (request.kind !== 'mailbox') return { kind: 'invalid_kind', rowIndex };
+  return { kind: 'valid', request, rowIndex };
+}
+
+async function readStrictDispatchRequestWithIndex(
+  teamName: string,
+  requestId: string,
+  cwd: string,
+): Promise<{ read: StrictDispatchLookupResult; store?: StrictValidatedDispatchStore }> {
+  const store = await readStrictDispatchStore(teamName, cwd);
+  if (store.kind !== 'valid_store') return { read: store };
+  return { read: lookupStrictDispatchRequest(store, requestId), store };
+}
+
+/**
+ * Reads raw dispatch evidence for the direct mailbox authorization boundary.
+ * Unlike readDispatchRequest, it neither defaults nor rewrites persisted data.
+ */
+export async function readDispatchRequestStrict(
+  teamName: string,
+  requestId: string,
+  cwd: string,
+): Promise<StrictDispatchReadResult> {
+  const { read } = await readStrictDispatchRequestWithIndex(teamName, requestId, cwd);
+  if (read.kind === 'valid') return { kind: 'valid', request: { ...read.request } };
+  return read;
+}
+
+/**
+ * Patches only a uniquely validated pending mailbox request. Invalid or
+ * ambiguous persisted stores are left byte-for-byte untouched.
+ */
+export async function patchPendingDispatchReason(
+  teamName: string,
+  requestId: string,
+  reason: string,
+  cwd: string,
+): Promise<PatchPendingDispatchReasonResult> {
+  if (!existsSync(absPath(cwd, TeamPaths.root(teamName)))) return { kind: 'missing' };
+
+  try {
+    return await withDispatchLock(teamName, cwd, async () => {
+      const { read, store } = await readStrictDispatchRequestWithIndex(teamName, requestId, cwd);
+      if (read.kind === 'store_missing' || read.kind === 'request_missing') return { kind: 'missing' };
+      if (read.kind !== 'valid') return { kind: 'unsafe', read };
+      if (!store) return { kind: 'write_failed' };
+      if (read.request.status !== 'pending') return { kind: 'not_pending', request: { ...read.request } };
+
+      const nowIso = new Date().toISOString();
+      const nextRows = store.rawRows.map((row) => ({ ...row }));
+      nextRows[read.rowIndex] = {
+        ...nextRows[read.rowIndex],
+        last_reason: reason,
+        updated_at: nowIso,
+      };
+      try {
+        atomicWriteJson(absPath(cwd, TeamPaths.dispatchRequests(teamName)), nextRows);
+      } catch {
+        return { kind: 'write_failed' };
+      }
+      return {
+        kind: 'patched',
+        request: {
+          ...read.request,
+          last_reason: reason,
+          updated_at: nowIso,
+        },
+      };
+    });
+  } catch {
+    return { kind: 'write_failed' };
+  }
 }
 
 // ── Dedup ──────────────────────────────────────────────────────────────────

--- a/src/team/mailbox-notification-guard.ts
+++ b/src/team/mailbox-notification-guard.ts
@@ -1,0 +1,391 @@
+import {
+  readDispatchRequestStrict,
+  type StrictDispatchReadResult,
+  type TeamDispatchRequest,
+} from './dispatch-queue.js';
+import {
+  teamReadCanonicalMailboxMessageStrict,
+  teamReadConfig,
+  type StrictCanonicalMailboxMessageReadResult,
+} from './team-ops.js';
+import type { TeamConfig, TeamMailboxMessage } from './types.js';
+import { canonicalizeWorkers } from './worker-canonicalization.js';
+
+export interface MailboxNotificationGuardInput {
+  teamName: string;
+  recipient: string;
+  requestId: string;
+  messageId: string;
+  triggerMessage: string;
+}
+
+export type MailboxNotificationProvider = 'tmux' | 'cmux';
+
+export interface MailboxNotificationTarget {
+  provider: MailboxNotificationProvider;
+  providerTarget: string;
+  recipient: string;
+  recipientRole: 'leader' | 'worker';
+  paneId: string;
+  workerIndex?: number;
+}
+
+export type MailboxTargetOwnership =
+  | {
+      kind: 'owned';
+      provider: MailboxNotificationProvider;
+      providerTarget: string;
+      paneId: string;
+    }
+  | { kind: 'unavailable' }
+  | { kind: 'foreign' }
+  | { kind: 'provider_mismatch' };
+
+/** Fields that must remain identical between the guard's pre-effect re-reads. */
+export interface MailboxNotificationSecurityTuple {
+  configName: string;
+  configProviderTarget: string;
+  recipient: string;
+  recipientRole: 'leader' | 'worker';
+  canonicalPaneId: string;
+  canonicalWorkerIndex?: number;
+  requestId: string;
+  requestKind: 'mailbox';
+  requestTeamName: string;
+  requestRecipient: string;
+  requestMessageId: string;
+  requestTriggerMessage: string;
+  requestPaneId?: string;
+  requestWorkerIndex?: number;
+  requestTransportPreference: TeamDispatchRequest['transport_preference'];
+  requestFallbackAllowed: boolean;
+  requestStatus: 'pending';
+  mailboxOwner: string;
+  mailboxMessageId: string;
+  mailboxRecipient: string;
+  provider: MailboxNotificationProvider;
+  providerTarget: string;
+  providerPaneId: string;
+}
+
+export type MailboxNotificationGuardReason =
+  | 'mailbox_team_unavailable'
+  | 'mailbox_team_identity_mismatch'
+  | 'mailbox_request_missing'
+  | 'mailbox_dispatch_store_invalid'
+  | 'mailbox_request_ambiguous'
+  | 'mailbox_request_not_pending'
+  | 'mailbox_request_identity_mismatch'
+  | 'mailbox_target_missing'
+  | 'mailbox_target_metadata_mismatch'
+  | 'leader_pane_missing_deferred'
+  | 'mailbox_store_invalid'
+  | 'mailbox_message_missing'
+  | 'mailbox_message_ambiguous'
+  | 'mailbox_recipient_mismatch'
+  | 'mailbox_replay_suppressed'
+  | 'mailbox_provider_mismatch'
+  | 'mailbox_membership_unresolvable'
+  | 'mailbox_target_foreign';
+
+export type MailboxNotificationGuardResult =
+  | {
+      kind: 'allow';
+      target: MailboxNotificationTarget;
+      request: TeamDispatchRequest;
+      message: TeamMailboxMessage;
+      securityTuple: MailboxNotificationSecurityTuple;
+    }
+  | {
+      kind: 'suppress';
+      reason: MailboxNotificationGuardReason;
+      safePendingRequest?: TeamDispatchRequest;
+      target?: MailboxNotificationTarget;
+    };
+
+export interface MailboxNotificationGuardState {
+  config: TeamConfig | null;
+  dispatch: StrictDispatchReadResult;
+  mailbox: StrictCanonicalMailboxMessageReadResult;
+  ownership?: MailboxTargetOwnership;
+}
+
+export interface MailboxNotificationGuardDependencies {
+  readConfig: (teamName: string, cwd: string) => Promise<TeamConfig | null>;
+  readStrictDispatchRequest: (teamName: string, requestId: string, cwd: string) => Promise<StrictDispatchReadResult>;
+  readStrictMailboxMessage: (
+    teamName: string,
+    workerName: string,
+    messageId: string,
+    cwd: string,
+  ) => Promise<StrictCanonicalMailboxMessageReadResult>;
+  verifyProviderOwnership: (target: MailboxNotificationTarget) => Promise<MailboxTargetOwnership>;
+}
+
+function hasExactText(value: unknown): value is string {
+  return typeof value === 'string' && value !== '' && value === value.trim();
+}
+
+function providerForTarget(providerTarget: string): MailboxNotificationProvider {
+  return providerTarget.startsWith('cmux:') ? 'cmux' : 'tmux';
+}
+
+function dispatchFailureReason(read: Exclude<StrictDispatchReadResult, { kind: 'valid' }>): MailboxNotificationGuardReason {
+  switch (read.kind) {
+    case 'store_missing':
+    case 'request_missing':
+      return 'mailbox_request_missing';
+    case 'team_mismatch':
+      return 'mailbox_team_identity_mismatch';
+    case 'duplicate_request_id':
+    case 'ambiguous_request':
+      return 'mailbox_request_ambiguous';
+    case 'malformed_store':
+    case 'malformed_row':
+    case 'invalid_kind':
+    case 'invalid_status':
+      return 'mailbox_dispatch_store_invalid';
+  }
+  return 'mailbox_dispatch_store_invalid';
+}
+
+function mailboxFailureReason(
+  read: Exclude<StrictCanonicalMailboxMessageReadResult, { kind: 'valid' }>,
+): MailboxNotificationGuardReason {
+  switch (read.kind) {
+    case 'store_missing':
+      return 'mailbox_message_missing';
+    case 'malformed_store':
+    case 'malformed_message':
+      return 'mailbox_store_invalid';
+    case 'wrong_owner':
+    case 'recipient_mismatch':
+      return 'mailbox_recipient_mismatch';
+    case 'message_missing':
+      return 'mailbox_message_missing';
+    case 'duplicate_message_id':
+      return 'mailbox_message_ambiguous';
+    case 'replay_suppressed':
+      return 'mailbox_replay_suppressed';
+  }
+  return 'mailbox_store_invalid';
+}
+
+function resolveCanonicalTarget(
+  config: TeamConfig,
+  recipient: string,
+): { target: MailboxNotificationTarget } | { reason: MailboxNotificationGuardReason } {
+  if (!hasExactText(config.tmux_session)) return { reason: 'mailbox_team_unavailable' };
+
+  const providerTarget = config.tmux_session;
+  const provider = providerForTarget(providerTarget);
+  if (recipient === 'leader-fixed') {
+    if (!hasExactText(config.leader_pane_id)) return { reason: 'leader_pane_missing_deferred' };
+    return {
+      target: {
+        provider,
+        providerTarget,
+        recipient,
+        recipientRole: 'leader',
+        paneId: config.leader_pane_id,
+      },
+    };
+  }
+
+  if (!Array.isArray(config.workers)) return { reason: 'mailbox_target_missing' };
+  const worker = canonicalizeWorkers(config.workers).workers.find((candidate) => candidate.name === recipient);
+  if (!worker || !hasExactText(worker.pane_id)) return { reason: 'mailbox_target_missing' };
+  return {
+    target: {
+      provider,
+      providerTarget,
+      recipient,
+      recipientRole: 'worker',
+      paneId: worker.pane_id,
+      ...(typeof worker.index === 'number' && Number.isFinite(worker.index) ? { workerIndex: worker.index } : {}),
+    },
+  };
+}
+
+function ownershipFailureReason(ownership: MailboxTargetOwnership): MailboxNotificationGuardReason | null {
+  switch (ownership.kind) {
+    case 'unavailable':
+      return 'mailbox_membership_unresolvable';
+    case 'foreign':
+      return 'mailbox_target_foreign';
+    case 'provider_mismatch':
+      return 'mailbox_provider_mismatch';
+    case 'owned':
+      return null;
+  }
+  return 'mailbox_membership_unresolvable';
+}
+
+/**
+ * Purely evaluates current strict durable evidence. It has no transport,
+ * marker, lock, or persistence effects.
+ */
+export function evaluateMailboxNotificationGuard(
+  input: MailboxNotificationGuardInput,
+  state: MailboxNotificationGuardState,
+): MailboxNotificationGuardResult {
+  if (!hasExactText(input.teamName)) return { kind: 'suppress', reason: 'mailbox_team_unavailable' };
+  if (
+    !hasExactText(input.recipient)
+    || !hasExactText(input.requestId)
+    || !hasExactText(input.messageId)
+    || !hasExactText(input.triggerMessage)
+  ) {
+    return { kind: 'suppress', reason: 'mailbox_request_identity_mismatch' };
+  }
+  if (!state.config) return { kind: 'suppress', reason: 'mailbox_team_unavailable' };
+  if (state.config.name !== input.teamName) return { kind: 'suppress', reason: 'mailbox_team_identity_mismatch' };
+
+  if (state.dispatch.kind !== 'valid') {
+    return { kind: 'suppress', reason: dispatchFailureReason(state.dispatch) };
+  }
+  const request = state.dispatch.request;
+  if (request.status !== 'pending') return { kind: 'suppress', reason: 'mailbox_request_not_pending' };
+  const safePendingRequest = { ...request };
+  if (
+    request.request_id !== input.requestId
+    || request.team_name !== input.teamName
+    || request.to_worker !== input.recipient
+    || request.message_id !== input.messageId
+    || request.trigger_message !== input.triggerMessage
+  ) {
+    return { kind: 'suppress', reason: 'mailbox_request_identity_mismatch', safePendingRequest };
+  }
+
+  const targetResolution = resolveCanonicalTarget(state.config, input.recipient);
+  if ('reason' in targetResolution) {
+    return { kind: 'suppress', reason: targetResolution.reason, safePendingRequest };
+  }
+  const target = targetResolution.target;
+  if (request.pane_id !== target.paneId) {
+    return { kind: 'suppress', reason: 'mailbox_target_metadata_mismatch', safePendingRequest, target };
+  }
+  if (request.worker_index !== undefined && request.worker_index !== target.workerIndex) {
+    return { kind: 'suppress', reason: 'mailbox_target_metadata_mismatch', safePendingRequest, target };
+  }
+
+  if (state.mailbox.kind !== 'valid') {
+    return { kind: 'suppress', reason: mailboxFailureReason(state.mailbox), safePendingRequest, target };
+  }
+  const message = state.mailbox.message;
+  if (message.message_id !== input.messageId || message.to_worker !== input.recipient) {
+    return { kind: 'suppress', reason: 'mailbox_recipient_mismatch', safePendingRequest, target };
+  }
+
+  const ownership = state.ownership;
+  if (!ownership) return { kind: 'suppress', reason: 'mailbox_membership_unresolvable', safePendingRequest, target };
+  if (ownership.kind !== 'owned') {
+    return {
+      kind: 'suppress',
+      reason: ownershipFailureReason(ownership) ?? 'mailbox_membership_unresolvable',
+      safePendingRequest,
+      target,
+    };
+  }
+  if (
+    ownership.provider !== target.provider
+    || ownership.providerTarget !== target.providerTarget
+    || ownership.paneId !== target.paneId
+  ) {
+    return { kind: 'suppress', reason: 'mailbox_provider_mismatch', safePendingRequest, target };
+  }
+
+  return {
+    kind: 'allow',
+    target,
+    request: { ...request },
+    message: { ...message },
+    securityTuple: {
+      configName: state.config.name,
+      configProviderTarget: state.config.tmux_session,
+      recipient: input.recipient,
+      recipientRole: target.recipientRole,
+      canonicalPaneId: target.paneId,
+      ...(target.workerIndex !== undefined ? { canonicalWorkerIndex: target.workerIndex } : {}),
+      requestId: request.request_id,
+      requestKind: 'mailbox',
+      requestTeamName: request.team_name,
+      requestRecipient: request.to_worker,
+      requestMessageId: input.messageId,
+      requestTriggerMessage: request.trigger_message,
+      ...(request.pane_id !== undefined ? { requestPaneId: request.pane_id } : {}),
+      ...(request.worker_index !== undefined ? { requestWorkerIndex: request.worker_index } : {}),
+      requestTransportPreference: request.transport_preference,
+      requestFallbackAllowed: request.fallback_allowed,
+      requestStatus: 'pending',
+      mailboxOwner: input.recipient,
+      mailboxMessageId: message.message_id,
+      mailboxRecipient: message.to_worker,
+      provider: target.provider,
+      providerTarget: target.providerTarget,
+      providerPaneId: target.paneId,
+    },
+  };
+}
+
+/** Compares only authorization-relevant fields; diagnostic dispatch fields are absent by design. */
+export function mailboxNotificationSecurityTupleEquals(
+  left: MailboxNotificationSecurityTuple,
+  right: MailboxNotificationSecurityTuple,
+): boolean {
+  return left.configName === right.configName
+    && left.configProviderTarget === right.configProviderTarget
+    && left.recipient === right.recipient
+    && left.recipientRole === right.recipientRole
+    && left.canonicalPaneId === right.canonicalPaneId
+    && left.canonicalWorkerIndex === right.canonicalWorkerIndex
+    && left.requestId === right.requestId
+    && left.requestKind === right.requestKind
+    && left.requestTeamName === right.requestTeamName
+    && left.requestRecipient === right.requestRecipient
+    && left.requestMessageId === right.requestMessageId
+    && left.requestTriggerMessage === right.requestTriggerMessage
+    && left.requestPaneId === right.requestPaneId
+    && left.requestWorkerIndex === right.requestWorkerIndex
+    && left.requestTransportPreference === right.requestTransportPreference
+    && left.requestFallbackAllowed === right.requestFallbackAllowed
+    && left.requestStatus === right.requestStatus
+    && left.mailboxOwner === right.mailboxOwner
+    && left.mailboxMessageId === right.mailboxMessageId
+    && left.mailboxRecipient === right.mailboxRecipient
+    && left.provider === right.provider
+    && left.providerTarget === right.providerTarget
+    && left.providerPaneId === right.providerPaneId;
+}
+
+/**
+ * Reads current evidence through strict readers, then runs the pure evaluator.
+ * The injected provider verifier must be read-only; this module has no way to
+ * invoke a pane transport or write durable delivery markers.
+ */
+export async function readCurrentMailboxNotificationGuard(
+  input: MailboxNotificationGuardInput,
+  cwd: string,
+  dependencies: Partial<MailboxNotificationGuardDependencies> = {},
+): Promise<MailboxNotificationGuardResult> {
+  const readConfig = dependencies.readConfig ?? teamReadConfig;
+  const readStrictDispatch = dependencies.readStrictDispatchRequest ?? readDispatchRequestStrict;
+  const readStrictMailbox = dependencies.readStrictMailboxMessage ?? teamReadCanonicalMailboxMessageStrict;
+
+  const [config, dispatch, mailbox] = await Promise.all([
+    readConfig(input.teamName, cwd).catch(() => null),
+    readStrictDispatch(input.teamName, input.requestId, cwd).catch(() => ({ kind: 'malformed_store', cause: 'json' } as const)),
+    readStrictMailbox(input.teamName, input.recipient, input.messageId, cwd)
+      .catch(() => ({ kind: 'malformed_store', cause: 'json' } as const)),
+  ]);
+  const state: MailboxNotificationGuardState = { config, dispatch, mailbox };
+  const initial = evaluateMailboxNotificationGuard(input, state);
+  if (initial.kind !== 'suppress' || initial.reason !== 'mailbox_membership_unresolvable' || !initial.target) {
+    return initial;
+  }
+
+  const ownership = dependencies.verifyProviderOwnership
+    ? await dependencies.verifyProviderOwnership(initial.target).catch(() => ({ kind: 'unavailable' } as const))
+    : { kind: 'unavailable' } as const;
+  return evaluateMailboxNotificationGuard(input, { ...state, ownership });
+}

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -106,11 +106,12 @@ export interface MailboxNotificationAttemptDependencies {
   withRequestLock: <T>(lockPath: string, fn: () => Promise<T>) => Promise<T>;
 }
 
-type MailboxTombstoneCause = 'delivery' | 'commit';
-
-interface MailboxTombstone {
-  cause: MailboxTombstoneCause;
-}
+type MailboxTombstone =
+  | { cause: 'delivery' }
+  | {
+    cause: 'commit';
+    confirmationReason: 'worker_pane_notified' | 'leader_pane_notified';
+  };
 
 interface MailboxMarkerState {
   safe: boolean;
@@ -309,19 +310,19 @@ async function reconcileTombstone(
   tombstone: MailboxTombstone,
 ): Promise<DispatchOutcome> {
   let state = await readMailboxMarkerState(params, deps);
-  if ((state.mailboxMarked || state.dispatchMarked) && tombstone.cause === 'commit') {
+  if (tombstone.cause === 'commit') {
     state = await writeAndVerifyMailboxMarkers(params, deps);
+    if (state.mailboxMarked && state.dispatchMarked) {
+      mailboxNotificationTombstones.delete(key);
+    }
+    return markerOutcome(state, tombstone.confirmationReason);
   }
 
   if (state.mailboxMarked || state.dispatchMarked) {
     mailboxNotificationTombstones.delete(key);
     return markerOutcome(state, 'worker_pane_notified');
   }
-  return managedOutcome(
-    false,
-    'tmux_send_keys',
-    tombstone.cause === 'delivery' ? 'notification_delivery_uncertain' : 'notification_commit_uncertain',
-  );
+  return managedOutcome(false, 'tmux_send_keys', 'notification_delivery_uncertain');
 }
 
 /**
@@ -384,10 +385,10 @@ export async function runMailboxNotificationAttempt(
         return managedOutcome(false, effect.transport, 'notification_delivery_uncertain');
       }
 
-      mailboxNotificationTombstones.set(key, { cause: 'commit' });
+      mailboxNotificationTombstones.set(key, { cause: 'commit', confirmationReason: effect.reason });
       const markers = await writeAndVerifyMailboxMarkers(params, deps);
       const outcome = markerOutcome(markers, effect.reason);
-      if (markers.mailboxMarked || markers.dispatchMarked) mailboxNotificationTombstones.delete(key);
+      if (markers.mailboxMarked && markers.dispatchMarked) mailboxNotificationTombstones.delete(key);
       return outcome;
     });
   } catch {
@@ -638,20 +639,32 @@ export interface QueueBroadcastParams {
 }
 
 export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams): Promise<DispatchOutcome[]> {
-  const outcomes: DispatchOutcome[] = [];
   const recipientNames = new Set<string>();
+  const recipients = params.recipients.map((recipient, index) => {
+    const duplicate = recipientNames.has(recipient.workerName);
+    recipientNames.add(recipient.workerName);
+    return { ...recipient, duplicate, index };
+  });
+  const outcomes: DispatchOutcome[] = [];
+  const persistedRecipients: Array<{
+    workerName: string;
+    workerIndex: number;
+    paneId?: string;
+    triggerMessage: string;
+    message: { message_id: string; to_worker: string };
+    index: number;
+  }> = [];
 
-  for (const recipient of params.recipients) {
-    if (recipientNames.has(recipient.workerName)) {
-      outcomes.push({
+  for (const recipient of recipients) {
+    if (recipient.duplicate) {
+      outcomes[recipient.index] = {
         ok: false,
         transport: 'none',
         reason: 'broadcast_recipient_diverged',
         to_worker: recipient.workerName,
-      });
+      };
       continue;
     }
-    recipientNames.add(recipient.workerName);
 
     const triggerMessage = params.triggerFor(recipient.workerName);
     const message = await params.deps.sendDirectMessage(
@@ -661,6 +674,10 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
       params.body,
       params.cwd,
     );
+    persistedRecipients.push({ ...recipient, triggerMessage, message });
+  }
+
+  for (const recipient of persistedRecipients) {
     const queued = await enqueueDispatchRequest(
       params.teamName,
       {
@@ -668,8 +685,8 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         to_worker: recipient.workerName,
         worker_index: recipient.workerIndex,
         pane_id: recipient.paneId,
-        trigger_message: triggerMessage,
-        message_id: message.message_id,
+        trigger_message: recipient.triggerMessage,
+        message_id: recipient.message.message_id,
         transport_preference: params.transportPreference,
         fallback_allowed: params.fallbackAllowed,
       },
@@ -677,25 +694,25 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
     );
 
     if (queued.deduped) {
-      outcomes.push({
+      outcomes[recipient.index] = {
         ok: false,
         transport: 'none',
         reason: 'duplicate_pending_dispatch_request',
         request_id: queued.request.request_id,
-        message_id: message.message_id,
+        message_id: recipient.message.message_id,
         to_worker: recipient.workerName,
-      });
+      };
       continue;
     }
 
-    if (message.to_worker !== recipient.workerName) {
+    if (recipient.message.to_worker !== recipient.workerName) {
       const reasonOutcome = await persistPendingReason(
         {
           teamName: params.teamName,
           recipient: recipient.workerName,
           requestId: queued.request.request_id,
-          messageId: message.message_id,
-          triggerMessage,
+          messageId: recipient.message.message_id,
+          triggerMessage: recipient.triggerMessage,
           cwd: params.cwd,
         },
         mergeMailboxNotificationDependencies({
@@ -705,19 +722,19 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         true,
       );
       const { notification_managed: _managed, ...outcome } = reasonOutcome;
-      outcomes.push({
+      outcomes[recipient.index] = {
         ...outcome,
         request_id: queued.request.request_id,
-        message_id: message.message_id,
+        message_id: recipient.message.message_id,
         to_worker: recipient.workerName,
-      });
+      };
       continue;
     }
 
     const notifyOutcome = await Promise.resolve(params.notify(
       { workerName: recipient.workerName, workerIndex: recipient.workerIndex, paneId: recipient.paneId },
-      triggerMessage,
-      { request: queued.request, message_id: message.message_id },
+      recipient.triggerMessage,
+      { request: queued.request, message_id: recipient.message.message_id },
     )).catch((error) => ({
       ok: false,
       transport: fallbackTransportForPreference(params.transportPreference),
@@ -726,18 +743,18 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
     const { notification_managed: notificationManaged, ...outcome } = {
       ...notifyOutcome,
       request_id: queued.request.request_id,
-      message_id: message.message_id,
+      message_id: recipient.message.message_id,
       to_worker: recipient.workerName,
     };
-    outcomes.push(outcome);
+    outcomes[recipient.index] = outcome;
     if (notificationManaged) continue;
 
     if (isConfirmedNotification(outcome)) {
-      await params.deps.markMessageNotified(params.teamName, recipient.workerName, message.message_id, params.cwd);
+      await params.deps.markMessageNotified(params.teamName, recipient.workerName, recipient.message.message_id, params.cwd);
       await markDispatchRequestNotified(
         params.teamName,
         queued.request.request_id,
-        { message_id: message.message_id, last_reason: outcome.reason },
+        { message_id: recipient.message.message_id, last_reason: outcome.reason },
         params.cwd,
       );
     } else {
@@ -745,7 +762,7 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         teamName: params.teamName,
         request: queued.request,
         reason: outcome.reason,
-        messageId: message.message_id,
+        messageId: recipient.message.message_id,
         cwd: params.cwd,
       });
     }

--- a/src/team/mcp-comm.ts
+++ b/src/team/mcp-comm.ts
@@ -1,24 +1,44 @@
 /**
  * MCP Communication Layer - High-level dispatch functions.
  *
- * Coordinates inbox writes, mailbox messages, and dispatch requests
- * with notification callbacks. Mirrors OMX src/team/mcp-comm.ts exactly.
- *
- * Functions:
- * - queueInboxInstruction: write inbox + enqueue dispatch + notify
- * - queueDirectMailboxMessage: send message + enqueue dispatch + notify
- * - queueBroadcastMailboxMessage: broadcast to all recipients
- * - waitForDispatchReceipt: poll with exponential backoff
+ * Coordinates inbox writes, mailbox messages, and dispatch requests with
+ * notification callbacks. Direct mailbox notifications are authorized against
+ * current strict durable state before any pane effect.
  */
+
+import { realpathSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 
 import {
   enqueueDispatchRequest,
   readDispatchRequest,
+  readDispatchRequestStrict,
   transitionDispatchRequest,
   markDispatchRequestNotified,
+  patchPendingDispatchReason,
+  type StrictDispatchReadResult,
   type TeamDispatchRequest,
   type TeamDispatchRequestInput,
 } from './dispatch-queue.js';
+import {
+  teamMarkMessageNotified,
+  teamReadCanonicalMailboxMessageStrict,
+  type StrictCanonicalMailboxMessageReadResult,
+} from './team-ops.js';
+import {
+  mailboxNotificationSecurityTupleEquals,
+  readCurrentMailboxNotificationGuard,
+  type MailboxNotificationGuardInput,
+  type MailboxNotificationGuardResult,
+  type MailboxNotificationTarget,
+} from './mailbox-notification-guard.js';
+import {
+  invokeDirectMailboxEffect,
+  verifyTeamTargetOwnership,
+  type DirectMailboxEffectResult,
+} from './tmux-session.js';
+import { absPath, TeamPaths } from './state-paths.js';
+import { withProcessIdentityFileLock } from './process-identity-lock.js';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -38,6 +58,8 @@ export interface DispatchOutcome {
   request_id?: string;
   message_id?: string;
   to_worker?: string;
+  /** Internal handoff marker; removed before queue functions return. */
+  notification_managed?: true;
 }
 
 export type TeamNotifier = (
@@ -54,9 +76,53 @@ export interface InboxWriter {
 /** Dependency interface for mailbox message operations */
 export interface MailboxSender {
   sendDirectMessage(teamName: string, fromWorker: string, toWorker: string, body: string, cwd: string): Promise<{ message_id: string; to_worker: string }>;
+  /** Retained for callers that provide the historical mailbox sender shape. */
   broadcastMessage(teamName: string, fromWorker: string, body: string, cwd: string): Promise<Array<{ message_id: string; to_worker: string }>>;
-  markMessageNotified(teamName: string, workerName: string, messageId: string, cwd: string): Promise<void>;
+  markMessageNotified(teamName: string, workerName: string, messageId: string, cwd: string): Promise<void | boolean>;
 }
+
+export interface MailboxNotificationAttemptParams {
+  teamName: string;
+  recipient: string;
+  requestId: string;
+  messageId: string;
+  triggerMessage: string;
+  cwd: string;
+}
+
+export interface MailboxNotificationAttemptDependencies {
+  readGuard: (input: MailboxNotificationGuardInput, cwd: string) => Promise<MailboxNotificationGuardResult>;
+  readStrictDispatch: (teamName: string, requestId: string, cwd: string) => Promise<StrictDispatchReadResult>;
+  readStrictMailbox: (
+    teamName: string,
+    workerName: string,
+    messageId: string,
+    cwd: string,
+  ) => Promise<StrictCanonicalMailboxMessageReadResult>;
+  invokeEffect: (target: MailboxNotificationTarget, message: string) => Promise<DirectMailboxEffectResult>;
+  markMailbox: (teamName: string, workerName: string, messageId: string, cwd: string) => Promise<boolean>;
+  markDispatch: (teamName: string, requestId: string, cwd: string) => Promise<TeamDispatchRequest | null>;
+  patchPendingReason: (teamName: string, requestId: string, reason: string, cwd: string) => Promise<{ kind: string }>;
+  withRequestLock: <T>(lockPath: string, fn: () => Promise<T>) => Promise<T>;
+}
+
+type MailboxTombstoneCause = 'delivery' | 'commit';
+
+interface MailboxTombstone {
+  cause: MailboxTombstoneCause;
+}
+
+interface MailboxMarkerState {
+  safe: boolean;
+  mailboxMarked: boolean;
+  dispatchMarked: boolean;
+}
+
+/**
+ * These are deliberately process-local. Without a persisted attempt phase,
+ * delivery uncertainty after a restart or in another process remains ambiguous.
+ */
+const mailboxNotificationTombstones = new Map<string, MailboxTombstone>();
 
 // ── Internal helpers ───────────────────────────────────────────────────────
 
@@ -86,6 +152,247 @@ function fallbackTransportForPreference(
 function notifyExceptionReason(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `notify_exception:${message}`;
+}
+
+function isExactText(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value === value.trim();
+}
+
+function canonicalNotificationLockIdentity(lockPath: string): string {
+  try {
+    return realpathSync(lockPath);
+  } catch {
+    try {
+      return join(realpathSync(dirname(lockPath)), basename(lockPath));
+    } catch {
+      return lockPath;
+    }
+  }
+}
+
+function managedOutcome(
+  ok: boolean,
+  transport: DispatchTransport,
+  reason: string,
+): DispatchOutcome {
+  return { ok, transport, reason, notification_managed: true };
+}
+
+function defaultMailboxNotificationDependencies(): MailboxNotificationAttemptDependencies {
+  return {
+    readGuard: (input, cwd) => readCurrentMailboxNotificationGuard(input, cwd, {
+      verifyProviderOwnership: verifyTeamTargetOwnership,
+    }),
+    readStrictDispatch: readDispatchRequestStrict,
+    readStrictMailbox: teamReadCanonicalMailboxMessageStrict,
+    invokeEffect: invokeDirectMailboxEffect,
+    markMailbox: teamMarkMessageNotified,
+    markDispatch: (teamName, requestId, cwd) => markDispatchRequestNotified(teamName, requestId, {}, cwd),
+    patchPendingReason: patchPendingDispatchReason,
+    withRequestLock: (lockPath, fn) => withProcessIdentityFileLock(lockPath, fn),
+  };
+}
+
+function mergeMailboxNotificationDependencies(
+  overrides: Partial<MailboxNotificationAttemptDependencies>,
+): MailboxNotificationAttemptDependencies {
+  return { ...defaultMailboxNotificationDependencies(), ...overrides };
+}
+
+function requestMatchesAttempt(
+  request: TeamDispatchRequest,
+  params: MailboxNotificationAttemptParams,
+): boolean {
+  return request.request_id === params.requestId
+    && request.kind === 'mailbox'
+    && request.team_name === params.teamName
+    && request.to_worker === params.recipient
+    && request.message_id === params.messageId;
+}
+
+function mailboxResultMatchesAttempt(
+  read: StrictCanonicalMailboxMessageReadResult,
+  params: MailboxNotificationAttemptParams,
+): boolean {
+  if (read.kind !== 'valid' && read.kind !== 'replay_suppressed') return false;
+  return read.message.message_id === params.messageId && read.message.to_worker === params.recipient;
+}
+
+async function readMailboxMarkerState(
+  params: MailboxNotificationAttemptParams,
+  deps: MailboxNotificationAttemptDependencies,
+): Promise<MailboxMarkerState> {
+  try {
+    const [dispatch, mailbox] = await Promise.all([
+      deps.readStrictDispatch(params.teamName, params.requestId, params.cwd),
+      deps.readStrictMailbox(params.teamName, params.recipient, params.messageId, params.cwd),
+    ]);
+    const dispatchMatches = dispatch.kind === 'valid' && requestMatchesAttempt(dispatch.request, params);
+    const mailboxMatches = mailboxResultMatchesAttempt(mailbox, params);
+    return {
+      safe: dispatchMatches && mailboxMatches,
+      dispatchMarked: dispatchMatches && (dispatch.request.status === 'notified' || dispatch.request.status === 'delivered'),
+      mailboxMarked: mailboxMatches && mailbox.kind === 'replay_suppressed',
+    };
+  } catch {
+    return { safe: false, dispatchMarked: false, mailboxMarked: false };
+  }
+}
+
+async function writeAndVerifyMailboxMarkers(
+  params: MailboxNotificationAttemptParams,
+  deps: MailboxNotificationAttemptDependencies,
+): Promise<MailboxMarkerState> {
+  const before = await readMailboxMarkerState(params, deps);
+  if (!before.safe) return before;
+
+  const writes: Array<Promise<unknown>> = [];
+  if (!before.mailboxMarked) {
+    writes.push(deps.markMailbox(params.teamName, params.recipient, params.messageId, params.cwd).catch(() => false));
+  }
+  if (!before.dispatchMarked) {
+    writes.push(deps.markDispatch(params.teamName, params.requestId, params.cwd).catch(() => null));
+  }
+  await Promise.all(writes);
+  return readMailboxMarkerState(params, deps);
+}
+
+function markerOutcome(
+  state: MailboxMarkerState,
+  confirmationReason: 'worker_pane_notified' | 'leader_pane_notified',
+): DispatchOutcome {
+  if (state.mailboxMarked && state.dispatchMarked) {
+    return managedOutcome(true, 'tmux_send_keys', confirmationReason);
+  }
+  if (state.mailboxMarked) {
+    return managedOutcome(true, 'tmux_send_keys', 'notification_commit_dispatch_failed');
+  }
+  if (state.dispatchMarked) {
+    return managedOutcome(true, 'tmux_send_keys', 'notification_commit_mailbox_failed');
+  }
+  return managedOutcome(false, 'tmux_send_keys', 'notification_commit_uncertain');
+}
+
+async function persistPendingReason(
+  params: MailboxNotificationAttemptParams,
+  deps: MailboxNotificationAttemptDependencies,
+  reason: string,
+  canPatch: boolean,
+): Promise<DispatchOutcome> {
+  if (!canPatch) return managedOutcome(false, 'none', reason);
+  try {
+    const patched = await deps.patchPendingReason(params.teamName, params.requestId, reason, params.cwd);
+    if (patched.kind === 'patched') {
+      if (reason === 'leader_pane_missing_deferred') {
+        return managedOutcome(true, 'mailbox', 'leader_pane_missing_mailbox_persisted');
+      }
+      return managedOutcome(false, 'none', reason);
+    }
+  } catch {
+    // A failed diagnostic patch must not make a pre-effect suppression retryable by assumption.
+  }
+  return managedOutcome(false, 'none', 'pending_reason_persist_failed');
+}
+
+async function suppressFromGuard(
+  params: MailboxNotificationAttemptParams,
+  deps: MailboxNotificationAttemptDependencies,
+  guard: Extract<MailboxNotificationGuardResult, { kind: 'suppress' }>,
+): Promise<DispatchOutcome> {
+  return persistPendingReason(params, deps, guard.reason, !!guard.safePendingRequest);
+}
+
+async function reconcileTombstone(
+  params: MailboxNotificationAttemptParams,
+  deps: MailboxNotificationAttemptDependencies,
+  key: string,
+  tombstone: MailboxTombstone,
+): Promise<DispatchOutcome> {
+  let state = await readMailboxMarkerState(params, deps);
+  if ((state.mailboxMarked || state.dispatchMarked) && tombstone.cause === 'commit') {
+    state = await writeAndVerifyMailboxMarkers(params, deps);
+  }
+
+  if (state.mailboxMarked || state.dispatchMarked) {
+    mailboxNotificationTombstones.delete(key);
+    return markerOutcome(state, 'worker_pane_notified');
+  }
+  return managedOutcome(
+    false,
+    'tmux_send_keys',
+    tombstone.cause === 'delivery' ? 'notification_delivery_uncertain' : 'notification_commit_uncertain',
+  );
+}
+
+/**
+ * Runs one direct mailbox notification attempt. The process-identity lock and
+ * tombstone are deliberately outside the dispatch lock so checked marker and
+ * reason writes can use their existing dispatch serialization without nesting it.
+ */
+export async function runMailboxNotificationAttempt(
+  params: MailboxNotificationAttemptParams,
+  overrides: Partial<MailboxNotificationAttemptDependencies> = {},
+): Promise<DispatchOutcome> {
+  if (!isExactText(params.teamName) || !isExactText(params.recipient) || !isExactText(params.requestId)
+    || !isExactText(params.messageId) || !isExactText(params.triggerMessage)) {
+    return managedOutcome(false, 'none', 'mailbox_request_identity_mismatch');
+  }
+
+  const deps = mergeMailboxNotificationDependencies(overrides);
+  const lockPath = absPath(params.cwd, TeamPaths.mailboxNotificationLock(params.teamName, params.requestId));
+  const key = canonicalNotificationLockIdentity(lockPath);
+
+  try {
+    return await deps.withRequestLock(lockPath, async () => {
+      const existingTombstone = mailboxNotificationTombstones.get(key);
+      if (existingTombstone) return reconcileTombstone(params, deps, key, existingTombstone);
+
+      const guardInput: MailboxNotificationGuardInput = {
+        teamName: params.teamName,
+        recipient: params.recipient,
+        requestId: params.requestId,
+        messageId: params.messageId,
+        triggerMessage: params.triggerMessage,
+      };
+      const current = await deps.readGuard(guardInput, params.cwd);
+      if (current.kind === 'suppress') return suppressFromGuard(params, deps, current);
+
+      const final = await deps.readGuard(guardInput, params.cwd);
+      if (final.kind === 'suppress') return suppressFromGuard(params, deps, final);
+      if (!mailboxNotificationSecurityTupleEquals(current.securityTuple, final.securityTuple)) {
+        return persistPendingReason(params, deps, 'mailbox_security_tuple_changed', true);
+      }
+
+      mailboxNotificationTombstones.set(key, { cause: 'delivery' });
+      let effect: DirectMailboxEffectResult;
+      try {
+        effect = await deps.invokeEffect(final.target, final.request.trigger_message);
+      } catch {
+        effect = {
+          kind: 'attempted_unconfirmed',
+          transport: 'tmux_send_keys',
+          reason: 'notification_delivery_uncertain',
+          cause: 'threw',
+        };
+      }
+
+      if (effect.kind === 'not_attempted') {
+        mailboxNotificationTombstones.delete(key);
+        return persistPendingReason(params, deps, effect.reason, true);
+      }
+      if (effect.kind === 'attempted_unconfirmed') {
+        return managedOutcome(false, effect.transport, 'notification_delivery_uncertain');
+      }
+
+      mailboxNotificationTombstones.set(key, { cause: 'commit' });
+      const markers = await writeAndVerifyMailboxMarkers(params, deps);
+      const outcome = markerOutcome(markers, effect.reason);
+      if (markers.mailboxMarked || markers.dispatchMarked) mailboxNotificationTombstones.delete(key);
+      return outcome;
+    });
+  } catch {
+    return managedOutcome(false, 'none', 'mailbox_notification_busy');
+  }
 }
 
 async function markImmediateDispatchFailure(params: {
@@ -280,12 +587,14 @@ export async function queueDirectMailboxMessage(params: QueueDirectMessageParams
     transport: fallbackTransportForPreference(params.transportPreference),
     reason: notifyExceptionReason(error),
   } as DispatchOutcome));
-  const outcome: DispatchOutcome = {
+  const { notification_managed: notificationManaged, ...outcome } = {
     ...notifyOutcome,
     request_id: queued.request.request_id,
     message_id: message.message_id,
     to_worker: params.toWorker,
   };
+  if (notificationManaged) return outcome;
+
   if (isLeaderPaneMissingMailboxPersistedOutcome(queued.request, outcome)) {
     await markLeaderPaneMissingDeferred({
       teamName: params.teamName,
@@ -329,14 +638,29 @@ export interface QueueBroadcastParams {
 }
 
 export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams): Promise<DispatchOutcome[]> {
-  const messages = await params.deps.broadcastMessage(params.teamName, params.fromWorker, params.body, params.cwd);
-  const recipientByName = new Map(params.recipients.map((r) => [r.workerName, r]));
   const outcomes: DispatchOutcome[] = [];
+  const recipientNames = new Set<string>();
 
-  for (const message of messages) {
-    const recipient = recipientByName.get(message.to_worker);
-    if (!recipient) continue;
+  for (const recipient of params.recipients) {
+    if (recipientNames.has(recipient.workerName)) {
+      outcomes.push({
+        ok: false,
+        transport: 'none',
+        reason: 'broadcast_recipient_diverged',
+        to_worker: recipient.workerName,
+      });
+      continue;
+    }
+    recipientNames.add(recipient.workerName);
 
+    const triggerMessage = params.triggerFor(recipient.workerName);
+    const message = await params.deps.sendDirectMessage(
+      params.teamName,
+      params.fromWorker,
+      recipient.workerName,
+      params.body,
+      params.cwd,
+    );
     const queued = await enqueueDispatchRequest(
       params.teamName,
       {
@@ -344,7 +668,7 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
         to_worker: recipient.workerName,
         worker_index: recipient.workerIndex,
         pane_id: recipient.paneId,
-        trigger_message: params.triggerFor(recipient.workerName),
+        trigger_message: triggerMessage,
         message_id: message.message_id,
         transport_preference: params.transportPreference,
         fallback_allowed: params.fallbackAllowed,
@@ -364,23 +688,49 @@ export async function queueBroadcastMailboxMessage(params: QueueBroadcastParams)
       continue;
     }
 
+    if (message.to_worker !== recipient.workerName) {
+      const reasonOutcome = await persistPendingReason(
+        {
+          teamName: params.teamName,
+          recipient: recipient.workerName,
+          requestId: queued.request.request_id,
+          messageId: message.message_id,
+          triggerMessage,
+          cwd: params.cwd,
+        },
+        mergeMailboxNotificationDependencies({
+          patchPendingReason: patchPendingDispatchReason,
+        }),
+        'broadcast_recipient_diverged',
+        true,
+      );
+      const { notification_managed: _managed, ...outcome } = reasonOutcome;
+      outcomes.push({
+        ...outcome,
+        request_id: queued.request.request_id,
+        message_id: message.message_id,
+        to_worker: recipient.workerName,
+      });
+      continue;
+    }
+
     const notifyOutcome = await Promise.resolve(params.notify(
       { workerName: recipient.workerName, workerIndex: recipient.workerIndex, paneId: recipient.paneId },
-      params.triggerFor(recipient.workerName),
+      triggerMessage,
       { request: queued.request, message_id: message.message_id },
     )).catch((error) => ({
       ok: false,
       transport: fallbackTransportForPreference(params.transportPreference),
       reason: notifyExceptionReason(error),
     } as DispatchOutcome));
-
-    const outcome: DispatchOutcome = {
+    const { notification_managed: notificationManaged, ...outcome } = {
       ...notifyOutcome,
       request_id: queued.request.request_id,
       message_id: message.message_id,
       to_worker: recipient.workerName,
     };
     outcomes.push(outcome);
+    if (notificationManaged) continue;
 
     if (isConfirmedNotification(outcome)) {
       await params.deps.markMessageNotified(params.teamName, recipient.workerName, message.message_id, params.cwd);

--- a/src/team/state-paths.ts
+++ b/src/team/state-paths.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { isAbsolute, join } from 'path';
 
 /**
@@ -79,6 +80,8 @@ export const TeamPaths = {
 
   dispatchLockDir: (teamName: string) =>
     `.omc/state/team/${teamName}/dispatch/.lock`,
+  mailboxNotificationLock: (teamName: string, requestId: string) =>
+    `.omc/state/team/${teamName}/dispatch/.mailbox-notification-${createHash('sha256').update(requestId).digest('hex')}.lock`,
 
   workerStatus: (teamName: string, workerName: string) =>
     `.omc/state/team/${teamName}/workers/${workerName}/status.json`,

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -107,6 +107,21 @@ export type {
 };
 export type { PublishTaskRecoveryCheckpointInput } from './task-recovery-checkpoint.js';
 
+/**
+ * Result of an exact lookup in the canonical mailbox JSON file. This is a
+ * guard-only reader and intentionally never falls back to legacy JSONL.
+ */
+export type StrictCanonicalMailboxMessageReadResult =
+  | { kind: 'valid'; message: TeamMailboxMessage }
+  | { kind: 'store_missing' }
+  | { kind: 'malformed_store'; cause: 'json' | 'non_object' | 'messages_non_array' }
+  | { kind: 'wrong_owner' }
+  | { kind: 'malformed_message'; messageIndex: number; field: string }
+  | { kind: 'message_missing' }
+  | { kind: 'duplicate_message_id'; messageId: string; messageIndexes: number[] }
+  | { kind: 'recipient_mismatch'; messageIndex: number }
+  | { kind: 'replay_suppressed'; message: TeamMailboxMessage; marker: 'notified_at' | 'delivered_at' };
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -639,6 +654,105 @@ async function readMailbox(teamName: string, workerName: string, cwd: string): P
     return { worker: workerName, messages: mailbox.messages };
   }
   return readLegacyMailboxJsonl(teamName, workerName, cwd);
+}
+
+function isStrictCanonicalMailboxRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function isStrictCanonicalMailboxText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '' && value === value.trim();
+}
+
+function isStrictCanonicalMailboxTimestamp(value: unknown): value is string {
+  return isStrictCanonicalMailboxText(value) && Number.isFinite(Date.parse(value));
+}
+
+function materializeStrictCanonicalMailboxMessage(raw: Record<string, unknown>): TeamMailboxMessage {
+  const message: TeamMailboxMessage = {
+    message_id: raw.message_id as string,
+    from_worker: raw.from_worker as string,
+    to_worker: raw.to_worker as string,
+    body: raw.body as string,
+    created_at: raw.created_at as string,
+  };
+  if ('notified_at' in raw) message.notified_at = raw.notified_at as string;
+  if ('delivered_at' in raw) message.delivered_at = raw.delivered_at as string;
+  return message;
+}
+
+function validateStrictCanonicalMailboxMessage(
+  raw: unknown,
+  messageIndex: number,
+): TeamMailboxMessage | Extract<StrictCanonicalMailboxMessageReadResult, { kind: 'malformed_message' }> {
+  if (!isStrictCanonicalMailboxRecord(raw)) return { kind: 'malformed_message', messageIndex, field: '$' };
+  if (!isStrictCanonicalMailboxText(raw.message_id)) return { kind: 'malformed_message', messageIndex, field: 'message_id' };
+  if (!isStrictCanonicalMailboxText(raw.from_worker)) return { kind: 'malformed_message', messageIndex, field: 'from_worker' };
+  if (!isStrictCanonicalMailboxText(raw.to_worker)) return { kind: 'malformed_message', messageIndex, field: 'to_worker' };
+  if (!isStrictCanonicalMailboxText(raw.body)) return { kind: 'malformed_message', messageIndex, field: 'body' };
+  if (!isStrictCanonicalMailboxTimestamp(raw.created_at)) return { kind: 'malformed_message', messageIndex, field: 'created_at' };
+  if ('notified_at' in raw && !isStrictCanonicalMailboxTimestamp(raw.notified_at)) {
+    return { kind: 'malformed_message', messageIndex, field: 'notified_at' };
+  }
+  if ('delivered_at' in raw && !isStrictCanonicalMailboxTimestamp(raw.delivered_at)) {
+    return { kind: 'malformed_message', messageIndex, field: 'delivered_at' };
+  }
+  return materializeStrictCanonicalMailboxMessage(raw);
+}
+
+/**
+ * Reads one exact message from the canonical JSON mailbox without using the
+ * compatibility JSONL fallback. It validates every canonical record first so
+ * a corrupt or ambiguous mailbox cannot authorize a pane notification.
+ */
+export async function teamReadCanonicalMailboxMessageStrict(
+  teamName: string,
+  workerName: string,
+  messageId: string,
+  cwd: string,
+): Promise<StrictCanonicalMailboxMessageReadResult> {
+  const path = absPath(cwd, TeamPaths.mailbox(teamName, workerName));
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'ENOENT'
+      ? { kind: 'store_missing' }
+      : { kind: 'malformed_store', cause: 'json' };
+  }
+  if (!isStrictCanonicalMailboxRecord(parsed)) return { kind: 'malformed_store', cause: 'non_object' };
+  if (parsed.worker !== workerName) return { kind: 'wrong_owner' };
+  if (!Array.isArray(parsed.messages)) return { kind: 'malformed_store', cause: 'messages_non_array' };
+
+  const messages: TeamMailboxMessage[] = [];
+  for (let messageIndex = 0; messageIndex < parsed.messages.length; messageIndex += 1) {
+    const validated = validateStrictCanonicalMailboxMessage(parsed.messages[messageIndex], messageIndex);
+    if (!('message_id' in validated)) return validated;
+    messages.push(validated);
+  }
+
+  const indexesByMessageId = new Map<string, number[]>();
+  for (const [messageIndex, message] of messages.entries()) {
+    const indexes = indexesByMessageId.get(message.message_id) ?? [];
+    indexes.push(messageIndex);
+    indexesByMessageId.set(message.message_id, indexes);
+  }
+  const requestedIndexes = indexesByMessageId.get(messageId) ?? [];
+  if (requestedIndexes.length > 1) {
+    return { kind: 'duplicate_message_id', messageId, messageIndexes: requestedIndexes };
+  }
+  const duplicate = [...indexesByMessageId.entries()].find(([, indexes]) => indexes.length > 1);
+  if (duplicate) return { kind: 'duplicate_message_id', messageId: duplicate[0], messageIndexes: duplicate[1] };
+  if (requestedIndexes.length === 0) return { kind: 'message_missing' };
+
+  const messageIndex = requestedIndexes[0]!;
+  const message = messages[messageIndex]!;
+  if (message.to_worker !== workerName) return { kind: 'recipient_mismatch', messageIndex };
+  if (message.notified_at) return { kind: 'replay_suppressed', message: { ...message }, marker: 'notified_at' };
+  if (message.delivered_at) return { kind: 'replay_suppressed', message: { ...message }, marker: 'delivered_at' };
+  return { kind: 'valid', message: { ...message } };
 }
 
 async function writeMailbox(teamName: string, workerName: string, mailbox: TeamMailbox, cwd: string): Promise<void> {

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -17,6 +17,7 @@ import { validateTeamName } from './team-name.js';
 import { getOmcRoot } from '../lib/worktree-paths.js';
 import { tmuxExec, tmuxExecAsync, tmuxShell, tmuxCmdAsync } from '../cli/tmux-utils.js';
 import { configureTmuxClipboardForSession, configureTmuxClipboardForSessionAsync } from '../cli/tmux-clipboard.js';
+import type { MailboxNotificationTarget, MailboxTargetOwnership } from './mailbox-notification-guard.js';
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 const execFileAsync = promisify(execFile);
@@ -215,6 +216,186 @@ async function cmuxCaptureSurface(surfaceId: string): Promise<string> {
 
 async function cmuxCloseSurface(surfaceId: string): Promise<void> {
   await cmuxExecAsync(['close-surface', '--surface', surfaceId]);
+}
+
+const TMUX_MAILBOX_PANE_ID = /^%\d+$/;
+const TMUX_MAILBOX_TARGET = /^[^\s:]+(?::[^\s:]+)?$/;
+
+function isExactOpaqueCmuxIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value === value.trim() && !/[\x00-\x1f\x7f\s]/.test(value);
+}
+
+function parseCmuxResourceIds(output: string, collectionName: 'panes' | 'surfaces'): string[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output) as unknown;
+  } catch {
+    return null;
+  }
+
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>)[collectionName])
+      ? (parsed as Record<string, unknown>)[collectionName] as unknown[]
+      : null;
+  if (!entries) return null;
+
+  const ids: string[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
+    const id = (entry as Record<string, unknown>).id;
+    if (!isExactOpaqueCmuxIdentifier(id)) return null;
+    if (!ids.includes(id)) ids.push(id);
+  }
+  return ids;
+}
+
+type MailboxOwnershipCommand = (args: string[]) => Promise<{ stdout: string; stderr: string }>;
+
+export interface MailboxTargetOwnershipDependencies {
+  tmuxExec: MailboxOwnershipCommand;
+  cmuxExec: MailboxOwnershipCommand;
+}
+
+const defaultMailboxTargetOwnershipDependencies: MailboxTargetOwnershipDependencies = {
+  tmuxExec: (args) => tmuxExecAsync(args),
+  cmuxExec: cmuxExecAsync,
+};
+
+/**
+ * Proves that a configured direct-mailbox target still belongs to its exact
+ * provider target. This performs read-only provider queries and never touches
+ * a candidate pane/surface.
+ */
+export async function verifyTeamTargetOwnership(
+  target: MailboxNotificationTarget,
+  dependencies: MailboxTargetOwnershipDependencies = defaultMailboxTargetOwnershipDependencies,
+): Promise<MailboxTargetOwnership> {
+  const expectedProvider = target.providerTarget.startsWith('cmux:') ? 'cmux' : 'tmux';
+  if (target.provider !== expectedProvider) return { kind: 'provider_mismatch' };
+
+  if (target.provider === 'tmux') {
+    if (
+      typeof target.providerTarget !== 'string'
+      || target.providerTarget.length === 0
+      || target.providerTarget !== target.providerTarget.trim()
+      || !TMUX_MAILBOX_TARGET.test(target.providerTarget)
+      || !TMUX_MAILBOX_PANE_ID.test(target.paneId)
+    ) {
+      return { kind: 'unavailable' };
+    }
+
+    try {
+      const result = await dependencies.tmuxExec([
+        'list-panes', '-t', target.providerTarget, '-F', '#{pane_id}',
+      ]);
+      const paneIds: string[] = [];
+      for (const line of result.stdout.split(/\r?\n/)) {
+        const paneId = line.trim();
+        if (!paneId) continue;
+        if (!TMUX_MAILBOX_PANE_ID.test(paneId)) return { kind: 'unavailable' };
+        if (!paneIds.includes(paneId)) paneIds.push(paneId);
+      }
+      if (paneIds.length === 0) return { kind: 'unavailable' };
+      return paneIds.includes(target.paneId)
+        ? { kind: 'owned', provider: 'tmux', providerTarget: target.providerTarget, paneId: target.paneId }
+        : { kind: 'foreign' };
+    } catch {
+      return { kind: 'unavailable' };
+    }
+  }
+
+  const workspace = target.providerTarget.slice('cmux:'.length);
+  if (
+    !isExactOpaqueCmuxIdentifier(workspace)
+    || !isExactOpaqueCmuxIdentifier(target.paneId)
+    || TMUX_MAILBOX_PANE_ID.test(target.paneId)
+  ) {
+    return { kind: 'unavailable' };
+  }
+
+  try {
+    const panes = parseCmuxResourceIds(
+      (await dependencies.cmuxExec(['--json', 'list-panes', '--workspace', workspace])).stdout,
+      'panes',
+    );
+    if (!panes || panes.length === 0) return { kind: 'unavailable' };
+
+    for (const pane of panes) {
+      const surfaces = parseCmuxResourceIds(
+        (await dependencies.cmuxExec([
+          '--json', 'list-pane-surfaces', '--workspace', workspace, '--pane', pane,
+        ])).stdout,
+        'surfaces',
+      );
+      if (!surfaces) return { kind: 'unavailable' };
+      if (surfaces.includes(target.paneId)) {
+        return {
+          kind: 'owned',
+          provider: 'cmux',
+          providerTarget: target.providerTarget,
+          paneId: target.paneId,
+        };
+      }
+    }
+    return { kind: 'foreign' };
+  } catch {
+    return { kind: 'unavailable' };
+  }
+}
+
+export type DirectMailboxEffectResult =
+  | { kind: 'not_attempted'; reason: string }
+  | { kind: 'confirmed'; transport: 'tmux_send_keys'; reason: 'worker_pane_notified' | 'leader_pane_notified' }
+  | { kind: 'attempted_unconfirmed'; transport: 'tmux_send_keys'; reason: 'notification_delivery_uncertain'; cause: 'returned_false' | 'threw' };
+
+export interface DirectMailboxEffectDependencies {
+  sendWorker: typeof sendToWorker;
+  sendLeader: typeof injectToLeaderPane;
+}
+
+const defaultDirectMailboxEffectDependencies: DirectMailboxEffectDependencies = {
+  sendWorker: sendToWorker,
+  sendLeader: injectToLeaderPane,
+};
+
+/**
+ * Direct-mailbox-only adapter. Once the public boolean transport has been
+ * called, a false result or exception is conservatively treated as uncertain.
+ */
+export async function invokeDirectMailboxEffect(
+  target: MailboxNotificationTarget,
+  message: string,
+  dependencies: DirectMailboxEffectDependencies = defaultDirectMailboxEffectDependencies,
+): Promise<DirectMailboxEffectResult> {
+  if (!target.paneId || !message) return { kind: 'not_attempted', reason: 'mailbox_target_missing' };
+  if (target.provider === 'cmux' && !isCmuxContext()) {
+    return { kind: 'not_attempted', reason: 'mailbox_membership_unresolvable' };
+  }
+  try {
+    const notified = target.recipientRole === 'leader'
+      ? await dependencies.sendLeader(target.providerTarget, target.paneId, message)
+      : await dependencies.sendWorker(target.providerTarget, target.paneId, message);
+    return notified
+      ? {
+          kind: 'confirmed',
+          transport: 'tmux_send_keys',
+          reason: target.recipientRole === 'leader' ? 'leader_pane_notified' : 'worker_pane_notified',
+        }
+      : {
+          kind: 'attempted_unconfirmed',
+          transport: 'tmux_send_keys',
+          reason: 'notification_delivery_uncertain',
+          cause: 'returned_false',
+        };
+  } catch {
+    return {
+      kind: 'attempted_unconfirmed',
+      transport: 'tmux_send_keys',
+      reason: 'notification_delivery_uncertain',
+      cause: 'threw',
+    };
+  }
 }
 
 export type TeamSessionMode = 'split-pane' | 'dedicated-window' | 'detached-session';
@@ -1498,7 +1679,11 @@ export async function injectToLeaderPane(
     }
     const captured = await capturePaneAsync(leaderPaneId);
     if (paneHasActiveTask(captured)) {
-      await tmuxExecAsync(['send-keys', '-t', leaderPaneId, 'C-c']);
+      if (isCmuxSurfaceTarget(leaderPaneId)) {
+        await cmuxSendSurfaceKey(leaderPaneId, 'C-c');
+      } else {
+        await tmuxExecAsync(['send-keys', '-t', leaderPaneId, 'C-c']);
+      }
       await new Promise<void>(r => setTimeout(r, 250));
     }
   } catch { /* best-effort */ }


### PR DESCRIPTION
## Summary

Fixes #3471.

The phantom prompt is produced by `generateMailboxTriggerMessage()` and reached panes through the direct API chain:

`executeTeamApiOperation('send-message'|'broadcast')` → `queueDirectMailboxMessage` / `queueBroadcastMailboxMessage` → direct notification → `sendToWorker` / `injectToLeaderPane`.

The concrete `dispatch-team / worker-1 / %9` failure mode came from globally addressed tmux pane IDs: a stale or reused `%9` could be targeted without proving that it still belonged to the configured team target.

## Changes

- Require strict raw dispatch evidence with exact team, request, recipient, trigger, message, pane/index, status, and transport fields.
- Require the exact canonical mailbox JSON message with no notified/delivered replay marker.
- Prove exact tmux `session[:window]` pane membership or documented cmux workspace → pane → surface membership before any capture, interrupt, send, or submit effect.
- Re-read the full security tuple immediately before delivery.
- Serialize by request and install a same-process uncertainty tombstone before effect invocation, including canonical physical state-path aliases.
- Treat false/throw after invocation as `notification_delivery_uncertain`; never automatically resend in that process.
- Check and reconcile mailbox/dispatch markers without re-sending.
- Keep broadcast persistence, request creation, and per-recipient outcome mapping 1:1.
- Make the `%9` regression and owned worker/leader delivery tests fully hermetic from host tmux/cmux.

## Compatibility

Unchanged:

- mailbox and dispatch persisted schemas/statuses
- prompt wording
- compatibility readers
- cooldown behavior
- Claude-session identity design
- generic startup/nudge transport contracts
- dormant `drainPendingTeamDispatch` registration state

## Verification

- Focused issue suite: 5 files, 48 tests passed.
- Full team suite: 116 files, 1,417 tests passed; 1 skipped.
- Full repository suite: 611 files, 10,689 tests passed; 8 skipped.
- `npx tsc --noEmit`: passed.
- `npm run lint`: 0 errors; 20 pre-existing warnings outside changed files.
- `npm run build`: passed.
- `npm pack --dry-run`: passed.
- Independent Architect review: CLEAR / APPROVE.
- Independent executor QA/red-team: PASS / APPROVE.
- Core and transport cleanup reviews: CLEAR / APPROVE.

The cmux ownership implementation is based on the documented read-only `--json list-panes` and `--json list-pane-surfaces` contract. Ambient cmux variables are execution preconditions, not ownership evidence, and tmux-shaped `%N` identifiers are rejected for cmux targets.

## Known boundary

The in-process uncertainty tombstone is intentionally not persisted. After an attempted-but-unconfirmed effect with no durable marker, cross-process or restart replay remains ambiguous; this change does not claim cross-crash exactly-once delivery. A stronger guarantee requires a separately approved persisted attempt protocol.

## Rollback

Revert commit `faf1587b2`. No data migration is required; ephemeral locks and tombstones leave no persisted schema changes.

Pending independent adversarial GJC review; do not merge yet.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*