### PR TITLE
feat(hud): slim default HUD — percentages by default, compact extra-usage cost

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1232,6 +1232,7 @@ Configure HUD elements in `~/.claude/settings.json`:
 | `ralph`      | Show ralph loop status                                                                                               | `true`  |
 | `autopilot`  | Show autopilot status                                                                                                | `true`  |
 | `showTokens` | Show transcript-derived token usage (`tok:i1.2k/o340`, plus `r...` reasoning and `s...` session total when reliable) | `false` |
+| `useBars`    | Render rate-limit and context usage as `[████░░]` progress bars instead of plain percentages (the `full`/`dense` presets enable it)  | `false` |
 
 Additional `omcHud` layout and label options (top-level):
 

--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -113,7 +113,7 @@ Shows only the essentials:
 ```
 
 ### Focused (Default)
-Shows all relevant elements:
+Shows all relevant elements as compact percentages (rate-limit/context progress bars are opt-in via `useBars`, or use the `full`/`dense` presets):
 ```
 [OMC] branch:main | ralph:3/10 | US-002 | ultrawork skill:planner | ctx:67% | agents:2 | bg:3/5 | todos:2/5
 ```
@@ -190,7 +190,7 @@ You can manually edit the config file. Each option can be set individually - any
     "profile": true,
     "promptTime": true,
     "sessionHealth": true,
-    "useBars": true,
+    "useBars": false,
     "showCallCounts": true,
     "callCountsFormat": "auto",
     "safeMode": true,

--- a/src/__tests__/hud/defaults.test.ts
+++ b/src/__tests__/hud/defaults.test.ts
@@ -80,6 +80,12 @@ describe('HUD Default Configuration', () => {
       expect(PRESET_CONFIGS.minimal.gitBranch).toBe(false);
     });
 
+    it('should default focused to percentages (bars opt-in) and keep bars in full/dense', () => {
+      expect(PRESET_CONFIGS.focused.useBars).toBe(false);
+      expect(PRESET_CONFIGS.full.useBars).toBe(true);
+      expect(PRESET_CONFIGS.dense.useBars).toBe(true);
+    });
+
     it('should keep token usage display disabled in all presets', () => {
       presets.forEach(preset => {
         expect(PRESET_CONFIGS[preset].showTokens).toBe(false);

--- a/src/__tests__/hud/extra-usage.test.ts
+++ b/src/__tests__/hud/extra-usage.test.ts
@@ -177,8 +177,8 @@ describe('renderRateLimits — extra usage', () => {
     const result = renderRateLimits(limits);
     expect(result).toContain('extra:');
     expect(result).toContain('18%');
-    expect(result).toContain('$3.10');
-    expect(result).toContain('$17.00');
+    expect(result).toContain('($3.10/$17)'); // real cents kept, whole limit drops .00
+    expect(result).not.toContain('$17.00');
   });
 
   it('renders 0% extra usage with correct dollar amounts', () => {
@@ -191,19 +191,60 @@ describe('renderRateLimits — extra usage', () => {
     const result = renderRateLimits(limits);
     expect(result).toContain('extra:');
     expect(result).toContain('0%');
-    expect(result).toContain('$0.00');
-    expect(result).toContain('$17.00');
+    expect(result).toContain('($0/$17)');
+    expect(result).not.toContain('.00');
   });
 
-  it('defaults spent to $0.00 when extraUsageSpentUsd is absent', () => {
+  it('defaults spent to $0 when extraUsageSpentUsd is absent', () => {
     const limits: RateLimits = {
       ...base,
       extraUsagePercent: 5,
       extraUsageLimitUsd: 10,
     };
     const result = renderRateLimits(limits);
-    expect(result).toContain('$0.00');
-    expect(result).toContain('$10.00');
+    expect(result).toContain('($0/$10)');
+    expect(result).not.toContain('.00');
+  });
+
+  it('keeps real cents but drops a trailing .00', () => {
+    const limits: RateLimits = {
+      ...base,
+      extraUsagePercent: 100,
+      extraUsageSpentUsd: 15.62,
+      extraUsageLimitUsd: 14,
+    };
+    const result = renderRateLimits(limits);
+    expect(result).toContain('($15.62/$14)'); // cents preserved, whole limit drops .00
+    expect(result).not.toContain('$16');       // real spend is not rounded away
+    expect(result).not.toContain('$14.00');
+  });
+
+  it('shows sub-dollar spend instead of masquerading as $0', () => {
+    const limits: RateLimits = {
+      ...base,
+      extraUsagePercent: 42,
+      extraUsageSpentUsd: 0.42,
+      extraUsageLimitUsd: 1,
+    };
+    const result = renderRateLimits(limits);
+    expect(result).toContain('($0.42/$1)');
+    expect(result).not.toContain('($0/');
+  });
+
+  it('omits the dollar part when spend or limit is non-finite', () => {
+    for (const bad of [Infinity, NaN, -Infinity]) {
+      const limits: RateLimits = {
+        ...base,
+        extraUsagePercent: 50,
+        extraUsageSpentUsd: bad,
+        extraUsageLimitUsd: 1,
+      };
+      const result = renderRateLimits(limits);
+      expect(result).toContain('extra:');
+      expect(result).not.toContain('$NaN');
+      expect(result).not.toContain('$Infinity');
+      expect(result).not.toContain('($'); // dollar part omitted entirely
+    }
   });
 
   it('uses red color at >= 90%', () => {
@@ -291,8 +332,8 @@ describe('renderRateLimitsWithBar — extra usage', () => {
     const result = renderRateLimitsWithBar(limits);
     expect(result).toContain('extra:');
     expect(result).toContain('18%');
-    expect(result).toContain('$3.10');
-    expect(result).toContain('$17.00');
+    expect(result).toContain('($3.10/$17)'); // real cents kept, whole limit drops .00
+    expect(result).not.toContain('$17.00');
     // Bar characters present
     expect(result).toMatch(/[█░]/);
   });

--- a/src/hud/elements/limits.ts
+++ b/src/hud/elements/limits.ts
@@ -57,6 +57,18 @@ function formatResetTime(date: Date | null | undefined): string | null {
 }
 
 /**
+ * Format a USD amount for the HUD: drop a trailing ".00" so whole values read
+ * "$14" while real cents are preserved ("$15.62"). Keeps the display compact
+ * without hiding sub-dollar spend as "$0". Callers must guard against
+ * non-finite input (NaN/Infinity) before calling.
+ * e.g. 14 → "$14", 15.62 → "$15.62", 0.4 → "$0.40", 0 → "$0".
+ */
+function formatUsd(amount: number): string {
+  const rounded = Math.round(amount * 100) / 100;
+  return Number.isInteger(rounded) ? `$${rounded}` : `$${rounded.toFixed(2)}`;
+}
+
+/**
  * Render rate limits display.
  *
  * Format: 5h:45%(3h42m) wk:12%(2d5h) mo:8%(15d3h) sn:20%(1d2h) op:5%(1d2h)
@@ -129,7 +141,10 @@ export function renderRateLimits(limits: RateLimits | null, stale?: boolean): st
     const extra = Math.min(100, Math.max(0, Math.round(limits.extraUsagePercent)));
     const extraColor = getColor(extra);
     const extraReset = formatResetTime(limits.extraUsageResetsAt);
-    const dollarPart = `${DIM}($${(limits.extraUsageSpentUsd ?? 0).toFixed(2)}/$${limits.extraUsageLimitUsd.toFixed(2)})${RESET}`;
+    const spentUsd = limits.extraUsageSpentUsd ?? 0;
+    const dollarPart = Number.isFinite(spentUsd) && Number.isFinite(limits.extraUsageLimitUsd)
+      ? `${DIM}(${formatUsd(spentUsd)}/${formatUsd(limits.extraUsageLimitUsd)})${RESET}`
+      : '';
 
     const extraPart = extraReset
       ? `${DIM}extra:${RESET}${extraColor}${extra}%${RESET}${staleMarker}${dollarPart}${DIM}(${resetPrefix}${extraReset})${RESET}`
@@ -283,7 +298,10 @@ export function renderRateLimitsWithBar(
     const extraEmpty = barWidth - extraFilled;
     const extraBar = `${extraColor}${'█'.repeat(extraFilled)}${DIM}${'░'.repeat(extraEmpty)}${RESET}`;
     const extraReset = formatResetTime(limits.extraUsageResetsAt);
-    const dollarPart = `${DIM}($${(limits.extraUsageSpentUsd ?? 0).toFixed(2)}/$${limits.extraUsageLimitUsd.toFixed(2)})${RESET}`;
+    const spentUsd = limits.extraUsageSpentUsd ?? 0;
+    const dollarPart = Number.isFinite(spentUsd) && Number.isFinite(limits.extraUsageLimitUsd)
+      ? `${DIM}(${formatUsd(spentUsd)}/${formatUsd(limits.extraUsageLimitUsd)})${RESET}`
+      : '';
 
     const extraPart = extraReset
       ? `${DIM}extra:${RESET}[${extraBar}]${extraColor}${extra}%${RESET}${staleMarker}${dollarPart}${DIM}(${resetPrefix}${extraReset})${RESET}`

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -833,7 +833,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     showSessionDuration: true,
     showHealthIndicator: true,
     showTokens: false,
-    useBars: true,
+    useBars: false, // Percentages by default (leaner); opt into bars via config or the full/dense presets
     showCallCounts: true,
     showLastTool: false,
     sessionSummary: false, // Opt-in: sends transcript to claude -p


### PR DESCRIPTION
> Re-opens #3518 (which GitHub would not let me reopen via API). Its block was an **inconclusive tooling failure on the review bot's side** — per its own words: *"GitHub GraphQL was also rate-limited, preventing a trustworthy full hosted-evidence review. No contributor-code conclusion is asserted from this planning/tooling failure. The PR is left open and unmerged."* No change to the code is required from that review; re-running here for a clean hosted review. Same source-only commit `59a9c691`.

## Summary

Slims the **default** (`focused`) HUD so it reads more calmly at a glance, and compacts the extra-usage cost. Targets `dev` per CONTRIBUTING §2/§8 (the previous PR mistakenly targeted `main`).

- **Percentages by default** — `focused` renders rate-limit / context usage as plain percentages instead of `[████░░]` bars. Bars stay available via `useBars: true` or the `full`/`dense` presets (unchanged), so this is opt-out, not a removal.
  - `5h:[████░░░░]6%(4h27m)` → `5h:6%(4h27m)`, `ctx:[████░░░░░░]0%` → `ctx:0%`
- **Compact, safe extra-usage cost** — drop a trailing `.00` while preserving real cents.
  - `($15.62/$14.00)` → `($15.62/$14)`; `$14.00` → `$14`, but `$0.42` stays `$0.42`.

## Why (product direction — flagging for maintainer confirmation)

The goal is to help **new / default-config users feel more confident**: the out-of-box HUD is quite dense, and bars + cents add visual noise without adding information the percentage doesn't already convey. This is a **maintainer-owned default-UX change**, so I'm explicitly deferring the final product call to you — happy to gate it behind a preset/flag instead of changing `focused` if you'd prefer a more conservative rollout.

**Migration / blast radius:** only default-resolved `focused` configurations change. Anyone on an explicit `useBars`, `full`, or `dense` config is unaffected, and bars are one setting away (`"useBars": true`). No data/behavioral change beyond display.

## Billing semantics (addresses the prior review's blocker)

The earlier revision rounded to whole dollars (`Math.round`), which the review correctly flagged: it hid sub-$1 spend as `$0` and could emit `$NaN`/`$Infinity`/`$-1`. This revision replaces that with `formatUsd()`:

- Whole values drop `.00` (`$14`), **real cents are preserved** (`$15.62`, `$0.42`) — sub-dollar spend never masquerades as `$0`.
- The dollar part is **guarded against non-finite** spend/limit (omitted rather than rendering `$NaN`/`$Infinity`).
- Enterprise cost stays on its separate currency-aware path (untouched).

New tests cover strip-trailing behavior, sub-dollar-not-`$0`, and non-finite-omitted (`Infinity`/`NaN`/`-Infinity`).

## On the "commit the built artifacts" request

The prior review (and the inline Codex bot) asked to commit rebuilt `dist/**` and `bridge/cli.cjs`. **CONTRIBUTING.md §6 says the opposite** — in bold: *"Do NOT commit `dist/` or `bridge/` … CI enforces this: the 'No Committed Build Artifacts' check fails any PR whose diff touches `dist/` or `bridge/` … Your source change still ships — `bridge/` is rebuilt from it when the maintainer merges."* That CI job (`ci.yml` `no-committed-build-artifacts`) is active.

I also confirmed this is how the repo actually operates: **`dev`'s committed `dist` is currently 335 files behind a clean `npm run build`**, so artifacts are demonstrably not kept in sync per-PR — they're regenerated at merge/release. Committing them here would fail CI and be inconsistent with those 330+ other stale files without making a plugin-clone install correct.

So this PR is **source-only, by design**. If you'd actually prefer contributors to commit artifacts (which would mean updating §6 and the CI check), say the word and I'll add the regenerated outputs.

## Verification (local, Node 20)

- `npm run build`: passes.
- `tsc --noEmit`: 0 errors.
- Full `vitest run`: every HUD suite passes, including the updated `extra-usage` suite (26 tests: strip-trailing + sub-dollar + non-finite edge cases). The only suite failures are the pre-existing `team/*` process/tmux-identity tests, unrelated to this diff.

## Files

`src/hud/types.ts`, `src/hud/elements/limits.ts`, `src/__tests__/hud/{defaults,extra-usage}.test.ts`, `docs/REFERENCE.md`, `skills/hud/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
