### PR TITLE
fix(release): guard coordinator across shipped surfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
           test -s .github/release-body.md
           cp .github/release-body.md release-notes.md
 
+      - name: Verify plugin shipping surface
+        run: npm run plugin:shipping:verify
+
       - name: Build
         run: npm run build
 
@@ -94,19 +97,36 @@ jobs:
           node scripts/release-boundary.mjs prepare-stage --seed-tarball "$SEED_TARBALL" --stage "$STAGE" --git-head "$GITHUB_SHA"
           FINAL_NAME=$(npm pack "$STAGE/package" --ignore-scripts --pack-destination "$FINAL_DIR" --silent)
           FINAL_TARBALL="$FINAL_DIR/$FINAL_NAME"
+          FINAL_TARBALL_SHA256=$(sha256sum "$FINAL_TARBALL" | cut -d ' ' -f 1)
           node scripts/release-boundary.mjs assert-archive --tarball "$FINAL_TARBALL" --version "$VERSION" --git-head "$GITHUB_SHA"
           node scripts/release-boundary.mjs write-evidence --tarball "$FINAL_TARBALL" --output "$EVIDENCE_JSON"
           printf 'FINAL_TARBALL=%s\n' "$FINAL_TARBALL" >> "$GITHUB_ENV"
           printf 'EVIDENCE_JSON=%s\n' "$EVIDENCE_JSON" >> "$GITHUB_ENV"
+          printf 'FINAL_TARBALL_SHA256=%s\n' "$FINAL_TARBALL_SHA256" >> "$GITHUB_ENV"
 
       - name: Smoke test staged archive
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          SMOKE_PREFIX="$RUNNER_TEMP/release-smoke"
+          SMOKE_ROOT="$RUNNER_TEMP/release-smoke"
+          SMOKE_PREFIX="$SMOKE_ROOT/package"
+          SMOKE_HOME="$SMOKE_ROOT/home"
+          SMOKE_CLAUDE_CONFIG_DIR="$SMOKE_HOME/.claude"
+          SMOKE_GJC_CONFIG_DIR="$SMOKE_HOME/.gjc"
+          SMOKE_PROJECT="$SMOKE_ROOT/project"
+          rm -rf "$SMOKE_ROOT"
+          mkdir -p "$SMOKE_HOME" "$SMOKE_PROJECT" "$SMOKE_CLAUDE_CONFIG_DIR" "$SMOKE_GJC_CONFIG_DIR"
           npm install --ignore-scripts --prefix "$SMOKE_PREFIX" "$FINAL_TARBALL"
-          test "$("$SMOKE_PREFIX/node_modules/.bin/omc" --version)" = "$VERSION"
-          "$SMOKE_PREFIX/node_modules/.bin/omc" --help
-          API_HELP=$("$SMOKE_PREFIX/node_modules/.bin/omc-cli" team api --help)
+          SMOKE_PACKAGE_ROOT="$SMOKE_PREFIX/node_modules/oh-my-claude-sisyphus"
+          test -f "$SMOKE_PACKAGE_ROOT/bridge/claude-md-coordinator.cjs"
+          test -f "$SMOKE_PACKAGE_ROOT/scripts/setup-claude-md.sh"
+          test -f "$SMOKE_PACKAGE_ROOT/scripts/lib/config-dir.sh"
+          test -s "$SMOKE_PACKAGE_ROOT/skills/omc-reference/SKILL.md"
+          test -f "$SMOKE_PACKAGE_ROOT/skills/setup/SKILL.md"
+          test -f "$SMOKE_PACKAGE_ROOT/skills/omc-setup/SKILL.md"
+          test -f "$SMOKE_PACKAGE_ROOT/skills/omc-setup/phases/01-install-claude-md.md"
+          test "$(env -i PATH="$PATH" HOME="$SMOKE_HOME" CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" GJC_CONFIG_DIR="$SMOKE_GJC_CONFIG_DIR" OMC_SETUP_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" CLAUDE_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" "$SMOKE_PREFIX/node_modules/.bin/omc" --version)" = "$VERSION"
+          env -i PATH="$PATH" HOME="$SMOKE_HOME" CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" GJC_CONFIG_DIR="$SMOKE_GJC_CONFIG_DIR" OMC_SETUP_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" CLAUDE_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" "$SMOKE_PREFIX/node_modules/.bin/omc" --help
+          API_HELP=$(env -i PATH="$PATH" HOME="$SMOKE_HOME" CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" GJC_CONFIG_DIR="$SMOKE_GJC_CONFIG_DIR" OMC_SETUP_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" CLAUDE_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" "$SMOKE_PREFIX/node_modules/.bin/omc-cli" team api --help)
           case "$API_HELP" in
             *recover-worker*write-task-checkpoint*read-recovery-result*) ;;
             *)
