### PR TITLE
fix(team): make watchdog task publication atomic

### DIFF
--- a/src/lib/__tests__/atomic-write.test.ts
+++ b/src/lib/__tests__/atomic-write.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { FileHandle } from 'fs/promises';
+
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const fsPromisesControl = vi.hoisted(() => ({
+  renameHook: undefined as undefined | ((from: string | URL, to: string | URL) => Promise<void>),
+  openHook: undefined as undefined | (() => Promise<void>),
+  writeHook: undefined as undefined | ((fd: FileHandle) => void),
+}));
+
+vi.mock('fs/promises', async importOriginal => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    rename: async (from: string | URL, to: string | URL) => {
+      await fsPromisesControl.renameHook?.(from, to);
+      await actual.rename(from, to);
+    },
+    open: async (
+      filePath: Parameters<typeof actual.open>[0],
+      flags: Parameters<typeof actual.open>[1],
+      mode?: Parameters<typeof actual.open>[2],
+    ) => {
+      await fsPromisesControl.openHook?.();
+      const fd = await actual.open(filePath, flags, mode);
+      fsPromisesControl.writeHook?.(fd);
+      return fd;
+    },
+  };
+});
+
+import { atomicWriteJson } from '../atomic-write.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  return { promise: new Promise<void>(done => { resolve = done; }), resolve };
+}
+
+describe('atomicWriteJson', () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    fsPromisesControl.renameHook = undefined;
+    fsPromisesControl.openHook = undefined;
+    fsPromisesControl.writeHook = undefined;
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes only complete JSON while rename is pending', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-'));
+    directories.push(directory);
+    const filePath = join(directory, 'state.json');
+    const oldValue = { status: 'old' };
+    const nextValue = { status: 'new', items: ['complete'] };
+    const renameEntered = deferred();
+    const releaseRename = deferred();
+    writeFileSync(filePath, JSON.stringify(oldValue));
+    fsPromisesControl.renameHook = async (_from, to) => {
+      if (to === filePath) {
+        renameEntered.resolve();
+        await releaseRename.promise;
+      }
+    };
+
+    const writer = atomicWriteJson(filePath, nextValue);
+    try {
+      await renameEntered.promise;
+      expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual(oldValue);
+    } finally {
+      releaseRename.resolve();
+    }
+    await writer;
+
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual(nextValue);
+  });
+
+  it('completes short writes before renaming the JSON payload', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-short-write-'));
+    directories.push(directory);
+    const filePath = join(directory, 'state.json');
+    const nextValue = { status: 'new', items: ['complete', 'utf8-✓'] };
+    const expectedContent = JSON.stringify(nextValue, null, 2);
+    const writeOffsets: number[] = [];
+
+    fsPromisesControl.writeHook = fd => {
+      const originalWrite = fd.write.bind(fd);
+      Object.defineProperty(fd, 'write', {
+        value: async (buffer: Buffer, offset: number, length: number, position: number) => {
+          writeOffsets.push(offset);
+          return originalWrite(buffer, offset, Math.min(length, 3), position);
+        },
+      });
+    };
+    fsPromisesControl.renameHook = async (from, to) => {
+      if (to === filePath) {
+        expect(readFileSync(from)).toEqual(Buffer.from(expectedContent, 'utf8'));
+      }
+    };
+
+    await atomicWriteJson(filePath, nextValue);
+
+    expect(writeOffsets).toEqual(
+      Array.from({ length: Math.ceil(Buffer.byteLength(expectedContent) / 3) }, (_, index) => index * 3),
+    );
+    expect(readFileSync(filePath, 'utf8')).toBe(expectedContent);
+  });
+
+  it('rejects zero-byte write progress, preserves the old target, and removes the temp file', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-zero-progress-'));
+    directories.push(directory);
+    const filePath = join(directory, 'state.json');
+    const oldValue = { status: 'old' };
+    writeFileSync(filePath, JSON.stringify(oldValue));
+    fsPromisesControl.writeHook = fd => {
+      Object.defineProperty(fd, 'write', {
+        value: async (buffer: Buffer) => ({ bytesWritten: 0, buffer }),
+      });
+    };
+
+    await expect(atomicWriteJson(filePath, { status: 'new' })).rejects.toThrow(
+      'Failed to write complete JSON payload',
+    );
+
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual(oldValue);
+    expect(readdirSync(directory)).toEqual(['state.json']);
+  });
+
+  it('propagates FileHandle write failures, preserves the old target, and removes the temp file', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-write-error-'));
+    directories.push(directory);
+    const filePath = join(directory, 'state.json');
+    const oldValue = { status: 'old' };
+    const failure = new Error('temp write failed');
+    writeFileSync(filePath, JSON.stringify(oldValue));
+    fsPromisesControl.writeHook = fd => {
+      Object.defineProperty(fd, 'write', {
+        value: async () => { throw failure; },
+      });
+    };
+
+    await expect(atomicWriteJson(filePath, { status: 'new' })).rejects.toBe(failure);
+
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual(oldValue);
+    expect(readdirSync(directory)).toEqual(['state.json']);
+  });
+
+  it('creates missing parents and publishes owner-only replacement files', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-parent-'));
+    directories.push(directory);
+    const filePath = join(directory, 'nested', 'state.json');
+
+    await atomicWriteJson(filePath, { status: 'new' });
+
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual({ status: 'new' });
+    expect(statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+
+  it('propagates temp write failures without publishing a target', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-write-error-'));
+    directories.push(directory);
+    const filePath = join(directory, 'state.json');
+    const failure = new Error('temp write failed');
+    fsPromisesControl.openHook = async () => { throw failure; };
+
+    await expect(atomicWriteJson(filePath, { status: 'new' })).rejects.toBe(failure);
+
+    expect(existsSync(filePath)).toBe(false);
+    expect(readdirSync(directory)).toEqual([]);
+  });
+
+  it('propagates rename failures, preserves the old target, and removes the temp file', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-error-'));
+    directories.push(directory);
+    const filePath = join(directory, 'state.json');
+    const oldValue = { status: 'old' };
+    const failure = new Error('rename failed');
+    writeFileSync(filePath, JSON.stringify(oldValue));
+    fsPromisesControl.renameHook = async () => { throw failure; };
+
+    await expect(atomicWriteJson(filePath, { status: 'new' })).rejects.toBe(failure);
+
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual(oldValue);
+    expect(readdirSync(directory)).toEqual(['state.json']);
+    expect(existsSync(filePath)).toBe(true);
+  });
+});

