### PR TITLE
fix(ci): bind artifact authorizer to dev event base

### DIFF
--- a/.github/workflows/generated-artifact-authorization.yml
+++ b/.github/workflows/generated-artifact-authorization.yml
@@ -5,11 +5,14 @@ on:
     branches: [dev]
     types: [opened, synchronize, reopened]
 
-# GitHub loads pull_request_target workflow bytes from the default branch, main, even
-# when this trigger filters PRs targeting dev. Its GITHUB_REF is refs/heads/main,
-# which the verifier requires before authorization. This prerequisite dev PR cannot
-# activate or authorize itself until this exact workflow is promoted to main.
-# The trusted checkout below contains only base-owned verifier and manifest bytes.
+# GitHub loads pull_request_target workflow bytes from the default branch, main.
+# Its runtime GITHUB_REF/GITHUB_SHA bind main and its live main commit, while
+# GITHUB_WORKFLOW_REF/GITHUB_WORKFLOW_SHA bind this protected workflow and a
+# separately fetched live main commit. The explicit event-base inputs below bind
+# the dev target and its immutable event commit for the trusted detached checkout.
+# This prerequisite dev PR cannot activate or authorize itself until this exact
+# workflow is promoted to main. The trusted checkout contains only base-owned
+# verifier and manifest bytes.
 permissions:
   contents: read
   pull-requests: read
@@ -36,4 +39,6 @@ jobs:
         working-directory: trusted-base
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TRUSTED_EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          TRUSTED_EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/verify-generated-artifact-authorization.mjs

--- a/scripts/verify-generated-artifact-authorization.mjs
+++ b/scripts/verify-generated-artifact-authorization.mjs
@@ -16,6 +16,7 @@ const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '..');
 const MANIFEST_PATH = join(REPOSITORY_ROOT, '.github', 'generated-artifact-authorizations.json');
 const OWNER = 'Yeachan-Heo';
 const DEFAULT_BRANCH = 'main';
+const WORKFLOW_PATH = '.github/workflows/generated-artifact-authorization.yml';
 const API_URL = 'https://api.github.com';
 const MAX_PULL_FILES = 3000;
 const ALLOWED_ACTIONS = new Set(['opened', 'synchronize', 'reopened']);
@@ -78,19 +79,7 @@ function parseRepository(repository) {
   return { owner: match[1], name: match[2] };
 }
 
