### PR TITLE
chore(release): v4.15.6 — Named Stage Profiles & Reliability Fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.15.5",
+      "version": "4.15.6",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.15.5"
+  "version": "4.15.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,34 +1,33 @@
-# oh-my-claudecode v4.15.5: Reliability Fixes
+# oh-my-claudecode v4.15.6: Named Stage Profiles & Reliability Fixes
 
 ## Release Notes
 
-Release with **8 bug fixes** and **2 other changes** across **9 merged PRs**, plus one release-gate fix found during local macOS verification.
+Release with **1 new feature**, **10 bug fixes** across **11 merged PRs**.
 
 ### Highlights
 
-- **fix(ci): bind artifact authorizer to dev event base** (#3486)
-- **fix(team): make watchdog task publication atomic** (#3488)
-- **fix(windows): avoid Git console flashes in hooks and HUD** (#3484)
+- **feat(autopilot): add named stage profiles** (#3492)
+
+### New Features
+
+- **feat(autopilot): add named stage profiles** (#3492)
 
 ### Bug Fixes
 
-- **fix(ci): bind artifact authorizer to dev event base** (#3486)
-- **fix(windows): keep prompt hook timeout ownership in runner** (#3490)
-- **fix(team): make watchdog task publication atomic** (#3488)
-- **fix(windows): avoid Git console flashes in hooks and HUD** (#3484)
-- **fix(hooks): make SessionEnd shutdown durable and bounded** (#3478)
-- **fix: narrow workflow drift decision detection** (#3475)
-- **fix: validate direct team mailbox targets** (#3473)
-- **fix(team): fall back to locale-stable process start detection on macOS**
-
-### Other Changes
-
-- **test(project-memory): guard packed learner against command harvesting** (#3495)
-- **ci: add base-owned generated artifact authorizer** (#3480)
+- **fix(release): guard coordinator across shipped surfaces** (#3516)
+- **fix: ship complete plugin runtime closure** (#3479)
+- **fix(windows): ship hidden worktree git subprocesses** (#3501)
+- **fix(ultragoal): make the /goal handoff satisfy the guard, not just the ledger** (#3514)
+- **fix(lsp): handle server-to-client requests** (#3511)
+- **fix(ultragoal): defer /goal guard until confirmation** (#3510)
+- **fix(beads): correct CLI instruction syntax** (#3505)
+- **fix(session-start): keep plugin drift guidance on marketplace channel** (#3500)
+- **fix(session-start): align update notices with plugin channel** (#3499)
+- **fix(windows): bound generic-hook runner timeout ownership and nested git** (#3496)
 
 ### Stats
 
-- **9 PRs merged** | **0 new features** | **8 bug fixes** | **0 security/hardening improvements** | **2 other changes**
+- **11 PRs merged** | **1 new feature** | **10 bug fixes** | **0 security/hardening improvements** | **0 other changes**
 
 ### Install / Update
 
@@ -37,7 +36,7 @@ The npm CLI and the Claude Code marketplace/plugin are separate install tracks, 
 **CLI / runtime:**
 
 ```bash
-npm install -g oh-my-claude-sisyphus@4.15.5
+npm install -g oh-my-claude-sisyphus@4.15.6
 ```
 
 **Claude Code plugin:**
@@ -46,10 +45,10 @@ npm install -g oh-my-claude-sisyphus@4.15.5
 /plugin marketplace update omc
 ```
 
-**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.4...v4.15.5
+**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.5...v4.15.6
 
 ## Contributors
 
 Thank you to all contributors who made this release possible!
 
-@Yeachan-Heo
+@FrontHeadlock @Yeachan-Heo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,30 @@
-# oh-my-claudecode v4.15.5: Reliability Fixes
+# oh-my-claudecode v4.15.6: Named Stage Profiles & Reliability Fixes
 
 ## Release Notes
 
-Release with **8 bug fixes** and **2 other changes** across **9 merged PRs**, plus one release-gate fix found during local macOS verification.
+Release with **1 new feature**, **10 bug fixes** across **11 merged PRs**.
 
 ### Highlights
 
-- **fix(ci): bind artifact authorizer to dev event base** (#3486)
-- **fix(team): make watchdog task publication atomic** (#3488)
-- **fix(windows): avoid Git console flashes in hooks and HUD** (#3484)
+- **feat(autopilot): add named stage profiles** (#3492)
+
+### New Features
+
+- **feat(autopilot): add named stage profiles** (#3492)
 
 ### Bug Fixes
 
-- **fix(ci): bind artifact authorizer to dev event base** (#3486)
-- **fix(windows): keep prompt hook timeout ownership in runner** (#3490)
-- **fix(team): make watchdog task publication atomic** (#3488)
-- **fix(windows): avoid Git console flashes in hooks and HUD** (#3484)
-- **fix(hooks): make SessionEnd shutdown durable and bounded** (#3478)
-- **fix: narrow workflow drift decision detection** (#3475)
-- **fix: validate direct team mailbox targets** (#3473)
-- **fix(team): fall back to locale-stable process start detection on macOS**
-
-### Other Changes
-
-- **test(project-memory): guard packed learner against command harvesting** (#3495)
-- **ci: add base-owned generated artifact authorizer** (#3480)
+- **fix(release): guard coordinator across shipped surfaces** (#3516)
+- **fix: ship complete plugin runtime closure** (#3479)
+- **fix(windows): ship hidden worktree git subprocesses** (#3501)
+- **fix(ultragoal): make the /goal handoff satisfy the guard, not just the ledger** (#3514)
+- **fix(lsp): handle server-to-client requests** (#3511)
+- **fix(ultragoal): defer /goal guard until confirmation** (#3510)
+- **fix(beads): correct CLI instruction syntax** (#3505)
+- **fix(session-start): keep plugin drift guidance on marketplace channel** (#3500)
+- **fix(session-start): align update notices with plugin channel** (#3499)
+- **fix(windows): bound generic-hook runner timeout ownership and nested git** (#3496)
 
 ### Stats
 
-- **9 PRs merged** | **0 new features** | **8 bug fixes** | **0 security/hardening improvements** | **2 other changes**
+- **11 PRs merged** | **1 new feature** | **10 bug fixes** | **0 security/hardening improvements** | **0 other changes**

--- a/README.md
+++ b/README.md
@@ -645,18 +645,19 @@ Top personal non-fork, non-archived repos from all-time OMC contributors (100+ G
 
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) — [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) (⭐ 38k)
 - [@junhoyeo](https://github.com/junhoyeo) — [tokscale](https://github.com/junhoyeo/tokscale) (⭐ 4.5k)
-- [@psmux](https://github.com/psmux) — [psmux](https://github.com/psmux/psmux) (⭐ 2.9k)
-- [@MeroZemory](https://github.com/MeroZemory) — [ida-multi-mcp](https://github.com/MeroZemory/ida-multi-mcp) (⭐ 324)
+- [@psmux](https://github.com/psmux) — [psmux](https://github.com/psmux/psmux) (⭐ 3k)
+- [@MeroZemory](https://github.com/MeroZemory) — [ida-multi-mcp](https://github.com/MeroZemory/ida-multi-mcp) (⭐ 330)
 - [@BowTiedSwan](https://github.com/BowTiedSwan) — [buildflow](https://github.com/BowTiedSwan/buildflow) (⭐ 295)
 - [@J-Pster](https://github.com/J-Pster) — [Psters_AI_Workflow](https://github.com/J-Pster/Psters_AI_Workflow) (⭐ 291)
 - [@alohays](https://github.com/alohays) — [awesome-visual-representation-learning-with-transformers](https://github.com/alohays/awesome-visual-representation-learning-with-transformers) (⭐ 271)
+- [@devswha](https://github.com/devswha) — [patina](https://github.com/devswha/patina) (⭐ 264)
 - [@jcwleo](https://github.com/jcwleo) — [random-network-distillation-pytorch](https://github.com/jcwleo/random-network-distillation-pytorch) (⭐ 263)
-- [@devswha](https://github.com/devswha) — [patina](https://github.com/devswha/patina) (⭐ 262)
-- [@HaD0Yun](https://github.com/HaD0Yun) — [Doyunha-Gopeak](https://github.com/HaD0Yun/Doyunha-Gopeak) (⭐ 230)
+- [@HaD0Yun](https://github.com/HaD0Yun) — [Doyunha-Gopeak](https://github.com/HaD0Yun/Doyunha-Gopeak) (⭐ 234)
 - [@shaun0927](https://github.com/shaun0927) — [openchrome](https://github.com/shaun0927/openchrome) (⭐ 224)
 - [@emgeee](https://github.com/emgeee) — [mean-tutorial](https://github.com/emgeee/mean-tutorial) (⭐ 200)
 - [@anduinnn](https://github.com/anduinnn) — [HiFiNi-Auto-CheckIn](https://github.com/anduinnn/HiFiNi-Auto-CheckIn) (⭐ 170)
 - [@Znuff](https://github.com/Znuff) — [consolas-powerline](https://github.com/Znuff/consolas-powerline) (⭐ 146)
+- [@changeroa](https://github.com/changeroa) — [StyleGallery](https://github.com/changeroa/StyleGallery) (⭐ 133)
 
 <!-- OMC:FEATURED-CONTRIBUTORS:END -->
 

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -834,8 +834,8 @@ function executeClaudeMdTransaction(request) {
 
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
-var COMPILED_ENGINE_VERSION = true ? "4.15.5" : "";
-var COMPILED_SOURCE_SHA256 = true ? "0003333f19779df7ddef40aca0ba997901b2e9174458314940064be9a8425234" : "";
+var COMPILED_ENGINE_VERSION = true ? "4.15.6" : "";
+var COMPILED_SOURCE_SHA256 = true ? "e3f8b38cb0e1e6d443e723ec6b22887aa1bdb364a62055b8d946a9de2e05ec58" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/dist/cli/claude-md-coordinator.d.ts
+++ b/dist/cli/claude-md-coordinator.d.ts
@@ -1,0 +1,24 @@
+import { type ClaudeMdTransactionResult } from '../installer/claude-md-transaction.js';
+export declare const CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
+export interface ClaudeMdCoordinatorHandshake {
+    schemaVersion: typeof CLAUDE_MD_COORDINATOR_SCHEMA_VERSION;
+    engineVersion: string;
+    sourceSha256: string;
+}
+export declare function runClaudeMdCoordinatorHandshake(): {
+    exitCode: 0 | 2;
+    response: ClaudeMdCoordinatorHandshake | ClaudeMdCoordinatorErrorResponse;
+};
+export interface ClaudeMdCoordinatorErrorResponse {
+    ok: false;
+    exitCode: 2 | 3;
+    error: string;
+    schemaVersion: typeof CLAUDE_MD_COORDINATOR_SCHEMA_VERSION;
+}
+export type ClaudeMdCoordinatorResponse = ClaudeMdCoordinatorErrorResponse | ClaudeMdTransactionResult;
+/** Validates the versioned stdin protocol and converts every operational failure to a JSON response. */
+export declare function runClaudeMdCoordinator(input: unknown): {
+    exitCode: number;
+    response: ClaudeMdCoordinatorResponse;
+};
+//# sourceMappingURL=claude-md-coordinator.d.ts.map

--- a/dist/cli/claude-md-coordinator.js
+++ b/dist/cli/claude-md-coordinator.js
@@ -1,0 +1,87 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { isStrictChildPath } from '../installer/claude-md-transaction.js';
+import { executeClaudeMdTransaction } from '../installer/claude-md-transaction.js';
+export const CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
+const COMPILED_ENGINE_VERSION = typeof __OMC_COORDINATOR_ENGINE_VERSION__ === 'string' ? __OMC_COORDINATOR_ENGINE_VERSION__ : '';
+const COMPILED_SOURCE_SHA256 = typeof __OMC_COORDINATOR_SOURCE_SHA256__ === 'string' ? __OMC_COORDINATOR_SOURCE_SHA256__ : '';
+export function runClaudeMdCoordinatorHandshake() {
+    if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
+        return { exitCode: 2, response: coordinatorError(2, 'Coordinator build handshake is unavailable') };
+    }
+    return { exitCode: 0, response: { schemaVersion: CLAUDE_MD_COORDINATOR_SCHEMA_VERSION, engineVersion: COMPILED_ENGINE_VERSION, sourceSha256: COMPILED_SOURCE_SHA256 } };
+}
+function coordinatorError(exitCode, error) { return { ok: false, exitCode, error, schemaVersion: CLAUDE_MD_COORDINATOR_SCHEMA_VERSION }; }
+function isObject(value) { return typeof value === 'object' && value !== null && !Array.isArray(value); }
+/** Refuse links in every source component, then prove the resolved target remains in the resolved plugin root. */
+function verifiedSource(pluginRootInput, sourceInput) {
+    const pluginRoot = resolve(pluginRootInput);
+    const sourcePath = resolve(sourceInput);
+    if (!isStrictChildPath(pluginRootInput, sourceInput))
+        throw new Error('Source must be inside plugin root');
+    if (lstatSync(pluginRoot).isSymbolicLink())
+        throw new Error('Plugin root must not be a symbolic link');
+    const rootReal = realpathSync(pluginRoot);
+    let component = pluginRoot;
+    const suffix = relative(pluginRoot, sourcePath).split(/[\\/]/);
+    for (const part of suffix) {
+        component = resolve(component, part);
+        if (lstatSync(component).isSymbolicLink())
+            throw new Error('Source path must not traverse a symbolic link');
+    }
+    const stat = lstatSync(sourcePath);
+    if (!stat.isFile())
+        throw new Error('Source must be a regular file');
+    const sourceReal = realpathSync(sourcePath);
+    if (!isStrictChildPath(rootReal, sourceReal))
+        throw new Error('Resolved source escapes plugin root');
+    return { pluginRoot, sourcePath, bytes: readFileSync(sourcePath) };
+}
+/** Validates the versioned stdin protocol and converts every operational failure to a JSON response. */
+export function runClaudeMdCoordinator(input) {
+    try {
+        if (!isObject(input))
+            return { exitCode: 2, response: coordinatorError(2, 'Request must be an object') };
+        const allowed = new Set(['schemaVersion', 'engineVersion', 'mode', 'configRoot', 'pluginRoot', 'sourcePath', 'sourceSha256', 'sourceVersion']);
+        if (Object.keys(input).some(key => !allowed.has(key)))
+            return { exitCode: 2, response: coordinatorError(2, 'Unknown request field') };
+        const { mode } = input;
+        if (input.schemaVersion !== CLAUDE_MD_COORDINATOR_SCHEMA_VERSION || input.engineVersion !== COMPILED_ENGINE_VERSION || (mode !== 'local' && mode !== 'global-overwrite' && mode !== 'global-preserve') || typeof input.configRoot !== 'string' || typeof input.pluginRoot !== 'string' || typeof input.sourcePath !== 'string' || typeof input.sourceSha256 !== 'string' || typeof input.sourceVersion !== 'string')
+            return { exitCode: 2, response: coordinatorError(2, 'Invalid coordinator request') };
+        if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256)
+            return { exitCode: 2, response: coordinatorError(2, 'Coordinator build handshake is unavailable') };
+        const source = verifiedSource(input.pluginRoot, input.sourcePath);
+        const sourceSha256 = createHash('sha256').update(source.bytes).digest('hex');
+        if (sourceSha256 !== COMPILED_SOURCE_SHA256 || input.sourceSha256 !== COMPILED_SOURCE_SHA256 || input.sourceVersion !== COMPILED_ENGINE_VERSION)
+            return { exitCode: 2, response: coordinatorError(2, 'Canonical source handshake mismatch') };
+        const result = executeClaudeMdTransaction({ mode, root: input.configRoot, source: source.sourcePath, sourceRoot: source.pluginRoot, sourceBytes: source.bytes, version: input.sourceVersion });
+        return { exitCode: result.exitCode, response: result };
+    }
+    catch (error) {
+        return { exitCode: 3, response: coordinatorError(3, `Coordinator I/O validation failed: ${error instanceof Error ? error.message : String(error)}`) };
+    }
+}
+function main() {
+    if (process.argv.slice(2).length === 1 && process.argv[2] === '--handshake') {
+        const outcome = runClaudeMdCoordinatorHandshake();
+        process.stdout.write(`${JSON.stringify(outcome.response)}\n`);
+        process.exitCode = outcome.exitCode;
+        return;
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(readFileSync(0)));
+    }
+    catch {
+        process.stdout.write(`${JSON.stringify(coordinatorError(2, 'Malformed UTF-8 JSON request'))}\n`);
+        process.exitCode = 2;
+        return;
+    }
+    const outcome = runClaudeMdCoordinator(parsed);
+    process.stdout.write(`${JSON.stringify(outcome.response)}\n`);
+    process.exitCode = outcome.exitCode;
+}
+if (process.argv[1] && /claude-md-coordinator\.(?:[cm]?js|ts)$/.test(process.argv[1]))
+    main();
+//# sourceMappingURL=claude-md-coordinator.js.map

--- a/dist/cli/commands/capabilities.d.ts
+++ b/dist/cli/commands/capabilities.d.ts
@@ -1,0 +1,94 @@
+export declare const CAPABILITIES_LOCK_SCHEMA_VERSION = "1.0";
+export declare const DEFAULT_CAPABILITIES_LOCKFILE = "omc-capabilities.lock.json";
+type FixtureKind = 'tool_selection' | 'arg_validity' | 'required_args' | 'structured_output' | 'no_hallucinated_tool' | 'tool_restraint';
+type FixtureExpectedOutcome = 'pass' | 'fail';
+export interface CapabilityFixture {
+    id: string;
+    kind: FixtureKind;
+    description: string;
+    expectedOutcome: FixtureExpectedOutcome;
+    toolName?: string;
+    args?: Record<string, unknown>;
+    expectedToolName?: string;
+}
+export interface CapabilityFixtureResult {
+    id: string;
+    kind: FixtureKind;
+    ok: boolean;
+    outcome: FixtureExpectedOutcome;
+    message: string;
+}
+interface CapabilityToolSurface {
+    name: string;
+    description: string;
+    inputSchema: {
+        type: 'object';
+        properties: Record<string, unknown>;
+        required: string[];
+    };
+}
+interface CapabilityAgentSurface {
+    name: string;
+    description: string;
+    tools: string[] | null;
+    disallowedTools: string[];
+    model: string | null;
+    defaultModel: string | null;
+}
+interface CapabilitySkillSurface {
+    name: string;
+    digest: string;
+    title: string | null;
+}
+interface CapabilitySurface {
+    schemaVersion: string;
+    generatedBy: 'omc capabilities';
+    contract: {
+        runner: 'deterministic-local';
+        liveProbeCompatible: true;
+        fixtureKinds: FixtureKind[];
+    };
+    tools: CapabilityToolSurface[];
+    agents: CapabilityAgentSurface[];
+    skills: CapabilitySkillSurface[];
+}
+export interface CapabilitiesLockfile {
+    schemaVersion: string;
+    generatedBy: 'omc capabilities lock';
+    surfaceDigest: string;
+    surface: CapabilitySurface;
+    fixtures: CapabilityFixture[];
+    fixtureResults: CapabilityFixtureResult[];
+}
+interface CapabilitiesCheckFailure {
+    code: string;
+    message: string;
+    expected?: unknown;
+    actual?: unknown;
+}
+export interface CapabilitiesCheckReport {
+    ok: boolean;
+    lockfile: string;
+    surfaceDigest: string;
+    lockedSurfaceDigest: string;
+    failures: CapabilitiesCheckFailure[];
+    fixtureResults: CapabilityFixtureResult[];
+}
+interface CapabilityCommandOptions {
+    json?: boolean;
+    lockfile?: string;
+}
+export declare function skillNameFromSkillFilePath(skillFilePath: string): string;
+export declare function collectCapabilitySurface(root?: string): CapabilitySurface;
+export declare function digestCapabilitySurface(surface: CapabilitySurface): string;
+export declare function defaultCapabilityFixtures(surface?: CapabilitySurface): CapabilityFixture[];
+export declare function runDeterministicCapabilityFixtures(fixtures: CapabilityFixture[], surface?: CapabilitySurface): CapabilityFixtureResult[];
+export declare function buildCapabilitiesLockfile(): CapabilitiesLockfile;
+export declare function checkCapabilitiesLockfile(lockfilePath: string): CapabilitiesCheckReport;
+export declare function capabilitiesLockCommand(options: CapabilityCommandOptions): Promise<number>;
+export declare function capabilitiesCheckCommand(options: CapabilityCommandOptions): Promise<number>;
+export declare function __capabilitiesTestOnly(): {
+    requiredArgTool?: string;
+};
+export {};
+//# sourceMappingURL=capabilities.d.ts.map

--- a/dist/cli/commands/session-friction-report.d.ts
+++ b/dist/cli/commands/session-friction-report.d.ts
@@ -1,0 +1,16 @@
+import { type SessionFrictionReport } from '../../features/session-friction-report/index.js';
+export interface SessionFrictionReportCommandOptions {
+    limit?: number;
+    session?: string;
+    since?: string;
+    project?: string;
+    json?: boolean;
+    workingDirectory?: string;
+}
+interface LoggerLike {
+    log: (message?: unknown) => void;
+}
+export declare function formatSessionFrictionReport(report: SessionFrictionReport): string;
+export declare function sessionFrictionReportCommand(options: SessionFrictionReportCommandOptions, logger?: LoggerLike): Promise<SessionFrictionReport>;
+export {};
+//# sourceMappingURL=session-friction-report.d.ts.map

--- a/dist/features/session-friction-report/index.d.ts
+++ b/dist/features/session-friction-report/index.d.ts
@@ -1,0 +1,4 @@
+import type { SessionFrictionReport, SessionFrictionReportOptions } from './types.js';
+export declare function generateSessionFrictionReport(rawOptions?: SessionFrictionReportOptions): Promise<SessionFrictionReport>;
+export type { SessionFrictionReport, SessionFrictionReportOptions, SessionFrictionSession, SessionFrictionSignal, } from './types.js';
+//# sourceMappingURL=index.d.ts.map

--- a/dist/features/session-friction-report/types.d.ts
+++ b/dist/features/session-friction-report/types.d.ts
@@ -1,0 +1,65 @@
+export interface SessionFrictionReportOptions {
+    workingDirectory?: string;
+    sessionId?: string;
+    since?: string;
+    project?: string;
+    limit?: number;
+}
+export interface SessionFrictionSignal {
+    severity: 'info' | 'warn' | 'critical';
+    code: string;
+    message: string;
+    evidence: Record<string, number | string | boolean | null>;
+}
+export interface SessionFrictionSession {
+    sessionId: string;
+    projectPath?: string;
+    sources: string[];
+    firstTimestamp?: string;
+    lastTimestamp?: string;
+    transcriptBytes: number;
+    transcriptLines: number;
+    userTurns: number;
+    assistantTurns: number;
+    toolCalls: number;
+    toolResults: number;
+    errorResults: number;
+    maxLineBytes: number;
+    largestMessageBytes: number;
+    estimatedContextPercent: number | null;
+    contextWindowTokens: number | null;
+    inputTokens: number | null;
+    maxIdleGapMinutes: number | null;
+    replayEvents: number;
+    replayAgentsSpawned: number;
+    replayAgentsFailed: number;
+    replayToolCalls: number;
+    replayHooksFired: number;
+    frictionScore: number;
+    signals: SessionFrictionSignal[];
+}
+export interface SessionFrictionReport {
+    generatedAt: string;
+    scope: {
+        mode: 'current' | 'project' | 'all';
+        project?: string;
+        workingDirectory: string;
+        since?: string;
+    };
+    privacy: {
+        localOnly: true;
+        rawContentIncluded: false;
+        summary: string;
+    };
+    totals: {
+        sessions: number;
+        transcriptBytes: number;
+        transcriptLines: number;
+        toolCalls: number;
+        errorResults: number;
+        criticalSignals: number;
+        warningSignals: number;
+    };
+    sessions: SessionFrictionSession[];
+}
+//# sourceMappingURL=types.d.ts.map

--- a/dist/features/session-friction-report/types.js
+++ b/dist/features/session-friction-report/types.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=types.js.map

--- a/dist/hooks/autopilot/named-workflow-resume-validator.d.ts
+++ b/dist/hooks/autopilot/named-workflow-resume-validator.d.ts
@@ -1,0 +1,37 @@
+import type { AutopilotState } from "./types.js";
+export declare const WORKFLOW_TRANSCRIPT_RECORD_TOO_LARGE = "workflow_transcript_record_too_large";
+export declare function takeNamedWorkflowTranscriptFailure(sessionId: string | undefined): string | null;
+type RecordValue = Record<string, unknown>;
+/** Named persisted state is supported only where its no-follow contract can be enforced. */
+export declare function namedWorkflowRuntimeSupported(): boolean;
+export type NamedWorkflowValidation = {
+    tracking: NonNullable<AutopilotState["pipelineTracking"]>;
+    task: string;
+};
+/** Validate persisted named workflow structure without filesystem or transcript access. */
+export declare function validateNamedWorkflowStateStructure(state: AutopilotState, sessionId: string | undefined): NamedWorkflowValidation | null;
+/** Validate the complete descriptor and authenticated transcript chain without mutating state. */
+export declare function validateNamedWorkflowState(state: AutopilotState, sessionId: string | undefined): NamedWorkflowValidation | null;
+export type PreparedNamedWorkflowAdvance = {
+    updated: AutopilotState;
+    commitToken: {
+        transcriptPath: string;
+        transcriptIdentity: RecordValue;
+        stageId: string;
+        sessionId: string;
+        boundary: RecordValue;
+        evidenceHash: string;
+    };
+};
+/**
+ * Reauthenticate a prepared transcript observation immediately before persistence.
+ * Callers must invoke this while holding the state mutation lock.
+ */
+export declare function refreshNamedWorkflowBoundaryForCommit(advance: PreparedNamedWorkflowAdvance): boolean;
+/**
+ * Prepare an authenticated, one-stage named workflow transition from its
+ * append-only transcript. The caller must persist this exact update atomically.
+ */
+export declare function prepareNamedWorkflowAdvance(state: AutopilotState, sessionId: string | undefined): PreparedNamedWorkflowAdvance | null;
+export {};
+//# sourceMappingURL=named-workflow-resume-validator.d.ts.map

--- a/dist/hooks/merge-readiness/index.d.ts
+++ b/dist/hooks/merge-readiness/index.d.ts
@@ -1,0 +1,4 @@
+export * from "./report.js";
+export * from "./runtime.js";
+export * from "./types.js";
+//# sourceMappingURL=index.d.ts.map

--- a/dist/hooks/merge-readiness/index.js
+++ b/dist/hooks/merge-readiness/index.js
@@ -1,0 +1,4 @@
+export * from "./report.js";
+export * from "./runtime.js";
+export * from "./types.js";
+//# sourceMappingURL=index.js.map

--- a/dist/hooks/merge-readiness/mcq.d.ts
+++ b/dist/hooks/merge-readiness/mcq.d.ts
@@ -1,0 +1,64 @@
+/**
+ * Merge Readiness MCQ module.
+ *
+ * Objective multiple-choice scoring for the post-task explainability gate.
+ * The runtime uses these pure helpers to judge human answers without semantic
+ * guessing: an MCQ has exactly one correct option, and code checks equality.
+ *
+ * Depth profiles (v1, unified with skills/merge-readiness/SKILL.md):
+ *   quick    -> threshold 0.70, max 3 MCQs, dims: why/change/risk
+ *   standard -> threshold 0.80, max 5 MCQs, dims: why/change/tradeoff/risk/team
+ *   deep     -> threshold 0.90, max 8 MCQs (redundancy across dims)
+ *
+ * "max rounds" == total MCQs presented. The AI distributes MCQs across the
+ * required dimensions (with redundancy for deep) up to that count.
+ */
+export type MergeReadinessDimension = "why" | "change" | "tradeoff" | "risk" | "team";
+export type MergeReadinessProfile = "quick" | "standard" | "deep";
+export declare const MERGE_READINESS_DIMENSIONS: readonly MergeReadinessDimension[];
+/**
+ * Readiness thresholds per depth profile, expressed as a required correctness
+ * rate over the answered MCQs.
+ */
+export declare const MERGE_READINESS_THRESHOLDS: Readonly<Record<MergeReadinessProfile, number>>;
+/** Total MCQs presented per profile (the "max rounds" cap). */
+export declare const MERGE_READINESS_MAX_ROUNDS: Readonly<Record<MergeReadinessProfile, number>>;
+export interface MergeReadinessMCQOption {
+    id: string;
+    text: string;
+}
+export interface MergeReadinessMCQQuestion {
+    id: string;
+    dimension: MergeReadinessDimension;
+    stem: string;
+    options: MergeReadinessMCQOption[];
+    /** Option id that is objectively correct. */
+    correctOptionId: string;
+    /** Why the correct option is right / what understanding it verifies. */
+    rationale?: string;
+}
+export interface MergeReadinessMCQAnswer {
+    questionId: string;
+    selectedOptionId: string;
+    isCorrect: boolean;
+    answeredAt?: string;
+}
+export declare function profileThreshold(profile: MergeReadinessProfile): number;
+export declare function profileMaxRounds(profile: MergeReadinessProfile): number;
+/**
+ * Dimensions that must be covered before the gate can pass.
+ * Quick is a lighter gate (why/change/risk); standard and deep cover all five.
+ */
+export declare function requiredDimensionsForProfile(profile: MergeReadinessProfile): MergeReadinessDimension[];
+/** Objective check: does the selected option match the correct one? */
+export declare function scoreMCQResponse(question: MergeReadinessMCQQuestion, selectedOptionId: string): boolean;
+/** Correctness rate over answered MCQs, in [0, 1]. Empty -> 0. */
+export declare function computeCorrectnessRate(answers: MergeReadinessMCQAnswer[]): number;
+export declare function isCorrectnessPass(rate: number, threshold: number): boolean;
+/**
+ * Whether every required dimension has at least one answered MCQ.
+ * The gate does not pass until required coverage exists, even if the rate
+ * is high, so a human cannot skip a dimension they cannot explain.
+ */
+export declare function hasRequiredDimensionCoverage(answers: MergeReadinessMCQAnswer[], questions: MergeReadinessMCQQuestion[], requiredDimensions: MergeReadinessDimension[]): boolean;
+//# sourceMappingURL=mcq.d.ts.map

--- a/dist/hooks/merge-readiness/report.d.ts
+++ b/dist/hooks/merge-readiness/report.d.ts
@@ -1,0 +1,6 @@
+import type { MergeReadinessState } from "./types.js";
+/** Render the authoritative session state as a report without filesystem side effects. */
+export declare function formatMergeReadinessReport(state: MergeReadinessState): string;
+/** Remove answer keys and interim scoring from the public state_read surface. */
+export declare function redactMergeReadinessState(state: MergeReadinessState): Record<string, unknown>;
+//# sourceMappingURL=report.d.ts.map

--- a/dist/hooks/merge-readiness/runtime.d.ts
+++ b/dist/hooks/merge-readiness/runtime.d.ts
@@ -1,0 +1,64 @@
+import { type MergeReadinessMCQQuestion } from "./mcq.js";
+import type { MergeReadinessEvidence, MergeReadinessProfile, MergeReadinessPromptResult, MergeReadinessResult, MergeReadinessState } from "./types.js";
+export declare function parseMergeReadinessProfile(promptText: string): MergeReadinessProfile;
+export declare function slugifyMergeReadiness(input: string): string;
+export declare function collectMergeReadinessEvidence(directory: string, baseRef?: string, sessionId?: string): MergeReadinessEvidence;
+export declare function readMergeReadinessState(directory: string, sessionId?: string): MergeReadinessState | null;
+export declare function writeMergeReadinessState(directory: string, state: MergeReadinessState, sessionId?: string): boolean;
+/**
+ * Seed initial merge-readiness state. Called by the bridge on `/merge-readiness`
+ * and by the autopilot adapter's onEnter. Collects evidence, picks the profile
+ * threshold/maxRounds/required dims from mcq.ts, and marks the state as
+ * awaiting AI-generated content (doc + MCQs).
+ */
+export declare function createInitialMergeReadinessState(directory: string, promptText: string, sessionId?: string, baseRef?: string): MergeReadinessState;
+/**
+ * AI writes the generated explanation doc (5 sections) + MCQs into state.
+ * Called after the AI has read the evidence and produced narrative + questions.
+ * Each question must carry correctOptionId so the runtime can score objectively.
+ */
+export declare function setMergeReadinessContent(directory: string, content: {
+    why: string;
+    whatChanged: string;
+    tradeoffs: string;
+    risksConsidered: string;
+    teamUnderstanding: string;
+    questions: MergeReadinessMCQQuestion[];
+}, sessionId?: string): MergeReadinessState | null;
+/**
+ * Record one MCQ answer (objective scoring via scoreMCQResponse), append it,
+ * and finalize the gate if all required questions are answered.
+ */
+export declare function recordMergeReadinessMCQAnswer(directory: string, questionId: string, selectedOptionId: string, sessionId?: string): MergeReadinessState | null;
+/** Correlate only a marked native AskUserQuestion result to the current MCQ. */
+export declare function recordMergeReadinessAskUserQuestionResult(directory: string, toolInput: unknown, toolOutput: unknown, sessionId?: string): MergeReadinessState | null;
+export declare function validateMergeReadinessContent(content: {
+    why: string;
+    whatChanged: string;
+    tradeoffs: string;
+    risksConsidered: string;
+    teamUnderstanding: string;
+    questions: MergeReadinessMCQQuestion[];
+}, state: Pick<MergeReadinessState, "required_dimensions" | "max_rounds">): string[];
+export declare function overrideMergeReadiness(directory: string, reason: string, sessionId?: string): MergeReadinessState | null;
+export declare function cancelMergeReadiness(directory: string, sessionId?: string): MergeReadinessState | null;
+export declare function formatMergeReadinessQuestionMessage(state: MergeReadinessState): string;
+/**
+ * @deprecated Legacy text-answer recorder. Only routes to the old open-ended
+ * round shape when the state has no AI-generated MCQs yet. When MCQs exist,
+ * the AI-driven recordMergeReadinessMCQAnswer path is canonical.
+ */
+export declare function recordMergeReadinessAnswer(directory: string, answer: string, sessionId?: string): MergeReadinessState | null;
+export declare function isLikelyMergeReadinessAnswer(promptText: string): boolean;
+export declare function handleMergeReadinessPromptSubmit(directory: string, promptText: string, sessionId?: string): MergeReadinessPromptResult;
+/**
+ * Stop-hook gate. Reads state; if active and not yet passed, blocks the session
+ * and injects the pending MCQ (or an awaiting-content nudge). Releases on pass.
+ */
+export declare function checkMergeReadiness(sessionId: string | undefined, directory: string, cancelInProgress: boolean): Promise<{
+    shouldBlock: boolean;
+    message: string;
+    result: MergeReadinessResult;
+} | null>;
+export type { MergeReadinessRound } from "./types.js";
+//# sourceMappingURL=runtime.d.ts.map

--- a/dist/hooks/merge-readiness/types.d.ts
+++ b/dist/hooks/merge-readiness/types.d.ts
@@ -1,0 +1,123 @@
+/**
+ * Merge Readiness state, evidence, and result types.
+ *
+ * The v1 explainability gate is MCQ-driven: the AI generates an explanation
+ * document (5 narrative sections) plus a set of multiple-choice questions, the
+ * human answers them one per round (deep-interview style), and the runtime
+ * scores each answer objectively (selected option === correct option).
+ *
+ * Canonical dimension/profile/threshold definitions live in ./mcq.js and are
+ * re-exported here so existing imports from ./types.js keep compiling.
+ */
+export type { MergeReadinessDimension, MergeReadinessProfile, MergeReadinessMCQOption, MergeReadinessMCQQuestion, MergeReadinessMCQAnswer, } from "./mcq.js";
+import type { MergeReadinessDimension, MergeReadinessProfile, MergeReadinessMCQQuestion, MergeReadinessMCQAnswer } from "./mcq.js";
+export type MergeReadinessPhase = "evidence" | "content" | "questioning" | "complete";
+export type MergeReadinessResult = "pending" | "pass" | "paused" | "blocked" | "overridden" | "cancelled";
+export interface MergeReadinessEvidence {
+    changedFiles: string[];
+    /** Untracked paths are context only; they are never proof for --from-diff. */
+    untrackedFiles?: string[];
+    status: string;
+    diffStat: string;
+    sourceArtifacts: string[];
+    testEvidence: string[];
+    reviewEvidence: string[];
+    missingEvidence: string[];
+    /** The base ref the diff was computed against (explicit baseRef arg or auto-detected upstream). */
+    base_ref?: string;
+}
+/**
+ * @deprecated v1 uses objective MCQ scoring (questions + answers). This open
+ * ended round shape is retained only for backward-compatible state files and
+ * the legacy prompt-as-answer fallback; new code should not populate it.
+ */
+export interface MergeReadinessRound {
+    round: number;
+    dimension: MergeReadinessDimension;
+    question: string;
+    answer?: string;
+    score?: number;
+    created_at: string;
+    answered_at?: string;
+}
+export interface MergeReadinessState {
+    active: boolean;
+    session_id?: string;
+    current_phase: "merge-readiness";
+    phase: MergeReadinessPhase;
+    profile: MergeReadinessProfile;
+    threshold: number;
+    max_rounds: number;
+    required_dimensions: MergeReadinessDimension[];
+    /** @deprecated retained for backward-compatible state files; MCQ path uses questions/answers. */
+    rounds: MergeReadinessRound[];
+    /** AI-generated MCQs for this change. Empty until the AI calls setMergeReadinessContent. */
+    questions: MergeReadinessMCQQuestion[];
+    /** Human MCQ answers recorded one per round. */
+    answers: MergeReadinessMCQAnswer[];
+    /** True until the AI writes the generated doc + MCQs into state. */
+    awaiting_content: boolean;
+    validation_errors?: string[];
+    /** Next unanswered MCQ the human should see (deep-interview one-per-round). */
+    pending_question?: MergeReadinessMCQQuestion;
+    evidence: MergeReadinessEvidence;
+    /** Correctness rate over answered MCQs, in [0, 1]. */
+    readiness_score: number;
+    dimension_scores: Partial<Record<MergeReadinessDimension, number>>;
+    result: MergeReadinessResult;
+    why: string;
+    whatChanged: string;
+    tradeoffs: string;
+    risksConsidered: string;
+    teamUnderstanding: string;
+    started_at: string;
+    updated_at: string;
+    completed_at?: string;
+    override_reason?: string;
+    /** Operator identity that recorded the override (session id of the override call). */
+    override_owner?: string;
+    /** Operator identity that cancelled the gate (session id, or "legacy" for the no-session bulk path). */
+    cancel_owner?: string;
+    change_summary: string;
+    slug: string;
+    /** Evidence source mode: --from-diff requires a diff; --from-artifacts accepts .omc artifacts. */
+    source_mode?: "diff" | "artifacts";
+    /** Summaries of prior terminal attempts on this session, preserved across re-starts. */
+    prior_attempts?: MergeReadinessAttempt[];
+}
+export interface MergeReadinessAttempt {
+    profile: MergeReadinessProfile;
+    threshold: number;
+    max_rounds: number;
+    required_dimensions: MergeReadinessDimension[];
+    change_summary: string;
+    slug: string;
+    why: string;
+    whatChanged: string;
+    tradeoffs: string;
+    risksConsidered: string;
+    teamUnderstanding: string;
+    started_at?: string;
+    completed_at?: string;
+    result: MergeReadinessResult;
+    override_reason?: string;
+    override_owner?: string;
+    cancel_owner?: string;
+    readiness_score: number;
+    dimension_scores: Partial<Record<MergeReadinessDimension, number>>;
+    questions: MergeReadinessMCQQuestion[];
+    answers: MergeReadinessMCQAnswer[];
+    evidence_summary: {
+        changedFiles: string[];
+        source_mode?: "diff" | "artifacts";
+        missingEvidence: string[];
+        sourceArtifactCount: number;
+        testEvidenceCount: number;
+        reviewEvidenceCount: number;
+    };
+}
+export interface MergeReadinessPromptResult {
+    handled: boolean;
+    message?: string;
+}
+//# sourceMappingURL=types.d.ts.map

--- a/dist/hooks/merge-readiness/types.js
+++ b/dist/hooks/merge-readiness/types.js
@@ -1,0 +1,13 @@
+/**
+ * Merge Readiness state, evidence, and result types.
+ *
+ * The v1 explainability gate is MCQ-driven: the AI generates an explanation
+ * document (5 narrative sections) plus a set of multiple-choice questions, the
+ * human answers them one per round (deep-interview style), and the runtime
+ * scores each answer objectively (selected option === correct option).
+ *
+ * Canonical dimension/profile/threshold definitions live in ./mcq.js and are
+ * re-exported here so existing imports from ./types.js keep compiling.
+ */
+export {};
+//# sourceMappingURL=types.js.map

--- a/dist/hooks/rules-injector/parser.test.d.ts
+++ b/dist/hooks/rules-injector/parser.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=parser.test.d.ts.map

--- a/dist/hooks/session-end/action-runner.d.ts
+++ b/dist/hooks/session-end/action-runner.d.ts
@@ -1,0 +1,18 @@
+import type { SessionEndActionName, SessionEndActionState, SessionEndJobV1 } from './cleanup-manifest.js';
+export interface ActionRunContext {
+    directory: string;
+    sessionId: string;
+    job: SessionEndJobV1;
+    actionName: SessionEndActionName;
+    action: SessionEndActionState;
+    ownerNonce: string;
+    runnerNonce: string;
+    deadlineAt: number;
+}
+export interface ActionRunResult {
+    code: string;
+    completed: boolean;
+}
+/** Each deferred action runs in its own detached process group. The manifest remains the only authority for claim/result transitions. */
+export declare function runSessionEndAction(context: ActionRunContext, _execute: () => Promise<void>): Promise<ActionRunResult>;
+//# sourceMappingURL=action-runner.d.ts.map

--- a/dist/hooks/session-end/action-watchdog.d.ts
+++ b/dist/hooks/session-end/action-watchdog.d.ts
@@ -1,0 +1,11 @@
+export interface SessionEndWatchdogControl {
+    directory: string;
+    jobId: string;
+    action: string;
+    attempt: number;
+    runnerNonce: string;
+    deadlineAt: number;
+}
+/** Durable deadline evidence names the detached action runner from its control record when available. */
+export declare function armSessionEndActionWatchdog(control: SessionEndWatchdogControl): () => void;
+//# sourceMappingURL=action-watchdog.d.ts.map

--- a/dist/hooks/session-end/cleanup-manifest.d.ts
+++ b/dist/hooks/session-end/cleanup-manifest.d.ts
@@ -1,0 +1,116 @@
+export type SessionEndActionName = 'foreground-cleanup' | 'wiki-capture' | 'team-cleanup' | 'python-cleanup' | 'reply-cleanup' | 'callback' | 'notification' | 'openclaw';
+export type ActionStatus = 'pending' | 'claimed' | 'retryable' | 'completed' | 'expired';
+export interface SessionEndActionState {
+    class: 'required' | 'best-effort';
+    phase: 'deferred-required' | 'deferred-best-effort';
+    status: ActionStatus;
+    attempts: number;
+    idempotencyKey: string;
+    payload: Record<string, unknown>;
+    budgetMs: number;
+    claimantNonce?: string;
+    claimedAt?: string;
+    runner?: {
+        attempt: number;
+        runnerNonce: string;
+        phase: 'reserved' | 'started' | 'armed' | 'result-recorded' | 'terminal';
+        deadlineAt: string;
+    };
+    lastOutcomeCode?: string;
+    completedAt?: string;
+}
+export interface ProducerSlot {
+    state: 'absent' | 'prepared' | 'sealed' | 'no-op';
+    intentKey?: string;
+    payloadDigest?: string;
+    sealedAt?: string;
+    sealedBy?: 'foreground' | 'recovery' | 'wiki-producer';
+}
+export interface WorkerOwner {
+    nonce: string;
+    pid: number;
+    processStartIdentity: string;
+    claimedAt: string;
+    heartbeatAt: string;
+    leaseExpiresAt: string;
+    runDeadlineAt: string;
+    leaseGeneration: number;
+    claimedFromRevision: number;
+}
+export interface SessionEndJobV1 {
+    version: 1;
+    jobId: string;
+    sessionId: string;
+    scopeKey: string;
+    revision: number;
+    createdAt: string;
+    updatedAt: string;
+    producerGraceExpiresAt: string;
+    bestEffortDeadlineAt: string;
+    producers: {
+        core: ProducerSlot;
+        wiki: ProducerSlot;
+    };
+    actions: Record<SessionEndActionName, SessionEndActionState>;
+    owner: WorkerOwner | null;
+    phase: 'collecting' | 'ready' | 'processing' | 'recoverable-failure' | 'complete';
+    completion?: {
+        completedAt: string;
+        terminalDigest: string;
+        terminalRevision: number;
+    };
+}
+export interface OpenClawRoutingSnapshot {
+    openClawConfig?: string;
+    replyChannel?: string;
+    replyTarget?: string;
+    replyThread?: string;
+    tmux?: string;
+    tmuxPane?: string;
+}
+export interface DiscoveryTicket {
+    sessionId: string;
+    claimNonce?: string;
+    leaseExpiresAt?: string;
+    attempts: number;
+    retryAt: string;
+    acknowledgedAt?: string;
+}
+export declare function sessionEndJobPath(directory: string, sessionId: string): string;
+export declare function sessionEndJobsDirectory(directory: string): string;
+/** Terminality is solely a manifest property. Discovery tickets are deliberately excluded. */
+export declare function isManifestTerminal(job: SessionEndJobV1): boolean;
+export declare function readSessionEndJob(directory: string, sessionId: string): SessionEndJobV1 | null;
+/** Locked expected-revision CAS with an exact post-write reread. */
+export declare function mutateSessionEndJob(directory: string, sessionId: string, expectedRevision: number, mutate: (job: SessionEndJobV1) => void): SessionEndJobV1 | null;
+export declare function prepareCoreManifest(directory: string, sessionId: string, payload: Record<string, unknown>): SessionEndJobV1 | null;
+/** Foreground cleanup is idempotent local work; its durable result is the prerequisite for producer-grace sealing. */
+export declare function completeForegroundCleanup(directory: string, sessionId: string, outcome: Record<string, unknown>): SessionEndJobV1 | null;
+export declare function completeForegroundCleanupAndSealCore(directory: string, sessionId: string, outcome: Record<string, unknown>): SessionEndJobV1 | null;
+export declare function sealCoreManifest(directory: string, sessionId: string): SessionEndJobV1 | null;
+export declare function sealWikiManifest(directory: string, sessionId: string, payload?: Record<string, unknown>): SessionEndJobV1 | null;
+export declare function claimSessionEndJob(directory: string, sessionId: string, nonce: string, identity: string, deadlineAt: number): SessionEndJobV1 | null;
+export declare function renewSessionEndLease(directory: string, sessionId: string, nonce: string, generation: number, deadlineAt: number): SessionEndJobV1 | null;
+/** Reaping is intentionally separate from a new claim. Caller must establish dead or PID-reused identity. */
+export declare function reapStaleSessionEndOwner(directory: string, sessionId: string, expectedNonce: string, expectedGeneration: number, liveness: 'dead' | 'mismatch'): SessionEndJobV1 | null;
+export declare function releaseSessionEndJob(directory: string, sessionId: string, nonce: string, generation: number): SessionEndJobV1 | null;
+export declare function updateSessionEndJob(directory: string, sessionId: string, expectedOwner: string, mutate: (job: SessionEndJobV1) => void): SessionEndJobV1 | null;
+export declare function claimSessionEndAction(directory: string, sessionId: string, ownerNonce: string, name: SessionEndActionName, deadlineAt: number): SessionEndJobV1 | null;
+export declare function markSessionEndActionRunner(directory: string, sessionId: string, ownerNonce: string, name: SessionEndActionName, runnerNonce: string, phase: 'started' | 'armed' | 'result-recorded'): SessionEndJobV1 | null;
+export declare function finishSessionEndAction(directory: string, sessionId: string, ownerNonce: string, name: SessionEndActionName, runnerNonce: string, completed: boolean, code: string): SessionEndJobV1 | null;
+/** Claims fair durable discovery tickets and retires tickets whose manifests are terminal. */
+export declare function claimSessionEndDiscoveryTickets(directory: string, limit?: number, leaseMs?: number): Array<{
+    sessionId: string;
+    nonce: string;
+}>;
+export declare function releaseSessionEndDiscoveryTicket(directory: string, sessionId: string, nonce: string, spawned: boolean): void;
+export declare function acknowledgeSessionEndDiscoveryTicket(directory: string, sessionId: string): void;
+/** Compatibility read-only page retained for callers that do not claim tickets. */
+export declare function takeSessionEndDiscoveryPage(directory: string, limit?: number): string[];
+/** Recovery may seal a prepared core only after foreground cleanup has a durable completed result. */
+export declare function recoverPreparedCoreProducer(directory: string, sessionId: string): SessionEndJobV1 | null;
+/** A prepared core cannot be recovered once its foreground prerequisite is exhausted after grace. */
+export declare function failClosedExhaustedForegroundCleanup(directory: string, sessionId: string): SessionEndJobV1 | null;
+/** A wiki-only handoff cannot safely infer the missing core cleanup intent. */
+export declare function failClosedMissingCoreProducer(directory: string, sessionId: string): SessionEndJobV1 | null;
+//# sourceMappingURL=cleanup-manifest.d.ts.map

--- a/dist/hooks/session-end/worker.d.ts
+++ b/dist/hooks/session-end/worker.d.ts
@@ -1,0 +1,13 @@
+import { type SessionEndActionName } from './cleanup-manifest.js';
+export interface SessionEndWorkerPayload {
+    directory: string;
+    sessionId: string;
+}
+/** Durable OpenClaw routing is supplied from the manifest to the action runner, never from worker ambient state. */
+export declare function workerEnvironment(): NodeJS.ProcessEnv;
+export declare function spawnSessionEndWorker(payload: SessionEndWorkerPayload): boolean;
+export declare function executeSessionEndAction(name: SessionEndActionName, payload: SessionEndWorkerPayload, deadlineAt: number): Promise<void>;
+export declare function processSessionEndWorker(payload: SessionEndWorkerPayload): Promise<void>;
+/** Bounded fair SessionStart recovery based on durable tickets, not a directory page. */
+export declare function reconcileSessionEndJobs(directory: string, sessionIds?: readonly string[]): void;
+//# sourceMappingURL=worker.d.ts.map

--- a/dist/installer/claude-md-analysis.d.ts
+++ b/dist/installer/claude-md-analysis.d.ts
@@ -1,0 +1,60 @@
+import { type LegacyGuideVariant } from './legacy-claude-md-corpus.js';
+/** Decodes valid UTF-8 without silently stripping a leading byte-order mark. */
+export declare function decodeClaudeMdUtf8(bytes: Buffer, path: string): string;
+export declare const OMC_START_MARKER = "<!-- OMC:START -->";
+export declare const OMC_END_MARKER = "<!-- OMC:END -->";
+export interface ClaudeMdLine {
+    start: number;
+    contentEnd: number;
+    eolEnd: number;
+    text: string;
+    eol: '' | '\n' | '\r\n';
+}
+export interface ClaudeMdRange {
+    start: number;
+    end: number;
+}
+export interface ManagedClaudeMdRange extends ClaudeMdRange {
+    contentStart: number;
+    contentEnd: number;
+}
+export type MarkerState = 'none' | 'complete' | 'corrupt';
+export interface MarkerParseResult {
+    state: MarkerState;
+    lines: ClaudeMdLine[];
+    managedRanges: ManagedClaudeMdRange[];
+    outsideRanges: ClaudeMdRange[];
+    diagnostics: string[];
+    counters: AnalysisCounters;
+}
+export interface AnalysisCounters {
+    lineVisits: number;
+    parserSteps: number;
+    candidateWindows: number;
+    bytesHashed: number;
+}
+export interface LegacyExactMatch extends ClaudeMdRange {
+    variantId: string;
+}
+export interface LegacyManualFinding extends ClaudeMdRange {
+    reason: string;
+}
+export interface LegacyGuideAnalysis {
+    markers: MarkerParseResult;
+    exactMatches: LegacyExactMatch[];
+    manualFindings: LegacyManualFinding[];
+    counters: AnalysisCounters;
+}
+/** Parse source coordinates without altering any input byte or EOL spelling. */
+export declare function parseClaudeMdLines(content: string): ClaudeMdLine[];
+/**
+ * Parse exact, standalone marker lines. Any ordering, nesting, duplicate, or
+ * unmatched marker makes the complete structure corrupt and exposes no ranges.
+ */
+export declare function parseClaudeMdMarkers(content: string): MarkerParseResult;
+/** Exact identity matcher. Only LF/CRLF spelling is normalized; all line content is literal. */
+export declare function analyzeLegacyClaudeMd(content: string): LegacyGuideAnalysis;
+/** Remove source-coordinate ranges descending so every retained slice is byte-for-byte unchanged. */
+export declare function removeClaudeMdRanges(content: string, ranges: readonly ClaudeMdRange[]): string;
+export declare function getLegacyGuideManifestForVerification(): readonly LegacyGuideVariant[];
+//# sourceMappingURL=claude-md-analysis.d.ts.map

--- a/dist/installer/claude-md-transaction.d.ts
+++ b/dist/installer/claude-md-transaction.d.ts
@@ -1,0 +1,76 @@
+import * as nodeFs from 'node:fs';
+import * as nativePath from 'node:path';
+export declare const CLAUDE_MD_IMPORT_START = "<!-- OMC:IMPORT:START -->";
+export declare const CLAUDE_MD_IMPORT_END = "<!-- OMC:IMPORT:END -->";
+export declare const CLAUDE_MD_IMPORT_BLOCK = "<!-- OMC:IMPORT:START -->\n@CLAUDE-omc.md\n<!-- OMC:IMPORT:END -->\n";
+export type ClaudeMdTransactionMode = 'local' | 'global-overwrite' | 'global-preserve';
+export type ClaudeMdTransactionExitCode = 0 | 3 | 4 | 5 | 6;
+/** Metadata returned to callers. Content bytes and temporary paths are deliberately private. */
+export interface ClaudeMdOperation {
+    path: string;
+    type: 'write' | 'delete';
+    existedBefore: boolean;
+}
+export interface ClaudeMdTransactionResult {
+    ok: boolean;
+    exitCode: ClaudeMdTransactionExitCode;
+    mode: ClaudeMdTransactionMode;
+    operations: ClaudeMdOperation[];
+    completedOperations: ClaudeMdOperation[];
+    backups: string[];
+    createdPaths: string[];
+    deletedPaths: string[];
+    mutatedPaths: string[];
+    removedRanges: Array<{
+        start: number;
+        end: number;
+    }>;
+    removedVariants: string[];
+    warnings: string[];
+    error?: string;
+    failedPhase?: 'validation' | 'backup' | 'mutation' | 'rollback';
+    failedPath?: string;
+    rollback: Array<{
+        path: string;
+        ok: boolean;
+        error?: string;
+    }>;
+    tempCleanup: Array<{
+        path: string;
+        ok: boolean;
+        error?: string;
+    }>;
+}
+export interface ClaudeMdTransactionFs {
+    existsSync: typeof nodeFs.existsSync;
+    lstatSync: typeof nodeFs.lstatSync;
+    mkdirSync: typeof nodeFs.mkdirSync;
+    openSync: typeof nodeFs.openSync;
+    closeSync: typeof nodeFs.closeSync;
+    readFileSync: typeof nodeFs.readFileSync;
+    renameSync: typeof nodeFs.renameSync;
+    rmSync: typeof nodeFs.rmSync;
+    unlinkSync: typeof nodeFs.unlinkSync;
+    writeFileSync: typeof nodeFs.writeFileSync;
+}
+export interface ClaudeMdTransactionRequest {
+    mode: ClaudeMdTransactionMode;
+    root: string;
+    source: string;
+    sourceRoot?: string;
+    version?: string;
+    /** A coordinator-verified canonical buffer. This prevents a second source read/swap. */
+    sourceBytes?: Buffer;
+    /** Test-only synchronous filesystem seam. */
+    fs?: ClaudeMdTransactionFs;
+}
+/** Decodes only valid UTF-8 without stripping a leading byte-order mark. */
+export declare function decodeClaudeMdUtf8(bytes: Buffer, path: string): string;
+/**
+ * Returns whether candidate is a strict lexical child of root using the supplied host path implementation.
+ * The injectable path implementation exists solely for platform-independent lexical tests.
+ */
+export declare function isStrictChildPath(root: string, candidate: string, path?: Pick<typeof nativePath, 'isAbsolute' | 'relative' | 'resolve'>): boolean;
+export declare function validateRootedRegularFile(root: string, path: string, allowAbsent?: boolean, fs?: ClaudeMdTransactionFs): string;
+export declare function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest): ClaudeMdTransactionResult;
+//# sourceMappingURL=claude-md-transaction.d.ts.map

--- a/dist/installer/legacy-claude-md-corpus.d.ts
+++ b/dist/installer/legacy-claude-md-corpus.d.ts
@@ -1,0 +1,16 @@
+/** Static reviewed legacy guide signatures; no runtime filesystem, Git, or network access. */
+export interface LegacyGuideVariant {
+    id: string;
+    sourceCommit: string;
+    markerless: true;
+    gitBlobSha: string;
+    rawByteLength: number;
+    rawSha256: string;
+    normalizedSha256: string;
+    lineCount: number;
+    terminalEolPolicy: 'required' | 'forbidden' | 'either';
+    openingLine: string;
+    finalLine: string;
+}
+export declare const LEGACY_CLAUDE_MD_VARIANTS: readonly LegacyGuideVariant[];
+//# sourceMappingURL=legacy-claude-md-corpus.d.ts.map

--- a/dist/mcp/disable-tools.d.ts
+++ b/dist/mcp/disable-tools.d.ts
@@ -1,0 +1,29 @@
+import { type ToolCategory } from '../constants/index.js';
+/**
+ * Map from user-facing OMC_DISABLE_TOOLS group names to ToolCategory values.
+ * Supports both canonical names and common aliases.
+ */
+export declare const DISABLE_TOOLS_GROUP_MAP: Record<string, ToolCategory>;
+/**
+ * Parse OMC_DISABLE_TOOLS env var value into a Set of disabled ToolCategory values.
+ *
+ * Accepts a comma-separated list of group names (case-insensitive).
+ * Unknown names are silently ignored.
+ *
+ * @param envValue - The env var value to parse. Defaults to process.env.OMC_DISABLE_TOOLS.
+ * @returns Set of ToolCategory values that should be disabled.
+ *
+ * @example
+ * // OMC_DISABLE_TOOLS=lsp,python-repl,project-memory
+ * parseDisabledGroups(); // Set { 'lsp', 'python', 'memory' }
+ */
+export declare function parseDisabledGroups(envValue?: string): Set<ToolCategory>;
+export declare function tagCategory<T extends {
+    name: string;
+}>(tools: T[], category: ToolCategory): (T & {
+    category: ToolCategory;
+})[];
+export declare function filterDisabledTools<T extends {
+    category?: ToolCategory;
+}>(tools: T[], envValue?: string): T[];
+//# sourceMappingURL=disable-tools.d.ts.map

--- a/dist/team/mailbox-notification-guard.d.ts
+++ b/dist/team/mailbox-notification-guard.d.ts
@@ -1,0 +1,96 @@
+import { type StrictDispatchReadResult, type TeamDispatchRequest } from './dispatch-queue.js';
+import { type StrictCanonicalMailboxMessageReadResult } from './team-ops.js';
+import type { TeamConfig, TeamMailboxMessage } from './types.js';
+export interface MailboxNotificationGuardInput {
+    teamName: string;
+    recipient: string;
+    requestId: string;
+    messageId: string;
+    triggerMessage: string;
+}
+export type MailboxNotificationProvider = 'tmux' | 'cmux';
+export interface MailboxNotificationTarget {
+    provider: MailboxNotificationProvider;
+    providerTarget: string;
+    recipient: string;
+    recipientRole: 'leader' | 'worker';
+    paneId: string;
+    workerIndex?: number;
+}
+export type MailboxTargetOwnership = {
+    kind: 'owned';
+    provider: MailboxNotificationProvider;
+    providerTarget: string;
+    paneId: string;
+} | {
+    kind: 'unavailable';
+} | {
+    kind: 'foreign';
+} | {
+    kind: 'provider_mismatch';
+};
+/** Fields that must remain identical between the guard's pre-effect re-reads. */
+export interface MailboxNotificationSecurityTuple {
+    configName: string;
+    configProviderTarget: string;
+    recipient: string;
+    recipientRole: 'leader' | 'worker';
+    canonicalPaneId: string;
+    canonicalWorkerIndex?: number;
+    requestId: string;
+    requestKind: 'mailbox';
+    requestTeamName: string;
+    requestRecipient: string;
+    requestMessageId: string;
+    requestTriggerMessage: string;
+    requestPaneId?: string;
+    requestWorkerIndex?: number;
+    requestTransportPreference: TeamDispatchRequest['transport_preference'];
+    requestFallbackAllowed: boolean;
+    requestStatus: 'pending';
+    mailboxOwner: string;
+    mailboxMessageId: string;
+    mailboxRecipient: string;
+    provider: MailboxNotificationProvider;
+    providerTarget: string;
+    providerPaneId: string;
+}
+export type MailboxNotificationGuardReason = 'mailbox_team_unavailable' | 'mailbox_team_identity_mismatch' | 'mailbox_request_missing' | 'mailbox_dispatch_store_invalid' | 'mailbox_request_ambiguous' | 'mailbox_request_not_pending' | 'mailbox_request_identity_mismatch' | 'mailbox_target_missing' | 'mailbox_target_metadata_mismatch' | 'leader_pane_missing_deferred' | 'mailbox_store_invalid' | 'mailbox_message_missing' | 'mailbox_message_ambiguous' | 'mailbox_recipient_mismatch' | 'mailbox_replay_suppressed' | 'mailbox_provider_mismatch' | 'mailbox_membership_unresolvable' | 'mailbox_target_foreign';
+export type MailboxNotificationGuardResult = {
+    kind: 'allow';
+    target: MailboxNotificationTarget;
+    request: TeamDispatchRequest;
+    message: TeamMailboxMessage;
+    securityTuple: MailboxNotificationSecurityTuple;
+} | {
+    kind: 'suppress';
+    reason: MailboxNotificationGuardReason;
+    safePendingRequest?: TeamDispatchRequest;
+    target?: MailboxNotificationTarget;
+};
+export interface MailboxNotificationGuardState {
+    config: TeamConfig | null;
+    dispatch: StrictDispatchReadResult;
+    mailbox: StrictCanonicalMailboxMessageReadResult;
+    ownership?: MailboxTargetOwnership;
+}
+export interface MailboxNotificationGuardDependencies {
+    readConfig: (teamName: string, cwd: string) => Promise<TeamConfig | null>;
+    readStrictDispatchRequest: (teamName: string, requestId: string, cwd: string) => Promise<StrictDispatchReadResult>;
+    readStrictMailboxMessage: (teamName: string, workerName: string, messageId: string, cwd: string) => Promise<StrictCanonicalMailboxMessageReadResult>;
+    verifyProviderOwnership: (target: MailboxNotificationTarget) => Promise<MailboxTargetOwnership>;
+}
+/**
+ * Purely evaluates current strict durable evidence. It has no transport,
+ * marker, lock, or persistence effects.
+ */
+export declare function evaluateMailboxNotificationGuard(input: MailboxNotificationGuardInput, state: MailboxNotificationGuardState): MailboxNotificationGuardResult;
+/** Compares only authorization-relevant fields; diagnostic dispatch fields are absent by design. */
+export declare function mailboxNotificationSecurityTupleEquals(left: MailboxNotificationSecurityTuple, right: MailboxNotificationSecurityTuple): boolean;
+/**
+ * Reads current evidence through strict readers, then runs the pure evaluator.
+ * The injected provider verifier must be read-only; this module has no way to
+ * invoke a pane transport or write durable delivery markers.
+ */
+export declare function readCurrentMailboxNotificationGuard(input: MailboxNotificationGuardInput, cwd: string, dependencies?: Partial<MailboxNotificationGuardDependencies>): Promise<MailboxNotificationGuardResult>;
+//# sourceMappingURL=mailbox-notification-guard.d.ts.map

--- a/dist/team/process-identity-lock.d.ts
+++ b/dist/team/process-identity-lock.d.ts
@@ -1,0 +1,5 @@
+/** Atomic hard-link lock with positive-death-only stale owner/reclaimer takeover. */
+export declare function withProcessIdentityFileLock<T>(lockPath: string, fn: () => Promise<T> | T, timeoutMs?: number): Promise<T>;
+/** Non-waiting variant for short synchronous projection repairs. */
+export declare function withProcessIdentityFileLockSync<T>(lockPath: string, fn: () => T): T;
+//# sourceMappingURL=process-identity-lock.d.ts.map

--- a/dist/team/recovery-request-store.d.ts
+++ b/dist/team/recovery-request-store.d.ts
@@ -1,0 +1,97 @@
+import type { RecoverDeadWorkerV2Error, RecoverDeadWorkerV2Result } from './types.js';
+export declare function isSafeRecoveryRequestId(requestId: string): boolean;
+export interface RecoveryRequestPayload {
+    operation: 'recover-worker';
+    workspaceHash: string;
+    teamName: string;
+    workerName: string;
+}
+export interface RecoveryRequestReservation {
+    schema_version: 1;
+    kind: 'reservation' | 'alias';
+    request_id: string;
+    payload_hash: string;
+    operation: 'recover-worker';
+    workspace_hash: string;
+    team_name: string;
+    worker_name: string;
+    recovery_id: string;
+    created_at: string;
+    expires_at: string;
+    alias_of_request_id?: string;
+}
+export interface RecoveryOutcomeError {
+    code: RecoverDeadWorkerV2Error;
+    message?: string;
+    commit_uncertain?: boolean;
+}
+export interface RecoveryOutcomePending {
+    schema_version: 1;
+    kind: 'phase';
+    request_id: string;
+    recovery_id: string;
+    team_name: string;
+    worker_name: string;
+    phase: 'reserved' | 'elected' | 'requeued' | 'ready' | 'active' | 'services_pending' | 'adopted';
+    continuation: 'none' | 'selected' | 'reserved' | 'adopted';
+    adoption: 'not_started' | 'pending' | 'adopted';
+    services: 'not_started' | 'pending' | 'synced' | 'repair_required';
+    manifest: 'not_started' | 'synced' | 'repair_required';
+    state_revision?: number;
+    updated_at: string;
+}
+export interface RecoveryOutcomeFinal {
+    schema_version: 1;
+    kind: 'final';
+    request_id: string;
+    recovery_id: string;
+    team_name: string;
+    worker_name: string;
+    outcome: 'succeeded' | 'failed' | 'commit_unknown';
+    result?: RecoverDeadWorkerV2Result;
+    error?: RecoveryOutcomeError;
+    continuation: 'none' | 'selected' | 'reserved' | 'adopted';
+    adoption: 'not_started' | 'pending' | 'adopted';
+    services: 'synced' | 'repair_required' | 'terminal_degraded';
+    manifest: 'synced' | 'repair_required';
+    completed_at: string;
+    expires_at: string;
+}
+export type RecoveryDurableOutcome = RecoveryOutcomePending | RecoveryOutcomeFinal;
+export type RequestReservationResult = {
+    kind: 'created' | 'joined' | 'aliased';
+    reservation: RecoveryRequestReservation;
+} | {
+    kind: 'conflict';
+    reservation: RecoveryRequestReservation;
+};
+export declare function canonicalRecoveryPayloadHash(payload: RecoveryRequestPayload): string;
+export declare function reserveRecoveryRequest(cwd: string, requestId: string, payload: RecoveryRequestPayload, recoveryId?: string): RequestReservationResult;
+/** Publish a new immutable request ID that points at an existing recovery. */
+export declare function aliasActiveRecoveryRequest(cwd: string, requestId: string, payload: RecoveryRequestPayload, active: RecoveryRequestReservation): RequestReservationResult;
+export declare function readRecoveryRequestReservation(cwd: string, requestId: string): RecoveryRequestReservation | null;
+export declare function writeRecoveryPhase(cwd: string, phase: RecoveryOutcomePending): RecoveryOutcomePending;
+export declare function writeRecoveryFinal(cwd: string, outcome: RecoveryOutcomeFinal): RecoveryOutcomeFinal;
+export type RecoveryFinalState = {
+    kind: 'missing';
+} | {
+    kind: 'invalid';
+} | {
+    kind: 'valid';
+    final: RecoveryOutcomeFinal & {
+        result: RecoverDeadWorkerV2Result;
+    };
+};
+export declare function readRecoveryFinalState(cwd: string, requestId: string): RecoveryFinalState;
+export declare function isMatchingRecoveryFinal(outcome: RecoveryDurableOutcome | null | undefined, expected?: Partial<{
+    requestId: string;
+    recoveryId: string;
+    teamName: string;
+    workerName: string;
+}>): outcome is RecoveryOutcomeFinal & {
+    result: RecoverDeadWorkerV2Result;
+};
+/** Final records take precedence, then the newest immutable phase. */
+export declare function readRecoveryOutcome(cwd: string, requestId: string): RecoveryDurableOutcome | null;
+export declare function readRecoveryResult(cwd: string, requestId: string): RecoverDeadWorkerV2Result | null;
+//# sourceMappingURL=recovery-request-store.d.ts.map

--- a/dist/team/recovery-saga.d.ts
+++ b/dist/team/recovery-saga.d.ts
@@ -1,0 +1,80 @@
+import type { RecoverDeadWorkerV2Error, RecoverDeadWorkerV2Result, TaskRecoveryAdoptionProof, TeamTask } from './types.js';
+export interface RecoverySagaInput {
+    requestId: string;
+    recoveryId: string;
+    teamName: string;
+    workerName: string;
+    replacementGeneration: number;
+    /** Owner-only secret. Never place this value in a task reservation. */
+    adoptionToken: string;
+    /** Persisted original pane identity; confirmed live/dead before a success is returned. */
+    originalPaneId?: string;
+}
+export interface RecoverySagaDependencies {
+    cwd: string;
+    getLiveness: (teamName: string, workerName: string) => Promise<'dead' | 'alive' | 'unknown'>;
+    listOwnedInProgressTasks: (teamName: string, workerName: string) => Promise<TeamTask[]>;
+    /** Must validate every checkpoint before any transition is made. */
+    validateCheckpoint: (teamName: string, task: TeamTask) => Promise<{
+        ok: true;
+        sequence: number;
+    } | {
+        ok: false;
+        error: RecoverDeadWorkerV2Error;
+    }>;
+    requeue: (input: RecoverySagaInput, taskId: string, adoptionTokenHash: string) => Promise<{
+        ok: true;
+        sequence: number;
+    } | {
+        ok: false;
+        error: RecoverDeadWorkerV2Error;
+    }>;
+    spawnGatedPane: (input: RecoverySagaInput) => Promise<{
+        ok: true;
+        paneId: string;
+        paneAttemptId: string;
+        committed: boolean;
+        stateRevision?: number;
+        manifestSync?: 'synced' | 'repair_required';
+    } | {
+        ok: false;
+        error: RecoverDeadWorkerV2Error;
+    }>;
+    /** Writes activate only after the attempt-specific ready marker is observed. */
+    activatePane: (input: RecoverySagaInput, paneAttemptId: string) => Promise<{
+        ok: true;
+    } | {
+        ok: false;
+        error: RecoverDeadWorkerV2Error;
+    }>;
+    /** Runtime-owner operation: adopts all reservations in order, before run. */
+    adoptAll: (input: RecoverySagaInput, proof: TaskRecoveryAdoptionProof, taskIds: string[]) => Promise<{
+        ok: true;
+        continuations: Array<{
+            taskId: string;
+            taskVersion: number;
+            sequence: number;
+            payload: unknown;
+            claimToken: string;
+        }>;
+    } | {
+        ok: false;
+        error: RecoverDeadWorkerV2Error;
+    }>;
+    writeRun: (input: RecoverySagaInput, paneAttemptId: string, continuations: Array<{
+        taskId: string;
+        taskVersion: number;
+        sequence: number;
+        payload: unknown;
+        claimToken: string;
+    }>) => Promise<void>;
+    persistActive: (input: RecoverySagaInput, paneId: string) => Promise<{
+        stateRevision: number;
+        manifestSync: 'synced' | 'repair_required';
+    }>;
+    repairServices: (input: RecoverySagaInput) => Promise<'synced' | 'repair_required'>;
+    killAttemptPane: (paneAttemptId: string) => Promise<void>;
+}
+/** Recovery-only transaction. It intentionally has no general worker scaling behavior. */
+export declare function runRecoverySaga(input: RecoverySagaInput, deps: RecoverySagaDependencies): Promise<RecoverDeadWorkerV2Result>;
+//# sourceMappingURL=recovery-saga.d.ts.map

--- a/dist/team/runtime-owner-client.d.ts
+++ b/dist/team/runtime-owner-client.d.ts
@@ -1,0 +1,65 @@
+import { readLatestOwnerEpoch } from './team-owner-epoch.js';
+import type { RecoverDeadWorkerV2Result } from './types.js';
+export interface RecoveryOwnerBootstrap {
+    expectedEpoch: number;
+    predecessorEpoch: number;
+    predecessorNonce: string | null;
+    predecessorPid: number | null;
+    predecessorProcessStartedAt: string | null;
+    pid: number;
+    processStartedAt: string;
+    nonce: string;
+    recoveryId: string;
+}
+export interface RecoverDeadWorkerOwnerInput {
+    teamName: string;
+    cwd: string;
+    workerName: string;
+    requestId: string;
+    timeoutMs?: number;
+    bootstrap?: RecoveryOwnerBootstrap;
+}
+export interface RecoveryOwnerClient {
+    recoverDeadWorker(input: RecoverDeadWorkerOwnerInput): Promise<RecoverDeadWorkerV2Result>;
+}
+export type RecoveryOwnerDispatch = (input: RecoverDeadWorkerOwnerInput) => Promise<RecoverDeadWorkerV2Result>;
+export declare function withRecoveryAdmissionLock<T>(cwd: string, payloadHash: string, fn: () => Promise<T> | T): Promise<T>;
+export interface RecoveryIntentRecord {
+    schema_version: 1;
+    kind: 'recover-worker';
+    request_id: string;
+    recovery_id: string;
+    team_name: string;
+    worker_name: string;
+    operation: 'recover-worker';
+    workspace_hash: string;
+    payload_hash: string;
+    created_at: string;
+}
+declare function publishRecoveryOwnerBootstrapCandidate(input: RecoverDeadWorkerOwnerInput, recoveryId: string, expectedEpoch: number, nonce: string, pid: number, processStartedAt: string, predecessor: ReturnType<typeof readLatestOwnerEpoch>): Promise<void>;
+declare function hasLiveOrUnknownBootstrapCandidate(input: RecoverDeadWorkerOwnerInput, recoveryId: string, expectedEpoch: number, predecessor: ReturnType<typeof readLatestOwnerEpoch>): boolean;
+/** Narrow white-box hooks for deterministic crash/retry protocol tests. */
+export declare const recoveryOwnerBootstrapTestHooks: {
+    publishCandidate: typeof publishRecoveryOwnerBootstrapCandidate;
+    hasLiveOrUnknownCandidate: typeof hasLiveOrUnknownBootstrapCandidate;
+};
+export declare function parseRecoveryIntent(raw: string): RecoveryIntentRecord;
+export declare function isExpectedRecoveryOwnerSuccessor(owner: ReturnType<typeof readLatestOwnerEpoch>, expectedEpoch: number, childPid: number, childProcessStartedAt: string | null, fenceOk: boolean, expectedNonce?: string): boolean;
+/** Durable admission/replay client. The injected owner alone performs recovery effects. */
+export declare function createRecoveryOwnerClient(dispatch: RecoveryOwnerDispatch, timing?: {
+    minTimeoutMs?: number;
+    maxTimeoutMs?: number;
+    pollIntervalMs?: number;
+    persistentOwnerBootstrap?: boolean;
+    bootstrapOwner?: (input: RecoverDeadWorkerOwnerInput, priorEpoch: number | null) => Promise<boolean>;
+}): RecoveryOwnerClient;
+/** Install the long-lived owner dispatcher without coupling the public client to runtime-cli startup. */
+export declare function setRuntimeOwnerDispatch(dispatch: RecoveryOwnerDispatch | undefined): void;
+/**
+ * Stable named client used by runtime-v2. Admission is durable and dispatch is
+ * non-recursive: the runtime owner invokes the private executor, never the
+ * public recoverDeadWorkerV2 facade.
+ */
+export declare function requestRuntimeOwnerRecovery(input: RecoverDeadWorkerOwnerInput): Promise<RecoverDeadWorkerV2Result>;
+export {};
+//# sourceMappingURL=runtime-owner-client.d.ts.map

--- a/dist/team/task-recovery-checkpoint.d.ts
+++ b/dist/team/task-recovery-checkpoint.d.ts
@@ -1,0 +1,36 @@
+import type { TaskRecoveryCheckpoint, TaskRecoveryCheckpointValidation, TeamTaskV2 } from './types.js';
+export declare const MAX_TASK_RECOVERY_CHECKPOINT_BYTES: number;
+export interface PublishTaskRecoveryCheckpointInput {
+    teamName: string;
+    taskId: string;
+    workerName: string;
+    taskVersion: number;
+    claimToken: string;
+    sequence: number;
+    resumePayload: unknown;
+    updatedAt?: string;
+}
+export interface TaskRecoveryCheckpointTaskAccess {
+    readTask: (teamName: string, taskId: string, cwd: string) => Promise<TeamTaskV2 | null>;
+    withTaskLock: <T>(teamName: string, taskId: string, cwd: string, fn: () => Promise<T>) => Promise<{
+        ok: true;
+        value: T;
+    } | {
+        ok: false;
+    }>;
+}
+export type PublishTaskRecoveryCheckpointResult = {
+    ok: true;
+    checkpoint: TaskRecoveryCheckpoint;
+    path: string;
+    replayed: boolean;
+} | {
+    ok: false;
+    error: 'claim_conflict' | 'invalid_checkpoint' | 'publication_conflict';
+};
+export declare function hashTaskRecoveryCheckpointPayload(payload: unknown): string;
+export declare function taskRecoveryClaimTokenHash(claimToken: string): string;
+export declare function publishTaskRecoveryCheckpoint(input: PublishTaskRecoveryCheckpointInput, cwd: string, access: TaskRecoveryCheckpointTaskAccess): Promise<PublishTaskRecoveryCheckpointResult>;
+export declare function selectTaskRecoveryCheckpoint(teamName: string, task: TeamTaskV2, cwd: string): Promise<TaskRecoveryCheckpointValidation>;
+export declare function readTaskRecoveryCheckpoint(path: string): Promise<TaskRecoveryCheckpointValidation>;
+//# sourceMappingURL=task-recovery-checkpoint.d.ts.map

--- a/dist/team/team-owner-epoch.d.ts
+++ b/dist/team/team-owner-epoch.d.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from 'node:child_process';
+import type { TeamConfig, TeamRuntimeOwnerEpoch } from './types.js';
+export interface OwnerFence {
+    epoch: number;
+    nonce: string;
+}
+export interface OwnerEpochRecord extends TeamRuntimeOwnerEpoch {
+    schema_version: 1;
+    heartbeat?: {
+        observed_at: string;
+        detail?: string;
+    };
+    payload_hash: string;
+}
+export interface OwnerEpochInput {
+    pid?: number;
+    processStartedAt?: string;
+    nonce?: string;
+    heartbeat?: OwnerEpochRecord['heartbeat'];
+}
+export type OwnerFenceCheck = {
+    ok: true;
+    record: OwnerEpochRecord;
+} | {
+    ok: false;
+    reason: 'missing' | 'malformed' | 'superseded' | 'mismatch';
+};
+export declare function processStartIdentityForPlatform(pid: number, platform?: NodeJS.Platform, exec?: typeof execFileSync): string | null;
+export declare function isValidProcessStartIdentity(value: unknown, platform?: NodeJS.Platform): value is string;
+export declare function currentProcessStartIdentity(pid?: number): string | null;
+export declare function isProcessIdentityDead(record: Pick<OwnerEpochRecord, 'pid' | 'process_started_at'>): boolean;
+export declare function readLatestOwnerEpoch(cwd: string, teamName: string): OwnerEpochRecord | null;
+/** Publish a complete, canonical epoch through a hard link. Epoch files are never reclaimed. */
+export declare function publishOwnerEpoch(cwd: string, teamName: string, epoch: number, input?: OwnerEpochInput): OwnerEpochRecord;
+export declare function requireOwnerProcessIdentity(record: OwnerEpochRecord, pid?: number, processStartedAt?: string | null): OwnerEpochRecord;
+export declare function acquireSuccessorOwnerEpoch(cwd: string, teamName: string, input?: OwnerEpochInput): OwnerEpochRecord;
+export declare function checkOwnerFence(cwd: string, teamName: string, fence: OwnerFence): OwnerFenceCheck;
+export declare function requireOwnerFence(cwd: string, teamName: string, fence: OwnerFence): OwnerEpochRecord;
+export declare function isFreshRecoveryElection(config: TeamConfig, fence: OwnerFence, expectedRevision: number): boolean;
+export declare function isSameAttemptSuccessorRebind(config: TeamConfig, prior: TeamRuntimeOwnerEpoch, successor: OwnerFence, requestId: string, recoveryId: string): boolean;
+export declare function isActiveRecoveryEffect(config: TeamConfig, fence: OwnerFence, requestId: string, recoveryId: string): boolean;
+export declare function isFencedServiceMaintenance(config: TeamConfig, fence: OwnerFence): boolean;
+//# sourceMappingURL=team-owner-epoch.d.ts.map

--- a/dist/team/team-projection.d.ts
+++ b/dist/team/team-projection.d.ts
@@ -1,0 +1,21 @@
+import { type OwnerFence } from './team-owner-epoch.js';
+export type ProjectionRepairResult = {
+    classification: 'synced';
+    revision: number;
+} | {
+    classification: 'repair_required';
+    revision: number | null;
+    reason: 'fence_lost' | 'config_changed' | 'recovery_changed' | 'invalid_config' | 'io_error';
+};
+export interface ProjectionRepairOptions {
+    fence: OwnerFence;
+    recoveryId?: string;
+    maxAttempts?: number;
+}
+/**
+ * Repair the mutable manifest projection only while the owner fence and source revision remain
+ * current. A delayed repair stages a new temp after every mismatch and therefore cannot rename
+ * a revision N+1 projection over a committed N+2 projection.
+ */
+export declare function repairTeamProjection(cwd: string, teamName: string, options: ProjectionRepairOptions): ProjectionRepairResult;
+//# sourceMappingURL=team-projection.d.ts.map

--- a/dist/team/team-projection.js
+++ b/dist/team/team-projection.js
@@ -1,0 +1,72 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { randomUUID } from 'crypto';
+import { absPath, TeamPaths } from './state-paths.js';
+import { checkOwnerFence } from './team-owner-epoch.js';
+import { deriveManifestProjection } from './team-state-reader.js';
+function parseConfig(path) {
+    try {
+        const config = JSON.parse(readFileSync(path, 'utf8'));
+        return Number.isSafeInteger(config.state_revision) ? config : null;
+    }
+    catch {
+        return null;
+    }
+}
+function parseManifest(path) {
+    try {
+        return JSON.parse(readFileSync(path, 'utf8'));
+    }
+    catch {
+        return null;
+    }
+}
+function sameRecovery(config, recoveryId) {
+    return recoveryId === undefined || config.active_recovery?.recovery_id === recoveryId || config.last_recovery?.recovery_id === recoveryId;
+}
+/**
+ * Repair the mutable manifest projection only while the owner fence and source revision remain
+ * current. A delayed repair stages a new temp after every mismatch and therefore cannot rename
+ * a revision N+1 projection over a committed N+2 projection.
+ */
+export function repairTeamProjection(cwd, teamName, options) {
+    const configPath = absPath(cwd, TeamPaths.config(teamName));
+    const manifestPath = absPath(cwd, TeamPaths.manifest(teamName));
+    const attempts = options.maxAttempts ?? 3;
+    let lastRevision = null;
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (!checkOwnerFence(cwd, teamName, options.fence).ok)
+            return { classification: 'repair_required', revision: lastRevision, reason: 'fence_lost' };
+        const config = parseConfig(configPath);
+        if (!config || config.state_revision === undefined)
+            return { classification: 'repair_required', revision: null, reason: existsSync(configPath) ? 'invalid_config' : 'io_error' };
+        if (!sameRecovery(config, options.recoveryId))
+            return { classification: 'repair_required', revision: config.state_revision, reason: 'recovery_changed' };
+        lastRevision = config.state_revision;
+        const manifest = parseManifest(manifestPath);
+        const projection = deriveManifestProjection(config, manifest);
+        const bytes = JSON.stringify(projection);
+        mkdirSync(dirname(manifestPath), { recursive: true, mode: 0o700 });
+        const temp = join(dirname(manifestPath), `.manifest.${config.state_revision}.${randomUUID()}.tmp`);
+        writeFileSync(temp, bytes, { encoding: 'utf8', mode: 0o600, flush: true });
+        const beforeRename = parseConfig(configPath);
+        const validBeforeRename = checkOwnerFence(cwd, teamName, options.fence).ok
+            && beforeRename?.state_revision === config.state_revision
+            && sameRecovery(beforeRename, options.recoveryId);
+        if (!validBeforeRename) {
+            unlinkSync(temp);
+            continue;
+        }
+        renameSync(temp, manifestPath);
+        const afterRename = parseConfig(configPath);
+        const written = parseManifest(manifestPath);
+        if (checkOwnerFence(cwd, teamName, options.fence).ok
+            && afterRename?.state_revision === config.state_revision
+            && sameRecovery(afterRename, options.recoveryId)
+            && written?.state_revision === config.state_revision) {
+            return { classification: 'synced', revision: config.state_revision };
+        }
+    }
+    return { classification: 'repair_required', revision: lastRevision, reason: 'config_changed' };
+}
+//# sourceMappingURL=team-projection.js.map

--- a/dist/team/team-state-reader.d.ts
+++ b/dist/team/team-state-reader.d.ts
@@ -1,0 +1,24 @@
+import type { TeamConfig, TeamManifestV2 } from './types.js';
+export type TeamStateSource = 'absent' | 'legacy' | 'revisioned' | 'malformed' | 'io_error';
+export type TeamStateClassification = 'absent' | 'legacy_merged' | 'config_authoritative' | 'manifest_only_legacy' | 'invalid_config' | 'io_error';
+export interface RawTeamState<T> {
+    source: TeamStateSource;
+    value: T | null;
+    error?: string;
+}
+export interface TeamStateSnapshot {
+    classification: TeamStateClassification;
+    config: RawTeamState<TeamConfig>;
+    manifest: RawTeamState<TeamManifestV2>;
+    /** Safe reader view. Revisioned config fields always win. */
+    state: TeamConfig | TeamManifestV2 | null;
+    manifestSync: 'synced' | 'repair_required';
+}
+/**
+ * Read config and manifest independently. Once config carries a numeric revision it is the
+ * authority even if the projection is stale, malformed, or unavailable.
+ */
+export declare function readTeamState(cwd: string, teamName: string): TeamStateSnapshot;
+/** Build the projection shape from authoritative configuration without reading a stale manifest. */
+export declare function deriveManifestProjection(config: TeamConfig, existing?: TeamManifestV2 | null): TeamManifestV2;
+//# sourceMappingURL=team-state-reader.d.ts.map

--- a/dist/team/team-state-reader.js
+++ b/dist/team/team-state-reader.js
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync } from 'fs';
+import { absPath, TeamPaths } from './state-paths.js';
+function rawJson(path) {
+    if (!existsSync(path))
+        return { source: 'absent', value: null };
+    try {
+        const value = JSON.parse(readFileSync(path, 'utf8'));
+        if (!value || typeof value !== 'object' || Array.isArray(value))
+            return { source: 'malformed', value: null };
+        return { source: typeof value.state_revision === 'number' ? 'revisioned' : 'legacy', value: value };
+    }
+    catch (error) {
+        const code = error.code;
+        return { source: code ? 'io_error' : 'malformed', value: null, error: error instanceof Error ? error.message : String(error) };
+    }
+}
+function manifestOnly(config, manifest) {
+    if (!manifest)
+        return config;
+    const projected = manifest;
+    // Only fields absent from config are safe projection backfill. Never accept worker/session,
+    // lifecycle/counters/policy/governance data from a revisioned projection.
+    const backfill = {};
+    for (const key of ['permissions_snapshot', 'leader_cwd', 'team_state_root', 'workspace_mode', 'worktree_mode', 'lifecycle_profile', 'leader_pane_id', 'hud_pane_id', 'resize_hook_name', 'resize_hook_target']) {
+        if (config[key] === undefined && projected[key] !== undefined)
+            backfill[key] = projected[key];
+    }
+    return { ...backfill, ...config, tmux_session: config.tmux_session };
+}
+/**
+ * Read config and manifest independently. Once config carries a numeric revision it is the
+ * authority even if the projection is stale, malformed, or unavailable.
+ */
+export function readTeamState(cwd, teamName) {
+    const config = rawJson(absPath(cwd, TeamPaths.config(teamName)));
+    const manifest = rawJson(absPath(cwd, TeamPaths.manifest(teamName)));
+    if (config.source === 'io_error') {
+        return { classification: 'io_error', config, manifest, state: null, manifestSync: 'repair_required' };
+    }
+    if (config.source === 'revisioned' && config.value) {
+        const matching = manifest.source === 'revisioned' && manifest.value
+            && manifest.value.state_revision === config.value.state_revision;
+        return {
+            classification: 'config_authoritative',
+            config,
+            manifest,
+            state: manifestOnly(config.value, matching ? manifest.value : null),
+            manifestSync: matching ? 'synced' : 'repair_required',
+        };
+    }
+    if (manifest.source === 'io_error')
+        return { classification: 'io_error', config, manifest, state: null, manifestSync: 'repair_required' };
+    if (config.source === 'malformed')
+        return { classification: 'invalid_config', config, manifest, state: null, manifestSync: 'repair_required' };
+    if (config.source === 'legacy' && config.value && manifest.source === 'legacy' && manifest.value) {
+        // Legacy merging is deliberately limited to the pre-revision world.
+        return { classification: 'legacy_merged', config, manifest, state: { ...manifest.value, ...config.value, tmux_session: config.value.tmux_session }, manifestSync: 'synced' };
+    }
+    if (config.source === 'legacy' && config.value)
+        return { classification: 'legacy_merged', config, manifest, state: config.value, manifestSync: manifest.source === 'absent' ? 'repair_required' : 'synced' };
+    if (config.source === 'absent' && manifest.source === 'legacy' && manifest.value)
+        return { classification: 'manifest_only_legacy', config, manifest, state: manifest.value, manifestSync: 'synced' };
+    if (config.source === 'absent' && manifest.source === 'absent')
+        return { classification: 'absent', config, manifest, state: null, manifestSync: 'repair_required' };
+    return { classification: 'invalid_config', config, manifest, state: null, manifestSync: 'repair_required' };
+}
+/** Build the projection shape from authoritative configuration without reading a stale manifest. */
+export function deriveManifestProjection(config, existing) {
+    const source = existing;
+    return {
+        schema_version: 2,
+        name: config.name,
+        task: config.task,
+        leader: { ...(source?.leader ?? { worker_id: 'leader', role: 'leader' }), session_id: config.tmux_session },
+        policy: config.policy ?? source?.policy ?? { display_mode: 'split_pane', worker_launch_mode: config.worker_launch_mode, dispatch_mode: 'hook_preferred_with_fallback', dispatch_ack_timeout_ms: 3000 },
+        governance: config.governance ?? source?.governance ?? { delegation_only: false, plan_approval_required: false, nested_teams_allowed: false, one_team_per_leader_session: false, cleanup_requires_all_workers_inactive: false },
+        permissions_snapshot: source?.permissions_snapshot ?? { approval_mode: 'default', sandbox_mode: 'default', network_access: false },
+        tmux_session: config.tmux_session,
+        worker_count: config.worker_count,
+        workers: config.workers,
+        next_task_id: config.next_task_id,
+        created_at: config.created_at,
+        leader_cwd: config.leader_cwd,
+        team_state_root: config.team_state_root,
+        workspace_mode: config.workspace_mode,
+        worktree_mode: config.worktree_mode,
+        lifecycle_profile: config.lifecycle_profile,
+        leader_pane_id: config.leader_pane_id,
+        hud_pane_id: config.hud_pane_id,
+        resize_hook_name: config.resize_hook_name,
+        resize_hook_target: config.resize_hook_target,
+        next_worker_index: config.next_worker_index,
+        // Retain revision in the durable projection although old manifest typings predate it.
+        state_revision: config.state_revision,
+    };
+}
+//# sourceMappingURL=team-state-reader.js.map

--- a/dist/team/worker-activation-gate.d.ts
+++ b/dist/team/worker-activation-gate.d.ts
@@ -1,0 +1,37 @@
+export interface RecoveryActivationGate {
+    recoveryId: string;
+    workerName: string;
+    replacementGeneration: number;
+    paneAttemptId: string;
+    readyPath: string;
+    activatePath: string;
+    runPath: string;
+    providerArgv: string[];
+    cwd: string;
+    env?: NodeJS.ProcessEnv;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+}
+export type RecoveryActivationGateResult = {
+    outcome: 'ran';
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+} | {
+    outcome: 'activation_timeout' | 'run_timeout' | 'invalid_provider_argv' | 'provider_spawn_failed';
+};
+interface GateRecord {
+    recovery_id: string;
+    worker_name: string;
+    replacement_generation: number;
+    pane_attempt_id: string;
+    written_at: string;
+}
+export declare function waitForRecoveryGateRecord(path: string, expected: Omit<GateRecord, 'written_at'>, timeoutMs: number, pollIntervalMs?: number): Promise<boolean>;
+/**
+ * Provider-independent activation barrier. The provider process is not created
+ * until the runtime owner has first published activate and then run for this
+ * exact pane attempt. Credentials are deliberately not written by this runner.
+ */
+export declare function runWorkerActivationGate(gate: RecoveryActivationGate): Promise<RecoveryActivationGateResult>;
+export {};
+//# sourceMappingURL=worker-activation-gate.d.ts.map

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.15.5 -->
+<!-- OMC:VERSION:4.15.6 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.15.5",
+      "version": "4.15.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
# oh-my-claudecode v4.15.6: Named Stage Profiles & Reliability Fixes

## Release Notes

Release with **1 new feature**, **10 bug fixes** across **11 merged PRs**.

### Highlights

- **feat(autopilot): add named stage profiles** (#3492)

### New Features

- **feat(autopilot): add named stage profiles** (#3492)

### Bug Fixes

- **fix(release): guard coordinator across shipped surfaces** (#3516)
- **fix: ship complete plugin runtime closure** (#3479)
- **fix(windows): ship hidden worktree git subprocesses** (#3501)
- **fix(ultragoal): make the /goal handoff satisfy the guard, not just the ledger** (#3514)
- **fix(lsp): handle server-to-client requests** (#3511)
- **fix(ultragoal): defer /goal guard until confirmation** (#3510)
- **fix(beads): correct CLI instruction syntax** (#3505)
- **fix(session-start): keep plugin drift guidance on marketplace channel** (#3500)
- **fix(session-start): align update notices with plugin channel** (#3499)
- **fix(windows): bound generic-hook runner timeout ownership and nested git** (#3496)

### Stats

- **11 PRs merged** | **1 new feature** | **10 bug fixes** | **0 security/hardening improvements** | **0 other changes**

### Install / Update

The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.

**CLI / runtime:**

```bash
npm install -g oh-my-claude-sisyphus@4.15.6
```

**Claude Code plugin:**

```text
/plugin marketplace update omc
```

**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.5...v4.15.6

## Contributors

Thank you to all contributors who made this release possible!

@FrontHeadlock @Yeachan-Heo