@@ -114,6 +134,17 @@ jobs:
               exit 1
               ;;
           esac
+          cd "$SMOKE_PROJECT"
+          env -i PATH="$PATH" HOME="$SMOKE_HOME" CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" GJC_CONFIG_DIR="$SMOKE_GJC_CONFIG_DIR" OMC_SETUP_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" CLAUDE_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" bash -c 'bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" local'
+          cmp "$SMOKE_PACKAGE_ROOT/docs/CLAUDE.md" "$SMOKE_PROJECT/.claude/CLAUDE.md"
+          cmp "$SMOKE_PACKAGE_ROOT/skills/omc-reference/SKILL.md" "$SMOKE_PROJECT/.claude/skills/omc-reference/SKILL.md"
+          COORDINATOR_SHA256=$(sha256sum "$SMOKE_PACKAGE_ROOT/bridge/claude-md-coordinator.cjs" | cut -d ' ' -f 1)
+          test "$FINAL_TARBALL_SHA256" = "$(sha256sum "$FINAL_TARBALL" | cut -d ' ' -f 1)"
+          test "$COORDINATOR_SHA256" = "$(node -e 'const fs = require("node:fs"); const crypto = require("node:crypto"); process.stdout.write(crypto.createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex"));' "$SMOKE_PACKAGE_ROOT/bridge/claude-md-coordinator.cjs")"
+          test "$COORDINATOR_SHA256" = "$(node -e 'const evidence = require(process.argv[1]); const file = evidence.archiveManifest.files.find(({ path }) => path === "package/bridge/claude-md-coordinator.cjs"); process.stdout.write(file?.sha256 ?? "");' "$EVIDENCE_JSON")"
+          test "$(node -p 'require(process.argv[1]).gitHead' "$SMOKE_PACKAGE_ROOT/package.json")" = "$GITHUB_SHA"
+          test "$(node -p 'require(process.argv[1]).sourceSha' "$EVIDENCE_JSON")" = "$GITHUB_SHA"
+          test "$(node -p 'require(process.argv[1]).sha256' "$EVIDENCE_JSON")" = "$FINAL_TARBALL_SHA256"
 
       - name: Upload release archive evidence
         uses: actions/upload-artifact@v4

