### PR TITLE
fix(session-start): keep plugin drift guidance on marketplace channel

### DIFF
--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -522,9 +522,11 @@ function compactBudgetedText(text, maxChars) {
 function formatUpdateNoticeForUser(updateInfo, options = {}) {
   const latestVersion = updateInfo?.latestVersion || 'latest';
   const currentVersion = updateInfo?.currentVersion || 'unknown';
-  const action = options.autoUpgradePrompt === false
-    ? 'To update later, run: omc update'
-    : 'Run /update to upgrade now, or use /plugin install oh-my-claudecode';
+  const action = updateInfo?.source === 'marketplace'
+    ? 'To update the plugin channel, run: /plugin marketplace update omc && /omc-setup'
+    : (options.autoUpgradePrompt === false
+      ? 'To update later, run: omc update'
+      : 'Run /update to upgrade now, or use /plugin install oh-my-claudecode');
   return `[OMC UPDATE AVAILABLE] oh-my-claudecode v${latestVersion} is available (current: v${currentVersion}). ${action}`;
 }
 
@@ -685,13 +687,16 @@ function detectVersionDrift() {
   const pluginVersion = getPluginVersion();
   const npmVersion = getNpmVersion();
   const claudeMdVersion = getClaudeMdVersion();
+  const marketplaceChannel = getPluginUpdateChannelVersion();
 
   // Need at least plugin version to detect drift
   if (!pluginVersion) return null;
 
   const drift = [];
 
-  if (npmVersion && npmVersion !== pluginVersion) {
+  // Managed plugin installs are intentionally governed by the marketplace clone,
+  // so a newer npm CLI/cache version is not proof that the plugin channel can act.
+  if (!marketplaceChannel.managed && npmVersion && npmVersion !== pluginVersion) {
     drift.push({ component: 'npm package (omc CLI)', current: npmVersion, expected: pluginVersion });
   }
 
@@ -711,7 +716,13 @@ function detectVersionDrift() {
 
   if (drift.length === 0) return null;
 
-  return { pluginVersion, npmVersion, claudeMdVersion, drift };
+  return {
+    pluginVersion,
+    npmVersion,
+    claudeMdVersion,
+    drift,
+    source: marketplaceChannel.managed ? 'marketplace' : 'npm',
+  };
 }
 
 // Check if we should notify (once per unique drift combination)
@@ -753,7 +764,7 @@ async function checkNpmUpdate(currentVersion) {
     }
     const updateAvailable = semverCompare(marketplaceVersion, currentVersion) > 0;
     writeUpdateCheckCache(marketplaceVersion, currentVersion, updateAvailable, 'marketplace');
-    return updateAvailable ? { currentVersion, latestVersion: marketplaceVersion } : null;
+    return updateAvailable ? { currentVersion, latestVersion: marketplaceVersion, source: 'marketplace' } : null;
   }
 
   const cacheFile = getUpdateCheckCachePath();
@@ -766,7 +777,7 @@ async function checkNpmUpdate(currentVersion) {
       const cached = JSON.parse(readFileSync(cacheFile, 'utf-8'));
       if (cached.timestamp && (now - cached.timestamp) < CACHE_DURATION && (!cached.source || cached.source === 'npm')) {
         return (cached.updateAvailable && semverCompare(cached.latestVersion, currentVersion) > 0)
-          ? { currentVersion, latestVersion: cached.latestVersion }
+          ? { currentVersion, latestVersion: cached.latestVersion, source: 'npm' }
           : null;
       }
     }
@@ -787,7 +798,7 @@ async function checkNpmUpdate(currentVersion) {
 
     writeUpdateCheckCache(latestVersion, currentVersion, updateAvailable, 'npm');
 
-    return updateAvailable ? { currentVersion, latestVersion } : null;
+    return updateAvailable ? { currentVersion, latestVersion, source: 'npm' } : null;
   } catch { return null; } finally { clearTimeout(timeoutId); }
 }
 
@@ -917,7 +928,9 @@ async function main() {
       for (const d of driftInfo.drift) {
         driftMsg += `${d.component}: ${d.current} (expected ${d.expected})\n`;
       }
-      driftMsg += `\nRun 'omc update' to sync all components.`;
+      driftMsg += driftInfo.source === 'marketplace'
+        ? `\nRun '/plugin marketplace update omc && /omc-setup' to sync plugin-managed components.`
+        : `\nRun 'omc update' to sync all components.`;
 
       messages.push(`<session-restore>\n\n${driftMsg}\n\n</session-restore>\n\n---\n`);
     }

--- a/src/__tests__/session-start-script-context.test.ts
+++ b/src/__tests__/session-start-script-context.test.ts
@@ -501,6 +501,63 @@ ${'- oversized startup guidance\n'.repeat(700)}
     expect(output.systemMessage).toContain('[OMC UPDATE AVAILABLE]');
     expect(output.systemMessage).toContain('v4.15.4');
     expect(output.systemMessage).not.toContain('4.15.5');
+    expect(output.systemMessage).toContain('/plugin marketplace update omc && /omc-setup');
+    expect(output.systemMessage).not.toContain('/update');
+  });
+
+  it('does not emit npm-channel drift guidance when managed marketplace plugin is current', () => {
+    const claudeDir = join(fakeHome, '.claude');
+    const pluginRoot = join(claudeDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.15.4');
+    const marketplaceRoot = join(claudeDir, 'plugins', 'marketplaces', 'omc');
+    mkdirSync(join(claudeDir, '.omc'), { recursive: true });
+    mkdirSync(join(claudeDir, 'hud'), { recursive: true });
+    mkdirSync(pluginRoot, { recursive: true });
+    mkdirSync(join(marketplaceRoot, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '4.15.4', type: 'module' }));
+    writeFileSync(join(marketplaceRoot, '.claude-plugin', 'marketplace.json'), JSON.stringify({
+      plugins: [{ name: 'oh-my-claudecode', version: '4.15.4' }],
+    }));
+    writeFileSync(join(claudeDir, '.omc-version.json'), JSON.stringify({ version: '4.15.5' }));
+    writeFileSync(join(claudeDir, 'hud', 'omc-hud.mjs'), '');
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({ statusLine: 'node ~/.claude/hud/omc-hud.mjs' }));
+    writeFileSync(
+      join(claudeDir, '.omc', 'update-check.json'),
+      JSON.stringify({
+        timestamp: Date.now(),
+        latestVersion: '4.15.5',
+        currentVersion: '4.15.4',
+        updateAvailable: true,
+        source: 'npm',
+      }),
+    );
+
+    const result = spawnSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'session-marketplace-current-npm-newer',
+        cwd: fakeProject,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        OMC_NOTIFY: '0',
+      },
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const output = JSON.parse(result.stdout) as {
+      systemMessage?: string;
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    const combined = `${output.systemMessage ?? ''}\n${output.hookSpecificOutput?.additionalContext ?? ''}`;
+    expect(combined).not.toContain('[OMC VERSION DRIFT DETECTED]');
+    expect(combined).not.toContain("Run 'omc update'");
+    expect(combined).not.toContain('4.15.5');
   });
 
 });


### PR DESCRIPTION
## Summary

Follow-up to #3499 after independent hostile review found two channel-drift gaps:

- suppress npm/plugin version-drift warnings for managed marketplace plugin installs when the marketplace channel is current;
- carry update source through marketplace-derived update notices so plugin users see `/plugin marketplace update omc && /omc-setup`, not npm `/update` guidance.

## Validation

- `npm test -- --run src/__tests__/session-start-script-context.test.ts src/__tests__/session-start-timeout-cleanup.test.ts src/__tests__/update-check-path.test.ts` — 14 passed
- `node --check scripts/session-start.mjs`
- `npx eslint src/__tests__/session-start-script-context.test.ts`
- `npm run lint` — 0 errors / 18 pre-existing warnings
- `npm run build`
- post-restore source-only recheck: `npm test -- --run src/__tests__/session-start-script-context.test.ts`, `node --check scripts/session-start.mjs`, `npx eslint src/__tests__/session-start-script-context.test.ts`, `git diff --check`

No main merge, release, publish, retag, or admin bypass.

— gaebal-gajae