--- a/src/lib/atomic-write.ts
+++ b/src/lib/atomic-write.ts
@@ -54,12 +54,24 @@ export async function atomicWriteJson(
     ensureDirSync(dir);
 
     // Serialize data to JSON
-    const jsonContent = JSON.stringify(data, null, 2);
+    const jsonContent = Buffer.from(JSON.stringify(data, null, 2), "utf-8");
 
     // Write to temp file with exclusive creation (wx = O_CREAT | O_EXCL | O_WRONLY)
     const fd = await fs.open(tempPath, "wx", 0o600);
     try {
-      await fd.write(jsonContent, 0, "utf-8");
+      let offset = 0;
+      while (offset < jsonContent.length) {
+        const { bytesWritten } = await fd.write(
+          jsonContent,
+          offset,
+          jsonContent.length - offset,
+          offset,
+        );
+        if (bytesWritten === 0) {
+          throw new Error("Failed to write complete JSON payload");
+        }
+        offset += bytesWritten;
+      }
       // Sync file data to disk before rename
       await fd.sync();
     } finally {

--- a/src/team/__tests__/runtime-cli.test.ts
+++ b/src/team/__tests__/runtime-cli.test.ts
@@ -22,9 +22,74 @@ import {
   readTaskOutputFallback,
   writeResultArtifact,
   runPersistentRecoveryOwnerLoop,
+  finalizeRuntimeShutdown,
 } from '../runtime-cli.js';
 import { aliasActiveRecoveryRequest, canonicalRecoveryPayloadHash, readRecoveryOutcome, reserveRecoveryRequest, writeRecoveryFinal } from '../recovery-request-store.js';
 import { absPath, TeamPaths } from '../state-paths.js';
+
+describe('runtime-cli legacy watchdog shutdown', () => {
+  it('quiesces v1 before snapshotting, shutdown, and publication', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'runtime-cli-shutdown-order-'));
+    try {
+      const teamName = 'shutdown-order';
+      const stateRoot = join(cwd, '.omc', 'state', 'team', teamName);
+      const tasksDir = join(stateRoot, 'tasks');
+      mkdirSync(tasksDir, { recursive: true });
+      writeFileSync(join(tasksDir, '1.json'), JSON.stringify({
+        id: '1',
+        status: 'completed',
+        result: 'pre-shutdown task result',
+      }), 'utf-8');
+
+      let releaseStop!: () => void;
+      const stopPending = new Promise<void>(resolve => { releaseStop = resolve; });
+      const phases: string[] = [];
+      let published: { taskResults: Array<{ taskId: string; status: string; summary: string }> } | undefined;
+      const completing = finalizeRuntimeShutdown(
+        { stopWatchdog: () => stopPending },
+        false,
+        async () => {
+          phases.push('collect');
+          return buildCliOutput(stateRoot, teamName, 'completed', 1, Date.now() - 1_000);
+        },
+        async () => {
+          phases.push('shutdown');
+          rmSync(stateRoot, { recursive: true, force: true });
+        },
+        async output => {
+          phases.push('publish');
+          published = output;
+        },
+      );
+
+      await Promise.resolve();
+      expect(phases).toEqual([]);
+      releaseStop();
+
+      const output = await completing;
+      expect(phases).toEqual(['collect', 'shutdown', 'publish']);
+      expect(existsSync(stateRoot)).toBe(false);
+      expect(output.taskResults).toEqual([
+        { taskId: '1', status: 'completed', summary: 'pre-shutdown task result' },
+      ]);
+      expect(published?.taskResults).toEqual(output.taskResults);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not stop the v1 watchdog seam for runtime v2', async () => {
+    const stopWatchdog = vi.fn(async () => undefined);
+    await finalizeRuntimeShutdown(
+      { stopWatchdog },
+      true,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+    );
+    expect(stopWatchdog).not.toHaveBeenCalled();
+  });
+});
 
 describe('runtime-cli auto-merge compatibility', () => {
   it('rejects explicit auto-merge when runtime v2 is disabled', () => {

--- a/src/team/__tests__/runtime-watchdog-retry.test.ts
+++ b/src/team/__tests__/runtime-watchdog-retry.test.ts
@@ -1,504 +1,363 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+const fsPromisesControl = vi.hoisted(() => ({
+  renameHook: undefined as undefined | ((from: string | URL, to: string | URL) => Promise<void>),
+  taskTargetWriteFileCalls: 0,
+  taskTargetPath: undefined as string | undefined,
+}));
+
+const historicalDirectWriteControl = vi.hoisted(() => ({
+  taskTargetPath: undefined as string | undefined,
+  signalTruncation: undefined as undefined | (() => void),
+  awaitRelease: undefined as undefined | (() => Promise<void>),
+}));
+
+vi.mock('fs/promises', async importOriginal => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    writeFile: async (path: string | URL, data: string | Uint8Array, options?: Parameters<typeof actual.writeFile>[2]) => {
+      if (path === fsPromisesControl.taskTargetPath) {
+        fsPromisesControl.taskTargetWriteFileCalls++;
+        throw new Error('direct task-target writeFile publication is forbidden');
+      }
+      await actual.writeFile(path, data, options);
+    },
+    rename: async (from: string | URL, to: string | URL) => {
+      await fsPromisesControl.renameHook?.(from, to);
+      await actual.rename(from, to);
+    },
+  };
+});
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type { TeamRuntime } from '../runtime.js';
+import { watchdogCliWorkers } from '../runtime.js';
 import { DEFAULT_MAX_TASK_RETRIES, readTaskFailure, writeTaskFailure } from '../task-file-ops.js';
-
-let watchdogCliWorkers: typeof import('../runtime.js').watchdogCliWorkers;
 
 const tmuxMocks = vi.hoisted(() => ({
   isWorkerAlive: vi.fn(),
   spawnWorkerInPane: vi.fn(),
   sendToWorker: vi.fn(),
+  splitTeamWorkerPane: vi.fn(),
+  killTeamPane: vi.fn(),
+  applyMainVerticalLayout: vi.fn(),
 }));
-
 const modelContractMocks = vi.hoisted(() => ({
   buildWorkerArgv: vi.fn(() => ['codex']),
   getWorkerEnv: vi.fn(() => ({})),
   isPromptModeAgent: vi.fn(() => true),
   getPromptModeArgs: vi.fn(() => ['-p', 'stub prompt']),
+  resolveValidatedBinaryPath: vi.fn(() => '/usr/bin/codex'),
 }));
 
-function makeRuntime(cwd: string, teamName: string): TeamRuntime {
+vi.mock('../tmux-session.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../tmux-session.js')>()),
+  isWorkerAlive: tmuxMocks.isWorkerAlive,
+  spawnWorkerInPane: tmuxMocks.spawnWorkerInPane,
+  sendToWorker: tmuxMocks.sendToWorker,
+  splitTeamWorkerPane: tmuxMocks.splitTeamWorkerPane,
+  killTeamPane: tmuxMocks.killTeamPane,
+  applyMainVerticalLayout: tmuxMocks.applyMainVerticalLayout,
+}));
+
+vi.mock('../model-contract.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../model-contract.js')>()),
+  buildWorkerArgv: modelContractMocks.buildWorkerArgv,
+  getWorkerEnv: modelContractMocks.getWorkerEnv,
+  isPromptModeAgent: modelContractMocks.isPromptModeAgent,
+  getPromptModeArgs: modelContractMocks.getPromptModeArgs,
+  resolveValidatedBinaryPath: modelContractMocks.resolveValidatedBinaryPath,
+}));
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  return { promise: new Promise<void>(done => { resolve = done; }), resolve };
+}
+
+function makeRuntime(cwd: string, teamName: string, tasks = [{ subject: 'Task 1', description: 'Do work' }]): TeamRuntime {
   return {
     teamName,
     sessionName: 'test-session:0',
     leaderPaneId: '%0',
     ownsWindow: false,
-    config: {
-      teamName,
-      workerCount: 1,
-      agentTypes: ['codex'],
-      tasks: [{ subject: 'Task 1', description: 'Do work' }],
-      cwd,
-    },
+    config: { teamName, workerCount: 1, agentTypes: ['codex'], tasks, cwd },
     workerNames: ['worker-1'],
     workerPaneIds: ['%1'],
-    activeWorkers: new Map([
-      ['worker-1', { paneId: '%1', taskId: '1', spawnedAt: Date.now() }],
-    ]),
+    activeWorkers: new Map([['worker-1', { paneId: '%1', taskId: '1', spawnedAt: Date.now() }]]),
     cwd,
   };
 }
 
