### PR TITLE
fix(windows): separate prompt host and worker timeouts

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -98,10 +98,12 @@ Fires when the user submits a prompt.
 
 | Script | Role | Timeout |
 |--------|------|---------|
-| `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 10s |
-| `skill-injector.mjs` | Injects skill prompts | 15s |
+| `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 30s outer host fuse; 8s trusted Worker limit |
+| `skill-injector.mjs` | Injects skill prompts | 30s outer host fuse; 12s trusted Worker limit |
 
 Runs on all user input (`matcher: "*"`). When the keyword detector finds keywords like "ultrawork", "ralph", or "autopilot", it injects the corresponding skill invocation instruction via `additionalContext`.
+
+The 30s timeout is a per-command outer host fuse that includes launcher startup before `run.cjs`. Once the runner reaches its exact trusted Worker branch, `keyword-detector.mjs` is limited to 8s and `skill-injector.mjs` to 12s; lower manifest limits are never extended. A command that never reaches `run.cjs` can consume its full 30s outer fuse. The host schedules the two commands externally, so this does not claim an aggregate prompt latency.
 
 ### SessionStart
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -924,9 +924,9 @@ OMC registers 21 hook scripts across 11 Claude Code lifecycle events. For detail
 
 ### Hooks by Lifecycle Event
 
-| Event                  | Scripts                                                                                                           | Timeout          |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------- |
-| **UserPromptSubmit**   | `keyword-detector.mjs`, `skill-injector.mjs`                                                                      | 10s, 15s         |
+| Event                  | Scripts                                                                                                           | Timeout                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| **UserPromptSubmit**   | `keyword-detector.mjs`, `skill-injector.mjs`                                                                      | 30s outer fuse per command; 8s, 12s trusted Worker limits |
 | **SessionStart**       | `session-start.mjs`, `project-memory-session.mjs`, `setup-init.mjs` (init), `setup-maintenance.mjs` (maintenance) | 5s, 5s, 30s, 60s |
 | **PreToolUse**         | `pre-tool-enforcer.mjs`                                                                                           | 3s               |
 | **PermissionRequest**  | `permission-handler.mjs` (Bash only)                                                                              | 5s               |
@@ -937,6 +937,8 @@ OMC registers 21 hook scripts across 11 Claude Code lifecycle events. For detail
 | **PreCompact**         | `pre-compact.mjs`, `project-memory-precompact.mjs`                                                                | 10s, 5s          |
 | **Stop**               | `context-guard-stop.mjs`, `workflow-drift-guard.mjs`, `persistent-mode.mjs`, `code-simplifier.mjs`                | 5s, 3s, 10s, 5s  |
 | **SessionEnd**         | `session-end.mjs`                                                                                                 | 30s              |
+
+For each UserPromptSubmit command, 30s is the outer host fuse, including any launcher delay before `run.cjs`. Only exact canonical targets in the trusted Worker branch receive the 8s keyword-detector or 12s skill-injector execution caps; generic, untrusted, and non-prompt child paths retain their existing timeout behavior. A command that never starts the runner can take the entire 30s per-command fuse, and host scheduling does not imply an aggregate latency.
 
 The `workflow-drift-guard` blocks only supported source-associated local selection forks with a known minimum of two live alternatives—including exact binary questions and cardinality templates; explicit open input and every unsupported or ambiguous form fail open.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,12 +8,12 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/keyword-detector.mjs",
-            "timeout": 10
+            "timeout": 30
           },
           {
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/skill-injector.mjs",
-            "timeout": 15
+            "timeout": 30
           }
         ]
       }

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -123,6 +123,18 @@ function resolveInnerTimeoutMs(manifestHook) {
   return Math.max(1, manifestHook.timeoutMs - resolveTimeoutCushionMs(manifestHook.timeoutMs, manifestHook.event));
 }
 
