### PR TITLE
fix(windows): hide command windows for auto-slash-command execSync spawns

### DIFF
--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -59,7 +59,7 @@ describe('resolveLiveData - basic', () => {
     mockedExecSync.mockReturnValue('hello world\n');
     const result = resolveLiveData('!echo hello');
     expect(result).toBe('<live-data command="echo hello">hello world\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledWith('echo hello', expect.objectContaining({ timeout: 10_000 }));
+    expect(mockedExecSync).toHaveBeenCalledWith('echo hello', expect.objectContaining({ timeout: 10_000, windowsHide: true }));
   });
 
   it('handles multiple commands', () => {
@@ -442,6 +442,7 @@ describe('resolveLiveData - multi-line scripts', () => {
       'bash',
       expect.objectContaining({
         input: 'echo "hello"\necho "world"',
+        windowsHide: true,
       })
     );
   });

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -387,6 +387,7 @@ function executeCommand(command: string): { stdout: string; error: boolean } {
       maxBuffer: MAX_OUTPUT_BYTES + 1024,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let output = stdout ?? "";
@@ -535,6 +536,7 @@ export function resolveLiveData(content: string): string {
         maxBuffer: MAX_OUTPUT_BYTES + 1024,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
       });
       scriptReplacements.set(
         block.startLine,


### PR DESCRIPTION
Follow-up to #3484 (`fix(windows): avoid Git console flashes in hooks and HUD`). That PR added `windowsHide` to the git-specific `execFileSync` calls in `src/hooks/auto-slash-command/live-data.ts` (`checkIfModified`, `checkIfBranch`) but left the two general command runners in the same file untouched:

- `executeCommand(command)` — runs every `!cmd` live-data replacement.
- `!begin-script` block runner — runs every user-authored shell script in a live-data section.

Both go through `execSync`, so on Windows they still spawn `cmd.exe` and flash a console window per call. Any `!echo …` or `!begin-script …` regressed back to the pre-#3484 behaviour.

## Change

- Add `windowsHide: true` to both `execSync` option objects. Matches the pattern the rest of the sweep uses; no-op on non-Windows.
- Strengthen two existing tests in `src/__tests__/live-data.test.ts` to assert the option is set (previously used `expect.objectContaining` without checking `windowsHide`).

## Verification

- `npx vitest run src/__tests__/live-data.test.ts` — 40/40 passed.
- `npx tsc --noEmit` — clean.
- Ran the reverse check locally (removed `windowsHide` from src, tests failed as expected) to confirm the assertions actually exercise the option.

Diff is 4 lines of `src` + 1 line each in 2 test cases.