-function makeRuntimeWithTask(cwd: string, teamName: string, taskId: string): TeamRuntime {
-  return {
-    teamName,
-    sessionName: 'test-session:0',
-    leaderPaneId: '%0',
-    ownsWindow: false,
-    config: {
-      teamName,
-      workerCount: 1,
-      agentTypes: ['codex'],
-      tasks: [{ subject: 'Task 1', description: 'Do work' }],
-      cwd,
-    },
-    workerNames: ['worker-1'],
-    workerPaneIds: ['%1'],
-    activeWorkers: new Map([
-      ['worker-1', { paneId: '%1', taskId, spawnedAt: Date.now() }],
-    ]),
-    cwd,
-  };
-}
-
-function initTask(cwd: string, teamName: string): string {
+function initTask(cwd: string, teamName: string, task: Record<string, unknown> = {}): string {
   const root = join(cwd, '.omc', 'state', 'team', teamName);
   mkdirSync(join(root, 'tasks'), { recursive: true });
   mkdirSync(join(root, 'workers', 'worker-1'), { recursive: true });
   writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({
-    id: '1',
-    subject: 'Task 1',
-    description: 'Do work',
-    status: 'in_progress',
-    owner: 'worker-1',
-    assignedAt: new Date().toISOString(),
-  }), 'utf-8');
+    id: '1', subject: 'Task 1', description: 'Do work', status: 'in_progress', owner: 'worker-1',
+    assignedAt: new Date().toISOString(), ...task,
+  }));
   return root;
 }
 
