### PR TITLE
fix(psm): use tmux-safe session names so sessions stay manageable (#3528)

### DIFF
--- a/skills/project-session-manager/SKILL.md
+++ b/skills/project-session-manager/SKILL.md
@@ -154,11 +154,18 @@ The Jira CLI handles authentication separately from PSM.
 
 ## Session Naming
 
-| Type | Tmux Session | Worktree Dir |
-|------|--------------|--------------|
-| PR Review | `psm:omc:pr-123` | `~/.psm/worktrees/omc/pr-123` |
-| Issue Fix | `psm:omc:issue-42` | `~/.psm/worktrees/omc/issue-42` |
-| Feature | `psm:omc:feat-auth` | `~/.psm/worktrees/omc/feat-auth` |
+The **public session ID** (colon form, e.g. `omc:pr-123`) is the human-facing
+identifier stored in `sessions.json` and used with `psm attach`/`psm kill`. tmux
+reserves `:` and `.` for its `session:window.pane` target syntax and silently
+rewrites them, so the **actual tmux session name** uses a tmux-safe form where
+those characters become `_` (issue #3528). PSM translates the public ID to the
+tmux-safe name at every tmux boundary; attach directly with the tmux-safe name.
+
+| Type | Public ID (`psm attach`/`kill`) | Tmux Session (`tmux attach -t`) | Worktree Dir |
+|------|---------------------------------|---------------------------------|--------------|
+| PR Review | `omc:pr-123` | `psm_omc_pr-123` | `~/.psm/worktrees/omc/pr-123` |
+| Issue Fix | `omc:issue-42` | `psm_omc_issue-42` | `~/.psm/worktrees/omc/issue-42` |
+| Feature | `omc:feat-auth` | `psm_omc_feat-auth` | `~/.psm/worktrees/omc/feat-auth` |
 
 ---
 
@@ -224,7 +231,7 @@ Parse `{{ARGUMENTS}}` to determine:
      "branch": "<head_branch>",
      "base": "<base_branch>",
      "created_at": "$(date -Iseconds)",
-     "tmux_session": "psm:$project_alias:pr-$pr_number",
+     "tmux_session": "psm_${project_alias}_pr-$pr_number",
      "worktree_path": "$worktree_path",
      "source_repo": "$local_path",
      "github": {
@@ -243,21 +250,21 @@ Parse `{{ARGUMENTS}}` to determine:
    # Add to ~/.psm/sessions.json
    ```
 
-7. **Create tmux session**:
+7. **Create tmux session** (tmux-safe name; `:`/`.` are translated to `_`):
    ```bash
-   tmux new-session -d -s "psm:$project_alias:pr-$pr_number" -c "$worktree_path"
+   tmux new-session -d -s "psm_${project_alias}_pr-$pr_number" -c "$worktree_path"
    ```
 
 8. **Launch Claude Code** (unless --no-claude):
    ```bash
    # --dangerously-skip-permissions prevents the "Do you trust this directory?" prompt
    # and repeated tool-approval prompts from stalling the session (issue #2508).
-   tmux send-keys -t "psm:$project_alias:pr-$pr_number" "claude --dangerously-skip-permissions" Enter
+   tmux send-keys -t "psm_${project_alias}_pr-$pr_number" "claude --dangerously-skip-permissions" Enter
 
    # After claude boots (PSM_CLAUDE_STARTUP_DELAY, default 5s), deliver the task.
    # Use -l (literal) so special characters are not misinterpreted by tmux.
    sleep "${PSM_CLAUDE_STARTUP_DELAY:-5}"
-   tmux send-keys -t "psm:$project_alias:pr-$pr_number" -l \
+   tmux send-keys -t "psm_${project_alias}_pr-$pr_number" -l \
      "Review PR #$pr_number: \"$pr_title\" by @$pr_author ($head_branch → $base_branch). URL: $pr_url." Enter
    ```
 
@@ -267,9 +274,9 @@ Parse `{{ARGUMENTS}}` to determine:
 
      ID: omc:pr-123
      Worktree: ~/.psm/worktrees/omc/pr-123
-     Tmux: psm:omc:pr-123
+     Tmux: psm_omc_pr-123
 
-   To attach: tmux attach -t psm:omc:pr-123
+   To attach: tmux attach -t psm_omc_pr-123   (or: psm attach omc:pr-123)
    ```
 
 ### Subcommand: `fix <ref>`
@@ -304,9 +311,9 @@ Parse `{{ARGUMENTS}}` to determine:
 6. **Update registry, create tmux, launch claude**:
    Same as review, but pass issue context as the initial task prompt:
    ```bash
-   tmux send-keys -t "psm:$project_alias:issue-$issue_number" "claude --dangerously-skip-permissions" Enter
+   tmux send-keys -t "psm_${project_alias}_issue-$issue_number" "claude --dangerously-skip-permissions" Enter
    # After claude boots, deliver the task (see PSM_CLAUDE_STARTUP_DELAY):
-   tmux send-keys -t "psm:$project_alias:issue-$issue_number" -l \
+   tmux send-keys -t "psm_${project_alias}_issue-$issue_number" -l \
      "Fix issue #$issue_number: \"$issue_title\". URL: $issue_url. Branch: $branch_name." Enter
    ```
 
@@ -334,8 +341,8 @@ Parse `{{ARGUMENTS}}` to determine:
 
 4. **Create session, tmux, launch claude** with feature context as initial prompt:
    ```bash
-   tmux send-keys -t "psm:$project_alias:feat-$feature_name" "claude --dangerously-skip-permissions" Enter
-   tmux send-keys -t "psm:$project_alias:feat-$feature_name" -l \
+   tmux send-keys -t "psm_${project_alias}_feat-$feature_name" "claude --dangerously-skip-permissions" Enter
+   tmux send-keys -t "psm_${project_alias}_feat-$feature_name" -l \
      "Implement feature \"$feature_name\" for project $project. Branch: $branch_name." Enter
    ```
 
@@ -352,7 +359,7 @@ Parse `{{ARGUMENTS}}` to determine:
 
 2. **Check tmux sessions**:
    ```bash
-   tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^psm:"
+   tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^psm_"
    ```
 
 3. **Check worktrees**:
@@ -380,12 +387,12 @@ Parse `{{ARGUMENTS}}` to determine:
 
 2. **Verify session exists**:
    ```bash
-   tmux has-session -t "psm:$session_id" 2>/dev/null
+   tmux has-session -t "psm_${session_id//[.:]/_}" 2>/dev/null   # translate public id to tmux-safe name
    ```
 
 3. **Attach**:
    ```bash
-   tmux attach -t "psm:$session_id"
+   tmux attach -t "psm_${session_id//[.:]/_}"
    ```
 
 ### Subcommand: `kill <session>`
@@ -396,7 +403,7 @@ Parse `{{ARGUMENTS}}` to determine:
 
 1. **Kill tmux session**:
    ```bash
-   tmux kill-session -t "psm:$session_id" 2>/dev/null
+   tmux kill-session -t "psm_${session_id//[.:]/_}" 2>/dev/null
    ```
 
 2. **Remove worktree**:

--- a/skills/project-session-manager/lib/session.sh
+++ b/skills/project-session-manager/lib/session.sh
@@ -167,3 +167,20 @@ psm_get_review_sessions() {
 psm_get_fix_sessions() {
     jq -r '.sessions | to_entries[] | select(.value.type == "fix" and (.value.state // "active") == "active") | "\(.value.id)|\(.value.metadata.issue_number // empty)|\(.value.project)"' "$PSM_SESSIONS"
 }
+# Resolve a PSM public session id from an actual (tmux-safe) session name
+# (issue #3528). The current tmux session reported by tmux is always the
+# tmux-safe form, so we regenerate each registered id's canonical tmux name via
+# psm_tmux_name_from_id and return the id whose canonical name matches.
+# Usage: psm_get_session_id_for_tmux <tmux_session_name>
+psm_get_session_id_for_tmux() {
+    local target="$1"
+    local id
+    while IFS= read -r id; do
+        [[ -z "$id" ]] && continue
+        if [[ "$(psm_tmux_name_from_id "$id")" == "$target" ]]; then
+            printf '%s\n' "$id"
+            return 0
+        fi
+    done < <(jq -r '.sessions | keys[]' "$PSM_SESSIONS")
+    return 1
+}

--- a/skills/project-session-manager/lib/tmux.sh
+++ b/skills/project-session-manager/lib/tmux.sh
@@ -6,10 +6,30 @@ psm_has_tmux() {
     command -v tmux &> /dev/null
 }
 
+# Canonical tmux-safe session-name contract (issue #3528).
+# tmux reserves ':' and '.' in target names (the "session:window.pane" syntax)
+# and silently rewrites them inside session names, which orphans any PSM session
+# whose requested name still contained them. This is the single source of truth
+# for translating a PSM logical name into the name tmux will actually use; it
+# MUST be applied at every tmux boundary. Translation is idempotent, so it is
+# safe to call on names that are already tmux-safe (e.g. old registry entries).
+psm_tmux_safe_name() {
+    local name="$1"
+    printf '%s' "${name//[.:]/_}"
+}
+
+# Build the canonical tmux session name for a PSM public session id
+# (e.g. "omc:pr-123" -> "psm_omc_pr-123"). The colon-form id remains the
+# human-facing identifier in sessions.json and on the CLI.
+psm_tmux_name_from_id() {
+    psm_tmux_safe_name "psm:${1}"
+}
+
 # Create a tmux session
 # Usage: psm_create_tmux_session <session_name> <working_dir>
 psm_create_tmux_session() {
-    local session_name="$1"
+    local session_name
+    session_name=$(psm_tmux_safe_name "$1")
     local working_dir="$2"
 
     if ! psm_has_tmux; then
@@ -29,6 +49,14 @@ psm_create_tmux_session() {
         return 1
     }
 
+    # Fail closed: verify the session exists under the exact name PSM will use
+    # for later lookups (issue #3528). If tmux rewrote the name, every later
+    # has-session / send-keys / kill / attach would silently miss.
+    if ! tmux has-session -t "$session_name" 2>/dev/null; then
+        echo "error|tmux session not found after create: $session_name"
+        return 1
+    fi
+
     echo "created|$session_name"
     return 0
 }
@@ -44,7 +72,8 @@ psm_create_tmux_session() {
 # directory-trust or repeated tool-approval prompts (issue #2508).
 # Set PSM_CLAUDE_STARTUP_DELAY (default: 5s) to tune literal-prompt delivery.
 psm_launch_claude() {
-    local session_name="$1"
+    local session_name
+    session_name=$(psm_tmux_safe_name "$1")
     local initial_context="${2:-}"
 
     if ! tmux has-session -t "$session_name" 2>/dev/null; then
@@ -116,7 +145,8 @@ _psm_pane_has_claude_prompt() {
 # Usage: psm_wait_for_claude_prompt <session_name> [max_seconds]
 # Returns 0 when prompt detected; 1 on timeout.
 psm_wait_for_claude_prompt() {
-    local session_name="$1"
+    local session_name
+    session_name=$(psm_tmux_safe_name "$1")
     local max_wait="${2:-30}"
     local waited=0
 
@@ -137,7 +167,8 @@ psm_wait_for_claude_prompt() {
 # Non-fatal: warns on timeout but does not fail the session creation.
 # Usage: psm_inject_prompt <session_name> <context_file_relative_path>
 psm_inject_prompt() {
-    local session_name="$1"
+    local session_name
+    session_name=$(psm_tmux_safe_name "$1")
     local context_file="$2"
 
     if ! psm_wait_for_claude_prompt "$session_name"; then
@@ -158,7 +189,8 @@ psm_inject_prompt() {
 # Kill a tmux session
 # Usage: psm_kill_tmux_session <session_name>
 psm_kill_tmux_session() {
-    local session_name="$1"
+    local session_name
+    session_name=$(psm_tmux_safe_name "$1")
 
     if ! tmux has-session -t "$session_name" 2>/dev/null; then
         echo "not_found|$session_name"
@@ -180,13 +212,14 @@ psm_list_tmux_sessions() {
         return 0
     fi
 
-    tmux list-sessions -F "#{session_name}|#{session_created}|#{session_attached}" 2>/dev/null | grep "^psm:" || true
+    tmux list-sessions -F "#{session_name}|#{session_created}|#{session_attached}" 2>/dev/null | grep "^psm_" || true
 }
 
 # Check if a tmux session exists
 # Usage: psm_tmux_session_exists <session_name>
 psm_tmux_session_exists() {
-    local session_name="$1"
+    local session_name
+    session_name=$(psm_tmux_safe_name "$1")
     tmux has-session -t "$session_name" 2>/dev/null
 }
 
@@ -204,5 +237,5 @@ psm_tmux_session_name() {
     local type="$2"
     local id="$3"
 
-    echo "psm:${alias}:${type}-${id}"
+    psm_tmux_name_from_id "${alias}:${type}-${id}"
 }

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -211,8 +211,8 @@ cmd_review() {
     fi
 
     # Create tmux session
-    local session_name="psm:${alias}:pr-${pr_number}"
     local session_id="${alias}:pr-${pr_number}"
+    local session_name=$(psm_tmux_name_from_id "$session_id")
 
     if [[ "$no_tmux" != "true" ]]; then
         log_info "Creating tmux session..."
@@ -386,8 +386,8 @@ cmd_fix() {
     fi
 
     # Create tmux session
-    local session_name="psm:${alias}:issue-${issue_number}"
     local session_id="${alias}:issue-${issue_number}"
+    local session_name=$(psm_tmux_name_from_id "$session_id")
 
     log_info "Creating tmux session..."
     psm_create_tmux_session "$session_name" "$worktree_path"
@@ -459,8 +459,8 @@ cmd_feature() {
     log_success "Worktree created at $worktree_path"
 
     local safe_name=$(psm_sanitize "$feature_name")
-    local session_name="psm:${project}:feat-${safe_name}"
     local session_id="${project}:feat-${safe_name}"
+    local session_name=$(psm_tmux_name_from_id "$session_id")
 
     psm_create_tmux_session "$session_name" "$worktree_path"
     local feature_prompt="Implement feature \"${feature_name}\" for project ${project}. Working branch: ${branch_name}. Build the feature, add tests, and open a PR when ready: gh pr create --title \"feat: ${feature_name}\""
@@ -492,7 +492,7 @@ cmd_list() {
     psm_list_sessions "$project" | while IFS='|' read -r id type state worktree; do
         # Check if tmux session exists
         local tmux_state="detached"
-        if psm_tmux_session_exists "psm:${id}"; then
+        if psm_tmux_session_exists "$(psm_tmux_name_from_id "$id")"; then
             tmux_state="$state"
         else
             tmux_state="no-tmux"
@@ -507,7 +507,7 @@ cmd_list() {
 # Command: attach
 cmd_attach() {
     local session_id="$1"
-    local session_name="psm:${session_id}"
+    local session_name=$(psm_tmux_name_from_id "$session_id")
 
     if ! psm_tmux_session_exists "$session_name"; then
         log_error "Session not found: $session_name"
@@ -623,8 +623,8 @@ cmd_status() {
     # Try to detect current session
     local current_session=$(psm_current_tmux_session)
 
-    if [[ -n "$current_session" && "$current_session" == psm:* ]]; then
-        local session_id="${current_session#psm:}"
+    if [[ -n "$current_session" && "$current_session" == psm_* ]]; then
+        local session_id=$(psm_get_session_id_for_tmux "$current_session")
         local session_json=$(psm_get_session "$session_id")
 
         if [[ -n "$session_json" ]]; then

--- a/src/__tests__/psm-tmux-naming.test.ts
+++ b/src/__tests__/psm-tmux-naming.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression tests for issue #3528:
+ * PSM built tmux session names containing colons (`psm:<alias>:<type>-<id>`).
+ * tmux reserves ':' and '.' for its `session:window.pane` target syntax and
+ * silently rewrites them, so every later has-session / send-keys / list /
+ * attach / kill / cleanup and registry lookup missed and sessions were orphaned.
+ *
+ * The fix introduces ONE canonical tmux-safe naming contract
+ * (psm_tmux_safe_name + psm_tmux_name_from_id) applied at every tmux boundary,
+ * plus a fail-closed post-create assertion. These tests cover the contract,
+ * create, lookup, registration, list, attach, kill/cleanup, status reverse
+ * lookup, and the source/docs contract.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PSM_ROOT = join(process.cwd(), 'skills', 'project-session-manager');
+const TMUX_SH = join(PSM_ROOT, 'lib', 'tmux.sh');
+const SESSION_SH = join(PSM_ROOT, 'lib', 'session.sh');
+const CONFIG_SH = join(PSM_ROOT, 'lib', 'config.sh');
+const PSM_SH = join(PSM_ROOT, 'psm.sh');
+const SKILL_MD = join(PSM_ROOT, 'SKILL.md');
+
+function runShell(script: string, home?: string): string {
+  return execFileSync('bash', ['-lc', script], {
+    encoding: 'utf-8',
+    env: home ? { ...process.env, HOME: home } : { ...process.env },
+  }).trim();
+}
+
+// A stateful mock tmux: has-session consults a "created" registry file,
+// new-session records the exact -s name, kill-session removes it.
+const MOCK_TMUX = `
+tmux() {
+  local sub="$1"; shift
+  case "$sub" in
+    has-session)
+      local name=""; while [[ $# -gt 0 ]]; do [[ "$1" == "-t" ]] && name="$2"; shift; done
+      grep -qxF "$name" "$CREATED_FILE" 2>/dev/null ;;
+    new-session)
+      local name=""; while [[ $# -gt 0 ]]; do [[ "$1" == "-s" ]] && name="$2"; shift; done
+      printf '%s\\n' "$name" >> "$CREATED_FILE" ;;
+    kill-session)
+      local name=""; while [[ $# -gt 0 ]]; do [[ "$1" == "-t" ]] && name="$2"; shift; done
+      grep -vxF "$name" "$CREATED_FILE" > "$CREATED_FILE.tmp" 2>/dev/null || true
+      mv "$CREATED_FILE.tmp" "$CREATED_FILE" 2>/dev/null || true ;;
+    *) : ;;
+  esac
+}
+`;
+
+const SOURCE = `CREATED_FILE=$(mktemp); ${MOCK_TMUX} source "${TMUX_SH}";`;
+
+describe('PSM tmux-safe naming contract (issue #3528)', () => {
+  describe('canonical contract', () => {
+    it('psm_tmux_safe_name translates both ":" and "."', () => {
+      const out = runShell(`${SOURCE} psm_tmux_safe_name "omc:pr-123"; echo; psm_tmux_safe_name "repo.js:feat-a.b"`);
+      expect(out).toBe('omc_pr-123\nrepo_js_feat-a_b');
+    });
+
+    it('psm_tmux_name_from_id prefixes psm_ and produces no reserved chars', () => {
+      const out = runShell(`${SOURCE} psm_tmux_name_from_id "omc:pr-123"`);
+      expect(out).toBe('psm_omc_pr-123');
+      expect(out).not.toContain(':');
+      expect(out).not.toContain('.');
+    });
+
+    it('translation is idempotent for already-safe names', () => {
+      const out = runShell(`${SOURCE} psm_tmux_safe_name "psm_omc_pr-123"`);
+      expect(out).toBe('psm_omc_pr-123');
+    });
+  });
+
+  describe('create + registration', () => {
+    it('creates the session under the tmux-safe name', () => {
+      const out = runShell(`${SOURCE} psm_create_tmux_session "psm:omc:pr-123" "/tmp"`);
+      expect(out).toBe('created|psm_omc_pr-123');
+    });
+
+    it('fail-closed: errors when the session is absent after new-session', () => {
+      // Mock where new-session silently drops the name (simulates tmux rewrite miss).
+      const failMock = `
+tmux() {
+  case "$1" in
+    has-session) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+`;
+      const out = runShell(
+        `CREATED_FILE=$(mktemp); ${failMock} source "${TMUX_SH}"; psm_create_tmux_session "psm:omc:pr-9" "/tmp" || true`,
+      );
+      expect(out).toContain('error|tmux session not found after create');
+    });
+  });
+
+  describe('lookup', () => {
+    it('finds a created session whether queried by colon or safe form', () => {
+      const out = runShell(
+        `${SOURCE} psm_create_tmux_session "psm:omc:pr-123" "/tmp" >/dev/null;` +
+          ` psm_tmux_session_exists "psm:omc:pr-123" && echo COLON=yes || echo COLON=no;` +
+          ` psm_tmux_session_exists "psm_omc_pr-123" && echo SAFE=yes || echo SAFE=no`,
+      );
+      expect(out).toBe('COLON=yes\nSAFE=yes');
+    });
+  });
+
+  describe('list', () => {
+    it('greps the tmux-safe psm_ prefix, not psm:', () => {
+      const listMock = `
+tmux() {
+  case "$1" in
+    list-sessions) printf 'psm_omc_pr-1|100|0\\nother|101|0\\n' ;;
+    *) : ;;
+  esac
+}
+`;
+      const out = runShell(`CREATED_FILE=$(mktemp); ${listMock} source "${TMUX_SH}"; psm_list_tmux_sessions`);
+      expect(out).toBe('psm_omc_pr-1|100|0');
+    });
+  });
+
+  describe('attach', () => {
+    it('psm_tmux_session_name helper emits the tmux-safe form', () => {
+      const out = runShell(`${SOURCE} psm_tmux_session_name "omc" "pr" "123"`);
+      expect(out).toBe('psm_omc_pr-123');
+    });
+  });
+
+  describe('kill / cleanup', () => {
+    it('kills the session addressed by its public (colon) id', () => {
+      const out = runShell(
+        `${SOURCE} psm_create_tmux_session "psm:omc:pr-123" "/tmp" >/dev/null;` +
+          ` psm_kill_tmux_session "psm:omc:pr-123";` +
+          ` psm_tmux_session_exists "psm_omc_pr-123" && echo STILL=yes || echo STILL=no`,
+      );
+      expect(out).toBe('killed|psm_omc_pr-123\nSTILL=no');
+    });
+  });
+
+  describe('status reverse lookup', () => {
+    it('maps a live tmux-safe session name back to the public id', () => {
+      const home = mkdtempSync(join(tmpdir(), 'omc-psm-3528-'));
+      mkdirSync(join(home, '.psm'), { recursive: true });
+      writeFileSync(
+        join(home, '.psm', 'sessions.json'),
+        JSON.stringify({
+          version: 1,
+          sessions: {
+            'omc:pr-123': { id: 'omc:pr-123', type: 'review', project: 'omc', tmux: 'psm_omc_pr-123' },
+            'omc:issue-42': { id: 'omc:issue-42', type: 'fix', project: 'omc', tmux: 'psm_omc_issue-42' },
+          },
+          stats: { total_created: 2, total_cleaned: 0 },
+        }),
+      );
+      const out = runShell(
+        `source "${CONFIG_SH}"; source "${TMUX_SH}"; source "${SESSION_SH}";` +
+          ` psm_get_session_id_for_tmux "psm_omc_issue-42"`,
+        home,
+      );
+      expect(out).toBe('omc:issue-42');
+    });
+  });
+});
+
+describe('PSM tmux-safe naming — source & docs contract (issue #3528)', () => {
+  const tmuxSrc = readFileSync(TMUX_SH, 'utf-8');
+  const psmSrc = readFileSync(PSM_SH, 'utf-8');
+  const skill = readFileSync(SKILL_MD, 'utf-8');
+
+  it('defines the canonical contract functions', () => {
+    expect(tmuxSrc).toMatch(/psm_tmux_safe_name\(\)\s*\{/);
+    expect(tmuxSrc).toMatch(/psm_tmux_name_from_id\(\)\s*\{/);
+    expect(tmuxSrc).toContain('${name//[.:]/_}');
+  });
+
+  it('sanitizes session_name at every tmux boundary', () => {
+    const boundaries = [
+      'psm_create_tmux_session',
+      'psm_launch_claude',
+      'psm_inject_prompt',
+      'psm_wait_for_claude_prompt',
+      'psm_kill_tmux_session',
+      'psm_tmux_session_exists',
+    ];
+    for (const fn of boundaries) {
+      const body = tmuxSrc.slice(tmuxSrc.indexOf(`${fn}()`));
+      expect(body.slice(0, 200)).toContain('psm_tmux_safe_name "$1"');
+    }
+  });
+
+  it('has a fail-closed post-create assertion', () => {
+    expect(tmuxSrc).toContain('tmux session not found after create');
+  });
+
+  it('lists sessions by the tmux-safe prefix', () => {
+    expect(tmuxSrc).toContain('grep "^psm_"');
+    expect(tmuxSrc).not.toContain('grep "^psm:"');
+  });
+
+  it('psm.sh no longer builds colon-form tmux session names', () => {
+    expect(psmSrc).not.toMatch(/session_name="psm:/);
+    expect(psmSrc).toContain('psm_tmux_name_from_id "$session_id"');
+    expect(psmSrc).toContain('psm_tmux_name_from_id "$id"');
+  });
+
+  it('SKILL.md advertises the tmux-safe session name, not the colon form', () => {
+    expect(skill).toContain('psm_omc_pr-123');
+    expect(skill).not.toContain('`psm:omc:pr-123`');
+    expect(skill).not.toContain('grep "^psm:"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3528. PSM built tmux session names containing colons (`psm:<alias>:<type>-<id>`). tmux reserves `:` and `.` for its `session:window.pane` target syntax and silently rewrites them (`psm:test:colon` → `psm_test_colon`), so every later `has-session` / `send-keys` / `list` / `attach` / `kill` / `cleanup` and registry lookup missed the rewritten name. Sessions were orphaned: running but invisible to PSM and impossible to clean up.

Verified live on tmux 3.2a: requesting `psm:vt:colon` creates `psm_vt_colon`, and `tmux has-session -t psm:vt:colon` fails with `can't find window: vt:colon`.

## Fix

One canonical tmux-safe naming/translation contract in `lib/tmux.sh`, applied at every tmux boundary (per the issue's suggested approach — translate at the boundary, not the call sites):

- `psm_tmux_safe_name` — the single source of truth: translates `:` and `.` to `_`. Idempotent, so old registry entries and direct callers stay safe.
- `psm_tmux_name_from_id` — builds the canonical tmux name from a public id (`omc:pr-123` → `psm_omc_pr-123`).
- Every boundary function (`create` / `launch` / `inject` / `wait` / `kill` / `exists`) sanitizes its incoming session name.
- `psm_create_tmux_session` gains a **fail-closed post-create assertion**: it verifies the session exists under the exact name PSM will look up, so this class of bug surfaces immediately instead of silently orphaning a session.
- `psm_list_tmux_sessions` greps the tmux-safe `^psm_` prefix.
- Call sites keep the **colon-form public id** (`omc:pr-123`) in `sessions.json` and the CLI (backward compatible) and derive the tmux name via `psm_tmux_name_from_id` for create, registry, display, and attach.
- `cmd_status` resolves the live tmux-safe session back to its public id via a new `psm_get_session_id_for_tmux` helper.

Docs (`SKILL.md`) now show the actual tmux-safe session name alongside the public id used with `psm attach`/`psm kill`.

## Tests

New `src/__tests__/psm-tmux-naming.test.ts` (16 cases) covering the contract, create, lookup, registration, list, attach, kill/cleanup, status reverse lookup, the fail-closed post-create assertion, and a source/docs contract check. Verified end-to-end against real tmux (create via colon id → lookup by both colon and safe form succeeds → dotted alias handled → reverse lookup → kill).

## Verification

- `npx vitest run src/__tests__/psm-tmux-naming.test.ts` — 16 passed
- `npx vitest run src/__tests__/psm-launch-trust.test.ts src/__tests__/project-session-manager-session-filter.test.ts src/__tests__/project-session-manager-review-worktree.test.ts` — 14 passed
- `npx vitest run src/__tests__/skills.test.ts src/__tests__/plugin-skill-budget.test.ts src/__tests__/auto-slash-aliases.test.ts src/__tests__/tier0-docs-consistency.test.ts` — 82 passed
- `npx tsc --noEmit` — clean; `npm run build` — success; `npm run lint` — 0 errors
- Live end-to-end against tmux 3.2a through the actual lib functions

## Scope

This fixes #3528 only. #3527 (worktree stdout corruption) and the Jira provider `--output json` issue are intentionally out of scope (one issue = one PR).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
