### PR TITLE
fix(windows): ship hidden worktree git subprocesses

### DIFF
--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -33,6 +33,7 @@ type PackageJson = {
 };
 
 type PackedPackage = {
+  extractedPackageRoot: string;
   files: Set<string>;
   packageJson: PackageJson;
   pluginJson: PluginJson;
@@ -178,6 +179,7 @@ function getPackedPackage(): PackedPackage {
 
     const extractedPackageRoot = join(packDirCache, 'package');
     packedPackageCache = {
+      extractedPackageRoot,
       files: new Set(files),
       packageJson: JSON.parse(
         readFileSync(join(extractedPackageRoot, 'package.json'), 'utf-8'),
@@ -261,6 +263,19 @@ describe('npm package bin surface regression', () => {
     );
     expect(resultHelp).toContain('team_name');
     expect(resultHelp).toContain('request_id');
+  });
+
+  it('packs the fixed worktree-paths dist with hidden Windows git subprocesses', () => {
+    const source = readFileSync(join(PACKAGE_ROOT, 'src', 'lib', 'worktree-paths.ts'), 'utf-8');
+    const packedDist = readFileSync(
+      join(packedPackageFixture.extractedPackageRoot, 'dist', 'lib', 'worktree-paths.js'),
+      'utf-8',
+    );
+
+    expect(packedPackageFixture.files.has('dist/lib/worktree-paths.js')).toBe(true);
+    expect(source.match(/windowsHide/g)).toHaveLength(7);
+    expect(packedDist).not.toContain('execSync(');
+    expect(packedDist.match(/windowsHide: true/g)).toHaveLength(7);
   });
 
   it('packs the complete source-controlled plugin and hook payload', () => {


### PR DESCRIPTION
## Summary
- rebuild the shipped `dist/lib/worktree-paths.js` from current `src/lib/worktree-paths.ts` so the packaged runtime hides the seven Git subprocesses on Windows
- add a source/dist parity guard for the exact worktree-paths Git subprocess sites
- add an npm package regression proving the packed tarball carries the fixed runtime

## Why
The reporter's WMI trace corrected the issue scope: `OMC_NOTIFY=0` does not stop the console flashes. The observed `cmd.exe`/`conhost.exe` chain comes from the shipped `dist/lib/worktree-paths.js` used by SessionEnd/HUD/PostToolUse. Current source already has the Windows hiding fix, but the committed package dist was stale.

This PR is intentionally smaller than #3479: it repairs only the shipped worktree-paths dist drift and focused regressions for #3498, without duplicating #3479's broader trust-root/runtime closure.

Fixes #3498

## Verification
- `npm test -- --run src/lib/__tests__/worktree-paths.test.ts src/lib/__tests__/worktree-paths-superproject-cache.test.ts tests/lint/worktree-paths-source-dist-parity.test.ts src/__tests__/npm-package-bin-surface.test.ts`
- `npm run lint`
- `npm run build`
- `npm pack --ignore-scripts` + local install smoke (`bin/oh-my-claudecode.js --version`)
- `npm test -- --run src/__tests__/generated-artifact-authorization.test.ts scripts/verify-generated-artifact-authorization.mjs`
- fresh `tsc --outDir <tmp>` output exactly matches committed `dist/lib/worktree-paths.js`

## Generated artifact policy
This PR intentionally changes one generated artifact: `dist/lib/worktree-paths.js`. The local verifier tests pass, but the hosted generated-artifact authorization workflow is the source of truth. If it requires owner authorization, this PR should remain open until the owner adds the exact authorization rather than bypassing the policy.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
