### PR TITLE
fix(lsp): handle server-to-client requests

### DIFF
--- a/src/tools/lsp/__tests__/client-handle-data.test.ts
+++ b/src/tools/lsp/__tests__/client-handle-data.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { spawn } from 'child_process';
 
 // Mock servers module
 vi.mock('../servers.js', () => ({
@@ -35,6 +36,21 @@ function buildLspMessage(body: string): Buffer {
 
 function jsonRpcResponse(id: number, result: unknown): string {
   return JSON.stringify({ jsonrpc: '2.0', id, result });
+}
+
+function decodeLspMessage(message: string): Record<string, unknown> {
+  const bodyStart = message.indexOf('\r\n\r\n') + 4;
+  return JSON.parse(message.slice(bodyStart));
+}
+
+function setupWritableClient(client: LspClient) {
+  const writes: string[] = [];
+  (client as any).process = {
+    stdin: {
+      write: vi.fn((message: string) => writes.push(message)),
+    },
+  };
+  return writes;
 }
 
 function setupPendingRequest(client: LspClient, id: number) {
@@ -174,5 +190,196 @@ describe('LspClient handleData byte-length fix (#1026)', () => {
     (client as any).handleData(Buffer.concat([bad, good]));
 
     expect(resolve).toHaveBeenCalledWith('recovered');
+  });
+
+  it('replies to registration requests with the exact error and preserves string, zero, and empty IDs', () => {
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    const writes = setupWritableClient(client);
+
+    for (const id of ['ts1', 0, '']) {
+      (client as any).handleData(buildLspMessage(JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'client/registerCapability',
+      })));
+    }
+
+    expect(writes.map(decodeLspMessage)).toEqual([
+      {
+        jsonrpc: '2.0',
+        id: 'ts1',
+        error: { code: -32803, message: 'Dynamic capability registration is not supported' },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 0,
+        error: { code: -32803, message: 'Dynamic capability registration is not supported' },
+      },
+      {
+        jsonrpc: '2.0',
+        id: '',
+        error: { code: -32803, message: 'Dynamic capability registration is not supported' },
+      },
+    ]);
+  });
+
+  it('replies to unknown server requests with Method not found', () => {
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    const writes = setupWritableClient(client);
+
+    (client as any).handleData(buildLspMessage(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'window/showMessageRequest',
+    })));
+
+    expect(writes).toHaveLength(1);
+    expect(decodeLspMessage(writes[0])).toEqual({
+      jsonrpc: '2.0',
+      id: 7,
+      error: { code: -32601, message: 'Method not found' },
+    });
+  });
+
+  it('does not reply to fractional-ID requests or route them to pending responses', () => {
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    const writes = setupWritableClient(client);
+    const { resolve } = setupPendingRequest(client, 1.5);
+
+    (client as any).handleData(buildLspMessage(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1.5,
+      method: 'client/registerCapability',
+    })));
+
+    expect(writes).toHaveLength(0);
+    expect(resolve).not.toHaveBeenCalled();
+    expect((client as any).pendingRequests.has(1.5)).toBe(true);
+    clearTimeout((client as any).pendingRequests.get(1.5).timeout);
+    (client as any).pendingRequests.delete(1.5);
+  });
+
+  it('preserves numeric response resolution and rejection without string-ID coercion', () => {
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    const resolved = setupPendingRequest(client, 1);
+    const rejected = setupPendingRequest(client, 2);
+
+    (client as any).handleData(buildLspMessage(JSON.stringify({ jsonrpc: '2.0', id: '1', result: 'wrong' })));
+    (client as any).handleData(buildLspMessage(jsonRpcResponse(1, 'right')));
+    (client as any).handleData(buildLspMessage(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      error: { code: -32000, message: 'rejected' },
+    })));
+
+    expect(resolved.resolve).toHaveBeenCalledWith('right');
+    expect(rejected.reject).toHaveBeenCalledWith(new Error('rejected'));
+    expect((client as any).pendingRequests.has(1)).toBe(false);
+    expect((client as any).pendingRequests.has(2)).toBe(false);
+  });
+
+  it('does not correlate method-bearing frames as responses', () => {
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    const pending = setupPendingRequest(client, 3);
+
+    (client as any).handleData(buildLspMessage(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 3,
+      method: null,
+      result: 'spoofed',
+    })));
+
+    expect(pending.resolve).not.toHaveBeenCalled();
+    expect((client as any).pendingRequests.has(3)).toBe(true);
+    clearTimeout((client as any).pendingRequests.get(3).timeout);
+    (client as any).pendingRequests.delete(3);
+  });
+
+  it('keeps method-only messages as notifications without writing a response', () => {
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    const writes = setupWritableClient(client);
+    const uri = 'file:///tmp/ws/test.ts';
+    const diagnostics = [{ message: 'problem', severity: 1 }];
+
+    (client as any).handleData(buildLspMessage(JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'textDocument/publishDiagnostics',
+      params: { uri, diagnostics },
+    })));
+
+    expect(writes).toHaveLength(0);
+    expect((client as any).diagnostics.get(uri)).toEqual(diagnostics);
+  });
+
+  it('releases a queued public request only after its registration error reply is pumped', async () => {
+    const writes: string[] = [];
+    let stdoutData: ((data: Buffer) => void) | undefined;
+    let pumpRegistrationReply: (() => void) | undefined;
+    let pumpQueuedWorkspaceResult: (() => void) | undefined;
+    let registrationReplyObserved = false;
+    const stdin = {
+      write: vi.fn((message: string) => {
+        writes.push(message);
+        const outgoing = decodeLspMessage(message);
+        if (outgoing.method === 'initialize') {
+          stdoutData!(buildLspMessage(jsonRpcResponse(outgoing.id as number, { capabilities: {} })));
+        } else if (outgoing.method === 'initialized') {
+          stdoutData!(buildLspMessage(JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'ts1',
+            method: 'client/registerCapability',
+          })));
+        } else if (outgoing.id === 'ts1' && (outgoing.error as { code?: number } | undefined)?.code === -32803) {
+          pumpRegistrationReply = () => {
+            expect(outgoing).toEqual({
+              jsonrpc: '2.0',
+              id: 'ts1',
+              error: { code: -32803, message: 'Dynamic capability registration is not supported' },
+            });
+            registrationReplyObserved = true;
+          };
+        } else if (outgoing.method === 'workspace/symbol') {
+          pumpQueuedWorkspaceResult = () => {
+            expect(registrationReplyObserved).toBe(true);
+            stdoutData!(buildLspMessage(jsonRpcResponse(outgoing.id as number, [])));
+          };
+        }
+      }),
+    };
+    vi.mocked(spawn).mockReturnValueOnce({
+      stdin,
+      stdout: { on: vi.fn((event: string, listener: (data: Buffer) => void) => {
+        if (event === 'data') stdoutData = listener;
+      }) },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+      kill: vi.fn(),
+      pid: 12345,
+    } as any);
+
+    const client = new LspClient('/tmp/ws', SERVER_CONFIG);
+    await client.connect();
+    const request = client.workspaceSymbols('queued');
+    let resolved = false;
+    request.then(() => { resolved = true; });
+
+    expect(writes).toHaveLength(4);
+    expect(decodeLspMessage(writes[2])).toEqual({
+      jsonrpc: '2.0',
+      id: 'ts1',
+      error: { code: -32803, message: 'Dynamic capability registration is not supported' },
+    });
+    expect(decodeLspMessage(writes[3])).toMatchObject({ id: 2, method: 'workspace/symbol' });
+    expect(pumpRegistrationReply).toBeDefined();
+    expect(pumpQueuedWorkspaceResult).toBeDefined();
+    expect(registrationReplyObserved).toBe(false);
+    expect(resolved).toBe(false);
+
+    pumpRegistrationReply!();
+    expect(registrationReplyObserved).toBe(true);
+    pumpQueuedWorkspaceResult!();
+
+    await expect(request).resolves.toEqual([]);
+    expect(resolved).toBe(true);
   });
 });

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -120,6 +120,9 @@ export interface CodeAction {
 /**
  * JSON-RPC Request/Response types
  */
+/** Inbound server request IDs may be strings or integer numbers. */
+type JsonRpcServerRequestId = number | string;
+
 interface JsonRpcRequest {
   jsonrpc: '2.0';
   id: number;
@@ -132,6 +135,19 @@ interface JsonRpcResponse {
   id: number;
   result?: unknown;
   error?: { code: number; message: string; data?: unknown };
+}
+
+interface JsonRpcServerRequest {
+  jsonrpc: '2.0';
+  id: JsonRpcServerRequestId;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcErrorResponse {
+  jsonrpc: '2.0';
+  id: JsonRpcServerRequestId;
+  error: { code: number; message: string };
 }
 
 interface JsonRpcNotification {
@@ -349,24 +365,49 @@ export class LspClient {
   /**
    * Handle a parsed JSON-RPC message
    */
-  private handleMessage(message: JsonRpcResponse | JsonRpcNotification): void {
-    if ('id' in message && message.id !== undefined) {
+  private handleMessage(message: JsonRpcResponse | JsonRpcNotification | JsonRpcServerRequest): void {
+    const record = message as unknown as Record<string, unknown>;
+    const hasOwnMethod = Object.prototype.hasOwnProperty.call(message, 'method');
+    const hasOwnId = Object.prototype.hasOwnProperty.call(message, 'id');
+
+    if (hasOwnMethod && typeof record.method === 'string') {
+      const id = record.id;
+      if (hasOwnId) {
+        if (typeof id === 'string' || (typeof id === 'number' && Number.isInteger(id))) {
+          this.handleServerRequest(message as JsonRpcServerRequest);
+        }
+        return;
+      }
+
+      this.handleNotification(message as JsonRpcNotification);
+      return;
+    }
+
+    if (!hasOwnMethod && hasOwnId && typeof record.id === 'number') {
       // Response to a request
-      const pending = this.pendingRequests.get(message.id);
+      const response = message as JsonRpcResponse;
+      const pending = this.pendingRequests.get(response.id);
       if (pending) {
         clearTimeout(pending.timeout);
-        this.pendingRequests.delete(message.id);
+        this.pendingRequests.delete(response.id);
 
-        if (message.error) {
-          pending.reject(new Error(message.error.message));
+        if (response.error) {
+          pending.reject(new Error(response.error.message));
         } else {
-          pending.resolve(message.result);
+          pending.resolve(response.result);
         }
       }
-    } else if ('method' in message) {
-      // Notification from server
-      this.handleNotification(message as JsonRpcNotification);
     }
+  }
+
+  /** Reply to unsupported server requests without claiming they succeeded. */
+  private handleServerRequest(request: JsonRpcServerRequest): void {
+    const error = request.method === 'client/registerCapability'
+      ? { code: -32803, message: 'Dynamic capability registration is not supported' }
+      : { code: -32601, message: 'Method not found' };
+    const response: JsonRpcErrorResponse = { jsonrpc: '2.0', id: request.id, error };
+    const content = JSON.stringify(response);
+    this.process?.stdin?.write(`Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`);
   }
 
   /**


### PR DESCRIPTION
## Summary
- classify JSON-RPC server requests (`method` + integer/string `id`) before client-response correlation
- return `RequestFailed` for unsupported `client/registerCapability` and `MethodNotFound` for unknown server requests without falsely acknowledging registrations
- preserve numeric response and notification behavior while adding deterministic queue-progress regressions

## Verification
- `npm run test:run -- src/tools/lsp/__tests__/client-handle-data.test.ts src/tools/lsp/__tests__/client-devcontainer.test.ts src/tools/lsp/__tests__/client-timeout-env.test.ts src/tools/lsp/__tests__/client-win32-spawn.test.ts` (28 passed)
- `npx tsc --noEmit`
- `npm run lint` (0 errors; pre-existing warnings only)
- `npm run build`; generated `dist/` and `bridge/` parity inspected and restored before commit
- native TypeScript 7.0.2 raw-LSP probe: `client/registerCapability` ID `ts1` received exact `-32803` response; subsequent document-symbol response ID 2 arrived in 112ms
- full suite: 11,364 tests passed; three unrelated load-sensitive timeout failures passed in isolated rerun

Fixes #3508

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*