### PR TITLE
feat(hud): support 智谱 BigModel (open.bigmodel.cn) quota via z.ai path

### DIFF
--- a/src/__tests__/hud/usage-api.test.ts
+++ b/src/__tests__/hud/usage-api.test.ts
@@ -62,10 +62,18 @@ describe('isZaiHost', () => {
     expect(isZaiHost('https://foo.bar.z.ai')).toBe(true);
   });
 
-  it('rejects hosts that merely contain z.ai as substring', () => {
+  it('accepts 智谱 BigModel domestic host (shares the z.ai quota API)', () => {
+    expect(isZaiHost('https://open.bigmodel.cn/api/anthropic')).toBe(true);
+    expect(isZaiHost('https://bigmodel.cn')).toBe(true);
+    expect(isZaiHost('https://api.bigmodel.cn/v1')).toBe(true);
+  });
+
+  it('rejects hosts that merely contain z.ai or bigmodel.cn as substring', () => {
     expect(isZaiHost('https://z.ai.evil.tld')).toBe(false);
     expect(isZaiHost('https://notz.ai')).toBe(false);
     expect(isZaiHost('https://z.ai.example.com')).toBe(false);
+    expect(isZaiHost('https://bigmodel.cn.evil.tld')).toBe(false);
+    expect(isZaiHost('https://notbigmodel.cn')).toBe(false);
   });
 
   it('rejects unrelated hosts', () => {
@@ -792,6 +800,22 @@ describe('getUsage routing', () => {
     expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
     const callArgs = httpsModule.default.request.mock.calls[0][0];
     expect(callArgs.hostname).toBe('api.z.ai');
+    expect(callArgs.path).toBe('/api/monitor/usage/quota/limit');
+  });
+
+  it('routes 智谱 BigModel (open.bigmodel.cn) to the shared z.ai quota API', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://open.bigmodel.cn/api/anthropic';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-token';
+
+    // https.request mock not wired, so fetchUsageFromZai resolves to null (network error)
+    const result = await getUsage();
+    expect(result.rateLimits).toBeNull();
+    expect(result.error).toBe('network');
+
+    // Verify the bigmodel.cn quota endpoint was called (same path as z.ai)
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
+    const callArgs = httpsModule.default.request.mock.calls[0][0];
+    expect(callArgs.hostname).toBe('open.bigmodel.cn');
     expect(callArgs.path).toBe('/api/monitor/usage/quota/limit');
   });
 

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -138,13 +138,23 @@ interface ZaiQuotaResponse {
 const ZAI_UNIT_WEEK = 6;
 
 /**
- * Check if a URL points to z.ai (exact hostname match)
+ * Check if a URL points to z.ai or 智谱 BigModel (domestic).
+ *
+ * z.ai is 智谱's international brand and shares the same
+ * /api/monitor/usage/quota/limit endpoint and bearer-token auth as the
+ * domestic open.bigmodel.cn host, so both are routed through the z.ai
+ * usage path.
  */
 export function isZaiHost(urlString: string): boolean {
   try {
     const url = new URL(urlString);
     const hostname = url.hostname.toLowerCase();
-    return hostname === 'z.ai' || hostname.endsWith('.z.ai');
+    return (
+      hostname === 'z.ai' ||
+      hostname.endsWith('.z.ai') ||
+      hostname === 'bigmodel.cn' ||
+      hostname.endsWith('.bigmodel.cn')
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Extend `isZaiHost()` to recognize `bigmodel.cn` / `*.bigmodel.cn` (智谱 BigModel domestic) so GLM Coding Plan quota renders in the HUD instead of leaking an unrelated Anthropic subscription's rate limits.

## Problem

Users running Claude Code against GLM via `ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic` see **incorrect** quota in the OMC HUD: the `5h` / `wk` numbers come from their Anthropic OAuth subscription (read from the macOS Keychain), not from GLM. The displayed rate limit has nothing to do with the model actually in use.

## Root cause

`open.bigmodel.cn` is 智谱's **domestic** host; `z.ai` is its **international** brand. They share the exact same quota API:

- Endpoint: `/api/monitor/usage/quota/limit`
- Auth: `Authorization: <token>` (raw `ANTHROPIC_AUTH_TOKEN`, no `Bearer`)
- Response: `data.limits[]` with `type` (`TOKENS_LIMIT` / `TIME_LIMIT`), `percentage`, `unit` (3 = 5h, 6 = weekly), `nextResetTime`

`isZaiHost()` only matched `z.ai`/`*.z.ai`, so `bigmodel.cn` fell through to the Anthropic OAuth branch in `getUsage()` — surfacing whatever Anthropic credentials happened to be in the Keychain.

## Solution

One-line extension to `isZaiHost()` to also match `bigmodel.cn` / `*.bigmodel.cn`. `fetchUsageFromZai()` already derives the quota URL from `ANTHROPIC_BASE_URL` (`${protocol}//${host}/api/monitor/usage/quota/limit`), so it hits `open.bigmodel.cn` correctly, and `parseZaiResponse()` already classifies `unit` / `TIME_LIMIT` into 5h / weekly / monthly. No new fetch or parse code needed.

As a side effect this also fixes the cross-wiring: `bigmodel.cn` no longer falls through to Anthropic OAuth.

## Verification

- `isZaiHost('https://open.bigmodel.cn/api/anthropic')` → `true`
- Live end-to-end with the patched module — `getUsage()` returns real GLM quota fetched from `open.bigmodel.cn/api/monitor/usage/quota/limit` (e.g. `5h:3% wk:8% mo:12%` with reset timestamps); usage cache written with `source: "zai"`.
- Added unit tests for the host matcher and a `getUsage` routing test asserting the `open.bigmodel.cn` endpoint is hit.

> Note: I could not run the full `npm run test:run` locally (no `node_modules` in my checkout). CI will exercise the suite; functional behavior was verified by invoking the patched `getUsage()` against the live API.

## References

Same endpoint already used across the GLM Coding Plan ecosystem:
- farion1231/cc-switch#1588 — documents the `bigmodel.cn` quota endpoint + response shape
- zai-org/zai-coding-plugins (`glm-plan-usage`) — official GLM quota-query plugin
