### PR TITLE
feat(graph): durable orchestration graph with in-graph loop + ASCII visualizer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,6 +28,7 @@
     "./skills/deep-interview/",
     "./skills/deepinit/",
     "./skills/external-context/",
+    "./skills/graph/",
     "./skills/hud/",
     "./skills/learner/",
     "./skills/local-build-reminder/",

--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ Named profiles currently require Linux with the `flock` utility because their tr
 
 V1 intentionally excludes model fields or routing (`stageModels`), inline execution, dynamic commands/modes/state, arbitrary stages or plugins, and the separate custom-skill frontmatter parser mismatch. See [Named Autopilot Stage Profiles ADR](docs/adr/03487-named-autopilot-stage-profiles.md) and [Reference](docs/REFERENCE.md#named-autopilot-stage-profiles-v1).
 
+#### Durable orchestration Graph (v1)
+
+Use Graph when a long-running task needs explicit branches, parallel work, human gates, and crash-resumable progress:
+
+```text
+/oh-my-claudecode:graph "extract payments into a separately deployable service"
+```
+
+Graph first drafts a typed execution plan, renders every node and route for inspection, and requires approval of the exact revision before any work starts. Its built-in `agent`, `command`, `human-approval`, and `join` nodes support fixed and conditional routes, parallel fan-out/fan-in, and bounded returns to earlier nodes.
+
+Graph records cross-node control flow; it does not replace Ralph's persistent implementation loop or Autopilot's staged autonomous workflow. A node may iterate locally, while Graph remains the top-level scheduler. Pause preserves the run for resume; explicit abandon is permanent and retains the ledger. Graph v1 execution requires Linux with `/proc` and `flock`, does not guarantee exactly-once external side effects, and does not include a visual editor or public authoring DSL. See the [Graph reference](docs/REFERENCE.md#durable-orchestration-graph-v1) and [decision record](docs/adr/v1-durable-orchestration-graph.md).
+
 
 That's it. Everything else is automatic.
 
@@ -144,6 +156,7 @@ OMC exposes two different surfaces:
 | Setup                                          | `omc setup`                                   | `/setup` or `/omc-setup`                                                | Both are real entrypoints. `/setup` is the easiest plugin-first path.                                                                |
 | Ask providers                                  | `omc ask codex "review this patch"`           | `/ask codex "review this patch"`                                        | Both route through the same advisor flow. Providers: `claude`, `codex`, `gemini`, `antigravity`, `grok`, `cursor`.                                            |
 | Team orchestration                             | `omc team 2:codex "review auth flow"`         | `/team 3:executor "fix all TypeScript errors"`                          | Both exist, but they are different runtimes: `omc team` launches tmux CLI workers; `/team` runs the in-session native team workflow. |
+| Durable Graph                                  | Guarded `omc graph` operations               | `/oh-my-claudecode:graph <goal>`                                        | The skill drafts, obtains exact-revision approval, and dispatches work; terminal operations guard the durable state machine.         |
 | Autopilot / Ralph / Ultrawork / Deep Interview | —                                             | `/autopilot ...`, `/ralph ...`, `/ultrawork ...`, `/deep-interview ...` | These are in-session skills. There is no `omc autopilot` / `omc ralph` / `omc ultrawork` CLI subcommand in this repo.                |
 | Autoresearch                                   | `omc autoresearch` (**hard-deprecated shim**) | `/deep-interview --autoresearch ...` + `/oh-my-claudecode:autoresearch` | Setup stays in deep-interview; execution now belongs to the stateful skill.                                                          |
 
@@ -302,6 +315,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 | **Team (recommended)**      | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list                         |
 | **omc team (CLI)**          | tmux CLI workers — real `claude`/`codex`/`gemini`/`antigravity`/`grok`/`cursor-agent` processes in split-panes       | Codex/Gemini/Antigravity/Grok/Cursor CLI tasks; on-demand spawn, die when done             |
 | **ccg**                     | Tri-model advisors via `/ask codex` + `/ask antigravity`, Claude synthesizes             | Mixed backend+UI work needing both Codex and Antigravity                     |
+| **Graph**                   | Human-approved nodes, routes, and durable scheduler progress                             | Long-running work with branches, parallel joins, human gates, and resume |
 | **Autopilot**               | Autonomous execution (single lead agent)                                                | End-to-end feature work with minimal ceremony                           |
 | **Ultrawork**               | Maximum parallelism (non-team)                                                          | Burst parallel fixes/refactors where Team isn't needed                  |
 | **Ralph**                   | Persistent mode with verify/fix loops                                                   | Tasks that must complete fully (no silent partials)                     |
@@ -313,7 +327,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 
 ### Goal Workflow Guidance
 
-Use only one primary loop authority in a session. Claude Code `/goal` is useful for a native cross-turn completion condition, while Ralph owns single-agent verified completion, Team owns parallel staged execution, and UltraQA owns repeated quality-gate cycling. Artifact-only Ultragoal is the safe fallback when you need durable goal artifacts and evidence without starting another loop.
+Use only one primary orchestration authority in a session. Graph owns explicit cross-node routing and durable recovery, Claude Code `/goal` provides a native cross-turn completion condition, Ralph owns single-agent verified completion, Team owns parallel staged execution, and UltraQA owns repeated quality-gate cycling. Artifact-only Ultragoal is the safe fallback when you need durable goal artifacts and evidence without starting another loop.
 
 For `/goal` behavior, rely on Claude Code/Anthropic sources: the [Claude Code `/goal` docs](https://code.claude.com/docs/en/goal) and [Anthropic Claude Code changelog](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md). Do **not** claim the `/goal` evaluator independently runs commands or reads files; surface test output, diffs, and review evidence in the conversation before treating a goal as proven.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,7 @@
 5. [Agent Templates](#agent-templates)
 6. [Session Resume](#session-resume)
 7. [Autopilot](#autopilot)
+8. [Durable Orchestration Graph (v1)](#durable-orchestration-graph-v1)
 
 ---
 
@@ -571,6 +572,58 @@ All state is persisted to `.omc/state/autopilot-state.json` and includes:
 - Agent spawn count and metrics
 - Phase duration tracking
 - Session binding
+
+---
+
+## Durable Orchestration Graph (v1)
+
+Graph is a separate top-level runtime for development work whose control flow must remain explicit across parallel branches, conditional remediation, human gates, and process interruption. The public in-session entrypoint is:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+The skill creates a draft and renders the exact revision for inspection. Execution is forbidden until the human approves that revision ID and descriptor hash. Bare natural-language mentions of "graph" do not activate the mode.
+
+### Runtime boundary
+
+The `src/graph/` core adds no runtime dependency and owns descriptor validation and hashing, deterministic scheduling, immutable revision handling, claim leases, Graph-wide transactions, control ownership, and bounded presentation. Skill, CLI, hook, state, and HUD integrations are adapters. They must not become alternate graph authorities.
+
+One session-scoped `graph-state.json` transaction object is authoritative for recovery. It embeds approved descriptor revisions, committed transition history, the current projection, claims, selected edges, traversal and join tokens, pending approval or reconciliation data, evidence references, and a monotonic commit sequence. Logs, HUD state, and exports can be regenerated.
+
+### Descriptor and scheduler contract
+
+- Built-in nodes are `agent`, `command`, `human-approval`, and `join`.
+- Edges support fixed continuation, declared conditional routes, parallel fan-out/fan-in, and bounded back-edges.
+- V1 fork/join regions are structured and non-overlapping; nested, overlapping, or crossing open regions fail validation.
+- Each fan-out traversal receives its own cohort and branch tokens, so a join waits only for branches selected in that traversal.
+- Terminal success requires fresh evidence from the declared verification node.
+
+An `agent` node may perform bounded local iteration, but it does not activate global Ralph mode. Graph remains the sole top-level scheduler. Ralph continues to own persistent implementation/verification loops, and Autopilot continues to own its existing staged workflow.
+
+### Durability and effects
+
+A successful mutation atomically commits the node result, selected route, traversal counters, ready nodes, and join state under revision, sequence, transition, attempt, and lease fences. Recovery reconstructs readiness from the approved descriptor and committed ledger and does not rerun committed successful work.
+
+This is an exactly-once scheduler-transition guarantee, not an exactly-once external-side-effect guarantee. Side-effect-free or durably idempotent work can be reclaimed after lease expiry. Ambiguous effects move to reconciliation, where evidence or an explicit human decision is required before progress resumes.
+
+Structural patches stop new dispatch and require approval of a new immutable revision after old claims and reconciliation have settled. Historical descriptors and evidence remain preserved.
+
+### Lifecycle and state integration
+
+- `pause` fences or drains work, preserves the resumable run, and releases root control.
+- `resume` reacquires the same session, run, and revision with a new nonce.
+- `abandon` requires exact run/revision confirmation, records terminal `cancelled`, and retains the ledger. Destructive purge is outside v1.
+- Generic state reads and bounded summaries are allowed; generic Graph writes and deletion are not.
+- `state_clear(graph)` returns `guarded_mode`; `state_clear(all)` skips Graph; force does not bypass the guard.
+
+The in-session skill owns drafting, approval questions, node dispatch, and result reporting. Guarded `omc graph` operations expose the runtime state machine for terminal automation without acting as a task executor or raw state editor; exact subcommand names remain intentionally undocumented until that surface is final.
+
+### Platform and scope
+
+Graph v1 execution requires Linux with `/proc` and owner-fenced `flock`; unsupported platforms fail before control reservation or state mutation. V1 excludes a visual editor, public stable authoring DSL, plugin-defined node kinds, arbitrary executable edge code, nested or overlapping fork regions, distributed scheduling, destructive purge, and exactly-once external side effects.
+
+See [ADR: Durable Orchestration Graph V1](./adr/v1-durable-orchestration-graph.md) for the decision record and [Reference Documentation](./REFERENCE.md#durable-orchestration-graph-v1) for the user-facing lifecycle contract.
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -13,8 +13,10 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated-opt-in-only)
 - [Agents (29 Total)](#agents-29-total)
-- [Goal Workflow UX: `/goal`, Ralph, Team, UltraQA, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultraqa-ultragoal)
-- [Skills (38 Total)](#skills-38-total)
+- [Goal Workflow UX: Graph, `/goal`, Ralph, Team, UltraQA, Ultragoal](#goal-workflow-ux-graph-goal-ralph-team-ultraqa-ultragoal)
+- [Named autopilot stage profiles (v1)](#named-autopilot-stage-profiles-v1)
+- [Durable orchestration Graph (v1)](#durable-orchestration-graph-v1)
+- [Skills (39 Total)](#skills-39-total)
 - [Slash Commands](#slash-commands)
 - [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
 - [Hooks System](#hooks-system)
@@ -729,12 +731,13 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ---
 
-## Goal Workflow UX: `/goal`, Ralph, Team, UltraQA, Ultragoal
+## Goal Workflow UX: Graph, `/goal`, Ralph, Team, UltraQA, Ultragoal
 
-OMC exposes several ways to pursue a goal-shaped task. They are complementary, not interchangeable. Choose one primary loop authority per session and use the others as evidence producers or handoff targets.
+OMC exposes several ways to pursue a goal-shaped task. They are complementary, not interchangeable. Choose one primary orchestration authority per session and use the others as evidence producers or handoff targets.
 
 | Surface                 | Runtime owner                                     | User-facing promise                                           | Completion evidence                                                          | Notes                                                                                                                                                           |
 | ----------------------- | ------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Graph                   | OMC approved-graph scheduler                      | Follow explicit nodes and routes with durable crash recovery  | Immutable revision, transition ledger, node evidence, and terminal verifier  | Prefer when branches, joins, human gates, and bounded returns must remain visible across interruptions.                                                        |
 | Claude Code `/goal`     | Claude Code native session loop                   | Keep working toward one stated completion condition           | Evidence surfaced in the conversation for the `/goal` evaluator              | Cite Claude Code/Anthropic docs or changelog only for `/goal` behavior. The evaluator must not be described as independently running commands or reading files. |
 | Ralph                   | OMC skill + Stop-hook enforcement                 | Persistent single-owner implementation until PRD stories pass | Tests/build/lint/typecheck plus reviewer verification                        | Prefer when correctness depends on OMC's PRD, progress, and reviewer gates.                                                                                     |
 | Team                    | OMC native/team or CLI team runtime               | Coordinated multi-agent execution over assigned tasks         | Worker task results, commits, staged `team-verify`/`team-fix` evidence       | Prefer when ownership boundaries and parallel lanes matter.                                                                                                     |
@@ -754,7 +757,7 @@ Do not cite OpenAI/Codex documentation as authority for Claude Code `/goal`. In 
 
 When multiple loops could apply, use this deterministic policy:
 
-1. **refuse**: if Ralph, Team, UltraQA, autopilot, or another Stop-hook loop is already active and a new `/goal` would compete for continuation authority.
+1. **refuse**: if Graph, Ralph, Team, UltraQA, autopilot, or another Stop-hook loop is already active and a new `/goal` would compete for continuation authority.
 2. **adopt_existing**: if Claude Code `/goal` is already active and the OMC workflow can attach evidence to that same condition without changing loop ownership.
 3. **artifact_only**: if `/goal` is unavailable because of hooks/trust/settings, or if the user only needs durable planning, checkpointing, and evidence capture.
 
@@ -800,7 +803,51 @@ Autopilot continues to own cancel, resume, cleanup, state inspection, HUD, and S
 
 V1 deliberately defers `stageModels` and all model/provider/role routing, inline/no-spawn execution, dynamic commands/modes/state files, arbitrary stages/prompts/plugins and control-flow extensions, and the separate custom-skill inline-array frontmatter parser mismatch. See [ADR 03487](./adr/03487-named-autopilot-stage-profiles.md) for the decision record.
 
-## Skills (38 Total)
+## Durable orchestration Graph (v1)
+
+Invoke Graph explicitly inside a Claude Code / OMC session:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+A bare natural-language mention of "graph" does not activate the workflow. The skill first creates and validates a draft, then renders its exact revision ID and integrity hash together with all nodes, commands, routes, joins, back-edge bounds, concurrency, and terminal verification responsibility. No node work starts until the human approves that exact revision.
+
+### Execution model
+
+| Node kind | Behavior |
+| --- | --- |
+| `agent` | Dispatches bounded development work and returns a structured result. |
+| `command` | Runs a permission-governed command or automated test and records evidence. |
+| `human-approval` | Waits durably for an explicit human decision. |
+| `join` | Reunites only the branches selected for the current fan-out traversal. |
+
+Declared edges provide fixed continuation, result-selected conditional routes, parallel fan-out/fan-in, and bounded returns to an earlier node. V1 supports structured, non-overlapping fork/join regions; nested or crossing open regions are rejected. A discovered structural change becomes a patch proposal: dispatch pauses, the human inspects a new revision, and only exact-revision approval can activate it. Earlier descriptors, results, and evidence remain in history.
+
+Graph makes cross-node control explicit. Ralph remains the persistent single-owner implementation and verification loop, while Autopilot remains its staged autonomous workflow. An `agent` node may iterate locally without activating global Ralph mode; Graph still owns readiness, routing, joins, and recovery.
+
+### Pause, resume, and abandon
+
+- Ordinary cancellation pauses the run, fences or drains active work, preserves `graph-state.json`, and releases top-level control.
+- Resume reacquires the same session, run, and revision with a new ownership nonce. It does not create a replacement run or rerun already committed successful work.
+- Abandon is an explicit permanent transition to terminal `cancelled`. It requires confirmation of the exact run and revision and retains the ledger and evidence. V1 has no destructive purge.
+- Waiting for initial approval, a human node, patch approval, or reconciliation is durable and does not busy-loop.
+
+The session-scoped `graph-state.json` is the recovery authority. It contains immutable revisions, committed transitions, the current projection, claims, selected routes, join tokens, and evidence references. HUD output, logs, and exports are bounded disposable views.
+
+Terminal automation uses guarded `omc graph` state-machine operations. Exact subcommand names are not part of this v1 documentation contract. The CLI does not execute agent, command, or human nodes itself and does not expose raw Graph state replacement.
+
+### Safety and v1 boundaries
+
+Graph guarantees exactly-once committed scheduler transitions, not exactly-once external side effects. Side-effect-free or durably idempotent work can retry after an interrupted claim. An ambiguous external effect enters visible reconciliation instead of being silently replayed.
+
+Generic state tools may read, list, report status, and show bounded Graph summaries. Generic `state_write(graph)` is unavailable. `state_clear(graph)` returns `guarded_mode`, while `state_clear(all)` skips Graph and reports the skip; force does not bypass either protection. Use Graph-specific pause or abandon operations for lifecycle changes.
+
+Graph v1 execution is Linux-only and requires owner-fenced `flock` plus `/proc` process identity. Unsupported platforms fail before control reservation or Graph state mutation. V1 does not provide a visual editor, public stable authoring DSL, plugin-defined node kinds, arbitrary executable edge expressions, distributed scheduling, nested/overlapping fork regions, or exactly-once external effects.
+
+See [ADR: Durable Orchestration Graph V1](./adr/v1-durable-orchestration-graph.md) for the architectural decision and its relationship to [Autopilot profile ADR 03487](./adr/03487-named-autopilot-stage-profiles.md).
+
+## Skills (39 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
@@ -821,6 +868,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `deep-interview`          | Socratic deep interview with ambiguity gating                    | `/deep-interview`                           |
 | `deepinit`                | Generate hierarchical AGENTS.md docs                             | `/oh-my-claudecode:deepinit`                |
 | `external-context`        | Parallel document-specialist research                            | `/oh-my-claudecode:external-context`        |
+| `graph`                   | Human-approved durable graph orchestration                       | `/oh-my-claudecode:graph <goal>`            |
 | `hud`                     | Configure HUD/statusline                                         | `/oh-my-claudecode:hud`                     |
 | `skillify`                | Extract reusable skill from session                              | `/oh-my-claudecode:skillify`                |
 | `learner`                 | **Deprecated** compatibility alias for `skillify`                | `/oh-my-claudecode:learner`                 |
@@ -864,6 +912,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:deep-dive <problem>`                  | Run the trace → deep-interview pipeline                                                       |
 | `/deep-interview <idea>`                                 | Socratic interview with ambiguity scoring before execution                                    |
 | `/oh-my-claudecode:deepinit [path]`                      | Index codebase with hierarchical AGENTS.md files                                              |
+| `/oh-my-claudecode:graph <goal>`                         | Draft, approve, and run a durable orchestration graph                                          |
 | `/oh-my-claudecode:mcp-setup`                            | Configure MCP servers                                                                         |
 | `/oh-my-claudecode:omc-doctor`                           | Diagnose and fix installation issues                                                          |
 | `/oh-my-claudecode:plan <description>`                   | Start planning session (supports consensus structured deliberation)                           |

--- a/docs/adr/v1-durable-orchestration-graph.md
+++ b/docs/adr/v1-durable-orchestration-graph.md
@@ -1,0 +1,105 @@
+# ADR: Durable Orchestration Graph V1
+
+- **Status:** Accepted for v1
+- **Decision scope:** Explicit, human-approved, crash-resumable control flow for long-running development work
+
+## Decision
+
+OMC will add Graph as a separate top-level orchestration runtime, invoked explicitly in session with:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+Graph turns the goal into a typed execution descriptor whose approved revisions are immutable. It renders that descriptor for inspection and requires human approval of the exact revision ID and hash before any node may run. The approved graph, transition ledger, current projection, claims, selected routes, join tokens, and revision history live together in one authoritative, session-scoped `graph-state.json` transaction object.
+
+Graph does not replace Ralph or widen Autopilot. Ralph remains a persistent implementation and verification loop. Autopilot remains its established staged autonomous workflow. A Graph `agent` node may perform bounded local iteration, but Graph remains the only top-level scheduler and records which node is active, which edge was selected, and what is ready next.
+
+## Drivers
+
+- Long-running tasks lose their global shape when the next action exists only in an agent's conversation context.
+- Parallel branches, conditional remediation, human gates, and crash recovery require explicit persisted control state.
+- Completed work must survive driver or agent interruption without relying on prompt memory.
+- Structural changes discovered during execution need reviewable, immutable revisions rather than silent graph mutation.
+- Existing Ralph and Autopilot users require compatibility, not a migration to a new runtime.
+
+## Descriptor, approval, and revisions
+
+The v1 descriptor declares stable node IDs, node kinds, entry nodes, typed edges and route labels, joins, concurrency, bounded back-edges, and terminal verification responsibility. Its canonical JSON is hashed with SHA-256; mutable attempts, outputs, owners, and timestamps are excluded from the descriptor hash.
+
+The approval view identifies every node, command, route, join, return bound, concurrency limit, and terminal verification node. Drafting and validation may occur before approval, but dispatch may not. Approval binds to the exact revision ID and descriptor hash.
+
+Agents may propose structural patches but may not apply them. A proposal pauses new dispatch, waits for old claims and reconciliation to settle, and requires human approval of a new immutable revision. The ledger retains earlier descriptors, results, and evidence; completed node IDs cannot be silently reused.
+
+## Nodes and routes
+
+V1 has four built-in node kinds:
+
+| Node | Responsibility |
+| --- | --- |
+| `agent` | Perform bounded delegated development work and return a structured result. |
+| `command` | Run a permission-governed command or automated test and report structured evidence. |
+| `human-approval` | Wait durably for an explicit human decision. |
+| `join` | Deterministically synchronize the selected branches of one fan-out traversal. |
+
+Edges support fixed continuation, declared conditional routes, parallel fan-out/fan-in, and bounded returns to an earlier node. V1 fork/join regions are structured and non-overlapping: every fan-out owns one join, and nested or crossing open regions are rejected. Edge conditions are declared route labels, not arbitrary executable expressions.
+
+## State, commits, and recovery
+
+The scheduler commits a node result, selected route, traversal counters, resulting readiness, and join state in one compare-and-swap transaction. A monotonic sequence, revision/hash fence, transition ID, activation ID, attempt ID, and claim lease prevent duplicate or stale work from winning after recovery.
+
+This provides exactly-once committed scheduler transitions. It does **not** provide exactly-once external side effects. Side-effect-free work and work with durable idempotency keys may be retried after an expired lease. An ambiguous external effect enters visible reconciliation and requires evidence or a human decision before the graph continues.
+
+Recovery rebuilds readiness from the approved revision and committed history. Successful committed nodes are not rerun. Logs, HUD projections, and exports are disposable views; they are not recovery authorities.
+
+## Runtime ownership and lifecycle
+
+Graph is mutually exclusive with other root persistent workflow owners, including standalone Ralph and Autopilot. A child adapter cannot release the Graph root or become a second scheduler.
+
+Ordinary Graph cancellation maps to `pause`: new dispatch stops, claims and children are fenced or drained, durable state becomes `paused`, and root control is released. `resume` reacquires the same session, run, and revision with a new ownership nonce; it does not create a replacement run. Permanent termination is the explicit `abandon` operation, which requires exact run/revision confirmation, records terminal `cancelled`, and retains the full ledger and evidence. Destructive purge is outside v1.
+
+The in-session skill owns descriptor drafting, exact-revision questions, node dispatch, and result reporting. Terminal automation may use guarded `omc graph` operations, but those operations are a state-machine boundary, not a general task executor or a raw state editor.
+
+## Public-state handling
+
+Generic state surfaces may read, list, report status, and render bounded summaries for Graph. They may not replace or delete Graph state. Generic `state_write(graph)` is unavailable; `state_clear(graph)` returns `guarded_mode`; `state_clear(all)` skips Graph and reports the skip. A force flag does not bypass these protections. Pausing and abandoning use Graph-specific atomic operations.
+
+## Platform boundary
+
+Graph v1 execution requires Linux with `/proc` process identity and owner-fenced `flock`. An unsupported runtime fails before reserving control or creating or mutating Graph state. Pure descriptor validation and scheduler logic may remain portable and tested elsewhere.
+
+## Alternatives
+
+### Extend Team task dependencies
+
+Rejected. Team task files do not provide graph-wide atomic route selection, join cohorts, immutable revisions, claim fencing, or a complete recovery ledger.
+
+### Encode Graph as an Autopilot named profile
+
+Rejected. Named profiles intentionally compose a closed set of linear Autopilot stages. [ADR 03487](./03487-named-autopilot-stage-profiles.md) explicitly defers branches, loops, DAGs, and arbitrary workflow engines to a separate architecture.
+
+### Implement Graph only in prompts
+
+Rejected. Prompt memory cannot prove atomic resume, prevent stale completion, or distinguish committed work from an interrupted external effect.
+
+### Adopt a general graph engine or plugin DSL
+
+Rejected for v1. OMC needs a small local scheduler with its own state, ownership, and recovery contracts. A dependency or public extension surface would broaden compatibility and trust requirements before those contracts are proven.
+
+## Why chosen
+
+A separate deterministic core keeps explicit control flow and durable recovery testable without changing Ralph or Autopilot semantics. Human-approved immutable revisions make execution inspectable, while the single transaction object keeps structure, progress, and evidence consistent after interruption.
+
+## Consequences
+
+Graph adds more ceremony than a loop: users must inspect the graph, approve revisions, and reconcile ambiguous side effects. In exchange, long-running branching work has a durable global plan, explicit parallelism, bounded remediation paths, and recoverable progress.
+
+Graph-specific state and ownership paths require parity across plugin and standalone-installed hooks. Generic state mutation remains intentionally narrower than for older modes.
+
+## Migration and compatibility
+
+There is no migration for existing Ralph, Autopilot, or Team workflows. Graph activates only through its explicit skill entrypoint; bare natural-language mentions of "graph" do not select the mode. Existing invocations and state identities remain unchanged.
+
+## Follow-ups and explicit deferrals
+
+V1 does not include a visual editor, a public stable authoring DSL, plugin-defined node kinds, arbitrary executable edge code, distributed or cross-repository scheduling, nested or overlapping fork/join regions, destructive state purge, silent agent graph mutation, or exactly-once external side effects.

--- a/examples/graph/README.md
+++ b/examples/graph/README.md
@@ -1,0 +1,64 @@
+# Graph-Ralph Example: Auth Feature
+
+This example demonstrates the graph+ralph integration: **graph defines the structure, ralph executes each node.**
+
+## The Graph
+
+```
+explore -> plan -> implement -> test
+                      ↑           |
+                      └─── fix ──┘
+                      ↓
+                   retry (max 3)
+```
+
+## Nodes (4 agent nodes, each executed by ralph)
+
+| Node | Title | Ralph's Job |
+|------|-------|-------------|
+| explore | Codebase Exploration | PRD: map architecture, find patterns, document tech stack |
+| plan | Implementation Plan | PRD: design routes, middleware, token strategy, schema |
+| implement | Implementation | PRD: create endpoints, JWT middleware, schema migration |
+| test | Test & Verify | PRD: integration tests for all auth flows, run suite |
+
+## Edges (5)
+
+| Edge | Type | Purpose |
+|------|------|---------|
+| explore -> plan | fixed | Sequential |
+| plan -> implement | fixed | Sequential |
+| implement -> test | conditional (done) | Happy path |
+| implement -> implement | back_edge (retry, max 3) | Retry on failure |
+| test -> implement | conditional (fix) | Tests found issues |
+
+## How to Run
+
+```bash
+# 1. Load the descriptor
+/graph examples/graph/auth-feature-descriptor.json
+
+# Or describe the goal directly
+/graph "Add user authentication to the API with login, register, and token refresh"
+```
+
+## What Happens
+
+1. **Phase 1 (Graph Engineering)**: The descriptor is loaded, validated, and presented for human approval. The SHA-256 hash is computed and sealed.
+
+2. **Phase 2 (Loop Engineering)**: The driver loop begins:
+   - Claims `explore` node -> ralph executes it (PRD -> stories -> verify -> reviewer -> done)
+   - Commits result, advances to `plan`
+   - Ralph executes `plan` node
+   - Commits, advances to `implement`
+   - Ralph executes `implement` (with retry back-edge if needed)
+   - On success, advances to `test`
+   - Ralph executes `test` (terminal verification)
+   - If tests fail, conditional edge `fix` routes back to `implement`
+   - When `test` succeeds with evidence, graph is complete
+
+## Key Integration Points
+
+- **Graph descriptor** defines the DAG structure (what runs, in what order)
+- **Ralph** provides persistence per node (PRD, stories, verification, reviewer)
+- **Back-edge** with `max_traversals: 3` bounds retries
+- **Terminal verification** requires fresh evidence (test results)

--- a/examples/graph/auth-feature-descriptor.json
+++ b/examples/graph/auth-feature-descriptor.json
@@ -1,0 +1,76 @@
+{
+  "descriptor_version": 1,
+  "run_id": "example-add-auth-20260722",
+  "revision_id": "rev-1",
+  "goal": "Add user authentication to the API with login, register, and token refresh",
+  "nodes": [
+    {
+      "id": "explore",
+      "kind": "agent",
+      "title": "Codebase Exploration",
+      "instructions": "Explore the codebase to understand the existing architecture, patterns, and auth-related code. Map the directory structure, find existing middleware, identify the database schema, and document the tech stack. Output a summary of findings that will inform the implementation plan.",
+      "timeout_ms": 300000,
+      "max_attempts": 2,
+      "effect_policy": { "policy": "side_effect_free" }
+    },
+    {
+      "id": "plan",
+      "kind": "agent",
+      "title": "Implementation Plan",
+      "instructions": "Based on the exploration findings, design the authentication implementation. Define the API routes (/login, /register, /refresh), middleware structure, token strategy (JWT), and database schema changes. Output a concrete plan with file paths and interfaces.",
+      "timeout_ms": 300000,
+      "max_attempts": 2,
+      "effect_policy": { "policy": "side_effect_free" }
+    },
+    {
+      "id": "implement",
+      "kind": "agent",
+      "title": "Implementation",
+      "instructions": "Implement the authentication feature according to the plan. Create the login, register, and token refresh endpoints. Add JWT middleware. Update the database schema. Write the code in the appropriate files. Ensure TypeScript compiles without errors.",
+      "timeout_ms": 1800000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "idempotent", "idempotency_key_template": "auth-impl-{iteration}" }
+    },
+    {
+      "id": "test",
+      "kind": "agent",
+      "title": "Test & Verify",
+      "instructions": "Write integration tests for all auth flows: successful login, wrong password, token refresh, expired token, register validation. Run the test suite, lint, and typecheck. All tests must pass. Output test results as evidence.",
+      "timeout_ms": 600000,
+      "max_attempts": 2,
+      "effect_policy": { "policy": "side_effect_free" }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1-explore-plan",
+      "from": "explore",
+      "to": "plan",
+      "kind": "fixed"
+    },
+    {
+      "id": "e2-plan-implement",
+      "from": "plan",
+      "to": "implement",
+      "kind": "fixed"
+    },
+    {
+      "id": "e3-implement-test",
+      "from": "implement",
+      "to": "test",
+      "kind": "conditional",
+      "route": "done"
+    },
+    {
+      "id": "e4-implement-retry",
+      "from": "implement",
+      "to": "implement",
+      "kind": "back_edge",
+      "route": "retry",
+      "max_traversals": 3
+    }
+  ],
+  "entry_node_ids": ["explore"],
+  "concurrency_limit": 1,
+  "terminal_verification_node_id": "test"
+}

--- a/scripts/graph/__tests__/visualize.test.mjs
+++ b/scripts/graph/__tests__/visualize.test.mjs
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { renderAsciiGraph, renderHeader, topologicalOrder } from '../visualize.mjs';
+
+const descriptorPath = fileURLToPath(
+  new URL('../../../examples/graph/auth-feature-descriptor.json', import.meta.url),
+);
+const descriptor = JSON.parse(readFileSync(descriptorPath, 'utf8'));
+
+describe('topologicalOrder', () => {
+  it('orders nodes by DFS, excluding back-edges', () => {
+    expect(topologicalOrder(descriptor)).toEqual(['explore', 'plan', 'implement', 'test']);
+  });
+});
+
+describe('renderAsciiGraph', () => {
+  const nodeStatus = new Map([
+    ['explore', 'completed'],
+    ['plan', 'completed'],
+    ['implement', 'running'],
+    ['test', 'ready'],
+  ]);
+  const output = renderAsciiGraph(descriptor, nodeStatus, 'running');
+
+  it('renders every node id and title', () => {
+    expect(output).toContain('explore');
+    expect(output).toContain('Codebase Exploration');
+    expect(output).toContain('plan');
+    expect(output).toContain('Implementation Plan');
+    expect(output).toContain('implement');
+    expect(output).toContain('Implementation');
+    expect(output).toContain('test');
+    expect(output).toContain('Test & Verify');
+  });
+
+  it('uses box-drawing chars and downward arrows', () => {
+    expect(output).toContain('┌');
+    expect(output).toContain('└');
+    expect(output).toContain('│');
+    expect(output).toContain('▼');
+  });
+
+  it('marks each status with its emoji', () => {
+    expect(output).toContain('✅');
+    expect(output).toContain('▶️');
+    expect(output).toContain('⏳');
+  });
+
+  it('renders a top progress line listing completed nodes', () => {
+    expect(output).toContain('Progress: 2/4 done');
+    expect(output).toContain('[explore✅]');
+    expect(output).toContain('[plan✅]');
+    expect(output).toContain('implement▶️');
+    expect(output).toContain('test⏳');
+  });
+
+  it('labels the conditional edge route', () => {
+    expect(output).toContain('done');
+  });
+
+  it('renders the back-edge as a labeled side-note', () => {
+    expect(output).toContain('retry');
+    expect(output).toContain('max 3');
+    expect(output).toContain('-> implement');
+  });
+
+  it('does not emit mermaid', () => {
+    expect(output).not.toContain('mermaid');
+    expect(output).not.toContain('flowchart');
+    expect(output).not.toContain('classDef');
+  });
+});
+
+describe('renderHeader', () => {
+  const state = {
+    status: 'running',
+    active_revision_id: 'rev-1',
+    active_revision_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    revisions: { 'rev-1': { descriptor } },
+  };
+  const output = renderHeader(state, descriptor);
+
+  it('includes goal, run status, hash, entry, terminal, concurrency', () => {
+    expect(output).toContain('Goal:');
+    expect(output).toContain('Run: running');
+    expect(output).toContain('#a1b2c3d4');
+    expect(output).toContain('Entry: explore');
+    expect(output).toContain('Terminal: test');
+    expect(output).toContain('Concurrency: 1');
+  });
+});

--- a/scripts/graph/visualize.mjs
+++ b/scripts/graph/visualize.mjs
@@ -1,0 +1,635 @@
+#!/usr/bin/env node
+/**
+ * Graph-Ralph Visualizer
+ *
+ * Reads a graph state JSON file and renders an ASCII-art diagram with each
+ * node marked by its current activation status:
+ *   - ready (pending)    : ⏳
+ *   - running (active)   : ▶️
+ *   - completed (done)    : ✅
+ *   - failed (error)      : ❌
+ *
+ * ASCII art renders inline in Claude Code's terminal (Mermaid does not).
+ * ANSI color is applied only when stdout is a TTY, so captured/piped output
+ * stays as clean box-drawing + emoji text.
+ *
+ * Usage:
+ *   node scripts/graph/visualize.mjs <path-to-graph-state.json>
+ *   node scripts/graph/visualize.mjs --demo   # simulate a running state
+ *   node scripts/graph/visualize.mjs --descriptor <descriptor.json>
+ */
+
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { argv, exit, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Status metadata
+// ---------------------------------------------------------------------------
+
+const VALID_STATUSES = new Set(['ready', 'running', 'completed', 'failed']);
+
+// emoji always shown; ANSI color applied only when stdout is a TTY
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+
+const STATUS_META = {
+  ready: { emoji: '⏳', word: 'ready', color: DIM },
+  running: { emoji: '▶️', word: 'running', color: YELLOW },
+  completed: { emoji: '✅', word: 'completed', color: GREEN },
+  failed: { emoji: '❌', word: 'failed', color: RED },
+};
+
+const USE_COLOR = stdout.isTTY === true;
+
+// Cap inner box width so long node IDs (up to 256 chars per ID_PATTERN) do
+// not blow the box out past a normal terminal width. Long IDs are truncated
+// with an ellipsis instead; see formatLeftContent.
+const MAX_INNER_WIDTH = 72;
+const ELLIPSIS = '…';
+
+function maybeColor(text, color) {
+  return USE_COLOR && color ? `${color}${text}${RESET}` : text;
+}
+
+function statusMeta(status) {
+  return STATUS_META[status] ?? STATUS_META.ready;
+}
+
+// ---------------------------------------------------------------------------
+// Visual-width helpers (account for emoji double width + ANSI escapes)
+// ---------------------------------------------------------------------------
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(text) {
+  return text.replace(ANSI_RE, '');
+}
+
+function visualWidth(text) {
+  const clean = stripAnsi(text);
+  let width = 0;
+  for (const ch of clean) {
+    const code = ch.codePointAt(0);
+    // variation selectors, ZWJ, combining marks -> zero width
+    if (code === 0xfe0f || code === 0xfe0e || code === 0x200d) continue;
+    if (code >= 0x0300 && code <= 0x036f) continue;
+    // emoji / pictographic -> double width
+    if (code >= 0x1f300) { width += 2; continue; }
+    if (code === 0x23f3 || code === 0x2705 || code === 0x274c || code === 0x25b6 || code === 0x25c0 || code === 0x2b22) {
+      width += 2;
+      continue;
+    }
+    width += 1;
+  }
+  return width;
+}
+
+function padRight(text, width) {
+  const w = visualWidth(text);
+  return w >= width ? text : text + ' '.repeat(width - w);
+}
+
+function hardBreak(text, width) {
+  const out = [];
+  for (let i = 0; i < text.length; i += width) out.push(text.slice(i, i + width));
+  return out;
+}
+
+function wrapText(text, width) {
+  const safeWidth = Math.max(1, width);
+  const words = String(text ?? '').split(/\s+/).filter(Boolean);
+  if (!words.length) return [''];
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    if (!current) current = word;
+    else if (visualWidth(current + ' ' + word) <= safeWidth) current += ' ' + word;
+    else { lines.push(current); current = word; }
+  }
+  if (current) lines.push(current);
+  return lines.flatMap((line) =>
+    visualWidth(line) > safeWidth ? hardBreak(line, safeWidth) : [line],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Graph layout
+// ---------------------------------------------------------------------------
+
+function normalizeStatus(status) {
+  return VALID_STATUSES.has(status) ? status : 'ready';
+}
+
+function buildNodeStatusMap(state) {
+  const map = new Map();
+  if (!state?.projection?.activations) return map;
+  for (const activation of Object.values(state.projection.activations)) {
+    const existingStatus = map.get(activation.node_id);
+    const status = normalizeStatus(activation.status);
+    // A 'ready'/'running' activation means the node is being (re)tried and
+    // should override a stale 'failed' activation left behind by a back-edge
+    // retry. Only keep 'failed' when no live activation remains for the node.
+    const statusIsLive = status === 'ready' || status === 'running';
+    const existingIsLive = existingStatus === 'ready' || existingStatus === 'running';
+    if (!existingStatus) {
+      map.set(activation.node_id, status);
+    } else if (statusIsLive && !existingIsLive) {
+      map.set(activation.node_id, status);
+    } else if (!statusIsLive && existingIsLive) {
+      // keep existing live status
+    } else if (priority(existingStatus) < priority(status)) {
+      map.set(activation.node_id, status);
+    }
+  }
+  return map;
+}
+
+function priority(status) {
+  return { running: 4, failed: 3, completed: 2, ready: 1 }[status] ?? 0;
+}
+
+/**
+ * DFS topological order over non-back-edge edges. Back-edges are excluded
+ * (they point backward, often to self) and rendered separately as side-notes.
+ * Successors are visited in declared edge order so siblings group together.
+ */
+export function topologicalOrder(descriptor) {
+  const nodes = descriptor.nodes ?? [];
+  const successors = new Map();
+  for (const node of nodes) successors.set(node.id, []);
+  for (const edge of descriptor.edges ?? []) {
+    if ((edge.kind ?? 'fixed') === 'back_edge') continue;
+    if (!successors.has(edge.from)) successors.set(edge.from, []);
+    successors.get(edge.from).push(edge.to);
+  }
+  const visited = new Set();
+  const onStack = new Set();
+  const post = [];
+  function visit(id) {
+    if (visited.has(id) || onStack.has(id)) return;
+    onStack.add(id);
+    for (const target of successors.get(id) ?? []) visit(target);
+    onStack.delete(id);
+    visited.add(id);
+    post.push(id);
+  }
+  for (const entry of descriptor.entry_node_ids ?? []) visit(entry);
+  for (const node of nodes) visit(node.id);
+  return post.reverse();
+}
+
+/**
+ * Build the left side of a node box's status row (emoji + prefix + id) and
+ * truncate the id with an ellipsis so the row fits within MAX_INNER_WIDTH.
+ * Shared by pickInnerWidth (sizing) and renderNodeBox (rendering) so the box
+ * width and the rendered content can never drift out of agreement.
+ *
+ * Returns { display, width } where display is the plain (uncolored) string
+ * and width is its visual width.
+ */
+function formatLeftContent(node, status) {
+  const meta = statusMeta(status);
+  const prefix = node.kind === 'join' ? '⬢ ' : '';
+  const head = `${meta.emoji} ${prefix}`;
+  const headW = visualWidth(head);
+  const rightW = visualWidth(meta.word);
+  // Reserve headW + rightW + 4 (left/right padding + gaps) inside the cap.
+  const idBudget = MAX_INNER_WIDTH - headW - rightW - 4;
+  const id = String(node.id ?? '');
+  const idW = visualWidth(id);
+  if (idW <= idBudget) {
+    const display = `${head}${id}`;
+    return { display, width: headW + idW };
+  }
+  const ellipsisW = visualWidth(ELLIPSIS);
+  const budget = Math.max(1, idBudget - ellipsisW);
+  // Trim code points (not bytes) until the id fits the remaining budget.
+  let kept = '';
+  let keptW = 0;
+  for (const ch of id) {
+    const chW = visualWidth(ch);
+    if (keptW + chW > budget) break;
+    kept += ch;
+    keptW += chW;
+  }
+  const display = `${head}${kept}${ELLIPSIS}`;
+  return { display, width: headW + keptW + ellipsisW };
+}
+
+function pickInnerWidth(descriptor, nodeStatus) {
+  let width = 28;
+  for (const node of descriptor.nodes ?? []) {
+    const status = normalizeStatus(nodeStatus.get(node.id) ?? 'ready');
+    const { width: leftW } = formatLeftContent(node, status);
+    const rightW = visualWidth(statusMeta(status).word);
+    const need = leftW + rightW + 4;
+    if (need > width) width = need;
+  }
+  // Cap at a terminal-friendly max; long IDs are truncated by
+  // formatLeftContent rather than widening the box unbounded.
+  return Math.min(width, MAX_INNER_WIDTH);
+}
+
+function renderNodeBox(node, status, innerWidth) {
+  const meta = statusMeta(status);
+  const { display: leftRaw, width: leftW } = formatLeftContent(node, status);
+  const left = maybeColor(leftRaw, meta.color);
+  const right = maybeColor(meta.word, meta.color);
+  const gapW = innerWidth - 2 - leftW - visualWidth(meta.word);
+  const gap = gapW > 1 ? ' '.repeat(gapW) : ' ';
+
+  const rounded = node.kind === 'human-approval';
+  const tl = rounded ? '╭' : '┌';
+  const tr = rounded ? '╮' : '┐';
+  const bl = rounded ? '╰' : '└';
+  const br = rounded ? '╯' : '┘';
+  const bar = '─'.repeat(innerWidth);
+
+  const rows = [];
+  rows.push(`${tl}${bar}${tr}`);
+  rows.push(`│${padRight(' ' + left + gap + right + ' ', innerWidth)}│`);
+  const titleLines = wrapText(node.title ?? '', innerWidth - 2);
+  for (const titleLine of titleLines.length ? titleLines : ['']) {
+    rows.push(`│${padRight(' ' + titleLine + ' ', innerWidth)}│`);
+  }
+  rows.push(`${bl}${bar}${br}`);
+  return rows;
+}
+
+function renderForwardEdge(edge, centerCol) {
+  const kind = edge.kind ?? 'fixed';
+  const isConditional = kind === 'conditional';
+  const isFanOut = kind === 'fan_out';
+  const shaft = isFanOut ? '║' : (isConditional ? '╎' : '│');
+  const head = isConditional ? '▽' : '▼';
+  const label = (edge.route || edge.branch_id) ? ` ${edge.route || edge.branch_id}` : '';
+  const indent = ' '.repeat(centerCol);
+  return [`${indent}${shaft}${label}`, `${indent}${head}`];
+}
+
+function renderBackEdgeNote(edge, innerWidth) {
+  const route = edge.route ?? 'retry';
+  const max = typeof edge.max_traversals === 'number' ? ` (max ${edge.max_traversals})` : '';
+  const label = `↺ ${route}${max} -> ${edge.to}`;
+  const dashCount = Math.max(4, innerWidth - 8);
+  return `   ◂${'─'.repeat(dashCount)}┘  ${label}`;
+}
+
+export function renderAsciiGraph(descriptor, nodeStatus, runStatus) {
+  const order = topologicalOrder(descriptor);
+  const byId = new Map((descriptor.nodes ?? []).map((node) => [node.id, node]));
+  const innerWidth = pickInnerWidth(descriptor, nodeStatus);
+  const boxIndent = 2;
+  const centerCol = boxIndent + 1 + Math.floor(innerWidth / 2);
+  const indent = ' '.repeat(boxIndent);
+
+  const forwardBySource = new Map();
+  const backBySource = new Map();
+  for (const edge of descriptor.edges ?? []) {
+    const map = (edge.kind ?? 'fixed') === 'back_edge' ? backBySource : forwardBySource;
+    if (!map.has(edge.from)) map.set(edge.from, []);
+    map.get(edge.from).push(edge);
+  }
+
+  // Progress summary line: at-a-glance completion view across the whole graph.
+  let completed = 0;
+  const progressParts = [];
+  for (const id of order) {
+    const status = normalizeStatus(nodeStatus.get(id) ?? 'ready');
+    const meta = statusMeta(status);
+    if (status === 'completed') completed += 1;
+    const token = `${id}${meta.emoji}`;
+    const colored = maybeColor(token, meta.color);
+    progressParts.push(status === 'completed' ? `[${colored}]` : colored);
+  }
+  const total = order.length;
+
+  const lines = [];
+  if (runStatus) {
+    lines.push(`(run status: ${runStatus})`);
+    lines.push('');
+  }
+  lines.push(`Progress: ${completed}/${total} done  ${progressParts.join(' -> ')}`);
+  lines.push('');
+
+  for (let index = 0; index < order.length; index += 1) {
+    const node = byId.get(order[index]);
+    if (!node) continue;
+    const status = normalizeStatus(nodeStatus.get(node.id) ?? 'ready');
+    for (const row of renderNodeBox(node, status, innerWidth)) {
+      lines.push(indent + row);
+    }
+    for (const edge of backBySource.get(node.id) ?? []) {
+      lines.push(indent + renderBackEdgeNote(edge, innerWidth));
+    }
+    const forwards = forwardBySource.get(node.id) ?? [];
+    for (const edge of forwards) {
+      lines.push(...renderForwardEdge(edge, centerCol));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function renderHeader(state, descriptor) {
+  const hash = state?.active_revision_hash ?? 'pending';
+  const hashShort =
+    typeof hash === 'string' && hash.length >= 8 ? hash.slice(0, 8) : (hash || 'pending');
+  const goal = descriptor.goal ?? '(no goal)';
+  const status = state?.status ?? 'unknown';
+  const entry = (descriptor.entry_node_ids ?? []).join(', ') || '(none)';
+  const terminal = descriptor.terminal_verification_node_id ?? '(none)';
+  const concurrency = descriptor.concurrency_limit ?? 1;
+
+  const lines = [];
+  const goalLines = wrapText(goal, 58);
+  lines.push(`Goal: ${goalLines[0]}`);
+  for (let index = 1; index < goalLines.length; index += 1) {
+    lines.push(`      ${goalLines[index]}`);
+  }
+  lines.push(`Run: ${status}   #${hashShort}   Concurrency: ${concurrency}`);
+  lines.push(`Entry: ${entry}   Terminal: ${terminal}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// State / descriptor loading (unchanged behavior)
+// ---------------------------------------------------------------------------
+
+function loadState(path) {
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: Graph state file not found: ${path}`);
+      console.error('');
+      console.error('Ralph/graph may not be running. Use --demo to see a simulated state:');
+      console.error('  node scripts/graph/visualize.mjs --demo');
+      exit(1);
+    }
+    if (error.code === 'EACCES') {
+      console.error(`Error: Permission denied reading: ${path}`);
+      exit(1);
+    }
+    if (error.code === 'EISDIR') {
+      console.error(`Error: Expected a file but found a directory: ${path}`);
+      console.error('  Specify the graph-state.json file path, not a directory.');
+      exit(1);
+    }
+    if (error.code === 'ENOTDIR') {
+      console.error(`Error: Path contains a non-directory component: ${path}`);
+      console.error('  Check the file path for typos or incorrect separators.');
+      exit(1);
+    }
+    console.error(`Error reading file ${path}: ${error.message}`);
+    exit(1);
+  }
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.error(`Error: Invalid JSON in state file: ${path}`);
+      console.error(`  ${error.message}`);
+      exit(1);
+    }
+    console.error(`Error parsing JSON from ${path}: ${error.message}`);
+    exit(1);
+  }
+}
+
+function extractDescriptor(state) {
+  const revisionId = state.active_revision_id;
+  const revision = state.revisions?.[revisionId];
+  if (!revision?.descriptor) {
+    throw new Error(`Could not find descriptor for revision ${revisionId}`);
+  }
+  return revision.descriptor;
+}
+
+// NOTE: canonicalJson and computeDescriptorHash duplicate the logic in
+// src/graph/descriptor.ts. They are kept here so the script runs without
+// requiring `npm run build` first. If the canonical JSON format in the
+// source changes, update this function to match. See computeDescriptorHash
+// in src/graph/descriptor.ts for the authoritative implementation.
+function canonicalJson(value) {
+  if (value === undefined) {
+    throw new TypeError('Canonical JSON does not support undefined values');
+  }
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Canonical JSON does not support non-finite numbers');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value;
+    const entries = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+
+function computeDescriptorHash(descriptor) {
+  const payload = {
+    descriptor_version: descriptor.descriptor_version,
+    run_id: descriptor.run_id,
+    revision_id: descriptor.revision_id,
+    goal: descriptor.goal,
+    nodes: descriptor.nodes,
+    edges: descriptor.edges,
+    entry_node_ids: descriptor.entry_node_ids,
+    concurrency_limit: descriptor.concurrency_limit,
+    terminal_verification_node_id: descriptor.terminal_verification_node_id,
+  };
+  return createHash('sha256').update(canonicalJson(payload)).digest('hex');
+}
+
+function loadExampleDescriptor() {
+  const descriptorPath = new URL('../../examples/graph/auth-feature-descriptor.json', import.meta.url);
+  try {
+    return JSON.parse(readFileSync(descriptorPath, 'utf8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error('Error: Example descriptor file not found:');
+      console.error(`  ${descriptorPath.pathname}`);
+      console.error('');
+      console.error('The demo requires examples/graph/auth-feature-descriptor.json to exist.');
+      console.error('Reinstall the oh-my-claudecode package or restore the file from git.');
+      exit(1);
+    }
+    if (error instanceof SyntaxError) {
+      console.error('Error: Example descriptor file has invalid JSON:');
+      console.error(`  ${error.message}`);
+      exit(1);
+    }
+    console.error(`Error loading example descriptor: ${error.message}`);
+    exit(1);
+  }
+}
+
+function demoState() {
+  const descriptor = loadExampleDescriptor();
+  const revisionId = descriptor.revision_id ?? 'rev-1';
+  let hash;
+  try {
+    hash = computeDescriptorHash(descriptor);
+  } catch (error) {
+    console.error(`Error computing descriptor hash: ${error.message}`);
+    console.error('The example descriptor may be malformed. Check examples/graph/auth-feature-descriptor.json');
+    exit(1);
+  }
+  return {
+    status: 'running',
+    active_revision_id: revisionId,
+    active_revision_hash: hash,
+    revisions: {
+      [revisionId]: {
+        revision_id: revisionId,
+        descriptor_hash: hash,
+        created_at: '2026-07-22T00:00:00Z',
+        invalidated_node_ids: [],
+        descriptor: { ...descriptor, descriptor_hash: hash },
+      },
+    },
+    projection: {
+      activations: {
+        'act-1': { activation_id: 'act-1', node_id: 'explore', status: 'completed', attempt_no: 1, attempt_ids: ['att-1'], traversal_owner_id: 'act-1' },
+        'act-2': { activation_id: 'act-2', node_id: 'plan', status: 'completed', attempt_no: 1, attempt_ids: ['att-2'], traversal_owner_id: 'act-2' },
+        'act-3': { activation_id: 'act-3', node_id: 'implement', status: 'running', attempt_no: 1, attempt_ids: ['att-3'], active_attempt_id: 'att-3', traversal_owner_id: 'act-3' },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+  };
+}
+
+function loadDescriptor(path) {
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: Descriptor file not found: ${path}`);
+      exit(1);
+    }
+    if (error.code === 'EISDIR') {
+      console.error(`Error: Expected a file but found a directory: ${path}`);
+      exit(1);
+    }
+    console.error(`Error reading file ${path}: ${error.message}`);
+    exit(1);
+  }
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.error(`Error: Invalid JSON in descriptor file: ${path}`);
+      console.error(`  ${error.message}`);
+      exit(1);
+    }
+    console.error(`Error parsing JSON from ${path}: ${error.message}`);
+    exit(1);
+  }
+}
+
+function stateFromDescriptor(descriptor) {
+  const revisionId = descriptor.revision_id ?? 'rev-1';
+  const activations = {};
+  for (const [index, node] of descriptor.entry_node_ids.entries()) {
+    activations[`act-entry-${index}`] = {
+      activation_id: `act-entry-${index}`,
+      node_id: node,
+      status: 'ready',
+      attempt_no: 0,
+      attempt_ids: [],
+      traversal_owner_id: `act-entry-${index}`,
+    };
+  }
+  return {
+    status: 'awaiting_approval',
+    active_revision_id: revisionId,
+    active_revision_hash: descriptor.descriptor_hash ?? 'pending',
+    revisions: {
+      [revisionId]: {
+        revision_id: revisionId,
+        descriptor_hash: descriptor.descriptor_hash ?? 'pending',
+        created_at: '2026-07-22T00:00:00Z',
+        invalidated_node_ids: [],
+        descriptor,
+      },
+    },
+    projection: {
+      activations,
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+  };
+}
+
+function main() {
+  const args = argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.log('Usage: visualize.mjs <graph-state.json>');
+    console.log('       visualize.mjs --demo');
+    console.log('       visualize.mjs --descriptor <descriptor.json>');
+    console.log('');
+    console.log('Renders an ASCII-art diagram of the graph (renders inline in Claude Code).');
+    exit(0);
+  }
+
+  let state;
+  if (args[0] === '--demo') {
+    state = demoState();
+  } else if (args[0] === '--descriptor') {
+    if (!args[1]) {
+      console.error('Error: --descriptor requires a file path');
+      exit(1);
+    }
+    const descriptor = loadDescriptor(args[1]);
+    state = stateFromDescriptor(descriptor);
+  } else {
+    state = loadState(args[0]);
+  }
+
+  try {
+    const descriptor = extractDescriptor(state);
+    const nodeStatus = buildNodeStatusMap(state);
+
+    console.log(renderHeader(state, descriptor));
+    console.log(renderAsciiGraph(descriptor, nodeStatus, state?.status));
+  } catch (error) {
+    console.error(`Error: Could not render graph visualization: ${error.message}`);
+    console.error('');
+    console.error('The graph state file may be malformed or corrupted.');
+    console.error('Check that the file was written by a valid oh-my-claudecode graph run.');
+    exit(1);
+  }
+}
+
+// Run main() only when executed directly, not when imported by tests.
+const isMain =
+  argv[1] && fileURLToPath(import.meta.url) === resolve(argv[1]);
+if (isMain) {
+  main();
+}

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: graph
+description: Durable, human-approved orchestration graph for explicit multi-node development workflows
+argument-hint: "<development goal>"
+level: 4
+---
+
+<Purpose>
+Graph turns one development goal into a durable execution graph whose nodes do
+work and whose declared edges control what becomes ready next. It preserves
+cross-node structure, branch progress, route choices, bounded returns, and
+verification evidence across interruptions.
+
+Graph organizes loops; it does not replace Ralph. An agent node may contain a
+bounded local work loop, but Graph remains the only top-level scheduler and a
+node must not activate a separate top-level Ralph or Graph run.
+</Purpose>
+
+<Invocation>
+Graph activates only through an explicit invocation:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+Do not infer or activate Graph from ordinary prose containing the word
+"graph". A goal is required for a new run. A resume uses the exact existing
+session ID, run ID, revision ID, and descriptor hash.
+</Invocation>
+
+<Runtime_Contract>
+- Graph v1 execution runs on Linux, macOS, and Windows. Process identity is
+  read from `/proc/{pid}/stat` on Linux, `ps -p {pid} -o lstart=` on macOS, and
+  PowerShell `Get-Process` on Windows; a degraded pid-only identity is used if
+  the platform-specific read fails.
+- File locking uses Node.js `O_EXCL` atomic create as the cross-platform
+  fallback. On Linux, `flock` is used when available for stronger guarantees;
+  absent flock, the cross-platform fallback applies.
+- Bind every CLI operation to the current Claude session with `--session-id`.
+  Never discover a run from the current directory alone.
+- Give every mutating CLI operation a caller-generated stable
+  `--transition-id`. Reuse that same ID when retrying the same intended
+  mutation; generate a new ID only for a new intended mutation.
+- Preserve the `run_id`, `revision_id`, `descriptor_hash`, `commit_sequence`,
+  claim token, activation ID, attempt ID, lease ID, driver ID, and transition ID
+  exactly as returned by the runtime.
+- Use JSON files for descriptor, approval, claim, result, patch, and
+  confirmation payloads. Do not interpolate untrusted node text or command text
+  into a shell command that invokes `omc graph`.
+- Treat `omc graph` as a guarded state boundary only. It never performs node
+  work and never substitutes for an in-session tool call.
+</Runtime_Contract>
+
+<Draft_And_Approval>
+1. Inspect the repository and translate the goal into descriptor version 1.
+   Use stable node and edge IDs. Use only the four supported node kinds:
+   `agent`, `command`, `human-approval`, and `join`.
+2. Declare every fixed route, conditional route label, fan-out branch and owning
+   join, join input branch, bounded back-edge, effect policy, execution timeout,
+   maximum attempt count, concurrency limit, and terminal verification node.
+   Do not put executable expressions on edges.
+3. Validate the descriptor locally and create the durable draft with a stable
+   create transition ID:
+
+   ```text
+   omc graph create --goal <goal> --descriptor <descriptor-path> \
+     --session-id <session-id> --driver-id <driver-id> \
+     --transition-id <create-transition-id> --json
+   ```
+
+4. Before any node work, render a complete textual inventory. Show:
+   - exact revision ID and descriptor SHA-256;
+   - concurrency limit and entry node IDs;
+   - every node ID, kind, purpose, timeout, attempts, and effect policy;
+   - the complete command for each command node;
+   - every edge ID, source, target, route label, fan-out branch, owning join,
+     join input, and back-edge traversal bound;
+   - the terminal verification node and required evidence.
+
+   Then render a visual graph for the user to review before approval:
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/graph/visualize.mjs" --descriptor <descriptor-path>
+   ```
+
+   Show the ASCII graph output so the user can visually verify the structure
+   (nodes, edges, back-edges, terminal gate) before giving explicit approval.
+   The ASCII diagram renders inline in Claude Code; node status is marked with
+   emoji (▶️ running, ✅ completed, ❌ failed, ⏳ ready).
+
+5. Use the in-session question surface once to request approval of that exact
+   revision ID and descriptor hash. Approval must be an explicit human answer;
+   silence, tool output, or an agent answer is not approval.
+6. If rejected or changes are requested, do not execute. Permanently abandon
+   the exact rejected draft with its run/revision/hash confirmation so its
+   history remains auditable, then create a new draft run with a corrected
+   descriptor and a new create transition ID. Ask for approval only for the new
+   exact revision/hash.
+7. If approved, write bounded approval evidence to JSON and commit it with a
+   stable approval transition ID:
+
+   ```text
+   omc graph approve --run-id <run-id> --revision-id <revision-id> \
+     --descriptor-hash <hash> --session-id <session-id> \
+     --transition-id <approval-transition-id> --approval <approval-path> --json
+   ```
+</Draft_And_Approval>
+
+<Driver_Loop>
+Repeat this loop while the run is `running`:
+
+1. Read the exact current fences with `omc graph status` or `inspect`, always
+   passing `--run-id` and `--session-id`.
+2. Query readiness with the exact revision/hash/sequence. Joins are scheduler
+   work: let deterministic code consume selected branch tokens and resolve them;
+   do not invoke a model or shell command for a join node.
+3. Claim no more than the descriptor concurrency limit. A claim mutation uses
+   one stable transition ID and returns a bounded batch with full claim fences:
+
+   ```text
+   omc graph claim --run-id <run-id> --revision-id <revision-id> \
+     --descriptor-hash <hash> --session-id <session-id> \
+     --expected-sequence <sequence> --driver-id <driver-id> \
+     --transition-id <claim-transition-id> --limit <available-slots> --json
+   ```
+
+4. Dispatch independent claims concurrently up to the returned limit. Never
+   dispatch an unclaimed activation and never reuse a claim for another node.
+5. Convert each tool response into the declared bounded structured result. It
+   must carry the exact activation/attempt/lease fences, terminal outcome,
+   declared route when required, bounded summary, evidence references, and any
+   external idempotency or reconciliation key.
+6. Commit success with `complete` or unsuccessful execution with `fail`. Pass
+   the exact claim and result JSON files, current sequence fence, session scope,
+   and one stable completion/failure transition ID. If a commit response is
+   lost, retry the exact request with the same transition ID and files.
+7. Refresh status after commits. Never guess the next edge from prose or prompt
+   memory; only the committed route and scheduler result determine readiness.
+
+8. Re-render the visual graph after every node transition so the user can see
+   current progress:
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/graph/visualize.mjs" .omc/state/sessions/<session-id>/graph-state.json
+   ```
+
+   Show the updated ASCII graph with node status markers (▶️ running, ✅
+   completed, ❌ failed, ⏳ ready) after each claim, commit, back-edge
+   traversal, or terminal verification. This gives the user continuous
+   visibility into where the loop is within the graph boundaries.
+</Driver_Loop>
+
+<Node_Execution>
+- **agent**: Invoke the native in-session Agent/Task surface with the node's
+  approved instructions, declared timeout, effect policy, and bounded attempt
+  context. A bounded node-local loop is allowed only inside that activation.
+- **command**: Invoke the exact approved command through the permission-governed
+  Bash surface. Do not invoke it inside the Graph CLI or bypass the user's normal
+  permission decision. Capture exit status and bounded evidence.
+- **human-approval**: Use the in-session question surface and durably record the
+  answer as the node result. Waiting for an answer is a durable wait, not a
+  reason to poll.
+- **join**: Perform no external work. Deterministic scheduler code waits for and
+  consumes the selected cohort's branch tokens exactly once.
+
+Malformed output, an undeclared route, an exhausted back-edge bound, a stale
+lease, or a mismatched revision/sequence fails closed. Do not repair these by
+inventing a route or silently rerunning a side effect. Enter reconciliation when
+the external effect is ambiguous.
+</Node_Execution>
+
+<Patch_Protocol>
+When execution reveals a structural change:
+
+1. Agents may propose a descriptor patch but may not apply it.
+2. Submit the proposal against the exact base revision/hash/sequence with a
+   stable `propose-patch` transition ID. The run enters
+   `waiting_patch_approval`, advances its dispatch generation, and stops new
+   claims.
+3. Let already-running old-revision claims drain. Do not approve while any old
+   claim or reconciliation record is unresolved.
+4. Render the complete new revision plus a separate list of any committed-work
+   invalidations. Use the question surface to request exact new-revision/hash
+   approval.
+5. Commit approved patch evidence with `approve-patch` and a stable transition
+   ID. Resume only from the revision/hash/sequence returned by that operation.
+
+A stale-base proposal, late old-revision result, or unapproved patch cannot
+change readiness.
+</Patch_Protocol>
+
+<Wait_Stop_And_Resume>
+- `awaiting_approval`, `waiting_human`, `waiting_patch_approval`, and unresolved
+  `reconciling` are durable wait phases. Persist the wait reason and yield; do
+  not busy-poll or repeatedly inject continuation prompts.
+- A normal user cancel means `pause`: fence/dispose current claims through the
+  guarded runtime, preserve the complete ledger, and release only the matching
+  root owner. Pause is resumable.
+- Permanent `abandon` is separate. Require exact run/revision/hash confirmation,
+  commit terminal `cancelled`, and retain descriptor/history/evidence. There is
+  no destructive purge in v1.
+- Resume only the exact paused run with its existing session/run/revision/hash
+  and a new driver identity plus stable resume transition ID. Never create a
+  replacement run when resume fences do not match.
+</Wait_Stop_And_Resume>
+
+<Completion_Gate>
+Do not report Graph success until the approved terminal verification node has
+completed successfully with fresh evidence, every selected branch cohort has
+joined, no runnable/claimed/reconciling activation remains, and runtime status
+is `succeeded`. A terminal node failure or success without evidence is not
+completion.
+</Completion_Gate>

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -52,6 +52,7 @@ describe('HUD watch mode initialization', () => {
   let readRalphStateForHud: ReturnType<typeof vi.fn>;
   let readUltraworkStateForHud: ReturnType<typeof vi.fn>;
   let readAutopilotStateForHud: ReturnType<typeof vi.fn>;
+  let readGraphStateForHud: ReturnType<typeof vi.fn>;
   let getUsage: ReturnType<typeof vi.fn>;
   let render: ReturnType<typeof vi.fn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -70,6 +71,7 @@ describe('HUD watch mode initialization', () => {
     readRalphStateForHud = vi.fn(() => null);
     readUltraworkStateForHud = vi.fn(() => null);
     readAutopilotStateForHud = vi.fn(() => null);
+    readGraphStateForHud = vi.fn(() => null);
     getUsage = vi.fn(async () => overrides.getUsageResult ?? null);
     render = vi.fn(async () => '[HUD] ok');
 
@@ -123,6 +125,7 @@ describe('HUD watch mode initialization', () => {
       readUltraworkStateForHud,
       readPrdStateForHud: vi.fn(() => null),
       readAutopilotStateForHud,
+      readGraphStateForHud,
     }));
 
     vi.doMock('../../hud/usage-api.js', () => ({
@@ -215,6 +218,22 @@ describe('HUD watch mode initialization', () => {
     expect(readRalphStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
     expect(readUltraworkStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
     expect(readAutopilotStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
+  });
+
+  it('still calls getUsage when readGraphStateForHud throws (watch-mode init must not abort)', async () => {
+    // rateLimits must be enabled so getUsage() is on the critical render path.
+    const hud = await importHudModule({ config: makeConfig(true) });
+    readGraphStateForHud.mockImplementation(() => {
+      throw new Error('graph state read exploded');
+    });
+
+    await hud.main(true, false);
+
+    // The graph reader throwing must NOT abort the init flow: getUsage is the
+    // critical path that must still run, and render must still produce output.
+    expect(readGraphStateForHud).toHaveBeenCalledTimes(1);
+    expect(getUsage).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it('merges stdin generic rate limits over usage API data when available', async () => {

--- a/src/__tests__/installer-mcp-config.test.ts
+++ b/src/__tests__/installer-mcp-config.test.ts
@@ -113,6 +113,7 @@ describe('installer MCP config ownership (issue #1802)', () => {
         PostToolUse: [],
         PostToolUseFailure: [],
         PreToolUse: [],
+        SessionEnd: [],
         SessionStart: [],
         Stop: [],
         UserPromptSubmit: [],

--- a/src/__tests__/mode-names-ralplan.test.ts
+++ b/src/__tests__/mode-names-ralplan.test.ts
@@ -8,6 +8,16 @@ import {
 } from '../lib/mode-names.js';
 
 describe('mode-names ralplan', () => {
+  it('registers Graph with its canonical durable state file', () => {
+    expect(MODE_NAMES.GRAPH).toBe('graph');
+    expect(ALL_MODE_NAMES).toContain('graph');
+    expect(MODE_STATE_FILE_MAP.graph).toBe('graph-state.json');
+  });
+
+  it('does not register Graph for generic SessionEnd cleanup', () => {
+    expect(SESSION_END_MODE_STATE_FILES.some(entry => entry.mode === 'graph')).toBe(false);
+  });
+
   it('MODE_NAMES should include AUTORESEARCH', () => {
     expect(MODE_NAMES.AUTORESEARCH).toBe('autoresearch');
   });

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (37 canonical + 4 aliases)', () => {
+    it('should return correct number of skills (38 canonical + 4 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 41 entries: 37 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
-      expect(skills).toHaveLength(41);
+      // 42 entries: 38 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
+      expect(skills).toHaveLength(42);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -135,6 +135,7 @@ describe('Builtin Skills', () => {
         'deepinit',
         'omc-doctor',
         'external-context',
+        'graph',
         'hud',
         'skillify',
         'learner',
@@ -856,7 +857,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(37);
+      expect(names).toHaveLength(38);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -894,7 +895,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; cancel-ralph, psm, and learner aliases still exist
-      expect(names).toHaveLength(41);
+      expect(names).toHaveLength(42);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/cli/__tests__/graph-registration.test.ts
+++ b/src/cli/__tests__/graph-registration.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+process.env.OMC_CLI_SKIP_PARSE = '1';
+
+const graphCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('../commands/graph.js', () => ({ graphCommand: graphCommandMock }));
+
+describe('Commander Graph registration', () => {
+  it('registers one command and forwards raw arguments to its strict boundary', async () => {
+    const { buildProgram } = await import('../index.js');
+    const program = buildProgram();
+    const commands = program.commands.filter((command) => command.name() === 'graph');
+
+    expect(commands).toHaveLength(1);
+    await program.parseAsync([
+      'node',
+      'omc',
+      'graph',
+      'status',
+      '--run-id',
+      'run-1',
+      '--session-id',
+      'session-1',
+      '--json',
+    ]);
+    expect(graphCommandMock).toHaveBeenCalledWith([
+      'status',
+      '--run-id',
+      'run-1',
+      '--session-id',
+      'session-1',
+      '--json',
+    ]);
+  });
+});

--- a/src/cli/commands/__tests__/graph.test.ts
+++ b/src/cli/commands/__tests__/graph.test.ts
@@ -1,0 +1,368 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  GRAPH_COMMAND_OPERATIONS,
+  graphCommand,
+  type GraphCommandRequest,
+  type GraphCommandService,
+} from '../graph.js';
+
+function captureConsole() {
+  const out: string[] = [];
+  const err: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    out.push(args.map(String).join(' '));
+  });
+  const error = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    err.push(args.map(String).join(' '));
+  });
+  return { out, err, restore: () => { log.mockRestore(); error.mockRestore(); } };
+}
+
+function serviceReturning(result: unknown = { state: 'ok' }): {
+  service: GraphCommandService;
+  requests: GraphCommandRequest[];
+} {
+  const requests: GraphCommandRequest[] = [];
+  return {
+    requests,
+    service: {
+      async execute(request) {
+        requests.push(request);
+        return result;
+      },
+    },
+  };
+}
+
+const HASH = 'a'.repeat(64);
+const SESSION = ['--session-id', 'session-1'] as const;
+const TRANSITION = ['--transition-id', 'transition-1'] as const;
+const COMMON = [
+  '--run-id', 'run-1',
+  '--revision-id', 'revision-1',
+  '--descriptor-hash', HASH,
+  ...SESSION,
+] as const;
+const SEQUENCED = [...COMMON, '--expected-sequence', '7'] as const;
+const DRIVER = ['--driver-id', 'driver-1'] as const;
+const MUTATING_OPERATIONS = new Set([
+  'create',
+  'approve',
+  'claim',
+  'complete',
+  'fail',
+  'propose-patch',
+  'approve-patch',
+  'pause',
+  'abandon',
+  'resume',
+  'resolve-join',
+  'renew-claim',
+  'recover-expired-claim',
+  'record-late-claim-result',
+  'release-attempt-for-retry',
+  'resolve-reconciliation',
+]);
+
+const operationArgs: Record<(typeof GRAPH_COMMAND_OPERATIONS)[number], string[]> = {
+  create: [
+    '--goal', 'Extract payments',
+    '--descriptor', '{"descriptor_version":1}',
+    ...SESSION,
+    ...DRIVER,
+    ...TRANSITION,
+  ],
+  inspect: ['--run-id', 'run-1', ...SESSION],
+  approve: [...COMMON, ...TRANSITION, '--approval', '{"approved":true,"reviewer":"human"}'],
+  ready: [...SEQUENCED],
+  claim: [...SEQUENCED, ...DRIVER, ...TRANSITION, '--limit', '3'],
+  complete: [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--claim', '{"lease_id":"lease-1"}',
+    '--result', '{"outcome":"succeeded"}',
+  ],
+  fail: [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--claim', '{"lease_id":"lease-1"}',
+    '--result', '{"outcome":"failed"}',
+  ],
+  'propose-patch': [
+    '--run-id', 'run-1',
+    ...SESSION,
+    '--base-revision-id', 'revision-1',
+    '--base-descriptor-hash', HASH,
+    '--expected-sequence', '7',
+    ...TRANSITION,
+    '--patch', '{"revision_id":"revision-2"}',
+  ],
+  'approve-patch': [
+    '--run-id', 'run-1',
+    ...SESSION,
+    '--base-revision-id', 'revision-1',
+    '--base-descriptor-hash', HASH,
+    '--expected-sequence', '7',
+    ...TRANSITION,
+    '--approval', '{"approved":true}',
+  ],
+  status: ['--run-id', 'run-1', ...SESSION],
+  pause: [...SEQUENCED, ...DRIVER, ...TRANSITION],
+  abandon: [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--confirmation', '{"run_id":"run-1","revision_id":"revision-1","abandon":true}',
+  ],
+  resume: [...COMMON, ...DRIVER, ...TRANSITION],
+  'resolve-join': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--activation-id', 'act-join-1',
+    '--identities', '{"next_activation_ids":{"join-to-verify":"act-verify"}}',
+  ],
+  'renew-claim': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--lease-id', 'lease-1',
+    ...DRIVER,
+    '--tracking-id', 'tool-1',
+    '--tool-still-running', 'true',
+    '--now', '2026-07-21T00:00:01.000Z',
+  ],
+  'recover-expired-claim': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--lease-id', 'lease-1',
+    '--now', '2026-07-21T00:00:02.000Z',
+    '--new-attempt-id', 'attempt-2',
+    '--new-lease-id', 'lease-2',
+    '--new-tracking-id', 'tool-2',
+    ...DRIVER,
+    '--reconciliation-id', 'reconciliation-1',
+  ],
+  'record-late-claim-result': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--lease-id', 'lease-1',
+    '--attempt-id', 'attempt-1',
+    '--recorded-at', '2026-07-21T00:00:03.000Z',
+    '--summary', 'old result arrived after takeover',
+  ],
+  'release-attempt-for-retry': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--activation-id', 'act-1',
+    '--attempt-id', 'attempt-1',
+  ],
+  'resolve-reconciliation': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--evidence', '{"kind":"human","ref":"resolution-1"}',
+    '--resolved-at', '2026-07-21T00:00:04.000Z',
+  ],
+};
+
+describe('omc graph CLI boundary', () => {
+  let captured: ReturnType<typeof captureConsole>;
+
+  beforeEach(() => {
+    captured = captureConsole();
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    captured.restore();
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('prints help without invoking a runtime service', async () => {
+    const { service, requests } = serviceReturning();
+
+    await graphCommand([], service);
+
+    expect(captured.out.join('\n')).toMatch(/omc graph/);
+    expect(captured.out.join('\n')).toMatch(/create.*approve.*claim/s);
+    expect(captured.out.join('\n')).not.toMatch(/settle-session/);
+    expect(requests).toEqual([]);
+  });
+
+  it.each(GRAPH_COMMAND_OPERATIONS)('strictly parses and delegates %s', async (operation) => {
+    const { service, requests } = serviceReturning({ phase: 'running' });
+
+    await graphCommand([operation, ...operationArgs[operation], '--json'], service);
+
+    expect(process.exitCode).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ operation, cwd: process.cwd() });
+    expect(requests[0].input.session_id).toBe('session-1');
+    if (MUTATING_OPERATIONS.has(operation)) {
+      expect(requests[0].input.transition_id).toBe('transition-1');
+    } else {
+      expect(requests[0].input).not.toHaveProperty('transition_id');
+    }
+    expect(JSON.parse(captured.out[0])).toMatchObject({
+      ok: true,
+      operation,
+      result: { phase: 'running' },
+    });
+  });
+
+  it('parses JSON object flags from a file path', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omc-graph-cli-'));
+    const original = process.cwd();
+    process.chdir(cwd);
+    try {
+      await writeFile(join(cwd, 'descriptor.json'), '{"descriptor_version":1,"run_id":"run-1"}');
+      const { service, requests } = serviceReturning();
+
+      await graphCommand([
+        'create',
+        '--goal', 'Extract payments',
+        '--descriptor', 'descriptor.json',
+        ...SESSION,
+        ...DRIVER,
+        ...TRANSITION,
+      ], service);
+
+      expect(requests[0].input.descriptor).toEqual({ descriptor_version: 1, run_id: 'run-1' });
+    } finally {
+      process.chdir(original);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('delegates hidden session settlement with explicit session, driver, and transition scope', async () => {
+    const { service, requests } = serviceReturning({ settled_lease_ids: ['lease-1'] });
+
+    await graphCommand([
+      'settle-session',
+      ...SESSION,
+      ...DRIVER,
+      ...TRANSITION,
+      '--json',
+    ], service);
+
+    expect(requests).toEqual([{
+      operation: 'settle-session',
+      cwd: process.cwd(),
+      input: {
+        session_id: 'session-1',
+        driver_id: 'driver-1',
+        transition_id: 'transition-1',
+      },
+    }]);
+    expect(JSON.parse(captured.out[0])).toMatchObject({
+      ok: true,
+      operation: 'settle-session',
+      result: { settled_lease_ids: ['lease-1'] },
+    });
+  });
+
+  it('rejects hidden session settlement without explicit session scope', async () => {
+    const { service, requests } = serviceReturning();
+
+    await graphCommand(['settle-session', ...DRIVER, ...TRANSITION], service);
+
+    expect(process.exitCode).toBe(1);
+    expect(requests).toEqual([]);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/--session-id/);
+  });
+
+  it.each(GRAPH_COMMAND_OPERATIONS)('rejects a missing required flag for %s before delegation', async (operation) => {
+    const { service, requests } = serviceReturning();
+    const args = operationArgs[operation].slice(2);
+
+    await graphCommand([operation, ...args], service);
+
+    expect(process.exitCode).toBe(1);
+    expect(requests).toEqual([]);
+    expect(JSON.parse(captured.err[0])).toMatchObject({ ok: false, operation });
+  });
+
+  it('rejects unknown, duplicate, malformed JSON, and invalid numeric flags', async () => {
+    const cases = [
+      ['status', '--run-id', 'run-1', '--unknown', 'value'],
+      ['status', '--run-id', 'run-1', ...SESSION, '--run-id', 'run-2'],
+      ['create', '--goal', 'goal', '--descriptor', '{bad', ...SESSION, ...DRIVER, ...TRANSITION],
+      ['claim', ...SEQUENCED, ...DRIVER, ...TRANSITION, '--limit', '0'],
+    ];
+
+    for (const args of cases) {
+      captured.err.length = 0;
+      process.exitCode = 0;
+      const { service, requests } = serviceReturning();
+      await graphCommand(args, service);
+      expect(process.exitCode).toBe(1);
+      expect(requests).toEqual([]);
+      expect(() => JSON.parse(captured.err[0])).not.toThrow();
+    }
+  });
+
+  it('rejects omitted session scope and mutating transition identity', async () => {
+    const { service, requests } = serviceReturning();
+
+    await graphCommand(['status', '--run-id', 'run-1'], service);
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/--session-id/);
+
+    captured.err.length = 0;
+    process.exitCode = 0;
+    await graphCommand(
+      ['claim', ...SEQUENCED, ...DRIVER, '--limit', '3'],
+      service,
+    );
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/--transition-id/);
+    expect(requests).toEqual([]);
+  });
+
+  it('bounds successful output and service error messages', async () => {
+    const large = serviceReturning({ private_output: 'x'.repeat(100_000) });
+    await graphCommand(['status', '--run-id', 'run-1', ...SESSION], large.service);
+    expect(process.exitCode).toBe(1);
+    expect(Buffer.byteLength(captured.err[0], 'utf8')).toBeLessThan(4_096);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/output exceeds/i);
+
+    captured.err.length = 0;
+    process.exitCode = 0;
+    const failing: GraphCommandService = {
+      async execute() {
+        throw new Error('sensitive '.repeat(10_000));
+      },
+    };
+    await graphCommand(['status', '--run-id', 'run-1', ...SESSION], failing);
+    expect(process.exitCode).toBe(1);
+    expect(Buffer.byteLength(captured.err[0], 'utf8')).toBeLessThan(4_096);
+  });
+
+  it('contains no process or in-session tool execution path', async () => {
+    const source = await readFile(new URL('../graph.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/node:child_process|\bspawn\s*\(|\bexec(?:File)?\s*\(/);
+    expect(source).not.toMatch(/Agent|AskUserQuestion|\bBash\b/);
+  });
+
+  it('ships an explicit-only persistent in-session driver contract', async () => {
+    const skill = await readFile(
+      new URL('../../../../skills/graph/SKILL.md', import.meta.url),
+      'utf8',
+    );
+
+    expect(skill).toMatch(/name: graph/);
+    expect(skill).not.toMatch(/^triggers:/m);
+    expect(skill).toMatch(/\/oh-my-claudecode:graph <development goal>/);
+    expect(skill).toMatch(/exact revision ID and descriptor SHA-256/);
+    expect(skill).toMatch(/Agent\/Task surface/);
+    expect(skill).toMatch(/permission-governed\s+Bash surface/);
+    expect(skill).toMatch(/join.*deterministic scheduler/is);
+    expect(skill).toMatch(/do\s+not busy-poll/i);
+    expect(skill).toMatch(/normal user cancel means `pause`/i);
+    expect(skill).toMatch(/Permanent `abandon` is separate/);
+  });
+});

--- a/src/cli/commands/graph.ts
+++ b/src/cli/commands/graph.ts
@@ -1,0 +1,476 @@
+import { readFile, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export const GRAPH_COMMAND_OPERATIONS = [
+  'create',
+  'inspect',
+  'approve',
+  'ready',
+  'claim',
+  'complete',
+  'fail',
+  'propose-patch',
+  'approve-patch',
+  'status',
+  'pause',
+  'abandon',
+  'resume',
+  'resolve-join',
+  'renew-claim',
+  'recover-expired-claim',
+  'record-late-claim-result',
+  'release-attempt-for-retry',
+  'resolve-reconciliation',
+] as const;
+
+const GRAPH_INTERNAL_COMMAND_OPERATIONS = ['settle-session'] as const;
+
+export type GraphCommandOperation =
+  | (typeof GRAPH_COMMAND_OPERATIONS)[number]
+  | (typeof GRAPH_INTERNAL_COMMAND_OPERATIONS)[number];
+
+export interface GraphCommandRequest {
+  operation: GraphCommandOperation;
+  cwd: string;
+  input: Readonly<Record<string, unknown>>;
+}
+
+/** Implementations must perform guarded state transitions only. */
+export interface GraphCommandService {
+  execute(request: GraphCommandRequest): Promise<unknown>;
+}
+
+export class GraphCommandError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphCommandError';
+    this.code = code;
+  }
+}
+
+export const GRAPH_HELP = `omc graph - Durable, human-approved orchestration graph state boundary
+
+Usage:
+  omc graph create --goal <text> --descriptor <json-or-path> --session-id <id> --driver-id <id> --transition-id <id> [--json]
+  omc graph inspect --run-id <id> --session-id <id> [--json]
+  omc graph approve --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --transition-id <id> --approval <json-or-path> [--json]
+  omc graph ready --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> [--json]
+  omc graph claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> --limit <n> [--json]
+  omc graph complete --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
+  omc graph fail --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
+  omc graph propose-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --patch <json-or-path> [--json]
+  omc graph approve-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --approval <json-or-path> [--json]
+  omc graph status --run-id <id> --session-id <id> [--json]
+  omc graph pause --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> [--json]
+  omc graph abandon --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --confirmation <json-or-path> [--json]
+  omc graph resume --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --driver-id <id> --transition-id <id> [--json]
+  omc graph resolve-join --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --activation-id <id> --identities <json-or-path> [--json]
+  omc graph renew-claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --driver-id <id> --tracking-id <id> --tool-still-running --now <iso8601> [--json]
+  omc graph recover-expired-claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --now <iso8601> --new-attempt-id <id> --new-lease-id <id> --new-tracking-id <id> --driver-id <id> --reconciliation-id <id> [--json]
+  omc graph record-late-claim-result --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --attempt-id <id> --recorded-at <iso8601> --summary <text> [--json]
+  omc graph release-attempt-for-retry --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --activation-id <id> --attempt-id <id> [--json]
+  omc graph resolve-reconciliation --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --evidence <json-or-path> --resolved-at <iso8601> [--json]
+
+JSON flags accept either an inline JSON object or a path to a JSON object.
+Every operation returns one bounded JSON envelope. This command delegates state
+operations to the graph runtime; it does not execute graph node work.
+`;
+
+type FlagKind = 'id' | 'hash' | 'text' | 'sequence' | 'limit' | 'json' | 'boolean';
+
+interface FlagDefinition {
+  flag: string;
+  field: string;
+  kind: FlagKind;
+}
+
+const RUN: FlagDefinition = { flag: '--run-id', field: 'run_id', kind: 'id' };
+const REVISION: FlagDefinition = { flag: '--revision-id', field: 'revision_id', kind: 'id' };
+const HASH: FlagDefinition = { flag: '--descriptor-hash', field: 'descriptor_hash', kind: 'hash' };
+const SEQUENCE: FlagDefinition = {
+  flag: '--expected-sequence',
+  field: 'expected_sequence',
+  kind: 'sequence',
+};
+const SESSION: FlagDefinition = { flag: '--session-id', field: 'session_id', kind: 'id' };
+const DRIVER: FlagDefinition = { flag: '--driver-id', field: 'driver_id', kind: 'id' };
+const TRANSITION: FlagDefinition = {
+  flag: '--transition-id',
+  field: 'transition_id',
+  kind: 'id',
+};
+const BASE_REVISION: FlagDefinition = {
+  flag: '--base-revision-id',
+  field: 'base_revision_id',
+  kind: 'id',
+};
+const BASE_HASH: FlagDefinition = {
+  flag: '--base-descriptor-hash',
+  field: 'base_descriptor_hash',
+  kind: 'hash',
+};
+const ACTIVATION: FlagDefinition = { flag: '--activation-id', field: 'activation_id', kind: 'id' };
+const LEASE: FlagDefinition = { flag: '--lease-id', field: 'lease_id', kind: 'id' };
+const ATTEMPT: FlagDefinition = { flag: '--attempt-id', field: 'attempt_id', kind: 'id' };
+const TRACKING: FlagDefinition = { flag: '--tracking-id', field: 'tracking_id', kind: 'id' };
+const RECONCILIATION: FlagDefinition = {
+  flag: '--reconciliation-id',
+  field: 'reconciliation_id',
+  kind: 'id',
+};
+
+const OPERATION_FLAGS: Record<GraphCommandOperation, readonly FlagDefinition[]> = {
+  create: [
+    { flag: '--goal', field: 'goal', kind: 'text' },
+    { flag: '--descriptor', field: 'descriptor', kind: 'json' },
+    SESSION,
+    DRIVER,
+    TRANSITION,
+  ],
+  inspect: [RUN, SESSION],
+  approve: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    TRANSITION,
+    { flag: '--approval', field: 'approval', kind: 'json' },
+  ],
+  ready: [RUN, REVISION, HASH, SESSION, SEQUENCE],
+  claim: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    DRIVER,
+    TRANSITION,
+    { flag: '--limit', field: 'limit', kind: 'limit' },
+  ],
+  complete: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--claim', field: 'claim', kind: 'json' },
+    { flag: '--result', field: 'result', kind: 'json' },
+  ],
+  fail: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--claim', field: 'claim', kind: 'json' },
+    { flag: '--result', field: 'result', kind: 'json' },
+  ],
+  'propose-patch': [
+    RUN,
+    SESSION,
+    BASE_REVISION,
+    BASE_HASH,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--patch', field: 'patch', kind: 'json' },
+  ],
+  'approve-patch': [
+    RUN,
+    SESSION,
+    BASE_REVISION,
+    BASE_HASH,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--approval', field: 'approval', kind: 'json' },
+  ],
+  status: [RUN, SESSION],
+  pause: [RUN, REVISION, HASH, SESSION, SEQUENCE, DRIVER, TRANSITION],
+  abandon: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--confirmation', field: 'confirmation', kind: 'json' },
+  ],
+  resume: [RUN, REVISION, HASH, SESSION, DRIVER, TRANSITION],
+  'resolve-join': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    ACTIVATION,
+    { flag: '--identities', field: 'identities', kind: 'json' },
+  ],
+  'renew-claim': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    DRIVER,
+    TRACKING,
+    { flag: '--tool-still-running', field: 'tool_still_running', kind: 'boolean' },
+    { flag: '--now', field: 'now', kind: 'text' },
+  ],
+  'recover-expired-claim': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    { flag: '--now', field: 'now', kind: 'text' },
+    { flag: '--new-attempt-id', field: 'new_attempt_id', kind: 'id' },
+    { flag: '--new-lease-id', field: 'new_lease_id', kind: 'id' },
+    { flag: '--new-tracking-id', field: 'new_tracking_id', kind: 'id' },
+    DRIVER,
+    RECONCILIATION,
+  ],
+  'record-late-claim-result': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    ATTEMPT,
+    { flag: '--recorded-at', field: 'recorded_at', kind: 'text' },
+    { flag: '--summary', field: 'summary', kind: 'text' },
+  ],
+  'release-attempt-for-retry': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    ACTIVATION,
+    ATTEMPT,
+  ],
+  'resolve-reconciliation': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--evidence', field: 'evidence', kind: 'json' },
+    { flag: '--resolved-at', field: 'resolved_at', kind: 'text' },
+  ],
+  'settle-session': [SESSION, DRIVER, TRANSITION],
+};
+
+const MAX_JSON_INPUT_BYTES = 256 * 1024;
+const MAX_JSON_OUTPUT_BYTES = 64 * 1024;
+const MAX_ERROR_CHARS = 1_000;
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+function resolveOperation(raw: string | undefined): GraphCommandOperation | undefined {
+  return [...GRAPH_COMMAND_OPERATIONS, ...GRAPH_INTERNAL_COMMAND_OPERATIONS]
+    .find((operation) => operation === raw);
+}
+
+function parseRawFlags(
+  operation: GraphCommandOperation,
+  args: readonly string[],
+): Map<string, string> {
+  const definitions = OPERATION_FLAGS[operation];
+  const allowed = new Set(definitions.map((definition) => definition.flag));
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--json') continue;
+    const equals = token.indexOf('=');
+    const flag = equals >= 0 ? token.slice(0, equals) : token;
+    if (!allowed.has(flag)) {
+      throw new GraphCommandError('unknown_argument', `Unknown argument for graph ${operation}: ${token}`);
+    }
+    if (values.has(flag)) {
+      throw new GraphCommandError('duplicate_argument', `Duplicate argument for graph ${operation}: ${flag}`);
+    }
+    const value = equals >= 0 ? token.slice(equals + 1) : args[index + 1];
+    if (!value || (equals < 0 && value.startsWith('--'))) {
+      throw new GraphCommandError('missing_value', `Missing value after ${flag}`);
+    }
+    values.set(flag, value);
+    if (equals < 0) index += 1;
+  }
+
+  for (const definition of definitions) {
+    if (!values.has(definition.flag)) {
+      throw new GraphCommandError('missing_argument', `Missing required ${definition.flag} for graph ${operation}`);
+    }
+  }
+  return values;
+}
+
+async function parseJsonObject(raw: string, flag: string, cwd: string): Promise<Record<string, unknown>> {
+  let source = raw.trim();
+  try {
+    if (!source.startsWith('{') && !source.startsWith('[')) {
+      const path = resolve(cwd, source);
+      const metadata = await stat(path);
+      if (!metadata.isFile()) throw new Error('path is not a regular file');
+      if (metadata.size > MAX_JSON_INPUT_BYTES) {
+        throw new Error(`file exceeds ${MAX_JSON_INPUT_BYTES} bytes`);
+      }
+      source = await readFile(path, 'utf8');
+    } else if (Buffer.byteLength(source, 'utf8') > MAX_JSON_INPUT_BYTES) {
+      throw new Error(`inline value exceeds ${MAX_JSON_INPUT_BYTES} bytes`);
+    }
+    const parsed = JSON.parse(source) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('value must be a JSON object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new GraphCommandError('invalid_json_input', `Invalid ${flag}: ${message}`);
+  }
+}
+
+function parseScalar(raw: string, definition: FlagDefinition): string | number | boolean {
+  const trimmed = raw.trim();
+  if (definition.kind === 'id') {
+    if (!ID_PATTERN.test(trimmed)) {
+      throw new GraphCommandError('invalid_identifier', `Invalid ${definition.flag}`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === 'hash') {
+    if (!HASH_PATTERN.test(trimmed)) {
+      throw new GraphCommandError('invalid_hash', `Invalid ${definition.flag}; expected lowercase SHA-256`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === 'text') {
+    if (!trimmed || trimmed.length > 32_768) {
+      throw new GraphCommandError('invalid_text', `Invalid ${definition.flag}`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === 'sequence' || definition.kind === 'limit') {
+    if (!/^\d+$/.test(trimmed)) {
+      throw new GraphCommandError('invalid_number', `Invalid ${definition.flag}; expected an integer`);
+    }
+    const value = Number(trimmed);
+    const valid = definition.kind === 'sequence'
+      ? Number.isSafeInteger(value) && value >= 0
+      : Number.isSafeInteger(value) && value >= 1 && value <= 64;
+    if (!valid) throw new GraphCommandError('invalid_number', `Invalid ${definition.flag}`);
+    return value;
+  }
+  if (definition.kind === 'boolean') {
+    if (trimmed !== 'true' && trimmed !== 'false') {
+      throw new GraphCommandError('invalid_boolean', `Invalid ${definition.flag}; expected 'true' or 'false'`);
+    }
+    return trimmed === 'true';
+  }
+  throw new GraphCommandError('invalid_argument', `Unsupported scalar flag ${definition.flag}`);
+}
+
+async function parseRequest(
+  operation: GraphCommandOperation,
+  args: readonly string[],
+  cwd: string,
+): Promise<GraphCommandRequest> {
+  const raw = parseRawFlags(operation, args);
+  const input: Record<string, unknown> = {};
+  for (const definition of OPERATION_FLAGS[operation]) {
+    const value = raw.get(definition.flag)!;
+    input[definition.field] = definition.kind === 'json'
+      ? await parseJsonObject(value, definition.flag, cwd)
+      : parseScalar(value, definition);
+  }
+  return { operation, cwd, input: Object.freeze(input) };
+}
+
+async function loadDefaultService(): Promise<GraphCommandService> {
+  const runtimeModulePath = '../../graph/runtime.js';
+  try {
+    const runtime = await import(runtimeModulePath) as {
+      graphCommandService?: GraphCommandService;
+    };
+    if (runtime.graphCommandService?.execute) return runtime.graphCommandService;
+  } catch {
+    // The runtime adapter is added independently from this boundary.
+  }
+  throw new GraphCommandError(
+    'runtime_unavailable',
+    'Graph runtime adapter is unavailable; export graphCommandService from src/graph/runtime.ts',
+  );
+}
+
+function serializeBounded(value: unknown): string {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new GraphCommandError('invalid_output', 'Graph service returned a non-JSON result');
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_JSON_OUTPUT_BYTES) {
+    throw new GraphCommandError(
+      'output_too_large',
+      `Graph command output exceeds ${MAX_JSON_OUTPUT_BYTES} bytes`,
+    );
+  }
+  return serialized;
+}
+
+function boundedErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length <= MAX_ERROR_CHARS ? message : `${message.slice(0, MAX_ERROR_CHARS)}...`;
+}
+
+export async function graphCommand(
+  args: string[],
+  injectedService?: GraphCommandService,
+): Promise<void> {
+  const rawOperation = args[0];
+  if (!rawOperation || rawOperation === 'help' || rawOperation === '--help' || rawOperation === '-h') {
+    console.log(GRAPH_HELP);
+    return;
+  }
+  const operation = resolveOperation(rawOperation);
+  if (!operation) {
+    const displayedOperation = boundedErrorMessage(rawOperation);
+    process.exitCode = 1;
+    console.error(serializeBounded({
+      ok: false,
+      operation: displayedOperation,
+      code: 'unknown_operation',
+      error: `Unknown graph operation: ${displayedOperation}`,
+    }));
+    return;
+  }
+
+  try {
+    const request = await parseRequest(operation, args.slice(1), process.cwd());
+    const service = injectedService ?? await loadDefaultService();
+    const result = await service.execute(request);
+    console.log(serializeBounded({ ok: true, operation, result: result ?? null }));
+  } catch (error) {
+    process.exitCode = 1;
+    const code = error instanceof GraphCommandError ? error.code : 'runtime_error';
+    console.error(serializeBounded({
+      ok: false,
+      operation,
+      code,
+      error: boundedErrorMessage(error),
+    }));
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,7 @@ import { capabilitiesCheckCommand, capabilitiesLockCommand } from './commands/ca
 import { sessionSearchCommand } from './commands/session-search.js';
 import { sessionFrictionReportCommand } from './commands/session-friction-report.js';
 import { teamCommand } from './commands/team.js';
+import { graphCommand } from './commands/graph.js';
 import { ralphthonCommand } from './commands/ralphthon.js';
 import { ultragoalCommand, ULTRAGOAL_HELP } from './commands/ultragoal.js';
 import {
@@ -1478,6 +1479,20 @@ program
   .argument('[args...]', 'team subcommand arguments')
   .action(async (args: string[]) => {
     await teamCommand(args);
+  });
+
+/**
+ * Graph command - guarded durable graph state transitions.
+ */
+program
+  .command('graph')
+  .description('Guarded durable orchestration graph state operations')
+  .helpOption(false)
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .argument('[args...]', 'graph operation and arguments')
+  .action(async (args: string[]) => {
+    await graphCommand(args);
   });
 
 /**

--- a/src/graph/__tests__/control-owner.test.ts
+++ b/src/graph/__tests__/control-owner.test.ts
@@ -1,0 +1,551 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import {
+  ControlOwnerError,
+  ControlOwnerStore,
+  classifyControlMode,
+} from '../control-owner.js';
+
+const temporaryDirectories: string[] = [];
+const GRAPH_REVISION = { revision_id: 'revision-1', revision_hash: 'a'.repeat(64) };
+
+function createStore(events: string[] = []) {
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-control-owner-'));
+  temporaryDirectories.push(worktreeRoot);
+  return new ControlOwnerStore({
+    sessionId: 'session-control',
+    worktreeRoot,
+    platform: {
+      preflight: () => {
+        events.push('preflight');
+        return { pid: 123, process_start: '456' };
+      },
+      isProcessIdentityLive: () => false,
+    },
+    dependencies: {
+      fileExists: (path) => {
+        events.push('read');
+        return existsSync(path);
+      },
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic: atomicWriteJsonSync,
+      withExclusiveLock: (_path, callback) => {
+        events.push('lock');
+        return { acquired: true, value: callback() };
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe('ControlOwnerStore', () => {
+  it('preflights before reservation and gives competing roots one winner', () => {
+    const events: string[] = [];
+    const store = createStore(events);
+    const reserved = store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+
+    expect(events.slice(0, 2)).toEqual(['preflight', 'lock']);
+    expect(reserved.root).toMatchObject({ mode: 'graph', phase: 'reserved', nonce: 'nonce-1' });
+    expect(() => store.reserveRoot({
+      mode: 'autopilot',
+      run_id: 'autopilot-1',
+      nonce: 'nonce-2',
+      reserved_at: '2026-07-21T00:00:01.000Z',
+    })).toThrowError(ControlOwnerError);
+  });
+
+  it('accepts a pid-only reservation_process (empty process_start) so a host that could not capture start time does not wedge control authority', () => {
+    // When ps/powershell/proc is unavailable at reservation time, preflight()
+    // returns process_start: ''. The store must still accept the reserved
+    // control state on read() (pid-only identity) instead of rejecting it as
+    // malformed_control, which would permanently break control authority.
+    const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-control-owner-pidonly-'));
+    temporaryDirectories.push(worktreeRoot);
+    const store = new ControlOwnerStore({
+      sessionId: 'session-pidonly',
+      worktreeRoot,
+      platform: {
+        preflight: () => ({ pid: 999, process_start: '' }),
+        isProcessIdentityLive: () => true,
+      },
+      dependencies: {
+        fileExists: (path) => existsSync(path),
+        readText: (path) => readFileSync(path, 'utf8'),
+        writeAtomic: atomicWriteJsonSync,
+        withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+      },
+    });
+
+    const reserved = store.reserveRoot({
+      mode: 'autopilot',
+      run_id: 'run-pidonly',
+      nonce: 'nonce-pidonly',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+
+    expect(reserved.root?.reservation_process).toEqual({ pid: 999, process_start: '' });
+    // read() must not throw malformed_control for the pid-only form.
+    const reloaded = store.read();
+    expect(reloaded?.root?.reservation_process).toEqual({ pid: 999, process_start: '' });
+  });
+
+  it('gives concurrent root reservations exactly one winner', async () => {
+    const store = createStore();
+    const results = await Promise.allSettled(
+      (['graph', 'ralph', 'autopilot', 'team'] as const).map((mode, index) =>
+        Promise.resolve().then(() => store.reserveRoot({
+          mode,
+          run_id: `${mode}-run`,
+          nonce: `nonce-${index}`,
+          reserved_at: '2026-07-21T00:00:00.000Z',
+          ...(mode === 'graph' ? { graph_revision: GRAPH_REVISION } : {}),
+        })),
+      ),
+    );
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(3);
+    expect(store.read()?.root).not.toBeNull();
+  });
+
+  it('recovers reserve-create-promote and fences a stale releaser by nonce', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+    expect(() => store.recoverGraphReservation({
+      session_id: 'session-control',
+      run_id: 'run-1',
+      revision_id: 'revision-1',
+      revision_hash: 'b'.repeat(64),
+      status: 'running',
+      reservation_nonce: 'nonce-1',
+      observed_at: '2026-07-21T00:00:00.500Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:00.500Z',
+      },
+    })).toThrow(/revision\/hash/i);
+    const recovered = store.recoverGraphReservation({
+      session_id: 'session-control',
+      run_id: 'run-1',
+      revision_id: 'revision-1',
+      revision_hash: 'a'.repeat(64),
+      status: 'running',
+      reservation_nonce: 'nonce-1',
+      observed_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    expect(recovered.action).toBe('promoted');
+    expect(store.read()?.root?.phase).toBe('active');
+
+    const stale = store.releaseRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'stale-nonce',
+      disposition: {
+        graph_status: 'paused',
+        claims_fenced: true,
+        children_drained: true,
+      },
+      released_at: '2026-07-21T00:00:02.000Z',
+    });
+    expect(stale.released).toBe(false);
+    expect(store.read()?.root?.nonce).toBe('nonce-1');
+  });
+
+  it('permits only declared exact-lineage children', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+    store.promoteRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    const registered = store.registerChild({
+      mode: 'team',
+      session_id: 'team-session',
+      run_id: 'team-run',
+      parent: { mode: 'graph', session_id: 'session-control', run_id: 'run-1' },
+      graph_claim: {
+        activation_id: 'activation-a',
+        attempt_id: 'attempt-a',
+        lease_id: 'lease-a',
+        revision_id: 'revision-1',
+        revision_hash: 'a'.repeat(64),
+        dispatch_generation: 0,
+      },
+      registered_at: '2026-07-21T00:00:02.000Z',
+    });
+    expect(registered.root?.children).toHaveLength(1);
+
+    expect(() => store.registerChild({
+      mode: 'ralph',
+      session_id: 'ralph-session',
+      run_id: 'ralph-run',
+      parent: { mode: 'graph', session_id: 'session-control', run_id: 'run-1' },
+      registered_at: '2026-07-21T00:00:03.000Z',
+    })).toThrow(/lineage/i);
+  });
+
+  it('rejects persisted cyclic lineage and Graph children without exact claims', () => {
+    const cyclic = createStore();
+    cyclic.reserveRoot({
+      mode: 'autopilot', run_id: 'auto-run', nonce: 'nonce-auto',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    const cyclicState = cyclic.read()!;
+    atomicWriteJsonSync(cyclic.path, {
+      ...cyclicState,
+      root: {
+        ...cyclicState.root!,
+        children: [{
+          mode: 'ralph', session_id: 'session-control', run_id: 'ralph-run',
+          parent: { mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-run' },
+          registered_at: '2026-07-21T00:00:01.000Z',
+        }, {
+          mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-run',
+          parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph-run' },
+          registered_at: '2026-07-21T00:00:01.000Z',
+        }],
+      },
+    });
+    expect(() => cyclic.read()).toThrow(/reachable|lineage/i);
+
+    const missingClaim = createStore();
+    missingClaim.reserveRoot({
+      mode: 'graph', run_id: 'graph-run', nonce: 'nonce-graph',
+      graph_revision: GRAPH_REVISION,
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    const graphState = missingClaim.read()!;
+    atomicWriteJsonSync(missingClaim.path, {
+      ...graphState,
+      root: {
+        ...graphState.root!,
+        children: [{
+          mode: 'team', session_id: 'team-session', run_id: 'team-run',
+          parent: { mode: 'graph', session_id: 'session-control', run_id: 'graph-run' },
+          registered_at: '2026-07-21T00:00:01.000Z',
+        }],
+      },
+    });
+    expect(() => missingClaim.read()).toThrow(/claim/i);
+  });
+
+  it('implements the full Autopilot and Ralph child matrix and rejects mismatched parents', () => {
+    const autopilot = createStore();
+    autopilot.reserveRoot({
+      mode: 'autopilot', run_id: 'autopilot-run', nonce: 'nonce-auto',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    autopilot.promoteRoot({
+      mode: 'autopilot', run_id: 'autopilot-run', nonce: 'nonce-auto',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-auto', lease_id: 'lease-auto',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    for (const mode of ['ralph', 'team', 'ultrawork', 'ultraqa', 'ralplan', 'deep-interview'] as const) {
+      autopilot.registerChild({
+        mode,
+        session_id: `${mode}-session`,
+        run_id: `${mode}-run`,
+        parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'autopilot-run' },
+        registered_at: '2026-07-21T00:00:02.000Z',
+      });
+    }
+    expect(autopilot.read()?.root?.children).toHaveLength(6);
+    expect(() => autopilot.registerChild({
+      mode: 'team',
+      session_id: 'bad-session',
+      run_id: 'bad-run',
+      parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'wrong-run' },
+      registered_at: '2026-07-21T00:00:03.000Z',
+    })).toThrow(/parent lineage/i);
+
+    const ralph = createStore();
+    ralph.reserveRoot({
+      mode: 'ralph', run_id: 'ralph-root', nonce: 'nonce-ralph',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    ralph.promoteRoot({
+      mode: 'ralph', run_id: 'ralph-root', nonce: 'nonce-ralph',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-ralph', lease_id: 'lease-ralph',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    for (const mode of ['team', 'ultrawork', 'ultraqa', 'ralplan'] as const) {
+      ralph.registerChild({
+        mode,
+        session_id: `${mode}-session`,
+        run_id: `${mode}-run`,
+        parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph-root' },
+        registered_at: '2026-07-21T00:00:02.000Z',
+      });
+    }
+    expect(ralph.read()?.root?.children).toHaveLength(4);
+  });
+
+  it('represents Autopilot -> Ralph -> Ultrawork as one exact tree', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'autopilot', run_id: 'auto', nonce: 'nonce-auto',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    store.promoteRoot({
+      mode: 'autopilot', run_id: 'auto', nonce: 'nonce-auto',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver', lease_id: 'driver-lease',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    store.registerChild({
+      mode: 'ralph', session_id: 'session-control', run_id: 'ralph-child',
+      parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'auto' },
+      registered_at: '2026-07-21T00:00:02.000Z',
+    });
+    store.registerChild({
+      mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-child',
+      parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph-child' },
+      registered_at: '2026-07-21T00:00:03.000Z',
+    });
+
+    expect(store.read()?.root?.children.map((child) => child.parent.mode)).toEqual([
+      'autopilot',
+      'ralph',
+    ]);
+    expect(() => store.registerChild({
+      mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-child',
+      parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'auto' },
+      registered_at: '2026-07-21T00:00:04.000Z',
+    })).toThrow(/already registered/i);
+  });
+
+  it('resumes only the exact paused graph run with a new nonce', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+    store.promoteRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    expect(store.releaseRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      disposition: { graph_status: 'paused', claims_fenced: true, children_drained: true },
+      released_at: '2026-07-21T00:00:02.000Z',
+    }).released).toBe(true);
+
+    const resumed = store.reservePausedGraph({
+      run_id: 'run-1',
+      revision_id: 'revision-1',
+      revision_hash: 'a'.repeat(64),
+      nonce: 'new-nonce',
+      graph_state: {
+        session_id: 'session-control',
+        run_id: 'run-1',
+        revision_id: 'revision-1',
+        status: 'paused',
+      },
+      reserved_at: '2026-07-21T00:00:03.000Z',
+    });
+    expect(resumed.root?.nonce).toBe('new-nonce');
+    expect(store.releaseRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      disposition: { graph_status: 'paused', claims_fenced: true, children_drained: true },
+      released_at: '2026-07-21T00:00:04.000Z',
+    }).released).toBe(false);
+  });
+
+  it('classifies every canonical persistent control surface exhaustively', () => {
+    for (const mode of [
+      'graph',
+      'autopilot',
+      'autoresearch',
+      'ralph',
+      'team',
+      'ultrawork',
+      'ultraqa',
+      'ralplan',
+      'deep-interview',
+      'self-improve',
+    ] as const) {
+      expect(classifyControlMode(mode)).toBe('root');
+    }
+    expect(classifyControlMode('merge-readiness')).toBe('non_owner');
+    expect(classifyControlMode('skill-active')).toBe('non_owner');
+    expect(classifyControlMode('unknown-mode')).toBe('unknown');
+  });
+
+  it('adopts one identity-complete legacy root and rejects multiple roots', () => {
+    const single = createStore();
+    const adopted = single.adoptLegacyRoots({
+      nonce: 'legacy-nonce',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [{
+        mode: 'autopilot', session_id: 'session-control', run_id: 'auto-run', active: true,
+      }],
+    });
+    expect(adopted.root).toMatchObject({ mode: 'autopilot', run_id: 'auto-run', phase: 'active' });
+
+    const conflicting = createStore();
+    expect(() => conflicting.adoptLegacyRoots({
+      nonce: 'legacy-conflict',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto-run', active: true },
+        { mode: 'team', session_id: 'session-control', run_id: 'team-run', active: true },
+      ],
+    })).toThrow(/exactly one legacy root/i);
+  });
+
+  it('adopts legacy Ralph/Ultrawork only with mutual exact links', () => {
+    const candidates = [{
+      mode: 'ralph' as const,
+      session_id: 'session-control',
+      run_id: 'ralph-run',
+      active: true,
+      linked_ultrawork: true,
+    }, {
+      mode: 'ultrawork' as const,
+      session_id: 'session-control',
+      run_id: 'uw-run',
+      active: true,
+      linked_to_ralph: true,
+      parent: { mode: 'ralph' as const, session_id: 'session-control', run_id: 'ralph-run' },
+    }];
+    const matched = createStore().adoptLegacyRoots({
+      nonce: 'legacy-ralph', candidates, adopted_at: '2026-07-21T00:00:00.000Z',
+    });
+    expect(matched.root?.children).toMatchObject([{ mode: 'ultrawork', run_id: 'uw-run' }]);
+
+    const mismatched = createStore();
+    expect(() => mismatched.adoptLegacyRoots({
+      nonce: 'legacy-bad-link',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [{ ...candidates[0] }, { ...candidates[1], linked_to_ralph: false }],
+    })).toThrow(/mutual/i);
+  });
+
+  it('adopts the exact legacy Autopilot -> Ralph -> Ultrawork lineage', () => {
+    const store = createStore();
+    const adopted = store.adoptLegacyRoots({
+      nonce: 'legacy-tree',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+        {
+          mode: 'ralph', session_id: 'session-control', run_id: 'ralph', active: true,
+          linked_ultrawork: true,
+          parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'auto' },
+        },
+        {
+          mode: 'ultrawork', session_id: 'session-control', run_id: 'uw', active: true,
+          linked_to_ralph: true,
+          parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph' },
+        },
+      ],
+    });
+
+    expect(adopted.root?.children.map((child) => `${child.parent.mode}->${child.mode}`)).toEqual([
+      'autopilot->ralph',
+      'ralph->ultrawork',
+    ]);
+  });
+
+  it('fails closed on duplicate, cyclic, and unclaimed legacy identities', () => {
+    expect(() => createStore().adoptLegacyRoots({
+      nonce: 'legacy-duplicate', adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+      ],
+    })).toThrow(/duplicate/i);
+
+    expect(() => createStore().adoptLegacyRoots({
+      nonce: 'legacy-cycle', adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+        {
+          mode: 'ralph', session_id: 'session-control', run_id: 'ralph', active: true,
+          linked_ultrawork: true,
+          parent: { mode: 'ultrawork', session_id: 'session-control', run_id: 'uw' },
+        },
+        {
+          mode: 'ultrawork', session_id: 'session-control', run_id: 'uw', active: true,
+          linked_to_ralph: true,
+          parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph' },
+        },
+      ],
+    })).toThrow(/cyclic|unreachable/i);
+
+    expect(() => createStore().adoptLegacyRoots({
+      nonce: 'legacy-graph', adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        {
+          mode: 'graph', session_id: 'session-control', run_id: 'graph', active: true,
+          graph_revision: GRAPH_REVISION,
+        },
+        {
+          mode: 'team', session_id: 'team-control', run_id: 'team', active: true,
+          parent: { mode: 'graph', session_id: 'session-control', run_id: 'graph' },
+        },
+      ],
+    })).toThrow(/claim/i);
+  });
+});

--- a/src/graph/__tests__/descriptor.test.ts
+++ b/src/graph/__tests__/descriptor.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GraphDescriptorValidationError,
+  canonicalJson,
+  computeDescriptorHash,
+  parseGraphDescriptor,
+  sealGraphDescriptor,
+  verifyDescriptorHash,
+} from '../index.js';
+import { executableNode, forkJoinDescriptor, loopDescriptor } from './fixtures.js';
+
+describe('graph descriptor', () => {
+  it('strictly parses all four node kinds and seals the exact revision', () => {
+    const input = forkJoinDescriptor();
+    const sealed = sealGraphDescriptor(input);
+
+    expect(sealed.descriptor_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(verifyDescriptorHash(sealed)).toBe(true);
+    expect(parseGraphDescriptor(sealed)).toEqual(sealed);
+    expect(new Set(sealed.nodes.map((node) => node.kind))).toEqual(
+      new Set(['agent', 'command', 'human-approval', 'join']),
+    );
+  });
+
+  it('rejects unknown fields, duplicate IDs, and undeclared conditional routes', () => {
+    const extra = { ...forkJoinDescriptor(), status: 'running' };
+    expect(() => parseGraphDescriptor(extra)).toThrow();
+
+    const duplicate = forkJoinDescriptor();
+    duplicate.nodes.push(executableNode('branch-a'));
+    expect(() => parseGraphDescriptor(duplicate)).toThrow(GraphDescriptorValidationError);
+
+    const routes = loopDescriptor();
+    routes.edges.push({
+      id: 'test-pass-2',
+      kind: 'conditional',
+      from: 'test',
+      to: 'verify',
+      route: 'pass',
+    });
+    expect(() => parseGraphDescriptor(routes)).toThrow(/route/i);
+  });
+
+  it('uses compact key-sorted canonical JSON and excludes hash/runtime fields', () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, x: 1 } })).toBe('{"a":{"x":1,"y":2},"z":1}');
+
+    const descriptor = forkJoinDescriptor();
+    const first = computeDescriptorHash(descriptor);
+    const decorated = {
+      ...descriptor,
+      descriptor_hash: 'f'.repeat(64),
+      status: 'running',
+      updated_at: 'later',
+    };
+
+    expect(computeDescriptorHash(decorated)).toBe(first);
+    expect(computeDescriptorHash({ ...descriptor, goal: 'Different goal' })).not.toBe(first);
+  });
+
+  it('accepts a bounded return and rejects a non-back-edge cycle', () => {
+    expect(() => parseGraphDescriptor(loopDescriptor())).not.toThrow();
+
+    const cycle = loopDescriptor();
+    // Convert the retry back_edge (now at index 4 after the forward give-up
+    // exit was added to remediate) into a conditional so the remediate->test
+    // return becomes a forward cycle.
+    const retryEdge = cycle.edges.find((edge) => edge.id === 'retry-test')!;
+    cycle.edges[cycle.edges.indexOf(retryEdge)] = {
+      id: 'retry-test',
+      kind: 'conditional',
+      from: 'remediate',
+      to: 'test',
+      route: 'retry',
+    };
+    expect(() => parseGraphDescriptor(cycle)).toThrow(/cycle/i);
+  });
+
+  it('requires every reachable successful path to lead to terminal verification', () => {
+    const descriptor = loopDescriptor();
+    descriptor.nodes.push(executableNode('dead-end'));
+    descriptor.edges.push({
+      id: 'test-abandon',
+      kind: 'conditional',
+      from: 'test',
+      to: 'dead-end',
+      route: 'abandon',
+    });
+
+    expect(() => parseGraphDescriptor(descriptor)).toThrow(/terminal verification/i);
+  });
+
+  it('rejects a non-terminal node whose only outgoing edge is a back_edge (wedged once max_traversals is exhausted)', () => {
+    // A back-edge-only node has no forward exit: once max_traversals is
+    // exhausted, selectEdges throws traversal_bound_exceeded on the completing
+    // path and the result becomes permanently uncommittable. Require a
+    // non-back-edge exit path for every non-terminal node.
+    const descriptor = loopDescriptor();
+    // Remove the forward give-up exit so remediate is back-edge-only.
+    descriptor.edges = descriptor.edges.filter((edge) => edge.id !== 'remediate-give-up');
+
+    expect(() => parseGraphDescriptor(descriptor)).toThrow(/non-back-edge exit/i);
+  });
+
+  it('accepts branch-local returns and rejects fork region crossings', () => {
+    const local = forkJoinDescriptor();
+    local.nodes.push(executableNode('branch-a-check'), executableNode('branch-a-fix'));
+    local.edges = local.edges.filter((edge) => edge.id !== 'a-to-join');
+    local.edges.push(
+      { id: 'a-to-check', kind: 'fixed', from: 'branch-a', to: 'branch-a-check' },
+      {
+        id: 'a-check-pass',
+        kind: 'conditional',
+        from: 'branch-a-check',
+        to: 'join-build',
+        route: 'pass',
+      },
+      {
+        id: 'a-check-fail',
+        kind: 'conditional',
+        from: 'branch-a-check',
+        to: 'branch-a-fix',
+        route: 'fail',
+      },
+      {
+        id: 'a-fix-give-up',
+        kind: 'conditional',
+        from: 'branch-a-fix',
+        to: 'join-build',
+        route: 'give-up',
+      },
+      {
+        id: 'a-return',
+        kind: 'back_edge',
+        from: 'branch-a-fix',
+        to: 'branch-a-check',
+        route: 'retry',
+        max_traversals: 2,
+      },
+    );
+    expect(() => parseGraphDescriptor(local)).not.toThrow();
+
+    const crossing = structuredClone(local);
+    const returnEdge = crossing.edges.find((edge) => edge.id === 'a-return');
+    if (returnEdge?.kind === 'back_edge') returnEdge.to = 'branch-b';
+    expect(() => parseGraphDescriptor(crossing)).toThrow(/fork|branch|region/i);
+  });
+
+  it('rejects nested forks and accepts sequential fork/join regions', () => {
+    const nested = forkJoinDescriptor();
+    nested.nodes.push(
+      executableNode('nested-a'),
+      executableNode('nested-b'),
+      {
+        id: 'nested-join',
+        kind: 'join',
+        title: 'Nested join',
+        fan_out_node_id: 'branch-a',
+        input_branch_ids: ['nested-a', 'nested-b'],
+      },
+    );
+    nested.edges = nested.edges.filter((edge) => edge.id !== 'a-to-join');
+    nested.edges.push(
+      {
+        id: 'nested-fan-a',
+        kind: 'fan_out',
+        from: 'branch-a',
+        to: 'nested-a',
+        branch_id: 'nested-a',
+        owner_join_id: 'nested-join',
+      },
+      {
+        id: 'nested-fan-b',
+        kind: 'fan_out',
+        from: 'branch-a',
+        to: 'nested-b',
+        branch_id: 'nested-b',
+        owner_join_id: 'nested-join',
+      },
+      { id: 'nested-a-join', kind: 'fixed', from: 'nested-a', to: 'nested-join' },
+      { id: 'nested-b-join', kind: 'fixed', from: 'nested-b', to: 'nested-join' },
+      { id: 'nested-out', kind: 'fixed', from: 'nested-join', to: 'join-build' },
+    );
+    expect(() => parseGraphDescriptor(nested)).toThrow(/nested|fork region/i);
+
+    const sequential = forkJoinDescriptor();
+    sequential.nodes.push(
+      executableNode('fan-second'),
+      executableNode('second-a'),
+      executableNode('second-b'),
+      {
+        id: 'join-second',
+        kind: 'join',
+        title: 'Second join',
+        fan_out_node_id: 'fan-second',
+        input_branch_ids: ['a2', 'b2'],
+      },
+    );
+    sequential.edges = sequential.edges.filter((edge) => edge.id !== 'join-to-verify');
+    sequential.edges.push(
+      { id: 'first-to-second', kind: 'fixed', from: 'join-build', to: 'fan-second' },
+      {
+        id: 'second-fan-a',
+        kind: 'fan_out',
+        from: 'fan-second',
+        to: 'second-a',
+        branch_id: 'a2',
+        owner_join_id: 'join-second',
+      },
+      {
+        id: 'second-fan-b',
+        kind: 'fan_out',
+        from: 'fan-second',
+        to: 'second-b',
+        branch_id: 'b2',
+        owner_join_id: 'join-second',
+      },
+      { id: 'second-a-join', kind: 'fixed', from: 'second-a', to: 'join-second' },
+      { id: 'second-b-join', kind: 'fixed', from: 'second-b', to: 'join-second' },
+      { id: 'second-to-verify', kind: 'fixed', from: 'join-second', to: 'verify' },
+    );
+    expect(() => parseGraphDescriptor(sequential)).not.toThrow();
+  });
+});

--- a/src/graph/__tests__/fixtures.ts
+++ b/src/graph/__tests__/fixtures.ts
@@ -1,0 +1,118 @@
+import type { GraphDescriptorInput } from '../types.js';
+
+const SIDE_EFFECT_FREE = { policy: 'side_effect_free' } as const;
+
+export function executableNode(
+  id: string,
+  kind: 'agent' | 'command' = 'agent',
+): GraphDescriptorInput['nodes'][number] {
+  if (kind === 'command') {
+    return {
+      id,
+      kind,
+      title: id,
+      command: `run-${id}`,
+      timeout_ms: 1_000,
+      max_attempts: 2,
+      effect_policy: SIDE_EFFECT_FREE,
+    };
+  }
+
+  return {
+    id,
+    kind,
+    title: id,
+    instructions: `Do ${id}`,
+    timeout_ms: 1_000,
+    max_attempts: 2,
+    effect_policy: SIDE_EFFECT_FREE,
+  };
+}
+
+export function forkJoinDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: 'run-1',
+    revision_id: 'revision-1',
+    goal: 'Build and verify two branches',
+    entry_node_ids: ['approval'],
+    concurrency_limit: 2,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      {
+        id: 'approval',
+        kind: 'human-approval',
+        title: 'Approve the graph',
+        prompt: 'Approve this graph revision?',
+      },
+      executableNode('analyze'),
+      executableNode('branch-a'),
+      executableNode('branch-b', 'command'),
+      {
+        id: 'join-build',
+        kind: 'join',
+        title: 'Join build branches',
+        fan_out_node_id: 'analyze',
+        input_branch_ids: ['a', 'b'],
+      },
+      executableNode('verify', 'command'),
+    ],
+    edges: [
+      { id: 'approval-to-analyze', kind: 'fixed', from: 'approval', to: 'analyze' },
+      {
+        id: 'fan-a',
+        kind: 'fan_out',
+        from: 'analyze',
+        to: 'branch-a',
+        branch_id: 'a',
+        owner_join_id: 'join-build',
+      },
+      {
+        id: 'fan-b',
+        kind: 'fan_out',
+        from: 'analyze',
+        to: 'branch-b',
+        branch_id: 'b',
+        owner_join_id: 'join-build',
+      },
+      { id: 'a-to-join', kind: 'fixed', from: 'branch-a', to: 'join-build' },
+      { id: 'b-to-join', kind: 'fixed', from: 'branch-b', to: 'join-build' },
+      { id: 'join-to-verify', kind: 'fixed', from: 'join-build', to: 'verify' },
+    ],
+  };
+}
+
+export function loopDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: 'run-loop',
+    revision_id: 'revision-loop',
+    goal: 'Retry a failing verification within a bound',
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      executableNode('start'),
+      executableNode('test', 'command'),
+      executableNode('remediate'),
+      executableNode('verify', 'command'),
+    ],
+    edges: [
+      { id: 'start-test', kind: 'fixed', from: 'start', to: 'test' },
+      { id: 'test-pass', kind: 'conditional', from: 'test', to: 'verify', route: 'pass' },
+      { id: 'test-fail', kind: 'conditional', from: 'test', to: 'remediate', route: 'fail' },
+      // Forward exit from remediate so the node is not back-edge-only: once the
+      // retry bound is exhausted the run can still proceed to verification
+      // instead of wedging with traversal_bound_exceeded.
+      { id: 'remediate-give-up', kind: 'conditional', from: 'remediate', to: 'verify', route: 'give-up' },
+      {
+        id: 'retry-test',
+        kind: 'back_edge',
+        from: 'remediate',
+        to: 'test',
+        route: 'retry',
+        max_traversals: 2,
+      },
+    ],
+  };
+}

--- a/src/graph/__tests__/recovery.test.ts
+++ b/src/graph/__tests__/recovery.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  issueGraphClaim,
+  recordLateClaimResult,
+  recoverExpiredGraphClaim,
+  renewGraphClaim,
+  settleDriverClaims,
+} from '../claims.js';
+import { sealGraphDescriptor } from '../descriptor.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+function runningState(policy: 'side_effect_free' | 'idempotent' | 'reconcile' = 'side_effect_free') {
+  const input = forkJoinDescriptor();
+  const first = input.nodes.find((node) => node.id === 'analyze');
+  if (!first) throw new Error('test fixture missing analyze node');
+  if (first.kind === 'agent' || first.kind === 'command') {
+    first.effect_policy = policy === 'idempotent'
+      ? { policy: 'idempotent', idempotency_key_template: 'payment:{attempt}' }
+      : { policy };
+  }
+  const descriptor = sealGraphDescriptor(input);
+  return createInitialGraphState({
+    session_id: 'session-recovery',
+    control_nonce: 'control-recovery',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {
+        activation: {
+          activation_id: 'activation',
+          node_id: 'analyze',
+          status: 'running',
+          attempt_no: 1,
+          attempt_ids: ['attempt-1'],
+          active_attempt_id: 'attempt-1',
+          traversal_owner_id: 'root',
+        },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    approval: {
+      approved_at: '2026-07-21T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'approval' },
+    },
+  });
+}
+
+function claimState(policy: 'side_effect_free' | 'idempotent' | 'reconcile' = 'side_effect_free') {
+  return issueGraphClaim(runningState(policy), {
+    activation_id: 'activation',
+    attempt_id: 'attempt-1',
+    attempt_no: 1,
+    claim_owner_session_id: 'session-recovery',
+    driver_instance_id: 'driver-1',
+    lease_id: 'lease-1',
+    tracking_id: 'tool-1',
+    issued_at: '2026-07-21T00:00:00.000Z',
+    execution_timeout_ms: 1_000,
+    grace_ms: 500,
+    max_renewals: 2,
+    effect_policy: policy === 'idempotent'
+      ? { policy: 'idempotent', idempotency_key_template: 'payment:{attempt}' }
+      : { policy },
+    ...(policy === 'idempotent' ? { external_idempotency_key: 'payment:42' } : {}),
+  }).state;
+}
+
+const retryProjection = (
+  projection: ReturnType<typeof runningState>['projection'],
+  input: { activation_id: string; attempt_id: string; attempt_no: number },
+) => ({
+  ...projection,
+  activations: {
+    ...projection.activations,
+    [input.activation_id]: {
+      ...projection.activations[input.activation_id],
+      status: 'running' as const,
+      attempt_no: input.attempt_no,
+      attempt_ids: [...projection.activations[input.activation_id].attempt_ids, input.attempt_id],
+      active_attempt_id: input.attempt_id,
+    },
+  },
+});
+
+describe('graph claim recovery', () => {
+  it('renews only the matching live tracked lease before expiry and within its cap', () => {
+    const state = claimState();
+    const renewed = renewGraphClaim(state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(renewed.state.claims['lease-1']).toMatchObject({
+      renewal_count: 1,
+      expires_at: '2026-07-21T00:00:02.500Z',
+    });
+    expect(() => renewGraphClaim(renewed.state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'different-tool',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:01.100Z',
+    })).toThrow(/tracking/i);
+
+    const second = renewGraphClaim(renewed.state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:02.000Z',
+    });
+    expect(() => renewGraphClaim(second.state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:02.100Z',
+    })).toThrow(/renewal cap/i);
+    expect(() => renewGraphClaim(state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:02.000Z',
+    })).toThrow(/expired/i);
+  });
+
+  it('binds issuance to the authority session and exact approved node timeout', () => {
+    const state = runningState();
+    const base = {
+      activation_id: 'activation',
+      attempt_id: 'attempt-1',
+      attempt_no: 1,
+      claim_owner_session_id: 'different-session',
+      driver_instance_id: 'driver-1',
+      lease_id: 'lease-invalid',
+      tracking_id: 'tool-1',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      execution_timeout_ms: 1_000,
+      grace_ms: 500,
+      max_renewals: 2,
+      effect_policy: { policy: 'side_effect_free' } as const,
+    };
+    expect(() => issueGraphClaim(state, base)).toThrow(/authority session/i);
+    expect(() => issueGraphClaim(state, {
+      ...base,
+      claim_owner_session_id: 'session-recovery',
+      execution_timeout_ms: 2_000,
+    })).toThrow(/approved node timeout/i);
+    expect(() => recoverExpiredGraphClaim(claimState(), {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'different-session',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection)).toThrow(/authority session/i);
+  });
+
+  it('takes over idempotent work only with its durable key intact', () => {
+    const recovered = recoverExpiredGraphClaim(claimState('idempotent'), {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection);
+
+    expect(recovered.disposition).toBe('taken_over');
+    expect(recovered.state.claims['lease-2'].external_idempotency_key).toBe('payment:42');
+  });
+
+  it('takes over expired retry-safe work with a new attempt while retaining activation identity', () => {
+    const state = claimState();
+    const recovered = recoverExpiredGraphClaim(state, {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection);
+
+    expect(recovered.disposition).toBe('taken_over');
+    expect(recovered.state.claims['lease-1'].status).toBe('expired_retryable');
+    expect(recovered.state.claims['lease-2']).toMatchObject({
+      status: 'live',
+      activation_id: 'activation',
+      attempt_id: 'attempt-2',
+      attempt_no: 2,
+    });
+    expect(recovered.state.projection.activations.activation.attempt_ids).toEqual([
+      'attempt-1',
+      'attempt-2',
+    ]);
+
+    expect(() => recoverExpiredGraphClaim(recovered.state, {
+      lease_id: 'lease-2',
+      now: '2026-07-21T00:00:04.000Z',
+      new_attempt_id: 'attempt-3',
+      new_lease_id: 'lease-3',
+      new_tracking_id: 'tool-3',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-3',
+      reconciliation_id: 'reconciliation-2',
+    }, retryProjection)).toThrow(/maximum attempts/i);
+  });
+
+  it('moves ambiguous expired work to reconciliation and never creates a replacement claim', () => {
+    const state = claimState('reconcile');
+    const recovered = recoverExpiredGraphClaim(state, {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, () => {
+      throw new Error('ambiguous work must not retry');
+    });
+
+    expect(recovered.disposition).toBe('reconciling');
+    expect(recovered.state.claims['lease-2']).toBeUndefined();
+    expect(recovered.state.reconciliations['reconciliation-1']).toMatchObject({
+      status: 'unresolved',
+      activation_id: 'activation',
+    });
+  });
+
+  it('records an expired lease completion only as bounded diagnostic evidence', () => {
+    const state = recoverExpiredGraphClaim(claimState(), {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection).state;
+    const projection = state.projection;
+    const late = recordLateClaimResult(state, {
+      lease_id: 'lease-1',
+      attempt_id: 'attempt-1',
+      recorded_at: '2026-07-21T00:00:03.000Z',
+      summary: 'old result arrived after takeover',
+    });
+
+    expect(late.state.projection).toStrictEqual(projection);
+    expect(late.state.diagnostics.at(-1)).toMatchObject({
+      kind: 'late_result',
+      lease_id: 'lease-1',
+      attempt_id: 'attempt-1',
+    });
+  });
+
+  it('fences SessionEnd claims without deleting their authority', () => {
+    const safe = settleDriverClaims(claimState(), {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+    const ambiguous = settleDriverClaims(claimState('reconcile'), {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(safe.state.claims['lease-1'].status).toBe('abandoned_retryable');
+    expect(ambiguous.state.claims['lease-1'].status).toBe('reconciling');
+    expect(Object.values(ambiguous.state.reconciliations)).toHaveLength(1);
+  });
+
+  it('B4: session-end scope fences ALL live claims regardless of driver-id', () => {
+    // Two live claims owned by different drivers in the same session.
+    const base = claimState();
+    const secondClaim = issueGraphClaim(runningState(), {
+      activation_id: 'activation',
+      attempt_id: 'attempt-1',
+      attempt_no: 1,
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      lease_id: 'lease-2',
+      tracking_id: 'tool-2',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      execution_timeout_ms: 1_000,
+      grace_ms: 500,
+      max_renewals: 2,
+      effect_policy: { policy: 'side_effect_free' },
+    });
+    // claimState() already has lease-1 (driver-1); add lease-2 (driver-2).
+    const both = {
+      ...secondClaim.state,
+      claims: {
+        ...base.claims,
+        ...secondClaim.state.claims,
+      },
+    };
+
+    // driver scope (default) only fences driver-1's claim.
+    const driverScoped = settleDriverClaims(both, {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+    expect(driverScoped.settled_lease_ids).toEqual(['lease-1']);
+    expect(driverScoped.state.claims['lease-2'].status).toBe('live');
+
+    // session scope fences both claims even though only driver-1 was passed.
+    const sessionScoped = settleDriverClaims(both, {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+      scope: 'session',
+    });
+    expect(sessionScoped.settled_lease_ids.sort()).toEqual(['lease-1', 'lease-2']);
+    expect(sessionScoped.state.claims['lease-1'].status).toBe('abandoned_retryable');
+    expect(sessionScoped.state.claims['lease-2'].status).toBe('abandoned_retryable');
+  });
+});

--- a/src/graph/__tests__/revision.test.ts
+++ b/src/graph/__tests__/revision.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalJson, sealGraphDescriptor } from '../descriptor.js';
+import {
+  GraphRevisionError,
+  approveGraphPatch,
+  approvePendingGraphRevision,
+  proposeGraphPatch,
+  replacePendingDraft,
+} from '../revisions.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+function approvedState() {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  return createInitialGraphState({
+    session_id: 'session-revision',
+    control_nonce: 'control-revision',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {
+        completed: {
+          activation_id: 'completed',
+          node_id: 'branch-a',
+          status: 'completed',
+          attempt_no: 1,
+          attempt_ids: ['attempt-a'],
+          completed_transition_id: 'transition-a',
+          traversal_owner_id: 'root',
+        },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    approval: {
+      approved_at: '2026-07-21T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'approval-1' },
+    },
+  });
+}
+
+function nextDescriptor(changeCompletedNode = false) {
+  const next = forkJoinDescriptor();
+  next.revision_id = 'revision-2';
+  next.goal = 'Build and verify two branches with an approved patch';
+  if (changeCompletedNode) {
+    const node = next.nodes.find((candidate) => candidate.id === 'branch-a');
+    if (node) node.title = 'repurposed completed work';
+  }
+  return sealGraphDescriptor(next);
+}
+
+describe('graph revisions', () => {
+  it('replaces a rejected pending draft without making it runnable, then approves the exact replacement', () => {
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const pending = createInitialGraphState({
+      session_id: 'session-revision',
+      control_nonce: 'control-revision',
+      descriptor,
+      status: 'awaiting_approval',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection: {
+        activations: {},
+        cohorts: {},
+        branch_tokens: {},
+        traversal_counts: {},
+        committed_transitions: {},
+        terminal_verification_activation_ids: [],
+      },
+    });
+    const replacement = nextDescriptor();
+    const replaced = replacePendingDraft(pending, {
+      descriptor: replacement,
+      replaced_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(replaced).toMatchObject({
+      status: 'awaiting_approval',
+      active_revision_id: 'revision-2',
+      active_revision_hash: replacement.descriptor_hash,
+      pending_approval: {
+        revision_id: 'revision-2',
+        revision_hash: replacement.descriptor_hash,
+      },
+    });
+    expect(replaced.projection.activations).toEqual({});
+
+    const approved = approvePendingGraphRevision(replaced, {
+      revision_id: 'revision-2',
+      revision_hash: replacement.descriptor_hash,
+      approved_at: '2026-07-21T00:00:02.000Z',
+      approval_evidence: { kind: 'human', ref: 'approve-replacement' },
+    }, (approvedDescriptor) => ({
+      activations: {
+        approval: {
+          activation_id: 'approval',
+          node_id: approvedDescriptor.entry_node_ids[0],
+          status: 'ready',
+          attempt_no: 0,
+          attempt_ids: [],
+          traversal_owner_id: 'root',
+        },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    }));
+    expect(approved.status).toBe('running');
+    expect(approved.pending_approval).toBeUndefined();
+    expect(approved.revisions['revision-2'].approval).toMatchObject({
+      revision_id: 'revision-2',
+      revision_hash: replacement.descriptor_hash,
+    });
+  });
+
+  it('advances dispatch generation and pauses new dispatch on proposal', () => {
+    const state = approvedState();
+    const proposed = proposeGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [{ kind: 'file', ref: 'patch.json' }],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(proposed.status).toBe('waiting_patch_approval');
+    expect(proposed.dispatch_generation).toBe(1);
+    expect(proposed.pending_patch).toMatchObject({
+      proposal_id: 'patch-1',
+      base_dispatch_generation: 0,
+      proposed_revision_id: 'revision-2',
+    });
+    expect(proposed.revisions['revision-2']).toBeUndefined();
+  });
+
+  it('blocks approval until old claims drain and reconciliation is resolved', () => {
+    const state = proposeGraphPatch(approvedState(), {
+      proposal_id: 'patch-1',
+      base_revision_id: 'revision-1',
+      base_revision_hash: approvedState().active_revision_hash,
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    state.claims['lease-old'] = {
+      run_id: state.run_id,
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: 0,
+      activation_id: 'completed',
+      attempt_id: 'attempt-a',
+      attempt_no: 1,
+      claim_owner_session_id: state.session_id,
+      driver_instance_id: 'driver',
+      lease_id: 'lease-old',
+      tracking_id: 'tool',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      expires_at: '2026-07-21T00:01:00.000Z',
+      lease_duration_ms: 60_000,
+      renewal_count: 0,
+      max_renewals: 1,
+      effect_policy: { policy: 'side_effect_free' },
+      status: 'live',
+    };
+
+    expect(() => approveGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: state.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrow(/live claim/i);
+
+    state.claims['lease-old'].status = 'reconciling';
+    state.claims['lease-old'].fenced_at = '2026-07-21T00:00:01.500Z';
+    state.reconciliations['reconciliation-old'] = {
+      reconciliation_id: 'reconciliation-old',
+      activation_id: 'completed',
+      attempt_id: 'attempt-a',
+      lease_id: 'lease-old',
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: 0,
+      status: 'unresolved',
+      reason: 'external_effect_ambiguous',
+      created_at: '2026-07-21T00:00:01.500Z',
+    };
+    expect(() => approveGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: state.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrow(/unresolved reconciliation/i);
+  });
+
+  it('keeps stale-base and unapproved patch proposals inert', () => {
+    const state = approvedState();
+    const before = canonicalJson(state);
+    expect(() => proposeGraphPatch(state, {
+      proposal_id: 'patch-stale',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: '0'.repeat(64),
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    })).toThrow(/stale base/i);
+    expect(canonicalJson(state)).toBe(before);
+    expect(state.revisions['revision-2']).toBeUndefined();
+  });
+
+  it('rejects silent repurposing of a completed node ID', () => {
+    const state = approvedState();
+    const proposed = proposeGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_descriptor: nextDescriptor(true),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(() => approveGraphPatch(proposed, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: proposed.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrowError(GraphRevisionError);
+  });
+
+  it('activates an immutable approved revision only with explicit invalidation evidence', () => {
+    const state = approvedState();
+    const descriptor = nextDescriptor(true);
+    const proposed = proposeGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_descriptor: descriptor,
+      invalidated_node_ids: ['branch-a'],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    const approved = approveGraphPatch(proposed, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: descriptor.descriptor_hash,
+      invalidated_node_ids: ['branch-a'],
+      approval_evidence: { kind: 'human', ref: 'approve-invalidating-branch-a' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection, _descriptor, invalidated) => ({
+      ...projection,
+      activations: Object.fromEntries(
+        Object.entries(projection.activations).filter(([, activation]) => !invalidated.has(activation.node_id)),
+      ),
+    }));
+
+    expect(approved.active_revision_id).toBe('revision-2');
+    expect(approved.active_revision_hash).toBe(descriptor.descriptor_hash);
+    expect(approved.pending_patch).toBeUndefined();
+    expect(approved.revisions['revision-1'].descriptor.descriptor_hash).toBe(state.active_revision_hash);
+    expect(approved.revisions['revision-2'].approval?.evidence.ref).toBe('approve-invalidating-branch-a');
+    expect(canonicalJson(approved.revisions['revision-2'].descriptor)).toBe(canonicalJson(descriptor));
+    expect(approved.projection.activations.completed).toBeUndefined();
+  });
+});

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -1,0 +1,464 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { sealGraphDescriptor } from '../descriptor.js';
+import { graphCommandService } from '../runtime.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { GraphStateStore } from '../store.js';
+import type { GraphSchedulerProjection } from '../types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+type ForkJoin = ReturnType<typeof forkJoinDescriptor>;
+
+const temporaryDirectories: string[] = [];
+let originalCwd = '';
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+// Drop into a fresh temp worktree dir so the runtime's GraphStateStore (which
+// resolves against process.cwd() when no worktreeRoot is given) writes into an
+// isolated .omc/state tree. The store requires a session-scoped write path.
+function useTempWorktree(sessionId: string): { worktree: string; store: GraphStateStore } {
+  const worktree = mkdtempSync(join(tmpdir(), 'omc-graph-runtime-'));
+  temporaryDirectories.push(worktree);
+  mkdirSync(join(worktree, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+  process.chdir(worktree);
+  const store = new GraphStateStore({
+    sessionId,
+    worktreeRoot: worktree,
+    dependencies: {
+      fileExists: existsSync,
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic: (path, value) => writeFileSync(path, JSON.stringify(value)),
+      withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+    },
+  });
+  return { worktree, store };
+}
+
+function linearDescriptor(opts: { reconcile?: boolean; runId?: string; goal?: string } = {}): ForkJoin {
+  return {
+    descriptor_version: 1,
+    run_id: opts.runId ?? 'run-linear',
+    revision_id: 'revision-linear',
+    goal: opts.goal ?? 'Linear side-effect-free path',
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      {
+        id: 'start', kind: 'agent', title: 'start', instructions: 'Do start',
+        timeout_ms: 1_000, max_attempts: 2,
+        effect_policy: opts.reconcile ? { policy: 'reconcile' } : { policy: 'side_effect_free' },
+      },
+      {
+        id: 'verify', kind: 'command', title: 'verify', command: 'run-verify',
+        timeout_ms: 1_000, max_attempts: 2, effect_policy: { policy: 'side_effect_free' },
+      },
+    ],
+    edges: [{ id: 'start-verify', kind: 'fixed', from: 'start', to: 'verify' }],
+  } as unknown as ForkJoin;
+}
+
+function seedRunning(sessionId: string, descriptor: ReturnType<typeof sealGraphDescriptor>, startNodeId = 'start', projectionOverride?: GraphSchedulerProjection) {
+  const { store } = useTempWorktree(sessionId);
+  const startActivationId = `${descriptor.run_id}:act:${startNodeId}:entry`;
+  const state = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'nonce-runtime',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: projectionOverride ?? {
+      activations: {
+        [startActivationId]: {
+          activation_id: startActivationId, node_id: startNodeId, status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: startActivationId,
+        },
+      },
+      cohorts: {}, branch_tokens: {}, traversal_counts: {},
+      committed_transitions: {}, terminal_verification_activation_ids: [],
+    },
+    approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approval-1' } },
+  });
+  store.create(state);
+  return { store, startActivationId };
+}
+
+async function exec(operation: string, input: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return graphCommandService.execute({ operation: operation as never, cwd: process.cwd(), input }) as Promise<Record<string, unknown>>;
+}
+
+describe('graphCommandService runtime operations', () => {
+  it('B6: claims a human-approval node, transitions to waiting_human, and completes with the human answer', async () => {
+    const sessionId = 'session-human-approval';
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const { store, startActivationId } = seedRunning(sessionId, descriptor, 'approval');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 'transition-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+
+    const claim = claimed.result.claims[0];
+    expect(claim.kind).toBe('human-approval');
+    expect(claim.waiting_human).toBe(true);
+    expect(claim.activation_id).toBe(startActivationId);
+
+    const afterClaim = store.read()!;
+    expect(afterClaim.status).toBe('waiting_human');
+    expect(afterClaim.claims[claim.lease_id as string]).toMatchObject({ status: 'live' });
+
+    const completed = await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 'transition-approve',
+      claim: { lease_id: claim.lease_id, activation_id: claim.activation_id, attempt_id: claim.attempt_id },
+      result: {
+        outcome: 'succeeded',
+        evidence_refs: [{ kind: 'human', ref: 'human-answer-yes', summary: 'Operator approved' }],
+      },
+    }) as { result: { outcome: string; created_activation_ids: string[] } };
+
+    expect(completed.result.outcome).toBe('succeeded');
+    expect(completed.result.created_activation_ids).toHaveLength(1);
+    const afterComplete = store.read()!;
+    expect(afterComplete.claims[claim.lease_id as string].status).toBe('completed');
+  });
+
+  it('B2: resolve-join resolves a ready join activation through the runtime', async () => {
+    const sessionId = 'session-resolve-join';
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'approval');
+
+    // approval (human-approval) -> complete -> analyze (fan-out) -> branches -> join
+    const ap = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim-approval', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const aClaim = ap.result.claims[0];
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-complete-approval',
+      claim: { lease_id: aClaim.lease_id, activation_id: aClaim.activation_id, attempt_id: aClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'human', ref: 'ok' }] },
+    });
+
+    const az = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      driver_id: 'driver-1', transition_id: 't-claim-analyze', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const zClaim = az.result.claims[0];
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 3,
+      transition_id: 't-complete-analyze',
+      claim: { lease_id: zClaim.lease_id, activation_id: zClaim.activation_id, attempt_id: zClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'analyze' }] },
+    });
+
+    for (const i of [0, 1]) {
+      const bc = await exec('claim', {
+        session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+        descriptor_hash: descriptor.descriptor_hash, expected_sequence: 4 + i * 2,
+        driver_id: 'driver-1', transition_id: `t-claim-branch-${i}`, limit: 1,
+      }) as { result: { claims: Array<Record<string, unknown>> } };
+      const bClaim = bc.result.claims[0];
+      await exec('complete', {
+        session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+        descriptor_hash: descriptor.descriptor_hash, expected_sequence: 5 + i * 2,
+        transition_id: `t-complete-branch-${i}`,
+        claim: { lease_id: bClaim.lease_id, activation_id: bClaim.activation_id, attempt_id: bClaim.attempt_id },
+        result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: `branch-${i}` }] },
+        // Completing the second branch fills the cohort and activates the join;
+        // supply the join activation identity the scheduler needs at arrival.
+        identities: { join_activation_id: `${descriptor.run_id}:act:join-build:resolved` },
+      });
+    }
+
+    const readyForJoin = await exec('ready', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 8,
+    }) as { joins: Array<Record<string, unknown>> };
+    expect(readyForJoin.joins).toHaveLength(1);
+    const joinActivationId = readyForJoin.joins[0].activation_id as string;
+
+    const resolved = await exec('resolve-join', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 8,
+      transition_id: 't-resolve-join',
+      activation_id: joinActivationId,
+      identities: { next_activation_ids: { 'join-to-verify': `${descriptor.run_id}:act:verify:resolved` } },
+    }) as { result: { outcome: string; created_activation_ids: string[] } };
+
+    expect(resolved.result.outcome).toBe('join_resolved');
+    expect(resolved.result.created_activation_ids).toHaveLength(1);
+    const finalState = store.read()!;
+    expect(finalState.projection.activations[joinActivationId].status).toBe('completed');
+  });
+
+  it('B3: renew-claim renews a live tracked lease and rejects a mismatched owner', async () => {
+    const sessionId = 'session-renew';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+
+    const renewed = await exec('renew-claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-renew',
+      lease_id: claim.lease_id, driver_id: 'driver-1', tracking_id: claim.tracking_id,
+      tool_still_running: true, now: '2026-07-21T00:00:01.000Z',
+    }) as { result: { renewal_count: number } };
+
+    expect(renewed.result.renewal_count).toBe(1);
+    const after = store.read()!;
+    expect(after.claims[claim.lease_id as string].renewal_count).toBe(1);
+
+    await expect(exec('renew-claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-renew-wrong',
+      lease_id: claim.lease_id, driver_id: 'driver-other', tracking_id: claim.tracking_id,
+      tool_still_running: true, now: '2026-07-21T00:00:01.500Z',
+    })).rejects.toThrow(/owner/i);
+  });
+
+  it('B3: release-attempt-for-retry returns an activation to ready and fences its claim', async () => {
+    const sessionId = 'session-release';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+
+    const released = await exec('release-attempt-for-retry', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-release',
+      activation_id: claim.activation_id, attempt_id: claim.attempt_id,
+    }) as { result: { released: boolean } };
+
+    expect(released.result.released).toBe(true);
+    const after = store.read()!;
+    expect(after.projection.activations[claim.activation_id as string].status).toBe('ready');
+    expect(after.claims[claim.lease_id as string].status).toBe('fenced');
+  });
+
+  it('B3: record-late-claim-result records a bounded diagnostic for a fenced lease', async () => {
+    const sessionId = 'session-late';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+    // Fence the claim via release-attempt-for-retry so it is no longer live,
+    // making it eligible for a late-result diagnostic.
+    await exec('release-attempt-for-retry', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-release',
+      activation_id: claim.activation_id, attempt_id: claim.attempt_id,
+    });
+
+    const late = await exec('record-late-claim-result', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-late',
+      lease_id: claim.lease_id, attempt_id: claim.attempt_id,
+      recorded_at: '2026-07-21T00:00:03.000Z',
+      summary: 'old result arrived after release',
+    }) as { result: { kind: string; lease_id: string } };
+
+    expect(late.result.kind).toBe('late_result');
+    expect(late.result.lease_id).toBe(claim.lease_id);
+    const after = store.read()!;
+    expect(after.diagnostics.at(-1)).toMatchObject({ kind: 'late_result', lease_id: claim.lease_id });
+  });
+
+  it('B3: recover-expired-claim takes over an expired side-effect-free lease', async () => {
+    const sessionId = 'session-recover';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+    // recoverExpiredGraphClaim requires `now` to be at/after the lease expiry.
+    const expiresAt = claim.expires_at as string;
+    const recoverNow = new Date(Date.parse(expiresAt) + 1_000).toISOString();
+
+    const recovered = await exec('recover-expired-claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-recover',
+      lease_id: claim.lease_id, now: recoverNow,
+      new_attempt_id: 'attempt-2', new_lease_id: 'lease-2', new_tracking_id: 'tool-2',
+      driver_id: 'driver-2', reconciliation_id: 'reconciliation-1',
+    }) as { result: { disposition: string; replacement_lease_id: string } };
+
+    expect(recovered.result.disposition).toBe('taken_over');
+    expect(recovered.result.replacement_lease_id).toBe('lease-2');
+    const after = store.read()!;
+    expect(after.claims['lease-2']).toMatchObject({ status: 'live', attempt_no: 2 });
+    expect(after.claims[claim.lease_id as string].status).toBe('expired_retryable');
+  });
+
+  it('B5: resolve-reconciliation exits the reconciling phase back to running', async () => {
+    const sessionId = 'session-reconcile';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ reconcile: true, runId: 'run-reconcile', goal: 'Reconcile-policy path' }));
+    const { store, startActivationId } = seedRunning(sessionId, descriptor, 'start');
+    // Force the graph into 'reconciling' with an unresolved reconciliation record
+    // (as recoverExpiredGraphClaim would for a reconcile-policy claim).
+    const leaseId = 'lease-reconcile-1';
+    const running = store.read()!;
+    const reconcilingState = {
+      ...running,
+      status: 'reconciling' as const,
+      projection: {
+        ...running.projection,
+        activations: {
+          ...running.projection.activations,
+          [startActivationId]: {
+            ...running.projection.activations[startActivationId],
+            status: 'running' as const,
+            attempt_no: 1,
+            attempt_ids: ['attempt-1'],
+            active_attempt_id: 'attempt-1',
+          },
+        },
+      },
+      claims: {
+        [leaseId]: {
+          run_id: running.run_id,
+          revision_id: running.active_revision_id,
+          revision_hash: running.active_revision_hash,
+          dispatch_generation: running.dispatch_generation,
+          activation_id: startActivationId,
+          attempt_id: 'attempt-1',
+          attempt_no: 1,
+          claim_owner_session_id: sessionId,
+          driver_instance_id: 'driver-1',
+          lease_id: leaseId,
+          tracking_id: 'tool-1',
+          issued_at: '2026-07-21T00:00:00.000Z',
+          expires_at: '2026-07-21T00:00:02.000Z',
+          lease_duration_ms: 2_000,
+          renewal_count: 0,
+          max_renewals: 2,
+          effect_policy: { policy: 'reconcile' },
+          status: 'reconciling' as const,
+          fenced_at: '2026-07-21T00:00:02.000Z',
+        },
+      },
+      reconciliations: {
+        'reconciliation-1': {
+          reconciliation_id: 'reconciliation-1',
+          activation_id: startActivationId,
+          attempt_id: 'attempt-1',
+          lease_id: leaseId,
+          revision_id: running.active_revision_id,
+          revision_hash: running.active_revision_hash,
+          dispatch_generation: running.dispatch_generation,
+          status: 'unresolved' as const,
+          reason: 'expired_ambiguous' as const,
+          created_at: '2026-07-21T00:00:02.000Z',
+        },
+      },
+    } as unknown as typeof running;
+    // Overwrite the state file directly through the store's write path.
+    const storePath = (store as unknown as { path: string }).path;
+    writeFileSync(storePath, JSON.stringify(reconcilingState));
+    // Sanity: the store re-reads the reconciling state.
+    expect(store.read()?.status).toBe('reconciling');
+
+    const resolved = await exec('resolve-reconciliation', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      transition_id: 't-resolve-recon',
+      evidence: { kind: 'human', ref: 'operator-resolved', summary: 'Operator confirmed no external effect' },
+      resolved_at: '2026-07-21T00:00:05.000Z',
+    }) as { result: { status: string; resolved_reconciliation_ids: string[] } };
+
+    expect(resolved.result.status).toBe('running');
+    expect(resolved.result.resolved_reconciliation_ids).toEqual(['reconciliation-1']);
+    const after = store.read()!;
+    expect(after.status).toBe('running');
+    expect(after.reconciliations['reconciliation-1'].status).toBe('accepted');
+  });
+
+  it('non-blocker: create is idempotent only when the descriptor hash matches', async () => {
+    const sessionId = 'session-idempotent';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-linear', goal: 'Original goal' }));
+    const { store } = useTempWorktree(sessionId);
+    // Seed an existing graph with the SAME run_id/revision_id but a DIFFERENT goal
+    // (and therefore a different descriptor hash).
+    const otherInput = linearDescriptor({ runId: descriptor.run_id, goal: 'A different goal for hash mismatch' });
+    const otherDescriptor = sealGraphDescriptor(otherInput);
+    expect(otherDescriptor.run_id).toBe(descriptor.run_id);
+    expect(otherDescriptor.revision_id).toBe(descriptor.revision_id);
+    expect(otherDescriptor.descriptor_hash).not.toBe(descriptor.descriptor_hash);
+    store.create(createInitialGraphState({
+      session_id: sessionId,
+      control_nonce: 'nonce-idem',
+      descriptor: otherDescriptor,
+      status: 'running',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection: {
+        activations: {}, cohorts: {}, branch_tokens: {}, traversal_counts: {},
+        committed_transitions: {}, terminal_verification_activation_ids: [],
+      },
+      approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approve' } },
+    }));
+
+    // create with a different hash must throw hash_mismatch, not silently return.
+    await expect(exec('create', {
+      goal: descriptor.goal,
+      descriptor,
+      session_id: sessionId,
+      driver_id: 'driver-1',
+      transition_id: 't-create-mismatch',
+    })).rejects.toThrow(/hash_mismatch/);
+
+    // Re-creating with the exact same descriptor is idempotent.
+    const idempotent = await exec('create', {
+      goal: otherDescriptor.goal,
+      descriptor: otherDescriptor,
+      session_id: sessionId,
+      driver_id: 'driver-1',
+      transition_id: 't-create-idem',
+    }) as { run_id: string };
+    expect(idempotent.run_id).toBe(otherDescriptor.run_id);
+  });
+});

--- a/src/graph/__tests__/scheduler.test.ts
+++ b/src/graph/__tests__/scheduler.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GraphSchedulerError,
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+  releaseAttemptForRetry,
+  resolveJoin,
+  sealGraphDescriptor,
+} from '../index.js';
+import type {
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SchedulerTransitionIdentities,
+} from '../types.js';
+import { forkJoinDescriptor, loopDescriptor } from './fixtures.js';
+
+function begin(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+): GraphSchedulerProjection {
+  return beginActivationAttempt(projection, {
+    activation_id: activationId,
+    attempt_id: attemptId,
+  });
+}
+
+function succeed(
+  descriptor: ReturnType<typeof sealGraphDescriptor>,
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+  transitionId: string,
+  identities: SchedulerTransitionIdentities = {},
+  route?: string,
+  evidenceRefs: GraphEvidenceReference[] = [],
+) {
+  return applyNodeResult(descriptor, projection, {
+    activation_id: activationId,
+    transition_id: transitionId,
+    result: {
+      outcome: 'succeeded',
+      attempt_id: attemptId,
+      evidence_refs: evidenceRefs,
+      ...(route ? { route } : {}),
+    },
+    identities,
+  });
+}
+
+describe('graph scheduler', () => {
+  it('retries under one activation and gives each attempt a distinct identity', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    let projection = initializeGraphProjection(descriptor, {
+      start: 'activation-start',
+    });
+    projection = begin(projection, 'activation-start', 'attempt-1');
+    projection = releaseAttemptForRetry(projection, {
+      activation_id: 'activation-start',
+      attempt_id: 'attempt-1',
+    });
+    projection = begin(projection, 'activation-start', 'attempt-2');
+
+    expect(projection.activations['activation-start']).toMatchObject({
+      activation_id: 'activation-start',
+      attempt_no: 2,
+      active_attempt_id: 'attempt-2',
+      attempt_ids: ['attempt-1', 'attempt-2'],
+    });
+  });
+
+  it('fails closed on an undeclared route and enforces a back-edge bound per lineage', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    let projection = initializeGraphProjection(descriptor, { start: 'a-start' });
+    projection = begin(projection, 'a-start', 'try-start');
+    projection = succeed(descriptor, projection, 'a-start', 'try-start', 't-start', {
+      next_activation_ids: { 'start-test': 'a-test-1' },
+    }).projection;
+
+    projection = begin(projection, 'a-test-1', 'try-test-1');
+    expect(() =>
+      succeed(descriptor, projection, 'a-test-1', 'try-test-1', 'bad-route', {}, 'unknown'),
+    ).toThrow(/undeclared route/i);
+
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-test-1',
+      'try-test-1',
+      't-test-1',
+      { next_activation_ids: { 'test-fail': 'a-fix-1' } },
+      'fail',
+    ).projection;
+    projection = begin(projection, 'a-fix-1', 'try-fix-1');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-fix-1',
+      'try-fix-1',
+      't-fix-1',
+      { next_activation_ids: { 'retry-test': 'a-test-2' } },
+      'retry',
+    ).projection;
+    projection = begin(projection, 'a-test-2', 'try-test-2');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-test-2',
+      'try-test-2',
+      't-test-2',
+      { next_activation_ids: { 'test-fail': 'a-fix-2' } },
+      'fail',
+    ).projection;
+    projection = begin(projection, 'a-fix-2', 'try-fix-2');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-fix-2',
+      'try-fix-2',
+      't-fix-2',
+      { next_activation_ids: { 'retry-test': 'a-test-3' } },
+      'retry',
+    ).projection;
+    projection = begin(projection, 'a-test-3', 'try-test-3');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-test-3',
+      'try-test-3',
+      't-test-3',
+      { next_activation_ids: { 'test-fail': 'a-fix-3' } },
+      'fail',
+    ).projection;
+    projection = begin(projection, 'a-fix-3', 'try-fix-3');
+
+    expect(() =>
+      succeed(
+        descriptor,
+        projection,
+        'a-fix-3',
+        'try-fix-3',
+        't-fix-3',
+        { next_activation_ids: { 'retry-test': 'a-test-4' } },
+        'retry',
+      ),
+    ).toThrow(/traversal bound/i);
+  });
+
+  it('creates a selected fan-out cohort and consumes its branch tokens once at join', () => {
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    let projection = initializeGraphProjection(descriptor, { approval: 'act-approval' });
+    expect(listReadyExecutableActivations(descriptor, projection).map((item) => item.node_id))
+      .toEqual(['approval']);
+    projection = begin(projection, 'act-approval', 'try-approval');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-approval',
+      'try-approval',
+      'transition-approval',
+      { next_activation_ids: { 'approval-to-analyze': 'act-analyze' } },
+    ).projection;
+    expect(listReadyExecutableActivations(descriptor, projection).map((item) => item.node_id))
+      .toEqual(['analyze']);
+    projection = begin(projection, 'act-analyze', 'try-analyze');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-analyze',
+      'try-analyze',
+      'transition-analyze',
+      {
+        cohort_id: 'cohort-build',
+        next_activation_ids: { 'fan-a': 'act-a', 'fan-b': 'act-b' },
+        branch_token_ids: { 'fan-a': 'token-a', 'fan-b': 'token-b' },
+      },
+    ).projection;
+
+    expect(listReadyExecutableActivations(descriptor, projection).map((item) => item.activation_id))
+      .toEqual(['act-a', 'act-b']);
+    expect(projection.cohorts['cohort-build'].expected_branch_token_ids).toEqual([
+      'token-a',
+      'token-b',
+    ]);
+
+    projection = begin(projection, 'act-a', 'try-a');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-a',
+      'try-a',
+      'transition-a',
+    ).projection;
+    expect(listReadyJoinActivations(descriptor, projection)).toEqual([]);
+
+    projection = begin(projection, 'act-b', 'try-b');
+    const completedB = succeed(
+      descriptor,
+      projection,
+      'act-b',
+      'try-b',
+      'transition-b',
+      { join_activation_id: 'act-join' },
+    );
+    projection = completedB.projection;
+    expect(listReadyJoinActivations(descriptor, projection).map((item) => item.activation_id))
+      .toEqual(['act-join']);
+
+    const replay = succeed(
+      descriptor,
+      projection,
+      'act-b',
+      'try-b',
+      'transition-b',
+      { join_activation_id: 'act-join' },
+    );
+    expect(replay.replayed).toBe(true);
+    expect(replay.projection).toBe(projection);
+    expect(() =>
+      succeed(
+        descriptor,
+        projection,
+        'act-b',
+        'try-b',
+        'transition-b',
+        { join_activation_id: 'different-id' },
+      ),
+    ).toThrow(/fingerprint/i);
+
+    const joined = resolveJoin(descriptor, projection, {
+      activation_id: 'act-join',
+      transition_id: 'transition-join',
+      identities: { next_activation_ids: { 'join-to-verify': 'act-verify' } },
+    });
+    projection = joined.projection;
+    expect(projection.branch_tokens['token-a'].status).toBe('consumed');
+    expect(projection.branch_tokens['token-b'].status).toBe('consumed');
+    const joinReplay = resolveJoin(descriptor, projection, {
+      activation_id: 'act-join',
+      transition_id: 'transition-join',
+      identities: { next_activation_ids: { 'join-to-verify': 'act-verify' } },
+    });
+    expect(joinReplay.replayed).toBe(true);
+    expect(() =>
+      resolveJoin(descriptor, projection, {
+        activation_id: 'act-join',
+        transition_id: 'transition-join',
+        identities: { next_activation_ids: { 'join-to-verify': 'different-verify' } },
+      }),
+    ).toThrow(/fingerprint/i);
+    expect(() =>
+      resolveJoin(descriptor, projection, {
+        activation_id: 'act-join',
+        transition_id: 'another-transition',
+        identities: { next_activation_ids: { 'join-to-verify': 'other-verify' } },
+      }),
+    ).toThrow(GraphSchedulerError);
+
+    projection = begin(projection, 'act-verify', 'try-verify');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-verify',
+      'try-verify',
+      'transition-verify',
+      {},
+      undefined,
+      [{ kind: 'test', ref: 'npm-test', summary: 'All checks passed' }],
+    ).projection;
+    expect(isGraphSucceeded(descriptor, projection)).toBe(true);
+  });
+
+  it('does not report success while runnable work remains', () => {
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const projection = initializeGraphProjection(descriptor, { approval: 'act-approval' });
+
+    expect(isGraphSucceeded(descriptor, projection)).toBe(false);
+  });
+
+  it('requires evidence for terminal success and keeps terminal failure non-successful', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    let projection = initializeGraphProjection(descriptor, { start: 'act-start' });
+    projection = begin(projection, 'act-start', 'try-start');
+    projection = succeed(descriptor, projection, 'act-start', 'try-start', 'transition-start', {
+      next_activation_ids: { 'start-test': 'act-test' },
+    }).projection;
+    projection = begin(projection, 'act-test', 'try-test');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-test',
+      'try-test',
+      'transition-test',
+      { next_activation_ids: { 'test-pass': 'act-verify' } },
+      'pass',
+    ).projection;
+    projection = begin(projection, 'act-verify', 'try-verify');
+
+    expect(() =>
+      succeed(
+        descriptor,
+        projection,
+        'act-verify',
+        'try-verify',
+        'transition-no-evidence',
+      ),
+    ).toThrow(/fresh evidence/i);
+
+    const failed = applyNodeResult(descriptor, projection, {
+      activation_id: 'act-verify',
+      transition_id: 'transition-failed-verify',
+      result: {
+        outcome: 'failed',
+        attempt_id: 'try-verify',
+        output_summary: 'Verification failed',
+        evidence_refs: [{ kind: 'test', ref: 'npm-test', summary: 'One test failed' }],
+      },
+    });
+    expect(failed.projection.activations['act-verify'].status).toBe('failed');
+    expect(isGraphSucceeded(descriptor, failed.projection)).toBe(false);
+  });
+});

--- a/src/graph/__tests__/state-store.test.ts
+++ b/src/graph/__tests__/state-store.test.ts
@@ -1,0 +1,278 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import { sealGraphDescriptor } from '../descriptor.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { approveGraphPatch, proposeGraphPatch } from '../revisions.js';
+import { GraphStateStore, GraphStoreError } from '../store.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+const temporaryDirectories: string[] = [];
+
+function createStore(writeAtomic = atomicWriteJsonSync) {
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-graph-store-'));
+  temporaryDirectories.push(worktreeRoot);
+  return new GraphStateStore({
+    sessionId: 'session-store',
+    worktreeRoot,
+    dependencies: {
+      fileExists: existsSync,
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic,
+      withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+    },
+  });
+}
+
+function initialState() {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  return createInitialGraphState({
+    session_id: 'session-store',
+    control_nonce: 'control-store',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {},
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    approval: {
+      approved_at: '2026-07-21T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'approval-1' },
+    },
+  });
+}
+
+afterEach(() => {
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe('GraphStateStore', () => {
+  it('uses only the explicit session-scoped authority path', () => {
+    const store = createStore();
+    store.create(initialState());
+
+    expect(store.path).toContain('/state/sessions/session-store/graph-state.json');
+    expect(store.path).not.toContain('/state/graph-state.json');
+    expect(store.read()?.session_id).toBe('session-store');
+  });
+
+  it('commits one complete generation and replays an exact transition without a second write', () => {
+    const writeAtomic = vi.fn(atomicWriteJsonSync);
+    const store = createStore(writeAtomic);
+    const created = store.create(initialState());
+    const request = {
+      transition_id: 'transition-complete-a',
+      operation: 'complete-node',
+      operation_fingerprint: 'complete-node:activation-a:attempt-a',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: created.dispatch_generation,
+        commit_sequence: created.commit_sequence,
+      },
+    } as const;
+
+    const committed = store.mutate(request, (state) => ({
+      next: {
+        ...state,
+        diagnostics: [
+          ...state.diagnostics,
+          {
+            kind: 'operation' as const,
+            recorded_at: '2026-07-21T00:00:01.000Z',
+            summary: 'node completed once',
+          },
+        ],
+      },
+      result: { selected_edge_ids: ['fan-a'] },
+    }));
+
+    const replay = store.mutate(request, () => {
+      throw new Error('replayed callbacks must not execute');
+    });
+
+    expect(committed.replayed).toBe(false);
+    expect(committed.state.commit_sequence).toBe(1);
+    expect(replay).toMatchObject({ replayed: true, result: { selected_edge_ids: ['fan-a'] } });
+    expect(replay.state.diagnostics).toHaveLength(1);
+    expect(writeAtomic).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows one expected-sequence writer and rejects the stale competitor', async () => {
+    const store = createStore();
+    const created = store.create(initialState());
+    const expected = {
+      session_id: created.session_id,
+      run_id: created.run_id,
+      revision_id: created.active_revision_id,
+      revision_hash: created.active_revision_hash,
+      dispatch_generation: created.dispatch_generation,
+      commit_sequence: 0,
+    };
+
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() => store.mutate({
+        transition_id: 'writer-a',
+        operation: 'race',
+        operation_fingerprint: 'race:a',
+        expected,
+      }, (state) => ({ next: state, result: 'a' }))),
+      Promise.resolve().then(() => store.mutate({
+        transition_id: 'writer-b',
+        operation: 'race',
+        operation_fingerprint: 'race:b',
+        expected,
+      }, (state) => ({ next: state, result: 'b' }))),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(store.read()?.commit_sequence).toBe(1);
+  });
+
+  it('exposes a complete old or new generation across atomic writer failures', () => {
+    const store = createStore();
+    const created = store.create(initialState());
+    let mode: 'before' | 'after' = 'before';
+    const failingStore = new GraphStateStore({
+      sessionId: 'session-store',
+      worktreeRoot: store.worktreeRoot,
+      dependencies: {
+        fileExists: existsSync,
+        readText: (path) => readFileSync(path, 'utf8'),
+        withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+        writeAtomic: (path, value) => {
+          if (mode === 'before') throw new Error('before rename');
+          atomicWriteJsonSync(path, value);
+          throw new Error('after rename');
+        },
+      },
+    });
+    const request = {
+      transition_id: 'atomic-transition',
+      operation: 'atomic-test',
+      operation_fingerprint: 'atomic-test:v1',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: 0,
+        commit_sequence: 0,
+      },
+    } as const;
+
+    expect(() => failingStore.mutate(request, (state) => ({ next: state, result: 'new' })))
+      .toThrow('before rename');
+    expect(store.read()?.commit_sequence).toBe(0);
+
+    mode = 'after';
+    expect(() => failingStore.mutate(request, (state) => ({ next: state, result: 'new' })))
+      .toThrow('after rename');
+    expect(store.read()).toMatchObject({
+      commit_sequence: 1,
+      transitions: [{ transition_id: 'atomic-transition' }],
+    });
+  });
+
+  it('fails closed for a reused transition ID with a different request fence', () => {
+    const store = createStore();
+    const created = store.create(initialState());
+    const base = {
+      transition_id: 'same-id',
+      operation: 'complete-node',
+      operation_fingerprint: 'complete:one',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: 0,
+        commit_sequence: 0,
+      },
+    } as const;
+    store.mutate(base, (state) => ({ next: state, result: 'ok' }));
+
+    expect(() => store.mutate(
+      { ...base, operation_fingerprint: 'complete:different' },
+      (state) => ({ next: state, result: 'wrong' }),
+    )).toThrowError(GraphStoreError);
+  });
+
+  it('accepts an old dispatch generation only while the exact pending patch base remains unchanged', () => {
+    const store = createStore();
+    const base = initialState();
+    const proposedInput = forkJoinDescriptor();
+    proposedInput.revision_id = 'revision-2';
+    proposedInput.goal = 'Patched graph';
+    const proposedDescriptor = sealGraphDescriptor(proposedInput);
+    const proposed = proposeGraphPatch(base, {
+      proposal_id: 'patch-1',
+      base_revision_id: base.active_revision_id,
+      base_revision_hash: base.active_revision_hash,
+      proposed_descriptor: proposedDescriptor,
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    store.create(proposed);
+    const oldFence = {
+      session_id: proposed.session_id,
+      run_id: proposed.run_id,
+      revision_id: proposed.active_revision_id,
+      revision_hash: proposed.active_revision_hash,
+      dispatch_generation: 0,
+      commit_sequence: 0,
+    };
+    const drained = store.mutate({
+      transition_id: 'old-claim-complete',
+      operation: 'complete-node',
+      operation_fingerprint: 'old-claim:lease-1',
+      expected: oldFence,
+      fence_scope: 'pending_patch_base',
+    }, (state) => ({ next: state, result: 'drained' }));
+    expect(drained.state.commit_sequence).toBe(1);
+
+    const activated = store.mutate({
+      transition_id: 'approve-patch',
+      operation: 'approve-patch',
+      operation_fingerprint: 'approve:patch-1',
+      expected: {
+        ...oldFence,
+        dispatch_generation: 1,
+        commit_sequence: 1,
+      },
+    }, (state) => ({
+      next: approveGraphPatch(state, {
+        proposal_id: 'patch-1',
+        base_revision_id: base.active_revision_id,
+        base_revision_hash: base.active_revision_hash,
+        proposed_revision_hash: proposedDescriptor.descriptor_hash,
+        invalidated_node_ids: [],
+        approval_evidence: { kind: 'human', ref: 'approve-patch' },
+        approved_at: '2026-07-21T00:00:02.000Z',
+      }, (projection) => projection),
+      result: 'approved',
+    }));
+    expect(activated.state.active_revision_id).toBe('revision-2');
+
+    expect(() => store.mutate({
+      transition_id: 'late-old-claim',
+      operation: 'complete-node',
+      operation_fingerprint: 'old-claim:lease-2',
+      expected: { ...oldFence, commit_sequence: 2 },
+      fence_scope: 'pending_patch_base',
+    }, (state) => ({ next: state, result: 'must-not-commit' }))).toThrow(/pending patch/i);
+  });
+});

--- a/src/graph/claims.ts
+++ b/src/graph/claims.ts
@@ -1,0 +1,476 @@
+import { canonicalJson } from './descriptor.js';
+import {
+  GRAPH_MAX_DIAGNOSTICS,
+  GRAPH_MAX_RECONCILIATIONS,
+  parseGraphState,
+  type GraphClaim,
+  type GraphDiagnostic,
+  type GraphReconciliationRecord,
+  type GraphState,
+} from './runtime-types.js';
+import type { GraphEffectPolicy, GraphSchedulerProjection } from './types.js';
+
+const MAX_EXECUTION_TIMEOUT_MS = 86_400_000;
+const MAX_GRACE_MS = 3_600_000;
+const MAX_RENEWALS = 20;
+
+export class GraphClaimError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphClaimError';
+    this.code = code;
+  }
+}
+
+export interface IssueGraphClaimInput {
+  activation_id: string;
+  attempt_id: string;
+  attempt_no: number;
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  lease_id: string;
+  tracking_id: string;
+  issued_at: string;
+  execution_timeout_ms: number;
+  grace_ms: number;
+  max_renewals: number;
+  effect_policy: GraphEffectPolicy;
+  external_idempotency_key?: string;
+}
+
+export interface GraphClaimResult {
+  state: GraphState;
+  claim: GraphClaim;
+}
+
+export interface RenewGraphClaimInput {
+  lease_id: string;
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  tracking_id: string;
+  tool_still_running: boolean;
+  now: string;
+}
+
+export interface RecoverExpiredGraphClaimInput {
+  lease_id: string;
+  now: string;
+  new_attempt_id: string;
+  new_lease_id: string;
+  new_tracking_id: string;
+  claimant_session_id: string;
+  driver_instance_id: string;
+  reconciliation_id: string;
+}
+
+export interface ReplacementAttemptInput {
+  activation_id: string;
+  attempt_id: string;
+  attempt_no: number;
+}
+
+export type ReplaceAttemptProjection = (
+  projection: GraphSchedulerProjection,
+  input: ReplacementAttemptInput,
+) => GraphSchedulerProjection;
+
+export interface GraphClaimRecoveryResult {
+  state: GraphState;
+  disposition: 'taken_over' | 'reconciling';
+  claim?: GraphClaim;
+  reconciliation?: GraphReconciliationRecord;
+}
+
+function timestamp(value: string, name: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new GraphClaimError('invalid_timestamp', `${name} must be an ISO timestamp`);
+  return parsed;
+}
+
+function assertIdentifier(value: string, name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw new GraphClaimError('invalid_identity', `${name} must be a stable identifier`);
+  }
+}
+
+function activeDescriptor(state: GraphState) {
+  return state.revisions[state.active_revision_id].descriptor;
+}
+
+function findClaim(state: GraphState, leaseId: string): GraphClaim {
+  const claim = state.claims[leaseId];
+  if (!claim) throw new GraphClaimError('claim_not_found', `Claim ${leaseId} does not exist`);
+  return claim;
+}
+
+function ensureLiveClaim(state: GraphState, leaseId: string): GraphClaim {
+  const claim = findClaim(state, leaseId);
+  if (claim.status !== 'live') throw new GraphClaimError('claim_not_live', `Claim ${leaseId} is no longer live`);
+  return claim;
+}
+
+function cloneWithClaims(state: GraphState, claims: Record<string, GraphClaim>): GraphState {
+  return { ...structuredClone(state), claims };
+}
+
+function validateLeasePolicy(input: IssueGraphClaimInput): void {
+  if (!Number.isSafeInteger(input.execution_timeout_ms)
+    || input.execution_timeout_ms < 100
+    || input.execution_timeout_ms > MAX_EXECUTION_TIMEOUT_MS) {
+    throw new GraphClaimError('invalid_timeout', 'Execution timeout is outside the configured bound');
+  }
+  if (!Number.isSafeInteger(input.grace_ms) || input.grace_ms <= 0 || input.grace_ms > MAX_GRACE_MS) {
+    throw new GraphClaimError('invalid_grace', 'Lease grace must be positive and bounded');
+  }
+  if (!Number.isSafeInteger(input.max_renewals)
+    || input.max_renewals < 0
+    || input.max_renewals > MAX_RENEWALS) {
+    throw new GraphClaimError('invalid_renewal_cap', 'Claim renewal cap is outside the configured bound');
+  }
+  if (input.effect_policy.policy === 'idempotent' && !input.external_idempotency_key) {
+    throw new GraphClaimError('missing_idempotency_key', 'Idempotent claims require a durable idempotency key');
+  }
+  if (input.effect_policy.policy !== 'idempotent' && input.external_idempotency_key) {
+    throw new GraphClaimError('unexpected_idempotency_key', 'Only idempotent claims may carry an idempotency key');
+  }
+}
+
+export function issueGraphClaim(stateInput: GraphState, input: IssueGraphClaimInput): GraphClaimResult {
+  const state = parseGraphState(stateInput);
+  if (state.status !== 'running') {
+    throw new GraphClaimError('dispatch_paused', `Cannot issue a claim while graph status is ${state.status}`);
+  }
+  for (const id of [
+    input.activation_id,
+    input.attempt_id,
+    input.lease_id,
+    input.driver_instance_id,
+    input.tracking_id,
+  ]) assertIdentifier(id, 'claim identity');
+  validateLeasePolicy(input);
+  if (state.claims[input.lease_id]) throw new GraphClaimError('duplicate_lease', `Lease ${input.lease_id} already exists`);
+  if (Object.values(state.claims).some(
+    (claim) => claim.activation_id === input.activation_id && claim.status === 'live',
+  )) {
+    throw new GraphClaimError('activation_claimed', `Activation ${input.activation_id} already has a live claim`);
+  }
+  const activation = state.projection.activations[input.activation_id];
+  if (!activation
+    || activation.status !== 'running'
+    || activation.active_attempt_id !== input.attempt_id
+    || activation.attempt_no !== input.attempt_no) {
+    throw new GraphClaimError('attempt_fence_mismatch', 'Claim activation/attempt fence does not match projection');
+  }
+  const node = activeDescriptor(state).nodes.find((candidate) => candidate.id === activation.node_id);
+  if (!node) {
+    throw new GraphClaimError('node_not_found', `Node ${activation.node_id} does not exist`);
+  }
+  // B6: human-approval nodes are executable via the in-session question surface.
+  // They carry no effect_policy or timeout_ms, so skip the executable-kind and
+  // policy/timeout gates for them; the claim is a durable wait fence.
+  if (node.kind === 'human-approval') {
+    if (input.claim_owner_session_id !== state.session_id) {
+      throw new GraphClaimError('claim_session_mismatch', 'Claim owner must match the Graph authority session');
+    }
+    const issuedAt = timestamp(input.issued_at, 'issued_at');
+    const leaseDuration = input.execution_timeout_ms + input.grace_ms;
+    const claim: GraphClaim = {
+      run_id: state.run_id,
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: state.dispatch_generation,
+      activation_id: input.activation_id,
+      attempt_id: input.attempt_id,
+      attempt_no: input.attempt_no,
+      claim_owner_session_id: input.claim_owner_session_id,
+      driver_instance_id: input.driver_instance_id,
+      lease_id: input.lease_id,
+      tracking_id: input.tracking_id,
+      issued_at: input.issued_at,
+      expires_at: new Date(issuedAt + leaseDuration).toISOString(),
+      lease_duration_ms: leaseDuration,
+      renewal_count: 0,
+      max_renewals: input.max_renewals,
+      effect_policy: structuredClone(input.effect_policy),
+      status: 'live',
+    };
+    const next = cloneWithClaims(state, { ...state.claims, [claim.lease_id]: claim });
+    return { state: parseGraphState(next), claim: structuredClone(claim) };
+  }
+  if (node.kind !== 'agent' && node.kind !== 'command') {
+    throw new GraphClaimError('node_not_executable', 'Only executable agent/command activations can be claimed');
+  }
+  if (canonicalJson(node.effect_policy) !== canonicalJson(input.effect_policy)) {
+    throw new GraphClaimError('effect_policy_mismatch', 'Claim effect policy does not match the approved descriptor');
+  }
+  if (input.claim_owner_session_id !== state.session_id) {
+    throw new GraphClaimError('claim_session_mismatch', 'Claim owner must match the Graph authority session');
+  }
+  if (input.execution_timeout_ms !== node.timeout_ms) {
+    throw new GraphClaimError('timeout_mismatch', 'Claim timeout must equal the exact approved node timeout');
+  }
+  const issuedAt = timestamp(input.issued_at, 'issued_at');
+  const leaseDuration = input.execution_timeout_ms + input.grace_ms;
+  const claim: GraphClaim = {
+    run_id: state.run_id,
+    revision_id: state.active_revision_id,
+    revision_hash: state.active_revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    activation_id: input.activation_id,
+    attempt_id: input.attempt_id,
+    attempt_no: input.attempt_no,
+    claim_owner_session_id: input.claim_owner_session_id,
+    driver_instance_id: input.driver_instance_id,
+    lease_id: input.lease_id,
+    tracking_id: input.tracking_id,
+    issued_at: input.issued_at,
+    expires_at: new Date(issuedAt + leaseDuration).toISOString(),
+    lease_duration_ms: leaseDuration,
+    renewal_count: 0,
+    max_renewals: input.max_renewals,
+    effect_policy: structuredClone(input.effect_policy),
+    ...(input.external_idempotency_key
+      ? { external_idempotency_key: input.external_idempotency_key }
+      : {}),
+    status: 'live',
+  };
+  const next = cloneWithClaims(state, { ...state.claims, [claim.lease_id]: claim });
+  return { state: parseGraphState(next), claim: structuredClone(claim) };
+}
+
+export function renewGraphClaim(stateInput: GraphState, input: RenewGraphClaimInput): GraphClaimResult {
+  const state = parseGraphState(stateInput);
+  const claim = ensureLiveClaim(state, input.lease_id);
+  if (claim.claim_owner_session_id !== input.claim_owner_session_id
+    || claim.driver_instance_id !== input.driver_instance_id) {
+    throw new GraphClaimError('lease_owner_mismatch', 'Claim owner/driver does not match the live lease');
+  }
+  if (claim.tracking_id !== input.tracking_id || !input.tool_still_running) {
+    throw new GraphClaimError('tracking_mismatch', 'Renewal requires the matching live tool tracking identity');
+  }
+  const now = timestamp(input.now, 'now');
+  if (now >= timestamp(claim.expires_at, 'claim.expires_at')) {
+    throw new GraphClaimError('lease_expired', 'Expired claims cannot be renewed');
+  }
+  if (claim.renewal_count >= claim.max_renewals) {
+    throw new GraphClaimError('renewal_cap', 'Claim renewal cap has been reached');
+  }
+  const renewed: GraphClaim = {
+    ...claim,
+    last_renewed_at: input.now,
+    expires_at: new Date(now + claim.lease_duration_ms).toISOString(),
+    renewal_count: claim.renewal_count + 1,
+  };
+  const next = cloneWithClaims(state, { ...state.claims, [claim.lease_id]: renewed });
+  return { state: parseGraphState(next), claim: structuredClone(renewed) };
+}
+
+function reconciliationFor(
+  claim: GraphClaim,
+  input: RecoverExpiredGraphClaimInput,
+  reason: GraphReconciliationRecord['reason'],
+): GraphReconciliationRecord {
+  return {
+    reconciliation_id: input.reconciliation_id,
+    activation_id: claim.activation_id,
+    attempt_id: claim.attempt_id,
+    lease_id: claim.lease_id,
+    revision_id: claim.revision_id,
+    revision_hash: claim.revision_hash,
+    dispatch_generation: claim.dispatch_generation,
+    status: 'unresolved',
+    reason,
+    created_at: input.now,
+  };
+}
+
+export function recoverExpiredGraphClaim(
+  stateInput: GraphState,
+  input: RecoverExpiredGraphClaimInput,
+  replaceAttempt: ReplaceAttemptProjection,
+): GraphClaimRecoveryResult {
+  const state = parseGraphState(stateInput);
+  const claim = ensureLiveClaim(state, input.lease_id);
+  const now = timestamp(input.now, 'now');
+  if (now < timestamp(claim.expires_at, 'claim.expires_at')) {
+    throw new GraphClaimError('lease_live', 'Live claim cannot be taken over before expiry');
+  }
+  if (claim.effect_policy.policy === 'reconcile') {
+    if (state.reconciliations[input.reconciliation_id]) {
+      throw new GraphClaimError('duplicate_reconciliation', 'Reconciliation identity already exists');
+    }
+    if (Object.keys(state.reconciliations).length >= GRAPH_MAX_RECONCILIATIONS) {
+      throw new GraphClaimError('reconciliation_limit', 'Reconciliation limit has been reached');
+    }
+    const reconciliation = reconciliationFor(claim, input, 'expired_ambiguous');
+    const fenced: GraphClaim = { ...claim, status: 'reconciling', fenced_at: input.now };
+    const next: GraphState = {
+      ...structuredClone(state),
+      status: 'reconciling',
+      claims: { ...state.claims, [claim.lease_id]: fenced },
+      reconciliations: { ...state.reconciliations, [reconciliation.reconciliation_id]: reconciliation },
+    };
+    return { state: parseGraphState(next), disposition: 'reconciling', reconciliation };
+  }
+  if (claim.effect_policy.policy === 'idempotent' && !claim.external_idempotency_key) {
+    throw new GraphClaimError('missing_idempotency_key', 'Idempotent takeover requires the durable external key');
+  }
+  if (input.claimant_session_id !== state.session_id) {
+    throw new GraphClaimError('claim_session_mismatch', 'Takeover claimant must match the Graph authority session');
+  }
+  const activation = state.projection.activations[claim.activation_id];
+  const node = activeDescriptor(state).nodes.find((candidate) => candidate.id === activation?.node_id);
+  if (!activation || !node || (node.kind !== 'agent' && node.kind !== 'command')) {
+    throw new GraphClaimError('attempt_fence_mismatch', 'Expired claim no longer maps to an approved executable activation');
+  }
+  if (claim.attempt_no >= node.max_attempts) {
+    throw new GraphClaimError('attempt_limit', `Approved node ${node.id} has reached its maximum attempts`);
+  }
+  for (const id of [input.new_attempt_id, input.new_lease_id, input.new_tracking_id]) {
+    assertIdentifier(id, 'replacement identity');
+  }
+  if (state.claims[input.new_lease_id]) throw new GraphClaimError('duplicate_lease', 'Replacement lease already exists');
+  if (input.new_attempt_id === claim.attempt_id || input.new_lease_id === claim.lease_id) {
+    throw new GraphClaimError('replacement_identity_reused', 'Takeover requires a new attempt and lease identity');
+  }
+  const replacement: GraphClaim = {
+    ...claim,
+    attempt_id: input.new_attempt_id,
+    attempt_no: claim.attempt_no + 1,
+    claim_owner_session_id: input.claimant_session_id,
+    driver_instance_id: input.driver_instance_id,
+    lease_id: input.new_lease_id,
+    tracking_id: input.new_tracking_id,
+    issued_at: input.now,
+    expires_at: new Date(now + claim.lease_duration_ms).toISOString(),
+    renewal_count: 0,
+    status: 'live',
+  };
+  delete replacement.last_renewed_at;
+  delete replacement.fenced_at;
+  delete replacement.replacement_lease_id;
+  const fenced: GraphClaim = {
+    ...claim,
+    status: 'expired_retryable',
+    fenced_at: input.now,
+    replacement_lease_id: replacement.lease_id,
+  };
+  const projection = replaceAttempt(state.projection, {
+    activation_id: claim.activation_id,
+    attempt_id: replacement.attempt_id,
+    attempt_no: replacement.attempt_no,
+  });
+  const next: GraphState = {
+    ...structuredClone(state),
+    projection,
+    claims: {
+      ...state.claims,
+      [fenced.lease_id]: fenced,
+      [replacement.lease_id]: replacement,
+    },
+  };
+  return { state: parseGraphState(next), disposition: 'taken_over', claim: replacement };
+}
+
+export interface LateClaimResultInput {
+  lease_id: string;
+  attempt_id: string;
+  recorded_at: string;
+  summary: string;
+}
+
+export function recordLateClaimResult(
+  stateInput: GraphState,
+  input: LateClaimResultInput,
+): { state: GraphState; diagnostic: GraphDiagnostic } {
+  const state = parseGraphState(stateInput);
+  const claim = findClaim(state, input.lease_id);
+  if (claim.attempt_id !== input.attempt_id) {
+    throw new GraphClaimError('attempt_fence_mismatch', 'Late result attempt does not match the fenced lease');
+  }
+  if (claim.status === 'live') {
+    throw new GraphClaimError('claim_live', 'A live claim result is not a late diagnostic');
+  }
+  timestamp(input.recorded_at, 'recorded_at');
+  if (input.summary.length === 0 || input.summary.length > 8_192) {
+    throw new GraphClaimError('diagnostic_too_large', 'Late-result summary must be non-empty and bounded');
+  }
+  const diagnostic: GraphDiagnostic = {
+    kind: 'late_result',
+    recorded_at: input.recorded_at,
+    summary: input.summary,
+    activation_id: claim.activation_id,
+    attempt_id: claim.attempt_id,
+    lease_id: claim.lease_id,
+  };
+  const diagnostics = [...state.diagnostics, diagnostic].slice(-GRAPH_MAX_DIAGNOSTICS);
+  return { state: parseGraphState({ ...state, diagnostics }), diagnostic };
+}
+
+export interface SettleDriverClaimsInput {
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  recorded_at: string;
+  /**
+   * 'driver' (default) fences only live claims owned by driver_instance_id.
+   * 'session' fences ALL live claims for the session regardless of driver-id;
+   * used at session-end when the whole session is terminating and every live
+   * claim must be fenced so concurrency slots do not leak.
+   */
+  scope?: 'driver' | 'session';
+}
+
+export function settleDriverClaims(
+  stateInput: GraphState,
+  input: SettleDriverClaimsInput,
+): { state: GraphState; settled_lease_ids: string[] } {
+  const state = parseGraphState(stateInput);
+  timestamp(input.recorded_at, 'recorded_at');
+  const scope = input.scope ?? 'driver';
+  const claims = structuredClone(state.claims);
+  const reconciliations = structuredClone(state.reconciliations);
+  const settled: string[] = [];
+  let hasAmbiguous = false;
+  for (const claim of Object.values(claims)) {
+    if (claim.status !== 'live'
+      || claim.claim_owner_session_id !== input.claim_owner_session_id) continue;
+    // In 'driver' scope only fence claims owned by the passed driver. In
+    // 'session' scope fence every live claim in the session.
+    if (scope === 'driver' && claim.driver_instance_id !== input.driver_instance_id) continue;
+    settled.push(claim.lease_id);
+    claim.fenced_at = input.recorded_at;
+    if (claim.effect_policy.policy !== 'reconcile') {
+      claim.status = 'abandoned_retryable';
+      continue;
+    }
+    hasAmbiguous = true;
+    claim.status = 'reconciling';
+    const reconciliationId = `session-end:${claim.lease_id}`;
+    if (!reconciliations[reconciliationId]) {
+      reconciliations[reconciliationId] = {
+        reconciliation_id: reconciliationId,
+        activation_id: claim.activation_id,
+        attempt_id: claim.attempt_id,
+        lease_id: claim.lease_id,
+        revision_id: claim.revision_id,
+        revision_hash: claim.revision_hash,
+        dispatch_generation: claim.dispatch_generation,
+        status: 'unresolved',
+        reason: 'session_end_ambiguous',
+        created_at: input.recorded_at,
+      };
+    }
+  }
+  if (Object.keys(reconciliations).length > GRAPH_MAX_RECONCILIATIONS) {
+    throw new GraphClaimError('reconciliation_limit', 'SessionEnd would exceed the reconciliation bound');
+  }
+  const next: GraphState = {
+    ...structuredClone(state),
+    ...(hasAmbiguous ? { status: 'reconciling' as const } : {}),
+    claims,
+    reconciliations,
+  };
+  return { state: parseGraphState(next), settled_lease_ids: settled };
+}

--- a/src/graph/control-owner.ts
+++ b/src/graph/control-owner.ts
@@ -1,0 +1,725 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import { withStateFileMutationLock } from '../lib/mode-state-io.js';
+import { resolveSessionStatePaths } from '../lib/worktree-paths.js';
+import { graphPlatform, type GraphPlatformAdapter } from './platform.js';
+import type {
+  ControlChildRegistration,
+  ControlLineageIdentity,
+  ControlOwnerState,
+  ControlRoot,
+  GraphClaimLineage,
+  GraphControlMode,
+  GraphDriverLease,
+  GraphProcessIdentity,
+} from './runtime-types.js';
+
+const CONTROL_MAX_BYTES = 1024 * 1024;
+const ROOT_MODES: readonly GraphControlMode[] = [
+  'graph',
+  'autopilot',
+  'autoresearch',
+  'ralph',
+  'team',
+  'ultrawork',
+  'ultraqa',
+  'ralplan',
+  'deep-interview',
+  'self-improve',
+];
+const NON_OWNER_MODES = new Set(['merge-readiness', 'skill-active', 'support', 'read-only']);
+
+export type ControlModeClassification = 'root' | 'non_owner' | 'unknown';
+
+export function classifyControlMode(mode: string): ControlModeClassification {
+  if ((ROOT_MODES as readonly string[]).includes(mode)) return 'root';
+  if (NON_OWNER_MODES.has(mode)) return 'non_owner';
+  return 'unknown';
+}
+
+export class ControlOwnerError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'ControlOwnerError';
+    this.code = code;
+  }
+}
+
+export interface ControlOwnerDependencies {
+  fileExists(path: string): boolean;
+  readText(path: string): string;
+  writeAtomic(path: string, value: unknown): void;
+  withExclusiveLock<T>(path: string, callback: () => T): { acquired: boolean; value: T | undefined };
+}
+
+export interface ControlOwnerStoreOptions {
+  sessionId: string;
+  worktreeRoot?: string;
+  platform?: GraphPlatformAdapter;
+  dependencies?: Partial<ControlOwnerDependencies>;
+}
+
+const DEFAULT_DEPENDENCIES: ControlOwnerDependencies = {
+  fileExists: existsSync,
+  readText: (path) => readFileSync(path, 'utf8'),
+  writeAtomic: atomicWriteJsonSync,
+  withExclusiveLock: (path, callback) => withStateFileMutationLock(path, callback, true),
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new ControlOwnerError('malformed_control', `${name} must be an object`);
+  return value;
+}
+
+function exactKeys(value: Record<string, unknown>, required: string[], optional: string[], name: string): void {
+  const allowed = new Set([...required, ...optional]);
+  const missing = required.filter((key) => !(key in value));
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new ControlOwnerError(
+      'malformed_control',
+      `${name} has invalid keys${missing.length ? `; missing ${missing.join(', ')}` : ''}${unknown.length ? `; unknown ${unknown.join(', ')}` : ''}`,
+    );
+  }
+}
+
+function text(value: unknown, name: string, max = 256): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > max) {
+    throw new ControlOwnerError('malformed_control', `${name} must be a non-empty bounded string`);
+  }
+  return value;
+}
+
+function timestamp(value: unknown, name: string): string {
+  const result = text(value, name, 64);
+  if (!Number.isFinite(Date.parse(result))) {
+    throw new ControlOwnerError('malformed_control', `${name} must be an ISO timestamp`);
+  }
+  return result;
+}
+
+function mode(value: unknown, name: string): GraphControlMode {
+  const result = text(value, name, 32);
+  if (classifyControlMode(result) !== 'root') {
+    throw new ControlOwnerError('unknown_mode', `${name} is not a canonical root-capable mode`);
+  }
+  return result as GraphControlMode;
+}
+
+function processIdentity(value: unknown, name: string): GraphProcessIdentity {
+  const identity = record(value, name);
+  exactKeys(identity, ['pid', 'process_start'], [], name);
+  if (!Number.isSafeInteger(identity.pid) || (identity.pid as number) <= 0) {
+    throw new ControlOwnerError('malformed_control', `${name}.pid is invalid`);
+  }
+  // process_start may be the empty string when the host could not capture a
+  // start time at reservation time (ps/powershell/proc unavailable once). The
+  // runtime functions with pid-only identity - isProcessIdentityLive() falls
+  // back to pid-only liveness - so the empty form is accepted here. Rejecting
+  // it would make every subsequent read() reject the reserved control state as
+  // malformed_control, permanently wedging control authority.
+  if (typeof identity.process_start !== 'string' || !/^\d*$/.test(identity.process_start)) {
+    throw new ControlOwnerError('malformed_control', `${name}.process_start is invalid`);
+  }
+  return value as GraphProcessIdentity;
+}
+
+function driverLease(value: unknown, name: string): GraphDriverLease {
+  const lease = record(value, name);
+  exactKeys(lease, ['driver_instance_id', 'lease_id', 'expires_at'], [], name);
+  text(lease.driver_instance_id, `${name}.driver_instance_id`, 128);
+  text(lease.lease_id, `${name}.lease_id`, 128);
+  timestamp(lease.expires_at, `${name}.expires_at`);
+  return value as GraphDriverLease;
+}
+
+function lineage(value: unknown, name: string): ControlLineageIdentity {
+  const identity = record(value, name);
+  exactKeys(identity, ['mode', 'session_id', 'run_id'], [], name);
+  return {
+    mode: mode(identity.mode, `${name}.mode`),
+    session_id: text(identity.session_id, `${name}.session_id`),
+    run_id: text(identity.run_id, `${name}.run_id`, 128),
+  };
+}
+
+function claimLineage(value: unknown, name: string): GraphClaimLineage {
+  const claim = record(value, name);
+  exactKeys(claim, [
+    'activation_id', 'attempt_id', 'lease_id', 'revision_id', 'revision_hash', 'dispatch_generation',
+  ], [], name);
+  for (const key of ['activation_id', 'attempt_id', 'lease_id', 'revision_id'] as const) {
+    text(claim[key], `${name}.${key}`, 128);
+  }
+  if (typeof claim.revision_hash !== 'string' || !/^[a-f0-9]{64}$/.test(claim.revision_hash)) {
+    throw new ControlOwnerError('malformed_control', `${name}.revision_hash is invalid`);
+  }
+  if (!Number.isSafeInteger(claim.dispatch_generation) || (claim.dispatch_generation as number) < 0) {
+    throw new ControlOwnerError('malformed_control', `${name}.dispatch_generation is invalid`);
+  }
+  return value as GraphClaimLineage;
+}
+
+function graphRevision(value: unknown, name: string): { revision_id: string; revision_hash: string } {
+  const revision = record(value, name);
+  exactKeys(revision, ['revision_id', 'revision_hash'], [], name);
+  const revisionId = text(revision.revision_id, `${name}.revision_id`, 128);
+  if (typeof revision.revision_hash !== 'string' || !/^[a-f0-9]{64}$/.test(revision.revision_hash)) {
+    throw new ControlOwnerError('malformed_control', `${name}.revision_hash is invalid`);
+  }
+  return { revision_id: revisionId, revision_hash: revision.revision_hash };
+}
+
+function childRegistration(value: unknown, name: string): ControlChildRegistration {
+  const child = record(value, name);
+  exactKeys(child, ['mode', 'session_id', 'run_id', 'parent', 'registered_at'], ['graph_claim'], name);
+  const identity = lineage(
+    { mode: child.mode, session_id: child.session_id, run_id: child.run_id },
+    name,
+  );
+  const parent = lineage(child.parent, `${name}.parent`);
+  timestamp(child.registered_at, `${name}.registered_at`);
+  return {
+    ...identity,
+    parent,
+    ...(child.graph_claim === undefined ? {} : { graph_claim: claimLineage(child.graph_claim, `${name}.graph_claim`) }),
+    registered_at: child.registered_at as string,
+  };
+}
+
+function identityKey(identity: ControlLineageIdentity): string {
+  return `${identity.mode}\0${identity.session_id}\0${identity.run_id}`;
+}
+
+function sameIdentity(left: ControlLineageIdentity, right: ControlLineageIdentity): boolean {
+  return identityKey(left) === identityKey(right);
+}
+
+function parseControlOwnerState(value: unknown, expectedSessionId?: string): ControlOwnerState {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined || Buffer.byteLength(serialized, 'utf8') > CONTROL_MAX_BYTES) {
+    throw new ControlOwnerError('control_too_large', 'Control owner state exceeds the configured bound');
+  }
+  const state = record(value, 'control state');
+  exactKeys(state, ['format_version', 'session_id', 'generation', 'root', 'updated_at'], ['last_release'], 'control state');
+  if (state.format_version !== 1) throw new ControlOwnerError('malformed_control', 'Unsupported control format version');
+  const sessionId = text(state.session_id, 'control state.session_id');
+  if (expectedSessionId && sessionId !== expectedSessionId) {
+    throw new ControlOwnerError('session_mismatch', 'Control state belongs to a different session');
+  }
+  if (!Number.isSafeInteger(state.generation) || (state.generation as number) < 0) {
+    throw new ControlOwnerError('malformed_control', 'Control generation is invalid');
+  }
+  timestamp(state.updated_at, 'control state.updated_at');
+  if (state.last_release !== undefined) {
+    const release = record(state.last_release, 'control state.last_release');
+    exactKeys(release, ['mode', 'run_id', 'nonce', 'disposition', 'released_at'], [], 'control state.last_release');
+    mode(release.mode, 'control state.last_release.mode');
+    text(release.run_id, 'control state.last_release.run_id', 128);
+    text(release.nonce, 'control state.last_release.nonce', 128);
+    if (release.disposition !== 'paused' && release.disposition !== 'terminal') {
+      throw new ControlOwnerError('malformed_control', 'Control release disposition is invalid');
+    }
+    timestamp(release.released_at, 'control state.last_release.released_at');
+  }
+  if (state.root === null) return structuredClone(value as ControlOwnerState);
+
+  const root = record(state.root, 'control state.root');
+  exactKeys(root, [
+    'mode', 'session_id', 'run_id', 'nonce', 'phase', 'reservation_process',
+    'children', 'created_at', 'updated_at',
+  ], ['driver_lease', 'graph_revision'], 'control state.root');
+  const rootIdentity = lineage({ mode: root.mode, session_id: root.session_id, run_id: root.run_id }, 'control state.root');
+  if (rootIdentity.session_id !== sessionId) {
+    throw new ControlOwnerError('session_mismatch', 'Control root session does not match its state file');
+  }
+  text(root.nonce, 'control state.root.nonce', 128);
+  if (root.phase !== 'reserved' && root.phase !== 'active') {
+    throw new ControlOwnerError('malformed_control', 'Control root phase is invalid');
+  }
+  processIdentity(root.reservation_process, 'control state.root.reservation_process');
+  if (root.driver_lease !== undefined) driverLease(root.driver_lease, 'control state.root.driver_lease');
+  if (rootIdentity.mode === 'graph') {
+    if (root.graph_revision === undefined) {
+      throw new ControlOwnerError('malformed_control', 'Graph control root requires an exact revision/hash fence');
+    }
+    graphRevision(root.graph_revision, 'control state.root.graph_revision');
+  } else if (root.graph_revision !== undefined) {
+    throw new ControlOwnerError('malformed_control', 'Only Graph control roots may carry graph_revision');
+  }
+  timestamp(root.created_at, 'control state.root.created_at');
+  timestamp(root.updated_at, 'control state.root.updated_at');
+  if (!Array.isArray(root.children) || root.children.length > 128) {
+    throw new ControlOwnerError('malformed_control', 'Control child registrations are invalid');
+  }
+  const children = root.children.map((child, index) => childRegistration(child, `control state.root.children[${index}]`));
+  const identities = new Set([identityKey(rootIdentity)]);
+  for (const child of children) {
+    if (identities.has(identityKey(child))) throw new ControlOwnerError('duplicate_child', 'Control child identity is duplicated');
+    if (!identities.has(identityKey(child.parent))) {
+      throw new ControlOwnerError('lineage_mismatch', 'Control child parent is not reachable from the root');
+    }
+    if (!allowedChild(child.parent.mode, child.mode)) {
+      throw new ControlOwnerError('lineage_rejected', `Stored ${child.parent.mode} -> ${child.mode} lineage is not allowed`);
+    }
+    if (child.parent.mode === 'graph' && (!child.graph_claim || child.mode !== 'team')) {
+      throw new ControlOwnerError('graph_claim_required', 'Stored Graph child requires exact Team claim lineage');
+    }
+    if (child.parent.mode !== 'graph' && child.graph_claim) {
+      throw new ControlOwnerError('graph_claim_unexpected', 'Stored non-Graph child cannot carry graph claim lineage');
+    }
+    identities.add(identityKey(child));
+  }
+  return structuredClone(value as ControlOwnerState);
+}
+
+function allowedChild(parentMode: GraphControlMode, childMode: GraphControlMode): boolean {
+  if (parentMode === 'autopilot') {
+    return ['ralph', 'team', 'ultrawork', 'ultraqa', 'ralplan', 'deep-interview'].includes(childMode);
+  }
+  if (parentMode === 'ralph') return ['team', 'ultrawork', 'ultraqa', 'ralplan'].includes(childMode);
+  return parentMode === 'graph' && childMode === 'team';
+}
+
+export interface ReserveRootInput {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  reserved_at: string;
+  graph_revision?: { revision_id: string; revision_hash: string };
+}
+
+export interface PromoteRootInput {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  promoted_at: string;
+  driver_lease: GraphDriverLease;
+}
+
+export interface RegisterChildInput extends Omit<ControlChildRegistration, 'registered_at'> {
+  registered_at: string;
+}
+
+export interface GraphReleaseDisposition {
+  graph_status: 'paused' | 'failed' | 'cancelled' | 'succeeded';
+  claims_fenced: boolean;
+  children_drained: boolean;
+}
+
+export interface ReleaseRootInput {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  disposition: GraphReleaseDisposition;
+  released_at: string;
+}
+
+export interface LegacyControlCandidate {
+  mode: GraphControlMode;
+  session_id?: string;
+  run_id?: string;
+  active: boolean;
+  terminal?: boolean;
+  parent?: ControlLineageIdentity;
+  linked_ultrawork?: boolean;
+  linked_to_ralph?: boolean;
+  graph_revision?: { revision_id: string; revision_hash: string };
+  graph_claim?: GraphClaimLineage;
+}
+
+export interface AdoptLegacyRootsInput {
+  candidates: LegacyControlCandidate[];
+  nonce: string;
+  adopted_at: string;
+}
+
+export class ControlOwnerStore {
+  readonly sessionId: string;
+  readonly worktreeRoot: string | undefined;
+  readonly path: string;
+  private readonly readPath: string;
+  private readonly platform: GraphPlatformAdapter;
+  private readonly dependencies: ControlOwnerDependencies;
+
+  constructor(options: ControlOwnerStoreOptions) {
+    const paths = resolveSessionStatePaths('control-owner', options.sessionId, options.worktreeRoot);
+    if (!paths.sessionScoped || paths.effectiveWrite !== paths.sessionScoped) {
+      throw new ControlOwnerError('unsafe_state_path', 'Control ownership requires an explicit session-scoped path');
+    }
+    this.sessionId = options.sessionId;
+    this.worktreeRoot = options.worktreeRoot;
+    this.path = paths.effectiveWrite;
+    this.readPath = paths.sessionScoped;
+    this.platform = options.platform ?? graphPlatform;
+    this.dependencies = { ...DEFAULT_DEPENDENCIES, ...options.dependencies };
+  }
+
+  read(): ControlOwnerState | null {
+    if (!this.dependencies.fileExists(this.readPath)) return null;
+    let value: unknown;
+    try {
+      value = JSON.parse(this.dependencies.readText(this.readPath));
+    } catch (error) {
+      throw new ControlOwnerError('malformed_control', `Cannot parse control-owner-state.json: ${String(error)}`);
+    }
+    return parseControlOwnerState(value, this.sessionId);
+  }
+
+  reserveRoot(input: ReserveRootInput): ControlOwnerState {
+    const owner = this.platform.preflight();
+    timestamp(input.reserved_at, 'reserved_at');
+    if (input.mode === 'graph' && !input.graph_revision) {
+      throw new ControlOwnerError('graph_revision_required', 'Graph reservation requires an exact revision/hash fence');
+    }
+    if (input.mode !== 'graph' && input.graph_revision) {
+      throw new ControlOwnerError('graph_revision_unexpected', 'Only Graph reservations may carry graph_revision');
+    }
+    return this.mutate((current) => {
+      if (current?.root) {
+        throw new ControlOwnerError('root_conflict', `Session is already controlled by ${current.root.mode}/${current.root.run_id}`);
+      }
+      const root: ControlRoot = {
+        mode: input.mode,
+        session_id: this.sessionId,
+        run_id: text(input.run_id, 'run_id', 128),
+        nonce: text(input.nonce, 'nonce', 128),
+        phase: 'reserved',
+        reservation_process: owner,
+        ...(input.graph_revision ? { graph_revision: graphRevision(input.graph_revision, 'graph_revision') } : {}),
+        children: [],
+        created_at: input.reserved_at,
+        updated_at: input.reserved_at,
+      };
+      return {
+        format_version: 1,
+        session_id: this.sessionId,
+        generation: (current?.generation ?? 0) + 1,
+        root,
+        ...(current?.last_release ? { last_release: current.last_release } : {}),
+        updated_at: input.reserved_at,
+      };
+    });
+  }
+
+  promoteRoot(input: PromoteRootInput): ControlOwnerState {
+    timestamp(input.promoted_at, 'promoted_at');
+    driverLease(input.driver_lease, 'driver_lease');
+    return this.mutate((current) => {
+      const root = this.requireExactRoot(current, input);
+      if (root.phase !== 'reserved') throw new ControlOwnerError('already_active', 'Control root is already active');
+      return this.withRoot(current!, {
+        ...root,
+        phase: 'active',
+        driver_lease: structuredClone(input.driver_lease),
+        updated_at: input.promoted_at,
+      }, input.promoted_at);
+    });
+  }
+
+  registerChild(input: RegisterChildInput): ControlOwnerState {
+    timestamp(input.registered_at, 'registered_at');
+    return this.mutate((current) => {
+      if (!current?.root || current.root.phase !== 'active') {
+        throw new ControlOwnerError('root_inactive', 'Child registration requires an active root');
+      }
+      const child = childRegistration(input, 'child registration');
+      if (current.root.children.some((candidate) => sameIdentity(candidate, child))) {
+        throw new ControlOwnerError('duplicate_child', 'Child identity is already registered');
+      }
+      const parent = sameIdentity(current.root, child.parent)
+        ? current.root
+        : current.root.children.find((candidate) => sameIdentity(candidate, child.parent));
+      if (!parent) throw new ControlOwnerError('parent_lineage_mismatch', 'Exact parent lineage is not registered');
+      if (!allowedChild(parent.mode, child.mode)) {
+        throw new ControlOwnerError('lineage_rejected', `${parent.mode} -> ${child.mode} lineage is not allowed`);
+      }
+      if (parent.mode === 'graph' && (!child.graph_claim || child.mode !== 'team')) {
+        throw new ControlOwnerError('graph_claim_required', 'Graph permits only Team with an exact agent-node claim lineage');
+      }
+      if (parent.mode !== 'graph' && child.graph_claim) {
+        throw new ControlOwnerError('graph_claim_unexpected', 'Graph claim lineage is only valid for Graph -> Team');
+      }
+      return this.withRoot(current, {
+        ...current.root,
+        children: [...current.root.children, child],
+        updated_at: input.registered_at,
+      }, input.registered_at);
+    });
+  }
+
+  releaseRoot(input: ReleaseRootInput): { state: ControlOwnerState | null; released: boolean } {
+    timestamp(input.released_at, 'released_at');
+    let released = false;
+    const state = this.mutate((current) => {
+      if (!current?.root
+        || current.root.mode !== input.mode
+        || current.root.run_id !== input.run_id
+        || current.root.nonce !== input.nonce) return current ?? this.emptyState(input.released_at);
+      if (!input.disposition.children_drained || current.root.children.length > 0) {
+        throw new ControlOwnerError('children_live', 'Control release requires all exact children to be drained');
+      }
+      if (input.mode === 'graph' && input.disposition.graph_status === 'paused' && !input.disposition.claims_fenced) {
+        throw new ControlOwnerError('claims_live', 'Paused Graph release requires all claims to be fenced');
+      }
+      released = true;
+      return {
+        ...current,
+        generation: current.generation + 1,
+        root: null,
+        last_release: {
+          mode: input.mode,
+          run_id: input.run_id,
+          nonce: input.nonce,
+          disposition: input.disposition.graph_status === 'paused' ? 'paused' : 'terminal',
+          released_at: input.released_at,
+        },
+        updated_at: input.released_at,
+      };
+    }, false);
+    return { state, released };
+  }
+
+  reservePausedGraph(input: {
+    run_id: string;
+    revision_id: string;
+    revision_hash: string;
+    nonce: string;
+    graph_state: { session_id: string; run_id: string; revision_id: string; status: 'paused' };
+    reserved_at: string;
+  }): ControlOwnerState {
+    if (input.graph_state.session_id !== this.sessionId
+      || input.graph_state.run_id !== input.run_id
+      || input.graph_state.revision_id !== input.revision_id
+      || input.graph_state.status !== 'paused') {
+      throw new ControlOwnerError('resume_mismatch', 'Resume requires the exact paused session/run/revision');
+    }
+    return this.reserveRoot({
+      mode: 'graph', run_id: input.run_id, nonce: input.nonce, reserved_at: input.reserved_at,
+      graph_revision: { revision_id: input.revision_id, revision_hash: input.revision_hash },
+    });
+  }
+
+  recoverGraphReservation(input: {
+    session_id: string;
+    run_id: string;
+    revision_id: string;
+    revision_hash: string;
+    status: 'draft' | 'awaiting_approval' | 'running' | 'waiting_human' | 'waiting_patch_approval' | 'reconciling' | 'paused' | 'failed' | 'cancelled' | 'succeeded';
+    reservation_nonce: string;
+    observed_at: string;
+    driver_lease: GraphDriverLease;
+  }): { state: ControlOwnerState; action: 'promoted' | 'released' | 'waiting' | 'already_active' } {
+    timestamp(input.observed_at, 'observed_at');
+    driverLease(input.driver_lease, 'driver_lease');
+    let action: 'promoted' | 'released' | 'waiting' | 'already_active' = 'waiting';
+    const state = this.mutate((current) => {
+      const root = this.requireExactRoot(current, {
+        mode: 'graph', run_id: input.run_id, nonce: input.reservation_nonce,
+      });
+      if (input.session_id !== this.sessionId) {
+        throw new ControlOwnerError('session_mismatch', 'Graph recovery session does not match control authority');
+      }
+      if (!root.graph_revision
+        || root.graph_revision.revision_id !== input.revision_id
+        || root.graph_revision.revision_hash !== input.revision_hash) {
+        throw new ControlOwnerError('revision_mismatch', 'Graph recovery revision/hash does not match the reservation');
+      }
+      if (root.phase === 'active') {
+        action = 'already_active';
+        return current!;
+      }
+      const live = this.platform.isProcessIdentityLive(root.reservation_process);
+      if (live === 'unknown') throw new ControlOwnerError('owner_unverifiable', 'Reservation process identity is unverifiable');
+      if (live) {
+        action = 'waiting';
+        return current!;
+      }
+      if (['failed', 'cancelled', 'succeeded'].includes(input.status)) {
+        action = 'released';
+        return {
+          ...current!,
+          generation: current!.generation + 1,
+          root: null,
+          last_release: {
+            mode: 'graph', run_id: input.run_id, nonce: input.reservation_nonce,
+            disposition: 'terminal', released_at: input.observed_at,
+          },
+          updated_at: input.observed_at,
+        };
+      }
+      action = 'promoted';
+      return this.withRoot(current!, {
+        ...root,
+        phase: 'active',
+        driver_lease: structuredClone(input.driver_lease),
+        updated_at: input.observed_at,
+      }, input.observed_at);
+    }, false);
+    return { state, action };
+  }
+
+  adoptLegacyRoots(input: AdoptLegacyRootsInput): ControlOwnerState {
+    const owner = this.platform.preflight();
+    timestamp(input.adopted_at, 'adopted_at');
+    return this.mutate((current) => {
+      if (current?.root) throw new ControlOwnerError('root_conflict', 'Cannot adopt legacy state over an existing root');
+      const active = input.candidates.filter((candidate) => candidate.active && !candidate.terminal);
+      if (active.some((candidate) => !candidate.session_id || !candidate.run_id)) {
+        throw new ControlOwnerError('legacy_identity_incomplete', 'Legacy active state is missing session/run identity');
+      }
+      const keys = active.map((candidate) => identityKey({
+        mode: candidate.mode,
+        session_id: candidate.session_id!,
+        run_id: candidate.run_id!,
+      }));
+      if (new Set(keys).size !== keys.length) {
+        throw new ControlOwnerError('legacy_identity_duplicate', 'Legacy active state contains duplicate identities');
+      }
+      const roots = active.filter((candidate) => !candidate.parent);
+      if (roots.length !== 1) {
+        throw new ControlOwnerError('legacy_root_conflict', 'Legacy adoption requires exactly one legacy root');
+      }
+      const rootCandidate = roots[0];
+      if (rootCandidate.session_id !== this.sessionId) {
+        throw new ControlOwnerError('session_mismatch', 'Legacy root session does not match control authority');
+      }
+      const rootIdentity: ControlLineageIdentity = {
+        mode: rootCandidate.mode,
+        session_id: rootCandidate.session_id!,
+        run_id: rootCandidate.run_id!,
+      };
+      const childCandidates = active.filter((candidate) => candidate !== rootCandidate);
+      for (const ralph of active.filter((candidate) => candidate.mode === 'ralph')) {
+        const ralphIdentity: ControlLineageIdentity = {
+          mode: 'ralph', session_id: ralph.session_id!, run_id: ralph.run_id!,
+        };
+        const linked = childCandidates.filter(
+          (candidate) => candidate.mode === 'ultrawork' && candidate.parent && sameIdentity(candidate.parent, ralphIdentity),
+        );
+        if (linked.length > 0 || ralph.linked_ultrawork) {
+          if (ralph.linked_ultrawork !== true
+            || linked.length !== 1
+            || linked[0].linked_to_ralph !== true) {
+            throw new ControlOwnerError('legacy_link_mismatch', 'Legacy Ralph/Ultrawork requires mutual exact links');
+          }
+        }
+      }
+      if (childCandidates.some((candidate) => candidate.linked_to_ralph
+        && candidate.parent?.mode !== 'ralph')) {
+        throw new ControlOwnerError('legacy_link_mismatch', 'Legacy linked Ultrawork has no exact Ralph parent');
+      }
+      const children: ControlChildRegistration[] = [];
+      const reachable = new Set([identityKey(rootIdentity)]);
+      const pending = [...childCandidates];
+      while (pending.length > 0) {
+        const index = pending.findIndex(
+          (candidate) => candidate.parent && reachable.has(identityKey(candidate.parent)),
+        );
+        if (index < 0) {
+          throw new ControlOwnerError('legacy_lineage_mismatch', 'Legacy child lineage is cyclic or unreachable from the root');
+        }
+        const [candidate] = pending.splice(index, 1);
+        if (!candidate.parent || !allowedChild(candidate.parent.mode, candidate.mode)) {
+          throw new ControlOwnerError('legacy_lineage_rejected', 'Legacy child lineage is not recognized');
+        }
+        if (candidate.parent.mode === 'graph' && (!candidate.graph_claim || candidate.mode !== 'team')) {
+          throw new ControlOwnerError('graph_claim_required', 'Legacy Graph child requires an exact Team claim lineage');
+        }
+        if (candidate.parent.mode !== 'graph' && candidate.graph_claim) {
+          throw new ControlOwnerError('graph_claim_unexpected', 'Legacy non-Graph child cannot carry graph claim lineage');
+        }
+        const child: ControlChildRegistration = {
+          mode: candidate.mode,
+          session_id: candidate.session_id!,
+          run_id: candidate.run_id!,
+          parent: structuredClone(candidate.parent),
+          ...(candidate.graph_claim ? { graph_claim: structuredClone(candidate.graph_claim) } : {}),
+          registered_at: input.adopted_at,
+        };
+        children.push(child);
+        reachable.add(identityKey(child));
+      }
+      const root: ControlRoot = {
+        ...rootIdentity,
+        nonce: text(input.nonce, 'nonce', 128),
+        phase: 'active',
+        reservation_process: owner,
+        ...(rootCandidate.mode === 'graph'
+          ? {
+              graph_revision: rootCandidate.graph_revision
+                ? graphRevision(rootCandidate.graph_revision, 'legacy graph_revision')
+                : (() => { throw new ControlOwnerError('legacy_identity_incomplete', 'Legacy Graph root lacks revision/hash'); })(),
+            }
+          : {}),
+        children,
+        created_at: input.adopted_at,
+        updated_at: input.adopted_at,
+      };
+      return {
+        format_version: 1,
+        session_id: this.sessionId,
+        generation: (current?.generation ?? 0) + 1,
+        root,
+        updated_at: input.adopted_at,
+      };
+    });
+  }
+
+  private emptyState(at: string): ControlOwnerState {
+    return {
+      format_version: 1,
+      session_id: this.sessionId,
+      generation: 0,
+      root: null,
+      updated_at: at,
+    };
+  }
+
+  private requireExactRoot(
+    current: ControlOwnerState | null,
+    input: { mode: GraphControlMode; run_id: string; nonce: string },
+  ): ControlRoot {
+    if (!current?.root
+      || current.root.mode !== input.mode
+      || current.root.run_id !== input.run_id
+      || current.root.nonce !== input.nonce) {
+      throw new ControlOwnerError('root_fence_mismatch', 'Control root session/run/nonce fence does not match');
+    }
+    return current.root;
+  }
+
+  private withRoot(current: ControlOwnerState, root: ControlRoot, at: string): ControlOwnerState {
+    return {
+      ...current,
+      generation: current.generation + 1,
+      root,
+      updated_at: at,
+    };
+  }
+
+  private mutate(
+    callback: (current: ControlOwnerState | null) => ControlOwnerState,
+    writeUnchanged = true,
+  ): ControlOwnerState {
+    const locked = this.dependencies.withExclusiveLock(this.path, () => {
+      const current = this.read();
+      const next = parseControlOwnerState(callback(current), this.sessionId);
+      if (writeUnchanged || JSON.stringify(next) !== JSON.stringify(current)) {
+        this.dependencies.writeAtomic(this.path, next);
+      }
+      return next;
+    });
+    if (!locked.acquired || !locked.value) {
+      throw new ControlOwnerError('lock_busy', 'Could not acquire the exclusive control-owner lock');
+    }
+    return locked.value;
+  }
+}

--- a/src/graph/descriptor.ts
+++ b/src/graph/descriptor.ts
@@ -1,0 +1,451 @@
+import { createHash } from 'node:crypto';
+
+import { parseGraphDescriptorShape } from './schema.js';
+import type {
+  GraphBackEdge,
+  GraphDescriptor,
+  GraphDescriptorInput,
+  GraphEdge,
+  GraphFanOutEdge,
+  GraphNode,
+  SealedGraphDescriptor,
+} from './types.js';
+
+export class GraphDescriptorValidationError extends Error {
+  readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super(`Invalid graph descriptor: ${issues.join('; ')}`);
+    this.name = 'GraphDescriptorValidationError';
+    this.issues = issues;
+  }
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Canonical JSON does not support non-finite numbers');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+
+function descriptorHashPayload(input: GraphDescriptorInput): Omit<GraphDescriptorInput, 'descriptor_hash'> {
+  return {
+    descriptor_version: input.descriptor_version,
+    run_id: input.run_id,
+    revision_id: input.revision_id,
+    goal: input.goal,
+    nodes: input.nodes,
+    edges: input.edges,
+    entry_node_ids: input.entry_node_ids,
+    concurrency_limit: input.concurrency_limit,
+    terminal_verification_node_id: input.terminal_verification_node_id,
+  };
+}
+
+export function computeDescriptorHash(input: GraphDescriptorInput): string {
+  return createHash('sha256').update(canonicalJson(descriptorHashPayload(input))).digest('hex');
+}
+
+export function verifyDescriptorHash(
+  input: GraphDescriptorInput,
+): input is SealedGraphDescriptor {
+  return typeof input.descriptor_hash === 'string'
+    && input.descriptor_hash === computeDescriptorHash(input);
+}
+
+function duplicates(values: string[]): string[] {
+  const seen = new Set<string>();
+  const found = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) found.add(value);
+    seen.add(value);
+  }
+  return [...found].sort();
+}
+
+function groupByFrom(edges: GraphEdge[]): Map<string, GraphEdge[]> {
+  const result = new Map<string, GraphEdge[]>();
+  for (const edge of edges) {
+    const group = result.get(edge.from) ?? [];
+    group.push(edge);
+    result.set(edge.from, group);
+  }
+  return result;
+}
+
+function adjacencyFor(edges: GraphEdge[], includeBackEdges: boolean): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!includeBackEdges && edge.kind === 'back_edge') continue;
+    const targets = result.get(edge.from) ?? [];
+    targets.push(edge.to);
+    result.set(edge.from, targets);
+  }
+  return result;
+}
+
+function isReachable(start: string, target: string, adjacency: Map<string, string[]>): boolean {
+  const pending = [start];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current === target) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return false;
+}
+
+function reachableSet(starts: string[], adjacency: Map<string, string[]>): Set<string> {
+  const pending = [...starts];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return visited;
+}
+
+function findForwardCycle(nodeIds: string[], adjacency: Map<string, string[]>): string[] | undefined {
+  const visited = new Set<string>();
+  const active = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (nodeId: string): string[] | undefined => {
+    if (active.has(nodeId)) {
+      const start = stack.indexOf(nodeId);
+      return [...stack.slice(start), nodeId];
+    }
+    if (visited.has(nodeId)) return undefined;
+    visited.add(nodeId);
+    active.add(nodeId);
+    stack.push(nodeId);
+    for (const target of adjacency.get(nodeId) ?? []) {
+      const cycle = visit(target);
+      if (cycle) return cycle;
+    }
+    stack.pop();
+    active.delete(nodeId);
+    return undefined;
+  };
+
+  for (const nodeId of nodeIds) {
+    const cycle = visit(nodeId);
+    if (cycle) return cycle;
+  }
+  return undefined;
+}
+
+interface ForkBranchRegion {
+  fanOutNodeId: string;
+  joinNodeId: string;
+  branchId: string;
+  startNodeId: string;
+  nodes: Set<string>;
+}
+
+function collectBranchRegion(
+  edge: GraphFanOutEdge,
+  allAdjacency: Map<string, string[]>,
+  joinNodeId: string,
+): Set<string> {
+  const pending = [edge.to];
+  const result = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current === joinNodeId || result.has(current)) continue;
+    result.add(current);
+    pending.push(...(allAdjacency.get(current) ?? []));
+  }
+  return result;
+}
+
+function validateOutgoingContracts(
+  descriptor: GraphDescriptor,
+  nodes: Map<string, GraphNode>,
+  outgoing: Map<string, GraphEdge[]>,
+  issues: string[],
+): void {
+  for (const node of descriptor.nodes) {
+    const edges = outgoing.get(node.id) ?? [];
+    if (node.id === descriptor.terminal_verification_node_id) {
+      if (edges.length > 0) issues.push(`terminal verification node ${node.id} must not have outgoing edges`);
+      continue;
+    }
+    if (edges.length === 0) {
+      issues.push(`node ${node.id} cannot reach terminal verification because it has no outgoing edge`);
+      continue;
+    }
+
+    // A node whose only outgoing edge(s) are back_edges has no forward exit.
+    // Once max_traversals is exhausted the scheduler's selectEdges throws
+    // traversal_bound_exceeded on the completing path, leaving the result
+    // permanently uncommittable and the claim wedged. Require every non-terminal
+    // node to declare at least one non-back-edge exit path.
+    if (edges.every((edge) => edge.kind === 'back_edge')) {
+      issues.push(
+        `node ${node.id} has no non-back-edge exit; a back-edge-only node wedges once max_traversals is exhausted`,
+      );
+    }
+
+    const kinds = new Set(edges.map((edge) => edge.kind));
+    if (node.kind === 'join') {
+      if (edges.length !== 1 || edges[0].kind !== 'fixed') {
+        issues.push(`join node ${node.id} must have exactly one fixed outgoing edge`);
+      }
+      continue;
+    }
+    if (kinds.has('fixed') && (edges.length !== 1 || kinds.size !== 1)) {
+      issues.push(`node ${node.id} must use one fixed edge or an explicit route/fan-out set`);
+    }
+    if (kinds.has('fan_out')) {
+      if (kinds.size !== 1 || edges.length < 2) {
+        issues.push(`fan-out node ${node.id} must declare at least two fan_out edges and no other edge kind`);
+      }
+    } else if (!kinds.has('fixed')) {
+      if ([...kinds].some((kind) => kind !== 'conditional' && kind !== 'back_edge')) {
+        issues.push(`node ${node.id} has an unsupported routed edge combination`);
+      }
+      const routes = edges
+        .filter((edge): edge is Extract<GraphEdge, { route: string }> => 'route' in edge)
+        .map((edge) => edge.route);
+      const repeatedRoutes = duplicates(routes);
+      if (repeatedRoutes.length > 0) {
+        issues.push(`node ${node.id} declares duplicate route(s): ${repeatedRoutes.join(', ')}`);
+      }
+    }
+  }
+
+  for (const edge of descriptor.edges) {
+    if (!nodes.has(edge.from)) issues.push(`edge ${edge.id} references missing source node ${edge.from}`);
+    if (!nodes.has(edge.to)) issues.push(`edge ${edge.id} references missing target node ${edge.to}`);
+  }
+}
+
+function validateForkRegions(
+  descriptor: GraphDescriptor,
+  nodes: Map<string, GraphNode>,
+  outgoing: Map<string, GraphEdge[]>,
+  allAdjacency: Map<string, string[]>,
+  issues: string[],
+): void {
+  const fanGroups = new Map<string, GraphFanOutEdge[]>();
+  for (const edge of descriptor.edges) {
+    if (edge.kind !== 'fan_out') continue;
+    const group = fanGroups.get(edge.from) ?? [];
+    group.push(edge);
+    fanGroups.set(edge.from, group);
+  }
+
+  const regions: ForkBranchRegion[] = [];
+  for (const [fanOutNodeId, fanEdges] of fanGroups) {
+    const ownerJoinIds = new Set(fanEdges.map((edge) => edge.owner_join_id));
+    if (ownerJoinIds.size !== 1) {
+      issues.push(`fan-out node ${fanOutNodeId} must have one owning join`);
+      continue;
+    }
+    const joinNodeId = fanEdges[0].owner_join_id;
+    const joinNode = nodes.get(joinNodeId);
+    if (joinNode?.kind !== 'join') {
+      issues.push(`fan-out node ${fanOutNodeId} references non-join owner ${joinNodeId}`);
+      continue;
+    }
+    if (joinNode.fan_out_node_id !== fanOutNodeId) {
+      issues.push(`join ${joinNodeId} does not bind fan-out node ${fanOutNodeId}`);
+    }
+    const branchIds = fanEdges.map((edge) => edge.branch_id);
+    const repeatedBranches = duplicates(branchIds);
+    if (repeatedBranches.length > 0) {
+      issues.push(`fan-out node ${fanOutNodeId} repeats branch ID(s): ${repeatedBranches.join(', ')}`);
+    }
+    if (
+      [...new Set(branchIds)].sort().join('\0')
+      !== [...new Set(joinNode.input_branch_ids)].sort().join('\0')
+    ) {
+      issues.push(`join ${joinNodeId} input branches do not match fan-out ${fanOutNodeId}`);
+    }
+    if (duplicates(joinNode.input_branch_ids).length > 0) {
+      issues.push(`join ${joinNodeId} repeats an input branch ID`);
+    }
+
+    const groupRegions: ForkBranchRegion[] = fanEdges.map((edge) => ({
+      fanOutNodeId,
+      joinNodeId,
+      branchId: edge.branch_id,
+      startNodeId: edge.to,
+      nodes: collectBranchRegion(edge, allAdjacency, joinNodeId),
+    }));
+    regions.push(...groupRegions);
+
+    for (const region of groupRegions) {
+      if (!region.nodes.has(region.startNodeId)) {
+        issues.push(`fork branch ${region.branchId} has no region`);
+      }
+      if (!isReachable(region.startNodeId, joinNodeId, allAdjacency)) {
+        issues.push(`fork branch ${region.branchId} cannot reach owning join ${joinNodeId}`);
+      }
+      for (const nodeId of region.nodes) {
+        const node = nodes.get(nodeId);
+        if (node?.kind === 'join' && nodeId !== joinNodeId) {
+          issues.push(`nested join ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+        }
+        if ((outgoing.get(nodeId) ?? []).some((edge) => edge.kind === 'fan_out')) {
+          issues.push(`nested fan-out ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+        }
+        if (!isReachable(nodeId, joinNodeId, allAdjacency)) {
+          issues.push(`fork branch ${region.branchId} contains node ${nodeId} that cannot reach its join`);
+        }
+      }
+      const reachesJoin = descriptor.edges.some(
+        (edge) => region.nodes.has(edge.from) && edge.to === joinNodeId,
+      );
+      if (!reachesJoin) issues.push(`fork branch ${region.branchId} has no declared join input`);
+    }
+
+    for (let left = 0; left < groupRegions.length; left += 1) {
+      for (let right = left + 1; right < groupRegions.length; right += 1) {
+        const overlap = [...groupRegions[left].nodes].filter((id) => groupRegions[right].nodes.has(id));
+        if (overlap.length > 0) {
+          issues.push(
+            `fork branches ${groupRegions[left].branchId} and ${groupRegions[right].branchId} overlap at ${overlap.join(', ')}`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const node of descriptor.nodes) {
+    if (node.kind === 'join' && !fanGroups.has(node.fan_out_node_id)) {
+      issues.push(`join ${node.id} has no matching fan-out node ${node.fan_out_node_id}`);
+    }
+  }
+
+  for (let left = 0; left < regions.length; left += 1) {
+    for (let right = left + 1; right < regions.length; right += 1) {
+      if (regions[left].fanOutNodeId === regions[right].fanOutNodeId) continue;
+      const overlap = [...regions[left].nodes].some((id) => regions[right].nodes.has(id));
+      if (overlap) {
+        issues.push(
+          `fork regions ${regions[left].fanOutNodeId} and ${regions[right].fanOutNodeId} overlap or nest`,
+        );
+      }
+    }
+  }
+
+  for (const region of regions) {
+    for (const edge of descriptor.edges) {
+      if (edge.kind === 'fan_out' && edge.from === region.fanOutNodeId && edge.branch_id === region.branchId) {
+        continue;
+      }
+      const fromInside = region.nodes.has(edge.from);
+      const toInside = region.nodes.has(edge.to);
+      if (!fromInside && toInside) {
+        issues.push(`edge ${edge.id} crosses into fork branch ${region.branchId}`);
+      }
+      if (fromInside && !toInside && edge.to !== region.joinNodeId) {
+        issues.push(`edge ${edge.id} crosses out of fork branch ${region.branchId}`);
+      }
+      if (edge.kind === 'back_edge' && fromInside !== toInside) {
+        issues.push(`back-edge ${edge.id} crosses fork region ${region.fanOutNodeId}`);
+      }
+    }
+  }
+
+  for (const node of descriptor.nodes) {
+    if (node.kind !== 'join') continue;
+    const ownerRegions = regions.filter((region) => region.joinNodeId === node.id);
+    for (const edge of descriptor.edges.filter((candidate) => candidate.to === node.id)) {
+      if (!ownerRegions.some((region) => region.nodes.has(edge.from))) {
+        issues.push(`edge ${edge.id} enters join ${node.id} outside its owning fork region`);
+      }
+    }
+  }
+}
+
+export function validateGraphDescriptor(descriptor: GraphDescriptor): GraphDescriptor {
+  const issues: string[] = [];
+  const repeatedNodeIds = duplicates(descriptor.nodes.map((node) => node.id));
+  if (repeatedNodeIds.length > 0) issues.push(`duplicate node ID(s): ${repeatedNodeIds.join(', ')}`);
+  const repeatedEdgeIds = duplicates(descriptor.edges.map((edge) => edge.id));
+  if (repeatedEdgeIds.length > 0) issues.push(`duplicate edge ID(s): ${repeatedEdgeIds.join(', ')}`);
+  const repeatedEntries = duplicates(descriptor.entry_node_ids);
+  if (repeatedEntries.length > 0) issues.push(`duplicate entry node ID(s): ${repeatedEntries.join(', ')}`);
+
+  const nodes = new Map(descriptor.nodes.map((node) => [node.id, node]));
+  const outgoing = groupByFrom(descriptor.edges);
+  validateOutgoingContracts(descriptor, nodes, outgoing, issues);
+
+  for (const entry of descriptor.entry_node_ids) {
+    if (!nodes.has(entry)) issues.push(`entry node ${entry} does not exist`);
+  }
+  const terminalNode = nodes.get(descriptor.terminal_verification_node_id);
+  if (!terminalNode) {
+    issues.push(`terminal verification node ${descriptor.terminal_verification_node_id} does not exist`);
+  } else if (terminalNode.kind !== 'agent' && terminalNode.kind !== 'command') {
+    issues.push('terminal verification must be an executable agent or command node');
+  }
+
+  const allAdjacency = adjacencyFor(descriptor.edges, true);
+  const forwardAdjacency = adjacencyFor(descriptor.edges, false);
+  const reachable = reachableSet(descriptor.entry_node_ids, allAdjacency);
+  const unreachable = descriptor.nodes.map((node) => node.id).filter((id) => !reachable.has(id));
+  if (unreachable.length > 0) issues.push(`unreachable node(s): ${unreachable.join(', ')}`);
+
+  const cycle = findForwardCycle(descriptor.nodes.map((node) => node.id), forwardAdjacency);
+  if (cycle) issues.push(`non-back-edge cycle detected: ${cycle.join(' -> ')}`);
+
+  for (const edge of descriptor.edges.filter(
+    (candidate): candidate is GraphBackEdge => candidate.kind === 'back_edge',
+  )) {
+    if (!isReachable(edge.to, edge.from, forwardAdjacency)) {
+      issues.push(`back-edge ${edge.id} is not a structural return to an earlier node`);
+    }
+  }
+
+  if (terminalNode) {
+    const cannotVerify = descriptor.nodes
+      .map((node) => node.id)
+      .filter((id) => !isReachable(id, terminalNode.id, allAdjacency));
+    if (cannotVerify.length > 0) {
+      issues.push(
+        `every successful path must reach terminal verification; failing node(s): ${cannotVerify.join(', ')}`,
+      );
+    }
+  }
+
+  validateForkRegions(descriptor, nodes, outgoing, allAdjacency, issues);
+  if (issues.length > 0) throw new GraphDescriptorValidationError([...new Set(issues)]);
+  return descriptor;
+}
+
+export function parseGraphDescriptor(input: unknown): GraphDescriptor {
+  const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+  if (descriptor.descriptor_hash && !verifyDescriptorHash(descriptor)) {
+    throw new GraphDescriptorValidationError(['descriptor hash does not match the exact revision']);
+  }
+  return descriptor;
+}
+
+export function sealGraphDescriptor(input: unknown): SealedGraphDescriptor {
+  const descriptor = parseGraphDescriptor(input);
+  return {
+    ...descriptor,
+    descriptor_hash: computeDescriptorHash(descriptor),
+  };
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './schema.js';
+export * from './descriptor.js';
+export * from './scheduler.js';

--- a/src/graph/platform.ts
+++ b/src/graph/platform.ts
@@ -1,0 +1,143 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+import type { GraphProcessIdentity } from './runtime-types.js';
+
+export class GraphPlatformError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphPlatformError';
+    this.code = code;
+  }
+}
+
+export type GraphProcessLiveness = boolean | 'unknown';
+
+export interface GraphPlatformAdapter {
+  preflight(): GraphProcessIdentity;
+  isProcessIdentityLive(identity: GraphProcessIdentity): GraphProcessLiveness;
+}
+
+export interface GraphPlatformDependencies {
+  platform: NodeJS.Platform;
+  pid: number;
+  fileExists(path: string): boolean;
+  readText(path: string): string;
+  execCommand(command: string): string;
+}
+
+function parseLinuxProcessStart(stat: string): string | null {
+  const commandEnd = stat.lastIndexOf(')');
+  if (commandEnd < 0) return null;
+  const fields = stat.slice(commandEnd + 2).trim().split(/\s+/);
+  const processStart = fields[19];
+  return processStart && /^\d+$/.test(processStart) ? processStart : null;
+}
+
+function readProcessStartLinux(pid: number, deps: GraphPlatformDependencies): string | null {
+  try {
+    return parseLinuxProcessStart(deps.readText(`/proc/${pid}/stat`));
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStartDarwin(pid: number, deps: GraphPlatformDependencies): string | null {
+  try {
+    const output = deps.execCommand(`LC_ALL=C ps -p ${pid} -o lstart=`);
+    const trimmed = output.trim();
+    if (!trimmed) return null;
+    const ms = Date.parse(trimmed);
+    if (!Number.isFinite(ms)) return null;
+    return String(Math.floor(ms / 1000));
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStartWindows(pid: number, deps: GraphPlatformDependencies): string | null {
+  try {
+    const output = deps.execCommand(
+      `powershell -NoProfile -Command "[math]::Floor(((Get-Process -Id ${pid} -ErrorAction SilentlyContinue).StartTime - (Get-Date '1970-01-01')).TotalSeconds)"`,
+    );
+    const trimmed = output.trim();
+    return /^\d+$/.test(trimmed) ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStart(pid: number, platform: NodeJS.Platform, deps: GraphPlatformDependencies): string | null {
+  if (platform === 'linux') return readProcessStartLinux(pid, deps);
+  if (platform === 'darwin') return readProcessStartDarwin(pid, deps);
+  if (platform === 'win32') return readProcessStartWindows(pid, deps);
+  return null;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Tracks pids that have already emitted the pid-only fallback warning so we
+// warn once per pid instead of on every liveness poll. The fallback loses
+// PID-reuse protection; the warning is observability only and does not change
+// liveness semantics.
+const warnedPidOnlyFallback = new Set<number>();
+
+export function createGraphPlatformAdapter(
+  overrides: Partial<GraphPlatformDependencies> = {},
+): GraphPlatformAdapter {
+  const dependencies: GraphPlatformDependencies = {
+    platform: process.platform,
+    pid: process.pid,
+    fileExists: existsSync,
+    readText: (path) => readFileSync(path, 'utf8'),
+    execCommand: (command) =>
+      execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 }),
+    ...overrides,
+  };
+  return {
+    preflight(): GraphProcessIdentity {
+      const processStart = readProcessStart(dependencies.pid, dependencies.platform, dependencies);
+      if (!processStart) {
+        return { pid: dependencies.pid, process_start: '' };
+      }
+      return { pid: dependencies.pid, process_start: processStart };
+    },
+
+    isProcessIdentityLive(identity: GraphProcessIdentity): GraphProcessLiveness {
+      if (!Number.isSafeInteger(identity.pid) || identity.pid <= 0) return 'unknown';
+      // pid-only liveness is always available as a fallback (e.g. when the host
+      // could not capture process_start at reservation time). A dead pid is
+      // definitively not live; only return 'unknown' if even this check throws.
+      let alive: boolean;
+      try {
+        alive = isProcessAlive(identity.pid);
+      } catch {
+        return 'unknown';
+      }
+      if (!alive) return false;
+      if (!identity.process_start) {
+        if (!warnedPidOnlyFallback.has(identity.pid)) {
+          warnedPidOnlyFallback.add(identity.pid);
+          console.warn(
+            `graph: pid-only liveness fallback used for pid ${identity.pid} (process_start unavailable); PID-reuse protection is degraded`,
+          );
+        }
+        return true;
+      }
+      const current = readProcessStart(identity.pid, dependencies.platform, dependencies);
+      if (!current) return 'unknown';
+      return current === identity.process_start;
+    },
+  };
+}
+
+export const graphPlatform = createGraphPlatformAdapter();

--- a/src/graph/revisions.ts
+++ b/src/graph/revisions.ts
@@ -1,0 +1,310 @@
+import { canonicalJson, parseGraphDescriptor, verifyDescriptorHash } from './descriptor.js';
+import {
+  parseGraphState,
+  type GraphApprovalRecord,
+  type GraphRevisionRecord,
+  type GraphState,
+} from './runtime-types.js';
+import type {
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from './types.js';
+
+export class GraphRevisionError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphRevisionError';
+    this.code = code;
+  }
+}
+
+function timestamp(value: string, name: string): void {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new GraphRevisionError('invalid_timestamp', `${name} must be an ISO timestamp`);
+  }
+}
+
+function sealedDescriptor(value: unknown): SealedGraphDescriptor {
+  const descriptor = parseGraphDescriptor(value) as SealedGraphDescriptor;
+  if (!verifyDescriptorHash(descriptor)) {
+    throw new GraphRevisionError('descriptor_unsealed', 'Revision descriptor hash does not match');
+  }
+  return descriptor;
+}
+
+function sortedUnique(values: string[], name: string): string[] {
+  if (values.length > 1_000 || values.some((value) => value.length === 0 || value.length > 128)) {
+    throw new GraphRevisionError('invalid_invalidation', `${name} must be a bounded node ID list`);
+  }
+  const result = [...new Set(values)].sort();
+  if (result.length !== values.length) {
+    throw new GraphRevisionError('invalid_invalidation', `${name} cannot contain duplicate node IDs`);
+  }
+  return result;
+}
+
+function assertHumanEvidence(evidence: GraphEvidenceReference, name: string): void {
+  if (evidence.kind !== 'human' || evidence.ref.length === 0 || evidence.ref.length > 2_048) {
+    throw new GraphRevisionError('approval_evidence_invalid', `${name} requires bounded human evidence`);
+  }
+}
+
+export interface ReplacePendingDraftInput {
+  descriptor: SealedGraphDescriptor;
+  replaced_at: string;
+}
+
+export function replacePendingDraft(stateInput: GraphState, input: ReplacePendingDraftInput): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.replaced_at, 'replaced_at');
+  if (state.status !== 'awaiting_approval'
+    || !state.pending_approval
+    || state.revisions[state.active_revision_id].approval
+    || state.commit_sequence !== 0
+    || state.transitions.length !== 0
+    || Object.keys(state.claims).length !== 0
+    || Object.keys(state.reconciliations).length !== 0
+    || Object.keys(state.projection.activations).length !== 0
+    || Object.keys(state.projection.committed_transitions).length !== 0) {
+    throw new GraphRevisionError(
+      'draft_not_replaceable',
+      'Only an unapproved graph with no claims, history, or runnable projection can replace its pending draft',
+    );
+  }
+  const descriptor = sealedDescriptor(input.descriptor);
+  if (descriptor.run_id !== state.run_id) {
+    throw new GraphRevisionError('run_mismatch', 'Replacement draft must retain the graph run identity');
+  }
+  if (descriptor.revision_id === state.active_revision_id || state.revisions[descriptor.revision_id]) {
+    throw new GraphRevisionError('revision_reused', 'Replacement draft requires a new immutable revision ID');
+  }
+  const revision: GraphRevisionRecord = {
+    revision_id: descriptor.revision_id,
+    descriptor_hash: descriptor.descriptor_hash,
+    descriptor: structuredClone(descriptor),
+    created_at: input.replaced_at,
+    invalidated_node_ids: [],
+  };
+  return parseGraphState({
+    ...structuredClone(state),
+    active_revision_id: descriptor.revision_id,
+    active_revision_hash: descriptor.descriptor_hash,
+    revisions: { ...state.revisions, [descriptor.revision_id]: revision },
+    pending_approval: {
+      revision_id: descriptor.revision_id,
+      revision_hash: descriptor.descriptor_hash,
+      requested_at: input.replaced_at,
+    },
+    updated_at: input.replaced_at,
+  });
+}
+
+export interface ApprovePendingGraphRevisionInput {
+  revision_id: string;
+  revision_hash: string;
+  approved_at: string;
+  approval_evidence: GraphEvidenceReference;
+}
+
+export type InitializeApprovedProjection = (
+  descriptor: SealedGraphDescriptor,
+) => GraphSchedulerProjection;
+
+export function approvePendingGraphRevision(
+  stateInput: GraphState,
+  input: ApprovePendingGraphRevisionInput,
+  initializeProjection: InitializeApprovedProjection,
+): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.approved_at, 'approved_at');
+  assertHumanEvidence(input.approval_evidence, 'Initial graph approval');
+  if (state.status !== 'awaiting_approval' || !state.pending_approval) {
+    throw new GraphRevisionError('approval_not_pending', 'Graph is not awaiting initial approval');
+  }
+  if (state.pending_approval.revision_id !== input.revision_id
+    || state.pending_approval.revision_hash !== input.revision_hash
+    || state.active_revision_id !== input.revision_id
+    || state.active_revision_hash !== input.revision_hash) {
+    throw new GraphRevisionError('approval_fence_mismatch', 'Initial approval does not bind the exact pending revision/hash');
+  }
+  if (Object.keys(state.claims).length > 0 || state.transitions.length > 0) {
+    throw new GraphRevisionError('approval_not_quiescent', 'Initial approval cannot cross claims or committed history');
+  }
+  const current = state.revisions[input.revision_id];
+  if (!current || current.approval) {
+    throw new GraphRevisionError('approval_reused', 'Pending revision is missing or already approved');
+  }
+  const approval: GraphApprovalRecord = {
+    revision_id: input.revision_id,
+    revision_hash: input.revision_hash,
+    approved_at: input.approved_at,
+    evidence: structuredClone(input.approval_evidence),
+  };
+  const projection = initializeProjection(structuredClone(current.descriptor));
+  return parseGraphState({
+    ...structuredClone(state),
+    status: 'running',
+    revisions: {
+      ...state.revisions,
+      [current.revision_id]: { ...current, approval },
+    },
+    projection,
+    pending_approval: undefined,
+    updated_at: input.approved_at,
+  });
+}
+
+export interface ProposeGraphPatchInput {
+  proposal_id: string;
+  base_revision_id: string;
+  base_revision_hash: string;
+  proposed_descriptor: SealedGraphDescriptor;
+  invalidated_node_ids: string[];
+  proposal_evidence: GraphEvidenceReference[];
+  proposed_at: string;
+}
+
+export function proposeGraphPatch(stateInput: GraphState, input: ProposeGraphPatchInput): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.proposed_at, 'proposed_at');
+  if (state.status !== 'running' && state.status !== 'waiting_human') {
+    throw new GraphRevisionError('patch_not_allowed', `Cannot propose a patch while graph status is ${state.status}`);
+  }
+  if (state.pending_patch) throw new GraphRevisionError('patch_pending', 'A graph patch is already pending');
+  if (state.active_revision_id !== input.base_revision_id
+    || state.active_revision_hash !== input.base_revision_hash) {
+    throw new GraphRevisionError('stale_base', 'Patch proposal has a stale base revision/hash');
+  }
+  const proposed = sealedDescriptor(input.proposed_descriptor);
+  if (proposed.run_id !== state.run_id) {
+    throw new GraphRevisionError('run_mismatch', 'Patch descriptor must retain the graph run identity');
+  }
+  if (proposed.revision_id === state.active_revision_id || state.revisions[proposed.revision_id]) {
+    throw new GraphRevisionError('revision_reused', 'Patch requires a new immutable revision ID');
+  }
+  if (input.proposal_evidence.length > 64) {
+    throw new GraphRevisionError('evidence_limit', 'Patch proposal evidence exceeds the configured bound');
+  }
+  const invalidated = sortedUnique(input.invalidated_node_ids, 'invalidated_node_ids');
+  if (invalidated.some((nodeId) => !state.revisions[state.active_revision_id].descriptor.nodes.some((node) => node.id === nodeId))) {
+    throw new GraphRevisionError('unknown_invalidation', 'Patch invalidation references an unknown current node ID');
+  }
+  return parseGraphState({
+    ...structuredClone(state),
+    status: 'waiting_patch_approval',
+    dispatch_generation: state.dispatch_generation + 1,
+    pending_patch: {
+      proposal_id: input.proposal_id,
+      base_revision_id: input.base_revision_id,
+      base_revision_hash: input.base_revision_hash,
+      base_dispatch_generation: state.dispatch_generation,
+      proposed_revision_id: proposed.revision_id,
+      proposed_revision_hash: proposed.descriptor_hash,
+      proposed_descriptor: structuredClone(proposed),
+      invalidated_node_ids: invalidated,
+      proposal_evidence: structuredClone(input.proposal_evidence),
+      proposed_at: input.proposed_at,
+    },
+    updated_at: input.proposed_at,
+  });
+}
+
+export interface ApproveGraphPatchInput {
+  proposal_id: string;
+  base_revision_id: string;
+  base_revision_hash: string;
+  proposed_revision_hash: string;
+  invalidated_node_ids: string[];
+  approval_evidence: GraphEvidenceReference;
+  approved_at: string;
+}
+
+export type RecomputeProjectionForRevision = (
+  projection: GraphSchedulerProjection,
+  descriptor: SealedGraphDescriptor,
+  invalidatedNodeIds: ReadonlySet<string>,
+) => GraphSchedulerProjection;
+
+export function approveGraphPatch(
+  stateInput: GraphState,
+  input: ApproveGraphPatchInput,
+  recomputeProjection: RecomputeProjectionForRevision,
+): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.approved_at, 'approved_at');
+  assertHumanEvidence(input.approval_evidence, 'Patch approval');
+  const patch = state.pending_patch;
+  if (state.status !== 'waiting_patch_approval' || !patch) {
+    throw new GraphRevisionError('patch_not_pending', 'No approved patch transition is pending');
+  }
+  if (patch.proposal_id !== input.proposal_id
+    || patch.base_revision_id !== input.base_revision_id
+    || patch.base_revision_hash !== input.base_revision_hash
+    || patch.proposed_revision_hash !== input.proposed_revision_hash
+    || state.active_revision_id !== patch.base_revision_id
+    || state.active_revision_hash !== patch.base_revision_hash) {
+    throw new GraphRevisionError('patch_fence_mismatch', 'Patch approval does not bind the exact pending base/proposal');
+  }
+  const requestedInvalidations = sortedUnique(input.invalidated_node_ids, 'invalidated_node_ids');
+  if (canonicalJson(requestedInvalidations) !== canonicalJson([...patch.invalidated_node_ids].sort())) {
+    throw new GraphRevisionError('invalidation_mismatch', 'Patch approval must enumerate the exact proposed invalidation set');
+  }
+  if (Object.values(state.claims).some((claim) => claim.status === 'live')) {
+    throw new GraphRevisionError('live_claims', 'Patch approval is blocked until every live claim drains');
+  }
+  if (Object.values(state.reconciliations).some((record) => record.status === 'unresolved')) {
+    throw new GraphRevisionError('unresolved_reconciliation', 'Patch approval is blocked by unresolved reconciliation');
+  }
+
+  const baseDescriptor = state.revisions[patch.base_revision_id].descriptor;
+  const nextDescriptor = sealedDescriptor(patch.proposed_descriptor);
+  const nextNodes = new Map(nextDescriptor.nodes.map((node) => [node.id, node]));
+  const invalidated = new Set(requestedInvalidations);
+  const completedNodeIds = new Set(
+    Object.values(state.projection.activations)
+      .filter((activation) => activation.status === 'completed')
+      .map((activation) => activation.node_id),
+  );
+  for (const nodeId of completedNodeIds) {
+    const before = baseDescriptor.nodes.find((node) => node.id === nodeId);
+    const after = nextNodes.get(nodeId);
+    if ((!before || !after || canonicalJson(before) !== canonicalJson(after)) && !invalidated.has(nodeId)) {
+      throw new GraphRevisionError(
+        'completed_node_repurposed',
+        `Completed node ID ${nodeId} changed without explicit approved invalidation`,
+      );
+    }
+  }
+  const approval: GraphApprovalRecord = {
+    revision_id: nextDescriptor.revision_id,
+    revision_hash: nextDescriptor.descriptor_hash,
+    approved_at: input.approved_at,
+    evidence: structuredClone(input.approval_evidence),
+  };
+  const revision: GraphRevisionRecord = {
+    revision_id: nextDescriptor.revision_id,
+    descriptor_hash: nextDescriptor.descriptor_hash,
+    descriptor: structuredClone(nextDescriptor),
+    created_at: patch.proposed_at,
+    approval,
+    invalidated_node_ids: requestedInvalidations,
+  };
+  const projection = recomputeProjection(
+    structuredClone(state.projection),
+    structuredClone(nextDescriptor),
+    invalidated,
+  );
+  return parseGraphState({
+    ...structuredClone(state),
+    status: 'running',
+    active_revision_id: nextDescriptor.revision_id,
+    active_revision_hash: nextDescriptor.descriptor_hash,
+    revisions: { ...state.revisions, [nextDescriptor.revision_id]: revision },
+    projection,
+    pending_patch: undefined,
+    updated_at: input.approved_at,
+  });
+}

--- a/src/graph/runtime-types.ts
+++ b/src/graph/runtime-types.ts
@@ -1,0 +1,835 @@
+import { parseGraphDescriptor, verifyDescriptorHash } from './descriptor.js';
+import type {
+  GraphEffectPolicy,
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from './types.js';
+
+export const GRAPH_STATE_FORMAT_VERSION = 1 as const;
+export const GRAPH_STATE_MAX_BYTES = 8 * 1024 * 1024;
+export const GRAPH_MAX_TRANSITIONS = 10_000;
+export const GRAPH_MAX_DIAGNOSTICS = 128;
+export const GRAPH_MAX_RECONCILIATIONS = 1_000;
+export const GRAPH_MAX_CLAIMS = 2_000;
+export const GRAPH_MAX_TRANSITION_RESULT_BYTES = 32 * 1024;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type GraphRunStatus =
+  | 'draft'
+  | 'awaiting_approval'
+  | 'running'
+  | 'waiting_human'
+  | 'waiting_patch_approval'
+  | 'reconciling'
+  | 'paused'
+  | 'failed'
+  | 'cancelled'
+  | 'succeeded';
+
+export interface GraphApprovalRecord {
+  revision_id: string;
+  revision_hash: string;
+  approved_at: string;
+  evidence: GraphEvidenceReference;
+}
+
+export interface GraphRevisionRecord {
+  revision_id: string;
+  descriptor_hash: string;
+  descriptor: SealedGraphDescriptor;
+  created_at: string;
+  approval?: GraphApprovalRecord;
+  invalidated_node_ids: string[];
+}
+
+export interface GraphStateTransition {
+  transition_id: string;
+  operation: string;
+  operation_fingerprint: string;
+  request_fingerprint: string;
+  sequence: number;
+  committed_at: string;
+  result: JsonValue;
+}
+
+export type GraphClaimStatus =
+  | 'live'
+  | 'completed'
+  | 'expired_retryable'
+  | 'abandoned_retryable'
+  | 'reconciling'
+  | 'fenced';
+
+export interface GraphClaim {
+  run_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+  activation_id: string;
+  attempt_id: string;
+  attempt_no: number;
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  lease_id: string;
+  tracking_id: string;
+  issued_at: string;
+  expires_at: string;
+  last_renewed_at?: string;
+  lease_duration_ms: number;
+  renewal_count: number;
+  max_renewals: number;
+  effect_policy: GraphEffectPolicy;
+  external_idempotency_key?: string;
+  status: GraphClaimStatus;
+  fenced_at?: string;
+  replacement_lease_id?: string;
+}
+
+export type GraphReconciliationStatus =
+  | 'unresolved'
+  | 'committed'
+  | 'proved_not_applied'
+  | 'accepted'
+  | 'invalidated';
+
+export interface GraphReconciliationRecord {
+  reconciliation_id: string;
+  activation_id: string;
+  attempt_id: string;
+  lease_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+  status: GraphReconciliationStatus;
+  reason: 'expired_ambiguous' | 'session_end_ambiguous' | 'external_effect_ambiguous';
+  created_at: string;
+  resolved_at?: string;
+  resolution_evidence?: GraphEvidenceReference;
+}
+
+export interface GraphDiagnostic {
+  kind: 'late_result' | 'operation' | 'recovery' | 'control';
+  recorded_at: string;
+  summary: string;
+  activation_id?: string;
+  attempt_id?: string;
+  lease_id?: string;
+}
+
+export interface GraphPendingApproval {
+  revision_id: string;
+  revision_hash: string;
+  requested_at: string;
+}
+
+export interface GraphPendingPatch {
+  proposal_id: string;
+  base_revision_id: string;
+  base_revision_hash: string;
+  base_dispatch_generation: number;
+  proposed_revision_id: string;
+  proposed_revision_hash: string;
+  proposed_descriptor: SealedGraphDescriptor;
+  invalidated_node_ids: string[];
+  proposal_evidence: GraphEvidenceReference[];
+  proposed_at: string;
+}
+
+export interface GraphState {
+  format_version: typeof GRAPH_STATE_FORMAT_VERSION;
+  session_id: string;
+  run_id: string;
+  control_nonce: string;
+  status: GraphRunStatus;
+  active_revision_id: string;
+  active_revision_hash: string;
+  dispatch_generation: number;
+  commit_sequence: number;
+  revisions: Record<string, GraphRevisionRecord>;
+  transitions: GraphStateTransition[];
+  projection: GraphSchedulerProjection;
+  claims: Record<string, GraphClaim>;
+  reconciliations: Record<string, GraphReconciliationRecord>;
+  diagnostics: GraphDiagnostic[];
+  pending_approval?: GraphPendingApproval;
+  pending_patch?: GraphPendingPatch;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateInitialGraphStateInput {
+  session_id: string;
+  control_nonce: string;
+  descriptor: SealedGraphDescriptor;
+  projection: GraphSchedulerProjection;
+  status?: GraphRunStatus;
+  created_at: string;
+  approval?: Omit<GraphApprovalRecord, 'revision_id' | 'revision_hash'> & {
+    revision_id?: string;
+    revision_hash?: string;
+  };
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export function createInitialGraphState(input: CreateInitialGraphStateInput): GraphState {
+  const descriptor = parseGraphDescriptor(input.descriptor) as SealedGraphDescriptor;
+  if (!verifyDescriptorHash(descriptor)) throw new Error('Initial graph descriptor must be sealed');
+  if (
+    input.approval
+    && (
+      (input.approval.revision_id && input.approval.revision_id !== descriptor.revision_id)
+      || (input.approval.revision_hash && input.approval.revision_hash !== descriptor.descriptor_hash)
+      || input.approval.evidence.kind !== 'human'
+    )
+  ) {
+    throw new Error('Initial graph approval must bind the exact revision/hash with human evidence');
+  }
+  const status = input.status ?? (input.approval ? 'running' : 'awaiting_approval');
+  if (!input.approval && status !== 'draft' && status !== 'awaiting_approval') {
+    throw new Error(`Graph status ${status} requires exact revision approval`);
+  }
+  if (input.approval && (status === 'draft' || status === 'awaiting_approval')) {
+    throw new Error(`Approved graph cannot remain in ${status}`);
+  }
+  if (!input.approval && Object.values(input.projection.activations).some(
+    (activation) => activation.status === 'ready' || activation.status === 'running',
+  )) {
+    throw new Error('Unapproved graph cannot expose claimable work');
+  }
+  const approval: GraphApprovalRecord | undefined = input.approval
+    ? {
+        revision_id: descriptor.revision_id,
+        revision_hash: descriptor.descriptor_hash,
+        approved_at: input.approval.approved_at,
+        evidence: clone(input.approval.evidence),
+      }
+    : undefined;
+  const revision: GraphRevisionRecord = {
+    revision_id: descriptor.revision_id,
+    descriptor_hash: descriptor.descriptor_hash,
+    descriptor: clone(descriptor),
+    created_at: input.created_at,
+    ...(approval ? { approval } : {}),
+    invalidated_node_ids: [],
+  };
+  return {
+    format_version: GRAPH_STATE_FORMAT_VERSION,
+    session_id: input.session_id,
+    run_id: descriptor.run_id,
+    control_nonce: input.control_nonce,
+    status,
+    active_revision_id: descriptor.revision_id,
+    active_revision_hash: descriptor.descriptor_hash,
+    dispatch_generation: 0,
+    commit_sequence: 0,
+    revisions: { [descriptor.revision_id]: revision },
+    transitions: [],
+    projection: clone(input.projection),
+    claims: {},
+    reconciliations: {},
+    diagnostics: [],
+    ...(!input.approval
+      ? {
+          pending_approval: {
+            revision_id: descriptor.revision_id,
+            revision_hash: descriptor.descriptor_hash,
+            requested_at: input.created_at,
+          },
+        }
+      : {}),
+    created_at: input.created_at,
+    updated_at: input.created_at,
+  };
+}
+
+export class GraphStateValidationError extends Error {
+  readonly code = 'invalid_graph_state';
+
+  constructor(message: string) {
+    super(`Invalid graph state: ${message}`);
+    this.name = 'GraphStateValidationError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new GraphStateValidationError(`${name} must be an object`);
+  return value;
+}
+
+function requireString(value: unknown, name: string, max = 32_768): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > max) {
+    throw new GraphStateValidationError(`${name} must be a non-empty bounded string`);
+  }
+  return value;
+}
+
+function requireInteger(value: unknown, name: string, max = Number.MAX_SAFE_INTEGER): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0 || (value as number) > max) {
+    throw new GraphStateValidationError(`${name} must be a bounded non-negative integer`);
+  }
+  return value as number;
+}
+
+function requireTimestamp(value: unknown, name: string): string {
+  const result = requireString(value, name, 64);
+  if (!Number.isFinite(Date.parse(result))) throw new GraphStateValidationError(`${name} must be an ISO timestamp`);
+  return result;
+}
+
+function assertExactKeys(record: Record<string, unknown>, required: string[], optional: string[], name: string): void {
+  const allowed = new Set([...required, ...optional]);
+  const unknown = Object.keys(record).filter((key) => !allowed.has(key));
+  const missing = required.filter((key) => !(key in record));
+  if (missing.length > 0) throw new GraphStateValidationError(`${name} missing ${missing.join(', ')}`);
+  if (unknown.length > 0) throw new GraphStateValidationError(`${name} has unknown ${unknown.join(', ')}`);
+}
+
+function requireStringArray(value: unknown, name: string, max: number): string[] {
+  if (!Array.isArray(value) || value.length > max) {
+    throw new GraphStateValidationError(`${name} must be a bounded array`);
+  }
+  const result = value.map((item, index) => requireString(item, `${name}[${index}]`, 128));
+  if (new Set(result).size !== result.length) throw new GraphStateValidationError(`${name} contains duplicates`);
+  return result;
+}
+
+function validateEvidence(value: unknown, name: string): GraphEvidenceReference {
+  const evidence = requireRecord(value, name);
+  assertExactKeys(evidence, ['kind', 'ref'], ['summary'], name);
+  if (!['file', 'command', 'test', 'human', 'url'].includes(String(evidence.kind))) {
+    throw new GraphStateValidationError(`${name}.kind is invalid`);
+  }
+  requireString(evidence.ref, `${name}.ref`, 2_048);
+  if (evidence.summary !== undefined) requireString(evidence.summary, `${name}.summary`, 2_048);
+  return value as GraphEvidenceReference;
+}
+
+function validateEffectPolicy(value: unknown, name: string): GraphEffectPolicy {
+  const policy = requireRecord(value, name);
+  if (policy.policy === 'side_effect_free' || policy.policy === 'reconcile') {
+    assertExactKeys(policy, ['policy'], [], name);
+    return value as GraphEffectPolicy;
+  }
+  if (policy.policy === 'idempotent') {
+    assertExactKeys(policy, ['policy', 'idempotency_key_template'], [], name);
+    requireString(policy.idempotency_key_template, `${name}.idempotency_key_template`, 512);
+    return value as GraphEffectPolicy;
+  }
+  throw new GraphStateValidationError(`${name}.policy is invalid`);
+}
+
+function validateApproval(value: unknown, name: string, revisionId: string, revisionHash: string): GraphApprovalRecord {
+  const approval = requireRecord(value, name);
+  assertExactKeys(approval, ['revision_id', 'revision_hash', 'approved_at', 'evidence'], [], name);
+  if (approval.revision_id !== revisionId || approval.revision_hash !== revisionHash) {
+    throw new GraphStateValidationError(`${name} does not bind the exact revision/hash`);
+  }
+  requireTimestamp(approval.approved_at, `${name}.approved_at`);
+  const evidence = validateEvidence(approval.evidence, `${name}.evidence`);
+  if (evidence.kind !== 'human') throw new GraphStateValidationError(`${name} requires human evidence`);
+  return value as GraphApprovalRecord;
+}
+
+function validateProjection(value: unknown, descriptor: SealedGraphDescriptor): GraphSchedulerProjection {
+  const projection = requireRecord(value, 'projection');
+  assertExactKeys(projection, [
+    'activations',
+    'cohorts',
+    'branch_tokens',
+    'traversal_counts',
+    'committed_transitions',
+    'terminal_verification_activation_ids',
+  ], [], 'projection');
+  const nodeIds = new Set(descriptor.nodes.map((node) => node.id));
+  const activations = requireRecord(projection.activations, 'projection.activations');
+  for (const [key, raw] of Object.entries(activations)) {
+    const activation = requireRecord(raw, `projection.activations.${key}`);
+    assertExactKeys(activation, [
+      'activation_id', 'node_id', 'status', 'attempt_no', 'attempt_ids', 'traversal_owner_id',
+    ], [
+      'active_attempt_id', 'completed_transition_id', 'cohort_id', 'branch_token_id',
+    ], `projection.activations.${key}`);
+    if (activation.activation_id !== key) throw new GraphStateValidationError(`activation key ${key} mismatches identity`);
+    const nodeId = requireString(activation.node_id, `projection.activations.${key}.node_id`, 128);
+    if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`activation ${key} references unknown node ${nodeId}`);
+    if (!['ready', 'running', 'completed', 'failed'].includes(String(activation.status))) {
+      throw new GraphStateValidationError(`activation ${key} has invalid status`);
+    }
+    const attemptNo = requireInteger(activation.attempt_no, `projection.activations.${key}.attempt_no`, 20);
+    const attempts = requireStringArray(activation.attempt_ids, `projection.activations.${key}.attempt_ids`, 20);
+    if (attemptNo !== attempts.length) throw new GraphStateValidationError(`activation ${key} attempt count mismatch`);
+    requireString(activation.traversal_owner_id, `projection.activations.${key}.traversal_owner_id`, 128);
+    if (activation.active_attempt_id !== undefined) {
+      const activeAttempt = requireString(activation.active_attempt_id, `projection.activations.${key}.active_attempt_id`, 128);
+      if (!attempts.includes(activeAttempt)) throw new GraphStateValidationError(`activation ${key} active attempt is unknown`);
+    }
+    if (activation.status === 'running' && !activation.active_attempt_id) {
+      throw new GraphStateValidationError(`running activation ${key} has no active attempt`);
+    }
+  }
+
+  const cohorts = requireRecord(projection.cohorts, 'projection.cohorts');
+  for (const [key, raw] of Object.entries(cohorts)) {
+    const cohort = requireRecord(raw, `projection.cohorts.${key}`);
+    assertExactKeys(cohort, [
+      'cohort_id', 'fan_out_node_id', 'owner_join_id', 'expected_branch_token_ids', 'consumed',
+    ], ['join_activation_id'], `projection.cohorts.${key}`);
+    if (cohort.cohort_id !== key) throw new GraphStateValidationError(`cohort key ${key} mismatches identity`);
+    for (const property of ['fan_out_node_id', 'owner_join_id'] as const) {
+      const nodeId = requireString(cohort[property], `projection.cohorts.${key}.${property}`, 128);
+      if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`cohort ${key} references unknown node ${nodeId}`);
+    }
+    requireStringArray(cohort.expected_branch_token_ids, `projection.cohorts.${key}.expected_branch_token_ids`, 64);
+    if (typeof cohort.consumed !== 'boolean') throw new GraphStateValidationError(`cohort ${key}.consumed must be boolean`);
+    if (cohort.join_activation_id !== undefined && !(String(cohort.join_activation_id) in activations)) {
+      throw new GraphStateValidationError(`cohort ${key} references unknown join activation`);
+    }
+  }
+
+  const tokens = requireRecord(projection.branch_tokens, 'projection.branch_tokens');
+  for (const [key, raw] of Object.entries(tokens)) {
+    const token = requireRecord(raw, `projection.branch_tokens.${key}`);
+    assertExactKeys(token, [
+      'branch_token_id', 'cohort_id', 'branch_id', 'owner_join_id', 'status',
+    ], ['current_activation_id', 'consumed_by_activation_id'], `projection.branch_tokens.${key}`);
+    if (token.branch_token_id !== key) throw new GraphStateValidationError(`branch token key ${key} mismatches identity`);
+    if (!(String(token.cohort_id) in cohorts)) throw new GraphStateValidationError(`branch token ${key} references unknown cohort`);
+    requireString(token.branch_id, `projection.branch_tokens.${key}.branch_id`, 128);
+    requireString(token.owner_join_id, `projection.branch_tokens.${key}.owner_join_id`, 128);
+    if (!['active', 'arrived', 'consumed'].includes(String(token.status))) {
+      throw new GraphStateValidationError(`branch token ${key} has invalid status`);
+    }
+    for (const property of ['current_activation_id', 'consumed_by_activation_id'] as const) {
+      if (token[property] !== undefined && !(String(token[property]) in activations)) {
+        throw new GraphStateValidationError(`branch token ${key} references unknown activation`);
+      }
+    }
+  }
+
+  const traversals = requireRecord(projection.traversal_counts, 'projection.traversal_counts');
+  for (const [edgeId, count] of Object.entries(traversals)) {
+    if (!descriptor.edges.some((edge) => edge.id === edgeId && edge.kind === 'back_edge')) {
+      throw new GraphStateValidationError(`traversal count references unknown back-edge ${edgeId}`);
+    }
+    requireInteger(count, `projection.traversal_counts.${edgeId}`, 100);
+  }
+
+  const committed = requireRecord(projection.committed_transitions, 'projection.committed_transitions');
+  if (Object.keys(committed).length > GRAPH_MAX_TRANSITIONS) {
+    throw new GraphStateValidationError('scheduler committed transitions exceed the configured bound');
+  }
+  for (const [key, raw] of Object.entries(committed)) {
+    const transition = requireRecord(raw, `projection.committed_transitions.${key}`);
+    assertExactKeys(transition, [
+      'transition_id', 'activation_id', 'node_id', 'outcome', 'request_fingerprint',
+      'selected_edge_ids', 'created_activation_ids', 'evidence_refs',
+    ], [
+      'cohort_id', 'attempt_id', 'route', 'output_summary', 'external_idempotency_key',
+    ], `projection.committed_transitions.${key}`);
+    if (transition.transition_id !== key) throw new GraphStateValidationError(`scheduler transition key ${key} mismatches identity`);
+    if (!(String(transition.activation_id) in activations)) {
+      throw new GraphStateValidationError(`scheduler transition ${key} references unknown activation`);
+    }
+    const nodeId = requireString(transition.node_id, `projection.committed_transitions.${key}.node_id`, 128);
+    if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`scheduler transition ${key} references unknown node`);
+    if (!['succeeded', 'failed', 'join_resolved'].includes(String(transition.outcome))) {
+      throw new GraphStateValidationError(`scheduler transition ${key} has invalid outcome`);
+    }
+    requireString(transition.request_fingerprint, `projection.committed_transitions.${key}.request_fingerprint`, 64);
+    requireStringArray(transition.selected_edge_ids, `projection.committed_transitions.${key}.selected_edge_ids`, 64);
+    requireStringArray(transition.created_activation_ids, `projection.committed_transitions.${key}.created_activation_ids`, 64);
+    if (!Array.isArray(transition.evidence_refs) || transition.evidence_refs.length > 64) {
+      throw new GraphStateValidationError(`scheduler transition ${key} evidence is invalid`);
+    }
+    transition.evidence_refs.forEach((item, index) => validateEvidence(item, `scheduler transition ${key} evidence[${index}]`));
+  }
+
+  const terminalIds = requireStringArray(
+    projection.terminal_verification_activation_ids,
+    'projection.terminal_verification_activation_ids',
+    GRAPH_MAX_TRANSITIONS,
+  );
+  for (const activationId of terminalIds) {
+    const activation = activations[activationId] as Record<string, unknown> | undefined;
+    if (!activation || activation.node_id !== descriptor.terminal_verification_node_id) {
+      throw new GraphStateValidationError(`terminal verification activation ${activationId} is invalid`);
+    }
+  }
+  return value as GraphSchedulerProjection;
+}
+
+function validateRevision(value: unknown, key: string, runId: string): GraphRevisionRecord {
+  const revision = requireRecord(value, `revisions.${key}`);
+  assertExactKeys(revision, [
+    'revision_id', 'descriptor_hash', 'descriptor', 'created_at', 'invalidated_node_ids',
+  ], ['approval'], `revisions.${key}`);
+  const revisionId = requireString(revision.revision_id, `revisions.${key}.revision_id`, 128);
+  const hash = requireString(revision.descriptor_hash, `revisions.${key}.descriptor_hash`, 64);
+  if (!/^[a-f0-9]{64}$/.test(hash)) throw new GraphStateValidationError(`revision ${key} hash is invalid`);
+  if (revisionId !== key) throw new GraphStateValidationError(`revision key ${key} does not match revision_id`);
+  const descriptor = parseGraphDescriptor(revision.descriptor) as SealedGraphDescriptor;
+  if (!verifyDescriptorHash(descriptor) || descriptor.descriptor_hash !== hash) {
+    throw new GraphStateValidationError(`revision ${key} descriptor hash mismatch`);
+  }
+  if (descriptor.revision_id !== key || descriptor.run_id !== runId) {
+    throw new GraphStateValidationError(`revision ${key} descriptor identity mismatch`);
+  }
+  requireTimestamp(revision.created_at, `revisions.${key}.created_at`);
+  if (!Array.isArray(revision.invalidated_node_ids)) {
+    throw new GraphStateValidationError(`revisions.${key}.invalidated_node_ids must be an array`);
+  }
+  requireStringArray(revision.invalidated_node_ids, `revisions.${key}.invalidated_node_ids`, 1_000);
+  if (revision.approval !== undefined) validateApproval(revision.approval, `revisions.${key}.approval`, key, hash);
+  return value as GraphRevisionRecord;
+}
+
+export function parseGraphState(input: unknown): GraphState {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(input);
+  } catch (error) {
+    throw new GraphStateValidationError(`state is not JSON serializable: ${String(error)}`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > GRAPH_STATE_MAX_BYTES) {
+    throw new GraphStateValidationError(`state exceeds ${GRAPH_STATE_MAX_BYTES} bytes`);
+  }
+  const state = requireRecord(input, 'state');
+  assertExactKeys(state, [
+    'format_version', 'session_id', 'run_id', 'control_nonce', 'status', 'active_revision_id',
+    'active_revision_hash', 'dispatch_generation', 'commit_sequence', 'revisions',
+    'transitions', 'projection', 'claims', 'reconciliations', 'diagnostics',
+    'created_at', 'updated_at',
+  ], ['pending_approval', 'pending_patch'], 'state');
+  if (state.format_version !== GRAPH_STATE_FORMAT_VERSION) {
+    throw new GraphStateValidationError('unsupported format_version');
+  }
+  const sessionId = requireString(state.session_id, 'session_id', 256);
+  const runId = requireString(state.run_id, 'run_id', 128);
+  requireString(state.control_nonce, 'control_nonce', 128);
+  const activeRevisionId = requireString(state.active_revision_id, 'active_revision_id', 128);
+  const activeHash = requireString(state.active_revision_hash, 'active_revision_hash', 64);
+  if (!/^[a-f0-9]{64}$/.test(activeHash)) throw new GraphStateValidationError('active_revision_hash is invalid');
+  requireInteger(state.dispatch_generation, 'dispatch_generation');
+  const sequence = requireInteger(state.commit_sequence, 'commit_sequence', GRAPH_MAX_TRANSITIONS);
+  requireTimestamp(state.created_at, 'created_at');
+  requireTimestamp(state.updated_at, 'updated_at');
+  const statuses: GraphRunStatus[] = [
+    'draft', 'awaiting_approval', 'running', 'waiting_human', 'waiting_patch_approval',
+    'reconciling', 'paused', 'failed', 'cancelled', 'succeeded',
+  ];
+  if (!statuses.includes(state.status as GraphRunStatus)) throw new GraphStateValidationError('invalid status');
+
+  const revisions = requireRecord(state.revisions, 'revisions');
+  for (const [key, revision] of Object.entries(revisions)) validateRevision(revision, key, runId);
+  const active = revisions[activeRevisionId] as GraphRevisionRecord | undefined;
+  if (!active || active.descriptor_hash !== activeHash) {
+    throw new GraphStateValidationError('active revision/hash is not embedded');
+  }
+  const approvedStatuses = new Set<GraphRunStatus>([
+    'running', 'waiting_human', 'waiting_patch_approval', 'reconciling', 'paused',
+    'failed', 'cancelled', 'succeeded',
+  ]);
+  if (approvedStatuses.has(state.status as GraphRunStatus) && !active.approval) {
+    throw new GraphStateValidationError(`status ${String(state.status)} requires exact active revision approval`);
+  }
+
+  if (!Array.isArray(state.transitions) || state.transitions.length > GRAPH_MAX_TRANSITIONS) {
+    throw new GraphStateValidationError('transitions exceed the configured bound');
+  }
+  const transitionIds = new Set<string>();
+  let priorSequence = 0;
+  for (const raw of state.transitions) {
+    const transition = requireRecord(raw, 'transition');
+    assertExactKeys(transition, [
+      'transition_id', 'operation', 'operation_fingerprint', 'request_fingerprint',
+      'sequence', 'committed_at', 'result',
+    ], [], 'transition');
+    const id = requireString(transition.transition_id, 'transition.transition_id', 128);
+    if (transitionIds.has(id)) throw new GraphStateValidationError(`duplicate transition ${id}`);
+    transitionIds.add(id);
+    const currentSequence = requireInteger(transition.sequence, 'transition.sequence', GRAPH_MAX_TRANSITIONS);
+    if (currentSequence <= priorSequence) throw new GraphStateValidationError('transition sequence is not monotonic');
+    priorSequence = currentSequence;
+    requireString(transition.operation, 'transition.operation', 128);
+    requireString(transition.operation_fingerprint, 'transition.operation_fingerprint', 1_024);
+    const fingerprint = requireString(transition.request_fingerprint, 'transition.request_fingerprint', 64);
+    if (!/^[a-f0-9]{64}$/.test(fingerprint)) {
+      throw new GraphStateValidationError(`transition ${id} request_fingerprint is invalid`);
+    }
+    requireTimestamp(transition.committed_at, 'transition.committed_at');
+    if (Buffer.byteLength(JSON.stringify(transition.result), 'utf8') > GRAPH_MAX_TRANSITION_RESULT_BYTES) {
+      throw new GraphStateValidationError(`transition ${id} result exceeds the configured bound`);
+    }
+  }
+  if (state.transitions.length > 0 && priorSequence !== sequence) {
+    throw new GraphStateValidationError('commit_sequence does not match transition history');
+  }
+  if (state.transitions.length === 0 && sequence !== 0) {
+    throw new GraphStateValidationError('nonzero commit_sequence has no transition history');
+  }
+
+  validateProjection(state.projection, active.descriptor);
+  const claims = requireRecord(state.claims, 'claims');
+  const reconciliations = requireRecord(state.reconciliations, 'reconciliations');
+  if (Object.keys(claims).length > GRAPH_MAX_CLAIMS) throw new GraphStateValidationError('claims exceed the configured bound');
+  if (Object.keys(reconciliations).length > GRAPH_MAX_RECONCILIATIONS) {
+    throw new GraphStateValidationError('reconciliations exceed the configured bound');
+  }
+  for (const [leaseId, raw] of Object.entries(claims)) {
+    const claim = requireRecord(raw, `claims.${leaseId}`);
+    assertExactKeys(claim, [
+      'run_id', 'revision_id', 'revision_hash', 'dispatch_generation', 'activation_id',
+      'attempt_id', 'attempt_no', 'claim_owner_session_id', 'driver_instance_id',
+      'lease_id', 'tracking_id', 'issued_at', 'expires_at', 'lease_duration_ms',
+      'renewal_count', 'max_renewals', 'effect_policy', 'status',
+    ], [
+      'external_idempotency_key', 'last_renewed_at', 'fenced_at', 'replacement_lease_id',
+    ], `claims.${leaseId}`);
+    if (claim.lease_id !== leaseId) throw new GraphStateValidationError(`claim key ${leaseId} mismatches identity`);
+    if (claim.run_id !== runId) throw new GraphStateValidationError(`claim ${leaseId} run fence mismatches`);
+    const revisionId = requireString(claim.revision_id, `claims.${leaseId}.revision_id`, 128);
+    const revisionHash = requireString(claim.revision_hash, `claims.${leaseId}.revision_hash`, 64);
+    const claimRevision = revisions[revisionId] as GraphRevisionRecord | undefined;
+    if (!claimRevision || claimRevision.descriptor_hash !== revisionHash) {
+      throw new GraphStateValidationError(`claim ${leaseId} revision fence is invalid`);
+    }
+    requireInteger(claim.dispatch_generation, `claims.${leaseId}.dispatch_generation`);
+    const activationId = requireString(claim.activation_id, `claims.${leaseId}.activation_id`, 128);
+    const activation = (state.projection as GraphSchedulerProjection).activations[activationId];
+    if (!activation) throw new GraphStateValidationError(`claim ${leaseId} references unknown activation`);
+    const attemptId = requireString(claim.attempt_id, `claims.${leaseId}.attempt_id`, 128);
+    const attemptNo = requireInteger(claim.attempt_no, `claims.${leaseId}.attempt_no`, 20);
+    if (!activation.attempt_ids.includes(attemptId) || activation.attempt_no < attemptNo) {
+      throw new GraphStateValidationError(`claim ${leaseId} attempt fence is invalid`);
+    }
+    for (const property of ['claim_owner_session_id', 'driver_instance_id', 'tracking_id'] as const) {
+      requireString(claim[property], `claims.${leaseId}.${property}`, 256);
+    }
+    const issued = requireTimestamp(claim.issued_at, `claims.${leaseId}.issued_at`);
+    const expires = requireTimestamp(claim.expires_at, `claims.${leaseId}.expires_at`);
+    const duration = requireInteger(claim.lease_duration_ms, `claims.${leaseId}.lease_duration_ms`, 86_400_000);
+    const leaseStart = claim.last_renewed_at === undefined
+      ? issued
+      : requireTimestamp(claim.last_renewed_at, `claims.${leaseId}.last_renewed_at`);
+    if (duration <= 0 || Date.parse(expires) - Date.parse(leaseStart) !== duration) {
+      throw new GraphStateValidationError(`claim ${leaseId} lease duration is inconsistent`);
+    }
+    const renewals = requireInteger(claim.renewal_count, `claims.${leaseId}.renewal_count`, 20);
+    const maxRenewals = requireInteger(claim.max_renewals, `claims.${leaseId}.max_renewals`, 20);
+    if (renewals > maxRenewals) throw new GraphStateValidationError(`claim ${leaseId} renewal cap is exceeded`);
+    const policy = validateEffectPolicy(claim.effect_policy, `claims.${leaseId}.effect_policy`);
+    if (policy.policy === 'idempotent') {
+      requireString(claim.external_idempotency_key, `claims.${leaseId}.external_idempotency_key`, 512);
+    } else if (claim.external_idempotency_key !== undefined) {
+      throw new GraphStateValidationError(`claim ${leaseId} has an unexpected idempotency key`);
+    }
+    if (!['live', 'completed', 'expired_retryable', 'abandoned_retryable', 'reconciling', 'fenced'].includes(String(claim.status))) {
+      throw new GraphStateValidationError(`claim ${leaseId} has invalid status`);
+    }
+    if (claim.status !== 'live' && claim.fenced_at === undefined) {
+      throw new GraphStateValidationError(`non-live claim ${leaseId} requires fenced_at`);
+    }
+    if (claim.fenced_at !== undefined) requireTimestamp(claim.fenced_at, `claims.${leaseId}.fenced_at`);
+    if (claim.replacement_lease_id !== undefined) {
+      requireString(claim.replacement_lease_id, `claims.${leaseId}.replacement_lease_id`, 128);
+    }
+  }
+
+  for (const [id, raw] of Object.entries(reconciliations)) {
+    const record = requireRecord(raw, `reconciliations.${id}`);
+    assertExactKeys(record, [
+      'reconciliation_id', 'activation_id', 'attempt_id', 'lease_id', 'revision_id',
+      'revision_hash', 'dispatch_generation', 'status', 'reason', 'created_at',
+    ], ['resolved_at', 'resolution_evidence'], `reconciliations.${id}`);
+    if (record.reconciliation_id !== id) throw new GraphStateValidationError(`reconciliation key ${id} mismatches identity`);
+    const leaseId = requireString(record.lease_id, `reconciliations.${id}.lease_id`, 128);
+    const claim = claims[leaseId] as Record<string, unknown> | undefined;
+    if (!claim || record.activation_id !== claim.activation_id || record.attempt_id !== claim.attempt_id) {
+      throw new GraphStateValidationError(`reconciliation ${id} claim lineage is invalid`);
+    }
+    if (record.revision_id !== claim.revision_id || record.revision_hash !== claim.revision_hash
+      || record.dispatch_generation !== claim.dispatch_generation) {
+      throw new GraphStateValidationError(`reconciliation ${id} revision fence is invalid`);
+    }
+    if (!['unresolved', 'committed', 'proved_not_applied', 'accepted', 'invalidated'].includes(String(record.status))) {
+      throw new GraphStateValidationError(`reconciliation ${id} status is invalid`);
+    }
+    if (!['expired_ambiguous', 'session_end_ambiguous', 'external_effect_ambiguous'].includes(String(record.reason))) {
+      throw new GraphStateValidationError(`reconciliation ${id} reason is invalid`);
+    }
+    requireTimestamp(record.created_at, `reconciliations.${id}.created_at`);
+    if (record.status === 'unresolved' && (record.resolved_at !== undefined || record.resolution_evidence !== undefined)) {
+      throw new GraphStateValidationError(`unresolved reconciliation ${id} cannot have resolution fields`);
+    }
+    if (record.status !== 'unresolved') {
+      requireTimestamp(record.resolved_at, `reconciliations.${id}.resolved_at`);
+      validateEvidence(record.resolution_evidence, `reconciliations.${id}.resolution_evidence`);
+    }
+  }
+
+  if (!Array.isArray(state.diagnostics) || state.diagnostics.length > GRAPH_MAX_DIAGNOSTICS) {
+    throw new GraphStateValidationError('diagnostics exceed the configured bound');
+  }
+  state.diagnostics.forEach((raw, index) => {
+    const diagnostic = requireRecord(raw, `diagnostics[${index}]`);
+    assertExactKeys(diagnostic, ['kind', 'recorded_at', 'summary'], [
+      'activation_id', 'attempt_id', 'lease_id',
+    ], `diagnostics[${index}]`);
+    if (!['late_result', 'operation', 'recovery', 'control'].includes(String(diagnostic.kind))) {
+      throw new GraphStateValidationError(`diagnostics[${index}].kind is invalid`);
+    }
+    requireTimestamp(diagnostic.recorded_at, `diagnostics[${index}].recorded_at`);
+    requireString(diagnostic.summary, `diagnostics[${index}].summary`, 8_192);
+    for (const property of ['activation_id', 'attempt_id', 'lease_id'] as const) {
+      if (diagnostic[property] !== undefined) requireString(diagnostic[property], `diagnostics[${index}].${property}`, 128);
+    }
+  });
+
+  if (state.pending_approval !== undefined) {
+    const pending = requireRecord(state.pending_approval, 'pending_approval');
+    assertExactKeys(pending, ['revision_id', 'revision_hash', 'requested_at'], [], 'pending_approval');
+    if (pending.revision_id !== activeRevisionId || pending.revision_hash !== activeHash) {
+      throw new GraphStateValidationError('pending approval does not bind the active revision/hash');
+    }
+    requireTimestamp(pending.requested_at, 'pending_approval.requested_at');
+  }
+  if (state.status === 'awaiting_approval' && !state.pending_approval) {
+    throw new GraphStateValidationError('awaiting_approval requires pending_approval');
+  }
+  if (state.status !== 'awaiting_approval' && state.pending_approval) {
+    throw new GraphStateValidationError('pending_approval must be absent outside awaiting_approval');
+  }
+  if (state.pending_approval && active.approval) {
+    throw new GraphStateValidationError('approved revision cannot remain pending approval');
+  }
+  if (!active.approval && Object.values((state.projection as GraphSchedulerProjection).activations).some(
+    (activation) => activation.status === 'ready' || activation.status === 'running',
+  )) {
+    throw new GraphStateValidationError('unapproved graph cannot expose claimable work');
+  }
+
+  if (state.pending_patch !== undefined) {
+    const patch = requireRecord(state.pending_patch, 'pending_patch');
+    assertExactKeys(patch, [
+      'proposal_id', 'base_revision_id', 'base_revision_hash', 'base_dispatch_generation',
+      'proposed_revision_id', 'proposed_revision_hash', 'proposed_descriptor',
+      'invalidated_node_ids', 'proposal_evidence', 'proposed_at',
+    ], [], 'pending_patch');
+    requireString(patch.proposal_id, 'pending_patch.proposal_id', 128);
+    if (patch.base_revision_id !== activeRevisionId || patch.base_revision_hash !== activeHash) {
+      throw new GraphStateValidationError('pending patch base does not bind active revision/hash');
+    }
+    const baseGeneration = requireInteger(patch.base_dispatch_generation, 'pending_patch.base_dispatch_generation');
+    if (baseGeneration + 1 !== state.dispatch_generation) {
+      throw new GraphStateValidationError('pending patch dispatch generation is invalid');
+    }
+    const proposed = parseGraphDescriptor(patch.proposed_descriptor) as SealedGraphDescriptor;
+    if (!verifyDescriptorHash(proposed)
+      || proposed.revision_id !== patch.proposed_revision_id
+      || proposed.descriptor_hash !== patch.proposed_revision_hash
+      || proposed.run_id !== runId
+      || proposed.revision_id === activeRevisionId) {
+      throw new GraphStateValidationError('pending patch proposed descriptor identity/hash is invalid');
+    }
+    requireStringArray(patch.invalidated_node_ids, 'pending_patch.invalidated_node_ids', 1_000);
+    if (!Array.isArray(patch.proposal_evidence) || patch.proposal_evidence.length > 64) {
+      throw new GraphStateValidationError('pending patch proposal evidence is invalid');
+    }
+    patch.proposal_evidence.forEach((item, index) => validateEvidence(item, `pending_patch.proposal_evidence[${index}]`));
+    requireTimestamp(patch.proposed_at, 'pending_patch.proposed_at');
+  }
+  if (state.pending_patch && state.status !== 'waiting_patch_approval') {
+    throw new GraphStateValidationError('pending_patch requires waiting_patch_approval status');
+  }
+  if (!state.pending_patch && state.status === 'waiting_patch_approval') {
+    throw new GraphStateValidationError('waiting_patch_approval requires pending_patch');
+  }
+  if (Object.values(claims).some(
+    (raw) => (raw as Record<string, unknown>).claim_owner_session_id !== sessionId,
+  )) {
+    throw new GraphStateValidationError('claim owner session does not match graph authority session');
+  }
+  return clone(input as GraphState);
+}
+
+export type GraphControlMode =
+  | 'graph'
+  | 'autopilot'
+  | 'autoresearch'
+  | 'ralph'
+  | 'team'
+  | 'ultrawork'
+  | 'ultraqa'
+  | 'ralplan'
+  | 'deep-interview'
+  | 'self-improve';
+
+export interface GraphProcessIdentity {
+  pid: number;
+  process_start: string;
+}
+
+export interface GraphDriverLease {
+  driver_instance_id: string;
+  lease_id: string;
+  expires_at: string;
+}
+
+export interface GraphClaimLineage {
+  activation_id: string;
+  attempt_id: string;
+  lease_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+}
+
+export interface ControlLineageIdentity {
+  mode: GraphControlMode;
+  session_id: string;
+  run_id: string;
+}
+
+export interface ControlChildRegistration extends ControlLineageIdentity {
+  parent: ControlLineageIdentity;
+  graph_claim?: GraphClaimLineage;
+  registered_at: string;
+}
+
+export interface ControlRoot extends ControlLineageIdentity {
+  nonce: string;
+  phase: 'reserved' | 'active';
+  reservation_process: GraphProcessIdentity;
+  driver_lease?: GraphDriverLease;
+  graph_revision?: { revision_id: string; revision_hash: string };
+  children: ControlChildRegistration[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ControlReleaseRecord {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  disposition: 'paused' | 'terminal';
+  released_at: string;
+}
+
+export interface ControlOwnerState {
+  format_version: 1;
+  session_id: string;
+  generation: number;
+  root: ControlRoot | null;
+  last_release?: ControlReleaseRecord;
+  updated_at: string;
+}

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -1,0 +1,1372 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalJson, parseGraphDescriptor, sealGraphDescriptor } from './descriptor.js';
+import {
+  issueGraphClaim,
+  recoverExpiredGraphClaim,
+  recordLateClaimResult,
+  renewGraphClaim,
+  settleDriverClaims,
+} from './claims.js';
+import { approveGraphPatch, approvePendingGraphRevision, proposeGraphPatch } from './revisions.js';
+import {
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+  releaseAttemptForRetry,
+  resolveJoin,
+} from './scheduler.js';
+import { ControlOwnerStore } from './control-owner.js';
+import { createInitialGraphState, type GraphClaim, type GraphState, type JsonValue } from './runtime-types.js';
+import { GraphStateStore } from './store.js';
+import type {
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from './types.js';
+
+type GraphCommandOperation =
+  | 'create' | 'inspect' | 'approve' | 'ready' | 'claim' | 'complete' | 'fail'
+  | 'propose-patch' | 'approve-patch' | 'status' | 'pause' | 'abandon' | 'resume'
+  | 'settle-session'
+  | 'resolve-join'
+  | 'renew-claim' | 'recover-expired-claim' | 'record-late-claim-result'
+  | 'release-attempt-for-retry'
+  | 'resolve-reconciliation';
+
+interface GraphCommandRequest {
+  operation: GraphCommandOperation;
+  cwd: string;
+  input: Readonly<Record<string, unknown>>;
+}
+
+interface GraphCommandService {
+  execute(request: GraphCommandRequest): Promise<unknown>;
+}
+
+const DRIVER_LEASE_DURATION_MS = 60 * 60 * 1000;
+// Human-approval waits are durable (no busy-poll). The claim lease is a bounded
+// placeholder so the waiting claim survives state validation; renewals are not
+// used because the wait is event-driven via the in-session question surface.
+const HUMAN_APPROVAL_LEASE_MS = 60 * 60 * 1000;
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireObject<T = Record<string, unknown>>(value: unknown, field: string): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${field} must be a JSON object`);
+  }
+  return value as T;
+}
+
+function requireInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value as number;
+}
+
+function requireEvidence(value: unknown, field: string): GraphEvidenceReference {
+  const evidence = requireObject(value, field);
+  const kind = requireString(evidence.kind, `${field}.kind`);
+  if (!['file', 'command', 'test', 'human', 'url'].includes(kind)) {
+    throw new Error(`${field}.kind is invalid`);
+  }
+  requireString(evidence.ref, `${field}.ref`);
+  return evidence as unknown as GraphEvidenceReference;
+}
+
+function buildFence(state: GraphState) {
+  return {
+    session_id: state.session_id,
+    run_id: state.run_id,
+    revision_id: state.active_revision_id,
+    revision_hash: state.active_revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    commit_sequence: state.commit_sequence,
+  };
+}
+
+function operationFingerprint(operation: string, input: Readonly<Record<string, unknown>>): string {
+  return canonicalJson({ operation, input });
+}
+
+function entryActivationIdsFor(descriptor: SealedGraphDescriptor): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const nodeId of descriptor.entry_node_ids) {
+    result[nodeId] = `${descriptor.run_id}:act:${nodeId}:entry`;
+  }
+  return result;
+}
+
+function driverLease(driverInstanceId: string, issuedAt: string) {
+  return {
+    driver_instance_id: driverInstanceId,
+    lease_id: randomUUID(),
+    expires_at: new Date(Date.parse(issuedAt) + DRIVER_LEASE_DURATION_MS).toISOString(),
+  };
+}
+
+function summarizeState(state: GraphState) {
+  return {
+    run_id: state.run_id,
+    session_id: state.session_id,
+    status: state.status,
+    active_revision_id: state.active_revision_id,
+    active_revision_hash: state.active_revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    commit_sequence: state.commit_sequence,
+    control_nonce: state.control_nonce,
+    transition_count: state.transitions.length,
+    claim_count: Object.keys(state.claims).length,
+    live_claim_count: Object.values(state.claims).filter((claim) => claim.status === 'live').length,
+    unresolved_reconciliation_count: Object.values(state.reconciliations).filter((record) => record.status === 'unresolved').length,
+    diagnostic_count: state.diagnostics.length,
+    succeeded: isGraphSucceeded(state.revisions[state.active_revision_id].descriptor, state.projection),
+    pending_approval: state.pending_approval ?? null,
+    pending_patch: state.pending_patch ? {
+      proposal_id: state.pending_patch.proposal_id,
+      base_revision_id: state.pending_patch.base_revision_id,
+      proposed_revision_id: state.pending_patch.proposed_revision_id,
+      invalidated_node_ids: state.pending_patch.invalidated_node_ids,
+    } : null,
+  };
+}
+
+function readinessView(state: GraphState) {
+  const descriptor = state.revisions[state.active_revision_id].descriptor;
+  const executable = listReadyExecutableActivations(descriptor, state.projection).map((activation) => ({
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    attempt_no: activation.attempt_no,
+  }));
+  const joins = listReadyJoinActivations(descriptor, state.projection).map((activation) => ({
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    cohort_id: activation.cohort_id,
+  }));
+  const liveClaims = Object.values(state.claims)
+    .filter((claim) => claim.status === 'live')
+    .map((claim) => ({
+      lease_id: claim.lease_id,
+      activation_id: claim.activation_id,
+      attempt_id: claim.attempt_id,
+      expires_at: claim.expires_at,
+    }));
+  return {
+    executable,
+    joins,
+    live_claims: liveClaims,
+    available_slots: Math.max(0, descriptor.concurrency_limit - liveClaims.length),
+  };
+}
+
+async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<unknown> {
+  const goal = requireString(input.goal, 'goal');
+  const descriptorInput = requireObject(input.descriptor, 'descriptor');
+  const sessionId = requireString(input.session_id, 'session_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const parsed = parseGraphDescriptor(descriptorInput);
+  const sealed = sealGraphDescriptor(parsed);
+  if (sealed.goal !== goal) {
+    throw new Error('descriptor goal does not match --goal');
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const existing = store.read();
+  if (existing) {
+    if (existing.run_id !== sealed.run_id) {
+      throw new Error(`graph state already exists for session ${sessionId} with a different run_id`);
+    }
+    // Idempotent retry: only return the existing graph when the exact descriptor
+    // hash matches. Retrying create with a modified descriptor must NOT silently
+    // return the old graph.
+    if (existing.active_revision_hash !== sealed.descriptor_hash) {
+      throw new Error(
+        `hash_mismatch: graph state already exists for run ${sealed.run_id} with descriptor hash ${existing.active_revision_hash}, cannot replace with ${sealed.descriptor_hash}`,
+      );
+    }
+    return summarizeState(existing);
+  }
+
+  const initialProjection: GraphSchedulerProjection = {
+    activations: {},
+    cohorts: {},
+    branch_tokens: {},
+    traversal_counts: {},
+    committed_transitions: {},
+    terminal_verification_activation_ids: [],
+  };
+
+  const controlNonce = randomUUID();
+  const createdAt = now();
+
+  const initialState = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: controlNonce,
+    descriptor: sealed,
+    projection: initialProjection,
+    status: 'awaiting_approval',
+    created_at: createdAt,
+  });
+
+  const created = store.create(initialState);
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  controlStore.reserveRoot({
+    mode: 'graph',
+    run_id: sealed.run_id,
+    nonce: controlNonce,
+    reserved_at: createdAt,
+    graph_revision: { revision_id: sealed.revision_id, revision_hash: sealed.descriptor_hash },
+  });
+
+  return {
+    run_id: created.run_id,
+    revision_id: created.active_revision_id,
+    descriptor_hash: created.active_revision_hash,
+    status: created.status,
+    control_nonce: created.control_nonce,
+    created_at: created.created_at,
+    transition_id: transitionId,
+    driver_id: driverId,
+  };
+}
+
+function executeInspect(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  const descriptor = state.revisions[state.active_revision_id].descriptor;
+  return {
+    summary: summarizeState(state),
+    descriptor: {
+      run_id: descriptor.run_id,
+      revision_id: descriptor.revision_id,
+      goal: descriptor.goal,
+      descriptor_hash: descriptor.descriptor_hash,
+      entry_node_ids: descriptor.entry_node_ids,
+      terminal_verification_node_id: descriptor.terminal_verification_node_id,
+      concurrency_limit: descriptor.concurrency_limit,
+      node_count: descriptor.nodes.length,
+      edge_count: descriptor.edges.length,
+    },
+    readiness: readinessView(state),
+  };
+}
+
+function executeStatus(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  return { summary: summarizeState(state), readiness: readinessView(state) };
+}
+
+function executeReady(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  if (state.active_revision_id !== revisionId || state.active_revision_hash !== descriptorHash) {
+    throw new Error('revision/hash fence does not match active revision');
+  }
+  if (state.commit_sequence !== expectedSequence) {
+    throw new Error(`expected sequence ${expectedSequence}, found ${state.commit_sequence}`);
+  }
+  return readinessView(state);
+}
+
+function executeApprove(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const approvalInput = requireObject(input.approval, 'approval');
+  const approvedAt = requireString(approvalInput.approved_at ?? approvalInput.approvedAt, 'approval.approved_at');
+  const evidence = requireEvidence(approvalInput.evidence ?? approvalInput.approval_evidence, 'approval.evidence');
+  const driverId = requireString(approvalInput.driver_id ?? approvalInput.driverId, 'approval.driver_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'approve',
+    operation_fingerprint: operationFingerprint('approve', { revisionId, descriptorHash, driverId, approvedAt, evidence: evidence.ref }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: 0,
+    },
+  }, (current) => {
+    if (current.status !== 'awaiting_approval') {
+      throw new Error(`cannot approve graph in status ${current.status}`);
+    }
+    const next = approvePendingGraphRevision(current, {
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      approved_at: approvedAt,
+      approval_evidence: evidence,
+    }, (descriptor) => initializeGraphProjection(descriptor, entryActivationIdsFor(descriptor)));
+    return { next, result: { approved: true, revision_id: revisionId } };
+  });
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  // NOTE (finding #5): mutate-then-control ordering is intentionally retained here. Unlike
+  // executeResume, the control op is promoteRoot (the root was reserved during executeCreate),
+  // so if mutate throws, promote never runs and there is NO divergence. If mutate succeeds and
+  // promote throws, the graph is 'running' with a still-reserved root (phase='reserved'), which
+  // is recoverable via recoverGraphReservation. Reordering to control-first would trade this
+  // recoverable divergence for an active-root-over-awaiting_approval state whose cleanup would
+  // release a root that executeCreate reserved (a different, non-minimal compensation), so the
+  // reorder is not clearly safer here.
+  if (!result.replayed) {
+    controlStore.promoteRoot({
+      mode: 'graph',
+      run_id: runId,
+      nonce: result.state.control_nonce,
+      promoted_at: approvedAt,
+      driver_lease: driverLease(driverId, approvedAt),
+    });
+  }
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeClaim(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const limit = requireInteger(input.limit, 'limit');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'claim',
+    operation_fingerprint: operationFingerprint('claim', { revisionId, descriptorHash, expectedSequence, driverId, limit }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'running') {
+      throw new Error(`cannot claim while graph status is ${current.status}`);
+    }
+    const descriptor = current.revisions[current.active_revision_id].descriptor;
+    const liveCount = Object.values(current.claims).filter((claim) => claim.status === 'live').length;
+    const available = Math.min(limit, Math.max(0, descriptor.concurrency_limit - liveCount));
+    if (available === 0) {
+      return { next: current, result: { claims: [], available_slots: 0 } };
+    }
+    const ready = listReadyExecutableActivations(descriptor, current.projection).slice(0, available);
+    const issuedAt = now();
+    const issued: JsonValue[] = [];
+    let working = current;
+    for (const activation of ready) {
+      const attemptId = randomUUID();
+      const leaseId = randomUUID();
+      const trackingId = randomUUID();
+      const projection = beginActivationAttempt(working.projection, {
+        activation_id: activation.activation_id,
+        attempt_id: attemptId,
+      });
+      const node = descriptor.nodes.find((candidate) => candidate.id === activation.node_id);
+      if (!node) {
+        throw new Error(`activation ${activation.activation_id} has no matching node`);
+      }
+      if (node.kind === 'human-approval') {
+        // B6: human-approval nodes are executable via the in-session question surface.
+        // Issue a durable claim that fences the activation while we wait for the human
+        // answer, then transition the run to 'waiting_human' so the driver yields. The
+        // subsequent `complete` operation records the human's answer as the node result
+        // and fences this claim like any other. We bypass issueGraphClaim because
+        // human-approval nodes carry no effect_policy/timeout_ms; we build the claim
+        // directly using a bounded, authority-scoped lease.
+        const attemptId = randomUUID();
+        const leaseId = randomUUID();
+        const trackingId = randomUUID();
+        const projection = beginActivationAttempt(working.projection, {
+          activation_id: activation.activation_id,
+          attempt_id: attemptId,
+        });
+        const issuedAt = now();
+        const humanClaim: GraphClaim = {
+          run_id: working.run_id,
+          revision_id: working.active_revision_id,
+          revision_hash: working.active_revision_hash,
+          dispatch_generation: working.dispatch_generation,
+          activation_id: activation.activation_id,
+          attempt_id: attemptId,
+          attempt_no: activation.attempt_no + 1,
+          claim_owner_session_id: sessionId,
+          driver_instance_id: driverId,
+          lease_id: leaseId,
+          tracking_id: trackingId,
+          issued_at: issuedAt,
+          expires_at: new Date(Date.parse(issuedAt) + HUMAN_APPROVAL_LEASE_MS).toISOString(),
+          lease_duration_ms: HUMAN_APPROVAL_LEASE_MS,
+          renewal_count: 0,
+          max_renewals: 0,
+          effect_policy: { policy: 'side_effect_free' },
+          status: 'live' as const,
+        };
+        const intermediate: GraphState = {
+          ...working,
+          projection,
+          claims: { ...working.claims, [leaseId]: humanClaim },
+          status: 'waiting_human' as const,
+        };
+        working = intermediate;
+        issued.push({
+          lease_id: leaseId,
+          activation_id: activation.activation_id,
+          attempt_id: attemptId,
+          attempt_no: activation.attempt_no + 1,
+          tracking_id: trackingId,
+          expires_at: issuedAt,
+          node_id: activation.node_id,
+          kind: 'human-approval',
+          waiting_human: true,
+        });
+        continue;
+      }
+      if (node.kind !== 'agent' && node.kind !== 'command') {
+        throw new Error(`activation ${activation.activation_id} is not on an executable node`);
+      }
+      const intermediate: GraphState = { ...working, projection };
+      const claimResult = issueGraphClaim(intermediate, {
+        activation_id: activation.activation_id,
+        attempt_id: attemptId,
+        attempt_no: activation.attempt_no + 1,
+        claim_owner_session_id: sessionId,
+        driver_instance_id: driverId,
+        lease_id: leaseId,
+        tracking_id: trackingId,
+        issued_at: issuedAt,
+        execution_timeout_ms: node.timeout_ms,
+        grace_ms: 5 * 60 * 1000,
+        max_renewals: 3,
+        effect_policy: node.effect_policy,
+        ...(node.effect_policy.policy === 'idempotent'
+          ? { external_idempotency_key: `${node.effect_policy.idempotency_key_template}-${attemptId}` }
+          : {}),
+      });
+      working = claimResult.state;
+      issued.push({
+        lease_id: claimResult.claim.lease_id,
+        activation_id: claimResult.claim.activation_id,
+        attempt_id: claimResult.claim.attempt_id,
+        attempt_no: claimResult.claim.attempt_no,
+        tracking_id: claimResult.claim.tracking_id,
+        expires_at: claimResult.claim.expires_at,
+        node_id: activation.node_id,
+      });
+    }
+    return { next: working, result: { claims: issued, available_slots: descriptor.concurrency_limit - liveCount - issued.length } };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function applyResultOperation(
+  operation: 'complete' | 'fail',
+  input: Readonly<Record<string, unknown>>,
+): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const claimInput = requireObject(input.claim, 'claim');
+  const resultInput = requireObject(input.result, 'result');
+
+  const leaseId = requireString(claimInput.lease_id, 'claim.lease_id');
+  const activationId = requireString(claimInput.activation_id, 'claim.activation_id');
+  const attemptId = requireString(claimInput.attempt_id, 'claim.attempt_id');
+  const outcome = requireString(resultInput.outcome, 'result.outcome');
+  const route = typeof resultInput.route === 'string' ? resultInput.route : undefined;
+  const outputSummary = typeof resultInput.output_summary === 'string' ? resultInput.output_summary : undefined;
+  const evidenceRefsRaw = Array.isArray(resultInput.evidence_refs) ? resultInput.evidence_refs : [];
+  const evidenceRefs = evidenceRefsRaw.map((value, index) => requireEvidence(value, `result.evidence_refs[${index}]`));
+  const externalIdempotencyKey = typeof resultInput.external_idempotency_key === 'string'
+    ? resultInput.external_idempotency_key
+    : undefined;
+  // Optional scheduler identities for edges the runtime does not auto-generate.
+  // Currently only join_activation_id is caller-supplied (used when completing a
+  // branch whose arrival fills the cohort and activates the join).
+  const identitiesInput = input.identities && typeof input.identities === 'object' && !Array.isArray(input.identities)
+    ? input.identities as Record<string, unknown>
+    : {};
+  const joinActivationId = typeof identitiesInput.join_activation_id === 'string'
+    ? identitiesInput.join_activation_id
+    : undefined;
+
+  if (operation === 'complete' && outcome !== 'succeeded') {
+    throw new Error('complete requires outcome=succeeded; use fail for failed results');
+  }
+  if (operation === 'fail' && outcome !== 'failed') {
+    throw new Error('fail requires outcome=failed; use complete for succeeded results');
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation,
+    operation_fingerprint: operationFingerprint(operation, { leaseId, activationId, attemptId, outcome, route, outputSummary, evidenceRefs }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    const claim = current.claims[leaseId];
+    if (!claim) throw new Error(`claim ${leaseId} not found`);
+    if (claim.status !== 'live') throw new Error(`claim ${leaseId} is not live (status=${claim.status})`);
+    if (claim.activation_id !== activationId || claim.attempt_id !== attemptId) {
+      throw new Error('claim fence does not match provided activation/attempt');
+    }
+    const descriptor = current.revisions[current.active_revision_id].descriptor;
+    const activationNodeId = current.projection.activations[activationId]?.node_id;
+    const edgesForNode = descriptor.edges.filter((edge) => edge.from === activationNodeId);
+    const nextActivationIds: Record<string, string> = {};
+    const branchTokenIds: Record<string, string> = {};
+    let cohortId: string | undefined;
+    const hasFanOut = edgesForNode.some((edge) => edge.kind === 'fan_out');
+    if (hasFanOut) {
+      cohortId = randomUUID();
+    }
+    for (const edge of edgesForNode) {
+      nextActivationIds[edge.id] = `${descriptor.run_id}:act:${edge.to}:${randomUUID()}`;
+      if (edge.kind === 'fan_out') {
+        branchTokenIds[edge.id] = `${descriptor.run_id}:token:${edge.branch_id}:${randomUUID()}`;
+      }
+    }
+    const schedulerResult = applyNodeResult(descriptor, current.projection, {
+      transition_id: transitionId,
+      activation_id: activationId,
+      identities: {
+        next_activation_ids: nextActivationIds,
+        ...(cohortId ? { cohort_id: cohortId } : {}),
+        ...(hasFanOut ? { branch_token_ids: branchTokenIds } : {}),
+        ...(joinActivationId ? { join_activation_id: joinActivationId } : {}),
+      },
+      result: {
+        attempt_id: attemptId,
+        outcome: outcome as 'succeeded' | 'failed',
+        evidence_refs: evidenceRefs,
+        ...(route ? { route } : {}),
+        ...(outputSummary ? { output_summary: outputSummary } : {}),
+        ...(externalIdempotencyKey ? { external_idempotency_key: externalIdempotencyKey } : {}),
+      },
+    });
+    const next: GraphState = {
+      ...current,
+      projection: schedulerResult.projection,
+      // B6: completing a claim while the run is waiting for a human answer ends
+      // the durable wait (the human answered), so return to 'running' and let the
+      // driver claim the next ready activation. Without this the run would wedge
+      // in 'waiting_human' after the human-approval node completes.
+      ...(current.status === 'waiting_human' ? { status: 'running' as const } : {}),
+      claims: {
+        ...current.claims,
+        [leaseId]: {
+          ...claim,
+          status: 'completed' as const,
+          fenced_at: now(),
+        },
+      },
+    };
+    return {
+      next,
+      result: {
+        transition_id: transitionId,
+        activation_id: activationId,
+        node_id: schedulerResult.transition.node_id,
+        outcome: schedulerResult.transition.outcome,
+        selected_edge_ids: schedulerResult.transition.selected_edge_ids,
+        created_activation_ids: schedulerResult.transition.created_activation_ids,
+        succeeded: isGraphSucceeded(descriptor, schedulerResult.projection),
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executePause(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'pause',
+    operation_fingerprint: operationFingerprint('pause', { runId, revisionId, descriptorHash, driverId }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot pause graph in status ${current.status}`);
+    }
+    const liveClaims = Object.values(current.claims).filter((claim) => claim.status === 'live');
+    if (liveClaims.length > 0) {
+      throw new Error(`cannot pause graph with ${liveClaims.length} live claims; fence them first`);
+    }
+    const next: GraphState = { ...current, status: 'paused' as const };
+    return { next, result: { paused: true, run_id: runId } };
+  });
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  const releasedAt = now();
+  // NOTE (finding #5): mutate-then-control ordering is intentionally retained here. The control
+  // op is releaseRoot. Reordering to release-first would make the mutate-after-release-success
+  // failure leave a 'running' graph with NO control root (already released), which is not
+  // cleanly recoverable: executeResume's reservePausedGraph requires status='paused'. The status
+  // quo divergence (mutate succeeds, releaseRoot throws e.g. children_live -> paused graph with
+  // an active root) keeps the root present and is less severe than a rootless running graph, so
+  // the reorder is not clearly safer here.
+  controlStore.releaseRoot({
+    mode: 'graph',
+    run_id: runId,
+    nonce: result.state.control_nonce,
+    disposition: {
+      graph_status: 'paused',
+      claims_fenced: true,
+      children_drained: true,
+    },
+    released_at: releasedAt,
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeAbandon(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const confirmationInput = requireObject(input.confirmation, 'confirmation');
+  const confirmedRunId = requireString(confirmationInput.run_id ?? confirmationInput.runId, 'confirmation.run_id');
+  if (confirmedRunId !== runId) {
+    throw new Error('confirmation run_id does not match');
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'abandon',
+    operation_fingerprint: operationFingerprint('abandon', { runId, revisionId, descriptorHash }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    const next: GraphState = { ...current, status: 'cancelled' as const };
+    return { next, result: { abandoned: true, run_id: runId } };
+  });
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  controlStore.releaseRoot({
+    mode: 'graph',
+    run_id: runId,
+    nonce: result.state.control_nonce,
+    disposition: {
+      graph_status: 'cancelled',
+      claims_fenced: true,
+      children_drained: true,
+    },
+    released_at: now(),
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeResume(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  if (state.status !== 'paused') {
+    throw new Error(`cannot resume graph in status ${state.status}`);
+  }
+  if (state.active_revision_id !== revisionId || state.active_revision_hash !== descriptorHash) {
+    throw new Error('resume fence does not match active revision/hash');
+  }
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  const resumedAt = now();
+  // Control-first ordering (finding #5 mitigation): reserve+promote the control root BEFORE
+  // persisting status='running'. If the control step throws (e.g. a prior pause left a stale
+  // root -> root_conflict), the graph state is unchanged (still 'paused') -> clean failure,
+  // user can retry. This is strictly safer than the prior mutate-then-control order, which
+  // left the graph 'running' with a stale/missing control root and masked the divergence on
+  // replay (the #3 fix skips control ops when result.replayed). The remaining divergence
+  // window is the rare case where control succeeds but store.mutate then throws (e.g. a
+  // concurrent sequence advance); in that case we attempt to release the freshly promoted
+  // root as cleanup. releaseRoot is idempotent and, on a freshly reserved root with no
+  // children and a paused graph (pause enforces no live claims), the release is truthful and
+  // will actually release, restoring control to the pre-resume state.
+  const isReplay = state.transitions.some((transition) => transition.transition_id === transitionId);
+  if (!isReplay) {
+    controlStore.reservePausedGraph({
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      nonce: state.control_nonce,
+      graph_state: {
+        session_id: sessionId,
+        run_id: runId,
+        revision_id: revisionId,
+        status: 'paused',
+      },
+      reserved_at: resumedAt,
+    });
+    controlStore.promoteRoot({
+      mode: 'graph',
+      run_id: runId,
+      nonce: state.control_nonce,
+      promoted_at: resumedAt,
+      driver_lease: driverLease(driverId, resumedAt),
+    });
+  }
+
+  let result;
+  try {
+    result = store.mutate<JsonValue>({
+      transition_id: transitionId,
+      operation: 'resume',
+      operation_fingerprint: operationFingerprint('resume', { runId, revisionId, descriptorHash, driverId }),
+      expected: buildFence(state),
+    }, (current) => {
+      const next: GraphState = { ...current, status: 'running' as const };
+      return { next, result: { resumed: true, run_id: runId } };
+    });
+  } catch (mutateError) {
+    if (!isReplay) {
+      // Control root was just reserved+promoted but the graph mutate failed. Attempt to
+      // release the root so control does not diverge (active root over a still-paused
+      // graph). Swallow release errors: the graph is unchanged and retryable regardless,
+      // and a failed cleanup does not make things worse than the original throw.
+      try {
+        controlStore.releaseRoot({
+          mode: 'graph',
+          run_id: runId,
+          nonce: state.control_nonce,
+          disposition: {
+            graph_status: 'paused',
+            claims_fenced: true,
+            children_drained: true,
+          },
+          released_at: now(),
+        });
+      } catch {
+        // best-effort cleanup; surface the original mutate error below
+      }
+    }
+    throw mutateError;
+  }
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeProposePatch(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const baseRevisionId = requireString(input.base_revision_id, 'base_revision_id');
+  const baseDescriptorHash = requireString(input.base_descriptor_hash, 'base_descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const patchInput = requireObject(input.patch, 'patch');
+  const proposedDescriptorInput = requireObject(patchInput.proposed_descriptor ?? patchInput.proposedDescriptor, 'patch.proposed_descriptor');
+  const invalidatedNodeIds = Array.isArray(patchInput.invalidated_node_ids)
+    ? patchInput.invalidated_node_ids.map((value, index) => requireString(value, `patch.invalidated_node_ids[${index}]`))
+    : [];
+  const proposalEvidence = Array.isArray(patchInput.proposal_evidence)
+    ? patchInput.proposal_evidence.map((value, index) => requireEvidence(value, `patch.proposal_evidence[${index}]`))
+    : [];
+
+  const proposedSealed = sealGraphDescriptor(parseGraphDescriptor(proposedDescriptorInput));
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'propose-patch',
+    operation_fingerprint: operationFingerprint('propose-patch', { runId, baseRevisionId, baseDescriptorHash, proposedRevisionId: proposedSealed.revision_id }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: baseRevisionId,
+      revision_hash: baseDescriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    const next = proposeGraphPatch(current, {
+      proposal_id: transitionId,
+      base_revision_id: baseRevisionId,
+      base_revision_hash: baseDescriptorHash,
+      proposed_descriptor: proposedSealed,
+      invalidated_node_ids: invalidatedNodeIds,
+      proposal_evidence: proposalEvidence,
+      proposed_at: now(),
+    });
+    return { next, result: { proposed: true, proposed_revision_id: proposedSealed.revision_id } };
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeApprovePatch(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const baseRevisionId = requireString(input.base_revision_id, 'base_revision_id');
+  const baseDescriptorHash = requireString(input.base_descriptor_hash, 'base_descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const approvalInput = requireObject(input.approval, 'approval');
+  const evidence = requireEvidence(approvalInput.evidence ?? approvalInput.approval_evidence, 'approval.evidence');
+  const invalidatedNodeIds = Array.isArray(approvalInput.invalidated_node_ids)
+    ? approvalInput.invalidated_node_ids.map((value, index) => requireString(value, `approval.invalidated_node_ids[${index}]`))
+    : [];
+  const proposedRevisionHash = requireString(approvalInput.proposed_revision_hash ?? approvalInput.proposedDescriptorHash, 'approval.proposed_revision_hash');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'approve-patch',
+    operation_fingerprint: operationFingerprint('approve-patch', { runId, baseRevisionId, baseDescriptorHash, proposedRevisionHash }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: baseRevisionId,
+      revision_hash: baseDescriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+    fence_scope: 'pending_patch_base',
+  }, (current) => {
+    if (!current.pending_patch) throw new Error('no pending patch to approve');
+    const recompute: (projection: GraphSchedulerProjection, descriptor: SealedGraphDescriptor, invalidated: ReadonlySet<string>) => GraphSchedulerProjection = (projection, descriptor, invalidated) => {
+      const next: GraphSchedulerProjection = {
+        activations: {},
+        cohorts: {},
+        branch_tokens: {},
+        traversal_counts: { ...projection.traversal_counts },
+        committed_transitions: Object.fromEntries(
+          Object.entries(projection.committed_transitions).filter(
+            ([, transition]) => !invalidated.has(transition.node_id),
+          ),
+        ),
+        terminal_verification_activation_ids: [...projection.terminal_verification_activation_ids],
+      };
+      for (const [activationId, activation] of Object.entries(projection.activations)) {
+        if (invalidated.has(activation.node_id)) continue;
+        next.activations[activationId] = { ...activation, attempt_ids: [...activation.attempt_ids] };
+      }
+      for (const [cohortId, cohort] of Object.entries(projection.cohorts)) {
+        const joinAlive = cohort.join_activation_id && next.activations[cohort.join_activation_id];
+        if (joinAlive || cohort.consumed) {
+          next.cohorts[cohortId] = { ...cohort, expected_branch_token_ids: [...cohort.expected_branch_token_ids] };
+        }
+      }
+      for (const [tokenId, token] of Object.entries(projection.branch_tokens)) {
+        if (token.current_activation_id && next.activations[token.current_activation_id]) {
+          next.branch_tokens[tokenId] = { ...token };
+        }
+      }
+      for (const nodeId of descriptor.entry_node_ids) {
+        const hasActivation = Object.values(next.activations).some((activation) => activation.node_id === nodeId);
+        if (!hasActivation) {
+          const activationId = `${descriptor.run_id}:act:${nodeId}:entry`;
+          next.activations[activationId] = {
+            activation_id: activationId,
+            node_id: nodeId,
+            status: 'ready',
+            attempt_no: 0,
+            attempt_ids: [],
+            traversal_owner_id: activationId,
+          };
+        }
+      }
+      return next;
+    };
+    const next = approveGraphPatch(current, {
+      proposal_id: current.pending_patch.proposal_id,
+      base_revision_id: baseRevisionId,
+      base_revision_hash: baseDescriptorHash,
+      proposed_revision_hash: proposedRevisionHash,
+      invalidated_node_ids: invalidatedNodeIds,
+      approval_evidence: evidence,
+      approved_at: now(),
+    }, recompute);
+    return { next, result: { approved: true, active_revision_id: next.active_revision_id } };
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeSettleSession(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state) {
+    return { result: { settled_lease_ids: [] }, replayed: false };
+  }
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'settle-session',
+    operation_fingerprint: operationFingerprint('settle-session', { sessionId, driverId }),
+    expected: buildFence(state),
+  }, (current) => {
+    const settled = settleDriverClaims(current, {
+      claim_owner_session_id: sessionId,
+      driver_instance_id: driverId,
+      recorded_at: now(),
+      // B4: session-end fences ALL live claims in the session regardless of
+      // driver-id (the session is terminating). The driver_id is retained for
+      // the diagnostic/audit record but does not filter the fence set.
+      scope: 'session',
+    });
+    return { next: settled.state, result: { settled_lease_ids: settled.settled_lease_ids } };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeResolveJoin(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const activationId = requireString(input.activation_id, 'activation_id');
+  const identitiesInput = requireObject(input.identities, 'identities');
+  const nextActivationIdsInput = requireObject(identitiesInput.next_activation_ids, 'identities.next_activation_ids');
+  const nextActivationIds: Record<string, string> = {};
+  for (const [edgeId, value] of Object.entries(nextActivationIdsInput)) {
+    nextActivationIds[edgeId] = requireString(value, `identities.next_activation_ids.${edgeId}`);
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'resolve-join',
+    operation_fingerprint: operationFingerprint('resolve-join', { runId, revisionId, descriptorHash, activationId, nextActivationIds }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot resolve join while graph status is ${current.status}`);
+    }
+    const descriptor = current.revisions[current.active_revision_id].descriptor;
+    const schedulerResult = resolveJoin(descriptor, current.projection, {
+      activation_id: activationId,
+      transition_id: transitionId,
+      identities: { next_activation_ids: nextActivationIds },
+    });
+    const next: GraphState = { ...current, projection: schedulerResult.projection };
+    return {
+      next,
+      result: {
+        transition_id: transitionId,
+        activation_id: activationId,
+        node_id: schedulerResult.transition.node_id,
+        outcome: schedulerResult.transition.outcome,
+        selected_edge_ids: schedulerResult.transition.selected_edge_ids,
+        created_activation_ids: schedulerResult.transition.created_activation_ids,
+        succeeded: isGraphSucceeded(descriptor, schedulerResult.projection),
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeRenewClaim(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const leaseId = requireString(input.lease_id, 'lease_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const trackingId = requireString(input.tracking_id, 'tracking_id');
+  const toolStillRunning = input.tool_still_running === true;
+  const renewAt = requireString(input.now, 'now');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'renew-claim',
+    operation_fingerprint: operationFingerprint('renew-claim', { runId, revisionId, descriptorHash, leaseId, driverId, trackingId }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'running') {
+      throw new Error(`cannot renew claim while graph status is ${current.status}`);
+    }
+    const renewed = renewGraphClaim(current, {
+      lease_id: leaseId,
+      claim_owner_session_id: sessionId,
+      driver_instance_id: driverId,
+      tracking_id: trackingId,
+      tool_still_running: toolStillRunning,
+      now: renewAt,
+    });
+    return {
+      next: renewed.state,
+      result: {
+        lease_id: renewed.claim.lease_id,
+        renewal_count: renewed.claim.renewal_count,
+        expires_at: renewed.claim.expires_at,
+        last_renewed_at: renewed.claim.last_renewed_at ?? null,
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeRecoverExpiredClaim(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const leaseId = requireString(input.lease_id, 'lease_id');
+  const recoverAt = requireString(input.now, 'now');
+  const newAttemptId = requireString(input.new_attempt_id, 'new_attempt_id');
+  const newLeaseId = requireString(input.new_lease_id, 'new_lease_id');
+  const newTrackingId = requireString(input.new_tracking_id, 'new_tracking_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const reconciliationId = requireString(input.reconciliation_id, 'reconciliation_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'recover-expired-claim',
+    operation_fingerprint: operationFingerprint('recover-expired-claim', { runId, revisionId, descriptorHash, leaseId, newLeaseId, reconciliationId }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'reconciling') {
+      throw new Error(`cannot recover expired claim while graph status is ${current.status}`);
+    }
+    const recovered = recoverExpiredGraphClaim(current, {
+      lease_id: leaseId,
+      now: recoverAt,
+      new_attempt_id: newAttemptId,
+      new_lease_id: newLeaseId,
+      new_tracking_id: newTrackingId,
+      claimant_session_id: sessionId,
+      driver_instance_id: driverId,
+      reconciliation_id: reconciliationId,
+    }, (projection, replaceInput) => {
+      // The expired claim's activation is still 'running' with the old attempt.
+      // Begin a fresh replacement attempt on the same activation (mirrors the
+      // retry projection used by the claims recovery tests): append the new
+      // attempt id and advance attempt_no/active_attempt_id.
+      const activation = projection.activations[replaceInput.activation_id];
+      if (!activation) {
+        throw new Error(`replacement attempt references unknown activation ${replaceInput.activation_id}`);
+      }
+      return {
+        ...projection,
+        activations: {
+          ...projection.activations,
+          [replaceInput.activation_id]: {
+            ...activation,
+            status: 'running' as const,
+            attempt_no: replaceInput.attempt_no,
+            attempt_ids: [...activation.attempt_ids, replaceInput.attempt_id],
+            active_attempt_id: replaceInput.attempt_id,
+          },
+        },
+      };
+    });
+    return {
+      next: recovered.state,
+      result: {
+        disposition: recovered.disposition,
+        ...(recovered.claim ? { replacement_lease_id: recovered.claim.lease_id } : {}),
+        ...(recovered.reconciliation ? { reconciliation_id: recovered.reconciliation.reconciliation_id } : {}),
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeRecordLateClaimResult(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const leaseId = requireString(input.lease_id, 'lease_id');
+  const attemptId = requireString(input.attempt_id, 'attempt_id');
+  const recordedAt = requireString(input.recorded_at, 'recorded_at');
+  const summary = requireString(input.summary, 'summary');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'record-late-claim-result',
+    operation_fingerprint: operationFingerprint('record-late-claim-result', { runId, revisionId, descriptorHash, leaseId, attemptId }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    const late = recordLateClaimResult(current, {
+      lease_id: leaseId,
+      attempt_id: attemptId,
+      recorded_at: recordedAt,
+      summary,
+    });
+    return {
+      next: late.state,
+      result: {
+        kind: late.diagnostic.kind,
+        lease_id: late.diagnostic.lease_id ?? null,
+        attempt_id: late.diagnostic.attempt_id ?? null,
+        recorded_at: late.diagnostic.recorded_at,
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeReleaseAttemptForRetry(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const activationId = requireString(input.activation_id, 'activation_id');
+  const attemptId = requireString(input.attempt_id, 'attempt_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'release-attempt-for-retry',
+    operation_fingerprint: operationFingerprint('release-attempt-for-retry', { runId, revisionId, descriptorHash, activationId, attemptId }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot release attempt while graph status is ${current.status}`);
+    }
+    const projection = releaseAttemptForRetry(current.projection, {
+      activation_id: activationId,
+      attempt_id: attemptId,
+    });
+    // Releasing a running attempt returns the activation to 'ready' and drops the
+    // active attempt. Fence any live claim bound to that exact attempt so the
+    // concurrency slot does not leak while the activation waits for a new claim.
+    const claims = { ...current.claims };
+    for (const [id, claim] of Object.entries(claims)) {
+      if (claim.status === 'live' && claim.activation_id === activationId && claim.attempt_id === attemptId) {
+        claims[id] = { ...claim, status: 'fenced' as const, fenced_at: now() };
+      }
+    }
+    const next: GraphState = { ...current, projection, claims };
+    return {
+      next,
+      result: { activation_id: activationId, attempt_id: attemptId, released: true },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeResolveReconciliation(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const evidence = requireEvidence(input.evidence, 'evidence');
+  const resolvedAt = requireString(input.resolved_at, 'resolved_at');
+
+  const store = new GraphStateStore({ sessionId });
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'resolve-reconciliation',
+    operation_fingerprint: operationFingerprint('resolve-reconciliation', { runId, revisionId, descriptorHash, resolvedAt, evidenceRef: evidence.ref }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      dispatch_generation: 0,
+      commit_sequence: expectedSequence,
+    },
+  }, (current) => {
+    if (current.status !== 'reconciling') {
+      throw new Error(`cannot resolve reconciliation while graph status is ${current.status}`);
+    }
+    const unresolved = Object.values(current.reconciliations).filter(
+      (record) => record.status === 'unresolved',
+    );
+    if (unresolved.length === 0) {
+      throw new Error('no unresolved reconciliation records to resolve');
+    }
+    // B5: mark every unresolved reconciliation as accepted (the operator/human
+    // resolved the ambiguity with evidence) and transition the run back to
+    // 'running' so claim/resume/complete can proceed. An expired reconcile-policy
+    // claim no longer permanently breaks the run.
+    const reconciliations = { ...current.reconciliations };
+    for (const record of unresolved) {
+      reconciliations[record.reconciliation_id] = {
+        ...record,
+        status: 'accepted' as const,
+        resolved_at: resolvedAt,
+        resolution_evidence: evidence,
+      };
+    }
+    const next: GraphState = { ...current, status: 'running' as const, reconciliations };
+    return {
+      next,
+      result: {
+        resolved_reconciliation_ids: unresolved.map((record) => record.reconciliation_id),
+        status: 'running',
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+export const graphCommandService: GraphCommandService = {
+  async execute(request: GraphCommandRequest): Promise<unknown> {
+    switch (request.operation) {
+      case 'create': return executeCreate(request.input);
+      case 'inspect': return executeInspect(request.input);
+      case 'status': return executeStatus(request.input);
+      case 'ready': return executeReady(request.input);
+      case 'approve': return executeApprove(request.input);
+      case 'claim': return executeClaim(request.input);
+      case 'complete': return applyResultOperation('complete', request.input);
+      case 'fail': return applyResultOperation('fail', request.input);
+      case 'pause': return executePause(request.input);
+      case 'abandon': return executeAbandon(request.input);
+      case 'resume': return executeResume(request.input);
+      case 'propose-patch': return executeProposePatch(request.input);
+      case 'approve-patch': return executeApprovePatch(request.input);
+      case 'settle-session': return executeSettleSession(request.input);
+      case 'resolve-join': return executeResolveJoin(request.input);
+      case 'renew-claim': return executeRenewClaim(request.input);
+      case 'recover-expired-claim': return executeRecoverExpiredClaim(request.input);
+      case 'record-late-claim-result': return executeRecordLateClaimResult(request.input);
+      case 'release-attempt-for-retry': return executeReleaseAttemptForRetry(request.input);
+      case 'resolve-reconciliation': return executeResolveReconciliation(request.input);
+      default: throw new Error(`unknown graph operation: ${request.operation}`);
+    }
+  },
+};

--- a/src/graph/scheduler.ts
+++ b/src/graph/scheduler.ts
@@ -1,0 +1,657 @@
+import { createHash } from 'node:crypto';
+
+import { canonicalJson } from './descriptor.js';
+import { parseGraphNodeResult } from './schema.js';
+import type {
+  ApplyNodeResultInput,
+  BeginActivationAttemptInput,
+  GraphActivation,
+  GraphBackEdge,
+  GraphBranchToken,
+  GraphCommittedTransition,
+  GraphDescriptor,
+  GraphEdge,
+  GraphNode,
+  GraphSchedulerProjection,
+  ReleaseAttemptForRetryInput,
+  ResolveJoinInput,
+  SchedulerApplyResult,
+  SchedulerTransitionIdentities,
+} from './types.js';
+
+export class GraphSchedulerError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphSchedulerError';
+    this.code = code;
+  }
+}
+
+function cloneProjection(projection: GraphSchedulerProjection): GraphSchedulerProjection {
+  return {
+    activations: Object.fromEntries(
+      Object.entries(projection.activations).map(([id, activation]) => [
+        id,
+        { ...activation, attempt_ids: [...activation.attempt_ids] },
+      ]),
+    ),
+    cohorts: Object.fromEntries(
+      Object.entries(projection.cohorts).map(([id, cohort]) => [
+        id,
+        { ...cohort, expected_branch_token_ids: [...cohort.expected_branch_token_ids] },
+      ]),
+    ),
+    branch_tokens: Object.fromEntries(
+      Object.entries(projection.branch_tokens).map(([id, token]) => [id, { ...token }]),
+    ),
+    traversal_counts: { ...projection.traversal_counts },
+    committed_transitions: Object.fromEntries(
+      Object.entries(projection.committed_transitions).map(([id, transition]) => [
+        id,
+        {
+          ...transition,
+          selected_edge_ids: [...transition.selected_edge_ids],
+          created_activation_ids: [...transition.created_activation_ids],
+          evidence_refs: transition.evidence_refs.map((evidence) => ({ ...evidence })),
+        },
+      ]),
+    ),
+    terminal_verification_activation_ids: [...projection.terminal_verification_activation_ids],
+  };
+}
+
+function nodeMap(descriptor: GraphDescriptor): Map<string, GraphNode> {
+  return new Map(descriptor.nodes.map((node) => [node.id, node]));
+}
+
+function outgoingEdges(descriptor: GraphDescriptor, nodeId: string): GraphEdge[] {
+  return descriptor.edges.filter((edge) => edge.from === nodeId);
+}
+
+function getActivation(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+): GraphActivation {
+  const activation = projection.activations[activationId];
+  if (!activation) {
+    throw new GraphSchedulerError('activation_not_found', `Activation ${activationId} does not exist`);
+  }
+  return activation;
+}
+
+function ensureUniqueIdentity(
+  projection: GraphSchedulerProjection,
+  kind: 'activation' | 'attempt' | 'cohort' | 'branch token',
+  id: string,
+  pending: Set<string> = new Set(),
+): void {
+  let exists = pending.has(id);
+  if (kind === 'activation') exists ||= id in projection.activations;
+  if (kind === 'attempt') {
+    exists ||= Object.values(projection.activations).some((activation) =>
+      activation.attempt_ids.includes(id));
+  }
+  if (kind === 'cohort') exists ||= id in projection.cohorts;
+  if (kind === 'branch token') exists ||= id in projection.branch_tokens;
+  if (exists) {
+    throw new GraphSchedulerError('duplicate_identity', `${kind} identity ${id} is already in use`);
+  }
+  pending.add(id);
+}
+
+function newActivation(
+  activationId: string,
+  nodeId: string,
+  options: {
+    cohortId?: string;
+    branchTokenId?: string;
+    traversalOwnerId?: string;
+  } = {},
+): GraphActivation {
+  return {
+    activation_id: activationId,
+    node_id: nodeId,
+    status: 'ready',
+    attempt_no: 0,
+    attempt_ids: [],
+    traversal_owner_id: options.traversalOwnerId ?? activationId,
+    ...(options.cohortId ? { cohort_id: options.cohortId } : {}),
+    ...(options.branchTokenId ? { branch_token_id: options.branchTokenId } : {}),
+  };
+}
+
+export function initializeGraphProjection(
+  descriptor: GraphDescriptor,
+  entryActivationIds: Record<string, string>,
+): GraphSchedulerProjection {
+  const projection: GraphSchedulerProjection = {
+    activations: {},
+    cohorts: {},
+    branch_tokens: {},
+    traversal_counts: {},
+    committed_transitions: {},
+    terminal_verification_activation_ids: [],
+  };
+  const pending = new Set<string>();
+  for (const nodeId of descriptor.entry_node_ids) {
+    const activationId = entryActivationIds[nodeId];
+    if (!activationId) {
+      throw new GraphSchedulerError(
+        'missing_identity',
+        `Entry node ${nodeId} requires an activation identity`,
+      );
+    }
+    ensureUniqueIdentity(projection, 'activation', activationId, pending);
+    projection.activations[activationId] = newActivation(activationId, nodeId);
+  }
+  const unknownEntries = Object.keys(entryActivationIds).filter(
+    (nodeId) => !descriptor.entry_node_ids.includes(nodeId),
+  );
+  if (unknownEntries.length > 0) {
+    throw new GraphSchedulerError(
+      'unexpected_identity',
+      `Activation identities were provided for non-entry nodes: ${unknownEntries.join(', ')}`,
+    );
+  }
+  return projection;
+}
+
+export function beginActivationAttempt(
+  projection: GraphSchedulerProjection,
+  input: BeginActivationAttemptInput,
+): GraphSchedulerProjection {
+  const activation = getActivation(projection, input.activation_id);
+  if (activation.status !== 'ready') {
+    throw new GraphSchedulerError(
+      'activation_not_ready',
+      `Activation ${activation.activation_id} is ${activation.status}, not ready`,
+    );
+  }
+  ensureUniqueIdentity(projection, 'attempt', input.attempt_id);
+  const next = cloneProjection(projection);
+  next.activations[input.activation_id] = {
+    ...next.activations[input.activation_id],
+    status: 'running',
+    attempt_no: activation.attempt_no + 1,
+    attempt_ids: [...activation.attempt_ids, input.attempt_id],
+    active_attempt_id: input.attempt_id,
+  };
+  return next;
+}
+
+export function releaseAttemptForRetry(
+  projection: GraphSchedulerProjection,
+  input: ReleaseAttemptForRetryInput,
+): GraphSchedulerProjection {
+  const activation = getActivation(projection, input.activation_id);
+  if (activation.status !== 'running' || activation.active_attempt_id !== input.attempt_id) {
+    throw new GraphSchedulerError(
+      'attempt_fenced',
+      `Attempt ${input.attempt_id} does not own running activation ${input.activation_id}`,
+    );
+  }
+  const next = cloneProjection(projection);
+  const released = { ...next.activations[input.activation_id], status: 'ready' as const };
+  delete released.active_attempt_id;
+  next.activations[input.activation_id] = released;
+  return next;
+}
+
+function replayedTransition(
+  projection: GraphSchedulerProjection,
+  transitionId: string,
+  activationId: string,
+  requestFingerprint: string,
+): SchedulerApplyResult | undefined {
+  const transition = projection.committed_transitions[transitionId];
+  if (!transition) return undefined;
+  if (transition.activation_id !== activationId) {
+    throw new GraphSchedulerError(
+      'transition_fenced',
+      `Transition ${transitionId} is already committed for activation ${transition.activation_id}`,
+    );
+  }
+  if (transition.request_fingerprint !== requestFingerprint) {
+    throw new GraphSchedulerError(
+      'transition_fenced',
+      `Transition ${transitionId} request fingerprint does not match the committed request`,
+    );
+  }
+  return { projection, transition, replayed: true };
+}
+
+function requestFingerprint(kind: 'node_result' | 'join', value: unknown): string {
+  return createHash('sha256').update(canonicalJson({ kind, value })).digest('hex');
+}
+
+function requireRunningAttempt(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+): GraphActivation {
+  const activation = getActivation(projection, activationId);
+  if (activation.status !== 'running' || activation.active_attempt_id !== attemptId) {
+    throw new GraphSchedulerError(
+      'attempt_fenced',
+      `Attempt ${attemptId} does not own running activation ${activationId}`,
+    );
+  }
+  return activation;
+}
+
+function selectEdges(
+  descriptor: GraphDescriptor,
+  activation: GraphActivation,
+  route: string | undefined,
+  projection: GraphSchedulerProjection,
+): GraphEdge[] {
+  const edges = outgoingEdges(descriptor, activation.node_id);
+  if (edges.length === 0) {
+    if (route) throw new GraphSchedulerError('undeclared_route', `Node ${activation.node_id} has no declared routes`);
+    return [];
+  }
+  if (edges.every((edge) => edge.kind === 'fan_out')) {
+    if (route) throw new GraphSchedulerError('undeclared_route', `Fan-out node ${activation.node_id} does not accept route ${route}`);
+    return edges;
+  }
+  if (edges.length === 1 && edges[0].kind === 'fixed') {
+    if (route) throw new GraphSchedulerError('undeclared_route', `Fixed node ${activation.node_id} does not accept route ${route}`);
+    return edges;
+  }
+  if (!route) {
+    throw new GraphSchedulerError('route_required', `Node ${activation.node_id} requires one declared route`);
+  }
+  const selected = edges.filter(
+    (edge) => (edge.kind === 'conditional' || edge.kind === 'back_edge') && edge.route === route,
+  );
+  if (selected.length !== 1) {
+    throw new GraphSchedulerError(
+      'undeclared_route',
+      `Node ${activation.node_id} received undeclared route ${route}`,
+    );
+  }
+  const edge = selected[0];
+  if (edge.kind === 'back_edge') {
+    const count = projection.traversal_counts[traversalCounterKey(activation, edge)] ?? 0;
+    if (count >= edge.max_traversals) {
+      throw new GraphSchedulerError(
+        'traversal_bound_exceeded',
+        `Back-edge ${edge.id} traversal bound ${edge.max_traversals} is exhausted`,
+      );
+    }
+  }
+  return selected;
+}
+
+export function traversalCounterKey(
+  activation: Pick<GraphActivation, 'traversal_owner_id'>,
+  edge: Pick<GraphBackEdge, 'id'>,
+): string {
+  return canonicalJson([activation.traversal_owner_id, edge.id]);
+}
+
+function requiredIdentity(
+  identities: Record<string, string> | undefined,
+  edgeId: string,
+  kind: string,
+): string {
+  const id = identities?.[edgeId];
+  if (!id) {
+    throw new GraphSchedulerError('missing_identity', `Edge ${edgeId} requires a ${kind} identity`);
+  }
+  return id;
+}
+
+function arriveAtJoin(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  activation: GraphActivation,
+  targetJoinId: string,
+  identities: SchedulerTransitionIdentities,
+  createdActivationIds: string[],
+): void {
+  if (!activation.cohort_id || !activation.branch_token_id) {
+    throw new GraphSchedulerError(
+      'join_owner_missing',
+      `Activation ${activation.activation_id} cannot enter join ${targetJoinId} without a branch token`,
+    );
+  }
+  const token = projection.branch_tokens[activation.branch_token_id];
+  const cohort = projection.cohorts[activation.cohort_id];
+  if (!token || !cohort || token.owner_join_id !== targetJoinId || cohort.owner_join_id !== targetJoinId) {
+    throw new GraphSchedulerError('join_owner_mismatch', `Branch token does not own join ${targetJoinId}`);
+  }
+  if (token.status !== 'active' || token.current_activation_id !== activation.activation_id) {
+    throw new GraphSchedulerError('branch_token_fenced', `Branch token ${token.branch_token_id} is not active here`);
+  }
+  const arrived: GraphBranchToken = { ...token, status: 'arrived' };
+  delete arrived.current_activation_id;
+  projection.branch_tokens[token.branch_token_id] = arrived;
+
+  const allArrived = cohort.expected_branch_token_ids.every(
+    (tokenId) => projection.branch_tokens[tokenId]?.status === 'arrived',
+  );
+  if (!allArrived) return;
+  if (cohort.join_activation_id) {
+    throw new GraphSchedulerError('duplicate_join_activation', `Cohort ${cohort.cohort_id} already activated its join`);
+  }
+  const joinActivationId = identities.join_activation_id;
+  if (!joinActivationId) {
+    throw new GraphSchedulerError('missing_identity', `Ready join ${targetJoinId} requires an activation identity`);
+  }
+  ensureUniqueIdentity(projection, 'activation', joinActivationId);
+  projection.activations[joinActivationId] = newActivation(joinActivationId, targetJoinId, {
+    cohortId: cohort.cohort_id,
+  });
+  projection.cohorts[cohort.cohort_id] = { ...cohort, join_activation_id: joinActivationId };
+  createdActivationIds.push(joinActivationId);
+
+  const join = nodeMap(descriptor).get(targetJoinId);
+  if (join?.kind !== 'join') {
+    throw new GraphSchedulerError('join_not_found', `Join node ${targetJoinId} does not exist`);
+  }
+}
+
+function createFanOut(
+  projection: GraphSchedulerProjection,
+  activation: GraphActivation,
+  edges: Extract<GraphEdge, { kind: 'fan_out' }>[],
+  identities: SchedulerTransitionIdentities,
+  createdActivationIds: string[],
+): string {
+  const cohortId = identities.cohort_id;
+  if (!cohortId) throw new GraphSchedulerError('missing_identity', 'Fan-out requires a cohort identity');
+  ensureUniqueIdentity(projection, 'cohort', cohortId);
+  const pendingActivations = new Set<string>();
+  const pendingTokens = new Set<string>();
+  const tokenIds: string[] = [];
+
+  for (const edge of edges) {
+    const activationId = requiredIdentity(identities.next_activation_ids, edge.id, 'next activation');
+    const tokenId = requiredIdentity(identities.branch_token_ids, edge.id, 'branch token');
+    ensureUniqueIdentity(projection, 'activation', activationId, pendingActivations);
+    ensureUniqueIdentity(projection, 'branch token', tokenId, pendingTokens);
+    projection.activations[activationId] = newActivation(activationId, edge.to, {
+      cohortId,
+      branchTokenId: tokenId,
+      traversalOwnerId: tokenId,
+    });
+    projection.branch_tokens[tokenId] = {
+      branch_token_id: tokenId,
+      cohort_id: cohortId,
+      branch_id: edge.branch_id,
+      owner_join_id: edge.owner_join_id,
+      status: 'active',
+      current_activation_id: activationId,
+    };
+    tokenIds.push(tokenId);
+    createdActivationIds.push(activationId);
+  }
+  projection.cohorts[cohortId] = {
+    cohort_id: cohortId,
+    fan_out_node_id: activation.node_id,
+    owner_join_id: edges[0].owner_join_id,
+    expected_branch_token_ids: tokenIds,
+    consumed: false,
+  };
+  return cohortId;
+}
+
+function createNextActivation(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  activation: GraphActivation,
+  edge: GraphEdge,
+  identities: SchedulerTransitionIdentities,
+  createdActivationIds: string[],
+): void {
+  const target = nodeMap(descriptor).get(edge.to);
+  if (target?.kind === 'join') {
+    arriveAtJoin(descriptor, projection, activation, edge.to, identities, createdActivationIds);
+    return;
+  }
+  const activationId = requiredIdentity(identities.next_activation_ids, edge.id, 'next activation');
+  ensureUniqueIdentity(projection, 'activation', activationId);
+  projection.activations[activationId] = newActivation(activationId, edge.to, {
+    cohortId: activation.cohort_id,
+    branchTokenId: activation.branch_token_id,
+    traversalOwnerId: activation.traversal_owner_id,
+  });
+  createdActivationIds.push(activationId);
+  if (activation.branch_token_id) {
+    const token = projection.branch_tokens[activation.branch_token_id];
+    if (!token || token.status !== 'active' || token.current_activation_id !== activation.activation_id) {
+      throw new GraphSchedulerError(
+        'branch_token_fenced',
+        `Branch token ${activation.branch_token_id} is not owned by ${activation.activation_id}`,
+      );
+    }
+    projection.branch_tokens[activation.branch_token_id] = {
+      ...token,
+      current_activation_id: activationId,
+    };
+  }
+  if (edge.kind === 'back_edge') {
+    const key = traversalCounterKey(activation, edge);
+    projection.traversal_counts[key] = (projection.traversal_counts[key] ?? 0) + 1;
+  }
+}
+
+function commitTransition(
+  projection: GraphSchedulerProjection,
+  transition: GraphCommittedTransition,
+): SchedulerApplyResult {
+  projection.committed_transitions[transition.transition_id] = transition;
+  return { projection, transition, replayed: false };
+}
+
+export function applyNodeResult(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  rawInput: ApplyNodeResultInput,
+): SchedulerApplyResult {
+  const result = parseGraphNodeResult(rawInput.result);
+  const identities = rawInput.identities ?? {};
+  const fingerprint = requestFingerprint('node_result', {
+    activation_id: rawInput.activation_id,
+    result,
+    identities,
+  });
+  const replay = replayedTransition(
+    projection,
+    rawInput.transition_id,
+    rawInput.activation_id,
+    fingerprint,
+  );
+  if (replay) return replay;
+  const activation = requireRunningAttempt(projection, rawInput.activation_id, result.attempt_id);
+  const node = nodeMap(descriptor).get(activation.node_id);
+  if (!node) throw new GraphSchedulerError('node_not_found', `Node ${activation.node_id} does not exist`);
+  if (node.kind === 'join') {
+    throw new GraphSchedulerError('join_is_automatic', `Join ${node.id} must be resolved by the scheduler`);
+  }
+  if (result.outcome === 'failed' && result.route) {
+    throw new GraphSchedulerError('undeclared_route', 'Failed node results cannot select an outgoing route');
+  }
+  if (
+    node.id === descriptor.terminal_verification_node_id
+    && result.outcome === 'succeeded'
+    && result.evidence_refs.length === 0
+  ) {
+    throw new GraphSchedulerError(
+      'terminal_evidence_required',
+      'Terminal verification requires fresh evidence before success',
+    );
+  }
+
+  const next = cloneProjection(projection);
+  const nextActivation = next.activations[activation.activation_id];
+  nextActivation.status = result.outcome === 'succeeded' ? 'completed' : 'failed';
+  nextActivation.completed_transition_id = rawInput.transition_id;
+  const selected = result.outcome === 'succeeded'
+    ? selectEdges(descriptor, activation, result.route, projection)
+    : [];
+  const createdActivationIds: string[] = [];
+  let cohortId: string | undefined;
+
+  if (selected.length > 0 && selected.every((edge) => edge.kind === 'fan_out')) {
+    cohortId = createFanOut(
+      next,
+      activation,
+      selected as Extract<GraphEdge, { kind: 'fan_out' }>[],
+      identities,
+      createdActivationIds,
+    );
+  } else if (selected.length === 1) {
+    createNextActivation(
+      descriptor,
+      next,
+      activation,
+      selected[0],
+      identities,
+      createdActivationIds,
+    );
+  }
+
+  if (node.id === descriptor.terminal_verification_node_id && result.outcome === 'succeeded') {
+    next.terminal_verification_activation_ids.push(activation.activation_id);
+  }
+  const transition: GraphCommittedTransition = {
+    transition_id: rawInput.transition_id,
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    outcome: result.outcome,
+    request_fingerprint: fingerprint,
+    selected_edge_ids: selected.map((edge) => edge.id),
+    created_activation_ids: createdActivationIds,
+    attempt_id: result.attempt_id,
+    evidence_refs: result.evidence_refs.map((evidence) => ({ ...evidence })),
+    ...(result.route ? { route: result.route } : {}),
+    ...(result.output_summary ? { output_summary: result.output_summary } : {}),
+    ...(result.external_idempotency_key
+      ? { external_idempotency_key: result.external_idempotency_key }
+      : {}),
+    ...(cohortId ? { cohort_id: cohortId } : {}),
+  };
+  return commitTransition(next, transition);
+}
+
+export function resolveJoin(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: ResolveJoinInput,
+): SchedulerApplyResult {
+  const identities = input.identities ?? {};
+  const fingerprint = requestFingerprint('join', {
+    activation_id: input.activation_id,
+    identities,
+  });
+  const replay = replayedTransition(
+    projection,
+    input.transition_id,
+    input.activation_id,
+    fingerprint,
+  );
+  if (replay) return replay;
+  const activation = getActivation(projection, input.activation_id);
+  const node = nodeMap(descriptor).get(activation.node_id);
+  if (node?.kind !== 'join') {
+    throw new GraphSchedulerError('join_not_found', `Activation ${input.activation_id} is not a join`);
+  }
+  if (activation.status !== 'ready' || !activation.cohort_id) {
+    throw new GraphSchedulerError('join_not_ready', `Join activation ${input.activation_id} is not ready`);
+  }
+  const cohort = projection.cohorts[activation.cohort_id];
+  if (!cohort || cohort.owner_join_id !== node.id || cohort.join_activation_id !== activation.activation_id) {
+    throw new GraphSchedulerError('join_owner_mismatch', `Join activation ${input.activation_id} does not own its cohort`);
+  }
+  if (cohort.consumed) {
+    throw new GraphSchedulerError('join_already_consumed', `Cohort ${cohort.cohort_id} is already consumed`);
+  }
+  const tokens = cohort.expected_branch_token_ids.map((id) => projection.branch_tokens[id]);
+  if (tokens.some((token) => !token || token.status !== 'arrived')) {
+    throw new GraphSchedulerError('join_not_ready', `Join ${node.id} is still waiting for selected branch tokens`);
+  }
+  const edge = outgoingEdges(descriptor, node.id)[0];
+  if (!edge || edge.kind !== 'fixed') {
+    throw new GraphSchedulerError('invalid_join_edge', `Join ${node.id} does not have one fixed outgoing edge`);
+  }
+  const nextActivationId = requiredIdentity(identities.next_activation_ids, edge.id, 'next activation');
+  ensureUniqueIdentity(projection, 'activation', nextActivationId);
+
+  const next = cloneProjection(projection);
+  next.activations[activation.activation_id] = {
+    ...next.activations[activation.activation_id],
+    status: 'completed',
+    completed_transition_id: input.transition_id,
+  };
+  next.activations[nextActivationId] = newActivation(nextActivationId, edge.to);
+  next.cohorts[cohort.cohort_id] = { ...next.cohorts[cohort.cohort_id], consumed: true };
+  for (const token of tokens) {
+    next.branch_tokens[token.branch_token_id] = {
+      ...next.branch_tokens[token.branch_token_id],
+      status: 'consumed',
+      consumed_by_activation_id: activation.activation_id,
+    };
+  }
+  const transition: GraphCommittedTransition = {
+    transition_id: input.transition_id,
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    outcome: 'join_resolved',
+    request_fingerprint: fingerprint,
+    selected_edge_ids: [edge.id],
+    created_activation_ids: [nextActivationId],
+    evidence_refs: [],
+    cohort_id: cohort.cohort_id,
+  };
+  return commitTransition(next, transition);
+}
+
+export function listReadyExecutableActivations(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+): GraphActivation[] {
+  const nodes = nodeMap(descriptor);
+  return Object.values(projection.activations)
+    .filter((activation) => activation.status === 'ready' && nodes.get(activation.node_id)?.kind !== 'join')
+    .sort((left, right) => left.activation_id.localeCompare(right.activation_id));
+}
+
+export function listReadyJoinActivations(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+): GraphActivation[] {
+  const nodes = nodeMap(descriptor);
+  return Object.values(projection.activations)
+    .filter((activation) => activation.status === 'ready' && nodes.get(activation.node_id)?.kind === 'join')
+    .sort((left, right) => left.activation_id.localeCompare(right.activation_id));
+}
+
+export function isGraphSucceeded(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+): boolean {
+  if (projection.terminal_verification_activation_ids.length === 0) return false;
+  const terminalIds = new Set(projection.terminal_verification_activation_ids);
+  if (
+    [...terminalIds].some(
+      (id) => {
+        const activation = projection.activations[id];
+        const transition = activation?.completed_transition_id
+          ? projection.committed_transitions[activation.completed_transition_id]
+          : undefined;
+        return activation?.node_id !== descriptor.terminal_verification_node_id
+          || activation.status !== 'completed'
+          || transition?.outcome !== 'succeeded'
+          || transition.evidence_refs.length === 0;
+      },
+    )
+  ) {
+    return false;
+  }
+  return Object.values(projection.activations).every((activation) => activation.status === 'completed')
+    && Object.values(projection.cohorts).every((cohort) => cohort.consumed);
+}

--- a/src/graph/schema.ts
+++ b/src/graph/schema.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+
+import type {
+  GraphDescriptor,
+  GraphEvidenceReference,
+  GraphNodeResult,
+} from './types.js';
+
+const idSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, 'must be a stable identifier');
+const textSchema = z.string().min(1).max(32_768);
+
+const sideEffectFreeSchema = z.object({ policy: z.literal('side_effect_free') }).strict();
+const idempotentSchema = z
+  .object({
+    policy: z.literal('idempotent'),
+    idempotency_key_template: z.string().min(1).max(512),
+  })
+  .strict();
+const reconcileSchema = z.object({ policy: z.literal('reconcile') }).strict();
+
+export const graphEffectPolicySchema = z.discriminatedUnion('policy', [
+  sideEffectFreeSchema,
+  idempotentSchema,
+  reconcileSchema,
+]);
+
+const nodeBase = {
+  id: idSchema,
+  title: z.string().min(1).max(256),
+};
+const executableNodeBase = {
+  ...nodeBase,
+  timeout_ms: z.number().int().min(100).max(86_400_000),
+  max_attempts: z.number().int().min(1).max(20),
+  effect_policy: graphEffectPolicySchema,
+};
+
+export const graphAgentNodeSchema = z
+  .object({
+    ...executableNodeBase,
+    kind: z.literal('agent'),
+    instructions: textSchema,
+  })
+  .strict();
+export const graphCommandNodeSchema = z
+  .object({
+    ...executableNodeBase,
+    kind: z.literal('command'),
+    command: textSchema,
+  })
+  .strict();
+export const graphHumanApprovalNodeSchema = z
+  .object({
+    ...nodeBase,
+    kind: z.literal('human-approval'),
+    prompt: textSchema,
+  })
+  .strict();
+export const graphJoinNodeSchema = z
+  .object({
+    ...nodeBase,
+    kind: z.literal('join'),
+    fan_out_node_id: idSchema,
+    input_branch_ids: z.array(idSchema).min(2).max(64),
+  })
+  .strict();
+
+export const graphNodeSchema = z.discriminatedUnion('kind', [
+  graphAgentNodeSchema,
+  graphCommandNodeSchema,
+  graphHumanApprovalNodeSchema,
+  graphJoinNodeSchema,
+]);
+
+const edgeBase = { id: idSchema, from: idSchema, to: idSchema };
+export const graphFixedEdgeSchema = z.object({ ...edgeBase, kind: z.literal('fixed') }).strict();
+export const graphConditionalEdgeSchema = z
+  .object({ ...edgeBase, kind: z.literal('conditional'), route: idSchema })
+  .strict();
+export const graphFanOutEdgeSchema = z
+  .object({
+    ...edgeBase,
+    kind: z.literal('fan_out'),
+    branch_id: idSchema,
+    owner_join_id: idSchema,
+  })
+  .strict();
+export const graphBackEdgeSchema = z
+  .object({
+    ...edgeBase,
+    kind: z.literal('back_edge'),
+    route: idSchema,
+    max_traversals: z.number().int().min(1).max(100),
+  })
+  .strict();
+
+export const graphEdgeSchema = z.discriminatedUnion('kind', [
+  graphFixedEdgeSchema,
+  graphConditionalEdgeSchema,
+  graphFanOutEdgeSchema,
+  graphBackEdgeSchema,
+]);
+
+export const graphDescriptorSchema = z
+  .object({
+    descriptor_version: z.literal(1),
+    run_id: idSchema,
+    revision_id: idSchema,
+    goal: textSchema,
+    nodes: z.array(graphNodeSchema).min(1).max(1_000),
+    edges: z.array(graphEdgeSchema).max(5_000),
+    entry_node_ids: z.array(idSchema).min(1).max(64),
+    concurrency_limit: z.number().int().min(1).max(64),
+    terminal_verification_node_id: idSchema,
+    descriptor_hash: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  })
+  .strict();
+
+export const graphEvidenceReferenceSchema = z
+  .object({
+    kind: z.enum(['file', 'command', 'test', 'human', 'url']),
+    ref: z.string().min(1).max(2_048),
+    summary: z.string().max(2_048).optional(),
+  })
+  .strict();
+
+export const graphNodeResultSchema = z
+  .object({
+    outcome: z.enum(['succeeded', 'failed']),
+    attempt_id: idSchema,
+    route: idSchema.optional(),
+    output_summary: z.string().max(8_192).optional(),
+    evidence_refs: z.array(graphEvidenceReferenceSchema).max(64),
+    external_idempotency_key: z.string().min(1).max(512).optional(),
+  })
+  .strict();
+
+export function parseGraphDescriptorShape(input: unknown): GraphDescriptor {
+  return graphDescriptorSchema.parse(input) as GraphDescriptor;
+}
+
+export function parseGraphNodeResult(input: unknown): GraphNodeResult {
+  return graphNodeResultSchema.parse(input) as GraphNodeResult;
+}
+
+export function parseGraphEvidenceReference(input: unknown): GraphEvidenceReference {
+  return graphEvidenceReferenceSchema.parse(input) as GraphEvidenceReference;
+}

--- a/src/graph/store.ts
+++ b/src/graph/store.ts
@@ -1,0 +1,292 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import { withStateFileMutationLock } from '../lib/mode-state-io.js';
+import { resolveSessionStatePaths } from '../lib/worktree-paths.js';
+import { canonicalJson } from './descriptor.js';
+import {
+  GRAPH_MAX_TRANSITIONS,
+  GRAPH_STATE_MAX_BYTES,
+  GRAPH_MAX_TRANSITION_RESULT_BYTES,
+  parseGraphState,
+  type GraphState,
+  type GraphStateTransition,
+  type JsonValue,
+} from './runtime-types.js';
+
+export type GraphFenceScope = 'active' | 'pending_patch_base';
+
+export interface GraphStateFence {
+  session_id: string;
+  run_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+  commit_sequence: number;
+}
+
+export interface GraphMutationRequest {
+  transition_id: string;
+  operation: string;
+  operation_fingerprint: string;
+  expected: GraphStateFence;
+  fence_scope?: GraphFenceScope;
+}
+
+export interface GraphMutationValue<T extends JsonValue> {
+  next: GraphState;
+  result: T;
+}
+
+export interface GraphMutationResult<T extends JsonValue> {
+  state: GraphState;
+  result: T;
+  replayed: boolean;
+}
+
+export interface GraphStateStoreDependencies {
+  fileExists(path: string): boolean;
+  readText(path: string): string;
+  writeAtomic(path: string, value: unknown): void;
+  withExclusiveLock<T>(path: string, callback: () => T): { acquired: boolean; value: T | undefined };
+  now?(): string;
+}
+
+export interface GraphStateStoreOptions {
+  sessionId: string;
+  worktreeRoot?: string;
+  dependencies?: Partial<GraphStateStoreDependencies>;
+}
+
+export class GraphStoreError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphStoreError';
+    this.code = code;
+  }
+}
+
+const DEFAULT_DEPENDENCIES: GraphStateStoreDependencies = {
+  fileExists: existsSync,
+  readText: (path) => readFileSync(path, 'utf8'),
+  writeAtomic: atomicWriteJsonSync,
+  withExclusiveLock: (path, callback) => withStateFileMutationLock(path, callback, true),
+  now: () => new Date().toISOString(),
+};
+
+function boundedJsonClone<T extends JsonValue>(value: T, label: string): T {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch (error) {
+    throw new GraphStoreError('invalid_result', `${label} is not JSON serializable: ${String(error)}`);
+  }
+  if (serialized === undefined) {
+    throw new GraphStoreError('invalid_result', `${label} must be a JSON value`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > GRAPH_MAX_TRANSITION_RESULT_BYTES) {
+    throw new GraphStoreError('result_too_large', `${label} exceeds ${GRAPH_MAX_TRANSITION_RESULT_BYTES} bytes`);
+  }
+  return JSON.parse(serialized) as T;
+}
+
+function requestFingerprint(request: GraphMutationRequest): string {
+  return createHash('sha256')
+    .update(canonicalJson({
+      transition_id: request.transition_id,
+      operation: request.operation,
+      operation_fingerprint: request.operation_fingerprint,
+      expected: request.expected,
+      fence_scope: request.fence_scope ?? 'active',
+    }))
+    .digest('hex');
+}
+
+function assertIdentifier(value: string, name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw new GraphStoreError('invalid_request', `${name} must be a stable identifier`);
+  }
+}
+
+function assertRequest(request: GraphMutationRequest): void {
+  assertIdentifier(request.transition_id, 'transition_id');
+  if (request.operation.length === 0 || request.operation.length > 128) {
+    throw new GraphStoreError('invalid_request', 'operation must be a bounded string');
+  }
+  if (request.operation_fingerprint.length === 0 || request.operation_fingerprint.length > 1_024) {
+    throw new GraphStoreError('invalid_request', 'operation_fingerprint must be a bounded string');
+  }
+  if (!Number.isSafeInteger(request.expected.commit_sequence) || request.expected.commit_sequence < 0) {
+    throw new GraphStoreError('invalid_request', 'expected commit_sequence must be non-negative');
+  }
+}
+
+function assertFence(state: GraphState, request: GraphMutationRequest): void {
+  const expected = request.expected;
+  if (state.session_id !== expected.session_id) {
+    throw new GraphStoreError('session_mismatch', 'Graph session fence does not match');
+  }
+  if (state.run_id !== expected.run_id) {
+    throw new GraphStoreError('run_mismatch', 'Graph run fence does not match');
+  }
+  if (state.commit_sequence !== expected.commit_sequence) {
+    throw new GraphStoreError(
+      'sequence_conflict',
+      `Expected commit sequence ${expected.commit_sequence}, found ${state.commit_sequence}`,
+    );
+  }
+
+  if ((request.fence_scope ?? 'active') === 'pending_patch_base') {
+    const patch = state.pending_patch;
+    if (
+      state.status !== 'waiting_patch_approval'
+      || !patch
+      || patch.base_revision_id !== expected.revision_id
+      || patch.base_revision_hash !== expected.revision_hash
+      || patch.base_dispatch_generation !== expected.dispatch_generation
+      || state.active_revision_id !== expected.revision_id
+      || state.active_revision_hash !== expected.revision_hash
+    ) {
+      throw new GraphStoreError('stale_patch_base', 'Pending patch no longer binds the expected claim generation');
+    }
+    return;
+  }
+
+  if (state.active_revision_id !== expected.revision_id || state.active_revision_hash !== expected.revision_hash) {
+    throw new GraphStoreError('revision_conflict', 'Active graph revision/hash fence does not match');
+  }
+  if (state.dispatch_generation !== expected.dispatch_generation) {
+    throw new GraphStoreError('dispatch_generation_conflict', 'Graph dispatch generation fence does not match');
+  }
+}
+
+function assertStoreManagedFieldsUnchanged(before: GraphState, next: GraphState): void {
+  if (next.format_version !== before.format_version || next.session_id !== before.session_id || next.run_id !== before.run_id) {
+    throw new GraphStoreError('identity_mutation', 'Mutation callbacks cannot replace graph authority identity');
+  }
+  if (next.commit_sequence !== before.commit_sequence) {
+    throw new GraphStoreError('sequence_mutation', 'Mutation callbacks cannot edit commit_sequence directly');
+  }
+  if (canonicalJson(next.transitions) !== canonicalJson(before.transitions)) {
+    throw new GraphStoreError('history_mutation', 'Mutation callbacks cannot edit committed transition history directly');
+  }
+}
+
+export class GraphStateStore {
+  readonly sessionId: string;
+  readonly worktreeRoot: string | undefined;
+  readonly path: string;
+  private readonly readPath: string;
+  private readonly dependencies: GraphStateStoreDependencies;
+
+  constructor(options: GraphStateStoreOptions) {
+    const paths = resolveSessionStatePaths('graph', options.sessionId, options.worktreeRoot);
+    if (!paths.sessionScoped || paths.effectiveWrite !== paths.sessionScoped) {
+      throw new GraphStoreError('unsafe_state_path', 'Graph requires an explicit session-scoped write path');
+    }
+    this.sessionId = options.sessionId;
+    this.worktreeRoot = options.worktreeRoot;
+    this.path = paths.effectiveWrite;
+    this.readPath = paths.sessionScoped;
+    this.dependencies = { ...DEFAULT_DEPENDENCIES, ...options.dependencies };
+  }
+
+  read(): GraphState | null {
+    if (!this.dependencies.fileExists(this.readPath)) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(this.dependencies.readText(this.readPath));
+    } catch (error) {
+      throw new GraphStoreError('malformed_state', `Cannot parse graph-state.json: ${String(error)}`);
+    }
+    const state = parseGraphState(parsed);
+    if (state.session_id !== this.sessionId) {
+      throw new GraphStoreError('session_mismatch', 'Graph state belongs to a different session');
+    }
+    return state;
+  }
+
+  create(state: GraphState): GraphState {
+    const result = this.dependencies.withExclusiveLock(this.path, () => {
+      if (this.dependencies.fileExists(this.readPath)) {
+        throw new GraphStoreError('already_exists', 'Graph state already exists for this session');
+      }
+      const validated = parseGraphState(state);
+      if (validated.session_id !== this.sessionId) {
+        throw new GraphStoreError('session_mismatch', 'Initial Graph state session does not match the store');
+      }
+      if (validated.commit_sequence !== 0 || validated.transitions.length !== 0) {
+        throw new GraphStoreError('invalid_initial_state', 'Initial Graph state must start at sequence zero');
+      }
+      this.assertStateSize(validated);
+      this.dependencies.writeAtomic(this.path, validated);
+      return validated;
+    });
+    if (!result.acquired || !result.value) {
+      throw new GraphStoreError('lock_busy', 'Could not acquire the exclusive Graph state lock');
+    }
+    return result.value;
+  }
+
+  mutate<T extends JsonValue>(
+    request: GraphMutationRequest,
+    callback: (state: GraphState) => GraphMutationValue<T>,
+  ): GraphMutationResult<T> {
+    assertRequest(request);
+    const fingerprint = requestFingerprint(request);
+    const locked = this.dependencies.withExclusiveLock(this.path, () => {
+      const current = this.read();
+      if (!current) throw new GraphStoreError('not_found', 'Graph state does not exist for this session');
+
+      const prior = current.transitions.find((transition) => transition.transition_id === request.transition_id);
+      if (prior) {
+        if (prior.request_fingerprint !== fingerprint) {
+          throw new GraphStoreError('transition_reused', 'Transition ID was already committed for a different request');
+        }
+        return { state: current, result: prior.result as T, replayed: true };
+      }
+
+      assertFence(current, request);
+      if (current.transitions.length >= GRAPH_MAX_TRANSITIONS) {
+        throw new GraphStoreError('transition_limit', 'Graph transition limit has been reached');
+      }
+      const mutation = callback(structuredClone(current));
+      assertStoreManagedFieldsUnchanged(current, mutation.next);
+      const result = boundedJsonClone(mutation.result, 'transition result');
+      const sequence = current.commit_sequence + 1;
+      const committedAt = this.dependencies.now?.() ?? new Date().toISOString();
+      const transition: GraphStateTransition = {
+        transition_id: request.transition_id,
+        operation: request.operation,
+        operation_fingerprint: request.operation_fingerprint,
+        request_fingerprint: fingerprint,
+        sequence,
+        committed_at: committedAt,
+        result,
+      };
+      const next = parseGraphState({
+        ...mutation.next,
+        commit_sequence: sequence,
+        transitions: [...current.transitions, transition],
+        updated_at: committedAt,
+      });
+      this.assertStateSize(next);
+      this.dependencies.writeAtomic(this.path, next);
+      return { state: next, result, replayed: false };
+    });
+    if (!locked.acquired || !locked.value) {
+      throw new GraphStoreError('lock_busy', 'Could not acquire the exclusive Graph state lock');
+    }
+    return locked.value;
+  }
+
+  private assertStateSize(state: GraphState): void {
+    const bytes = Buffer.byteLength(JSON.stringify(state), 'utf8');
+    if (bytes > GRAPH_STATE_MAX_BYTES) {
+      throw new GraphStoreError('state_too_large', `Graph state exceeds ${GRAPH_STATE_MAX_BYTES} bytes`);
+    }
+  }
+}

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,204 @@
+export type GraphNodeKind = 'agent' | 'command' | 'human-approval' | 'join';
+
+export type GraphEffectPolicy =
+  | { policy: 'side_effect_free' }
+  | { policy: 'idempotent'; idempotency_key_template: string }
+  | { policy: 'reconcile' };
+
+interface GraphNodeBase {
+  id: string;
+  kind: GraphNodeKind;
+  title: string;
+}
+
+interface GraphExecutableNodeBase extends GraphNodeBase {
+  timeout_ms: number;
+  max_attempts: number;
+  effect_policy: GraphEffectPolicy;
+}
+
+export interface GraphAgentNode extends GraphExecutableNodeBase {
+  kind: 'agent';
+  instructions: string;
+}
+
+export interface GraphCommandNode extends GraphExecutableNodeBase {
+  kind: 'command';
+  command: string;
+}
+
+export interface GraphHumanApprovalNode extends GraphNodeBase {
+  kind: 'human-approval';
+  prompt: string;
+}
+
+export interface GraphJoinNode extends GraphNodeBase {
+  kind: 'join';
+  fan_out_node_id: string;
+  input_branch_ids: string[];
+}
+
+export type GraphNode =
+  | GraphAgentNode
+  | GraphCommandNode
+  | GraphHumanApprovalNode
+  | GraphJoinNode;
+
+interface GraphEdgeBase {
+  id: string;
+  from: string;
+  to: string;
+}
+
+export interface GraphFixedEdge extends GraphEdgeBase {
+  kind: 'fixed';
+}
+
+export interface GraphConditionalEdge extends GraphEdgeBase {
+  kind: 'conditional';
+  route: string;
+}
+
+export interface GraphFanOutEdge extends GraphEdgeBase {
+  kind: 'fan_out';
+  branch_id: string;
+  owner_join_id: string;
+}
+
+export interface GraphBackEdge extends GraphEdgeBase {
+  kind: 'back_edge';
+  route: string;
+  max_traversals: number;
+}
+
+export type GraphEdge =
+  | GraphFixedEdge
+  | GraphConditionalEdge
+  | GraphFanOutEdge
+  | GraphBackEdge;
+
+export interface GraphDescriptorInput {
+  descriptor_version: 1;
+  run_id: string;
+  revision_id: string;
+  goal: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  entry_node_ids: string[];
+  concurrency_limit: number;
+  terminal_verification_node_id: string;
+  descriptor_hash?: string;
+}
+
+export type GraphDescriptor = GraphDescriptorInput;
+
+export type SealedGraphDescriptor = GraphDescriptorInput & {
+  descriptor_hash: string;
+};
+
+export interface GraphEvidenceReference {
+  kind: 'file' | 'command' | 'test' | 'human' | 'url';
+  ref: string;
+  summary?: string;
+}
+
+export interface GraphNodeResult {
+  outcome: 'succeeded' | 'failed';
+  attempt_id: string;
+  route?: string;
+  output_summary?: string;
+  evidence_refs: GraphEvidenceReference[];
+  external_idempotency_key?: string;
+}
+
+export type GraphActivationStatus = 'ready' | 'running' | 'completed' | 'failed';
+
+export interface GraphActivation {
+  activation_id: string;
+  node_id: string;
+  status: GraphActivationStatus;
+  attempt_no: number;
+  attempt_ids: string[];
+  active_attempt_id?: string;
+  completed_transition_id?: string;
+  cohort_id?: string;
+  branch_token_id?: string;
+  traversal_owner_id: string;
+}
+
+export interface GraphBranchToken {
+  branch_token_id: string;
+  cohort_id: string;
+  branch_id: string;
+  owner_join_id: string;
+  status: 'active' | 'arrived' | 'consumed';
+  current_activation_id?: string;
+  consumed_by_activation_id?: string;
+}
+
+export interface GraphCohort {
+  cohort_id: string;
+  fan_out_node_id: string;
+  owner_join_id: string;
+  expected_branch_token_ids: string[];
+  join_activation_id?: string;
+  consumed: boolean;
+}
+
+export interface GraphCommittedTransition {
+  transition_id: string;
+  activation_id: string;
+  node_id: string;
+  outcome: 'succeeded' | 'failed' | 'join_resolved';
+  request_fingerprint: string;
+  selected_edge_ids: string[];
+  created_activation_ids: string[];
+  cohort_id?: string;
+  attempt_id?: string;
+  route?: string;
+  output_summary?: string;
+  evidence_refs: GraphEvidenceReference[];
+  external_idempotency_key?: string;
+}
+
+export interface GraphSchedulerProjection {
+  activations: Record<string, GraphActivation>;
+  cohorts: Record<string, GraphCohort>;
+  branch_tokens: Record<string, GraphBranchToken>;
+  traversal_counts: Record<string, number>;
+  committed_transitions: Record<string, GraphCommittedTransition>;
+  terminal_verification_activation_ids: string[];
+}
+
+export interface BeginActivationAttemptInput {
+  activation_id: string;
+  attempt_id: string;
+}
+
+export type ReleaseAttemptForRetryInput = BeginActivationAttemptInput;
+
+export interface SchedulerTransitionIdentities {
+  next_activation_ids?: Record<string, string>;
+  cohort_id?: string;
+  branch_token_ids?: Record<string, string>;
+  join_activation_id?: string;
+}
+
+export interface ApplyNodeResultInput {
+  activation_id: string;
+  transition_id: string;
+  result: GraphNodeResult;
+  identities?: SchedulerTransitionIdentities;
+}
+
+export interface ResolveJoinInput {
+  activation_id: string;
+  transition_id: string;
+  identities?: SchedulerTransitionIdentities;
+}
+
+export interface SchedulerApplyResult {
+  projection: GraphSchedulerProjection;
+  transition: GraphCommittedTransition;
+  replayed: boolean;
+}

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -2685,6 +2685,28 @@ This article argues that fake popularity signals damage trust in open source.`;
   // -------------------------------------------------------------------------
 
   describe('unified prefix detector: /omc: and /oh-my-claudecode: forms (spec g)', () => {
+    it.each([
+      '/graph migrate payments',
+      '/omc:graph migrate payments',
+      '/oh-my-claudecode:graph migrate payments',
+    ])('detects explicit Graph workflow invocation %s', (prompt) => {
+      const result = detectKeywordsWithType(prompt);
+      expect(result.find((entry) => entry.type === 'graph')).toBeDefined();
+    });
+
+    it.each([
+      'graph',
+      'please build a graph for this task',
+      'the graph keeps the project overview',
+      'run `/graph migrate payments` later',
+      '```\n/graph migrate payments\n```',
+      '/graph-state/runs.json',
+      '/graphical render',
+    ])('does not activate Graph from non-command text %s', (prompt) => {
+      const result = detectKeywordsWithType(prompt);
+      expect(result.find((entry) => entry.type === 'graph')).toBeUndefined();
+    });
+
     it('/omc:ralph fix auth detects ralph', () => {
       const result = detectKeywordsWithType('/omc:ralph fix auth');
       expect(result.find((r) => r.type === 'ralph')).toBeDefined();
@@ -2741,6 +2763,19 @@ This article argues that fake popularity signals damage trust in open source.`;
   // parseExplicitWorkflowSlashInvocation — unit tests (spec g)
   // -------------------------------------------------------------------------
   describe('parseExplicitWorkflowSlashInvocation — parser unit tests (spec g)', () => {
+    it('normalizes all Graph slash prefixes and preserves arguments', () => {
+      for (const prompt of [
+        '/graph migrate payments',
+        '/omc:graph migrate payments',
+        '/oh-my-claudecode:graph migrate payments',
+      ]) {
+        expect(parseExplicitWorkflowSlashInvocation(prompt)).toMatchObject({
+          skill: 'graph',
+          args: 'migrate payments',
+        });
+      }
+    });
+
     it('returns null for empty string', () => {
       expect(parseExplicitWorkflowSlashInvocation('')).toBeNull();
     });

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -16,6 +16,7 @@ import {
 
 export type KeywordType =
   | 'cancel'      // Priority 1
+  | 'graph'       // Priority 1.5 (explicit slash only)
   | 'ralph'       // Priority 2
   | 'autopilot'   // Priority 3
   | 'team'        // Priority 4.5 (team mode)
@@ -45,6 +46,7 @@ export interface DetectedKeyword {
  */
 const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   cancel: /\b(cancelomc|stopomc)\b/i,
+  graph: /(?!x)x/,
   ralph: /\b(ralph)\b(?!-)|(랄프)(?!로렌)|(ラルフ)(?!・?ローレン)/i,
   autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|\b(?:build|create|make)\s+me\s+(?:an?\s+)?(?:app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b|\bi\s+want\s+an?\s+(?:app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b|(오토파일럿)|(オートパイロット)/i,
   ultrawork: /\b(ultrawork|ulw)\b|(울트라워크)|(ウルトラワーク)/i,
@@ -92,7 +94,7 @@ const KEYWORD_SKIP_PREDICATES: Partial<Record<KeywordType, (text: string) => boo
  * Priority order for keyword detection
  */
 const KEYWORD_PRIORITY: KeywordType[] = [
-  'cancel', 'ralph', 'autopilot', 'team', 'ultrawork',
+  'cancel', 'graph', 'ralph', 'autopilot', 'team', 'ultrawork',
   'ccg', 'ralplan', 'tdd', 'code-review', 'security-review',
   'ultrathink', 'deepsearch', 'analyze', 'deep-interview', 'codex', 'gemini', 'cursor', 'antigravity'
 ];
@@ -105,6 +107,7 @@ const KEYWORD_PRIORITY: KeywordType[] = [
  */
 const CANONICAL_WORKFLOW_SLASH_SKILLS = [
   'autopilot',
+  'graph',
   'ralph',
   'team',
   'ultrawork',
@@ -128,6 +131,7 @@ const SLASH_SKILL_TO_KEYWORD_TYPE: Partial<
   Record<CanonicalWorkflowSlashSkill, KeywordType>
 > = {
   autopilot: 'autopilot',
+  graph: 'graph',
   ralph: 'ralph',
   team: 'team',
   ultrawork: 'ultrawork',

--- a/src/hooks/mode-registry/__tests__/session-isolation.test.ts
+++ b/src/hooks/mode-registry/__tests__/session-isolation.test.ts
@@ -15,6 +15,7 @@ import {
   hasModeState,
   isModeActiveInAnySession,
   getActiveSessionsForMode,
+  clearAllModeStates,
   clearStaleSessionDirs,
 } from '../index.js';
 
@@ -151,6 +152,68 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('Cross-session mode discovery (isModeActiveInAnySession)', () => {
+    it.each([
+      'running',
+      'waiting_human',
+      'waiting_patch_approval',
+      'reconciling',
+    ])('derives active Graph state from durable status %s', (status) => {
+      createSessionState('session-graph', 'graph', {
+        session_id: 'session-graph',
+        status,
+        active: false,
+      });
+
+      expect(isModeActive('graph', tempDir, 'session-graph')).toBe(true);
+      expect(getActiveModes(tempDir, 'session-graph')).toContain('graph');
+    });
+
+    it.each(['draft', 'awaiting_approval', 'paused', 'succeeded', 'failed', 'cancelled'])(
+      'treats Graph status %s as inactive',
+      (status) => {
+        createSessionState('session-graph', 'graph', {
+          session_id: 'session-graph',
+          status,
+          active: true,
+        });
+
+        expect(isModeActive('graph', tempDir, 'session-graph')).toBe(false);
+        expect(getActiveModes(tempDir, 'session-graph')).not.toContain('graph');
+      },
+    );
+
+    it('treats malformed, missing, and session-mismatched Graph state as inactive', () => {
+      const sessionId = 'session-graph';
+      const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const graphPath = join(sessionDir, 'graph-state.json');
+
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, '{not-json');
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, JSON.stringify({ session_id: sessionId, status: 'unknown' }));
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, JSON.stringify({ session_id: 'another-session', status: 'running' }));
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+    });
+
+    it('respects a generic workflow tombstone over durable Graph status', () => {
+      const sessionId = 'session-graph';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
+      createSessionState(sessionId, 'skill-active', {
+        version: 2,
+        active_skills: {
+          graph: {
+            skill_name: 'graph',
+            completed_at: new Date().toISOString(),
+          },
+        },
+      });
+
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      expect(getActiveModes(tempDir, sessionId)).not.toContain('graph');
+    });
+
     it('should find autoresearch active in any session', () => {
       createSessionState('session-A', 'autoresearch', { active: true });
       expect(isModeActiveInAnySession('autoresearch', tempDir)).toBe(true);
@@ -193,6 +256,16 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('clearModeState with sessionId', () => {
+    it('refuses generic Graph clear and preserves the durable ledger', () => {
+      const sessionId = 'graph-clear-guard';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
+      const graphPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'graph-state.json');
+      const before = readFileSync(graphPath, 'utf8');
+
+      expect(clearModeState('graph', tempDir, sessionId)).toBe(false);
+      expect(readFileSync(graphPath, 'utf8')).toBe(before);
+    });
+
     it('should clear session-specific state', () => {
       createSessionState('session-A', 'ultrawork', { active: true });
       createSessionState('session-B', 'ultrawork', { active: true });
@@ -273,6 +346,35 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('Stale session cleanup', () => {
+    it('preserves Graph authority during generic clear-all and stale cleanup', () => {
+      const sessionId = 'graph-durable-session';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'paused' });
+      createSessionState(sessionId, 'skill-active', {
+        version: 2,
+        active_skills: { graph: { skill_name: 'graph', completed_at: null } },
+      });
+      const stateDir = join(tempDir, '.omc', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const rootSlot = join(stateDir, 'skill-active-state.json');
+      writeFileSync(rootSlot, JSON.stringify({
+        version: 2,
+        active_skills: { graph: { skill_name: 'graph', completed_at: null } },
+      }));
+      const controlOwner = join(sessionDir, 'control-owner-state.json');
+      writeFileSync(controlOwner, JSON.stringify({ root: { mode: 'graph', run_id: 'run-1' } }));
+      const protectedPaths = [
+        join(sessionDir, 'graph-state.json'),
+        join(sessionDir, 'skill-active-state.json'),
+        rootSlot,
+        controlOwner,
+      ];
+      const before = protectedPaths.map(path => readFileSync(path, 'utf8'));
+
+      expect(clearAllModeStates(tempDir)).toBe(true);
+      expect(clearStaleSessionDirs(tempDir, -1)).not.toContain(sessionId);
+      protectedPaths.forEach((path, index) => expect(readFileSync(path, 'utf8')).toBe(before[index]));
+    });
+
     it('serializes marker writers on the same lock used by cleanup', () => {
       expect(createModeMarker('ralph', tempDir, { session_id: 'session-A', workflowRunId: 'old-run' })).toBe(true);
       const markerPath = join(tempDir, '.omc', 'state', 'ralph-verification.json');

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -59,6 +59,17 @@ const MODE_CONFIGS: Record<ExecutionMode, ModeConfig> = {
     activeProperty: "active",
     hasGlobalState: false,
   },
+  [MODE_NAMES.GRAPH]: {
+    name: "Graph",
+    stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH],
+    activeStatuses: [
+      "running",
+      "waiting_human",
+      "waiting_patch_approval",
+      "reconciling",
+    ],
+    hasGlobalState: false,
+  },
   [MODE_NAMES.TEAM]: {
     name: "Team",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.TEAM],
@@ -106,7 +117,11 @@ export { MODE_CONFIGS };
 /**
  * Modes that are mutually exclusive (cannot run concurrently)
  */
-const EXCLUSIVE_MODES: ExecutionMode[] = [MODE_NAMES.AUTOPILOT, MODE_NAMES.AUTORESEARCH];
+const EXCLUSIVE_MODES: ExecutionMode[] = [
+  MODE_NAMES.AUTOPILOT,
+  MODE_NAMES.AUTORESEARCH,
+  MODE_NAMES.GRAPH,
+];
 
 /**
  * Get the state directory path
@@ -227,10 +242,26 @@ function isJsonModeActive(
   mode: ExecutionMode,
   sessionId?: string,
 ): boolean {
+  const config = MODE_CONFIGS[mode];
+  // Workflow-slot tombstone override: when the session workflow ledger records
+  // this mode as tombstoned (soft-completed), the stale per-mode state file is
+  // ignored so a fresh invocation can proceed without clearing artifacts
+  // manually. This applies to durable-status modes (e.g. graph) too - a
+  // cancelled/finished graph whose skill slot was tombstoned must not read as
+  // active just because graph-state.json still holds an active status.
   if (isWorkflowSlotTombstonedForMode(cwd, mode, sessionId)) {
     return false;
   }
-  const config = MODE_CONFIGS[mode];
+
+  const stateIsActive = (state: Record<string, unknown>): boolean => {
+    if (config.activeStatuses) {
+      return typeof state.status === "string" && config.activeStatuses.includes(state.status);
+    }
+    if (config.activeProperty) {
+      return state[config.activeProperty] === true;
+    }
+    return true;
+  };
 
   // When sessionId is provided, ONLY check session-scoped path — no legacy fallback.
   // This prevents cross-session state leakage where one session's legacy file
@@ -246,11 +277,7 @@ function isJsonModeActive(
         return false;
       }
 
-      if (config.activeProperty) {
-        return state[config.activeProperty] === true;
-      }
-
-      return true;
+      return stateIsActive(state);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return false;
@@ -265,12 +292,7 @@ function isJsonModeActive(
     const content = readFileSync(stateFile, "utf-8");
     const state = JSON.parse(content);
 
-    if (config.activeProperty) {
-      return state[config.activeProperty] === true;
-    }
-
-    // Default: file existence means active
-    return true;
+    return stateIsActive(state);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
@@ -425,6 +447,26 @@ function readJsonSnapshot(filePath: string): { state: Record<string, unknown>; s
   }
 }
 
+function hasGraphAuthorityInSessionDir(sessionDir: string): boolean {
+  if (existsSync(join(sessionDir, MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH]))) return true;
+  const skillState = readJsonSnapshot(join(sessionDir, "skill-active-state.json"))?.state;
+  if (
+    skillState?.active_skills
+    && typeof skillState.active_skills === "object"
+    && (skillState.active_skills as Record<string, unknown>).graph
+  ) {
+    return true;
+  }
+  const controlOwner = readJsonSnapshot(join(sessionDir, "control-owner-state.json"))?.state;
+  const controlRoot = controlOwner?.root;
+  return Boolean(
+    controlRoot
+    && typeof controlRoot === "object"
+    && (controlRoot as Record<string, unknown>).mode === MODE_NAMES.GRAPH
+    && (controlRoot as Record<string, unknown>).phase === "active",
+  );
+}
+
 function clearDiscoveredJsonFile(
   filePath: string,
   observed: { state: Record<string, unknown>; snapshot: string } | null,
@@ -459,6 +501,7 @@ export function clearModeState(
   sessionId?: string,
   expectedState?: Record<string, unknown>,
 ): boolean {
+  if (mode === MODE_NAMES.GRAPH) return false;
   const config = MODE_CONFIGS[mode];
   let success = true;
   const markerFile = getMarkerFilePath(cwd, mode);
@@ -558,6 +601,7 @@ export function clearAllModeStates(cwd: string): boolean {
   let success = true;
 
   for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
+    if (mode === MODE_NAMES.GRAPH) continue;
     if (!clearModeState(mode, cwd)) {
       success = false;
     }
@@ -566,7 +610,13 @@ export function clearAllModeStates(cwd: string): boolean {
   // Clear skill-active-state.json (issue #1033)
   const skillStatePath = join(getStateDir(cwd), "skill-active-state.json");
   try {
-    if (!clearObservedJsonFile(skillStatePath)) throw new Error("state mutation lock unavailable");
+    const skillState = readJsonSnapshot(skillStatePath)?.state;
+    const graphSlot = skillState?.active_skills
+      && typeof skillState.active_skills === "object"
+      && (skillState.active_skills as Record<string, unknown>).graph;
+    if (!graphSlot && !clearObservedJsonFile(skillStatePath)) {
+      throw new Error("state mutation lock unavailable");
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
       success = false;
@@ -578,6 +628,7 @@ export function clearAllModeStates(cwd: string): boolean {
     const sessionIds = listSessionIds(cwd);
     for (const sid of sessionIds) {
       const sessionDir = getSessionStateDir(sid, cwd);
+      if (hasGraphAuthorityInSessionDir(sessionDir)) continue;
       rmSync(sessionDir, { recursive: true, force: true });
     }
   } catch {
@@ -649,6 +700,10 @@ export function clearStaleSessionDirs(
     const sessionDir = getSessionStateDir(sid, cwd);
     try {
       const files = readdirSync(sessionDir);
+
+      // Graph ledgers are durable recovery authority and are never removed by
+      // generic stale-session garbage collection.
+      if (hasGraphAuthorityInSessionDir(sessionDir)) continue;
 
       // Remove empty directories
       if (files.length === 0) {

--- a/src/hooks/mode-registry/types.ts
+++ b/src/hooks/mode-registry/types.ts
@@ -7,6 +7,7 @@
 export type ExecutionMode =
   | 'autopilot'
   | 'autoresearch'
+  | 'graph'
   | 'team'
   | 'ralph'
   | 'ultrawork'
@@ -24,6 +25,8 @@ export interface ModeConfig {
   markerFile?: string;
   /** Property to check in JSON state (if JSON-based) */
   activeProperty?: string;
+  /** Status values that mean active when durable status owns lifecycle. */
+  activeStatuses?: readonly string[];
   /** Whether state is SQLite-based (requires marker file) */
   isSqlite?: boolean;
   /** Whether mode has global state in ~/.claude/ */

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -195,6 +195,45 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
       });
     });
 
+    it("does not honor an autopilot cancel signal without an exclusive lock even when a graph state file is present (GRAPH-in-EXCLUSIVE_MODES safety invariant)", async () => {
+      // Regression guard: GRAPH was added to EXCLUSIVE_MODES. Its presence must
+      // not weaken the cancel-safety invariant - an autopilot cancel signal that
+      // cannot acquire the exclusive state lock must still be rejected so a
+      // forged cancel cannot suppress an active autopilot.
+      const sessionId = "graph-present-autopilot-cancel-no-flock";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const state = initAutopilot(tempDir, "Finish the task", sessionId)!;
+      state.phase = "planning";
+      state.project_path = tempDir;
+      writeFileSync(join(sessionDir, "autopilot-state.json"), JSON.stringify(state));
+      // Place a durable graph-state file alongside autopilot state. This is the
+      // artifact that GRAPH-in-EXCLUSIVE_MODES makes mode-registry aware of; it
+      // must not change the cancel verdict.
+      writeFileSync(join(sessionDir, "graph-state.json"), JSON.stringify({
+        format_version: 1,
+        session_id: sessionId,
+        run_id: "run-graph",
+        status: "running",
+      }));
+      const now = Date.now();
+      writeFileSync(join(sessionDir, "cancel-signal-state.json"), JSON.stringify({
+        active: true,
+        mode: "autopilot",
+        source: "state_clear",
+        requested_at: new Date(now).toISOString(),
+        expires_at: new Date(now + 30_000).toISOString(),
+        target_state_sha256: createHash("sha256").update(JSON.stringify(state)).digest("hex"),
+      }));
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
+
+      await expect(checkPersistentModes(sessionId, tempDir)).resolves.toMatchObject({
+        shouldBlock: true,
+        mode: "autopilot",
+      });
+    });
+
+
     it("honors a requested-at-only Ultrawork cancellation without flock when canonical autopilot discovery finds no target", async () => {
       const sessionId = "portable-generic-cancel-no-autopilot";
       activateUltrawork("Finish the task", sessionId, tempDir);

--- a/src/hooks/skill-state/__tests__/skill-state.test.ts
+++ b/src/hooks/skill-state/__tests__/skill-state.test.ts
@@ -15,6 +15,7 @@ import {
   writeSkillActiveStateCopies,
   upsertWorkflowSkillSlot,
   markWorkflowSkillCompleted,
+  markDurableWorkflowSkillCompleted,
   clearWorkflowSkillSlot,
   pruneExpiredWorkflowSkillTombstones,
   resolveAuthoritativeWorkflowSkill,
@@ -74,6 +75,7 @@ describe('skill-state', () => {
       expect(getSkillProtection('team')).toBe('none');
       expect(getSkillProtection('ultrawork')).toBe('none');
       expect(getSkillProtection('cancel')).toBe('none');
+      expect(getSkillProtection('graph')).toBe('none');
     });
 
     it('returns none for instant/read-only skills', () => {
@@ -1017,6 +1019,22 @@ describe('skill-state', () => {
   // Pure workflow-slot helpers — unit tests
   // -----------------------------------------------------------------------
   describe('upsertWorkflowSkillSlot — pure helper', () => {
+    it('recognizes Graph as a canonical workflow and creates its durable slot', () => {
+      const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'graph', {
+        session_id: 'graph-session',
+        mode_state_path: 'graph-state.json',
+        initialized_mode: 'graph',
+        initialized_state_path: '',
+        initialized_session_state_path: '',
+      });
+
+      expect(state.active_skills.graph).toMatchObject({
+        skill_name: 'graph',
+        completed_at: null,
+        initialized_mode: 'graph',
+      });
+    });
+
     it('creates a new slot with provided fields', () => {
       const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'ralph', {
         session_id: 's1',
@@ -1071,6 +1089,33 @@ describe('skill-state', () => {
   });
 
   describe('markWorkflowSkillCompleted — pure helper', () => {
+    it('does not tombstone a durable Graph slot on generic tool completion', () => {
+      const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'graph', {
+        session_id: 'graph-session',
+        mode_state_path: 'graph-state.json',
+        initialized_mode: 'graph',
+        initialized_state_path: '',
+        initialized_session_state_path: '',
+      });
+
+      expect(markWorkflowSkillCompleted(state, 'graph', '2026-07-21T00:00:00.000Z')).toBe(state);
+      expect(state.active_skills.graph?.completed_at).toBeNull();
+    });
+
+    it('allows the Graph runtime to tombstone only after a durable stop', () => {
+      const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'graph', {
+        session_id: 'graph-session',
+        mode_state_path: 'graph-state.json',
+        initialized_mode: 'graph',
+        initialized_state_path: '',
+        initialized_session_state_path: '',
+      });
+      const completedAt = '2026-07-21T00:00:00.000Z';
+      const tombstoned = markDurableWorkflowSkillCompleted(state, 'graph', completedAt);
+
+      expect(tombstoned.active_skills.graph?.completed_at).toBe(completedAt);
+    });
+
     it('sets completed_at to provided timestamp', () => {
       const ts = '2026-04-17T12:00:00.000Z';
       const state: SkillActiveStateV2 = {

--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -59,6 +59,7 @@ export const WORKFLOW_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
  */
 export const CANONICAL_WORKFLOW_SKILLS = [
   'autopilot',
+  'graph',
   'ralph',
   'team',
   'ultrawork',
@@ -106,6 +107,7 @@ const SKILL_PROTECTION: Record<string, SkillProtectionLevel> = {
   // === Canonical workflow skills — bypass support-skill protection; flow through the workflow-slot path ===
   autopilot: 'none',
   autoresearch: 'none',
+  graph: 'none',
   ralph: 'none',
   ultrawork: 'none',
   team: 'none',
@@ -342,6 +344,26 @@ export function markWorkflowSkillCompleted(
   now: string = new Date().toISOString(),
 ): SkillActiveStateV2 {
   const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
+  if (normalized === 'graph') return state;
+  return markWorkflowSkillCompletedUnchecked(state, normalized, now);
+}
+
+/** Tombstone Graph only after its durable state is paused or terminal. */
+export function markDurableWorkflowSkillCompleted(
+  state: SkillActiveStateV2,
+  skillName: string,
+  now: string = new Date().toISOString(),
+): SkillActiveStateV2 {
+  const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
+  if (normalized !== 'graph') return state;
+  return markWorkflowSkillCompletedUnchecked(state, normalized, now);
+}
+
+function markWorkflowSkillCompletedUnchecked(
+  state: SkillActiveStateV2,
+  normalized: string,
+  now: string,
+): SkillActiveStateV2 {
   const existing = state.active_skills[normalized];
   if (!existing) return state;
   const updated: ActiveSkillSlot = { ...existing, completed_at: now };

--- a/src/hud/__tests__/graph.test.ts
+++ b/src/hud/__tests__/graph.test.ts
@@ -1,0 +1,129 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { forkJoinDescriptor } from '../../graph/__tests__/fixtures.js';
+import { sealGraphDescriptor } from '../../graph/descriptor.js';
+import { createInitialGraphState } from '../../graph/runtime-types.js';
+import { initializeGraphProjection } from '../../graph/scheduler.js';
+import { renderGraph } from '../elements/graph.js';
+import {
+  getActiveSkills,
+  isAnyModeActive,
+  readGraphStateForHud,
+} from '../omc-state.js';
+
+function graphState(sessionId: string) {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  const projection = initializeGraphProjection(descriptor, { approval: 'activation-private-entry' });
+  return createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'test-control-nonce',
+    descriptor,
+    projection,
+    status: 'running',
+    created_at: '2026-07-20T00:00:00.000Z',
+    approval: {
+      approved_at: '2026-07-20T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'private-approval-evidence' },
+    },
+  });
+}
+
+describe('Graph HUD projection', () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('reads only the current session and exposes bounded public counters', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const sessionId = 'session-current';
+    const state = graphState(sessionId);
+    const stateDirectory = join(directory, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), JSON.stringify(state), 'utf8');
+
+    const projection = readGraphStateForHud(directory, sessionId);
+    expect(projection).toEqual({
+      status: 'running',
+      completedActivations: 0,
+      totalActivations: 1,
+      readyActivations: 1,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: state.active_revision_hash.slice(0, 12),
+    });
+    expect(readGraphStateForHud(directory, 'session-other')).toBeNull();
+    expect(isAnyModeActive(directory, sessionId)).toBe(true);
+    expect(getActiveSkills(directory, sessionId)).toContain('graph');
+  });
+
+  it('renders no goal, command, output, evidence, or full identity', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const state = graphState('session-private');
+    const stateDirectory = join(directory, '.omc', 'state');
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), JSON.stringify(state), 'utf8');
+
+    const rendered = renderGraph(readGraphStateForHud(directory));
+    expect(rendered).toMatch(/G:.*running.*0\/1.*ready:1.*live:0.*reconcile:0/);
+    expect(rendered).not.toMatch(/Build and verify|run-branch-b|private|human/);
+    expect(rendered).not.toContain(state.active_revision_hash);
+  });
+
+  it.each(['paused', 'failed', 'cancelled', 'succeeded'] as const)(
+    'hides terminal or inactive status %s',
+    (status) => {
+      const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+      directories.push(directory);
+      const state = { ...graphState('session-terminal'), status };
+      const stateDirectory = join(directory, '.omc', 'state');
+      mkdirSync(stateDirectory, { recursive: true });
+      writeFileSync(join(stateDirectory, 'graph-state.json'), JSON.stringify(state), 'utf8');
+
+      expect(readGraphStateForHud(directory)).toBeNull();
+    },
+  );
+
+  it('keeps the graph indicator visible on a transient partial write', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const stateDirectory = join(directory, '.omc', 'state');
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), '{"status":"running"}', 'utf8');
+
+    // File exists and is non-empty but fails parse/validate (mid-commit write).
+    // The graph must stay visible rather than disappearing during a live tick.
+    const projection = readGraphStateForHud(directory);
+    expect(projection).toEqual({
+      status: 'unreadable',
+      completedActivations: 0,
+      totalActivations: 0,
+      readyActivations: 0,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: '?',
+    });
+    expect(isAnyModeActive(directory)).toBe(true);
+    expect(getActiveSkills(directory)).toContain('graph');
+    expect(renderGraph(projection)).toMatch(/G:.*unreadable/);
+  });
+
+  it('returns null for an empty graph-state file', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const stateDirectory = join(directory, '.omc', 'state');
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), '', 'utf8');
+
+    expect(readGraphStateForHud(directory)).toBeNull();
+  });
+});

--- a/src/hud/elements/graph.ts
+++ b/src/hud/elements/graph.ts
@@ -1,0 +1,49 @@
+/**
+ * Compact, public-only Graph runtime status.
+ */
+
+import { cyan, red, yellow } from '../colors.js';
+
+export type ActiveGraphStatus =
+  | 'awaiting_approval'
+  | 'running'
+  | 'waiting_human'
+  | 'waiting_patch_approval'
+  | 'reconciling'
+  | 'unreadable';
+
+export interface GraphStateForHud {
+  status: ActiveGraphStatus;
+  completedActivations: number;
+  totalActivations: number;
+  readyActivations: number;
+  liveClaims: number;
+  unresolvedReconciliations: number;
+  revisionHashShort: string;
+}
+
+function renderStatus(status: ActiveGraphStatus): string {
+  if (status === 'reconciling') return red(status);
+  if (status === 'running') return cyan(status);
+  return yellow(status);
+}
+
+export function renderGraph(state: GraphStateForHud | null | undefined): string | null {
+  if (!state) return null;
+
+  if (state.status === 'unreadable') {
+    // Graph state file exists but could not be parsed (likely a transient
+    // partial write mid-commit). Keep the indicator visible so the run is not
+    // silently hidden during a live tick.
+    return `G:${renderStatus(state.status)}`;
+  }
+
+  return [
+    `G:${renderStatus(state.status)}`,
+    `${state.completedActivations}/${state.totalActivations}`,
+    `ready:${state.readyActivations}`,
+    `live:${state.liveClaims}`,
+    `reconcile:${state.unresolvedReconciliations}`,
+    `#${state.revisionHashShort}`,
+  ].join(' ');
+}

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -29,6 +29,7 @@ import {
   readUltraworkStateForHud,
   readPrdStateForHud,
   readAutopilotStateForHud,
+  readGraphStateForHud,
 } from "./omc-state.js";
 import { getUsage, getSubscriptionInfo } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
@@ -43,6 +44,7 @@ import type {
   SessionHealth,
   SessionSummaryState,
   UsageResult,
+  GraphStateForHud,
 } from "./types.js";
 import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
@@ -329,6 +331,23 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       cwd,
       currentSessionId ?? undefined,
     );
+    // readGraphStateForHud is best-effort: it must never abort the watch-mode
+    // init flow (which would prevent getUsage() from running and leave the HUD
+    // blank). The reader is defensive internally, but any unexpected throw
+    // (path resolution, import side-effects, future changes) is contained here
+    // so the rest of the render pipeline proceeds with graph === null.
+    let graph: GraphStateForHud | null = null;
+    try {
+      graph = readGraphStateForHud(cwd, currentSessionId ?? undefined);
+    } catch (error) {
+      if (process.env.OMC_DEBUG) {
+        console.error(
+          "[HUD] Graph state read failed (non-fatal):",
+          error instanceof Error ? error.message : error,
+        );
+      }
+      graph = null;
+    }
 
     // Read HUD state for background tasks
     const hudState = readHudState(cwd, currentSessionId ?? undefined);
@@ -465,6 +484,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       ultrawork,
       prd,
       autopilot,
+      graph,
       activeAgents: transcriptData.agents.filter((a) => a.status === "running"),
       todos: transcriptData.todos,
       backgroundTasks: getRunningTasks(hudState),

--- a/src/hud/omc-state.ts
+++ b/src/hud/omc-state.ts
@@ -15,8 +15,10 @@ import type {
   PrdStateForHud,
 } from './types.js';
 import type { AutopilotStateForHud } from './elements/autopilot.js';
+import type { ActiveGraphStatus, GraphStateForHud } from './elements/graph.js';
 import { validateNamedWorkflowStateStructure } from '../hooks/autopilot/named-workflow-resume-validator.js';
 import type { AutopilotState } from '../hooks/autopilot/types.js';
+import { parseGraphState } from '../graph/runtime-types.js';
 
 /**
  * Maximum age for state files to be considered "active".
@@ -372,6 +374,68 @@ export function readAutopilotStateForHud(directory: string, sessionId?: string):
 }
 
 // ============================================================================
+// Graph State
+// ============================================================================
+
+const ACTIVE_GRAPH_STATUSES = new Set<ActiveGraphStatus>([
+  'awaiting_approval',
+  'running',
+  'waiting_human',
+  'waiting_patch_approval',
+  'reconciling',
+]);
+
+/**
+ * Read the validated Graph state and return a bounded public projection.
+ * Durable waits are intentionally not hidden by the legacy two-hour HUD cutoff.
+ */
+export function readGraphStateForHud(directory: string, sessionId?: string): GraphStateForHud | null {
+  const stateFile = resolveStatePath(directory, 'graph-state.json', sessionId);
+  if (!stateFile) return null;
+
+  // Read the raw content first so we can distinguish "legitimately absent"
+  // (no file / empty file) from "file exists but is mid-write and unparseable".
+  // A transient partial write during commit must not silently drop the graph
+  // indicator while a run is live.
+  let content: string;
+  try {
+    content = readFileSync(stateFile, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (content.trim().length === 0) return null;
+
+  try {
+    const state = parseGraphState(JSON.parse(content));
+    if (!ACTIVE_GRAPH_STATUSES.has(state.status as ActiveGraphStatus)) return null;
+
+    const activations = Object.values(state.projection.activations);
+    return {
+      status: state.status as ActiveGraphStatus,
+      completedActivations: activations.filter((activation) => activation.status === 'completed').length,
+      totalActivations: activations.length,
+      readyActivations: activations.filter((activation) => activation.status === 'ready').length,
+      liveClaims: Object.values(state.claims).filter((claim) => claim.status === 'live').length,
+      unresolvedReconciliations: Object.values(state.reconciliations)
+        .filter((record) => record.status === 'unresolved').length,
+      revisionHashShort: state.active_revision_hash.slice(0, 12),
+    };
+  } catch {
+    // File exists and is non-empty but failed to parse/validate. Treat the
+    // graph as still active rather than hiding it (transient partial write).
+    return {
+      status: 'unreadable',
+      completedActivations: 0,
+      totalActivations: 0,
+      readyActivations: 0,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: '?',
+    };
+  }
+}
+
+// ============================================================================
 // Combined State Check
 // ============================================================================
 
@@ -382,8 +446,12 @@ export function isAnyModeActive(directory: string, sessionId?: string): boolean 
   const ralph = readRalphStateForHud(directory, sessionId);
   const ultrawork = readUltraworkStateForHud(directory, sessionId);
   const autopilot = readAutopilotStateForHud(directory, sessionId);
+  const graph = readGraphStateForHud(directory, sessionId);
 
-  return (ralph?.active ?? false) || (ultrawork?.active ?? false) || (autopilot?.active ?? false);
+  return (ralph?.active ?? false)
+    || (ultrawork?.active ?? false)
+    || (autopilot?.active ?? false)
+    || graph !== null;
 }
 
 /**
@@ -395,6 +463,10 @@ export function getActiveSkills(directory: string, sessionId?: string): string[]
   const autopilot = readAutopilotStateForHud(directory, sessionId);
   if (autopilot?.active) {
     skills.push('autopilot');
+  }
+
+  if (readGraphStateForHud(directory, sessionId)) {
+    skills.push('graph');
   }
 
   const ralph = readRalphStateForHud(directory, sessionId);

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -33,6 +33,7 @@ import { renderTokenUsage } from "./elements/token-usage.js";
 import { renderEnterpriseCost } from "./elements/enterprise-cost.js";
 import { renderPromptTime } from "./elements/prompt-time.js";
 import { renderAutopilot } from "./elements/autopilot.js";
+import { renderGraph } from "./elements/graph.js";
 import { renderCwd } from "./elements/cwd.js";
 import { renderHostname } from "./elements/hostname.js";
 import { renderGitRepo, renderGitBranch, renderGitStatus } from "./elements/git.js";
@@ -433,6 +434,11 @@ export async function render(
   if (enabledElements.autopilot && context.autopilot) {
     const autopilot = renderAutopilot(context.autopilot, config.thresholds);
     if (autopilot) rendered.set("autopilot", autopilot);
+  }
+
+  if (enabledElements.graph && context.graph) {
+    const graph = renderGraph(context.graph);
+    if (graph) rendered.set("graph", graph);
   }
 
   if (enabledElements.prdStory && context.prd) {

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AutopilotStateForHud } from './elements/autopilot.js';
+import type { GraphStateForHud } from './elements/graph.js';
 import type { ApiKeySource } from './elements/api-key-source.js';
 import type { SessionSummaryState } from './elements/session-summary.js';
 import type { PayloadEstimate } from './payload-estimate.js';
@@ -12,7 +13,7 @@ import type { MissionBoardConfig, MissionBoardState } from './mission-board.js';
 import { DEFAULT_MISSION_BOARD_CONFIG } from './mission-board.js';
 
 // Re-export for convenience
-export type { AutopilotStateForHud, ApiKeySource, SessionSummaryState };
+export type { AutopilotStateForHud, GraphStateForHud, ApiKeySource, SessionSummaryState };
 
 // ============================================================================
 // HUD State
@@ -340,6 +341,9 @@ export interface HudRenderContext {
   /** Autopilot state */
   autopilot: AutopilotStateForHud | null;
 
+  /** Durable Graph state */
+  graph?: GraphStateForHud | null;
+
   /** Active subagents from transcript */
   activeAgents: ActiveAgent[];
 
@@ -575,6 +579,7 @@ export interface HudElementConfig {
   rateLimits: boolean;  // Show 5h and weekly rate limits
   ralph: boolean;
   autopilot: boolean;
+  graph: boolean;
   prdStory: boolean;
   activeSkills: boolean;
   lastSkill: boolean;
@@ -654,7 +659,7 @@ export const DEFAULT_ELEMENT_ORDER: Required<LayoutConfig> = {
   line1: ['hostname', 'cwd', 'gitRepo', 'gitBranch', 'gitStatus', 'apiKeySource', 'profile'],
   main: [
     'omcLabel', 'model', 'enterpriseCost', 'rateLimits', 'customBuckets', 'permission', 'thinking',
-    'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'prd',
+    'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'graph', 'prd',
     'skills', 'lastSkill', 'contextBar', 'agents', 'background',
     'callCounts', 'lastTool', 'sessionSummary',
   ],
@@ -708,6 +713,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     rateLimits: true,  // Show rate limits by default
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     contextBar: true,
@@ -769,6 +775,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: false,
     activeSkills: true,
     lastSkill: true,
@@ -812,6 +819,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     lastSkill: true,
@@ -855,6 +863,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     lastSkill: true,
@@ -898,6 +907,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: false,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: false,
     activeSkills: true,
     lastSkill: true,
@@ -941,6 +951,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     lastSkill: true,

--- a/src/installer/__tests__/safe-installer.test.ts
+++ b/src/installer/__tests__/safe-installer.test.ts
@@ -68,6 +68,7 @@ describe('isOmcHook detection', () => {
     // These are the real commands OMC installs into settings.json
     expect(isOmcHook('node "$HOME/.claude/hooks/keyword-detector.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/session-start.mjs"')).toBe(true);
+    expect(isOmcHook('node "$HOME/.claude/hooks/session-end.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/pre-tool-use.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/post-tool-use.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/post-tool-use-failure.mjs"')).toBe(true);

--- a/src/installer/__tests__/session-end-template.test.ts
+++ b/src/installer/__tests__/session-end-template.test.ts
@@ -1,0 +1,92 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const roots: string[] = [];
+const templatePath = join(process.cwd(), 'templates', 'hooks', 'session-end.mjs');
+
+function temporaryRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('standalone SessionEnd Graph settlement hook', () => {
+  it('is bounded, shell-free, and delegates mutations to the Graph CLI', () => {
+    const source = readFileSync(templatePath, 'utf8');
+    expect(source).toContain("spawnSync('omc'");
+    expect(source).toContain("'settle-session'");
+    expect(source).toContain('shell: false');
+    expect(source).toContain('timeout: SETTLE_TIMEOUT_MS');
+    expect(source).not.toContain('writeFileSync');
+    expect(source).not.toContain('unlinkSync');
+  });
+
+  it('allows SessionEnd without invoking the CLI when Graph state is absent', () => {
+    const project = temporaryRoot('omc-session-end-no-graph-');
+    mkdirSync(join(project, '.git'), { recursive: true });
+
+    const output = execFileSync(process.execPath, [templatePath], {
+      cwd: project,
+      input: JSON.stringify({ hook_event_name: 'SessionEnd', session_id: 'session-1', cwd: project }),
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+
+    expect(JSON.parse(output)).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('passes stable, non-shell arguments to the CLI for existing Graph state', () => {
+    const project = temporaryRoot('omc-session-end-graph-');
+    const binDir = temporaryRoot('omc-session-end-bin-');
+    const capturePath = join(project, 'captured-args.txt');
+    const graphPath = join(project, '.omc', 'state', 'sessions', 'session-1', 'graph-state.json');
+    mkdirSync(join(project, '.git'), { recursive: true });
+    mkdirSync(join(graphPath, '..'), { recursive: true });
+    writeFileSync(graphPath, '{}');
+
+    // Cross-platform fake `omc` that captures its argv to a file. On Unix it
+    // is a /bin/sh script; on Windows a .cmd wrapper is required because
+    // spawnSync('omc', ..., { shell: false }) resolves via PATHEXT.
+    if (process.platform === 'win32') {
+      writeFileSync(join(binDir, 'omc.cmd'), `@echo off\r\nnode -e "require('fs').writeFileSync(process.env.OMC_GRAPH_CAPTURE, process.argv.slice(1).join('\\n')+'\\n')" %*\r\n`);
+    } else {
+      const fakeOmc = join(binDir, 'omc');
+      writeFileSync(fakeOmc, '#!/bin/sh\nprintf "%s\\n" "$@" > "$OMC_GRAPH_CAPTURE"\n');
+      chmodSync(fakeOmc, 0o755);
+    }
+
+    const output = execFileSync(process.execPath, [templatePath], {
+      cwd: project,
+      input: JSON.stringify({ hook_event_name: 'SessionEnd', session_id: 'session-1', cwd: project }),
+      encoding: 'utf8',
+      timeout: 5_000,
+      env: {
+        ...process.env,
+        PATH: `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`,
+        OMC_GRAPH_CAPTURE: capturePath,
+      },
+    }).trim();
+
+    expect(JSON.parse(output)).toEqual({ continue: true, suppressOutput: true });
+    expect(existsSync(capturePath)).toBe(true);
+    const args = readFileSync(capturePath, 'utf8').trim().split('\n');
+    expect(args.slice(0, 7)).toEqual([
+      'graph',
+      'settle-session',
+      '--session-id',
+      'session-1',
+      '--driver-id',
+      'session-end',
+      '--transition-id',
+    ]);
+    expect(args[7]).toMatch(/^session-end:[a-f0-9]{32}$/);
+    expect(args[8]).toBe('--json');
+  });
+});

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -117,6 +117,9 @@ describe('install() standalone hook reconciliation', () => {
     expect(writtenSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toBe(
       `node "${join(testClaudeDir, 'hooks', 'session-start.mjs').replace(/\\/g, '/')}"`,
     );
+    expect(writtenSettings.hooks?.SessionEnd?.[0]?.hooks?.[0]?.command).toBe(
+      `node "${join(testClaudeDir, 'hooks', 'session-end.mjs').replace(/\\/g, '/')}"`,
+    );
     expect((writtenSettings as { statusLine?: { command?: string } }).statusLine?.command).toContain(
       `${join(testClaudeDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`,
     );
@@ -133,6 +136,7 @@ describe('install() standalone hook reconciliation', () => {
     );
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
+    expect(readFileSync(join(testClaudeDir, 'hooks', 'session-end.mjs'), 'utf-8')).toContain('settle-session');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');
   });
 
@@ -199,6 +203,10 @@ describe('install() standalone hook reconciliation', () => {
         {
           file: 'session-start.mjs',
           input: { hook_event_name: 'SessionStart', session_id: 'ci-upgrade-test', cwd: projectDir },
+        },
+        {
+          file: 'session-end.mjs',
+          input: { hook_event_name: 'SessionEnd', session_id: 'ci-upgrade-test', cwd: projectDir },
         },
         {
           file: 'keyword-detector.mjs',
@@ -505,6 +513,7 @@ describe('install() plugin-provided hook deduplication (#2252)', () => {
     const legacyFiles = [
       'keyword-detector.mjs',
       'session-start.mjs',
+      'session-end.mjs',
       'pre-tool-use.mjs',
       'post-tool-use.mjs',
       'post-tool-use-failure.mjs',

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -293,6 +293,9 @@ export const CODE_SIMPLIFIER_SCRIPT_NODE = loadTemplate("code-simplifier.mjs");
 /** Node.js session start hook script - loaded from templates/hooks/session-start.mjs */
 export const SESSION_START_SCRIPT_NODE = loadTemplate("session-start.mjs");
 
+/** Node.js session end hook script - loaded from templates/hooks/session-end.mjs */
+export const SESSION_END_SCRIPT_NODE = loadTemplate("session-end.mjs");
+
 /** Post-tool-use Node.js script - loaded from templates/hooks/post-tool-use.mjs */
 export const POST_TOOL_USE_SCRIPT_NODE = loadTemplate("post-tool-use.mjs");
 
@@ -322,6 +325,26 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
           {
             type: "command" as const,
             command: buildHookCommand('session-start.mjs'),
+          },
+        ],
+      },
+    ],
+    // Graph-scoped SessionEnd cleanup. This hook is a fast no-op for any
+    // session that never used the Graph runtime: it returns SAFE_CONTINUE
+    // without invoking the CLI when no graph-state file exists for the
+    // session (see templates/hooks/session-end.mjs `existsSync(writePath)`
+    // gate). Registration is therefore safe for all standalone installs and
+    // does not perform work or mutate state for non-graph sessions. Plugin
+    // installs receive this hook via hooks/hooks.json instead.
+    SessionEnd: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "command" as const,
+            command: buildHookCommand('session-end.mjs'),
+            timeout: 30,
+            async: true,
           },
         ],
       },

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -309,6 +309,7 @@ export function isOmcStatusLine(statusLine: unknown): boolean {
 const OMC_HOOK_FILENAMES = new Set([
   'keyword-detector.mjs',
   'session-start.mjs',
+  'session-end.mjs',
   'pre-tool-use.mjs',
   'post-tool-use.mjs',
   'post-tool-use-failure.mjs',
@@ -746,6 +747,7 @@ function configureInstallerSettings(
 const STANDALONE_HOOK_TEMPLATE_FILES = [
   'keyword-detector.mjs',
   'session-start.mjs',
+  'session-end.mjs',
   'pre-tool-use.mjs',
   'post-tool-use.mjs',
   'post-tool-use-failure.mjs',

--- a/src/lib/mode-names.ts
+++ b/src/lib/mode-names.ts
@@ -10,6 +10,7 @@
 export const MODE_NAMES = {
   AUTOPILOT: 'autopilot',
   AUTORESEARCH: 'autoresearch',
+  GRAPH: 'graph',
   TEAM: 'team',
   RALPH: 'ralph',
   ULTRAWORK: 'ultrawork',
@@ -40,6 +41,7 @@ export type ModeName = typeof MODE_NAMES[keyof typeof MODE_NAMES];
 export const ALL_MODE_NAMES: readonly ModeName[] = [
   MODE_NAMES.AUTOPILOT,
   MODE_NAMES.AUTORESEARCH,
+  MODE_NAMES.GRAPH,
   MODE_NAMES.TEAM,
   MODE_NAMES.RALPH,
   MODE_NAMES.ULTRAWORK,
@@ -57,6 +59,7 @@ export const ALL_MODE_NAMES: readonly ModeName[] = [
 export const MODE_STATE_FILE_MAP: Readonly<Record<ModeName, string>> = {
   [MODE_NAMES.AUTOPILOT]: 'autopilot-state.json',
   [MODE_NAMES.AUTORESEARCH]: 'autoresearch-state.json',
+  [MODE_NAMES.GRAPH]: 'graph-state.json',
   [MODE_NAMES.TEAM]: 'team-state.json',
   [MODE_NAMES.RALPH]: 'ralph-state.json',
   [MODE_NAMES.ULTRAWORK]: 'ultrawork-state.json',

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -24,6 +24,17 @@ import { atomicWriteJsonSync } from './atomic-write.js';
 type MutationLockOwner = { version: 1; pid: number; processStart: string; createdAt: string; nonce: string };
 type MutationLock = { fd: number; path: string; owner: MutationLockOwner } | { unlocked: true };
 function flockPath(): string | null { return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null; }
+/**
+ * True only when the test harness explicitly simulates a runtime with NO
+ * locking primitives whatsoever (OMC_TEST_FLOCK_AVAILABLE=0). Distinct from a
+ * real flock-less runtime (Windows/macOS): there, linkSync-based O_EXCL locking
+ * is still a valid mutual-exclusion mechanism and may be used. Under the test
+ * simulation, exclusive locks must remain unavailable (return null) so callers
+ * fail closed - the same contract the dev branch established.
+ */
+function lockingDisabledForTest(): boolean {
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0';
+}
 const LOCK_REMOVAL_SCRIPT = String.raw`
 const fs = require('fs');
 const [operation, lockPath, expectedRaw] = process.argv.slice(1);
@@ -100,7 +111,12 @@ function guardedLockRemoval(path: string, operation: 'reclaim' | 'release', owne
 
 function acquireLockAt(path: string, requireExclusive = false): MutationLock | null {
   mkdirSync(dirname(path), { recursive: true });
-  if (!flockPath()) return requireExclusive ? null : { unlocked: true };
+  const hasFlock = !!flockPath();
+  // Under the explicit test no-locking simulation, exclusive locks are
+  // unavailable (fail closed), matching the dev contract. On real flock-less
+  // runtimes (Windows/macOS) we still fall through to linkSync-based locking.
+  if (lockingDisabledForTest()) return requireExclusive ? null : { unlocked: true };
+  if (!hasFlock && !requireExclusive) return { unlocked: true };
   const processStart = processStartIdentity(process.pid);
   if (!processStart || processStart === 'absent') {
     console.error(`[omc-lock] state_mutation_lock_owner_unverifiable: ${path}`);
@@ -121,12 +137,25 @@ function acquireLockAt(path: string, requireExclusive = false): MutationLock | n
       if (fd !== undefined) { try { closeSync(fd); } catch { /* best-effort descriptor cleanup */ } }
       try { unlinkSync(tempPath); } catch { /* best-effort unpublished temp cleanup */ }
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') return null;
-      const disposition = guardedLockRemoval(path, 'reclaim');
-      if (disposition === 'unverifiable') {
-        console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path}`);
-        return null;
+      if (hasFlock) {
+        const disposition = guardedLockRemoval(path, 'reclaim');
+        if (disposition === 'unverifiable') {
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path}`);
+          return null;
+        }
+        if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      } else {
+        try {
+          const existing = JSON.parse(readFileSync(path, 'utf8'));
+          if (typeof existing.createdAt === 'string' && Date.now() - Date.parse(existing.createdAt) > 60 * 60 * 1000) {
+            try { unlinkSync(path); } catch { /* race */ }
+          } else {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+          }
+        } catch {
+          try { unlinkSync(path); } catch { /* race */ }
+        }
       }
-      if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
   }
   return null;
@@ -139,7 +168,11 @@ function acquireMutationLock(filePath: string): MutationLock | null {
 function releaseMutationLock(lock: MutationLock | null): void {
   if (!lock || 'unlocked' in lock) return;
   try { closeSync(lock.fd); } catch { /* lock metadata ownership still guards release */ }
-  guardedLockRemoval(lock.path, 'release', lock.owner);
+  if (flockPath()) {
+    guardedLockRemoval(lock.path, 'release', lock.owner);
+  } else {
+    try { unlinkSync(lock.path); } catch { /* race or already removed */ }
+  }
 }
 
 /** Executes a read or mutation against a state file under its mutation lock. */

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -11,6 +11,9 @@ import {
   stateGetStatusTool,
 } from '../state-tools.js';
 import { emergencyMutateStateFileIf } from '../../lib/mode-state-io.js';
+import { sealGraphDescriptor } from '../../graph/descriptor.js';
+import { createInitialGraphState, type GraphRunStatus } from '../../graph/runtime-types.js';
+import { forkJoinDescriptor } from '../../graph/__tests__/fixtures.js';
 
 const TEST_DIR = '/tmp/state-tools-test';
 
@@ -92,6 +95,75 @@ function completedPortableWorkflowState(sessionId: string): Record<string, unkno
   ];
   tracking.activationBoundary = { ...initialBoundary, byteOffset: 2, fileIdentity: secondStable };
   return { ...state, active: false, phase: 'complete', status: 'private-terminal-status' };
+}
+
+function graphState(sessionId: string, status: GraphRunStatus = 'running') {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  const approved = !['draft', 'awaiting_approval'].includes(status);
+  const state = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'test-control-nonce',
+    descriptor,
+    status,
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {},
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    ...(approved
+      ? {
+          approval: {
+            approved_at: '2026-07-21T00:00:00.000Z',
+            evidence: { kind: 'human' as const, ref: 'private-human-evidence' },
+          },
+        }
+      : {}),
+  });
+  state.diagnostics.push({
+    kind: 'operation',
+    recorded_at: '2026-07-21T00:00:01.000Z',
+    summary: 'private diagnostic detail',
+  });
+  return state;
+}
+
+function fileSha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function writeGuardedGraphArtifacts(sessionId: string, status: GraphRunStatus | 'malformed' = 'running') {
+  const stateRoot = join(TEST_DIR, '.omc', 'state');
+  const sessionDir = join(stateRoot, 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  const paths = {
+    graph: join(sessionDir, 'graph-state.json'),
+    rootSlot: join(stateRoot, 'skill-active-state.json'),
+    sessionSlot: join(sessionDir, 'skill-active-state.json'),
+    controlOwner: join(sessionDir, 'control-owner-state.json'),
+  };
+  writeFileSync(paths.graph, status === 'malformed' ? '{not-json' : JSON.stringify(graphState(sessionId, status)));
+  const slot = JSON.stringify({
+    version: 2,
+    active_skills: {
+      graph: {
+        skill_name: 'graph',
+        session_id: sessionId,
+        completed_at: null,
+        private_slot_detail: 'must remain unchanged',
+      },
+    },
+  });
+  writeFileSync(paths.rootSlot, slot);
+  writeFileSync(paths.sessionSlot, slot);
+  writeFileSync(paths.controlOwner, JSON.stringify({
+    version: 1,
+    root: { mode: 'graph', session_id: sessionId, run_id: 'run-1', nonce: 'private-nonce' },
+  }));
+  return paths;
 }
 
 describe('state-tools', () => {
@@ -2171,6 +2243,176 @@ describe('state-tools', () => {
       });
 
       expect(result.content[0].text).toContain('Successfully wrote');
+    });
+  });
+
+  describe('Graph guarded state integration', () => {
+    it('registers Graph for read/status while rejecting generic write at the schema boundary', () => {
+      expect(stateReadTool.schema.mode.safeParse('graph').success).toBe(true);
+      expect(stateGetStatusTool.schema.mode.safeParse('graph').success).toBe(true);
+      expect(stateWriteTool.schema.mode.safeParse('graph').success).toBe(false);
+      expect(stateClearTool.schema.mode.safeParse('graph').success).toBe(true);
+      expect(stateClearTool.schema.mode.safeParse('all').success).toBe(true);
+      expect('force' in stateClearTool.schema).toBe(true);
+    });
+
+    it('returns a bounded Graph summary without descriptor, evidence, or diagnostic details', async () => {
+      const sessionId = 'graph-read-summary';
+      writeGuardedGraphArtifacts(sessionId);
+      const result = await stateReadTool.handler({
+        mode: 'graph',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const summary = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
+
+      expect(summary).toMatchObject({
+        type: 'graph_state_summary',
+        valid: true,
+        run_id: 'run-1',
+        status: 'running',
+        active_revision_id: 'revision-1',
+        commit_sequence: 0,
+      });
+      expect(Object.keys(summary)).toHaveLength(12);
+      expect(result.content[0].text).not.toMatch(
+        /private diagnostic detail|private-human-evidence|Build and verify two branches|run-branch-b/,
+      );
+    });
+
+    it('uses durable status for Graph status and active-list output', async () => {
+      const sessionId = 'graph-observational-status';
+      writeGuardedGraphArtifacts(sessionId, 'waiting_human');
+
+      const status = await stateGetStatusTool.handler({
+        mode: 'graph',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const active = await stateListActiveTool.handler({
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(status.content[0].text).toContain('**Active:** Yes');
+      expect(status.content[0].text).toContain('graph_state_summary');
+      expect(active.content[0].text).toContain('**graph**');
+    });
+
+    it('rejects direct generic Graph writes without changing its authority artifacts', async () => {
+      const sessionId = 'graph-write-guard';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+
+      const result = await stateWriteTool.handler({
+        mode: 'graph',
+        state: { status: 'cancelled', private_overwrite: true },
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('guarded_mode');
+      for (const [name, path] of Object.entries(paths)) {
+        expect(fileSha256(path), name).toBe(before[name]);
+      }
+    });
+
+    it.each([
+      ['running', 'active'],
+      ['paused', 'paused'],
+      ['succeeded', 'terminal'],
+      ['malformed', 'malformed'],
+    ] as const)('returns deterministic guarded clear classification for %s Graph state', async (status, classification) => {
+      const sessionId = `graph-clear-${status}`;
+      const paths = writeGuardedGraphArtifacts(sessionId, status);
+      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+
+      const result = await stateClearTool.handler({
+        mode: 'graph',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const guarded = JSON.parse(result.content[0].text);
+
+      expect(guarded).toMatchObject({
+        type: 'guarded_mode',
+        mode: 'graph',
+        operation: 'clear',
+        classification,
+        changed: false,
+      });
+      for (const [name, path] of Object.entries(paths)) {
+        expect(fileSha256(path), name).toBe(before[name]);
+      }
+    });
+
+    it('returns deterministic guarded clear classification when Graph state is missing', async () => {
+      const result = await stateClearTool.handler({
+        mode: 'graph',
+        force: true,
+        session_id: 'graph-clear-missing',
+        workingDirectory: TEST_DIR,
+      } as never);
+
+      expect(JSON.parse(result.content[0].text)).toMatchObject({
+        type: 'guarded_mode',
+        mode: 'graph',
+        classification: 'missing',
+        changed: false,
+      });
+    });
+
+    it('clear all reports Graph as skipped and preserves every Graph authority artifact', async () => {
+      const sessionId = 'graph-clear-all';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      const ordinaryPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+      writeFileSync(ordinaryPath, JSON.stringify({ active: true, session_id: sessionId }));
+      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+
+      const result = await stateClearTool.handler({
+        mode: 'all',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const clearAll = JSON.parse(result.content[0].text);
+
+      expect(clearAll).toMatchObject({
+        type: 'clear_all',
+        skipped: [{ mode: 'graph', reason: 'guarded_mode', classification: 'active' }],
+      });
+      expect(existsSync(ordinaryPath)).toBe(false);
+      for (const [name, path] of Object.entries(paths)) {
+        expect(fileSha256(path), name).toBe(before[name]);
+      }
+    });
+
+    it('clear all preserves Graph slot and control ownership when the primary ledger is missing', async () => {
+      const sessionId = 'graph-clear-all-missing-ledger';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      unlinkSync(paths.graph);
+      const protectedPaths = [paths.rootSlot, paths.sessionSlot, paths.controlOwner];
+      const before = protectedPaths.map(path => fileSha256(path));
+      const ordinaryPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+      writeFileSync(ordinaryPath, JSON.stringify({ active: true, session_id: sessionId }));
+
+      const result = await stateClearTool.handler({
+        mode: 'all',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const clearAll = JSON.parse(result.content[0].text);
+
+      expect(clearAll).toMatchObject({
+        type: 'clear_all',
+        skipped: [{ mode: 'graph', reason: 'guarded_mode', classification: 'missing' }],
+        preserved_graph_workflow_slot: true,
+      });
+      expect(existsSync(ordinaryPath)).toBe(false);
+      protectedPaths.forEach((path, index) => expect(fileSha256(path)).toBe(before[index]));
     });
   });
 });

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -53,12 +53,13 @@ import { namedWorkflowRuntimeSupported, validateNamedWorkflowStateStructure } fr
 import { cancelMergeReadiness, createInitialMergeReadinessState, readMergeReadinessState, setMergeReadinessContent, recordMergeReadinessMCQAnswer } from '../hooks/merge-readiness/runtime.js';
 import { formatMergeReadinessReport, redactMergeReadinessState } from '../hooks/merge-readiness/report.js';
 import type { AutopilotState } from '../hooks/autopilot/types.js';
+import { parseGraphState, type GraphRunStatus } from '../graph/runtime-types.js';
 
 // Canonical execution modes from mode-registry (deep-interview and self-improve
 // are first-class modes with dedicated MODE_CONFIGS entries; ralplan remains an
 // extra state-only mode handled via the registry-fallback path).
 const EXECUTION_MODES: [string, ...string[]] = [
-  'autopilot', 'autoresearch', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
+  'autopilot', 'autoresearch', 'graph', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
 ];
 
 // merge-readiness is read/clear-eligible (state_read/status/clear + /cancel work) but NOT write-eligible.
@@ -69,13 +70,22 @@ const STATE_TOOL_MODES: [string, ...string[]] = [
   'skill-active',
   'merge-readiness'
 ];
-// Modes that may be generically written via state_write. Excludes merge-readiness (runtime-owned).
+// Modes that may be generically written via state_write. Graph and
+// merge-readiness are runtime-owned and intentionally excluded.
 const STATE_WRITE_MODES: [string, ...string[]] = [
-  ...EXECUTION_MODES,
+  'autopilot',
+  'autoresearch',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+  'deep-interview',
+  'self-improve',
   'ralplan',
   'omc-teams',
   'skill-active'
 ];
+const STATE_CLEAR_MODES: [string, ...string[]] = [...STATE_TOOL_MODES, 'all'];
 const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'skill-active'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
@@ -386,7 +396,7 @@ function cleanupTeamRuntimeState(root: string, teamNames?: string[]): number {
 /**
  * Get the state file path for any mode (including swarm and ralplan).
  *
- * - For registry modes (8 modes): uses getStateFilePath from mode-registry
+ * - For registry modes: uses getStateFilePath from mode-registry
  * - For ralplan (not in registry): uses resolveStatePath from worktree-paths
  *
  * This handles swarm's SQLite (.db) file transparently.
@@ -732,6 +742,79 @@ interface WorkflowPublicState {
   progress: string;
 }
 
+interface GraphPublicStateSummary {
+  type: 'graph_state_summary';
+  valid: boolean;
+  format_version?: number;
+  run_id?: string;
+  status: GraphRunStatus | 'malformed';
+  active_revision_id?: string;
+  short_revision_hash?: string;
+  dispatch_generation?: number;
+  commit_sequence?: number;
+  progress?: {
+    total: number;
+    ready: number;
+    running: number;
+    completed: number;
+    failed: number;
+  };
+  claims?: {
+    total: number;
+    live: number;
+    reconciling: number;
+    unresolved_reconciliations: number;
+  };
+  pending?: { approval: boolean; patch: boolean };
+}
+
+function malformedGraphPublicState(): GraphPublicStateSummary {
+  return { type: 'graph_state_summary', valid: false, status: 'malformed' };
+}
+
+export function redactGraphPublicState(state: unknown): GraphPublicStateSummary {
+  try {
+    const graph = parseGraphState(state);
+    const activationStatuses = Object.values(graph.projection.activations).map(
+      activation => activation.status,
+    );
+    const claims = Object.values(graph.claims);
+    const reconciliations = Object.values(graph.reconciliations);
+    return {
+      type: 'graph_state_summary',
+      valid: true,
+      format_version: graph.format_version,
+      run_id: graph.run_id.slice(0, 128),
+      status: graph.status,
+      active_revision_id: graph.active_revision_id.slice(0, 128),
+      short_revision_hash: graph.active_revision_hash.slice(0, 12),
+      dispatch_generation: graph.dispatch_generation,
+      commit_sequence: graph.commit_sequence,
+      progress: {
+        total: activationStatuses.length,
+        ready: activationStatuses.filter(status => status === 'ready').length,
+        running: activationStatuses.filter(status => status === 'running').length,
+        completed: activationStatuses.filter(status => status === 'completed').length,
+        failed: activationStatuses.filter(status => status === 'failed').length,
+      },
+      claims: {
+        total: claims.length,
+        live: claims.filter(claim => claim.status === 'live').length,
+        reconciling: claims.filter(claim => claim.status === 'reconciling').length,
+        unresolved_reconciliations: reconciliations.filter(
+          reconciliation => reconciliation.status === 'unresolved',
+        ).length,
+      },
+      pending: {
+        approval: graph.pending_approval !== undefined,
+        patch: graph.pending_patch !== undefined,
+      },
+    };
+  } catch {
+    return malformedGraphPublicState();
+  }
+}
+
 function canonicalWorkflowJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalWorkflowJson).join(',')}]`;
   if (value && typeof value === 'object') {
@@ -802,9 +885,21 @@ function publicStateForMode(mode: StateToolMode, state: unknown): unknown {
   if (mode === 'autopilot') {
     return redactAutopilotPublicState(state);
   }
+  if (mode === 'graph') {
+    return redactGraphPublicState(state);
+  }
   return mode === 'merge-readiness'
     ? redactMergeReadinessState(state as Parameters<typeof redactMergeReadinessState>[0])
     : state;
+}
+
+function parsePublicStateContent(mode: StateToolMode, content: string): unknown {
+  try {
+    return publicStateForMode(mode, JSON.parse(content));
+  } catch (error) {
+    if (mode === 'graph') return malformedGraphPublicState();
+    throw error;
+  }
 }
 
 // ============================================================================
@@ -868,12 +963,12 @@ export const stateReadTool: ToolDefinition<{
         }
 
         const content = readFileSync(statePath, 'utf-8');
-        const state = JSON.parse(content);
+        const publicState = parsePublicStateContent(mode, content);
 
         return {
           content: [{
             type: 'text' as const,
-            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\``
+            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\``
           }]
         };
       }
@@ -909,8 +1004,8 @@ export const stateReadTool: ToolDefinition<{
       if (legacyExists) {
         try {
           const content = readFileSync(statePath, 'utf-8');
-          const state = JSON.parse(content);
-          output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\`\n\n`;
+          const publicState = parsePublicStateContent(mode, content);
+          output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\`\n\n`;
         } catch {
           output += `### Legacy Path (shared)\nPath: ${statePath}\n*Error reading state file*\n\n`;
         }
@@ -926,8 +1021,8 @@ export const stateReadTool: ToolDefinition<{
 
           try {
             const content = readFileSync(sessionStatePath, 'utf-8');
-            const state = JSON.parse(content);
-            output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\`\n\n`;
+            const publicState = parsePublicStateContent(mode, content);
+            output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\`\n\n`;
           } catch {
             output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n*Error reading state file*\n\n`;
           }
@@ -1009,6 +1104,21 @@ export const stateWriteTool: ToolDefinition<{
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
+
+      if ((mode as string) === 'graph') {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              type: 'guarded_mode',
+              mode: 'graph',
+              operation: 'write',
+              changed: false,
+            }),
+          }],
+          isError: true,
+        };
+      }
 
       // Validate custom state payload size if provided
       if (state) {
@@ -1224,25 +1334,136 @@ function recoverAutopilotEmergencyTransactions(root: string, sessionId?: string)
   }
 }
 
+type GraphClearClassification = 'active' | 'draft' | 'paused' | 'terminal' | 'malformed' | 'missing';
+
+function classifyGraphRunStatus(status: GraphRunStatus): GraphClearClassification {
+  if (MODE_CONFIGS.graph.activeStatuses?.includes(status)) return 'active';
+  if (status === 'draft') return 'draft';
+  if (status === 'paused') return 'paused';
+  return 'terminal';
+}
+
+function classifyGraphStateForClear(
+  root: string,
+  sessionId?: string,
+): GraphClearClassification {
+  const paths = sessionId
+    ? [getStateFilePath(root, 'graph', sessionId)]
+    : [
+        getStateFilePath(root, 'graph'),
+        ...listSessionIds(root)
+          .sort()
+          .map(sid => getStateFilePath(root, 'graph', sid)),
+      ];
+  const classifications: GraphClearClassification[] = [];
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    try {
+      classifications.push(classifyGraphRunStatus(parseGraphState(JSON.parse(readFileSync(path, 'utf8'))).status));
+    } catch {
+      classifications.push('malformed');
+    }
+  }
+  if (classifications.length === 0) return 'missing';
+  for (const classification of ['active', 'paused', 'draft', 'terminal', 'malformed'] as const) {
+    if (classifications.includes(classification)) return classification;
+  }
+  return 'malformed';
+}
+
+function hasGraphWorkflowSlot(root: string, sessionId?: string): boolean {
+  const paths = [resolveStatePath('skill-active', root)];
+  const sessionIds = sessionId ? [sessionId] : listSessionIds(root);
+  for (const sid of sessionIds) paths.push(resolveSessionStatePath('skill-active', sid, root));
+  return paths.some(path => {
+    const state = readJsonRecord(path);
+    return Boolean(
+      state?.active_skills
+      && typeof state.active_skills === 'object'
+      && (state.active_skills as Record<string, unknown>).graph,
+    );
+  });
+}
+
 export const stateClearTool: ToolDefinition<{
-  mode: z.ZodEnum<typeof STATE_TOOL_MODES>;
+  mode: z.ZodEnum<typeof STATE_CLEAR_MODES>;
+  force: z.ZodOptional<z.ZodBoolean>;
   workingDirectory: z.ZodOptional<z.ZodString>;
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
   name: 'state_clear',
-  description: 'Clear/delete state for a specific mode. Removes the state file and any associated marker files. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).',
+  description: 'Clear/delete state for a specific mode or all generically clearable modes. Graph is guarded and is never deleted by this tool. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).',
   annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
   schema: {
-    mode: z.enum(STATE_TOOL_MODES).describe('The mode to clear state for'),
+    mode: z.enum(STATE_CLEAR_MODES).describe('The mode to clear state for, or all'),
+    force: z.boolean().optional().describe('Request broad cleanup. This never bypasses guarded Graph state.'),
     workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
     session_id: z.string().optional().describe('Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).'),
   },
   handler: async (args) => {
-    const { mode, workingDirectory, session_id } = args;
+    const { mode, force, workingDirectory, session_id } = args;
 
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
+
+      if (sessionId) validateSessionId(sessionId);
+
+      if (mode === 'graph') {
+        const graphClassification = classifyGraphStateForClear(root, sessionId);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              type: 'guarded_mode',
+              mode: 'graph',
+              operation: 'clear',
+              classification: graphClassification,
+              changed: false,
+              force_bypassed: false,
+            }),
+          }],
+          isError: true,
+        };
+      }
+
+      if (mode === 'all') {
+        const graphClassification = classifyGraphStateForClear(root, sessionId);
+        const clearedModes: string[] = [];
+        const failedModes: string[] = [];
+        const preserveGraphWorkflowSlot = hasGraphWorkflowSlot(root, sessionId);
+        for (const candidate of STATE_TOOL_MODES) {
+          if (candidate === 'graph' || (candidate === 'skill-active' && preserveGraphWorkflowSlot)) {
+            continue;
+          }
+          const result = await stateClearTool.handler({
+            mode: candidate,
+            force,
+            workingDirectory,
+            session_id,
+          });
+          if (result.isError) failedModes.push(candidate);
+          else clearedModes.push(candidate);
+        }
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              type: 'clear_all',
+              cleared_modes: clearedModes,
+              failed_modes: failedModes,
+              skipped: [{
+                mode: 'graph',
+                reason: 'guarded_mode',
+                classification: graphClassification,
+              }],
+              preserved_graph_workflow_slot: preserveGraphWorkflowSlot,
+              force_bypassed: false,
+            }),
+          }],
+          ...(failedModes.length > 0 ? { isError: true } : {}),
+        };
+      }
 
       // Merge-readiness is an audit gate, so clearing it must leave a durable
       // terminal result and report rather than deleting the evidence trail.
@@ -1999,8 +2220,7 @@ export const stateGetStatusTool: ToolDefinition<{
           if (existsSync(statePath)) {
             try {
               const content = readFileSync(statePath, 'utf-8');
-              const state = JSON.parse(content);
-              statePreview = JSON.stringify(publicStateForMode(mode, state), null, 2).slice(0, 500);
+              statePreview = JSON.stringify(parsePublicStateContent(mode, content), null, 2).slice(0, 500);
               if (statePreview.length >= 500) statePreview += '\n...(truncated)';
             } catch {
               statePreview = 'Error reading state file';

--- a/templates/hooks/session-end.mjs
+++ b/templates/hooks/session-end.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SAFE_CONTINUE = { continue: true, suppressOutput: true };
+const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const SETTLE_TIMEOUT_MS = 2_000;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const { readSessionEndFrame } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { resolveSessionStatePathsForHook } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href
+);
+
+function writeSafeContinue() {
+  process.stdout.write(`${JSON.stringify(SAFE_CONTINUE)}\n`);
+}
+
+// Per-invocation nonce so a second SessionEnd in the same session produces a
+// distinct transition_id. A stable per-session+path digest would replay the
+// first invocation's recorded result (store idempotency) and could never
+// settle claims created since the prior session-end. The nonce is mixed into
+// the hash so the transition_id remains opaque but unique per firing.
+function stableTransitionId(sessionId, graphPath, nonce) {
+  const digest = createHash('sha256')
+    .update(`${sessionId}\0${graphPath}\0${nonce}`)
+    .digest('hex')
+    .slice(0, 32);
+  return `session-end:${digest}`;
+}
+
+// Best-effort per-invocation nonce. Prefer a high-resolution timestamp so
+// successive session-ends within one session are ordered and distinct; fall
+// back to a random value if hrtime is unavailable.
+function invocationNonce() {
+  try {
+    const [seconds, nanos] = process.hrtime();
+    return `${seconds}.${nanos}`;
+  } catch {
+    return `${Math.random().toString(36).slice(2)}-${Date.now()}`;
+  }
+}
+
+async function main() {
+  const frame = await readSessionEndFrame();
+  if (frame.status !== 'ok') {
+    writeSafeContinue();
+    return;
+  }
+
+  const input = frame.value;
+  const sessionId = input && typeof input === 'object' && typeof input.session_id === 'string'
+    ? input.session_id
+    : '';
+  const cwd = input && typeof input === 'object' && typeof input.cwd === 'string'
+    ? resolve(input.cwd)
+    : '';
+
+  if (!SESSION_ID.test(sessionId) || !cwd) {
+    writeSafeContinue();
+    return;
+  }
+
+  try {
+    const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
+    if (!existsSync(writePath)) {
+      writeSafeContinue();
+      return;
+    }
+
+    spawnSync('omc', [
+      'graph',
+      'settle-session',
+      '--session-id', sessionId,
+      '--driver-id', 'session-end',
+      '--transition-id', stableTransitionId(sessionId, writePath, invocationNonce()),
+      '--json',
+    ], {
+      cwd,
+      env: process.env,
+      shell: false,
+      stdio: 'ignore',
+      timeout: SETTLE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch {
+    // The durable runtime can recover an un-settled lease after this bounded hook exits.
+  }
+
+  writeSafeContinue();
+}
+
+main().catch(writeSafeContinue);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     testTimeout: 30000,
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'scripts/**/*.{test,spec}.{js,mjs,ts}',
       'tests/**/*.bench.ts',
       'tests/**/*.{test,spec}.ts',
     ],


### PR DESCRIPTION
## Summary

Adds a durable, human-approved orchestration graph runtime + an ASCII-art visualizer that renders inline in Claude Code (Mermaid does not).

### Graph runtime (`src/graph/`)
Turns a development goal into a durable execution graph whose nodes do work and whose edges control readiness. A driver loop claims, dispatches, and commits nodes within the graph boundaries:
- Descriptor + approval + patch protocol (sealed descriptor hashes, revision fences, `transition_id` idempotent replay)
- Session-scoped state isolation, cross-platform file locking, control-owner with process-identity liveness
- Scheduler: fixed / conditional / fan-out edges, joins, bounded back-edges, terminal verification gate
- `omc graph` CLI (state-boundary only; delegates to the runtime, never executes node work)
- HUD graph chip + state-tool surfaces

### ASCII visualizer (`scripts/graph/visualize.mjs`)
Replaces Mermaid with an ASCII-art diagram: box-drawing nodes with status emoji (▶️/✅/❌/⏳, ANSI color when TTY), labeled forward/back edges, a top progress line, and long-ID truncation. Three input modes: `--demo`, `--descriptor <path>`, `<state.json>`. Resolved via `${CLAUDE_PLUGIN_ROOT}` so it runs from any project cwd.

### Skill (`skills/graph/SKILL.md`)
`/oh-my-claudecode:graph <goal>` drafts the descriptor, renders the ASCII graph for review, requests explicit human approval of the exact revision/hash, then drives the loop and re-renders after each node transition.

## Review status
Three rounds of code review; correctness + cleanup findings addressed (idempotent-replay gating, patch-approval transition consistency, control-first resume ordering, mode-registry tombstone/active-status/GC, HUD error handling, visualizer width/status aggregation). Build artifacts (`dist/`, `bridge/`) excluded per CONTRIBUTING. `tsc --noEmit` clean; targeted suites pass (graph runtime, cli graph, visualize, control-owner, state-store, hud graph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)