+// Call only after resolveWorkerTarget has verified an exact canonical trusted prompt target.
+function resolveTrustedPromptWorkerTimeoutMs(targetPath, manifestHook, trustedPluginRoot) {
+  const calculatedTimeoutMs = resolveInnerTimeoutMs(manifestHook);
+  const canonicalTarget = normalizedComparisonPath(targetPath);
+  const capsByCanonicalTarget = new Map([
+    [normalizedComparisonPath(join(trustedPluginRoot, 'scripts', 'keyword-detector.mjs')), 8000],
+    [normalizedComparisonPath(join(trustedPluginRoot, 'scripts', 'skill-injector.mjs')), 12000],
+  ]);
+  const capMs = capsByCanonicalTarget.get(canonicalTarget);
+  return capMs ? Math.min(calculatedTimeoutMs, capMs) : calculatedTimeoutMs;
+}
+
 function resolveGenericTimeoutMs(manifestHook) {
   return manifestHook ? resolveInnerTimeoutMs(manifestHook) : DEFAULT_GENERIC_TIMEOUT_MS;
 }
@@ -393,7 +405,7 @@ if (require.main === module) {
     const extraArgs = process.argv.slice(3);
     const workerManifestHook = resolveWorkerTarget(resolution, extraArgs);
     if (workerManifestHook) {
-      const workerTimeoutMs = resolveInnerTimeoutMs(workerManifestHook);
+      const workerTimeoutMs = resolveTrustedPromptWorkerTimeoutMs(resolution.targetPath, workerManifestHook, resolution.trustedPluginRoot);
       runWorker(resolution.targetPath, workerManifestHook, workerTimeoutMs).then(status => {
         process.exitCode = status;
       });
@@ -409,6 +421,7 @@ if (require.main === module) {
 
 module.exports = {
   resolveInnerTimeoutMs,
+  resolveTrustedPromptWorkerTimeoutMs,
   resolveWorkerTarget,
   resolveHookTimeoutMs,
   resolveGenericTimeoutMs,

--- a/src/__tests__/run-cjs-graceful-fallback.test.ts
+++ b/src/__tests__/run-cjs-graceful-fallback.test.ts
@@ -62,16 +62,41 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
     const keywordDetector = promptHooks.find((hook: any) => hook.command.includes('keyword-detector.mjs'));
     const skillInjector = promptHooks.find((hook: any) => hook.command.includes('skill-injector.mjs'));
 
-    expect(keywordDetector?.timeout).toBe(10);
-    expect(skillInjector?.timeout).toBe(15);
+    expect(keywordDetector?.timeout).toBe(30);
+    expect(skillInjector?.timeout).toBe(30);
 
     const hooksDoc = readFileSync(join(__dirname, '..', '..', 'docs', 'HOOKS.md'), 'utf-8');
     const referenceDoc = readFileSync(join(__dirname, '..', '..', 'docs', 'REFERENCE.md'), 'utf-8');
 
-    expect(hooksDoc).toContain('| `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 10s |');
-    expect(hooksDoc).toContain('| `skill-injector.mjs` | Injects skill prompts | 15s |');
+    expect(hooksDoc).toContain('| `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 30s outer host fuse; 8s trusted Worker limit |');
+    expect(hooksDoc).toContain('| `skill-injector.mjs` | Injects skill prompts | 30s outer host fuse; 12s trusted Worker limit |');
+    expect(hooksDoc).toContain('A command that never reaches `run.cjs` can consume its full 30s outer fuse.');
     expect(referenceDoc).toContain('| **UserPromptSubmit**   | `keyword-detector.mjs`, `skill-injector.mjs`');
-    expect(referenceDoc).toContain('| 10s, 15s');
+    expect(referenceDoc).toContain('30s outer fuse per command; 8s, 12s trusted Worker limits');
+    expect(referenceDoc).toContain('A command that never starts the runner can take the entire 30s per-command fuse');
+  });
+
+  it('caps only trusted prompt Worker execution without extending lower manifest limits', () => {
+    const trustedPluginRoot = join(__dirname, '..', '..');
+    const policyProbe = `
+      const runner = require(process.argv[1]);
+      const root = process.argv[2];
+      const keyword = require('node:path').join(root, 'scripts', 'keyword-detector.mjs');
+      const skill = require('node:path').join(root, 'scripts', 'skill-injector.mjs');
+      const outer = { event: 'UserPromptSubmit', timeoutMs: 30000 };
+      const lower = { event: 'UserPromptSubmit', timeoutMs: 5000 };
+      process.stdout.write(JSON.stringify([
+        runner.resolveTrustedPromptWorkerTimeoutMs(keyword, outer, root),
+        runner.resolveTrustedPromptWorkerTimeoutMs(skill, outer, root),
+        runner.resolveTrustedPromptWorkerTimeoutMs(keyword, lower, root),
+        runner.resolveGenericTimeoutMs(outer),
+      ]));
+    `;
+    const values = JSON.parse(execFileSync(NODE, ['-e', policyProbe, RUN_CJS_PATH, trustedPluginRoot], {
+      encoding: 'utf-8',
+    }));
+
+    expect(values).toEqual([8000, 12000, 4000, 27000]);
   });
 
   it('exits 0 when no target argument is provided', () => {

--- a/src/__tests__/windows-prompt-hook-runner.test.ts
+++ b/src/__tests__/windows-prompt-hook-runner.test.ts
@@ -36,6 +36,36 @@ function run(target: string, root: string, env: NodeJS.ProcessEnv = {}, args: st
   return { status: result.status ?? 1, stdout: result.stdout || '', stderr: result.stderr || '' };
 }
 
+function runDelayedPromptRunner(root: string, target: string) {
+  const launcher = `
+    const { spawnSync } = require('node:child_process');
+    const [node, runner, root, target, delayMs, outerTimeoutMs] = process.argv.slice(1);
+    const startedAt = Date.now();
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(delayMs));
+    const runnerStartedAt = Date.now();
+    const result = spawnSync(node, [runner, target], {
+      encoding: 'utf8',
+      input: '{}',
+      env: { ...process.env, CLAUDE_PLUGIN_ROOT: root },
+      timeout: Number(outerTimeoutMs) - (runnerStartedAt - startedAt),
+    });
+    process.stdout.write(JSON.stringify({
+      evidence: 'argv-based delayed-launch model; not a native Windows reproduction',
+      startedAt,
+      runnerStartedAt,
+      finishedAt: Date.now(),
+      status: result.status,
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+    }));
+  `;
+  const result = spawnSync(NODE, ['-e', launcher, NODE, RUN_CJS_PATH, root, target, '11000', '30000'], {
+    encoding: 'utf-8',
+    timeout: 35000,
+  });
+  return JSON.parse(result.stdout || '{}');
+}
+
 afterEach(() => {
   for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
@@ -75,6 +105,25 @@ describe('Windows-safe prompt hook runner paths', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toBe('');
     expect(result.stderr).toContain('Hook keyword-detector.mjs timed out after 1ms; exiting fail-open.');
+  });
+
+  it('models an argv-delayed launch crossing 10s and failing open before the 30s host fuse', () => {
+    const cacheBase = mkdtempSync(join(tmpdir(), 'omc delayed prompt launch-'));
+    tempDirs.push(cacheBase);
+    const root = join(cacheBase, '4.7.0');
+    const target = join(root, 'scripts', 'keyword-detector.mjs');
+    makePlugin(root, "setInterval(() => {}, 1000); setTimeout(() => process.stdout.write('late'), 20);", 30);
+
+    const model = runDelayedPromptRunner(root, target);
+
+    expect(model.evidence).toContain('model; not a native Windows reproduction');
+    expect(model.runnerStartedAt - model.startedAt).toBeGreaterThan(10000);
+    expect(model.finishedAt - model.startedAt).toBeLessThan(30000);
+    expect(model.status).toBe(0);
+    expect(model.finishedAt - model.runnerStartedAt).toBeGreaterThanOrEqual(7500);
+    expect(model.finishedAt - model.runnerStartedAt).toBeLessThan(10000);
+    expect(model.stdout).toBe('');
+    expect(model.stderr).toBe('');
   });
 
   it('reaps a timed-out generic hook process tree', async () => {


### PR DESCRIPTION
## Summary
- raises each UserPromptSubmit host fuse to 30s so Git Bash/Node startup is covered before run.cjs begins
- preserves #3490 trusted Worker execution limits at 8s (keyword-detector) and 12s (skill-injector)
- adds a real argv-based delayed-launch model that invokes run.cjs after the legacy 10s boundary; it is explicitly not a native Windows reproduction

## Verification
- focused: 136 tests across prompt runner and opt-out owner suites
- lint: passed with 18 pre-existing warnings
- typecheck: passed
- build: passed
- plugin shipping verification and npm pack --dry-run: passed
- full suite: two runs found unrelated timing/state failures; each passed in isolated reruns. Hosted Windows CI remains a merge gate.

## Merge gate
Do not merge until required CI, including native Windows coverage, is green.

Closes #3524

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*