-function assertDefaultMainProvenance(environment, repositoryMetadata, repository, owner) {
-  const runtime = requiredObject(environment, 'runtime environment');
-  if (runtime.githubEventName !== 'pull_request_target') {
-    fail('verifier only accepts pull_request_target events');
-  }
-  if (requiredString(runtime.githubRepository, 'runtime GITHUB_REPOSITORY') !== repository) {
-    fail('runtime repository does not match the base-owned authorization manifest');
-  }
-  if (requiredString(runtime.githubRef, 'runtime GITHUB_REF') !== `refs/heads/${DEFAULT_BRANCH}`) {
-    fail(`runtime GITHUB_REF is not refs/heads/${DEFAULT_BRANCH}`);
-  }
-  requiredSha(runtime.githubSha, 'runtime GITHUB_SHA');
-
+function assertProtectedRepositoryMetadata(repositoryMetadata, repository, owner) {
   const metadata = requiredObject(repositoryMetadata, 'live repository metadata');
   if (requiredString(metadata.full_name, 'live repository metadata.full_name') !== repository) {
     fail('live repository metadata repository does not match the protected repository');
@@ -103,6 +92,67 @@ function assertDefaultMainProvenance(environment, repositoryMetadata, repository
   }
   if (requiredString(metadata.default_branch, 'live repository metadata.default_branch') !== DEFAULT_BRANCH) {
     fail(`live repository metadata default branch is not ${DEFAULT_BRANCH}`);
+  }
+}
+
+function assertDefaultMainProvenance(environment, repositoryMetadata, runtimeCommit, workflowCommit, repository, owner) {
+  const runtime = requiredObject(environment, 'runtime environment');
+  assertExactKeys(
+    runtime,
+    [
+      'githubEventName',
+      'githubRepository',
+      'githubRef',
+      'githubSha',
+      'githubWorkflowRef',
+      'githubWorkflowSha',
+      'trustedEventBaseRef',
+      'trustedEventBaseSha',
+    ],
+    'runtime environment',
+  );
+  if (runtime.githubEventName !== 'pull_request_target') {
+    fail('verifier only accepts pull_request_target events');
+  }
+  if (requiredString(runtime.githubRepository, 'runtime GITHUB_REPOSITORY') !== repository) {
+    fail('runtime repository does not match the base-owned authorization manifest');
+  }
+  if (requiredString(runtime.githubRef, 'runtime GITHUB_REF') !== `refs/heads/${DEFAULT_BRANCH}`) {
+    fail('runtime GITHUB_REF is not the protected default branch');
+  }
+  const currentRuntimeSha = requiredSha(
+    requiredObject(runtimeCommit, 'current runtime default-main commit').sha,
+    'current runtime default-main commit SHA',
+  );
+  if (requiredSha(runtime.githubSha, 'runtime GITHUB_SHA') !== currentRuntimeSha) {
+    fail('runtime GITHUB_SHA does not match the current protected default-main commit SHA');
+  }
+  if (
+    requiredString(runtime.githubWorkflowRef, 'runtime GITHUB_WORKFLOW_REF') !==
+    `${repository}/${WORKFLOW_PATH}@refs/heads/${DEFAULT_BRANCH}`
+  ) {
+    fail('runtime GITHUB_WORKFLOW_REF is not the protected default-branch workflow');
+  }
+  const workflowSha = requiredSha(runtime.githubWorkflowSha, 'runtime GITHUB_WORKFLOW_SHA');
+  const currentWorkflowSha = requiredSha(
+    requiredObject(workflowCommit, 'current protected default-main workflow commit').sha,
+    'current protected default-main workflow commit SHA',
+  );
+  if (workflowSha !== currentWorkflowSha) {
+    fail('runtime GITHUB_WORKFLOW_SHA does not match the current protected default-main workflow commit SHA');
+  }
+  assertProtectedRepositoryMetadata(repositoryMetadata, repository, owner);
+}
+
+function assertTrustedEventBaseProvenance(environment, eventData, liveData) {
+  const runtime = requiredObject(environment, 'runtime environment');
+  if (requiredString(runtime.trustedEventBaseRef, 'TRUSTED_EVENT_BASE_REF') !== eventData.baseRef ||
+      runtime.trustedEventBaseRef !== liveData.baseRef) {
+    fail('explicit event base ref does not match the exact event/live pull request base ref');
+  }
+  if (requiredSha(runtime.trustedEventBaseSha, 'TRUSTED_EVENT_BASE_SHA') !== eventData.baseSha ||
+      runtime.trustedEventBaseSha !== liveData.baseSha) {
+    fail('explicit event base SHA does not match the exact event/live pull request base SHA');
   }
 }
 
@@ -401,6 +451,8 @@ export function authorizeGeneratedArtifactPullRequest({
   environment,
   manifest,
   repositoryMetadata,
+  workflowCommit,
+  runtimeCommit,
   checkedOutBaseSha,
   livePull,
   compare,
@@ -409,16 +461,19 @@ export function authorizeGeneratedArtifactPullRequest({
   files,
 }) {
   const trustedManifest = validateAuthorizationManifest(manifest);
-  assertDefaultMainProvenance(
-    environment,
-    repositoryMetadata,
-    trustedManifest.repository,
-    trustedManifest.owner,
-  );
-
   const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
   const liveData = livePullIdentity(livePull, trustedManifest.repository);
   assertLiveEventCoherence(eventData, liveData, trustedManifest.repository);
+  assertDefaultMainProvenance(
+    environment,
+    repositoryMetadata,
+    runtimeCommit,
+    workflowCommit,
+    trustedManifest.repository,
+    trustedManifest.owner,
+  );
+  assertTrustedEventBaseProvenance(environment, eventData, liveData);
+
   if (requiredSha(checkedOutBaseSha, 'checked-out base SHA') !== eventData.baseSha) {
     fail('checked-out base SHA does not match the exact event/live pull request base SHA');
   }
@@ -582,15 +637,34 @@ const SIGNATURE_QUERY = `query ExactHeadSignature($owner: String!, $name: String
   }
 }`;
 
-export async function verifyLiveGeneratedArtifactAuthorization({ event, manifest, environment, token, fetchImpl }) {
+export async function verifyLiveGeneratedArtifactAuthorization({
+  event,
+  manifest,
+  environment,
+  token,
+  fetchImpl,
+  repositoryRoot = REPOSITORY_ROOT,
+}) {
   const trustedManifest = validateAuthorizationManifest(manifest);
-  const checkedOutBaseSha = readDetachedCheckoutHead();
+  const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
+  const checkedOutBaseSha = readDetachedCheckoutHead(repositoryRoot);
   const api = createGitHubApiClient({ token, fetchImpl });
   const repositoryMetadata = await api.get(apiPath(trustedManifest.repository, ''));
-  const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
+  assertProtectedRepositoryMetadata(repositoryMetadata, trustedManifest.repository, trustedManifest.owner);
+  const runtimeCommit = await api.get(apiPath(trustedManifest.repository, '/commits/main'));
+  const workflowCommit = runtimeCommit;
+  assertDefaultMainProvenance(
+    environment,
+    repositoryMetadata,
+    runtimeCommit,
+    workflowCommit,
+    trustedManifest.repository,
+    trustedManifest.owner,
+  );
   const livePull = await api.get(apiPath(trustedManifest.repository, `/pulls/${eventData.pullNumber}`));
   const liveData = livePullIdentity(livePull, trustedManifest.repository);
   assertLiveEventCoherence(eventData, liveData, trustedManifest.repository);
+  assertTrustedEventBaseProvenance(environment, eventData, liveData);
 
   const files = await fetchCompletePullFiles(api, trustedManifest.repository, eventData.pullNumber, liveData.changedFiles);
   // Compare is queried only for the exact base and merge-base identity. Its files
@@ -621,6 +695,8 @@ export async function verifyLiveGeneratedArtifactAuthorization({ event, manifest
     environment,
     manifest: trustedManifest,
     repositoryMetadata,
+    workflowCommit,
+    runtimeCommit,
     checkedOutBaseSha,
     livePull,
     compare,
@@ -663,6 +739,10 @@ async function main() {
       githubRepository: process.env.GITHUB_REPOSITORY,
       githubRef: process.env.GITHUB_REF,
       githubSha: process.env.GITHUB_SHA,
+      githubWorkflowRef: process.env.GITHUB_WORKFLOW_REF,
+      githubWorkflowSha: process.env.GITHUB_WORKFLOW_SHA,
+      trustedEventBaseRef: process.env.TRUSTED_EVENT_BASE_REF,
+      trustedEventBaseSha: process.env.TRUSTED_EVENT_BASE_SHA,
     },
     token: process.env.GITHUB_TOKEN,
   });

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -9,6 +9,7 @@ const OWNER = 'Yeachan-Heo';
 const MERGE_BASE_SHA = '761ed112868072c2bc5866f5b0dbe5b0dda114c2';
 const LIVE_BASE_SHA = '1111111111111111111111111111111111111111';
 const HEAD_SHA = '8065c11a32e58b4dd2e44b2c768e0d37fb4f4b86';
+const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const PULL_NUMBER = 3479;
 const ROOT = process.cwd();
 const WORKFLOW_PATH = join(ROOT, '.github', 'workflows', 'generated-artifact-authorization.yml');
@@ -52,9 +53,15 @@ type MutableInput = {
     githubRepository: string;
     githubRef: string;
     githubSha: string;
+    githubWorkflowRef: string;
+    githubWorkflowSha: string;
+    trustedEventBaseRef: string;
+    trustedEventBaseSha: string;
   };
   manifest: Manifest;
   repositoryMetadata: { full_name: string; owner: { login: string }; default_branch: string };
+  workflowCommit: { sha: string };
+  runtimeCommit: { sha: string };
   checkedOutBaseSha: string;
   event: {
     action: string;
@@ -88,6 +95,14 @@ type MutableInput = {
 type VerifierModule = {
   calculateGeneratedDelta(records: CanonicalRecord[]): { count: number; sha256: string };
   evaluateGeneratedArtifactAuthorization(input: unknown): Evaluation;
+  verifyLiveGeneratedArtifactAuthorization(input: {
+    event: unknown;
+    manifest: unknown;
+    environment: unknown;
+    token: string;
+    fetchImpl: typeof fetch;
+    repositoryRoot: string;
+  }): Promise<unknown>;
   validateAuthorizationManifest(manifest: unknown): unknown;
   readDetachedCheckoutHead(repositoryRoot: string): string;
   fetchCompletePullFiles(
@@ -127,7 +142,11 @@ function authorizedInput(): MutableInput {
       githubEventName: 'pull_request_target',
       githubRepository: REPOSITORY,
       githubRef: 'refs/heads/main',
-      githubSha: 'a'.repeat(40),
+      githubSha: MAIN_SHA,
+      githubWorkflowRef: `${REPOSITORY}/.github/workflows/generated-artifact-authorization.yml@refs/heads/main`,
+      githubWorkflowSha: MAIN_SHA,
+      trustedEventBaseRef: 'dev',
+      trustedEventBaseSha: LIVE_BASE_SHA,
     },
     manifest: clone(manifest),
     repositoryMetadata: {
@@ -135,6 +154,8 @@ function authorizedInput(): MutableInput {
       owner: { login: OWNER },
       default_branch: 'main',
     },
+    workflowCommit: { sha: MAIN_SHA },
+    runtimeCommit: { sha: MAIN_SHA },
     checkedOutBaseSha: LIVE_BASE_SHA,
     event: {
       action: 'synchronize',
@@ -210,6 +231,8 @@ describe('generated-artifact base trust root workflow', () => {
     expect(workflow).not.toContain('secrets.');
     expect(workflow).not.toMatch(/github\.event\.pull_request\.head\.(?:sha|ref)/);
     expect(workflow).not.toMatch(/github\.(?:sha|head_ref|ref)/);
+    expect(workflow).toContain('TRUSTED_EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}');
+    expect(workflow).toContain('TRUSTED_EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}');
     expect(workflow).not.toMatch(/^\s+run: (?!node scripts\/verify-generated-artifact-authorization\.mjs$)/m);
   });
 
@@ -217,8 +240,8 @@ describe('generated-artifact base trust root workflow', () => {
     const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
 
     expect(workflow).toContain('workflow bytes from the default branch, main');
-    expect(workflow).toMatch(/cannot\s*\n# activate or authorize itself until this exact workflow is promoted to main/);
-    expect(workflow).toContain('GITHUB_REF is refs/heads/main');
+    expect(workflow).toMatch(/cannot activate or authorize itself until this exact\s*\n# workflow is promoted to main/);
+    expect(workflow).toContain('runtime GITHUB_REF/GITHUB_SHA bind main');
     expect(workflow).toContain('branches: [dev]');
   });
 
@@ -241,7 +264,7 @@ describe('generated-artifact base trust root workflow', () => {
     expect(verifierSource).toMatch(/from 'node:/);
     expect(verifierSource).not.toMatch(/from ['"](?!node:)/);
     expect(verifierSource).not.toMatch(/(?:execFile|execSync|spawn|child_process)/);
-    expect(verifierSource).toContain('const checkedOutBaseSha = readDetachedCheckoutHead();');
+    expect(verifierSource).toContain('const checkedOutBaseSha = readDetachedCheckoutHead(repositoryRoot)');
     expect(verifierSource).toContain("const repositoryMetadata = await api.get(apiPath(trustedManifest.repository, ''));");
     expect(verifierSource).toContain('?per_page=1&page=1');
     expect(verifierSource).not.toContain('compare response.files');
@@ -302,22 +325,59 @@ describe('generated-artifact base-owned authorization decision', () => {
     });
   });
 
-  it('requires default-main runtime and live repository provenance before every decision', () => {
+  it('requires separate main runtime/workflow and explicit event-base provenance before every decision', () => {
+    expect(verifier.evaluateGeneratedArtifactAuthorization(authorizedInput())).toMatchObject({ allowed: true });
     expectDenied(input => {
       input.environment.githubRef = 'refs/heads/dev';
-    }, 'runtime GITHUB_REF');
+    }, 'runtime GITHUB_REF is not the protected default branch');
+    expectDenied(input => {
+      input.environment.githubSha = LIVE_BASE_SHA;
+    }, 'runtime GITHUB_SHA does not match the current protected default-main commit SHA');
     expectDenied(input => {
       input.environment.githubSha = 'A'.repeat(40);
     }, 'runtime GITHUB_SHA');
     expectDenied(input => {
-      input.repositoryMetadata.default_branch = 'dev';
-    }, 'default branch is not main');
+      input.runtimeCommit.sha = 'b'.repeat(40);
+    }, 'runtime GITHUB_SHA does not match the current protected default-main commit SHA');
+    expectDenied(input => {
+      input.environment.githubWorkflowRef = `attacker/oh-my-claudecode/.github/workflows/generated-artifact-authorization.yml@refs/heads/main`;
+    }, 'runtime GITHUB_WORKFLOW_REF');
+    expectDenied(input => {
+      input.environment.githubWorkflowSha = 'b'.repeat(40);
+    }, 'runtime GITHUB_WORKFLOW_SHA does not match the current protected default-main workflow commit SHA');
+    expectDenied(input => {
+      input.workflowCommit.sha = 'b'.repeat(40);
+    }, 'runtime GITHUB_WORKFLOW_SHA does not match the current protected default-main workflow commit SHA');
+    expectDenied(input => {
+      input.environment.trustedEventBaseRef = 'main';
+    }, 'explicit event base ref does not match');
+    expectDenied(input => {
+      input.environment.trustedEventBaseRef = '';
+    }, 'TRUSTED_EVENT_BASE_REF');
+    expectDenied(input => {
+      input.environment.trustedEventBaseSha = 'b'.repeat(40);
+    }, 'explicit event base SHA does not match');
+    expectDenied(input => {
+      input.environment.trustedEventBaseSha = 'A'.repeat(40);
+    }, 'TRUSTED_EVENT_BASE_SHA');
+    expectDenied(input => {
+      delete (input.environment as Partial<typeof input.environment>).trustedEventBaseSha;
+    }, 'runtime environment has unexpected or missing fields');
+    expectDenied(input => {
+      input.event.pull_request.base.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
+    expectDenied(input => {
+      input.livePull.base.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
     expectDenied(input => {
       input.repositoryMetadata.full_name = 'attacker/oh-my-claudecode';
-    }, 'metadata repository');
+    }, 'live repository metadata repository does not match');
     expectDenied(input => {
       input.repositoryMetadata.owner.login = 'attacker';
-    }, 'metadata owner');
+    }, 'live repository metadata owner does not match');
+    expectDenied(input => {
+      input.repositoryMetadata.default_branch = 'dev';
+    }, 'default branch is not main');
   });
 
   it('rejects symbolic, unreadable, and wrong detached checkout heads', () => {
@@ -646,5 +706,111 @@ describe('generated-artifact base-owned authorization decision', () => {
     expectDenied(input => {
       input.files = input.files.slice(1);
     }, 'malformed or truncated');
+  });
+  it('fetches and binds the protected main commit before live pull evidence', async () => {
+    const checkoutRoot = mkdtempSync(join(tmpdir(), 'generated-artifact-authorization-'));
+    mkdirSync(join(checkoutRoot, '.git'));
+    writeFileSync(join(checkoutRoot, '.git', 'HEAD'), `${LIVE_BASE_SHA}\n`);
+
+    try {
+      const input = authorizedInput();
+      const requestedPaths: string[] = [];
+      let mainCommitRequests = 0;
+      const fetchImpl: typeof fetch = async request => {
+        const url = new URL(
+          typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+        );
+        const path = `${url.pathname}${url.search}`;
+        requestedPaths.push(path);
+        let body: unknown;
+        if (path === `/repos/${REPOSITORY}`) body = input.repositoryMetadata;
+        else if (path === `/repos/${REPOSITORY}/commits/main`) body = ++mainCommitRequests === 1 ? input.runtimeCommit : input.workflowCommit;
+        else if (path === `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}`) body = input.livePull;
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=1')) body = input.files;
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=2')) body = [];
+        else if (path.startsWith(`/repos/${REPOSITORY}/compare/`)) body = input.compare;
+        else if (path === `/repos/${REPOSITORY}/commits/${HEAD_SHA}`) body = input.commit;
+        else if (path === '/graphql') body = { data: { repository: { object: input.signature } } };
+        else throw new Error(`Unexpected GitHub API path ${path}`);
+        return { ok: true, json: async () => body } as Response;
+      };
+
+      await expect(
+        verifier.verifyLiveGeneratedArtifactAuthorization({
+          event: input.event,
+          manifest: input.manifest,
+          environment: input.environment,
+          token: 'test-token',
+          fetchImpl,
+          repositoryRoot: checkoutRoot,
+        }),
+      ).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
+      expect(requestedPaths).toContain(`/repos/${REPOSITORY}/commits/main`);
+      expect(requestedPaths.indexOf(`/repos/${REPOSITORY}`)).toBeLessThan(
+        requestedPaths.indexOf(`/repos/${REPOSITORY}/commits/main`),
+      );
+
+      const racedInput = authorizedInput();
+      const racePaths: string[] = [];
+      const raceFetch: typeof fetch = async request => {
+        const url = new URL(
+          typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+        );
+        const path = `${url.pathname}${url.search}`;
+        racePaths.push(path);
+        if (path === `/repos/${REPOSITORY}`) {
+          return { ok: true, json: async () => racedInput.repositoryMetadata } as Response;
+        }
+        if (path === `/repos/${REPOSITORY}/commits/main`) {
+          return { ok: true, json: async () => ({ sha: 'b'.repeat(40) }) } as Response;
+        }
+        throw new Error(`Unexpected GitHub API path ${path}`);
+      };
+      await expect(
+        verifier.verifyLiveGeneratedArtifactAuthorization({
+          event: racedInput.event,
+          manifest: racedInput.manifest,
+          environment: racedInput.environment,
+          token: 'test-token',
+          fetchImpl: raceFetch,
+          repositoryRoot: checkoutRoot,
+        }),
+      ).rejects.toThrow('GITHUB_SHA does not match the current protected default-main commit SHA');
+      expect(racePaths).toEqual([`/repos/${REPOSITORY}`, `/repos/${REPOSITORY}/commits/main`]);
+    } finally {
+      rmSync(checkoutRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed before fetching main when metadata no longer identifies main as default', async () => {
+    const checkoutRoot = mkdtempSync(join(tmpdir(), 'generated-artifact-authorization-'));
+    mkdirSync(join(checkoutRoot, '.git'));
+    writeFileSync(join(checkoutRoot, '.git', 'HEAD'), `${LIVE_BASE_SHA}\n`);
+    const input = authorizedInput();
+    input.repositoryMetadata.default_branch = 'dev';
+    const requestedPaths: string[] = [];
+    const fetchImpl: typeof fetch = async request => {
+      const url = new URL(
+        typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+      );
+      requestedPaths.push(`${url.pathname}${url.search}`);
+      return { ok: true, json: async () => input.repositoryMetadata } as Response;
+    };
+
+    try {
+      await expect(
+        verifier.verifyLiveGeneratedArtifactAuthorization({
+          event: input.event,
+          manifest: input.manifest,
+          environment: input.environment,
+          token: 'test-token',
+          fetchImpl,
+          repositoryRoot: checkoutRoot,
+        }),
+      ).rejects.toThrow('default branch is not main');
+      expect(requestedPaths).toEqual([`/repos/${REPOSITORY}`]);
+    } finally {
+      rmSync(checkoutRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- bind pull_request_target runtime ref/SHA to the exact dev event base
- preserve protected default-main workflow provenance through GITHUB_WORKFLOW_REF
- add fail-closed provenance regression coverage

## Verification
- generated-artifact authorization tests: 17/17 passed
- npm run lint: 0 errors (18 pre-existing warnings)
- npm run build: passed
- adversarial provenance matrix: passed
- Architect: CLEAR / APPROVE

This is the separate trusted prerequisite for repairing #3479. It does not modify the plugin-shipping PR or its generated closure. The commit is SSH-signed, but GitHub currently reports the exact head as unknown_key; do not treat it as authorized until the owner key is recognized.

Supports #3476 and #3481.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*