### PR TITLE
ci: add main generated-artifact authorization trust root

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1,0 +1,1285 @@
+{
+  "schemaVersion": 2,
+  "repository": "Yeachan-Heo/oh-my-claudecode",
+  "owner": "Yeachan-Heo",
+  "authorizations": [
+    {
+      "pullNumber": 3537,
+      "targetRef": "main",
+      "mergeBaseSha": "76c90920b74494df6e34d6165be963bca8a9adf6",
+      "headSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 199,
+        "sha256": "3c1987d239441a787e5428d38b74e9bff51d694ad554d9fe34eae72cd78b059f"
+      },
+      "generatedFiles": [
+        {
+          "status": "added",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "78dd071627a4ea4dcb8083ab3895f285d067b597",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "dcd1a0d3b5efa9e0a93ad3029c770e77f3823783",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/mcp-server.cjs",
+          "sha": "bea373f283b6af5c84ac353ce96c6388c905e2e4",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/runtime-cli.cjs",
+          "sha": "a4121243c9f9bd9d34300a119f2780a459c5a275",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-bridge.cjs",
+          "sha": "86f371262ef4012150daaad587adfa8864a89b62",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-mcp.cjs",
+          "sha": "5884fa393bf8db92ac78efcd738b0c87b089fa79",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team.js",
+          "sha": "aa3058c2e64adb23f67e7d374817b8f5517477ec",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/autoresearch/contracts.js",
+          "sha": "17d7698caccaf85c1e98286027524d965ea60150",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/autoresearch/runtime.js",
+          "sha": "f59f6d651b390618ddb7d6cf9a4c953d4d935209",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/autoresearch-guided.js",
+          "sha": "0f5a18e7648889c7863e00dbe7a6ceb9620b3c3f",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/cli/claude-md-coordinator.d.ts",
+          "sha": "754af1bf0f0010ff64a5e28d3ae34ec830ac46e1",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/cli/claude-md-coordinator.js",
+          "sha": "ff43abcd03553d42d4fc56f5959e8a03570afe36",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/cli/commands/capabilities.d.ts",
+          "sha": "fcdf91207b6d08eb2d6ac24450f3b8015d0f996c",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/cli/commands/capabilities.js",
+          "sha": "55411d7cbcd0bc927348c6419a8b2b822a88a565",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/doctor-conflicts.d.ts",
+          "sha": "45501c66edab8300bd511327807959384eec9a47",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/doctor-conflicts.js",
+          "sha": "6dea8941045604686c6bdb61d3e1d23bf34adbd5",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/cli/commands/session-friction-report.d.ts",
+          "sha": "542d12d1ed6425ee01706b1936ceba0ef85a7e8f",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/cli/commands/session-friction-report.js",
+          "sha": "4a14b7e80be0b3aee4bc3f1c27ee66b7df72350a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/team.js",
+          "sha": "841c9a57dc24cc92e627b3a9cebdb9a9bf1fcd21",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/teleport.js",
+          "sha": "b87e18a6f4c07c19d4fdce051bb0298552e03d31",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/index.js",
+          "sha": "a71bc6f0be38e36f7a740a6034c57310558bd781",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/team.js",
+          "sha": "ba67c39e749c08a540889546279d47114c378d75",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/tmux-utils.js",
+          "sha": "734225a053c66d703d60e891b431b2361d61a62a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/config/loader.d.ts",
+          "sha": "7796ecdf9502e0a892d6e8f78d277e10647d4161",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/config/loader.js",
+          "sha": "e5015e4efa0c19005ca4a4a659f98c7361a0a2f4",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/features/auto-update.js",
+          "sha": "98edfb11cff4c5382d8547ba04c6d1d8828f8fe8",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/features/session-friction-report/index.d.ts",
+          "sha": "ba8415d6fad5e97b3fef754246a64474811a6b44",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/features/session-friction-report/index.js",
+          "sha": "99e339228c217ef75f3be8ac607b2171ca8a896e",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/features/session-friction-report/types.d.ts",
+          "sha": "5d7ab64c0d5d1e3cbc681d2b5819c86efa621f7a",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/features/session-friction-report/types.js",
+          "sha": "718fd38ae40c67ea23b242517cf9919f602c5a3e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/features/session-history-search/index.js",
+          "sha": "094919ccb10ff665e64922e8bd50ad290c492b0e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/auto-slash-command/live-data.js",
+          "sha": "8ca4e6d5ceb69d47ca31211c7e13f25a67a1cb4e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/adapters/qa-adapter.js",
+          "sha": "6697882b8e08b8f5fb57994e5c228e2fc11ff186",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/adapters/ralplan-adapter.js",
+          "sha": "46997d37b317edde9ae00739ee3d18ee09208369",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/cancel.d.ts",
+          "sha": "eb50fef227ad1b4a72f48e0098c04e0b32d4656a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/cancel.js",
+          "sha": "30e3424de29011306b02aecb78fd216c6e6729f1",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/enforcement.js",
+          "sha": "2de15e087c58d8b9bcb415bce81450c67819fe00",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/index.d.ts",
+          "sha": "f9ef643567c52f2cb687302e30043379bcae2f3a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/index.js",
+          "sha": "e707c7ed017651de11db3feb65da0c5245b19446",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/autopilot/named-workflow-resume-validator.d.ts",
+          "sha": "33e5ee8d067a017545ed2324f2c5d631524a19cd",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/autopilot/named-workflow-resume-validator.js",
+          "sha": "750376a511835f013a5e95e78063a70e12a076e5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/pipeline-types.d.ts",
+          "sha": "117d24c89f729ecb44725211d57f7bd96e657610",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/pipeline.d.ts",
+          "sha": "2dea5a76c7eba0736138650cac2e920402b4245e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/pipeline.js",
+          "sha": "760a8762b95f0c9b83757812c27656e2bfc95251",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/prompts.d.ts",
+          "sha": "d03960daf780fa6905682c6c8dd97ff04d0fae15",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/prompts.js",
+          "sha": "7d25190f8c33535155a3ae2430e75df8621a7490",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/runtime-insight.js",
+          "sha": "dd913142c7d083ff94de532ea00bf117b17f9c78",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/state.d.ts",
+          "sha": "27f68b129215920fa4d804d7f3205ddefc263dfa",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/state.js",
+          "sha": "4b887751ffecfcb5f3cdfb5463f466e227c52821",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/types.d.ts",
+          "sha": "1f1105cbef7c59c254a8195d3f4268f617b3c94b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/autopilot/validation.js",
+          "sha": "f28bd53b77a8ba621f9ca5ca354db682a09e4988",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/beads-context/constants.d.ts",
+          "sha": "e6b378e368efda893d7908930617fea85e3b539c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/beads-context/constants.js",
+          "sha": "42574bb6e2144bfea06715042fd6196ab724d661",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/bridge.js",
+          "sha": "bc6ffa196bb4140dde8905b34fc92a171688e92b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/code-simplifier/index.js",
+          "sha": "3c6cb3bbe42ffb7691d585a35ac05ae68a981f82",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/keyword-detector/index.js",
+          "sha": "eb24d0555e1f3b467570538c06cf4d7236725238",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/index.d.ts",
+          "sha": "0b30c2d95b31ecd021730d874b8ac10d849d7647",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/index.js",
+          "sha": "42dc38b76e5cfd09c3c66cb0aaaa1a83af89c23c",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/mcq.d.ts",
+          "sha": "3c68d4ded9e8f09d0264b443d0e5a205be2a2155",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/mcq.js",
+          "sha": "c0a8e510cf4b86c1f67eef72df34277bb0ead23f",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/report.d.ts",
+          "sha": "c511257af5d6841265dd39d80863cb97eace1444",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/report.js",
+          "sha": "4e2b8a61273a3e3b0ac1d3868cb515b533c87203",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/runtime.d.ts",
+          "sha": "db630923cffc4e895a16e388bff22a69edddd434",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/runtime.js",
+          "sha": "773e8b236e5360462449e6df98659f067713d386",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/types.d.ts",
+          "sha": "a95bba362c1e9fd9999e21082b142630a12efb91",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/merge-readiness/types.js",
+          "sha": "bc80b8b7b2fbfc7f82d01f28f71a02dc614782eb",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/mode-registry/index.d.ts",
+          "sha": "5b0c3f7d71f5a897c5d1db29f6860cce020f4c7b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/mode-registry/index.js",
+          "sha": "985493a1677b69e6412e1c065594e52452ec6bdf",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/mode-registry/types.d.ts",
+          "sha": "d8ef464c0bf12fee0ddb68b35c2e9eef0149e6fa",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/omc-orchestrator/index.js",
+          "sha": "8bb6bb666c006e082f9861b706554a3fc1e51bcb",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/idle-repo-state.js",
+          "sha": "84836f61a59b5c47097cf990f79cf0c301cc8b5d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/index.js",
+          "sha": "c9b6d7b37199bd1c2079741446957c4b7d15d572",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/project-memory/detector.js",
+          "sha": "8c5dbd33290abc9f93348795780827fc4ad64e4f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/project-memory/learner.js",
+          "sha": "ea31a50076219402cfca0abf2eca4a3df295ef17",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/ralph/loop.js",
+          "sha": "dc8a962374238d37cbb8f68ba1b1da1e4153302b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/ralph/verifier.js",
+          "sha": "3573de32fd567791f362f2f95353ba3c2b79c8db",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/rules-injector/parser.js",
+          "sha": "9346d3c7ab42436a19357307b661e9fcdf63a97a",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/rules-injector/parser.test.d.ts",
+          "sha": "807ec01fda4091fe6c4f98813f8403afaf3c9068",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/action-runner.d.ts",
+          "sha": "d059d81b37d4784607057df46ca2e8217772de69",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/action-runner.js",
+          "sha": "7e68939f74c4d3e0c7ad9f7434bba563dd8cdb61",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/action-watchdog.d.ts",
+          "sha": "9f23faeb7f4bb856f078c202206a5df952a3d272",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/action-watchdog.js",
+          "sha": "3be45e43afdbe068fd6d8e856c3b83e1cb0a7f6d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/callbacks.d.ts",
+          "sha": "cd0ef68387379c277b651419bc0aa89529049e61",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/callbacks.js",
+          "sha": "bf0b529adf256eea95c076616253fd83b34cd9c9",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/cleanup-manifest.d.ts",
+          "sha": "8584c2f253026e9d82199db9dbce66f06e92fab1",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/cleanup-manifest.js",
+          "sha": "ec318597dbbbdd1307ee213a4c92ca4c2a230d89",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/index.d.ts",
+          "sha": "a763b7ecc23b1e6af842c0690035e521b9fcf866",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/index.js",
+          "sha": "ec982fac3ff15cb5fe5f695c5eb071b8dfed0d01",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/worker.d.ts",
+          "sha": "914e377022124dc766103cfca7ed425170330985",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/session-end/worker.js",
+          "sha": "f39a16921b2a2b33121061e9eb582f7626279e9d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/skill-bridge.cjs",
+          "sha": "2df783288071697e277eb14738bf957d2f372014",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/subagent-tracker/index.d.ts",
+          "sha": "fd051473dd4846137ba6c6024c0a57246f32a03b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/subagent-tracker/index.js",
+          "sha": "3872b315e75876ab50fd59e328a4892c7e6d3e55",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/subagent-tracker/session-replay.d.ts",
+          "sha": "5be8f50c1b462c0f4f590d7f2bb6d3766eaefd52",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/subagent-tracker/session-replay.js",
+          "sha": "123916f4558e5dedbf5d2f451d64660c523c7cb6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/wiki/session-hooks.d.ts",
+          "sha": "79a1941662f589b2d04b188329186ee17b5ec7a0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/wiki/session-hooks.js",
+          "sha": "c663ab1fc99c043b2c43dfe34bae1e00144faed5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/wiki/storage.d.ts",
+          "sha": "472d330fc28a9f71e663a0e488c8fa3e490231b0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/wiki/storage.js",
+          "sha": "a03daaa17604177ddf1bc699a1a6ec8e29a16271",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/elements/autopilot.d.ts",
+          "sha": "ebbe5260343f2723a2d557d2585f330e6fa0bd03",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/elements/autopilot.js",
+          "sha": "6df964a1fbec325d91c84ae4c3b13788b36cfe13",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/elements/multi-repo.js",
+          "sha": "31647c45ff5f17f2525785bca97e3bf2c76bce2c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/omc-state.js",
+          "sha": "db9435bbd28c262b79677aae83b7c5d5ffe0c97b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/payload-estimate.js",
+          "sha": "e40980574edfd9a7c78a728021ecf29066ae7ff7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/index.d.ts",
+          "sha": "c749fc89e0fc8ab332a556f7606e9bf5cb542a85",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/index.js",
+          "sha": "6b370dd082136fa473b8fc5c21166ae84b16b5ee",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/claude-md-analysis.d.ts",
+          "sha": "8882ba7ceadf30781fd058051cbbe7ec7a4309e4",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/claude-md-analysis.js",
+          "sha": "f023750f286099eb28e89f1031fdae79fec24d9e",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/claude-md-transaction.d.ts",
+          "sha": "6dd63c21dcefa832a6f39189f12861ff4181e9ae",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/claude-md-transaction.js",
+          "sha": "8c72bb5918f9e13a38069d21242089d1ac3670ed",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.js",
+          "sha": "c29b846024883cedd2b4cd8d835a7290e245b79a",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/legacy-claude-md-corpus.d.ts",
+          "sha": "c52425a749a57dadd2b0e01de2091d60e4631423",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/legacy-claude-md-corpus.js",
+          "sha": "5f4ac5197a045caeb35c49fd0deb39d9e48dddf8",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/atomic-write.d.ts",
+          "sha": "8681c590bcf7a19fe33259dfc433e165784b9d50",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/atomic-write.js",
+          "sha": "0e77808f273ef5660e7a5adc05285a771069fe88",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/mode-names.d.ts",
+          "sha": "dbbccfa654ac47adcc7f287c09d60986b5063818",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/mode-names.js",
+          "sha": "7dddbb63dacaad8a12b3bf69c5227a51e4898302",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/mode-state-io.d.ts",
+          "sha": "49843d7ca5a94e8db81add3f8d9a130ae85d3165",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/mode-state-io.js",
+          "sha": "83c5703374ec87ae0ce166a204c51abbcc9e8f2f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/lib/worktree-paths.js",
+          "sha": "4f407249c83f51ba1cf9b59af029b610ce67a555",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/mcp/disable-tools.d.ts",
+          "sha": "751aaac656f2cf9bbb2a787f52d680bd28b2be78",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/mcp/disable-tools.js",
+          "sha": "1a58b9a549da547a8b705f035364199ab2a97721",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/notifications/reply-listener.d.ts",
+          "sha": "176bd5ab02acc64d1c9bc2bcb2478c35732f0592",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/notifications/reply-listener.js",
+          "sha": "27de08495ea109773b6cb32926b5cf0467b106c1",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/notifications/session-registry.d.ts",
+          "sha": "a7cc40ae5a585bc00e143c4d87f3c11e74523ca8",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/notifications/session-registry.js",
+          "sha": "a09076de14f0a1c75bca48198057bd806f73a59b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.d.ts",
+          "sha": "e99c3577a17cbe2091f753565f084636915f90c5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.js",
+          "sha": "32fa2629a420860fed3bb16bdd97211f37430417",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/providers/index.js",
+          "sha": "d533fe5b34764fad9152aa37efa64702ac152b67",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/shared/types.d.ts",
+          "sha": "4d550b804f719222c4686a73ac22d3e14d1194df",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/api-interop.d.ts",
+          "sha": "46bad3618681070215518bc75981203e28500dc7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/api-interop.js",
+          "sha": "a81a53957f3911fd05673a3d8a9759e062787662",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/dispatch-queue.d.ts",
+          "sha": "607509ee4893a8a7fc4316a7ec3e8a1bb20abe31",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/dispatch-queue.js",
+          "sha": "e5f0238e4b6bdf18ba93f06d2aa096d960baec4c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/git-worktree.js",
+          "sha": "fe39e12a0ec40d360857e288e26faac0493bdc1b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.d.ts",
+          "sha": "2d378e054aa71f39c50207842c9ade594c7e2952",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.js",
+          "sha": "383baee7836d8d73b67e47cf1a267217a8f5e188",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/mailbox-notification-guard.d.ts",
+          "sha": "5d855b0889eecc6daf6d0250d5cbb0a9ce749e74",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/mailbox-notification-guard.js",
+          "sha": "35df5fe16fb0a135f91d4ff2f73981e70ed2a755",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/mcp-comm.d.ts",
+          "sha": "5c3dadeec0fd379170c553fcf8f1a17c9256a116",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/mcp-comm.js",
+          "sha": "3726e2b5c0309b95976aa1feeed07e25a84a563a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/mcp-team-bridge.js",
+          "sha": "fce170e604bbe8e07d99bd73cd6e14750705770f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/merge-coordinator.js",
+          "sha": "a76806c731d7f0e14f6568eb8b57def253377f5a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/merge-orchestrator.d.ts",
+          "sha": "c97d7e1a8946c8285b0d8a6fe21286ff6d7eee26",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/merge-orchestrator.js",
+          "sha": "caebe040a0e737c7678287e8977262ac409faf70",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/model-contract.d.ts",
+          "sha": "a3a0a9f97438b542c7dd4cabe55c871d273c7394",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/model-contract.js",
+          "sha": "c23ca678511a8068516aefc467661908a5721895",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.d.ts",
+          "sha": "6284193ad6eea5e94fe91751629f3daf392f8738",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.js",
+          "sha": "671f0eb2ffa74273680b82a3db3adb36f7fccc7f",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/process-identity-lock.d.ts",
+          "sha": "0e59da124b93d15dcb5a460beae02f09f1b62e6d",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/process-identity-lock.js",
+          "sha": "bd0afc614b04211d60a2bda86cab0abc4703e042",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/recovery-request-store.d.ts",
+          "sha": "215439af25eedae4c98f0721bf03a4786ec1297c",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/recovery-request-store.js",
+          "sha": "442a5b2a711b8876b2e385a73cfd6791a6540abd",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/recovery-saga.d.ts",
+          "sha": "57172e6709afb29f30f1b4650fc0b3c3527fd0aa",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/recovery-saga.js",
+          "sha": "e4d75425e872255e5e99ec71bb974f3671f2bcb6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.d.ts",
+          "sha": "28398b2f3fae7b088bb219b1e770777a035d44e2",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.js",
+          "sha": "fa3aa98b24886e2c753468d5bfbc2ba9d19cfd32",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/runtime-owner-client.d.ts",
+          "sha": "b47693eda07af62aba06ff2e55c0ee48452192a9",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/runtime-owner-client.js",
+          "sha": "a51a87d2ea6ef0ca66b0c14ed4f83255a3dcc617",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.d.ts",
+          "sha": "f218deee3236a70a2f3fff517289e857a82d4a50",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js",
+          "sha": "cdd4ca7225b0df07d779bfb11c13ffde4cc36e6a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.d.ts",
+          "sha": "6bab63251c0181b57d69b7cee36ef3ad47c57791",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.js",
+          "sha": "0d6da19defca9a2c7cfd4f68aae859e1e8cd1278",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.d.ts",
+          "sha": "302ae77f1d577e31671997f0d830d36da5439339",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.js",
+          "sha": "b3756e2927b51ee0d8eb66ab5ebb2cb678705c17",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.d.ts",
+          "sha": "666dd2d4ae08480eaedb14f38392fce2a837627d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.js",
+          "sha": "9eba5b9a157929efb1c50110567b86ed1092a215",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.d.ts",
+          "sha": "4787d4d4a3da9248fc6d15f1e2f5eb5960e26e62",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.js",
+          "sha": "c2929fca041a5afab083a374a64aa44f97acc15f",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/task-recovery-checkpoint.d.ts",
+          "sha": "2808c57eb9310a9fd935683ce5e8ae2ce6c4b383",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/task-recovery-checkpoint.js",
+          "sha": "2d311ef83c52da6af5556c7321f44ee15ea6b69e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/team-ops.d.ts",
+          "sha": "0833141bb82743d62360230369c49fb48e2432d0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/team-ops.js",
+          "sha": "5b4b6644671c55973794947308fa137d0d9e5d5d",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/team-owner-epoch.d.ts",
+          "sha": "fb9d42dcb6d47398e597d0e496466fdff0360347",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/team-owner-epoch.js",
+          "sha": "1a4aadcbae8295189aacb4cd1b80b803caaaa4f3",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/team-projection.d.ts",
+          "sha": "29d42c8961093d5c62c69ab9926fb54ced8410e1",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/team-projection.js",
+          "sha": "0d57d2af4ae42166f7eb303893bf6af258c3814d",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/team-state-reader.d.ts",
+          "sha": "4506467ac1f07bb0780a7272fc86c058ea828705",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/team-state-reader.js",
+          "sha": "32a96f572989c905fc6848ec0f0b8c6a5a51bf83",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.d.ts",
+          "sha": "bb4218211e76c2f3edeff0bd3a6e7ba82c34cea7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.js",
+          "sha": "91fecb5e182718a1b1a23c9a1eb49a693b472d2f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/types.d.ts",
+          "sha": "851a97f086cbf3646c8cad293e608bcfbf7d94b8",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/worker-activation-gate.d.ts",
+          "sha": "90bc3732cc8da8be69146beb25e3bffbf4747b15",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/worker-activation-gate.js",
+          "sha": "afc3d8e989d62b5430e8ce14a1d86f5411fd5fa5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-bootstrap.d.ts",
+          "sha": "728995752b2d19e0113705d487f5f99d07d24500",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-bootstrap.js",
+          "sha": "be54e081d064287fd296ba0e0902b0ac82dc4a74",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-canonicalization.d.ts",
+          "sha": "3957b32a04e25169c0d23d7b910efc2a5114509a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-canonicalization.js",
+          "sha": "9625d73eebaffc55b3fbcfd2fa19559a28ff1fee",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-commit-cadence.d.ts",
+          "sha": "5894f394df6c56b650584475a1db49c97523688b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-commit-cadence.js",
+          "sha": "87110736e73aa470d501717613abeeb513032f89",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/client.d.ts",
+          "sha": "9dfdd99962d883205bc6d5581abf4e87e36efbb8",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/client.js",
+          "sha": "72f8df53b2c961e609a01f87ecf1613a37194d20",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/servers.d.ts",
+          "sha": "ef950bcd40b914edf3a81fbae0a26713548edad9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/servers.js",
+          "sha": "d81f6c7fdda13f784df84e9ea9172edcabbdfdae",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/state-tools.d.ts",
+          "sha": "e4a169ad8567b5b55097545c3778fb0c7f09a6fe",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/state-tools.js",
+          "sha": "4631d1fa44a2336c2424ceab4070ad7c2add7f06",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/trace-tools.js",
+          "sha": "26e57011adf4b70c86637b1ee5b469659114e1b7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/ultragoal/artifacts.js",
+          "sha": "3f3178eb0178cd651decd8847e684ec8c812d37b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/resolve-node.js",
+          "sha": "5543ee45709c16d6d8683a1afb0a3de0fe239753",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3538,
+      "targetRef": "dev",
+      "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
+      "headSha": "e798c12426f1f11701dede43a0f35c183651627e",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 4,
+        "sha256": "aaf1c49f22f4ce08b9299432e54f708e61e37434d3af48055bf195ff0b2005e6"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "ccab9e12230cb98627c610d015216451d9c6da7c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "102f7f2ec960a74079450bfb771fa566392f2840",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/claude-md-transaction.d.ts",
+          "sha": "91f44678af2a904d691d7bd61fdad5eae478a923",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/claude-md-transaction.js",
+          "sha": "6792903e324a83d1f68485b288757f2f2e61829b",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3539,
+      "targetRef": "dev",
+      "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
+      "headSha": "a82db66c18d88759cdd3455f65fd4ae9ae95dbc9",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 3,
+        "sha256": "b90fbed9042db47d77c35c2adcf4425446d725dd28b67991ad3d700a94e9e45d"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "78e4dd26cef8a0ac1908e822e5e1ce5e2e8be7af",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.d.ts",
+          "sha": "f5ffa2b1b1dee166e565aba9a7536a95f638ddf3",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.js",
+          "sha": "75b271300996bf04e421f5ebd227b7def846a1bd",
+          "previousFilename": null
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/generated-artifact-authorization.yml
+++ b/.github/workflows/generated-artifact-authorization.yml
@@ -1,0 +1,43 @@
+name: Generated Artifact Authorization
+
+on:
+  pull_request_target:
+    branches: [main, dev]
+    types: [opened, synchronize, reopened]
+
+# GitHub loads pull_request_target workflow bytes from the default branch, main.
+# Its runtime GITHUB_REF/GITHUB_SHA bind main and its live main commit, while
+# GITHUB_WORKFLOW_REF/GITHUB_WORKFLOW_SHA bind this protected workflow and a
+# separately fetched live main commit. The explicit event-base inputs below bind
+# the target branch and its immutable event commit for the trusted detached checkout.
+# This main-owned workflow authorizes only exact manifest records for main and dev targets. The trusted checkout contains only base-owned
+# verifier and manifest bytes.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  authorize-generated-artifacts:
+    name: Authorize generated artifacts from base trust root
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the immutable event base
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-base
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            .github/generated-artifact-authorizations.json
+            scripts/verify-generated-artifact-authorization.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify base-owned generated-artifact authorization
+        working-directory: trusted-base
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TRUSTED_EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          TRUSTED_EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/verify-generated-artifact-authorization.mjs

--- a/scripts/verify-generated-artifact-authorization.mjs
+++ b/scripts/verify-generated-artifact-authorization.mjs
@@ -1,0 +1,766 @@
+#!/usr/bin/env node
+/**
+ * Base-owned verifier for exceptional generated-artifact pull requests.
+ *
+ * This file is intentionally self-contained. The pull_request_target workflow
+ * checks out the event base SHA before invoking it, so neither this verifier
+ * nor the manifest can be supplied by the candidate pull request.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = resolve(SCRIPT_DIR, '..');
+const MANIFEST_PATH = join(REPOSITORY_ROOT, '.github', 'generated-artifact-authorizations.json');
+const OWNER = 'Yeachan-Heo';
+const DEFAULT_BRANCH = 'main';
+const WORKFLOW_PATH = '.github/workflows/generated-artifact-authorization.yml';
+const API_URL = 'https://api.github.com';
+const MAX_PULL_FILES = 3000;
+const ALLOWED_ACTIONS = new Set(['opened', 'synchronize', 'reopened']);
+const GENERATED_PREFIXES = ['dist/', 'bridge/'];
+const FILE_STATUSES = new Set(['added', 'modified', 'removed', 'renamed', 'copied', 'changed']);
+
+export class AuthorizationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AuthorizationError';
+  }
+}
+
+function fail(message) {
+  throw new AuthorizationError(message);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requiredObject(value, label) {
+  if (!isObject(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function requiredString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) fail(`${label} must be a non-empty string`);
+  return value;
+}
+
+function requiredPositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) fail(`${label} must be a positive integer`);
+  return value;
+}
+
+function requiredNonNegativeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) fail(`${label} must be a non-negative integer`);
+  return value;
+}
+
+function requiredSha(value, label) {
+  const sha = requiredString(value, label);
+  if (!/^[0-9a-f]{40}$/.test(sha)) fail(`${label} must be a lowercase 40-character SHA-1`);
+  return sha;
+}
+
+function assertExactKeys(value, expectedKeys, label) {
+  const actual = Object.keys(requiredObject(value, label)).sort();
+  const expected = [...expectedKeys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    fail(`${label} has unexpected or missing fields`);
+  }
+}
+
+function parseRepository(repository) {
+  const value = requiredString(repository, 'repository');
+  const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(value);
+  if (!match) fail('repository must be an owner/name slug');
+  return { owner: match[1], name: match[2] };
+}
+
+function assertProtectedRepositoryMetadata(repositoryMetadata, repository, owner) {
+  const metadata = requiredObject(repositoryMetadata, 'live repository metadata');
+  if (requiredString(metadata.full_name, 'live repository metadata.full_name') !== repository) {
+    fail('live repository metadata repository does not match the protected repository');
+  }
+  const metadataOwner = requiredObject(metadata.owner, 'live repository metadata.owner');
+  if (
+    requiredString(metadataOwner.login, 'live repository metadata.owner.login') !== owner
+  ) {
+    fail('live repository metadata owner does not match the protected owner');
+  }
+  if (requiredString(metadata.default_branch, 'live repository metadata.default_branch') !== DEFAULT_BRANCH) {
+    fail(`live repository metadata default branch is not ${DEFAULT_BRANCH}`);
+  }
+}
+
+function assertDefaultMainProvenance(environment, repositoryMetadata, runtimeCommit, workflowCommit, repository, owner) {
+  const runtime = requiredObject(environment, 'runtime environment');
+  assertExactKeys(
+    runtime,
+    [
+      'githubEventName',
+      'githubRepository',
+      'githubRef',
+      'githubSha',
+      'githubWorkflowRef',
+      'githubWorkflowSha',
+      'trustedEventBaseRef',
+      'trustedEventBaseSha',
+    ],
+    'runtime environment',
+  );
+  if (runtime.githubEventName !== 'pull_request_target') {
+    fail('verifier only accepts pull_request_target events');
+  }
+  if (requiredString(runtime.githubRepository, 'runtime GITHUB_REPOSITORY') !== repository) {
+    fail('runtime repository does not match the base-owned authorization manifest');
+  }
+  if (requiredString(runtime.githubRef, 'runtime GITHUB_REF') !== `refs/heads/${DEFAULT_BRANCH}`) {
+    fail('runtime GITHUB_REF is not the protected default branch');
+  }
+  const currentRuntimeSha = requiredSha(
+    requiredObject(runtimeCommit, 'current runtime default-main commit').sha,
+    'current runtime default-main commit SHA',
+  );
+  if (requiredSha(runtime.githubSha, 'runtime GITHUB_SHA') !== currentRuntimeSha) {
+    fail('runtime GITHUB_SHA does not match the current protected default-main commit SHA');
+  }
+  if (
+    requiredString(runtime.githubWorkflowRef, 'runtime GITHUB_WORKFLOW_REF') !==
+    `${repository}/${WORKFLOW_PATH}@refs/heads/${DEFAULT_BRANCH}`
+  ) {
+    fail('runtime GITHUB_WORKFLOW_REF is not the protected default-branch workflow');
+  }
+  const workflowSha = requiredSha(runtime.githubWorkflowSha, 'runtime GITHUB_WORKFLOW_SHA');
+  const currentWorkflowSha = requiredSha(
+    requiredObject(workflowCommit, 'current protected default-main workflow commit').sha,
+    'current protected default-main workflow commit SHA',
+  );
+  if (workflowSha !== currentWorkflowSha) {
+    fail('runtime GITHUB_WORKFLOW_SHA does not match the current protected default-main workflow commit SHA');
+  }
+  assertProtectedRepositoryMetadata(repositoryMetadata, repository, owner);
+}
+
+function assertTrustedEventBaseProvenance(environment, eventData, liveData) {
+  const runtime = requiredObject(environment, 'runtime environment');
+  if (requiredString(runtime.trustedEventBaseRef, 'TRUSTED_EVENT_BASE_REF') !== eventData.baseRef ||
+      runtime.trustedEventBaseRef !== liveData.baseRef) {
+    fail('explicit event base ref does not match the exact event/live pull request base ref');
+  }
+  if (requiredSha(runtime.trustedEventBaseSha, 'TRUSTED_EVENT_BASE_SHA') !== eventData.baseSha ||
+      runtime.trustedEventBaseSha !== liveData.baseSha) {
+    fail('explicit event base SHA does not match the exact event/live pull request base SHA');
+  }
+}
+
+export function readDetachedCheckoutHead(repositoryRoot = REPOSITORY_ROOT) {
+  const root = resolve(requiredString(repositoryRoot, 'verifier repository root'));
+  let head;
+  try {
+    head = readFileSync(join(root, '.git', 'HEAD'), 'utf8');
+  } catch {
+    fail('checked-out base .git/HEAD is unreadable');
+  }
+  if (!/^[0-9a-f]{40}\n$/.test(head)) {
+    fail('checked-out base .git/HEAD is not a detached lowercase 40-character SHA-1');
+  }
+  return head.slice(0, -1);
+}
+
+function isGeneratedPath(filename) {
+  return GENERATED_PREFIXES.some(prefix => filename.startsWith(prefix));
+}
+
+function recordTouchesGeneratedPath(record) {
+  return (
+    isGeneratedPath(record.filename) ||
+    (record.previousFilename !== null && isGeneratedPath(record.previousFilename))
+  );
+}
+
+function compareRecords(left, right) {
+  for (const key of ['filename', 'status', 'sha', 'previousFilename']) {
+    const a = left[key] ?? '';
+    const b = right[key] ?? '';
+    if (a < b) return -1;
+    if (a > b) return 1;
+  }
+  return 0;
+}
+
+function assertSafeRepositoryPath(filename, label) {
+  const path = requiredString(filename, label);
+  if (
+    path.includes('\u0000') ||
+    path.startsWith('/') ||
+    path.split('/').some(segment => segment === '' || segment === '.' || segment === '..')
+  ) {
+    fail(`${label} is not a canonical repository path`);
+  }
+  return path;
+}
+
+function canonicalRecord(status, filename, sha, previousFilename, label) {
+  if (!FILE_STATUSES.has(status)) fail(`${label}.status is not a supported GitHub file status`);
+  const canonicalFilename = assertSafeRepositoryPath(filename, `${label}.filename`);
+  const canonicalSha = requiredSha(sha, `${label}.sha`);
+
+  if (status === 'renamed' || status === 'copied') {
+    return {
+      status,
+      filename: canonicalFilename,
+      sha: canonicalSha,
+      previousFilename: assertSafeRepositoryPath(previousFilename, `${label}.previousFilename`),
+    };
+  }
+
+  if (previousFilename !== null && previousFilename !== undefined) {
+    fail(`${label}.previousFilename is only allowed for renamed or copied files`);
+  }
+
+  return { status, filename: canonicalFilename, sha: canonicalSha, previousFilename: null };
+}
+
+function sortAndAssertUnique(records, label) {
+  const sorted = [...records].sort(compareRecords);
+  const filenames = new Set();
+  for (const record of sorted) {
+    if (filenames.has(record.filename)) fail(`${label} contains duplicate filenames`);
+    filenames.add(record.filename);
+  }
+  return sorted;
+}
+
+/**
+ * Converts fully paginated GitHub pull-file records into the stable,
+ * base-owned representation hashed by the authorization manifest.
+ */
+export function canonicalizeChangedFiles(files, label = 'changed files') {
+  if (!Array.isArray(files)) fail(`${label} must be an array`);
+  const records = files.map((file, index) => {
+    const value = requiredObject(file, `${label}[${index}]`);
+    const status = requiredString(value.status, `${label}[${index}].status`);
+    const previousFilename = Object.hasOwn(value, 'previous_filename')
+      ? value.previous_filename
+      : null;
+    return canonicalRecord(status, value.filename, value.sha, previousFilename, `${label}[${index}]`);
+  });
+  return sortAndAssertUnique(records, label);
+}
+
+/**
+ * Validates canonical manifest records without accepting API-shaped aliases.
+ */
+export function canonicalizeAuthorizedRecords(records, label = 'authorized generated files') {
+  if (!Array.isArray(records)) fail(`${label} must be an array`);
+  const canonical = records.map((record, index) => {
+    const value = requiredObject(record, `${label}[${index}]`);
+    assertExactKeys(value, ['status', 'filename', 'sha', 'previousFilename'], `${label}[${index}]`);
+    return canonicalRecord(
+      requiredString(value.status, `${label}[${index}].status`),
+      value.filename,
+      value.sha,
+      value.previousFilename,
+      `${label}[${index}]`,
+    );
+  });
+  return sortAndAssertUnique(canonical, label);
+}
+
+export function canonicalizeGeneratedFiles(files, label = 'changed files') {
+  return canonicalizeChangedFiles(files, label).filter(recordTouchesGeneratedPath);
+}
+
+export function calculateGeneratedDelta(records) {
+  const canonical = canonicalizeAuthorizedRecords(records, 'generated delta records');
+  const serialized = JSON.stringify(canonical);
+  return {
+    count: canonical.length,
+    sha256: createHash('sha256').update(serialized, 'utf8').digest('hex'),
+  };
+}
+
+function recordsEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function validateAuthorizationManifest(manifest) {
+  assertExactKeys(manifest, ['schemaVersion', 'repository', 'owner', 'authorizations'], 'authorization manifest');
+  if (manifest.schemaVersion !== 2) fail('authorization manifest has an unsupported schema version');
+
+  const repository = requiredString(manifest.repository, 'authorization manifest.repository');
+  const { owner } = parseRepository(repository);
+  if (manifest.owner !== owner || manifest.owner !== OWNER) {
+    fail('authorization manifest owner is not the protected repository owner');
+  }
+  if (!Array.isArray(manifest.authorizations)) fail('authorization manifest.authorizations must be an array');
+
+  const seenPullNumbers = new Set();
+  const authorizations = manifest.authorizations.map((entry, index) => {
+    const label = `authorization manifest.authorizations[${index}]`;
+    assertExactKeys(
+      entry,
+      ['pullNumber', 'targetRef', 'mergeBaseSha', 'headSha', 'owner', 'expiresAt', 'generatedDelta', 'generatedFiles'],
+      label,
+    );
+    const pullNumber = requiredPositiveInteger(entry.pullNumber, `${label}.pullNumber`);
+    if (seenPullNumbers.has(pullNumber)) fail('authorization manifest contains duplicate pull numbers');
+    seenPullNumbers.add(pullNumber);
+
+    const targetRef = requiredString(entry.targetRef, `${label}.targetRef`);
+    if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(targetRef) || targetRef.includes('..')) {
+      fail(`${label}.targetRef is not a canonical ref name`);
+    }
+    const mergeBaseSha = requiredSha(entry.mergeBaseSha, `${label}.mergeBaseSha`);
+    const headSha = requiredSha(entry.headSha, `${label}.headSha`);
+    if (entry.owner !== manifest.owner) fail(`${label}.owner does not match the manifest owner`);
+    const expiresAt = requiredString(entry.expiresAt, `${label}.expiresAt`);
+    if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(expiresAt) || Number.isNaN(Date.parse(expiresAt))) {
+      fail(`${label}.expiresAt is not a canonical UTC timestamp`);
+    }
+
+    assertExactKeys(entry.generatedDelta, ['count', 'sha256'], `${label}.generatedDelta`);
+    const generatedDelta = {
+      count: requiredPositiveInteger(entry.generatedDelta.count, `${label}.generatedDelta.count`),
+      sha256: requiredString(entry.generatedDelta.sha256, `${label}.generatedDelta.sha256`),
+    };
+    if (!/^[0-9a-f]{64}$/.test(generatedDelta.sha256)) {
+      fail(`${label}.generatedDelta.sha256 must be a lowercase SHA-256 digest`);
+    }
+
+    const generatedFiles = canonicalizeAuthorizedRecords(entry.generatedFiles, `${label}.generatedFiles`);
+    const calculatedDelta = calculateGeneratedDelta(generatedFiles);
+    if (
+      calculatedDelta.count !== generatedDelta.count ||
+      calculatedDelta.sha256 !== generatedDelta.sha256
+    ) {
+      fail(`${label} generated file closure does not match its count and digest`);
+    }
+
+    return { pullNumber, targetRef, mergeBaseSha, headSha, owner: entry.owner, expiresAt, generatedDelta, generatedFiles };
+  });
+  return { schemaVersion: 2, repository, owner: manifest.owner, authorizations };
+}
+
+function eventIdentity(event, repository, owner) {
+  const payload = requiredObject(event, 'event');
+  if (!ALLOWED_ACTIONS.has(payload.action)) fail('event action is not an allowed pull_request_target action');
+  if (requiredPositiveInteger(payload.number, 'event.number') !== payload.number) fail('event.number is invalid');
+
+  const eventRepository = requiredObject(payload.repository, 'event.repository');
+  if (eventRepository.full_name !== repository) fail('event repository does not match the protected repository');
+  if (requiredObject(eventRepository.owner, 'event.repository.owner').login !== owner) {
+    fail('event repository owner does not match the protected owner');
+  }
+
+  const pull = requiredObject(payload.pull_request, 'event.pull_request');
+  const base = requiredObject(pull.base, 'event.pull_request.base');
+  const head = requiredObject(pull.head, 'event.pull_request.head');
+  const user = requiredObject(pull.user, 'event.pull_request.user');
+  const baseRepository = requiredObject(base.repo, 'event.pull_request.base.repo');
+  const headRepository = requiredObject(head.repo, 'event.pull_request.head.repo');
+  if (requiredString(baseRepository.full_name, 'event.pull_request.base.repo.full_name') !== repository) {
+    fail('event pull request base repository does not match the protected repository');
+  }
+
+  return {
+    pullNumber: payload.number,
+    baseRef: requiredString(base.ref, 'event.pull_request.base.ref'),
+    baseSha: requiredSha(base.sha, 'event.pull_request.base.sha'),
+    headSha: requiredSha(head.sha, 'event.pull_request.head.sha'),
+    headRepository: requiredString(headRepository.full_name, 'event.pull_request.head.repo.full_name'),
+    authorLogin: requiredString(user.login, 'event.pull_request.user.login'),
+    authorAssociation: requiredString(pull.author_association, 'event.pull_request.author_association'),
+  };
+}
+
+function livePullIdentity(livePull, repository) {
+  const pull = requiredObject(livePull, 'live pull request');
+  const base = requiredObject(pull.base, 'live pull request.base');
+  const head = requiredObject(pull.head, 'live pull request.head');
+  const user = requiredObject(pull.user, 'live pull request.user');
+  const baseRepository = requiredObject(base.repo, 'live pull request.base.repo');
+  const headRepository = requiredObject(head.repo, 'live pull request.head.repo');
+
+  return {
+    pullNumber: requiredPositiveInteger(pull.number, 'live pull request.number'),
+    baseRef: requiredString(base.ref, 'live pull request.base.ref'),
+    baseSha: requiredSha(base.sha, 'live pull request.base.sha'),
+    baseRepository: requiredString(baseRepository.full_name, 'live pull request.base.repo.full_name'),
+    headSha: requiredSha(head.sha, 'live pull request.head.sha'),
+    headRepository: requiredString(headRepository.full_name, 'live pull request.head.repo.full_name'),
+    authorLogin: requiredString(user.login, 'live pull request.user.login'),
+    authorAssociation: requiredString(pull.author_association, 'live pull request.author_association'),
+    changedFiles: requiredNonNegativeInteger(pull.changed_files, 'live pull request.changed_files'),
+  };
+}
+
+function assertLiveEventCoherence(eventData, liveData, repository) {
+  if (
+    liveData.pullNumber !== eventData.pullNumber ||
+    liveData.baseRef !== eventData.baseRef ||
+    liveData.baseSha !== eventData.baseSha ||
+    liveData.headSha !== eventData.headSha ||
+    liveData.headRepository !== eventData.headRepository ||
+    liveData.baseRepository !== repository
+  ) {
+    fail('event identity is stale or ref-confused relative to the live pull request');
+  }
+}
+
+function assertCompareBaseAndGetMergeBase(compare, expectedBaseSha) {
+  const response = requiredObject(compare, 'compare response');
+  const base = requiredObject(response.base_commit, 'compare response.base_commit');
+  if (requiredSha(base.sha, 'compare response.base_commit.sha') !== expectedBaseSha) {
+    fail('compare base does not match the exact live base SHA');
+  }
+  const mergeBase = requiredObject(response.merge_base_commit, 'compare response.merge_base_commit');
+  return requiredSha(mergeBase.sha, 'compare response.merge_base_commit.sha');
+}
+
+function assertOwnerCommitSignature(commit, signature, headSha, owner) {
+  const commitResponse = requiredObject(commit, 'head commit response');
+  if (requiredSha(commitResponse.sha, 'head commit response.sha') !== headSha) {
+    fail('head commit response does not match the exact live head SHA');
+  }
+
+  const restCommit = requiredObject(commitResponse.commit, 'head commit response.commit');
+  const verification = requiredObject(restCommit.verification, 'head commit response.commit.verification');
+  if (verification.verified !== true) fail('GitHub REST does not verify the exact head signature');
+  if (requiredObject(commitResponse.author, 'head commit response.author').login !== owner) {
+    fail('GitHub REST head commit author is not the protected owner');
+  }
+
+  const graphCommit = requiredObject(signature, 'GitHub GraphQL commit signature');
+  if (requiredSha(graphCommit.oid, 'GitHub GraphQL commit signature.oid') !== headSha) {
+    fail('GitHub GraphQL signature is not for the exact live head SHA');
+  }
+  const graphSignature = requiredObject(graphCommit.signature, 'GitHub GraphQL commit signature.signature');
+  if (graphSignature.isValid !== true) fail('GitHub GraphQL does not verify the exact head signature');
+  if (requiredObject(graphSignature.signer, 'GitHub GraphQL commit signature.signer').login !== owner) {
+    fail('GitHub GraphQL signature signer is not the protected owner');
+  }
+}
+
+/**
+ * Pure authorization decision. All inputs are base-owned or GitHub API data;
+ * callers must not pass candidate checkout data to this function.
+ */
+export function authorizeGeneratedArtifactPullRequest({
+  event,
+  environment,
+  manifest,
+  repositoryMetadata,
+  workflowCommit,
+  runtimeCommit,
+  checkedOutBaseSha,
+  livePull,
+  compare,
+  commit,
+  signature,
+  files,
+  now = new Date(),
+}) {
+  const trustedManifest = validateAuthorizationManifest(manifest);
+  const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
+  const liveData = livePullIdentity(livePull, trustedManifest.repository);
+  assertLiveEventCoherence(eventData, liveData, trustedManifest.repository);
+  assertDefaultMainProvenance(
+    environment,
+    repositoryMetadata,
+    runtimeCommit,
+    workflowCommit,
+    trustedManifest.repository,
+    trustedManifest.owner,
+  );
+  assertTrustedEventBaseProvenance(environment, eventData, liveData);
+
+  if (requiredSha(checkedOutBaseSha, 'checked-out base SHA') !== eventData.baseSha) {
+    fail('checked-out base SHA does not match the exact event/live pull request base SHA');
+  }
+
+  if (liveData.changedFiles > MAX_PULL_FILES) {
+    fail('live pull request exceeds GitHub\'s fully enumerable pull-file limit');
+  }
+  const liveFiles = canonicalizeChangedFiles(files, 'live pull request files');
+  if (liveFiles.length !== liveData.changedFiles) {
+    fail('live pull request file list is malformed or truncated');
+  }
+  const compareMergeBaseSha = assertCompareBaseAndGetMergeBase(compare, liveData.baseSha);
+
+  const generatedFiles = liveFiles.filter(recordTouchesGeneratedPath);
+  if (generatedFiles.length === 0) {
+    return {
+      requiresAuthorization: false,
+      pullNumber: eventData.pullNumber,
+      generatedDelta: { count: 0, sha256: null },
+    };
+  }
+
+  const authorization = trustedManifest.authorizations.find(entry => entry.pullNumber === eventData.pullNumber);
+  if (!authorization) fail('generated changes have no base-owned authorization entry');
+  if (Date.parse(authorization.expiresAt) <= now.getTime()) {
+    fail('generated-artifact authorization has expired');
+  }
+  if (
+    authorization.targetRef !== eventData.baseRef ||
+    authorization.targetRef !== liveData.baseRef ||
+    authorization.headSha !== eventData.headSha ||
+    authorization.headSha !== liveData.headSha
+  ) {
+    fail('generated changes do not match the authorized PR/target/head identity');
+  }
+  if (authorization.mergeBaseSha !== compareMergeBaseSha) {
+    fail('compare merge base does not match the authorized merge base SHA');
+  }
+  if (
+    eventData.headRepository !== trustedManifest.repository ||
+    liveData.headRepository !== trustedManifest.repository
+  ) {
+    fail('generated changes from a fork are never authorized');
+  }
+  if (
+    eventData.authorAssociation !== 'OWNER' ||
+    liveData.authorAssociation !== 'OWNER' ||
+    eventData.authorLogin !== trustedManifest.owner ||
+    liveData.authorLogin !== trustedManifest.owner
+  ) {
+    fail('generated changes require the protected owner as the pull request author');
+  }
+
+  assertOwnerCommitSignature(commit, signature, liveData.headSha, trustedManifest.owner);
+
+  const generatedDelta = calculateGeneratedDelta(generatedFiles);
+  if (
+    generatedDelta.count !== authorization.generatedDelta.count ||
+    generatedDelta.sha256 !== authorization.generatedDelta.sha256 ||
+    !recordsEqual(generatedFiles, authorization.generatedFiles)
+  ) {
+    fail('generated changes fall outside the base-owned authorized closure');
+  }
+
+  return {
+    requiresAuthorization: true,
+    pullNumber: eventData.pullNumber,
+    generatedDelta,
+  };
+}
+
+export function evaluateGeneratedArtifactAuthorization(input) {
+  try {
+    return { allowed: true, decision: authorizeGeneratedArtifactPullRequest(input) };
+  } catch (error) {
+    return {
+      allowed: false,
+      reason: error instanceof Error ? error.message : 'unknown authorization failure',
+    };
+  }
+}
+
+function apiPath(repository, suffix) {
+  const { owner, name } = parseRepository(repository);
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${suffix}`;
+}
+
+function requiredToken(token) {
+  return requiredString(token, 'GITHUB_TOKEN');
+}
+
+export function createGitHubApiClient({ token, fetchImpl = globalThis.fetch }) {
+  const bearerToken = requiredToken(token);
+  if (typeof fetchImpl !== 'function') fail('global fetch is unavailable');
+
+  async function request(path, options = {}) {
+    const response = await fetchImpl(`${API_URL}${path}`, {
+      ...options,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${bearerToken}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(options.headers ?? {}),
+      },
+    });
+    if (!response || response.ok !== true) {
+      fail(`GitHub API request failed for ${path}`);
+    }
+    try {
+      return await response.json();
+    } catch {
+      fail(`GitHub API returned malformed JSON for ${path}`);
+    }
+  }
+
+  return {
+    get(path) {
+      return request(path, { method: 'GET' });
+    },
+    graphql(query, variables) {
+      return request('/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables }),
+      });
+    },
+  };
+}
+
+export async function fetchCompletePullFiles(api, repository, pullNumber, expectedCount) {
+  const count = requiredNonNegativeInteger(expectedCount, 'expected pull file count');
+  if (count > MAX_PULL_FILES) fail('live pull request exceeds GitHub\'s fully enumerable pull-file limit');
+
+  const pages = Math.ceil(count / 100);
+  const files = [];
+  for (let page = 1; page <= pages; page += 1) {
+    const pageFiles = await api.get(apiPath(repository, `/pulls/${pullNumber}/files?per_page=100&page=${page}`));
+    if (!Array.isArray(pageFiles)) fail('GitHub pull file page is malformed');
+    const expectedPageLength = page === pages ? count - files.length : 100;
+    if (pageFiles.length !== expectedPageLength) fail('GitHub pull file page is truncated or inconsistent');
+    files.push(...pageFiles);
+  }
+
+  const overflow = await api.get(apiPath(repository, `/pulls/${pullNumber}/files?per_page=100&page=${pages + 1}`));
+  if (!Array.isArray(overflow) || overflow.length !== 0) {
+    fail('GitHub pull file pagination is truncated or inconsistent');
+  }
+  return files;
+}
+
+const SIGNATURE_QUERY = `query ExactHeadSignature($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Commit {
+        oid
+        signature {
+          isValid
+          signer {
+            login
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export async function verifyLiveGeneratedArtifactAuthorization({
+  event,
+  manifest,
+  environment,
+  token,
+  fetchImpl,
+  repositoryRoot = REPOSITORY_ROOT,
+}) {
+  const trustedManifest = validateAuthorizationManifest(manifest);
+  const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
+  const checkedOutBaseSha = readDetachedCheckoutHead(repositoryRoot);
+  const api = createGitHubApiClient({ token, fetchImpl });
+  const repositoryMetadata = await api.get(apiPath(trustedManifest.repository, ''));
+  assertProtectedRepositoryMetadata(repositoryMetadata, trustedManifest.repository, trustedManifest.owner);
+  const runtimeCommit = await api.get(apiPath(trustedManifest.repository, '/commits/main'));
+  const workflowCommit = runtimeCommit;
+  assertDefaultMainProvenance(
+    environment,
+    repositoryMetadata,
+    runtimeCommit,
+    workflowCommit,
+    trustedManifest.repository,
+    trustedManifest.owner,
+  );
+  const livePull = await api.get(apiPath(trustedManifest.repository, `/pulls/${eventData.pullNumber}`));
+  const liveData = livePullIdentity(livePull, trustedManifest.repository);
+  assertLiveEventCoherence(eventData, liveData, trustedManifest.repository);
+  assertTrustedEventBaseProvenance(environment, eventData, liveData);
+
+  const files = await fetchCompletePullFiles(api, trustedManifest.repository, eventData.pullNumber, liveData.changedFiles);
+  // Compare is queried only for the exact base and merge-base identity. Its files
+  // array is capped independently, so only fully paginated pull files are authoritative.
+  const compare = await api.get(
+    apiPath(
+      trustedManifest.repository,
+      `/compare/${encodeURIComponent(liveData.baseSha)}...${encodeURIComponent(liveData.headSha)}?per_page=1&page=1`,
+    ),
+  );
+  const commit = await api.get(apiPath(trustedManifest.repository, `/commits/${encodeURIComponent(liveData.headSha)}`));
+
+  const { owner, name } = parseRepository(trustedManifest.repository);
+  const graphResponse = await api.graphql(SIGNATURE_QUERY, {
+    owner,
+    name,
+    expression: liveData.headSha,
+  });
+  if (!isObject(graphResponse) || !isObject(graphResponse.data) || !isObject(graphResponse.data.repository)) {
+    fail('GitHub GraphQL signature response is malformed');
+  }
+  if (Array.isArray(graphResponse.errors) && graphResponse.errors.length > 0) {
+    fail('GitHub GraphQL signature response contains errors');
+  }
+
+  const decision = authorizeGeneratedArtifactPullRequest({
+    event,
+    environment,
+    manifest: trustedManifest,
+    repositoryMetadata,
+    workflowCommit,
+    runtimeCommit,
+    checkedOutBaseSha,
+    livePull,
+    compare,
+    commit,
+    signature: graphResponse.data.repository.object,
+    files,
+  });
+
+  // Close the observable push-race window before reporting authorization.
+  const finalLivePull = await api.get(apiPath(trustedManifest.repository, `/pulls/${eventData.pullNumber}`));
+  const finalLiveData = livePullIdentity(finalLivePull, trustedManifest.repository);
+  assertLiveEventCoherence(eventData, finalLiveData, trustedManifest.repository);
+  return decision;
+}
+
+export function loadBaseOwnedManifest(manifestPath = MANIFEST_PATH) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch {
+    fail('base-owned authorization manifest is unreadable or malformed JSON');
+  }
+  return validateAuthorizationManifest(parsed);
+}
+
+async function main() {
+  const eventPath = requiredString(process.env.GITHUB_EVENT_PATH, 'GITHUB_EVENT_PATH');
+  let event;
+  try {
+    event = JSON.parse(readFileSync(eventPath, 'utf8'));
+  } catch {
+    fail('GitHub event payload is unreadable or malformed JSON');
+  }
+
+  const decision = await verifyLiveGeneratedArtifactAuthorization({
+    event,
+    manifest: loadBaseOwnedManifest(),
+    environment: {
+      githubEventName: process.env.GITHUB_EVENT_NAME,
+      githubRepository: process.env.GITHUB_REPOSITORY,
+      githubRef: process.env.GITHUB_REF,
+      githubSha: process.env.GITHUB_SHA,
+      githubWorkflowRef: process.env.GITHUB_WORKFLOW_REF,
+      githubWorkflowSha: process.env.GITHUB_WORKFLOW_SHA,
+      trustedEventBaseRef: process.env.TRUSTED_EVENT_BASE_REF,
+      trustedEventBaseSha: process.env.TRUSTED_EVENT_BASE_SHA,
+    },
+    token: process.env.GITHUB_TOKEN,
+  });
+  const prefix = decision.requiresAuthorization ? 'authorized generated delta' : 'no generated changes';
+  console.log(`${prefix}: PR #${decision.pullNumber}`);
+}
+
+const entrypoint = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (entrypoint) {
+  main().catch(error => {
+    console.error(`generated-artifact authorization failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -1,0 +1,830 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const REPOSITORY = 'Yeachan-Heo/oh-my-claudecode';
+const OWNER = 'Yeachan-Heo';
+const MERGE_BASE_SHA = '76c90920b74494df6e34d6165be963bca8a9adf6';
+const LIVE_BASE_SHA = '21a6e488ce12d79b9a22d37e1093ac8e79f21029';
+const HEAD_SHA = '10078ece166ad36332390ecbaab2d5e247852bbc';
+const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const PULL_NUMBER = 3537;
+const ROOT = process.cwd();
+const WORKFLOW_PATH = join(ROOT, '.github', 'workflows', 'generated-artifact-authorization.yml');
+const MANIFEST_PATH = join(ROOT, '.github', 'generated-artifact-authorizations.json');
+const VERIFIER_PATH = join(ROOT, 'scripts', 'verify-generated-artifact-authorization.mjs');
+
+type CanonicalRecord = {
+  status: string;
+  filename: string;
+  sha: string;
+  previousFilename: string | null;
+};
+
+type Manifest = {
+  schemaVersion: number;
+  repository: string;
+  owner: string;
+  authorizations: Array<{
+    pullNumber: number;
+    targetRef: string;
+    mergeBaseSha: string;
+    headSha: string;
+    owner: string;
+    expiresAt: string;
+    generatedDelta: { count: number; sha256: string };
+    generatedFiles: CanonicalRecord[];
+  }>;
+};
+
+type Evaluation = { allowed: boolean; reason?: string; decision?: Record<string, unknown> };
+
+type ApiFile = {
+  status: string;
+  filename: string;
+  sha: string;
+  previous_filename?: string;
+};
+
+type MutableInput = {
+  environment: {
+    githubEventName: string;
+    githubRepository: string;
+    githubRef: string;
+    githubSha: string;
+    githubWorkflowRef: string;
+    githubWorkflowSha: string;
+    trustedEventBaseRef: string;
+    trustedEventBaseSha: string;
+  };
+  manifest: Manifest;
+  repositoryMetadata: { full_name: string; owner: { login: string }; default_branch: string };
+  workflowCommit: { sha: string };
+  runtimeCommit: { sha: string };
+  checkedOutBaseSha: string;
+  event: {
+    action: string;
+    number: number;
+    repository: { full_name: string; owner: { login: string } };
+    pull_request: {
+      base: { ref: string; sha: string; repo: { full_name: string } };
+      head: { sha: string; repo: { full_name: string } };
+      user: { login: string };
+      author_association: string;
+    };
+  };
+  livePull: {
+    number: number;
+    base: { ref: string; sha: string; repo: { full_name: string } };
+    head: { sha: string; repo: { full_name: string } };
+    user: { login: string };
+    author_association: string;
+    changed_files: number;
+  };
+  compare: {
+    base_commit: { sha: string };
+    merge_base_commit: { sha: string };
+    files?: unknown;
+  };
+  commit: { sha: string; commit: { verification: { verified: boolean } }; author: { login: string } };
+  signature: { oid: string; signature: { isValid: boolean; signer: { login: string } } };
+  files: ApiFile[];
+};
+
+type VerifierModule = {
+  calculateGeneratedDelta(records: CanonicalRecord[]): { count: number; sha256: string };
+  evaluateGeneratedArtifactAuthorization(input: unknown): Evaluation;
+  verifyLiveGeneratedArtifactAuthorization(input: {
+    event: unknown;
+    manifest: unknown;
+    environment: unknown;
+    token: string;
+    fetchImpl: typeof fetch;
+    repositoryRoot: string;
+  }): Promise<unknown>;
+  validateAuthorizationManifest(manifest: unknown): unknown;
+  readDetachedCheckoutHead(repositoryRoot: string): string;
+  fetchCompletePullFiles(
+    api: { get(path: string): Promise<unknown> },
+    repository: string,
+    pullNumber: number,
+    expectedCount: number,
+  ): Promise<unknown[]>;
+};
+
+
+const verifier = (await import(pathToFileURL(VERIFIER_PATH).href)) as unknown as VerifierModule;
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as Manifest;
+const exactAuthorization = (() => {
+  const authorization = manifest.authorizations.find(entry => entry.pullNumber === PULL_NUMBER);
+  if (!authorization) throw new Error('Missing exact #3537 base-owned authorization fixture');
+  return authorization;
+})();
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function apiFiles(records = exactAuthorization.generatedFiles): ApiFile[] {
+  return records.map(record => ({
+    status: record.status,
+    filename: record.filename,
+    sha: record.sha,
+    ...(record.previousFilename === null ? {} : { previous_filename: record.previousFilename }),
+  }));
+}
+
+function authorizedInput(): MutableInput {
+  const files = apiFiles();
+  return {
+    environment: {
+      githubEventName: 'pull_request_target',
+      githubRepository: REPOSITORY,
+      githubRef: 'refs/heads/main',
+      githubSha: MAIN_SHA,
+      githubWorkflowRef: `${REPOSITORY}/.github/workflows/generated-artifact-authorization.yml@refs/heads/main`,
+      githubWorkflowSha: MAIN_SHA,
+      trustedEventBaseRef: 'main',
+      trustedEventBaseSha: LIVE_BASE_SHA,
+    },
+    manifest: clone(manifest),
+    repositoryMetadata: {
+      full_name: REPOSITORY,
+      owner: { login: OWNER },
+      default_branch: 'main',
+    },
+    workflowCommit: { sha: MAIN_SHA },
+    runtimeCommit: { sha: MAIN_SHA },
+    checkedOutBaseSha: LIVE_BASE_SHA,
+    event: {
+      action: 'synchronize',
+      number: PULL_NUMBER,
+      repository: { full_name: REPOSITORY, owner: { login: OWNER } },
+      pull_request: {
+        base: { ref: 'main', sha: LIVE_BASE_SHA, repo: { full_name: REPOSITORY } },
+        head: { sha: HEAD_SHA, repo: { full_name: REPOSITORY } },
+        user: { login: OWNER },
+        author_association: 'OWNER',
+      },
+    },
+    livePull: {
+      number: PULL_NUMBER,
+      base: { ref: 'main', sha: LIVE_BASE_SHA, repo: { full_name: REPOSITORY } },
+      head: { sha: HEAD_SHA, repo: { full_name: REPOSITORY } },
+      user: { login: OWNER },
+      author_association: 'OWNER',
+      changed_files: files.length,
+    },
+    compare: {
+      base_commit: { sha: LIVE_BASE_SHA },
+      merge_base_commit: { sha: MERGE_BASE_SHA },
+    },
+    commit: {
+      sha: HEAD_SHA,
+      commit: { verification: { verified: true } },
+      author: { login: OWNER },
+    },
+    signature: {
+      oid: HEAD_SHA,
+      signature: { isValid: true, signer: { login: OWNER } },
+    },
+    files,
+  };
+}
+
+function expectDenied(mutate: (input: MutableInput) => void, reason: string) {
+  const input = authorizedInput();
+  mutate(input);
+  const result = verifier.evaluateGeneratedArtifactAuthorization(input);
+  expect(result.allowed).toBe(false);
+  expect(result.reason).toContain(reason);
+}
+
+
+describe('generated-artifact base trust root workflow', () => {
+  it('uses only a base-owned pull_request_target checkout and minimal read-only authority', () => {
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+    expect(workflow).toMatch(
+      /^on:\n\x20{2}pull_request_target:\n\x20{4}branches: \[main, dev\]\n\x20{4}types: \[opened, synchronize, reopened\]$/m,
+    );
+    expect(workflow).not.toMatch(/^\x20{2}pull_request:/m);
+    expect(workflow).toContain('contents: read');
+    expect(workflow).toContain('pull-requests: read');
+    expect(workflow).not.toMatch(/\b(?:write|id-token|issues|checks|actions):/);
+    expect(workflow).toContain('timeout-minutes: 5');
+    expect(workflow).toContain('uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683');
+    expect(workflow).toContain('ref: ${{ github.event.pull_request.base.sha }}');
+    expect(workflow).toContain('path: trusted-base');
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain('fetch-depth: 1');
+    expect(workflow).toContain('sparse-checkout: |');
+    expect(workflow).toContain('.github/generated-artifact-authorizations.json');
+    expect(workflow).toContain('scripts/verify-generated-artifact-authorization.mjs');
+    expect(workflow).toContain('sparse-checkout-cone-mode: false');
+    expect(workflow).toContain('working-directory: trusted-base');
+    expect(workflow).toContain('node scripts/verify-generated-artifact-authorization.mjs');
+    expect(workflow).toContain('GITHUB_TOKEN: ${{ github.token }}');
+    expect(workflow).not.toContain('actions/setup-node');
+    expect(workflow).not.toMatch(/\b(?:npm|cache):/);
+    expect(workflow).not.toContain('secrets.');
+    expect(workflow).not.toMatch(/github\.event\.pull_request\.head\.(?:sha|ref)/);
+    expect(workflow).not.toMatch(/github\.(?:sha|head_ref|ref)/);
+    expect(workflow).toContain('TRUSTED_EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}');
+    expect(workflow).toContain('TRUSTED_EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}');
+    expect(workflow).not.toMatch(/^\s+run: (?!node scripts\/verify-generated-artifact-authorization\.mjs$)/m);
+  });
+
+  it('covers both the main promotion and the retained dev authorization targets', () => {
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+    expect(workflow).toContain('workflow bytes from the default branch, main');
+    expect(workflow).toContain('branches: [main, dev]');
+    expect(manifest.authorizations.map(entry => [entry.pullNumber, entry.targetRef])).toEqual([
+      [3537, 'main'],
+      [3538, 'dev'],
+      [3539, 'dev'],
+    ]);
+    expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
+      targetRef: 'dev',
+      headSha: 'e798c12426f1f11701dede43a0f35c183651627e',
+      mergeBaseSha: '10078ece166ad36332390ecbaab2d5e247852bbc',
+    });
+  });
+
+  it('is immune to candidate workflow and checker replacement because the trusted workflow checks out only base bytes', () => {
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+    const candidateWorkflow = [
+      'on: pull_request',
+      'jobs:',
+      '  bypass:',
+      '    steps:',
+      '      - run: node scripts/candidate-checker.mjs',
+    ].join('\n');
+
+    expect(candidateWorkflow).toContain('candidate-checker.mjs');
+    expect(workflow).not.toContain('candidate-checker.mjs');
+    expect(workflow).not.toContain('actions/checkout@v4\n        with:\n          ref: ${{ github.event.pull_request.head.sha }}');
+    expect(workflow).toContain('ref: ${{ github.event.pull_request.base.sha }}');
+    expect(workflow).toContain('node scripts/verify-generated-artifact-authorization.mjs');
+    const verifierSource = readFileSync(VERIFIER_PATH, 'utf8');
+    expect(verifierSource).toMatch(/from 'node:/);
+    expect(verifierSource).not.toMatch(/from ['"](?!node:)/);
+    expect(verifierSource).not.toMatch(/(?:execFile|execSync|spawn|child_process)/);
+    expect(verifierSource).toContain('const checkedOutBaseSha = readDetachedCheckoutHead(repositoryRoot)');
+    expect(verifierSource).toContain("const repositoryMetadata = await api.get(apiPath(trustedManifest.repository, ''));");
+    expect(verifierSource).toContain('?per_page=1&page=1');
+    expect(verifierSource).not.toContain('compare response.files');
+  });
+});
+
+describe('generated-artifact base-owned authorization decision', () => {
+  it('contains the exact independently derived #3537 closure and allows only its exact positive case', () => {
+    expect(manifest).toMatchObject({
+      schemaVersion: 2,
+      repository: REPOSITORY,
+      owner: OWNER,
+    });
+    expect(exactAuthorization).toMatchObject({
+      pullNumber: PULL_NUMBER,
+      targetRef: 'main',
+      mergeBaseSha: MERGE_BASE_SHA,
+      headSha: HEAD_SHA,
+      owner: OWNER,
+      expiresAt: '2026-08-05T00:00:00.000Z',
+      generatedDelta: {
+        count: 199,
+        sha256: '3c1987d239441a787e5428d38b74e9bff51d694ad554d9fe34eae72cd78b059f',
+      },
+    });
+    expect(verifier.calculateGeneratedDelta(exactAuthorization.generatedFiles)).toEqual(exactAuthorization.generatedDelta);
+    expect(verifier.validateAuthorizationManifest(manifest)).toBeTruthy();
+    expect(LIVE_BASE_SHA).not.toBe(MERGE_BASE_SHA);
+
+    expect(verifier.evaluateGeneratedArtifactAuthorization(authorizedInput())).toEqual({
+      allowed: true,
+      decision: {
+        requiresAuthorization: true,
+        pullNumber: PULL_NUMBER,
+        generatedDelta: exactAuthorization.generatedDelta,
+      },
+    });
+  });
+
+  it('allows ordinary contributor pull requests with no generated changes and no authorization entry', () => {
+    const input = authorizedInput();
+    const sourceFile = { status: 'modified', filename: 'src/index.ts', sha: 'a'.repeat(40) };
+    input.event.pull_request.head.repo.full_name = 'contributor/oh-my-claudecode';
+    input.event.pull_request.user.login = 'contributor';
+    input.event.pull_request.author_association = 'CONTRIBUTOR';
+    input.livePull.head.repo.full_name = 'contributor/oh-my-claudecode';
+    input.livePull.user.login = 'contributor';
+    input.livePull.author_association = 'CONTRIBUTOR';
+    input.livePull.changed_files = 1;
+    input.files = [sourceFile];
+
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toEqual({
+      allowed: true,
+      decision: {
+        requiresAuthorization: false,
+        pullNumber: PULL_NUMBER,
+        generatedDelta: { count: 0, sha256: null },
+      },
+    });
+  });
+
+  it('requires separate main runtime/workflow and explicit event-base provenance before every decision', () => {
+    expect(verifier.evaluateGeneratedArtifactAuthorization(authorizedInput())).toMatchObject({ allowed: true });
+    expectDenied(input => {
+      input.environment.githubRef = 'refs/heads/dev';
+    }, 'runtime GITHUB_REF is not the protected default branch');
+    expectDenied(input => {
+      input.environment.githubSha = LIVE_BASE_SHA;
+    }, 'runtime GITHUB_SHA does not match the current protected default-main commit SHA');
+    expectDenied(input => {
+      input.environment.githubSha = 'A'.repeat(40);
+    }, 'runtime GITHUB_SHA');
+    expectDenied(input => {
+      input.runtimeCommit.sha = 'b'.repeat(40);
+    }, 'runtime GITHUB_SHA does not match the current protected default-main commit SHA');
+    expectDenied(input => {
+      input.environment.githubWorkflowRef = `attacker/oh-my-claudecode/.github/workflows/generated-artifact-authorization.yml@refs/heads/main`;
+    }, 'runtime GITHUB_WORKFLOW_REF');
+    expectDenied(input => {
+      input.environment.githubWorkflowSha = 'b'.repeat(40);
+    }, 'runtime GITHUB_WORKFLOW_SHA does not match the current protected default-main workflow commit SHA');
+    expectDenied(input => {
+      input.workflowCommit.sha = 'b'.repeat(40);
+    }, 'runtime GITHUB_WORKFLOW_SHA does not match the current protected default-main workflow commit SHA');
+    expectDenied(input => {
+      input.environment.trustedEventBaseRef = 'dev';
+    }, 'explicit event base ref does not match');
+    expectDenied(input => {
+      input.environment.trustedEventBaseRef = '';
+    }, 'TRUSTED_EVENT_BASE_REF');
+    expectDenied(input => {
+      input.environment.trustedEventBaseSha = 'b'.repeat(40);
+    }, 'explicit event base SHA does not match');
+    expectDenied(input => {
+      input.environment.trustedEventBaseSha = 'A'.repeat(40);
+    }, 'TRUSTED_EVENT_BASE_SHA');
+    expectDenied(input => {
+      delete (input.environment as Partial<typeof input.environment>).trustedEventBaseSha;
+    }, 'runtime environment has unexpected or missing fields');
+    expectDenied(input => {
+      input.event.pull_request.base.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
+    expectDenied(input => {
+      input.livePull.base.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
+    expectDenied(input => {
+      input.repositoryMetadata.full_name = 'attacker/oh-my-claudecode';
+    }, 'live repository metadata repository does not match');
+    expectDenied(input => {
+      input.repositoryMetadata.owner.login = 'attacker';
+    }, 'live repository metadata owner does not match');
+    expectDenied(input => {
+      input.repositoryMetadata.default_branch = 'dev';
+    }, 'default branch is not main');
+  });
+
+  it('rejects symbolic, unreadable, and wrong detached checkout heads', () => {
+    const checkoutRoot = mkdtempSync(join(tmpdir(), 'generated-artifact-authorization-'));
+    const gitDirectory = join(checkoutRoot, '.git');
+    mkdirSync(gitDirectory);
+    try {
+      writeFileSync(join(gitDirectory, 'HEAD'), `${LIVE_BASE_SHA}\n`);
+      const exactCheckedOutBaseSha = verifier.readDetachedCheckoutHead(checkoutRoot);
+      expect(exactCheckedOutBaseSha).toBe(LIVE_BASE_SHA);
+      const exactCheckoutInput = authorizedInput();
+      exactCheckoutInput.checkedOutBaseSha = exactCheckedOutBaseSha;
+      expect(verifier.evaluateGeneratedArtifactAuthorization(exactCheckoutInput)).toMatchObject({ allowed: true });
+
+      writeFileSync(join(gitDirectory, 'HEAD'), 'ref: refs/heads/main\n');
+      expect(() => verifier.readDetachedCheckoutHead(checkoutRoot)).toThrow('not a detached');
+      expect(() => verifier.readDetachedCheckoutHead(join(checkoutRoot, 'missing'))).toThrow('unreadable');
+
+      writeFileSync(join(gitDirectory, 'HEAD'), `${'b'.repeat(40)}\n`);
+      const wrongCheckedOutBaseSha = verifier.readDetachedCheckoutHead(checkoutRoot);
+      expect(wrongCheckedOutBaseSha).toBe('b'.repeat(40));
+      expectDenied(input => {
+        input.checkedOutBaseSha = wrongCheckedOutBaseSha;
+      }, 'checked-out base SHA does not match');
+    } finally {
+      rmSync(checkoutRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects stale or ref-confused live/event base and head identities', () => {
+    expectDenied(input => {
+      input.livePull.head.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
+    expectDenied(input => {
+      input.livePull.base.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
+    expectDenied(input => {
+      input.event.pull_request.base.sha = 'b'.repeat(40);
+    }, 'stale or ref-confused');
+  });
+
+  it('uses compare only for base and merge-base identity, never its capped files array', () => {
+    const omittedCompareFiles = authorizedInput();
+    expect(verifier.evaluateGeneratedArtifactAuthorization(omittedCompareFiles)).toMatchObject({ allowed: true });
+
+    const hiddenCompareFiles = authorizedInput();
+    hiddenCompareFiles.compare.files = [];
+    expect(verifier.evaluateGeneratedArtifactAuthorization(hiddenCompareFiles)).toMatchObject({ allowed: true });
+    const injectedCompareFiles = authorizedInput();
+    injectedCompareFiles.compare.files = Array.from({ length: 300 }, (_, index) => ({
+      status: 'added',
+      filename: `dist/compare-only-${index}.js`,
+      sha: 'b'.repeat(40),
+    }));
+    expect(verifier.evaluateGeneratedArtifactAuthorization(injectedCompareFiles)).toMatchObject({
+      allowed: true,
+      decision: { generatedDelta: exactAuthorization.generatedDelta },
+    });
+  });
+
+  it('rejects malformed or mismatched compare base and merge-base identities', () => {
+    expectDenied(input => {
+      input.compare.base_commit = {} as { sha: string };
+    }, 'base_commit.sha');
+    expectDenied(input => {
+      input.compare.base_commit.sha = 'b'.repeat(40);
+    }, 'compare base does not match');
+    expectDenied(input => {
+      input.compare.merge_base_commit = {} as { sha: string };
+    }, 'merge_base_commit.sha');
+    expectDenied(input => {
+      input.compare.merge_base_commit.sha = 'b'.repeat(40);
+    }, 'authorized merge base SHA');
+  });
+
+  it('rejects generated changes from forks and non-owner contributors', () => {
+    expectDenied(input => {
+      input.event.pull_request.head.repo.full_name = 'fork/oh-my-claudecode';
+      input.livePull.head.repo.full_name = 'fork/oh-my-claudecode';
+    }, 'fork');
+    expectDenied(input => {
+      input.event.pull_request.user.login = 'contributor';
+      input.livePull.user.login = 'contributor';
+      input.event.pull_request.author_association = 'CONTRIBUTOR';
+      input.livePull.author_association = 'CONTRIBUTOR';
+    }, 'protected owner');
+  });
+
+  it('rejects unsigned, unknown, and wrong-signer exact heads', () => {
+    expectDenied(input => {
+      input.commit.commit.verification.verified = false;
+    }, 'GitHub REST does not verify');
+    expectDenied(input => {
+      input.signature.signature.isValid = false;
+    }, 'GitHub GraphQL does not verify');
+    expectDenied(input => {
+      input.signature.signature.signer = null as unknown as { login: string };
+    }, 'signer must be an object');
+    expectDenied(input => {
+      input.signature.signature.signer.login = 'attacker';
+    }, 'signature signer');
+  });
+
+  it('rejects missing base authorization and any generated closure or digest violation', () => {
+    expectDenied(input => {
+      input.manifest.authorizations = [];
+    }, 'no base-owned authorization entry');
+    expectDenied(input => {
+      input.manifest.authorizations[0].generatedDelta.sha256 = 'b'.repeat(64);
+    }, 'count and digest');
+    expectDenied(input => {
+      input.files[0].sha = 'c'.repeat(40);
+    }, 'authorized closure');
+    expectDenied(input => {
+      input.manifest.authorizations[0].expiresAt = '2000-01-01T00:00:00.000Z';
+    }, 'authorization has expired');
+    expectDenied(input => {
+      input.files.push({ status: 'added', filename: 'dist/extra.js', sha: 'd'.repeat(40) });
+      input.livePull.changed_files += 1;
+    }, 'authorized closure');
+  });
+
+  it('requires exact authorization for generated-path rename, copy, and deletion records', () => {
+    const records: Array<{ api: ApiFile; canonical: CanonicalRecord }> = [
+      {
+        api: {
+          status: 'renamed',
+          filename: 'src/moved-generated.js',
+          sha: 'b'.repeat(40),
+          previous_filename: 'dist/moved-generated.js',
+        },
+        canonical: {
+          status: 'renamed',
+          filename: 'src/moved-generated.js',
+          sha: 'b'.repeat(40),
+          previousFilename: 'dist/moved-generated.js',
+        },
+      },
+      {
+        api: {
+          status: 'copied',
+          filename: 'docs/copied-generated.js',
+          sha: 'c'.repeat(40),
+          previous_filename: 'bridge/copied-generated.cjs',
+        },
+        canonical: {
+          status: 'copied',
+          filename: 'docs/copied-generated.js',
+          sha: 'c'.repeat(40),
+          previousFilename: 'bridge/copied-generated.cjs',
+        },
+      },
+      {
+        api: { status: 'removed', filename: 'dist/removed-generated.js', sha: 'd'.repeat(40) },
+        canonical: {
+          status: 'removed',
+          filename: 'dist/removed-generated.js',
+          sha: 'd'.repeat(40),
+          previousFilename: null,
+        },
+      },
+      {
+        api: {
+          status: 'renamed',
+          filename: 'dist/moved-into-generated.js',
+          sha: 'e'.repeat(40),
+          previous_filename: 'src/moved-into-generated.js',
+        },
+        canonical: {
+          status: 'renamed',
+          filename: 'dist/moved-into-generated.js',
+          sha: 'e'.repeat(40),
+          previousFilename: 'src/moved-into-generated.js',
+        },
+      },
+      {
+        api: {
+          status: 'copied',
+          filename: 'bridge/copied-into-generated.cjs',
+          sha: 'f'.repeat(40),
+          previous_filename: 'src/copied-into-generated.ts',
+        },
+        canonical: {
+          status: 'copied',
+          filename: 'bridge/copied-into-generated.cjs',
+          sha: 'f'.repeat(40),
+          previousFilename: 'src/copied-into-generated.ts',
+        },
+      },
+    ];
+
+    for (const record of records) {
+      const unauthorized = authorizedInput();
+      unauthorized.files = [record.api];
+      unauthorized.livePull.changed_files = 1;
+      unauthorized.manifest.authorizations = [];
+      expect(verifier.evaluateGeneratedArtifactAuthorization(unauthorized)).toMatchObject({
+        allowed: false,
+        reason: expect.stringContaining('no base-owned authorization entry'),
+      });
+
+      const authorized = authorizedInput();
+      authorized.files = [record.api];
+      authorized.livePull.changed_files = 1;
+      authorized.manifest.authorizations[0].generatedFiles = [record.canonical];
+      authorized.manifest.authorizations[0].generatedDelta = verifier.calculateGeneratedDelta([record.canonical]);
+      expect(verifier.evaluateGeneratedArtifactAuthorization(authorized)).toMatchObject({
+        allowed: true,
+        decision: { generatedDelta: authorized.manifest.authorizations[0].generatedDelta },
+      });
+
+      const outsideClosure = authorizedInput();
+      outsideClosure.files = [record.api];
+      outsideClosure.livePull.changed_files = 1;
+      expect(verifier.evaluateGeneratedArtifactAuthorization(outsideClosure)).toMatchObject({
+        allowed: false,
+        reason: expect.stringContaining('authorized closure'),
+      });
+    }
+  });
+
+  it('rejects malformed, missing, and inapplicable previous filenames before scope classification', () => {
+    const malformedRecords: Array<{ file: unknown; reason: string }> = [
+      {
+        file: { status: 'renamed', filename: 'src/missing.js', sha: 'b'.repeat(40) },
+        reason: 'previousFilename must be a non-empty string',
+      },
+      {
+        file: {
+          status: 'copied',
+          filename: 'src/null.js',
+          sha: 'b'.repeat(40),
+          previous_filename: null,
+        },
+        reason: 'previousFilename must be a non-empty string',
+      },
+      {
+        file: {
+          status: 'renamed',
+          filename: 'src/empty.js',
+          sha: 'b'.repeat(40),
+          previous_filename: '',
+        },
+        reason: 'previousFilename must be a non-empty string',
+      },
+      {
+        file: {
+          status: 'copied',
+          filename: 'src/absolute.js',
+          sha: 'b'.repeat(40),
+          previous_filename: '/dist/source.js',
+        },
+        reason: 'previousFilename is not a canonical repository path',
+      },
+      {
+        file: {
+          status: 'renamed',
+          filename: 'src/dot-segment.js',
+          sha: 'b'.repeat(40),
+          previous_filename: 'dist/../source.js',
+        },
+        reason: 'previousFilename is not a canonical repository path',
+      },
+      {
+        file: {
+          status: 'copied',
+          filename: 'src/double-separator.js',
+          sha: 'b'.repeat(40),
+          previous_filename: 'bridge//source.cjs',
+        },
+        reason: 'previousFilename is not a canonical repository path',
+      },
+      {
+        file: {
+          status: 'modified',
+          filename: 'src/inapplicable.js',
+          sha: 'b'.repeat(40),
+          previous_filename: 'dist/source.js',
+        },
+        reason: 'previousFilename is only allowed for renamed or copied files',
+      },
+    ];
+
+    for (const record of malformedRecords) {
+      const input = authorizedInput();
+      input.files = [record.file as ApiFile];
+      input.livePull.changed_files = 1;
+      expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
+        allowed: false,
+        reason: expect.stringContaining(record.reason),
+      });
+    }
+  });
+
+  it('treats fully paginated pull files, including an empty overflow page, as the sole file-set authority', async () => {
+    const requestedPaths: string[] = [];
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({ index }));
+    const api = {
+      get: async (path: string): Promise<unknown> => {
+        requestedPaths.push(path);
+        if (path.endsWith('page=1')) return firstPage;
+        if (path.endsWith('page=2')) return [{ index: 100 }];
+        if (path.endsWith('page=3')) return [];
+        throw new Error(`Unexpected path ${path}`);
+      },
+    };
+
+    await expect(verifier.fetchCompletePullFiles(api, REPOSITORY, PULL_NUMBER, 101)).resolves.toHaveLength(101);
+    expect(requestedPaths).toEqual([
+      `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}/files?per_page=100&page=1`,
+      `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}/files?per_page=100&page=2`,
+      `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}/files?per_page=100&page=3`,
+    ]);
+    await expect(
+      verifier.fetchCompletePullFiles(
+        { get: async (path: string): Promise<unknown> => (path.endsWith('page=1') ? firstPage : [{ extra: true }]) },
+        REPOSITORY,
+        PULL_NUMBER,
+        100,
+      ),
+    ).rejects.toThrow('pagination is truncated or inconsistent');
+    await expect(verifier.fetchCompletePullFiles(api, REPOSITORY, PULL_NUMBER, 3001)).rejects.toThrow('fully enumerable');
+  });
+
+  it('rejects malformed or truncated live pull-file evidence', () => {
+    expectDenied(input => {
+      input.livePull.changed_files += 1;
+    }, 'malformed or truncated');
+    expectDenied(input => {
+      input.files = input.files.slice(1);
+    }, 'malformed or truncated');
+  });
+  it('fetches and binds the protected main commit before live pull evidence', async () => {
+    const checkoutRoot = mkdtempSync(join(tmpdir(), 'generated-artifact-authorization-'));
+    mkdirSync(join(checkoutRoot, '.git'));
+    writeFileSync(join(checkoutRoot, '.git', 'HEAD'), `${LIVE_BASE_SHA}\n`);
+
+    try {
+      const input = authorizedInput();
+      const requestedPaths: string[] = [];
+      let mainCommitRequests = 0;
+      const fetchImpl: typeof fetch = async request => {
+        const url = new URL(
+          typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+        );
+        const path = `${url.pathname}${url.search}`;
+        requestedPaths.push(path);
+        let body: unknown;
+        if (path === `/repos/${REPOSITORY}`) body = input.repositoryMetadata;
+        else if (path === `/repos/${REPOSITORY}/commits/main`) body = ++mainCommitRequests === 1 ? input.runtimeCommit : input.workflowCommit;
+        else if (path === `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}`) body = input.livePull;
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=1')) body = input.files.slice(0, 100);
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=2')) body = input.files.slice(100);
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=3')) body = [];
+        else if (path.startsWith(`/repos/${REPOSITORY}/compare/`)) body = input.compare;
+        else if (path === `/repos/${REPOSITORY}/commits/${HEAD_SHA}`) body = input.commit;
+        else if (path === '/graphql') body = { data: { repository: { object: input.signature } } };
+        else throw new Error(`Unexpected GitHub API path ${path}`);
+        return { ok: true, json: async () => body } as Response;
+      };
+
+      await expect(
+        verifier.verifyLiveGeneratedArtifactAuthorization({
+          event: input.event,
+          manifest: input.manifest,
+          environment: input.environment,
+          token: 'test-token',
+          fetchImpl,
+          repositoryRoot: checkoutRoot,
+        }),
+      ).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
+      expect(requestedPaths).toContain(`/repos/${REPOSITORY}/commits/main`);
+      expect(requestedPaths.indexOf(`/repos/${REPOSITORY}`)).toBeLessThan(
+        requestedPaths.indexOf(`/repos/${REPOSITORY}/commits/main`),
+      );
+
+      const racedInput = authorizedInput();
+      const racePaths: string[] = [];
+      const raceFetch: typeof fetch = async request => {
+        const url = new URL(
+          typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+        );
+        const path = `${url.pathname}${url.search}`;
+        racePaths.push(path);
+        if (path === `/repos/${REPOSITORY}`) {
+          return { ok: true, json: async () => racedInput.repositoryMetadata } as Response;
+        }
+        if (path === `/repos/${REPOSITORY}/commits/main`) {
+          return { ok: true, json: async () => ({ sha: 'b'.repeat(40) }) } as Response;
+        }
+        throw new Error(`Unexpected GitHub API path ${path}`);
+      };
+      await expect(
+        verifier.verifyLiveGeneratedArtifactAuthorization({
+          event: racedInput.event,
+          manifest: racedInput.manifest,
+          environment: racedInput.environment,
+          token: 'test-token',
+          fetchImpl: raceFetch,
+          repositoryRoot: checkoutRoot,
+        }),
+      ).rejects.toThrow('GITHUB_SHA does not match the current protected default-main commit SHA');
+      expect(racePaths).toEqual([`/repos/${REPOSITORY}`, `/repos/${REPOSITORY}/commits/main`]);
+    } finally {
+      rmSync(checkoutRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed before fetching main when metadata no longer identifies main as default', async () => {
+    const checkoutRoot = mkdtempSync(join(tmpdir(), 'generated-artifact-authorization-'));
+    mkdirSync(join(checkoutRoot, '.git'));
+    writeFileSync(join(checkoutRoot, '.git', 'HEAD'), `${LIVE_BASE_SHA}\n`);
+    const input = authorizedInput();
+    input.repositoryMetadata.default_branch = 'dev';
+    const requestedPaths: string[] = [];
+    const fetchImpl: typeof fetch = async request => {
+      const url = new URL(
+        typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+      );
+      requestedPaths.push(`${url.pathname}${url.search}`);
+      return { ok: true, json: async () => input.repositoryMetadata } as Response;
+    };
+
+    try {
+      await expect(
+        verifier.verifyLiveGeneratedArtifactAuthorization({
+          event: input.event,
+          manifest: input.manifest,
+          environment: input.environment,
+          token: 'test-token',
+          fetchImpl,
+          repositoryRoot: checkoutRoot,
+        }),
+      ).rejects.toThrow('default branch is not main');
+      expect(requestedPaths).toEqual([`/repos/${REPOSITORY}`]);
+    } finally {
+      rmSync(checkoutRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- adds a main-owned, read-only `pull_request_target` trust root for generated-artifact authorization
- binds #3537 to its exact `main` target, head, merge base, full generated closure, owner, verified signature, and expiry
- retains independently recomputed `dev` records for #3538 and #3539; #3538 uses exact head `e798c12426f1f11701dede43a0f35c183651627e`

## Validation
- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts` — 19 passed
- `npx eslint src/__tests__/generated-artifact-authorization.test.ts`
- `node --check scripts/verify-generated-artifact-authorization.mjs`
- manifest load and workflow branch-coverage checks for `main` and `dev`

gaebal-gajae
