### PR TITLE
fix(installer): allow contained symlink config roots

### DIFF
--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -627,14 +627,34 @@ function validateRootedRegularFile(root, path, allowAbsent = true, fs = defaultF
     if (normalizedRoot === normalizedPath) throw new Error(`Not a regular file: ${normalizedPath}`);
     throw new Error(`Path escapes root: ${path}`);
   }
-  if (!fs.existsSync(normalizedPath)) {
-    if (allowAbsent) return normalizedPath;
-    throw new Error(`Missing path: ${normalizedPath}`);
+  let stat;
+  try {
+    stat = fs.lstatSync(normalizedPath);
+  } catch (error) {
+    if (error.code === "ENOENT" && allowAbsent) return normalizedPath;
+    if (error.code === "ENOENT") throw new Error(`Missing path: ${normalizedPath}`);
+    throw error;
   }
-  const stat = fs.lstatSync(normalizedPath);
   if (stat.isSymbolicLink()) throw new Error(`Refusing symlink: ${normalizedPath}`);
   if (!stat.isFile()) throw new Error(`Not a regular file: ${normalizedPath}`);
   return normalizedPath;
+}
+function captureTransactionRoot(root, fs) {
+  const alias = (0, import_node_path.resolve)(root);
+  const canonical = (0, import_node_path.resolve)(fs.realpathSync(alias));
+  const stat = fs.lstatSync(canonical);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`Invalid transaction root: ${alias}`);
+  return { alias, canonical, dev: typeof stat.dev === "number" ? stat.dev : void 0, ino: typeof stat.ino === "number" ? stat.ino : void 0 };
+}
+function verifyCapturedRoot(root, fs, verifyAlias) {
+  if (verifyAlias && (0, import_node_path.resolve)(fs.realpathSync(root.alias)) !== root.canonical) throw new Error(`Transaction root changed: ${root.alias}`);
+  if ((0, import_node_path.resolve)(fs.realpathSync(root.canonical)) !== root.canonical) throw new Error(`Transaction root changed: ${root.canonical}`);
+  const stat = fs.lstatSync(root.canonical);
+  if (stat.isSymbolicLink() || !stat.isDirectory() || root.dev !== void 0 && stat.dev !== root.dev || root.ino !== void 0 && stat.ino !== root.ino) throw new Error(`Invalid transaction root: ${root.canonical}`);
+}
+function validateTransactionTarget(root, path, allowAbsent, fs, verifyAlias) {
+  verifyCapturedRoot(root, fs, verifyAlias);
+  return validateRootedRegularFile(root.canonical, path, allowAbsent, fs);
 }
 function cleanCanonical(source) {
   const markers = parseClaudeMdMarkers(source);
@@ -690,22 +710,25 @@ function mergeForOverwrite(existing, canonical, version) {
 <!-- User customizations -->
 ${cleaned.content}`, ranges: cleaned.ranges, variants: cleaned.variants };
 }
-function exclusiveVerifiedBackup(state, fs) {
+function exclusiveVerifiedBackup(state, root, fs) {
   const directory = (0, import_node_path.dirname)(state.path);
   const stem = `${(0, import_node_path.basename)(state.path)}.backup.${(/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-")}`;
   for (let attempt = 0; attempt < 16; attempt += 1) {
     const backup = `${directory}/${stem}.${(0, import_node_crypto.randomBytes)(12).toString("hex")}`;
     try {
+      validateTransactionTarget(root, backup, true, fs, true);
       const fd = fs.openSync(backup, "wx", 384);
       try {
         fs.writeFileSync(fd, state.bytes);
       } finally {
         fs.closeSync(fd);
       }
+      validateTransactionTarget(root, backup, false, fs, true);
       if (!fs.readFileSync(backup).equals(state.bytes)) throw new Error(`Backup readback mismatch: ${backup}`);
       return backup;
     } catch (error) {
       try {
+        validateTransactionTarget(root, backup, true, fs, false);
         fs.unlinkSync(backup);
       } catch {
       }
@@ -714,18 +737,21 @@ function exclusiveVerifiedBackup(state, fs) {
   }
   throw new Error("Unable to create backup");
 }
-function atomicWrite(operation, fs) {
+function atomicWrite(operation, root, fs, verifyAlias) {
   const directory = (0, import_node_path.dirname)(operation.path);
-  fs.mkdirSync(directory, { recursive: true });
   operation.tempPath = `${directory}/.${(0, import_node_path.basename)(operation.path)}.omc-tmp-${(0, import_node_crypto.randomBytes)(12).toString("hex")}`;
+  validateTransactionTarget(root, operation.tempPath, true, fs, verifyAlias);
   fs.writeFileSync(operation.tempPath, operation.bytes, { flag: "wx", mode: 384 });
+  validateTransactionTarget(root, operation.tempPath, false, fs, verifyAlias);
+  validateTransactionTarget(root, operation.path, true, fs, verifyAlias);
   fs.renameSync(operation.tempPath, operation.path);
   operation.tempPath = void 0;
 }
-function cleanupTemps(operations, result, fs) {
+function cleanupTemps(operations, result, root, fs) {
   for (const operation of operations) if (operation.tempPath) {
     const tempPath = operation.tempPath;
     try {
+      validateTransactionTarget(root, tempPath, true, fs, false);
       fs.rmSync(tempPath, { force: true });
       result.tempCleanup.push({ path: tempPath, ok: true });
     } catch (error) {
@@ -735,21 +761,21 @@ function cleanupTemps(operations, result, fs) {
 }
 function executeClaudeMdTransaction(request) {
   const fs = request.fs ?? defaultFs;
-  let root;
+  let capturedRoot;
   let sourcePath;
   try {
-    root = (0, import_node_path.resolve)(request.root);
-    const rootStat = fs.lstatSync(root);
-    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) throw new Error(`Invalid transaction root: ${root}`);
-    sourcePath = validateRootedRegularFile(request.sourceRoot ?? root, request.source, !request.sourceBytes, fs);
+    capturedRoot = captureTransactionRoot(request.root, fs);
+    sourcePath = validateRootedRegularFile(request.sourceRoot ?? request.root, request.source, !request.sourceBytes, fs);
   } catch (error) {
     return failure(request, 3, message(error), "validation");
   }
+  const root = capturedRoot.canonical;
   const main2 = (0, import_node_path.resolve)(root, "CLAUDE.md");
   const companion = (0, import_node_path.resolve)(root, "CLAUDE-omc.md");
   try {
-    validateRootedRegularFile(root, main2, true, fs);
-    if (request.mode !== "local") validateRootedRegularFile(root, companion, true, fs);
+    verifyCapturedRoot(capturedRoot, fs, true);
+    validateTransactionTarget(capturedRoot, main2, true, fs, true);
+    if (request.mode !== "local") validateTransactionTarget(capturedRoot, companion, true, fs, true);
     const canonical = decodeClaudeMdUtf82(request.sourceBytes ?? fs.readFileSync(sourcePath), sourcePath);
     const mainBytes = fs.existsSync(main2) ? fs.readFileSync(main2) : void 0;
     const companionBytes = fs.existsSync(companion) ? fs.readFileSync(companion) : void 0;
@@ -781,8 +807,9 @@ function executeClaudeMdTransaction(request) {
     const appliedMainCleanup = effectiveOperations.some((operation) => operation.path === main2);
     const result = { ok: false, exitCode: 0, mode: request.mode, operations: effectiveOperations.map(publicOperation), completedOperations: [], backups: [], createdPaths: [], deletedPaths: [], mutatedPaths: [], removedRanges: appliedMainCleanup ? request.mode === "global-preserve" ? preserve.ranges : overwrite.ranges : [], removedVariants: appliedMainCleanup ? request.mode === "global-preserve" ? preserve.variants : overwrite.variants : [], warnings: [], rollback: [], tempCleanup: [] };
     try {
+      verifyCapturedRoot(capturedRoot, fs, true);
       for (const state of states.values()) if (state.existedBefore) {
-        state.backupPath = exclusiveVerifiedBackup(state, fs);
+        state.backupPath = exclusiveVerifiedBackup(state, capturedRoot, fs);
         result.backups.push(state.backupPath);
       }
     } catch (error) {
@@ -793,7 +820,8 @@ function executeClaudeMdTransaction(request) {
     }
     try {
       for (const operation of effectiveOperations) {
-        if (operation.type === "write") atomicWrite(operation, fs);
+        validateTransactionTarget(capturedRoot, operation.path, true, fs, true);
+        if (operation.type === "write") atomicWrite(operation, capturedRoot, fs, true);
         else fs.unlinkSync(operation.path);
         result.completedOperations.push(publicOperation(operation));
         result.mutatedPaths.push(operation.path);
@@ -814,8 +842,11 @@ function executeClaudeMdTransaction(request) {
           if (state.existedBefore) {
             const rollbackOperation = { path: state.path, type: "write", existedBefore: true, bytes: state.bytes };
             rollbackOperations.push(rollbackOperation);
-            atomicWrite(rollbackOperation, fs);
-          } else if (fs.existsSync(state.path)) fs.unlinkSync(state.path);
+            atomicWrite(rollbackOperation, capturedRoot, fs, false);
+          } else if (fs.existsSync(state.path)) {
+            validateTransactionTarget(capturedRoot, state.path, true, fs, false);
+            fs.unlinkSync(state.path);
+          }
           result.rollback.push({ path: state.path, ok: true });
         } catch (rollbackError) {
           result.failedPhase = "rollback";
@@ -823,7 +854,7 @@ function executeClaudeMdTransaction(request) {
           result.rollback.push({ path: state.path, ok: false, error: message(rollbackError) });
         }
       }
-      cleanupTemps([...effectiveOperations, ...rollbackOperations], result, fs);
+      cleanupTemps([...effectiveOperations, ...rollbackOperations], result, capturedRoot, fs);
       result.exitCode = result.rollback.every((item) => item.ok) && result.tempCleanup.every((item) => item.ok) ? 5 : 6;
       return result;
     }

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -759,6 +759,15 @@ function cleanupTemps(operations, result, root, fs) {
     }
   }
 }
+function lstatPresent(path, fs) {
+  try {
+    fs.lstatSync(path);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") return false;
+    throw error;
+  }
+}
 function executeClaudeMdTransaction(request) {
   const fs = request.fs ?? defaultFs;
   let capturedRoot;
@@ -828,6 +837,7 @@ function executeClaudeMdTransaction(request) {
         if (!operation.existedBefore && operation.type === "write") result.createdPaths.push(operation.path);
         if (operation.type === "delete") result.deletedPaths.push(operation.path);
       }
+      verifyCapturedRoot(capturedRoot, fs, true);
       result.ok = true;
       result.exitCode = 0;
       return result;
@@ -843,7 +853,7 @@ function executeClaudeMdTransaction(request) {
             const rollbackOperation = { path: state.path, type: "write", existedBefore: true, bytes: state.bytes };
             rollbackOperations.push(rollbackOperation);
             atomicWrite(rollbackOperation, capturedRoot, fs, false);
-          } else if (fs.existsSync(state.path)) {
+          } else if (lstatPresent(state.path, fs)) {
             validateTransactionTarget(capturedRoot, state.path, true, fs, false);
             fs.unlinkSync(state.path);
           }

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -16046,14 +16046,34 @@ function validateRootedRegularFile(root2, path25, allowAbsent = true, fs22 = def
     if (normalizedRoot === normalizedPath) throw new Error(`Not a regular file: ${normalizedPath}`);
     throw new Error(`Path escapes root: ${path25}`);
   }
-  if (!fs22.existsSync(normalizedPath)) {
-    if (allowAbsent) return normalizedPath;
-    throw new Error(`Missing path: ${normalizedPath}`);
+  let stat2;
+  try {
+    stat2 = fs22.lstatSync(normalizedPath);
+  } catch (error2) {
+    if (error2.code === "ENOENT" && allowAbsent) return normalizedPath;
+    if (error2.code === "ENOENT") throw new Error(`Missing path: ${normalizedPath}`);
+    throw error2;
   }
-  const stat2 = fs22.lstatSync(normalizedPath);
   if (stat2.isSymbolicLink()) throw new Error(`Refusing symlink: ${normalizedPath}`);
   if (!stat2.isFile()) throw new Error(`Not a regular file: ${normalizedPath}`);
   return normalizedPath;
+}
+function captureTransactionRoot(root2, fs22) {
+  const alias = (0, import_node_path3.resolve)(root2);
+  const canonical = (0, import_node_path3.resolve)(fs22.realpathSync(alias));
+  const stat2 = fs22.lstatSync(canonical);
+  if (stat2.isSymbolicLink() || !stat2.isDirectory()) throw new Error(`Invalid transaction root: ${alias}`);
+  return { alias, canonical, dev: typeof stat2.dev === "number" ? stat2.dev : void 0, ino: typeof stat2.ino === "number" ? stat2.ino : void 0 };
+}
+function verifyCapturedRoot(root2, fs22, verifyAlias) {
+  if (verifyAlias && (0, import_node_path3.resolve)(fs22.realpathSync(root2.alias)) !== root2.canonical) throw new Error(`Transaction root changed: ${root2.alias}`);
+  if ((0, import_node_path3.resolve)(fs22.realpathSync(root2.canonical)) !== root2.canonical) throw new Error(`Transaction root changed: ${root2.canonical}`);
+  const stat2 = fs22.lstatSync(root2.canonical);
+  if (stat2.isSymbolicLink() || !stat2.isDirectory() || root2.dev !== void 0 && stat2.dev !== root2.dev || root2.ino !== void 0 && stat2.ino !== root2.ino) throw new Error(`Invalid transaction root: ${root2.canonical}`);
+}
+function validateTransactionTarget(root2, path25, allowAbsent, fs22, verifyAlias) {
+  verifyCapturedRoot(root2, fs22, verifyAlias);
+  return validateRootedRegularFile(root2.canonical, path25, allowAbsent, fs22);
 }
 function cleanCanonical(source) {
   const markers = parseClaudeMdMarkers(source);
@@ -16109,22 +16129,25 @@ function mergeForOverwrite(existing, canonical, version3) {
 <!-- User customizations -->
 ${cleaned.content}`, ranges: cleaned.ranges, variants: cleaned.variants };
 }
-function exclusiveVerifiedBackup(state, fs22) {
+function exclusiveVerifiedBackup(state, root2, fs22) {
   const directory = (0, import_node_path3.dirname)(state.path);
   const stem = `${(0, import_node_path3.basename)(state.path)}.backup.${(/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-")}`;
   for (let attempt = 0; attempt < 16; attempt += 1) {
     const backup = `${directory}/${stem}.${(0, import_node_crypto.randomBytes)(12).toString("hex")}`;
     try {
+      validateTransactionTarget(root2, backup, true, fs22, true);
       const fd = fs22.openSync(backup, "wx", 384);
       try {
         fs22.writeFileSync(fd, state.bytes);
       } finally {
         fs22.closeSync(fd);
       }
+      validateTransactionTarget(root2, backup, false, fs22, true);
       if (!fs22.readFileSync(backup).equals(state.bytes)) throw new Error(`Backup readback mismatch: ${backup}`);
       return backup;
     } catch (error2) {
       try {
+        validateTransactionTarget(root2, backup, true, fs22, false);
         fs22.unlinkSync(backup);
       } catch {
       }
@@ -16133,18 +16156,21 @@ function exclusiveVerifiedBackup(state, fs22) {
   }
   throw new Error("Unable to create backup");
 }
-function atomicWrite(operation, fs22) {
+function atomicWrite(operation, root2, fs22, verifyAlias) {
   const directory = (0, import_node_path3.dirname)(operation.path);
-  fs22.mkdirSync(directory, { recursive: true });
   operation.tempPath = `${directory}/.${(0, import_node_path3.basename)(operation.path)}.omc-tmp-${(0, import_node_crypto.randomBytes)(12).toString("hex")}`;
+  validateTransactionTarget(root2, operation.tempPath, true, fs22, verifyAlias);
   fs22.writeFileSync(operation.tempPath, operation.bytes, { flag: "wx", mode: 384 });
+  validateTransactionTarget(root2, operation.tempPath, false, fs22, verifyAlias);
+  validateTransactionTarget(root2, operation.path, true, fs22, verifyAlias);
   fs22.renameSync(operation.tempPath, operation.path);
   operation.tempPath = void 0;
 }
-function cleanupTemps(operations, result, fs22) {
+function cleanupTemps(operations, result, root2, fs22) {
   for (const operation of operations) if (operation.tempPath) {
     const tempPath = operation.tempPath;
     try {
+      validateTransactionTarget(root2, tempPath, true, fs22, false);
       fs22.rmSync(tempPath, { force: true });
       result.tempCleanup.push({ path: tempPath, ok: true });
     } catch (error2) {
@@ -16154,21 +16180,21 @@ function cleanupTemps(operations, result, fs22) {
 }
 function executeClaudeMdTransaction(request) {
   const fs22 = request.fs ?? defaultFs;
-  let root2;
+  let capturedRoot;
   let sourcePath;
   try {
-    root2 = (0, import_node_path3.resolve)(request.root);
-    const rootStat = fs22.lstatSync(root2);
-    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) throw new Error(`Invalid transaction root: ${root2}`);
-    sourcePath = validateRootedRegularFile(request.sourceRoot ?? root2, request.source, !request.sourceBytes, fs22);
+    capturedRoot = captureTransactionRoot(request.root, fs22);
+    sourcePath = validateRootedRegularFile(request.sourceRoot ?? request.root, request.source, !request.sourceBytes, fs22);
   } catch (error2) {
     return failure(request, 3, message(error2), "validation");
   }
+  const root2 = capturedRoot.canonical;
   const main3 = (0, import_node_path3.resolve)(root2, "CLAUDE.md");
   const companion = (0, import_node_path3.resolve)(root2, "CLAUDE-omc.md");
   try {
-    validateRootedRegularFile(root2, main3, true, fs22);
-    if (request.mode !== "local") validateRootedRegularFile(root2, companion, true, fs22);
+    verifyCapturedRoot(capturedRoot, fs22, true);
+    validateTransactionTarget(capturedRoot, main3, true, fs22, true);
+    if (request.mode !== "local") validateTransactionTarget(capturedRoot, companion, true, fs22, true);
     const canonical = decodeClaudeMdUtf82(request.sourceBytes ?? fs22.readFileSync(sourcePath), sourcePath);
     const mainBytes = fs22.existsSync(main3) ? fs22.readFileSync(main3) : void 0;
     const companionBytes = fs22.existsSync(companion) ? fs22.readFileSync(companion) : void 0;
@@ -16200,8 +16226,9 @@ function executeClaudeMdTransaction(request) {
     const appliedMainCleanup = effectiveOperations.some((operation) => operation.path === main3);
     const result = { ok: false, exitCode: 0, mode: request.mode, operations: effectiveOperations.map(publicOperation), completedOperations: [], backups: [], createdPaths: [], deletedPaths: [], mutatedPaths: [], removedRanges: appliedMainCleanup ? request.mode === "global-preserve" ? preserve.ranges : overwrite.ranges : [], removedVariants: appliedMainCleanup ? request.mode === "global-preserve" ? preserve.variants : overwrite.variants : [], warnings: [], rollback: [], tempCleanup: [] };
     try {
+      verifyCapturedRoot(capturedRoot, fs22, true);
       for (const state of states.values()) if (state.existedBefore) {
-        state.backupPath = exclusiveVerifiedBackup(state, fs22);
+        state.backupPath = exclusiveVerifiedBackup(state, capturedRoot, fs22);
         result.backups.push(state.backupPath);
       }
     } catch (error2) {
@@ -16212,7 +16239,8 @@ function executeClaudeMdTransaction(request) {
     }
     try {
       for (const operation of effectiveOperations) {
-        if (operation.type === "write") atomicWrite(operation, fs22);
+        validateTransactionTarget(capturedRoot, operation.path, true, fs22, true);
+        if (operation.type === "write") atomicWrite(operation, capturedRoot, fs22, true);
         else fs22.unlinkSync(operation.path);
         result.completedOperations.push(publicOperation(operation));
         result.mutatedPaths.push(operation.path);
@@ -16233,8 +16261,11 @@ function executeClaudeMdTransaction(request) {
           if (state.existedBefore) {
             const rollbackOperation = { path: state.path, type: "write", existedBefore: true, bytes: state.bytes };
             rollbackOperations.push(rollbackOperation);
-            atomicWrite(rollbackOperation, fs22);
-          } else if (fs22.existsSync(state.path)) fs22.unlinkSync(state.path);
+            atomicWrite(rollbackOperation, capturedRoot, fs22, false);
+          } else if (fs22.existsSync(state.path)) {
+            validateTransactionTarget(capturedRoot, state.path, true, fs22, false);
+            fs22.unlinkSync(state.path);
+          }
           result.rollback.push({ path: state.path, ok: true });
         } catch (rollbackError) {
           result.failedPhase = "rollback";
@@ -16242,7 +16273,7 @@ function executeClaudeMdTransaction(request) {
           result.rollback.push({ path: state.path, ok: false, error: message(rollbackError) });
         }
       }
-      cleanupTemps([...effectiveOperations, ...rollbackOperations], result, fs22);
+      cleanupTemps([...effectiveOperations, ...rollbackOperations], result, capturedRoot, fs22);
       result.exitCode = result.rollback.every((item) => item.ok) && result.tempCleanup.every((item) => item.ok) ? 5 : 6;
       return result;
     }

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -16178,6 +16178,15 @@ function cleanupTemps(operations, result, root2, fs22) {
     }
   }
 }
+function lstatPresent(path25, fs22) {
+  try {
+    fs22.lstatSync(path25);
+    return true;
+  } catch (error2) {
+    if (error2.code === "ENOENT") return false;
+    throw error2;
+  }
+}
 function executeClaudeMdTransaction(request) {
   const fs22 = request.fs ?? defaultFs;
   let capturedRoot;
@@ -16247,6 +16256,7 @@ function executeClaudeMdTransaction(request) {
         if (!operation.existedBefore && operation.type === "write") result.createdPaths.push(operation.path);
         if (operation.type === "delete") result.deletedPaths.push(operation.path);
       }
+      verifyCapturedRoot(capturedRoot, fs22, true);
       result.ok = true;
       result.exitCode = 0;
       return result;
@@ -16262,7 +16272,7 @@ function executeClaudeMdTransaction(request) {
             const rollbackOperation = { path: state.path, type: "write", existedBefore: true, bytes: state.bytes };
             rollbackOperations.push(rollbackOperation);
             atomicWrite(rollbackOperation, capturedRoot, fs22, false);
-          } else if (fs22.existsSync(state.path)) {
+          } else if (lstatPresent(state.path, fs22)) {
             validateTransactionTarget(capturedRoot, state.path, true, fs22, false);
             fs22.unlinkSync(state.path);
           }
@@ -18079,7 +18089,6 @@ function install(options = {}) {
       }
     }
     if (!projectScoped) {
-      const claudeMdPath = (0, import_path58.join)(CLAUDE_CONFIG_DIR, "CLAUDE.md");
       const transaction = executeClaudeMdTransaction({
         mode: "global-overwrite",
         root: CLAUDE_CONFIG_DIR,
@@ -18089,7 +18098,7 @@ function install(options = {}) {
       });
       if (!transaction.ok) throw new Error(transaction.error ?? "CLAUDE.md transaction failed");
       for (const backupPath of transaction.backups) log3(`Backed up existing CLAUDE.md to ${backupPath}`);
-      log3(transaction.operations.some((operation) => operation.existedBefore && operation.path === claudeMdPath) ? "Updated CLAUDE.md (merged with existing content)" : "Created CLAUDE.md");
+      log3(transaction.operations.some((operation) => operation.type === "write" && operation.existedBefore && (0, import_path58.basename)(operation.path) === "CLAUDE.md") ? "Updated CLAUDE.md (merged with existing content)" : "Created CLAUDE.md");
     }
     let hudScriptPath = null;
     const hudDisabledByOption = options.skipHud === true;

--- a/dist/installer/claude-md-transaction.d.ts
+++ b/dist/installer/claude-md-transaction.d.ts
@@ -44,6 +44,7 @@ export interface ClaudeMdTransactionResult {
 export interface ClaudeMdTransactionFs {
     existsSync: typeof nodeFs.existsSync;
     lstatSync: typeof nodeFs.lstatSync;
+    realpathSync: typeof nodeFs.realpathSync;
     mkdirSync: typeof nodeFs.mkdirSync;
     openSync: typeof nodeFs.openSync;
     closeSync: typeof nodeFs.closeSync;

--- a/dist/installer/claude-md-transaction.js
+++ b/dist/installer/claude-md-transaction.js
@@ -182,6 +182,17 @@ function cleanupTemps(operations, result, root, fs) {
             }
         }
 }
+function lstatPresent(path, fs) {
+    try {
+        fs.lstatSync(path);
+        return true;
+    }
+    catch (error) {
+        if (error.code === 'ENOENT')
+            return false;
+        throw error;
+    }
+}
 export function executeClaudeMdTransaction(request) {
     const fs = request.fs ?? defaultFs;
     let capturedRoot;
@@ -266,6 +277,7 @@ export function executeClaudeMdTransaction(request) {
                 if (operation.type === 'delete')
                     result.deletedPaths.push(operation.path);
             }
+            verifyCapturedRoot(capturedRoot, fs, true);
             result.ok = true;
             result.exitCode = 0;
             return result;
@@ -283,7 +295,7 @@ export function executeClaudeMdTransaction(request) {
                         rollbackOperations.push(rollbackOperation);
                         atomicWrite(rollbackOperation, capturedRoot, fs, false);
                     }
-                    else if (fs.existsSync(state.path)) {
+                    else if (lstatPresent(state.path, fs)) {
                         validateTransactionTarget(capturedRoot, state.path, true, fs, false);
                         fs.unlinkSync(state.path);
                     }

--- a/dist/installer/claude-md-transaction.js
+++ b/dist/installer/claude-md-transaction.js
@@ -36,17 +36,43 @@ export function validateRootedRegularFile(root, path, allowAbsent = true, fs = d
             throw new Error(`Not a regular file: ${normalizedPath}`);
         throw new Error(`Path escapes root: ${path}`);
     }
-    if (!fs.existsSync(normalizedPath)) {
-        if (allowAbsent)
-            return normalizedPath;
-        throw new Error(`Missing path: ${normalizedPath}`);
+    let stat;
+    try {
+        stat = fs.lstatSync(normalizedPath);
     }
-    const stat = fs.lstatSync(normalizedPath);
+    catch (error) {
+        if (error.code === 'ENOENT' && allowAbsent)
+            return normalizedPath;
+        if (error.code === 'ENOENT')
+            throw new Error(`Missing path: ${normalizedPath}`);
+        throw error;
+    }
     if (stat.isSymbolicLink())
         throw new Error(`Refusing symlink: ${normalizedPath}`);
     if (!stat.isFile())
         throw new Error(`Not a regular file: ${normalizedPath}`);
     return normalizedPath;
+}
+function captureTransactionRoot(root, fs) {
+    const alias = resolve(root);
+    const canonical = resolve(fs.realpathSync(alias));
+    const stat = fs.lstatSync(canonical);
+    if (stat.isSymbolicLink() || !stat.isDirectory())
+        throw new Error(`Invalid transaction root: ${alias}`);
+    return { alias, canonical, dev: typeof stat.dev === 'number' ? stat.dev : undefined, ino: typeof stat.ino === 'number' ? stat.ino : undefined };
+}
+function verifyCapturedRoot(root, fs, verifyAlias) {
+    if (verifyAlias && resolve(fs.realpathSync(root.alias)) !== root.canonical)
+        throw new Error(`Transaction root changed: ${root.alias}`);
+    if (resolve(fs.realpathSync(root.canonical)) !== root.canonical)
+        throw new Error(`Transaction root changed: ${root.canonical}`);
+    const stat = fs.lstatSync(root.canonical);
+    if (stat.isSymbolicLink() || !stat.isDirectory() || (root.dev !== undefined && stat.dev !== root.dev) || (root.ino !== undefined && stat.ino !== root.ino))
+        throw new Error(`Invalid transaction root: ${root.canonical}`);
+}
+function validateTransactionTarget(root, path, allowAbsent, fs, verifyAlias) {
+    verifyCapturedRoot(root, fs, verifyAlias);
+    return validateRootedRegularFile(root.canonical, path, allowAbsent, fs);
 }
 function cleanCanonical(source) {
     const markers = parseClaudeMdMarkers(source);
@@ -101,12 +127,13 @@ function mergeForOverwrite(existing, canonical, version) {
     const cleaned = cleanedExisting(existing);
     return { content: cleaned.content.length === 0 ? managed : `${managed}\n<!-- User customizations -->\n${cleaned.content}`, ranges: cleaned.ranges, variants: cleaned.variants };
 }
-function exclusiveVerifiedBackup(state, fs) {
+function exclusiveVerifiedBackup(state, root, fs) {
     const directory = dirname(state.path);
     const stem = `${basename(state.path)}.backup.${new Date().toISOString().replace(/[:.]/g, '-')}`;
     for (let attempt = 0; attempt < 16; attempt += 1) {
         const backup = `${directory}/${stem}.${randomBytes(12).toString('hex')}`;
         try {
+            validateTransactionTarget(root, backup, true, fs, true);
             const fd = fs.openSync(backup, 'wx', 0o600);
             try {
                 fs.writeFileSync(fd, state.bytes);
@@ -114,12 +141,14 @@ function exclusiveVerifiedBackup(state, fs) {
             finally {
                 fs.closeSync(fd);
             }
+            validateTransactionTarget(root, backup, false, fs, true);
             if (!fs.readFileSync(backup).equals(state.bytes))
                 throw new Error(`Backup readback mismatch: ${backup}`);
             return backup;
         }
         catch (error) {
             try {
+                validateTransactionTarget(root, backup, true, fs, false);
                 fs.unlinkSync(backup);
             }
             catch { /* partial backup is best effort */ }
@@ -129,19 +158,22 @@ function exclusiveVerifiedBackup(state, fs) {
     }
     throw new Error('Unable to create backup');
 }
-function atomicWrite(operation, fs) {
+function atomicWrite(operation, root, fs, verifyAlias) {
     const directory = dirname(operation.path);
-    fs.mkdirSync(directory, { recursive: true });
     operation.tempPath = `${directory}/.${basename(operation.path)}.omc-tmp-${randomBytes(12).toString('hex')}`;
+    validateTransactionTarget(root, operation.tempPath, true, fs, verifyAlias);
     fs.writeFileSync(operation.tempPath, operation.bytes, { flag: 'wx', mode: 0o600 });
+    validateTransactionTarget(root, operation.tempPath, false, fs, verifyAlias);
+    validateTransactionTarget(root, operation.path, true, fs, verifyAlias);
     fs.renameSync(operation.tempPath, operation.path);
     operation.tempPath = undefined;
 }
-function cleanupTemps(operations, result, fs) {
+function cleanupTemps(operations, result, root, fs) {
     for (const operation of operations)
         if (operation.tempPath) {
             const tempPath = operation.tempPath;
             try {
+                validateTransactionTarget(root, tempPath, true, fs, false);
                 fs.rmSync(tempPath, { force: true });
                 result.tempCleanup.push({ path: tempPath, ok: true });
             }
@@ -152,24 +184,23 @@ function cleanupTemps(operations, result, fs) {
 }
 export function executeClaudeMdTransaction(request) {
     const fs = request.fs ?? defaultFs;
-    let root;
+    let capturedRoot;
     let sourcePath;
     try {
-        root = resolve(request.root);
-        const rootStat = fs.lstatSync(root);
-        if (rootStat.isSymbolicLink() || !rootStat.isDirectory())
-            throw new Error(`Invalid transaction root: ${root}`);
-        sourcePath = validateRootedRegularFile(request.sourceRoot ?? root, request.source, !request.sourceBytes, fs);
+        capturedRoot = captureTransactionRoot(request.root, fs);
+        sourcePath = validateRootedRegularFile(request.sourceRoot ?? request.root, request.source, !request.sourceBytes, fs);
     }
     catch (error) {
         return failure(request, 3, message(error), 'validation');
     }
+    const root = capturedRoot.canonical;
     const main = resolve(root, 'CLAUDE.md');
     const companion = resolve(root, 'CLAUDE-omc.md');
     try {
-        validateRootedRegularFile(root, main, true, fs);
+        verifyCapturedRoot(capturedRoot, fs, true);
+        validateTransactionTarget(capturedRoot, main, true, fs, true);
         if (request.mode !== 'local')
-            validateRootedRegularFile(root, companion, true, fs);
+            validateTransactionTarget(capturedRoot, companion, true, fs, true);
         const canonical = decodeClaudeMdUtf8(request.sourceBytes ?? fs.readFileSync(sourcePath), sourcePath);
         const mainBytes = fs.existsSync(main) ? fs.readFileSync(main) : undefined;
         const companionBytes = fs.existsSync(companion) ? fs.readFileSync(companion) : undefined;
@@ -208,9 +239,10 @@ export function executeClaudeMdTransaction(request) {
         const appliedMainCleanup = effectiveOperations.some(operation => operation.path === main);
         const result = { ok: false, exitCode: 0, mode: request.mode, operations: effectiveOperations.map(publicOperation), completedOperations: [], backups: [], createdPaths: [], deletedPaths: [], mutatedPaths: [], removedRanges: appliedMainCleanup ? request.mode === 'global-preserve' ? preserve.ranges : overwrite.ranges : [], removedVariants: appliedMainCleanup ? request.mode === 'global-preserve' ? preserve.variants : overwrite.variants : [], warnings: [], rollback: [], tempCleanup: [] };
         try {
+            verifyCapturedRoot(capturedRoot, fs, true);
             for (const state of states.values())
                 if (state.existedBefore) {
-                    state.backupPath = exclusiveVerifiedBackup(state, fs);
+                    state.backupPath = exclusiveVerifiedBackup(state, capturedRoot, fs);
                     result.backups.push(state.backupPath);
                 }
         }
@@ -222,8 +254,9 @@ export function executeClaudeMdTransaction(request) {
         }
         try {
             for (const operation of effectiveOperations) {
+                validateTransactionTarget(capturedRoot, operation.path, true, fs, true);
                 if (operation.type === 'write')
-                    atomicWrite(operation, fs);
+                    atomicWrite(operation, capturedRoot, fs, true);
                 else
                     fs.unlinkSync(operation.path);
                 result.completedOperations.push(publicOperation(operation));
@@ -248,10 +281,12 @@ export function executeClaudeMdTransaction(request) {
                     if (state.existedBefore) {
                         const rollbackOperation = { path: state.path, type: 'write', existedBefore: true, bytes: state.bytes };
                         rollbackOperations.push(rollbackOperation);
-                        atomicWrite(rollbackOperation, fs);
+                        atomicWrite(rollbackOperation, capturedRoot, fs, false);
                     }
-                    else if (fs.existsSync(state.path))
+                    else if (fs.existsSync(state.path)) {
+                        validateTransactionTarget(capturedRoot, state.path, true, fs, false);
                         fs.unlinkSync(state.path);
+                    }
                     result.rollback.push({ path: state.path, ok: true });
                 }
                 catch (rollbackError) {
@@ -260,7 +295,7 @@ export function executeClaudeMdTransaction(request) {
                     result.rollback.push({ path: state.path, ok: false, error: message(rollbackError) });
                 }
             }
-            cleanupTemps([...effectiveOperations, ...rollbackOperations], result, fs);
+            cleanupTemps([...effectiveOperations, ...rollbackOperations], result, capturedRoot, fs);
             result.exitCode = result.rollback.every(item => item.ok) && result.tempCleanup.every(item => item.ok) ? 5 : 6;
             return result;
         }

--- a/dist/installer/index.js
+++ b/dist/installer/index.js
@@ -2061,7 +2061,6 @@ export function install(options = {}) {
         // Keep the public installer on the same raw-byte transaction path as setup.
         // The public string merger remains exported for callers that use it directly.
         if (!projectScoped) {
-            const claudeMdPath = join(CLAUDE_CONFIG_DIR, 'CLAUDE.md');
             const transaction = executeClaudeMdTransaction({
                 mode: 'global-overwrite',
                 root: CLAUDE_CONFIG_DIR,
@@ -2073,7 +2072,7 @@ export function install(options = {}) {
                 throw new Error(transaction.error ?? 'CLAUDE.md transaction failed');
             for (const backupPath of transaction.backups)
                 log(`Backed up existing CLAUDE.md to ${backupPath}`);
-            log(transaction.operations.some(operation => operation.existedBefore && operation.path === claudeMdPath)
+            log(transaction.operations.some(operation => operation.type === 'write' && operation.existedBefore && basename(operation.path) === 'CLAUDE.md')
                 ? 'Updated CLAUDE.md (merged with existing content)'
                 : 'Created CLAUDE.md');
         }

--- a/src/__tests__/installer-omc-reference.test.ts
+++ b/src/__tests__/installer-omc-reference.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -265,5 +265,30 @@ describe('installer bundled + standalone skill sync', () => {
     expect(result.installedSkills).toContain('ralph/SKILL.md');
     expect(readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf-8')).not.toContain('stale content');
     expect(readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf-8')).toContain('name: ralph');
+  });
+
+  it('reports an existing CLAUDE.md as updated through a symlinked config root', async () => {
+    const canonicalConfigDir = join(tempRoot, 'canonical-claude-config');
+    rmSync(claudeConfigDir, { recursive: true, force: true });
+    mkdirSync(canonicalConfigDir, { recursive: true });
+    writeFileSync(join(canonicalConfigDir, 'CLAUDE.md'), 'existing user content\n');
+    symlinkSync(canonicalConfigDir, claudeConfigDir);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const installer = await loadInstallerWithEnv(claudeConfigDir, homeDir);
+      const result = installer.install({
+        skipClaudeCheck: true,
+        skipHud: true,
+        verbose: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(logSpy).toHaveBeenCalledWith('Updated CLAUDE.md (merged with existing content)');
+      expect(logSpy).not.toHaveBeenCalledWith('Created CLAUDE.md');
+      expect(readFileSync(join(canonicalConfigDir, 'CLAUDE.md'), 'utf-8')).toContain('<!-- OMC:START -->');
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/src/installer/__tests__/claude-md-transaction.test.ts
+++ b/src/installer/__tests__/claude-md-transaction.test.ts
@@ -122,6 +122,69 @@ describe('CLAUDE.md transactions', () => {
     expect(readFileSync(outside, 'utf8')).toBe('unchanged');
   });
 
+  it('refuses a dangling target symlink before mutation', () => {
+    const { root, source } = fixture();
+    const target = join(root, 'CLAUDE.md');
+    symlinkSync(join(root, 'missing-target'), target);
+    const result = executeClaudeMdTransaction({ mode: 'local', root, source, sourceRoot: join(root, 'plugin') });
+    expect(result).toMatchObject({ ok: false, exitCode: 3, failedPhase: 'validation' });
+    expect(nodeFs.lstatSync(target).isSymbolicLink()).toBe(true);
+  });
+
+  it('uses a nested symlinked root only through its captured canonical directory', () => {
+    const { root, source } = fixture();
+    const nested = `${root}-nested`;
+    const alias = `${root}-alias`;
+    roots.push(nested, alias);
+    symlinkSync(root, nested);
+    symlinkSync(nested, alias);
+    const result = executeClaudeMdTransaction({ mode: 'local', root: alias, source, sourceRoot: join(root, 'plugin') });
+    expect(result).toMatchObject({ ok: true, mutatedPaths: [join(root, 'CLAUDE.md')] });
+    expect(readFileSync(join(root, 'CLAUDE.md'), 'utf8')).toContain('# canonical');
+  });
+
+  it('rejects dangling and file transaction roots before mutation', () => {
+    const { root, source } = fixture();
+    const dangling = join(root, 'dangling-root');
+    const file = join(root, 'file-root');
+    symlinkSync(join(root, 'missing-root'), dangling);
+    writeFileSync(file, 'not a directory');
+    for (const invalidRoot of [dangling, file]) {
+      const result = executeClaudeMdTransaction({ mode: 'local', root: invalidRoot, source, sourceRoot: join(root, 'plugin') });
+      expect(result).toMatchObject({ ok: false, exitCode: 3, failedPhase: 'validation' });
+    }
+    expect(nodeFs.existsSync(join(root, 'CLAUDE.md'))).toBe(false);
+  });
+
+  it('refuses a companion target symlink before mutation', () => {
+    const { root, source } = fixture();
+    const outside = join(root, 'outside-companion');
+    writeFileSync(outside, 'unchanged');
+    symlinkSync(outside, join(root, 'CLAUDE-omc.md'));
+    const result = executeClaudeMdTransaction({ mode: 'global-preserve', root, source, sourceRoot: join(root, 'plugin') });
+    expect(result).toMatchObject({ ok: false, exitCode: 3, failedPhase: 'validation' });
+    expect(readFileSync(outside, 'utf8')).toBe('unchanged');
+  });
+
+  it('fails a changed root alias between forward operations and rolls back through the canonical root', () => {
+    const { root, source } = fixture();
+    const alternate = mkdtempSync(join(tmpdir(), 'omc-claude-md-transaction-alternate-'));
+    const alias = `${root}-alias`;
+    roots.push(alternate, alias);
+    symlinkSync(root, alias);
+    writeFileSync(join(root, 'CLAUDE.md'), 'user bytes');
+    let renames = 0;
+    const fs = { ...nodeFs, renameSync(oldPath: nodeFs.PathLike, newPath: nodeFs.PathLike) {
+      nodeFs.renameSync(oldPath, newPath);
+      if (++renames === 1) { nodeFs.unlinkSync(alias); symlinkSync(alternate, alias); }
+    } } as ClaudeMdTransactionFs;
+    const result = executeClaudeMdTransaction({ mode: 'global-preserve', root: alias, source, sourceRoot: join(root, 'plugin'), fs });
+    expect(result).toMatchObject({ ok: false, exitCode: 5, failedPhase: 'mutation', failedPath: join(root, 'CLAUDE.md') });
+    expect(readFileSync(join(root, 'CLAUDE.md'), 'utf8')).toBe('user bytes');
+    expect(nodeFs.existsSync(join(root, 'CLAUDE-omc.md'))).toBe(false);
+    expect(nodeFs.existsSync(join(alternate, 'CLAUDE.md'))).toBe(false);
+  });
+
   it('rejects invalid UTF-8 without changing targets', () => {
     const { root, source } = fixture();
     writeFileSync(join(root, 'CLAUDE.md'), Buffer.from([0xff]));

--- a/src/installer/__tests__/claude-md-transaction.test.ts
+++ b/src/installer/__tests__/claude-md-transaction.test.ts
@@ -185,6 +185,47 @@ describe('CLAUDE.md transactions', () => {
     expect(nodeFs.existsSync(join(alternate, 'CLAUDE.md'))).toBe(false);
   });
 
+  it('revalidates a changed root alias after the final local write and rolls back canonically', () => {
+    const { root, source } = fixture();
+    const alternate = mkdtempSync(join(tmpdir(), 'omc-claude-md-transaction-final-local-alternate-'));
+    const alias = `${root}-alias`;
+    roots.push(alternate, alias);
+    symlinkSync(root, alias);
+    const main = join(root, 'CLAUDE.md');
+    let renames = 0;
+    const fs = { ...nodeFs, renameSync(oldPath: nodeFs.PathLike, newPath: nodeFs.PathLike) {
+      nodeFs.renameSync(oldPath, newPath);
+      if (++renames === 1) { nodeFs.unlinkSync(alias); symlinkSync(alternate, alias); }
+    } } as ClaudeMdTransactionFs;
+    const result = executeClaudeMdTransaction({ mode: 'local', root: alias, source, sourceRoot: join(root, 'plugin'), fs });
+    expect(result).toMatchObject({ ok: false, exitCode: 5, failedPhase: 'mutation' });
+    expect(result.completedOperations).toEqual([{ path: main, type: 'write', existedBefore: false }]);
+    expect(nodeFs.existsSync(main)).toBe(false);
+    expect(nodeFs.existsSync(join(alternate, 'CLAUDE.md'))).toBe(false);
+  });
+
+  it('revalidates a changed root alias after the final delete and rolls back canonically', () => {
+    const { root, source } = fixture();
+    const alternate = mkdtempSync(join(tmpdir(), 'omc-claude-md-transaction-final-delete-alternate-'));
+    const alias = `${root}-alias`;
+    roots.push(alternate, alias);
+    symlinkSync(root, alias);
+    const main = join(root, 'CLAUDE.md');
+    const companion = join(root, 'CLAUDE-omc.md');
+    writeFileSync(main, 'user bytes');
+    writeFileSync(companion, 'orphan\n');
+    const fs = { ...nodeFs, unlinkSync(path: nodeFs.PathLike) {
+      nodeFs.unlinkSync(path);
+      if (path === companion) { nodeFs.unlinkSync(alias); symlinkSync(alternate, alias); }
+    } } as ClaudeMdTransactionFs;
+    const result = executeClaudeMdTransaction({ mode: 'global-overwrite', root: alias, source, sourceRoot: join(root, 'plugin'), fs });
+    expect(result).toMatchObject({ ok: false, exitCode: 5, failedPhase: 'mutation' });
+    expect(readFileSync(main, 'utf8')).toBe('user bytes');
+    expect(readFileSync(companion, 'utf8')).toBe('orphan\n');
+    expect(nodeFs.existsSync(join(alternate, 'CLAUDE.md'))).toBe(false);
+    expect(nodeFs.existsSync(join(alternate, 'CLAUDE-omc.md'))).toBe(false);
+  });
+
   it('rejects invalid UTF-8 without changing targets', () => {
     const { root, source } = fixture();
     writeFileSync(join(root, 'CLAUDE.md'), Buffer.from([0xff]));
@@ -241,6 +282,34 @@ describe('CLAUDE.md transactions', () => {
     expect(readFileSync(join(root, 'CLAUDE.md'), 'utf8')).toBe('user trailing bytes');
     expect(nodeFs.existsSync(join(root, 'CLAUDE-omc.md'))).toBe(false);
     expect(result.tempCleanup.every(item => item.ok)).toBe(true);
+  });
+
+  it('fails closed when a transaction-created path is swapped for a dangling symlink during rollback', () => {
+    const { root, source } = fixture();
+    const companion = join(root, 'CLAUDE-omc.md');
+    writeFileSync(join(root, 'CLAUDE.md'), 'user trailing bytes');
+    let renames = 0;
+    let dangling = false;
+    const fs = { ...nodeFs,
+      existsSync(path: nodeFs.PathLike) {
+        if (dangling && path === companion) return false;
+        return nodeFs.existsSync(path);
+      },
+      renameSync(oldPath: nodeFs.PathLike, newPath: nodeFs.PathLike) {
+        if (++renames === 2) throw new Error('second operation failed');
+        const result = nodeFs.renameSync(oldPath, newPath);
+        if (renames === 1) {
+          nodeFs.unlinkSync(companion);
+          nodeFs.symlinkSync(join(root, 'missing-companion'), companion);
+          dangling = true;
+        }
+        return result;
+      },
+    } as ClaudeMdTransactionFs;
+    const result = executeClaudeMdTransaction({ mode: 'global-preserve', root, source, sourceRoot: join(root, 'plugin'), fs });
+    expect(result).toMatchObject({ ok: false, exitCode: 6, failedPhase: 'rollback', failedPath: companion });
+    expect(result.rollback).toEqual([{ path: companion, ok: false, error: `Refusing symlink: ${companion}` }]);
+    expect(nodeFs.lstatSync(companion).isSymbolicLink()).toBe(true);
   });
 
   it('reports rollback failure with its phase and path', () => {

--- a/src/installer/claude-md-transaction.ts
+++ b/src/installer/claude-md-transaction.ts
@@ -182,6 +182,14 @@ function cleanupTemps(operations: readonly PlannedOperation[], result: ClaudeMdT
     try { validateTransactionTarget(root, tempPath, true, fs, false); fs.rmSync(tempPath, { force: true }); result.tempCleanup.push({ path: tempPath, ok: true }); } catch (error) { result.tempCleanup.push({ path: tempPath, ok: false, error: message(error) }); }
   }
 }
+function lstatPresent(path: string, fs: ClaudeMdTransactionFs): boolean {
+  try { fs.lstatSync(path); return true; }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
 
 export function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest): ClaudeMdTransactionResult {
   const fs = request.fs ?? defaultFs;
@@ -234,6 +242,7 @@ export function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest):
         if (!operation.existedBefore && operation.type === 'write') result.createdPaths.push(operation.path);
         if (operation.type === 'delete') result.deletedPaths.push(operation.path);
       }
+      verifyCapturedRoot(capturedRoot, fs, true);
       result.ok = true; result.exitCode = 0; return result;
     } catch (error) {
       result.error = message(error); result.failedPhase = 'mutation'; result.failedPath = effectiveOperations.find(operation => !result.completedOperations.some(done => done.path === operation.path))?.path;
@@ -245,7 +254,10 @@ export function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest):
             const rollbackOperation: PlannedOperation = { path: state.path, type: 'write', existedBefore: true, bytes: state.bytes };
             rollbackOperations.push(rollbackOperation);
             atomicWrite(rollbackOperation, capturedRoot, fs, false);
-          } else if (fs.existsSync(state.path)) { validateTransactionTarget(capturedRoot, state.path, true, fs, false); fs.unlinkSync(state.path); }
+          } else if (lstatPresent(state.path, fs)) {
+            validateTransactionTarget(capturedRoot, state.path, true, fs, false);
+            fs.unlinkSync(state.path);
+          }
           result.rollback.push({ path: state.path, ok: true });
         }
         catch (rollbackError) { result.failedPhase = 'rollback'; result.failedPath = state.path; result.rollback.push({ path: state.path, ok: false, error: message(rollbackError) }); }

--- a/src/installer/claude-md-transaction.ts
+++ b/src/installer/claude-md-transaction.ts
@@ -24,7 +24,7 @@ export interface ClaudeMdTransactionResult {
 }
 
 export interface ClaudeMdTransactionFs {
-  existsSync: typeof nodeFs.existsSync; lstatSync: typeof nodeFs.lstatSync; mkdirSync: typeof nodeFs.mkdirSync;
+  existsSync: typeof nodeFs.existsSync; lstatSync: typeof nodeFs.lstatSync; realpathSync: typeof nodeFs.realpathSync; mkdirSync: typeof nodeFs.mkdirSync;
   openSync: typeof nodeFs.openSync; closeSync: typeof nodeFs.closeSync; readFileSync: typeof nodeFs.readFileSync;
   renameSync: typeof nodeFs.renameSync; rmSync: typeof nodeFs.rmSync; unlinkSync: typeof nodeFs.unlinkSync;
   writeFileSync: typeof nodeFs.writeFileSync;
@@ -71,11 +71,35 @@ export function validateRootedRegularFile(root: string, path: string, allowAbsen
     if (normalizedRoot === normalizedPath) throw new Error(`Not a regular file: ${normalizedPath}`);
     throw new Error(`Path escapes root: ${path}`);
   }
-  if (!fs.existsSync(normalizedPath)) { if (allowAbsent) return normalizedPath; throw new Error(`Missing path: ${normalizedPath}`); }
-  const stat = fs.lstatSync(normalizedPath);
+  let stat: nodeFs.Stats;
+  try { stat = fs.lstatSync(normalizedPath); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT' && allowAbsent) return normalizedPath;
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') throw new Error(`Missing path: ${normalizedPath}`);
+    throw error;
+  }
   if (stat.isSymbolicLink()) throw new Error(`Refusing symlink: ${normalizedPath}`);
   if (!stat.isFile()) throw new Error(`Not a regular file: ${normalizedPath}`);
   return normalizedPath;
+}
+
+interface CapturedRoot { alias: string; canonical: string; dev?: number; ino?: number; }
+function captureTransactionRoot(root: string, fs: ClaudeMdTransactionFs): CapturedRoot {
+  const alias = resolve(root);
+  const canonical = resolve(fs.realpathSync(alias));
+  const stat = fs.lstatSync(canonical);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`Invalid transaction root: ${alias}`);
+  return { alias, canonical, dev: typeof stat.dev === 'number' ? stat.dev : undefined, ino: typeof stat.ino === 'number' ? stat.ino : undefined };
+}
+function verifyCapturedRoot(root: CapturedRoot, fs: ClaudeMdTransactionFs, verifyAlias: boolean): void {
+  if (verifyAlias && resolve(fs.realpathSync(root.alias)) !== root.canonical) throw new Error(`Transaction root changed: ${root.alias}`);
+  if (resolve(fs.realpathSync(root.canonical)) !== root.canonical) throw new Error(`Transaction root changed: ${root.canonical}`);
+  const stat = fs.lstatSync(root.canonical);
+  if (stat.isSymbolicLink() || !stat.isDirectory() || (root.dev !== undefined && stat.dev !== root.dev) || (root.ino !== undefined && stat.ino !== root.ino)) throw new Error(`Invalid transaction root: ${root.canonical}`);
+}
+function validateTransactionTarget(root: CapturedRoot, path: string, allowAbsent: boolean, fs: ClaudeMdTransactionFs, verifyAlias: boolean): string {
+  verifyCapturedRoot(root, fs, verifyAlias);
+  return validateRootedRegularFile(root.canonical, path, allowAbsent, fs);
 }
 
 function cleanCanonical(source: string): string {
@@ -128,42 +152,49 @@ function mergeForOverwrite(existing: string | null, canonical: string, version?:
   return { content: cleaned.content.length === 0 ? managed : `${managed}\n<!-- User customizations -->\n${cleaned.content}`, ranges: cleaned.ranges, variants: cleaned.variants };
 }
 
-function exclusiveVerifiedBackup(state: PreState, fs: ClaudeMdTransactionFs): string {
+function exclusiveVerifiedBackup(state: PreState, root: CapturedRoot, fs: ClaudeMdTransactionFs): string {
   const directory = dirname(state.path); const stem = `${basename(state.path)}.backup.${new Date().toISOString().replace(/[:.]/g, '-')}`;
   for (let attempt = 0; attempt < 16; attempt += 1) {
     const backup = `${directory}/${stem}.${randomBytes(12).toString('hex')}`;
     try {
+      validateTransactionTarget(root, backup, true, fs, true);
       const fd = fs.openSync(backup, 'wx', 0o600);
       try { fs.writeFileSync(fd, state.bytes!); } finally { fs.closeSync(fd); }
+      validateTransactionTarget(root, backup, false, fs, true);
       if (!fs.readFileSync(backup).equals(state.bytes!)) throw new Error(`Backup readback mismatch: ${backup}`);
       return backup;
-    } catch (error) { try { fs.unlinkSync(backup); } catch { /* partial backup is best effort */ } if (attempt === 15) throw error; }
+    } catch (error) { try { validateTransactionTarget(root, backup, true, fs, false); fs.unlinkSync(backup); } catch { /* partial backup is best effort */ } if (attempt === 15) throw error; }
   }
   throw new Error('Unable to create backup');
 }
-function atomicWrite(operation: PlannedOperation, fs: ClaudeMdTransactionFs): void {
-  const directory = dirname(operation.path); fs.mkdirSync(directory, { recursive: true });
+function atomicWrite(operation: PlannedOperation, root: CapturedRoot, fs: ClaudeMdTransactionFs, verifyAlias: boolean): void {
+  const directory = dirname(operation.path);
   operation.tempPath = `${directory}/.${basename(operation.path)}.omc-tmp-${randomBytes(12).toString('hex')}`;
-  fs.writeFileSync(operation.tempPath, operation.bytes!, { flag: 'wx', mode: 0o600 }); fs.renameSync(operation.tempPath, operation.path); operation.tempPath = undefined;
+  validateTransactionTarget(root, operation.tempPath, true, fs, verifyAlias);
+  fs.writeFileSync(operation.tempPath, operation.bytes!, { flag: 'wx', mode: 0o600 });
+  validateTransactionTarget(root, operation.tempPath, false, fs, verifyAlias);
+  validateTransactionTarget(root, operation.path, true, fs, verifyAlias);
+  fs.renameSync(operation.tempPath, operation.path); operation.tempPath = undefined;
 }
-function cleanupTemps(operations: readonly PlannedOperation[], result: ClaudeMdTransactionResult, fs: ClaudeMdTransactionFs): void {
+function cleanupTemps(operations: readonly PlannedOperation[], result: ClaudeMdTransactionResult, root: CapturedRoot, fs: ClaudeMdTransactionFs): void {
   for (const operation of operations) if (operation.tempPath) {
     const tempPath = operation.tempPath;
-    try { fs.rmSync(tempPath, { force: true }); result.tempCleanup.push({ path: tempPath, ok: true }); } catch (error) { result.tempCleanup.push({ path: tempPath, ok: false, error: message(error) }); }
+    try { validateTransactionTarget(root, tempPath, true, fs, false); fs.rmSync(tempPath, { force: true }); result.tempCleanup.push({ path: tempPath, ok: true }); } catch (error) { result.tempCleanup.push({ path: tempPath, ok: false, error: message(error) }); }
   }
 }
 
 export function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest): ClaudeMdTransactionResult {
   const fs = request.fs ?? defaultFs;
-  let root: string; let sourcePath: string;
+  let capturedRoot: CapturedRoot; let sourcePath: string;
   try {
-    root = resolve(request.root); const rootStat = fs.lstatSync(root);
-    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) throw new Error(`Invalid transaction root: ${root}`);
-    sourcePath = validateRootedRegularFile(request.sourceRoot ?? root, request.source, !request.sourceBytes, fs);
+    capturedRoot = captureTransactionRoot(request.root, fs);
+    sourcePath = validateRootedRegularFile(request.sourceRoot ?? request.root, request.source, !request.sourceBytes, fs);
   } catch (error) { return failure(request, 3, message(error), 'validation'); }
+  const root = capturedRoot.canonical;
   const main = resolve(root, 'CLAUDE.md'); const companion = resolve(root, 'CLAUDE-omc.md');
   try {
-    validateRootedRegularFile(root, main, true, fs); if (request.mode !== 'local') validateRootedRegularFile(root, companion, true, fs);
+    verifyCapturedRoot(capturedRoot, fs, true);
+    validateTransactionTarget(capturedRoot, main, true, fs, true); if (request.mode !== 'local') validateTransactionTarget(capturedRoot, companion, true, fs, true);
     const canonical = decodeClaudeMdUtf8(request.sourceBytes ?? fs.readFileSync(sourcePath), sourcePath);
     const mainBytes = fs.existsSync(main) ? fs.readFileSync(main) : undefined;
     const companionBytes = fs.existsSync(companion) ? fs.readFileSync(companion) : undefined;
@@ -191,10 +222,18 @@ export function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest):
     const states = new Map<string, PreState>(effectiveOperations.map(operation => [operation.path, { path: operation.path, existedBefore: operation.existedBefore, bytes: operation.path === main ? mainBytes : companionBytes }]));
     const appliedMainCleanup = effectiveOperations.some(operation => operation.path === main);
     const result: ClaudeMdTransactionResult = { ok: false, exitCode: 0, mode: request.mode, operations: effectiveOperations.map(publicOperation), completedOperations: [], backups: [], createdPaths: [], deletedPaths: [], mutatedPaths: [], removedRanges: appliedMainCleanup ? request.mode === 'global-preserve' ? preserve.ranges : overwrite.ranges : [], removedVariants: appliedMainCleanup ? request.mode === 'global-preserve' ? preserve.variants : overwrite.variants : [], warnings: [], rollback: [], tempCleanup: [] };
-    try { for (const state of states.values()) if (state.existedBefore) { state.backupPath = exclusiveVerifiedBackup(state, fs); result.backups.push(state.backupPath); } }
-    catch (error) { result.exitCode = 4; result.error = message(error); result.failedPhase = 'backup'; return result; }
     try {
-      for (const operation of effectiveOperations) { if (operation.type === 'write') atomicWrite(operation, fs); else fs.unlinkSync(operation.path); result.completedOperations.push(publicOperation(operation)); result.mutatedPaths.push(operation.path); if (!operation.existedBefore && operation.type === 'write') result.createdPaths.push(operation.path); if (operation.type === 'delete') result.deletedPaths.push(operation.path); }
+      verifyCapturedRoot(capturedRoot, fs, true);
+      for (const state of states.values()) if (state.existedBefore) { state.backupPath = exclusiveVerifiedBackup(state, capturedRoot, fs); result.backups.push(state.backupPath); }
+    } catch (error) { result.exitCode = 4; result.error = message(error); result.failedPhase = 'backup'; return result; }
+    try {
+      for (const operation of effectiveOperations) {
+        validateTransactionTarget(capturedRoot, operation.path, true, fs, true);
+        if (operation.type === 'write') atomicWrite(operation, capturedRoot, fs, true); else fs.unlinkSync(operation.path);
+        result.completedOperations.push(publicOperation(operation)); result.mutatedPaths.push(operation.path);
+        if (!operation.existedBefore && operation.type === 'write') result.createdPaths.push(operation.path);
+        if (operation.type === 'delete') result.deletedPaths.push(operation.path);
+      }
       result.ok = true; result.exitCode = 0; return result;
     } catch (error) {
       result.error = message(error); result.failedPhase = 'mutation'; result.failedPath = effectiveOperations.find(operation => !result.completedOperations.some(done => done.path === operation.path))?.path;
@@ -205,13 +244,13 @@ export function executeClaudeMdTransaction(request: ClaudeMdTransactionRequest):
           if (state.existedBefore) {
             const rollbackOperation: PlannedOperation = { path: state.path, type: 'write', existedBefore: true, bytes: state.bytes };
             rollbackOperations.push(rollbackOperation);
-            atomicWrite(rollbackOperation, fs);
-          } else if (fs.existsSync(state.path)) fs.unlinkSync(state.path);
+            atomicWrite(rollbackOperation, capturedRoot, fs, false);
+          } else if (fs.existsSync(state.path)) { validateTransactionTarget(capturedRoot, state.path, true, fs, false); fs.unlinkSync(state.path); }
           result.rollback.push({ path: state.path, ok: true });
         }
         catch (rollbackError) { result.failedPhase = 'rollback'; result.failedPath = state.path; result.rollback.push({ path: state.path, ok: false, error: message(rollbackError) }); }
       }
-      cleanupTemps([...effectiveOperations, ...rollbackOperations], result, fs); result.exitCode = result.rollback.every(item => item.ok) && result.tempCleanup.every(item => item.ok) ? 5 : 6; return result;
+      cleanupTemps([...effectiveOperations, ...rollbackOperations], result, capturedRoot, fs); result.exitCode = result.rollback.every(item => item.ok) && result.tempCleanup.every(item => item.ok) ? 5 : 6; return result;
     }
   } catch (error) { return failure(request, 3, message(error), 'validation'); }
 }

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -2402,7 +2402,6 @@ export function install(options: InstallOptions = {}): InstallResult {
     // Keep the public installer on the same raw-byte transaction path as setup.
     // The public string merger remains exported for callers that use it directly.
     if (!projectScoped) {
-      const claudeMdPath = join(CLAUDE_CONFIG_DIR, 'CLAUDE.md');
       const transaction = executeClaudeMdTransaction({
         mode: 'global-overwrite',
         root: CLAUDE_CONFIG_DIR,
@@ -2412,7 +2411,7 @@ export function install(options: InstallOptions = {}): InstallResult {
       });
       if (!transaction.ok) throw new Error(transaction.error ?? 'CLAUDE.md transaction failed');
       for (const backupPath of transaction.backups) log(`Backed up existing CLAUDE.md to ${backupPath}`);
-      log(transaction.operations.some(operation => operation.existedBefore && operation.path === claudeMdPath)
+      log(transaction.operations.some(operation => operation.type === 'write' && operation.existedBefore && basename(operation.path) === 'CLAUDE.md')
         ? 'Updated CLAUDE.md (merged with existing content)'
         : 'Created CLAUDE.md');
     }


### PR DESCRIPTION
Closes #3536.

## Security contract
- A config-root alias may be a symlink only when it resolves to an existing non-symlink directory.
- Transaction targets, backups, temporary files, and rollback paths derive from the captured canonical root.
- Forward work verifies alias stability plus canonical root identity; recovery never follows the mutable alias.
- Target symlinks, including dangling targets, remain refused. Source-root restrictions are unchanged.
- This uses repeated portable Node pathname checks at deterministic boundaries; it does **not** claim kernel-atomic protection against an adversarial rename between a check and syscall.

## Coverage
- Static Stow-style nested root alias and ordinary root success.
- Dangling/file roots, main/companion symlinks, dangling target symlink, and alias retarget during multi-operation reconciliation.
- Windows lexical containment regressions and built coordinator source-escape coverage.

## Verification
- `npx vitest run src/installer/__tests__/claude-md-transaction.test.ts` — 37 passed.
- `npm run lint` — passed with 18 pre-existing warnings.
- `npx tsc --noEmit` — passed.
- `npm run test:run` — 11,503 passed, 8 skipped.
- `npm run build` — passed.

## Red-team verdict
Initial adversarial review found two blockers: the bundled coordinator had not been regenerated after a late source change, and a dangling target symlink could be treated as absent. This PR regenerates the coordinator and adds an explicit dangling-target refusal test; focused and full verification then passed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*