### PR TITLE
fix(ultragoal): defer /goal guard until confirmation

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -195,10 +195,10 @@ Fires when Claude finishes a response.
 |--------|------|---------|
 | `context-guard-stop.mjs` | Monitors context usage | 5s |
 | `workflow-drift-guard.mjs` | Blocks narrow structured-question and fake-completion drift | 3s |
-| `persistent-mode.cjs` | Maintains active mode state (ralph, ultrawork, etc.) | 10s |
+| `persistent-mode.mjs` | Maintains active mode state (ralph, ultrawork, etc.) | 10s |
 | `code-simplifier.mjs` | Auto-simplifies modified files (opt-in) | 5s |
 
-`persistent-mode` injects a reinforcement message like "The boulder never stops" when an active execution mode is running, prompting continued work.
+`persistent-mode` injects a reinforcement message like "The boulder never stops" when an active execution mode is running, prompting continued work. A fresh unconfirmed ultragoal is exempt while Claude `/goal` confirmation is pending; confirmed runs remain fail-closed.
 
 ### SessionEnd
 
@@ -294,9 +294,10 @@ When a session ID is present, state is stored in session scope under `.omc/state
 `ultragoal-state.json` is the session-scoped Stop/PreToolUse guard for `$ultragoal` runs. The durable plan and audit trail remain `.omc/ultragoal/goals.json` and `.omc/ultragoal/ledger.jsonl`; the state file only records the active runtime guard.
 
 - **Location**: `.omc/state/sessions/{sessionId}/ultragoal-state.json` when a Claude session id is available; legacy fallback is `.omc/state/ultragoal-state.json`.
-- **Active fields**: `active: true`, `session_id`, `project_path`, `started_at`, `last_checked_at`, `current_phase`, optional `claude_goal_objective`, and `reinforcement_count`.
-- **Stop hook**: reinforces only when the state is active, fresh (within the normal 2-hour mode-state freshness window), session-matching, and project-matching. Terminal phases (`complete`, `completed`, `done`, `all-done`, `failed`, `cancelled`) and all-done `.omc/ultragoal/goals.json` plans are ignored.
-- **PreToolUse guard**: while active, tools are denied unless the hook can see a matching active Claude `/goal` snapshot. Use `ALLOW_ULTRAGOAL_WITHOUT_GOAL=1` only as an intentional local bypass.
+- **Active fields**: `active: true`, `session_id`, `project_path`, `started_at`, `last_checked_at`, `current_phase`, optional `claude_goal_objective`, `reinforcement_count`, `awaiting_confirmation`, and `awaiting_confirmation_set_at`.
+- **Pending confirmation**: a fresh unconfirmed state is exempt from both Stop reinforcement and matching-`/goal` PreToolUse enforcement. Freshness requires `awaiting_confirmation: true` and a timestamp age in `[0, 2 minutes)`; a non-empty `awaiting_confirmation_set_at` is authoritative, while an absent or blank value may fall back to `started_at`. Invalid, future, or expired timestamps fail closed.
+- **Stop hook**: after confirmation, reinforces only when the state is active, fresh (within the normal 2-hour mode-state freshness window), session-matching, and project-matching. Terminal phases (`complete`, `completed`, `done`, `all-done`, `failed`, `cancelled`) and all-done `.omc/ultragoal/goals.json` plans are ignored.
+- **PreToolUse guard**: after confirmation, tools are denied unless the hook can see a matching active Claude `/goal` snapshot. Use `ALLOW_ULTRAGOAL_WITHOUT_GOAL=1` only as an intentional local bypass.
 - **Completion**: after the final quality gate and ultragoal checkpoint, mark the state inactive or run `/oh-my-claudecode:cancel` so the state file is cleared with other workflow state.
 
 #### Canceling a Mode

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -935,12 +935,12 @@ OMC registers 21 hook scripts across 11 Claude Code lifecycle events. For detail
 | **SubagentStart**      | `subagent-tracker.mjs start`                                                                                      | 3s               |
 | **SubagentStop**       | `subagent-tracker.mjs stop`, `verify-deliverables.mjs`                                                            | 5s, 5s           |
 | **PreCompact**         | `pre-compact.mjs`, `project-memory-precompact.mjs`                                                                | 10s, 5s          |
-| **Stop**               | `context-guard-stop.mjs`, `workflow-drift-guard.mjs`, `persistent-mode.cjs`, `code-simplifier.mjs`                | 5s, 3s, 10s, 5s  |
+| **Stop**               | `context-guard-stop.mjs`, `workflow-drift-guard.mjs`, `persistent-mode.mjs`, `code-simplifier.mjs`                | 5s, 3s, 10s, 5s  |
 | **SessionEnd**         | `session-end.mjs`                                                                                                 | 30s              |
 
 The `workflow-drift-guard` blocks only supported source-associated local selection forks with a known minimum of two live alternatives—including exact binary questions and cardinality templates; explicit open input and every unsupported or ambiguous form fail open.
 
-> **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills** (activated via keyword-detector), not hooks. The `persistent-mode.cjs` hook enforces their continuation by blocking the Stop event.
+> **Note**: autopilot, ralph, ultrawork, and ultraqa are **skills** (activated via keyword-detector), not hooks. The `persistent-mode.mjs` hook enforces their continuation by blocking the Stop event. A fresh unconfirmed ultragoal does not enforce matching `/goal`; confirmed runs remain fail-closed.
 
 ### Code Simplifier Hook
 

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -508,21 +508,19 @@ function isAwaitingConfirmation(state) {
     return false;
   }
 
-  const setAt =
-    state.awaiting_confirmation_set_at ||
-    state.started_at ||
-    null;
-
-  if (!setAt) {
+  const preferred = state.awaiting_confirmation_set_at;
+  const timestamp = typeof preferred === "string" && preferred.trim()
+    ? preferred
+    : typeof state.started_at === "string" && state.started_at.trim()
+      ? state.started_at
+      : null;
+  if (!timestamp) {
     return false;
   }
 
-  const setAtMs = new Date(setAt).getTime();
-  if (!Number.isFinite(setAtMs)) {
-    return false;
-  }
-
-  return Date.now() - setAtMs < AWAITING_CONFIRMATION_TTL_MS;
+  const timestampMs = new Date(timestamp).getTime();
+  const ageMs = Date.now() - timestampMs;
+  return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < AWAITING_CONFIRMATION_TTL_MS;
 }
 
 function getAutopilotPhase(state) {

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -643,6 +643,25 @@ const ULTRAGOAL_TERMINAL_PHASES = new Set([
   'aborted',
 ]);
 
+const AWAITING_CONFIRMATION_TTL_MS = 2 * 60 * 1000;
+
+function isAwaitingConfirmation(state) {
+  if (!state || state.awaiting_confirmation !== true) return false;
+
+  const preferred = state.awaiting_confirmation_set_at;
+  const timestamp = typeof preferred === 'string' && preferred.trim()
+    ? preferred
+    : typeof state.started_at === 'string' && state.started_at.trim()
+      ? state.started_at
+      : null;
+  if (!timestamp) return false;
+
+  const timestampMs = new Date(timestamp).getTime();
+  const ageMs = Date.now() - timestampMs;
+  return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < AWAITING_CONFIRMATION_TTL_MS;
+}
+
+
 function isStaleModeState(state) {
   if (!state || typeof state !== 'object') return true;
   const timestamps = [state.last_checked_at, state.updated_at, state.started_at]
@@ -900,6 +919,7 @@ function evaluateUltragoalPreToolEnforcement(stateDir, directory, sessionId, dat
   if (isStaleModeState(state)) return null;
   if (state.project_path && resolve(String(state.project_path)) !== resolve(directory)) return null;
   if (isUltragoalTerminalState(state, directory)) return null;
+  if (isAwaitingConfirmation(state)) return null;
 
   const expected = getExpectedUltragoalObjective(state, directory);
   const actual = extractClaudeGoalSnapshot(data, sessionId, directory);

--- a/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
+++ b/src/hooks/persistent-mode/__tests__/ultragoal-persistence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
@@ -41,6 +41,28 @@ function writeUltragoalState(cwd: string, overrides: Record<string, unknown> = {
     `${JSON.stringify(state, null, 2)}\n`,
   );
   return state;
+}
+
+function ultragoalStatePath(cwd: string) {
+  return join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json');
+}
+
+function readUltragoalState(cwd: string) {
+  return JSON.parse(readFileSync(ultragoalStatePath(cwd), 'utf-8'));
+}
+
+function expectUltragoalEnforcement(cwd: string) {
+  const preTool = runHook(preToolScript, { cwd, session_id: 'session-a', tool_name: 'Bash', tool_input: {} });
+  const stop = runHook(persistentModeScript, { cwd, session_id: 'session-a' });
+  expect(preTool.hookSpecificOutput?.permissionDecision).toBe('deny');
+  expect(stop.decision).toBe('block');
+}
+
+function expectAwaitingConfirmationRelease(cwd: string) {
+  const preTool = runHook(preToolScript, { cwd, session_id: 'session-a', tool_name: 'Bash', tool_input: {} });
+  const stop = runHook(persistentModeScript, { cwd, session_id: 'session-a' });
+  expect(preTool.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  expect(stop.decision).toBeUndefined();
 }
 
 describe('ultragoal persistence and Claude /goal enforcement', () => {
@@ -137,6 +159,94 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
     expect(result.hookSpecificOutput?.permissionDecision).toBe('deny');
     expect(result.hookSpecificOutput?.permissionDecisionReason).toContain('ALLOW_ULTRAGOAL_WITHOUT_GOAL=1');
   });
+
+  it('releases both hooks only for a fresh awaiting-confirmation timestamp', () => {
+    const fresh = new Date().toISOString();
+    const preferred = makeTempProject('omc-ultragoal-awaiting-preferred-');
+    writeUltragoalState(preferred, { awaiting_confirmation: true, awaiting_confirmation_set_at: fresh });
+    expectAwaitingConfirmationRelease(preferred);
+
+    const insideTtl = makeTempProject('omc-ultragoal-awaiting-inside-ttl-');
+    writeUltragoalState(insideTtl, {
+      awaiting_confirmation: true,
+      awaiting_confirmation_set_at: new Date(Date.now() - 110_000).toISOString(),
+    });
+    expectAwaitingConfirmationRelease(insideTtl);
+
+    for (const [name, overrides] of [
+      ['false', { awaiting_confirmation: false, awaiting_confirmation_set_at: fresh }],
+      ['missing', {}],
+      ['stale', { awaiting_confirmation: true, awaiting_confirmation_set_at: new Date(Date.now() - 120_001).toISOString() }],
+      ['at or beyond TTL', { awaiting_confirmation: true, awaiting_confirmation_set_at: new Date(Date.now() - 120_000).toISOString() }],
+      ['future', { awaiting_confirmation: true, awaiting_confirmation_set_at: new Date(Date.now() + 60_000).toISOString() }],
+      ['invalid preferred', { awaiting_confirmation: true, awaiting_confirmation_set_at: 'invalid', started_at: fresh }],
+    ] as const) {
+      const cwd = makeTempProject(`omc-ultragoal-awaiting-${name.replace(/\s/g, '-')}-`);
+      writeUltragoalState(cwd, overrides);
+      expectUltragoalEnforcement(cwd);
+    }
+
+    for (const preferred of [undefined, '   '] as const) {
+      const cwd = makeTempProject('omc-ultragoal-awaiting-started-at-');
+      writeUltragoalState(cwd, { awaiting_confirmation: true, awaiting_confirmation_set_at: preferred, started_at: fresh });
+      expectAwaitingConfirmationRelease(cwd);
+    }
+  });
+
+  it('requires /goal after confirmation and allows the matching goal', () => {
+    const cwd = makeTempProject('omc-ultragoal-confirmation-transition-');
+    runHook(keywordScript, { cwd, session_id: 'session-a', prompt: '$ultragoal fix issue #3506' });
+    expectAwaitingConfirmationRelease(cwd);
+
+    runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Skill',
+      tool_input: { skill: 'oh-my-claudecode:ultragoal' },
+    });
+    expect(readUltragoalState(cwd).awaiting_confirmation).not.toBe(true);
+    expectUltragoalEnforcement(cwd);
+
+    const confirmedState = readUltragoalState(cwd);
+    confirmedState.claude_goal_objective = 'Complete issue #3506 ultragoal confirmation parity.';
+    writeFileSync(ultragoalStatePath(cwd), `${JSON.stringify(confirmedState, null, 2)}\n`);
+    const matchingGoal = runHook(preToolScript, {
+      cwd,
+      session_id: 'session-a',
+      tool_name: 'Bash',
+      tool_input: {},
+      goal: { objective: confirmedState.claude_goal_objective, status: 'active' },
+    });
+    expect(matchingGoal.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+  });
+
+  it('releases two keyword-detector activation and confirmation cycles in one session and project', () => {
+    const cwd = makeTempProject('omc-ultragoal-two-cycles-');
+    for (const prompt of ['$ultragoal fix issue #3506', 'run ultragoal for issue #3506 again']) {
+      runHook(keywordScript, { cwd, session_id: 'session-a', prompt });
+      expectAwaitingConfirmationRelease(cwd);
+      runHook(preToolScript, {
+        cwd,
+        session_id: 'session-a',
+        tool_name: 'Skill',
+        tool_input: { skill: 'oh-my-claudecode:ultragoal' },
+      });
+      expect(readUltragoalState(cwd).awaiting_confirmation).not.toBe(true);
+      expectUltragoalEnforcement(cwd);
+      const confirmedState = readUltragoalState(cwd);
+      confirmedState.claude_goal_objective = 'Complete issue #3506 recurring ultragoal run.';
+      writeFileSync(ultragoalStatePath(cwd), `${JSON.stringify(confirmedState, null, 2)}\n`);
+      const matchingGoal = runHook(preToolScript, {
+        cwd,
+        session_id: 'session-a',
+        tool_name: 'Bash',
+        tool_input: {},
+        goal: { objective: confirmedState.claude_goal_objective, status: 'active' },
+      });
+      expect(matchingGoal.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    }
+  });
+
 
   // Write a session-bound transcript (`<sessionId>.jsonl`) with the given record
   // contents, mirroring how Claude Code records `/goal` local-command output.
@@ -415,13 +525,25 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
     expect(existsSync(statePath)).toBe(false);
   });
 
+  it('does not activate or deny for quoted reported speech and pasted bug-report keyword mentions', () => {
+    for (const prompt of [
+      'The reporter said “please run ultragoal” during triage.',
+      'Pasted bug report: log line `[MAGIC KEYWORD DETECTED: ULTRAGOAL]` caused a prior failure.',
+    ]) {
+      const cwd = makeTempProject('omc-ultragoal-keyword-negative-');
+      runHook(keywordScript, { cwd, session_id: 'session-a', prompt });
+      expect(existsSync(ultragoalStatePath(cwd))).toBe(false);
+      const preTool = runHook(preToolScript, { cwd, session_id: 'session-a', tool_name: 'Bash', tool_input: {} });
+      expect(preTool.hookSpecificOutput?.permissionDecision).not.toBe('deny');
+    }
+  });
+
   it('activates ultragoal session state from explicit natural-language invocation', () => {
     const cwd = makeTempProject('omc-ultragoal-keyword-natural-');
 
     runHook(keywordScript, { cwd, session_id: 'session-a', prompt: 'run ultragoal for issue #3098' });
 
-    const statePath = join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json');
-    const state = JSON.parse(execFileSync('cat', [statePath], { encoding: 'utf-8' }));
+    const state = readUltragoalState(cwd);
     expect(state.active).toBe(true);
   });
 
@@ -430,8 +552,7 @@ describe('ultragoal persistence and Claude /goal enforcement', () => {
 
     runHook(keywordScript, { cwd, session_id: 'session-a', prompt: '$ultragoal fix issue #3098' });
 
-    const statePath = join(cwd, '.omc', 'state', 'sessions', 'session-a', 'ultragoal-state.json');
-    const state = JSON.parse(execFileSync('cat', [statePath], { encoding: 'utf-8' }));
+    const state = readUltragoalState(cwd);
     expect(state.active).toBe(true);
     expect(state.session_id).toBe('session-a');
     expect(state.current_phase).toBe('executing');


### PR DESCRIPTION
## Summary
- exempt only fresh, unconfirmed ultragoal state from restrictive matching-`/goal` enforcement
- make Stop and PreToolUse share the same fail-closed `[0, 2 minutes)` timestamp contract
- cover repeated same-session activation, confirmation transitions, timestamp boundaries, and quoted/pasted keyword false positives
- correct the documented production Stop hook path and lifecycle semantics

## Verification
- focused ultragoal/PreToolUse/keyword/package tests: 669 passed
- `npm run build`: passed
- `npm run lint`: 0 errors (18 unrelated existing warnings)
- `npm pack --dry-run --json`: passed; changed scripts are shipped directly
- broad suite: 11,363 passed; unrelated session-end timing and state-isolation failures were preserved as non-scope evidence
- cleanup sweep: zero blockers
- architect review: CLEAR / APPROVE
- executor adversarial QA: passed

Fixes #3506

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*