### PR TITLE
fix(team): submit tmux worker input with Enter so Codex CLI workers actually start

### DIFF
--- a/src/team/__tests__/tmux-session.spawn.test.ts
+++ b/src/team/__tests__/tmux-session.spawn.test.ts
@@ -188,6 +188,31 @@ describe('spawnWorkerInPane', () => {
     expect(mockedCalls.cmuxArgs[1]).toEqual(['send-key-surface', '--surface', 'cmux-worker-1', 'enter']);
   });
 
+  it('submits with the Enter key name so kitty-protocol TUIs accept it', async () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-501/default,1,0');
+    vi.stubEnv('CMUX_SURFACE_ID', '');
+
+    await sendTeamPaneKey('%1', 'C-m');
+
+    // A bare CR is ignored by TUIs that negotiated the kitty keyboard protocol
+    // (the Codex CLI does), leaving worker input typed but never submitted.
+    expect(mockedCalls.tmuxArgs).toContainEqual(['send-keys', '-t', '%1', 'Enter']);
+    expect(mockedCalls.tmuxArgs).not.toContainEqual(['send-keys', '-t', '%1', 'C-m']);
+  });
+
+  it('passes non-submit keys through to tmux unchanged', async () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-501/default,1,0');
+    vi.stubEnv('CMUX_SURFACE_ID', '');
+
+    await sendTeamPaneKey('%1', 'Tab');
+    await sendTeamPaneKey('%1', 'C-u');
+    await sendTeamPaneKey('%1', 'C-c');
+
+    expect(mockedCalls.tmuxArgs).toContainEqual(['send-keys', '-t', '%1', 'Tab']);
+    expect(mockedCalls.tmuxArgs).toContainEqual(['send-keys', '-t', '%1', 'C-u']);
+    expect(mockedCalls.tmuxArgs).toContainEqual(['send-keys', '-t', '%1', 'C-c']);
+  });
+
   it('uses cmux send-key-surface semantics for Enter and control keys', async () => {
     vi.stubEnv('TMUX', '');
     vi.stubEnv('CMUX_SURFACE_ID', 'cmux-leader');

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1339,12 +1339,26 @@ export async function captureTeamPane(paneId: string): Promise<string> {
   return capturePaneAsync(paneId);
 }
 
+/**
+ * `send-keys C-m` transmits a bare CR (0x0D). A TUI that has enabled the kitty
+ * keyboard protocol — the Codex CLI does — does not accept that as an Enter key
+ * event, so worker input is typed into the composer and never submitted. The
+ * `Enter` key name lets tmux encode whatever the pane actually negotiated, and
+ * resolves to the same CR for shells and for the Claude CLI.
+ *
+ * The cmux surface path is deliberately left alone: it applies its own key-name
+ * normalisation and has not been verified against Codex.
+ */
+function resolveTmuxSubmitKey(key: string): string {
+  return key === 'C-m' ? 'Enter' : key;
+}
+
 export async function sendTeamPaneKey(paneId: string, key: string): Promise<void> {
   if (isCmuxSurfaceTarget(paneId)) {
     await cmuxSendSurfaceKey(paneId, key);
     return;
   }
-  await tmuxExecAsync(['send-keys', '-t', paneId, key]);
+  await tmuxExecAsync(['send-keys', '-t', paneId, resolveTmuxSubmitKey(key)]);
 }
 
 export async function killTeamPane(paneId: string): Promise<void> {


### PR DESCRIPTION
## Problem

Codex CLI team workers never start. `omc team N:codex "<task>"` spawns the pane, Codex boots, the bootstrap instruction is typed into its composer — and then nothing happens. The task stays `pending` indefinitely and `omc team status` reports:

```
leader_guidance=Workers are still marked alive, but none are reporting progress.
```

The `send-message` API compounds this by reporting success while nothing was delivered:

```json
{"ok":true,"notification_outcome":{"ok":true,"transport":"tmux_send_keys","reason":"worker_pane_notified"}}
```

## Root cause

`sendTeamPaneKey()` submits with `C-m` (`src/team/tmux-session.ts`), and every Codex worker injection funnels through it via the `sendKey` helper in `sendToWorker`.

`send-keys C-m` transmits a bare CR (`0x0D`). The Codex CLI's ratatui TUI negotiates the kitty keyboard protocol, under which a bare CR is not an Enter **key event** — so the text lands in the composer and is never submitted. The `Enter` key name lets tmux encode whatever the pane actually negotiated.

Reproduced on a live Codex pane (tmux 3.7b, codex-cli 0.145.0, macOS):

| Keys sent to the pane | Result |
|---|---|
| `send-keys -l -- "<text>"` | text appears in the composer ✅ |
| `send-keys C-m` ×2 | not submitted ❌ |
| `send-keys Enter` | submitted, Codex responds ✅ |

The same mechanism breaks the directory-trust prompt: `detectPaneTrustPromptKind()` correctly detects `Do you trust the contents of this directory?` and dismisses it with `C-m`, which the menu also ignores. The subsequent literal text is then partly consumed by the menu and the worker can exit outright.

This is easy to misread as flaky, because it only bites **idle** panes. For a busy pane the first retry round sends `Tab`+`C-m`, and `Tab` is Codex's queue key — so mid-turn mailbox nudges do arrive (`Queued follow-up inputs`).

Note that `spawnWorkerInPane` already uses `'Enter'` for the shell-level launch command (lines ~972 and ~1292), which is why the pane starts correctly but never receives its first instruction.

## Fix

Translate the submit key inside `sendTeamPaneKey` before it reaches tmux:

```ts
function resolveTmuxSubmitKey(key: string): string {
  return key === 'C-m' ? 'Enter' : key;
}
```

`Enter` and `C-m` both resolve to CR for shells and for the Claude CLI, so this is a no-op for existing Claude workers while fixing Codex. Every other key (`Tab`, `C-u`, `C-c`) passes through untouched.

**The cmux surface path is deliberately unchanged.** It applies its own key-name normalisation (`send-key-surface … enter`) and I have no cmux environment to verify Codex behaviour there — the existing cmux expectations in `tmux-session.spawn.test.ts` still pass as written. If Codex-under-cmux shows the same symptom, that path likely needs the same mapping; I did not want to change behaviour I could not test.

## Verification

Two new unit tests in `src/team/__tests__/tmux-session.spawn.test.ts` cover the mapping and the pass-through.

End-to-end, on real `omc team 1:codex` dispatches: with the submit key corrected, workers claim their task, run it, call `transition-task-status`, and report back normally. Three dispatches completed this way (two greenfield implementations and one bug-fix task), each verified against an independently authored test suite.

## Not addressed here

There is a second, separate delivery failure worth flagging: if OMC types the bootstrap instruction while Codex is still painting its startup screen, the characters are swallowed and the composer ends up **empty**. Pressing Enter cannot recover that — the instruction has to be re-sent. I hit this on 1 of 3 dispatches. A robust fix probably means confirming delivery against worker/task state rather than assuming the write landed, which is a larger change than this one; happy to open a separate issue if useful.