--- a/scripts/release-boundary.mjs
+++ b/scripts/release-boundary.mjs
@@ -35,6 +35,7 @@ const EXPECTED_BINS = Object.freeze({
 const REQUIRED_ENTRYPOINTS = Object.freeze([
   'bin/oh-my-claudecode.js',
   'bridge/cli.cjs',
+  'bridge/claude-md-coordinator.cjs',
   'bridge/mcp-server.cjs',
   'bridge/runtime-cli.cjs',
   'bridge/team.js',

--- a/src/__tests__/release-boundary.test.ts
+++ b/src/__tests__/release-boundary.test.ts
@@ -128,6 +128,7 @@ function releaseTarball(gitHead = SHA, extraEntries: TarEntry[] = [], readme = '
     },
     { path: 'package/bin/oh-my-claudecode.js', content: '#!/usr/bin/env node\n', mode: 0o755 },
     { path: 'package/bridge/cli.cjs', content: 'module.exports = {};\n' },
+    { path: 'package/bridge/claude-md-coordinator.cjs', content: 'module.exports = {};\n' },
     { path: 'package/bridge/mcp-server.cjs', content: 'module.exports = {};\n' },
     { path: 'package/bridge/runtime-cli.cjs', content: 'module.exports = {};\n' },
     { path: 'package/bridge/team.js', content: 'export {};\n' },
@@ -377,12 +378,23 @@ describe('release-boundary.mjs', () => {
       tag: TAG,
       npmIntegrity: expect.stringMatching(/^sha512-/),
     });
+    expect(evidence.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(evidence.archiveManifest).toMatchObject({
+      algorithm: 'sha256',
+      digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    expect(evidence.archiveManifest.files).toContainEqual(expect.objectContaining({
+      path: 'package/bridge/claude-md-coordinator.cjs',
+      byteLength: expect.any(Number),
+      sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    }));
     expect(evidence.archiveManifest.files.map((file: { path: string }) => file.path)).toEqual([
       'package/.claude-plugin/marketplace.json',
       'package/.claude-plugin/plugin.json',
       'package/.mcp.json',
       'package/README.md',
       'package/bin/oh-my-claudecode.js',
+      'package/bridge/claude-md-coordinator.cjs',
       'package/bridge/cli.cjs',
       'package/bridge/mcp-server.cjs',
       'package/bridge/runtime-cli.cjs',
@@ -395,6 +407,18 @@ describe('release-boundary.mjs', () => {
     ]));
     expect(() => assertArchive(forbiddenPath, { version: VERSION, gitHead: SHA })).toThrow('forbidden operational artifact');
     expect(assertEvidence(tarballPath, evidencePath)).toEqual(evidence);
+    const missingCoordinatorPath = writeTarball(root, 'missing-coordinator.tgz', makeTarball([
+      { path: 'package/package.json', content: `${JSON.stringify(packageManifest(SHA), null, 2)}\n` },
+      { path: 'package/.claude-plugin/plugin.json', content: JSON.stringify({ name: 'oh-my-claudecode', version: VERSION }) },
+      { path: 'package/.claude-plugin/marketplace.json', content: JSON.stringify({ version: VERSION, plugins: [{ name: 'oh-my-claudecode', version: VERSION, source: './' }] }) },
+      { path: 'package/.mcp.json', content: JSON.stringify({ mcpServers: { omc: { command: 'node', args: ['${CLAUDE_PLUGIN_ROOT}/bridge/mcp-server.cjs'] } } }) },
+      { path: 'package/bin/oh-my-claudecode.js', content: '#!/usr/bin/env node\n', mode: 0o755 },
+      { path: 'package/bridge/cli.cjs', content: 'module.exports = {};\n' },
+      { path: 'package/bridge/mcp-server.cjs', content: 'module.exports = {};\n' },
+      { path: 'package/bridge/runtime-cli.cjs', content: 'module.exports = {};\n' },
+      { path: 'package/bridge/team.js', content: 'export {};\n' },
+    ]));
+    expect(() => assertArchive(missingCoordinatorPath, { version: VERSION, gitHead: SHA })).toThrow('bridge/claude-md-coordinator.cjs');
     await expect(cliMain([
       'assert-evidence',
       '--tarball',

--- a/src/__tests__/release-generation.test.ts
+++ b/src/__tests__/release-generation.test.ts
@@ -162,6 +162,7 @@ describe('release generation', () => {
     const install = stepIndex('Install dependencies');
     const trigger = stepIndex('Assert release trigger and npm availability');
     const notes = stepIndex('Validate release notes');
+    const pluginShipping = stepIndex('Verify plugin shipping surface');
     const build = stepIndex('Build');
     const functional = stepIndex('Run functional tests');
     const performance = stepIndex('Run subagent-lock performance test');
@@ -178,6 +179,8 @@ describe('release generation', () => {
     expect(install).toBeLessThan(trigger);
     expect(trigger).toBeLessThan(notes);
     expect(notes).toBeLessThan(build);
+    expect(notes).toBeLessThan(pluginShipping);
+    expect(pluginShipping).toBeLessThan(build);
     expect(build).toBeLessThan(functional);
     expect(functional).toBeLessThan(performance);
     expect(performance).toBeLessThan(hooks);
@@ -235,6 +238,10 @@ describe('release generation', () => {
     expect(workflow).not.toContain('npm view');
     expect(workflow).not.toContain('skipping publish');
     expect(workflow).toContain('npm run build');
+    expect(workflow).toContain('npm run plugin:shipping:verify');
+    expect(workflow).toContain(
+      '- name: Verify plugin shipping surface\n        run: npm run plugin:shipping:verify\n\n      - name: Build',
+    );
     expect(workflow).toContain('npm test -- --run');
     expect(workflow).toContain(
       'npm exec vitest -- run tests/perf/subagent-lock.bench.ts --fileParallelism=false --maxWorkers=1',
@@ -256,6 +263,8 @@ describe('release generation', () => {
     expect(workflow).toContain(
       'node scripts/release-boundary.mjs write-evidence --tarball "$FINAL_TARBALL" --output "$EVIDENCE_JSON"',
     );
+    expect(workflow).toContain('FINAL_TARBALL_SHA256=$(sha256sum "$FINAL_TARBALL" | cut -d \' \' -f 1)');
+    expect(workflow).toContain("printf 'FINAL_TARBALL_SHA256=%s\\n' \"$FINAL_TARBALL_SHA256\" >> \"$GITHUB_ENV\"");
     expect(workflow).toContain(
       'npm install --ignore-scripts --prefix "$SMOKE_PREFIX" "$FINAL_TARBALL"',
     );
@@ -264,6 +273,27 @@ describe('release generation', () => {
       '"$SMOKE_PREFIX/node_modules/.bin/omc-cli" team api --help',
     );
     expect(workflow).toContain('*recover-worker*write-task-checkpoint*read-recovery-result*');
+    expect(workflow).toContain('SMOKE_HOME="$SMOKE_ROOT/home"');
+    expect(workflow).toContain('SMOKE_CLAUDE_CONFIG_DIR="$SMOKE_HOME/.claude"');
+    expect(workflow).toContain('SMOKE_GJC_CONFIG_DIR="$SMOKE_HOME/.gjc"');
+    expect(workflow).toContain('SMOKE_PACKAGE_ROOT="$SMOKE_PREFIX/node_modules/oh-my-claude-sisyphus"');
+    expect(workflow).toContain('OMC_SETUP_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" CLAUDE_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT"');
+    expect(workflow).toContain('test -f "$SMOKE_PACKAGE_ROOT/skills/setup/SKILL.md"');
+    expect(workflow).toContain('test -f "$SMOKE_PACKAGE_ROOT/skills/omc-setup/SKILL.md"');
+    expect(workflow).toContain('test -f "$SMOKE_PACKAGE_ROOT/skills/omc-setup/phases/01-install-claude-md.md"');
+    expect(workflow).toContain('cd "$SMOKE_PROJECT"');
+    expect(workflow).not.toContain('working-directory: "$SMOKE_PROJECT"');
+    expect(workflow).toContain('bash -c \'bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" local\'');
+    expect(workflow).toContain('cmp "$SMOKE_PACKAGE_ROOT/docs/CLAUDE.md" "$SMOKE_PROJECT/.claude/CLAUDE.md"');
+    expect(workflow).toContain('cmp "$SMOKE_PACKAGE_ROOT/skills/omc-reference/SKILL.md" "$SMOKE_PROJECT/.claude/skills/omc-reference/SKILL.md"');
+    expect(workflow).toContain('test "$FINAL_TARBALL_SHA256" = "$(sha256sum "$FINAL_TARBALL" | cut -d \' \' -f 1)"');
+    expect(workflow).toContain('package/bridge/claude-md-coordinator.cjs');
+    expect(workflow).toContain('require(process.argv[1]).gitHead');
+    expect(workflow).toContain('require(process.argv[1]).sourceSha');
+    expect(workflow).toContain('require(process.argv[1]).sha256');
+    expect(workflow).toContain('archiveManifest.files.find(({ path }) => path === "package/bridge/claude-md-coordinator.cjs")');
+    expect(workflow).toContain('env -i PATH="$PATH" HOME="$SMOKE_HOME" CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" GJC_CONFIG_DIR="$SMOKE_GJC_CONFIG_DIR"');
+    expect(workflow).toContain('env -i PATH="$PATH" HOME="$SMOKE_HOME" CLAUDE_CONFIG_DIR="$SMOKE_CLAUDE_CONFIG_DIR" GJC_CONFIG_DIR="$SMOKE_GJC_CONFIG_DIR" OMC_SETUP_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" CLAUDE_PLUGIN_ROOT="$SMOKE_PACKAGE_ROOT" "$SMOKE_PREFIX/node_modules/.bin/omc" --version');
     expect(workflow).toContain('uses: actions/upload-artifact@v4');
     expect(workflow).toContain('${{ runner.temp }}/final/*.tgz');
     expect(workflow).toContain('${{ runner.temp }}/release-evidence.json');


### PR DESCRIPTION
## Summary

- fail release before Build when the committed plugin shipping closure is incomplete
- require `bridge/claude-md-coordinator.cjs` in the exact final staged npm archive
- smoke `setup-claude-md.sh local` from the unpacked final artifact with isolated HOME/Claude/GJC config and byte-exact output checks
- bind archive, coordinator, manifest, git-head, and source-SHA evidence in release tests

## Root cause

The `v4.15.4` and `v4.15.5` tag/plugin trees omit the ignored generated coordinator, while both published npm tarballs contain it because npm prepack/build regenerates the file. That build step masked the broken tag/plugin surface. Current `dev` contains #3479's committed plugin closure and CI verifier; this PR adds the missing release-owned ordering and exact-final-artifact gates.

## Evidence

- tags: `v4.15.4` → `cb6932311ac956687e3c66bb6a48d52a8df14d56`; `v4.15.5` → `04be148ad8c10c961cd2054c5ede059c8648bf02`; coordinator absent from both trees
- published npm `4.15.4` and `4.15.5`: coordinator present
- focused release/package/setup suite: 97/97 passed
- full suite: 11,447 passed; two unrelated transient failures passed 32/32 on isolated rerun
- build and typecheck passed; lint has 0 errors and 18 existing warnings; performance gate 3/3 passed
- exact staged tarball: archive SHA-256 `22ba3616f8f8f096b5122ec3106e4bb7d6f0d4116bac3868153250e0b1b98f12`
- coordinator SHA-256 `64feabee0f1e96124d2e0fdf14eaea880df8a6eb88f5ae76331b8680e4b547f2`
- archive manifest digest `ad636c9cee142bbe53e7ea2400481330e8cdf9ee6b6dacfe9ff9cf6596481c39`
- git/source SHA `09817cbb3b14b659da5878d5317f53d416ebf2e1`; isolated local setup and byte comparisons passed

Fixes #3515

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*