### PR TITLE
fix(hooks): make SessionEnd shutdown durable and bounded

### DIFF
--- a/scripts/lib/stdin.mjs
+++ b/scripts/lib/stdin.mjs
@@ -62,3 +62,80 @@ export async function readStdin(timeoutMs = 5000) {
     }
   });
 }
+
+/**
+ * Read one complete SessionEnd JSON frame under strict hook deadlines.
+ *
+ * @returns {Promise<
+ *   | { status: 'ok', value: unknown }
+ *   | { status: 'empty' | 'timeout' | 'overflow' | 'invalid' | 'error' }
+ * >}
+ */
+export function readSessionEndFrame() {
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    const chunks = [];
+    let byteLength = 0;
+    let settled = false;
+    let firstByteTimer;
+    let totalTimer;
+
+    const cleanup = () => {
+      clearTimeout(firstByteTimer);
+      clearTimeout(totalTimer);
+      stdin.off('data', onData);
+      stdin.off('end', onEnd);
+      stdin.off('error', onError);
+    };
+
+    const finish = (result, closeStdin = false) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (closeStdin && !stdin.destroyed) {
+        stdin.pause();
+        stdin.destroy();
+      }
+      resolve(result);
+    };
+
+    const onData = (chunk) => {
+      clearTimeout(firstByteTimer);
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteLength += buffer.length;
+      if (byteLength > 64 * 1024) {
+        finish({ status: 'overflow' }, true);
+        return;
+      }
+      chunks.push(buffer);
+    };
+
+    const onEnd = () => {
+      const input = Buffer.concat(chunks).toString('utf8');
+      if (input.trim().length === 0) {
+        finish({ status: 'empty' });
+        return;
+      }
+      try {
+        finish({ status: 'ok', value: JSON.parse(input) });
+      } catch {
+        finish({ status: 'invalid' });
+      }
+    };
+
+    const onError = () => finish({ status: 'error' }, true);
+
+    stdin.on('data', onData);
+    stdin.once('end', onEnd);
+    stdin.once('error', onError);
+
+    if (stdin.readableEnded) {
+      onEnd();
+      return;
+    }
+
+    firstByteTimer = setTimeout(() => finish({ status: 'timeout' }, true), 25);
+    totalTimer = setTimeout(() => finish({ status: 'timeout' }, true), 100);
+    stdin.resume();
+  });
+}

--- a/scripts/session-end.mjs
+++ b/scripts/session-end.mjs
@@ -1,24 +1,19 @@
 #!/usr/bin/env node
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-import { readStdin } from './lib/stdin.mjs';
+import { readSessionEndFrame } from './lib/stdin.mjs';
+
+const fallback = { continue: true, suppressOutput: true };
 
 async function main() {
-  // Read stdin with reduced timeout for SessionEnd — the input payload is small
-  // and doesn't need the default 5s wait. This saves ~4s toward the hook timeout (#1700).
-  const input = await readStdin(1000);
+  const frame = await readSessionEndFrame();
 
-  const fallback = { continue: true, suppressOutput: true };
-
-  if (input.trim().length === 0) {
+  if (frame.status !== 'ok') {
     console.log(JSON.stringify(fallback));
     return;
   }
 
   try {
-    const data = JSON.parse(input);
     const { processSessionEnd } = await import('../dist/hooks/session-end/index.js');
-    const result = await processSessionEnd(data);
+    const result = await processSessionEnd(frame.value);
     console.log(JSON.stringify(result));
   } catch (error) {
     console.error('[session-end] Error:', error.message);

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -288,6 +288,25 @@ function dispatchSessionStartNotificationInBackground(pluginRoot, payload) {
   }
 }
 
+function reconcileSessionEndJobsInBackground(pluginRoot, directory) {
+  const workerModuleUrl = pathToFileURL(join(pluginRoot, 'dist', 'hooks', 'session-end', 'worker.js')).href;
+  const childSource = `import(${JSON.stringify(workerModuleUrl)})\n`
+    + `  .then(({ reconcileSessionEndJobs }) => reconcileSessionEndJobs?.(${JSON.stringify(directory)}))\n`
+    + `  .catch(() => {});`;
+
+  try {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', childSource], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+      env: { ...process.env, OMC_HOOK_BACKGROUND_CHILD: '1' },
+    });
+    child.unref();
+  } catch {
+    // Reconciliation is best-effort and must not delay SessionStart.
+  }
+}
+
 function hasProjectMemoryContent(memory) {
   return Boolean(
     memory &&
@@ -821,6 +840,7 @@ async function main() {
 
     writeSessionStartedMarker(omcRoot, directory, sessionId);
     reconcileAbandonedSessionStarts(omcRoot, sessionId);
+    reconcileSessionEndJobsInBackground(getRuntimeBaseDir(), directory);
 
     // Check for version drift between components
     const driftInfo = detectVersionDrift();

--- a/scripts/wiki-session-end.mjs
+++ b/scripts/wiki-session-end.mjs
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
-import { readStdin } from './lib/stdin.mjs';
+import { readSessionEndFrame } from './lib/stdin.mjs';
+
+const fallback = { continue: true, suppressOutput: true };
 
 async function main() {
-  const input = await readStdin(1000);
-  const fallback = { continue: true, suppressOutput: true };
+  const frame = await readSessionEndFrame();
 
-  if (input.trim().length === 0) {
+  if (frame.status !== 'ok') {
     console.log(JSON.stringify(fallback));
     return;
   }
 
   try {
-    const data = JSON.parse(input);
-    const { onSessionEnd } = await import('../dist/hooks/wiki/session-hooks.js');
-    const result = onSessionEnd(data);
+    const { processWikiSessionEnd } = await import('../dist/hooks/session-end/index.js');
+    const result = await processWikiSessionEnd(frame.value);
     console.log(JSON.stringify(result));
   } catch (error) {
     console.error('[wiki-session-end] Error:', error.message);

--- a/src/__tests__/session-end-empty-stdin.test.ts
+++ b/src/__tests__/session-end-empty-stdin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
+const runCjs = join(process.cwd(), 'scripts', 'run.cjs');
 
 const sessionEndScripts = [
   ['session-end', join(process.cwd(), 'scripts', 'session-end.mjs')],
@@ -12,8 +13,8 @@ describe('SessionEnd hook stdin handling', () => {
   it.each(sessionEndScripts.flatMap(([name, script]) => [
     [name, 'empty stdin', script, ''],
     [name, 'whitespace stdin', script, '  \n\t  '],
-  ] as const))('%s treats %s as a clean no-op', (_name, _label, script, input) => {
-    const result = spawnSync(process.execPath, [script], {
+  ] as const))('%s treats promptly closed %s as a clean no-op through run.cjs', (_name, _label, script, input) => {
+    const result = spawnSync(process.execPath, [runCjs, script], {
       input,
       encoding: 'utf-8',
     });

--- a/src/__tests__/session-end-process-exit.test.ts
+++ b/src/__tests__/session-end-process-exit.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPO_ROOT = process.cwd();
+const RUN_CJS = join(REPO_ROOT, 'scripts', 'run.cjs');
+const SESSION_END_SCRIPTS = [
+  ['session-end', join(REPO_ROOT, 'scripts', 'session-end.mjs')],
+  ['wiki-session-end', join(REPO_ROOT, 'scripts', 'wiki-session-end.mjs')],
+] as const;
+const COMMAND_CEILING_MS = 500;
+const SEQUENTIAL_CEILING_MS = 1_000;
+const HAS_GENERATED_DIST = existsSync(join(REPO_ROOT, 'dist', 'hooks', 'session-end', 'worker.js'));
+
+interface ExitResult {
+  elapsedMs: number;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
+
+function runUntilClose(
+  script: string,
+  cwd: string,
+  input: string | undefined,
+  ceilingMs = COMMAND_CEILING_MS,
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<ExitResult> {
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const child = spawn(process.execPath, [RUN_CJS, script], {
+      cwd,
+      env: { ...process.env, ...extraEnv, CLAUDE_CONFIG_DIR: join(cwd, '.claude') },
+      stdio: ['pipe', 'ignore', 'ignore'],
+      windowsHide: true,
+    });
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, ceilingMs);
+
+    child.once('close', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ elapsedMs: Date.now() - startedAt, code, signal, timedOut });
+    });
+
+    if (input !== undefined) child.stdin.end(input);
+  });
+}
+
+function expectPromptExit(result: ExitResult, ceilingMs = COMMAND_CEILING_MS): void {
+  expect(result.timedOut).toBe(false);
+  expect(result.signal).toBeNull();
+  expect(result.code).toBe(0);
+  expect(result.elapsedMs).toBeLessThanOrEqual(ceilingMs);
+}
+
+function validSessionEndInput(cwd: string, sessionId: string): string {
+  return JSON.stringify({
+    session_id: sessionId,
+    transcript_path: join(cwd, 'transcript.jsonl'),
+    cwd,
+    permission_mode: 'default',
+    hook_event_name: 'SessionEnd',
+    reason: 'clear',
+  });
+}
+
+function configureDeferredAdapters(cwd: string): void {
+  const configDir = join(cwd, '.claude');
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, '.omc-config.json'), JSON.stringify({
+    notifications: { enabled: true },
+    stopHookCallbacks: { file: { enabled: true, path: join(cwd, 'callback.md'), format: 'markdown' } },
+  }));
+}
+
+describe('SessionEnd run.cjs process exit regressions (#3477)', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const directory of tempDirs.splice(0)) {
+      rmSync(directory, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 });
+    }
+  });
+
+  function createProject(): string {
+    const cwd = mkdtempSync(join(tmpdir(), 'omc-session-end-process-exit-'));
+    tempDirs.push(cwd);
+    writeFileSync(join(cwd, 'transcript.jsonl'), '');
+    return cwd;
+  }
+
+  it.each(SESSION_END_SCRIPTS)('%s exits with no bytes and an open stdin pipe', async (_name, script) => {
+    const result = await runUntilClose(script, createProject(), undefined);
+    expectPromptExit(result);
+  });
+
+  it.skipIf(!HAS_GENERATED_DIST).each(SESSION_END_SCRIPTS)('%s exits after promptly closed valid SessionEnd JSON with configured adapters', async (_name, script) => {
+    const cwd = createProject();
+    configureDeferredAdapters(cwd);
+    const sessionId = `configured-${_name}`;
+
+    const result = await runUntilClose(script, cwd, validSessionEndInput(cwd, sessionId));
+    expectPromptExit(result);
+
+    if (_name === 'session-end') {
+      const manifestPath = join(cwd, '.omc', 'state', 'session-end-jobs', `${sessionId}.json`);
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as { actions: Record<string, { phase: string }> };
+      expect(manifest.actions.callback.phase).toBe('deferred-best-effort');
+      expect(manifest.actions.notification.phase).toBe('deferred-best-effort');
+    }
+  });
+
+  it.skipIf(!HAS_GENERATED_DIST)('uses the generated dist closure: the shipped worker imports and can execute', async () => {
+    const distWorker = join(REPO_ROOT, 'dist', 'hooks', 'session-end', 'worker.js');
+    const distManifest = join(REPO_ROOT, 'dist', 'hooks', 'session-end', 'cleanup-manifest.js');
+    expect(readFileSync(distWorker, 'utf8')).toContain("getProcessStartIdentity");
+
+    const { prepareCoreManifest, sealCoreManifest, sealWikiManifest, mutateSessionEndJob, readSessionEndJob } =
+      await import(pathToFileURL(distManifest).href) as typeof import('../hooks/session-end/cleanup-manifest.js');
+    const { processSessionEndWorker } = await import(pathToFileURL(distWorker).href) as typeof import('../hooks/session-end/worker.js');
+    const cwd = createProject();
+    const sessionId = 'dist-worker-executes';
+    expect(prepareCoreManifest(cwd, sessionId, {})).not.toBeNull();
+    expect(sealCoreManifest(cwd, sessionId)).not.toBeNull();
+    expect(sealWikiManifest(cwd, sessionId)).not.toBeNull();
+    let manifest = readSessionEndJob(cwd, sessionId)!;
+    for (const name of Object.keys(manifest.actions)) {
+      manifest = mutateSessionEndJob(cwd, sessionId, manifest.revision, (job) => {
+        const action = job.actions[name as keyof typeof job.actions];
+        action.status = 'completed';
+        action.runner = { attempt: 1, runnerNonce: `${name}-terminal`, phase: 'terminal', deadlineAt: new Date().toISOString() };
+      })!;
+    }
+
+    await processSessionEndWorker({ directory: cwd, sessionId });
+    expect(readSessionEndJob(cwd, sessionId)).toMatchObject({ phase: 'complete', owner: null });
+  });
+
+  it.skipIf(!HAS_GENERATED_DIST)('keeps configured callbacks, proxies, and custom CA out of the foreground process', async () => {
+    const cwd = createProject();
+    configureDeferredAdapters(cwd);
+    const caPath = join(cwd, 'test-ca.pem');
+    writeFileSync(caPath, 'not a certificate');
+
+    const result = await runUntilClose(
+      join(REPO_ROOT, 'scripts', 'session-end.mjs'),
+      cwd,
+      validSessionEndInput(cwd, 'configured-network-routing'),
+      COMMAND_CEILING_MS,
+      {
+        HTTPS_PROXY: 'http://127.0.0.1:9',
+        HTTP_PROXY: 'http://127.0.0.1:9',
+        NODE_EXTRA_CA_CERTS: caPath,
+      },
+    );
+    expectPromptExit(result);
+    const manifest = JSON.parse(readFileSync(join(cwd, '.omc', 'state', 'session-end-jobs', 'configured-network-routing.json'), 'utf8')) as { actions: Record<string, { phase: string }> };
+    expect(manifest.actions.callback.phase).toBe('deferred-best-effort');
+    expect(manifest.actions.notification.phase).toBe('deferred-best-effort');
+  });
+
+  it.skipIf(!HAS_GENERATED_DIST)('wiki-session-end exits without waiting for a live wiki lock', async () => {
+    const cwd = createProject();
+    configureDeferredAdapters(cwd);
+    const wikiDir = join(cwd, '.omc', 'wiki');
+    mkdirSync(wikiDir, { recursive: true });
+    writeFileSync(join(cwd, '.omc', '.omc-config.json'), JSON.stringify({ wiki: { autoCapture: true } }));
+    writeFileSync(join(wikiDir, '.wiki-lock.lock'), JSON.stringify({ pid: process.pid, timestamp: Date.now() }));
+
+    const result = await runUntilClose(
+      join(REPO_ROOT, 'scripts', 'wiki-session-end.mjs'),
+      cwd,
+      validSessionEndInput(cwd, 'wiki-live-lock'),
+    );
+    expectPromptExit(result);
+  });
+
+  it.skipIf(!HAS_GENERATED_DIST)('runs the SessionEnd pair sequentially within the combined foreground budget', async () => {
+    const cwd = createProject();
+    configureDeferredAdapters(cwd);
+    const startedAt = Date.now();
+
+    for (const [name, script] of SESSION_END_SCRIPTS) {
+      expectPromptExit(await runUntilClose(script, cwd, validSessionEndInput(cwd, `sequential-${name}`)));
+    }
+
+    expect(Date.now() - startedAt).toBeLessThanOrEqual(SEQUENTIAL_CEILING_MS);
+  });
+});

--- a/src/__tests__/setup-contracts-regression.test.ts
+++ b/src/__tests__/setup-contracts-regression.test.ts
@@ -10,8 +10,7 @@
  * to avoid false positives and allowlist bloat.
  */
 
-import { describe, it, expect, afterEach, beforeAll } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import { fileURLToPath } from 'url';
@@ -656,6 +655,21 @@ describe('Contract 11: SessionEnd hooks are async (issue #3240)', () => {
     }
   });
 
