### PR TITLE
chore(release): v4.15.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.15.6",
+      "version": "4.15.7",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.15.6"
+  "version": "4.15.7"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,33 +1,29 @@
-# oh-my-claudecode v4.15.6: Named Stage Profiles & Reliability Fixes
+# oh-my-claudecode v4.15.7: Bug Fixes
 
 ## Release Notes
 
-Release with **1 new feature**, **10 bug fixes** across **11 merged PRs**.
+Release with **4 bug fixes**, **1 other change** across **5 merged PRs**.
 
 ### Highlights
 
-- **feat(autopilot): add named stage profiles** (#3492)
-
-### New Features
-
-- **feat(autopilot): add named stage profiles** (#3492)
+- **fix(psm): fail closed on malformed worktree results** (#3531)
+- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
+- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
 
 ### Bug Fixes
 
-- **fix(release): guard coordinator across shipped surfaces** (#3516)
-- **fix: ship complete plugin runtime closure** (#3479)
-- **fix(windows): ship hidden worktree git subprocesses** (#3501)
-- **fix(ultragoal): make the /goal handoff satisfy the guard, not just the ledger** (#3514)
-- **fix(lsp): handle server-to-client requests** (#3511)
-- **fix(ultragoal): defer /goal guard until confirmation** (#3510)
-- **fix(beads): correct CLI instruction syntax** (#3505)
-- **fix(session-start): keep plugin drift guidance on marketplace channel** (#3500)
-- **fix(session-start): align update notices with plugin channel** (#3499)
-- **fix(windows): bound generic-hook runner timeout ownership and nested git** (#3496)
+- **fix(psm): fail closed on malformed worktree results** (#3531)
+- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
+- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
+- **fix(windows): separate prompt host and worker timeouts** (#3525)
+
+### Other Changes
+
+- **ci: add main generated-artifact authorization trust root** (#3540)
 
 ### Stats
 
-- **11 PRs merged** | **1 new feature** | **10 bug fixes** | **0 security/hardening improvements** | **0 other changes**
+- **5 PRs merged** | **0 new features** | **4 bug fixes** | **0 security/hardening improvements** | **1 other change**
 
 ### Install / Update
 
@@ -36,7 +32,7 @@ The npm CLI and the Claude Code marketplace/plugin are separate install tracks, 
 **CLI / runtime:**
 
 ```bash
-npm install -g oh-my-claude-sisyphus@4.15.6
+npm install -g oh-my-claude-sisyphus@4.15.7
 ```
 
 **Claude Code plugin:**
@@ -45,10 +41,10 @@ npm install -g oh-my-claude-sisyphus@4.15.6
 /plugin marketplace update omc
 ```
 
-**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.5...v4.15.6
+**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.6...v4.15.7
 
 ## Contributors
 
 Thank you to all contributors who made this release possible!
 
-@FrontHeadlock @Yeachan-Heo
+@Yeachan-Heo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,26 @@
-# oh-my-claudecode v4.15.6: Named Stage Profiles & Reliability Fixes
+# oh-my-claudecode v4.15.7: Bug Fixes
 
 ## Release Notes
 
-Release with **1 new feature**, **10 bug fixes** across **11 merged PRs**.
+Release with **4 bug fixes**, **1 other change** across **5 merged PRs**.
 
 ### Highlights
 
-- **feat(autopilot): add named stage profiles** (#3492)
-
-### New Features
-
-- **feat(autopilot): add named stage profiles** (#3492)
+- **fix(psm): fail closed on malformed worktree results** (#3531)
+- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
+- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
 
 ### Bug Fixes
 
-- **fix(release): guard coordinator across shipped surfaces** (#3516)
-- **fix: ship complete plugin runtime closure** (#3479)
-- **fix(windows): ship hidden worktree git subprocesses** (#3501)
-- **fix(ultragoal): make the /goal handoff satisfy the guard, not just the ledger** (#3514)
-- **fix(lsp): handle server-to-client requests** (#3511)
-- **fix(ultragoal): defer /goal guard until confirmation** (#3510)
-- **fix(beads): correct CLI instruction syntax** (#3505)
-- **fix(session-start): keep plugin drift guidance on marketplace channel** (#3500)
-- **fix(session-start): align update notices with plugin channel** (#3499)
-- **fix(windows): bound generic-hook runner timeout ownership and nested git** (#3496)
+- **fix(psm): fail closed on malformed worktree results** (#3531)
+- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
+- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
+- **fix(windows): separate prompt host and worker timeouts** (#3525)
+
+### Other Changes
+
+- **ci: add main generated-artifact authorization trust root** (#3540)
 
 ### Stats
 
-- **11 PRs merged** | **1 new feature** | **10 bug fixes** | **0 security/hardening improvements** | **0 other changes**
+- **5 PRs merged** | **0 new features** | **4 bug fixes** | **0 security/hardening improvements** | **1 other change**

--- a/README.md
+++ b/README.md
@@ -646,18 +646,18 @@ Top personal non-fork, non-archived repos from all-time OMC contributors (100+ G
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) — [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) (⭐ 38k)
 - [@junhoyeo](https://github.com/junhoyeo) — [tokscale](https://github.com/junhoyeo/tokscale) (⭐ 4.5k)
 - [@psmux](https://github.com/psmux) — [psmux](https://github.com/psmux/psmux) (⭐ 3k)
-- [@MeroZemory](https://github.com/MeroZemory) — [ida-multi-mcp](https://github.com/MeroZemory/ida-multi-mcp) (⭐ 330)
+- [@MeroZemory](https://github.com/MeroZemory) — [ida-multi-mcp](https://github.com/MeroZemory/ida-multi-mcp) (⭐ 346)
 - [@BowTiedSwan](https://github.com/BowTiedSwan) — [buildflow](https://github.com/BowTiedSwan/buildflow) (⭐ 295)
 - [@J-Pster](https://github.com/J-Pster) — [Psters_AI_Workflow](https://github.com/J-Pster/Psters_AI_Workflow) (⭐ 291)
 - [@alohays](https://github.com/alohays) — [awesome-visual-representation-learning-with-transformers](https://github.com/alohays/awesome-visual-representation-learning-with-transformers) (⭐ 271)
-- [@devswha](https://github.com/devswha) — [patina](https://github.com/devswha/patina) (⭐ 264)
+- [@devswha](https://github.com/devswha) — [patina](https://github.com/devswha/patina) (⭐ 267)
 - [@jcwleo](https://github.com/jcwleo) — [random-network-distillation-pytorch](https://github.com/jcwleo/random-network-distillation-pytorch) (⭐ 263)
-- [@HaD0Yun](https://github.com/HaD0Yun) — [Doyunha-Gopeak](https://github.com/HaD0Yun/Doyunha-Gopeak) (⭐ 234)
+- [@HaD0Yun](https://github.com/HaD0Yun) — [Doyunha-Gopeak](https://github.com/HaD0Yun/Doyunha-Gopeak) (⭐ 235)
 - [@shaun0927](https://github.com/shaun0927) — [openchrome](https://github.com/shaun0927/openchrome) (⭐ 224)
 - [@emgeee](https://github.com/emgeee) — [mean-tutorial](https://github.com/emgeee/mean-tutorial) (⭐ 200)
 - [@anduinnn](https://github.com/anduinnn) — [HiFiNi-Auto-CheckIn](https://github.com/anduinnn/HiFiNi-Auto-CheckIn) (⭐ 170)
-- [@Znuff](https://github.com/Znuff) — [consolas-powerline](https://github.com/Znuff/consolas-powerline) (⭐ 146)
-- [@changeroa](https://github.com/changeroa) — [StyleGallery](https://github.com/changeroa/StyleGallery) (⭐ 133)
+- [@Znuff](https://github.com/Znuff) — [consolas-powerline](https://github.com/Znuff/consolas-powerline) (⭐ 145)
+- [@changeroa](https://github.com/changeroa) — [StyleGallery](https://github.com/changeroa/StyleGallery) (⭐ 138)
 
 <!-- OMC:FEATURED-CONTRIBUTORS:END -->
 

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -834,8 +834,8 @@ function executeClaudeMdTransaction(request) {
 
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
-var COMPILED_ENGINE_VERSION = true ? "4.15.6" : "";
-var COMPILED_SOURCE_SHA256 = true ? "e3f8b38cb0e1e6d443e723ec6b22887aa1bdb364a62055b8d946a9de2e05ec58" : "";
+var COMPILED_ENGINE_VERSION = true ? "4.15.7" : "";
+var COMPILED_SOURCE_SHA256 = true ? "b48e214289eabf8e720ab7565c563f9b1c40b0f69e506718e9ddd8c6caf23049" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.15.6 -->
+<!-- OMC:VERSION:4.15.7 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.15.6",
+      "version": "4.15.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Prepare v4.15.7 release metadata after the owner-authorized dev-to-main promotion.

This PR updates the package/plugin versions, lockfile, changelog, release body, README metadata, and CLAUDE.md marker.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*