### PR TITLE
ci: authorize exact generated closure for PR #3541 (dev)

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1280,6 +1280,26 @@
           "previousFilename": null
         }
       ]
+    },
+    {
+      "pullNumber": 3541,
+      "targetRef": "dev",
+      "mergeBaseSha": "42e0dec70e78acac1721e6f2978424b27954cad9",
+      "headSha": "2b760b06d6818be0c44b4163f9be8d273b72990c",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 1,
+        "sha256": "7ef32991a590162307bfe1356cf64c32839d03f4046072e47adf12dd99509b3e"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "d7515d5cdbca8a5517f77e31dd3eb703f5d7f404",
+          "previousFilename": null
+        }
+      ]
     }
   ]
 }

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -246,6 +246,7 @@ describe('generated-artifact base trust root workflow', () => {
       [3537, 'main'],
       [3538, 'dev'],
       [3539, 'dev'],
+      [3541, 'dev'],
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',


### PR DESCRIPTION
## Purpose

Authorizes the **exact generated closure** for PR #3541 by adding the base-owned generated-artifact authorization record to `.github/generated-artifact-authorizations.json`.

This is the sole mutation-owner transaction for the base-owned generated-artifact authorization of #3541. It does not modify records #3537/#3538/#3539.

## Authorization record

| Field | Value |
|---|---|
| `pullNumber` | 3541 |
| `targetRef` | `dev` |
| `mergeBaseSha` | `42e0dec70e78acac1721e6f2978424b27954cad9` |
| `headSha` | `2b760b06d6818be0c44b4163f9be8d273b72990c` |
| `owner` | `Yeachan-Heo` |
| `expiresAt` | `2026-08-05T00:00:00.000Z` |
| generated delta | count **1**, sha256 `7ef32991a590162307bfe1356cf64c32839d03f4046072e47adf12dd99509b3e` |
| generated files | `modified bridge/claude-md-coordinator.cjs` (blob `d7515d5cdbca8a5517f77e31dd3eb703f5d7f404`) |

## Determinism / trust

- The full base..head diff contains 9 modified files; only the generated-prefix path (`bridge/`, `dist/`) qualifies for the generated delta, which is exactly `bridge/claude-md-coordinator.cjs`.
- The per-file `sha` is the git blob object id at the exact head (`git rev-parse <head>:<path>`), semantics confirmed against the in-history #3537 record.
- The delta `count`/`sha256` were computed with the repository canonical `calculateGeneratedDelta`, and the full manifest passes `validateAuthorizationManifest`. The trust check is not weakened.

## Verification

- `src/__tests__/generated-artifact-authorization.test.ts` — 19/19 passing (membership guard updated to include the new dev record).
- Canonical `validateAuthorizationManifest` accepts the manifest; #3537/#3538/#3539 remain intact.
- Only authorization transaction files changed (manifest + its guard test).

## Relation

Authorizes the exact generated closure for #3541 (target `dev`). After merge to `dev`, #3541 checks are rerun/rebased against updated `dev`.