+  it('keeps both SessionEnd scripts on the direct asynchronous run.cjs path', () => {
+    if (!existsSync(HOOKS_JSON_PATH)) return;
+
+    const hooksJson = JSON.parse(readFileSync(HOOKS_JSON_PATH, 'utf-8')) as {
+      hooks: Record<string, Array<{ hooks: Array<{ type: string; command?: string; async?: boolean }> }>>;
+    };
+    const commands = (hooksJson.hooks.SessionEnd ?? [])
+      .flatMap(group => group.hooks)
+      .filter(hook => hook.type === 'command')
+      .map(hook => hook.command);
+
+    expect(commands).toContain('node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-end.mjs');
+    expect(commands).toContain('node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/wiki-session-end.mjs');
+  });
+
   it('non-SessionEnd hooks do not unconditionally carry async:true', () => {
     if (!existsSync(HOOKS_JSON_PATH)) return;
 
@@ -666,6 +680,7 @@ describe('Contract 11: SessionEnd hooks are async (issue #3240)', () => {
     // Only SessionEnd should have async:true; verify at least one event type that
     // is expected to be synchronous (Stop) is not accidentally marked async.
     const stopGroups = hooksJson.hooks?.['Stop'] ?? [];
+    expect(stopGroups.length).toBeGreaterThan(0);
     for (const group of stopGroups) {
       for (const hook of group.hooks ?? []) {
         if (hook.type === 'command') {

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -1923,6 +1923,9 @@ async function processSessionStart(input: HookInput): Promise<HookOutput> {
 
   writeSessionStartedMarker(directory, sessionId);
   await reconcileAbandonedSessionStarts(directory, sessionId);
+  void import('./session-end/worker.js')
+    .then(({ reconcileSessionEndJobs }) => reconcileSessionEndJobs(directory))
+    .catch(() => undefined);
 
   // Lazy-load session-start dependencies
   const { initSilentAutoUpdate } = await import("../features/auto-update.js");
@@ -3119,11 +3122,6 @@ export async function processHook(
           reason: (rawSE.reason as SessionEndInput["reason"]) ?? "other",
         };
         const result = await handleSessionEnd(sessionEndInput);
-        _openclaw.wake("session-end", {
-          sessionId: sessionEndInput.session_id,
-          projectPath: sessionEndInput.cwd,
-          reason: sessionEndInput.reason,
-        });
         return result;
       }
 

--- a/src/hooks/session-end/__tests__/cleanup-manifest.test.ts
+++ b/src/hooks/session-end/__tests__/cleanup-manifest.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  claimSessionEndAction,
+  claimSessionEndJob,
+  finishSessionEndAction,
+  isManifestTerminal,
+  markSessionEndActionRunner,
+  mutateSessionEndJob,
+  prepareCoreManifest,
+  readSessionEndJob,
+  reapStaleSessionEndOwner,
+  releaseSessionEndJob,
+  renewSessionEndLease,
+  sealCoreManifest,
+  sealWikiManifest,
+  sessionEndJobsDirectory,
+  takeSessionEndDiscoveryPage,
+} from '../cleanup-manifest.js';
+
+const directories: string[] = [];
+
+function project(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'omc-cleanup-manifest-'));
+  directories.push(directory);
+  return directory;
+}
+
+function preparedAndSealed(directory: string, sessionId = 'session-a') {
+  expect(prepareCoreManifest(directory, sessionId, { transcriptPath: '/tmp/transcript' })).not.toBeNull();
+  expect(sealCoreManifest(directory, sessionId)).not.toBeNull();
+  expect(sealWikiManifest(directory, sessionId)).not.toBeNull();
+  return sessionId;
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('durable SessionEnd cleanup manifest', () => {
+  it('serializes concurrent core/wiki producers and rejects a second worker claim', async () => {
+    const directory = project();
+    const sessionId = 'concurrent-producers';
+
+    await Promise.all([
+      Promise.resolve().then(() => prepareCoreManifest(directory, sessionId, { source: 'core', callback: true })),
+      Promise.resolve().then(() => sealWikiManifest(directory, sessionId, { source: 'wiki', capture: true })),
+    ]);
+    expect(sealCoreManifest(directory, sessionId)).not.toBeNull();
+
+    const before = readSessionEndJob(directory, sessionId);
+    expect(before?.producers.core.state).toBe('sealed');
+    expect(before?.producers.wiki.state).toBe('sealed');
+    expect(before?.actions.callback.payload).toMatchObject({ source: 'core', callback: true });
+    expect(before?.actions['wiki-capture'].payload).toMatchObject({ source: 'wiki', capture: true });
+
+    const [first, second] = await Promise.all([
+      Promise.resolve().then(() => claimSessionEndJob(directory, sessionId, 'worker-one', 'identity-one', Date.now() + 5_000)),
+      Promise.resolve().then(() => claimSessionEndJob(directory, sessionId, 'worker-two', 'identity-two', Date.now() + 5_000)),
+    ]);
+    expect([first, second].filter(Boolean)).toHaveLength(1);
+    expect(readSessionEndJob(directory, sessionId)?.owner?.nonce).toBe(first?.owner?.nonce ?? second?.owner?.nonce);
+  });
+
+  it('uses expected-revision CAS rather than accepting a stale mutation', () => {
+    const directory = project();
+    const sessionId = preparedAndSealed(directory, 'revision-cas');
+    const initial = readSessionEndJob(directory, sessionId);
+    expect(initial).not.toBeNull();
+
+    const current = mutateSessionEndJob(directory, sessionId, initial!.revision, (job) => {
+      job.phase = 'recoverable-failure';
+    });
+    const stale = mutateSessionEndJob(directory, sessionId, initial!.revision, (job) => {
+      job.phase = 'complete';
+    });
+
+    expect(current?.revision).toBe(initial!.revision + 1);
+    expect(stale).toBeNull();
+    expect(readSessionEndJob(directory, sessionId)?.phase).toBe('recoverable-failure');
+  });
+
+  it('renews leases and reaps only expired, positively dead or PID-reused owners', () => {
+    const directory = project();
+    const sessionId = preparedAndSealed(directory, 'leases');
+    const claimed = claimSessionEndJob(directory, sessionId, 'owner', 'old-start', Date.now() + 5_000);
+    expect(claimed?.owner).toMatchObject({ nonce: 'owner', leaseGeneration: 1 });
+    const renewed = renewSessionEndLease(directory, sessionId, 'owner', 1, Date.now() + 5_000);
+    expect(renewed?.owner?.leaseGeneration).toBe(2);
+
+    // A live owner is never a legal reap result, even after its lease is expired.
+    const path = join(sessionEndJobsDirectory(directory), `${sessionId}.json`);
+    const expired = JSON.parse(readFileSync(path, 'utf8')) as { owner: { leaseExpiresAt: string } };
+    expired.owner.leaseExpiresAt = new Date(Date.now() - 1_000).toISOString();
+    writeFileSync(path, JSON.stringify(expired));
+    const reap = reapStaleSessionEndOwner as unknown as (
+      directory: string, sessionId: string, nonce: string, generation: number, liveness: string,
+    ) => unknown;
+    expect(reap(directory, sessionId, 'owner', 2, 'live')).toBeNull();
+    expect(reapStaleSessionEndOwner(directory, sessionId, 'owner', 2, 'dead')?.owner).toBeNull();
+
+    const again = claimSessionEndJob(directory, sessionId, 'reused-owner', 'reused-start', Date.now() + 5_000);
+    const expiresAgain = JSON.parse(readFileSync(path, 'utf8')) as { owner: { leaseExpiresAt: string } };
+    expiresAgain.owner.leaseExpiresAt = new Date(Date.now() - 1_000).toISOString();
+    writeFileSync(path, JSON.stringify(expiresAgain));
+    expect(again?.owner).toBeTruthy();
+    expect(reapStaleSessionEndOwner(directory, sessionId, 'reused-owner', 1, 'mismatch')?.owner).toBeNull();
+  });
+
+  it('persists action claim, runner arm, result, and terminality separately from discovery tickets', () => {
+    const directory = project();
+    const sessionId = preparedAndSealed(directory, 'action-transitions');
+    const owner = claimSessionEndJob(directory, sessionId, 'owner', 'identity', Date.now() + 5_000)!;
+    const claimed = claimSessionEndAction(directory, sessionId, 'owner', 'team-cleanup', Date.now() + 5_000)!;
+    const runner = claimed.actions['team-cleanup'].runner!;
+    expect(claimed.actions['team-cleanup']).toMatchObject({ status: 'claimed', attempts: 1, runner: { phase: 'reserved' } });
+    expect(markSessionEndActionRunner(directory, sessionId, 'owner', 'team-cleanup', runner.runnerNonce, 'started')).not.toBeNull();
+    expect(markSessionEndActionRunner(directory, sessionId, 'owner', 'team-cleanup', runner.runnerNonce, 'armed')).not.toBeNull();
+    expect(finishSessionEndAction(directory, sessionId, 'owner', 'team-cleanup', runner.runnerNonce, true, 'completed')).not.toBeNull();
+
+    let current = readSessionEndJob(directory, sessionId)!;
+    for (const [name] of Object.entries(current.actions)) {
+      if (name === 'team-cleanup') continue;
+      current = mutateSessionEndJob(directory, sessionId, current.revision, (job) => {
+        job.actions[name as keyof typeof job.actions].status = 'completed';
+        job.actions[name as keyof typeof job.actions].runner = { attempt: 1, runnerNonce: `${name}-runner`, phase: 'terminal', deadlineAt: new Date().toISOString() };
+      })!;
+    }
+    const released = releaseSessionEndJob(directory, sessionId, 'owner', owner.owner!.leaseGeneration);
+    expect(released).not.toBeNull();
+    const terminal = readSessionEndJob(directory, sessionId)!;
+    expect(isManifestTerminal(terminal)).toBe(true);
+    expect(terminal.phase).toBe('complete');
+
+    // A stale ticket cannot make a terminal manifest non-terminal or runnable again.
+    writeFileSync(join(sessionEndJobsDirectory(directory), 'discovery.json'), JSON.stringify({
+      version: 2,
+      cursor: 0,
+      tickets: [{ sessionId, attempts: 0, retryAt: new Date(0).toISOString() }],
+    }));
+    expect(takeSessionEndDiscoveryPage(directory, 1)).toEqual([sessionId]);
+    expect(isManifestTerminal(readSessionEndJob(directory, sessionId)!)).toBe(true);
+  });
+
+  it('keeps more than sixteen queued jobs discoverable through bounded rotating pages', () => {
+    const directory = project();
+    const sessionIds = Array.from({ length: 21 }, (_, index) => `queued-${index}`);
+    for (const sessionId of sessionIds) {
+      expect(prepareCoreManifest(directory, sessionId, { sequence: sessionId })).not.toBeNull();
+      expect(sealCoreManifest(directory, sessionId)).not.toBeNull();
+    }
+
+    const discovered = new Set<string>();
+    for (let page = 0; page < 6; page++) for (const sessionId of takeSessionEndDiscoveryPage(directory, 4)) discovered.add(sessionId);
+    expect(discovered).toEqual(new Set(sessionIds));
+  });
+
+  it('leaves every simulated crash boundary recoverable instead of silently completing work', () => {
+    const directory = project();
+    const sessionId = preparedAndSealed(directory, 'crash-boundaries');
+    const owner = claimSessionEndJob(directory, sessionId, 'crashed-owner', 'identity', Date.now() + 5_000)!;
+    const action = claimSessionEndAction(directory, sessionId, 'crashed-owner', 'python-cleanup', Date.now() + 5_000)!;
+    const runner = action.actions['python-cleanup'].runner!;
+
+    // These snapshots model crashes before/after claim, arm, result, release, completion, and ticket retirement.
+    expect(readSessionEndJob(directory, sessionId)?.actions['python-cleanup'].runner?.phase).toBe('reserved');
+    expect(markSessionEndActionRunner(directory, sessionId, 'crashed-owner', 'python-cleanup', runner.runnerNonce, 'armed')).not.toBeNull();
+    expect(finishSessionEndAction(directory, sessionId, 'crashed-owner', 'python-cleanup', runner.runnerNonce, false, 'simulated-crash')).not.toBeNull();
+    expect(readSessionEndJob(directory, sessionId)?.actions['python-cleanup']).toMatchObject({ status: 'retryable', lastOutcomeCode: 'simulated-crash', runner: { phase: 'terminal' } });
+    expect(releaseSessionEndJob(directory, sessionId, 'crashed-owner', owner.owner!.leaseGeneration)).not.toBeNull();
+    expect(readSessionEndJob(directory, sessionId)).toMatchObject({ owner: null, phase: 'recoverable-failure' });
+    expect(takeSessionEndDiscoveryPage(directory, 1)).toEqual([sessionId]);
+  });
+});

--- a/src/hooks/session-end/__tests__/duplicate-notifications.test.ts
+++ b/src/hooks/session-end/__tests__/duplicate-notifications.test.ts
@@ -3,9 +3,15 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-vi.mock('../callbacks.js', () => ({
-  triggerStopCallbacks: vi.fn(async () => undefined),
-}));
+vi.mock('../callbacks.js', async () => {
+  const actual = await vi.importActual<typeof import('../callbacks.js')>('../callbacks.js');
+  return {
+    ...actual,
+    triggerStopCallbacks: vi.fn(async () => undefined),
+  };
+});
+
+const fetchMock = vi.fn();
 
 vi.mock('../../../features/auto-update.js', () => ({
   getOMCConfig: vi.fn(() => ({
@@ -41,8 +47,21 @@ vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
   })),
 }));
 
-import { processSessionEnd } from '../index.js';
-import { triggerStopCallbacks } from '../callbacks.js';
+const workerMocks = vi.hoisted(() => ({
+  processSessionEndWorker: vi.fn(),
+  spawnSessionEndWorker: vi.fn(),
+}));
+
+vi.mock('../worker.js', () => workerMocks);
+vi.mock('../../../lib/worktree-paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/worktree-paths.js')>(
+    '../../../lib/worktree-paths.js',
+  );
+  return { ...actual, resolveToWorktreeRoot: vi.fn((directory?: string) => directory ?? process.cwd()) };
+});
+
+import { processSessionEnd, runSessionEndCallbacks, runSessionEndNotifications } from '../index.js';
+import { readSessionEndJob } from '../cleanup-manifest.js';
 import { getOMCConfig } from '../../../features/auto-update.js';
 import { buildConfigFromEnv, getEnabledPlatforms, getNotificationConfig } from '../../../notifications/config.js';
 import { notify } from '../../../notifications/index.js';
@@ -63,6 +82,8 @@ describe('processSessionEnd notification deduplication (issue #1440)', () => {
       'utf-8',
     );
     vi.clearAllMocks();
+    fetchMock.mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
   });
 
   afterEach(() => {
@@ -70,7 +91,7 @@ describe('processSessionEnd notification deduplication (issue #1440)', () => {
     vi.unstubAllEnvs();
   });
 
-  it('does not re-dispatch session-end through notify() when config only comes from legacy stopHookCallbacks', async () => {
+  it('defers legacy callbacks without re-dispatching session-end through notify() when config only comes from stopHookCallbacks', async () => {
     vi.mocked(getOMCConfig).mockReturnValue({
       silentAutoUpdate: false,
       stopHookCallbacks: {
@@ -104,15 +125,30 @@ describe('processSessionEnd notification deduplication (issue #1440)', () => {
       reason: 'clear',
     });
 
-    expect(triggerStopCallbacks).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 'session-legacy-only' }),
-      { session_id: 'session-legacy-only', cwd: tmpDir },
-      { skipPlatforms: [] },
+    const manifest = readSessionEndJob(tmpDir, 'session-legacy-only');
+    expect(manifest).toEqual(expect.objectContaining({
+      producers: expect.objectContaining({ core: expect.objectContaining({ state: 'sealed' }) }),
+      actions: expect.objectContaining({
+        callback: expect.objectContaining({ status: 'pending', payload: expect.objectContaining({ transcriptPath, reason: 'clear' }) }),
+        notification: expect.objectContaining({ status: 'pending' }),
+      }),
+    }));
+    expect(workerMocks.spawnSessionEndWorker).toHaveBeenCalledWith({
+      directory: tmpDir,
+      sessionId: 'session-legacy-only',
+    });
+    expect(notify).not.toHaveBeenCalled();
+
+    await runSessionEndCallbacks(tmpDir, 'session-legacy-only');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/legacy',
+      expect.objectContaining({ method: 'POST' }),
     );
     expect(notify).not.toHaveBeenCalled();
   });
 
-  it('skips the legacy Discord callback when explicit session-end notifications already cover Discord', async () => {
+  it('defers deduplicated legacy Discord callbacks and explicit notifications to the worker', async () => {
     vi.mocked(getOMCConfig).mockReturnValue({
       silentAutoUpdate: false,
       stopHookCallbacks: {
@@ -155,11 +191,18 @@ describe('processSessionEnd notification deduplication (issue #1440)', () => {
       reason: 'clear',
     });
 
-    expect(triggerStopCallbacks).toHaveBeenCalledWith(
-      expect.objectContaining({ session_id: 'session-new-discord' }),
-      { session_id: 'session-new-discord', cwd: tmpDir },
-      { skipPlatforms: ['discord'] },
-    );
+    const manifest = readSessionEndJob(tmpDir, 'session-new-discord');
+    expect(manifest?.actions.callback).toEqual(expect.objectContaining({ status: 'pending' }));
+    expect(manifest?.actions.notification).toEqual(expect.objectContaining({
+      status: 'pending',
+      payload: expect.objectContaining({ transcriptPath, reason: 'clear' }),
+    }));
+    expect(notify).not.toHaveBeenCalled();
+
+    await runSessionEndCallbacks(tmpDir, 'session-new-discord');
+    await runSessionEndNotifications(tmpDir, 'session-new-discord');
+
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith(
       'session-end',
       expect.objectContaining({

--- a/src/hooks/session-end/__tests__/openclaw-session-end.test.ts
+++ b/src/hooks/session-end/__tests__/openclaw-session-end.test.ts
@@ -3,9 +3,13 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-vi.mock("../callbacks.js", () => ({
-  triggerStopCallbacks: vi.fn(async () => undefined),
-}));
+vi.mock('../callbacks.js', async () => {
+  const actual = await vi.importActual<typeof import('../callbacks.js')>('../callbacks.js');
+  return {
+    ...actual,
+    triggerStopCallbacks: vi.fn(async () => undefined),
+  };
+});
 
 vi.mock("../../../notifications/index.js", () => ({
   notify: vi.fn(async () => undefined),
@@ -34,9 +38,23 @@ vi.mock("../../../openclaw/index.js", () => ({
   wakeOpenClaw: vi.fn().mockResolvedValue({ gateway: "test", success: true }),
 }));
 
-import { _openclaw, processHook, type HookInput } from "../../bridge.js";
-import { processSessionEnd } from "../index.js";
-import { wakeOpenClaw } from "../../../openclaw/index.js";
+const workerMocks = vi.hoisted(() => ({
+  processSessionEndWorker: vi.fn(),
+  spawnSessionEndWorker: vi.fn(),
+}));
+
+vi.mock('../worker.js', () => workerMocks);
+vi.mock('../../../lib/worktree-paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/worktree-paths.js')>(
+    '../../../lib/worktree-paths.js',
+  );
+  return { ...actual, resolveToWorktreeRoot: vi.fn((directory?: string) => directory ?? process.cwd()) };
+});
+
+import { processHook, type HookInput } from '../../bridge.js';
+import { processSessionEnd, runSessionEndOpenClaw } from '../index.js';
+import { readSessionEndJob } from '../cleanup-manifest.js';
+import { wakeOpenClaw } from '../../../openclaw/index.js';
 
 describe("session-end OpenClaw behavior (issue #1456)", () => {
   let tmpDir: string;
@@ -63,85 +81,84 @@ describe("session-end OpenClaw behavior (issue #1456)", () => {
     vi.restoreAllMocks();
   });
 
-  it("wakes OpenClaw from the bridge during session-end when OMC_OPENCLAW=1", async () => {
-    process.env.OMC_OPENCLAW = "1";
-    const wakeSpy = vi.spyOn(_openclaw, "wake");
+  it('defers an enabled OpenClaw wake from the bridge and executes it in the worker adapter', async () => {
+    process.env.OMC_OPENCLAW = '1';
 
-    await processHook("session-end", {
-      session_id: "session-claw-1",
+    await processHook('session-end', {
+      session_id: 'session-claw-1',
       transcript_path: transcriptPath,
       cwd: tmpDir,
-      permission_mode: "default",
-      hook_event_name: "SessionEnd",
-      reason: "clear",
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
     } as unknown as HookInput);
 
-    expect(wakeSpy).toHaveBeenCalledWith(
-      "session-end",
-      expect.objectContaining({
-        sessionId: "session-claw-1",
-        projectPath: tmpDir,
-        reason: "clear",
-      }),
-    );
+    const manifest = readSessionEndJob(tmpDir, 'session-claw-1');
+    expect(manifest?.actions.openclaw).toEqual(expect.objectContaining({
+      status: 'pending',
+      payload: expect.objectContaining({ transcriptPath, reason: 'clear' }),
+    }));
+    expect(workerMocks.spawnSessionEndWorker).toHaveBeenCalledWith({
+      directory: tmpDir,
+      sessionId: 'session-claw-1',
+    });
+    expect(wakeOpenClaw).not.toHaveBeenCalled();
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await runSessionEndOpenClaw(tmpDir, 'session-claw-1');
 
     expect(wakeOpenClaw).toHaveBeenCalledWith(
-      "session-end",
+      'session-end',
       expect.objectContaining({
-        sessionId: "session-claw-1",
+        sessionId: 'session-claw-1',
         projectPath: tmpDir,
-        reason: "clear",
       }),
     );
   });
 
-  it("does not call wakeOpenClaw directly when processSessionEnd is invoked without the bridge", async () => {
-    process.env.OMC_OPENCLAW = "1";
+  it('does not call wakeOpenClaw directly when processSessionEnd is invoked without the bridge', async () => {
+    process.env.OMC_OPENCLAW = '1';
 
     await processSessionEnd({
-      session_id: "session-claw-2",
+      session_id: 'session-claw-2',
       transcript_path: transcriptPath,
       cwd: tmpDir,
-      permission_mode: "default",
-      hook_event_name: "SessionEnd",
-      reason: "clear",
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
     });
 
     expect(wakeOpenClaw).not.toHaveBeenCalled();
   });
 
-  it("does not call wakeOpenClaw when OMC_OPENCLAW is not set", async () => {
+  it('does not wake OpenClaw from the worker adapter when OMC_OPENCLAW is not set', async () => {
     delete process.env.OMC_OPENCLAW;
 
-    await processHook("session-end", {
-      session_id: "session-claw-3",
+    await processSessionEnd({
+      session_id: 'session-claw-3',
       transcript_path: transcriptPath,
       cwd: tmpDir,
-      permission_mode: "default",
-      hook_event_name: "SessionEnd",
-      reason: "clear",
-    } as unknown as HookInput);
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+    await runSessionEndOpenClaw(tmpDir, 'session-claw-3');
 
     expect(wakeOpenClaw).not.toHaveBeenCalled();
   });
 
-  it("does not throw even if wakeOpenClaw mock is configured to reject", async () => {
-    process.env.OMC_OPENCLAW = "1";
-    vi.mocked(wakeOpenClaw).mockRejectedValueOnce(new Error("gateway down"));
+  it('contains a rejected worker wake without failing session-end processing', async () => {
+    process.env.OMC_OPENCLAW = '1';
+    vi.mocked(wakeOpenClaw).mockRejectedValueOnce(new Error('gateway down'));
 
-    await expect(
-      processHook("session-end", {
-        session_id: "session-claw-4",
-        transcript_path: transcriptPath,
-        cwd: tmpDir,
-        permission_mode: "default",
-        hook_event_name: "SessionEnd",
-        reason: "clear",
-      } as unknown as HookInput),
-    ).resolves.toBeDefined();
+    await processSessionEnd({
+      session_id: 'session-claw-4',
+      transcript_path: transcriptPath,
+      cwd: tmpDir,
+      permission_mode: 'default',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+
+    await expect(runSessionEndOpenClaw(tmpDir, 'session-claw-4')).resolves.toBeUndefined();
   });
 });

--- a/src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/session-end-bridge-cleanup.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 
 vi.mock('../callbacks.js', () => ({
   triggerStopCallbacks: vi.fn(async () => undefined),
+  runSessionEndDeferredAction: vi.fn(async () => ({ status: 'completed' })),
 }));
 
 vi.mock('../../../notifications/index.js', () => ({
@@ -21,6 +22,7 @@ vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
 }));
 
 import { processSessionEndCleanupWorker } from '../index.js';
+import { prepareCoreManifest, sealCoreManifest, sealWikiManifest } from '../cleanup-manifest.js';
 import { cleanupBridgeSessions } from '../../../tools/python-repl/bridge-manager.js';
 
 describe('processSessionEndCleanupWorker python bridge cleanup', () => {
@@ -50,6 +52,10 @@ describe('processSessionEndCleanupWorker python bridge cleanup', () => {
       }),
     ];
     fs.writeFileSync(transcriptPath, transcriptLines.join('\n'), 'utf-8');
+
+    prepareCoreManifest(tmpDir, 'session-123', { transcriptPath });
+    sealCoreManifest(tmpDir, 'session-123');
+    sealWikiManifest(tmpDir, 'session-123');
 
     await processSessionEndCleanupWorker({
       directory: tmpDir,

--- a/src/hooks/session-end/__tests__/session-end-timeout.test.ts
+++ b/src/hooks/session-end/__tests__/session-end-timeout.test.ts
@@ -1,89 +1,31 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-// ── hooks.json timeout validation ──────────────────────────────────────────
-
-describe('SessionEnd hook timeout (issue #1700)', () => {
-  it('hooks.json SessionEnd timeout is at least 30 seconds', () => {
-    // Read from the repository root hooks.json
-    const hooksJsonPath = path.resolve(__dirname, '../../../../hooks/hooks.json');
-    const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
-
-    const sessionEndEntries = hooksJson.hooks.SessionEnd;
-    expect(sessionEndEntries).toBeDefined();
-    expect(Array.isArray(sessionEndEntries)).toBe(true);
-
-    for (const entry of sessionEndEntries) {
-      for (const hook of entry.hooks) {
-        expect(hook.timeout).toBeGreaterThanOrEqual(30);
-      }
-    }
-  });
-});
-
-// ── fire-and-forget notification behavior ──────────────────────────────────
-
-vi.mock('../callbacks.js', () => ({
-  triggerStopCallbacks: vi.fn(async () => {
-    // Simulate a slow notification (2s) — should not block session end
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-  }),
+const workerMocks = vi.hoisted(() => ({
+  spawnSessionEndWorker: vi.fn(),
 }));
 
-vi.mock('../../../notifications/index.js', () => ({
-  notify: vi.fn(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-  }),
+vi.mock('../worker.js', () => ({
+  spawnSessionEndWorker: workerMocks.spawnSessionEndWorker,
+  processSessionEndWorker: vi.fn(),
 }));
 
-vi.mock('../../../features/auto-update.js', () => ({
-  getOMCConfig: vi.fn(() => ({})),
-}));
-
-vi.mock('../../../notifications/config.js', () => ({
-  buildConfigFromEnv: vi.fn(() => null),
-  getEnabledPlatforms: vi.fn(() => []),
-  getNotificationConfig: vi.fn(() => null),
-}));
-
-vi.mock('../../../tools/python-repl/bridge-manager.js', () => ({
-  cleanupBridgeSessions: vi.fn(async () => ({
-    requestedSessions: 0,
-    foundSessions: 0,
-    terminatedSessions: 0,
-    errors: [],
-  })),
-}));
-
-vi.mock('../../../openclaw/index.js', () => ({
-  wakeOpenClaw: vi.fn().mockResolvedValue({ gateway: 'test', success: true }),
-}));
-
-const childProcessMocks = vi.hoisted(() => ({
-  spawn: vi.fn(() => ({ unref: vi.fn() })),
-}));
-
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('child_process')>();
+vi.mock('../../../lib/worktree-paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/worktree-paths.js')>(
+    '../../../lib/worktree-paths.js',
+  );
   return {
     ...actual,
-    spawn: childProcessMocks.spawn,
+    resolveToWorktreeRoot: vi.fn((directory?: string) => directory ?? process.cwd()),
   };
 });
 
-import { processSessionEnd, processSessionEndCleanupWorker, resolveSessionEndCleanupBudgetMs } from '../index.js';
-import { triggerStopCallbacks } from '../callbacks.js';
-import { cleanupBridgeSessions } from '../../../tools/python-repl/bridge-manager.js';
+import { processSessionEnd, resolveSessionEndCleanupBudgetMs } from '../index.js';
+import { readSessionEndJob } from '../cleanup-manifest.js';
 
-function decodeSpawnedCleanupPayload(): { sessionId?: string; initialTeamNames?: string[] } {
-  const spawnArgs = (childProcessMocks.spawn.mock.calls as unknown as Array<[unknown, string[]]>)[0]?.[1];
-  const encodedPayload = spawnArgs?.[spawnArgs.indexOf('--omc-session-end-cleanup-worker') + 1];
-  return JSON.parse(Buffer.from(encodedPayload ?? '', 'base64url').toString('utf-8'));
-}
-
-describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
+describe('SessionEnd foreground manifest handoff (issue #1700)', () => {
   let tmpDir: string;
   let transcriptPath: string;
 
@@ -92,10 +34,7 @@ describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
     transcriptPath = path.join(tmpDir, 'transcript.jsonl');
     fs.writeFileSync(
       transcriptPath,
-      JSON.stringify({
-        type: 'assistant',
-        message: { content: [{ type: 'text', text: 'done' }] },
-      }),
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } }),
       'utf-8',
     );
     vi.clearAllMocks();
@@ -103,114 +42,56 @@ describe('SessionEnd fire-and-forget notifications (issue #1700)', () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    vi.restoreAllMocks();
   });
 
+  it('keeps the SessionEnd manifest timeout at least 30 seconds', () => {
+    const hooksJsonPath = path.resolve(__dirname, '../../../../hooks/hooks.json');
+    const hooksJson = JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8'));
 
-  it('processSessionEnd captures session team state in the detached cleanup payload', async () => {
-    const sessionId = 'timeout-test-team-payload';
-    const cwd = process.cwd();
-    const sessionDir = path.join(cwd, '.omc', 'state', 'sessions', sessionId);
-    fs.mkdirSync(sessionDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(sessionDir, 'team-state.json'),
-      JSON.stringify({ active: true, session_id: sessionId, team_name: 'payload-team' }),
-      'utf-8',
-    );
-
-    try {
-      await processSessionEnd({
-        session_id: sessionId,
-        transcript_path: transcriptPath,
-        cwd,
-        permission_mode: 'default',
-        hook_event_name: 'SessionEnd',
-        reason: 'clear',
-      });
-
-      expect(decodeSpawnedCleanupPayload()).toEqual(expect.objectContaining({
-        sessionId,
-        initialTeamNames: ['payload-team'],
-      }));
-    } finally {
-      fs.rmSync(sessionDir, { recursive: true, force: true });
+    for (const entry of hooksJson.hooks.SessionEnd) {
+      for (const hook of entry.hooks) {
+        expect(hook.timeout).toBeGreaterThanOrEqual(30);
+      }
     }
   });
 
-  it('processSessionEnd schedules detached resource cleanup instead of running it in-process', async () => {
-    await processSessionEnd({
-      session_id: 'timeout-test-python',
+  it('returns within the foreground deadline after publishing deferred worker actions', async () => {
+    const sessionId = 'timeout-test-manifest';
+    const startedAt = Date.now();
+
+    await expect(processSessionEnd({
+      session_id: sessionId,
       transcript_path: transcriptPath,
       cwd: tmpDir,
       permission_mode: 'default',
       hook_event_name: 'SessionEnd',
       reason: 'clear',
-    });
+    })).resolves.toEqual({ continue: true });
 
-    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
-      process.execPath,
-      expect.arrayContaining(['--omc-session-end-cleanup-worker']),
-      expect.objectContaining({ detached: true, stdio: 'ignore' }),
-    );
-    expect(cleanupBridgeSessions).not.toHaveBeenCalled();
+    expect(Date.now() - startedAt).toBeLessThanOrEqual(500);
+    expect(workerMocks.spawnSessionEndWorker).toHaveBeenCalledWith({ directory: tmpDir, sessionId });
+
+    const manifest = readSessionEndJob(tmpDir, sessionId);
+    expect(manifest).toEqual(expect.objectContaining({
+      sessionId,
+      producers: expect.objectContaining({ core: expect.objectContaining({ state: 'sealed' }) }),
+    }));
+    expect(manifest?.actions.callback).toEqual(expect.objectContaining({
+      class: 'best-effort',
+      phase: 'deferred-best-effort',
+      status: 'pending',
+    }));
+    expect(manifest?.actions.notification).toEqual(expect.objectContaining({
+      class: 'best-effort',
+      phase: 'deferred-best-effort',
+      status: 'pending',
+    }));
   });
 
-  it('cleanup worker applies bounded parallel Python REPL cleanup options', async () => {
-    fs.writeFileSync(
-      transcriptPath,
-      JSON.stringify({
-        type: 'assistant',
-        message: { content: [{ type: 'tool_use', name: 'python_repl', input: { researchSessionID: 'py-worker' } }] },
-      }),
-      'utf-8',
-    );
-
-    await processSessionEndCleanupWorker({
-      directory: tmpDir,
-      sessionId: 'timeout-test-python-worker',
-      transcriptPath,
-      cleanupBudgetMs: 250,
-    });
-
-    expect(cleanupBridgeSessions).toHaveBeenCalledWith(
-      ['py-worker'],
-      expect.objectContaining({
-        gracePeriodMs: 100,
-        sigtermGraceMs: 100,
-        finalWaitMs: 50,
-        parallel: true,
-      }),
-    );
-  });
-
-  it('resolves bounded cleanup budget from env with sane defaults and cap', () => {
+  it('resolves the legacy cleanup budget environment setting compatibly', () => {
     expect(resolveSessionEndCleanupBudgetMs({})).toBe(2000);
     expect(resolveSessionEndCleanupBudgetMs({ OMC_SESSIONEND_CLEANUP_BUDGET_MS: '250' })).toBe(250);
     expect(resolveSessionEndCleanupBudgetMs({ OMC_SESSIONEND_CLEANUP_BUDGET_MS: '25000' })).toBe(10000);
     expect(resolveSessionEndCleanupBudgetMs({ OMC_SESSIONEND_CLEANUP_BUDGET_MS: 'not-a-number' })).toBe(2000);
-  });
-
-  it('processSessionEnd completes well before slow notifications finish', async () => {
-    const start = Date.now();
-
-    await processSessionEnd({
-      session_id: 'timeout-test-1',
-      transcript_path: transcriptPath,
-      cwd: tmpDir,
-      permission_mode: 'default',
-      hook_event_name: 'SessionEnd',
-      reason: 'clear',
-    });
-
-    const elapsed = Date.now() - start;
-
-    // triggerStopCallbacks was called (fire-and-forget)
-    expect(triggerStopCallbacks).toHaveBeenCalled();
-
-    // The function should complete in well under the 2s mock delay.
-    // Fire-and-forget cleanup should keep synchronous work fast and avoid
-    // waiting the full 2s for the mock notification to resolve.
-    // In practice this finishes in <100ms; 1500ms is a safe CI threshold.
-    expect(elapsed).toBeLessThan(1500);
   });
 });

--- a/src/hooks/session-end/__tests__/team-cleanup.test.ts
+++ b/src/hooks/session-end/__tests__/team-cleanup.test.ts
@@ -70,37 +70,12 @@ vi.mock('../../../lib/worktree-paths.js', async () => {
   };
 });
 
-import { processSessionEndCleanupWorker } from '../index.js';
-
-async function waitForAssertion(assertion: () => void, timeoutMs = 1000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown;
-  while (Date.now() < deadline) {
-    try {
-      assertion();
-      return;
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-  }
-  if (lastError) {
-    throw lastError;
-  }
-}
+import { cleanupSessionOwnedTeams } from '../index.js';
 
 describe('processSessionEnd team cleanup (#1632)', () => {
   let tmpDir: string;
-  let transcriptPath: string;
-
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'omc-session-end-team-cleanup-'));
-    transcriptPath = path.join(tmpDir, 'transcript.jsonl');
-    fs.writeFileSync(
-      transcriptPath,
-      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'done' }] } }),
-      'utf-8',
-    );
   });
 
   afterEach(() => {
@@ -132,22 +107,15 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: 'worker-1', pane_id: '%1' }],
     } as never);
 
-    await processSessionEndCleanupWorker({
-      directory: tmpDir,
-      sessionId,
-      transcriptPath,
-      cleanupBudgetMs: 10000,
-    });
+    await cleanupSessionOwnedTeams(tmpDir, sessionId);
 
-    await waitForAssertion(() => {
-      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
-        'delivery-team',
-        tmpDir,
-        { force: true, timeoutMs: 0 },
-      );
-      expect(teamCleanupMocks.shutdownTeam).not.toHaveBeenCalled();
-    });
-  }, 10000);
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+      'delivery-team',
+      tmpDir,
+      { force: true, timeoutMs: 0 },
+    );
+    expect(teamCleanupMocks.shutdownTeam).not.toHaveBeenCalled();
+  });
 
   it('force-shuts down a legacy runtime team referenced by the ending session', async () => {
     const sessionId = 'pid-1632-legacy';
@@ -166,25 +134,18 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       tmuxOwnsWindow: false,
     } as never);
 
-    await processSessionEndCleanupWorker({
-      directory: tmpDir,
-      sessionId,
-      transcriptPath,
-      cleanupBudgetMs: 2000,
-    });
+    await cleanupSessionOwnedTeams(tmpDir, sessionId);
 
-    await waitForAssertion(() => {
-      expect(teamCleanupMocks.shutdownTeam).toHaveBeenCalledWith(
-        'legacy-team',
-        'legacy-team:0',
-        tmpDir,
-        0,
-        undefined,
-        '%0',
-        false,
-      );
-      expect(teamCleanupMocks.shutdownTeamV2).not.toHaveBeenCalled();
-    });
+    expect(teamCleanupMocks.shutdownTeam).toHaveBeenCalledWith(
+      'legacy-team',
+      'legacy-team:0',
+      tmpDir,
+      0,
+      undefined,
+      '%0',
+      false,
+    );
+    expect(teamCleanupMocks.shutdownTeamV2).not.toHaveBeenCalled();
   });
 
 
@@ -195,21 +156,13 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: 'worker-1', pane_id: '%1' }],
     } as never);
 
-    await processSessionEndCleanupWorker({
-      directory: tmpDir,
-      sessionId,
-      transcriptPath,
-      cleanupBudgetMs: 2000,
-      initialTeamNames: ['captured-team'],
-    });
+    await cleanupSessionOwnedTeams(tmpDir, sessionId, ['captured-team']);
 
-    await waitForAssertion(() => {
-      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
-        'captured-team',
-        tmpDir,
-        { force: true, timeoutMs: 0 },
-      );
-    });
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+      'captured-team',
+      tmpDir,
+      { force: true, timeoutMs: 0 },
+    );
   });
 
 
@@ -220,22 +173,14 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: 'worker-1', pane_id: '%1' }],
     } as never);
 
-    await processSessionEndCleanupWorker({
-      directory: tmpDir,
-      sessionId,
-      transcriptPath,
-      cleanupBudgetMs: 2000,
-      initialTeamNames: ['../../evil', 'bad/name', '..', '', 'safe-team'],
-    });
+    await cleanupSessionOwnedTeams(tmpDir, sessionId, ['../../evil', 'bad/name', '..', '', 'safe-team']);
 
-    await waitForAssertion(() => {
-      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
-      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
-        'safe-team',
-        tmpDir,
-        { force: true, timeoutMs: 0 },
-      );
-    });
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+      'safe-team',
+      tmpDir,
+      { force: true, timeoutMs: 0 },
+    );
   });
 
   it('only cleans up manifests owned by the ending session', async () => {
@@ -258,20 +203,13 @@ describe('processSessionEnd team cleanup (#1632)', () => {
       workers: [{ name: `${teamName}-worker`, pane_id: '%1' }],
     })) as never);
 
-    await processSessionEndCleanupWorker({
-      directory: tmpDir,
-      sessionId,
-      transcriptPath,
-      cleanupBudgetMs: 2000,
-    });
+    await cleanupSessionOwnedTeams(tmpDir, sessionId);
 
-    await waitForAssertion(() => {
-      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
-      expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
-        'owned-team',
-        tmpDir,
-        { force: true, timeoutMs: 0 },
-      );
-    });
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledTimes(1);
+    expect(teamCleanupMocks.shutdownTeamV2).toHaveBeenCalledWith(
+      'owned-team',
+      tmpDir,
+      { force: true, timeoutMs: 0 },
+    );
   });
 });

--- a/src/hooks/session-end/__tests__/worker.test.ts
+++ b/src/hooks/session-end/__tests__/worker.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const actions = vi.hoisted(() => ({
+  cleanupSessionOwnedTeams: vi.fn(async () => ({ attempted: [], cleaned: [], failed: [] })),
+  cleanupSessionPython: vi.fn(async () => undefined),
+  cleanupSessionReplies: vi.fn(async () => undefined),
+  runSessionEndCallbacks: vi.fn(async () => undefined),
+  runSessionEndNotifications: vi.fn(async () => undefined),
+  runSessionEndOpenClaw: vi.fn(async () => undefined),
+  runForegroundSessionEndCleanup: vi.fn(async () => undefined),
+}));
+const processIdentity = vi.hoisted(() => ({
+  getProcessStartIdentity: vi.fn(async () => 'test-process-start'),
+  isProcessIdentityLive: vi.fn(async () => 'dead' as const),
+}));
+
+vi.mock('../index.js', () => actions);
+vi.mock('../../../platform/process-utils.js', () => processIdentity);
+vi.mock('../action-runner.js', () => ({
+  runSessionEndAction: vi.fn(async (_context: unknown, execute: () => Promise<void>) => {
+    await execute();
+    return { code: 'completed', completed: true };
+  }),
+}));
+
+import { prepareCoreManifest, readSessionEndJob, sealCoreManifest, sealWikiManifest } from '../cleanup-manifest.js';
+import { processSessionEndWorker, reconcileSessionEndJobs } from '../worker.js';
+
+const directories: string[] = [];
+
+function project(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'omc-session-end-worker-'));
+  directories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  processIdentity.getProcessStartIdentity.mockResolvedValue('test-process-start');
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('SessionEnd durable worker', () => {
+  it('concurrent workers execute each action at most once and leave a recoverable manifest', async () => {
+    const directory = project();
+    const sessionId = 'two-workers';
+    expect(prepareCoreManifest(directory, sessionId, { initialTeamNames: [] })).not.toBeNull();
+    expect(sealCoreManifest(directory, sessionId)).not.toBeNull();
+    expect(sealWikiManifest(directory, sessionId)).not.toBeNull();
+
+    await Promise.all([
+      processSessionEndWorker({ directory, sessionId }),
+      processSessionEndWorker({ directory, sessionId }),
+    ]);
+
+    const manifest = readSessionEndJob(directory, sessionId)!;
+    expect(manifest.owner).toBeNull();
+    expect(manifest.phase).toBe('complete');
+    expect(manifest.actions['wiki-capture']).toMatchObject({ status: 'completed', attempts: 0 });
+    for (const [name, action] of Object.entries(manifest.actions)) {
+      if (name === 'wiki-capture') continue;
+      expect(action).toMatchObject({ status: 'completed', attempts: 1, runner: { phase: 'terminal' } });
+    }
+    expect(actions.cleanupSessionOwnedTeams).toHaveBeenCalledTimes(1);
+    expect(actions.cleanupSessionPython).toHaveBeenCalledTimes(1);
+    expect(actions.cleanupSessionReplies).toHaveBeenCalledTimes(1);
+    expect(actions.runSessionEndCallbacks).toHaveBeenCalledTimes(1);
+    expect(actions.runSessionEndNotifications).toHaveBeenCalledTimes(1);
+    expect(actions.runSessionEndOpenClaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not take ownership when a process identity cannot be established', async () => {
+    const directory = project();
+    const sessionId = 'identity-unavailable';
+    expect(prepareCoreManifest(directory, sessionId, {})).not.toBeNull();
+    expect(sealCoreManifest(directory, sessionId)).not.toBeNull();
+    processIdentity.getProcessStartIdentity.mockResolvedValueOnce(null as never);
+
+    await processSessionEndWorker({ directory, sessionId });
+
+    expect(readSessionEndJob(directory, sessionId)).toMatchObject({ owner: null, phase: 'ready' });
+  });
+
+  it('starts bounded durable-ticket recovery without relying on a caller-supplied directory slice', () => {
+    const directory = project();
+    for (let index = 0; index < 6; index++) {
+      const sessionId = `recovery-${index}`;
+      expect(prepareCoreManifest(directory, sessionId, {})).not.toBeNull();
+      expect(sealCoreManifest(directory, sessionId)).not.toBeNull();
+    }
+
+    // The no-ID entry point must discover from the durable ticket index and return immediately.
+    expect(() => reconcileSessionEndJobs(directory)).not.toThrow();
+  });
+});

--- a/src/hooks/session-end/action-runner.ts
+++ b/src/hooks/session-end/action-runner.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import type { SessionEndActionName, SessionEndActionState, SessionEndJobV1 } from './cleanup-manifest.js';
+import { getProcessStartIdentity, killProcessTree } from '../../platform/process-utils.js';
+import { markSessionEndActionRunner, readSessionEndJob } from './cleanup-manifest.js';
+import { getOmcRoot } from '../../lib/worktree-paths.js';
+
+const RUNNER_ARG = '--omc-session-end-action-runner';
+export interface ActionRunContext { directory: string; sessionId: string; job: SessionEndJobV1; actionName: SessionEndActionName; action: SessionEndActionState; ownerNonce: string; runnerNonce: string; deadlineAt: number; }
+export interface ActionRunResult { code: string; completed: boolean; }
+function runDirectory(context: ActionRunContext): string { return path.join(getOmcRoot(context.directory), 'state', 'session-end-jobs', 'runs', context.job.jobId, context.actionName, String(context.action.attempts), context.runnerNonce); }
+
+/** Each deferred action runs in its own detached process group. The manifest remains the only authority for claim/result transitions. */
+export async function runSessionEndAction(context: ActionRunContext, _execute: () => Promise<void>): Promise<ActionRunResult> {
+  const runPath = runDirectory(context);
+  try {
+    fs.mkdirSync(runPath, { recursive: true });
+    if (Date.now() >= context.deadlineAt) return { code: 'deadline-before-arm', completed: false };
+    const childInput = { directory: context.directory, sessionId: context.sessionId, jobId: context.job.jobId, actionName: context.actionName, attempt: context.action.attempts, ownerNonce: context.ownerNonce, runnerNonce: context.runnerNonce, runPath, deadlineAt: context.deadlineAt };
+    const child = spawn(process.execPath, [fileURLToPath(import.meta.url), RUNNER_ARG, JSON.stringify(childInput)], { detached: true, stdio: 'ignore', windowsHide: true, env: process.env });
+    const identity = await getProcessStartIdentity(child.pid!, context.deadlineAt);
+    if (!identity) { await killProcessTree(child.pid!, 'SIGKILL'); return { code: 'runner-identity-unavailable', completed: false }; }
+    atomicWriteJsonSync(path.join(runPath, 'control.json'), { jobId: context.job.jobId, action: context.actionName, attempt: context.action.attempts, runnerNonce: context.runnerNonce, ownerNonce: context.ownerNonce, runner: { pid: child.pid, processStartIdentity: identity }, deadlineAt: new Date(context.deadlineAt).toISOString(), idempotencyKey: context.action.idempotencyKey });
+    atomicWriteJsonSync(path.join(runPath, 'arm.json'), { runnerNonce: context.runnerNonce, ownerNonce: context.ownerNonce, armedAt: new Date().toISOString() });
+    if (!markSessionEndActionRunner(context.directory, context.sessionId, context.ownerNonce, context.actionName, context.runnerNonce, 'armed')) { await killProcessTree(child.pid!, 'SIGKILL'); return { code: 'runner-claim-lost', completed: false }; }
+    const code = await new Promise<number | null>((resolve) => {
+      const timeout = setTimeout(() => { void killProcessTree(child.pid!, 'SIGKILL'); resolve(null); }, Math.max(1, context.deadlineAt - Date.now()));
+      child.once('exit', (exitCode) => { clearTimeout(timeout); resolve(exitCode); });
+      child.once('error', () => { clearTimeout(timeout); resolve(null); });
+    });
+    const completed = code === 0;
+    atomicWriteJsonSync(path.join(runPath, 'result.json'), { code: completed ? 'completed' : code === null ? 'runner-deadline' : `runner-exit-${code}`, completedAt: new Date().toISOString() });
+    return { code: completed ? 'completed' : code === null ? 'runner-deadline' : `runner-exit-${code}`, completed };
+  } catch (error) {
+    const code = error instanceof Error ? error.name || 'action-failed' : 'action-failed';
+    try { atomicWriteJsonSync(path.join(runPath, 'result.json'), { code, retryable: true, recordedAt: new Date().toISOString() }); } catch { /* manifest retains retry authority */ }
+    return { code, completed: false };
+  }
+}
+
+async function runActionRunnerEntrypoint(): Promise<void> {
+  const runnerIndex = process.argv.indexOf(RUNNER_ARG);
+  if (runnerIndex < 0) return;
+  try {
+    const input = JSON.parse(process.argv[runnerIndex + 1] ?? '') as { directory: string; sessionId: string; jobId: string; actionName: SessionEndActionName; attempt: number; ownerNonce: string; runnerNonce: string; runPath: string; deadlineAt: number };
+    while (Date.now() < input.deadlineAt) {
+      let armed = false;
+      try {
+        const arm = JSON.parse(fs.readFileSync(path.join(input.runPath, 'arm.json'), 'utf8')) as { runnerNonce?: string; ownerNonce?: string };
+        const job = readSessionEndJob(input.directory, input.sessionId);
+        const action = job?.actions[input.actionName];
+        armed = job?.jobId === input.jobId && job.owner?.nonce === input.ownerNonce && action?.status === 'claimed' && action.attempts === input.attempt && action.claimantNonce === input.ownerNonce && action.runner?.runnerNonce === input.runnerNonce && action.runner.phase === 'armed' && arm.runnerNonce === input.runnerNonce && arm.ownerNonce === input.ownerNonce;
+      } catch { /* publication is not complete yet */ }
+      if (armed) break;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    if (Date.now() >= input.deadlineAt) throw new Error('runner-arm-deadline');
+    const deadlineTimer = setTimeout(() => { process.exitCode = 124; process.exit(); }, Math.max(1, input.deadlineAt - Date.now()));
+    deadlineTimer.unref();
+    const { executeSessionEndAction } = await import('./worker.js');
+    await executeSessionEndAction(input.actionName, { directory: input.directory, sessionId: input.sessionId }, input.deadlineAt);
+    clearTimeout(deadlineTimer);
+    process.exitCode = 0;
+  } catch {
+    process.exitCode = 1;
+  }
+}
+void runActionRunnerEntrypoint();

--- a/src/hooks/session-end/action-watchdog.ts
+++ b/src/hooks/session-end/action-watchdog.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import { getOmcRoot } from '../../lib/worktree-paths.js';
+
+export interface SessionEndWatchdogControl { directory: string; jobId: string; action: string; attempt: number; runnerNonce: string; deadlineAt: number; }
+/** Durable deadline evidence names the detached action runner from its control record when available. */
+export function armSessionEndActionWatchdog(control: SessionEndWatchdogControl): () => void {
+  const runPath = path.join(getOmcRoot(control.directory), 'state', 'session-end-jobs', 'runs', control.jobId, control.action, String(control.attempt), control.runnerNonce);
+  const recordPath = path.join(runPath, 'watchdog.json');
+  let runner: unknown = { pid: process.pid, processStartIdentity: 'watchdog-parent' };
+  try { runner = JSON.parse(fs.readFileSync(path.join(runPath, 'control.json'), 'utf8')).runner ?? runner; } catch { /* runner control may race arm; manifest claim is authoritative */ }
+  try { fs.mkdirSync(path.dirname(recordPath), { recursive: true }); atomicWriteJsonSync(recordPath, { runner, startedAt: new Date().toISOString(), deadlineAt: new Date(control.deadlineAt).toISOString(), state: 'armed' }); } catch { return () => undefined; }
+  const timer = setTimeout(() => { try { atomicWriteJsonSync(recordPath, { runner, expiredAt: new Date().toISOString(), state: 'deadline-expired' }); } catch { /* manifest retry handles failures */ } }, Math.max(0, control.deadlineAt - Date.now()));
+  timer.unref();
+  return () => { clearTimeout(timer); try { atomicWriteJsonSync(recordPath, { runner, stoppedAt: new Date().toISOString(), state: 'terminal' }); } catch { /* best effort evidence only */ } };
+}

--- a/src/hooks/session-end/callbacks.ts
+++ b/src/hooks/session-end/callbacks.ts
@@ -43,243 +43,182 @@ export function formatSessionSummary(metrics: SessionMetrics, format: 'markdown'
 
 export interface TriggerStopCallbacksOptions {
   skipPlatforms?: Array<'file' | 'telegram' | 'discord'>;
+  /** Stable manifest action key for retries of a local callback write. */
+  idempotencyKey?: string;
+}
+
+
+export interface SessionEndDeferredAction {
+  name: string;
+  class: 'required' | 'best-effort';
+  payload: Record<string, unknown>;
+  budgetMs: number;
+  /** Stable durable action identity, when provided by the manifest worker. */
+  idempotencyKey?: string;
+}
+
+
+export interface SessionEndActionContext {
+  directory: string;
+  sessionId: string;
+  transcriptPath: string;
+  metrics: SessionMetrics;
+  input: { session_id: string; cwd: string };
+  deadlineAt: string;
+  action: SessionEndDeferredAction;
+}
+
+export interface SessionEndActionOutcome {
+  status: 'completed' | 'skipped' | 'failed' | 'deadline-exceeded';
+  detail?: string;
 }
 
 function normalizeDiscordTagList(tagList?: string[]): string[] {
-  if (!tagList || tagList.length === 0) {
-    return [];
-  }
-
-  return tagList
-    .map((tag) => tag.trim())
-    .filter((tag) => tag.length > 0)
-    .map((tag) => {
-      if (tag === '@here' || tag === '@everyone') {
-        return tag;
-      }
-
-      const roleMatch = tag.match(/^role:(\d+)$/);
-      if (roleMatch) {
-        return `<@&${roleMatch[1]}>`;
-      }
-
-      if (/^\d+$/.test(tag)) {
-        return `<@${tag}>`;
-      }
-
-      return tag;
-    });
+  return (tagList ?? []).map((tag) => tag.trim()).filter(Boolean).map((tag) => {
+    if (tag === '@here' || tag === '@everyone') return tag;
+    const roleMatch = tag.match(/^role:(\d+)$/);
+    if (roleMatch) return `<@&${roleMatch[1]}>`;
+    return /^\d+$/.test(tag) ? `<@${tag}>` : tag;
+  });
 }
 
 function normalizeTelegramTagList(tagList?: string[]): string[] {
-  if (!tagList || tagList.length === 0) {
-    return [];
-  }
-
-  return tagList
-    .map((tag) => tag.trim())
-    .filter((tag) => tag.length > 0)
-    .map((tag) => tag.startsWith('@') ? tag : `@${tag}`);
+  return (tagList ?? []).map((tag) => tag.trim()).filter(Boolean).map((tag) => tag.startsWith('@') ? tag : `@${tag}`);
 }
 
 function prefixMessageWithTags(message: string, tags: string[]): string {
-  if (tags.length === 0) {
-    return message;
-  }
-
-  return `${tags.join(' ')}\n${message}`;
+  return tags.length === 0 ? message : `${tags.join(' ')}\n${message}`;
 }
 
-/**
- * Interpolate path placeholders
- */
-export function interpolatePath(pathTemplate: string, sessionId: string): string {
+/** Interpolate path placeholders. */
+export function interpolatePath(pathTemplate: string, sessionId: string, idempotencyKey?: string): string {
   const now = new Date();
-  const date = now.toISOString().split('T')[0]; // YYYY-MM-DD
-  const time = now.toISOString().split('T')[1].split('.')[0].replace(/:/g, '-'); // HH-MM-SS
-
-  // Sanitize session_id: remove path separators and traversal sequences
+  const date = now.toISOString().split('T')[0];
+  const time = now.toISOString().split('T')[1].split('.')[0].replace(/:/g, '-');
   const safeSessionId = sessionId.replace(/[/\\..]/g, '_');
-
-  return normalize(pathTemplate
-    .replace(/~/g, homedir())
-    .replace(/\{session_id\}/g, safeSessionId)
-    .replace(/\{date\}/g, date)
-    .replace(/\{time\}/g, time));
+  const safeIdempotencyKey = (idempotencyKey ?? '').replace(/[^A-Za-z0-9_-]/g, '_');
+  return normalize(pathTemplate.replace(/~/g, homedir()).replace(/\{session_id\}/g, safeSessionId).replace(/\{idempotency_key\}/g, safeIdempotencyKey).replace(/\{date\}/g, date).replace(/\{time\}/g, time));
 }
 
+
 /**
- * File system callback - write session summary to file
+ * A file target containing `{idempotency_key}` converges retries to one path.
+ * Other file targets retain their configured overwrite semantics.
  */
-async function writeToFile(
-  config: StopCallbackFileConfig,
-  content: string,
-  sessionId: string
-): Promise<void> {
-  try {
-    const resolvedPath = interpolatePath(config.path, sessionId);
-    const dir = dirname(resolvedPath);
-
-    // Ensure directory exists
-    mkdirSync(dir, { recursive: true });
-
-    // Write file with restricted permissions (owner read/write only)
-    writeFileSync(resolvedPath, content, { encoding: 'utf-8', mode: 0o600 });
-    console.log(`[stop-callback] Session summary written to ${resolvedPath}`);
-  } catch (error) {
-    console.error('[stop-callback] File write failed:', error);
-    // Don't throw - callback failures shouldn't block session end
-  }
+async function writeToFile(config: StopCallbackFileConfig, content: string, sessionId: string, idempotencyKey?: string): Promise<void> {
+  const resolvedPath = interpolatePath(config.path, sessionId, idempotencyKey);
+  mkdirSync(dirname(resolvedPath), { recursive: true });
+  writeFileSync(resolvedPath, content, { encoding: 'utf-8', mode: 0o600 });
 }
 
+
 /**
- * Telegram callback - send notification via Telegram bot
+ * Remote callback delivery is explicitly at-least-once: after remote
+ * acceptance but before a response, a retry may send a duplicate.
  */
-async function sendTelegram(
-  config: StopCallbackTelegramConfig,
-  message: string
-): Promise<void> {
-  if (!config.botToken || !config.chatId) {
-    console.error('[stop-callback] Telegram: missing botToken or chatId');
-    return;
-  }
-
-  // Validate bot token format (digits:alphanumeric)
-  if (!/^[0-9]+:[A-Za-z0-9_-]+$/.test(config.botToken)) {
-    console.error('[stop-callback] Telegram: invalid bot token format');
-    return;
-  }
-
-  try {
-    const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: config.chatId,
-        text: message,
-        parse_mode: 'Markdown',
-      }),
-      signal: AbortSignal.timeout(10000),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Telegram API error: ${response.status} - ${response.statusText}`);
-    }
-
-    console.log('[stop-callback] Telegram notification sent');
-  } catch (error) {
-    // Don't log full error details which might contain the bot token
-    console.error('[stop-callback] Telegram send failed:', error instanceof Error ? error.message : 'Unknown error');
-    // Don't throw - callback failures shouldn't block session end
-  }
+async function sendTelegram(config: StopCallbackTelegramConfig, message: string, signal: AbortSignal, _idempotencyKey?: string): Promise<void> {
+  if (!config.botToken || !config.chatId || !/^[0-9]+:[A-Za-z0-9_-]+$/.test(config.botToken)) return;
+  const response = await fetch(`https://api.telegram.org/bot${config.botToken}/sendMessage`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ chat_id: config.chatId, text: message, parse_mode: 'Markdown' }), signal });
+  if (!response.ok) throw new Error(`Telegram API error: ${response.status}`);
 }
 
-/**
- * Discord callback - send notification via Discord webhook
- */
-async function sendDiscord(
-  config: StopCallbackDiscordConfig,
-  message: string
-): Promise<void> {
-  if (!config.webhookUrl) {
-    console.error('[stop-callback] Discord: missing webhookUrl');
-    return;
-  }
-
-  // Validate Discord webhook URL
-  try {
-    const url = new URL(config.webhookUrl);
-    const allowedHosts = ['discord.com', 'discordapp.com'];
-    if (!allowedHosts.some(host => url.hostname === host || url.hostname.endsWith(`.${host}`))) {
-      console.error('[stop-callback] Discord: webhook URL must be from discord.com or discordapp.com');
-      return;
-    }
-    if (url.protocol !== 'https:') {
-      console.error('[stop-callback] Discord: webhook URL must use HTTPS');
-      return;
-    }
-  } catch {
-    console.error('[stop-callback] Discord: invalid webhook URL');
-    return;
-  }
-
-  try {
-    const response = await fetch(config.webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        content: message,
-      }),
-      signal: AbortSignal.timeout(10000),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Discord webhook error: ${response.status} - ${response.statusText}`);
-    }
-
-    console.log('[stop-callback] Discord notification sent');
-  } catch (error) {
-    console.error('[stop-callback] Discord send failed:', error instanceof Error ? error.message : 'Unknown error');
-    // Don't throw - callback failures shouldn't block session end
-  }
+/** See sendTelegram: Discord webhooks have the same at-least-once boundary. */
+async function sendDiscord(config: StopCallbackDiscordConfig, message: string, signal: AbortSignal, _idempotencyKey?: string): Promise<void> {
+  if (!config.webhookUrl) return;
+  const url = new URL(config.webhookUrl);
+  const allowed = ['discord.com', 'discordapp.com'];
+  if (url.protocol !== 'https:' || !allowed.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`))) return;
+  const response = await fetch(config.webhookUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: message }), signal });
+  if (!response.ok) throw new Error(`Discord webhook error: ${response.status}`);
 }
 
