### PR TITLE
fix(windows): avoid Git console flashes in hooks and HUD

### DIFF
--- a/scripts/code-simplifier.mjs
+++ b/scripts/code-simplifier.mjs
@@ -19,7 +19,7 @@ import {
 } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readStdin } from './lib/stdin.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
 
@@ -46,7 +46,7 @@ function isEnabled(config) {
 
 function getModifiedFiles(cwd, extensions, maxFiles) {
   try {
-    const output = execSync('git diff HEAD --name-only', {
+    const output = execFileSync('git', ['diff', 'HEAD', '--name-only'], {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],

--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -22,7 +22,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
 import { join, dirname, resolve, basename } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { readStdin } from './lib/stdin.mjs';
@@ -79,7 +79,7 @@ function hasLocalGitMarker(startDir) {
 }
 
 function runGitRevParse(args, cwd) {
-  return execSync(`git rev-parse ${args.join(' ')}`, {
+  return execFileSync('git', ['rev-parse', ...args], {
     cwd,
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -99,6 +99,7 @@ function runCommand(command, args, cwd) {
       encoding: 'utf-8',
       timeout: COMMAND_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(command === 'git' ? { windowsHide: true } : {}),
     }).trim();
   } catch {
     return null;

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -6,7 +6,7 @@
  * Cross-platform: Windows, macOS, Linux
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, renameSync, unlinkSync } from 'fs';
 import { closeSync, openSync, readSync, statSync } from 'fs';
@@ -79,7 +79,7 @@ function resolveOmcRoot(startDir) {
 
   // 3) git rev-parse --show-toplevel
   try {
-    const top = execSync('git rev-parse --show-toplevel', {
+    const top = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -381,7 +381,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
 
   const effectiveCwd = cwd || process.cwd();
   try {
-    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+    const gitCommonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -389,7 +389,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
     }).trim();
 
     const mainRepoRoot = dirname(resolve(effectiveCwd, gitCommonDir));
-    const worktreeTop = execSync('git rev-parse --show-toplevel', {
+    const worktreeTop = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -10,7 +10,7 @@ import { closeSync, existsSync, fstatSync, lstatSync, mkdirSync, openSync, readF
 import { createHash } from 'crypto';
 import { dirname, join, resolve, basename } from 'path';
 import { homedir } from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { encodeProjectPath } from './lib/encode-project-path.mjs';
@@ -476,7 +476,7 @@ function resolveOmcRoot(startDir) {
 
   // 3) git rev-parse --show-toplevel
   try {
-    const top = execSync('git rev-parse --show-toplevel', {
+    const top = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -513,7 +513,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
 
   const effectiveCwd = cwd || process.cwd();
   try {
-    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+    const gitCommonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -523,7 +523,7 @@ function resolveTranscriptPath(transcriptPath, cwd) {
     const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
     const mainRepoRoot = dirname(absoluteCommonDir);
 
-    const worktreeTop = execSync('git rev-parse --show-toplevel', {
+    const worktreeTop = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/scripts/workflow-drift-guard.mjs
+++ b/scripts/workflow-drift-guard.mjs
@@ -78,7 +78,7 @@ function isCodePath(path) {
 
 function git(cwd, args) {
   try {
-    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 });
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000, windowsHide: true });
   } catch { return ''; }
 }
 

--- a/src/__tests__/hud/windows-platform.test.ts
+++ b/src/__tests__/hud/windows-platform.test.ts
@@ -3,6 +3,13 @@ import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'node:child_process';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageRoot = join(__dirname, '..', '..', '..');
@@ -187,19 +194,24 @@ describe('Windows HUD Platform Fixes (#739)', () => {
   // P1: Git execFileSync argv on Windows
   // =========================================================================
   describe('P1: Git shell-free execFileSync on Windows', () => {
-    it('git.ts should call git via execFileSync argv with windowsHide', () => {
-      const content = readFileSync(
-        join(packageRoot, 'src', 'hud', 'elements', 'git.ts'),
-        'utf-8',
+    it('invokes git with separate argv and hidden Windows process options', async () => {
+      const cwd = 'C:\\repo folder; & echo owned\\worktree';
+      vi.mocked(execFileSync).mockReturnValue('feature/space;name\\branch\n');
+      const { getGitBranch, resetGitCache } = await import('../../hud/elements/git.js');
+      resetGitCache();
+
+      expect(getGitBranch(cwd)).toBe('feature/space;name\\branch');
+      expect(execFileSync).toHaveBeenCalledWith(
+        'git',
+        ['branch', '--show-current'],
+        {
+          cwd,
+          encoding: 'utf-8',
+          timeout: 1000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
+        },
       );
-
-      expect(content).toContain("import { execFileSync } from 'node:child_process'");
-      expect(content).toContain("execFileSync('git', args, {");
-      expect(content).toContain('windowsHide: true');
-
-      expect(content).not.toContain("shell: process.platform === 'win32' ? 'cmd.exe' : undefined");
-      expect(content).not.toContain('cmd.exe');
-      expect(content).not.toContain('execSync');
     });
   });
 

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock('fs', async () => {
@@ -22,6 +23,7 @@ vi.mock('fs', async () => {
 });
 
 const mockedExecSync = vi.mocked(child_process.execSync);
+const mockedExecFileSync = vi.mocked(child_process.execFileSync);
 const mockedExistsSync = vi.mocked(fs.existsSync);
 const mockedReadFileSync = vi.mocked(fs.readFileSync);
 
@@ -202,34 +204,37 @@ describe('resolveLiveData - caching', () => {
 describe('resolveLiveData - conditional', () => {
   it('!if-modified skips when no files match', () => {
     // First call is git diff --name-only (condition check), returns no matching files
-    mockedExecSync.mockReturnValueOnce('README.md\npackage.json\n');
+    mockedExecFileSync.mockReturnValueOnce('README.md\npackage.json\n');
     const result = resolveLiveData('!if-modified src/** then git diff src/');
     expect(result).toContain('skipped="true"');
     expect(result).toContain('condition not met');
-    // Only the git diff --name-only call, not the actual command
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['diff', '--name-only'],
+      expect.objectContaining({ timeout: 5000, windowsHide: true }),
+    );
+    expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
   it('!if-modified executes when files match', () => {
-    mockedExecSync
-      .mockReturnValueOnce('src/main.ts\nREADME.md\n') // git diff --name-only
-      .mockReturnValueOnce('diff output\n'); // actual command
+    mockedExecFileSync.mockReturnValueOnce('src/main.ts\nREADME.md\n');
+    mockedExecSync.mockReturnValueOnce('diff output\n');
     const result = resolveLiveData('!if-modified src/** then git diff src/');
     expect(result).toContain('<live-data command="git diff src/">diff output\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecSync).toHaveBeenCalledTimes(1);
   });
 
   it('!if-branch skips when branch does not match', () => {
-    mockedExecSync.mockReturnValueOnce('main\n'); // git branch --show-current
+    mockedExecFileSync.mockReturnValueOnce('main\n');
     const result = resolveLiveData('!if-branch feat/* then echo "feature"');
     expect(result).toContain('skipped="true"');
     expect(result).toContain('branch does not match');
   });
 
   it('!if-branch executes when branch matches', () => {
-    mockedExecSync
-      .mockReturnValueOnce('feat/live-data\n') // git branch --show-current
-      .mockReturnValueOnce('feature\n'); // actual command
+    mockedExecFileSync.mockReturnValueOnce('feat/live-data\n');
+    mockedExecSync.mockReturnValueOnce('feature\n');
     const result = resolveLiveData('!if-branch feat/* then echo "feature"');
     expect(result).toContain('feature\n</live-data>');
     expect(result).not.toContain('skipped');

--- a/src/autoresearch/contracts.ts
+++ b/src/autoresearch/contracts.ts
@@ -44,6 +44,7 @@ function readGit(repoPath: string, args: string[]): string {
       cwd: repoPath,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };

--- a/src/autoresearch/runtime.ts
+++ b/src/autoresearch/runtime.ts
@@ -199,6 +199,7 @@ function readGit(repoPath: string, args: string[]): string {
       cwd: repoPath,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch (error) {
     const err = error as NodeJS.ErrnoException & { stderr?: string | Buffer };
@@ -215,6 +216,7 @@ function tryResolveGitCommit(worktreePath: string, ref: string): string | null {
   const result = spawnSync('git', ['rev-parse', '--verify', `${ref}^{commit}`], {
     cwd: worktreePath,
     encoding: 'utf-8',
+    windowsHide: true,
   });
   if (result.status !== 0) return null;
   const resolved = (result.stdout || '').trim();
@@ -301,6 +303,7 @@ function requireGitSuccess(worktreePath: string, args: string[]): void {
   const result = spawnSync('git', args, {
     cwd: worktreePath,
     encoding: 'utf-8',
+    windowsHide: true,
   });
   if (result.status === 0) return;
   throw new Error((result.stderr || '').trim() || `git ${args.join(' ')} failed`);
@@ -310,6 +313,7 @@ function gitStatusLines(worktreePath: string): string[] {
   const result = spawnSync('git', ['status', '--porcelain', '--untracked-files=all'], {
     cwd: worktreePath,
     encoding: 'utf-8',
+    windowsHide: true,
   });
   if (result.status !== 0) {
     throw new Error((result.stderr || '').trim() || `git status failed for ${worktreePath}`);

--- a/src/cli/autoresearch-guided.ts
+++ b/src/cli/autoresearch-guided.ts
@@ -311,6 +311,7 @@ function resolveMissionRepoRoot(missionDir: string): string {
     cwd: missionDir,
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
   }).trim();
 }
 

--- a/src/cli/commands/__tests__/teleport.test.ts
+++ b/src/cli/commands/__tests__/teleport.test.ts
@@ -45,13 +45,11 @@ describe('teleportCommand', () => {
   beforeEach(async () => {
     vi.resetAllMocks();
 
-    (execSync as ReturnType<typeof vi.fn>).mockImplementation((command: string) => {
-      if (command === 'git rev-parse --show-toplevel') return '/repo';
-      if (command === 'git remote get-url origin') return 'git@github.com:owner/repo.git';
-      return '';
+    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation((command: string, args: string[]) => {
+      if (command === 'git' && args.join(' ') === 'rev-parse --show-toplevel') return '/repo';
+      if (command === 'git' && args.join(' ') === 'remote get-url origin') return 'git@github.com:owner/repo.git';
+      return Buffer.from('');
     });
-
-    (execFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from(''));
 
     (existsSync as ReturnType<typeof vi.fn>).mockImplementation((target: unknown) => {
       if (typeof target !== 'string') return false;
@@ -94,18 +92,11 @@ describe('teleportCommand', () => {
   it('passes branchName and baseBranch as discrete array arguments, never as a shell string', async () => {
     await teleportCommand('#1', { base: 'main; touch /tmp/pwned', worktreePath: '/root' });
 
-    const calls = (execFileSync as ReturnType<typeof vi.fn>).mock.calls;
-    for (const [cmd, args] of calls) {
-      expect(Array.isArray(args)).toBe(true);
-      if (cmd !== 'git') continue;
-      expect(typeof cmd).toBe('string');
-    }
-
-    expect(calls).toContainEqual([
+    expect(execFileSync).toHaveBeenCalledWith(
       'git',
       ['fetch', 'origin', 'main; touch /tmp/pwned'],
-      expect.objectContaining({ cwd: '/repo' }),
-    ]);
+      { cwd: '/repo', stdio: 'pipe', windowsHide: true },
+    );
   });
 
   it('does not invoke execSync for git fetch/branch/worktree creation commands', async () => {
@@ -211,10 +202,10 @@ describe('teleportRemoveCommand', () => {
   it.each(['.git', '/repo/.git', 'C:\\repo\\.git'])(
     'refuses a main repo git-dir shape %s and does not remove the directory',
     async (gitDir) => {
-      (execSync as ReturnType<typeof vi.fn>).mockImplementation((command: string) => {
-        if (command === 'git status --porcelain') return '';
-        if (command === 'git rev-parse --git-dir') return `${gitDir}\n`;
-        return '';
+      (execFileSync as ReturnType<typeof vi.fn>).mockImplementation((command: string, args: string[]) => {
+        if (command === 'git' && args.join(' ') === 'status --porcelain') return '';
+        if (command === 'git' && args.join(' ') === 'rev-parse --git-dir') return `${gitDir}\n`;
+        return Buffer.from('');
       });
 
       const result = await teleportRemoveCommand(targetPath, {});
@@ -231,10 +222,10 @@ describe('teleportRemoveCommand', () => {
   );
 
   it('refuses an unexpected non-worktree git-dir and does not remove the directory', async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockImplementation((command: string) => {
-      if (command === 'git status --porcelain') return '';
-      if (command === 'git rev-parse --git-dir') return '/tmp/unexpected/gitdir\n';
-      return '';
+    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation((command: string, args: string[]) => {
+      if (command === 'git' && args.join(' ') === 'status --porcelain') return '';
+      if (command === 'git' && args.join(' ') === 'rev-parse --git-dir') return '/tmp/unexpected/gitdir\n';
+      return Buffer.from('');
     });
 
     const result = await teleportRemoveCommand(targetPath, { force: true });
@@ -250,10 +241,10 @@ describe('teleportRemoveCommand', () => {
   });
 
   it('removes a registered worktree through git worktree remove', async () => {
-    (execSync as ReturnType<typeof vi.fn>).mockImplementation((command: string) => {
-      if (command === 'git status --porcelain') return '';
-      if (command === 'git rev-parse --git-dir') return '/repo/.git/worktrees/repo-3089\n';
-      return '';
+    (execFileSync as ReturnType<typeof vi.fn>).mockImplementation((command: string, args: string[]) => {
+      if (command === 'git' && args.join(' ') === 'status --porcelain') return '';
+      if (command === 'git' && args.join(' ') === 'rev-parse --git-dir') return '/repo/.git/worktrees/repo-3089\n';
+      return Buffer.from('');
     });
 
     const result = await teleportRemoveCommand(targetPath, { force: true });
@@ -263,7 +254,7 @@ describe('teleportRemoveCommand', () => {
     expect(execFileSync).toHaveBeenCalledWith(
       'git',
       ['worktree', 'remove', '--force', targetPath],
-      expect.objectContaining({ cwd: '/repo' }),
+      { cwd: '/repo', stdio: 'pipe', windowsHide: true },
     );
   });
 });

--- a/src/cli/commands/teleport.ts
+++ b/src/cli/commands/teleport.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk from 'chalk';
-import { execSync, execFileSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { join, basename, isAbsolute, relative } from 'path';
@@ -329,8 +329,16 @@ function sanitize(str: string, maxLen: number = 30): string {
  */
 function getCurrentRepo(): { owner: string; repo: string; root: string; provider: ProviderName } | null {
   try {
-    const root = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8', timeout: 5000 }).trim();
-    const remoteUrl = execSync('git remote get-url origin', { encoding: 'utf-8', timeout: 5000 }).trim();
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      windowsHide: true,
+    }).trim();
+    const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      windowsHide: true,
+    }).trim();
     const parsed = parseRemoteUrl(remoteUrl);
     if (parsed) {
       return { owner: parsed.owner, repo: parsed.repo, root, provider: parsed.provider };
@@ -384,6 +392,7 @@ function createWorktree(
     execFileSync('git', ['fetch', 'origin', baseBranch], {
       cwd: repoRoot,
       stdio: 'pipe',
+      windowsHide: true,
     });
 
     // Create branch from base if it doesn't exist
@@ -391,6 +400,7 @@ function createWorktree(
       execFileSync('git', ['branch', branchName, `origin/${baseBranch}`], {
         cwd: repoRoot,
         stdio: 'pipe',
+        windowsHide: true,
       });
     } catch {
       // Branch might already exist, that's OK
@@ -400,6 +410,7 @@ function createWorktree(
     execFileSync('git', ['worktree', 'add', worktreePath, branchName], {
       cwd: repoRoot,
       stdio: 'pipe',
+      windowsHide: true,
     });
 
     return { success: true };
@@ -511,7 +522,7 @@ export async function teleportCommand(
             .replace('{branch}', branchName);
           execFileSync(
             'git', ['fetch', 'origin', refspec],
-            { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30000 }
+            { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30000, windowsHide: true },
           );
         } catch {
           // Branch might already exist
@@ -522,7 +533,7 @@ export async function teleportCommand(
         try {
           execFileSync(
             'git', ['fetch', 'origin', `${info.branch}:${branchName}`],
-            { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30000 }
+            { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'], timeout: 30000, windowsHide: true },
           );
         } catch {
           // Branch might already exist locally
@@ -649,9 +660,10 @@ export async function teleportListCommand(options: { json?: boolean }): Promise<
 
     let branch = 'unknown';
     try {
-      branch = execSync('git branch --show-current', {
+      branch = execFileSync('git', ['branch', '--show-current'], {
         cwd: worktreePath,
         encoding: 'utf-8',
+        windowsHide: true,
       }).trim();
     } catch {
       // Ignore
@@ -717,9 +729,10 @@ export async function teleportRemoveCommand(
   try {
     // Check for uncommitted changes
     if (!options.force) {
-      const status = execSync('git status --porcelain', {
+      const status = execFileSync('git', ['status', '--porcelain'], {
         cwd: worktreePath,
         encoding: 'utf-8',
+        windowsHide: true,
       });
 
       if (status.trim()) {
@@ -734,9 +747,10 @@ export async function teleportRemoveCommand(
     }
 
     // Find the main repo to run git worktree remove
-    const gitDir = execSync('git rev-parse --git-dir', {
+    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
       cwd: worktreePath,
       encoding: 'utf-8',
+      windowsHide: true,
     }).trim();
 
     // A removable worktree reports a git-dir inside the main repo's .git/worktrees directory.
@@ -763,6 +777,7 @@ export async function teleportRemoveCommand(
     execFileSync('git', args, {
       cwd: mainRepo,
       stdio: 'pipe',
+      windowsHide: true,
     });
 
     if (options.json) {

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -265,6 +265,7 @@ export function buildTmuxSessionName(cwd: string): string {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     if (branch) {
       branchToken = sanitizeTmuxToken(branch);

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -245,8 +245,8 @@ function syncMarketplaceClone(verbose: boolean = false): { ok: boolean; message:
   }
 
   const stdio = verbose ? 'inherit' : 'pipe';
-  const execOpts = { encoding: 'utf-8' as const, stdio: stdio as any, timeout: 60000 };
-  const queryExecOpts = { encoding: 'utf-8' as const, stdio: 'pipe' as const, timeout: 60000 };
+  const execOpts = { encoding: 'utf-8' as const, stdio: stdio as any, timeout: 60000, windowsHide: true };
+  const queryExecOpts = { encoding: 'utf-8' as const, stdio: 'pipe' as const, timeout: 60000, windowsHide: true };
 
   try {
     execFileSync('git', ['-C', marketplacePath, 'fetch', '--all', '--prune'], execOpts);

--- a/src/features/session-friction-report/index.ts
+++ b/src/features/session-friction-report/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { createReadStream, existsSync, readdirSync, statSync } from 'fs';
 import { dirname, join, normalize, resolve } from 'path';
 import { createInterface } from 'readline';
@@ -67,10 +67,11 @@ function parseSinceSpec(since?: string): number | undefined {
 
 function getMainRepoRoot(projectRoot: string): string | null {
   try {
-    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+    const gitCommonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
       cwd: projectRoot,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const mainRepoRoot = dirname(resolve(projectRoot, gitCommonDir));
     return mainRepoRoot === projectRoot ? null : mainRepoRoot;

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { createReadStream, existsSync, readdirSync, statSync } from 'fs';
 import { dirname, join, normalize, resolve } from 'path';
 import { createInterface } from 'readline';
@@ -69,10 +69,11 @@ function parseSinceSpec(since?: string): number | undefined {
 
 function getMainRepoRoot(projectRoot: string): string | null {
   try {
-    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+    const gitCommonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
       cwd: projectRoot,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const absoluteCommonDir = resolve(projectRoot, gitCommonDir);
     const mainRepoRoot = dirname(absoluteCommonDir);

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -15,7 +15,7 @@
  * - Security allowlist via .omc/config/live-data-policy.json
  */
 
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import safe from "safe-regex";
@@ -351,10 +351,11 @@ function globToRegex(glob: string): RegExp {
 
 function checkIfModified(pattern: string): boolean {
   try {
-    const output = execSync("git diff --name-only 2>/dev/null || true", {
+    const output = execFileSync("git", ["diff", "--name-only"], {
       timeout: 5000,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
     const regex = globToRegex(pattern);
     return output.split("\n").some((f) => regex.test(f.trim()));
@@ -365,10 +366,11 @@ function checkIfModified(pattern: string): boolean {
 
 function checkIfBranch(pattern: string): boolean {
   try {
-    const branch = execSync("git branch --show-current 2>/dev/null || true", {
+    const branch = execFileSync("git", ["branch", "--show-current"], {
       timeout: 5000,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     }).trim();
     return globToRegex(pattern).test(branch);
   } catch {

--- a/src/hooks/code-simplifier/index.ts
+++ b/src/hooks/code-simplifier/index.ts
@@ -10,7 +10,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { getGlobalOmcConfigCandidates } from '../../utils/paths.js';
 
 /** Config shape for the code-simplifier feature */
@@ -79,11 +79,12 @@ export function getModifiedFiles(
   maxFiles: number = DEFAULT_MAX_FILES,
 ): string[] {
   try {
-    const output = execSync('git diff HEAD --name-only', {
+    const output = execFileSync('git', ['diff', 'HEAD', '--name-only'], {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     });
 
     return output

--- a/src/hooks/omc-orchestrator/index.ts
+++ b/src/hooks/omc-orchestrator/index.ts
@@ -9,7 +9,7 @@
  */
 
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { getOmcRoot, getWorktreeRoot } from '../../lib/worktree-paths.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
 import { toForwardSlash } from '../../utils/paths.js';
@@ -177,18 +177,20 @@ function isDelegationToolName(toolName: string): boolean {
  */
 export function getGitDiffStats(directory: string): GitFileStat[] {
   try {
-    const output = execSync('git diff --numstat HEAD', {
+    const output = execFileSync('git', ['diff', '--numstat', 'HEAD'], {
       cwd: directory,
       encoding: 'utf-8',
       timeout: 5000,
+      windowsHide: true,
     }).trim();
 
     if (!output) return [];
 
-    const statusOutput = execSync('git status --porcelain', {
+    const statusOutput = execFileSync('git', ['status', '--porcelain'], {
       cwd: directory,
       encoding: 'utf-8',
       timeout: 5000,
+      windowsHide: true,
     }).trim();
 
     const statusMap = new Map<string, 'modified' | 'added' | 'deleted'>();

--- a/src/hooks/persistent-mode/__tests__/idle-repo-state.test.ts
+++ b/src/hooks/persistent-mode/__tests__/idle-repo-state.test.ts
@@ -13,6 +13,7 @@ describe('getIdleNotificationRepoState', () => {
   });
 
   it('builds a stable zero-backlog signature from git and GitHub state', () => {
+    const directory = 'C:\\repo folder; & echo owned\\worktree';
     vi.mocked(execFileSync)
       .mockReturnValueOnce('git@github.com:Yeachan-Heo/oh-my-claudecode.git\n')
       .mockReturnValueOnce('abc123\n')
@@ -21,7 +22,7 @@ describe('getIdleNotificationRepoState', () => {
       .mockReturnValueOnce('[]')
       .mockReturnValueOnce('[]');
 
-    const result = getIdleNotificationRepoState('/repo');
+    const result = getIdleNotificationRepoState(directory);
 
     expect(result).toEqual({
       signature: JSON.stringify({
@@ -34,6 +35,16 @@ describe('getIdleNotificationRepoState', () => {
       }),
       backlogZero: true,
     });
+    const gitOptions = {
+      cwd: directory,
+      encoding: 'utf-8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    };
+    expect(execFileSync).toHaveBeenNthCalledWith(1, 'git', ['remote', 'get-url', 'origin'], gitOptions);
+    expect(execFileSync).toHaveBeenNthCalledWith(2, 'git', ['rev-parse', 'HEAD'], gitOptions);
+    expect(execFileSync).toHaveBeenNthCalledWith(3, 'git', ['status', '--porcelain'], gitOptions);
   });
 
   it('returns non-zero backlog when PRs, issues, or failing runs exist', () => {

--- a/src/hooks/persistent-mode/idle-repo-state.ts
+++ b/src/hooks/persistent-mode/idle-repo-state.ts
@@ -32,6 +32,7 @@ function runCommand(command: string, args: string[], cwd: string): string | null
       encoding: 'utf-8',
       timeout: COMMAND_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
+      ...(command === 'git' ? { windowsHide: true } : {}),
     }).trim();
   } catch {
     return null;

--- a/src/hooks/project-memory/detector.ts
+++ b/src/hooks/project-memory/detector.ts
@@ -545,6 +545,7 @@ async function detectGitBranch(projectRoot: string): Promise<GitBranchPattern | 
     // Get default branch
     const { stdout } = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
       cwd: projectRoot,
+      windowsHide: true,
     });
 
     const match = stdout.trim().match(/refs\/remotes\/origin\/(.+)/);

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -10,7 +10,7 @@
  * Ported from oh-my-opencode's ralph hook.
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { readFileSync } from "fs";
 import { basename, join } from "path";
 import {
@@ -299,10 +299,11 @@ export function createRalphLoopHook(directory: string): RalphLoopHook {
 
     let branchName = "ralph/task";
     try {
-      branchName = execSync("git rev-parse --abbrev-ref HEAD", {
+      branchName = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd: directory,
         encoding: "utf-8",
         timeout: 5000,
+        windowsHide: true,
       }).trim();
     } catch {
       // Fallback outside git repos.

--- a/src/hud/elements/multi-repo.ts
+++ b/src/hud/elements/multi-repo.ts
@@ -14,7 +14,7 @@
  * returns null and the normal repo/branch/status elements take over.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import { cyan, dim, green, yellow } from '../colors.js';
@@ -69,12 +69,11 @@ export function resetMultiRepoCache(): void {
 
 function isGitRepo(dir: string): boolean {
   try {
-    execSync('git rev-parse --show-toplevel', {
+    execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: dir,
       encoding: 'utf-8',
       timeout: 1000,
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
       windowsHide: true,
     });
     return true;

--- a/src/lib/__tests__/worktree-paths-superproject-cache.test.ts
+++ b/src/lib/__tests__/worktree-paths-superproject-cache.test.ts
@@ -1,19 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("child_process", () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { join, resolve } from "path";
 import { clearWorktreeCache, getOmcRoot } from "../worktree-paths.js";
 
-const mockedExecSync = vi.mocked(execSync);
+const mockedExecFileSync = vi.mocked(execFileSync);
 
 describe("resolveSuperprojectRoot cache", () => {
   beforeEach(() => {
     clearWorktreeCache();
-    mockedExecSync.mockReset();
+    mockedExecFileSync.mockReset();
   });
 
   afterEach(() => {
@@ -23,7 +23,7 @@ describe("resolveSuperprojectRoot cache", () => {
 
   it("caches repeated explicit non-git root probes, including null results, without changing the literal root", () => {
     const relativeRoot = join("superproject-cache-non-git");
-    mockedExecSync.mockImplementation(() => {
+    mockedExecFileSync.mockImplementation(() => {
       throw Object.assign(new Error("not a submodule"), {
         status: 128,
         stderr:
@@ -33,28 +33,29 @@ describe("resolveSuperprojectRoot cache", () => {
 
     expect(getOmcRoot(relativeRoot)).toBe(join(relativeRoot, ".omc"));
     expect(getOmcRoot(relativeRoot)).toBe(join(relativeRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecSync).toHaveBeenLastCalledWith(
-      "git rev-parse --show-superproject-working-tree",
-      expect.objectContaining({ cwd: resolve(relativeRoot) }),
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenLastCalledWith(
+      "git",
+      ["rev-parse", "--show-superproject-working-tree"],
+      expect.objectContaining({ cwd: resolve(relativeRoot), windowsHide: true }),
     );
   });
 
   it("does not cache transient superproject probe errors", () => {
     const transientRoot = resolve("repos", "transient-superproject-error");
-    mockedExecSync.mockImplementation(() => {
+    mockedExecFileSync.mockImplementation(() => {
       throw new Error("spawn failed");
     });
 
     expect(getOmcRoot(transientRoot)).toBe(join(transientRoot, ".omc"));
     expect(getOmcRoot(transientRoot)).toBe(join(transientRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
   });
 
   it("does not cache a partial anchor after a nested probe fails", () => {
     const nestedRoot = resolve("repos", "partial", "inner");
     const outerRoot = resolve("repos", "partial");
-    mockedExecSync.mockImplementation((_command, options) => {
+    mockedExecFileSync.mockImplementation((_command, _args, options) => {
       if (options?.cwd === nestedRoot) return `${outerRoot}\n`;
       if (options?.cwd === outerRoot) throw new Error("transient outer failure");
       throw new Error(`unexpected cwd: ${String(options?.cwd)}`);
@@ -62,14 +63,14 @@ describe("resolveSuperprojectRoot cache", () => {
 
     expect(getOmcRoot(nestedRoot)).toBe(join(outerRoot, ".omc"));
     expect(getOmcRoot(nestedRoot)).toBe(join(outerRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(4);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(4);
   });
 
   it("caches the final outermost root after climbing nested submodules", () => {
     const nestedRoot = resolve("repos", "outer", "middle", "inner");
     const middleRoot = resolve("repos", "outer", "middle");
     const outerRoot = resolve("repos", "outer");
-    mockedExecSync.mockImplementation((_command, options) => {
+    mockedExecFileSync.mockImplementation((_command, _args, options) => {
       switch (options?.cwd) {
         case nestedRoot:
           return `${middleRoot}\n`;
@@ -83,16 +84,16 @@ describe("resolveSuperprojectRoot cache", () => {
     });
 
     expect(getOmcRoot(nestedRoot)).toBe(join(outerRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(3);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(3);
     expect(getOmcRoot(nestedRoot)).toBe(join(outerRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(3);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(3);
   });
 
   it("clearWorktreeCache invalidates both negative and positive superproject entries", () => {
     const nonGitRoot = resolve("repos", "no-superproject");
     const nestedRoot = resolve("repos", "outer", "inner");
     const outerRoot = resolve("repos", "outer");
-    mockedExecSync.mockImplementation((_command, options) => {
+    mockedExecFileSync.mockImplementation((_command, _args, options) => {
       if (options?.cwd === nonGitRoot) {
         throw Object.assign(new Error("not a submodule"), {
           status: 128,
@@ -106,17 +107,17 @@ describe("resolveSuperprojectRoot cache", () => {
 
     expect(getOmcRoot(nonGitRoot)).toBe(join(nonGitRoot, ".omc"));
     expect(getOmcRoot(nestedRoot)).toBe(join(outerRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(3);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(3);
 
     clearWorktreeCache();
 
     expect(getOmcRoot(nonGitRoot)).toBe(join(nonGitRoot, ".omc"));
     expect(getOmcRoot(nestedRoot)).toBe(join(outerRoot, ".omc"));
-    expect(mockedExecSync).toHaveBeenCalledTimes(6);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
   });
 
   it("evicts the least-recently-used superproject entry at capacity eight", () => {
-    mockedExecSync.mockReturnValue("");
+    mockedExecFileSync.mockReturnValue("");
     const roots = Array.from({ length: 9 }, (_value, index) =>
       resolve("repos", `cache-${index}`),
     );
@@ -124,14 +125,14 @@ describe("resolveSuperprojectRoot cache", () => {
     for (const root of roots.slice(0, 8)) {
       getOmcRoot(root);
     }
-    expect(mockedExecSync).toHaveBeenCalledTimes(8);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(8);
 
     getOmcRoot(roots[0]!);
     getOmcRoot(roots[8]!);
-    expect(mockedExecSync).toHaveBeenCalledTimes(9);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(9);
 
     getOmcRoot(roots[0]!);
     getOmcRoot(roots[1]!);
-    expect(mockedExecSync).toHaveBeenCalledTimes(10);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(10);
   });
 });

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -10,7 +10,7 @@
  */
 
 import { createHash } from 'crypto';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFileSync, unlinkSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
@@ -176,7 +176,7 @@ function resolveSuperprojectRoot(cwd: string): string | null {
   for (let depth = 0; depth < 32; depth++) {
     let superRoot: string;
     try {
-      superRoot = execSync('git rev-parse --show-superproject-working-tree', {
+      superRoot = execFileSync('git', ['rev-parse', '--show-superproject-working-tree'], {
         cwd: probeCwd,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -248,7 +248,7 @@ export function getGitTopLevel(cwd?: string): string | null {
   }
 
   try {
-    const root = execSync('git rev-parse --show-toplevel', {
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -482,7 +482,7 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
 
   let source: string;
   try {
-    const remoteUrl = execSync('git remote get-url origin', {
+    const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], {
       cwd: root,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -501,7 +501,7 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
   // directories despite sharing the same remote URL hash.
   let primaryRoot = root;
   try {
-    const commonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+    const commonDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
       cwd: root,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -1144,7 +1144,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
   // the main repo's encoded path. Use `git rev-parse --git-common-dir`
   // to find the main repo root and re-encode.
   try {
-    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+    const gitCommonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -1162,7 +1162,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
     // ecryptfs $HOME on Linux, autofs /home, etc.)
     try { mainRepoRoot = realpathSync(mainRepoRoot); } catch { /* keep as-is */ }
 
-    const worktreeTop = execSync('git rev-parse --show-toplevel', {
+    const worktreeTop = execFileSync('git', ['rev-parse', '--show-toplevel'], {
       cwd: effectiveCwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -1265,7 +1265,7 @@ export function validateWorkingDirectory(workingDirectory?: string): string {
 
 function getGitCommonDir(cwd: string): string | null {
   try {
-    const commonDir = execSync('git rev-parse --path-format=absolute --git-common-dir', {
+    const commonDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
       cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,7 +5,7 @@
  * access to provider-specific adapters.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type { ProviderName, RemoteUrlInfo, GitProvider } from './types.js';
 import { GitHubProvider } from './github.js';
 import { GitLabProvider } from './gitlab.js';
@@ -53,11 +53,12 @@ function getRemoteUrl(cwd?: string): string | null {
   if (cached !== undefined) return cached;
 
   try {
-    const url = execSync('git remote get-url origin', {
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], {
       cwd: resolvedCwd,
       encoding: 'utf-8',
       timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     const result = url || null;

--- a/src/team/__tests__/merge-orchestrator.test.ts
+++ b/src/team/__tests__/merge-orchestrator.test.ts
@@ -17,6 +17,7 @@ interface GitCall {
   cmd: string;
   args: readonly string[];
   cwd?: string;
+  options?: { cwd?: string; encoding?: string; stdio?: string; windowsHide?: boolean };
 }
 
 const mocks = vi.hoisted(() => {
@@ -42,8 +43,8 @@ const mocks = vi.hoisted(() => {
     calls,
     handlers,
     reset,
-    execFileSync: vi.fn((cmd: string, args: readonly string[], opts?: { cwd?: string; encoding?: string }) => {
-      calls.push({ cmd, args, cwd: opts?.cwd });
+    execFileSync: vi.fn((cmd: string, args: readonly string[], opts?: { cwd?: string; encoding?: string; stdio?: string; windowsHide?: boolean }) => {
+      calls.push({ cmd, args, cwd: opts?.cwd, options: opts });
       for (const h of handlers) {
         if (h.match(args, opts?.cwd)) {
           const r = h.handler(args, opts?.cwd);
@@ -174,6 +175,34 @@ function defaultHappyPath(_repoRoot: string, leaderBranch: string): void {
 beforeEach(() => {
   mocks.reset();
   process.env.OMC_RUNTIME_V2 = '1';
+});
+
+describe('Git process construction', () => {
+  it('uses git argv with hidden-window options for merger worktree setup', async () => {
+    const repoRoot = makeRepoRoot();
+    try {
+      const cfg = defaultConfig(repoRoot);
+      defaultHappyPath(repoRoot, cfg.leaderBranch);
+
+      const handle = await startMergeOrchestrator(cfg);
+      await handle.drainAndStop();
+
+      expect(mocks.calls).not.toHaveLength(0);
+      for (const call of mocks.calls) {
+        expect(call.cmd).toBe('git');
+        expect(Array.isArray(call.args)).toBe(true);
+        expect(call.options).toEqual(expect.objectContaining({ windowsHide: true }));
+      }
+      expect(mocks.calls).toContainEqual(expect.objectContaining({
+        cmd: 'git',
+        args: ['worktree', 'add', '--force', expect.any(String), cfg.leaderBranch],
+        cwd: repoRoot,
+        options: expect.objectContaining({ stdio: 'pipe', windowsHide: true }),
+      }));
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 afterEach(() => {

--- a/src/team/git-worktree.ts
+++ b/src/team/git-worktree.ts
@@ -95,7 +95,7 @@ export function getBranchName(teamName: string, workerName: string): string {
 }
 
 function git(repoRoot: string, args: string[], cwd = repoRoot): string {
-  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: 'pipe' }).trim();
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: 'pipe', windowsHide: true }).trim();
 }
 
 function isInsideGitRepo(repoRoot: string): boolean {
@@ -164,7 +164,7 @@ function isRegisteredWorktreePath(repoRoot: string, wtPath: string): boolean {
 
 function isDetached(wtPath: string): boolean {
   try {
-    const branch = execFileSync('git', ['branch', '--show-current'], { cwd: wtPath, encoding: 'utf-8', stdio: 'pipe' }).trim();
+    const branch = execFileSync('git', ['branch', '--show-current'], { cwd: wtPath, encoding: 'utf-8', stdio: 'pipe', windowsHide: true }).trim();
     return branch.length === 0;
   } catch {
     return false;
@@ -197,7 +197,7 @@ function statusEntryPath(line: string): string {
 function isWorktreeDirtyExcept(wtPath: string, ignoredRootPaths: string[] = []): { dirty: boolean; entries: string[] } {
   try {
     const ignored = new Set(ignoredRootPaths);
-    const entries = execFileSync('git', ['status', '--porcelain'], { cwd: wtPath, encoding: 'utf-8', stdio: 'pipe' })
+    const entries = execFileSync('git', ['status', '--porcelain'], { cwd: wtPath, encoding: 'utf-8', stdio: 'pipe', windowsHide: true })
       .split('\n')
       .filter(line => line.trim().length > 0);
     const relevantEntries = entries.filter(line => !ignored.has(statusEntryPath(line)));
@@ -472,7 +472,7 @@ export function ensureWorkerWorktree(
   validateResolvedPath(wtPath, join(getOmcRoot(repoRoot), 'team'));
 
   try {
-    execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe' });
+    execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe', windowsHide: true });
   } catch { /* ignore */ }
 
   if (existsSync(wtPath)) {
@@ -499,7 +499,7 @@ export function ensureWorkerWorktree(
   const args = mode === 'named'
     ? ['worktree', 'add', '-b', branch, wtPath, options.baseRef ?? 'HEAD']
     : ['worktree', 'add', '--detach', wtPath, options.baseRef ?? 'HEAD'];
-  execFileSync('git', args, { cwd: repoRoot, stdio: 'pipe' });
+  execFileSync('git', args, { cwd: repoRoot, stdio: 'pipe', windowsHide: true });
 
   const info: EnsureWorkerWorktreeResult = {
     path: wtPath,
@@ -617,7 +617,7 @@ export function removeWorkerWorktree(
 
     const wasRegisteredWorktree = isRegisteredWorktreePath(repoRoot, wtPath);
     try {
-      execFileSync('git', ['worktree', 'remove', wtPath], { cwd: repoRoot, stdio: 'pipe' });
+      execFileSync('git', ['worktree', 'remove', wtPath], { cwd: repoRoot, stdio: 'pipe', windowsHide: true });
     } catch (err) {
       if (wasRegisteredWorktree) {
         const detail = err instanceof Error && err.message ? `: ${err.message}` : '';
@@ -629,11 +629,11 @@ export function removeWorkerWorktree(
     }
 
     try {
-      execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe' });
+      execFileSync('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'pipe', windowsHide: true });
     } catch { /* ignore */ }
 
     try {
-      execFileSync('git', ['branch', '-D', branch], { cwd: repoRoot, stdio: 'pipe' });
+      execFileSync('git', ['branch', '-D', branch], { cwd: repoRoot, stdio: 'pipe', windowsHide: true });
     } catch { /* branch may not exist */ }
 
     // If a stale plain directory remains and it is not a registered worktree, remove it

--- a/src/team/mcp-team-bridge.ts
+++ b/src/team/mcp-team-bridge.ts
@@ -11,7 +11,7 @@
  * Polls task files, builds prompts, spawns CLI processes, reports results.
  */
 
-import { spawn, execSync, ChildProcess } from "child_process";
+import { spawn, execFileSync, ChildProcess } from "child_process";
 import { existsSync, openSync, readSync, closeSync } from "fs";
 import { join } from "path";
 import { writeFileWithMode, ensureDirWithMode } from "./fs-utils.js";
@@ -89,10 +89,11 @@ export function captureFileSnapshot(cwd: string): Set<string> {
   const files = new Set<string>();
   try {
     // Get all tracked files that are modified, added, or staged
-    const statusOutput = execSync("git status --porcelain", {
+    const statusOutput = execFileSync("git", ["status", "--porcelain"], {
       cwd,
       encoding: "utf-8",
       timeout: 10000,
+      windowsHide: true,
     });
     for (const line of statusOutput.split("\n")) {
       if (!line.trim()) continue;
@@ -105,9 +106,10 @@ export function captureFileSnapshot(cwd: string): Set<string> {
     }
 
     // Get untracked files
-    const untrackedOutput = execSync(
-      "git ls-files --others --exclude-standard",
-      { cwd, encoding: "utf-8", timeout: 10000 },
+    const untrackedOutput = execFileSync(
+      "git",
+      ["ls-files", "--others", "--exclude-standard"],
+      { cwd, encoding: "utf-8", timeout: 10000, windowsHide: true },
     );
     for (const line of untrackedOutput.split("\n")) {
       if (line.trim()) files.add(line.trim());

--- a/src/team/merge-coordinator.ts
+++ b/src/team/merge-coordinator.ts
@@ -54,12 +54,14 @@ export function configureHarnessMergeAttributes(repoRoot: string): void {
   execFileSync('git', ['config', 'merge.ours.driver', 'true'], {
     cwd: repoRoot,
     stdio: 'pipe',
+    windowsHide: true,
   });
 
   const commonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
     cwd: repoRoot,
     encoding: 'utf-8',
     stdio: 'pipe',
+    windowsHide: true,
   }).trim();
   const resolvedCommonDir = isAbsolute(commonDir) ? commonDir : join(repoRoot, commonDir);
   const infoDir = join(resolvedCommonDir, 'info');
@@ -109,7 +111,7 @@ export function checkMergeConflicts(
   try {
     execFileSync(
       'git', ['merge-tree', '--write-tree', baseBranch, workerBranch],
-      { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
     );
     // Exit code 0 means no conflicts
     return [];
@@ -133,16 +135,16 @@ export function checkMergeConflicts(
   // Fallback: file-overlap heuristic for Git < 2.38
   const mergeBase = execFileSync(
     'git', ['merge-base', baseBranch, workerBranch],
-    { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
   ).trim();
 
   const baseDiff = execFileSync(
     'git', ['diff', '--name-only', mergeBase, baseBranch],
-    { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
   ).trim();
   const workerDiff = execFileSync(
     'git', ['diff', '--name-only', mergeBase, workerBranch],
-    { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    { cwd: repoRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
   ).trim();
 
   if (!baseDiff || !workerDiff) {
@@ -175,7 +177,7 @@ export function mergeWorkerBranch(
     // Uses diff-index which ignores untracked files (e.g. .omc/ worktree metadata).
     try {
       execFileSync('git', ['diff-index', '--quiet', 'HEAD', '--'], {
-        cwd: repoRoot, stdio: 'pipe'
+        cwd: repoRoot, stdio: 'pipe', windowsHide: true
       });
     } catch {
       throw new Error('Working tree has uncommitted changes — commit or stash before merging');
@@ -183,17 +185,17 @@ export function mergeWorkerBranch(
 
     // Ensure we're on the base branch
     execFileSync('git', ['checkout', baseBranch], {
-      cwd: repoRoot, stdio: 'pipe'
+      cwd: repoRoot, stdio: 'pipe', windowsHide: true
     });
 
     // Attempt merge
     execFileSync('git', ['merge', '--no-ff', '-m', `Merge ${workerBranch} into ${baseBranch}`, workerBranch], {
-      cwd: repoRoot, stdio: 'pipe'
+      cwd: repoRoot, stdio: 'pipe', windowsHide: true
     });
 
     // Get merge commit hash
     const mergeCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd: repoRoot, encoding: 'utf-8', stdio: 'pipe'
+      cwd: repoRoot, encoding: 'utf-8', stdio: 'pipe', windowsHide: true
     }).trim();
 
     return {
@@ -206,7 +208,7 @@ export function mergeWorkerBranch(
   } catch (_err) {
     // Abort the failed merge
     try {
-      execFileSync('git', ['merge', '--abort'], { cwd: repoRoot, stdio: 'pipe' });
+      execFileSync('git', ['merge', '--abort'], { cwd: repoRoot, stdio: 'pipe', windowsHide: true });
     } catch { /* may not be in merge state */ }
 
     // Try to detect conflicting files
@@ -235,7 +237,7 @@ export function mergeAllWorkerBranches(
 
   // Determine base branch
   const base = baseBranch || execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-    cwd: repoRoot, encoding: 'utf-8', stdio: 'pipe'
+    cwd: repoRoot, encoding: 'utf-8', stdio: 'pipe', windowsHide: true
   }).trim();
 
   validateBranchName(base);

--- a/src/team/merge-orchestrator.ts
+++ b/src/team/merge-orchestrator.ts
@@ -258,6 +258,7 @@ function gitRevParseHead(repoRoot: string, branch: string): string {
     cwd: repoRoot,
     encoding: 'utf-8',
     stdio: 'pipe',
+    windowsHide: true,
   }).trim();
 }
 
@@ -267,6 +268,7 @@ function gitPath(worktreePath: string, gitPathName: string): string {
       cwd: worktreePath,
       encoding: 'utf-8',
       stdio: 'pipe',
+      windowsHide: true,
     }).trim();
     if (resolved) return resolved;
   } catch {
@@ -287,6 +289,7 @@ function isWorktreeRegistered(repoRoot: string, wtPath: string): boolean {
       cwd: repoRoot,
       encoding: 'utf-8',
       stdio: 'pipe',
+      windowsHide: true,
     });
     for (const line of out.split('\n')) {
       if (line.startsWith('worktree ')) {
@@ -309,6 +312,7 @@ function ensureMergerWorktree(repoRoot: string, mergerPath: string, leaderBranch
   execFileSync('git', ['worktree', 'add', '--force', mergerPath, leaderBranch], {
     cwd: repoRoot,
     stdio: 'pipe',
+    windowsHide: true,
   });
 }
 
@@ -318,6 +322,7 @@ function preflightMergerWorktree(mergerPath: string, leaderBranch: string): void
     execFileSync('git', ['fetch', '--no-tags', 'origin', leaderBranch], {
       cwd: mergerPath,
       stdio: 'pipe',
+      windowsHide: true,
     });
   } catch {
     // ignore
@@ -325,6 +330,7 @@ function preflightMergerWorktree(mergerPath: string, leaderBranch: string): void
   execFileSync('git', ['reset', '--hard', leaderBranch], {
     cwd: mergerPath,
     stdio: 'pipe',
+    windowsHide: true,
   });
 }
 
@@ -438,6 +444,7 @@ export async function startMergeOrchestrator(
         execFileSync('git', ['fetch', '--no-tags', 'origin', config.leaderBranch], {
           cwd: wtPath,
           stdio: 'pipe',
+          windowsHide: true,
         });
       } catch {
         // offline OK
@@ -447,6 +454,7 @@ export async function startMergeOrchestrator(
         execFileSync('git', ['rebase', config.leaderBranch], {
           cwd: wtPath,
           stdio: 'pipe',
+          windowsHide: true,
         });
         // Clean rebase — resume immediately.
         await resumeHookViaSentinel(wtPath);
@@ -463,6 +471,7 @@ export async function startMergeOrchestrator(
             cwd: wtPath,
             encoding: 'utf-8',
             stdio: 'pipe',
+            windowsHide: true,
           });
           conflictingFiles = parseUUFiles(status);
         } catch {
@@ -475,6 +484,7 @@ export async function startMergeOrchestrator(
               cwd: config.repoRoot,
               encoding: 'utf-8',
               stdio: 'pipe',
+              windowsHide: true,
             }).trim();
           } catch {
             return 'unknown';
@@ -543,7 +553,7 @@ export async function startMergeOrchestrator(
           mergeBaseSha = execFileSync(
             'git',
             ['merge-base', config.leaderBranch, entry.workerBranch],
-            { cwd: mergerPath, encoding: 'utf-8', stdio: 'pipe' },
+            { cwd: mergerPath, encoding: 'utf-8', stdio: 'pipe', windowsHide: true },
           ).trim();
         } catch {
           // best-effort
@@ -692,6 +702,7 @@ export async function startMergeOrchestrator(
         cwd: entry.workerWorktreePath,
         encoding: 'utf-8',
         stdio: 'pipe',
+        windowsHide: true,
       }).trim();
       if (status.length > 0) {
         const dirtyFiles = status

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -411,6 +411,7 @@ function resolveLeaderBranch(cwd: string): string {
     cwd,
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
   }).trim();
   if (!out) {
     throw new Error('auto-merge requires a non-detached leader branch (git branch --show-current returned empty)');

--- a/templates/hooks/code-simplifier.mjs
+++ b/templates/hooks/code-simplifier.mjs
@@ -19,7 +19,7 @@ import {
 } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -53,11 +53,12 @@ function isEnabled(config) {
 
 function getModifiedFiles(cwd, extensions, maxFiles) {
   try {
-    const output = execSync('git diff HEAD --name-only', {
+    const output = execFileSync('git', ['diff', 'HEAD', '--name-only'], {
       cwd,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
+      windowsHide: true,
     });
 
     return output

--- a/templates/hooks/workflow-drift-guard.mjs
+++ b/templates/hooks/workflow-drift-guard.mjs
@@ -78,7 +78,7 @@ function isCodePath(path) {
 
 function git(cwd, args) {
   try {
-    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 });
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000, windowsHide: true });
   } catch { return ''; }
 }
 

--- a/tests/lint/windows-hide-hooks.test.ts
+++ b/tests/lint/windows-hide-hooks.test.ts
@@ -1,55 +1,299 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = join(__dirname, '..', '..');
+const CHILD_PROCESS_METHODS = new Set(['exec', 'execSync', 'execFile', 'execFileSync', 'spawn', 'spawnSync']);
+const INSTALLED_HOOK_TEMPLATE_ROOT = 'templates/hooks';
 
-const RECURRING_HOOK_SCRIPTS = [
-  'scripts/pre-tool-enforcer.mjs',
-  'scripts/post-tool-verifier.mjs',
-  'scripts/context-guard-stop.mjs',
-  'scripts/code-simplifier.mjs',
-] as const;
-
-const CHILD_PROCESS_CALL = /\b(execSync|execFileSync|spawn|spawnSync)\s*\(\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*,\s*\{([\s\S]*?)\}\s*\)/g;
-const WINDOWS_HIDE_TRUE = /\bwindowsHide\s*:\s*true\b/;
+interface ProductionSource {
+  path: string;
+  content: string;
+}
 
 function toForwardSlash(path: string): string {
   return path.split(sep).join('/');
 }
 
-describe('Windows hook child-process hardening', () => {
-  it('recurring hook scripts hide nested child_process calls on Windows', () => {
-    const violations: string[] = [];
-    const scannedCalls: string[] = [];
+function walkFiles(directory: string, predicate: (path: string) => boolean): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === '__tests__' ? [] : walkFiles(path, predicate);
+    }
+    return entry.isFile() && predicate(path) ? [path] : [];
+  });
+}
 
-    for (const script of RECURRING_HOOK_SCRIPTS) {
-      const absolutePath = join(REPO_ROOT, script);
-      const content = readFileSync(absolutePath, 'utf-8');
-      const linesBefore = (index: number) => content.slice(0, index).split('\n').length;
+/**
+ * This is intentionally a production manifest rather than a repository-wide scan:
+ * source-reachable TypeScript, scripts registered by hooks/hooks.json, and every
+ * installed hook template. Release/build/developer scripts are therefore excluded.
+ */
+function productionManifest(): ProductionSource[] {
+  const sourceFiles = walkFiles(join(REPO_ROOT, 'src'), (path) =>
+    path.endsWith('.ts') &&
+    !/\.(?:test|spec)\.ts$/.test(path) &&
+    toForwardSlash(relative(REPO_ROOT, path)) !== 'src/lib/release-generation.ts',
+  );
+  const registeredScripts = new Set(
+    [...readFileSync(join(REPO_ROOT, 'hooks', 'hooks.json'), 'utf8').matchAll(/scripts\/([\w-]+\.mjs)/g)]
+      .map((match) => join(REPO_ROOT, 'scripts', match[1]!)),
+  );
+  const installedTemplates = walkFiles(join(REPO_ROOT, INSTALLED_HOOK_TEMPLATE_ROOT), (path) => path.endsWith('.mjs'));
 
-      for (const match of content.matchAll(CHILD_PROCESS_CALL)) {
-        const callName = match[1];
-        const optionsBlock = match[2] ?? '';
-        const line = linesBefore(match.index ?? 0);
-        scannedCalls.push(`${script}:${callName}`);
+  return [...new Set([...sourceFiles, ...registeredScripts, ...installedTemplates])]
+    .sort()
+    .map((path) => ({ path: toForwardSlash(relative(REPO_ROOT, path)), content: readFileSync(path, 'utf8') }));
+}
 
-        if (!WINDOWS_HIDE_TRUE.test(optionsBlock)) {
-          violations.push(`${toForwardSlash(relative(REPO_ROOT, absolutePath))}:${line}: ${callName} missing windowsHide: true`);
+function unwrap(expression: ts.Expression): ts.Expression {
+  while (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression) || ts.isTypeAssertionExpression(expression)) {
+    expression = expression.expression;
+  }
+  return expression;
+}
+
+function stringValue(expression: ts.Expression | undefined): string | undefined {
+  if (!expression) return undefined;
+  expression = unwrap(expression);
+  return ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression) ? expression.text : undefined;
+}
+
+function isGitCommand(expression: ts.Expression | undefined): boolean {
+  const value = stringValue(expression);
+  return value !== undefined && /(?:^|[\\/])git(?:\.exe)?$/i.test(value);
+}
+
+function isGitShellCommand(expression: ts.Expression | undefined): boolean {
+  if (!expression) return false;
+  expression = unwrap(expression);
+  const value = ts.isTemplateExpression(expression) ? expression.head.text : stringValue(expression);
+  return value !== undefined && /(?:^|\s)git(?:\.exe)?(?:\s|$)/i.test(value);
+}
+
+function propertyName(property: ts.ObjectLiteralElementLike): string | undefined {
+  if (!('name' in property) || !property.name) return undefined;
+  return ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : undefined;
+}
+
+function isGitCondition(expression: ts.Expression, commandParameter?: string): boolean {
+  if (!commandParameter) return false;
+  const text = expression.getText();
+  return new RegExp(`\\b${commandParameter}\\s*={2,3}\\s*['\"]git['\"]|['\"]git['\"]\\s*={2,3}\\s*${commandParameter}\\b`).test(text);
+}
+
+function optionValue(
+  expression: ts.Expression | undefined,
+  name: 'windowsHide' | 'shell',
+  declarations: Map<string, ts.Expression>,
+  commandParameter?: string,
+  seen = new Set<string>(),
+): boolean {
+  if (!expression) return false;
+  expression = unwrap(expression);
+
+  if (ts.isIdentifier(expression)) {
+    if (seen.has(expression.text)) return false;
+    const declaration = declarations.get(expression.text);
+    if (!declaration) return false;
+    seen.add(expression.text);
+    return optionValue(declaration, name, declarations, commandParameter, seen);
+  }
+
+  if (ts.isConditionalExpression(expression)) {
+    if (isGitCondition(expression.condition, commandParameter)) {
+      return optionValue(expression.whenTrue, name, declarations, commandParameter, seen);
+    }
+    return false;
+  }
+
+  if (!ts.isObjectLiteralExpression(expression)) return false;
+  for (const property of [...expression.properties].reverse()) {
+    if (ts.isPropertyAssignment(property) && propertyName(property) === name) {
+      return property.initializer.kind === ts.SyntaxKind.TrueKeyword;
+    }
+    if (ts.isSpreadAssignment(property)) {
+      // An unresolved spread could overwrite the option, so only a proven value is effective.
+      return optionValue(property.expression, name, declarations, commandParameter, seen);
+    }
+  }
+  return false;
+}
+
+function collectDeclarations(sourceFile: ts.SourceFile): Map<string, ts.Expression> {
+  const declarations = new Map<string, ts.Expression>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      declarations.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return declarations;
+}
+
+function childProcessCallees(sourceFile: ts.SourceFile): Map<string, string> {
+  const callees = new Map<string, string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && ['child_process', 'node:child_process'].includes(stringValue(node.moduleSpecifier) ?? '')) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const imported = element.propertyName?.text ?? element.name.text;
+          if (CHILD_PROCESS_METHODS.has(imported)) callees.set(element.name.text, imported);
+        }
+      }
+      if (bindings && ts.isNamespaceImport(bindings)) callees.set(bindings.name.text, '*');
+    }
+    if (ts.isVariableDeclaration(node) && node.initializer && ts.isCallExpression(node.initializer) &&
+        ts.isIdentifier(node.initializer.expression) && node.initializer.expression.text === 'require' &&
+        ['child_process', 'node:child_process'].includes(stringValue(node.initializer.arguments[0]) ?? '')) {
+      if (ts.isIdentifier(node.name)) callees.set(node.name.text, '*');
+      if (ts.isObjectBindingPattern(node.name)) {
+        for (const element of node.name.elements) {
+          const imported = element.propertyName?.getText() ?? element.name.getText();
+          if (CHILD_PROCESS_METHODS.has(imported) && ts.isIdentifier(element.name)) callees.set(element.name.text, imported);
         }
       }
     }
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer &&
+        ts.isCallExpression(node.initializer) && ts.isIdentifier(node.initializer.expression) &&
+        node.initializer.expression.text === 'promisify' && ts.isIdentifier(node.initializer.arguments[0]) &&
+        CHILD_PROCESS_METHODS.has(node.initializer.arguments[0].text)) {
+      callees.set(node.name.text, node.initializer.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return callees;
+}
 
-    expect(scannedCalls).toEqual([
-      'scripts/pre-tool-enforcer.mjs:execSync',
-      'scripts/pre-tool-enforcer.mjs:execSync',
-      'scripts/pre-tool-enforcer.mjs:execSync',
-      'scripts/post-tool-verifier.mjs:execSync',
-      'scripts/post-tool-verifier.mjs:execSync',
-      'scripts/post-tool-verifier.mjs:execSync',
-      'scripts/context-guard-stop.mjs:execSync',
-      'scripts/code-simplifier.mjs:execSync',
-    ]);
+function callKind(call: ts.CallExpression, callees: Map<string, string>): string | undefined {
+  const expression = call.expression;
+  if (ts.isIdentifier(expression)) return callees.get(expression.text);
+  if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.expression) &&
+      callees.get(expression.expression.text) === '*' && CHILD_PROCESS_METHODS.has(expression.name.text)) {
+    return expression.name.text;
+  }
+  return undefined;
+}
+
+function enclosingRunCommand(call: ts.CallExpression): string | undefined {
+  let node: ts.Node | undefined = call.parent;
+  while (node) {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === 'runCommand') {
+      return node.parameters[0] && ts.isIdentifier(node.parameters[0].name) ? node.parameters[0].name.text : undefined;
+    }
+    node = node.parent;
+  }
+  return undefined;
+}
+
+function scanGitProcessCalls(path: string, content: string): string[] {
+  const sourceFile = ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true);
+  const declarations = collectDeclarations(sourceFile);
+  const callees = childProcessCallees(sourceFile);
+  const violations: string[] = [];
+
+  const report = (node: ts.Node, message: string) => {
+    const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+    violations.push(`${path}:${line}: ${message}`);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const kind = callKind(node, callees);
+      const helperCommand = ts.isIdentifier(node.expression) && node.expression.text === 'runCommand';
+      const directGit = kind !== undefined && (kind === 'exec' || kind === 'execSync'
+        ? isGitShellCommand(node.arguments[0])
+        : isGitCommand(node.arguments[0]));
+      const helperGit = helperCommand && isGitCommand(node.arguments[0]);
+      const commandParameter = kind ? enclosingRunCommand(node) : undefined;
+      const helperProcessCall = kind !== undefined && commandParameter !== undefined;
+
+      if (directGit || helperProcessCall) {
+        const options = kind === 'exec' || kind === 'execSync' ? node.arguments[1] : node.arguments[2];
+        if (optionValue(options, 'shell', declarations, commandParameter)) {
+          report(node, `${kind} runs Git with shell: true`);
+        }
+        if (!optionValue(options, 'windowsHide', declarations, commandParameter)) {
+          report(node, `${kind} runs Git without effective windowsHide: true`);
+        }
+      }
+      if (helperGit) {
+        // The helper body is assessed above, including conditional Git-only spreads.
+        const declaration = sourceFile.statements.find((statement): statement is ts.FunctionDeclaration =>
+          ts.isFunctionDeclaration(statement) && statement.name?.text === 'runCommand',
+        );
+        if (!declaration || !declaration.body) report(node, 'runCommand Git helper has no local implementation');
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return violations;
+}
+
+describe('Windows Git child-process hardening', () => {
+  it('scans the defined production manifest and excludes developer automation', () => {
+    const manifest = productionManifest();
+    const paths = manifest.map(({ path }) => path);
+
+    expect(paths).toContain('src/hooks/persistent-mode/idle-repo-state.ts');
+    expect(paths).toContain('scripts/persistent-mode.mjs');
+    expect(paths).toContain('templates/hooks/persistent-mode.mjs');
+    expect(paths).not.toContain('scripts/release.ts');
+    expect(paths).not.toContain('src/__tests__/context-guard-stop.test.ts');
+    expect(manifest.flatMap(({ path, content }) => scanGitProcessCalls(path, content))).toEqual([]);
+  });
+
+  it('rejects owned Git shell strings, shell mode, missing options, aliases, and unsafe helpers', () => {
+    const violations = scanGitProcessCalls('seed.ts', `
+      import { execSync as execute, execFileSync } from 'node:child_process';
+      import * as cp from 'node:child_process';
+      execute(\`git status\`);
+      execFileSync('git', ['status'], { shell: true, windowsHide: true });
+      cp.spawnSync('git', ['status'], {});
+      function runCommand(command: string, args: string[]) { return execFileSync(command, args, {}); }
+      runCommand('git', ['status']);
+      const execFileAsync = promisify(execFile);
+      execFileAsync('git', ['status'], {});
+    `);
+
+    expect(violations).toHaveLength(5);
+    expect(violations.join('\n')).toContain('execSync runs Git without effective windowsHide: true');
+    expect(violations.join('\n')).toContain('execFileSync runs Git with shell: true');
+    expect(violations.join('\n')).toContain('spawnSync runs Git without effective windowsHide: true');
+  });
+
+  it('accepts multiline three-argument calls and referenced/spread Git-safe options', () => {
+    const violations = scanGitProcessCalls('seed.ts', `
+      import { execFileSync } from 'node:child_process';
+      const hidden = { windowsHide: true };
+      const options = { encoding: 'utf8', ...hidden };
+      execFileSync(
+        'git',
+        ['status', '--porcelain'],
+        options,
+      );
+      function runCommand(command: string, args: string[]) {
+        return execFileSync(command, args, { ...(command === 'git' ? { windowsHide: true } : {}) });
+      }
+      runCommand('git', ['status']);
+    `);
+
+    expect(violations).toEqual([]);
+  });
+
+  it('permits generic user shell execution and unowned commands', () => {
+    const violations = scanGitProcessCalls('seed.ts', `
+      import { execSync, execFileSync } from 'node:child_process';
+      execSync(userSuppliedCommand, { shell: true });
+      execFileSync('npm', ['test'], { shell: true });
+    `);
+
     expect(violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- replace source-reachable production shell-form Git execution with direct executable + argv construction
- apply `windowsHide: true` across owned hook, HUD, worktree, provider, persistent-mode, team, CLI, feature, and autoresearch Git paths
- add an AST-based production source guard plus focused process-construction regression tests
- keep generated `dist/**` and `bridge/**` artifacts out of this source-only change; #3479 owns shipping closure

## Verification
- `npm run test:run`: 615 files passed, 10,853 tests passed, 14 skipped
- focused #3482 suites: 71 tests passed, followed by affected worktree/hook/HUD/team suites (516 tests passed)
- `npm run lint`: 0 errors, 18 pre-existing/unrelated warnings
- `npx tsc --noEmit`: passed
- `git diff --check`: passed
- `npm run build`: passed in a clean detached worktree at commit `ed148b985649b0b2797cb124f705379216cb6d86`
- source-only audit: no committed `dist/**` or `bridge/**` changes

## Evidence boundary
Linux verification proves the process construction is direct `git` executable + argv with `windowsHide: true`. Hosted Windows CI can prove compatibility and Windows path behavior. Neither environment proves the absence of a visible console flash in the Claude Desktop GUI; that claim is intentionally not made here.

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>

Fixes #3482