-const DEFAULT_WATCHDOG_WAIT_TIMEOUT_MS = 5000;
-const WATCHDOG_WAIT_INTERVAL_MS = 20;
-
-function mockWorkerDiesOnceThenAlive(): void {
-  let firstCheck = true;
-  tmuxMocks.isWorkerAlive.mockImplementation(async () => {
-    if (firstCheck) {
-      firstCheck = false;
-      return false;
-    }
-    return true;
-  });
+async function runTick(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(20);
 }
 
-async function waitFor(
-  predicate: () => boolean,
-  timeoutMs = DEFAULT_WATCHDOG_WAIT_TIMEOUT_MS
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      if (predicate()) {
-        return;
-      }
-    } catch {
-      // Ignore transient file-read races while the watchdog updates task files.
-    }
-    await new Promise((resolve) => setTimeout(resolve, WATCHDOG_WAIT_INTERVAL_MS));
-  }
-
-  expect(predicate(), 'watchdog condition should become true').toBe(true);
-}
-
-async function readJsonFileWithRetry<T>(filePath: string): Promise<T> {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= 5; attempt++) {
-    try {
-      return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
-    } catch (error) {
-      lastError = error;
-      await new Promise((resolve) => setTimeout(resolve, WATCHDOG_WAIT_INTERVAL_MS));
-    }
-  }
-
-  throw lastError;
-}
-
-async function stopWatchdogAndSettle(stop: () => void): Promise<void> {
-  stop();
-  await new Promise((resolve) => setTimeout(resolve, WATCHDOG_WAIT_INTERVAL_MS * 3));
-}
-
-describe('watchdogCliWorkers dead-pane retry behavior', { timeout: 15000 }, () => {
+describe('watchdogCliWorkers dead-pane retry behavior', () => {
   let cwd: string;
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.useRealTimers();
-    vi.resetModules();
-    vi.doUnmock('../tmux-session.js');
-    vi.doUnmock('../model-contract.js');
-    vi.doUnmock('child_process');
     cwd = mkdtempSync(join(tmpdir(), 'runtime-watchdog-retry-'));
-    tmuxMocks.isWorkerAlive.mockReset();
-    tmuxMocks.spawnWorkerInPane.mockReset();
-    tmuxMocks.sendToWorker.mockReset();
-    tmuxMocks.isWorkerAlive.mockResolvedValue(false);
-    tmuxMocks.spawnWorkerInPane.mockResolvedValue(undefined);
-    tmuxMocks.sendToWorker.mockResolvedValue(true);
-    modelContractMocks.buildWorkerArgv.mockReset();
-    modelContractMocks.getWorkerEnv.mockReset();
-    modelContractMocks.isPromptModeAgent.mockReset();
-    modelContractMocks.getPromptModeArgs.mockReset();
-    modelContractMocks.buildWorkerArgv.mockReturnValue(['codex']);
-    modelContractMocks.getWorkerEnv.mockReturnValue({});
-    modelContractMocks.isPromptModeAgent.mockReturnValue(true);
-    modelContractMocks.getPromptModeArgs.mockReturnValue(['-p', 'stub prompt']);
+    tmuxMocks.isWorkerAlive.mockReset().mockResolvedValue(false);
+    tmuxMocks.spawnWorkerInPane.mockReset().mockResolvedValue(undefined);
+    tmuxMocks.sendToWorker.mockReset().mockResolvedValue(true);
+    tmuxMocks.splitTeamWorkerPane.mockReset().mockResolvedValue('%42');
+    tmuxMocks.killTeamPane.mockReset().mockResolvedValue(undefined);
+    tmuxMocks.applyMainVerticalLayout.mockReset().mockResolvedValue(undefined);
+    modelContractMocks.buildWorkerArgv.mockReset().mockReturnValue(['codex']);
+    modelContractMocks.getWorkerEnv.mockReset().mockReturnValue({});
+    modelContractMocks.isPromptModeAgent.mockReset().mockReturnValue(true);
+    modelContractMocks.getPromptModeArgs.mockReset().mockReturnValue(['-p', 'stub prompt']);
+    modelContractMocks.resolveValidatedBinaryPath.mockReset().mockReturnValue('/usr/bin/codex');
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-    vi.doMock('../tmux-session.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('../tmux-session.js')>();
-      return {
-        ...actual,
-        isWorkerAlive: tmuxMocks.isWorkerAlive,
-        spawnWorkerInPane: tmuxMocks.spawnWorkerInPane,
-        sendToWorker: tmuxMocks.sendToWorker,
-      };
-    });
-
-    vi.doMock('../model-contract.js', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('../model-contract.js')>();
-      return {
-        ...actual,
-        buildWorkerArgv: modelContractMocks.buildWorkerArgv,
-        getWorkerEnv: modelContractMocks.getWorkerEnv,
-        isPromptModeAgent: modelContractMocks.isPromptModeAgent,
-        getPromptModeArgs: modelContractMocks.getPromptModeArgs,
-      };
-    });
-
-    vi.doMock('child_process', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('child_process')>();
-      const { promisify: utilPromisify } = await import('util');
-
-      function mockExecFile(
-        _cmd: string,
-        args: string[],
-        cb: (error: Error | null, stdout: string, stderr: string) => void
-      ) {
-        if (args[0] === 'split-window') {
-          cb(null, '%42\n', '');
-          return {} as never;
-        }
-        cb(null, '', '');
-        return {} as never;
-      }
-
-      (mockExecFile as unknown as { [utilPromisify.custom]: unknown })[utilPromisify.custom] = async (
-        _cmd: string,
-        args: string[]
-      ) => {
-        if (args[0] === 'split-window') {
-          return { stdout: '%42\n', stderr: '' };
-        }
-        return { stdout: '', stderr: '' };
-      };
-
-      return {
-        ...actual,
-        execFile: mockExecFile,
-      };
-    });
-
-    ({ watchdogCliWorkers } = await import('../runtime.js'));
-  }, 30000);
+    vi.useFakeTimers();
+  });
 
   afterEach(() => {
-    vi.useRealTimers();
-    vi.doUnmock('../tmux-session.js');
-    vi.doUnmock('../model-contract.js');
-    vi.doUnmock('child_process');
+    fsPromisesControl.renameHook = undefined;
+    fsPromisesControl.taskTargetPath = undefined;
+    fsPromisesControl.taskTargetWriteFileCalls = 0;
+    historicalDirectWriteControl.taskTargetPath = undefined;
+    historicalDirectWriteControl.signalTruncation = undefined;
+    historicalDirectWriteControl.awaitRelease = undefined;
     warnSpy.mockRestore();
+    vi.useRealTimers();
+    vi.doUnmock('../lib/atomic-write.js');
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  it('requeues task when dead pane still has retries remaining', async () => {
-    mockWorkerDiesOnceThenAlive();
+  it('requeues once with the established five-retry budget', async () => {
     const teamName = 'dead-pane-requeue-team';
     const root = initTask(cwd, teamName);
-    const runtime = makeRuntime(cwd, teamName);
-    const stop = watchdogCliWorkers(runtime, 20);
-    try {
-      await waitFor(() => {
-        const retryCount = readTaskFailure(teamName, '1', { cwd })?.retryCount ?? 0;
-        const requeueWarned = warnSpy.mock.calls.some(([msg]: [unknown]) => (
-          String(msg).includes('dead pane — requeuing task 1 (retry 1/5)')
-        ));
-        return retryCount >= 1 && requeueWarned;
-      }, 2000);
-    } finally {
-      await stopWatchdogAndSettle(stop);
-    }
+    const stop = watchdogCliWorkers(makeRuntime(cwd, teamName), 20);
+    await runTick();
+    await stop();
 
-    const task = await readJsonFileWithRetry<{
-      status: string;
-      owner: string | null;
-    }>(join(root, 'tasks', '1.json'));
-    const failure = readTaskFailure(teamName, '1', { cwd });
-
+    const task = JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8')) as { status: string; owner: string | null };
     expect(['pending', 'in_progress']).toContain(task.status);
     expect(task.owner === null || task.owner === 'worker-1').toBe(true);
-    expect(failure?.retryCount).toBe(1);
-    expect(
-      warnSpy.mock.calls.some(([msg]: [unknown]) => String(msg).includes('dead pane — requeuing task 1 (retry 1/5)'))
-    ).toBe(true);
+    expect(readTaskFailure(teamName, '1', { cwd })?.retryCount).toBe(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dead pane — requeuing task 1 (retry 1/5)'));
   });
 
-  it('multi-task requeue: nextPendingTaskIndex picks requeued task, not a different pending task', async () => {
-    mockWorkerDiesOnceThenAlive();
+  it('reassigns the requeued first task before a later pending task', async () => {
     const teamName = 'multi-task-requeue-team';
-    const root = join(cwd, '.omc', 'state', 'team', teamName);
-    mkdirSync(join(root, 'tasks'), { recursive: true });
-    mkdirSync(join(root, 'workers', 'worker-1'), { recursive: true });
-
-    // Task 1: in_progress, assigned to worker-1 (will be requeued when pane dies)
-    writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({
-      id: '1',
-      subject: 'Task 1',
-      description: 'First task',
-      status: 'in_progress',
-      owner: 'worker-1',
-      assignedAt: new Date().toISOString(),
-    }), 'utf-8');
-
-    // Task 2: already completed — should NOT be picked up
-    writeFileSync(join(root, 'tasks', '2.json'), JSON.stringify({
-      id: '2',
-      subject: 'Task 2',
-      description: 'Second task',
-      status: 'completed',
-      owner: 'worker-2',
-      completedAt: new Date().toISOString(),
-    }), 'utf-8');
-
-    // Task 3: pending — this exists but task 1 should be requeued and picked first
-    writeFileSync(join(root, 'tasks', '3.json'), JSON.stringify({
-      id: '3',
-      subject: 'Task 3',
-      description: 'Third task',
-      status: 'pending',
-      owner: null,
-    }), 'utf-8');
-
-    const runtime: TeamRuntime = {
-      teamName,
-      sessionName: 'test-session:0',
-      leaderPaneId: '%0',
-      ownsWindow: false,
-      config: {
-        teamName,
-        workerCount: 1,
-        agentTypes: ['codex'],
-        tasks: [
-          { subject: 'Task 1', description: 'First task' },
-          { subject: 'Task 2', description: 'Second task' },
-          { subject: 'Task 3', description: 'Third task' },
-        ],
-        cwd,
-      },
-      workerNames: ['worker-1'],
-      workerPaneIds: ['%1'],
-      activeWorkers: new Map([
-        ['worker-1', { paneId: '%1', taskId: '1', spawnedAt: Date.now() }],
-      ]),
-      cwd,
-    };
-
+    const root = initTask(cwd, teamName);
+    writeFileSync(join(root, 'tasks', '2.json'), JSON.stringify({ id: '2', subject: 'Task 2', description: 'Done', status: 'completed', owner: 'worker-2' }));
+    writeFileSync(join(root, 'tasks', '3.json'), JSON.stringify({ id: '3', subject: 'Task 3', description: 'Later', status: 'pending', owner: null }));
+    const runtime = makeRuntime(cwd, teamName, [
+      { subject: 'Task 1', description: 'Do work' }, { subject: 'Task 2', description: 'Done' }, { subject: 'Task 3', description: 'Later' },
+    ]);
     const stop = watchdogCliWorkers(runtime, 20);
-    try {
-      await waitFor(() => {
-        const retryCount = readTaskFailure(teamName, '1', { cwd })?.retryCount ?? 0;
-        const task1 = JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf-8')) as {
-          status: string;
-          owner: string | null;
-        };
-        const task3 = JSON.parse(readFileSync(join(root, 'tasks', '3.json'), 'utf-8')) as {
-          status: string;
-          owner: string | null;
-        };
+    await runTick();
+    await stop();
 
-        return retryCount >= 1
-          && task1.status === 'in_progress'
-          && task1.owner === 'worker-1'
-          && task3.status === 'pending'
-          && task3.owner === null;
-      });
-    } finally {
-      await stopWatchdogAndSettle(stop);
-    }
-
-    // After requeue, task 1 should be pending (requeued) and task 3 stays pending.
-    // nextPendingTaskIndex iterates by index, so task 1 (index 0) is picked first.
-    // The spawnWorkerInPane call confirms a respawn happened.
-    // The task that got re-assigned should be task 1 (not task 3),
-    // because nextPendingTaskIndex scans from index 0 and task 1 was requeued to pending.
-    const task1 = await readJsonFileWithRetry<{
-      status: string;
-      owner: string | null;
-    }>(join(root, 'tasks', '1.json'));
-    // Task 1 should have been requeued, and may be immediately re-assigned depending on environment timing.
+    const task1 = JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8')) as { status: string; owner: string | null };
+    const task3 = JSON.parse(readFileSync(join(root, 'tasks', '3.json'), 'utf8')) as { status: string; owner: string | null };
     expect(['pending', 'in_progress']).toContain(task1.status);
     expect(task1.owner === null || task1.owner === 'worker-1').toBe(true);
-
-    // Task 3 should still be pending and unowned — it was NOT the one picked
-    const task3 = await readJsonFileWithRetry<{
-      status: string;
-      owner: string | null;
-    }>(join(root, 'tasks', '3.json'));
-    expect(task3.status).toBe('pending');
-    expect(task3.owner).toBeNull();
+    expect(task3).toMatchObject({ status: 'pending', owner: null });
   });
 
-  it('permanently fails task when dead pane exhausts retry budget', async () => {
+  it('fails a dead pane task at the unchanged retry limit', async () => {
     const teamName = 'dead-pane-exhausted-team';
     const root = initTask(cwd, teamName);
-    for (let i = 0; i < DEFAULT_MAX_TASK_RETRIES - 1; i++) {
-      writeTaskFailure(teamName, '1', `pre-error-${i}`, { cwd });
-    }
+    for (let i = 0; i < DEFAULT_MAX_TASK_RETRIES - 1; i++) writeTaskFailure(teamName, '1', `pre-error-${i}`, { cwd });
     const runtime = makeRuntime(cwd, teamName);
     const stop = watchdogCliWorkers(runtime, 20);
-    try {
-      await waitFor(() => runtime.activeWorkers.size === 0);
-    } finally {
-      await stopWatchdogAndSettle(stop);
-    }
+    await runTick();
+    await stop();
 
-    const task = await readJsonFileWithRetry<{
-      status: string;
-      summary?: string;
-    }>(join(root, 'tasks', '1.json'));
-    const failure = readTaskFailure(teamName, '1', { cwd });
-
+    const task = JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8')) as { status: string; summary?: string };
     expect(task.status).toBe('failed');
     expect(task.summary).toContain('Worker pane died before done.json was written');
-    expect(failure?.retryCount).toBe(DEFAULT_MAX_TASK_RETRIES);
+    expect(readTaskFailure(teamName, '1', { cwd })?.retryCount).toBe(DEFAULT_MAX_TASK_RETRIES);
     expect(tmuxMocks.spawnWorkerInPane).not.toHaveBeenCalled();
   });
 
-  it('serializes concurrent dead-pane retries across watchdog instances', async () => {
-    mockWorkerDiesOnceThenAlive();
+  it('serializes concurrent watchdog retries for the same task', async () => {
     const teamName = 'dead-pane-contention-team';
     const root = initTask(cwd, teamName);
-    const runtimeA = makeRuntime(cwd, teamName);
-    const runtimeB = makeRuntime(cwd, teamName);
+    const stopA = watchdogCliWorkers(makeRuntime(cwd, teamName), 20);
+    const stopB = watchdogCliWorkers(makeRuntime(cwd, teamName), 20);
+    await runTick();
+    await Promise.all([stopA(), stopB()]);
 
-    const stopA = watchdogCliWorkers(runtimeA, 20);
-    const stopB = watchdogCliWorkers(runtimeB, 20);
-    try {
-      await waitFor(() => (readTaskFailure(teamName, '1', { cwd })?.retryCount ?? 0) >= 1);
-    } finally {
-      await Promise.all([
-        stopWatchdogAndSettle(stopA),
-        stopWatchdogAndSettle(stopB),
-      ]);
-    }
-
-    // Give the second watchdog one more tick to observe the settled state.
-    await new Promise(resolve => setTimeout(resolve, 80));
-
-    const task = await readJsonFileWithRetry<{
-      status: string;
-      owner: string | null;
-    }>(join(root, 'tasks', '1.json'));
-    const failure = readTaskFailure(teamName, '1', { cwd });
-
+    const task = JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8')) as { status: string; owner: string | null };
     expect(['pending', 'in_progress']).toContain(task.status);
     expect(task.owner === null || task.owner === 'worker-1').toBe(true);
-    expect(failure?.retryCount).toBe(1);
+    expect(readTaskFailure(teamName, '1', { cwd })?.retryCount).toBe(1);
   });
 
-  it('does not requeue or increment retries when dead-pane detection races with completion', async () => {
-    const teamName = 'dead-pane-completed-race-team';
-    const root = join(cwd, '.omc', 'state', 'team', teamName);
-    mkdirSync(join(root, 'tasks'), { recursive: true });
-    mkdirSync(join(root, 'workers', 'worker-1'), { recursive: true });
-
-    writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({
-      id: '1',
-      subject: 'Task 1',
-      description: 'Do work',
-      status: 'completed',
-      owner: 'worker-1',
-      summary: 'already completed elsewhere',
-      result: 'already completed elsewhere',
-      completedAt: new Date().toISOString(),
-    }), 'utf-8');
-
-    const runtime = makeRuntimeWithTask(cwd, teamName, '1');
+  it('keeps completion and owner-transfer guards ahead of retry recovery', async () => {
+    const teamName = 'dead-pane-guards-team';
+    const root = initTask(cwd, teamName, { status: 'completed', summary: 'done elsewhere' });
+    const runtime = makeRuntime(cwd, teamName);
     const stop = watchdogCliWorkers(runtime, 20);
-    try {
-      await waitFor(() => runtime.activeWorkers.size === 0);
-    } finally {
-      await stopWatchdogAndSettle(stop);
-    }
+    await runTick();
+    await stop();
+    expect(JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8'))).toMatchObject({ status: 'completed', summary: 'done elsewhere' });
+    expect(readTaskFailure(teamName, '1', { cwd })).toBeNull();
 
-    const task = await readJsonFileWithRetry<{
-      status: string;
-      owner: string | null;
-      summary?: string;
-      completedAt?: string;
-    }>(join(root, 'tasks', '1.json'));
-    const failure = readTaskFailure(teamName, '1', { cwd });
-
-    expect(task.status).toBe('completed');
-    expect(task.owner).toBe('worker-1');
-    expect(task.summary).toBe('already completed elsewhere');
-    expect(task.completedAt).toBeTruthy();
-    expect(failure).toBeNull();
-    expect(tmuxMocks.spawnWorkerInPane).not.toHaveBeenCalled();
-    expect(
-      warnSpy.mock.calls.some(([msg]: [unknown]) => String(msg).includes('dead pane — requeuing task'))
-    ).toBe(false);
+    writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({ id: '1', subject: 'Task 1', description: 'Do work', status: 'in_progress', owner: 'worker-2' }));
+    const ownerStop = watchdogCliWorkers(makeRuntime(cwd, teamName), 20);
+    await runTick();
+    await ownerStop();
+    expect(JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8'))).toMatchObject({ status: 'in_progress', owner: 'worker-2' });
+    expect(readTaskFailure(teamName, '1', { cwd })).toBeNull();
   });
 
-  it('does not requeue or increment retries when dead-pane worker no longer owns the task', async () => {
-    const teamName = 'dead-pane-owner-race-team';
-    const root = join(cwd, '.omc', 'state', 'team', teamName);
-    mkdirSync(join(root, 'tasks'), { recursive: true });
-    mkdirSync(join(root, 'workers', 'worker-1'), { recursive: true });
-
-    writeFileSync(join(root, 'tasks', '1.json'), JSON.stringify({
-      id: '1',
-      subject: 'Task 1',
-      description: 'Do work',
-      status: 'in_progress',
-      owner: 'worker-2',
-      assignedAt: new Date().toISOString(),
-    }), 'utf-8');
-
-    const runtime = makeRuntimeWithTask(cwd, teamName, '1');
+  it('keeps a mutating dead-pane tick alive until every retry effect completes', async () => {
+    const teamName = 'watchdog-stop-quiescence-team';
+    const root = initTask(cwd, teamName);
+    const taskPath = join(root, 'tasks', '1.json');
+    const runtime = makeRuntime(cwd, teamName);
+    const spawnEntered = deferred();
+    const releaseSpawn = deferred();
+    tmuxMocks.spawnWorkerInPane.mockImplementationOnce(async (_sessionName, paneId) => {
+      expect(paneId).toBe('%42');
+      spawnEntered.resolve();
+      await releaseSpawn.promise;
+    });
     const stop = watchdogCliWorkers(runtime, 20);
+    vi.advanceTimersByTime(20);
+    let stopResolved = false;
     try {
-      await waitFor(() => runtime.activeWorkers.size === 0);
+      await spawnEntered.promise;
+      const stopping = stop().then(() => { stopResolved = true; });
+      await Promise.resolve();
+      expect(stopResolved).toBe(false);
+      expect(JSON.parse(readFileSync(taskPath, 'utf8'))).toMatchObject({ status: 'in_progress', owner: 'worker-1' });
+      expect(readTaskFailure(teamName, '1', { cwd })).toMatchObject({ retryCount: 1 });
+      expect(runtime.workerPaneIds).toEqual([]);
+      expect(runtime.activeWorkers.size).toBe(0);
+
+      releaseSpawn.resolve();
+      await stopping;
+      const snapshot = {
+        task: readFileSync(taskPath, 'utf8'),
+        sidecar: readTaskFailure(teamName, '1', { cwd }),
+        workerPaneIds: [...runtime.workerPaneIds],
+        activeWorkers: [...runtime.activeWorkers.entries()],
+        warnings: warnSpy.mock.calls.length,
+      };
+      expect(JSON.parse(snapshot.task)).toMatchObject({ status: 'in_progress', owner: 'worker-1' });
+      expect(snapshot.sidecar).toMatchObject({ retryCount: 1 });
+      expect(tmuxMocks.splitTeamWorkerPane).toHaveBeenCalledWith('%0', 'right', cwd);
+      expect(tmuxMocks.spawnWorkerInPane).toHaveBeenCalledTimes(1);
+      expect(snapshot.workerPaneIds).toEqual(['%42']);
+      expect(snapshot.activeWorkers).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dead pane — requeuing task 1 (retry 1/5)'));
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect({
+        task: readFileSync(taskPath, 'utf8'),
+        sidecar: readTaskFailure(teamName, '1', { cwd }),
+        workerPaneIds: [...runtime.workerPaneIds],
+        activeWorkers: [...runtime.activeWorkers.entries()],
+        warnings: warnSpy.mock.calls.length,
+      }).toEqual(snapshot);
     } finally {
-      await stopWatchdogAndSettle(stop);
+      releaseSpawn.resolve();
+      await stop();
     }
+  });
 
-    const task = await readJsonFileWithRetry<{
-      status: string;
-      owner: string | null;
-    }>(join(root, 'tasks', '1.json'));
-    const failure = readTaskFailure(teamName, '1', { cwd });
+  it('keeps the previous task JSON parseable until atomic task publication', async () => {
+    const teamName = 'watchdog-atomic-publication-team';
+    const root = initTask(cwd, teamName);
+    const taskPath = join(root, 'tasks', '1.json');
+    const oldTask = JSON.parse(readFileSync(taskPath, 'utf8'));
+    const renameEntered = deferred();
+    const releaseRename = deferred();
+    fsPromisesControl.taskTargetPath = taskPath;
+    fsPromisesControl.renameHook = async (_from, to) => {
+      if (to === taskPath) {
+        renameEntered.resolve();
+        await releaseRename.promise;
+      }
+    };
+    const stop = watchdogCliWorkers(makeRuntime(cwd, teamName), 20);
+    vi.advanceTimersByTime(20);
+    try {
+      await renameEntered.promise;
+      expect(JSON.parse(readFileSync(taskPath, 'utf8'))).toEqual(oldTask);
+    } finally {
+      releaseRename.resolve();
+    }
+    await stop();
+    const task = JSON.parse(readFileSync(taskPath, 'utf8')) as { status: string; owner: string | null };
+    expect(task).toMatchObject({ status: 'in_progress', owner: 'worker-1' });
+    expect(readTaskFailure(teamName, '1', { cwd })).toMatchObject({ retryCount: 1 });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dead pane — requeuing task 1 (retry 1/5)'));
+    expect(fsPromisesControl.taskTargetWriteFileCalls).toBe(0);
+  });
 
-    expect(task.status).toBe('in_progress');
-    expect(task.owner).toBe('worker-2');
-    expect(failure).toBeNull();
-    expect(tmuxMocks.spawnWorkerInPane).not.toHaveBeenCalled();
-    expect(
-      warnSpy.mock.calls.some(([msg]: [unknown]) => String(msg).includes('dead pane — requeuing task'))
-    ).toBe(false);
+  it('reproduces the historical direct-write parse failure as a controlled baseline', async () => {
+    const teamName = 'watchdog-historical-direct-write-team';
+    const root = initTask(cwd, teamName);
+    const taskPath = join(root, 'tasks', '1.json');
+    const truncated = deferred();
+    const releaseDirectWrite = deferred();
+    historicalDirectWriteControl.taskTargetPath = taskPath;
+    historicalDirectWriteControl.signalTruncation = truncated.resolve;
+    historicalDirectWriteControl.awaitRelease = () => releaseDirectWrite.promise;
+
+    // This isolated mock models the rejected direct visible-target publication,
+    // not the production atomic writer covered by the neighboring green test.
+    vi.resetModules();
+    vi.doMock('../../lib/atomic-write.js', async importOriginal => {
+      const actual = await importOriginal<typeof import('../../lib/atomic-write.js')>();
+      return {
+        ...actual,
+        atomicWriteJson: async (filePath: string, data: unknown) => {
+          if (filePath !== historicalDirectWriteControl.taskTargetPath) {
+            await actual.atomicWriteJson(filePath, data);
+            return;
+          }
+
+          const content = JSON.stringify(data, null, 2);
+          writeFileSync(filePath, '', 'utf8');
+          historicalDirectWriteControl.signalTruncation?.();
+          await historicalDirectWriteControl.awaitRelease?.();
+          writeFileSync(filePath, content, 'utf8');
+        },
+      };
+    });
+
+    let stop: (() => Promise<void>) | undefined;
+    try {
+      const { watchdogCliWorkers: historicalWatchdogCliWorkers } = await import('../runtime.js');
+      stop = historicalWatchdogCliWorkers(makeRuntime(cwd, teamName), 20);
+      vi.advanceTimersByTime(20);
+      await truncated.promise;
+
+      let parseError: unknown;
+      try {
+        JSON.parse(readFileSync(taskPath, 'utf8'));
+      } catch (error) {
+        parseError = error;
+      }
+      expect(parseError).toBeInstanceOf(SyntaxError);
+      expect((parseError as SyntaxError).message).toBe('Unexpected end of JSON input');
+    } finally {
+      releaseDirectWrite.resolve();
+      await stop?.();
+      vi.doUnmock('../../lib/atomic-write.js');
+      vi.resetModules();
+    }
   });
 });

--- a/src/team/runtime-cli.ts
+++ b/src/team/runtime-cli.ts
@@ -739,6 +739,33 @@ function collectTaskResults(stateRoot: string): TaskResult[] {
   }
 }
 
+async function stopLegacyWatchdog(
+  runtime: Pick<TeamRuntime, 'stopWatchdog'> | null,
+  useV2: boolean,
+): Promise<void> {
+  if (!useV2 && runtime?.stopWatchdog) {
+    await runtime.stopWatchdog();
+  }
+}
+
+/**
+ * Preserve watchdog quiescence before capturing terminal output, then tear down
+ * the team and publish that immutable snapshot. Shutdown may remove v1 state.
+ */
+export async function finalizeRuntimeShutdown<T>(
+  runtime: Pick<TeamRuntime, 'stopWatchdog'> | null,
+  useV2: boolean,
+  collectOutput: () => Promise<T>,
+  shutdown: () => Promise<void>,
+  publishOutput: (output: T) => Promise<void>,
+): Promise<T> {
+  await stopLegacyWatchdog(runtime, useV2);
+  const output = await collectOutput();
+  await shutdown();
+  await publishOutput(output);
+  return output;
+}
+
 async function main(): Promise<void> {
   const startTime = Date.now();
   const logLeaderNudgeEventFailure = createSwallowedErrorLogger(
@@ -810,40 +837,40 @@ async function main(): Promise<void> {
     pollActive = false;
     finalStatus = status;
 
-    // 1. Stop watchdog first (v1 only) — prevents late tick from racing with result collection
-    if (!useV2 && runtime?.stopWatchdog) {
-      runtime.stopWatchdog();
-    }
 
-    // 2. Shutdown team
-    if (runtime) {
-      try {
-        if (useV2) {
-          await shutdownTeamV2(runtime.teamName, runtime.cwd, { force: true });
-        } else {
-          await shutdownTeam(
-            runtime.teamName,
-            runtime.sessionName,
-            runtime.cwd,
-            2_000,
-            runtime.workerPaneIds,
-            runtime.leaderPaneId,
-            runtime.ownsWindow,
-          );
+    const output = await finalizeRuntimeShutdown(
+      runtime,
+      useV2,
+      async () => buildCliOutput(stateRoot, teamName, finalStatus, workerCount, startTime),
+      async () => {
+        if (!runtime) return;
+        try {
+          if (useV2) {
+            await shutdownTeamV2(runtime.teamName, runtime.cwd, { force: true });
+          } else {
+            await shutdownTeam(
+              runtime.teamName,
+              runtime.sessionName,
+              runtime.cwd,
+              2_000,
+              runtime.workerPaneIds,
+              runtime.leaderPaneId,
+              runtime.ownsWindow,
+            );
+          }
+        } catch (err) {
+          process.stderr.write(`[runtime-cli] shutdown error: ${err}\n`);
         }
-      } catch (err) {
-        process.stderr.write(`[runtime-cli] shutdown error: ${err}\n`);
-      }
-    }
-
-    const output = buildCliOutput(stateRoot, teamName, finalStatus, workerCount, startTime);
-    const finishedAt = new Date().toISOString();
-
-    try {
-      await writeResultArtifact(output, finishedAt);
-    } catch (err) {
-      process.stderr.write(`[runtime-cli] Failed to persist result artifact: ${err}\n`);
-    }
+      },
+      async publishedOutput => {
+        const finishedAt = new Date().toISOString();
+        try {
+          await writeResultArtifact(publishedOutput, finishedAt);
+        } catch (err) {
+          process.stderr.write(`[runtime-cli] Failed to persist result artifact: ${err}\n`);
+        }
+      },
+    );
 
     // 3. Write result to stdout
     process.stdout.write(JSON.stringify(output) + '\n');

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile, readFile, rm, rename } from 'fs/promises';
+import { mkdir, readFile, rm, rename, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { tmuxExecAsync } from '../cli/tmux-utils.js';
@@ -14,6 +14,7 @@ import {
   composeInitialInbox, ensureWorkerStateDir, writeWorkerOverlay, generateTriggerMessage,
 } from './worker-bootstrap.js';
 import { cleanupTeamWorktrees } from './git-worktree.js';
+import { atomicWriteJson } from '../lib/atomic-write.js';
 import {
   withTaskLock,
   writeTaskFailure,
@@ -50,7 +51,7 @@ export interface TeamRuntime {
   cwd: string;
   /** Preflight-validated absolute binary paths, keyed by agent type */
   resolvedBinaryPaths?: Partial<Record<CliAgentType, string>>;
-  stopWatchdog?: () => void;
+  stopWatchdog?: () => Promise<void>;
 }
 
 export interface WorkerStatus {
@@ -118,8 +119,7 @@ function stateRoot(cwd: string, teamName: string): string {
 }
 
 async function writeJson(filePath: string, data: unknown): Promise<void> {
-  await mkdir(join(filePath, '..'), { recursive: true });
-  await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  await atomicWriteJson(filePath, data);
 }
 
 async function readJsonSafe<T>(filePath: string): Promise<T | null> {
@@ -542,8 +542,9 @@ export async function monitorTeam(teamName: string, cwd: string, workerPaneIds: 
  * Runtime-owned worker watchdog/orchestrator loop.
  * Handles done.json completion, dead pane failures, and next-task spawning.
  */
-export function watchdogCliWorkers(runtime: TeamRuntime, intervalMs: number): () => void {
-  let tickInFlight = false;
+export function watchdogCliWorkers(runtime: TeamRuntime, intervalMs: number): () => Promise<void> {
+  let activeTick: Promise<void> | null = null;
+  let stopped = false;
   let consecutiveFailures = 0;
   const MAX_CONSECUTIVE_FAILURES = 3;
   // Track consecutive unresponsive ticks per worker
@@ -551,8 +552,6 @@ export function watchdogCliWorkers(runtime: TeamRuntime, intervalMs: number): ()
   const UNRESPONSIVE_KILL_THRESHOLD = 3;
 
   const tick = async () => {
-    if (tickInFlight) return;
-    tickInFlight = true;
     try {
       const workers = [...runtime.activeWorkers.entries()];
       if (workers.length === 0) return;
@@ -663,14 +662,24 @@ export function watchdogCliWorkers(runtime: TeamRuntime, intervalMs: number): ()
         }
         clearInterval(intervalId);
       }
-    } finally {
-      tickInFlight = false;
     }
   };
 
-  const intervalId = setInterval(() => { tick(); }, intervalMs);
+  const startTick = () => {
+    if (stopped || activeTick) return;
+    const tickPromise = tick();
+    activeTick = tickPromise;
+    void tickPromise.finally(() => {
+      if (activeTick === tickPromise) activeTick = null;
+    });
+  };
+  const intervalId = setInterval(startTick, intervalMs);
 
-  return () => clearInterval(intervalId);
+  return async () => {
+    stopped = true;
+    clearInterval(intervalId);
+    await activeTick;
+  };
 }
 
 /**


### PR DESCRIPTION
## Incident

Fixes the post-merge dev CI failure in run https://github.com/Yeachan-Heo/oh-my-claudecode/actions/runs/29311318404 at baseline `ea43ba198a7c191a9b18d0151c50da258d2857a0`:

`src/team/__tests__/runtime-watchdog-retry.test.ts > requeues task when dead pane still has retries remaining`

The failing reader exhausted its parse attempts after observing a concurrently truncated task JSON file (`Unexpected end of JSON input`).

## Root cause

Two independent production contracts were violated:

1. Legacy runtime JSON publication overwrote visible targets directly, so lock-free readers could observe partial bytes.
2. Watchdog stop cancelled future intervals but did not await an already-running async tick before shutdown/result collection.

## Fix

- Route legacy runtime JSON publication through the existing atomic temp-file/rename helper.
- Guarantee the helper writes the complete UTF-8 payload, including short-write handling, before fsync/rename.
- Make watchdog stop idempotent and await active-tick quiescence.
- Snapshot terminal task results after stop and before shutdown can remove state, then publish the frozen result.
- Replace parse retries/settling sleeps with deterministic rename/spawn barriers.
- Add controlled historical-red evidence reproducing the exact one-shot `Unexpected end of JSON input` through the public watchdog path.

Retry semantics are unchanged: `DEFAULT_MAX_TASK_RETRIES` remains 5; lock scope, sidecar-before-task ordering, completion-wins, owner-transfer skip, exhaustion, and contention behavior are preserved. Atomicity remains per-file, not a sidecar+task transaction.

## Verification at exact head

Head: `864cdb65a893d7fe9e03b0f9fd55e1d004094797`

- Focused helper/watchdog/CLI/task-file tests: 127/127 passed.
- Watchdog regression suite: 8/8 passed across 50 consecutive runs.
- Adjacent runtime suite: 229/229 passed.
- Worktree runtime e2e: 7/7 passed.
- `npx tsc --noEmit`: passed.
- `npm run lint`: 0 errors; 18 pre-existing warnings.
- `npm run build`: passed; generated `dist/**` and `bridge/**` restored and excluded.
- Full suite: 10,869 passed; one unrelated `state-tools` concurrency assertion failed in the full parallel run and passed 58/58 in isolated rerun.
- `git diff --check`: passed.
- Source-only diff: no `dist/**` or `bridge/**` changes.

## Review and evidence boundaries

- Fresh exact-head GJC Architect: CLEAR / APPROVE.
- Fresh exact-head GJC Critic: OKAY.
- Commit contains `Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>`.
- Cryptographic verification is not claimed: local `git verify-commit` could not verify because the SSH allowed-signers file is not configured.
- Focused atomic/watchdog barriers were not run on Windows; existing Windows path-only checks are not represented as validation of this fix.
- This implementation lane must not merge the PR.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*