-/**
- * Main callback trigger - called from session-end hook
- *
- * Executes all enabled callbacks in parallel with a timeout.
- * Failures in individual callbacks don't block session end.
- */
+
+async function runLegacyCallbacks(metrics: SessionMetrics, options: TriggerStopCallbacksOptions, signal: AbortSignal): Promise<void> {
+  const callbacks = getOMCConfig().stopHookCallbacks;
+  if (!callbacks) return;
+  const skipPlatforms = new Set(options.skipPlatforms ?? []);
+  const idempotencyKey = options.idempotencyKey ?? `session-end:${metrics.session_id}:legacy-callback`;
+  const work: Promise<void>[] = [];
+  if (!skipPlatforms.has('file') && callbacks.file?.enabled && callbacks.file.path) work.push(writeToFile(callbacks.file, formatSessionSummary(metrics, callbacks.file.format || 'markdown'), metrics.session_id, idempotencyKey));
+  if (!skipPlatforms.has('telegram') && callbacks.telegram?.enabled) work.push(sendTelegram(callbacks.telegram, prefixMessageWithTags(formatSessionSummary(metrics), normalizeTelegramTagList(callbacks.telegram.tagList)), signal, idempotencyKey));
+  if (!skipPlatforms.has('discord') && callbacks.discord?.enabled) work.push(sendDiscord(callbacks.discord, prefixMessageWithTags(formatSessionSummary(metrics), normalizeDiscordTagList(callbacks.discord.tagList)), signal, idempotencyKey));
+  await Promise.all(work);
+}
+
+/** Backward-compatible callback entry point used by existing callers and tests. */
 export async function triggerStopCallbacks(
   metrics: SessionMetrics,
   _input: { session_id: string; cwd: string },
-  options: TriggerStopCallbacksOptions = {}
+  options: TriggerStopCallbacksOptions = {},
 ): Promise<void> {
-  const config = getOMCConfig();
-  const callbacks = config.stopHookCallbacks;
-  const skipPlatforms = new Set(options.skipPlatforms ?? []);
-
-  if (!callbacks) {
-    return; // No callbacks configured
-  }
-
-  // Execute all enabled callbacks (non-blocking)
-  const promises: Promise<void>[] = [];
-
-  if (!skipPlatforms.has('file') && callbacks.file?.enabled && callbacks.file.path) {
-    const format = callbacks.file.format || 'markdown';
-    const summary = formatSessionSummary(metrics, format);
-    promises.push(writeToFile(callbacks.file, summary, metrics.session_id));
-  }
-
-  if (!skipPlatforms.has('telegram') && callbacks.telegram?.enabled) {
-    const summary = formatSessionSummary(metrics, 'markdown');
-    const tags = normalizeTelegramTagList(callbacks.telegram.tagList);
-    const message = prefixMessageWithTags(summary, tags);
-    promises.push(sendTelegram(callbacks.telegram, message));
-  }
-
-  if (!skipPlatforms.has('discord') && callbacks.discord?.enabled) {
-    const summary = formatSessionSummary(metrics, 'markdown');
-    const tags = normalizeDiscordTagList(callbacks.discord.tagList);
-    const message = prefixMessageWithTags(summary, tags);
-    promises.push(sendDiscord(callbacks.discord, message));
-  }
-
-  if (promises.length === 0) {
-    return; // No enabled callbacks
-  }
-
-  // Wait for all callbacks with a 5-second timeout
-  // This ensures callbacks don't block session end indefinitely
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
   try {
-    await Promise.race([
-      Promise.allSettled(promises),
-      new Promise<void>((resolve) => setTimeout(resolve, 5000)),
-    ]);
+    await runLegacyCallbacks(metrics, options, controller.signal);
   } catch (error) {
-    // Swallow any errors - callbacks should never block session end
-    console.error('[stop-callback] Callback execution error:', error);
+    console.error('[stop-callback] Callback failed:', error instanceof Error ? error.message : 'Unknown error');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stringList(value: unknown): Array<'file' | 'telegram' | 'discord'> {
+  return Array.isArray(value) ? value.filter((item): item is 'file' | 'telegram' | 'discord' => item === 'file' || item === 'telegram' || item === 'discord') : [];
+}
+
+async function runWithinDeadline<T>(deadlineAt: number, run: (signal: AbortSignal) => Promise<T>): Promise<T | undefined> {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) return undefined;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([run(controller.signal), new Promise<undefined>((resolve) => {
+      timer = setTimeout(() => { controller.abort(); resolve(undefined); }, remaining);
+    })]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Executes deferred actions only after the manifest worker has armed them. */
+export async function runSessionEndDeferredAction(action: SessionEndDeferredAction, context: SessionEndActionContext): Promise<SessionEndActionOutcome> {
+  const manifestDeadline = Date.parse(context.deadlineAt);
+  const deadlineAt = Math.min(Number.isFinite(manifestDeadline) ? manifestDeadline : Date.now(), Date.now() + Math.max(0, action.budgetMs));
+  if (deadlineAt <= Date.now()) return { status: 'deadline-exceeded' };
+
+  try {
+    const result = await runWithinDeadline(deadlineAt, async (signal) => {
+      switch (action.name) {
+        case 'legacy-callback':
+          await runLegacyCallbacks(context.metrics, {
+            skipPlatforms: stringList(action.payload.skipPlatforms),
+            idempotencyKey: action.idempotencyKey,
+          }, signal);
+          return 'completed' as const;
+        // Notification transports are at-least-once; acceptance can precede an
+        // unavailable response, so a durable retry may notify again.
+
+        case 'notification': {
+          const { notify } = await import('../../notifications/index.js');
+          const result = await notify('session-end', { sessionId: context.sessionId, projectPath: context.directory, durationMs: context.metrics.duration_ms, agentsSpawned: context.metrics.agents_spawned, agentsCompleted: context.metrics.agents_completed, modesUsed: context.metrics.modes_used, reason: context.metrics.reason, timestamp: context.metrics.ended_at, profileName: typeof action.payload.profileName === 'string' ? action.payload.profileName : undefined });
+          if (!result?.anySuccess) throw new Error('notification-not-accepted');
+          return 'completed' as const;
+        }
+        // OpenClaw wake is at-least-once for the same acceptance-before-result
+        // ambiguity; callers must tolerate duplicate wake requests.
+        case 'openclaw-wake': {
+          if (action.payload.enabled !== true || process.env.OMC_OPENCLAW !== '1') return 'skipped' as const;
+          const { wakeOpenClaw } = await import('../../openclaw/index.js');
+          const result = await wakeOpenClaw('session-end', { sessionId: context.sessionId, projectPath: context.directory, reason: typeof action.payload.reason === 'string' ? action.payload.reason : context.metrics.reason });
+          if (!result?.success) throw new Error('openclaw-wake-not-accepted');
+          return 'completed' as const;
+        }
+        default:
+          return 'skipped' as const;
+      }
+    });
+    return result === undefined ? { status: 'deadline-exceeded' } : { status: result };
+  } catch (error) {
+    return { status: 'failed', detail: error instanceof Error ? error.message : 'Unknown action failure' };
   }
 }

--- a/src/hooks/session-end/cleanup-manifest.ts
+++ b/src/hooks/session-end/cleanup-manifest.ts
@@ -1,0 +1,241 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import { getOmcRoot, validateSessionId } from '../../lib/worktree-paths.js';
+
+export type SessionEndActionName = 'foreground-cleanup' | 'wiki-capture' | 'team-cleanup' | 'python-cleanup' | 'reply-cleanup' | 'callback' | 'notification' | 'openclaw';
+export type ActionStatus = 'pending' | 'claimed' | 'retryable' | 'completed' | 'expired';
+
+export interface SessionEndActionState {
+  class: 'required' | 'best-effort'; phase: 'deferred-required' | 'deferred-best-effort'; status: ActionStatus;
+  attempts: number; idempotencyKey: string; payload: Record<string, unknown>; budgetMs: number;
+  claimantNonce?: string; claimedAt?: string;
+  runner?: { attempt: number; runnerNonce: string; phase: 'reserved' | 'started' | 'armed' | 'result-recorded' | 'terminal'; deadlineAt: string };
+  lastOutcomeCode?: string; completedAt?: string;
+}
+export interface ProducerSlot { state: 'absent' | 'prepared' | 'sealed' | 'no-op'; intentKey?: string; payloadDigest?: string; sealedAt?: string; sealedBy?: 'foreground' | 'recovery' | 'wiki-producer'; }
+export interface WorkerOwner { nonce: string; pid: number; processStartIdentity: string; claimedAt: string; heartbeatAt: string; leaseExpiresAt: string; runDeadlineAt: string; leaseGeneration: number; claimedFromRevision: number; }
+export interface SessionEndJobV1 {
+  version: 1; jobId: string; sessionId: string; scopeKey: string; revision: number; createdAt: string; updatedAt: string;
+  producerGraceExpiresAt: string; bestEffortDeadlineAt: string; producers: { core: ProducerSlot; wiki: ProducerSlot };
+  actions: Record<SessionEndActionName, SessionEndActionState>; owner: WorkerOwner | null;
+  phase: 'collecting' | 'ready' | 'processing' | 'recoverable-failure' | 'complete';
+  completion?: { completedAt: string; terminalDigest: string; terminalRevision: number };
+}
+
+const ACTIONS: Array<[SessionEndActionName, 'required' | 'best-effort']> = [
+  ['foreground-cleanup', 'required'], ['wiki-capture', 'required'], ['team-cleanup', 'required'], ['python-cleanup', 'required'], ['reply-cleanup', 'required'],
+  ['callback', 'best-effort'], ['notification', 'best-effort'], ['openclaw', 'best-effort'],
+];
+const LOCK_WAIT = new Int32Array(new SharedArrayBuffer(4));
+const DISCOVERY_FILE = 'discovery.json';
+export interface DiscoveryTicket { sessionId: string; claimNonce?: string; leaseExpiresAt?: string; attempts: number; retryAt: string; acknowledgedAt?: string; }
+interface DiscoveryIndex { version: 2; cursor: number; tickets: DiscoveryTicket[]; }
+
+export function sessionEndJobPath(directory: string, sessionId: string): string { validateSessionId(sessionId); return path.join(getOmcRoot(directory), 'state', 'session-end-jobs', `${sessionId}.json`); }
+export function sessionEndJobsDirectory(directory: string): string { return path.join(getOmcRoot(directory), 'state', 'session-end-jobs'); }
+function digest(value: unknown): string { return createHash('sha256').update(JSON.stringify(value)).digest('hex'); }
+function nowIso(): string { return new Date().toISOString(); }
+function lockPath(file: string): string { return `${file}.lock`; }
+interface ManifestLock { pid: number; processStartIdentity: string | null; nonce: string; createdAt: string; }
+function lockIsReclaimable(lock: string): boolean {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(lock, 'utf8')) as ManifestLock;
+    if (Number.isInteger(parsed.pid) && parsed.pid > 0) {
+      try {
+        process.kill(parsed.pid, 0);
+        if (parsed.processStartIdentity && process.platform === 'linux') { try { const stat = fs.readFileSync(`/proc/${parsed.pid}/stat`, 'utf8'); if ((stat.substring(stat.lastIndexOf(')') + 2).split(' ')[19] ?? '') !== parsed.processStartIdentity) return true; } catch { return true; } }
+        return false;
+      } catch { return true; }
+    }
+    return Date.now() - Date.parse(parsed.createdAt) > 30_000;
+  } catch { try { return Date.now() - fs.statSync(lock).mtimeMs > 30_000; } catch { return false; } }
+}
+function withLock<T>(file: string, body: () => T): T {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const lock = lockPath(file); const reclaim = `${lock}.reclaim`; let fd: number | undefined; const nonce = randomUUID();
+  for (let attempt = 0; attempt < 250; attempt++) {
+    try {
+      if (fs.existsSync(reclaim)) throw Object.assign(new Error('reclaim-in-progress'), { code: 'EEXIST' });
+      fd = fs.openSync(lock, 'wx');
+      let processStartIdentity: string | null = null; try { const stat = fs.readFileSync(`/proc/${process.pid}/stat`, 'utf8'); processStartIdentity = stat.substring(stat.lastIndexOf(')') + 2).split(' ')[19] ?? null; } catch { /* platform fallback retains nonce/timestamp bounded stale reclaim */ }
+      fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, processStartIdentity, nonce, createdAt: nowIso() }));
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (attempt > 20 && lockIsReclaimable(lock)) {
+        let reclaimFd: number | undefined;
+        try {
+          reclaimFd = fs.openSync(reclaim, 'wx');
+          if (lockIsReclaimable(lock)) fs.unlinkSync(lock);
+        } catch { /* another contender owns reclamation */ }
+        finally { if (reclaimFd !== undefined) { fs.closeSync(reclaimFd); try { fs.unlinkSync(reclaim); } catch { /* next contender observes absence */ } } }
+      }
+      Atomics.wait(LOCK_WAIT, 0, 0, Math.min(20, attempt + 1));
+    }
+  }
+  if (fd === undefined) throw new Error('session-end-manifest-lock-timeout');
+  try { return body(); } finally { fs.closeSync(fd); try { const holder = JSON.parse(fs.readFileSync(lock, 'utf8')) as ManifestLock; if (holder.nonce === nonce) fs.unlinkSync(lock); } catch { /* missing or replaced lock is not ours to remove */ } }
+}
+function readPath(jobPath: string): SessionEndJobV1 | null { try { return JSON.parse(fs.readFileSync(jobPath, 'utf8')) as SessionEndJobV1; } catch { return null; } }
+function discoveryPath(directory: string): string { return path.join(sessionEndJobsDirectory(directory), DISCOVERY_FILE); }
+function readIndex(file: string): DiscoveryIndex {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as Partial<DiscoveryIndex>;
+    if (parsed.version === 2 && Array.isArray(parsed.tickets)) return { version: 2, cursor: Number.isInteger(parsed.cursor) ? parsed.cursor! : 0, tickets: parsed.tickets.filter((ticket): ticket is DiscoveryTicket => !!ticket && typeof ticket.sessionId === 'string').map(ticket => ({ sessionId: ticket.sessionId, attempts: Number.isInteger(ticket.attempts) ? ticket.attempts : 0, retryAt: typeof ticket.retryAt === 'string' ? ticket.retryAt : nowIso(), claimNonce: ticket.claimNonce, leaseExpiresAt: ticket.leaseExpiresAt, acknowledgedAt: ticket.acknowledgedAt })) };
+  } catch { /* empty index */ }
+  return { version: 2, cursor: 0, tickets: [] };
+}
+function updateTicket(directory: string, sessionId: string, present: boolean): void {
+  const file = discoveryPath(directory);
+  withLock(file, () => {
+    const index = readIndex(file); const ticket = index.tickets.find(item => item.sessionId === sessionId);
+    if (!present) index.tickets = index.tickets.filter(item => item.sessionId !== sessionId);
+    else if (!ticket) index.tickets.push({ sessionId, attempts: 0, retryAt: nowIso() });
+    index.cursor = index.tickets.length === 0 ? 0 : index.cursor % index.tickets.length;
+    atomicWriteJsonSync(file, index);
+  });
+}
+function newAction(name: SessionEndActionName, actionClass: 'required' | 'best-effort', payload: Record<string, unknown>): SessionEndActionState { return { class: actionClass, phase: actionClass === 'required' ? 'deferred-required' : 'deferred-best-effort', status: 'pending', attempts: 0, idempotencyKey: digest([name, payload]), payload, budgetMs: actionClass === 'required' ? 9_000 : 2_000 }; }
+
+/** Terminality is solely a manifest property. Discovery tickets are deliberately excluded. */
+export function isManifestTerminal(job: SessionEndJobV1): boolean { return ['sealed', 'no-op'].includes(job.producers.core.state) && ['sealed', 'no-op'].includes(job.producers.wiki.state) && Object.values(job.actions).every((action) => action.class === 'required' ? action.status === 'completed' : action.status === 'completed' || action.status === 'expired') && job.owner === null && Object.values(job.actions).every((action) => !action.runner || action.runner.phase === 'terminal'); }
+export function readSessionEndJob(directory: string, sessionId: string): SessionEndJobV1 | null { try { return readPath(sessionEndJobPath(directory, sessionId)); } catch { return null; } }
+
+/** Locked expected-revision CAS with an exact post-write reread. */
+export function mutateSessionEndJob(directory: string, sessionId: string, expectedRevision: number, mutate: (job: SessionEndJobV1) => void): SessionEndJobV1 | null {
+  let terminal = false;
+  try {
+    const jobPath = sessionEndJobPath(directory, sessionId);
+    const result = withLock(jobPath, () => {
+      const current = readPath(jobPath);
+      if (!current || current.revision !== expectedRevision) return null;
+      mutate(current);
+      const next: SessionEndJobV1 = { ...current, revision: current.revision + 1, updatedAt: nowIso() };
+      if (isManifestTerminal(next) && next.phase !== 'complete') { next.phase = 'complete'; next.completion = { completedAt: next.updatedAt, terminalDigest: digest({ producers: next.producers, actions: next.actions }), terminalRevision: next.revision }; }
+      atomicWriteJsonSync(jobPath, next);
+      const reread = readPath(jobPath);
+      if (!reread || reread.revision !== next.revision || digest(reread) !== digest(next)) throw new Error('session-end-manifest-reread-mismatch');
+      terminal = reread.phase === 'complete';
+      return reread;
+    });
+    if (result && terminal) acknowledgeSessionEndDiscoveryTicket(directory, sessionId);
+    return result;
+  } catch { return null; }
+}
+function mutateLatest(directory: string, sessionId: string, mutate: (job: SessionEndJobV1) => void): SessionEndJobV1 | null { for (let i = 0; i < 8; i++) { const current = readSessionEndJob(directory, sessionId); if (!current) return null; const result = mutateSessionEndJob(directory, sessionId, current.revision, mutate); if (result) return result; } return null; }
+
+export function prepareCoreManifest(directory: string, sessionId: string, payload: Record<string, unknown>): SessionEndJobV1 | null {
+  let jobPath: string; try { jobPath = sessionEndJobPath(directory, sessionId); } catch { return null; }
+  try {
+    const result = withLock(jobPath, () => {
+      const existing = readPath(jobPath);
+      if (existing) {
+        if (existing.phase === 'complete' || existing.producers.core.state !== 'absent') return existing;
+        const next = { ...existing, producers: { ...existing.producers, core: { state: 'prepared' as const, intentKey: digest(payload), payloadDigest: digest(payload) } }, actions: { ...existing.actions }, revision: existing.revision + 1, updatedAt: nowIso() };
+        for (const [name, action] of Object.entries(next.actions)) if (name !== 'wiki-capture') action.payload = payload;
+        atomicWriteJsonSync(jobPath, next); const reread = readPath(jobPath); if (!reread || reread.revision !== next.revision) throw new Error('session-end-manifest-reread-mismatch'); return reread;
+      }
+      const now = nowIso(); const actions = Object.fromEntries(ACTIONS.map(([name, klass]) => [name, newAction(name, klass, payload)])) as SessionEndJobV1['actions'];
+      const job: SessionEndJobV1 = { version: 1, jobId: randomUUID(), sessionId, scopeKey: digest(directory), revision: 0, createdAt: now, updatedAt: now, producerGraceExpiresAt: new Date(Date.now() + 30_000).toISOString(), bestEffortDeadlineAt: new Date(Date.now() + 10_000).toISOString(), producers: { core: { state: 'prepared', intentKey: digest(payload), payloadDigest: digest(payload) }, wiki: { state: 'absent' } }, actions, owner: null, phase: 'collecting' };
+      atomicWriteJsonSync(jobPath, job); return readPath(jobPath);
+    });
+    if (result) updateTicket(directory, sessionId, true);
+    return result;
+  } catch { return null; }
+}
+/** Foreground cleanup is idempotent local work; its durable result is the prerequisite for producer-grace sealing. */
+export function completeForegroundCleanup(directory: string, sessionId: string, outcome: Record<string, unknown>): SessionEndJobV1 | null {
+  return mutateLatest(directory, sessionId, job => {
+    const action = job.actions['foreground-cleanup'];
+    if (action.status === 'completed') return;
+    if (action.status !== 'pending' && action.status !== 'retryable') throw new Error('foreground-cleanup-conflict');
+    action.status = 'completed'; action.completedAt = nowIso(); action.lastOutcomeCode = 'completed'; action.payload = { ...action.payload, foregroundResult: outcome };
+  });
+}
+export function completeForegroundCleanupAndSealCore(
+  directory: string,
+  sessionId: string,
+  outcome: Record<string, unknown>,
+): SessionEndJobV1 | null {
+  return mutateLatest(directory, sessionId, (job) => {
+    const action = job.actions['foreground-cleanup'];
+    if (action.status !== 'completed') {
+      if (action.status !== 'pending' && action.status !== 'retryable') throw new Error('foreground-cleanup-conflict');
+      action.status = 'completed';
+      action.completedAt = nowIso();
+      action.lastOutcomeCode = 'completed';
+      action.payload = { ...action.payload, foregroundResult: outcome };
+    }
+    if (job.phase !== 'complete' && job.producers.core.state !== 'sealed') {
+      job.producers.core = { ...job.producers.core, state: 'sealed', sealedAt: nowIso(), sealedBy: 'foreground' };
+      if (job.phase === 'collecting') job.phase = 'ready';
+    }
+  });
+}
+export function sealCoreManifest(directory: string, sessionId: string): SessionEndJobV1 | null { return mutateLatest(directory, sessionId, (job) => { if (job.phase !== 'complete' && job.producers.core.state !== 'sealed') { job.producers.core = { ...job.producers.core, state: 'sealed', sealedAt: nowIso(), sealedBy: 'foreground' }; if (job.phase === 'collecting') job.phase = 'ready'; } }); }
+export function sealWikiManifest(directory: string, sessionId: string, payload?: Record<string, unknown>): SessionEndJobV1 | null {
+  let jobPath: string; try { jobPath = sessionEndJobPath(directory, sessionId); } catch { return null; }
+  try {
+    const result = withLock(jobPath, () => {
+      const existing = readPath(jobPath);
+      if (!existing) {
+        const now = nowIso();
+        const actions = Object.fromEntries(ACTIONS.map(([name, klass]) => [name, newAction(name, klass, {})])) as SessionEndJobV1['actions'];
+        const wiki = payload ? { state: 'sealed' as const, intentKey: digest(payload), payloadDigest: digest(payload), sealedAt: now, sealedBy: 'wiki-producer' as const } : { state: 'no-op' as const, sealedAt: now, sealedBy: 'wiki-producer' as const };
+        if (payload) actions['wiki-capture'].payload = payload; else { actions['wiki-capture'].status = 'completed'; actions['wiki-capture'].completedAt = now; }
+        const job: SessionEndJobV1 = { version: 1, jobId: randomUUID(), sessionId, scopeKey: digest(directory), revision: 0, createdAt: now, updatedAt: now, producerGraceExpiresAt: new Date(Date.now() + 30_000).toISOString(), bestEffortDeadlineAt: new Date(Date.now() + 10_000).toISOString(), producers: { core: { state: 'absent' }, wiki }, actions, owner: null, phase: 'collecting' };
+        atomicWriteJsonSync(jobPath, job); return readPath(jobPath);
+      }
+      if (existing.phase === 'complete' || ['sealed', 'no-op'].includes(existing.producers.wiki.state)) return existing;
+      const now = nowIso(); const next = structuredClone(existing); next.revision++; next.updatedAt = now;
+      next.producers.wiki = payload ? { state: 'sealed', intentKey: digest(payload), payloadDigest: digest(payload), sealedAt: now, sealedBy: 'wiki-producer' } : { state: 'no-op', sealedAt: now, sealedBy: 'wiki-producer' };
+      if (payload) next.actions['wiki-capture'].payload = payload; else { next.actions['wiki-capture'].status = 'completed'; next.actions['wiki-capture'].completedAt = now; }
+      atomicWriteJsonSync(jobPath, next); return readPath(jobPath);
+    });
+    if (result) updateTicket(directory, sessionId, true);
+    return result;
+  } catch { return null; }
+}
+export function claimSessionEndJob(directory: string, sessionId: string, nonce: string, identity: string, deadlineAt: number): SessionEndJobV1 | null { const current = readSessionEndJob(directory, sessionId); if (!current) return null; const now = Date.now(); return mutateSessionEndJob(directory, sessionId, current.revision, (job) => { if (job.phase === 'complete' || job.owner) throw new Error('claim-conflict'); job.owner = { nonce, pid: process.pid, processStartIdentity: identity, claimedAt: nowIso(), heartbeatAt: nowIso(), leaseExpiresAt: new Date(Math.min(now + 750, deadlineAt)).toISOString(), runDeadlineAt: new Date(deadlineAt).toISOString(), leaseGeneration: 1, claimedFromRevision: job.revision }; job.phase = 'processing'; }); }
+export function renewSessionEndLease(directory: string, sessionId: string, nonce: string, generation: number, deadlineAt: number): SessionEndJobV1 | null { const current = readSessionEndJob(directory, sessionId); if (!current) return null; return mutateSessionEndJob(directory, sessionId, current.revision, (job) => { const owner = job.owner; if (!owner || owner.nonce !== nonce || owner.leaseGeneration !== generation) throw new Error('lease-conflict'); owner.leaseGeneration++; owner.heartbeatAt = nowIso(); owner.leaseExpiresAt = new Date(Math.min(Date.now() + 750, deadlineAt)).toISOString(); }); }
+/** Reaping is intentionally separate from a new claim. Caller must establish dead or PID-reused identity. */
+export function reapStaleSessionEndOwner(directory: string, sessionId: string, expectedNonce: string, expectedGeneration: number, liveness: 'dead' | 'mismatch'): SessionEndJobV1 | null { const current = readSessionEndJob(directory, sessionId); if (!current || Date.now() < Date.parse(current.owner?.leaseExpiresAt ?? '')) return null; return mutateSessionEndJob(directory, sessionId, current.revision, (job) => { if (!job.owner || job.owner.nonce !== expectedNonce || job.owner.leaseGeneration !== expectedGeneration || Date.now() < Date.parse(job.owner.leaseExpiresAt) || (liveness !== 'dead' && liveness !== 'mismatch')) throw new Error('reap-conflict'); if (Object.values(job.actions).some(action => action.status === 'claimed' && action.runner && action.runner.phase !== 'terminal' && Date.now() < Date.parse(action.runner.deadlineAt))) throw new Error('runner-still-bounded'); for (const action of Object.values(job.actions)) { if (action.status === 'claimed' && action.claimantNonce === expectedNonce) { action.status = 'retryable'; action.claimantNonce = undefined; action.lastOutcomeCode = 'owner-reaped'; if (action.runner) action.runner.phase = 'terminal'; } } job.owner = null; job.phase = 'recoverable-failure'; }); }
+export function releaseSessionEndJob(directory: string, sessionId: string, nonce: string, generation: number): SessionEndJobV1 | null { const current = readSessionEndJob(directory, sessionId); if (!current) return null; return mutateSessionEndJob(directory, sessionId, current.revision, (job) => { if (!job.owner || job.owner.nonce !== nonce || job.owner.leaseGeneration !== generation) throw new Error('release-conflict'); job.owner = null; if (job.phase !== 'complete') job.phase = 'recoverable-failure'; }); }
+export function updateSessionEndJob(directory: string, sessionId: string, expectedOwner: string, mutate: (job: SessionEndJobV1) => void): SessionEndJobV1 | null { const current = readSessionEndJob(directory, sessionId); if (!current) return null; return mutateSessionEndJob(directory, sessionId, current.revision, (job) => { if (job.owner?.nonce !== expectedOwner || job.phase === 'complete') throw new Error('owner-conflict'); mutate(job); }); }
+export function claimSessionEndAction(directory: string, sessionId: string, ownerNonce: string, name: SessionEndActionName, deadlineAt: number): SessionEndJobV1 | null { return updateSessionEndJob(directory, sessionId, ownerNonce, (job) => { const action = job.actions[name]; if (!action || !['pending', 'retryable'].includes(action.status) || action.claimantNonce) throw new Error('action-claim-conflict'); if (action.class === 'best-effort' && Date.now() >= Date.parse(job.bestEffortDeadlineAt)) { action.status = 'expired'; action.lastOutcomeCode = 'deadline-expired'; return; } action.status = 'claimed'; action.attempts++; action.claimantNonce = ownerNonce; action.claimedAt = nowIso(); action.runner = { attempt: action.attempts, runnerNonce: randomUUID(), phase: 'reserved', deadlineAt: new Date(deadlineAt).toISOString() }; }); }
+export function markSessionEndActionRunner(directory: string, sessionId: string, ownerNonce: string, name: SessionEndActionName, runnerNonce: string, phase: 'started' | 'armed' | 'result-recorded'): SessionEndJobV1 | null { return updateSessionEndJob(directory, sessionId, ownerNonce, (job) => { const action = job.actions[name]; if (action.status !== 'claimed' || action.runner?.runnerNonce !== runnerNonce) throw new Error('runner-phase-conflict'); action.runner.phase = phase; }); }
+export function finishSessionEndAction(directory: string, sessionId: string, ownerNonce: string, name: SessionEndActionName, runnerNonce: string, completed: boolean, code: string): SessionEndJobV1 | null { return updateSessionEndJob(directory, sessionId, ownerNonce, (job) => { const action = job.actions[name]; if (action.status !== 'claimed' || action.claimantNonce !== ownerNonce || action.runner?.runnerNonce !== runnerNonce) throw new Error('action-result-conflict'); action.status = completed ? 'completed' : 'retryable'; action.lastOutcomeCode = code; action.completedAt = completed ? nowIso() : undefined; action.claimantNonce = undefined; action.runner.phase = 'terminal'; }); }
+/** Claims fair durable discovery tickets. Completion acknowledgement is independent from manifest terminality. */
+export function claimSessionEndDiscoveryTickets(directory: string, limit = 4, leaseMs = 15_000): Array<{ sessionId: string; nonce: string }> {
+  try { const file = discoveryPath(directory); if (!fs.existsSync(file)) return []; return withLock(file, () => {
+    const index = readIndex(file); const now = Date.now(); const claimed: Array<{ sessionId: string; nonce: string }> = [];
+    for (let offset = 0; offset < index.tickets.length && claimed.length < Math.max(0, limit); offset++) {
+      const ticket = index.tickets[(index.cursor + offset) % index.tickets.length];
+      const leased = ticket.leaseExpiresAt && Date.parse(ticket.leaseExpiresAt) > now;
+      if (ticket.acknowledgedAt || leased || Date.parse(ticket.retryAt) > now) continue;
+      const nonce = randomUUID(); ticket.claimNonce = nonce; ticket.leaseExpiresAt = new Date(now + leaseMs).toISOString(); claimed.push({ sessionId: ticket.sessionId, nonce });
+    }
+    index.cursor = index.tickets.length ? (index.cursor + Math.max(1, claimed.length)) % index.tickets.length : 0; atomicWriteJsonSync(file, index); return claimed;
+  }); } catch { return []; }
+}
+export function releaseSessionEndDiscoveryTicket(directory: string, sessionId: string, nonce: string, spawned: boolean): void {
+  try { const file = discoveryPath(directory); withLock(file, () => { const index = readIndex(file); const ticket = index.tickets.find(item => item.sessionId === sessionId); if (!ticket || ticket.claimNonce !== nonce) return; ticket.claimNonce = undefined; ticket.leaseExpiresAt = undefined; if (!spawned) { ticket.attempts++; ticket.retryAt = new Date(Date.now() + Math.min(30_000, 250 * 2 ** Math.min(ticket.attempts, 7))).toISOString(); } else ticket.retryAt = nowIso(); atomicWriteJsonSync(file, index); }); } catch { /* recovery retries lease expiry */ }
+}
+export function acknowledgeSessionEndDiscoveryTicket(directory: string, sessionId: string): void { try { const file = discoveryPath(directory); withLock(file, () => { const index = readIndex(file); const ticket = index.tickets.find(item => item.sessionId === sessionId); if (!ticket) return; ticket.acknowledgedAt = nowIso(); ticket.claimNonce = undefined; ticket.leaseExpiresAt = undefined; atomicWriteJsonSync(file, index); }); } catch { /* terminal ticket remains safely rediscoverable */ } }
+/** Compatibility read-only page retained for callers that do not claim tickets. */
+export function takeSessionEndDiscoveryPage(directory: string, limit = 4): string[] { return claimSessionEndDiscoveryTickets(directory, limit).map(ticket => ticket.sessionId); }
+
+
+/** Recovery may seal a prepared core only after foreground cleanup has a durable completed result. */
+export function recoverPreparedCoreProducer(directory: string, sessionId: string): SessionEndJobV1 | null {
+  return mutateLatest(directory, sessionId, job => {
+    if (!['prepared', 'sealed'].includes(job.producers.core.state) || Date.now() < Date.parse(job.producerGraceExpiresAt)) return;
+    const foreground = job.actions['foreground-cleanup'];
+    if (foreground?.status !== 'completed') return;
+    if (job.producers.core.state === 'prepared') job.producers.core = { ...job.producers.core, state: 'sealed', sealedAt: nowIso(), sealedBy: 'recovery' };
+    if (job.producers.wiki.state === 'absent') job.producers.wiki = { state: 'no-op', sealedAt: nowIso(), sealedBy: 'recovery' };
+    if (job.phase === 'collecting') job.phase = 'ready';
+  });
+}

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -1,17 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as readline from 'readline';
-import { spawn as spawnChildProcess } from 'child_process';
-import { fileURLToPath } from 'url';
-import { triggerStopCallbacks } from './callbacks.js';
+import { runSessionEndDeferredAction } from './callbacks.js';
 import { getOMCConfig } from '../../features/auto-update.js';
 import { buildConfigFromEnv, getEnabledPlatforms, getNotificationConfig } from '../../notifications/config.js';
