### PR TITLE
fix(ask): run provider advisors read-only (no repo writes)

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -42,8 +42,8 @@ const ANTIGRAVITY_TIMEOUT_MS = (() => {
 /**
  * Build CLI args for a given provider.
  * - claude: `claude -p <prompt>` (or `claude -p` reading the prompt from stdin)
- * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
- * - gemini: `gemini -p <prompt> --yolo`
+ * - codex: `codex exec --sandbox read-only <prompt>` (advisor is READ-ONLY)
+ * - gemini: `gemini -p <prompt> --approval-mode plan` (advisor is READ-ONLY)
  * - antigravity: `agy --dangerously-skip-permissions -p <prompt>` (Antigravity CLI;
  *   `-p` takes the prompt as its value and cannot read it from stdin, so the
  *   prompt is always passed as an arg with approval flags first, like grok)
@@ -53,10 +53,10 @@ const ANTIGRAVITY_TIMEOUT_MS = (() => {
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
-    return ['exec', '--dangerously-bypass-approvals-and-sandbox', pipePromptViaStdin ? '-' : prompt];
+    return ['exec', '--sandbox', 'read-only', pipePromptViaStdin ? '-' : prompt];
   }
   if (provider === 'gemini') {
-    return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
+    return pipePromptViaStdin ? ['--approval-mode', 'plan'] : ['-p', prompt, '--approval-mode', 'plan'];
   }
   if (provider === 'antigravity') {
     // Antigravity (`agy`): `-p`/`--print` takes the prompt as its VALUE (next

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -757,7 +757,7 @@ describe('run-provider-advisor script contract', () => {
       });
       expect(calls[1]).toMatchObject({
         command: 'codex',
-        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
+        args: ['exec', '--sandbox', 'read-only', '-'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'windows cmd support 你好' },
       });
     } finally {
@@ -820,7 +820,7 @@ describe('run-provider-advisor script contract', () => {
       });
       expect(calls[1]).toMatchObject({
         command: 'gemini',
-        args: ['--yolo'],
+        args: ['--approval-mode', 'plan'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'ship safely 你好' },
       });
     } finally {
@@ -853,7 +853,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'codex',
-        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
+        args: ['exec', '--sandbox', 'read-only', '-'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: multilinePrompt },
       });
     } finally {
@@ -886,7 +886,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'gemini',
-        args: ['--yolo'],
+        args: ['--approval-mode', 'plan'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: longPrompt },
       });
     } finally {


### PR DESCRIPTION
## Problem

`omc ask codex|gemini` runs the provider advisors **write-enabled**:

```
codex  exec --dangerously-bypass-approvals-and-sandbox <prompt>
gemini -p <prompt> --yolo
```

`omc ask` is an **advisor** surface — it returns an opinion. It should never be able to modify the caller's repository. In write mode an advisor can create/edit files in the user's working tree (I hit this in practice: a `gemini` advisor call created and edited several files in an active, shared working tree, which then had to be untangled from another session's WIP).

## Change

Make both advisors **read-only** (they can still read the repo for context, but cannot write):

```
codex  -> exec --sandbox read-only            (codex exec is non-interactive → no hang)
gemini -> -p <prompt> --approval-mode plan     (plan = read-only)
```

Two lines in `scripts/run-provider-advisor.js` (+ doc comment), and the matching spawn-arg expectations in `src/cli/__tests__/ask.test.ts`.

## Verification

- `npx vitest run src/cli/__tests__/ask.test.ts` → **42/42 pass**.
- Manual: with the patch, a codex advisor asked to create a file replies *"filesystem is read-only … sandbox: read-only"* and no file is created; the answer is still produced.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
