### PR TITLE
fix(beads): correct CLI instruction syntax

### DIFF
--- a/src/hooks/beads-context/__tests__/index.test.ts
+++ b/src/hooks/beads-context/__tests__/index.test.ts
@@ -155,20 +155,55 @@ describe('beads-context', () => {
   });
 
   describe('constants', () => {
-    it('BEADS_INSTRUCTIONS should contain beads CLI commands', () => {
-      expect(BEADS_INSTRUCTIONS).toContain('bd create');
-      expect(BEADS_INSTRUCTIONS).toContain('bd list');
-      expect(BEADS_INSTRUCTIONS).toContain('bd show');
-      expect(BEADS_INSTRUCTIONS).toContain('bd update');
-      expect(BEADS_INSTRUCTIONS).toContain('bd deps');
-    });
+    const instructionContracts = [
+      {
+        instructions: BEADS_INSTRUCTIONS,
+        commands: [
+          'bd create "title"',
+          'bd list',
+          'bd show <id>',
+          'bd close <id>',
+          'bd dep add <id> <depends-on-id>',
+          'Add a dependency: <id> depends on <depends-on-id>',
+          'bd update abc123 --status in_progress',
+          'bd close abc123',
+        ],
+        invalidCommands: [
+          /`bd\s+update\s+[^`\n]*\s--status\s+done`/,
+          /`bd\s+deps\b[^`\n]*`/,
+          /`bd\s+dep(?:s)?\b[^`\n]*\s--add\b[^`\n]*`/,
+        ],
+      },
+      {
+        instructions: BEADS_RUST_INSTRUCTIONS,
+        commands: [
+          'br create "title"',
+          'br list',
+          'br show <id>',
+          'br close <id>',
+          'br dep add <id> <depends-on-id>',
+          'Add a dependency: <id> depends on <depends-on-id>',
+          'br update abc123 --status in_progress',
+          'br close abc123',
+        ],
+        invalidCommands: [
+          /`br\s+update\s+[^`\n]*\s--status\s+done`/,
+          /`br\s+deps\b[^`\n]*`/,
+          /`br\s+dep(?:s)?\b[^`\n]*\s--add\b[^`\n]*`/,
+        ],
+      },
+    ];
 
-    it('BEADS_RUST_INSTRUCTIONS should contain beads-rust CLI commands', () => {
-      expect(BEADS_RUST_INSTRUCTIONS).toContain('br create');
-      expect(BEADS_RUST_INSTRUCTIONS).toContain('br list');
-      expect(BEADS_RUST_INSTRUCTIONS).toContain('br show');
-      expect(BEADS_RUST_INSTRUCTIONS).toContain('br update');
-      expect(BEADS_RUST_INSTRUCTIONS).toContain('br deps');
-    });
+    it.each(instructionContracts)(
+      'contains valid exact commands and rejects obsolete syntax',
+      ({ instructions, commands, invalidCommands }) => {
+        for (const command of commands) {
+          expect(instructions).toContain(command);
+        }
+        for (const invalidCommand of invalidCommands) {
+          expect(instructions).not.toMatch(invalidCommand);
+        }
+      },
+    );
   });
 });

--- a/src/hooks/beads-context/constants.ts
+++ b/src/hooks/beads-context/constants.ts
@@ -6,13 +6,13 @@ You have access to the \`bd\` (beads) CLI for persistent task tracking.
 - \`bd create "title"\` - Create new task
 - \`bd list\` - List all tasks
 - \`bd show <id>\` - Show task details
-- \`bd update <id> --status done\` - Mark task done
-- \`bd deps <id> --add <other-id>\` - Add dependency
+- \`bd close <id>\` - Mark task complete
+- \`bd dep add <id> <depends-on-id>\` - Add a dependency: <id> depends on <depends-on-id>
 
 ### Usage Pattern
 1. Create tasks for work items: \`bd create "Implement feature X"\`
 2. Track progress: \`bd update abc123 --status in_progress\`
-3. Mark complete: \`bd update abc123 --status done\`
+3. Mark complete: \`bd close abc123\`
 
 Prefer using beads over built-in TaskCreate/TodoWrite for persistent tracking.`;
 
@@ -24,12 +24,12 @@ You have access to the \`br\` (beads-rust) CLI for persistent task tracking.
 - \`br create "title"\` - Create new task
 - \`br list\` - List all tasks
 - \`br show <id>\` - Show task details
-- \`br update <id> --status done\` - Mark task done
-- \`br deps <id> --add <other-id>\` - Add dependency
+- \`br close <id>\` - Mark task complete
+- \`br dep add <id> <depends-on-id>\` - Add a dependency: <id> depends on <depends-on-id>
 
 ### Usage Pattern
 1. Create tasks for work items: \`br create "Implement feature X"\`
 2. Track progress: \`br update abc123 --status in_progress\`
-3. Mark complete: \`br update abc123 --status done\`
+3. Mark complete: \`br close abc123\`
 
 Prefer using beads-rust over built-in TaskCreate/TodoWrite for persistent tracking.`;


### PR DESCRIPTION
## Summary
- replace obsolete `bd` completion/dependency examples with verified `bd close` and `bd dep add <id> <depends-on-id>` syntax
- independently update beads-rust guidance to its verified `br close` and `br dep add` contract
- strengthen semantic regression tests with exact valid commands and command-scoped rejection of `done`, plural `deps`, and dependency `--add`

## Upstream evidence
- beads v1.1.0 tagged README/source: `bd close <id>` and `bd dep add <child> <parent>`
- beads-rust v0.2.16 tagged README: `br close`, `br update ... --status in_progress`, and `br dep add <child> <parent>`

## Scope
This corrects dormant, package-shipped instruction source. It does not activate or change runtime context wiring.

## Verification
- focused regression: 13/13 passed (and failed first against the old constants)
- `npx tsc --noEmit`
- `npm run lint` (0 errors; 18 pre-existing unrelated warnings)
- full suite: 627 files passed, 2 skipped; 11,355 tests passed, 14 skipped
- `npm run build`
- verified corrected/legacy-absent command matrix in generated dist, bridge, and actual npm tarball members; generated outputs were not committed

Closes #3504