-import { notify } from '../../notifications/index.js';
 import type { NotificationPlatform } from '../../notifications/types.js';
 import { cleanupBridgeSessions } from '../../tools/python-repl/bridge-manager.js';
 import { resolveToWorktreeRoot, getOmcRoot, validateSessionId, isValidTranscriptPath, resolveSessionStatePath } from '../../lib/worktree-paths.js';
 import { SESSION_END_MODE_STATE_FILES, SESSION_METRICS_MODE_FILES } from '../../lib/mode-names.js';
 import { clearModeStateFile, readModeState } from '../../lib/mode-state-io.js';
+import { completeForegroundCleanup, completeForegroundCleanupAndSealCore, prepareCoreManifest, sealWikiManifest } from './cleanup-manifest.js';
+import { spawnSessionEndWorker } from './worker.js';
+import { buildWikiSessionEndCaptureIntent } from '../wiki/session-hooks.js';
 
 export interface SessionEndInput {
   session_id: string;
@@ -58,7 +58,6 @@ export interface SessionEndCleanupWorkerPayload {
   initialTeamNames?: string[];
 }
 
-const SESSION_END_CLEANUP_WORKER_ARG = '--omc-session-end-cleanup-worker';
 
 const SESSION_END_SAFE_TEAM_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
@@ -85,27 +84,6 @@ export function resolveSessionEndCleanupBudgetMs(env: NodeJS.ProcessEnv = proces
   return Math.min(Math.floor(parsed), MAX_SESSION_END_CLEANUP_BUDGET_MS);
 }
 
-function unrefDelay(ms: number): Promise<'timeout'> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => resolve('timeout'), ms);
-    if (typeof timer.unref === 'function') {
-      timer.unref();
-    }
-  });
-}
-
-function runSessionEndCleanupWithBudget(
-  budgetMs: number,
-  cleanup: () => Promise<unknown>,
-): Promise<void> {
-  const cleanupPromise = cleanup().catch(() => undefined);
-  if (budgetMs <= 0) {
-    return cleanupPromise.then(() => undefined);
-  }
-  return Promise.race([cleanupPromise, unrefDelay(budgetMs)])
-    .then(() => undefined)
-    .catch(() => undefined);
-}
 
 function hasExplicitNotificationConfig(profileName?: string): boolean {
   const config = getOMCConfig();
@@ -712,7 +690,7 @@ async function findSessionOwnedTeams(directory: string, sessionId: string): Prom
   return [...teamNames];
 }
 
