### PR TITLE
fix(hud): prune stale statusLine cache files

### DIFF
--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -51,6 +51,26 @@ cleanup_empty_temp_files() {
   done
 }
 
+# Session-scoped cache files are never reclaimed otherwise: one stdin/statusline
+# pair per session, forever. Prune pairs no render has touched in N days (a live
+# session rewrites its own mtime on every frame). Stamp-gated to once a day so
+# the hot path does not spawn find on every render.
+CACHE_MAX_AGE_DAYS=${OMC_HUD_CACHE_MAX_AGE_DAYS:-14}
+cleanup_old_session_files() {
+  stamp="$CACHE_DIR/.last-prune"
+  if [ -f "$stamp" ]; then
+    now=$(date +%s 2>/dev/null || printf '0')
+    stamp_mtime=$(file_mtime "$stamp")
+    if [ -n "$stamp_mtime" ] && [ "$now" -gt 0 ] && [ $((now - stamp_mtime)) -lt 86400 ]; then
+      return
+    fi
+  fi
+  : > "$stamp" 2>/dev/null || return
+  find "$CACHE_DIR" -maxdepth 1 -type f \
+    \( -name 'stdin.*.json' -o -name 'statusline.*.txt' \) \
+    -mtime +"$CACHE_MAX_AGE_DAYS" -delete 2>/dev/null || :
+}
+
 cleanup_stale_render_locks() {
   for stale_lock_dir in "$CACHE_DIR"/render.*.lock; do
     [ -d "$stale_lock_dir" ] || continue
@@ -61,6 +81,7 @@ cleanup_stale_render_locks() {
 
 cleanup_empty_temp_files
 cleanup_stale_render_locks
+cleanup_old_session_files
 
 # Capture Claude's current statusLine stdin first so rendered output can be
 # scoped per session/worktree instead of leaking across concurrent sessions.

--- a/src/installer/__tests__/hud-cache-wrapper.test.ts
+++ b/src/installer/__tests__/hud-cache-wrapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -286,6 +286,87 @@ describe('HUD cached statusLine launcher', () => {
 
       expect(result.status).toBe(0);
       expect(result.stdout).toBe('NEW ENV SESSION HUD\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes session cache files no render has touched in OMC_HUD_CACHE_MAX_AGE_DAYS days', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'CACHED HUD LINE\n');
+      mkdirSync(join(staged.cacheDir, 'render.session-123.lock'));
+
+      const deadOutput = join(staged.cacheDir, 'statusline.dead-session.txt');
+      const deadInput = join(staged.cacheDir, 'stdin.dead-session.json');
+      const liveOutput = join(staged.cacheDir, 'statusline.live-session.txt');
+      writeFileSync(deadOutput, 'DEAD SESSION\n');
+      writeFileSync(deadInput, '{}');
+      writeFileSync(liveOutput, 'LIVE SESSION\n');
+      const twentyDaysAgo = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+      utimesSync(deadOutput, twentyDaysAgo, twentyDaysAgo);
+      utimesSync(deadInput, twentyDaysAgo, twentyDaysAgo);
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(existsSync(deadOutput)).toBe(false);
+      expect(existsSync(deadInput)).toBe(false);
+      expect(existsSync(liveOutput)).toBe(true);
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes at most once a day so the hot path does not spawn find on every render', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'CACHED HUD LINE\n');
+      mkdirSync(join(staged.cacheDir, 'render.session-123.lock'));
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const render = () => spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(render().status).toBe(0);
+      expect(existsSync(join(staged.cacheDir, '.last-prune'))).toBe(true);
+
+      // Age a file only after the first prune stamped the cache directory.
+      const stale = join(staged.cacheDir, 'statusline.aged-after-stamp.txt');
+      writeFileSync(stale, 'AGED AFTER STAMP\n');
+      const twentyDaysAgo = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+      utimesSync(stale, twentyDaysAgo, twentyDaysAgo);
+
+      expect(render().status).toBe(0);
+      expect(existsSync(stale)).toBe(true);
     } finally {
       rmSync(staged.dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

`scripts/lib/hud-cache-wrapper.sh` writes one `stdin.<session>.json` + `statusline.<session>.txt` pair per session into `hud/cache/` and never reclaims them. The existing sweeps (`cleanup_empty_temp_files`, `cleanup_stale_render_locks`) only cover empty temps and stale locks, so the session pairs accumulate for the life of the install — 55 files / 220K after about five weeks of light use here, with the oldest entries dating back to first install.

Small in absolute terms, but unbounded and never touched again.

## Change

`cleanup_old_session_files()` prunes `stdin.*.json` / `statusline.*.txt` older than `OMC_HUD_CACHE_MAX_AGE_DAYS` (default 14), called alongside the two existing cleanups.

- A live session rewrites its own cache mtime on every frame, so age alone is a sufficient liveness test — no PID tracking or session registry needed.
- A `.last-prune` stamp gates the sweep to once per day, so the hot path doesn't spawn `find` on every render.
- Single `find` invocation rather than a shell loop with two `stat` calls per file.
- Threshold is env-overridable, consistent with the other knobs in the wrapper (`OMC_HUD_LOCK_STALE_SECONDS`, `OMC_HUD_SYNC_REFRESH`).

## Tests

Two cases added to `src/installer/__tests__/hud-cache-wrapper.test.ts`, in the style of the existing ones:

- stale session pair pruned, recent pair kept
- second render within a day does not re-sweep (stamp gate holds), and the stamp is written

```
Test Files  2 passed (2)
     Tests  11 passed (11)
```

Both new tests fail against the unmodified wrapper and pass with it (verified by stashing the shell change).

No `dist/` or `bridge/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)