### PR TITLE
fix(psm): fail closed on malformed worktree results (#3527)

### DIFF
--- a/skills/project-session-manager/lib/worktree.sh
+++ b/skills/project-session-manager/lib/worktree.sh
@@ -73,13 +73,13 @@ psm_create_pr_worktree() {
 
     # Fetch the PR branch
     cd "$local_repo" || return 1
-    git fetch origin "pull/${pr_number}/head:psm-pr-${pr_number}-review" 2>/dev/null || {
+    git fetch origin "pull/${pr_number}/head:psm-pr-${pr_number}-review" >/dev/null 2>&1 || {
         echo "error|Failed to fetch PR #${pr_number}"
         return 1
     }
 
     # Create worktree
-    git worktree add "$worktree_path" "psm-pr-${pr_number}-review" 2>/dev/null || {
+    git worktree add "$worktree_path" "psm-pr-${pr_number}-review" >/dev/null 2>&1 || {
         echo "error|Failed to create worktree"
         return 1
     }
@@ -114,19 +114,19 @@ psm_create_issue_worktree() {
     cd "$local_repo" || return 1
 
     # Fetch latest from origin
-    git fetch origin "$base_branch" 2>/dev/null || {
+    git fetch origin "$base_branch" >/dev/null 2>&1 || {
         echo "error|Failed to fetch $base_branch"
         return 1
     }
 
     # Create and checkout new branch
-    git branch "$branch_name" "origin/$base_branch" 2>/dev/null || {
+    git branch "$branch_name" "origin/$base_branch" >/dev/null 2>&1 || {
         # Branch might already exist
         true
     }
 
     # Create worktree
-    git worktree add "$worktree_path" "$branch_name" 2>/dev/null || {
+    git worktree add "$worktree_path" "$branch_name" >/dev/null 2>&1 || {
         echo "error|Failed to create worktree"
         return 1
     }
@@ -159,16 +159,16 @@ psm_create_feature_worktree() {
     cd "$local_repo" || return 1
 
     # Fetch latest
-    git fetch origin "$base_branch" 2>/dev/null || {
+    git fetch origin "$base_branch" >/dev/null 2>&1 || {
         echo "error|Failed to fetch $base_branch"
         return 1
     }
 
     # Create branch
-    git branch "$branch_name" "origin/$base_branch" 2>/dev/null || true
+    git branch "$branch_name" "origin/$base_branch" >/dev/null 2>&1 || true
 
     # Create worktree
-    git worktree add "$worktree_path" "$branch_name" 2>/dev/null || {
+    git worktree add "$worktree_path" "$branch_name" >/dev/null 2>&1 || {
         echo "error|Failed to create worktree"
         return 1
     }

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -31,6 +31,75 @@ log_success() { echo -e "${GREEN}[PSM]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[PSM]${NC} $*"; }
 log_error() { echo -e "${RED}[PSM]${NC} $*" >&2; }
 
+# Validate a worktree-creation result string against the expected protocol schema.
+# Fails closed on any contamination so a malformed result never becomes a wrong/empty cwd.
+# Usage: psm_validate_worktree_result <raw_result> <schema>   (schema: pr|branched)
+psm_validate_worktree_result() {
+    local raw="$1"
+    local schema="$2"
+    # Only 'pr' and 'branched' schemas are supported
+    if [[ "$schema" != "pr" && "$schema" != "branched" ]]; then
+        log_error "Malformed worktree result: unknown schema"
+        return 1
+    fi
+    # Reject empty result
+    if [[ -z "$raw" ]]; then
+        log_error "Malformed worktree result: empty result"
+        return 1
+    fi
+    # Reject embedded newline (prepended OR appended noise -> more than one logical line)
+    if [[ "$raw" == *$'\n'* ]]; then
+        log_error "Malformed worktree result: unexpected multiline output"
+        return 1
+    fi
+    # Split on '|' WITHOUT dropping trailing empty fields ('read -a' would drop them,
+    # which would let a stray trailing delimiter smuggle in an extra field).
+    local -a fields=()
+    local remainder="$raw"
+    while true; do
+        fields+=("${remainder%%|*}")
+        [[ "$remainder" == *"|"* ]] || break
+        remainder="${remainder#*|}"
+    done
+    local status="${fields[0]}"
+    local count="${#fields[@]}"
+    local path="${fields[1]:-}"
+    local branch="${fields[2]:-}"
+    case "$status" in
+        created|exists)
+            # Required fields must be present and not whitespace-only, or the caller
+            # could launch tmux in an empty/unusable working directory.
+            case "$schema" in
+                pr)
+                    if [[ "$count" -ne 2 ]] || [[ "$path" =~ ^[[:space:]]*$ ]]; then
+                        log_error "Malformed worktree result: invalid $status record"
+                        return 1
+                    fi
+                    ;;
+                branched)
+                    if [[ "$count" -ne 3 ]] || [[ "$path" =~ ^[[:space:]]*$ ]] || [[ "$branch" =~ ^[[:space:]]*$ ]]; then
+                        log_error "Malformed worktree result: invalid $status record"
+                        return 1
+                    fi
+                    ;;
+            esac
+            ;;
+        error)
+            # error|message : exactly 2 fields, message is an opaque diagnostic (not a path)
+            if [[ "$count" -ne 2 ]] || [[ "${fields[1]:-}" =~ ^[[:space:]]*$ ]]; then
+                log_error "Malformed worktree result: invalid error record"
+                return 1
+            fi
+            ;;
+        *)
+            log_error "Malformed worktree result: invalid status"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+
 # Check dependencies
 check_dependencies() {
     local missing=()
@@ -174,12 +243,16 @@ cmd_review() {
 
     # Create worktree
     log_info "Creating worktree..."
-    local worktree_result
-    worktree_result=$(psm_create_pr_worktree "$local_path" "$alias" "$pr_number" "$head_branch")
+    local worktree_result worktree_rc=0
+    worktree_result=$(psm_create_pr_worktree "$local_path" "$alias" "$pr_number" "$head_branch") || worktree_rc=$?
 
     local worktree_status
     local worktree_path
     IFS='|' read -r worktree_status worktree_path <<< "$worktree_result"
+    if ! psm_validate_worktree_result "$worktree_result" pr; then
+        return 1
+    fi
+
 
     if [[ "$worktree_status" == "exists" ]]; then
         log_warn "Worktree already exists at $worktree_path"
@@ -352,11 +425,15 @@ cmd_fix() {
 
     # Create worktree
     log_info "Creating worktree and branch..."
-    local worktree_result
-    worktree_result=$(psm_create_issue_worktree "$local_path" "$alias" "$issue_number" "$slug" "$base")
+    local worktree_result worktree_rc=0
+    worktree_result=$(psm_create_issue_worktree "$local_path" "$alias" "$issue_number" "$slug" "$base") || worktree_rc=$?
 
     local worktree_status worktree_path branch_name
     IFS='|' read -r worktree_status worktree_path branch_name <<< "$worktree_result"
+    if ! psm_validate_worktree_result "$worktree_result" branched; then
+        return 1
+    fi
+
 
     if [[ "$worktree_status" == "exists" ]]; then
         log_warn "Worktree already exists at $worktree_path"
@@ -442,11 +519,14 @@ cmd_feature() {
 
     # Create worktree
     log_info "Creating worktree and branch..."
-    local worktree_result
-    worktree_result=$(psm_create_feature_worktree "$local_path" "$project" "$feature_name" "$base")
+    local worktree_result worktree_rc=0
+    worktree_result=$(psm_create_feature_worktree "$local_path" "$project" "$feature_name" "$base") || worktree_rc=$?
 
     local worktree_status worktree_path branch_name
     IFS='|' read -r worktree_status worktree_path branch_name <<< "$worktree_result"
+    if ! psm_validate_worktree_result "$worktree_result" branched; then
+        return 1
+    fi
 
     if [[ "$worktree_status" == "exists" ]]; then
         log_warn "Worktree already exists at $worktree_path"

--- a/src/__tests__/project-session-manager-worktree-protocol.test.ts
+++ b/src/__tests__/project-session-manager-worktree-protocol.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const WORKTREE_LIB_PATH = join(process.cwd(), 'skills', 'project-session-manager', 'lib', 'worktree.sh');
+const PSM_PATH = join(process.cwd(), 'skills', 'project-session-manager', 'psm.sh');
+const REAL_GIT = execFileSync('bash', ['-lc', 'command -v git'], { encoding: 'utf-8' }).trim();
+
+function commandExit(script: string, env: NodeJS.ProcessEnv): { status: number; stderr: string } {
+  try {
+    execFileSync('bash', ['-c', script], { env, encoding: 'utf-8', stdio: 'pipe' });
+    return { status: 0, stderr: '' };
+  } catch (error: unknown) {
+    const processError = error as { status?: number; stderr?: Buffer | string };
+    return { status: processError.status ?? 1, stderr: String(processError.stderr ?? '') };
+  }
+}
+
+function functionBody(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1;
+    if (source[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+  }
+  throw new Error(`Could not find closing brace for ${name}`);
+}
+
+describe('project-session-manager worktree result protocol', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    { creator: 'psm_create_pr_worktree', args: ['demo', '42', 'head'], fields: 2, branch: 'psm-pr-42-review' },
+    { creator: 'psm_create_issue_worktree', args: ['demo', '42', 'demo-fix', 'main'], fields: 3 },
+    { creator: 'psm_create_feature_worktree', args: ['demo', 'Demo Feature', 'main'], fields: 3 },
+  ])('keeps $creator stdout isolated from git output', ({ creator, args, fields, branch }) => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-psm-protocol-'));
+    tempDirs.push(root);
+    const repo = join(root, 'repo');
+    const worktreeRoot = join(root, 'worktrees');
+    const shimDir = join(root, 'shim');
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(shimDir, { recursive: true });
+
+    execFileSync(REAL_GIT, ['init', '-b', 'main'], { cwd: repo });
+    execFileSync(REAL_GIT, ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync(REAL_GIT, ['config', 'user.name', 'Test User'], { cwd: repo });
+    writeFileSync(join(repo, 'README.md'), 'test\n');
+    execFileSync(REAL_GIT, ['add', 'README.md'], { cwd: repo });
+    execFileSync(REAL_GIT, ['commit', '-m', 'initial'], { cwd: repo });
+    execFileSync(REAL_GIT, ['branch', 'origin/main'], { cwd: repo });
+    if (branch) execFileSync(REAL_GIT, ['branch', branch], { cwd: repo });
+
+    const shim = join(shimDir, 'git');
+    writeFileSync(shim, `#!/usr/bin/env bash
+if [[ "$1" == "worktree" && "$2" == "add" ]]; then
+  echo PSM_GIT_WORKTREE_STDOUT_SENTINEL
+  exec "$REAL_GIT" "$@"
+fi
+if [[ "$1" == "fetch" ]]; then
+  exit 0
+fi
+exec "$REAL_GIT" "$@"
+`);
+    chmodSync(shim, 0o755);
+
+    // RED before the patch: the sentinel was captured before the protocol line; green after it.
+    const stdout = execFileSync(
+      'bash',
+      ['-c', 'source "$SCRIPT_PATH"; psm_get_worktree_root() { printf "%s" "$WORKTREE_ROOT"; }; psm_sanitize() { echo "$1" | tr "[:upper:]" "[:lower:]" | sed "s/[^a-z0-9-]/-/g" | sed "s/--*/-/g" | head -c 30; }; "$CREATOR" "$REPO" "$@"', 'protocol', ...args],
+      {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          SCRIPT_PATH: WORKTREE_LIB_PATH,
+          WORKTREE_ROOT: worktreeRoot,
+          CREATOR: creator,
+          REPO: repo,
+          REAL_GIT,
+          PATH: `${shimDir}:${process.env.PATH}`,
+        },
+      },
+    );
+    const record = stdout.trimEnd();
+    expect(record).not.toContain('\n');
+    expect(record).not.toContain('PSM_GIT_WORKTREE_STDOUT_SENTINEL');
+    const resultFields = record.split('|');
+    expect(resultFields).toHaveLength(fields);
+    expect(resultFields[0]).toBe('created');
+    expect(resultFields[1]).not.toBe('');
+    if (fields === 3) expect(resultFields[2]).not.toBe('');
+  });
+
+  it.each([
+    { raw: 'noise\ncreated|/tmp/wt', schema: 'pr', valid: false },
+    { raw: 'noise\ncreated|/tmp/wt|feature/x', schema: 'branched', valid: false },
+    { raw: 'created|/tmp/wt\nnoise', schema: 'pr', valid: false },
+    { raw: '', schema: 'pr', valid: false },
+    { raw: 'weird|/tmp/wt', schema: 'pr', valid: false },
+    { raw: 'created|', schema: 'pr', valid: false },
+    { raw: 'created||feature/x', schema: 'branched', valid: false },
+    { raw: 'created|/tmp/wt|extra', schema: 'pr', valid: false },
+    { raw: 'created|/tmp/wt', schema: 'branched', valid: false },
+    { raw: 'created|/tmp/wt|', schema: 'branched', valid: false },
+    { raw: 'created|/tmp/wt|feature/x|extra', schema: 'branched', valid: false },
+    { raw: 'error|msg|extra', schema: 'pr', valid: false },
+    { raw: 'created|/tmp/wt', schema: 'pr', valid: true },
+    { raw: 'exists|/tmp/wt', schema: 'pr', valid: true },
+    { raw: 'created|/tmp/wt|feature/x', schema: 'branched', valid: true },
+    { raw: 'exists|/tmp/wt|feature/x', schema: 'branched', valid: true },
+    { raw: 'error|Failed to create worktree', schema: 'pr', valid: true },
+    { raw: 'error|Failed to create worktree', schema: 'branched', valid: true },
+    { raw: 'created|   ', schema: 'pr', valid: false },
+    { raw: 'created|   |feature/x', schema: 'branched', valid: false },
+    { raw: 'created|/tmp/wt|   ', schema: 'branched', valid: false },
+    { raw: 'created|/tmp/wt|', schema: 'pr', valid: false },
+    { raw: 'error|   ', schema: 'pr', valid: false },
+    { raw: 'created|/tmp/wt', schema: 'weird', valid: false },
+  ])('validates raw protocol records ($schema, $raw)', ({ raw, schema, valid }) => {
+    const result = commandExit('source "$PSM"; psm_validate_worktree_result "$ARG" "$SCHEMA"', {
+      ...process.env,
+      PSM: PSM_PATH,
+      ARG: raw,
+      SCHEMA: schema,
+    });
+    expect(result.status === 0).toBe(valid);
+  });
+
+  it.each([
+    { result: 'exists|/tmp/wt|feature/demo', creatorRc: '1', status: 0, malformed: false },
+    { result: 'error|Failed to create worktree', creatorRc: '1', status: 1, malformed: false },
+    { result: 'HEAD is now at abc\ncreated|/tmp/wt|feature/demo', creatorRc: '3', status: 1, malformed: true },
+  ])('handles cmd_feature creator results under errexit', ({ result, creatorRc, status, malformed }) => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-psm-feature-'));
+    tempDirs.push(root);
+    const repo = join(root, 'repo');
+    const markers = join(root, 'markers');
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(markers, { recursive: true });
+
+    const execution = commandExit(`
+source "$PSM"
+psm_get_project() { printf 'repo|%s|main' "$REPO"; }
+psm_create_feature_worktree() { printf '%s' "$RESULT"; return "$CREATOR_RC"; }
+psm_create_tmux_session() { touch "$MARKERS/tmux"; }
+psm_launch_claude() { touch "$MARKERS/claude"; }
+psm_add_session() { touch "$MARKERS/session"; }
+cmd_feature demo 'Demo Feature'
+`, {
+      ...process.env,
+      PSM: PSM_PATH,
+      REPO: repo,
+      MARKERS: markers,
+      RESULT: result,
+      CREATOR_RC: creatorRc,
+    });
+    expect(execution.status).toBe(status);
+    expect(readdirSync(markers)).toEqual([]);
+    if (malformed) expect(execution.stderr).toContain('Malformed worktree result');
+  });
+
+  it('captures safely and validates before side effects in every consumer', () => {
+    const source = readFileSync(PSM_PATH, 'utf-8');
+    const cases = [
+      {
+        name: 'cmd_review', creator: 'psm_create_pr_worktree',
+        sideEffects: ['psm_render_template', 'psm_create_tmux_session', 'psm_launch_claude', 'psm_add_session', 'context_file'],
+      },
+      {
+        name: 'cmd_fix', creator: 'psm_create_issue_worktree',
+        sideEffects: ['psm_render_template', 'psm_create_tmux_session', 'psm_launch_claude', 'psm_add_session', 'fix_context_file'],
+      },
+      {
+        name: 'cmd_feature', creator: 'psm_create_feature_worktree',
+        sideEffects: ['psm_create_tmux_session', 'psm_launch_claude', 'psm_add_session'],
+      },
+    ];
+
+    for (const entry of cases) {
+      const body = functionBody(source, entry.name);
+      const capture = `worktree_result=$(%s`.replace('%s', entry.creator);
+      const captureOffset = body.indexOf(capture);
+      expect(captureOffset).toBeGreaterThanOrEqual(0);
+      expect(body.indexOf(capture, captureOffset + 1)).toBe(-1);
+      const captureLineEnd = body.indexOf('\n', captureOffset);
+      expect(body.slice(captureOffset, captureLineEnd)).toContain('|| worktree_rc=');
+
+      const readOffset = body.indexOf("IFS='|' read -r", captureOffset);
+      expect(readOffset).toBeGreaterThan(captureOffset);
+      const validator = 'psm_validate_worktree_result "$worktree_result"';
+      const validatorOffset = body.indexOf(validator, readOffset);
+      expect(validatorOffset).toBeGreaterThan(readOffset);
+      expect(body.slice(readOffset, validatorOffset)).toMatch(/^IFS='\|' read -r[^\n]*<<< "\$worktree_result"\n\s*if ! \s*$/);
+      expect(body.slice(readOffset)).toMatch(/^IFS='\|' read -r[^\n]*<<< "\$worktree_result"\n\s*if ! psm_validate_worktree_result "\$worktree_result" (?:pr|branched); then\n\s*return 1\n\s*fi\n/);
+
+      for (const sideEffect of entry.sideEffects) {
+        expect(body.indexOf(sideEffect)).toBeGreaterThan(validatorOffset);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`psm_create_pr_worktree` / `psm_create_issue_worktree` / `psm_create_feature_worktree` return a `status|path[|branch]` protocol line on stdout, but `git worktree add` (previously only `2>/dev/null`) leaked its own stdout (`branch '…' set up to track…`, `HEAD is now at …`) ahead of that line. In `psm.sh` the callers parse with `IFS='|' read` (first line only), so `worktree_path` ended up empty and the tmux session launched in the **wrong checkout**. Affects the `review`, `fix`, and `feature` paths.

This hardens the protocol boundary at both ends:

- **Producer (skills/project-session-manager/lib/worktree.sh):** all three `git worktree add` calls — and the adjacent internal `git fetch` / `git branch` commands — now redirect **both** streams (`>/dev/null 2>&1`), so each creator emits exactly one protocol record on stdout. `stderr` was already suppressed, and the explicit `error|…` records are unchanged.
- **Consumer (skills/project-session-manager/psm.sh):** a shared `psm_validate_worktree_result` fail-closed validator is invoked immediately after each parse, before any side effect (context render/write, tmux, Claude launch, session registry). It rejects empty results, embedded newlines (prepended/appended noise), unknown status, unknown schema, wrong arity, extra fields (including trailing empties), and empty/whitespace-only required path/branch. Captures are made errexit-safe (`worktree_result=$(…) || worktree_rc=$?`) so intentional non-zero `exists`/`error` returns still dispatch correctly under `set -euo pipefail`. Valid `created`/`exists`/`error` behavior is preserved.

A malformed or contaminated result now fails closed with a clear error instead of launching in an incorrect cwd.

Scope is intentionally limited to #3527. The separate tmux colon-session-name bug (#3528) is **not** touched here.

## Testing

New `src/__tests__/project-session-manager-worktree-protocol.test.ts` (vitest + bash harness):
- **Producer isolation** (table-driven, all 3 creators): a PATH-first `git` shim emits a stdout sentinel for `worktree add` then delegates to real git; asserts the captured protocol line is a single clean record with a non-empty path/branch and no sentinel. Verified **red before** the fix (12 failing) and green after.
- **Validator table**: prepended/appended noise, empty/unknown status, empty & whitespace-only path/branch, wrong arity, trailing-empty extra fields, unknown schema, and valid `created`/`exists`/`error` per schema.
- **cmd_feature errexit cases**: valid `exists`/`error`/malformed under `set -e` with side-effect markers proving nothing launches on malformed input.
- **All-three structural/order proof** for `cmd_review`/`cmd_fix`/`cmd_feature`.

## Verification

```
npm run test:run -- src/__tests__/project-session-manager-worktree-protocol.test.ts src/__tests__/project-session-manager-review-worktree.test.ts src/__tests__/project-session-manager-session-filter.test.ts
npm run lint
npm run build
```

- Focused tests: **35 passed** (31 new + 3 review-worktree + 1 session-filter)
- lint: 0 errors; build: success

Fixes #3527

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