-async function cleanupSessionOwnedTeams(
+export async function cleanupSessionOwnedTeams(
   directory: string,
   sessionId: string,
   initialTeamNames: string[] = [],
@@ -814,230 +792,105 @@ export function exportSessionSummary(directory: string, metrics: SessionMetrics)
 
 
 
-function splitPythonCleanupBudget(cleanupBudgetMs: number): { gracePeriodMs: number; sigtermGraceMs: number; finalWaitMs: number } {
-  const budget = Math.max(0, cleanupBudgetMs);
-  const gracePeriodMs = Math.min(500, Math.floor(budget * 0.4));
-  const sigtermGraceMs = Math.min(500, Math.floor(budget * 0.4));
-  const finalWaitMs = Math.min(250, Math.max(0, budget - gracePeriodMs - sigtermGraceMs));
-  return { gracePeriodMs, sigtermGraceMs, finalWaitMs };
-}
-
-function encodeCleanupWorkerPayload(payload: SessionEndCleanupWorkerPayload): string {
-  return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
-}
-
-function decodeCleanupWorkerPayload(encoded: string): SessionEndCleanupWorkerPayload | null {
-  try {
-    const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf-8')) as Partial<SessionEndCleanupWorkerPayload>;
-    if (
-      typeof parsed.directory !== 'string' ||
-      typeof parsed.sessionId !== 'string' ||
-      typeof parsed.transcriptPath !== 'string' ||
-      typeof parsed.cleanupBudgetMs !== 'number' ||
-      !Number.isFinite(parsed.cleanupBudgetMs) ||
-      (parsed.initialTeamNames !== undefined && !Array.isArray(parsed.initialTeamNames))
-    ) {
-      return null;
-    }
-    return {
-      directory: parsed.directory,
-      sessionId: parsed.sessionId,
-      transcriptPath: parsed.transcriptPath,
-      cleanupBudgetMs: parsed.cleanupBudgetMs,
-      initialTeamNames: parsed.initialTeamNames?.map(normalizeSessionEndTeamName).filter((value): value is string => value !== null),
-    };
-  } catch {
-    return null;
+export async function cleanupSessionPython(directory: string, sessionId: string): Promise<void> {
+  const manifest = prepareCoreManifest(directory, sessionId, {});
+  const transcriptPath = typeof manifest?.actions['python-cleanup'].payload.transcriptPath === 'string'
+    ? manifest.actions['python-cleanup'].payload.transcriptPath : '';
+  const sessionIds = await extractPythonReplSessionIdsFromTranscript(transcriptPath);
+  if (sessionIds.length > 0) {
+    await cleanupBridgeSessions(sessionIds, { gracePeriodMs: 500, sigtermGraceMs: 500, finalWaitMs: 250, parallel: true });
   }
 }
 
-function spawnSessionEndCleanupWorker(payload: SessionEndCleanupWorkerPayload): void {
-  try {
-    const child = spawnChildProcess(
-      process.execPath,
-      [fileURLToPath(import.meta.url), SESSION_END_CLEANUP_WORKER_ARG, encodeCleanupWorkerPayload(payload)],
-      {
-        detached: true,
-        stdio: 'ignore',
-        env: process.env,
-      },
-    );
-    child.unref();
-  } catch {
-    // SessionEnd must not fail if best-effort cleanup cannot be scheduled.
-  }
-}
-
+/** Compatibility export; durable ownership is handled by the manifest worker. */
 export async function processSessionEndCleanupWorker(payload: SessionEndCleanupWorkerPayload): Promise<void> {
-  const cleanupBudgetMs = Math.max(0, Math.min(payload.cleanupBudgetMs, MAX_SESSION_END_CLEANUP_BUDGET_MS));
-  const pythonCleanupBudget = splitPythonCleanupBudget(cleanupBudgetMs);
-
-  await Promise.allSettled([
-    runSessionEndCleanupWithBudget(cleanupBudgetMs, () =>
-      cleanupSessionOwnedTeams(payload.directory, payload.sessionId, payload.initialTeamNames),
-    ),
-    (async () => {
-      const pythonSessionIds = await extractPythonReplSessionIdsFromTranscript(payload.transcriptPath);
-      if (pythonSessionIds.length > 0) {
-        await cleanupBridgeSessions(pythonSessionIds, {
-          ...pythonCleanupBudget,
-          parallel: true,
-        });
-      }
-    })().catch(() => undefined),
-  ]);
+  await cleanupSessionPython(payload.directory, payload.sessionId);
 }
 
-function runSessionEndCleanupWorkerAndExit(payload: SessionEndCleanupWorkerPayload): void {
-  const cleanupBudgetMs = Math.max(0, Math.min(payload.cleanupBudgetMs, MAX_SESSION_END_CLEANUP_BUDGET_MS));
-  const forceExitTimer = setTimeout(() => {
-    process.exit(0);
-  }, Math.max(cleanupBudgetMs + 250, 250));
-
-  void processSessionEndCleanupWorker(payload)
-    .catch(() => undefined)
-    .finally(() => {
-      clearTimeout(forceExitTimer);
-      process.exit(0);
-    });
+export async function cleanupSessionReplies(sessionId: string): Promise<void> {
+  const { removeSession, loadAllMappings } = await import('../../notifications/session-registry.js');
+  if (!removeSession(sessionId)) throw new Error('reply-registry-remove-lock-failed');
+  if (loadAllMappings().length === 0) {
+    const { stopReplyListener } = await import('../../notifications/reply-listener.js');
+    const result = await stopReplyListener();
+    if (!result.success) throw new Error('reply-listener-stop-failed');
+  }
 }
 
-/**
- * Process session end
- */
+export async function runSessionEndCallbacks(directory: string, sessionId: string, idempotencyKey?: string, strict = false): Promise<void> {
+  const metrics = recordSessionMetrics(directory, { session_id: sessionId, transcript_path: '', cwd: directory, permission_mode: '', hook_event_name: 'SessionEnd', reason: 'other' });
+  const profileName = process.env.OMC_NOTIFY_PROFILE;
+  const config = getNotificationConfig(profileName);
+  const platforms = config && hasExplicitNotificationConfig(profileName) ? getEnabledPlatforms(config, 'session-end') : [];
+  const outcome = await runSessionEndDeferredAction({ name: 'legacy-callback', class: 'best-effort', idempotencyKey, payload: { skipPlatforms: platforms.length > 0 ? getLegacyPlatformsCoveredByNotifications(platforms) : [], idempotencyKey }, budgetMs: 2_000 }, { directory, sessionId, transcriptPath: '', metrics, input: { session_id: sessionId, cwd: directory }, deadlineAt: new Date(Date.now() + 2_000).toISOString(), action: { name: 'legacy-callback', class: 'best-effort', idempotencyKey, payload: { idempotencyKey }, budgetMs: 2_000 } });
+  if (strict && outcome.status !== 'completed' && outcome.status !== 'skipped') throw new Error(`legacy-callback-${outcome.status}`);
+}
+
+export async function runSessionEndNotifications(directory: string, sessionId: string, strict = false): Promise<void> {
+  const profileName = process.env.OMC_NOTIFY_PROFILE;
+  const config = getNotificationConfig(profileName);
+  if (!config || !hasExplicitNotificationConfig(profileName)) return;
+  const metrics = recordSessionMetrics(directory, { session_id: sessionId, transcript_path: '', cwd: directory, permission_mode: '', hook_event_name: 'SessionEnd', reason: 'other' });
+  const outcome = await runSessionEndDeferredAction({ name: 'notification', class: 'best-effort', payload: { profileName }, budgetMs: 2_000 }, { directory, sessionId, transcriptPath: '', metrics, input: { session_id: sessionId, cwd: directory }, deadlineAt: new Date(Date.now() + 2_000).toISOString(), action: { name: 'notification', class: 'best-effort', payload: { profileName }, budgetMs: 2_000 } });
+  if (strict && outcome.status !== 'completed' && outcome.status !== 'skipped') throw new Error(`notification-${outcome.status}`);
+}
+
+export async function runSessionEndOpenClaw(directory: string, sessionId: string, strict = false): Promise<void> {
+  const metrics = recordSessionMetrics(directory, { session_id: sessionId, transcript_path: '', cwd: directory, permission_mode: '', hook_event_name: 'SessionEnd', reason: 'other' });
+  const outcome = await runSessionEndDeferredAction({ name: 'openclaw-wake', class: 'best-effort', payload: { enabled: process.env.OMC_OPENCLAW === '1', reason: metrics.reason, sessionId }, budgetMs: 2_000 }, { directory, sessionId, transcriptPath: '', metrics, input: { session_id: sessionId, cwd: directory }, deadlineAt: new Date(Date.now() + 2_000).toISOString(), action: { name: 'openclaw-wake', class: 'best-effort', payload: {}, budgetMs: 2_000 } });
+  if (strict && outcome.status !== 'completed' && outcome.status !== 'skipped') throw new Error(`openclaw-wake-${outcome.status}`);
+}
+
+/** Foreground cleanup has no network/process waits and records its result before the core producer is sealed. */
+export async function runForegroundSessionEndCleanup(directory: string, sessionId: string, persistResult = true): Promise<Record<string, unknown>> {
+  const removed = cleanupTransientState(directory, sessionId);
+  cleanupModeStates(directory, sessionId);
+  cleanupMissionState(directory, sessionId);
+  cleanupSessionStartedMarker(directory, sessionId);
+  const outcome = { removedTransientFiles: removed, completedAt: new Date().toISOString() };
+  if (persistResult) {
+    const completed = completeForegroundCleanup(directory, sessionId, outcome);
+    if (!completed) throw new Error('foreground-cleanup-result-not-durable');
+  }
+  return outcome;
+}
+
+/** Foreground path: only durable local state and worker launch; deferred adapters are worker-owned. */
+function buildDurableSessionEndPayload(directory: string, input: SessionEndInput): Record<string, unknown> {
+  const teamState = readModeState<Record<string, unknown>>('team', directory, input.session_id);
+  const teamName = extractTeamNameFromState(teamState);
+  // Keep only routing identifiers and booleans: credentials remain in the inherited worker environment.
+  return {
+    transcriptPath: input.transcript_path,
+    cwd: input.cwd,
+    reason: input.reason,
+    initialTeamNames: teamName ? [teamName] : [],
+    notificationProfile: typeof process.env.OMC_NOTIFY_PROFILE === 'string' ? process.env.OMC_NOTIFY_PROFILE : undefined,
+    openClawEnabled: process.env.OMC_OPENCLAW === '1',
+  };
+}
+
 export async function processSessionEnd(input: SessionEndInput): Promise<HookOutput> {
-  // Normalize cwd to the git worktree root so .omc/state/ is always resolved
-  // from the repo root, even when Claude Code is running from a subdirectory (issue #891).
   const directory = resolveToWorktreeRoot(input.cwd);
-
-  // Record and export session metrics to disk
+  const payload = buildDurableSessionEndPayload(directory, input);
+  const manifest = prepareCoreManifest(directory, input.session_id, payload);
+  if (!manifest) return { continue: true };
   const metrics = recordSessionMetrics(directory, input);
   exportSessionSummary(directory, metrics);
-
-  const cleanupBudgetMs = resolveSessionEndCleanupBudgetMs();
-  const fireAndForget: Promise<unknown>[] = [];
-  const sessionTeamName = extractTeamNameFromState(
-    readModeState<Record<string, unknown>>('team', directory, input.session_id),
-  );
-
-  // Best-effort tmux/Python cleanup can involve ref'd timers and subprocesses.
-  // Run it in a detached bounded worker so SessionEnd hook latency is isolated
-  // from resource teardown while still attempting cleanup (#3144).
-  spawnSessionEndCleanupWorker({
-    directory,
-    sessionId: input.session_id,
-    transcriptPath: input.transcript_path,
-    cleanupBudgetMs,
-    initialTeamNames: sessionTeamName ? [sessionTeamName] : [],
-  });
-
-  // Clean up transient state files
-  cleanupTransientState(directory, input.session_id);
-
-  // Clean up mode state files to prevent stale state issues
-  // This ensures the stop hook won't malfunction in subsequent sessions
-  // Pass session_id to only clean up this session's states
-  cleanupModeStates(directory, input.session_id);
-
-  // Clean up mission-state.json entries belonging to this session
-  // Without this, the HUD keeps showing stale mode/mission info
-  cleanupMissionState(directory, input.session_id);
-
-  // Mark this session as normally ended so SessionStart reconciliation does
-  // not treat it as hard-terminated.
-  cleanupSessionStartedMarker(directory, input.session_id);
-
-  const profileName = process.env.OMC_NOTIFY_PROFILE;
-  const notificationConfig = getNotificationConfig(profileName);
-  const shouldUseNewNotificationSystem = Boolean(
-    notificationConfig && hasExplicitNotificationConfig(profileName)
-  );
-  const enabledNotificationPlatforms = shouldUseNewNotificationSystem && notificationConfig
-    ? getEnabledPlatforms(notificationConfig, 'session-end')
-    : [];
-
-  // Fire-and-forget: notifications and reply-listener cleanup are non-critical
-  // and should not count against the SessionEnd hook timeout (#1700).
-  // We collect the promises but don't await them — Node will flush what it can
-  // before the process exits (the hook runner keeps the process alive until
-  // stdout closes).
-
-  // Trigger stop hook callbacks (#395). When an explicit session-end notification
-  // config already covers Discord/Telegram, skip the overlapping legacy callback
-  // path so session-end is only dispatched once per platform.
-  fireAndForget.push(
-    triggerStopCallbacks(metrics, {
-      session_id: input.session_id,
-      cwd: input.cwd,
-    }, {
-      skipPlatforms: shouldUseNewNotificationSystem
-        ? getLegacyPlatformsCoveredByNotifications(enabledNotificationPlatforms)
-        : [],
-    }).catch(() => { /* notification failures must not block session end */ }),
-  );
-
-  // Trigger the new notification system when session-end notifications come
-  // from an explicit notifications/profile/env config. Legacy stopHookCallbacks
-  // are already handled above and must not be dispatched twice.
-  if (shouldUseNewNotificationSystem) {
-    fireAndForget.push(
-      notify('session-end', {
-        sessionId: input.session_id,
-        projectPath: input.cwd,
-        durationMs: metrics.duration_ms,
-        agentsSpawned: metrics.agents_spawned,
-        agentsCompleted: metrics.agents_completed,
-        modesUsed: metrics.modes_used,
-        reason: metrics.reason,
-        timestamp: metrics.ended_at,
-        profileName,
-      }).catch(() => { /* notification failures must not block session end */ }),
-    );
-  }
-
-  // Clean up reply session registry and stop daemon if no active sessions remain
-  fireAndForget.push(
-    (async () => {
-      try {
-        const { removeSession, loadAllMappings } = await import('../../notifications/session-registry.js');
-        const { stopReplyListener } = await import('../../notifications/reply-listener.js');
-
-        // Remove this session's message mappings
-        removeSession(input.session_id);
-
-        // Stop daemon if registry is now empty (no other active sessions)
-        const remainingMappings = loadAllMappings();
-        if (remainingMappings.length === 0) {
-          await stopReplyListener();
-        }
-      } catch {
-        // Reply listener cleanup failures should never block session end
-      }
-    })(),
-  );
-
-  // Don't await — let Node flush these before the process exits.
-  // The hook runner keeps the process alive until stdout closes, so these
-  // will settle naturally. Awaiting them would defeat the fire-and-forget
-  // optimization and risk hitting the hook timeout (#1700).
-  void Promise.allSettled(fireAndForget);
-
-  // Return simple response - metrics are persisted to .omc/sessions/
+  let foregroundOutcome: Record<string, unknown>;
+  try { foregroundOutcome = await runForegroundSessionEndCleanup(directory, input.session_id, false); } catch { return { continue: true }; }
+  const sealed = completeForegroundCleanupAndSealCore(directory, input.session_id, foregroundOutcome);
+  if (sealed) spawnSessionEndWorker({ directory, sessionId: input.session_id });
   return { continue: true };
 }
 
-/**
- * Main hook entry point
- */
-
-const cleanupWorkerArgIndex = process.argv.indexOf(SESSION_END_CLEANUP_WORKER_ARG);
-if (cleanupWorkerArgIndex >= 0) {
-  const payload = decodeCleanupWorkerPayload(process.argv[cleanupWorkerArgIndex + 1] ?? '');
-  if (payload) {
-    runSessionEndCleanupWorkerAndExit(payload);
-  } else {
-    process.exit(0);
-  }
+/** Wiki producer has no foreground lock or write; it only seals a durable capture/no-op intent. */
+export async function processWikiSessionEnd(input: SessionEndInput): Promise<HookOutput> {
+  const directory = resolveToWorktreeRoot(input.cwd);
+  const intent = buildWikiSessionEndCaptureIntent({ cwd: directory, session_id: input.session_id });
+  sealWikiManifest(directory, input.session_id, intent ? { ...intent } : undefined);
+  spawnSessionEndWorker({ directory, sessionId: input.session_id });
+  return { continue: true };
 }
 
 export async function handleSessionEnd(input: SessionEndInput): Promise<HookOutput> {

--- a/src/hooks/session-end/worker.ts
+++ b/src/hooks/session-end/worker.ts
@@ -1,0 +1,99 @@
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { fileURLToPath } from 'url';
+import { claimSessionEndAction, claimSessionEndDiscoveryTickets, claimSessionEndJob, finishSessionEndAction, markSessionEndActionRunner, readSessionEndJob, reapStaleSessionEndOwner, recoverPreparedCoreProducer, releaseSessionEndDiscoveryTicket, releaseSessionEndJob, renewSessionEndLease, type SessionEndActionName } from './cleanup-manifest.js';
+import { runSessionEndAction } from './action-runner.js';
+import { armSessionEndActionWatchdog } from './action-watchdog.js';
+import { getProcessStartIdentity, isProcessIdentityLive } from '../../platform/process-utils.js';
+
+const WORKER_ARG = '--omc-session-end-worker';
+const MAX_WORKER_MS = 10_000;
+export interface SessionEndWorkerPayload { directory: string; sessionId: string; }
+
+/** Routing and CA paths are passed to the child, but never copied into a durable manifest. */
+function workerEnvironment(): NodeJS.ProcessEnv {
+  const keys = ['PATH', 'HOME', 'USERPROFILE', 'TMPDIR', 'TEMP', 'TMP', 'SystemRoot', 'COMSPEC', 'LANG', 'LC_ALL', 'NODE_ENV', 'CLAUDE_CONFIG_DIR', 'OMC_STATE_DIR', 'OMC_HOOK_CONFIG', 'OMC_CONFIG_PATH', 'OMC_NOTIFY', 'OMC_NOTIFY_PROFILE', 'OMC_OPENCLAW', 'HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'all_proxy', 'no_proxy', 'NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'SSL_CERT_DIR', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'];
+  return Object.fromEntries(keys.flatMap((key) => process.env[key] === undefined ? [] : [[key, process.env[key]]]));
+}
+export function spawnSessionEndWorker(payload: SessionEndWorkerPayload): boolean {
+  try { const child = spawn(process.execPath, [fileURLToPath(import.meta.url), WORKER_ARG, JSON.stringify(payload)], { detached: true, stdio: 'ignore', env: workerEnvironment(), windowsHide: true }); child.unref(); return true; } catch { return false; }
+}
+export async function executeSessionEndAction(name: SessionEndActionName, payload: SessionEndWorkerPayload, deadlineAt: number): Promise<void> {
+  const legacy = await import('./index.js');
+  const routing = readSessionEndJob(payload.directory, payload.sessionId)?.actions.notification.payload;
+  if (typeof routing?.notificationProfile === 'string') process.env.OMC_NOTIFY_PROFILE = routing.notificationProfile;
+  if (routing?.openClawEnabled === true) process.env.OMC_OPENCLAW = '1';
+  if (name === 'foreground-cleanup') return legacy.runForegroundSessionEndCleanup(payload.directory, payload.sessionId, false).then(() => undefined);
+  if (name === 'wiki-capture') { const intent = readSessionEndJob(payload.directory, payload.sessionId)?.actions['wiki-capture'].payload; const { commitWikiSessionEndCaptureIntent } = await import('../wiki/session-hooks.js'); if (!await commitWikiSessionEndCaptureIntent(intent as unknown as Parameters<typeof commitWikiSessionEndCaptureIntent>[0], { deadlineAt: Math.min(deadlineAt, Date.now() + 9_000) })) throw new Error('wiki-capture-incomplete'); return; }
+  if (name === 'team-cleanup') { const names = readSessionEndJob(payload.directory, payload.sessionId)?.actions['team-cleanup'].payload.initialTeamNames; const result = await legacy.cleanupSessionOwnedTeams(payload.directory, payload.sessionId, Array.isArray(names) ? names.filter((name): name is string => typeof name === 'string') : []); if (result.failed.length > 0) throw new Error(`team-cleanup-incomplete:${result.failed.map(item => item.teamName).join(',')}`); return; }
+  if (name === 'python-cleanup') return legacy.cleanupSessionPython(payload.directory, payload.sessionId).then(() => undefined);
+  if (name === 'reply-cleanup') return legacy.cleanupSessionReplies(payload.sessionId);
+  if (name === 'callback') return legacy.runSessionEndCallbacks(payload.directory, payload.sessionId, readSessionEndJob(payload.directory, payload.sessionId)?.actions.callback.idempotencyKey, true);
+  if (name === 'notification') return legacy.runSessionEndNotifications(payload.directory, payload.sessionId, true);
+  return legacy.runSessionEndOpenClaw(payload.directory, payload.sessionId, true);
+}
+async function reapIfProvenStale(payload: SessionEndWorkerPayload, deadlineAt: number): Promise<void> {
+  const job = readSessionEndJob(payload.directory, payload.sessionId); const owner = job?.owner;
+  if (!owner || Date.now() < Date.parse(owner.leaseExpiresAt)) return;
+  const liveness = await isProcessIdentityLive(owner.pid, owner.processStartIdentity, Math.min(deadlineAt, Date.now() + 250));
+  if (liveness === 'dead' || liveness === 'mismatch') reapStaleSessionEndOwner(payload.directory, payload.sessionId, owner.nonce, owner.leaseGeneration, liveness);
+}
+export async function processSessionEndWorker(payload: SessionEndWorkerPayload): Promise<void> {
+  const deadlineAt = Date.now() + MAX_WORKER_MS; const nonce = randomUUID(); const identity = await getProcessStartIdentity(process.pid, Math.min(deadlineAt, Date.now() + 250));
+  if (!identity) return;
+  let claimed = claimSessionEndJob(payload.directory, payload.sessionId, nonce, identity, deadlineAt);
+  if (!claimed) { await reapIfProvenStale(payload, deadlineAt); claimed = claimSessionEndJob(payload.directory, payload.sessionId, nonce, identity, deadlineAt); }
+  if (!claimed || !claimed.owner) return;
+  let admitted = readSessionEndJob(payload.directory, payload.sessionId);
+  const graceExpired = admitted ? Date.now() >= Date.parse(admitted.producerGraceExpiresAt) : false;
+  if (admitted && graceExpired) {
+    recoverPreparedCoreProducer(payload.directory, payload.sessionId);
+    admitted = readSessionEndJob(payload.directory, payload.sessionId);
+  }
+  let producerReady = Boolean(admitted && ['sealed', 'no-op'].includes(admitted.producers.core.state) && ['sealed', 'no-op'].includes(admitted.producers.wiki.state));
+  let generation = claimed.owner.leaseGeneration;
+  try {
+    for (const name of Object.keys(claimed.actions) as SessionEndActionName[]) {
+      if (Date.now() >= deadlineAt) break;
+      const before = readSessionEndJob(payload.directory, payload.sessionId);
+      if (!before || before.owner?.nonce !== nonce) break;
+      if (!producerReady && (name !== 'foreground-cleanup' || !graceExpired || before.producers.core.state !== 'prepared')) continue;
+      if (name === 'wiki-capture' && before.producers.wiki.state === 'absent') continue;
+      const owned = claimSessionEndAction(payload.directory, payload.sessionId, nonce, name, deadlineAt);
+      const action = owned?.actions[name];
+      if (!owned || !action || action.status !== 'claimed' || !action.runner) continue;
+      const renewed = renewSessionEndLease(payload.directory, payload.sessionId, nonce, generation, deadlineAt);
+      if (!renewed?.owner) break;
+      generation = renewed.owner.leaseGeneration;
+      if (!markSessionEndActionRunner(payload.directory, payload.sessionId, nonce, name, action.runner.runnerNonce, 'started')) break;
+      const stopWatchdog = armSessionEndActionWatchdog({ directory: payload.directory, jobId: owned.jobId, action: name, attempt: action.attempts, runnerNonce: action.runner.runnerNonce, deadlineAt: Math.min(deadlineAt, Date.now() + action.budgetMs) });
+      const actionDeadline = Math.min(deadlineAt, Date.now() + action.budgetMs);
+      let leaseLost = false;
+      const heartbeatTimer = setInterval(() => { const renewedLease = renewSessionEndLease(payload.directory, payload.sessionId, nonce, generation, deadlineAt); if (!renewedLease?.owner) leaseLost = true; else generation = renewedLease.owner.leaseGeneration; }, 250);
+      heartbeatTimer.unref();
+      const result = await runSessionEndAction({ directory: payload.directory, sessionId: payload.sessionId, job: owned, actionName: name, action, ownerNonce: nonce, runnerNonce: action.runner.runnerNonce, deadlineAt: actionDeadline }, () => executeSessionEndAction(name, payload, actionDeadline));
+      clearInterval(heartbeatTimer);
+      stopWatchdog();
+      if (leaseLost) break;
+      finishSessionEndAction(payload.directory, payload.sessionId, nonce, name, action.runner.runnerNonce, result.completed, result.code);
+      if (name === 'foreground-cleanup' && result.completed) {
+        recoverPreparedCoreProducer(payload.directory, payload.sessionId);
+        const recovered = readSessionEndJob(payload.directory, payload.sessionId);
+        producerReady = Boolean(recovered && ['sealed', 'no-op'].includes(recovered.producers.core.state) && ['sealed', 'no-op'].includes(recovered.producers.wiki.state));
+      }
+      const heartbeat = renewSessionEndLease(payload.directory, payload.sessionId, nonce, generation, deadlineAt);
+      if (!heartbeat?.owner) break;
+      generation = heartbeat.owner.leaseGeneration;
+    }
+  } finally { releaseSessionEndJob(payload.directory, payload.sessionId, nonce, generation); }
+}
+/** Bounded fair SessionStart recovery based on durable tickets, not a directory page. */
+export function reconcileSessionEndJobs(directory: string, sessionIds?: readonly string[]): void {
+  const tickets = sessionIds ? [...sessionIds].slice(0, 4).map(sessionId => ({ sessionId, nonce: '' })) : claimSessionEndDiscoveryTickets(directory, 4);
+  for (const ticket of tickets) {
+    const spawned = spawnSessionEndWorker({ directory, sessionId: ticket.sessionId });
+    if (ticket.nonce && !spawned) releaseSessionEndDiscoveryTicket(directory, ticket.sessionId, ticket.nonce, false);
+  }
+}
+const workerIndex = process.argv.indexOf(WORKER_ARG);
+if (workerIndex >= 0) { try { const payload = JSON.parse(process.argv[workerIndex + 1] ?? '') as SessionEndWorkerPayload; void processSessionEndWorker(payload); } catch { /* invalid child input exits naturally */ } }

--- a/src/hooks/wiki/session-hooks.ts
+++ b/src/hooks/wiki/session-hooks.ts
@@ -8,6 +8,8 @@
  */
 
 import { existsSync, readFileSync } from 'fs';
+import { createHash } from 'crypto';
+
 import { join } from 'path';
 import { getOmcRoot } from '../../lib/worktree-paths.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
@@ -16,6 +18,7 @@ import {
   readIndex,
   readPage,
   readAllPages,
+  readLog,
   listPages,
   withWikiLock,
   writePageUnsafe,
@@ -25,6 +28,56 @@ import {
 } from './storage.js';
 import { WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG } from './types.js';
 import type { WikiConfig } from './types.js';
+
+export interface WikiSessionEndCaptureIntent {
+  kind: 'wiki-session-end-capture';
+  root: string;
+  sessionId: string;
+  filename: string;
+  capturedAt: string;
+  /** Durable intent identity; safe to persist because it is a one-way digest. */
+  captureKey?: string;
+
+}
+
+export interface WikiSessionEndCommitOptions {
+  /** Absolute deadline in epoch milliseconds for a worker-owned commit. */
+  deadlineAt?: number;
+  /** Maximum time to wait for the existing wiki lock. */
+  lockTimeoutMs?: number;
+}
+
+function captureKeyFor(intent: Pick<WikiSessionEndCaptureIntent, 'sessionId' | 'filename' | 'capturedAt' | 'captureKey'>): string {
+  if (typeof intent.captureKey === 'string' && /^[a-f0-9]{64}$/.test(intent.captureKey)) {
+    return intent.captureKey;
+  }
+  return createHash('sha256')
+    .update(`${intent.sessionId}\u0000${intent.filename}\u0000${intent.capturedAt}`)
+    .digest('hex');
+}
+
+
+function pageHasCaptureKey(page: ReturnType<typeof readPage>, captureKey: string): boolean {
+  return page?.content.includes(`<!-- omc-wiki-capture:${captureKey} -->`) ?? false;
+}
+
+function logHasCaptureKey(root: string, captureKey: string): boolean {
+  return readLog(root)?.includes(`omc-wiki-capture:${captureKey}`) ?? false;
+}
+
+
+function isBeforeDeadline(deadlineAt: number | undefined): boolean {
+  return deadlineAt === undefined || Date.now() <= deadlineAt;
+}
+
+function captureFilename(sessionId: string, capturedAt: string): string {
+  const dateSlug = capturedAt.split('T')[0] ?? 'unknown-date';
+  let hash = 0;
+  for (let index = 0; index < sessionId.length; index += 1) {
+    hash = ((hash << 5) - hash + sessionId.charCodeAt(index)) | 0;
+  }
+  return `session-log-${dateSlug}-${(hash >>> 0).toString(16).padStart(8, '0')}.md`;
+}
 
 /**
  * Load wiki config from .omc-config.json.
@@ -48,6 +101,93 @@ function loadWikiConfig(root: string): WikiConfig {
     // Ignore config errors, use defaults
   }
   return DEFAULT_WIKI_CONFIG;
+}
+
+/**
+ * Build a JSON-safe SessionEnd capture intent without taking the wiki lock or
+ * mutating the filesystem. The manifest worker durably owns and commits it.
+ */
+export function buildWikiSessionEndCaptureIntent(
+  data: { cwd?: string; session_id?: string },
+): WikiSessionEndCaptureIntent | null {
+  try {
+    const root = data.cwd || process.cwd();
+    if (!loadWikiConfig(root).autoCapture || !existsSync(getWikiDir(root))) return null;
+
+    const sessionId = data.session_id || `session-${Date.now()}`;
+    const capturedAt = new Date().toISOString();
+    const filename = captureFilename(sessionId, capturedAt);
+    const captureKey = captureKeyFor({ sessionId, filename, capturedAt });
+    return {
+      kind: 'wiki-session-end-capture',
+      root,
+      sessionId,
+      filename,
+      capturedAt,
+      captureKey,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Commit a capture intent under the existing wiki lock. Replaying the same
+ * intent never duplicates its page or its log entry.
+ */
+export function commitWikiSessionEndCaptureIntent(
+  intent: WikiSessionEndCaptureIntent,
+  options: WikiSessionEndCommitOptions = {},
+): boolean {
+  if (!isBeforeDeadline(options.deadlineAt)) return false;
+
+  try {
+    const captureKey = captureKeyFor(intent);
+    let committed = false;
+    withWikiLock(intent.root, () => {
+      if (!isBeforeDeadline(options.deadlineAt)) return;
+
+      const existingPage = readPage(intent.root, intent.filename);
+      if (!pageHasCaptureKey(existingPage, captureKey)) {
+        const dateSlug = intent.capturedAt.split('T')[0] ?? 'unknown-date';
+        writePageUnsafe(intent.root, {
+          filename: intent.filename,
+          frontmatter: {
+            title: `Session Log ${dateSlug}`,
+            tags: ['session-log', 'auto-captured'],
+            created: intent.capturedAt,
+            updated: intent.capturedAt,
+            sources: [intent.sessionId],
+            links: [],
+            category: 'session-log',
+            confidence: 'medium',
+            schemaVersion: WIKI_SCHEMA_VERSION,
+          },
+          content: `\n# Session Log ${dateSlug}\n\nAuto-captured session metadata.\nSession ID: ${intent.sessionId}\n<!-- omc-wiki-capture:${captureKey} -->\n\nReview and promote significant findings to curated wiki pages via \`wiki_ingest\`.\n`,
+        });
+      }
+
+      if (!isBeforeDeadline(options.deadlineAt)) return;
+      if (!logHasCaptureKey(intent.root, captureKey)) {
+        appendLogUnsafe(intent.root, {
+          timestamp: intent.capturedAt,
+          operation: 'ingest',
+          pagesAffected: [intent.filename],
+          summary: `Auto-captured session log for ${intent.sessionId} (omc-wiki-capture:${captureKey})`,
+        });
+      }
+
+      if (!isBeforeDeadline(options.deadlineAt)) return;
+      committed = pageHasCaptureKey(readPage(intent.root, intent.filename), captureKey)
+        && logHasCaptureKey(intent.root, captureKey);
+    }, {
+      deadlineAt: options.deadlineAt,
+      timeoutMs: options.lockTimeoutMs,
+    });
+    return committed;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -98,68 +238,11 @@ export function onSessionStart(data: { cwd?: string }): { additionalContext?: st
 }
 
 /**
- * SessionEnd hook: bounded append-only capture of session metadata.
- *
- * Captures raw session data as a session-log page.
- * Does NOT do LLM-judged curation — that happens via skill on next session.
- * Hard timeout: 3s via Promise.race pattern (sync version uses try/catch + time check).
+ * SessionEnd foreground compatibility hook. It deliberately constructs no
+ * writes and never acquires the wiki lock; the session wrapper enqueues the
+ * intent for the manifest worker to commit.
  */
-export function onSessionEnd(data: { cwd?: string; session_id?: string }): { continue: boolean } {
-  const startTime = Date.now();
-  const TIMEOUT_MS = 3_000;
-
-  try {
-    const root = data.cwd || process.cwd();
-    const config = loadWikiConfig(root);
-
-    if (!config.autoCapture) {
-      return { continue: true };
-    }
-
-    const wikiDir = getWikiDir(root);
-    if (!existsSync(wikiDir)) {
-      // Don't create wiki dir just for session logging
-      return { continue: true };
-    }
-
-    const sessionId = data.session_id || `session-${Date.now()}`;
-    const now = new Date().toISOString();
-    const dateSlug = now.split('T')[0]; // YYYY-MM-DD
-    const filename = `session-log-${dateSlug}-${sessionId.slice(-8)}.md`;
-
-    withWikiLock(root, () => {
-      // Time check inside lock
-      if (Date.now() - startTime > TIMEOUT_MS) return;
-
-      writePageUnsafe(root, {
-        filename,
-        frontmatter: {
-          title: `Session Log ${dateSlug}`,
-          tags: ['session-log', 'auto-captured'],
-          created: now,
-          updated: now,
-          sources: [sessionId],
-          links: [],
-          category: 'session-log',
-          confidence: 'medium',
-          schemaVersion: WIKI_SCHEMA_VERSION,
-        },
-        content: `\n# Session Log ${dateSlug}\n\nAuto-captured session metadata.\nSession ID: ${sessionId}\n\nReview and promote significant findings to curated wiki pages via \`wiki_ingest\`.\n`,
-      });
-
-      appendLogUnsafe(root, {
-        timestamp: now,
-        operation: 'ingest',
-        pagesAffected: [filename],
-        summary: `Auto-captured session log for ${sessionId}`,
-      });
-
-      // Do NOT rebuild index here — keep SessionEnd fast
-    });
-  } catch {
-    // Silently fail — session end should never block
-  }
-
+export function onSessionEnd(_data: { cwd?: string; session_id?: string }): { continue: boolean } {
   return { continue: true };
 }
 

--- a/src/hooks/wiki/storage.ts
+++ b/src/hooks/wiki/storage.ts
@@ -70,6 +70,13 @@ export function ensureWikiDir(root: string): string {
 // Mutation Boundary
 // ============================================================================
 
+export interface WikiLockOptions {
+  /** Maximum time to wait for the wiki lock. Ordinary callers retain the existing 5s default. */
+  timeoutMs?: number;
+  /** Optional absolute deadline for worker-owned work. */
+  deadlineAt?: number;
+}
+
 /**
  * Execute a function under the wiki-wide file lock.
  * All write operations MUST go through this boundary.
@@ -77,10 +84,14 @@ export function ensureWikiDir(root: string): string {
  * Uses synchronous file lock (withFileLockSync) because wiki operations
  * are called from sync hook contexts (notepad pattern).
  */
-export function withWikiLock<T>(root: string, fn: () => T): T {
+export function withWikiLock<T>(root: string, fn: () => T, options?: WikiLockOptions): T {
   const wikiDir = ensureWikiDir(root);
   const lockPath = lockPathFor(join(wikiDir, '.wiki-lock'));
-  return withFileLockSync(lockPath, fn, { timeoutMs: 5_000, retryDelayMs: 50 });
+  const remainingMs = options?.deadlineAt === undefined
+    ? undefined
+    : Math.max(0, options.deadlineAt - Date.now());
+  const timeoutMs = Math.min(options?.timeoutMs ?? 5_000, remainingMs ?? Infinity);
+  return withFileLockSync(lockPath, fn, { timeoutMs, retryDelayMs: 50 });
 }
 
 // ============================================================================

--- a/src/lib/atomic-write.ts
+++ b/src/lib/atomic-write.ts
@@ -237,6 +237,92 @@ export function atomicWriteJsonSync(filePath: string, data: unknown): void {
   atomicWriteFileSync(filePath, jsonContent);
 }
 
+/**
+ * Bounded set of independently atomic writes. This is not a multi-file
+ * transaction: a crash between renames can expose a prefix of the batch.
+ * Every visible file, however, is fully written and durable before return.
+ */
+export interface AtomicBatchWrite {
+  path: string;
+  content: string;
+  mode?: number;
+}
+
+const ATOMIC_BATCH_MAX_WRITES = 64;
+const ATOMIC_BATCH_MAX_CONTENT_BYTES = 1024 * 1024;
+
+export function atomicWriteBatchSync(writes: AtomicBatchWrite[]): void {
+  if (writes.length > ATOMIC_BATCH_MAX_WRITES) {
+    throw new Error(`Atomic batch exceeds ${ATOMIC_BATCH_MAX_WRITES} writes`);
+  }
+
+  const targets = new Set<string>();
+  let totalBytes = 0;
+  const pending = writes.map((write) => {
+    if (!write.path || typeof write.content !== "string") {
+      throw new TypeError("Atomic batch writes require a path and string content");
+    }
+    if (write.mode !== undefined && (!Number.isInteger(write.mode) || write.mode < 0 || write.mode > 0o777)) {
+      throw new RangeError("Atomic batch write mode must be a valid file mode");
+    }
+    if (targets.has(write.path)) {
+      throw new Error(`Atomic batch contains duplicate target: ${write.path}`);
+    }
+    targets.add(write.path);
+    totalBytes += Buffer.byteLength(write.content, "utf-8");
+    if (totalBytes > ATOMIC_BATCH_MAX_CONTENT_BYTES) {
+      throw new Error(`Atomic batch exceeds ${ATOMIC_BATCH_MAX_CONTENT_BYTES} bytes`);
+    }
+
+    const dir = path.dirname(write.path);
+    ensureDirSync(dir);
+    return {
+      ...write,
+      dir,
+      tempPath: path.join(dir, `.${path.basename(write.path)}.tmp.${crypto.randomUUID()}`),
+    };
+  });
+
+  const renamedDirectories = new Set<string>();
+  try {
+    for (const write of pending) {
+      const fd = fsSync.openSync(write.tempPath, "wx", write.mode ?? 0o600);
+      try {
+        fsSync.writeSync(fd, write.content, 0, "utf-8");
+        fsSync.fsyncSync(fd);
+      } finally {
+        fsSync.closeSync(fd);
+      }
+    }
+
+    for (const write of pending) {
+      fsSync.renameSync(write.tempPath, write.path);
+      renamedDirectories.add(write.dir);
+    }
+
+    for (const dir of renamedDirectories) {
+      try {
+        const dirFd = fsSync.openSync(dir, "r");
+        try {
+          fsSync.fsyncSync(dirFd);
+        } finally {
+          fsSync.closeSync(dirFd);
+        }
+      } catch {
+        // Some platforms do not support directory fsync.
+      }
+    }
+  } finally {
+    for (const write of pending) {
+      try {
+        fsSync.unlinkSync(write.tempPath);
+      } catch {
+        // The temp file was renamed or could not be created.
+      }
+    }
+  }
+}
+
 export async function safeReadJson<T>(filePath: string): Promise<T | null> {
   try {
     // Check if file exists

--- a/src/notifications/__tests__/reply-listener.test.ts
+++ b/src/notifications/__tests__/reply-listener.test.ts
@@ -297,7 +297,7 @@ describe("reply-listener", () => {
     });
 
     it("detects stale PID file", () => {
-      const pid = 99999; // Non-existent process
+      const pid = 2_147_483_647; // Outside the supported PID range on test platforms
 
       // isProcessAlive would return false
       let isRunning = false;

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -20,6 +20,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, chmodSy
 import { join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
 import { tmuxExec } from '../cli/tmux-utils.js';
 import { request as httpsRequest } from 'https';
 import { resolveDaemonModulePath } from '../utils/daemon-module-path.js';
@@ -31,14 +32,21 @@ import {
 } from '../features/rate-limit-wait/tmux-detector.js';
 import {
   lookupByMessageId,
+  lockRegistryIfEmpty,
   removeMessagesByPane,
   pruneStale,
   type SessionMapping,
 } from './session-registry.js';
+
 import type { ReplyConfig } from './types.js';
 import { parseMentionAllowedMentions } from './config.js';
 import { redactTokens } from './redact.js';
-import { isProcessAlive } from '../platform/index.js';
+import {
+  getProcessStartIdentity,
+  isProcessAlive,
+  isProcessIdentityLive,
+  terminateOwnedProcessTree,
+} from '../platform/index.js';
 import {
   validateSlackMessage,
   SlackConnectionStateTracker,
@@ -93,6 +101,10 @@ export interface ReplyListenerState {
   messagesInjected: number;
   errors: number;
   lastError?: string;
+  /** Unique per-launch generation used to reject stale PID/state pairs. */
+  generation?: string;
+  /** Platform-provided start identity that prevents PID-reuse signalling. */
+  processStartIdentity?: string;
 }
 
 /** Daemon configuration (written to state file) */
@@ -248,26 +260,39 @@ export async function buildDaemonConfig(): Promise<ReplyListenerDaemonConfig | n
   }
 }
 
-/**
- * Read PID file
- */
-function readPidFile(): number | null {
+interface ReplyListenerPidRecord {
+  pid: number;
+  generation?: string;
+  processStartIdentity?: string;
+}
+
+/** Read the PID record, accepting the legacy numeric format for cleanup only. */
+function readPidRecord(): ReplyListenerPidRecord | null {
   try {
-    if (!existsSync(PID_FILE_PATH)) {
+    if (!existsSync(PID_FILE_PATH)) return null;
+    const content = readFileSync(PID_FILE_PATH, 'utf-8').trim();
+    const parsed = JSON.parse(content) as Partial<ReplyListenerPidRecord>;
+    return typeof parsed.pid === 'number' && Number.isInteger(parsed.pid) && parsed.pid > 0
+      ? { pid: parsed.pid, generation: parsed.generation, processStartIdentity: parsed.processStartIdentity }
+      : null;
+  } catch {
+    try {
+      const pid = Number.parseInt(readFileSync(PID_FILE_PATH, 'utf-8').trim(), 10);
+      return Number.isInteger(pid) && pid > 0 ? { pid } : null;
+    } catch {
       return null;
     }
-    const content = readFileSync(PID_FILE_PATH, 'utf-8');
-    return parseInt(content.trim(), 10);
-  } catch {
-    return null;
   }
 }
 
-/**
- * Write PID file with secure permissions
- */
-function writePidFile(pid: number): void {
-  writeSecureFile(PID_FILE_PATH, String(pid));
+/** Read PID only for existing liveness/status callers. */
+function readPidFile(): number | null {
+  return readPidRecord()?.pid ?? null;
+}
+
+/** Write a generation-bound PID record with secure permissions. */
+function writePidFile(record: ReplyListenerPidRecord): void {
+  writeSecureFile(PID_FILE_PATH, JSON.stringify(record));
 }
 
 /**
@@ -1005,7 +1030,8 @@ export function startReplyListener(_config: ReplyListenerDaemonConfig): DaemonRe
 
     const pid = child.pid;
     if (pid) {
-      writePidFile(pid);
+      const generation = randomUUID();
+      writePidFile({ pid, generation });
 
       const state: ReplyListenerState = {
         isRunning: true,
@@ -1016,8 +1042,19 @@ export function startReplyListener(_config: ReplyListenerDaemonConfig): DaemonRe
         discordLastMessageId: null,
         messagesInjected: 0,
         errors: 0,
+        generation,
       };
       writeDaemonState(state);
+
+      void getProcessStartIdentity(pid).then((processStartIdentity) => {
+        if (!processStartIdentity) return;
+        const current = readDaemonState();
+        const currentPid = readPidRecord();
+        if (current?.pid !== pid || current.generation !== generation || currentPid?.generation !== generation) return;
+        current.processStartIdentity = processStartIdentity;
+        writeDaemonState(current);
+        writePidFile({ pid, generation, processStartIdentity });
+      }).catch(() => {});
 
       log(`Reply listener daemon started with PID ${pid}`);
 
@@ -1041,51 +1078,71 @@ export function startReplyListener(_config: ReplyListenerDaemonConfig): DaemonRe
   }
 }
 
-/**
- * Stop the reply listener daemon
- */
-export function stopReplyListener(): DaemonResponse {
-  const pid = readPidFile();
+/** Stop only the exact live listener generation; never signal a reused PID. */
+export async function stopReplyListener(): Promise<DaemonResponse> {
+  const record = readPidRecord();
+  if (!record) return { success: true, message: 'Reply listener daemon is not running' };
 
-  if (pid === null) {
-    return {
-      success: true,
-      message: 'Reply listener daemon is not running',
-    };
+  if (!isProcessAlive(record.pid)) {
+    removePidFile();
+    return { success: true, message: 'Reply listener daemon was not running (cleaned up stale PID file)' };
   }
 
-  if (!isProcessAlive(pid)) {
-    removePidFile();
-    return {
-      success: true,
-      message: 'Reply listener daemon was not running (cleaned up stale PID file)',
-    };
+  const state = readDaemonState();
+  if (
+    !record.generation ||
+    !record.processStartIdentity ||
+    state?.pid !== record.pid ||
+    state.generation !== record.generation ||
+    state.processStartIdentity !== record.processStartIdentity
+  ) {
+    return { success: false, message: 'Refusing to stop listener without an exact live identity' };
+  }
+
+  // Revalidate under the registry lock. It is held through termination so a
+  // concurrent registration cannot be accepted for a listener we are stopping.
+  const emptyRegistryLock = lockRegistryIfEmpty();
+  if (emptyRegistryLock === 'active') {
+    return { success: true, message: 'Reply listener retained for active sessions', state };
+  }
+  if (emptyRegistryLock === null) {
+    return { success: false, message: 'Could not durably verify an empty reply registry' };
   }
 
   try {
-    process.kill(pid, 'SIGTERM');
-    removePidFile();
-
-    const state = readDaemonState();
-    if (state) {
-      state.isRunning = false;
-      state.pid = null;
-      writeDaemonState(state);
+    const deadlineAt = Date.now() + 500;
+    const liveness = await isProcessIdentityLive(record.pid, record.processStartIdentity, deadlineAt);
+    if (liveness !== 'live') {
+      return {
+        success: liveness === 'dead',
+        message: liveness === 'dead'
+          ? 'Reply listener was not running'
+          : 'Refusing to stop listener after identity revalidation failed',
+      };
     }
 
-    log(`Reply listener daemon stopped (PID ${pid})`);
-
-    return {
-      success: true,
-      message: `Reply listener daemon stopped (PID ${pid})`,
-      state: state ?? undefined,
-    };
+    const termination = await terminateOwnedProcessTree({
+      pid: record.pid,
+      expectedStartIdentity: record.processStartIdentity,
+      deadlineAt: new Date(deadlineAt).toISOString(),
+    });
+    if (termination !== 'terminated' && termination !== 'already-dead') {
+      return { success: false, message: 'Refusing to stop listener after termination identity revalidation failed' };
+    }
+    removePidFile();
+    state.isRunning = false;
+    state.pid = null;
+    writeDaemonState(state);
+    log(`Reply listener daemon stopped (PID ${record.pid})`);
+    return { success: true, message: `Reply listener daemon stopped (PID ${record.pid})`, state };
   } catch (error) {
     return {
       success: false,
       message: 'Failed to stop daemon',
       error: error instanceof Error ? error.message : String(error),
     };
+  } finally {
+    emptyRegistryLock();
   }
 }
 

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -281,16 +281,13 @@ function releaseRegistryLock(lock: RegistryLockHandle): void {
 }
 
 /**
- * Execute critical section with registry lock, waiting up to cumulative deadline.
- * If the lock cannot be acquired within the deadline, proceeds best-effort without lock.
+ * Execute a mutation while holding the registry lock. Mutations never proceed
+ * without ownership: callers receive `null` and can retry after lock failure.
  */
-function withRegistryLockOrWait<T>(onLocked: () => T): T {
+function withRegistryLock<T>(onLocked: () => T): T | null {
   const lock = acquireRegistryLockOrWait();
-  if (lock === null) {
-    // Lock timed out — proceed best-effort. Write contention is mitigated
-    // by JSONL append-only format (each write appends a complete line).
-    return onLocked();
-  }
+
+  if (lock === null) return null;
   try {
     return onLocked();
   } finally {
@@ -299,20 +296,26 @@ function withRegistryLockOrWait<T>(onLocked: () => T): T {
 }
 
 /**
- * Execute critical section with registry lock.
+ * Reserve an empty registry while the exact listener generation is stopped.
+ * Holding this lock prevents a concurrent notification registration from being
+ * lost between its empty check and process termination.
  */
-function withRegistryLock<T>(onLocked: () => T, onLockUnavailable: () => T): T {
+export function lockRegistryIfEmpty(): (() => void) | 'active' | null {
   const lock = acquireRegistryLock();
-  if (lock === null) {
-    return onLockUnavailable();
-  }
-
-  try {
-    return onLocked();
-  } finally {
+  if (lock === null) return null;
+  if (readAllMappingsUnsafe().length > 0) {
     releaseRegistryLock(lock);
+    return 'active';
   }
+  let released = false;
+  return () => {
+    if (!released) {
+      released = true;
+      releaseRegistryLock(lock);
+    }
+  };
 }
+
 
 /**
  * Register a message mapping (atomic JSONL append).
@@ -320,33 +323,39 @@ function withRegistryLock<T>(onLocked: () => T, onLockUnavailable: () => T): T {
  * Uses O_WRONLY | O_APPEND | O_CREAT for atomic appends (up to PIPE_BUF bytes on Linux).
  * Each mapping serializes to well under 4096 bytes, making this operation atomic.
  */
-export function registerMessage(mapping: SessionMapping): void {
-  withRegistryLockOrWait(
-    () => {
-      ensureRegistryDir();
+export function registerMessage(mapping: SessionMapping): boolean {
+  return withRegistryLock(() => {
+    ensureRegistryDir();
+    const existing = readAllMappingsUnsafe().find((candidate) =>
+      candidate.platform === mapping.platform &&
+      candidate.messageId === mapping.messageId &&
+      candidate.sessionId === mapping.sessionId &&
+      candidate.tmuxPaneId === mapping.tmuxPaneId,
+    );
+    if (existing) return true;
 
-      const line = JSON.stringify(mapping) + '\n';
-      const fd = openSync(
-        getRegistryPath(),
-        constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
-        SECURE_FILE_MODE,
-      );
+    const line = JSON.stringify(mapping) + '\n';
+    const fd = openSync(
+      getRegistryPath(),
+      constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT,
+      SECURE_FILE_MODE,
+    );
 
-      try {
-        const buf = Buffer.from(line, 'utf-8');
-        writeSync(fd, buf);
-      } finally {
-        closeSync(fd);
-      }
-    },
-  );
+    try {
+      writeSync(fd, Buffer.from(line, 'utf-8'));
+      return true;
+    } finally {
+      closeSync(fd);
+    }
+  }) ?? false;
 }
+
 
 /**
  * Load all mappings from the JSONL file
  */
 export function loadAllMappings(): SessionMapping[] {
-  return withRegistryLockOrWait(() => readAllMappingsUnsafe());
+  return withRegistryLock(() => readAllMappingsUnsafe()) ?? readAllMappingsUnsafe();
 }
 
 /**
@@ -395,78 +404,48 @@ export function lookupByMessageId(platform: string, messageId: string): SessionM
  * Remove all entries for a given session ID.
  * This is a rewrite operation (infrequent - only on session-end).
  */
-export function removeSession(sessionId: string): void {
-  withRegistryLock(
-    () => {
-      const mappings = readAllMappingsUnsafe();
-      const filtered = mappings.filter(m => m.sessionId !== sessionId);
-
-      if (filtered.length === mappings.length) {
-        // No changes needed
-        return;
-      }
-
-      rewriteRegistryUnsafe(filtered);
-    },
-    () => {
-      // Best-effort cleanup: if lock unavailable, leave entries as-is.
-    },
-  );
+export function removeSession(sessionId: string): boolean {
+  return withRegistryLock(() => {
+    const mappings = readAllMappingsUnsafe();
+    const filtered = mappings.filter(m => m.sessionId !== sessionId);
+    if (filtered.length !== mappings.length) rewriteRegistryUnsafe(filtered);
+    return true;
+  }) ?? false;
 }
+
 
 /**
  * Remove all entries for a given pane ID.
  * Called by reply listener when pane verification fails (stale pane cleanup).
  */
-export function removeMessagesByPane(paneId: string): void {
-  withRegistryLock(
-    () => {
-      const mappings = readAllMappingsUnsafe();
-      const filtered = mappings.filter(m => m.tmuxPaneId !== paneId);
-
-      if (filtered.length === mappings.length) {
-        // No changes needed
-        return;
-      }
-
-      rewriteRegistryUnsafe(filtered);
-    },
-    () => {
-      // Best-effort cleanup: if lock unavailable, leave entries as-is.
-    },
-  );
+export function removeMessagesByPane(paneId: string): boolean {
+  return withRegistryLock(() => {
+    const mappings = readAllMappingsUnsafe();
+    const filtered = mappings.filter(m => m.tmuxPaneId !== paneId);
+    if (filtered.length !== mappings.length) rewriteRegistryUnsafe(filtered);
+    return true;
+  }) ?? false;
 }
+
 
 /**
  * Remove entries older than MAX_AGE_MS (24 hours).
  * This is a rewrite operation (infrequent - called periodically by daemon).
  */
-export function pruneStale(): void {
-  withRegistryLock(
-    () => {
-      const now = Date.now();
-      const mappings = readAllMappingsUnsafe();
-      const filtered = mappings.filter(m => {
-        try {
-          const age = now - new Date(m.createdAt).getTime();
-          return age < MAX_AGE_MS;
-        } catch {
-          // Invalid timestamp, remove it
-          return false;
-        }
-      });
-
-      if (filtered.length === mappings.length) {
-        // No changes needed
-        return;
+export function pruneStale(): boolean {
+  return withRegistryLock(() => {
+    const now = Date.now();
+    const mappings = readAllMappingsUnsafe();
+    const filtered = mappings.filter(m => {
+      try {
+        return now - new Date(m.createdAt).getTime() < MAX_AGE_MS;
+      } catch {
+        return false;
       }
-
-      rewriteRegistryUnsafe(filtered);
-    },
-    () => {
-      // Best-effort cleanup: if lock unavailable, leave entries as-is.
-    },
-  );
+    });
+    if (filtered.length !== mappings.length) rewriteRegistryUnsafe(filtered);
+    return true;
+  }) ?? false;
 }
 
 /**

--- a/src/platform/process-utils.ts
+++ b/src/platform/process-utils.ts
@@ -9,6 +9,20 @@ import * as fsPromises from 'fs/promises';
 
 const execFileAsync = promisify(execFile);
 
+function remainingDeadlineMs(deadlineAt?: number): number | undefined {
+  if (deadlineAt === undefined) return undefined;
+  return Math.max(0, deadlineAt - Date.now());
+}
+
+function isDeadlineExceeded(deadlineAt?: number): boolean {
+  return deadlineAt !== undefined && remainingDeadlineMs(deadlineAt) === 0;
+}
+
+function parseDeadline(deadlineAt: string): number | undefined {
+  const value = Date.parse(deadlineAt);
+  return Number.isFinite(value) ? value : undefined;
+}
+
 /**
  * Kill a process and optionally its entire process tree.
  *
@@ -84,25 +98,25 @@ export function isProcessAlive(pid: number): boolean {
  * Get process start time for PID reuse detection.
  * Returns milliseconds timestamp on macOS/Windows, jiffies on Linux.
  */
-export async function getProcessStartTime(pid: number): Promise<number | undefined> {
-  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+export async function getProcessStartTime(pid: number, deadlineAt?: number): Promise<number | undefined> {
+  if (!Number.isInteger(pid) || pid <= 0 || isDeadlineExceeded(deadlineAt)) return undefined;
 
   if (process.platform === 'win32') {
-    return getProcessStartTimeWindows(pid);
+    return getProcessStartTimeWindows(pid, deadlineAt);
   } else if (process.platform === 'darwin') {
-    return getProcessStartTimeMacOS(pid);
+    return getProcessStartTimeMacOS(pid, deadlineAt);
   } else if (process.platform === 'linux') {
-    return getProcessStartTimeLinux(pid);
+    return getProcessStartTimeLinux(pid, deadlineAt);
   }
   return undefined;
 }
 
-async function getProcessStartTimeWindows(pid: number): Promise<number | undefined> {
+async function getProcessStartTimeWindows(pid: number, deadlineAt?: number): Promise<number | undefined> {
   try {
     const { stdout } = await execFileAsync('wmic', [
       'process', 'where', `ProcessId=${pid}`,
       'get', 'CreationDate', '/format:csv'
-    ], { timeout: 5000, windowsHide: true });
+    ], { timeout: Math.max(1, Math.min(5000, remainingDeadlineMs(deadlineAt) ?? 5000)), windowsHide: true });
 
     const wmicTime = parseWmicCreationDate(stdout);
     if (wmicTime !== undefined) return wmicTime;
@@ -110,10 +124,13 @@ async function getProcessStartTimeWindows(pid: number): Promise<number | undefin
     // WMIC is deprecated on newer Windows builds; fall back to PowerShell.
   }
 
-  const cimTime = await getProcessStartTimeWindowsPowerShellCim(pid);
+  if (isDeadlineExceeded(deadlineAt)) return undefined;
+  const cimTime = await getProcessStartTimeWindowsPowerShellCim(pid, deadlineAt);
   if (cimTime !== undefined) return cimTime;
 
-  return getProcessStartTimeWindowsPowerShellProcess(pid);
+  return isDeadlineExceeded(deadlineAt)
+    ? undefined
+    : getProcessStartTimeWindowsPowerShellProcess(pid, deadlineAt);
 }
 
 function parseWmicCreationDate(stdout: string): number | undefined {
@@ -145,7 +162,7 @@ function parseWindowsEpochMilliseconds(stdout: string): number | undefined {
   return Number.isFinite(value) ? value : undefined;
 }
 
-async function getProcessStartTimeWindowsPowerShellCim(pid: number): Promise<number | undefined> {
+async function getProcessStartTimeWindowsPowerShellCim(pid: number, deadlineAt?: number): Promise<number | undefined> {
   try {
     const { stdout } = await execFileAsync(
       'powershell',
@@ -155,7 +172,7 @@ async function getProcessStartTimeWindowsPowerShellCim(pid: number): Promise<num
         '-Command',
         `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction Stop; if ($p -and $p.CreationDate) { [DateTimeOffset]$p.CreationDate | ForEach-Object { $_.ToUnixTimeMilliseconds() } }`
       ],
-      { timeout: 5000, windowsHide: true }
+      { timeout: Math.max(1, Math.min(5000, remainingDeadlineMs(deadlineAt) ?? 5000)), windowsHide: true }
     );
     return parseWindowsEpochMilliseconds(stdout);
   } catch {
@@ -163,7 +180,7 @@ async function getProcessStartTimeWindowsPowerShellCim(pid: number): Promise<num
   }
 }
 
-async function getProcessStartTimeWindowsPowerShellProcess(pid: number): Promise<number | undefined> {
+async function getProcessStartTimeWindowsPowerShellProcess(pid: number, deadlineAt?: number): Promise<number | undefined> {
   try {
     const { stdout } = await execFileAsync(
       'powershell',
@@ -173,7 +190,7 @@ async function getProcessStartTimeWindowsPowerShellProcess(pid: number): Promise
         '-Command',
         `$p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue; if ($p -and $p.StartTime) { [DateTimeOffset]$p.StartTime | ForEach-Object { $_.ToUnixTimeMilliseconds() } }`
       ],
-      { timeout: 5000, windowsHide: true }
+      { timeout: Math.max(1, Math.min(5000, remainingDeadlineMs(deadlineAt) ?? 5000)), windowsHide: true }
     );
     return parseWindowsEpochMilliseconds(stdout);
   } catch {
@@ -181,10 +198,11 @@ async function getProcessStartTimeWindowsPowerShellProcess(pid: number): Promise
   }
 }
 
-async function getProcessStartTimeMacOS(pid: number): Promise<number | undefined> {
+async function getProcessStartTimeMacOS(pid: number, deadlineAt?: number): Promise<number | undefined> {
   try {
     const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'lstart='], {
       env: { ...process.env, LC_ALL: 'C' },
+      timeout: Math.max(1, Math.min(5000, remainingDeadlineMs(deadlineAt) ?? 5000)),
       windowsHide: true
     });
     const date = new Date(stdout.trim());
@@ -194,7 +212,8 @@ async function getProcessStartTimeMacOS(pid: number): Promise<number | undefined
   }
 }
 
-async function getProcessStartTimeLinux(pid: number): Promise<number | undefined> {
+async function getProcessStartTimeLinux(pid: number, deadlineAt?: number): Promise<number | undefined> {
+  if (isDeadlineExceeded(deadlineAt)) return undefined;
   try {
     const stat = await fsPromises.readFile(`/proc/${pid}/stat`, 'utf8');
     const closeParen = stat.lastIndexOf(')');
@@ -229,4 +248,72 @@ export async function gracefulKill(
 
   await new Promise(r => setTimeout(r, 1000));
   return isProcessAlive(pid) ? 'failed' : 'forced';
+}
+
+/** Stable PID-reuse identity suitable for a durable worker manifest. */
+export async function getProcessStartIdentity(pid: number, deadlineAt?: number): Promise<string | null> {
+  const startTime = await getProcessStartTime(pid, deadlineAt);
+  return startTime === undefined || isDeadlineExceeded(deadlineAt) ? null : String(startTime);
+}
+
+export async function isProcessIdentityLive(
+  pid: number,
+  expectedStartIdentity: string,
+  deadlineAt?: number,
+): Promise<'live' | 'dead' | 'mismatch' | 'unknown'> {
+  if (!Number.isInteger(pid) || pid <= 0 || !expectedStartIdentity || isDeadlineExceeded(deadlineAt)) {
+    return isDeadlineExceeded(deadlineAt) ? 'unknown' : 'dead';
+  }
+  if (!isProcessAlive(pid)) return 'dead';
+
+  const identity = await getProcessStartIdentity(pid, deadlineAt);
+  if (identity === null) return isProcessAlive(pid) ? 'unknown' : 'dead';
+  return identity === expectedStartIdentity ? 'live' : 'mismatch';
+}
+
+export interface TerminateOwnedProcessTreeOptions {
+  pid: number;
+  expectedStartIdentity: string;
+  deadlineAt: string;
+  force?: boolean;
+}
+
+/**
+ * Terminate only a process whose durable start identity still matches. The
+ * Windows path is asynchronous and receives the worker's remaining deadline,
+ * preventing taskkill from holding SessionEnd for its legacy five seconds.
+ */
+export async function terminateOwnedProcessTree(
+  options: TerminateOwnedProcessTreeOptions,
+): Promise<'terminated' | 'already-dead' | 'identity-mismatch' | 'unknown' | 'deadline-exceeded'> {
+  const deadline = parseDeadline(options.deadlineAt);
+  if (deadline === undefined || isDeadlineExceeded(deadline)) return 'deadline-exceeded';
+
+  const liveness = await isProcessIdentityLive(options.pid, options.expectedStartIdentity, deadline);
+  if (liveness === 'dead') return 'already-dead';
+  if (liveness === 'mismatch') return 'identity-mismatch';
+  if (liveness === 'unknown') {
+    return isDeadlineExceeded(deadline) ? 'deadline-exceeded' : 'unknown';
+  }
+  if (isDeadlineExceeded(deadline)) return 'deadline-exceeded';
+
+  if (process.platform !== 'win32') {
+    return killProcessTreeUnix(options.pid, options.force ? 'SIGKILL' : 'SIGTERM')
+      ? 'terminated'
+      : (isProcessAlive(options.pid) ? 'unknown' : 'already-dead');
+  }
+
+  const timeout = remainingDeadlineMs(deadline);
+  if (!timeout) return 'deadline-exceeded';
+  try {
+    const args = ['/T', '/PID', String(options.pid)];
+    if (options.force) args.unshift('/F');
+    await execFileAsync('taskkill.exe', args, { windowsHide: true, timeout });
+    return 'terminated';
+  } catch (error: unknown) {
+    if (isDeadlineExceeded(deadline)) return 'deadline-exceeded';
+    const status = (error as { status?: number }).status;
+    if (status === 128 || !isProcessAlive(options.pid)) return 'already-dead';
+    return 'unknown';
+  }
 }

--- a/templates/hooks/lib/stdin.mjs
+++ b/templates/hooks/lib/stdin.mjs
@@ -60,3 +60,80 @@ export async function readStdin(timeoutMs = 2000) {
     }
   });
 }
+
+/**
+ * Read one complete SessionEnd JSON frame under strict hook deadlines.
+ *
+ * @returns {Promise<
+ *   | { status: 'ok', value: unknown }
+ *   | { status: 'empty' | 'timeout' | 'overflow' | 'invalid' | 'error' }
+ * >}
+ */
+export function readSessionEndFrame() {
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    const chunks = [];
+    let byteLength = 0;
+    let settled = false;
+    let firstByteTimer;
+    let totalTimer;
+
+    const cleanup = () => {
+      clearTimeout(firstByteTimer);
+      clearTimeout(totalTimer);
+      stdin.off('data', onData);
+      stdin.off('end', onEnd);
+      stdin.off('error', onError);
+    };
+
+    const finish = (result, closeStdin = false) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (closeStdin && !stdin.destroyed) {
+        stdin.pause();
+        stdin.destroy();
+      }
+      resolve(result);
+    };
+
+    const onData = (chunk) => {
+      clearTimeout(firstByteTimer);
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteLength += buffer.length;
+      if (byteLength > 64 * 1024) {
+        finish({ status: 'overflow' }, true);
+        return;
+      }
+      chunks.push(buffer);
+    };
+
+    const onEnd = () => {
+      const input = Buffer.concat(chunks).toString('utf8');
+      if (input.trim().length === 0) {
+        finish({ status: 'empty' });
+        return;
+      }
+      try {
+        finish({ status: 'ok', value: JSON.parse(input) });
+      } catch {
+        finish({ status: 'invalid' });
+      }
+    };
+
+    const onError = () => finish({ status: 'error' }, true);
+
+    stdin.on('data', onData);
+    stdin.once('end', onEnd);
+    stdin.once('error', onError);
+
+    if (stdin.readableEnded) {
+      onEnd();
+      return;
+    }
+
+    firstByteTimer = setTimeout(() => finish({ status: 'timeout' }, true), 25);
+    totalTimer = setTimeout(() => finish({ status: 'timeout' }, true), 100);
+    stdin.resume();
+  });
+}


### PR DESCRIPTION
## Summary
- persist SessionEnd cleanup state and wiki capture intent before hook return
- execute deferred cleanup through durable, lease-fenced, crash-recoverable workers
- add bounded stdin handling and real `scripts/run.cjs` process-exit regression coverage
- retain the exact generated `dist` closure used by the plugin shipping path

## Verification
- `npx vitest run src/__tests__/session-end-process-exit.test.ts --maxWorkers=1 --fileParallelism=false` — 8/8 passed
- focused SessionEnd manifest/worker/wiki/reply/team/callback/OpenClaw suite — 107/107 passed
- `npm run build` — passed
- `npm run lint` — 0 errors
- independent architect review — CLEAR / APPROVE
- independent executor QA — PASS

Fixes #3477

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*