### PR TITLE
fix(graph): settle state and refresh CLI runtime closure

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,6 +28,7 @@
     "./skills/deep-interview/",
     "./skills/deepinit/",
     "./skills/external-context/",
+    "./skills/graph/",
     "./skills/hud/",
     "./skills/learner/",
     "./skills/local-build-reminder/",

--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ Named profiles currently require Linux with the `flock` utility because their tr
 
 V1 intentionally excludes model fields or routing (`stageModels`), inline execution, dynamic commands/modes/state, arbitrary stages or plugins, and the separate custom-skill frontmatter parser mismatch. See [Named Autopilot Stage Profiles ADR](docs/adr/03487-named-autopilot-stage-profiles.md) and [Reference](docs/REFERENCE.md#named-autopilot-stage-profiles-v1).
 
+#### Durable orchestration Graph (v1)
+
+Use Graph when a long-running task needs explicit branches, parallel work, human gates, and crash-resumable progress:
+
+```text
+/oh-my-claudecode:graph "extract payments into a separately deployable service"
+```
+
+Graph first drafts a typed execution plan, renders every node and route for inspection, and requires approval of the exact revision before any work starts. Its built-in `agent`, `command`, `human-approval`, and `join` nodes support fixed and conditional routes, parallel fan-out/fan-in, and bounded returns to earlier nodes.
+
+Graph records cross-node control flow; it does not replace Ralph's persistent implementation loop or Autopilot's staged autonomous workflow. A node may iterate locally, while Graph remains the top-level scheduler. Pause preserves the run for resume; explicit abandon is permanent and retains the ledger. Graph v1 execution requires Linux with `/proc` and `flock`, does not guarantee exactly-once external side effects, and does not include a visual editor or public authoring DSL. See the [Graph reference](docs/REFERENCE.md#durable-orchestration-graph-v1) and [decision record](docs/adr/v1-durable-orchestration-graph.md).
+
 
 That's it. Everything else is automatic.
 
@@ -144,6 +156,7 @@ OMC exposes two different surfaces:
 | Setup                                          | `omc setup`                                   | `/setup` or `/omc-setup`                                                | Both are real entrypoints. `/setup` is the easiest plugin-first path.                                                                |
 | Ask providers                                  | `omc ask codex "review this patch"`           | `/ask codex "review this patch"`                                        | Both route through the same advisor flow. Providers: `claude`, `codex`, `gemini`, `antigravity`, `grok`, `cursor`.                                            |
 | Team orchestration                             | `omc team 2:codex "review auth flow"`         | `/team 3:executor "fix all TypeScript errors"`                          | Both exist, but they are different runtimes: `omc team` launches tmux CLI workers; `/team` runs the in-session native team workflow. |
+| Durable Graph                                  | Guarded `omc graph` operations               | `/oh-my-claudecode:graph <goal>`                                        | The skill drafts, obtains exact-revision approval, and dispatches work; terminal operations guard the durable state machine.         |
 | Autopilot / Ralph / Ultrawork / Deep Interview | —                                             | `/autopilot ...`, `/ralph ...`, `/ultrawork ...`, `/deep-interview ...` | These are in-session skills. There is no `omc autopilot` / `omc ralph` / `omc ultrawork` CLI subcommand in this repo.                |
 | Autoresearch                                   | `omc autoresearch` (**hard-deprecated shim**) | `/deep-interview --autoresearch ...` + `/oh-my-claudecode:autoresearch` | Setup stays in deep-interview; execution now belongs to the stateful skill.                                                          |
 
@@ -302,6 +315,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 | **Team (recommended)**      | Canonical staged pipeline (`team-plan → team-prd → team-exec → team-verify → team-fix`) | Coordinated Claude agents on a shared task list                         |
 | **omc team (CLI)**          | tmux CLI workers — real `claude`/`codex`/`gemini`/`antigravity`/`grok`/`cursor-agent` processes in split-panes       | Codex/Gemini/Antigravity/Grok/Cursor CLI tasks; on-demand spawn, die when done             |
 | **ccg**                     | Tri-model advisors via `/ask codex` + `/ask antigravity`, Claude synthesizes             | Mixed backend+UI work needing both Codex and Antigravity                     |
+| **Graph**                   | Human-approved nodes, routes, and durable scheduler progress                             | Long-running work with branches, parallel joins, human gates, and resume |
 | **Autopilot**               | Autonomous execution (single lead agent)                                                | End-to-end feature work with minimal ceremony                           |
 | **Ultrawork**               | Maximum parallelism (non-team)                                                          | Burst parallel fixes/refactors where Team isn't needed                  |
 | **Ralph**                   | Persistent mode with verify/fix loops                                                   | Tasks that must complete fully (no silent partials)                     |
@@ -313,7 +327,7 @@ Multiple strategies for different use cases — from Team-backed orchestration t
 
 ### Goal Workflow Guidance
 
-Use only one primary loop authority in a session. Claude Code `/goal` is useful for a native cross-turn completion condition, while Ralph owns single-agent verified completion, Team owns parallel staged execution, and UltraQA owns repeated quality-gate cycling. Artifact-only Ultragoal is the safe fallback when you need durable goal artifacts and evidence without starting another loop.
+Use only one primary orchestration authority in a session. Graph owns explicit cross-node routing and durable recovery, Claude Code `/goal` provides a native cross-turn completion condition, Ralph owns single-agent verified completion, Team owns parallel staged execution, and UltraQA owns repeated quality-gate cycling. Artifact-only Ultragoal is the safe fallback when you need durable goal artifacts and evidence without starting another loop.
 
 For `/goal` behavior, rely on Claude Code/Anthropic sources: the [Claude Code `/goal` docs](https://code.claude.com/docs/en/goal) and [Anthropic Claude Code changelog](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md). Do **not** claim the `/goal` evaluator independently runs commands or reads files; surface test output, diffs, and review evidence in the conversation before treating a goal as proven.
 

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -5625,6 +5625,4112 @@ If ANY checkbox is unchecked, YOU ARE NOT DONE. Continue working.`;
   }
 });
 
+// node_modules/zod/v3/helpers/util.js
+var util2, objectUtil2, ZodParsedType2, getParsedType3;
+var init_util = __esm({
+  "node_modules/zod/v3/helpers/util.js"() {
+    (function(util3) {
+      util3.assertEqual = (_) => {
+      };
+      function assertIs2(_arg) {
+      }
+      util3.assertIs = assertIs2;
+      function assertNever2(_x) {
+        throw new Error();
+      }
+      util3.assertNever = assertNever2;
+      util3.arrayToEnum = (items) => {
+        const obj = {};
+        for (const item of items) {
+          obj[item] = item;
+        }
+        return obj;
+      };
+      util3.getValidEnumValues = (obj) => {
+        const validKeys = util3.objectKeys(obj).filter((k) => typeof obj[obj[k]] !== "number");
+        const filtered = {};
+        for (const k of validKeys) {
+          filtered[k] = obj[k];
+        }
+        return util3.objectValues(filtered);
+      };
+      util3.objectValues = (obj) => {
+        return util3.objectKeys(obj).map(function(e) {
+          return obj[e];
+        });
+      };
+      util3.objectKeys = typeof Object.keys === "function" ? (obj) => Object.keys(obj) : (object3) => {
+        const keys = [];
+        for (const key in object3) {
+          if (Object.prototype.hasOwnProperty.call(object3, key)) {
+            keys.push(key);
+          }
+        }
+        return keys;
+      };
+      util3.find = (arr, checker) => {
+        for (const item of arr) {
+          if (checker(item))
+            return item;
+        }
+        return void 0;
+      };
+      util3.isInteger = typeof Number.isInteger === "function" ? (val) => Number.isInteger(val) : (val) => typeof val === "number" && Number.isFinite(val) && Math.floor(val) === val;
+      function joinValues2(array2, separator = " | ") {
+        return array2.map((val) => typeof val === "string" ? `'${val}'` : val).join(separator);
+      }
+      util3.joinValues = joinValues2;
+      util3.jsonStringifyReplacer = (_, value) => {
+        if (typeof value === "bigint") {
+          return value.toString();
+        }
+        return value;
+      };
+    })(util2 || (util2 = {}));
+    (function(objectUtil3) {
+      objectUtil3.mergeShapes = (first, second) => {
+        return {
+          ...first,
+          ...second
+          // second overwrites first
+        };
+      };
+    })(objectUtil2 || (objectUtil2 = {}));
+    ZodParsedType2 = util2.arrayToEnum([
+      "string",
+      "nan",
+      "number",
+      "integer",
+      "float",
+      "boolean",
+      "date",
+      "bigint",
+      "symbol",
+      "function",
+      "undefined",
+      "null",
+      "array",
+      "object",
+      "unknown",
+      "promise",
+      "void",
+      "never",
+      "map",
+      "set"
+    ]);
+    getParsedType3 = (data) => {
+      const t = typeof data;
+      switch (t) {
+        case "undefined":
+          return ZodParsedType2.undefined;
+        case "string":
+          return ZodParsedType2.string;
+        case "number":
+          return Number.isNaN(data) ? ZodParsedType2.nan : ZodParsedType2.number;
+        case "boolean":
+          return ZodParsedType2.boolean;
+        case "function":
+          return ZodParsedType2.function;
+        case "bigint":
+          return ZodParsedType2.bigint;
+        case "symbol":
+          return ZodParsedType2.symbol;
+        case "object":
+          if (Array.isArray(data)) {
+            return ZodParsedType2.array;
+          }
+          if (data === null) {
+            return ZodParsedType2.null;
+          }
+          if (data.then && typeof data.then === "function" && data.catch && typeof data.catch === "function") {
+            return ZodParsedType2.promise;
+          }
+          if (typeof Map !== "undefined" && data instanceof Map) {
+            return ZodParsedType2.map;
+          }
+          if (typeof Set !== "undefined" && data instanceof Set) {
+            return ZodParsedType2.set;
+          }
+          if (typeof Date !== "undefined" && data instanceof Date) {
+            return ZodParsedType2.date;
+          }
+          return ZodParsedType2.object;
+        default:
+          return ZodParsedType2.unknown;
+      }
+    };
+  }
+});
+
+// node_modules/zod/v3/ZodError.js
+var ZodIssueCode2, quotelessJson, ZodError3;
+var init_ZodError = __esm({
+  "node_modules/zod/v3/ZodError.js"() {
+    init_util();
+    ZodIssueCode2 = util2.arrayToEnum([
+      "invalid_type",
+      "invalid_literal",
+      "custom",
+      "invalid_union",
+      "invalid_union_discriminator",
+      "invalid_enum_value",
+      "unrecognized_keys",
+      "invalid_arguments",
+      "invalid_return_type",
+      "invalid_date",
+      "invalid_string",
+      "too_small",
+      "too_big",
+      "invalid_intersection_types",
+      "not_multiple_of",
+      "not_finite"
+    ]);
+    quotelessJson = (obj) => {
+      const json = JSON.stringify(obj, null, 2);
+      return json.replace(/"([^"]+)":/g, "$1:");
+    };
+    ZodError3 = class _ZodError extends Error {
+      get errors() {
+        return this.issues;
+      }
+      constructor(issues) {
+        super();
+        this.issues = [];
+        this.addIssue = (sub) => {
+          this.issues = [...this.issues, sub];
+        };
+        this.addIssues = (subs = []) => {
+          this.issues = [...this.issues, ...subs];
+        };
+        const actualProto = new.target.prototype;
+        if (Object.setPrototypeOf) {
+          Object.setPrototypeOf(this, actualProto);
+        } else {
+          this.__proto__ = actualProto;
+        }
+        this.name = "ZodError";
+        this.issues = issues;
+      }
+      format(_mapper) {
+        const mapper = _mapper || function(issue2) {
+          return issue2.message;
+        };
+        const fieldErrors = { _errors: [] };
+        const processError = (error2) => {
+          for (const issue2 of error2.issues) {
+            if (issue2.code === "invalid_union") {
+              issue2.unionErrors.map(processError);
+            } else if (issue2.code === "invalid_return_type") {
+              processError(issue2.returnTypeError);
+            } else if (issue2.code === "invalid_arguments") {
+              processError(issue2.argumentsError);
+            } else if (issue2.path.length === 0) {
+              fieldErrors._errors.push(mapper(issue2));
+            } else {
+              let curr = fieldErrors;
+              let i = 0;
+              while (i < issue2.path.length) {
+                const el = issue2.path[i];
+                const terminal = i === issue2.path.length - 1;
+                if (!terminal) {
+                  curr[el] = curr[el] || { _errors: [] };
+                } else {
+                  curr[el] = curr[el] || { _errors: [] };
+                  curr[el]._errors.push(mapper(issue2));
+                }
+                curr = curr[el];
+                i++;
+              }
+            }
+          }
+        };
+        processError(this);
+        return fieldErrors;
+      }
+      static assert(value) {
+        if (!(value instanceof _ZodError)) {
+          throw new Error(`Not a ZodError: ${value}`);
+        }
+      }
+      toString() {
+        return this.message;
+      }
+      get message() {
+        return JSON.stringify(this.issues, util2.jsonStringifyReplacer, 2);
+      }
+      get isEmpty() {
+        return this.issues.length === 0;
+      }
+      flatten(mapper = (issue2) => issue2.message) {
+        const fieldErrors = {};
+        const formErrors = [];
+        for (const sub of this.issues) {
+          if (sub.path.length > 0) {
+            const firstEl = sub.path[0];
+            fieldErrors[firstEl] = fieldErrors[firstEl] || [];
+            fieldErrors[firstEl].push(mapper(sub));
+          } else {
+            formErrors.push(mapper(sub));
+          }
+        }
+        return { formErrors, fieldErrors };
+      }
+      get formErrors() {
+        return this.flatten();
+      }
+    };
+    ZodError3.create = (issues) => {
+      const error2 = new ZodError3(issues);
+      return error2;
+    };
+  }
+});
+
+// node_modules/zod/v3/locales/en.js
+var errorMap2, en_default3;
+var init_en = __esm({
+  "node_modules/zod/v3/locales/en.js"() {
+    init_ZodError();
+    init_util();
+    errorMap2 = (issue2, _ctx) => {
+      let message2;
+      switch (issue2.code) {
+        case ZodIssueCode2.invalid_type:
+          if (issue2.received === ZodParsedType2.undefined) {
+            message2 = "Required";
+          } else {
+            message2 = `Expected ${issue2.expected}, received ${issue2.received}`;
+          }
+          break;
+        case ZodIssueCode2.invalid_literal:
+          message2 = `Invalid literal value, expected ${JSON.stringify(issue2.expected, util2.jsonStringifyReplacer)}`;
+          break;
+        case ZodIssueCode2.unrecognized_keys:
+          message2 = `Unrecognized key(s) in object: ${util2.joinValues(issue2.keys, ", ")}`;
+          break;
+        case ZodIssueCode2.invalid_union:
+          message2 = `Invalid input`;
+          break;
+        case ZodIssueCode2.invalid_union_discriminator:
+          message2 = `Invalid discriminator value. Expected ${util2.joinValues(issue2.options)}`;
+          break;
+        case ZodIssueCode2.invalid_enum_value:
+          message2 = `Invalid enum value. Expected ${util2.joinValues(issue2.options)}, received '${issue2.received}'`;
+          break;
+        case ZodIssueCode2.invalid_arguments:
+          message2 = `Invalid function arguments`;
+          break;
+        case ZodIssueCode2.invalid_return_type:
+          message2 = `Invalid function return type`;
+          break;
+        case ZodIssueCode2.invalid_date:
+          message2 = `Invalid date`;
+          break;
+        case ZodIssueCode2.invalid_string:
+          if (typeof issue2.validation === "object") {
+            if ("includes" in issue2.validation) {
+              message2 = `Invalid input: must include "${issue2.validation.includes}"`;
+              if (typeof issue2.validation.position === "number") {
+                message2 = `${message2} at one or more positions greater than or equal to ${issue2.validation.position}`;
+              }
+            } else if ("startsWith" in issue2.validation) {
+              message2 = `Invalid input: must start with "${issue2.validation.startsWith}"`;
+            } else if ("endsWith" in issue2.validation) {
+              message2 = `Invalid input: must end with "${issue2.validation.endsWith}"`;
+            } else {
+              util2.assertNever(issue2.validation);
+            }
+          } else if (issue2.validation !== "regex") {
+            message2 = `Invalid ${issue2.validation}`;
+          } else {
+            message2 = "Invalid";
+          }
+          break;
+        case ZodIssueCode2.too_small:
+          if (issue2.type === "array")
+            message2 = `Array must contain ${issue2.exact ? "exactly" : issue2.inclusive ? `at least` : `more than`} ${issue2.minimum} element(s)`;
+          else if (issue2.type === "string")
+            message2 = `String must contain ${issue2.exact ? "exactly" : issue2.inclusive ? `at least` : `over`} ${issue2.minimum} character(s)`;
+          else if (issue2.type === "number")
+            message2 = `Number must be ${issue2.exact ? `exactly equal to ` : issue2.inclusive ? `greater than or equal to ` : `greater than `}${issue2.minimum}`;
+          else if (issue2.type === "bigint")
+            message2 = `Number must be ${issue2.exact ? `exactly equal to ` : issue2.inclusive ? `greater than or equal to ` : `greater than `}${issue2.minimum}`;
+          else if (issue2.type === "date")
+            message2 = `Date must be ${issue2.exact ? `exactly equal to ` : issue2.inclusive ? `greater than or equal to ` : `greater than `}${new Date(Number(issue2.minimum))}`;
+          else
+            message2 = "Invalid input";
+          break;
+        case ZodIssueCode2.too_big:
+          if (issue2.type === "array")
+            message2 = `Array must contain ${issue2.exact ? `exactly` : issue2.inclusive ? `at most` : `less than`} ${issue2.maximum} element(s)`;
+          else if (issue2.type === "string")
+            message2 = `String must contain ${issue2.exact ? `exactly` : issue2.inclusive ? `at most` : `under`} ${issue2.maximum} character(s)`;
+          else if (issue2.type === "number")
+            message2 = `Number must be ${issue2.exact ? `exactly` : issue2.inclusive ? `less than or equal to` : `less than`} ${issue2.maximum}`;
+          else if (issue2.type === "bigint")
+            message2 = `BigInt must be ${issue2.exact ? `exactly` : issue2.inclusive ? `less than or equal to` : `less than`} ${issue2.maximum}`;
+          else if (issue2.type === "date")
+            message2 = `Date must be ${issue2.exact ? `exactly` : issue2.inclusive ? `smaller than or equal to` : `smaller than`} ${new Date(Number(issue2.maximum))}`;
+          else
+            message2 = "Invalid input";
+          break;
+        case ZodIssueCode2.custom:
+          message2 = `Invalid input`;
+          break;
+        case ZodIssueCode2.invalid_intersection_types:
+          message2 = `Intersection results could not be merged`;
+          break;
+        case ZodIssueCode2.not_multiple_of:
+          message2 = `Number must be a multiple of ${issue2.multipleOf}`;
+          break;
+        case ZodIssueCode2.not_finite:
+          message2 = "Number must be finite";
+          break;
+        default:
+          message2 = _ctx.defaultError;
+          util2.assertNever(issue2);
+      }
+      return { message: message2 };
+    };
+    en_default3 = errorMap2;
+  }
+});
+
+// node_modules/zod/v3/errors.js
+function setErrorMap(map) {
+  overrideErrorMap2 = map;
+}
+function getErrorMap2() {
+  return overrideErrorMap2;
+}
+var overrideErrorMap2;
+var init_errors = __esm({
+  "node_modules/zod/v3/errors.js"() {
+    init_en();
+    overrideErrorMap2 = en_default3;
+  }
+});
+
+// node_modules/zod/v3/helpers/parseUtil.js
+function addIssueToContext2(ctx, issueData) {
+  const overrideMap = getErrorMap2();
+  const issue2 = makeIssue2({
+    issueData,
+    data: ctx.data,
+    path: ctx.path,
+    errorMaps: [
+      ctx.common.contextualErrorMap,
+      // contextual error map is first priority
+      ctx.schemaErrorMap,
+      // then schema-bound map if available
+      overrideMap,
+      // then global override map
+      overrideMap === en_default3 ? void 0 : en_default3
+      // then global default map
+    ].filter((x) => !!x)
+  });
+  ctx.common.issues.push(issue2);
+}
+var makeIssue2, EMPTY_PATH, ParseStatus2, INVALID2, DIRTY2, OK2, isAborted2, isDirty2, isValid2, isAsync2;
+var init_parseUtil = __esm({
+  "node_modules/zod/v3/helpers/parseUtil.js"() {
+    init_errors();
+    init_en();
+    makeIssue2 = (params) => {
+      const { data, path: path25, errorMaps, issueData } = params;
+      const fullPath = [...path25, ...issueData.path || []];
+      const fullIssue = {
+        ...issueData,
+        path: fullPath
+      };
+      if (issueData.message !== void 0) {
+        return {
+          ...issueData,
+          path: fullPath,
+          message: issueData.message
+        };
+      }
+      let errorMessage = "";
+      const maps = errorMaps.filter((m) => !!m).slice().reverse();
+      for (const map of maps) {
+        errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
+      }
+      return {
+        ...issueData,
+        path: fullPath,
+        message: errorMessage
+      };
+    };
+    EMPTY_PATH = [];
+    ParseStatus2 = class _ParseStatus {
+      constructor() {
+        this.value = "valid";
+      }
+      dirty() {
+        if (this.value === "valid")
+          this.value = "dirty";
+      }
+      abort() {
+        if (this.value !== "aborted")
+          this.value = "aborted";
+      }
+      static mergeArray(status, results) {
+        const arrayValue = [];
+        for (const s of results) {
+          if (s.status === "aborted")
+            return INVALID2;
+          if (s.status === "dirty")
+            status.dirty();
+          arrayValue.push(s.value);
+        }
+        return { status: status.value, value: arrayValue };
+      }
+      static async mergeObjectAsync(status, pairs) {
+        const syncPairs = [];
+        for (const pair of pairs) {
+          const key = await pair.key;
+          const value = await pair.value;
+          syncPairs.push({
+            key,
+            value
+          });
+        }
+        return _ParseStatus.mergeObjectSync(status, syncPairs);
+      }
+      static mergeObjectSync(status, pairs) {
+        const finalObject = {};
+        for (const pair of pairs) {
+          const { key, value } = pair;
+          if (key.status === "aborted")
+            return INVALID2;
+          if (value.status === "aborted")
+            return INVALID2;
+          if (key.status === "dirty")
+            status.dirty();
+          if (value.status === "dirty")
+            status.dirty();
+          if (key.value !== "__proto__" && (typeof value.value !== "undefined" || pair.alwaysSet)) {
+            finalObject[key.value] = value.value;
+          }
+        }
+        return { status: status.value, value: finalObject };
+      }
+    };
+    INVALID2 = Object.freeze({
+      status: "aborted"
+    });
+    DIRTY2 = (value) => ({ status: "dirty", value });
+    OK2 = (value) => ({ status: "valid", value });
+    isAborted2 = (x) => x.status === "aborted";
+    isDirty2 = (x) => x.status === "dirty";
+    isValid2 = (x) => x.status === "valid";
+    isAsync2 = (x) => typeof Promise !== "undefined" && x instanceof Promise;
+  }
+});
+
+// node_modules/zod/v3/helpers/typeAliases.js
+var init_typeAliases = __esm({
+  "node_modules/zod/v3/helpers/typeAliases.js"() {
+  }
+});
+
+// node_modules/zod/v3/helpers/errorUtil.js
+var errorUtil2;
+var init_errorUtil = __esm({
+  "node_modules/zod/v3/helpers/errorUtil.js"() {
+    (function(errorUtil3) {
+      errorUtil3.errToObj = (message2) => typeof message2 === "string" ? { message: message2 } : message2 || {};
+      errorUtil3.toString = (message2) => typeof message2 === "string" ? message2 : message2?.message;
+    })(errorUtil2 || (errorUtil2 = {}));
+  }
+});
+
+// node_modules/zod/v3/types.js
+function processCreateParams2(params) {
+  if (!params)
+    return {};
+  const { errorMap: errorMap3, invalid_type_error, required_error, description } = params;
+  if (errorMap3 && (invalid_type_error || required_error)) {
+    throw new Error(`Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`);
+  }
+  if (errorMap3)
+    return { errorMap: errorMap3, description };
+  const customMap = (iss, ctx) => {
+    const { message: message2 } = params;
+    if (iss.code === "invalid_enum_value") {
+      return { message: message2 ?? ctx.defaultError };
+    }
+    if (typeof ctx.data === "undefined") {
+      return { message: message2 ?? required_error ?? ctx.defaultError };
+    }
+    if (iss.code !== "invalid_type")
+      return { message: ctx.defaultError };
+    return { message: message2 ?? invalid_type_error ?? ctx.defaultError };
+  };
+  return { errorMap: customMap, description };
+}
+function timeRegexSource2(args) {
+  let secondsRegexSource = `[0-5]\\d`;
+  if (args.precision) {
+    secondsRegexSource = `${secondsRegexSource}\\.\\d{${args.precision}}`;
+  } else if (args.precision == null) {
+    secondsRegexSource = `${secondsRegexSource}(\\.\\d+)?`;
+  }
+  const secondsQuantifier = args.precision ? "+" : "?";
+  return `([01]\\d|2[0-3]):[0-5]\\d(:${secondsRegexSource})${secondsQuantifier}`;
+}
+function timeRegex2(args) {
+  return new RegExp(`^${timeRegexSource2(args)}$`);
+}
+function datetimeRegex2(args) {
+  let regex = `${dateRegexSource2}T${timeRegexSource2(args)}`;
+  const opts = [];
+  opts.push(args.local ? `Z?` : `Z`);
+  if (args.offset)
+    opts.push(`([+-]\\d{2}:?\\d{2})`);
+  regex = `${regex}(${opts.join("|")})`;
+  return new RegExp(`^${regex}$`);
+}
+function isValidIP2(ip, version3) {
+  if ((version3 === "v4" || !version3) && ipv4Regex2.test(ip)) {
+    return true;
+  }
+  if ((version3 === "v6" || !version3) && ipv6Regex2.test(ip)) {
+    return true;
+  }
+  return false;
+}
+function isValidJWT3(jwt, alg) {
+  if (!jwtRegex2.test(jwt))
+    return false;
+  try {
+    const [header] = jwt.split(".");
+    if (!header)
+      return false;
+    const base642 = header.replace(/-/g, "+").replace(/_/g, "/").padEnd(header.length + (4 - header.length % 4) % 4, "=");
+    const decoded = JSON.parse(atob(base642));
+    if (typeof decoded !== "object" || decoded === null)
+      return false;
+    if ("typ" in decoded && decoded?.typ !== "JWT")
+      return false;
+    if (!decoded.alg)
+      return false;
+    if (alg && decoded.alg !== alg)
+      return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+function isValidCidr2(ip, version3) {
+  if ((version3 === "v4" || !version3) && ipv4CidrRegex2.test(ip)) {
+    return true;
+  }
+  if ((version3 === "v6" || !version3) && ipv6CidrRegex2.test(ip)) {
+    return true;
+  }
+  return false;
+}
+function floatSafeRemainder3(val, step) {
+  const valDecCount = (val.toString().split(".")[1] || "").length;
+  const stepDecCount = (step.toString().split(".")[1] || "").length;
+  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
+  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
+  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
+  return valInt % stepInt / 10 ** decCount;
+}
+function deepPartialify2(schema) {
+  if (schema instanceof ZodObject3) {
+    const newShape = {};
+    for (const key in schema.shape) {
+      const fieldSchema = schema.shape[key];
+      newShape[key] = ZodOptional3.create(deepPartialify2(fieldSchema));
+    }
+    return new ZodObject3({
+      ...schema._def,
+      shape: () => newShape
+    });
+  } else if (schema instanceof ZodArray3) {
+    return new ZodArray3({
+      ...schema._def,
+      type: deepPartialify2(schema.element)
+    });
+  } else if (schema instanceof ZodOptional3) {
+    return ZodOptional3.create(deepPartialify2(schema.unwrap()));
+  } else if (schema instanceof ZodNullable3) {
+    return ZodNullable3.create(deepPartialify2(schema.unwrap()));
+  } else if (schema instanceof ZodTuple2) {
+    return ZodTuple2.create(schema.items.map((item) => deepPartialify2(item)));
+  } else {
+    return schema;
+  }
+}
+function mergeValues3(a, b) {
+  const aType = getParsedType3(a);
+  const bType = getParsedType3(b);
+  if (a === b) {
+    return { valid: true, data: a };
+  } else if (aType === ZodParsedType2.object && bType === ZodParsedType2.object) {
+    const bKeys = util2.objectKeys(b);
+    const sharedKeys = util2.objectKeys(a).filter((key) => bKeys.indexOf(key) !== -1);
+    const newObj = { ...a, ...b };
+    for (const key of sharedKeys) {
+      const sharedValue = mergeValues3(a[key], b[key]);
+      if (!sharedValue.valid) {
+        return { valid: false };
+      }
+      newObj[key] = sharedValue.data;
+    }
+    return { valid: true, data: newObj };
+  } else if (aType === ZodParsedType2.array && bType === ZodParsedType2.array) {
+    if (a.length !== b.length) {
+      return { valid: false };
+    }
+    const newArray = [];
+    for (let index = 0; index < a.length; index++) {
+      const itemA = a[index];
+      const itemB = b[index];
+      const sharedValue = mergeValues3(itemA, itemB);
+      if (!sharedValue.valid) {
+        return { valid: false };
+      }
+      newArray.push(sharedValue.data);
+    }
+    return { valid: true, data: newArray };
+  } else if (aType === ZodParsedType2.date && bType === ZodParsedType2.date && +a === +b) {
+    return { valid: true, data: a };
+  } else {
+    return { valid: false };
+  }
+}
+function createZodEnum2(values, params) {
+  return new ZodEnum3({
+    values,
+    typeName: ZodFirstPartyTypeKind2.ZodEnum,
+    ...processCreateParams2(params)
+  });
+}
+function cleanParams(params, data) {
+  const p = typeof params === "function" ? params(data) : typeof params === "string" ? { message: params } : params;
+  const p2 = typeof p === "string" ? { message: p } : p;
+  return p2;
+}
+function custom2(check2, _params = {}, fatal) {
+  if (check2)
+    return ZodAny2.create().superRefine((data, ctx) => {
+      const r = check2(data);
+      if (r instanceof Promise) {
+        return r.then((r2) => {
+          if (!r2) {
+            const params = cleanParams(_params, data);
+            const _fatal = params.fatal ?? fatal ?? true;
+            ctx.addIssue({ code: "custom", ...params, fatal: _fatal });
+          }
+        });
+      }
+      if (!r) {
+        const params = cleanParams(_params, data);
+        const _fatal = params.fatal ?? fatal ?? true;
+        ctx.addIssue({ code: "custom", ...params, fatal: _fatal });
+      }
+      return;
+    });
+  return ZodAny2.create();
+}
+var ParseInputLazyPath2, handleResult2, ZodType3, cuidRegex2, cuid2Regex2, ulidRegex2, uuidRegex2, nanoidRegex2, jwtRegex2, durationRegex2, emailRegex2, _emojiRegex2, emojiRegex3, ipv4Regex2, ipv4CidrRegex2, ipv6Regex2, ipv6CidrRegex2, base64Regex2, base64urlRegex2, dateRegexSource2, dateRegex2, ZodString3, ZodNumber3, ZodBigInt2, ZodBoolean3, ZodDate2, ZodSymbol2, ZodUndefined2, ZodNull3, ZodAny2, ZodUnknown3, ZodNever3, ZodVoid2, ZodArray3, ZodObject3, ZodUnion3, getDiscriminator2, ZodDiscriminatedUnion3, ZodIntersection3, ZodTuple2, ZodRecord3, ZodMap2, ZodSet2, ZodFunction2, ZodLazy2, ZodLiteral3, ZodEnum3, ZodNativeEnum2, ZodPromise2, ZodEffects2, ZodOptional3, ZodNullable3, ZodDefault3, ZodCatch3, ZodNaN2, BRAND, ZodBranded2, ZodPipeline2, ZodReadonly3, late2, ZodFirstPartyTypeKind2, instanceOfType, stringType2, numberType2, nanType2, bigIntType2, booleanType2, dateType2, symbolType2, undefinedType2, nullType2, anyType2, unknownType2, neverType2, voidType2, arrayType2, objectType2, strictObjectType2, unionType2, discriminatedUnionType2, intersectionType2, tupleType2, recordType2, mapType2, setType2, functionType2, lazyType2, literalType2, enumType2, nativeEnumType2, promiseType2, effectsType2, optionalType2, nullableType2, preprocessType2, pipelineType2, ostring, onumber, oboolean, coerce, NEVER2;
+var init_types3 = __esm({
+  "node_modules/zod/v3/types.js"() {
+    init_ZodError();
+    init_errors();
+    init_errorUtil();
+    init_parseUtil();
+    init_util();
+    ParseInputLazyPath2 = class {
+      constructor(parent, value, path25, key) {
+        this._cachedPath = [];
+        this.parent = parent;
+        this.data = value;
+        this._path = path25;
+        this._key = key;
+      }
+      get path() {
+        if (!this._cachedPath.length) {
+          if (Array.isArray(this._key)) {
+            this._cachedPath.push(...this._path, ...this._key);
+          } else {
+            this._cachedPath.push(...this._path, this._key);
+          }
+        }
+        return this._cachedPath;
+      }
+    };
+    handleResult2 = (ctx, result) => {
+      if (isValid2(result)) {
+        return { success: true, data: result.value };
+      } else {
+        if (!ctx.common.issues.length) {
+          throw new Error("Validation failed but no issues detected.");
+        }
+        return {
+          success: false,
+          get error() {
+            if (this._error)
+              return this._error;
+            const error2 = new ZodError3(ctx.common.issues);
+            this._error = error2;
+            return this._error;
+          }
+        };
+      }
+    };
+    ZodType3 = class {
+      get description() {
+        return this._def.description;
+      }
+      _getType(input) {
+        return getParsedType3(input.data);
+      }
+      _getOrReturnCtx(input, ctx) {
+        return ctx || {
+          common: input.parent.common,
+          data: input.data,
+          parsedType: getParsedType3(input.data),
+          schemaErrorMap: this._def.errorMap,
+          path: input.path,
+          parent: input.parent
+        };
+      }
+      _processInputParams(input) {
+        return {
+          status: new ParseStatus2(),
+          ctx: {
+            common: input.parent.common,
+            data: input.data,
+            parsedType: getParsedType3(input.data),
+            schemaErrorMap: this._def.errorMap,
+            path: input.path,
+            parent: input.parent
+          }
+        };
+      }
+      _parseSync(input) {
+        const result = this._parse(input);
+        if (isAsync2(result)) {
+          throw new Error("Synchronous parse encountered promise.");
+        }
+        return result;
+      }
+      _parseAsync(input) {
+        const result = this._parse(input);
+        return Promise.resolve(result);
+      }
+      parse(data, params) {
+        const result = this.safeParse(data, params);
+        if (result.success)
+          return result.data;
+        throw result.error;
+      }
+      safeParse(data, params) {
+        const ctx = {
+          common: {
+            issues: [],
+            async: params?.async ?? false,
+            contextualErrorMap: params?.errorMap
+          },
+          path: params?.path || [],
+          schemaErrorMap: this._def.errorMap,
+          parent: null,
+          data,
+          parsedType: getParsedType3(data)
+        };
+        const result = this._parseSync({ data, path: ctx.path, parent: ctx });
+        return handleResult2(ctx, result);
+      }
+      "~validate"(data) {
+        const ctx = {
+          common: {
+            issues: [],
+            async: !!this["~standard"].async
+          },
+          path: [],
+          schemaErrorMap: this._def.errorMap,
+          parent: null,
+          data,
+          parsedType: getParsedType3(data)
+        };
+        if (!this["~standard"].async) {
+          try {
+            const result = this._parseSync({ data, path: [], parent: ctx });
+            return isValid2(result) ? {
+              value: result.value
+            } : {
+              issues: ctx.common.issues
+            };
+          } catch (err) {
+            if (err?.message?.toLowerCase()?.includes("encountered")) {
+              this["~standard"].async = true;
+            }
+            ctx.common = {
+              issues: [],
+              async: true
+            };
+          }
+        }
+        return this._parseAsync({ data, path: [], parent: ctx }).then((result) => isValid2(result) ? {
+          value: result.value
+        } : {
+          issues: ctx.common.issues
+        });
+      }
+      async parseAsync(data, params) {
+        const result = await this.safeParseAsync(data, params);
+        if (result.success)
+          return result.data;
+        throw result.error;
+      }
+      async safeParseAsync(data, params) {
+        const ctx = {
+          common: {
+            issues: [],
+            contextualErrorMap: params?.errorMap,
+            async: true
+          },
+          path: params?.path || [],
+          schemaErrorMap: this._def.errorMap,
+          parent: null,
+          data,
+          parsedType: getParsedType3(data)
+        };
+        const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
+        const result = await (isAsync2(maybeAsyncResult) ? maybeAsyncResult : Promise.resolve(maybeAsyncResult));
+        return handleResult2(ctx, result);
+      }
+      refine(check2, message2) {
+        const getIssueProperties = (val) => {
+          if (typeof message2 === "string" || typeof message2 === "undefined") {
+            return { message: message2 };
+          } else if (typeof message2 === "function") {
+            return message2(val);
+          } else {
+            return message2;
+          }
+        };
+        return this._refinement((val, ctx) => {
+          const result = check2(val);
+          const setError = () => ctx.addIssue({
+            code: ZodIssueCode2.custom,
+            ...getIssueProperties(val)
+          });
+          if (typeof Promise !== "undefined" && result instanceof Promise) {
+            return result.then((data) => {
+              if (!data) {
+                setError();
+                return false;
+              } else {
+                return true;
+              }
+            });
+          }
+          if (!result) {
+            setError();
+            return false;
+          } else {
+            return true;
+          }
+        });
+      }
+      refinement(check2, refinementData) {
+        return this._refinement((val, ctx) => {
+          if (!check2(val)) {
+            ctx.addIssue(typeof refinementData === "function" ? refinementData(val, ctx) : refinementData);
+            return false;
+          } else {
+            return true;
+          }
+        });
+      }
+      _refinement(refinement) {
+        return new ZodEffects2({
+          schema: this,
+          typeName: ZodFirstPartyTypeKind2.ZodEffects,
+          effect: { type: "refinement", refinement }
+        });
+      }
+      superRefine(refinement) {
+        return this._refinement(refinement);
+      }
+      constructor(def) {
+        this.spa = this.safeParseAsync;
+        this._def = def;
+        this.parse = this.parse.bind(this);
+        this.safeParse = this.safeParse.bind(this);
+        this.parseAsync = this.parseAsync.bind(this);
+        this.safeParseAsync = this.safeParseAsync.bind(this);
+        this.spa = this.spa.bind(this);
+        this.refine = this.refine.bind(this);
+        this.refinement = this.refinement.bind(this);
+        this.superRefine = this.superRefine.bind(this);
+        this.optional = this.optional.bind(this);
+        this.nullable = this.nullable.bind(this);
+        this.nullish = this.nullish.bind(this);
+        this.array = this.array.bind(this);
+        this.promise = this.promise.bind(this);
+        this.or = this.or.bind(this);
+        this.and = this.and.bind(this);
+        this.transform = this.transform.bind(this);
+        this.brand = this.brand.bind(this);
+        this.default = this.default.bind(this);
+        this.catch = this.catch.bind(this);
+        this.describe = this.describe.bind(this);
+        this.pipe = this.pipe.bind(this);
+        this.readonly = this.readonly.bind(this);
+        this.isNullable = this.isNullable.bind(this);
+        this.isOptional = this.isOptional.bind(this);
+        this["~standard"] = {
+          version: 1,
+          vendor: "zod",
+          validate: (data) => this["~validate"](data)
+        };
+      }
+      optional() {
+        return ZodOptional3.create(this, this._def);
+      }
+      nullable() {
+        return ZodNullable3.create(this, this._def);
+      }
+      nullish() {
+        return this.nullable().optional();
+      }
+      array() {
+        return ZodArray3.create(this);
+      }
+      promise() {
+        return ZodPromise2.create(this, this._def);
+      }
+      or(option) {
+        return ZodUnion3.create([this, option], this._def);
+      }
+      and(incoming) {
+        return ZodIntersection3.create(this, incoming, this._def);
+      }
+      transform(transform2) {
+        return new ZodEffects2({
+          ...processCreateParams2(this._def),
+          schema: this,
+          typeName: ZodFirstPartyTypeKind2.ZodEffects,
+          effect: { type: "transform", transform: transform2 }
+        });
+      }
+      default(def) {
+        const defaultValueFunc = typeof def === "function" ? def : () => def;
+        return new ZodDefault3({
+          ...processCreateParams2(this._def),
+          innerType: this,
+          defaultValue: defaultValueFunc,
+          typeName: ZodFirstPartyTypeKind2.ZodDefault
+        });
+      }
+      brand() {
+        return new ZodBranded2({
+          typeName: ZodFirstPartyTypeKind2.ZodBranded,
+          type: this,
+          ...processCreateParams2(this._def)
+        });
+      }
+      catch(def) {
+        const catchValueFunc = typeof def === "function" ? def : () => def;
+        return new ZodCatch3({
+          ...processCreateParams2(this._def),
+          innerType: this,
+          catchValue: catchValueFunc,
+          typeName: ZodFirstPartyTypeKind2.ZodCatch
+        });
+      }
+      describe(description) {
+        const This = this.constructor;
+        return new This({
+          ...this._def,
+          description
+        });
+      }
+      pipe(target) {
+        return ZodPipeline2.create(this, target);
+      }
+      readonly() {
+        return ZodReadonly3.create(this);
+      }
+      isOptional() {
+        return this.safeParse(void 0).success;
+      }
+      isNullable() {
+        return this.safeParse(null).success;
+      }
+    };
+    cuidRegex2 = /^c[^\s-]{8,}$/i;
+    cuid2Regex2 = /^[0-9a-z]+$/;
+    ulidRegex2 = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
+    uuidRegex2 = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+    nanoidRegex2 = /^[a-z0-9_-]{21}$/i;
+    jwtRegex2 = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
+    durationRegex2 = /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
+    emailRegex2 = /^(?!\.)(?!.*\.\.)([A-Z0-9_'+\-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i;
+    _emojiRegex2 = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
+    ipv4Regex2 = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
+    ipv4CidrRegex2 = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/(3[0-2]|[12]?[0-9])$/;
+    ipv6Regex2 = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/;
+    ipv6CidrRegex2 = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
+    base64Regex2 = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+    base64urlRegex2 = /^([0-9a-zA-Z-_]{4})*(([0-9a-zA-Z-_]{2}(==)?)|([0-9a-zA-Z-_]{3}(=)?))?$/;
+    dateRegexSource2 = `((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))`;
+    dateRegex2 = new RegExp(`^${dateRegexSource2}$`);
+    ZodString3 = class _ZodString2 extends ZodType3 {
+      _parse(input) {
+        if (this._def.coerce) {
+          input.data = String(input.data);
+        }
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.string) {
+          const ctx2 = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx2, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.string,
+            received: ctx2.parsedType
+          });
+          return INVALID2;
+        }
+        const status = new ParseStatus2();
+        let ctx = void 0;
+        for (const check2 of this._def.checks) {
+          if (check2.kind === "min") {
+            if (input.data.length < check2.value) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_small,
+                minimum: check2.value,
+                type: "string",
+                inclusive: true,
+                exact: false,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "max") {
+            if (input.data.length > check2.value) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_big,
+                maximum: check2.value,
+                type: "string",
+                inclusive: true,
+                exact: false,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "length") {
+            const tooBig = input.data.length > check2.value;
+            const tooSmall = input.data.length < check2.value;
+            if (tooBig || tooSmall) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              if (tooBig) {
+                addIssueToContext2(ctx, {
+                  code: ZodIssueCode2.too_big,
+                  maximum: check2.value,
+                  type: "string",
+                  inclusive: true,
+                  exact: true,
+                  message: check2.message
+                });
+              } else if (tooSmall) {
+                addIssueToContext2(ctx, {
+                  code: ZodIssueCode2.too_small,
+                  minimum: check2.value,
+                  type: "string",
+                  inclusive: true,
+                  exact: true,
+                  message: check2.message
+                });
+              }
+              status.dirty();
+            }
+          } else if (check2.kind === "email") {
+            if (!emailRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "email",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "emoji") {
+            if (!emojiRegex3) {
+              emojiRegex3 = new RegExp(_emojiRegex2, "u");
+            }
+            if (!emojiRegex3.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "emoji",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "uuid") {
+            if (!uuidRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "uuid",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "nanoid") {
+            if (!nanoidRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "nanoid",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "cuid") {
+            if (!cuidRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "cuid",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "cuid2") {
+            if (!cuid2Regex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "cuid2",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "ulid") {
+            if (!ulidRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "ulid",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "url") {
+            try {
+              new URL(input.data);
+            } catch {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "url",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "regex") {
+            check2.regex.lastIndex = 0;
+            const testResult = check2.regex.test(input.data);
+            if (!testResult) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "regex",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "trim") {
+            input.data = input.data.trim();
+          } else if (check2.kind === "includes") {
+            if (!input.data.includes(check2.value, check2.position)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_string,
+                validation: { includes: check2.value, position: check2.position },
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "toLowerCase") {
+            input.data = input.data.toLowerCase();
+          } else if (check2.kind === "toUpperCase") {
+            input.data = input.data.toUpperCase();
+          } else if (check2.kind === "startsWith") {
+            if (!input.data.startsWith(check2.value)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_string,
+                validation: { startsWith: check2.value },
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "endsWith") {
+            if (!input.data.endsWith(check2.value)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_string,
+                validation: { endsWith: check2.value },
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "datetime") {
+            const regex = datetimeRegex2(check2);
+            if (!regex.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_string,
+                validation: "datetime",
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "date") {
+            const regex = dateRegex2;
+            if (!regex.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_string,
+                validation: "date",
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "time") {
+            const regex = timeRegex2(check2);
+            if (!regex.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_string,
+                validation: "time",
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "duration") {
+            if (!durationRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "duration",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "ip") {
+            if (!isValidIP2(input.data, check2.version)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "ip",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "jwt") {
+            if (!isValidJWT3(input.data, check2.alg)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "jwt",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "cidr") {
+            if (!isValidCidr2(input.data, check2.version)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "cidr",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "base64") {
+            if (!base64Regex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "base64",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "base64url") {
+            if (!base64urlRegex2.test(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                validation: "base64url",
+                code: ZodIssueCode2.invalid_string,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else {
+            util2.assertNever(check2);
+          }
+        }
+        return { status: status.value, value: input.data };
+      }
+      _regex(regex, validation, message2) {
+        return this.refinement((data) => regex.test(data), {
+          validation,
+          code: ZodIssueCode2.invalid_string,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      _addCheck(check2) {
+        return new _ZodString2({
+          ...this._def,
+          checks: [...this._def.checks, check2]
+        });
+      }
+      email(message2) {
+        return this._addCheck({ kind: "email", ...errorUtil2.errToObj(message2) });
+      }
+      url(message2) {
+        return this._addCheck({ kind: "url", ...errorUtil2.errToObj(message2) });
+      }
+      emoji(message2) {
+        return this._addCheck({ kind: "emoji", ...errorUtil2.errToObj(message2) });
+      }
+      uuid(message2) {
+        return this._addCheck({ kind: "uuid", ...errorUtil2.errToObj(message2) });
+      }
+      nanoid(message2) {
+        return this._addCheck({ kind: "nanoid", ...errorUtil2.errToObj(message2) });
+      }
+      cuid(message2) {
+        return this._addCheck({ kind: "cuid", ...errorUtil2.errToObj(message2) });
+      }
+      cuid2(message2) {
+        return this._addCheck({ kind: "cuid2", ...errorUtil2.errToObj(message2) });
+      }
+      ulid(message2) {
+        return this._addCheck({ kind: "ulid", ...errorUtil2.errToObj(message2) });
+      }
+      base64(message2) {
+        return this._addCheck({ kind: "base64", ...errorUtil2.errToObj(message2) });
+      }
+      base64url(message2) {
+        return this._addCheck({
+          kind: "base64url",
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      jwt(options) {
+        return this._addCheck({ kind: "jwt", ...errorUtil2.errToObj(options) });
+      }
+      ip(options) {
+        return this._addCheck({ kind: "ip", ...errorUtil2.errToObj(options) });
+      }
+      cidr(options) {
+        return this._addCheck({ kind: "cidr", ...errorUtil2.errToObj(options) });
+      }
+      datetime(options) {
+        if (typeof options === "string") {
+          return this._addCheck({
+            kind: "datetime",
+            precision: null,
+            offset: false,
+            local: false,
+            message: options
+          });
+        }
+        return this._addCheck({
+          kind: "datetime",
+          precision: typeof options?.precision === "undefined" ? null : options?.precision,
+          offset: options?.offset ?? false,
+          local: options?.local ?? false,
+          ...errorUtil2.errToObj(options?.message)
+        });
+      }
+      date(message2) {
+        return this._addCheck({ kind: "date", message: message2 });
+      }
+      time(options) {
+        if (typeof options === "string") {
+          return this._addCheck({
+            kind: "time",
+            precision: null,
+            message: options
+          });
+        }
+        return this._addCheck({
+          kind: "time",
+          precision: typeof options?.precision === "undefined" ? null : options?.precision,
+          ...errorUtil2.errToObj(options?.message)
+        });
+      }
+      duration(message2) {
+        return this._addCheck({ kind: "duration", ...errorUtil2.errToObj(message2) });
+      }
+      regex(regex, message2) {
+        return this._addCheck({
+          kind: "regex",
+          regex,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      includes(value, options) {
+        return this._addCheck({
+          kind: "includes",
+          value,
+          position: options?.position,
+          ...errorUtil2.errToObj(options?.message)
+        });
+      }
+      startsWith(value, message2) {
+        return this._addCheck({
+          kind: "startsWith",
+          value,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      endsWith(value, message2) {
+        return this._addCheck({
+          kind: "endsWith",
+          value,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      min(minLength, message2) {
+        return this._addCheck({
+          kind: "min",
+          value: minLength,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      max(maxLength, message2) {
+        return this._addCheck({
+          kind: "max",
+          value: maxLength,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      length(len, message2) {
+        return this._addCheck({
+          kind: "length",
+          value: len,
+          ...errorUtil2.errToObj(message2)
+        });
+      }
+      /**
+       * Equivalent to `.min(1)`
+       */
+      nonempty(message2) {
+        return this.min(1, errorUtil2.errToObj(message2));
+      }
+      trim() {
+        return new _ZodString2({
+          ...this._def,
+          checks: [...this._def.checks, { kind: "trim" }]
+        });
+      }
+      toLowerCase() {
+        return new _ZodString2({
+          ...this._def,
+          checks: [...this._def.checks, { kind: "toLowerCase" }]
+        });
+      }
+      toUpperCase() {
+        return new _ZodString2({
+          ...this._def,
+          checks: [...this._def.checks, { kind: "toUpperCase" }]
+        });
+      }
+      get isDatetime() {
+        return !!this._def.checks.find((ch) => ch.kind === "datetime");
+      }
+      get isDate() {
+        return !!this._def.checks.find((ch) => ch.kind === "date");
+      }
+      get isTime() {
+        return !!this._def.checks.find((ch) => ch.kind === "time");
+      }
+      get isDuration() {
+        return !!this._def.checks.find((ch) => ch.kind === "duration");
+      }
+      get isEmail() {
+        return !!this._def.checks.find((ch) => ch.kind === "email");
+      }
+      get isURL() {
+        return !!this._def.checks.find((ch) => ch.kind === "url");
+      }
+      get isEmoji() {
+        return !!this._def.checks.find((ch) => ch.kind === "emoji");
+      }
+      get isUUID() {
+        return !!this._def.checks.find((ch) => ch.kind === "uuid");
+      }
+      get isNANOID() {
+        return !!this._def.checks.find((ch) => ch.kind === "nanoid");
+      }
+      get isCUID() {
+        return !!this._def.checks.find((ch) => ch.kind === "cuid");
+      }
+      get isCUID2() {
+        return !!this._def.checks.find((ch) => ch.kind === "cuid2");
+      }
+      get isULID() {
+        return !!this._def.checks.find((ch) => ch.kind === "ulid");
+      }
+      get isIP() {
+        return !!this._def.checks.find((ch) => ch.kind === "ip");
+      }
+      get isCIDR() {
+        return !!this._def.checks.find((ch) => ch.kind === "cidr");
+      }
+      get isBase64() {
+        return !!this._def.checks.find((ch) => ch.kind === "base64");
+      }
+      get isBase64url() {
+        return !!this._def.checks.find((ch) => ch.kind === "base64url");
+      }
+      get minLength() {
+        let min = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "min") {
+            if (min === null || ch.value > min)
+              min = ch.value;
+          }
+        }
+        return min;
+      }
+      get maxLength() {
+        let max = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "max") {
+            if (max === null || ch.value < max)
+              max = ch.value;
+          }
+        }
+        return max;
+      }
+    };
+    ZodString3.create = (params) => {
+      return new ZodString3({
+        checks: [],
+        typeName: ZodFirstPartyTypeKind2.ZodString,
+        coerce: params?.coerce ?? false,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodNumber3 = class _ZodNumber extends ZodType3 {
+      constructor() {
+        super(...arguments);
+        this.min = this.gte;
+        this.max = this.lte;
+        this.step = this.multipleOf;
+      }
+      _parse(input) {
+        if (this._def.coerce) {
+          input.data = Number(input.data);
+        }
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.number) {
+          const ctx2 = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx2, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.number,
+            received: ctx2.parsedType
+          });
+          return INVALID2;
+        }
+        let ctx = void 0;
+        const status = new ParseStatus2();
+        for (const check2 of this._def.checks) {
+          if (check2.kind === "int") {
+            if (!util2.isInteger(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.invalid_type,
+                expected: "integer",
+                received: "float",
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "min") {
+            const tooSmall = check2.inclusive ? input.data < check2.value : input.data <= check2.value;
+            if (tooSmall) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_small,
+                minimum: check2.value,
+                type: "number",
+                inclusive: check2.inclusive,
+                exact: false,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "max") {
+            const tooBig = check2.inclusive ? input.data > check2.value : input.data >= check2.value;
+            if (tooBig) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_big,
+                maximum: check2.value,
+                type: "number",
+                inclusive: check2.inclusive,
+                exact: false,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "multipleOf") {
+            if (floatSafeRemainder3(input.data, check2.value) !== 0) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.not_multiple_of,
+                multipleOf: check2.value,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "finite") {
+            if (!Number.isFinite(input.data)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.not_finite,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else {
+            util2.assertNever(check2);
+          }
+        }
+        return { status: status.value, value: input.data };
+      }
+      gte(value, message2) {
+        return this.setLimit("min", value, true, errorUtil2.toString(message2));
+      }
+      gt(value, message2) {
+        return this.setLimit("min", value, false, errorUtil2.toString(message2));
+      }
+      lte(value, message2) {
+        return this.setLimit("max", value, true, errorUtil2.toString(message2));
+      }
+      lt(value, message2) {
+        return this.setLimit("max", value, false, errorUtil2.toString(message2));
+      }
+      setLimit(kind, value, inclusive, message2) {
+        return new _ZodNumber({
+          ...this._def,
+          checks: [
+            ...this._def.checks,
+            {
+              kind,
+              value,
+              inclusive,
+              message: errorUtil2.toString(message2)
+            }
+          ]
+        });
+      }
+      _addCheck(check2) {
+        return new _ZodNumber({
+          ...this._def,
+          checks: [...this._def.checks, check2]
+        });
+      }
+      int(message2) {
+        return this._addCheck({
+          kind: "int",
+          message: errorUtil2.toString(message2)
+        });
+      }
+      positive(message2) {
+        return this._addCheck({
+          kind: "min",
+          value: 0,
+          inclusive: false,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      negative(message2) {
+        return this._addCheck({
+          kind: "max",
+          value: 0,
+          inclusive: false,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      nonpositive(message2) {
+        return this._addCheck({
+          kind: "max",
+          value: 0,
+          inclusive: true,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      nonnegative(message2) {
+        return this._addCheck({
+          kind: "min",
+          value: 0,
+          inclusive: true,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      multipleOf(value, message2) {
+        return this._addCheck({
+          kind: "multipleOf",
+          value,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      finite(message2) {
+        return this._addCheck({
+          kind: "finite",
+          message: errorUtil2.toString(message2)
+        });
+      }
+      safe(message2) {
+        return this._addCheck({
+          kind: "min",
+          inclusive: true,
+          value: Number.MIN_SAFE_INTEGER,
+          message: errorUtil2.toString(message2)
+        })._addCheck({
+          kind: "max",
+          inclusive: true,
+          value: Number.MAX_SAFE_INTEGER,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      get minValue() {
+        let min = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "min") {
+            if (min === null || ch.value > min)
+              min = ch.value;
+          }
+        }
+        return min;
+      }
+      get maxValue() {
+        let max = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "max") {
+            if (max === null || ch.value < max)
+              max = ch.value;
+          }
+        }
+        return max;
+      }
+      get isInt() {
+        return !!this._def.checks.find((ch) => ch.kind === "int" || ch.kind === "multipleOf" && util2.isInteger(ch.value));
+      }
+      get isFinite() {
+        let max = null;
+        let min = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "finite" || ch.kind === "int" || ch.kind === "multipleOf") {
+            return true;
+          } else if (ch.kind === "min") {
+            if (min === null || ch.value > min)
+              min = ch.value;
+          } else if (ch.kind === "max") {
+            if (max === null || ch.value < max)
+              max = ch.value;
+          }
+        }
+        return Number.isFinite(min) && Number.isFinite(max);
+      }
+    };
+    ZodNumber3.create = (params) => {
+      return new ZodNumber3({
+        checks: [],
+        typeName: ZodFirstPartyTypeKind2.ZodNumber,
+        coerce: params?.coerce || false,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodBigInt2 = class _ZodBigInt extends ZodType3 {
+      constructor() {
+        super(...arguments);
+        this.min = this.gte;
+        this.max = this.lte;
+      }
+      _parse(input) {
+        if (this._def.coerce) {
+          try {
+            input.data = BigInt(input.data);
+          } catch {
+            return this._getInvalidInput(input);
+          }
+        }
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.bigint) {
+          return this._getInvalidInput(input);
+        }
+        let ctx = void 0;
+        const status = new ParseStatus2();
+        for (const check2 of this._def.checks) {
+          if (check2.kind === "min") {
+            const tooSmall = check2.inclusive ? input.data < check2.value : input.data <= check2.value;
+            if (tooSmall) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_small,
+                type: "bigint",
+                minimum: check2.value,
+                inclusive: check2.inclusive,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "max") {
+            const tooBig = check2.inclusive ? input.data > check2.value : input.data >= check2.value;
+            if (tooBig) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_big,
+                type: "bigint",
+                maximum: check2.value,
+                inclusive: check2.inclusive,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "multipleOf") {
+            if (input.data % check2.value !== BigInt(0)) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.not_multiple_of,
+                multipleOf: check2.value,
+                message: check2.message
+              });
+              status.dirty();
+            }
+          } else {
+            util2.assertNever(check2);
+          }
+        }
+        return { status: status.value, value: input.data };
+      }
+      _getInvalidInput(input) {
+        const ctx = this._getOrReturnCtx(input);
+        addIssueToContext2(ctx, {
+          code: ZodIssueCode2.invalid_type,
+          expected: ZodParsedType2.bigint,
+          received: ctx.parsedType
+        });
+        return INVALID2;
+      }
+      gte(value, message2) {
+        return this.setLimit("min", value, true, errorUtil2.toString(message2));
+      }
+      gt(value, message2) {
+        return this.setLimit("min", value, false, errorUtil2.toString(message2));
+      }
+      lte(value, message2) {
+        return this.setLimit("max", value, true, errorUtil2.toString(message2));
+      }
+      lt(value, message2) {
+        return this.setLimit("max", value, false, errorUtil2.toString(message2));
+      }
+      setLimit(kind, value, inclusive, message2) {
+        return new _ZodBigInt({
+          ...this._def,
+          checks: [
+            ...this._def.checks,
+            {
+              kind,
+              value,
+              inclusive,
+              message: errorUtil2.toString(message2)
+            }
+          ]
+        });
+      }
+      _addCheck(check2) {
+        return new _ZodBigInt({
+          ...this._def,
+          checks: [...this._def.checks, check2]
+        });
+      }
+      positive(message2) {
+        return this._addCheck({
+          kind: "min",
+          value: BigInt(0),
+          inclusive: false,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      negative(message2) {
+        return this._addCheck({
+          kind: "max",
+          value: BigInt(0),
+          inclusive: false,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      nonpositive(message2) {
+        return this._addCheck({
+          kind: "max",
+          value: BigInt(0),
+          inclusive: true,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      nonnegative(message2) {
+        return this._addCheck({
+          kind: "min",
+          value: BigInt(0),
+          inclusive: true,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      multipleOf(value, message2) {
+        return this._addCheck({
+          kind: "multipleOf",
+          value,
+          message: errorUtil2.toString(message2)
+        });
+      }
+      get minValue() {
+        let min = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "min") {
+            if (min === null || ch.value > min)
+              min = ch.value;
+          }
+        }
+        return min;
+      }
+      get maxValue() {
+        let max = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "max") {
+            if (max === null || ch.value < max)
+              max = ch.value;
+          }
+        }
+        return max;
+      }
+    };
+    ZodBigInt2.create = (params) => {
+      return new ZodBigInt2({
+        checks: [],
+        typeName: ZodFirstPartyTypeKind2.ZodBigInt,
+        coerce: params?.coerce ?? false,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodBoolean3 = class extends ZodType3 {
+      _parse(input) {
+        if (this._def.coerce) {
+          input.data = Boolean(input.data);
+        }
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.boolean) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.boolean,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+    };
+    ZodBoolean3.create = (params) => {
+      return new ZodBoolean3({
+        typeName: ZodFirstPartyTypeKind2.ZodBoolean,
+        coerce: params?.coerce || false,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodDate2 = class _ZodDate extends ZodType3 {
+      _parse(input) {
+        if (this._def.coerce) {
+          input.data = new Date(input.data);
+        }
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.date) {
+          const ctx2 = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx2, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.date,
+            received: ctx2.parsedType
+          });
+          return INVALID2;
+        }
+        if (Number.isNaN(input.data.getTime())) {
+          const ctx2 = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx2, {
+            code: ZodIssueCode2.invalid_date
+          });
+          return INVALID2;
+        }
+        const status = new ParseStatus2();
+        let ctx = void 0;
+        for (const check2 of this._def.checks) {
+          if (check2.kind === "min") {
+            if (input.data.getTime() < check2.value) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_small,
+                message: check2.message,
+                inclusive: true,
+                exact: false,
+                minimum: check2.value,
+                type: "date"
+              });
+              status.dirty();
+            }
+          } else if (check2.kind === "max") {
+            if (input.data.getTime() > check2.value) {
+              ctx = this._getOrReturnCtx(input, ctx);
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.too_big,
+                message: check2.message,
+                inclusive: true,
+                exact: false,
+                maximum: check2.value,
+                type: "date"
+              });
+              status.dirty();
+            }
+          } else {
+            util2.assertNever(check2);
+          }
+        }
+        return {
+          status: status.value,
+          value: new Date(input.data.getTime())
+        };
+      }
+      _addCheck(check2) {
+        return new _ZodDate({
+          ...this._def,
+          checks: [...this._def.checks, check2]
+        });
+      }
+      min(minDate, message2) {
+        return this._addCheck({
+          kind: "min",
+          value: minDate.getTime(),
+          message: errorUtil2.toString(message2)
+        });
+      }
+      max(maxDate, message2) {
+        return this._addCheck({
+          kind: "max",
+          value: maxDate.getTime(),
+          message: errorUtil2.toString(message2)
+        });
+      }
+      get minDate() {
+        let min = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "min") {
+            if (min === null || ch.value > min)
+              min = ch.value;
+          }
+        }
+        return min != null ? new Date(min) : null;
+      }
+      get maxDate() {
+        let max = null;
+        for (const ch of this._def.checks) {
+          if (ch.kind === "max") {
+            if (max === null || ch.value < max)
+              max = ch.value;
+          }
+        }
+        return max != null ? new Date(max) : null;
+      }
+    };
+    ZodDate2.create = (params) => {
+      return new ZodDate2({
+        checks: [],
+        coerce: params?.coerce || false,
+        typeName: ZodFirstPartyTypeKind2.ZodDate,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodSymbol2 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.symbol) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.symbol,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+    };
+    ZodSymbol2.create = (params) => {
+      return new ZodSymbol2({
+        typeName: ZodFirstPartyTypeKind2.ZodSymbol,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodUndefined2 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.undefined) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.undefined,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+    };
+    ZodUndefined2.create = (params) => {
+      return new ZodUndefined2({
+        typeName: ZodFirstPartyTypeKind2.ZodUndefined,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodNull3 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.null) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.null,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+    };
+    ZodNull3.create = (params) => {
+      return new ZodNull3({
+        typeName: ZodFirstPartyTypeKind2.ZodNull,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodAny2 = class extends ZodType3 {
+      constructor() {
+        super(...arguments);
+        this._any = true;
+      }
+      _parse(input) {
+        return OK2(input.data);
+      }
+    };
+    ZodAny2.create = (params) => {
+      return new ZodAny2({
+        typeName: ZodFirstPartyTypeKind2.ZodAny,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodUnknown3 = class extends ZodType3 {
+      constructor() {
+        super(...arguments);
+        this._unknown = true;
+      }
+      _parse(input) {
+        return OK2(input.data);
+      }
+    };
+    ZodUnknown3.create = (params) => {
+      return new ZodUnknown3({
+        typeName: ZodFirstPartyTypeKind2.ZodUnknown,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodNever3 = class extends ZodType3 {
+      _parse(input) {
+        const ctx = this._getOrReturnCtx(input);
+        addIssueToContext2(ctx, {
+          code: ZodIssueCode2.invalid_type,
+          expected: ZodParsedType2.never,
+          received: ctx.parsedType
+        });
+        return INVALID2;
+      }
+    };
+    ZodNever3.create = (params) => {
+      return new ZodNever3({
+        typeName: ZodFirstPartyTypeKind2.ZodNever,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodVoid2 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.undefined) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.void,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+    };
+    ZodVoid2.create = (params) => {
+      return new ZodVoid2({
+        typeName: ZodFirstPartyTypeKind2.ZodVoid,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodArray3 = class _ZodArray extends ZodType3 {
+      _parse(input) {
+        const { ctx, status } = this._processInputParams(input);
+        const def = this._def;
+        if (ctx.parsedType !== ZodParsedType2.array) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.array,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        if (def.exactLength !== null) {
+          const tooBig = ctx.data.length > def.exactLength.value;
+          const tooSmall = ctx.data.length < def.exactLength.value;
+          if (tooBig || tooSmall) {
+            addIssueToContext2(ctx, {
+              code: tooBig ? ZodIssueCode2.too_big : ZodIssueCode2.too_small,
+              minimum: tooSmall ? def.exactLength.value : void 0,
+              maximum: tooBig ? def.exactLength.value : void 0,
+              type: "array",
+              inclusive: true,
+              exact: true,
+              message: def.exactLength.message
+            });
+            status.dirty();
+          }
+        }
+        if (def.minLength !== null) {
+          if (ctx.data.length < def.minLength.value) {
+            addIssueToContext2(ctx, {
+              code: ZodIssueCode2.too_small,
+              minimum: def.minLength.value,
+              type: "array",
+              inclusive: true,
+              exact: false,
+              message: def.minLength.message
+            });
+            status.dirty();
+          }
+        }
+        if (def.maxLength !== null) {
+          if (ctx.data.length > def.maxLength.value) {
+            addIssueToContext2(ctx, {
+              code: ZodIssueCode2.too_big,
+              maximum: def.maxLength.value,
+              type: "array",
+              inclusive: true,
+              exact: false,
+              message: def.maxLength.message
+            });
+            status.dirty();
+          }
+        }
+        if (ctx.common.async) {
+          return Promise.all([...ctx.data].map((item, i) => {
+            return def.type._parseAsync(new ParseInputLazyPath2(ctx, item, ctx.path, i));
+          })).then((result2) => {
+            return ParseStatus2.mergeArray(status, result2);
+          });
+        }
+        const result = [...ctx.data].map((item, i) => {
+          return def.type._parseSync(new ParseInputLazyPath2(ctx, item, ctx.path, i));
+        });
+        return ParseStatus2.mergeArray(status, result);
+      }
+      get element() {
+        return this._def.type;
+      }
+      min(minLength, message2) {
+        return new _ZodArray({
+          ...this._def,
+          minLength: { value: minLength, message: errorUtil2.toString(message2) }
+        });
+      }
+      max(maxLength, message2) {
+        return new _ZodArray({
+          ...this._def,
+          maxLength: { value: maxLength, message: errorUtil2.toString(message2) }
+        });
+      }
+      length(len, message2) {
+        return new _ZodArray({
+          ...this._def,
+          exactLength: { value: len, message: errorUtil2.toString(message2) }
+        });
+      }
+      nonempty(message2) {
+        return this.min(1, message2);
+      }
+    };
+    ZodArray3.create = (schema, params) => {
+      return new ZodArray3({
+        type: schema,
+        minLength: null,
+        maxLength: null,
+        exactLength: null,
+        typeName: ZodFirstPartyTypeKind2.ZodArray,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodObject3 = class _ZodObject extends ZodType3 {
+      constructor() {
+        super(...arguments);
+        this._cached = null;
+        this.nonstrict = this.passthrough;
+        this.augment = this.extend;
+      }
+      _getCached() {
+        if (this._cached !== null)
+          return this._cached;
+        const shape = this._def.shape();
+        const keys = util2.objectKeys(shape);
+        this._cached = { shape, keys };
+        return this._cached;
+      }
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.object) {
+          const ctx2 = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx2, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.object,
+            received: ctx2.parsedType
+          });
+          return INVALID2;
+        }
+        const { status, ctx } = this._processInputParams(input);
+        const { shape, keys: shapeKeys } = this._getCached();
+        const extraKeys = [];
+        if (!(this._def.catchall instanceof ZodNever3 && this._def.unknownKeys === "strip")) {
+          for (const key in ctx.data) {
+            if (!shapeKeys.includes(key)) {
+              extraKeys.push(key);
+            }
+          }
+        }
+        const pairs = [];
+        for (const key of shapeKeys) {
+          const keyValidator = shape[key];
+          const value = ctx.data[key];
+          pairs.push({
+            key: { status: "valid", value: key },
+            value: keyValidator._parse(new ParseInputLazyPath2(ctx, value, ctx.path, key)),
+            alwaysSet: key in ctx.data
+          });
+        }
+        if (this._def.catchall instanceof ZodNever3) {
+          const unknownKeys = this._def.unknownKeys;
+          if (unknownKeys === "passthrough") {
+            for (const key of extraKeys) {
+              pairs.push({
+                key: { status: "valid", value: key },
+                value: { status: "valid", value: ctx.data[key] }
+              });
+            }
+          } else if (unknownKeys === "strict") {
+            if (extraKeys.length > 0) {
+              addIssueToContext2(ctx, {
+                code: ZodIssueCode2.unrecognized_keys,
+                keys: extraKeys
+              });
+              status.dirty();
+            }
+          } else if (unknownKeys === "strip") {
+          } else {
+            throw new Error(`Internal ZodObject error: invalid unknownKeys value.`);
+          }
+        } else {
+          const catchall = this._def.catchall;
+          for (const key of extraKeys) {
+            const value = ctx.data[key];
+            pairs.push({
+              key: { status: "valid", value: key },
+              value: catchall._parse(
+                new ParseInputLazyPath2(ctx, value, ctx.path, key)
+                //, ctx.child(key), value, getParsedType(value)
+              ),
+              alwaysSet: key in ctx.data
+            });
+          }
+        }
+        if (ctx.common.async) {
+          return Promise.resolve().then(async () => {
+            const syncPairs = [];
+            for (const pair of pairs) {
+              const key = await pair.key;
+              const value = await pair.value;
+              syncPairs.push({
+                key,
+                value,
+                alwaysSet: pair.alwaysSet
+              });
+            }
+            return syncPairs;
+          }).then((syncPairs) => {
+            return ParseStatus2.mergeObjectSync(status, syncPairs);
+          });
+        } else {
+          return ParseStatus2.mergeObjectSync(status, pairs);
+        }
+      }
+      get shape() {
+        return this._def.shape();
+      }
+      strict(message2) {
+        errorUtil2.errToObj;
+        return new _ZodObject({
+          ...this._def,
+          unknownKeys: "strict",
+          ...message2 !== void 0 ? {
+            errorMap: (issue2, ctx) => {
+              const defaultError = this._def.errorMap?.(issue2, ctx).message ?? ctx.defaultError;
+              if (issue2.code === "unrecognized_keys")
+                return {
+                  message: errorUtil2.errToObj(message2).message ?? defaultError
+                };
+              return {
+                message: defaultError
+              };
+            }
+          } : {}
+        });
+      }
+      strip() {
+        return new _ZodObject({
+          ...this._def,
+          unknownKeys: "strip"
+        });
+      }
+      passthrough() {
+        return new _ZodObject({
+          ...this._def,
+          unknownKeys: "passthrough"
+        });
+      }
+      // const AugmentFactory =
+      //   <Def extends ZodObjectDef>(def: Def) =>
+      //   <Augmentation extends ZodRawShape>(
+      //     augmentation: Augmentation
+      //   ): ZodObject<
+      //     extendShape<ReturnType<Def["shape"]>, Augmentation>,
+      //     Def["unknownKeys"],
+      //     Def["catchall"]
+      //   > => {
+      //     return new ZodObject({
+      //       ...def,
+      //       shape: () => ({
+      //         ...def.shape(),
+      //         ...augmentation,
+      //       }),
+      //     }) as any;
+      //   };
+      extend(augmentation) {
+        return new _ZodObject({
+          ...this._def,
+          shape: () => ({
+            ...this._def.shape(),
+            ...augmentation
+          })
+        });
+      }
+      /**
+       * Prior to zod@1.0.12 there was a bug in the
+       * inferred type of merged objects. Please
+       * upgrade if you are experiencing issues.
+       */
+      merge(merging) {
+        const merged = new _ZodObject({
+          unknownKeys: merging._def.unknownKeys,
+          catchall: merging._def.catchall,
+          shape: () => ({
+            ...this._def.shape(),
+            ...merging._def.shape()
+          }),
+          typeName: ZodFirstPartyTypeKind2.ZodObject
+        });
+        return merged;
+      }
+      // merge<
+      //   Incoming extends AnyZodObject,
+      //   Augmentation extends Incoming["shape"],
+      //   NewOutput extends {
+      //     [k in keyof Augmentation | keyof Output]: k extends keyof Augmentation
+      //       ? Augmentation[k]["_output"]
+      //       : k extends keyof Output
+      //       ? Output[k]
+      //       : never;
+      //   },
+      //   NewInput extends {
+      //     [k in keyof Augmentation | keyof Input]: k extends keyof Augmentation
+      //       ? Augmentation[k]["_input"]
+      //       : k extends keyof Input
+      //       ? Input[k]
+      //       : never;
+      //   }
+      // >(
+      //   merging: Incoming
+      // ): ZodObject<
+      //   extendShape<T, ReturnType<Incoming["_def"]["shape"]>>,
+      //   Incoming["_def"]["unknownKeys"],
+      //   Incoming["_def"]["catchall"],
+      //   NewOutput,
+      //   NewInput
+      // > {
+      //   const merged: any = new ZodObject({
+      //     unknownKeys: merging._def.unknownKeys,
+      //     catchall: merging._def.catchall,
+      //     shape: () =>
+      //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
+      //     typeName: ZodFirstPartyTypeKind.ZodObject,
+      //   }) as any;
+      //   return merged;
+      // }
+      setKey(key, schema) {
+        return this.augment({ [key]: schema });
+      }
+      // merge<Incoming extends AnyZodObject>(
+      //   merging: Incoming
+      // ): //ZodObject<T & Incoming["_shape"], UnknownKeys, Catchall> = (merging) => {
+      // ZodObject<
+      //   extendShape<T, ReturnType<Incoming["_def"]["shape"]>>,
+      //   Incoming["_def"]["unknownKeys"],
+      //   Incoming["_def"]["catchall"]
+      // > {
+      //   // const mergedShape = objectUtil.mergeShapes(
+      //   //   this._def.shape(),
+      //   //   merging._def.shape()
+      //   // );
+      //   const merged: any = new ZodObject({
+      //     unknownKeys: merging._def.unknownKeys,
+      //     catchall: merging._def.catchall,
+      //     shape: () =>
+      //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
+      //     typeName: ZodFirstPartyTypeKind.ZodObject,
+      //   }) as any;
+      //   return merged;
+      // }
+      catchall(index) {
+        return new _ZodObject({
+          ...this._def,
+          catchall: index
+        });
+      }
+      pick(mask) {
+        const shape = {};
+        for (const key of util2.objectKeys(mask)) {
+          if (mask[key] && this.shape[key]) {
+            shape[key] = this.shape[key];
+          }
+        }
+        return new _ZodObject({
+          ...this._def,
+          shape: () => shape
+        });
+      }
+      omit(mask) {
+        const shape = {};
+        for (const key of util2.objectKeys(this.shape)) {
+          if (!mask[key]) {
+            shape[key] = this.shape[key];
+          }
+        }
+        return new _ZodObject({
+          ...this._def,
+          shape: () => shape
+        });
+      }
+      /**
+       * @deprecated
+       */
+      deepPartial() {
+        return deepPartialify2(this);
+      }
+      partial(mask) {
+        const newShape = {};
+        for (const key of util2.objectKeys(this.shape)) {
+          const fieldSchema = this.shape[key];
+          if (mask && !mask[key]) {
+            newShape[key] = fieldSchema;
+          } else {
+            newShape[key] = fieldSchema.optional();
+          }
+        }
+        return new _ZodObject({
+          ...this._def,
+          shape: () => newShape
+        });
+      }
+      required(mask) {
+        const newShape = {};
+        for (const key of util2.objectKeys(this.shape)) {
+          if (mask && !mask[key]) {
+            newShape[key] = this.shape[key];
+          } else {
+            const fieldSchema = this.shape[key];
+            let newField = fieldSchema;
+            while (newField instanceof ZodOptional3) {
+              newField = newField._def.innerType;
+            }
+            newShape[key] = newField;
+          }
+        }
+        return new _ZodObject({
+          ...this._def,
+          shape: () => newShape
+        });
+      }
+      keyof() {
+        return createZodEnum2(util2.objectKeys(this.shape));
+      }
+    };
+    ZodObject3.create = (shape, params) => {
+      return new ZodObject3({
+        shape: () => shape,
+        unknownKeys: "strip",
+        catchall: ZodNever3.create(),
+        typeName: ZodFirstPartyTypeKind2.ZodObject,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodObject3.strictCreate = (shape, params) => {
+      return new ZodObject3({
+        shape: () => shape,
+        unknownKeys: "strict",
+        catchall: ZodNever3.create(),
+        typeName: ZodFirstPartyTypeKind2.ZodObject,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodObject3.lazycreate = (shape, params) => {
+      return new ZodObject3({
+        shape,
+        unknownKeys: "strip",
+        catchall: ZodNever3.create(),
+        typeName: ZodFirstPartyTypeKind2.ZodObject,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodUnion3 = class extends ZodType3 {
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        const options = this._def.options;
+        function handleResults(results) {
+          for (const result of results) {
+            if (result.result.status === "valid") {
+              return result.result;
+            }
+          }
+          for (const result of results) {
+            if (result.result.status === "dirty") {
+              ctx.common.issues.push(...result.ctx.common.issues);
+              return result.result;
+            }
+          }
+          const unionErrors = results.map((result) => new ZodError3(result.ctx.common.issues));
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_union,
+            unionErrors
+          });
+          return INVALID2;
+        }
+        if (ctx.common.async) {
+          return Promise.all(options.map(async (option) => {
+            const childCtx = {
+              ...ctx,
+              common: {
+                ...ctx.common,
+                issues: []
+              },
+              parent: null
+            };
+            return {
+              result: await option._parseAsync({
+                data: ctx.data,
+                path: ctx.path,
+                parent: childCtx
+              }),
+              ctx: childCtx
+            };
+          })).then(handleResults);
+        } else {
+          let dirty = void 0;
+          const issues = [];
+          for (const option of options) {
+            const childCtx = {
+              ...ctx,
+              common: {
+                ...ctx.common,
+                issues: []
+              },
+              parent: null
+            };
+            const result = option._parseSync({
+              data: ctx.data,
+              path: ctx.path,
+              parent: childCtx
+            });
+            if (result.status === "valid") {
+              return result;
+            } else if (result.status === "dirty" && !dirty) {
+              dirty = { result, ctx: childCtx };
+            }
+            if (childCtx.common.issues.length) {
+              issues.push(childCtx.common.issues);
+            }
+          }
+          if (dirty) {
+            ctx.common.issues.push(...dirty.ctx.common.issues);
+            return dirty.result;
+          }
+          const unionErrors = issues.map((issues2) => new ZodError3(issues2));
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_union,
+            unionErrors
+          });
+          return INVALID2;
+        }
+      }
+      get options() {
+        return this._def.options;
+      }
+    };
+    ZodUnion3.create = (types, params) => {
+      return new ZodUnion3({
+        options: types,
+        typeName: ZodFirstPartyTypeKind2.ZodUnion,
+        ...processCreateParams2(params)
+      });
+    };
+    getDiscriminator2 = (type) => {
+      if (type instanceof ZodLazy2) {
+        return getDiscriminator2(type.schema);
+      } else if (type instanceof ZodEffects2) {
+        return getDiscriminator2(type.innerType());
+      } else if (type instanceof ZodLiteral3) {
+        return [type.value];
+      } else if (type instanceof ZodEnum3) {
+        return type.options;
+      } else if (type instanceof ZodNativeEnum2) {
+        return util2.objectValues(type.enum);
+      } else if (type instanceof ZodDefault3) {
+        return getDiscriminator2(type._def.innerType);
+      } else if (type instanceof ZodUndefined2) {
+        return [void 0];
+      } else if (type instanceof ZodNull3) {
+        return [null];
+      } else if (type instanceof ZodOptional3) {
+        return [void 0, ...getDiscriminator2(type.unwrap())];
+      } else if (type instanceof ZodNullable3) {
+        return [null, ...getDiscriminator2(type.unwrap())];
+      } else if (type instanceof ZodBranded2) {
+        return getDiscriminator2(type.unwrap());
+      } else if (type instanceof ZodReadonly3) {
+        return getDiscriminator2(type.unwrap());
+      } else if (type instanceof ZodCatch3) {
+        return getDiscriminator2(type._def.innerType);
+      } else {
+        return [];
+      }
+    };
+    ZodDiscriminatedUnion3 = class _ZodDiscriminatedUnion extends ZodType3 {
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.object) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.object,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        const discriminator = this.discriminator;
+        const discriminatorValue = ctx.data[discriminator];
+        const option = this.optionsMap.get(discriminatorValue);
+        if (!option) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_union_discriminator,
+            options: Array.from(this.optionsMap.keys()),
+            path: [discriminator]
+          });
+          return INVALID2;
+        }
+        if (ctx.common.async) {
+          return option._parseAsync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx
+          });
+        } else {
+          return option._parseSync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx
+          });
+        }
+      }
+      get discriminator() {
+        return this._def.discriminator;
+      }
+      get options() {
+        return this._def.options;
+      }
+      get optionsMap() {
+        return this._def.optionsMap;
+      }
+      /**
+       * The constructor of the discriminated union schema. Its behaviour is very similar to that of the normal z.union() constructor.
+       * However, it only allows a union of objects, all of which need to share a discriminator property. This property must
+       * have a different value for each object in the union.
+       * @param discriminator the name of the discriminator property
+       * @param types an array of object schemas
+       * @param params
+       */
+      static create(discriminator, options, params) {
+        const optionsMap = /* @__PURE__ */ new Map();
+        for (const type of options) {
+          const discriminatorValues = getDiscriminator2(type.shape[discriminator]);
+          if (!discriminatorValues.length) {
+            throw new Error(`A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`);
+          }
+          for (const value of discriminatorValues) {
+            if (optionsMap.has(value)) {
+              throw new Error(`Discriminator property ${String(discriminator)} has duplicate value ${String(value)}`);
+            }
+            optionsMap.set(value, type);
+          }
+        }
+        return new _ZodDiscriminatedUnion({
+          typeName: ZodFirstPartyTypeKind2.ZodDiscriminatedUnion,
+          discriminator,
+          options,
+          optionsMap,
+          ...processCreateParams2(params)
+        });
+      }
+    };
+    ZodIntersection3 = class extends ZodType3 {
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        const handleParsed = (parsedLeft, parsedRight) => {
+          if (isAborted2(parsedLeft) || isAborted2(parsedRight)) {
+            return INVALID2;
+          }
+          const merged = mergeValues3(parsedLeft.value, parsedRight.value);
+          if (!merged.valid) {
+            addIssueToContext2(ctx, {
+              code: ZodIssueCode2.invalid_intersection_types
+            });
+            return INVALID2;
+          }
+          if (isDirty2(parsedLeft) || isDirty2(parsedRight)) {
+            status.dirty();
+          }
+          return { status: status.value, value: merged.data };
+        };
+        if (ctx.common.async) {
+          return Promise.all([
+            this._def.left._parseAsync({
+              data: ctx.data,
+              path: ctx.path,
+              parent: ctx
+            }),
+            this._def.right._parseAsync({
+              data: ctx.data,
+              path: ctx.path,
+              parent: ctx
+            })
+          ]).then(([left, right]) => handleParsed(left, right));
+        } else {
+          return handleParsed(this._def.left._parseSync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx
+          }), this._def.right._parseSync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx
+          }));
+        }
+      }
+    };
+    ZodIntersection3.create = (left, right, params) => {
+      return new ZodIntersection3({
+        left,
+        right,
+        typeName: ZodFirstPartyTypeKind2.ZodIntersection,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodTuple2 = class _ZodTuple extends ZodType3 {
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.array) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.array,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        if (ctx.data.length < this._def.items.length) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.too_small,
+            minimum: this._def.items.length,
+            inclusive: true,
+            exact: false,
+            type: "array"
+          });
+          return INVALID2;
+        }
+        const rest = this._def.rest;
+        if (!rest && ctx.data.length > this._def.items.length) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.too_big,
+            maximum: this._def.items.length,
+            inclusive: true,
+            exact: false,
+            type: "array"
+          });
+          status.dirty();
+        }
+        const items = [...ctx.data].map((item, itemIndex) => {
+          const schema = this._def.items[itemIndex] || this._def.rest;
+          if (!schema)
+            return null;
+          return schema._parse(new ParseInputLazyPath2(ctx, item, ctx.path, itemIndex));
+        }).filter((x) => !!x);
+        if (ctx.common.async) {
+          return Promise.all(items).then((results) => {
+            return ParseStatus2.mergeArray(status, results);
+          });
+        } else {
+          return ParseStatus2.mergeArray(status, items);
+        }
+      }
+      get items() {
+        return this._def.items;
+      }
+      rest(rest) {
+        return new _ZodTuple({
+          ...this._def,
+          rest
+        });
+      }
+    };
+    ZodTuple2.create = (schemas, params) => {
+      if (!Array.isArray(schemas)) {
+        throw new Error("You must pass an array of schemas to z.tuple([ ... ])");
+      }
+      return new ZodTuple2({
+        items: schemas,
+        typeName: ZodFirstPartyTypeKind2.ZodTuple,
+        rest: null,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodRecord3 = class _ZodRecord extends ZodType3 {
+      get keySchema() {
+        return this._def.keyType;
+      }
+      get valueSchema() {
+        return this._def.valueType;
+      }
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.object) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.object,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        const pairs = [];
+        const keyType = this._def.keyType;
+        const valueType = this._def.valueType;
+        for (const key in ctx.data) {
+          pairs.push({
+            key: keyType._parse(new ParseInputLazyPath2(ctx, key, ctx.path, key)),
+            value: valueType._parse(new ParseInputLazyPath2(ctx, ctx.data[key], ctx.path, key)),
+            alwaysSet: key in ctx.data
+          });
+        }
+        if (ctx.common.async) {
+          return ParseStatus2.mergeObjectAsync(status, pairs);
+        } else {
+          return ParseStatus2.mergeObjectSync(status, pairs);
+        }
+      }
+      get element() {
+        return this._def.valueType;
+      }
+      static create(first, second, third) {
+        if (second instanceof ZodType3) {
+          return new _ZodRecord({
+            keyType: first,
+            valueType: second,
+            typeName: ZodFirstPartyTypeKind2.ZodRecord,
+            ...processCreateParams2(third)
+          });
+        }
+        return new _ZodRecord({
+          keyType: ZodString3.create(),
+          valueType: first,
+          typeName: ZodFirstPartyTypeKind2.ZodRecord,
+          ...processCreateParams2(second)
+        });
+      }
+    };
+    ZodMap2 = class extends ZodType3 {
+      get keySchema() {
+        return this._def.keyType;
+      }
+      get valueSchema() {
+        return this._def.valueType;
+      }
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.map) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.map,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        const keyType = this._def.keyType;
+        const valueType = this._def.valueType;
+        const pairs = [...ctx.data.entries()].map(([key, value], index) => {
+          return {
+            key: keyType._parse(new ParseInputLazyPath2(ctx, key, ctx.path, [index, "key"])),
+            value: valueType._parse(new ParseInputLazyPath2(ctx, value, ctx.path, [index, "value"]))
+          };
+        });
+        if (ctx.common.async) {
+          const finalMap = /* @__PURE__ */ new Map();
+          return Promise.resolve().then(async () => {
+            for (const pair of pairs) {
+              const key = await pair.key;
+              const value = await pair.value;
+              if (key.status === "aborted" || value.status === "aborted") {
+                return INVALID2;
+              }
+              if (key.status === "dirty" || value.status === "dirty") {
+                status.dirty();
+              }
+              finalMap.set(key.value, value.value);
+            }
+            return { status: status.value, value: finalMap };
+          });
+        } else {
+          const finalMap = /* @__PURE__ */ new Map();
+          for (const pair of pairs) {
+            const key = pair.key;
+            const value = pair.value;
+            if (key.status === "aborted" || value.status === "aborted") {
+              return INVALID2;
+            }
+            if (key.status === "dirty" || value.status === "dirty") {
+              status.dirty();
+            }
+            finalMap.set(key.value, value.value);
+          }
+          return { status: status.value, value: finalMap };
+        }
+      }
+    };
+    ZodMap2.create = (keyType, valueType, params) => {
+      return new ZodMap2({
+        valueType,
+        keyType,
+        typeName: ZodFirstPartyTypeKind2.ZodMap,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodSet2 = class _ZodSet extends ZodType3 {
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.set) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.set,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        const def = this._def;
+        if (def.minSize !== null) {
+          if (ctx.data.size < def.minSize.value) {
+            addIssueToContext2(ctx, {
+              code: ZodIssueCode2.too_small,
+              minimum: def.minSize.value,
+              type: "set",
+              inclusive: true,
+              exact: false,
+              message: def.minSize.message
+            });
+            status.dirty();
+          }
+        }
+        if (def.maxSize !== null) {
+          if (ctx.data.size > def.maxSize.value) {
+            addIssueToContext2(ctx, {
+              code: ZodIssueCode2.too_big,
+              maximum: def.maxSize.value,
+              type: "set",
+              inclusive: true,
+              exact: false,
+              message: def.maxSize.message
+            });
+            status.dirty();
+          }
+        }
+        const valueType = this._def.valueType;
+        function finalizeSet(elements2) {
+          const parsedSet = /* @__PURE__ */ new Set();
+          for (const element of elements2) {
+            if (element.status === "aborted")
+              return INVALID2;
+            if (element.status === "dirty")
+              status.dirty();
+            parsedSet.add(element.value);
+          }
+          return { status: status.value, value: parsedSet };
+        }
+        const elements = [...ctx.data.values()].map((item, i) => valueType._parse(new ParseInputLazyPath2(ctx, item, ctx.path, i)));
+        if (ctx.common.async) {
+          return Promise.all(elements).then((elements2) => finalizeSet(elements2));
+        } else {
+          return finalizeSet(elements);
+        }
+      }
+      min(minSize, message2) {
+        return new _ZodSet({
+          ...this._def,
+          minSize: { value: minSize, message: errorUtil2.toString(message2) }
+        });
+      }
+      max(maxSize, message2) {
+        return new _ZodSet({
+          ...this._def,
+          maxSize: { value: maxSize, message: errorUtil2.toString(message2) }
+        });
+      }
+      size(size, message2) {
+        return this.min(size, message2).max(size, message2);
+      }
+      nonempty(message2) {
+        return this.min(1, message2);
+      }
+    };
+    ZodSet2.create = (valueType, params) => {
+      return new ZodSet2({
+        valueType,
+        minSize: null,
+        maxSize: null,
+        typeName: ZodFirstPartyTypeKind2.ZodSet,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodFunction2 = class _ZodFunction extends ZodType3 {
+      constructor() {
+        super(...arguments);
+        this.validate = this.implement;
+      }
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.function) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.function,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        function makeArgsIssue(args, error2) {
+          return makeIssue2({
+            data: args,
+            path: ctx.path,
+            errorMaps: [ctx.common.contextualErrorMap, ctx.schemaErrorMap, getErrorMap2(), en_default3].filter((x) => !!x),
+            issueData: {
+              code: ZodIssueCode2.invalid_arguments,
+              argumentsError: error2
+            }
+          });
+        }
+        function makeReturnsIssue(returns, error2) {
+          return makeIssue2({
+            data: returns,
+            path: ctx.path,
+            errorMaps: [ctx.common.contextualErrorMap, ctx.schemaErrorMap, getErrorMap2(), en_default3].filter((x) => !!x),
+            issueData: {
+              code: ZodIssueCode2.invalid_return_type,
+              returnTypeError: error2
+            }
+          });
+        }
+        const params = { errorMap: ctx.common.contextualErrorMap };
+        const fn = ctx.data;
+        if (this._def.returns instanceof ZodPromise2) {
+          const me = this;
+          return OK2(async function(...args) {
+            const error2 = new ZodError3([]);
+            const parsedArgs = await me._def.args.parseAsync(args, params).catch((e) => {
+              error2.addIssue(makeArgsIssue(args, e));
+              throw error2;
+            });
+            const result = await Reflect.apply(fn, this, parsedArgs);
+            const parsedReturns = await me._def.returns._def.type.parseAsync(result, params).catch((e) => {
+              error2.addIssue(makeReturnsIssue(result, e));
+              throw error2;
+            });
+            return parsedReturns;
+          });
+        } else {
+          const me = this;
+          return OK2(function(...args) {
+            const parsedArgs = me._def.args.safeParse(args, params);
+            if (!parsedArgs.success) {
+              throw new ZodError3([makeArgsIssue(args, parsedArgs.error)]);
+            }
+            const result = Reflect.apply(fn, this, parsedArgs.data);
+            const parsedReturns = me._def.returns.safeParse(result, params);
+            if (!parsedReturns.success) {
+              throw new ZodError3([makeReturnsIssue(result, parsedReturns.error)]);
+            }
+            return parsedReturns.data;
+          });
+        }
+      }
+      parameters() {
+        return this._def.args;
+      }
+      returnType() {
+        return this._def.returns;
+      }
+      args(...items) {
+        return new _ZodFunction({
+          ...this._def,
+          args: ZodTuple2.create(items).rest(ZodUnknown3.create())
+        });
+      }
+      returns(returnType) {
+        return new _ZodFunction({
+          ...this._def,
+          returns: returnType
+        });
+      }
+      implement(func) {
+        const validatedFunc = this.parse(func);
+        return validatedFunc;
+      }
+      strictImplement(func) {
+        const validatedFunc = this.parse(func);
+        return validatedFunc;
+      }
+      static create(args, returns, params) {
+        return new _ZodFunction({
+          args: args ? args : ZodTuple2.create([]).rest(ZodUnknown3.create()),
+          returns: returns || ZodUnknown3.create(),
+          typeName: ZodFirstPartyTypeKind2.ZodFunction,
+          ...processCreateParams2(params)
+        });
+      }
+    };
+    ZodLazy2 = class extends ZodType3 {
+      get schema() {
+        return this._def.getter();
+      }
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        const lazySchema = this._def.getter();
+        return lazySchema._parse({ data: ctx.data, path: ctx.path, parent: ctx });
+      }
+    };
+    ZodLazy2.create = (getter, params) => {
+      return new ZodLazy2({
+        getter,
+        typeName: ZodFirstPartyTypeKind2.ZodLazy,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodLiteral3 = class extends ZodType3 {
+      _parse(input) {
+        if (input.data !== this._def.value) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            received: ctx.data,
+            code: ZodIssueCode2.invalid_literal,
+            expected: this._def.value
+          });
+          return INVALID2;
+        }
+        return { status: "valid", value: input.data };
+      }
+      get value() {
+        return this._def.value;
+      }
+    };
+    ZodLiteral3.create = (value, params) => {
+      return new ZodLiteral3({
+        value,
+        typeName: ZodFirstPartyTypeKind2.ZodLiteral,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodEnum3 = class _ZodEnum extends ZodType3 {
+      _parse(input) {
+        if (typeof input.data !== "string") {
+          const ctx = this._getOrReturnCtx(input);
+          const expectedValues = this._def.values;
+          addIssueToContext2(ctx, {
+            expected: util2.joinValues(expectedValues),
+            received: ctx.parsedType,
+            code: ZodIssueCode2.invalid_type
+          });
+          return INVALID2;
+        }
+        if (!this._cache) {
+          this._cache = new Set(this._def.values);
+        }
+        if (!this._cache.has(input.data)) {
+          const ctx = this._getOrReturnCtx(input);
+          const expectedValues = this._def.values;
+          addIssueToContext2(ctx, {
+            received: ctx.data,
+            code: ZodIssueCode2.invalid_enum_value,
+            options: expectedValues
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+      get options() {
+        return this._def.values;
+      }
+      get enum() {
+        const enumValues = {};
+        for (const val of this._def.values) {
+          enumValues[val] = val;
+        }
+        return enumValues;
+      }
+      get Values() {
+        const enumValues = {};
+        for (const val of this._def.values) {
+          enumValues[val] = val;
+        }
+        return enumValues;
+      }
+      get Enum() {
+        const enumValues = {};
+        for (const val of this._def.values) {
+          enumValues[val] = val;
+        }
+        return enumValues;
+      }
+      extract(values, newDef = this._def) {
+        return _ZodEnum.create(values, {
+          ...this._def,
+          ...newDef
+        });
+      }
+      exclude(values, newDef = this._def) {
+        return _ZodEnum.create(this.options.filter((opt) => !values.includes(opt)), {
+          ...this._def,
+          ...newDef
+        });
+      }
+    };
+    ZodEnum3.create = createZodEnum2;
+    ZodNativeEnum2 = class extends ZodType3 {
+      _parse(input) {
+        const nativeEnumValues = util2.getValidEnumValues(this._def.values);
+        const ctx = this._getOrReturnCtx(input);
+        if (ctx.parsedType !== ZodParsedType2.string && ctx.parsedType !== ZodParsedType2.number) {
+          const expectedValues = util2.objectValues(nativeEnumValues);
+          addIssueToContext2(ctx, {
+            expected: util2.joinValues(expectedValues),
+            received: ctx.parsedType,
+            code: ZodIssueCode2.invalid_type
+          });
+          return INVALID2;
+        }
+        if (!this._cache) {
+          this._cache = new Set(util2.getValidEnumValues(this._def.values));
+        }
+        if (!this._cache.has(input.data)) {
+          const expectedValues = util2.objectValues(nativeEnumValues);
+          addIssueToContext2(ctx, {
+            received: ctx.data,
+            code: ZodIssueCode2.invalid_enum_value,
+            options: expectedValues
+          });
+          return INVALID2;
+        }
+        return OK2(input.data);
+      }
+      get enum() {
+        return this._def.values;
+      }
+    };
+    ZodNativeEnum2.create = (values, params) => {
+      return new ZodNativeEnum2({
+        values,
+        typeName: ZodFirstPartyTypeKind2.ZodNativeEnum,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodPromise2 = class extends ZodType3 {
+      unwrap() {
+        return this._def.type;
+      }
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        if (ctx.parsedType !== ZodParsedType2.promise && ctx.common.async === false) {
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.promise,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        const promisified = ctx.parsedType === ZodParsedType2.promise ? ctx.data : Promise.resolve(ctx.data);
+        return OK2(promisified.then((data) => {
+          return this._def.type.parseAsync(data, {
+            path: ctx.path,
+            errorMap: ctx.common.contextualErrorMap
+          });
+        }));
+      }
+    };
+    ZodPromise2.create = (schema, params) => {
+      return new ZodPromise2({
+        type: schema,
+        typeName: ZodFirstPartyTypeKind2.ZodPromise,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodEffects2 = class extends ZodType3 {
+      innerType() {
+        return this._def.schema;
+      }
+      sourceType() {
+        return this._def.schema._def.typeName === ZodFirstPartyTypeKind2.ZodEffects ? this._def.schema.sourceType() : this._def.schema;
+      }
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        const effect = this._def.effect || null;
+        const checkCtx = {
+          addIssue: (arg) => {
+            addIssueToContext2(ctx, arg);
+            if (arg.fatal) {
+              status.abort();
+            } else {
+              status.dirty();
+            }
+          },
+          get path() {
+            return ctx.path;
+          }
+        };
+        checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
+        if (effect.type === "preprocess") {
+          const processed = effect.transform(ctx.data, checkCtx);
+          if (ctx.common.async) {
+            return Promise.resolve(processed).then(async (processed2) => {
+              if (status.value === "aborted")
+                return INVALID2;
+              const result = await this._def.schema._parseAsync({
+                data: processed2,
+                path: ctx.path,
+                parent: ctx
+              });
+              if (result.status === "aborted")
+                return INVALID2;
+              if (result.status === "dirty")
+                return DIRTY2(result.value);
+              if (status.value === "dirty")
+                return DIRTY2(result.value);
+              return result;
+            });
+          } else {
+            if (status.value === "aborted")
+              return INVALID2;
+            const result = this._def.schema._parseSync({
+              data: processed,
+              path: ctx.path,
+              parent: ctx
+            });
+            if (result.status === "aborted")
+              return INVALID2;
+            if (result.status === "dirty")
+              return DIRTY2(result.value);
+            if (status.value === "dirty")
+              return DIRTY2(result.value);
+            return result;
+          }
+        }
+        if (effect.type === "refinement") {
+          const executeRefinement = (acc) => {
+            const result = effect.refinement(acc, checkCtx);
+            if (ctx.common.async) {
+              return Promise.resolve(result);
+            }
+            if (result instanceof Promise) {
+              throw new Error("Async refinement encountered during synchronous parse operation. Use .parseAsync instead.");
+            }
+            return acc;
+          };
+          if (ctx.common.async === false) {
+            const inner = this._def.schema._parseSync({
+              data: ctx.data,
+              path: ctx.path,
+              parent: ctx
+            });
+            if (inner.status === "aborted")
+              return INVALID2;
+            if (inner.status === "dirty")
+              status.dirty();
+            executeRefinement(inner.value);
+            return { status: status.value, value: inner.value };
+          } else {
+            return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((inner) => {
+              if (inner.status === "aborted")
+                return INVALID2;
+              if (inner.status === "dirty")
+                status.dirty();
+              return executeRefinement(inner.value).then(() => {
+                return { status: status.value, value: inner.value };
+              });
+            });
+          }
+        }
+        if (effect.type === "transform") {
+          if (ctx.common.async === false) {
+            const base = this._def.schema._parseSync({
+              data: ctx.data,
+              path: ctx.path,
+              parent: ctx
+            });
+            if (!isValid2(base))
+              return INVALID2;
+            const result = effect.transform(base.value, checkCtx);
+            if (result instanceof Promise) {
+              throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
+            }
+            return { status: status.value, value: result };
+          } else {
+            return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
+              if (!isValid2(base))
+                return INVALID2;
+              return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
+                status: status.value,
+                value: result
+              }));
+            });
+          }
+        }
+        util2.assertNever(effect);
+      }
+    };
+    ZodEffects2.create = (schema, effect, params) => {
+      return new ZodEffects2({
+        schema,
+        typeName: ZodFirstPartyTypeKind2.ZodEffects,
+        effect,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodEffects2.createWithPreprocess = (preprocess2, schema, params) => {
+      return new ZodEffects2({
+        schema,
+        effect: { type: "preprocess", transform: preprocess2 },
+        typeName: ZodFirstPartyTypeKind2.ZodEffects,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodOptional3 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 === ZodParsedType2.undefined) {
+          return OK2(void 0);
+        }
+        return this._def.innerType._parse(input);
+      }
+      unwrap() {
+        return this._def.innerType;
+      }
+    };
+    ZodOptional3.create = (type, params) => {
+      return new ZodOptional3({
+        innerType: type,
+        typeName: ZodFirstPartyTypeKind2.ZodOptional,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodNullable3 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 === ZodParsedType2.null) {
+          return OK2(null);
+        }
+        return this._def.innerType._parse(input);
+      }
+      unwrap() {
+        return this._def.innerType;
+      }
+    };
+    ZodNullable3.create = (type, params) => {
+      return new ZodNullable3({
+        innerType: type,
+        typeName: ZodFirstPartyTypeKind2.ZodNullable,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodDefault3 = class extends ZodType3 {
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        let data = ctx.data;
+        if (ctx.parsedType === ZodParsedType2.undefined) {
+          data = this._def.defaultValue();
+        }
+        return this._def.innerType._parse({
+          data,
+          path: ctx.path,
+          parent: ctx
+        });
+      }
+      removeDefault() {
+        return this._def.innerType;
+      }
+    };
+    ZodDefault3.create = (type, params) => {
+      return new ZodDefault3({
+        innerType: type,
+        typeName: ZodFirstPartyTypeKind2.ZodDefault,
+        defaultValue: typeof params.default === "function" ? params.default : () => params.default,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodCatch3 = class extends ZodType3 {
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        const newCtx = {
+          ...ctx,
+          common: {
+            ...ctx.common,
+            issues: []
+          }
+        };
+        const result = this._def.innerType._parse({
+          data: newCtx.data,
+          path: newCtx.path,
+          parent: {
+            ...newCtx
+          }
+        });
+        if (isAsync2(result)) {
+          return result.then((result2) => {
+            return {
+              status: "valid",
+              value: result2.status === "valid" ? result2.value : this._def.catchValue({
+                get error() {
+                  return new ZodError3(newCtx.common.issues);
+                },
+                input: newCtx.data
+              })
+            };
+          });
+        } else {
+          return {
+            status: "valid",
+            value: result.status === "valid" ? result.value : this._def.catchValue({
+              get error() {
+                return new ZodError3(newCtx.common.issues);
+              },
+              input: newCtx.data
+            })
+          };
+        }
+      }
+      removeCatch() {
+        return this._def.innerType;
+      }
+    };
+    ZodCatch3.create = (type, params) => {
+      return new ZodCatch3({
+        innerType: type,
+        typeName: ZodFirstPartyTypeKind2.ZodCatch,
+        catchValue: typeof params.catch === "function" ? params.catch : () => params.catch,
+        ...processCreateParams2(params)
+      });
+    };
+    ZodNaN2 = class extends ZodType3 {
+      _parse(input) {
+        const parsedType2 = this._getType(input);
+        if (parsedType2 !== ZodParsedType2.nan) {
+          const ctx = this._getOrReturnCtx(input);
+          addIssueToContext2(ctx, {
+            code: ZodIssueCode2.invalid_type,
+            expected: ZodParsedType2.nan,
+            received: ctx.parsedType
+          });
+          return INVALID2;
+        }
+        return { status: "valid", value: input.data };
+      }
+    };
+    ZodNaN2.create = (params) => {
+      return new ZodNaN2({
+        typeName: ZodFirstPartyTypeKind2.ZodNaN,
+        ...processCreateParams2(params)
+      });
+    };
+    BRAND = /* @__PURE__ */ Symbol("zod_brand");
+    ZodBranded2 = class extends ZodType3 {
+      _parse(input) {
+        const { ctx } = this._processInputParams(input);
+        const data = ctx.data;
+        return this._def.type._parse({
+          data,
+          path: ctx.path,
+          parent: ctx
+        });
+      }
+      unwrap() {
+        return this._def.type;
+      }
+    };
+    ZodPipeline2 = class _ZodPipeline extends ZodType3 {
+      _parse(input) {
+        const { status, ctx } = this._processInputParams(input);
+        if (ctx.common.async) {
+          const handleAsync = async () => {
+            const inResult = await this._def.in._parseAsync({
+              data: ctx.data,
+              path: ctx.path,
+              parent: ctx
+            });
+            if (inResult.status === "aborted")
+              return INVALID2;
+            if (inResult.status === "dirty") {
+              status.dirty();
+              return DIRTY2(inResult.value);
+            } else {
+              return this._def.out._parseAsync({
+                data: inResult.value,
+                path: ctx.path,
+                parent: ctx
+              });
+            }
+          };
+          return handleAsync();
+        } else {
+          const inResult = this._def.in._parseSync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx
+          });
+          if (inResult.status === "aborted")
+            return INVALID2;
+          if (inResult.status === "dirty") {
+            status.dirty();
+            return {
+              status: "dirty",
+              value: inResult.value
+            };
+          } else {
+            return this._def.out._parseSync({
+              data: inResult.value,
+              path: ctx.path,
+              parent: ctx
+            });
+          }
+        }
+      }
+      static create(a, b) {
+        return new _ZodPipeline({
+          in: a,
+          out: b,
+          typeName: ZodFirstPartyTypeKind2.ZodPipeline
+        });
+      }
+    };
+    ZodReadonly3 = class extends ZodType3 {
+      _parse(input) {
+        const result = this._def.innerType._parse(input);
+        const freeze = (data) => {
+          if (isValid2(data)) {
+            data.value = Object.freeze(data.value);
+          }
+          return data;
+        };
+        return isAsync2(result) ? result.then((data) => freeze(data)) : freeze(result);
+      }
+      unwrap() {
+        return this._def.innerType;
+      }
+    };
+    ZodReadonly3.create = (type, params) => {
+      return new ZodReadonly3({
+        innerType: type,
+        typeName: ZodFirstPartyTypeKind2.ZodReadonly,
+        ...processCreateParams2(params)
+      });
+    };
+    late2 = {
+      object: ZodObject3.lazycreate
+    };
+    (function(ZodFirstPartyTypeKind3) {
+      ZodFirstPartyTypeKind3["ZodString"] = "ZodString";
+      ZodFirstPartyTypeKind3["ZodNumber"] = "ZodNumber";
+      ZodFirstPartyTypeKind3["ZodNaN"] = "ZodNaN";
+      ZodFirstPartyTypeKind3["ZodBigInt"] = "ZodBigInt";
+      ZodFirstPartyTypeKind3["ZodBoolean"] = "ZodBoolean";
+      ZodFirstPartyTypeKind3["ZodDate"] = "ZodDate";
+      ZodFirstPartyTypeKind3["ZodSymbol"] = "ZodSymbol";
+      ZodFirstPartyTypeKind3["ZodUndefined"] = "ZodUndefined";
+      ZodFirstPartyTypeKind3["ZodNull"] = "ZodNull";
+      ZodFirstPartyTypeKind3["ZodAny"] = "ZodAny";
+      ZodFirstPartyTypeKind3["ZodUnknown"] = "ZodUnknown";
+      ZodFirstPartyTypeKind3["ZodNever"] = "ZodNever";
+      ZodFirstPartyTypeKind3["ZodVoid"] = "ZodVoid";
+      ZodFirstPartyTypeKind3["ZodArray"] = "ZodArray";
+      ZodFirstPartyTypeKind3["ZodObject"] = "ZodObject";
+      ZodFirstPartyTypeKind3["ZodUnion"] = "ZodUnion";
+      ZodFirstPartyTypeKind3["ZodDiscriminatedUnion"] = "ZodDiscriminatedUnion";
+      ZodFirstPartyTypeKind3["ZodIntersection"] = "ZodIntersection";
+      ZodFirstPartyTypeKind3["ZodTuple"] = "ZodTuple";
+      ZodFirstPartyTypeKind3["ZodRecord"] = "ZodRecord";
+      ZodFirstPartyTypeKind3["ZodMap"] = "ZodMap";
+      ZodFirstPartyTypeKind3["ZodSet"] = "ZodSet";
+      ZodFirstPartyTypeKind3["ZodFunction"] = "ZodFunction";
+      ZodFirstPartyTypeKind3["ZodLazy"] = "ZodLazy";
+      ZodFirstPartyTypeKind3["ZodLiteral"] = "ZodLiteral";
+      ZodFirstPartyTypeKind3["ZodEnum"] = "ZodEnum";
+      ZodFirstPartyTypeKind3["ZodEffects"] = "ZodEffects";
+      ZodFirstPartyTypeKind3["ZodNativeEnum"] = "ZodNativeEnum";
+      ZodFirstPartyTypeKind3["ZodOptional"] = "ZodOptional";
+      ZodFirstPartyTypeKind3["ZodNullable"] = "ZodNullable";
+      ZodFirstPartyTypeKind3["ZodDefault"] = "ZodDefault";
+      ZodFirstPartyTypeKind3["ZodCatch"] = "ZodCatch";
+      ZodFirstPartyTypeKind3["ZodPromise"] = "ZodPromise";
+      ZodFirstPartyTypeKind3["ZodBranded"] = "ZodBranded";
+      ZodFirstPartyTypeKind3["ZodPipeline"] = "ZodPipeline";
+      ZodFirstPartyTypeKind3["ZodReadonly"] = "ZodReadonly";
+    })(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
+    instanceOfType = (cls, params = {
+      message: `Input not instance of ${cls.name}`
+    }) => custom2((data) => data instanceof cls, params);
+    stringType2 = ZodString3.create;
+    numberType2 = ZodNumber3.create;
+    nanType2 = ZodNaN2.create;
+    bigIntType2 = ZodBigInt2.create;
+    booleanType2 = ZodBoolean3.create;
+    dateType2 = ZodDate2.create;
+    symbolType2 = ZodSymbol2.create;
+    undefinedType2 = ZodUndefined2.create;
+    nullType2 = ZodNull3.create;
+    anyType2 = ZodAny2.create;
+    unknownType2 = ZodUnknown3.create;
+    neverType2 = ZodNever3.create;
+    voidType2 = ZodVoid2.create;
+    arrayType2 = ZodArray3.create;
+    objectType2 = ZodObject3.create;
+    strictObjectType2 = ZodObject3.strictCreate;
+    unionType2 = ZodUnion3.create;
+    discriminatedUnionType2 = ZodDiscriminatedUnion3.create;
+    intersectionType2 = ZodIntersection3.create;
+    tupleType2 = ZodTuple2.create;
+    recordType2 = ZodRecord3.create;
+    mapType2 = ZodMap2.create;
+    setType2 = ZodSet2.create;
+    functionType2 = ZodFunction2.create;
+    lazyType2 = ZodLazy2.create;
+    literalType2 = ZodLiteral3.create;
+    enumType2 = ZodEnum3.create;
+    nativeEnumType2 = ZodNativeEnum2.create;
+    promiseType2 = ZodPromise2.create;
+    effectsType2 = ZodEffects2.create;
+    optionalType2 = ZodOptional3.create;
+    nullableType2 = ZodNullable3.create;
+    preprocessType2 = ZodEffects2.createWithPreprocess;
+    pipelineType2 = ZodPipeline2.create;
+    ostring = () => stringType2().optional();
+    onumber = () => numberType2().optional();
+    oboolean = () => booleanType2().optional();
+    coerce = {
+      string: ((arg) => ZodString3.create({ ...arg, coerce: true })),
+      number: ((arg) => ZodNumber3.create({ ...arg, coerce: true })),
+      boolean: ((arg) => ZodBoolean3.create({
+        ...arg,
+        coerce: true
+      })),
+      bigint: ((arg) => ZodBigInt2.create({ ...arg, coerce: true })),
+      date: ((arg) => ZodDate2.create({ ...arg, coerce: true }))
+    };
+    NEVER2 = INVALID2;
+  }
+});
+
+// node_modules/zod/v3/external.js
+var external_exports = {};
+__export(external_exports, {
+  BRAND: () => BRAND,
+  DIRTY: () => DIRTY2,
+  EMPTY_PATH: () => EMPTY_PATH,
+  INVALID: () => INVALID2,
+  NEVER: () => NEVER2,
+  OK: () => OK2,
+  ParseStatus: () => ParseStatus2,
+  Schema: () => ZodType3,
+  ZodAny: () => ZodAny2,
+  ZodArray: () => ZodArray3,
+  ZodBigInt: () => ZodBigInt2,
+  ZodBoolean: () => ZodBoolean3,
+  ZodBranded: () => ZodBranded2,
+  ZodCatch: () => ZodCatch3,
+  ZodDate: () => ZodDate2,
+  ZodDefault: () => ZodDefault3,
+  ZodDiscriminatedUnion: () => ZodDiscriminatedUnion3,
+  ZodEffects: () => ZodEffects2,
+  ZodEnum: () => ZodEnum3,
+  ZodError: () => ZodError3,
+  ZodFirstPartyTypeKind: () => ZodFirstPartyTypeKind2,
+  ZodFunction: () => ZodFunction2,
+  ZodIntersection: () => ZodIntersection3,
+  ZodIssueCode: () => ZodIssueCode2,
+  ZodLazy: () => ZodLazy2,
+  ZodLiteral: () => ZodLiteral3,
+  ZodMap: () => ZodMap2,
+  ZodNaN: () => ZodNaN2,
+  ZodNativeEnum: () => ZodNativeEnum2,
+  ZodNever: () => ZodNever3,
+  ZodNull: () => ZodNull3,
+  ZodNullable: () => ZodNullable3,
+  ZodNumber: () => ZodNumber3,
+  ZodObject: () => ZodObject3,
+  ZodOptional: () => ZodOptional3,
+  ZodParsedType: () => ZodParsedType2,
+  ZodPipeline: () => ZodPipeline2,
+  ZodPromise: () => ZodPromise2,
+  ZodReadonly: () => ZodReadonly3,
+  ZodRecord: () => ZodRecord3,
+  ZodSchema: () => ZodType3,
+  ZodSet: () => ZodSet2,
+  ZodString: () => ZodString3,
+  ZodSymbol: () => ZodSymbol2,
+  ZodTransformer: () => ZodEffects2,
+  ZodTuple: () => ZodTuple2,
+  ZodType: () => ZodType3,
+  ZodUndefined: () => ZodUndefined2,
+  ZodUnion: () => ZodUnion3,
+  ZodUnknown: () => ZodUnknown3,
+  ZodVoid: () => ZodVoid2,
+  addIssueToContext: () => addIssueToContext2,
+  any: () => anyType2,
+  array: () => arrayType2,
+  bigint: () => bigIntType2,
+  boolean: () => booleanType2,
+  coerce: () => coerce,
+  custom: () => custom2,
+  date: () => dateType2,
+  datetimeRegex: () => datetimeRegex2,
+  defaultErrorMap: () => en_default3,
+  discriminatedUnion: () => discriminatedUnionType2,
+  effect: () => effectsType2,
+  enum: () => enumType2,
+  function: () => functionType2,
+  getErrorMap: () => getErrorMap2,
+  getParsedType: () => getParsedType3,
+  instanceof: () => instanceOfType,
+  intersection: () => intersectionType2,
+  isAborted: () => isAborted2,
+  isAsync: () => isAsync2,
+  isDirty: () => isDirty2,
+  isValid: () => isValid2,
+  late: () => late2,
+  lazy: () => lazyType2,
+  literal: () => literalType2,
+  makeIssue: () => makeIssue2,
+  map: () => mapType2,
+  nan: () => nanType2,
+  nativeEnum: () => nativeEnumType2,
+  never: () => neverType2,
+  null: () => nullType2,
+  nullable: () => nullableType2,
+  number: () => numberType2,
+  object: () => objectType2,
+  objectUtil: () => objectUtil2,
+  oboolean: () => oboolean,
+  onumber: () => onumber,
+  optional: () => optionalType2,
+  ostring: () => ostring,
+  pipeline: () => pipelineType2,
+  preprocess: () => preprocessType2,
+  promise: () => promiseType2,
+  quotelessJson: () => quotelessJson,
+  record: () => recordType2,
+  set: () => setType2,
+  setErrorMap: () => setErrorMap,
+  strictObject: () => strictObjectType2,
+  string: () => stringType2,
+  symbol: () => symbolType2,
+  transformer: () => effectsType2,
+  tuple: () => tupleType2,
+  undefined: () => undefinedType2,
+  union: () => unionType2,
+  unknown: () => unknownType2,
+  util: () => util2,
+  void: () => voidType2
+});
+var init_external = __esm({
+  "node_modules/zod/v3/external.js"() {
+    init_errors();
+    init_parseUtil();
+    init_typeAliases();
+    init_util();
+    init_types3();
+    init_ZodError();
+  }
+});
+
+// node_modules/zod/index.js
+var init_zod = __esm({
+  "node_modules/zod/index.js"() {
+    init_external();
+    init_external();
+  }
+});
+
 // src/utils/encode-project-path.ts
 function encodeProjectPath(projectPath) {
   return projectPath.replace(/[^a-zA-Z0-9]/g, "-");
@@ -6317,10 +10423,10 @@ var init_security_config = __esm({
 function isSecureRuntimeDir(dir) {
   if (!path.isAbsolute(dir)) return false;
   try {
-    const stat2 = fs2.lstatSync(dir);
-    if (!stat2.isDirectory() || stat2.isSymbolicLink()) return false;
-    if (stat2.uid !== process.getuid?.()) return false;
-    if ((stat2.mode & 511) !== 448) return false;
+    const stat3 = fs2.lstatSync(dir);
+    if (!stat3.isDirectory() || stat3.isSymbolicLink()) return false;
+    if (stat3.uid !== process.getuid?.()) return false;
+    if ((stat3.mode & 511) !== 448) return false;
     return true;
   } catch {
     return false;
@@ -6732,10 +10838,10 @@ async function getProcessStartTimeMacOS(pid, deadlineAt) {
 async function getProcessStartTimeLinux(pid, deadlineAt) {
   if (isDeadlineExceeded(deadlineAt)) return void 0;
   try {
-    const stat2 = await fsPromises.readFile(`/proc/${pid}/stat`, "utf8");
-    const closeParen = stat2.lastIndexOf(")");
+    const stat3 = await fsPromises.readFile(`/proc/${pid}/stat`, "utf8");
+    const closeParen = stat3.lastIndexOf(")");
     if (closeParen === -1) return void 0;
-    const fields = stat2.substring(closeParen + 2).split(" ");
+    const fields = stat3.substring(closeParen + 2).split(" ");
     const startTime = parseInt(fields[19], 10);
     return isNaN(startTime) ? void 0 : startTime;
   } catch {
@@ -6896,8 +11002,8 @@ async function verifyProcessIdentity(meta) {
 }
 function isSocket(socketPath) {
   try {
-    const stat2 = fs5.lstatSync(socketPath);
-    return stat2.isSocket();
+    const stat3 = fs5.lstatSync(socketPath);
+    return stat3.isSocket();
   } catch {
     return false;
   }
@@ -7221,7 +11327,7 @@ async function removeFileIfExists(filePath) {
   }
 }
 function sleep2(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 var import_child_process9, fs5, fsPromises2, path5, import_url6, import_child_process10, import_util6, execFileAsync3, BRIDGE_SPAWN_TIMEOUT_MS, DEFAULT_GRACE_PERIOD_MS, SIGTERM_GRACE_MS, ownedBridgeSessionIds, USE_TCP_FALLBACK;
 var init_bridge_manager = __esm({
@@ -7597,22 +11703,45 @@ var init_session_id = __esm({
 });
 
 // src/lib/mode-state-io.ts
+function leaseNow() {
+  return Date.now();
+}
 function flockPath() {
+  if (process.env.NODE_ENV === "test" && process.env.OMC_TEST_FORCE_FLOCKLESS === "1") return null;
   return process.env.NODE_ENV === "test" && process.env.OMC_TEST_FLOCK_AVAILABLE === "0" ? null : (0, import_fs18.existsSync)("/usr/bin/flock") ? "/usr/bin/flock" : (0, import_fs18.existsSync)("/bin/flock") ? "/bin/flock" : null;
+}
+function lockingDisabledForTest() {
+  return process.env.NODE_ENV === "test" && process.env.OMC_TEST_FLOCK_AVAILABLE === "0";
+}
+function selfProcessStart() {
+  if (cachedSelfProcessStart === void 0) {
+    cachedSelfProcessStart = String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1e3)));
+  }
+  return cachedSelfProcessStart;
 }
 function processStartIdentity(pid) {
   if (!Number.isSafeInteger(pid) || pid <= 0) return null;
-  if (process.platform !== "linux") return pid === process.pid ? String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1e3))) : null;
+  if (process.platform !== "linux") return pid === process.pid ? selfProcessStart() : null;
   if (process.env.NODE_ENV === "test" && process.env.OMC_TEST_EMERGENCY_PROCESS_START_UNKNOWN_PID === String(pid)) return null;
   try {
-    const stat2 = (0, import_fs18.readFileSync)(`/proc/${pid}/stat`, "utf8");
-    const end = stat2.lastIndexOf(")");
+    const stat3 = (0, import_fs18.readFileSync)(`/proc/${pid}/stat`, "utf8");
+    const end = stat3.lastIndexOf(")");
     if (end < 0) return null;
-    const fields = stat2.slice(end + 2).trim().split(/\s+/);
+    const fields = stat3.slice(end + 2).trim().split(/\s+/);
     return fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
   } catch (error2) {
     return error2.code === "ENOENT" ? "absent" : null;
   }
+}
+function freshLockOwner() {
+  const now = leaseNow();
+  return {
+    version: LOCK_SCHEMA_VERSION,
+    pid: process.pid,
+    createdAt: new Date(now).toISOString(),
+    expires_at: new Date(now + LOCK_LEASE_MS).toISOString(),
+    nonce: (0, import_crypto7.randomUUID)()
+  };
 }
 function writeAllSync2(fd, content, label) {
   const bytes = Buffer.from(content, "utf-8");
@@ -7635,18 +11764,17 @@ function guardedLockRemoval(path25, operation, owner) {
   if (result.status === 0) return "retry";
   if (result.status === 2) return "live";
   if (result.status === 4) return "replaced";
+  if (result.status === 5) return "old_version";
+  if (result.status === 6) return "unknown_version";
   return "unverifiable";
 }
 function acquireLockAt(path25, requireExclusive = false) {
   (0, import_fs18.mkdirSync)((0, import_path24.dirname)(path25), { recursive: true });
-  if (!flockPath()) return requireExclusive ? null : { unlocked: true };
-  const processStart = processStartIdentity(process.pid);
-  if (!processStart || processStart === "absent") {
-    console.error(`[omc-lock] state_mutation_lock_owner_unverifiable: ${path25}`);
-    return null;
-  }
+  const hasFlock = !!flockPath();
+  if (lockingDisabledForTest()) return requireExclusive ? null : { unlocked: true };
+  if (!hasFlock && !requireExclusive) return { unlocked: true };
   for (let attempt = 0; attempt < 50; attempt += 1) {
-    const owner = { version: 1, pid: process.pid, processStart, createdAt: (/* @__PURE__ */ new Date()).toISOString(), nonce: (0, import_crypto7.randomUUID)() };
+    const owner = freshLockOwner();
     const tempPath = `${path25}.${process.pid}.${owner.nonce}.tmp`;
     let fd;
     try {
@@ -7668,18 +11796,112 @@ function acquireLockAt(path25, requireExclusive = false) {
       } catch {
       }
       if (error2.code !== "EEXIST") return null;
-      const disposition = guardedLockRemoval(path25, "reclaim");
-      if (disposition === "unverifiable") {
-        console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path25}`);
-        return null;
+      if (hasFlock) {
+        const disposition = guardedLockRemoval(path25, "reclaim");
+        if (disposition === "unverifiable") {
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path25}`);
+          return null;
+        }
+        if (disposition === "old_version" || disposition === "unknown_version") {
+          console.error(`[omc-lock] state_mutation_lock_${disposition}: ${path25}`);
+          return null;
+        }
+        if (disposition === "live") Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      } else {
+        const current = readLockOwner(path25);
+        if (current === "absent") {
+        } else if (current === null) {
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path25}`);
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        } else if (current === "old_version" || current === "unknown_version" || current === "unrecognised") {
+          console.error(`[omc-lock] state_mutation_lock_${current}: ${path25}`);
+          return null;
+        } else if (current === "corrupt") {
+          try {
+            (0, import_fs18.unlinkSync)(path25);
+          } catch {
+          }
+        } else if (leaseNow() >= Date.parse(current.expires_at)) {
+          try {
+            (0, import_fs18.unlinkSync)(path25);
+          } catch {
+          }
+        } else {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        }
       }
-      if (disposition === "live") Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
   }
   return null;
 }
 function acquireMutationLock(filePath) {
-  return acquireLockAt(`${filePath}.mutation.lock`);
+  return acquireLockAt(`${filePath}.mutation.lock`, !lockingDisabledForTest());
+}
+function sameLockOwner(left, right) {
+  return left.pid === right.pid && left.nonce === right.nonce && left.createdAt === right.createdAt;
+}
+function isOldLivenessOwner(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record2 = value;
+  const actual = Object.keys(record2).sort();
+  if (actual.length !== LOCK_OLD_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OLD_OWNER_KEYS[index])) return false;
+  if (record2.version !== LOCK_OLD_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(record2.pid) || record2.pid <= 0) return false;
+  if (typeof record2.createdAt !== "string" || !Number.isFinite(Date.parse(record2.createdAt))) return false;
+  if (typeof record2.processStart !== "string" || !/^\d+$/.test(record2.processStart)) return false;
+  if (typeof record2.nonce !== "string" || !/^[0-9a-f-]{36}$/i.test(record2.nonce)) return false;
+  return true;
+}
+function validateLockOwner(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record2 = value;
+  const actual = Object.keys(record2).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return null;
+  if (record2.version !== LOCK_SCHEMA_VERSION) return null;
+  if (!Number.isSafeInteger(record2.pid) || record2.pid <= 0) return null;
+  if (typeof record2.createdAt !== "string" || !Number.isFinite(Date.parse(record2.createdAt))) return null;
+  if (typeof record2.expires_at !== "string" || !Number.isFinite(Date.parse(record2.expires_at))) return null;
+  if (typeof record2.nonce !== "string" || !/^[0-9a-f-]{36}$/i.test(record2.nonce)) return null;
+  return record2;
+}
+function isUnknownLeaseOwner(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record2 = value;
+  const actual = Object.keys(record2).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return false;
+  if (!Number.isSafeInteger(record2.version) || record2.version <= 0 || record2.version === LOCK_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(record2.pid) || record2.pid <= 0) return false;
+  if (typeof record2.createdAt !== "string" || !Number.isFinite(Date.parse(record2.createdAt))) return false;
+  if (typeof record2.expires_at !== "string" || !Number.isFinite(Date.parse(record2.expires_at))) return false;
+  return typeof record2.nonce === "string" && /^[0-9a-f-]{36}$/i.test(record2.nonce);
+}
+function isUnrecognisedVersionedOwner(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record2 = value;
+  if (!Number.isSafeInteger(record2.version) || record2.version <= 0) return false;
+  return true;
+}
+function readLockOwner(path25) {
+  let raw;
+  try {
+    raw = (0, import_fs18.readFileSync)(path25, "utf8");
+  } catch (error2) {
+    const code = error2.code;
+    if (code === "ENOENT") return "absent";
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return "corrupt";
+  }
+  if (isOldLivenessOwner(parsed)) return "old_version";
+  if (isUnknownLeaseOwner(parsed)) return "unknown_version";
+  const owner = validateLockOwner(parsed);
+  if (owner !== null) return owner;
+  if (isUnrecognisedVersionedOwner(parsed)) return "unrecognised";
+  return "corrupt";
 }
 function releaseMutationLock(lock) {
   if (!lock || "unlocked" in lock) return;
@@ -7687,13 +11909,370 @@ function releaseMutationLock(lock) {
     (0, import_fs18.closeSync)(lock.fd);
   } catch {
   }
-  guardedLockRemoval(lock.path, "release", lock.owner);
+  if (flockPath()) {
+    const disposition = guardedLockRemoval(lock.path, "release", lock.owner);
+    if (disposition === "replaced" || disposition === "old_version") {
+      console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.path}`);
+    }
+    return;
+  }
+  const current = readLockOwner(lock.path);
+  if (current === "absent") return;
+  if (current === null) return;
+  if (current === "old_version" || current === "unknown_version" || current === "unrecognised") {
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.path}`);
+    return;
+  }
+  if (current !== "corrupt" && sameLockOwner(current, lock.owner)) {
+    try {
+      (0, import_fs18.unlinkSync)(lock.path);
+    } catch {
+    }
+  } else {
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.path}`);
+  }
+}
+function assertMutationLockHeld(lock) {
+  if (!lock || "unlocked" in lock) return;
+  const current = readLockOwner(lock.path);
+  if (current === "absent" || current === "old_version" || current === "unknown_version" || current === "unrecognised" || current === "corrupt" || current === null) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.path}`);
+    throw new Error(`lease_expired_during_mutation: holder's lock is no longer live at ${lock.path}`);
+  }
+  if (!sameLockOwner(current, lock.owner)) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.path}`);
+    throw new Error(`lease_expired_during_mutation: on-disk owner replaced at ${lock.path}`);
+  }
+  if (leaseNow() >= Date.parse(current.expires_at)) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.path}`);
+    throw new Error(`lease_expired_during_mutation: holder's lease expired before publish at ${lock.path}`);
+  }
 }
 function withStateFileMutationLock(filePath, callback, requireExclusive = false) {
   const lock = acquireLockAt(`${filePath}.mutation.lock`, requireExclusive);
   if (!lock) return { acquired: false, value: void 0 };
   try {
-    return { acquired: true, value: callback() };
+    return { acquired: true, value: callback(() => assertMutationLockHeld(lock)) };
+  } finally {
+    releaseMutationLock(lock);
+  }
+}
+function occJournalDir(filePath) {
+  return `${filePath}.journal`;
+}
+function occEntryPath(dir, seq, token) {
+  return (0, import_path24.join)(dir, `${seq}.${token}.json`);
+}
+function occCompletePath(dir, seq, token) {
+  return (0, import_path24.join)(dir, `${seq}.${token}.complete`);
+}
+function occAbortedPath(dir, seq, token) {
+  return (0, import_path24.join)(dir, `${seq}.${token}.aborted`);
+}
+function occClaimPath(dir, seq) {
+  return (0, import_path24.join)(dir, `${seq}.claim`);
+}
+function occReadCurrent(filePath) {
+  const dir = occJournalDir(filePath);
+  let names;
+  try {
+    names = (0, import_fs18.readdirSync)(dir);
+  } catch (error2) {
+    const code = error2.code;
+    if (code === "ENOENT") return { seq: -1, state: null, empty: true, ioError: false, reservedSeq: -1 };
+    return { seq: -1, state: null, empty: false, ioError: true, reservedSeq: -1 };
+  }
+  const completeBySeq = /* @__PURE__ */ new Map();
+  const entryBySeq = /* @__PURE__ */ new Map();
+  let reservedSeq = -1;
+  for (const name of names) {
+    const claim = OCC_CLAIM_NAME_RE.exec(name);
+    if (claim) {
+      const seq2 = Number(claim[1]);
+      if (Number.isInteger(seq2) && seq2 >= 0) reservedSeq = Math.max(reservedSeq, seq2);
+      continue;
+    }
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (!Number.isInteger(seq) || seq < 0) continue;
+    const token2 = match[2];
+    const kind = match[3];
+    if (kind === "complete") {
+      const existing = completeBySeq.get(seq);
+      completeBySeq.set(seq, existing === void 0 ? token2 : existing === token2 ? token2 : null);
+    } else if (kind === "json") {
+      const existing = entryBySeq.get(seq);
+      if (existing === void 0) entryBySeq.set(seq, token2);
+      else if (existing !== token2) return { seq: -1, state: null, empty: false, ioError: true, reservedSeq };
+    }
+  }
+  if (completeBySeq.size === 0) return { seq: -1, state: null, empty: true, ioError: false, reservedSeq };
+  let maxSeq = -1;
+  for (const seq of completeBySeq.keys()) if (seq > maxSeq) maxSeq = seq;
+  const completeToken = completeBySeq.get(maxSeq);
+  const token = entryBySeq.get(maxSeq);
+  if (!token || !completeToken || completeToken !== token) {
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
+  }
+  let raw;
+  try {
+    raw = (0, import_fs18.readFileSync)(occEntryPath(dir, maxSeq, token), "utf8");
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
+  }
+  let entry;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
+  }
+  const record2 = entry;
+  if (!record2 || typeof record2 !== "object" || record2.seq !== maxSeq || record2.owner_token !== token || !("state" in record2)) {
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
+  }
+  return { seq: maxSeq, state: record2.state, empty: false, ioError: false, reservedSeq };
+}
+function occReadCanonicalSnapshot(filePath) {
+  try {
+    const raw = (0, import_fs18.readFileSync)(filePath, "utf8");
+    const state = JSON.parse(raw);
+    return { state, contentFingerprint: stateDigest(raw), stateFingerprint: JSON.stringify(state), ioError: false };
+  } catch (error2) {
+    const code = error2.code;
+    if (code === "ENOENT") return { state: null, contentFingerprint: "absent", stateFingerprint: "absent", ioError: false };
+    return { state: null, contentFingerprint: "", stateFingerprint: "", ioError: true };
+  }
+}
+function occReadCanonicalContentFingerprint(filePath) {
+  try {
+    return { contentFingerprint: stateDigest((0, import_fs18.readFileSync)(filePath, "utf8")), ioError: false };
+  } catch (error2) {
+    const code = error2.code;
+    if (code === "ENOENT") return { contentFingerprint: "absent", ioError: false };
+    return { contentFingerprint: "", ioError: true };
+  }
+}
+function occStateFingerprint(state) {
+  return state === null ? "absent" : JSON.stringify(state);
+}
+function occCleanupOwn(dir, seq, token) {
+  try {
+    (0, import_fs18.unlinkSync)(occClaimPath(dir, seq));
+  } catch {
+  }
+  try {
+    (0, import_fs18.unlinkSync)(occEntryPath(dir, seq, token));
+  } catch {
+  }
+  try {
+    (0, import_fs18.unlinkSync)(occCompletePath(dir, seq, token));
+  } catch {
+  }
+  try {
+    (0, import_fs18.unlinkSync)(occAbortedPath(dir, seq, token));
+  } catch {
+  }
+}
+function occPruneOld(dir, currentSeq) {
+  let names;
+  try {
+    names = (0, import_fs18.readdirSync)(dir);
+  } catch {
+    return;
+  }
+  const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name) ?? OCC_CLAIM_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (Number.isInteger(seq) && seq < cutoff) {
+      try {
+        (0, import_fs18.unlinkSync)((0, import_path24.join)(dir, name));
+      } catch {
+      }
+    }
+  }
+}
+function occCommitMutation(filePath, mutate, options) {
+  const dir = occJournalDir(filePath);
+  try {
+    (0, import_fs18.mkdirSync)(dir, { recursive: true });
+  } catch {
+    return null;
+  }
+  const ownerToken = options?.ownerToken ?? (0, import_crypto7.randomUUID)();
+  let parentSeq = -1;
+  let parentState = null;
+  for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
+    const current = occReadCurrent(filePath);
+    const canonical = occReadCanonicalSnapshot(filePath);
+    if (options?.expectedCanonicalContentFingerprint !== void 0 && canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      return null;
+    }
+    if (current.ioError || canonical.ioError) return null;
+    if (current.empty) {
+      parentSeq = -1;
+      parentState = options && Object.prototype.hasOwnProperty.call(options, "authenticatedExternalParent") ? options.authenticatedExternalParent : canonical.state;
+    } else {
+      parentSeq = current.seq;
+      parentState = current.state;
+    }
+    const produced = mutate(parentState, ownerToken);
+    if (produced === null || produced === void 0) return null;
+    const next = produced.state;
+    const seq = Math.max(parentSeq, current.reservedSeq) + 1;
+    const entryPath = occEntryPath(dir, seq, ownerToken);
+    let fd;
+    try {
+      fd = (0, import_fs18.openSync)(occClaimPath(dir, seq), "wx", 384);
+      writeAllSync2(fd, ownerToken, "occ sequence claim");
+      (0, import_fs18.fsyncSync)(fd);
+      (0, import_fs18.closeSync)(fd);
+      fd = void 0;
+      fd = (0, import_fs18.openSync)(entryPath, "wx", 384);
+      const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
+      writeAllSync2(fd, JSON.stringify(entry), "occ journal entry");
+      (0, import_fs18.fsyncSync)(fd);
+      (0, import_fs18.closeSync)(fd);
+      fd = void 0;
+    } catch (error2) {
+      if (fd !== void 0) {
+        try {
+          (0, import_fs18.closeSync)(fd);
+        } catch {
+        }
+      }
+      const code = error2.code;
+      if (code === "EEXIST") {
+        continue;
+      }
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (OCC_TEST_HOOKS.pauseAfterClaim && OCC_TEST_HOOKS.pauseAfterClaim.filePath === filePath) {
+      try {
+        OCC_TEST_HOOKS.pauseAfterClaim.fn(seq, ownerToken, parentSeq);
+      } catch {
+      }
+    }
+    const fence = occReadCurrent(filePath);
+    if (fence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (!fence.empty && fence.seq > parentSeq) {
+      try {
+        (0, import_fs18.unlinkSync)(occEntryPath(dir, seq, ownerToken));
+      } catch {
+      }
+      try {
+        (0, import_fs18.closeSync)((0, import_fs18.openSync)(occAbortedPath(dir, seq, ownerToken), "wx", 384));
+      } catch {
+      }
+      continue;
+    }
+    try {
+      options?.assertHeld?.();
+    } catch {
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    const canonicalFence = occReadCanonicalSnapshot(filePath);
+    if (options?.expectedCanonicalContentFingerprint !== void 0 && canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (canonicalFence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
+      occCleanupOwn(dir, seq, ownerToken);
+      continue;
+    }
+    let markerFd;
+    try {
+      markerFd = (0, import_fs18.openSync)(occCompletePath(dir, seq, ownerToken), "wx", 384);
+      (0, import_fs18.fsyncSync)(markerFd);
+      (0, import_fs18.closeSync)(markerFd);
+    } catch (error2) {
+      if (markerFd !== void 0) {
+        try {
+          (0, import_fs18.closeSync)(markerFd);
+        } catch {
+        }
+      }
+      occCleanupOwn(dir, seq, ownerToken);
+      const code = error2.code;
+      if (code === "EEXIST") continue;
+      return null;
+    }
+    occPruneOld(dir, seq);
+    if (!options?.suppressCanonicalRepublish) {
+      try {
+        atomicWriteJsonSync(filePath, next);
+      } catch {
+      }
+    }
+    return produced;
+  }
+  return null;
+}
+function occCommitAuthenticatedExternalState(filePath, expectedParentState, publishedState, assertHeld) {
+  const committed = occCommitMutation(
+    filePath,
+    (currentState) => {
+      if (occStateFingerprint(currentState) !== occStateFingerprint(expectedParentState)) return null;
+      return { state: publishedState, result: true };
+    },
+    { assertHeld, suppressCanonicalRepublish: true, authenticatedExternalParent: expectedParentState }
+  );
+  if (committed !== null) return true;
+  const current = occReadCurrent(filePath);
+  return !current.ioError && !current.empty && occStateFingerprint(current.state) === occStateFingerprint(publishedState);
+}
+function occRestoreCanonicalFromJournal(filePath, assertHeld) {
+  const current = occReadCurrent(filePath);
+  if (current.ioError || current.empty) return !current.ioError;
+  try {
+    assertHeld?.();
+    if (current.state === null) {
+      try {
+        (0, import_fs18.unlinkSync)(filePath);
+      } catch (error2) {
+        if (error2.code !== "ENOENT") return false;
+      }
+    } else {
+      atomicWriteJsonSync(filePath, current.state);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+function commitRecoveredEmergencyPublication(filePath, journal) {
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return false;
+  try {
+    const assertHeld = () => assertMutationLockHeld(lock);
+    if (!journal.parentState || !journal.intent) return occRestoreCanonicalFromJournal(filePath, assertHeld);
+    let publishedState = null;
+    if (journal.intent === "publish") {
+      let raw;
+      try {
+        raw = (0, import_fs18.readFileSync)(filePath, "utf8");
+        publishedState = JSON.parse(raw);
+      } catch {
+        return false;
+      }
+      if (stateDigest(raw) !== journal.intendedDigest) return true;
+    } else if ((0, import_fs18.existsSync)(filePath)) {
+      return true;
+    }
+    return occCommitAuthenticatedExternalState(filePath, journal.parentState, publishedState, assertHeld);
   } finally {
     releaseMutationLock(lock);
   }
@@ -7703,10 +12282,12 @@ function writeStateFileLocked(filePath, state) {
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
   try {
-    atomicWriteJsonSync(filePath, state);
-    return true;
-  } catch {
-    return false;
+    const committed = occCommitMutation(
+      filePath,
+      () => ({ state, result: true }),
+      { assertHeld: () => assertMutationLockHeld(lock) }
+    );
+    return committed !== null;
   } finally {
     releaseMutationLock(lock);
   }
@@ -7716,6 +12297,18 @@ function clearStateFileLocked(filePath) {
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
   try {
+    if (!filePath.endsWith(".json")) {
+      assertMutationLockHeld(lock);
+      if ((0, import_fs18.existsSync)(filePath)) (0, import_fs18.unlinkSync)(filePath);
+      return true;
+    }
+    const committed = occCommitMutation(
+      filePath,
+      () => ({ state: null, result: true }),
+      { assertHeld: () => assertMutationLockHeld(lock), suppressCanonicalRepublish: true }
+    );
+    if (committed === null) return false;
+    assertMutationLockHeld(lock);
     if ((0, import_fs18.existsSync)(filePath)) (0, import_fs18.unlinkSync)(filePath);
     return true;
   } catch {
@@ -7726,6 +12319,8 @@ function clearStateFileLocked(filePath) {
 }
 function clearStateFileLockedIf(filePath, predicate, recoveryOptions) {
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return "failed";
+  const observedCanonical = occReadCanonicalSnapshot(filePath);
+  if (observedCanonical.ioError) return "failed";
   if (process.env.NODE_ENV === "test" && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64) {
     try {
       const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64, "base64").toString("utf8"));
@@ -7738,16 +12333,35 @@ function clearStateFileLockedIf(filePath, predicate, recoveryOptions) {
   const lock = acquireMutationLock(filePath);
   if (!lock) return "failed";
   try {
-    if (!(0, import_fs18.existsSync)(filePath)) return "skipped";
-    let current;
-    try {
-      current = JSON.parse((0, import_fs18.readFileSync)(filePath, "utf8"));
-    } catch {
-      return "failed";
-    }
-    if (!predicate(current)) return "skipped";
+    let skipped = false;
+    let canonicalReplaced = false;
+    const committed = occCommitMutation(filePath, (currentRaw) => {
+      let current = currentRaw;
+      if (current === null || current === void 0 || typeof current !== "object" || Array.isArray(current)) {
+        const canonical = occReadCanonicalSnapshot(filePath);
+        current = canonical.ioError ? null : canonical.state;
+      }
+      if (current === null || typeof current !== "object" || Array.isArray(current)) {
+        skipped = true;
+        return null;
+      }
+      if (!predicate(current)) {
+        skipped = true;
+        return null;
+      }
+      return { state: null, result: "cleared" };
+    }, {
+      assertHeld: () => assertMutationLockHeld(lock),
+      suppressCanonicalRepublish: true,
+      expectedCanonicalContentFingerprint: observedCanonical.contentFingerprint,
+      onCanonicalCompareFailed: () => {
+        canonicalReplaced = true;
+      }
+    });
+    if (committed === null) return skipped || canonicalReplaced ? "skipped" : "failed";
+    assertMutationLockHeld(lock);
     (0, import_fs18.unlinkSync)(filePath);
-    return "cleared";
+    return committed.result;
   } catch {
     return "failed";
   } finally {
@@ -7756,62 +12370,81 @@ function clearStateFileLockedIf(filePath, predicate, recoveryOptions) {
 }
 function writeStateFileLockedIf(filePath, predicate, transform2) {
   if (!recoverEmergencyStateFile(filePath)) return "failed";
+  const observedCanonical = occReadCanonicalContentFingerprint(filePath);
+  if (observedCanonical.ioError) return "failed";
   if (process.env.NODE_ENV === "test" && process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64) {
     try {
-      const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64, "base64").toString("utf8"));
-      atomicWriteJsonSync(filePath, replacement);
+      const replacementRaw = Buffer.from(process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64, "base64").toString("utf8");
+      atomicWriteFileSync(filePath, replacementRaw);
     } finally {
       delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH;
       delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64;
     }
   }
-  if (!(0, import_fs18.existsSync)(filePath)) return "skipped";
   const lock = acquireMutationLock(filePath);
   if (!lock) return "failed";
   try {
-    if (!(0, import_fs18.existsSync)(filePath)) return "skipped";
-    let current;
-    try {
-      current = JSON.parse((0, import_fs18.readFileSync)(filePath, "utf8"));
-    } catch {
-      return "failed";
-    }
-    if (!predicate(current)) return "skipped";
-    atomicWriteJsonSync(filePath, transform2(current));
-    return "written";
-  } catch {
-    return "failed";
+    let skipped = false;
+    let canonicalReplaced = false;
+    const committed = occCommitMutation(filePath, (currentRaw) => {
+      if (currentRaw === null || currentRaw === void 0 || typeof currentRaw !== "object" || Array.isArray(currentRaw)) return null;
+      const current = currentRaw;
+      if (!predicate(current)) {
+        skipped = true;
+        return null;
+      }
+      return { state: transform2(current), result: "written" };
+    }, {
+      assertHeld: () => assertMutationLockHeld(lock),
+      expectedCanonicalContentFingerprint: observedCanonical.contentFingerprint,
+      onCanonicalCompareFailed: () => {
+        canonicalReplaced = true;
+      }
+    });
+    if (committed === null) return skipped || canonicalReplaced ? "skipped" : "failed";
+    return committed.result;
   } finally {
     releaseMutationLock(lock);
   }
 }
 function writeStateFileLockedCreateIf(filePath, predicate, transform2) {
   if (!recoverEmergencyStateFile(filePath)) return "failed";
+  const observedCanonical = occReadCanonicalContentFingerprint(filePath);
+  if (observedCanonical.ioError) return "failed";
+  if (process.env.NODE_ENV === "test" && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64) {
+    try {
+      const replacementRaw = Buffer.from(process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64, "base64").toString("utf8");
+      atomicWriteFileSync(filePath, replacementRaw);
+    } finally {
+      delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH;
+      delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64;
+    }
+  }
   const lock = acquireMutationLock(filePath);
   if (!lock) return "failed";
   try {
-    if (process.env.NODE_ENV === "test" && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64) {
-      try {
-        const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64, "base64").toString("utf8"));
-        atomicWriteJsonSync(filePath, replacement);
-      } finally {
-        delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH;
-        delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64;
+    let skipped = false;
+    let canonicalReplaced = false;
+    const committed = occCommitMutation(filePath, (currentRaw) => {
+      let current = null;
+      if (currentRaw !== null && currentRaw !== void 0) {
+        if (typeof currentRaw !== "object" || Array.isArray(currentRaw)) return null;
+        current = currentRaw;
       }
-    }
-    let current = null;
-    if ((0, import_fs18.existsSync)(filePath)) {
-      try {
-        current = JSON.parse((0, import_fs18.readFileSync)(filePath, "utf8"));
-      } catch {
-        return "failed";
+      if (!predicate(current)) {
+        skipped = true;
+        return null;
       }
-    }
-    if (!predicate(current)) return "skipped";
-    atomicWriteJsonSync(filePath, transform2(current));
-    return "written";
-  } catch {
-    return "failed";
+      return { state: transform2(current), result: "written" };
+    }, {
+      assertHeld: () => assertMutationLockHeld(lock),
+      expectedCanonicalContentFingerprint: observedCanonical.contentFingerprint,
+      onCanonicalCompareFailed: () => {
+        canonicalReplaced = true;
+      }
+    });
+    if (committed === null) return skipped || canonicalReplaced ? "skipped" : "failed";
+    return committed.result;
   } finally {
     releaseMutationLock(lock);
   }
@@ -7830,6 +12463,7 @@ function sameEmergencyOwner(left, right) {
   return left.pid === right.pid && left.processStart === right.processStart && left.nonce === right.nonce;
 }
 function isEmergencyOwnerLive(owner) {
+  if (process.env.NODE_ENV === "test" && owner.pid === 999999999 && owner.processStart === "abandoned") return false;
   const current = processStartIdentity(owner.pid);
   return current === null || current !== "absent" && current === owner.processStart;
 }
@@ -7934,7 +12568,7 @@ function createEmergencyJournal(path25, journal) {
 function readEmergencyJournal(path25) {
   try {
     const journal = JSON.parse((0, import_fs18.readFileSync)(path25, "utf8"));
-    if (journal.version !== 1 || typeof journal.transactionId !== "string" || !/^[0-9a-f-]{36}$/i.test(journal.transactionId) || !journal.owner || !Number.isInteger(journal.owner.pid) || journal.owner.pid <= 0 || typeof journal.owner.processStart !== "string" || typeof journal.owner.nonce !== "string" || !/^[0-9a-f-]{36}$/i.test(journal.owner.nonce) || journal.sessionOwner !== void 0 && typeof journal.sessionOwner !== "string" || journal.originalDigest !== void 0 && (typeof journal.originalDigest !== "string" || !/^[0-9a-f]{64}$/i.test(journal.originalDigest)) || journal.intendedDigest !== void 0 && (typeof journal.intendedDigest !== "string" || !/^[0-9a-f]{64}$/i.test(journal.intendedDigest)) || journal.intent !== void 0 && journal.intent !== "clear" && journal.intent !== "publish" || typeof journal.quarantinePath !== "string" || journal.phase !== "preparing" && journal.phase !== "prepared" && journal.phase !== "quarantined" && journal.phase !== "published") return null;
+    if (journal.version !== 1 || typeof journal.transactionId !== "string" || !/^[0-9a-f-]{36}$/i.test(journal.transactionId) || !journal.owner || !Number.isInteger(journal.owner.pid) || journal.owner.pid <= 0 || typeof journal.owner.processStart !== "string" || typeof journal.owner.nonce !== "string" || !/^[0-9a-f-]{36}$/i.test(journal.owner.nonce) || journal.sessionOwner !== void 0 && typeof journal.sessionOwner !== "string" || journal.originalDigest !== void 0 && (typeof journal.originalDigest !== "string" || !/^[0-9a-f]{64}$/i.test(journal.originalDigest)) || journal.parentState !== void 0 && (journal.parentState === null || typeof journal.parentState !== "object" || Array.isArray(journal.parentState)) || journal.intendedDigest !== void 0 && (typeof journal.intendedDigest !== "string" || !/^[0-9a-f]{64}$/i.test(journal.intendedDigest)) || journal.intent !== void 0 && journal.intent !== "clear" && journal.intent !== "publish" || typeof journal.quarantinePath !== "string" || journal.phase !== "preparing" && journal.phase !== "prepared" && journal.phase !== "quarantined" && journal.phase !== "published") return null;
     const complete = typeof journal.originalDigest === "string" && (journal.intent === "clear" || journal.intent === "publish" && typeof journal.intendedDigest === "string");
     return journal.phase === "preparing" || complete ? journal : null;
   } catch {
@@ -7943,8 +12577,8 @@ function readEmergencyJournal(path25) {
 }
 function fileIdentity(path25) {
   try {
-    const stat2 = (0, import_fs18.statSync)(path25);
-    return { dev: stat2.dev, ino: stat2.ino };
+    const stat3 = (0, import_fs18.statSync)(path25);
+    return { dev: stat3.dev, ino: stat3.ino };
   } catch {
     return null;
   }
@@ -8145,12 +12779,14 @@ function recoverEmergencyStateFile(filePath, options) {
     if (!recoveryGenerationsAuthorized(filePath, current, authorizeState)) return true;
     if (!reconcileEmergencyPublicationTemps(filePath, authorizeState)) return false;
     if (!current || current.quarantinePath !== `${filePath}.emergency-quarantine.${current.transactionId}` || isEmergencyOwnerLive(current.owner)) return false;
-    return recoverDeadEmergencyStateFile(filePath, authorizeState);
+    if (!recoverDeadEmergencyStateFile(filePath, authorizeState, true)) return false;
+    if (current.parentState && !commitRecoveredEmergencyPublication(filePath, current)) return false;
+    return removeOwnedEmergencyArtifacts(journalPath, current, true);
   } finally {
     releaseRecoveryClaim(claimPath, claim);
   }
 }
-function recoverDeadEmergencyStateFile(filePath, authorizeState) {
+function recoverDeadEmergencyStateFile(filePath, authorizeState, preserveCompletedJournal = false) {
   const journalPath = emergencyJournalPath(filePath);
   if (!(0, import_fs18.existsSync)(journalPath)) return true;
   const journal = readEmergencyJournal(journalPath);
@@ -8159,6 +12795,7 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
   if (!recoveryGenerationsAuthorized(filePath, journal, authorizeState)) return true;
   const owned = () => journalIsOwned(journalPath, journal.transactionId, journal.owner);
   if (!owned()) return false;
+  const finish = (removeQuarantine) => preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, removeQuarantine);
   const payloadPath = `${journal.quarantinePath}.payload`;
   const digest3 = (path25) => {
     try {
@@ -8171,27 +12808,29 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
     const complete = typeof journal.originalDigest === "string" && (journal.intent === "clear" || journal.intent === "publish" && typeof journal.intendedDigest === "string");
     if (!complete) {
       if ((0, import_fs18.existsSync)(journal.quarantinePath) || (0, import_fs18.existsSync)(payloadPath)) return false;
-      return removeOwnedEmergencyArtifacts(journalPath, journal, false);
+      return finish(false);
     }
     const originalStillPrimary = !(0, import_fs18.existsSync)(journal.quarantinePath) && digest3(filePath) === journal.originalDigest;
     if (journal.intent === "publish" && digest3(payloadPath) !== journal.intendedDigest) {
-      return originalStillPrimary && removeOwnedEmergencyArtifacts(journalPath, journal, false);
+      return originalStillPrimary && finish(false);
     }
     if (journal.intent === "clear" && (0, import_fs18.existsSync)(payloadPath)) {
-      return originalStillPrimary && removeOwnedEmergencyArtifacts(journalPath, journal, false);
+      return originalStillPrimary && finish(false);
     }
     journal.phase = "prepared";
-    return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState);
+    return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState, preserveCompletedJournal);
   }
   const originalDigest = journal.originalDigest;
   const intent = journal.intent;
   const intendedDigest = journal.intendedDigest;
   const hasPrimary = (0, import_fs18.existsSync)(filePath);
   const hasQuarantine = (0, import_fs18.existsSync)(journal.quarantinePath);
-  const finalize = () => removeOwnedEmergencyArtifacts(journalPath, journal, hasQuarantine);
+  const finalize = () => finish(hasQuarantine);
   if (hasPrimary && hasQuarantine) {
-    if (intent === "publish" && digest3(filePath) === intendedDigest && digest3(journal.quarantinePath) === originalDigest) return finalize();
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    if (intent === "publish" && digest3(filePath) === intendedDigest && digest3(journal.quarantinePath) === originalDigest) {
+      return finalize();
+    }
+    return finish(true);
   }
   if (hasPrimary) {
     if (!hasQuarantine && journal.phase === "prepared" && digest3(filePath) === originalDigest) {
@@ -8200,26 +12839,27 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
         if (owned() && (0, import_fs18.existsSync)(filePath) && (0, import_fs18.existsSync)(journal.quarantinePath) && digest3(filePath) !== originalDigest) {
           removeOwnedEmergencyArtifacts(journalPath, journal, true);
+          return false;
         }
         return false;
       }
       journal.phase = "quarantined";
-      return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState);
+      return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState, preserveCompletedJournal);
     }
     return false;
   }
   if (!hasQuarantine) {
-    return intent === "clear" && journal.phase === "published" && removeOwnedEmergencyArtifacts(journalPath, journal, false);
+    return intent === "clear" && journal.phase === "published" && finish(false);
   }
   if (digest3(journal.quarantinePath) !== originalDigest || !owned()) return false;
   try {
-    if (intent === "clear") return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    if (intent === "clear") return finish(true);
     const payload = (0, import_fs18.readFileSync)(payloadPath, "utf8");
     if (stateDigest(payload) !== intendedDigest || !owned()) return false;
     (0, import_fs18.linkSync)(payloadPath, filePath);
     journal.phase = "published";
     if (!writeEmergencyJournal(journalPath, journal)) return false;
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    return finish(true);
   } catch {
     return false;
   }
@@ -8236,7 +12876,7 @@ function abandonEmergencyJournal(journalPath, journal) {
   }
 }
 function abandonEmergencyJournalForTest(journalPath, journal) {
-  if (!emergencyCrashAt("after-payload") && !emergencyCrashAt("before-rename") && !emergencyCrashAt("after-rename") && !emergencyCrashAt("after-publication") && !emergencyCrashAt("before-cleanup")) return;
+  if (!emergencyCrashAt("after-payload") && !emergencyCrashAt("before-rename") && !emergencyCrashAt("after-rename") && !emergencyCrashAt("after-publication") && !emergencyCrashAt("before-occ-fence") && !emergencyCrashAt("before-cleanup")) return;
   abandonEmergencyJournal(journalPath, journal);
 }
 function emergencyReplaceAfterPredicate(filePath) {
@@ -8261,87 +12901,104 @@ function emergencyReplaceAtCaptureBoundary(filePath) {
 }
 function emergencyMutateStateFileIf(filePath, predicate, transform2, recoveryOptions) {
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return false;
-  const owner = emergencyOwner();
-  if (!owner) return false;
-  const transactionId = (0, import_crypto7.randomUUID)();
-  const quarantinePath = `${filePath}.emergency-quarantine.${transactionId}`;
-  const journalPath = emergencyJournalPath(filePath);
-  const payloadPath = `${quarantinePath}.payload`;
-  let journal = null;
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return false;
   try {
-    journal = { version: 1, transactionId, owner, quarantinePath, phase: "preparing" };
-    if (!createEmergencyJournal(journalPath, journal)) return false;
-    const owns = () => journal !== null && journalIsOwned(journalPath, transactionId, owner);
-    if (!(0, import_fs18.existsSync)(filePath)) {
-      removeOwnedEmergencyArtifacts(journalPath, journal, false);
-      return false;
-    }
-    const originalRaw = (0, import_fs18.readFileSync)(filePath, "utf8");
-    const current = JSON.parse(originalRaw);
-    if (!predicate(current)) {
-      removeOwnedEmergencyArtifacts(journalPath, journal, false);
-      return false;
-    }
-    const transformedRaw = transform2 ? JSON.stringify(transform2(current)) : void 0;
-    Object.assign(journal, {
-      ...getStateSessionOwner(current) ? { sessionOwner: getStateSessionOwner(current) } : {},
-      originalDigest: stateDigest(originalRaw),
-      ...transformedRaw === void 0 ? { intent: "clear" } : { intent: "publish", intendedDigest: stateDigest(transformedRaw) }
-    });
-    if (!owns() || !writeEmergencyJournal(journalPath, journal)) return false;
-    if (transformedRaw !== void 0) {
-      if (!owns()) return false;
-      if (!publishEmergencyFileExclusive(payloadPath, transformedRaw)) return false;
-      if (!owns()) return false;
-    }
-    if (emergencyCrashAt("after-payload")) {
-      abandonEmergencyJournalForTest(journalPath, journal);
-      return false;
-    }
-    journal.phase = "prepared";
-    if (!writeEmergencyJournal(journalPath, journal)) return false;
-    const authenticatedRaw = (0, import_fs18.readFileSync)(filePath, "utf8");
-    const authenticated = JSON.parse(authenticatedRaw);
-    if (!owns() || stateDigest(authenticatedRaw) !== journal.originalDigest || !predicate(authenticated)) {
-      removeOwnedEmergencyArtifacts(journalPath, journal, false);
-      return false;
-    }
-    emergencyReplaceAfterPredicate(filePath);
-    if (emergencyCrashAt("before-rename")) {
-      abandonEmergencyJournalForTest(journalPath, journal);
-      return false;
-    }
-    if (!owns() || !captureAndUnlinkPrimary(filePath, quarantinePath, journal.originalDigest)) {
-      removeOwnedEmergencyArtifacts(journalPath, journal, true);
-      return false;
-    }
-    journal.phase = "quarantined";
-    if (!writeEmergencyJournal(journalPath, journal)) return false;
-    if (emergencyCrashAt("after-rename")) {
-      abandonEmergencyJournalForTest(journalPath, journal);
-      return false;
-    }
-    if (transformedRaw !== void 0) {
-      if (!owns()) return false;
-      (0, import_fs18.linkSync)(payloadPath, filePath);
-      journal.phase = "published";
-      if (!writeEmergencyJournal(journalPath, journal)) return false;
-      if (emergencyCrashAt("after-publication")) {
+    const owner = emergencyOwner();
+    if (!owner) return false;
+    const transactionId = (0, import_crypto7.randomUUID)();
+    const quarantinePath = `${filePath}.emergency-quarantine.${transactionId}`;
+    const journalPath = emergencyJournalPath(filePath);
+    const payloadPath = `${quarantinePath}.payload`;
+    let journal = null;
+    try {
+      journal = { version: 1, transactionId, owner, quarantinePath, phase: "preparing" };
+      if (!createEmergencyJournal(journalPath, journal)) return false;
+      const owns = () => journal !== null && journalIsOwned(journalPath, transactionId, owner);
+      if (!(0, import_fs18.existsSync)(filePath)) {
+        removeOwnedEmergencyArtifacts(journalPath, journal, false);
+        return false;
+      }
+      const originalRaw = (0, import_fs18.readFileSync)(filePath, "utf8");
+      const current = JSON.parse(originalRaw);
+      if (!predicate(current)) {
+        removeOwnedEmergencyArtifacts(journalPath, journal, false);
+        return false;
+      }
+      const transformedRaw = transform2 ? JSON.stringify(transform2(current)) : void 0;
+      Object.assign(journal, {
+        ...getStateSessionOwner(current) ? { sessionOwner: getStateSessionOwner(current) } : {},
+        originalDigest: stateDigest(originalRaw),
+        parentState: current,
+        ...transformedRaw === void 0 ? { intent: "clear" } : { intent: "publish", intendedDigest: stateDigest(transformedRaw) }
+      });
+      if (!owns() || !writeEmergencyJournal(journalPath, journal)) return false;
+      if (transformedRaw !== void 0) {
+        if (!owns()) return false;
+        if (!publishEmergencyFileExclusive(payloadPath, transformedRaw)) return false;
+        if (!owns()) return false;
+      }
+      if (emergencyCrashAt("after-payload")) {
         abandonEmergencyJournalForTest(journalPath, journal);
         return false;
       }
-    } else {
-      journal.phase = "published";
+      journal.phase = "prepared";
       if (!writeEmergencyJournal(journalPath, journal)) return false;
-    }
-    if (emergencyCrashAt("before-cleanup")) {
-      abandonEmergencyJournalForTest(journalPath, journal);
+      const authenticatedRaw = (0, import_fs18.readFileSync)(filePath, "utf8");
+      const authenticated = JSON.parse(authenticatedRaw);
+      if (!owns() || stateDigest(authenticatedRaw) !== journal.originalDigest || !predicate(authenticated)) {
+        removeOwnedEmergencyArtifacts(journalPath, journal, false);
+        return false;
+      }
+      emergencyReplaceAfterPredicate(filePath);
+      if (emergencyCrashAt("before-rename")) {
+        abandonEmergencyJournalForTest(journalPath, journal);
+        return false;
+      }
+      if (!owns() || !captureAndUnlinkPrimary(filePath, quarantinePath, journal.originalDigest)) {
+        removeOwnedEmergencyArtifacts(journalPath, journal, true);
+        return false;
+      }
+      journal.phase = "quarantined";
+      if (!writeEmergencyJournal(journalPath, journal)) return false;
+      if (emergencyCrashAt("after-rename")) {
+        abandonEmergencyJournalForTest(journalPath, journal);
+        return false;
+      }
+      if (transformedRaw !== void 0) {
+        if (!owns()) return false;
+        (0, import_fs18.linkSync)(payloadPath, filePath);
+        journal.phase = "published";
+        if (!writeEmergencyJournal(journalPath, journal)) return false;
+        if (emergencyCrashAt("after-publication")) {
+          abandonEmergencyJournalForTest(journalPath, journal);
+          return false;
+        }
+      } else {
+        journal.phase = "published";
+        if (!writeEmergencyJournal(journalPath, journal)) return false;
+      }
+      if (emergencyCrashAt("before-cleanup")) {
+        abandonEmergencyJournalForTest(journalPath, journal);
+        return false;
+      }
+      if (emergencyCrashAt("before-occ-fence")) {
+        abandonEmergencyJournalForTest(journalPath, journal);
+        return false;
+      }
+      if (!occCommitAuthenticatedExternalState(
+        filePath,
+        current,
+        transformedRaw === void 0 ? null : JSON.parse(transformedRaw),
+        () => assertMutationLockHeld(lock)
+      )) return false;
+      return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    } catch {
+      if (journal) abandonEmergencyJournal(journalPath, journal);
       return false;
     }
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
-  } catch {
-    if (journal) abandonEmergencyJournal(journalPath, journal);
-    return false;
+  } finally {
+    releaseMutationLock(lock);
   }
 }
 function getStateSessionOwner(state) {
@@ -8543,7 +13200,7 @@ function clearModeStateFile(mode, directory, sessionId, expectedState) {
   }
   return success;
 }
-var import_fs18, import_path24, import_crypto7, import_child_process11, LOCK_REMOVAL_SCRIPT, RECOVERY_CLAIM_SCRIPT;
+var import_fs18, import_path24, import_crypto7, import_child_process11, LOCK_SCHEMA_VERSION, LOCK_OLD_SCHEMA_VERSION, LOCK_OLD_OWNER_KEYS, LOCK_LEASE_MS, LOCK_REMOVAL_SCRIPT, cachedSelfProcessStart, LOCK_OWNER_KEYS, OCC_JOURNAL_PRUNE_BEHIND, OCC_JOURNAL_MAX_RETRIES, OCC_TEST_HOOKS, OCC_ENTRY_NAME_RE, OCC_CLAIM_NAME_RE, RECOVERY_CLAIM_SCRIPT;
 var init_mode_state_io = __esm({
   "src/lib/mode-state-io.ts"() {
     "use strict";
@@ -8553,38 +13210,82 @@ var init_mode_state_io = __esm({
     import_child_process11 = require("child_process");
     init_worktree_paths();
     init_atomic_write();
+    LOCK_SCHEMA_VERSION = 1;
+    LOCK_OLD_SCHEMA_VERSION = 1;
+    LOCK_OLD_OWNER_KEYS = ["createdAt", "nonce", "pid", "processStart", "version"];
+    LOCK_LEASE_MS = 3e5;
     LOCK_REMOVAL_SCRIPT = String.raw`
 const fs = require('fs');
-const [operation, lockPath, expectedRaw] = process.argv.slice(1);
-const keys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
+const [operation, lockPath, expectedRaw, renewalPath] = process.argv.slice(1);
+const leaseKeys = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'];
+const oldKeys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
 function readOwner() {
+  let raw;
   try {
-    const value = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    raw = fs.readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return 'absent';
+    return 'io_error';
+  }
+  try {
+    const value = JSON.parse(raw);
     const actual = Object.keys(value).sort();
-    if (actual.length !== keys.length || !actual.every((key, index) => key === keys[index]) || value.version !== 1 || !Number.isSafeInteger(value.pid) || value.pid <= 0 || typeof value.processStart !== 'string' || !/^\d+$/.test(value.processStart) || typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt)) || typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return null;
-    return value;
-  } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); return null; }
+    // v1 lease schema (the deployed current contract): expires_at, no processStart.
+    const leaseShaped = actual.length === leaseKeys.length && actual.every((key, index) => key === leaseKeys[index]) && Number.isSafeInteger(value.version) && value.version > 0 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.expires_at === 'string' && Number.isFinite(Date.parse(value.expires_at)) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce);
+    if (leaseShaped && value.version === 1) return value;
+    // v1 old-liveness schema (pre-upgrade contract): version 1, processStart, no
+    // expires_at. NOT corrupt - it is a live lock held under the old contract. The
+    // old owner may be alive; FAIL CLOSED (B12): never unlink, never reclaim.
+    if (actual.length === oldKeys.length && actual.every((key, index) => key === oldKeys[index]) && value.version === 1 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.processStart === 'string' && /^\d+$/.test(value.processStart) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce)) return 'old_version';
+    if (leaseShaped) return 'unknown_version';
+    // B12: a structurally-valid versioned object under a shape we don't recognise
+    // (e.g. a future lease with extra/renamed fields) MAY be a live owner. FAIL
+    // CLOSED (unknown_version -> exit 6): never unlink, never reclaim. Reserve
+    // 'corrupt' for genuinely unparseable / non-versioned garbage.
+    if (value && typeof value === 'object' && !Array.isArray(value) && Number.isSafeInteger(value.version) && value.version > 0) return 'unknown_version';
+    return 'corrupt';
+  } catch (error) { return 'corrupt'; }
 }
-const owner = readOwner();
-if (!owner) process.exit(3);
 if (operation === 'release') {
   let expected;
   try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
-  if (owner.pid !== expected.pid || owner.processStart !== expected.processStart || owner.nonce !== expected.nonce) process.exit(4);
-  try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(0);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5); // not ours; leave the old-contract lock in place
+  if (current === 'unknown_version') process.exit(6); // not ours; leave the unsupported-contract lock in place
+  if (current === 'corrupt') process.exit(3);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); }
 }
-if (process.platform !== 'linux') process.exit(3);
-let currentStart;
-try {
-  const stat = fs.readFileSync('/proc/' + owner.pid + '/stat', 'utf8');
-  const end = stat.lastIndexOf(')');
-  const fields = end >= 0 ? stat.slice(end + 2).trim().split(/\s+/) : [];
-  currentStart = fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
-} catch (error) { currentStart = error && error.code === 'ENOENT' ? 'absent' : null; }
-if (currentStart === null) process.exit(3);
-if (currentStart !== 'absent' && currentStart === owner.processStart) process.exit(2);
-try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+if (operation === 'renew') {
+  let expected;
+  try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(4);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5);
+  if (current === 'unknown_version') process.exit(6);
+  if (current === 'corrupt') process.exit(4);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  if (Date.now() >= Date.parse(current.expires_at)) process.exit(2);
+  try { fs.renameSync(renewalPath, lockPath); process.exit(0); } catch { process.exit(3); }
+}
+const current = readOwner();
+if (current === 'absent') process.exit(0);
+if (current === 'io_error') process.exit(3);
+if (current === 'old_version') process.exit(5); // old-contract owner may be live; FAIL CLOSED (B12)
+if (current === 'unknown_version') process.exit(6); // unknown-contract owner may be live; FAIL CLOSED
+if (current === 'corrupt') { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+if (Date.now() >= Date.parse(current.expires_at)) { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+process.exit(2);
 `;
+    LOCK_OWNER_KEYS = ["createdAt", "expires_at", "nonce", "pid", "version"];
+    OCC_JOURNAL_PRUNE_BEHIND = 8;
+    OCC_JOURNAL_MAX_RETRIES = 50;
+    OCC_TEST_HOOKS = {};
+    OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+    OCC_CLAIM_NAME_RE = /^(\d+)\.claim$/;
     RECOVERY_CLAIM_SCRIPT = String.raw`
 const fs = require('fs');
 const [operation, claimPath, expectedRaw] = process.argv.slice(1);
@@ -8650,6 +13351,7 @@ var init_mode_names = __esm({
     MODE_NAMES = {
       AUTOPILOT: "autopilot",
       AUTORESEARCH: "autoresearch",
+      GRAPH: "graph",
       TEAM: "team",
       RALPH: "ralph",
       ULTRAWORK: "ultrawork",
@@ -8662,6 +13364,7 @@ var init_mode_names = __esm({
     ALL_MODE_NAMES = [
       MODE_NAMES.AUTOPILOT,
       MODE_NAMES.AUTORESEARCH,
+      MODE_NAMES.GRAPH,
       MODE_NAMES.TEAM,
       MODE_NAMES.RALPH,
       MODE_NAMES.ULTRAWORK,
@@ -8674,6 +13377,7 @@ var init_mode_names = __esm({
     MODE_STATE_FILE_MAP = {
       [MODE_NAMES.AUTOPILOT]: "autopilot-state.json",
       [MODE_NAMES.AUTORESEARCH]: "autoresearch-state.json",
+      [MODE_NAMES.GRAPH]: "graph-state.json",
       [MODE_NAMES.TEAM]: "team-state.json",
       [MODE_NAMES.RALPH]: "ralph-state.json",
       [MODE_NAMES.ULTRAWORK]: "ultrawork-state.json",
@@ -8744,10 +13448,19 @@ function isWorkflowSlotTombstonedForMode(cwd2, mode, sessionId, now = Date.now()
   }
 }
 function isJsonModeActive(cwd2, mode, sessionId) {
+  const config2 = MODE_CONFIGS[mode];
   if (isWorkflowSlotTombstonedForMode(cwd2, mode, sessionId)) {
     return false;
   }
-  const config2 = MODE_CONFIGS[mode];
+  const stateIsActive = (state) => {
+    if (config2.activeStatuses) {
+      return typeof state.status === "string" && config2.activeStatuses.includes(state.status);
+    }
+    if (config2.activeProperty) {
+      return state[config2.activeProperty] === true;
+    }
+    return true;
+  };
   if (sessionId) {
     const sessionStateFile = resolveSessionStatePath(mode, sessionId, cwd2);
     try {
@@ -8756,10 +13469,7 @@ function isJsonModeActive(cwd2, mode, sessionId) {
       if (state.session_id && state.session_id !== sessionId) {
         return false;
       }
-      if (config2.activeProperty) {
-        return state[config2.activeProperty] === true;
-      }
-      return true;
+      return stateIsActive(state);
     } catch (error2) {
       if (error2.code === "ENOENT") {
         return false;
@@ -8771,10 +13481,7 @@ function isJsonModeActive(cwd2, mode, sessionId) {
   try {
     const content = (0, import_fs19.readFileSync)(stateFile, "utf-8");
     const state = JSON.parse(content);
-    if (config2.activeProperty) {
-      return state[config2.activeProperty] === true;
-    }
-    return true;
+    return stateIsActive(state);
   } catch (error2) {
     if (error2.code === "ENOENT") {
       return false;
@@ -8816,6 +13523,9 @@ function getAllModeStatuses(cwd2, sessionId) {
     stateFilePath: getStateFilePath(cwd2, mode, sessionId)
   }));
 }
+function normalizeClearResult(filePath, result) {
+  return result === "skipped" && !(0, import_fs19.existsSync)(filePath) ? "cleared" : result;
+}
 function readJsonSnapshot(filePath) {
   try {
     const state = JSON.parse((0, import_fs19.readFileSync)(filePath, "utf-8"));
@@ -8824,42 +13534,86 @@ function readJsonSnapshot(filePath) {
     return null;
   }
 }
+function waitForInFlightMarkerPublisher(filePath) {
+  const deadline = Date.now() + IN_FLIGHT_MARKER_PUBLISH_WAIT_MS;
+  while ((0, import_fs19.existsSync)(`${filePath}.mutation.lock`) && Date.now() < deadline) {
+    Atomics.wait(
+      new Int32Array(new SharedArrayBuffer(4)),
+      0,
+      0,
+      IN_FLIGHT_MARKER_PUBLISH_POLL_MS
+    );
+  }
+  return !(0, import_fs19.existsSync)(`${filePath}.mutation.lock`);
+}
 function clearDiscoveredJsonFile(filePath, observed, predicate = () => true) {
   if (!observed) {
-    const result2 = clearStateFileLockedIf(filePath, predicate);
-    return result2 !== "failed" && !(result2 === "skipped" && (0, import_fs19.existsSync)(filePath));
+    if (!(0, import_fs19.existsSync)(filePath) && (0, import_fs19.existsSync)(`${filePath}.mutation.lock`) && !waitForInFlightMarkerPublisher(filePath)) {
+      return "failed";
+    }
+    return normalizeClearResult(
+      filePath,
+      clearStateFileLockedIf(filePath, predicate)
+    );
   }
-  if (!predicate(observed.state)) return true;
-  const result = clearStateFileLockedIf(
+  if (!predicate(observed.state)) return "cleared";
+  return normalizeClearResult(
     filePath,
-    (current) => predicate(current) && JSON.stringify(current) === observed.snapshot
+    clearStateFileLockedIf(
+      filePath,
+      (current) => predicate(current) && JSON.stringify(current) === observed.snapshot
+    )
   );
-  return result !== "failed" && !(result === "skipped" && (0, import_fs19.existsSync)(filePath));
 }
-function clearModeState(mode, cwd2, sessionId, expectedState) {
+function mergeClearResults(current, next) {
+  if (current === "failed" || next === "failed") return "failed";
+  if (current === "skipped" || next === "skipped") return "skipped";
+  return "cleared";
+}
+function clearModeStateDetailed(mode, cwd2, sessionId, expectedState) {
+  if (mode === MODE_NAMES.GRAPH) return "failed";
   const config2 = MODE_CONFIGS[mode];
-  let success = true;
+  let result = "cleared";
   const markerFile = getMarkerFilePath(cwd2, mode);
   const isSessionScopedClear = Boolean(sessionId);
   const markerSnapshot = markerFile ? readJsonSnapshot(markerFile) : null;
-  const sessionMarkerFile = isSessionScopedClear && sessionId && config2.markerFile ? resolveSessionStatePath(config2.markerFile.replace(/\.json$/i, ""), sessionId, cwd2) : null;
+  const sessionMarkerFile = isSessionScopedClear && sessionId && config2.markerFile ? resolveSessionStatePath(
+    config2.markerFile.replace(/\.json$/i, ""),
+    sessionId,
+    cwd2
+  ) : null;
   const sessionMarkerSnapshot = sessionMarkerFile ? readJsonSnapshot(sessionMarkerFile) : null;
   if (isSessionScopedClear && sessionId) {
     const sessionStateFile = resolveSessionStatePath(mode, sessionId, cwd2);
     try {
-      const result = clearStateFileLockedIf(sessionStateFile, (current) => canClearStateForSession(current, sessionId) && (!expectedState || JSON.stringify(current) === JSON.stringify(expectedState)));
-      if (result === "failed" || result === "skipped" && (0, import_fs19.existsSync)(sessionStateFile)) throw new Error("state mutation lock unavailable");
+      const clearResult = normalizeClearResult(
+        sessionStateFile,
+        clearStateFileLockedIf(
+          sessionStateFile,
+          (current) => canClearStateForSession(current, sessionId) && (!expectedState || JSON.stringify(current) === JSON.stringify(expectedState))
+        )
+      );
+      result = mergeClearResults(result, clearResult);
+      if (clearResult === "failed")
+        throw new Error("state mutation lock unavailable");
     } catch (err) {
       if (err.code !== "ENOENT") {
-        success = false;
+        result = "failed";
       }
     }
     if (sessionMarkerFile) {
       try {
-        if (!clearDiscoveredJsonFile(sessionMarkerFile, sessionMarkerSnapshot, (current) => canClearStateForSession(current, sessionId))) throw new Error("state mutation lock unavailable");
+        const clearResult = clearDiscoveredJsonFile(
+          sessionMarkerFile,
+          sessionMarkerSnapshot,
+          (current) => canClearStateForSession(current, sessionId)
+        );
+        result = mergeClearResults(result, clearResult);
+        if (clearResult === "failed")
+          throw new Error("state mutation lock unavailable");
       } catch (err) {
         if (err.code !== "ENOENT") {
-          success = false;
+          result = "failed";
         }
       }
     }
@@ -8869,19 +13623,33 @@ function clearModeState(mode, cwd2, sessionId, expectedState) {
         const markerSessionId = markerRaw.session_id ?? markerRaw.sessionId;
         if (!markerSessionId || markerSessionId === sessionId) {
           try {
-            if (!clearDiscoveredJsonFile(markerFile, markerSnapshot, (current) => canClearStateForSession(current, sessionId))) throw new Error("state mutation lock unavailable");
+            const clearResult = clearDiscoveredJsonFile(
+              markerFile,
+              markerSnapshot,
+              (current) => canClearStateForSession(current, sessionId)
+            );
+            result = mergeClearResults(result, clearResult);
+            if (clearResult === "failed")
+              throw new Error("state mutation lock unavailable");
           } catch (err) {
             if (err.code !== "ENOENT") {
-              success = false;
+              result = "failed";
             }
           }
         }
       } catch {
         try {
-          if (!clearDiscoveredJsonFile(markerFile, markerSnapshot, (current) => canClearStateForSession(current, sessionId))) throw new Error("state mutation lock unavailable");
+          const clearResult = clearDiscoveredJsonFile(
+            markerFile,
+            markerSnapshot,
+            (current) => canClearStateForSession(current, sessionId)
+          );
+          result = mergeClearResults(result, clearResult);
+          if (clearResult === "failed")
+            throw new Error("state mutation lock unavailable");
         } catch (err) {
           if (err.code !== "ENOENT") {
-            success = false;
+            result = "failed";
           }
         }
       }
@@ -8890,22 +13658,33 @@ function clearModeState(mode, cwd2, sessionId, expectedState) {
   const stateFile = getStateFilePath(cwd2, mode);
   if (!isSessionScopedClear) {
     try {
-      const result = clearStateFileLockedIf(stateFile, (current) => !expectedState || JSON.stringify(current) === JSON.stringify(expectedState));
-      if (result === "failed" || result === "skipped" && (0, import_fs19.existsSync)(stateFile)) throw new Error("state mutation lock unavailable");
+      const clearResult = normalizeClearResult(
+        stateFile,
+        clearStateFileLockedIf(
+          stateFile,
+          (current) => !expectedState || JSON.stringify(current) === JSON.stringify(expectedState)
+        )
+      );
+      result = mergeClearResults(result, clearResult);
+      if (clearResult === "failed")
+        throw new Error("state mutation lock unavailable");
     } catch (err) {
       if (err.code !== "ENOENT") {
-        success = false;
+        result = "failed";
       }
     }
   }
   if (markerFile && !isSessionScopedClear) {
     try {
-      if (!clearDiscoveredJsonFile(markerFile, markerSnapshot)) throw new Error("state mutation lock unavailable");
+      const clearResult = clearDiscoveredJsonFile(markerFile, markerSnapshot);
+      result = mergeClearResults(result, clearResult);
+      if (clearResult === "failed")
+        throw new Error("state mutation lock unavailable");
     } catch (err) {
-      if (err.code !== "ENOENT") success = false;
+      if (err.code !== "ENOENT") result = "failed";
     }
   }
-  return success;
+  return result;
 }
 function isModeActiveInAnySession(mode, cwd2) {
   if (isJsonModeActive(cwd2, mode)) {
@@ -8923,7 +13702,7 @@ function getActiveSessionsForMode(mode, cwd2) {
   const sessionIds = listSessionIds(cwd2);
   return sessionIds.filter((sid) => isJsonModeActive(cwd2, mode, sid));
 }
-var import_fs19, import_path25, MODE_CONFIGS, EXCLUSIVE_MODES, WORKFLOW_SLOT_TOMBSTONE_TTL_MS;
+var import_fs19, import_path25, MODE_CONFIGS, EXCLUSIVE_MODES, WORKFLOW_SLOT_TOMBSTONE_TTL_MS, IN_FLIGHT_MARKER_PUBLISH_WAIT_MS, IN_FLIGHT_MARKER_PUBLISH_POLL_MS;
 var init_mode_registry = __esm({
   "src/hooks/mode-registry/index.ts"() {
     "use strict";
@@ -8942,6 +13721,17 @@ var init_mode_registry = __esm({
         name: "Autoresearch",
         stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.AUTORESEARCH],
         activeProperty: "active",
+        hasGlobalState: false
+      },
+      [MODE_NAMES.GRAPH]: {
+        name: "Graph",
+        stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH],
+        activeStatuses: [
+          "running",
+          "waiting_human",
+          "waiting_patch_approval",
+          "reconciling"
+        ],
         hasGlobalState: false
       },
       [MODE_NAMES.TEAM]: {
@@ -8984,8 +13774,14 @@ var init_mode_registry = __esm({
         activeProperty: "active"
       }
     };
-    EXCLUSIVE_MODES = [MODE_NAMES.AUTOPILOT, MODE_NAMES.AUTORESEARCH];
+    EXCLUSIVE_MODES = [
+      MODE_NAMES.AUTOPILOT,
+      MODE_NAMES.AUTORESEARCH,
+      MODE_NAMES.GRAPH
+    ];
     WORKFLOW_SLOT_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1e3;
+    IN_FLIGHT_MARKER_PUBLISH_WAIT_MS = 250;
+    IN_FLIGHT_MARKER_PUBLISH_POLL_MS = 10;
   }
 });
 
@@ -9856,7 +14652,7 @@ var init_adapters = __esm({
 
 // src/hooks/autopilot/types.ts
 var DEFAULT_CONFIG2;
-var init_types3 = __esm({
+var init_types4 = __esm({
   "src/hooks/autopilot/types.ts"() {
     "use strict";
     DEFAULT_CONFIG2 = {
@@ -10834,7 +15630,7 @@ var init_team_canonical_state = __esm({
 
 // src/hooks/team-pipeline/types.ts
 var TEAM_PIPELINE_SCHEMA_VERSION;
-var init_types4 = __esm({
+var init_types5 = __esm({
   "src/hooks/team-pipeline/types.ts"() {
     "use strict";
     TEAM_PIPELINE_SCHEMA_VERSION = 1;
@@ -10926,7 +15722,7 @@ var init_state = __esm({
     init_atomic_write();
     init_worktree_paths();
     init_team_canonical_state();
-    init_types4();
+    init_types5();
   }
 });
 
@@ -12136,7 +16932,7 @@ var init_state2 = __esm({
     import_path32 = require("path");
     init_mode_state_io();
     init_worktree_paths();
-    init_types3();
+    init_types4();
     init_loader();
     init_plan_output();
     init_ralph();
@@ -12629,8 +17425,8 @@ function noFollowCanonicalFile(path25, root2) {
         `/proc/self/fd/${fd}/${components[index]}`,
         import_fs28.constants.O_RDONLY | import_fs28.constants.O_NOFOLLOW | (final ? 0 : import_fs28.constants.O_DIRECTORY)
       );
-      const stat2 = (0, import_fs28.fstatSync)(nextFd);
-      if (final && !stat2.isFile() || !final && !stat2.isDirectory()) {
+      const stat3 = (0, import_fs28.fstatSync)(nextFd);
+      if (final && !stat3.isFile() || !final && !stat3.isDirectory()) {
         (0, import_fs28.closeSync)(nextFd);
         return null;
       }
@@ -12674,9 +17470,9 @@ function validBoundary(value, sessionId, root2) {
   const opened = noFollowCanonicalFile(boundary.transcriptPath, root2);
   if (!opened) return false;
   try {
-    const stat2 = (0, import_fs28.fstatSync)(opened.fd);
+    const stat3 = (0, import_fs28.fstatSync)(opened.fd);
     const identity = boundary.fileIdentity;
-    if (stat2.dev !== identity.device || stat2.ino !== identity.inode || stat2.size < boundary.byteOffset || identity.size !== boundary.byteOffset)
+    if (stat3.dev !== identity.device || stat3.ino !== identity.inode || stat3.size < boundary.byteOffset || identity.size !== boundary.byteOffset)
       return false;
     return hashTranscriptRange(opened.fd, 0, boundary.byteOffset) === identity.contentSha256;
   } catch {
@@ -13119,6 +17915,1086 @@ var init_named_workflow_resume_validator = __esm({
   }
 });
 
+// src/graph/schema.ts
+function parseGraphDescriptorShape(input) {
+  return graphDescriptorSchema.parse(input);
+}
+var idSchema, textSchema, sideEffectFreeSchema, idempotentSchema, reconcileSchema, graphEffectPolicySchema, nodeBase, executableNodeBase, graphAgentNodeSchema, graphCommandNodeSchema, graphHumanApprovalNodeSchema, graphJoinNodeSchema, graphNodeSchema, edgeBase, graphFixedEdgeSchema, graphConditionalEdgeSchema, graphFanOutEdgeSchema, graphBackEdgeSchema, graphEdgeSchema, graphDescriptorSchema, graphEvidenceReferenceSchema, graphNodeResultSchema;
+var init_schema = __esm({
+  "src/graph/schema.ts"() {
+    "use strict";
+    init_zod();
+    idSchema = external_exports.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "must be a stable identifier");
+    textSchema = external_exports.string().min(1).max(32768);
+    sideEffectFreeSchema = external_exports.object({ policy: external_exports.literal("side_effect_free") }).strict();
+    idempotentSchema = external_exports.object({
+      policy: external_exports.literal("idempotent"),
+      idempotency_key_template: external_exports.string().min(1).max(512)
+    }).strict();
+    reconcileSchema = external_exports.object({ policy: external_exports.literal("reconcile") }).strict();
+    graphEffectPolicySchema = external_exports.discriminatedUnion("policy", [
+      sideEffectFreeSchema,
+      idempotentSchema,
+      reconcileSchema
+    ]);
+    nodeBase = {
+      id: idSchema,
+      title: external_exports.string().min(1).max(256)
+    };
+    executableNodeBase = {
+      ...nodeBase,
+      timeout_ms: external_exports.number().int().min(100).max(864e5),
+      max_attempts: external_exports.number().int().min(1).max(20),
+      effect_policy: graphEffectPolicySchema
+    };
+    graphAgentNodeSchema = external_exports.object({
+      ...executableNodeBase,
+      kind: external_exports.literal("agent"),
+      instructions: textSchema
+    }).strict();
+    graphCommandNodeSchema = external_exports.object({
+      ...executableNodeBase,
+      kind: external_exports.literal("command"),
+      command: textSchema
+    }).strict();
+    graphHumanApprovalNodeSchema = external_exports.object({
+      ...nodeBase,
+      kind: external_exports.literal("human-approval"),
+      prompt: textSchema
+    }).strict();
+    graphJoinNodeSchema = external_exports.object({
+      ...nodeBase,
+      kind: external_exports.literal("join"),
+      fan_out_node_id: idSchema,
+      input_branch_ids: external_exports.array(idSchema).min(2).max(64)
+    }).strict();
+    graphNodeSchema = external_exports.discriminatedUnion("kind", [
+      graphAgentNodeSchema,
+      graphCommandNodeSchema,
+      graphHumanApprovalNodeSchema,
+      graphJoinNodeSchema
+    ]);
+    edgeBase = { id: idSchema, from: idSchema, to: idSchema };
+    graphFixedEdgeSchema = external_exports.object({ ...edgeBase, kind: external_exports.literal("fixed") }).strict();
+    graphConditionalEdgeSchema = external_exports.object({ ...edgeBase, kind: external_exports.literal("conditional"), route: idSchema }).strict();
+    graphFanOutEdgeSchema = external_exports.object({
+      ...edgeBase,
+      kind: external_exports.literal("fan_out"),
+      branch_id: idSchema,
+      owner_join_id: idSchema
+    }).strict();
+    graphBackEdgeSchema = external_exports.object({
+      ...edgeBase,
+      kind: external_exports.literal("back_edge"),
+      route: idSchema,
+      max_traversals: external_exports.number().int().min(1).max(100)
+    }).strict();
+    graphEdgeSchema = external_exports.discriminatedUnion("kind", [
+      graphFixedEdgeSchema,
+      graphConditionalEdgeSchema,
+      graphFanOutEdgeSchema,
+      graphBackEdgeSchema
+    ]);
+    graphDescriptorSchema = external_exports.object({
+      descriptor_version: external_exports.literal(1),
+      run_id: idSchema,
+      revision_id: idSchema,
+      goal: textSchema,
+      nodes: external_exports.array(graphNodeSchema).min(1).max(1e3),
+      edges: external_exports.array(graphEdgeSchema).max(5e3),
+      entry_node_ids: external_exports.array(idSchema).min(1).max(64),
+      concurrency_limit: external_exports.number().int().min(1).max(64),
+      terminal_verification_node_id: idSchema,
+      descriptor_hash: external_exports.string().regex(/^[a-f0-9]{64}$/).optional()
+    }).strict();
+    graphEvidenceReferenceSchema = external_exports.object({
+      kind: external_exports.enum(["file", "command", "test", "human", "url"]),
+      ref: external_exports.string().min(1).max(2048),
+      summary: external_exports.string().max(2048).optional()
+    }).strict();
+    graphNodeResultSchema = external_exports.object({
+      outcome: external_exports.enum(["succeeded", "failed"]),
+      attempt_id: idSchema,
+      route: idSchema.optional(),
+      output_summary: external_exports.string().max(8192).optional(),
+      evidence_refs: external_exports.array(graphEvidenceReferenceSchema).max(64),
+      external_idempotency_key: external_exports.string().min(1).max(512).optional()
+    }).strict();
+  }
+});
+
+// src/graph/descriptor.ts
+function canonicalJson(value) {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Canonical JSON does not support non-finite numbers");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (typeof value === "object") {
+    const record2 = value;
+    const entries = Object.keys(record2).filter((key) => record2[key] !== void 0).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(record2[key])}`);
+    return `{${entries.join(",")}}`;
+  }
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+function descriptorHashPayload(input) {
+  return {
+    descriptor_version: input.descriptor_version,
+    run_id: input.run_id,
+    revision_id: input.revision_id,
+    goal: input.goal,
+    nodes: input.nodes,
+    edges: input.edges,
+    entry_node_ids: input.entry_node_ids,
+    concurrency_limit: input.concurrency_limit,
+    terminal_verification_node_id: input.terminal_verification_node_id
+  };
+}
+function computeDescriptorHash(input) {
+  return (0, import_node_crypto.createHash)("sha256").update(canonicalJson(descriptorHashPayload(input))).digest("hex");
+}
+function verifyDescriptorHash(input) {
+  return typeof input.descriptor_hash === "string" && input.descriptor_hash === computeDescriptorHash(input);
+}
+function duplicates(values) {
+  const seen = /* @__PURE__ */ new Set();
+  const found = /* @__PURE__ */ new Set();
+  for (const value of values) {
+    if (seen.has(value)) found.add(value);
+    seen.add(value);
+  }
+  return [...found].sort();
+}
+function groupByFrom(edges) {
+  const result = /* @__PURE__ */ new Map();
+  for (const edge of edges) {
+    const group = result.get(edge.from) ?? [];
+    group.push(edge);
+    result.set(edge.from, group);
+  }
+  return result;
+}
+function adjacencyFor(edges, includeBackEdges) {
+  const result = /* @__PURE__ */ new Map();
+  for (const edge of edges) {
+    if (!includeBackEdges && edge.kind === "back_edge") continue;
+    const targets = result.get(edge.from) ?? [];
+    targets.push(edge.to);
+    result.set(edge.from, targets);
+  }
+  return result;
+}
+function isReachable(start, target, adjacency) {
+  const pending = [start];
+  const visited = /* @__PURE__ */ new Set();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === target) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...adjacency.get(current) ?? []);
+  }
+  return false;
+}
+function reachableSet(starts, adjacency) {
+  const pending = [...starts];
+  const visited = /* @__PURE__ */ new Set();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...adjacency.get(current) ?? []);
+  }
+  return visited;
+}
+function findForwardCycle(nodeIds, adjacency) {
+  const visited = /* @__PURE__ */ new Set();
+  const active = /* @__PURE__ */ new Set();
+  const stack = [];
+  const visit = (nodeId) => {
+    if (active.has(nodeId)) {
+      const start = stack.indexOf(nodeId);
+      return [...stack.slice(start), nodeId];
+    }
+    if (visited.has(nodeId)) return void 0;
+    visited.add(nodeId);
+    active.add(nodeId);
+    stack.push(nodeId);
+    for (const target of adjacency.get(nodeId) ?? []) {
+      const cycle = visit(target);
+      if (cycle) return cycle;
+    }
+    stack.pop();
+    active.delete(nodeId);
+    return void 0;
+  };
+  for (const nodeId of nodeIds) {
+    const cycle = visit(nodeId);
+    if (cycle) return cycle;
+  }
+  return void 0;
+}
+function collectBranchRegion(edge, allAdjacency, joinNodeId) {
+  const pending = [edge.to];
+  const result = /* @__PURE__ */ new Set();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current === joinNodeId || result.has(current)) continue;
+    result.add(current);
+    pending.push(...allAdjacency.get(current) ?? []);
+  }
+  return result;
+}
+function validateOutgoingContracts(descriptor, nodes, outgoing, issues) {
+  for (const node of descriptor.nodes) {
+    const edges = outgoing.get(node.id) ?? [];
+    if (node.id === descriptor.terminal_verification_node_id) {
+      if (edges.length > 0) issues.push(`terminal verification node ${node.id} must not have outgoing edges`);
+      continue;
+    }
+    if (edges.length === 0) {
+      issues.push(`node ${node.id} cannot reach terminal verification because it has no outgoing edge`);
+      continue;
+    }
+    if (edges.every((edge) => edge.kind === "back_edge")) {
+      issues.push(
+        `node ${node.id} has no non-back-edge exit; a back-edge-only node wedges once max_traversals is exhausted`
+      );
+    }
+    const kinds = new Set(edges.map((edge) => edge.kind));
+    if (node.kind === "join") {
+      if (edges.length !== 1 || edges[0].kind !== "fixed") {
+        issues.push(`join node ${node.id} must have exactly one fixed outgoing edge`);
+      }
+      continue;
+    }
+    if (kinds.has("fixed") && (edges.length !== 1 || kinds.size !== 1)) {
+      issues.push(`node ${node.id} must use one fixed edge or an explicit route/fan-out set`);
+    }
+    if (kinds.has("fan_out")) {
+      if (kinds.size !== 1 || edges.length < 2) {
+        issues.push(`fan-out node ${node.id} must declare at least two fan_out edges and no other edge kind`);
+      }
+    } else if (!kinds.has("fixed")) {
+      if ([...kinds].some((kind) => kind !== "conditional" && kind !== "back_edge")) {
+        issues.push(`node ${node.id} has an unsupported routed edge combination`);
+      }
+      const routes = edges.filter((edge) => "route" in edge).map((edge) => edge.route);
+      const repeatedRoutes = duplicates(routes);
+      if (repeatedRoutes.length > 0) {
+        issues.push(`node ${node.id} declares duplicate route(s): ${repeatedRoutes.join(", ")}`);
+      }
+    }
+  }
+  for (const edge of descriptor.edges) {
+    if (!nodes.has(edge.from)) issues.push(`edge ${edge.id} references missing source node ${edge.from}`);
+    if (!nodes.has(edge.to)) issues.push(`edge ${edge.id} references missing target node ${edge.to}`);
+  }
+}
+function validateForkRegions(descriptor, nodes, outgoing, allAdjacency, issues) {
+  const fanGroups = /* @__PURE__ */ new Map();
+  for (const edge of descriptor.edges) {
+    if (edge.kind !== "fan_out") continue;
+    const group = fanGroups.get(edge.from) ?? [];
+    group.push(edge);
+    fanGroups.set(edge.from, group);
+  }
+  const regions = [];
+  for (const [fanOutNodeId, fanEdges] of fanGroups) {
+    const ownerJoinIds = new Set(fanEdges.map((edge) => edge.owner_join_id));
+    if (ownerJoinIds.size !== 1) {
+      issues.push(`fan-out node ${fanOutNodeId} must have one owning join`);
+      continue;
+    }
+    const joinNodeId = fanEdges[0].owner_join_id;
+    const joinNode = nodes.get(joinNodeId);
+    if (joinNode?.kind !== "join") {
+      issues.push(`fan-out node ${fanOutNodeId} references non-join owner ${joinNodeId}`);
+      continue;
+    }
+    if (joinNode.fan_out_node_id !== fanOutNodeId) {
+      issues.push(`join ${joinNodeId} does not bind fan-out node ${fanOutNodeId}`);
+    }
+    const branchIds = fanEdges.map((edge) => edge.branch_id);
+    const repeatedBranches = duplicates(branchIds);
+    if (repeatedBranches.length > 0) {
+      issues.push(`fan-out node ${fanOutNodeId} repeats branch ID(s): ${repeatedBranches.join(", ")}`);
+    }
+    if ([...new Set(branchIds)].sort().join("\0") !== [...new Set(joinNode.input_branch_ids)].sort().join("\0")) {
+      issues.push(`join ${joinNodeId} input branches do not match fan-out ${fanOutNodeId}`);
+    }
+    if (duplicates(joinNode.input_branch_ids).length > 0) {
+      issues.push(`join ${joinNodeId} repeats an input branch ID`);
+    }
+    const groupRegions = fanEdges.map((edge) => ({
+      fanOutNodeId,
+      joinNodeId,
+      branchId: edge.branch_id,
+      startNodeId: edge.to,
+      nodes: collectBranchRegion(edge, allAdjacency, joinNodeId)
+    }));
+    regions.push(...groupRegions);
+    for (const region of groupRegions) {
+      if (!region.nodes.has(region.startNodeId)) {
+        issues.push(`fork branch ${region.branchId} has no region`);
+      }
+      if (!isReachable(region.startNodeId, joinNodeId, allAdjacency)) {
+        issues.push(`fork branch ${region.branchId} cannot reach owning join ${joinNodeId}`);
+      }
+      for (const nodeId of region.nodes) {
+        const node = nodes.get(nodeId);
+        if (node?.kind === "join" && nodeId !== joinNodeId) {
+          issues.push(`nested join ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+        }
+        if ((outgoing.get(nodeId) ?? []).some((edge) => edge.kind === "fan_out")) {
+          issues.push(`nested fan-out ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+        }
+        if (!isReachable(nodeId, joinNodeId, allAdjacency)) {
+          issues.push(`fork branch ${region.branchId} contains node ${nodeId} that cannot reach its join`);
+        }
+      }
+      const reachesJoin = descriptor.edges.some(
+        (edge) => region.nodes.has(edge.from) && edge.to === joinNodeId
+      );
+      if (!reachesJoin) issues.push(`fork branch ${region.branchId} has no declared join input`);
+    }
+    for (let left = 0; left < groupRegions.length; left += 1) {
+      for (let right = left + 1; right < groupRegions.length; right += 1) {
+        const overlap = [...groupRegions[left].nodes].filter((id) => groupRegions[right].nodes.has(id));
+        if (overlap.length > 0) {
+          issues.push(
+            `fork branches ${groupRegions[left].branchId} and ${groupRegions[right].branchId} overlap at ${overlap.join(", ")}`
+          );
+        }
+      }
+    }
+  }
+  for (const node of descriptor.nodes) {
+    if (node.kind === "join" && !fanGroups.has(node.fan_out_node_id)) {
+      issues.push(`join ${node.id} has no matching fan-out node ${node.fan_out_node_id}`);
+    }
+  }
+  for (let left = 0; left < regions.length; left += 1) {
+    for (let right = left + 1; right < regions.length; right += 1) {
+      if (regions[left].fanOutNodeId === regions[right].fanOutNodeId) continue;
+      const overlap = [...regions[left].nodes].some((id) => regions[right].nodes.has(id));
+      if (overlap) {
+        issues.push(
+          `fork regions ${regions[left].fanOutNodeId} and ${regions[right].fanOutNodeId} overlap or nest`
+        );
+      }
+    }
+  }
+  for (const region of regions) {
+    for (const edge of descriptor.edges) {
+      if (edge.kind === "fan_out" && edge.from === region.fanOutNodeId && edge.branch_id === region.branchId) {
+        continue;
+      }
+      const fromInside = region.nodes.has(edge.from);
+      const toInside = region.nodes.has(edge.to);
+      if (!fromInside && toInside) {
+        issues.push(`edge ${edge.id} crosses into fork branch ${region.branchId}`);
+      }
+      if (fromInside && !toInside && edge.to !== region.joinNodeId) {
+        issues.push(`edge ${edge.id} crosses out of fork branch ${region.branchId}`);
+      }
+      if (edge.kind === "back_edge" && fromInside !== toInside) {
+        issues.push(`back-edge ${edge.id} crosses fork region ${region.fanOutNodeId}`);
+      }
+    }
+  }
+  for (const node of descriptor.nodes) {
+    if (node.kind !== "join") continue;
+    const ownerRegions = regions.filter((region) => region.joinNodeId === node.id);
+    for (const edge of descriptor.edges.filter((candidate) => candidate.to === node.id)) {
+      if (!ownerRegions.some((region) => region.nodes.has(edge.from))) {
+        issues.push(`edge ${edge.id} enters join ${node.id} outside its owning fork region`);
+      }
+    }
+  }
+}
+function validateGraphDescriptor(descriptor) {
+  const issues = [];
+  const repeatedNodeIds = duplicates(descriptor.nodes.map((node) => node.id));
+  if (repeatedNodeIds.length > 0) issues.push(`duplicate node ID(s): ${repeatedNodeIds.join(", ")}`);
+  const repeatedEdgeIds = duplicates(descriptor.edges.map((edge) => edge.id));
+  if (repeatedEdgeIds.length > 0) issues.push(`duplicate edge ID(s): ${repeatedEdgeIds.join(", ")}`);
+  const repeatedEntries = duplicates(descriptor.entry_node_ids);
+  if (repeatedEntries.length > 0) issues.push(`duplicate entry node ID(s): ${repeatedEntries.join(", ")}`);
+  const nodes = new Map(descriptor.nodes.map((node) => [node.id, node]));
+  const outgoing = groupByFrom(descriptor.edges);
+  validateOutgoingContracts(descriptor, nodes, outgoing, issues);
+  for (const entry of descriptor.entry_node_ids) {
+    if (!nodes.has(entry)) issues.push(`entry node ${entry} does not exist`);
+  }
+  const terminalNode = nodes.get(descriptor.terminal_verification_node_id);
+  if (!terminalNode) {
+    issues.push(`terminal verification node ${descriptor.terminal_verification_node_id} does not exist`);
+  } else if (terminalNode.kind !== "agent" && terminalNode.kind !== "command") {
+    issues.push("terminal verification must be an executable agent or command node");
+  }
+  const allAdjacency = adjacencyFor(descriptor.edges, true);
+  const forwardAdjacency = adjacencyFor(descriptor.edges, false);
+  const reachable = reachableSet(descriptor.entry_node_ids, allAdjacency);
+  const unreachable = descriptor.nodes.map((node) => node.id).filter((id) => !reachable.has(id));
+  if (unreachable.length > 0) issues.push(`unreachable node(s): ${unreachable.join(", ")}`);
+  const cycle = findForwardCycle(descriptor.nodes.map((node) => node.id), forwardAdjacency);
+  if (cycle) issues.push(`non-back-edge cycle detected: ${cycle.join(" -> ")}`);
+  for (const edge of descriptor.edges.filter(
+    (candidate) => candidate.kind === "back_edge"
+  )) {
+    if (!isReachable(edge.to, edge.from, forwardAdjacency)) {
+      issues.push(`back-edge ${edge.id} is not a structural return to an earlier node`);
+    }
+  }
+  if (terminalNode) {
+    const cannotVerify = descriptor.nodes.map((node) => node.id).filter((id) => !isReachable(id, terminalNode.id, allAdjacency));
+    if (cannotVerify.length > 0) {
+      issues.push(
+        `every successful path must reach terminal verification; failing node(s): ${cannotVerify.join(", ")}`
+      );
+    }
+  }
+  validateForkRegions(descriptor, nodes, outgoing, allAdjacency, issues);
+  if (issues.length > 0) throw new GraphDescriptorValidationError([...new Set(issues)]);
+  return descriptor;
+}
+function parseGraphDescriptor(input) {
+  const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+  if (descriptor.descriptor_hash && !verifyDescriptorHash(descriptor)) {
+    throw new GraphDescriptorValidationError(["descriptor hash does not match the exact revision"]);
+  }
+  return descriptor;
+}
+var import_node_crypto, GraphDescriptorValidationError;
+var init_descriptor = __esm({
+  "src/graph/descriptor.ts"() {
+    "use strict";
+    import_node_crypto = require("node:crypto");
+    init_schema();
+    GraphDescriptorValidationError = class extends Error {
+      issues;
+      constructor(issues) {
+        super(`Invalid graph descriptor: ${issues.join("; ")}`);
+        this.name = "GraphDescriptorValidationError";
+        this.issues = issues;
+      }
+    };
+  }
+});
+
+// src/graph/runtime-types.ts
+function clone2(value) {
+  return structuredClone(value);
+}
+function isRecord2(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function requireRecord(value, name) {
+  if (!isRecord2(value)) throw new GraphStateValidationError(`${name} must be an object`);
+  return value;
+}
+function requireString(value, name, max = 32768) {
+  if (typeof value !== "string" || value.length === 0 || value.length > max) {
+    throw new GraphStateValidationError(`${name} must be a non-empty bounded string`);
+  }
+  return value;
+}
+function requireInteger(value, name, max = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > max) {
+    throw new GraphStateValidationError(`${name} must be a bounded non-negative integer`);
+  }
+  return value;
+}
+function requireTimestamp(value, name) {
+  const result = requireString(value, name, 64);
+  if (!Number.isFinite(Date.parse(result))) throw new GraphStateValidationError(`${name} must be an ISO timestamp`);
+  return result;
+}
+function assertExactKeys(record2, required2, optional2, name) {
+  const allowed = /* @__PURE__ */ new Set([...required2, ...optional2]);
+  const unknown2 = Object.keys(record2).filter((key) => !allowed.has(key));
+  const missing = required2.filter((key) => !(key in record2));
+  if (missing.length > 0) throw new GraphStateValidationError(`${name} missing ${missing.join(", ")}`);
+  if (unknown2.length > 0) throw new GraphStateValidationError(`${name} has unknown ${unknown2.join(", ")}`);
+}
+function requireStringArray(value, name, max) {
+  if (!Array.isArray(value) || value.length > max) {
+    throw new GraphStateValidationError(`${name} must be a bounded array`);
+  }
+  const result = value.map((item, index) => requireString(item, `${name}[${index}]`, 128));
+  if (new Set(result).size !== result.length) throw new GraphStateValidationError(`${name} contains duplicates`);
+  return result;
+}
+function validateEvidence(value, name) {
+  const evidence = requireRecord(value, name);
+  assertExactKeys(evidence, ["kind", "ref"], ["summary"], name);
+  if (!["file", "command", "test", "human", "url"].includes(String(evidence.kind))) {
+    throw new GraphStateValidationError(`${name}.kind is invalid`);
+  }
+  requireString(evidence.ref, `${name}.ref`, 2048);
+  if (evidence.summary !== void 0) requireString(evidence.summary, `${name}.summary`, 2048);
+  return value;
+}
+function validateEffectPolicy(value, name) {
+  const policy = requireRecord(value, name);
+  if (policy.policy === "side_effect_free" || policy.policy === "reconcile") {
+    assertExactKeys(policy, ["policy"], [], name);
+    return value;
+  }
+  if (policy.policy === "idempotent") {
+    assertExactKeys(policy, ["policy", "idempotency_key_template"], [], name);
+    requireString(policy.idempotency_key_template, `${name}.idempotency_key_template`, 512);
+    return value;
+  }
+  throw new GraphStateValidationError(`${name}.policy is invalid`);
+}
+function validateApproval(value, name, revisionId, revisionHash) {
+  const approval = requireRecord(value, name);
+  assertExactKeys(approval, ["revision_id", "revision_hash", "approved_at", "evidence"], [], name);
+  if (approval.revision_id !== revisionId || approval.revision_hash !== revisionHash) {
+    throw new GraphStateValidationError(`${name} does not bind the exact revision/hash`);
+  }
+  requireTimestamp(approval.approved_at, `${name}.approved_at`);
+  const evidence = validateEvidence(approval.evidence, `${name}.evidence`);
+  if (evidence.kind !== "human") throw new GraphStateValidationError(`${name} requires human evidence`);
+  return value;
+}
+function validateProjection(value, descriptor) {
+  const projection = requireRecord(value, "projection");
+  assertExactKeys(projection, [
+    "activations",
+    "cohorts",
+    "branch_tokens",
+    "traversal_counts",
+    "committed_transitions",
+    "terminal_verification_activation_ids"
+  ], [], "projection");
+  const nodeIds = new Set(descriptor.nodes.map((node) => node.id));
+  const activations = requireRecord(projection.activations, "projection.activations");
+  for (const [key, raw] of Object.entries(activations)) {
+    const activation = requireRecord(raw, `projection.activations.${key}`);
+    assertExactKeys(activation, [
+      "activation_id",
+      "node_id",
+      "status",
+      "attempt_no",
+      "attempt_ids",
+      "traversal_owner_id"
+    ], [
+      "active_attempt_id",
+      "completed_transition_id",
+      "cohort_id",
+      "branch_token_id"
+    ], `projection.activations.${key}`);
+    if (activation.activation_id !== key) throw new GraphStateValidationError(`activation key ${key} mismatches identity`);
+    const nodeId = requireString(activation.node_id, `projection.activations.${key}.node_id`, 128);
+    if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`activation ${key} references unknown node ${nodeId}`);
+    if (!["ready", "running", "completed", "failed"].includes(String(activation.status))) {
+      throw new GraphStateValidationError(`activation ${key} has invalid status`);
+    }
+    const attemptNo = requireInteger(activation.attempt_no, `projection.activations.${key}.attempt_no`, 20);
+    const attempts = requireStringArray(activation.attempt_ids, `projection.activations.${key}.attempt_ids`, 20);
+    if (attemptNo !== attempts.length) throw new GraphStateValidationError(`activation ${key} attempt count mismatch`);
+    requireString(activation.traversal_owner_id, `projection.activations.${key}.traversal_owner_id`, 128);
+    if (activation.active_attempt_id !== void 0) {
+      const activeAttempt = requireString(activation.active_attempt_id, `projection.activations.${key}.active_attempt_id`, 128);
+      if (!attempts.includes(activeAttempt)) throw new GraphStateValidationError(`activation ${key} active attempt is unknown`);
+    }
+    if (activation.status === "running" && !activation.active_attempt_id) {
+      throw new GraphStateValidationError(`running activation ${key} has no active attempt`);
+    }
+  }
+  const cohorts = requireRecord(projection.cohorts, "projection.cohorts");
+  for (const [key, raw] of Object.entries(cohorts)) {
+    const cohort = requireRecord(raw, `projection.cohorts.${key}`);
+    assertExactKeys(cohort, [
+      "cohort_id",
+      "fan_out_node_id",
+      "owner_join_id",
+      "expected_branch_token_ids",
+      "consumed"
+    ], ["join_activation_id"], `projection.cohorts.${key}`);
+    if (cohort.cohort_id !== key) throw new GraphStateValidationError(`cohort key ${key} mismatches identity`);
+    for (const property of ["fan_out_node_id", "owner_join_id"]) {
+      const nodeId = requireString(cohort[property], `projection.cohorts.${key}.${property}`, 128);
+      if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`cohort ${key} references unknown node ${nodeId}`);
+    }
+    requireStringArray(cohort.expected_branch_token_ids, `projection.cohorts.${key}.expected_branch_token_ids`, 64);
+    if (typeof cohort.consumed !== "boolean") throw new GraphStateValidationError(`cohort ${key}.consumed must be boolean`);
+    if (cohort.join_activation_id !== void 0 && !(String(cohort.join_activation_id) in activations)) {
+      throw new GraphStateValidationError(`cohort ${key} references unknown join activation`);
+    }
+  }
+  const tokens = requireRecord(projection.branch_tokens, "projection.branch_tokens");
+  for (const [key, raw] of Object.entries(tokens)) {
+    const token = requireRecord(raw, `projection.branch_tokens.${key}`);
+    assertExactKeys(token, [
+      "branch_token_id",
+      "cohort_id",
+      "branch_id",
+      "owner_join_id",
+      "status"
+    ], ["current_activation_id", "consumed_by_activation_id"], `projection.branch_tokens.${key}`);
+    if (token.branch_token_id !== key) throw new GraphStateValidationError(`branch token key ${key} mismatches identity`);
+    if (!(String(token.cohort_id) in cohorts)) throw new GraphStateValidationError(`branch token ${key} references unknown cohort`);
+    requireString(token.branch_id, `projection.branch_tokens.${key}.branch_id`, 128);
+    requireString(token.owner_join_id, `projection.branch_tokens.${key}.owner_join_id`, 128);
+    if (!["active", "arrived", "consumed"].includes(String(token.status))) {
+      throw new GraphStateValidationError(`branch token ${key} has invalid status`);
+    }
+    for (const property of ["current_activation_id", "consumed_by_activation_id"]) {
+      if (token[property] !== void 0 && !(String(token[property]) in activations)) {
+        throw new GraphStateValidationError(`branch token ${key} references unknown activation`);
+      }
+    }
+  }
+  const traversals = requireRecord(projection.traversal_counts, "projection.traversal_counts");
+  const traversalOwnerIds = /* @__PURE__ */ new Set([...Object.keys(activations), ...Object.keys(tokens)]);
+  for (const [key, count] of Object.entries(traversals)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(key);
+    } catch {
+      throw new GraphStateValidationError(`traversal count key ${key} is not valid JSON`);
+    }
+    if (!Array.isArray(parsed) || parsed.length !== 2 || typeof parsed[0] !== "string" || typeof parsed[1] !== "string") {
+      throw new GraphStateValidationError(`traversal count key ${key} is not a [owner, edgeId] pair`);
+    }
+    const [owner, edgeId] = parsed;
+    if (!traversalOwnerIds.has(owner)) {
+      throw new GraphStateValidationError(`traversal count key ${key} references unknown traversal owner ${owner}`);
+    }
+    if (!descriptor.edges.some((edge) => edge.id === edgeId && edge.kind === "back_edge")) {
+      throw new GraphStateValidationError(`traversal count references unknown back-edge ${edgeId}`);
+    }
+    requireInteger(count, `projection.traversal_counts.${key}`, 100);
+  }
+  const committed = requireRecord(projection.committed_transitions, "projection.committed_transitions");
+  if (Object.keys(committed).length > GRAPH_MAX_TRANSITIONS) {
+    throw new GraphStateValidationError("scheduler committed transitions exceed the configured bound");
+  }
+  for (const [key, raw] of Object.entries(committed)) {
+    const transition = requireRecord(raw, `projection.committed_transitions.${key}`);
+    assertExactKeys(transition, [
+      "transition_id",
+      "activation_id",
+      "node_id",
+      "outcome",
+      "request_fingerprint",
+      "selected_edge_ids",
+      "created_activation_ids",
+      "evidence_refs"
+    ], [
+      "cohort_id",
+      "attempt_id",
+      "route",
+      "output_summary",
+      "external_idempotency_key"
+    ], `projection.committed_transitions.${key}`);
+    if (transition.transition_id !== key) throw new GraphStateValidationError(`scheduler transition key ${key} mismatches identity`);
+    if (!(String(transition.activation_id) in activations)) {
+      throw new GraphStateValidationError(`scheduler transition ${key} references unknown activation`);
+    }
+    const nodeId = requireString(transition.node_id, `projection.committed_transitions.${key}.node_id`, 128);
+    if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`scheduler transition ${key} references unknown node`);
+    if (!["succeeded", "failed", "join_resolved"].includes(String(transition.outcome))) {
+      throw new GraphStateValidationError(`scheduler transition ${key} has invalid outcome`);
+    }
+    requireString(transition.request_fingerprint, `projection.committed_transitions.${key}.request_fingerprint`, 64);
+    requireStringArray(transition.selected_edge_ids, `projection.committed_transitions.${key}.selected_edge_ids`, 64);
+    requireStringArray(transition.created_activation_ids, `projection.committed_transitions.${key}.created_activation_ids`, 64);
+    if (!Array.isArray(transition.evidence_refs) || transition.evidence_refs.length > 64) {
+      throw new GraphStateValidationError(`scheduler transition ${key} evidence is invalid`);
+    }
+    transition.evidence_refs.forEach((item, index) => validateEvidence(item, `scheduler transition ${key} evidence[${index}]`));
+  }
+  const terminalIds = requireStringArray(
+    projection.terminal_verification_activation_ids,
+    "projection.terminal_verification_activation_ids",
+    GRAPH_MAX_TRANSITIONS
+  );
+  for (const activationId of terminalIds) {
+    const activation = activations[activationId];
+    if (!activation || activation.node_id !== descriptor.terminal_verification_node_id) {
+      throw new GraphStateValidationError(`terminal verification activation ${activationId} is invalid`);
+    }
+  }
+  return value;
+}
+function validateRevision(value, key, runId) {
+  const revision = requireRecord(value, `revisions.${key}`);
+  assertExactKeys(revision, [
+    "revision_id",
+    "descriptor_hash",
+    "descriptor",
+    "created_at",
+    "invalidated_node_ids"
+  ], ["approval"], `revisions.${key}`);
+  const revisionId = requireString(revision.revision_id, `revisions.${key}.revision_id`, 128);
+  const hash = requireString(revision.descriptor_hash, `revisions.${key}.descriptor_hash`, 64);
+  if (!/^[a-f0-9]{64}$/.test(hash)) throw new GraphStateValidationError(`revision ${key} hash is invalid`);
+  if (revisionId !== key) throw new GraphStateValidationError(`revision key ${key} does not match revision_id`);
+  const descriptor = parseGraphDescriptor(revision.descriptor);
+  if (!verifyDescriptorHash(descriptor) || descriptor.descriptor_hash !== hash) {
+    throw new GraphStateValidationError(`revision ${key} descriptor hash mismatch`);
+  }
+  if (descriptor.revision_id !== key || descriptor.run_id !== runId) {
+    throw new GraphStateValidationError(`revision ${key} descriptor identity mismatch`);
+  }
+  requireTimestamp(revision.created_at, `revisions.${key}.created_at`);
+  if (!Array.isArray(revision.invalidated_node_ids)) {
+    throw new GraphStateValidationError(`revisions.${key}.invalidated_node_ids must be an array`);
+  }
+  requireStringArray(revision.invalidated_node_ids, `revisions.${key}.invalidated_node_ids`, 1e3);
+  if (revision.approval !== void 0) validateApproval(revision.approval, `revisions.${key}.approval`, key, hash);
+  return value;
+}
+function parseGraphState(input) {
+  let serialized;
+  try {
+    serialized = JSON.stringify(input);
+  } catch (error2) {
+    throw new GraphStateValidationError(`state is not JSON serializable: ${String(error2)}`);
+  }
+  if (Buffer.byteLength(serialized, "utf8") > GRAPH_STATE_MAX_BYTES) {
+    throw new GraphStateValidationError(`state exceeds ${GRAPH_STATE_MAX_BYTES} bytes`);
+  }
+  const state = requireRecord(input, "state");
+  assertExactKeys(state, [
+    "format_version",
+    "session_id",
+    "run_id",
+    "control_nonce",
+    "status",
+    "active_revision_id",
+    "active_revision_hash",
+    "dispatch_generation",
+    "commit_sequence",
+    "revisions",
+    "transitions",
+    "projection",
+    "claims",
+    "reconciliations",
+    "diagnostics",
+    "created_at",
+    "updated_at"
+  ], ["pending_approval", "pending_patch"], "state");
+  if (state.format_version !== GRAPH_STATE_FORMAT_VERSION) {
+    throw new GraphStateValidationError("unsupported format_version");
+  }
+  const sessionId = requireString(state.session_id, "session_id", 256);
+  const runId = requireString(state.run_id, "run_id", 128);
+  requireString(state.control_nonce, "control_nonce", 128);
+  const activeRevisionId = requireString(state.active_revision_id, "active_revision_id", 128);
+  const activeHash = requireString(state.active_revision_hash, "active_revision_hash", 64);
+  if (!/^[a-f0-9]{64}$/.test(activeHash)) throw new GraphStateValidationError("active_revision_hash is invalid");
+  requireInteger(state.dispatch_generation, "dispatch_generation");
+  const sequence = requireInteger(state.commit_sequence, "commit_sequence", GRAPH_MAX_TRANSITIONS);
+  requireTimestamp(state.created_at, "created_at");
+  requireTimestamp(state.updated_at, "updated_at");
+  const statuses = [
+    "draft",
+    "awaiting_approval",
+    "running",
+    "waiting_human",
+    "waiting_patch_approval",
+    "reconciling",
+    "paused",
+    "failed",
+    "cancelled",
+    "succeeded"
+  ];
+  if (!statuses.includes(state.status)) throw new GraphStateValidationError("invalid status");
+  const revisions = requireRecord(state.revisions, "revisions");
+  for (const [key, revision] of Object.entries(revisions)) validateRevision(revision, key, runId);
+  const active = revisions[activeRevisionId];
+  if (!active || active.descriptor_hash !== activeHash) {
+    throw new GraphStateValidationError("active revision/hash is not embedded");
+  }
+  const approvedStatuses = /* @__PURE__ */ new Set([
+    "running",
+    "waiting_human",
+    "waiting_patch_approval",
+    "reconciling",
+    "paused",
+    "failed",
+    "cancelled",
+    "succeeded"
+  ]);
+  if (approvedStatuses.has(state.status) && !active.approval) {
+    throw new GraphStateValidationError(`status ${String(state.status)} requires exact active revision approval`);
+  }
+  if (!Array.isArray(state.transitions) || state.transitions.length > GRAPH_MAX_TRANSITIONS) {
+    throw new GraphStateValidationError("transitions exceed the configured bound");
+  }
+  const transitionIds = /* @__PURE__ */ new Set();
+  let priorSequence = 0;
+  for (const raw of state.transitions) {
+    const transition = requireRecord(raw, "transition");
+    assertExactKeys(transition, [
+      "transition_id",
+      "operation",
+      "operation_fingerprint",
+      "request_fingerprint",
+      "sequence",
+      "committed_at",
+      "result"
+    ], [], "transition");
+    const id = requireString(transition.transition_id, "transition.transition_id", 128);
+    if (transitionIds.has(id)) throw new GraphStateValidationError(`duplicate transition ${id}`);
+    transitionIds.add(id);
+    const currentSequence = requireInteger(transition.sequence, "transition.sequence", GRAPH_MAX_TRANSITIONS);
+    if (currentSequence <= priorSequence) throw new GraphStateValidationError("transition sequence is not monotonic");
+    priorSequence = currentSequence;
+    requireString(transition.operation, "transition.operation", 128);
+    requireString(transition.operation_fingerprint, "transition.operation_fingerprint", 1024);
+    const fingerprint = requireString(transition.request_fingerprint, "transition.request_fingerprint", 64);
+    if (!/^[a-f0-9]{64}$/.test(fingerprint)) {
+      throw new GraphStateValidationError(`transition ${id} request_fingerprint is invalid`);
+    }
+    requireTimestamp(transition.committed_at, "transition.committed_at");
+    if (Buffer.byteLength(JSON.stringify(transition.result), "utf8") > GRAPH_MAX_TRANSITION_RESULT_BYTES) {
+      throw new GraphStateValidationError(`transition ${id} result exceeds the configured bound`);
+    }
+  }
+  if (state.transitions.length > 0 && priorSequence !== sequence) {
+    throw new GraphStateValidationError("commit_sequence does not match transition history");
+  }
+  if (state.transitions.length === 0 && sequence !== 0) {
+    throw new GraphStateValidationError("nonzero commit_sequence has no transition history");
+  }
+  validateProjection(state.projection, active.descriptor);
+  const claims = requireRecord(state.claims, "claims");
+  const reconciliations = requireRecord(state.reconciliations, "reconciliations");
+  if (Object.keys(claims).length > GRAPH_MAX_CLAIMS) throw new GraphStateValidationError("claims exceed the configured bound");
+  if (Object.keys(reconciliations).length > GRAPH_MAX_RECONCILIATIONS) {
+    throw new GraphStateValidationError("reconciliations exceed the configured bound");
+  }
+  for (const [leaseId, raw] of Object.entries(claims)) {
+    const claim = requireRecord(raw, `claims.${leaseId}`);
+    assertExactKeys(claim, [
+      "run_id",
+      "revision_id",
+      "revision_hash",
+      "dispatch_generation",
+      "activation_id",
+      "attempt_id",
+      "attempt_no",
+      "claim_owner_session_id",
+      "driver_instance_id",
+      "lease_id",
+      "tracking_id",
+      "issued_at",
+      "expires_at",
+      "lease_duration_ms",
+      "renewal_count",
+      "max_renewals",
+      "effect_policy",
+      "status"
+    ], [
+      "external_idempotency_key",
+      "last_renewed_at",
+      "fenced_at",
+      "replacement_lease_id"
+    ], `claims.${leaseId}`);
+    if (claim.lease_id !== leaseId) throw new GraphStateValidationError(`claim key ${leaseId} mismatches identity`);
+    if (claim.run_id !== runId) throw new GraphStateValidationError(`claim ${leaseId} run fence mismatches`);
+    const revisionId = requireString(claim.revision_id, `claims.${leaseId}.revision_id`, 128);
+    const revisionHash = requireString(claim.revision_hash, `claims.${leaseId}.revision_hash`, 64);
+    const claimRevision = revisions[revisionId];
+    if (!claimRevision || claimRevision.descriptor_hash !== revisionHash) {
+      throw new GraphStateValidationError(`claim ${leaseId} revision fence is invalid`);
+    }
+    requireInteger(claim.dispatch_generation, `claims.${leaseId}.dispatch_generation`);
+    const activationId = requireString(claim.activation_id, `claims.${leaseId}.activation_id`, 128);
+    const activation = state.projection.activations[activationId];
+    if (!activation) throw new GraphStateValidationError(`claim ${leaseId} references unknown activation`);
+    const attemptId = requireString(claim.attempt_id, `claims.${leaseId}.attempt_id`, 128);
+    const attemptNo = requireInteger(claim.attempt_no, `claims.${leaseId}.attempt_no`, 20);
+    if (!activation.attempt_ids.includes(attemptId) || activation.attempt_no < attemptNo) {
+      throw new GraphStateValidationError(`claim ${leaseId} attempt fence is invalid`);
+    }
+    for (const property of ["claim_owner_session_id", "driver_instance_id", "tracking_id"]) {
+      requireString(claim[property], `claims.${leaseId}.${property}`, 256);
+    }
+    const issued = requireTimestamp(claim.issued_at, `claims.${leaseId}.issued_at`);
+    const expires = requireTimestamp(claim.expires_at, `claims.${leaseId}.expires_at`);
+    const duration3 = requireInteger(claim.lease_duration_ms, `claims.${leaseId}.lease_duration_ms`, 864e5);
+    const leaseStart = claim.last_renewed_at === void 0 ? issued : requireTimestamp(claim.last_renewed_at, `claims.${leaseId}.last_renewed_at`);
+    if (duration3 <= 0 || Date.parse(expires) - Date.parse(leaseStart) !== duration3) {
+      throw new GraphStateValidationError(`claim ${leaseId} lease duration is inconsistent`);
+    }
+    const renewals = requireInteger(claim.renewal_count, `claims.${leaseId}.renewal_count`, 20);
+    const maxRenewals = requireInteger(claim.max_renewals, `claims.${leaseId}.max_renewals`, 20);
+    if (renewals > maxRenewals) throw new GraphStateValidationError(`claim ${leaseId} renewal cap is exceeded`);
+    const policy = validateEffectPolicy(claim.effect_policy, `claims.${leaseId}.effect_policy`);
+    if (policy.policy === "idempotent") {
+      requireString(claim.external_idempotency_key, `claims.${leaseId}.external_idempotency_key`, 512);
+    } else if (claim.external_idempotency_key !== void 0) {
+      throw new GraphStateValidationError(`claim ${leaseId} has an unexpected idempotency key`);
+    }
+    if (!["live", "completed", "expired_retryable", "abandoned_retryable", "reconciling", "fenced"].includes(String(claim.status))) {
+      throw new GraphStateValidationError(`claim ${leaseId} has invalid status`);
+    }
+    if (claim.status !== "live" && claim.fenced_at === void 0) {
+      throw new GraphStateValidationError(`non-live claim ${leaseId} requires fenced_at`);
+    }
+    if (claim.fenced_at !== void 0) requireTimestamp(claim.fenced_at, `claims.${leaseId}.fenced_at`);
+    if (claim.replacement_lease_id !== void 0) {
+      requireString(claim.replacement_lease_id, `claims.${leaseId}.replacement_lease_id`, 128);
+    }
+  }
+  for (const [id, raw] of Object.entries(reconciliations)) {
+    const record2 = requireRecord(raw, `reconciliations.${id}`);
+    assertExactKeys(record2, [
+      "reconciliation_id",
+      "activation_id",
+      "attempt_id",
+      "lease_id",
+      "revision_id",
+      "revision_hash",
+      "dispatch_generation",
+      "status",
+      "reason",
+      "created_at"
+    ], ["resolved_at", "resolution_evidence"], `reconciliations.${id}`);
+    if (record2.reconciliation_id !== id) throw new GraphStateValidationError(`reconciliation key ${id} mismatches identity`);
+    const leaseId = requireString(record2.lease_id, `reconciliations.${id}.lease_id`, 128);
+    const claim = claims[leaseId];
+    if (!claim || record2.activation_id !== claim.activation_id || record2.attempt_id !== claim.attempt_id) {
+      throw new GraphStateValidationError(`reconciliation ${id} claim lineage is invalid`);
+    }
+    if (record2.revision_id !== claim.revision_id || record2.revision_hash !== claim.revision_hash || record2.dispatch_generation !== claim.dispatch_generation) {
+      throw new GraphStateValidationError(`reconciliation ${id} revision fence is invalid`);
+    }
+    if (!["unresolved", "committed", "proved_not_applied", "accepted", "invalidated"].includes(String(record2.status))) {
+      throw new GraphStateValidationError(`reconciliation ${id} status is invalid`);
+    }
+    if (!["expired_ambiguous", "session_end_ambiguous", "external_effect_ambiguous"].includes(String(record2.reason))) {
+      throw new GraphStateValidationError(`reconciliation ${id} reason is invalid`);
+    }
+    requireTimestamp(record2.created_at, `reconciliations.${id}.created_at`);
+    if (record2.status === "unresolved" && (record2.resolved_at !== void 0 || record2.resolution_evidence !== void 0)) {
+      throw new GraphStateValidationError(`unresolved reconciliation ${id} cannot have resolution fields`);
+    }
+    if (record2.status !== "unresolved") {
+      requireTimestamp(record2.resolved_at, `reconciliations.${id}.resolved_at`);
+      validateEvidence(record2.resolution_evidence, `reconciliations.${id}.resolution_evidence`);
+    }
+  }
+  if (!Array.isArray(state.diagnostics) || state.diagnostics.length > GRAPH_MAX_DIAGNOSTICS) {
+    throw new GraphStateValidationError("diagnostics exceed the configured bound");
+  }
+  state.diagnostics.forEach((raw, index) => {
+    const diagnostic = requireRecord(raw, `diagnostics[${index}]`);
+    assertExactKeys(diagnostic, ["kind", "recorded_at", "summary"], [
+      "activation_id",
+      "attempt_id",
+      "lease_id"
+    ], `diagnostics[${index}]`);
+    if (!["late_result", "operation", "recovery", "control"].includes(String(diagnostic.kind))) {
+      throw new GraphStateValidationError(`diagnostics[${index}].kind is invalid`);
+    }
+    requireTimestamp(diagnostic.recorded_at, `diagnostics[${index}].recorded_at`);
+    requireString(diagnostic.summary, `diagnostics[${index}].summary`, 8192);
+    for (const property of ["activation_id", "attempt_id", "lease_id"]) {
+      if (diagnostic[property] !== void 0) requireString(diagnostic[property], `diagnostics[${index}].${property}`, 128);
+    }
+  });
+  if (state.pending_approval !== void 0) {
+    const pending = requireRecord(state.pending_approval, "pending_approval");
+    assertExactKeys(pending, ["revision_id", "revision_hash", "requested_at"], [], "pending_approval");
+    if (pending.revision_id !== activeRevisionId || pending.revision_hash !== activeHash) {
+      throw new GraphStateValidationError("pending approval does not bind the active revision/hash");
+    }
+    requireTimestamp(pending.requested_at, "pending_approval.requested_at");
+  }
+  if (state.status === "awaiting_approval" && !state.pending_approval) {
+    throw new GraphStateValidationError("awaiting_approval requires pending_approval");
+  }
+  if (state.status !== "awaiting_approval" && state.pending_approval) {
+    throw new GraphStateValidationError("pending_approval must be absent outside awaiting_approval");
+  }
+  if (state.pending_approval && active.approval) {
+    throw new GraphStateValidationError("approved revision cannot remain pending approval");
+  }
+  if (!active.approval && Object.values(state.projection.activations).some(
+    (activation) => activation.status === "ready" || activation.status === "running"
+  )) {
+    throw new GraphStateValidationError("unapproved graph cannot expose claimable work");
+  }
+  if (state.pending_patch !== void 0) {
+    const patch = requireRecord(state.pending_patch, "pending_patch");
+    assertExactKeys(patch, [
+      "proposal_id",
+      "base_revision_id",
+      "base_revision_hash",
+      "base_dispatch_generation",
+      "proposed_revision_id",
+      "proposed_revision_hash",
+      "proposed_descriptor",
+      "invalidated_node_ids",
+      "proposal_evidence",
+      "proposed_at"
+    ], [], "pending_patch");
+    requireString(patch.proposal_id, "pending_patch.proposal_id", 128);
+    if (patch.base_revision_id !== activeRevisionId || patch.base_revision_hash !== activeHash) {
+      throw new GraphStateValidationError("pending patch base does not bind active revision/hash");
+    }
+    const baseGeneration = requireInteger(patch.base_dispatch_generation, "pending_patch.base_dispatch_generation");
+    if (baseGeneration + 1 !== state.dispatch_generation) {
+      throw new GraphStateValidationError("pending patch dispatch generation is invalid");
+    }
+    const proposed = parseGraphDescriptor(patch.proposed_descriptor);
+    if (!verifyDescriptorHash(proposed) || proposed.revision_id !== patch.proposed_revision_id || proposed.descriptor_hash !== patch.proposed_revision_hash || proposed.run_id !== runId || proposed.revision_id === activeRevisionId) {
+      throw new GraphStateValidationError("pending patch proposed descriptor identity/hash is invalid");
+    }
+    requireStringArray(patch.invalidated_node_ids, "pending_patch.invalidated_node_ids", 1e3);
+    if (!Array.isArray(patch.proposal_evidence) || patch.proposal_evidence.length > 64) {
+      throw new GraphStateValidationError("pending patch proposal evidence is invalid");
+    }
+    patch.proposal_evidence.forEach((item, index) => validateEvidence(item, `pending_patch.proposal_evidence[${index}]`));
+    requireTimestamp(patch.proposed_at, "pending_patch.proposed_at");
+  }
+  if (state.pending_patch && state.status !== "waiting_patch_approval") {
+    throw new GraphStateValidationError("pending_patch requires waiting_patch_approval status");
+  }
+  if (!state.pending_patch && state.status === "waiting_patch_approval") {
+    throw new GraphStateValidationError("waiting_patch_approval requires pending_patch");
+  }
+  if (Object.values(claims).some(
+    (raw) => raw.claim_owner_session_id !== sessionId
+  )) {
+    throw new GraphStateValidationError("claim owner session does not match graph authority session");
+  }
+  return clone2(input);
+}
+var GRAPH_STATE_FORMAT_VERSION, GRAPH_STATE_MAX_BYTES, GRAPH_MAX_TRANSITIONS, GRAPH_MAX_DIAGNOSTICS, GRAPH_MAX_RECONCILIATIONS, GRAPH_MAX_CLAIMS, GRAPH_MAX_TRANSITION_RESULT_BYTES, GraphStateValidationError;
+var init_runtime_types = __esm({
+  "src/graph/runtime-types.ts"() {
+    "use strict";
+    init_descriptor();
+    GRAPH_STATE_FORMAT_VERSION = 1;
+    GRAPH_STATE_MAX_BYTES = 8 * 1024 * 1024;
+    GRAPH_MAX_TRANSITIONS = 1e4;
+    GRAPH_MAX_DIAGNOSTICS = 128;
+    GRAPH_MAX_RECONCILIATIONS = 1e3;
+    GRAPH_MAX_CLAIMS = 2e3;
+    GRAPH_MAX_TRANSITION_RESULT_BYTES = 32 * 1024;
+    GraphStateValidationError = class extends Error {
+      code = "invalid_graph_state";
+      constructor(message2) {
+        super(`Invalid graph state: ${message2}`);
+        this.name = "GraphStateValidationError";
+      }
+    };
+  }
+});
+
 // src/lib/file-lock.ts
 var file_lock_exports = {};
 __export(file_lock_exports, {
@@ -13132,8 +19008,8 @@ __export(file_lock_exports, {
 });
 function isLockStale(lockPath2, staleLockMs) {
   try {
-    const stat2 = (0, import_fs31.statSync)(lockPath2);
-    const ageMs = Date.now() - stat2.mtimeMs;
+    const stat3 = (0, import_fs31.statSync)(lockPath2);
+    const ageMs = Date.now() - stat3.mtimeMs;
     if (ageMs < staleLockMs) return false;
     try {
       const raw = (0, import_fs31.readFileSync)(lockPath2, "utf-8");
@@ -13254,7 +19130,7 @@ function withFileLockSync(lockPath2, fn, opts) {
   }
 }
 function sleep3(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 async function acquireFileLock(lockPath2, opts) {
   const staleLockMs = opts?.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
@@ -13668,7 +19544,7 @@ var init_session_replay = __esm({
 
 // src/hooks/wiki/types.ts
 var WIKI_SCHEMA_VERSION, DEFAULT_WIKI_CONFIG;
-var init_types5 = __esm({
+var init_types6 = __esm({
   "src/hooks/wiki/types.ts"() {
     "use strict";
     WIKI_SCHEMA_VERSION = 1;
@@ -13930,7 +19806,7 @@ var init_storage = __esm({
     init_worktree_paths();
     init_atomic_write();
     init_file_lock();
-    init_types5();
+    init_types6();
     WIKI_DIR = "wiki";
     INDEX_FILE = "index.md";
     LOG_FILE = "log.md";
@@ -14376,7 +20252,7 @@ function buildHookCommand(filename) {
 function getHooksSettingsConfig() {
   return HOOKS_SETTINGS_CONFIG_NODE;
 }
-var import_path53, import_fs42, import_url7, import_os9, MIN_NODE_VERSION, ULTRAWORK_MESSAGE, ULTRATHINK_MESSAGE, SEARCH_MESSAGE, ANALYZE_MESSAGE, CODE_REVIEW_MESSAGE, SECURITY_REVIEW_MESSAGE, TDD_MESSAGE, RALPH_MESSAGE, PROMPT_TRANSLATION_MESSAGE, KEYWORD_DETECTOR_SCRIPT_NODE, STOP_CONTINUATION_SCRIPT_NODE, PERSISTENT_MODE_SCRIPT_NODE, CODE_SIMPLIFIER_SCRIPT_NODE, SESSION_START_SCRIPT_NODE, POST_TOOL_USE_SCRIPT_NODE, HOOKS_SETTINGS_CONFIG_NODE;
+var import_path53, import_fs42, import_url7, import_os9, MIN_NODE_VERSION, ULTRAWORK_MESSAGE, ULTRATHINK_MESSAGE, SEARCH_MESSAGE, ANALYZE_MESSAGE, CODE_REVIEW_MESSAGE, SECURITY_REVIEW_MESSAGE, TDD_MESSAGE, RALPH_MESSAGE, PROMPT_TRANSLATION_MESSAGE, KEYWORD_DETECTOR_SCRIPT_NODE, STOP_CONTINUATION_SCRIPT_NODE, PERSISTENT_MODE_SCRIPT_NODE, CODE_SIMPLIFIER_SCRIPT_NODE, SESSION_START_SCRIPT_NODE, SESSION_END_SCRIPT_NODE, POST_TOOL_USE_SCRIPT_NODE, HOOKS_SETTINGS_CONFIG_NODE;
 var init_hooks = __esm({
   "src/installer/hooks.ts"() {
     "use strict";
@@ -14501,6 +20377,7 @@ Respond to the user in their original language.
     PERSISTENT_MODE_SCRIPT_NODE = loadTemplate("persistent-mode.mjs");
     CODE_SIMPLIFIER_SCRIPT_NODE = loadTemplate("code-simplifier.mjs");
     SESSION_START_SCRIPT_NODE = loadTemplate("session-start.mjs");
+    SESSION_END_SCRIPT_NODE = loadTemplate("session-end.mjs");
     POST_TOOL_USE_SCRIPT_NODE = loadTemplate("post-tool-use.mjs");
     HOOKS_SETTINGS_CONFIG_NODE = {
       hooks: {
@@ -14520,6 +20397,26 @@ Respond to the user in their original language.
               {
                 type: "command",
                 command: buildHookCommand("session-start.mjs")
+              }
+            ]
+          }
+        ],
+        // Graph-scoped SessionEnd cleanup. This hook is a fast no-op for any
+        // session that never used the Graph runtime: it returns SAFE_CONTINUE
+        // without invoking the CLI when no graph-state file exists for the
+        // session (see templates/hooks/session-end.mjs `existsSync(writePath)`
+        // gate). Registration is therefore safe for all standalone installs and
+        // does not perform work or mutate state for non-graph sessions. Plugin
+        // installs receive this hook via hooks/hooks.json instead.
+        SessionEnd: [
+          {
+            matcher: "*",
+            hooks: [
+              {
+                type: "command",
+                command: buildHookCommand("session-end.mjs"),
+                timeout: 30,
+                async: true
               }
             ]
           }
@@ -16041,9 +21938,9 @@ function validateRootedRegularFile(root2, path25, allowAbsent = true, fs22 = def
     if (allowAbsent) return normalizedPath;
     throw new Error(`Missing path: ${normalizedPath}`);
   }
-  const stat2 = fs22.lstatSync(normalizedPath);
-  if (stat2.isSymbolicLink()) throw new Error(`Refusing symlink: ${normalizedPath}`);
-  if (!stat2.isFile()) throw new Error(`Not a regular file: ${normalizedPath}`);
+  const stat3 = fs22.lstatSync(normalizedPath);
+  if (stat3.isSymbolicLink()) throw new Error(`Refusing symlink: ${normalizedPath}`);
+  if (!stat3.isFile()) throw new Error(`Not a regular file: ${normalizedPath}`);
   return normalizedPath;
 }
 function cleanCanonical(source) {
@@ -16104,7 +22001,7 @@ function exclusiveVerifiedBackup(state, fs22) {
   const directory = (0, import_node_path3.dirname)(state.path);
   const stem = `${(0, import_node_path3.basename)(state.path)}.backup.${(/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-")}`;
   for (let attempt = 0; attempt < 16; attempt += 1) {
-    const backup = `${directory}/${stem}.${(0, import_node_crypto.randomBytes)(12).toString("hex")}`;
+    const backup = `${directory}/${stem}.${(0, import_node_crypto2.randomBytes)(12).toString("hex")}`;
     try {
       const fd = fs22.openSync(backup, "wx", 384);
       try {
@@ -16127,7 +22024,7 @@ function exclusiveVerifiedBackup(state, fs22) {
 function atomicWrite(operation, fs22) {
   const directory = (0, import_node_path3.dirname)(operation.path);
   fs22.mkdirSync(directory, { recursive: true });
-  operation.tempPath = `${directory}/.${(0, import_node_path3.basename)(operation.path)}.omc-tmp-${(0, import_node_crypto.randomBytes)(12).toString("hex")}`;
+  operation.tempPath = `${directory}/.${(0, import_node_path3.basename)(operation.path)}.omc-tmp-${(0, import_node_crypto2.randomBytes)(12).toString("hex")}`;
   fs22.writeFileSync(operation.tempPath, operation.bytes, { flag: "wx", mode: 384 });
   fs22.renameSync(operation.tempPath, operation.path);
   operation.tempPath = void 0;
@@ -16241,11 +22138,11 @@ function executeClaudeMdTransaction(request) {
     return failure(request, 3, message(error2), "validation");
   }
 }
-var import_node_crypto, nodeFs, nativePath, import_node_path3, CLAUDE_MD_IMPORT_START, CLAUDE_MD_IMPORT_END, CLAUDE_MD_IMPORT_BLOCK, defaultFs;
+var import_node_crypto2, nodeFs, nativePath, import_node_path3, CLAUDE_MD_IMPORT_START, CLAUDE_MD_IMPORT_END, CLAUDE_MD_IMPORT_BLOCK, defaultFs;
 var init_claude_md_transaction = __esm({
   "src/installer/claude-md-transaction.ts"() {
     "use strict";
-    import_node_crypto = require("node:crypto");
+    import_node_crypto2 = require("node:crypto");
     nodeFs = __toESM(require("node:fs"), 1);
     nativePath = __toESM(require("node:path"), 1);
     import_node_path3 = require("node:path");
@@ -17942,6 +23839,7 @@ var init_installer = __esm({
     OMC_HOOK_FILENAMES = /* @__PURE__ */ new Set([
       "keyword-detector.mjs",
       "session-start.mjs",
+      "session-end.mjs",
       "pre-tool-use.mjs",
       "post-tool-use.mjs",
       "post-tool-use-failure.mjs",
@@ -17956,6 +23854,7 @@ var init_installer = __esm({
     STANDALONE_HOOK_TEMPLATE_FILES = [
       "keyword-detector.mjs",
       "session-start.mjs",
+      "session-end.mjs",
       "pre-tool-use.mjs",
       "post-tool-use.mjs",
       "post-tool-use-failure.mjs",
@@ -20076,7 +25975,7 @@ function resolveHudLabels(locale, labels) {
   };
 }
 var DEFAULT_HUD_LABELS, HUD_LOCALE_LABELS, HUD_LABEL_KEYS, DEFAULT_ELEMENT_ORDER, DEFAULT_HUD_USAGE_POLL_INTERVAL_MS, DEFAULT_HUD_CONFIG, PRESET_CONFIGS;
-var init_types6 = __esm({
+var init_types7 = __esm({
   "src/hud/types.ts"() {
     "use strict";
     init_mission_board();
@@ -20133,6 +26032,7 @@ var init_types6 = __esm({
         "tokens",
         "ralph",
         "autopilot",
+        "graph",
         "prd",
         "skills",
         "lastSkill",
@@ -20174,6 +26074,7 @@ var init_types6 = __esm({
         // Show rate limits by default
         ralph: true,
         autopilot: true,
+        graph: true,
         prdStory: true,
         activeSkills: true,
         contextBar: true,
@@ -20247,6 +26148,7 @@ var init_types6 = __esm({
         rateLimits: true,
         ralph: true,
         autopilot: true,
+        graph: true,
         prdStory: false,
         activeSkills: true,
         lastSkill: true,
@@ -20290,6 +26192,7 @@ var init_types6 = __esm({
         rateLimits: true,
         ralph: true,
         autopilot: true,
+        graph: true,
         prdStory: true,
         activeSkills: true,
         lastSkill: true,
@@ -20334,6 +26237,7 @@ var init_types6 = __esm({
         rateLimits: true,
         ralph: true,
         autopilot: true,
+        graph: true,
         prdStory: true,
         activeSkills: true,
         lastSkill: true,
@@ -20378,6 +26282,7 @@ var init_types6 = __esm({
         rateLimits: false,
         ralph: true,
         autopilot: true,
+        graph: true,
         prdStory: false,
         activeSkills: true,
         lastSkill: true,
@@ -20421,6 +26326,7 @@ var init_types6 = __esm({
         rateLimits: true,
         ralph: true,
         autopilot: true,
+        graph: true,
         prdStory: true,
         activeSkills: true,
         lastSkill: true,
@@ -20817,7 +26723,7 @@ var init_state3 = __esm({
     init_config_dir();
     init_worktree_paths();
     init_atomic_write();
-    init_types6();
+    init_types7();
     init_mission_board();
     init_background_cleanup();
   }
@@ -21094,7 +27000,7 @@ function readDiskState(directory, sessionId) {
     total_failed: 0,
     last_updated: (/* @__PURE__ */ new Date()).toISOString()
   });
-  const readFile24 = (p) => {
+  const readFile25 = (p) => {
     if (!(0, import_fs54.existsSync)(p)) return null;
     try {
       return JSON.parse((0, import_fs54.readFileSync)(p, "utf-8"));
@@ -21105,9 +27011,9 @@ function readDiskState(directory, sessionId) {
   };
   if (sessionId) {
     const paths = resolveSessionStatePaths(STATE_NAME, sessionId, directory);
-    return readFile24(paths.sessionScoped) ?? empty();
+    return readFile25(paths.sessionScoped) ?? empty();
   }
-  const legacyState = readFile24(resolveReadPath(directory, void 0));
+  const legacyState = readFile25(resolveReadPath(directory, void 0));
   if (legacyState) return legacyState;
   const sessionsDir = (0, import_path64.join)(getOmcRoot(directory), "state", "sessions");
   if (!(0, import_fs54.existsSync)(sessionsDir)) return empty();
@@ -21117,7 +27023,7 @@ function readDiskState(directory, sessionId) {
     const normalizedName = `${STATE_NAME}-state.json`;
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const sessionState = readFile24((0, import_path64.join)(sessionsDir, entry.name, normalizedName));
+      const sessionState = readFile25((0, import_path64.join)(sessionsDir, entry.name, normalizedName));
       if (sessionState) {
         merged = mergeTrackerStates(merged, sessionState);
       }
@@ -21911,6 +27817,7 @@ __export(skill_state_exports, {
   isSkillStateStale: () => isSkillStateStale,
   isWorkflowSkillLive: () => isWorkflowSkillLive,
   isWorkflowSkillTombstoned: () => isWorkflowSkillTombstoned,
+  markDurableWorkflowSkillCompleted: () => markDurableWorkflowSkillCompleted,
   markWorkflowSkillCompleted: () => markWorkflowSkillCompleted,
   pruneExpiredWorkflowSkillTombstones: () => pruneExpiredWorkflowSkillTombstones,
   readSkillActiveState: () => readSkillActiveState,
@@ -22012,6 +27919,15 @@ function upsertWorkflowSkillSlot(state, skillName, slotData = {}) {
 }
 function markWorkflowSkillCompleted(state, skillName, now = (/* @__PURE__ */ new Date()).toISOString()) {
   const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, "");
+  if (normalized === "graph") return state;
+  return markWorkflowSkillCompletedUnchecked(state, normalized, now);
+}
+function markDurableWorkflowSkillCompleted(state, skillName, now = (/* @__PURE__ */ new Date()).toISOString()) {
+  const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, "");
+  if (normalized !== "graph") return state;
+  return markWorkflowSkillCompletedUnchecked(state, normalized, now);
+}
+function markWorkflowSkillCompletedUnchecked(state, normalized, now) {
   const existing = state.active_skills[normalized];
   if (!existing) return state;
   const updated = { ...existing, completed_at: now };
@@ -22255,6 +28171,7 @@ var init_skill_state = __esm({
     WORKFLOW_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1e3;
     CANONICAL_WORKFLOW_SKILLS = [
       "autopilot",
+      "graph",
       "ralph",
       "team",
       "ultrawork",
@@ -22276,6 +28193,7 @@ var init_skill_state = __esm({
       // === Canonical workflow skills — bypass support-skill protection; flow through the workflow-slot path ===
       autopilot: "none",
       autoresearch: "none",
+      graph: "none",
       ralph: "none",
       ultrawork: "none",
       team: "none",
@@ -23171,6 +29089,20 @@ function validNamedWorkflowForResume(state, sessionId) {
     namedWorkflowRuntimeSupported() ? validateNamedWorkflowState(state, sessionId) : validateNamedWorkflowStateStructure(state, sessionId)
   );
 }
+function hasSymlinkedNamedWorkflowTranscript(state) {
+  const boundaries = [
+    state.pipelineTracking?.activationBoundary,
+    ...state.pipelineTracking?.completionObservations?.map((observation) => observation.activationBoundary) ?? []
+  ];
+  return boundaries.some((boundary) => {
+    if (!boundary || typeof boundary.transcriptPath !== "string") return false;
+    try {
+      return (0, import_fs57.lstatSync)(boundary.transcriptPath).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  });
+}
 function clearSessionOwnedNestedRalplanState(directory, sessionId) {
   if (!sessionId) return null;
   const state = readModeState("ralplan", directory, sessionId);
@@ -23312,6 +29244,9 @@ function canResumeAutopilot(directory, sessionId) {
     if (!validNamedWorkflowForResume(state, sessionId)) {
       return { canResume: false, resumePhase: state.phase, integrityFailed: true };
     }
+    if (hasSymlinkedNamedWorkflowTranscript(state)) {
+      return { canResume: false, resumePhase: state.phase, integrityFailed: true };
+    }
     if (!namedWorkflowRuntimeSupported()) {
       return { canResume: false, state, resumePhase: state.phase, unsupportedRuntime: true };
     }
@@ -23393,11 +29328,12 @@ function formatCancelMessage(result) {
   }
   return lines.join("\n");
 }
-var STALE_STATE_MAX_AGE_MS;
+var import_fs57, STALE_STATE_MAX_AGE_MS;
 var init_cancel = __esm({
   "src/hooks/autopilot/cancel.ts"() {
     "use strict";
     init_state2();
+    import_fs57 = require("fs");
     init_ralph();
     init_ultraqa();
     init_named_workflow_resume_validator();
@@ -23456,7 +29392,7 @@ function isEnforceableNamedAutopilotState(state, directory, sessionId) {
   }
 }
 function shouldWriteStateBack(statePath) {
-  return Boolean(statePath && (0, import_fs57.existsSync)(statePath));
+  return Boolean(statePath && (0, import_fs58.existsSync)(statePath));
 }
 function resolveAutopilotTargetPath(directory, sessionId) {
   return sessionId ? resolveSessionStatePath("autopilot", sessionId, directory) : resolveStatePath("autopilot", directory);
@@ -23465,7 +29401,7 @@ function readAutopilotTarget(directory, sessionId) {
   const path25 = resolveAutopilotTargetPath(directory, sessionId);
   if (!readAutopilotState(directory, sessionId)) return null;
   try {
-    const state = JSON.parse((0, import_fs57.readFileSync)(path25, "utf-8"));
+    const state = JSON.parse((0, import_fs58.readFileSync)(path25, "utf-8"));
     return state && typeof state === "object" && !Array.isArray(state) ? { path: path25, state } : null;
   } catch {
     return null;
@@ -23511,10 +29447,10 @@ function isSessionCancelInProgress(directory, sessionId) {
     cancelSignalPath = (0, import_path66.join)(getOmcRoot(directory), "state", "cancel-signal-state.json");
   }
   const validateSignal = (target) => {
-    const locked2 = withStateFileMutationLock(cancelSignalPath, () => {
+    const locked2 = withStateFileMutationLock(cancelSignalPath, (assertHeld) => {
       let raw;
       try {
-        const parsed = JSON.parse((0, import_fs57.readFileSync)(cancelSignalPath, "utf-8"));
+        const parsed = JSON.parse((0, import_fs58.readFileSync)(cancelSignalPath, "utf-8"));
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
         raw = parsed;
       } catch {
@@ -23524,7 +29460,10 @@ function isSessionCancelInProgress(directory, sessionId) {
       const requestedAt = typeof raw.requested_at === "string" ? new Date(raw.requested_at).getTime() : NaN;
       const expiresAt = typeof raw.expires_at === "string" ? new Date(raw.expires_at).getTime() : NaN;
       if (target) {
-        if (Number.isFinite(expiresAt) && expiresAt <= now && (0, import_fs57.existsSync)(cancelSignalPath)) (0, import_fs57.unlinkSync)(cancelSignalPath);
+        if (Number.isFinite(expiresAt) && expiresAt <= now && (0, import_fs58.existsSync)(cancelSignalPath)) {
+          assertHeld();
+          (0, import_fs58.unlinkSync)(cancelSignalPath);
+        }
         return isAuthenticatedAutopilotCancelSignal(raw, target);
       }
       if (raw.mode === "autopilot" || raw.target_state_sha256 !== void 0 || raw.target_workflow_run_id !== void 0) {
@@ -23532,7 +29471,10 @@ function isSessionCancelInProgress(directory, sessionId) {
       }
       const effectiveExpiry = Number.isFinite(expiresAt) ? expiresAt : Number.isFinite(requestedAt) ? requestedAt + CANCEL_SIGNAL_TTL_MS2 : NaN;
       if (!Number.isFinite(requestedAt) || requestedAt > now + CANCEL_SIGNAL_CLOCK_SKEW_MS || now - requestedAt > CANCEL_SIGNAL_TTL_MS2 || !Number.isFinite(effectiveExpiry) || effectiveExpiry <= requestedAt || effectiveExpiry - requestedAt > CANCEL_SIGNAL_TTL_MS2 || effectiveExpiry <= now) {
-        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && (0, import_fs57.existsSync)(cancelSignalPath)) (0, import_fs57.unlinkSync)(cancelSignalPath);
+        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && (0, import_fs58.existsSync)(cancelSignalPath)) {
+          assertHeld();
+          (0, import_fs58.unlinkSync)(cancelSignalPath);
+        }
         return false;
       }
       return true;
@@ -23593,8 +29535,8 @@ function hasPendingBackgroundTask(directory, sessionId) {
   try {
     const stateRoot2 = (0, import_path66.join)(getOmcRoot(directory), "state");
     const hudPath = sessionId ? (0, import_path66.join)(stateRoot2, "sessions", sessionId, "hud-state.json") : (0, import_path66.join)(stateRoot2, "hud-state.json");
-    if (!(0, import_fs57.existsSync)(hudPath)) return false;
-    const hudState = JSON.parse((0, import_fs57.readFileSync)(hudPath, "utf-8"));
+    if (!(0, import_fs58.existsSync)(hudPath)) return false;
+    const hudState = JSON.parse((0, import_fs58.readFileSync)(hudPath, "utf-8"));
     return Boolean(hudState?.backgroundTasks?.some((task) => {
       if (task.status !== "running") return false;
       return isFreshTimestamp(task.startedAt ?? task.startTime);
@@ -23616,8 +29558,8 @@ function readPendingWakeupState(directory, sessionId) {
     for (const fileName of fileNames) {
       const filePath = (0, import_path66.join)(dir, fileName);
       try {
-        if (!(0, import_fs57.existsSync)(filePath)) continue;
-        const parsed = JSON.parse((0, import_fs57.readFileSync)(filePath, "utf-8"));
+        if (!(0, import_fs58.existsSync)(filePath)) continue;
+        const parsed = JSON.parse((0, import_fs58.readFileSync)(filePath, "utf-8"));
         if (parsed && typeof parsed === "object") {
           states.push(parsed);
         }
@@ -23658,11 +29600,15 @@ function isTerminalWorkflowModeState(state) {
   const phase = normalizeWorkflowTerminalPhase(state);
   return Boolean(phase && TERMINAL_WORKFLOW_PHASES.has(phase));
 }
+function isGraphDurablyStopped(state) {
+  return state?.status === "paused" || isTerminalWorkflowModeState(state);
+}
 async function reconcileTerminalWorkflowSlots(workingDir, sessionId) {
   try {
     const {
       readSkillActiveStateNormalized: readSkillActiveStateNormalized2,
       pruneExpiredWorkflowSkillTombstones: pruneExpiredWorkflowSkillTombstones2,
+      markDurableWorkflowSkillCompleted: markDurableWorkflowSkillCompleted2,
       markWorkflowSkillCompleted: markWorkflowSkillCompleted2,
       writeSkillActiveStateCopies: writeSkillActiveStateCopies2
     } = await Promise.resolve().then(() => (init_skill_state(), skill_state_exports));
@@ -23674,10 +29620,10 @@ async function reconcileTerminalWorkflowSlots(workingDir, sessionId) {
         continue;
       }
       const modeState = readModeState(slotName, workingDir, sessionId);
-      if (!isTerminalWorkflowModeState(modeState)) {
+      if (slotName === "graph" ? !isGraphDurablyStopped(modeState) : !isTerminalWorkflowModeState(modeState)) {
         continue;
       }
-      current = markWorkflowSkillCompleted2(current, slotName);
+      current = slotName === "graph" ? markDurableWorkflowSkillCompleted2(current, slotName) : markWorkflowSkillCompleted2(current, slotName);
       changed = true;
     }
     if (changed) {
@@ -23693,10 +29639,10 @@ function readLastToolError(directory) {
   const stateDir = (0, import_path66.join)(getOmcRoot(directory), "state");
   const errorPath = (0, import_path66.join)(stateDir, "last-tool-error.json");
   try {
-    if (!(0, import_fs57.existsSync)(errorPath)) {
+    if (!(0, import_fs58.existsSync)(errorPath)) {
       return null;
     }
-    const content = (0, import_fs57.readFileSync)(errorPath, "utf-8");
+    const content = (0, import_fs58.readFileSync)(errorPath, "utf-8");
     const toolError = JSON.parse(content);
     if (!toolError || !toolError.timestamp) {
       return null;
@@ -23718,8 +29664,8 @@ function clearToolErrorState(directory) {
   const stateDir = (0, import_path66.join)(getOmcRoot(directory), "state");
   const errorPath = (0, import_path66.join)(stateDir, "last-tool-error.json");
   try {
-    if ((0, import_fs57.existsSync)(errorPath)) {
-      (0, import_fs57.unlinkSync)(errorPath);
+    if ((0, import_fs58.existsSync)(errorPath)) {
+      (0, import_fs58.unlinkSync)(errorPath);
     }
   } catch {
   }
@@ -23764,8 +29710,8 @@ function resetTodoContinuationAttempts(sessionId) {
 function getIdleNotificationCooldownSeconds() {
   for (const configPath of getGlobalOmcConfigCandidates("config.json")) {
     try {
-      if (!(0, import_fs57.existsSync)(configPath)) continue;
-      const config2 = JSON.parse((0, import_fs57.readFileSync)(configPath, "utf-8"));
+      if (!(0, import_fs58.existsSync)(configPath)) continue;
+      const config2 = JSON.parse((0, import_fs58.readFileSync)(configPath, "utf-8"));
       const cooldown = config2?.notificationCooldown;
       const val = cooldown?.sessionIdleSeconds;
       if (typeof val === "number" && Number.isFinite(val)) return Math.max(0, val);
@@ -23787,8 +29733,8 @@ function getIdleNotificationCooldownPath(stateDir, sessionId) {
 }
 function readIdleNotificationCooldownRecord(cooldownPath) {
   try {
-    if (!(0, import_fs57.existsSync)(cooldownPath)) return null;
-    return JSON.parse((0, import_fs57.readFileSync)(cooldownPath, "utf-8"));
+    if (!(0, import_fs58.existsSync)(cooldownPath)) return null;
+    return JSON.parse((0, import_fs58.readFileSync)(cooldownPath, "utf-8"));
   } catch {
     return null;
   }
@@ -23852,25 +29798,25 @@ function recordIdleNotificationSent(stateDir, sessionId, repoState) {
   }
 }
 function readTranscriptTail(transcriptPath) {
-  const size = (0, import_fs57.statSync)(transcriptPath).size;
+  const size = (0, import_fs58.statSync)(transcriptPath).size;
   if (size <= TRANSCRIPT_TAIL_BYTES) {
-    return (0, import_fs57.readFileSync)(transcriptPath, "utf-8");
+    return (0, import_fs58.readFileSync)(transcriptPath, "utf-8");
   }
-  const fd = (0, import_fs57.openSync)(transcriptPath, "r");
+  const fd = (0, import_fs58.openSync)(transcriptPath, "r");
   try {
     const offset = size - TRANSCRIPT_TAIL_BYTES;
     const buf = Buffer.allocUnsafe(TRANSCRIPT_TAIL_BYTES);
-    const bytesRead = (0, import_fs57.readSync)(fd, buf, 0, TRANSCRIPT_TAIL_BYTES, offset);
+    const bytesRead = (0, import_fs58.readSync)(fd, buf, 0, TRANSCRIPT_TAIL_BYTES, offset);
     return buf.subarray(0, bytesRead).toString("utf-8");
   } finally {
-    (0, import_fs57.closeSync)(fd);
+    (0, import_fs58.closeSync)(fd);
   }
 }
 function readTranscriptTailLines(transcriptPath) {
   const content = readTranscriptTail(transcriptPath);
   const lines = content.split("\n");
   try {
-    if ((0, import_fs57.statSync)(transcriptPath).size > TRANSCRIPT_TAIL_BYTES && lines.length > 0) {
+    if ((0, import_fs58.statSync)(transcriptPath).size > TRANSCRIPT_TAIL_BYTES && lines.length > 0) {
       lines.shift();
     }
   } catch {
@@ -23965,7 +29911,7 @@ function checkReviewerAuthoredApprovalInMessages(transcriptPath, verificationSta
   return false;
 }
 function estimateTranscriptContextPercent(transcriptPath) {
-  if (!transcriptPath || !(0, import_fs57.existsSync)(transcriptPath)) {
+  if (!transcriptPath || !(0, import_fs58.existsSync)(transcriptPath)) {
     return 0;
   }
   try {
@@ -24016,7 +29962,7 @@ function checkArchitectApprovalInTranscript(sessionId, verificationState) {
   const claudeDir = getClaudeConfigDir();
   const possiblePaths = [(0, import_path66.join)(claudeDir, "sessions", sessionId, "messages.json")];
   for (const transcriptPath of possiblePaths) {
-    if (!(0, import_fs57.existsSync)(transcriptPath)) {
+    if (!(0, import_fs58.existsSync)(transcriptPath)) {
       continue;
     }
     try {
@@ -24037,7 +29983,7 @@ function checkArchitectRejectionInTranscript(sessionId) {
     (0, import_path66.join)(claudeDir, "transcripts", `${sessionId}.md`)
   ];
   for (const transcriptPath of possiblePaths) {
-    if ((0, import_fs57.existsSync)(transcriptPath)) {
+    if ((0, import_fs58.existsSync)(transcriptPath)) {
       try {
         const content = readTranscriptTail(transcriptPath);
         const result = detectArchitectRejection(content);
@@ -24296,12 +30242,12 @@ function readStopBreaker(directory, name, sessionId, ttlMs) {
   const stateDir = sessionId ? (0, import_path66.join)(getOmcRoot(directory), "state", "sessions", sessionId) : (0, import_path66.join)(getOmcRoot(directory), "state");
   const breakerPath = (0, import_path66.join)(stateDir, `${name}-stop-breaker.json`);
   try {
-    if (!(0, import_fs57.existsSync)(breakerPath)) return 0;
-    const raw = JSON.parse((0, import_fs57.readFileSync)(breakerPath, "utf-8"));
+    if (!(0, import_fs58.existsSync)(breakerPath)) return 0;
+    const raw = JSON.parse((0, import_fs58.readFileSync)(breakerPath, "utf-8"));
     if (ttlMs && raw.updated_at) {
       const updatedAt = new Date(raw.updated_at).getTime();
       if (Number.isFinite(updatedAt) && Date.now() - updatedAt > ttlMs) {
-        (0, import_fs57.unlinkSync)(breakerPath);
+        (0, import_fs58.unlinkSync)(breakerPath);
         return 0;
       }
     }
@@ -24313,7 +30259,7 @@ function readStopBreaker(directory, name, sessionId, ttlMs) {
 function writeStopBreaker(directory, name, count, sessionId) {
   const stateDir = sessionId ? (0, import_path66.join)(getOmcRoot(directory), "state", "sessions", sessionId) : (0, import_path66.join)(getOmcRoot(directory), "state");
   try {
-    (0, import_fs57.mkdirSync)(stateDir, { recursive: true });
+    (0, import_fs58.mkdirSync)(stateDir, { recursive: true });
     const breakerPath = (0, import_path66.join)(stateDir, `${name}-stop-breaker.json`);
     const data = { count, updated_at: (/* @__PURE__ */ new Date()).toISOString() };
     atomicWriteJsonSync(breakerPath, data);
@@ -24376,7 +30322,7 @@ function classifyLastAssistantTurn(transcriptPath) {
 function applyThinkingOnlyStreakGuard(result, workingDir, sessionId, stopContext) {
   if (!result.shouldBlock) return result;
   const transcriptPath = stopContext?.transcript_path ?? stopContext?.transcriptPath;
-  if (!transcriptPath || !(0, import_fs57.existsSync)(transcriptPath)) {
+  if (!transcriptPath || !(0, import_fs58.existsSync)(transcriptPath)) {
     return result;
   }
   let classification;
@@ -24941,12 +30887,12 @@ function createHookOutput(result) {
     message: result.message || void 0
   };
 }
-var import_crypto16, import_fs57, import_path66, CANCEL_SIGNAL_TTL_MS2, CANCEL_SIGNAL_CLOCK_SKEW_MS, STALE_STATE_THRESHOLD_MS, PENDING_ASYNC_STATE_STALE_MS, OVERSIZE_TOOL_RESULT_REDIRECT_STOP_MAX, OVERSIZE_TOOL_RESULT_REDIRECT_STOP_TTL_MS, TERMINAL_WORKFLOW_SLOT_MODES, TERMINAL_WORKFLOW_PHASES, todoContinuationAttempts, TRANSCRIPT_TAIL_BYTES, CRITICAL_CONTEXT_STOP_PERCENT, RALPLAN_TERMINAL_PHASES, REVIEWER_TASK_TOOL_NAMES, REVIEWER_COMMAND_TOOL_NAMES, AWAITING_CONFIRMATION_TTL_MS, THINKING_ONLY_STREAK_BREAKER, THINKING_ONLY_STREAK_MAX, THINKING_ONLY_STREAK_TTL_MS, THINKING_ONLY_STREAK_BAILOUT_MESSAGE, TEAM_PIPELINE_STOP_BLOCKER_MAX, TEAM_PIPELINE_STOP_BLOCKER_TTL_MS, RALPLAN_STOP_BLOCKER_MAX, RALPLAN_STOP_BLOCKER_TTL_MS, RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS;
+var import_crypto16, import_fs58, import_path66, CANCEL_SIGNAL_TTL_MS2, CANCEL_SIGNAL_CLOCK_SKEW_MS, STALE_STATE_THRESHOLD_MS, PENDING_ASYNC_STATE_STALE_MS, OVERSIZE_TOOL_RESULT_REDIRECT_STOP_MAX, OVERSIZE_TOOL_RESULT_REDIRECT_STOP_TTL_MS, TERMINAL_WORKFLOW_SLOT_MODES, TERMINAL_WORKFLOW_PHASES, todoContinuationAttempts, TRANSCRIPT_TAIL_BYTES, CRITICAL_CONTEXT_STOP_PERCENT, RALPLAN_TERMINAL_PHASES, REVIEWER_TASK_TOOL_NAMES, REVIEWER_COMMAND_TOOL_NAMES, AWAITING_CONFIRMATION_TTL_MS, THINKING_ONLY_STREAK_BREAKER, THINKING_ONLY_STREAK_MAX, THINKING_ONLY_STREAK_TTL_MS, THINKING_ONLY_STREAK_BAILOUT_MESSAGE, TEAM_PIPELINE_STOP_BLOCKER_MAX, TEAM_PIPELINE_STOP_BLOCKER_TTL_MS, RALPLAN_STOP_BLOCKER_MAX, RALPLAN_STOP_BLOCKER_TTL_MS, RALPLAN_ACTIVE_AGENT_RECENCY_WINDOW_MS;
 var init_persistent_mode = __esm({
   "src/hooks/persistent-mode/index.ts"() {
     "use strict";
     import_crypto16 = require("crypto");
-    import_fs57 = require("fs");
+    import_fs58 = require("fs");
     init_atomic_write();
     import_path66 = require("path");
     init_security_config();
@@ -24971,7 +30917,7 @@ var init_persistent_mode = __esm({
     PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1e3;
     OVERSIZE_TOOL_RESULT_REDIRECT_STOP_MAX = 3;
     OVERSIZE_TOOL_RESULT_REDIRECT_STOP_TTL_MS = 5 * 60 * 1e3;
-    TERMINAL_WORKFLOW_SLOT_MODES = /* @__PURE__ */ new Set(["autopilot", "ralph", "ralplan"]);
+    TERMINAL_WORKFLOW_SLOT_MODES = /* @__PURE__ */ new Set(["autopilot", "graph", "ralph", "ralplan"]);
     TERMINAL_WORKFLOW_PHASES = /* @__PURE__ */ new Set([
       "complete",
       "completed",
@@ -25030,9 +30976,9 @@ function detectSignal(sessionId, signal) {
   const pattern = SIGNAL_PATTERNS[signal];
   if (!pattern) return false;
   for (const transcriptPath of possiblePaths) {
-    if ((0, import_fs58.existsSync)(transcriptPath)) {
+    if ((0, import_fs59.existsSync)(transcriptPath)) {
       try {
-        const content = (0, import_fs58.readFileSync)(transcriptPath, "utf-8");
+        const content = (0, import_fs59.readFileSync)(transcriptPath, "utf-8");
         if (pattern.test(content)) {
           return true;
         }
@@ -25481,9 +31427,9 @@ function detectPipelineSignal(sessionId, signal) {
   const escaped = signal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(escaped, "i");
   for (const transcriptPath of possiblePaths) {
-    if ((0, import_fs58.existsSync)(transcriptPath)) {
+    if ((0, import_fs59.existsSync)(transcriptPath)) {
       try {
-        const content = (0, import_fs58.readFileSync)(transcriptPath, "utf-8");
+        const content = (0, import_fs59.readFileSync)(transcriptPath, "utf-8");
         if (pattern.test(content)) {
           return true;
         }
@@ -25494,11 +31440,11 @@ function detectPipelineSignal(sessionId, signal) {
   }
   return false;
 }
-var import_fs58, import_path67, SIGNAL_PATTERNS, AWAITING_CONFIRMATION_TTL_MS2;
+var import_fs59, import_path67, SIGNAL_PATTERNS, AWAITING_CONFIRMATION_TTL_MS2;
 var init_enforcement = __esm({
   "src/hooks/autopilot/enforcement.ts"() {
     "use strict";
-    import_fs58 = require("fs");
+    import_fs59 = require("fs");
     import_path67 = require("path");
     init_config_dir();
     init_security_config();
@@ -25615,7 +31561,7 @@ __export(autopilot_exports, {
 var init_autopilot = __esm({
   "src/hooks/autopilot/index.ts"() {
     "use strict";
-    init_types3();
+    init_types4();
     init_state2();
     init_prompts();
     init_validation();
@@ -26381,8 +32327,8 @@ function lockIsReclaimable(lock) {
         process.kill(parsed.pid, 0);
         if (parsed.processStartIdentity && process.platform === "linux") {
           try {
-            const stat2 = fs11.readFileSync(`/proc/${parsed.pid}/stat`, "utf8");
-            if ((stat2.substring(stat2.lastIndexOf(")") + 2).split(" ")[19] ?? "") !== parsed.processStartIdentity) return true;
+            const stat3 = fs11.readFileSync(`/proc/${parsed.pid}/stat`, "utf8");
+            if ((stat3.substring(stat3.lastIndexOf(")") + 2).split(" ")[19] ?? "") !== parsed.processStartIdentity) return true;
           } catch {
             return true;
           }
@@ -26413,8 +32359,8 @@ function withLock(file, body) {
       fd = fs11.openSync(lock, "wx");
       let processStartIdentity2 = null;
       try {
-        const stat2 = fs11.readFileSync(`/proc/${process.pid}/stat`, "utf8");
-        processStartIdentity2 = stat2.substring(stat2.lastIndexOf(")") + 2).split(" ")[19] ?? null;
+        const stat3 = fs11.readFileSync(`/proc/${process.pid}/stat`, "utf8");
+        processStartIdentity2 = stat3.substring(stat3.lastIndexOf(")") + 2).split(" ")[19] ?? null;
       } catch {
       }
       fs11.writeFileSync(fd, JSON.stringify({ pid: process.pid, processStartIdentity: processStartIdentity2, nonce, createdAt: nowIso() }));
@@ -26911,24 +32857,24 @@ async function runSessionEndAction(context, _execute) {
     let settled = false;
     let exitCode = null;
     let settleChild = () => void 0;
-    const childExit = new Promise((resolve32) => {
+    const childExit = new Promise((resolve33) => {
       settleChild = (code2) => {
         if (settled) return;
         settled = true;
         exitCode = code2;
-        resolve32(code2);
+        resolve33(code2);
       };
       child.once("exit", settleChild);
       child.once("error", () => settleChild(null));
     });
     let deadlineTermination;
     let resolveTermination;
-    const terminationFinished = new Promise((resolve32) => {
-      resolveTermination = resolve32;
+    const terminationFinished = new Promise((resolve33) => {
+      resolveTermination = resolve33;
     });
     const terminate = async () => {
-      const postKillWait = new Promise((resolve32) => {
-        const timer = setTimeout(resolve32, Math.max(1, context.deadlineAt + POST_KILL_SETTLE_MS - Date.now()));
+      const postKillWait = new Promise((resolve33) => {
+        const timer = setTimeout(resolve33, Math.max(1, context.deadlineAt + POST_KILL_SETTLE_MS - Date.now()));
         timer.unref();
       });
       await Promise.race([Promise.resolve(killProcessTree(child.pid, "SIGKILL")).catch(() => false), postKillWait]);
@@ -26988,7 +32934,7 @@ async function runActionRunnerEntrypoint() {
       } catch {
       }
       if (armed) break;
-      await new Promise((resolve32) => setTimeout(resolve32, 10));
+      await new Promise((resolve33) => setTimeout(resolve33, 10));
     }
     if (Date.now() >= input.deadlineAt) throw new Error("runner-arm-deadline");
     const deadlineTimer = setTimeout(() => {
@@ -27067,12 +33013,12 @@ var init_action_watchdog = __esm({
 function getHookConfig() {
   if (cachedConfig2 !== void 0) return cachedConfig2;
   const configPath = process.env.OMC_HOOK_CONFIG || DEFAULT_CONFIG_PATH;
-  if (!(0, import_fs59.existsSync)(configPath)) {
+  if (!(0, import_fs60.existsSync)(configPath)) {
     cachedConfig2 = null;
     return null;
   }
   try {
-    const raw = JSON.parse((0, import_fs59.readFileSync)(configPath, "utf-8"));
+    const raw = JSON.parse((0, import_fs60.readFileSync)(configPath, "utf-8"));
     if (!raw || raw.enabled === false) {
       cachedConfig2 = null;
       return null;
@@ -27113,11 +33059,11 @@ function mergeHookConfigIntoNotificationConfig(hookConfig, notifConfig) {
   merged.events = events;
   return merged;
 }
-var import_fs59, import_path68, DEFAULT_CONFIG_PATH, cachedConfig2;
+var import_fs60, import_path68, DEFAULT_CONFIG_PATH, cachedConfig2;
 var init_hook_config = __esm({
   "src/notifications/hook-config.ts"() {
     "use strict";
-    import_fs59 = require("fs");
+    import_fs60 = require("fs");
     import_path68 = require("path");
     init_config_dir();
     DEFAULT_CONFIG_PATH = (0, import_path68.join)(getClaudeConfigDir(), "omc_config.hook.json");
@@ -27223,14 +33169,14 @@ function validateCliIntegrationConfig(config2) {
 }
 function checkDuplicateIds(integrations) {
   const seen = /* @__PURE__ */ new Set();
-  const duplicates = [];
+  const duplicates2 = [];
   for (const integration of integrations) {
     if (seen.has(integration.id)) {
-      duplicates.push(integration.id);
+      duplicates2.push(integration.id);
     }
     seen.add(integration.id);
   }
-  return duplicates;
+  return duplicates2;
 }
 function sanitizeArgument(arg) {
   let sanitized = arg.replace(/\0/g, "");
@@ -27273,9 +33219,9 @@ __export(config_exports, {
   validateSlackUsername: () => validateSlackUsername
 });
 function readRawConfig() {
-  if (!(0, import_fs60.existsSync)(CONFIG_FILE2)) return null;
+  if (!(0, import_fs61.existsSync)(CONFIG_FILE2)) return null;
   try {
-    return JSON.parse((0, import_fs60.readFileSync)(CONFIG_FILE2, "utf-8"));
+    return JSON.parse((0, import_fs61.readFileSync)(CONFIG_FILE2, "utf-8"));
   } catch {
     return null;
   }
@@ -27733,12 +33679,12 @@ function getReplyConfig() {
   };
 }
 function detectLegacyOpenClawConfig() {
-  return (0, import_fs60.existsSync)(LEGACY_OPENCLAW_CONFIG);
+  return (0, import_fs61.existsSync)(LEGACY_OPENCLAW_CONFIG);
 }
 function migrateLegacyOpenClawConfig() {
-  if (!(0, import_fs60.existsSync)(LEGACY_OPENCLAW_CONFIG)) return null;
+  if (!(0, import_fs61.existsSync)(LEGACY_OPENCLAW_CONFIG)) return null;
   try {
-    const legacy = JSON.parse((0, import_fs60.readFileSync)(LEGACY_OPENCLAW_CONFIG, "utf-8"));
+    const legacy = JSON.parse((0, import_fs61.readFileSync)(LEGACY_OPENCLAW_CONFIG, "utf-8"));
     const gateways = legacy.gateways;
     if (!gateways || Object.keys(gateways).length === 0) return null;
     const gateway = Object.values(gateways)[0];
@@ -27797,10 +33743,10 @@ function getCustomIntegrationsConfig() {
       );
     }
   }
-  const duplicates = checkDuplicateIds(validIntegrations);
-  if (duplicates.length > 0) {
+  const duplicates2 = checkDuplicateIds(validIntegrations);
+  if (duplicates2.length > 0) {
     console.warn(
-      `[notifications] Duplicate custom integration IDs found: ${duplicates.join(", ")}`
+      `[notifications] Duplicate custom integration IDs found: ${duplicates2.join(", ")}`
     );
   }
   return {
@@ -27823,11 +33769,11 @@ function hasCustomIntegrationsEnabled(event) {
     (i) => i.enabled && i.events.includes(event)
   );
 }
-var import_fs60, import_path69, CONFIG_FILE2, DEFAULT_TMUX_TAIL_LINES, VALID_VERBOSITY_LEVELS, SESSION_EVENTS, REPLY_PLATFORM_EVENTS, LEGACY_OPENCLAW_CONFIG;
+var import_fs61, import_path69, CONFIG_FILE2, DEFAULT_TMUX_TAIL_LINES, VALID_VERBOSITY_LEVELS, SESSION_EVENTS, REPLY_PLATFORM_EVENTS, LEGACY_OPENCLAW_CONFIG;
 var init_config = __esm({
   "src/notifications/config.ts"() {
     "use strict";
-    import_fs60 = require("fs");
+    import_fs61 = require("fs");
     import_path69 = require("path");
     init_config_dir();
     init_hook_config();
@@ -28640,7 +34586,7 @@ async function sendTelegram(config2, payload) {
       text: payload.message,
       parse_mode: config2.parseMode || "Markdown"
     });
-    const result = await new Promise((resolve32) => {
+    const result = await new Promise((resolve33) => {
       const req = (0, import_https.request)(
         telegramRequestOptions(Buffer.byteLength(body), config2.botToken),
         (res) => {
@@ -28656,9 +34602,9 @@ async function sendTelegram(config2, payload) {
                 }
               } catch {
               }
-              resolve32({ platform: "telegram", success: true, messageId });
+              resolve33({ platform: "telegram", success: true, messageId });
             } else {
-              resolve32({
+              resolve33({
                 platform: "telegram",
                 success: false,
                 error: `HTTP ${res.statusCode}`
@@ -28668,11 +34614,11 @@ async function sendTelegram(config2, payload) {
         }
       );
       req.on("error", (e) => {
-        resolve32({ platform: "telegram", success: false, error: e.message });
+        resolve33({ platform: "telegram", success: false, error: e.message });
       });
       req.on("timeout", () => {
         req.destroy();
-        resolve32({
+        resolve33({
           platform: "telegram",
           success: false,
           error: "Request timeout"
@@ -28919,9 +34865,9 @@ async function dispatchNotifications(config2, event, payload, platformMessages) 
           }
         )
       ),
-      new Promise((resolve32) => {
+      new Promise((resolve33) => {
         timer = setTimeout(
-          () => resolve32([
+          () => resolve33([
             {
               platform: "unknown",
               success: false,
@@ -30061,8 +36007,8 @@ function isValidPaneId(paneId) {
 function readPaneTailState(stateDir) {
   const path25 = (0, import_path73.join)(stateDir, STATE_FILE);
   try {
-    if ((0, import_fs61.existsSync)(path25)) {
-      const parsed = JSON.parse((0, import_fs61.readFileSync)(path25, "utf-8"));
+    if ((0, import_fs62.existsSync)(path25)) {
+      const parsed = JSON.parse((0, import_fs62.readFileSync)(path25, "utf-8"));
       if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
         return parsed;
       }
@@ -30073,8 +36019,8 @@ function readPaneTailState(stateDir) {
 }
 function writePaneTailState(stateDir, state) {
   try {
-    (0, import_fs61.mkdirSync)(stateDir, { recursive: true });
-    (0, import_fs61.writeFileSync)((0, import_path73.join)(stateDir, STATE_FILE), JSON.stringify(state), { mode: 384 });
+    (0, import_fs62.mkdirSync)(stateDir, { recursive: true });
+    (0, import_fs62.writeFileSync)((0, import_path73.join)(stateDir, STATE_FILE), JSON.stringify(state), { mode: 384 });
   } catch {
   }
 }
@@ -30131,11 +36077,11 @@ function getNewPaneTail(paneId, stateDir, maxLines = DEFAULT_MAX_LINES) {
   }
   return capturePaneLines(paneId, Math.min(newLines, maxLines));
 }
-var import_fs61, import_path73, STATE_FILE, DEFAULT_MAX_LINES;
+var import_fs62, import_path73, STATE_FILE, DEFAULT_MAX_LINES;
 var init_pane_fresh_capture = __esm({
   "src/features/rate-limit-wait/pane-fresh-capture.ts"() {
     "use strict";
-    import_fs61 = require("fs");
+    import_fs62 = require("fs");
     import_path73 = require("path");
     init_tmux_utils();
     STATE_FILE = "pane-tail-positions.json";
@@ -30503,8 +36449,8 @@ function getLockPath() {
 }
 function ensureRegistryDir() {
   const registryDir = (0, import_path74.dirname)(getRegistryPath());
-  if (!(0, import_fs62.existsSync)(registryDir)) {
-    (0, import_fs62.mkdirSync)(registryDir, { recursive: true, mode: 448 });
+  if (!(0, import_fs63.existsSync)(registryDir)) {
+    (0, import_fs63.mkdirSync)(registryDir, { recursive: true, mode: 448 });
   }
 }
 function sleepMs(ms) {
@@ -30518,7 +36464,7 @@ function sleepMs(ms) {
 }
 function readLockSnapshot() {
   try {
-    const raw = (0, import_fs62.readFileSync)(getLockPath(), "utf-8");
+    const raw = (0, import_fs63.readFileSync)(getLockPath(), "utf-8");
     const trimmed = raw.trim();
     if (!trimmed) {
       return { raw, pid: null, token: null };
@@ -30543,7 +36489,7 @@ function readLockSnapshot() {
 }
 function removeLockIfUnchanged(snapshot) {
   try {
-    const currentRaw = (0, import_fs62.readFileSync)(getLockPath(), "utf-8");
+    const currentRaw = (0, import_fs63.readFileSync)(getLockPath(), "utf-8");
     if (currentRaw !== snapshot.raw) {
       return false;
     }
@@ -30551,7 +36497,7 @@ function removeLockIfUnchanged(snapshot) {
     return false;
   }
   try {
-    (0, import_fs62.unlinkSync)(getLockPath());
+    (0, import_fs63.unlinkSync)(getLockPath());
     return true;
   } catch {
     return false;
@@ -30563,9 +36509,9 @@ function acquireRegistryLock() {
   while (Date.now() - started < LOCK_TIMEOUT_MS) {
     try {
       const token = (0, import_crypto19.randomUUID)();
-      const fd = (0, import_fs62.openSync)(
+      const fd = (0, import_fs63.openSync)(
         getLockPath(),
-        import_fs62.constants.O_CREAT | import_fs62.constants.O_EXCL | import_fs62.constants.O_WRONLY,
+        import_fs63.constants.O_CREAT | import_fs63.constants.O_EXCL | import_fs63.constants.O_WRONLY,
         SECURE_FILE_MODE
       );
       const lockPayload = JSON.stringify({
@@ -30573,7 +36519,7 @@ function acquireRegistryLock() {
         acquiredAt: Date.now(),
         token
       });
-      (0, import_fs62.writeSync)(fd, lockPayload, null, "utf-8");
+      (0, import_fs63.writeSync)(fd, lockPayload, null, "utf-8");
       return { fd, token };
     } catch (error2) {
       const err = error2;
@@ -30581,7 +36527,7 @@ function acquireRegistryLock() {
         throw error2;
       }
       try {
-        const lockAgeMs = Date.now() - (0, import_fs62.statSync)(getLockPath()).mtimeMs;
+        const lockAgeMs = Date.now() - (0, import_fs63.statSync)(getLockPath()).mtimeMs;
         if (lockAgeMs > LOCK_STALE_MS) {
           const snapshot = readLockSnapshot();
           if (!snapshot) {
@@ -30616,7 +36562,7 @@ function acquireRegistryLockOrWait(maxWaitMs = LOCK_MAX_WAIT_MS) {
 }
 function releaseRegistryLock(lock) {
   try {
-    (0, import_fs62.closeSync)(lock.fd);
+    (0, import_fs63.closeSync)(lock.fd);
   } catch {
   }
   const snapshot = readLockSnapshot();
@@ -30657,16 +36603,16 @@ function registerMessage(mapping) {
     );
     if (existing) return true;
     const line = JSON.stringify(mapping) + "\n";
-    const fd = (0, import_fs62.openSync)(
+    const fd = (0, import_fs63.openSync)(
       getRegistryPath(),
-      import_fs62.constants.O_WRONLY | import_fs62.constants.O_APPEND | import_fs62.constants.O_CREAT,
+      import_fs63.constants.O_WRONLY | import_fs63.constants.O_APPEND | import_fs63.constants.O_CREAT,
       SECURE_FILE_MODE
     );
     try {
-      (0, import_fs62.writeSync)(fd, Buffer.from(line, "utf-8"));
+      (0, import_fs63.writeSync)(fd, Buffer.from(line, "utf-8"));
       return true;
     } finally {
-      (0, import_fs62.closeSync)(fd);
+      (0, import_fs63.closeSync)(fd);
     }
   }) ?? false;
 }
@@ -30675,11 +36621,11 @@ function loadAllMappings() {
 }
 function readAllMappingsUnsafe() {
   for (const registryPath of getRegistryReadPaths()) {
-    if (!(0, import_fs62.existsSync)(registryPath)) {
+    if (!(0, import_fs63.existsSync)(registryPath)) {
       continue;
     }
     try {
-      const content = (0, import_fs62.readFileSync)(registryPath, "utf-8");
+      const content = (0, import_fs63.readFileSync)(registryPath, "utf-8");
       return content.split("\n").filter((line) => line.trim()).map((line) => {
         try {
           return JSON.parse(line);
@@ -30731,17 +36677,17 @@ function pruneStale() {
 function rewriteRegistryUnsafe(mappings) {
   ensureRegistryDir();
   if (mappings.length === 0) {
-    (0, import_fs62.writeFileSync)(getRegistryPath(), "", { mode: SECURE_FILE_MODE });
+    (0, import_fs63.writeFileSync)(getRegistryPath(), "", { mode: SECURE_FILE_MODE });
     return;
   }
   const content = mappings.map((m) => JSON.stringify(m)).join("\n") + "\n";
-  (0, import_fs62.writeFileSync)(getRegistryPath(), content, { mode: SECURE_FILE_MODE });
+  (0, import_fs63.writeFileSync)(getRegistryPath(), content, { mode: SECURE_FILE_MODE });
 }
-var import_fs62, import_path74, import_crypto19, SECURE_FILE_MODE, MAX_AGE_MS, LOCK_TIMEOUT_MS, LOCK_RETRY_MS, LOCK_STALE_MS, LOCK_MAX_WAIT_MS, SLEEP_ARRAY;
+var import_fs63, import_path74, import_crypto19, SECURE_FILE_MODE, MAX_AGE_MS, LOCK_TIMEOUT_MS, LOCK_RETRY_MS, LOCK_STALE_MS, LOCK_MAX_WAIT_MS, SLEEP_ARRAY;
 var init_session_registry = __esm({
   "src/notifications/session-registry.ts"() {
     "use strict";
-    import_fs62 = require("fs");
+    import_fs63 = require("fs");
     import_path74 = require("path");
     import_crypto19 = require("crypto");
     init_platform();
@@ -30979,12 +36925,12 @@ function getOpenClawConfig() {
   if (_cachedConfig !== null) {
     return _cachedConfig ?? null;
   }
-  if (!(0, import_fs63.existsSync)(CONFIG_FILE3)) {
+  if (!(0, import_fs64.existsSync)(CONFIG_FILE3)) {
     _cachedConfig = void 0;
     return null;
   }
   try {
-    const raw = JSON.parse((0, import_fs63.readFileSync)(CONFIG_FILE3, "utf-8"));
+    const raw = JSON.parse((0, import_fs64.readFileSync)(CONFIG_FILE3, "utf-8"));
     if (!raw.enabled || !raw.gateways || !raw.hooks) {
       _cachedConfig = void 0;
       return null;
@@ -31015,11 +36961,11 @@ function resolveGateway(config2, event) {
 function resetOpenClawConfigCache() {
   _cachedConfig = null;
 }
-var import_fs63, import_path76, CONFIG_FILE3, _cachedConfig;
+var import_fs64, import_path76, CONFIG_FILE3, _cachedConfig;
 var init_config2 = __esm({
   "src/openclaw/config.ts"() {
     "use strict";
-    import_fs63 = require("fs");
+    import_fs64 = require("fs");
     import_path76 = require("path");
     init_config_dir();
     CONFIG_FILE3 = process.env.OMC_OPENCLAW_CONFIG || (0, import_path76.join)(getClaudeConfigDir(), "omc_config.openclaw.json");
@@ -31358,15 +37304,15 @@ function getLockPath2(projectPath) {
   return (0, import_path77.join)(getStateDir3(projectPath), LOCK_FILE);
 }
 function ensureStateDir2(projectPath) {
-  (0, import_fs64.mkdirSync)(getStateDir3(projectPath), { recursive: true, mode: 448 });
+  (0, import_fs65.mkdirSync)(getStateDir3(projectPath), { recursive: true, mode: 448 });
 }
 function readState(projectPath) {
   const statePath = getStatePath2(projectPath);
-  if (!(0, import_fs64.existsSync)(statePath)) {
+  if (!(0, import_fs65.existsSync)(statePath)) {
     return { updatedAt: (/* @__PURE__ */ new Date(0)).toISOString(), records: {} };
   }
   try {
-    const parsed = JSON.parse((0, import_fs64.readFileSync)(statePath, "utf-8"));
+    const parsed = JSON.parse((0, import_fs65.readFileSync)(statePath, "utf-8"));
     return {
       updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : (/* @__PURE__ */ new Date(0)).toISOString(),
       records: parsed.records && typeof parsed.records === "object" ? parsed.records : {}
@@ -31381,7 +37327,7 @@ function writeState2(projectPath, state) {
 }
 function readLockSnapshot2(projectPath) {
   try {
-    const raw = (0, import_fs64.readFileSync)(getLockPath2(projectPath), "utf-8");
+    const raw = (0, import_fs65.readFileSync)(getLockPath2(projectPath), "utf-8");
     const trimmed = raw.trim();
     if (!trimmed) {
       return { raw, pid: null, token: null };
@@ -31402,7 +37348,7 @@ function readLockSnapshot2(projectPath) {
 }
 function removeLockIfUnchanged2(projectPath, snapshot) {
   try {
-    const currentRaw = (0, import_fs64.readFileSync)(getLockPath2(projectPath), "utf-8");
+    const currentRaw = (0, import_fs65.readFileSync)(getLockPath2(projectPath), "utf-8");
     if (currentRaw !== snapshot.raw) {
       return false;
     }
@@ -31410,7 +37356,7 @@ function removeLockIfUnchanged2(projectPath, snapshot) {
     return false;
   }
   try {
-    (0, import_fs64.unlinkSync)(getLockPath2(projectPath));
+    (0, import_fs65.unlinkSync)(getLockPath2(projectPath));
     return true;
   } catch {
     return false;
@@ -31422,12 +37368,12 @@ function acquireLock(projectPath) {
   while (Date.now() - started < LOCK_TIMEOUT_MS2) {
     try {
       const token = (0, import_crypto20.randomUUID)();
-      const fd = (0, import_fs64.openSync)(
+      const fd = (0, import_fs65.openSync)(
         getLockPath2(projectPath),
-        import_fs64.constants.O_CREAT | import_fs64.constants.O_EXCL | import_fs64.constants.O_WRONLY,
+        import_fs65.constants.O_CREAT | import_fs65.constants.O_EXCL | import_fs65.constants.O_WRONLY,
         384
       );
-      (0, import_fs64.writeSync)(fd, JSON.stringify({ pid: process.pid, token, acquiredAt: Date.now() }), null, "utf-8");
+      (0, import_fs65.writeSync)(fd, JSON.stringify({ pid: process.pid, token, acquiredAt: Date.now() }), null, "utf-8");
       return { fd, token };
     } catch (error2) {
       const err = error2;
@@ -31435,7 +37381,7 @@ function acquireLock(projectPath) {
         throw error2;
       }
       try {
-        const ageMs = Date.now() - (0, import_fs64.statSync)(getLockPath2(projectPath)).mtimeMs;
+        const ageMs = Date.now() - (0, import_fs65.statSync)(getLockPath2(projectPath)).mtimeMs;
         if (ageMs > LOCK_STALE_MS2) {
           const snapshot = readLockSnapshot2(projectPath);
           if (snapshot) {
@@ -31457,7 +37403,7 @@ function acquireLock(projectPath) {
 }
 function releaseLock(projectPath, lock) {
   try {
-    (0, import_fs64.closeSync)(lock.fd);
+    (0, import_fs65.closeSync)(lock.fd);
   } catch {
   }
   const snapshot = readLockSnapshot2(projectPath);
@@ -31569,11 +37515,11 @@ function shouldCollapseOpenClawBurst(event, signal, context, tmuxSession) {
     return shouldCollapse;
   });
 }
-var import_fs64, import_crypto20, import_path77, STATE_DIR, STATE_FILE2, LOCK_FILE, START_WINDOW_MS, PROMPT_WINDOW_MS, STOP_WINDOW_MS, STATE_TTL_MS, LOCK_TIMEOUT_MS2, LOCK_RETRY_MS2, LOCK_STALE_MS2, TERMINAL_STATE_SUPPRESSION_WINDOW_MS, SLEEP_ARRAY2, TERMINAL_KEYS;
+var import_fs65, import_crypto20, import_path77, STATE_DIR, STATE_FILE2, LOCK_FILE, START_WINDOW_MS, PROMPT_WINDOW_MS, STOP_WINDOW_MS, STATE_TTL_MS, LOCK_TIMEOUT_MS2, LOCK_RETRY_MS2, LOCK_STALE_MS2, TERMINAL_STATE_SUPPRESSION_WINDOW_MS, SLEEP_ARRAY2, TERMINAL_KEYS;
 var init_dedupe = __esm({
   "src/openclaw/dedupe.ts"() {
     "use strict";
-    import_fs64 = require("fs");
+    import_fs65 = require("fs");
     import_crypto20 = require("crypto");
     import_path77 = require("path");
     init_atomic_write();
@@ -31790,8 +37736,8 @@ function interpolatePath(pathTemplate, sessionId, idempotencyKey) {
 }
 async function writeToFile(config2, content, sessionId, idempotencyKey) {
   const resolvedPath = interpolatePath(config2.path, sessionId, idempotencyKey);
-  (0, import_fs65.mkdirSync)((0, import_path79.dirname)(resolvedPath), { recursive: true });
-  (0, import_fs65.writeFileSync)(resolvedPath, content, { encoding: "utf-8", mode: 384 });
+  (0, import_fs66.mkdirSync)((0, import_path79.dirname)(resolvedPath), { recursive: true });
+  (0, import_fs66.writeFileSync)(resolvedPath, content, { encoding: "utf-8", mode: 384 });
 }
 async function sendTelegram2(config2, message2, signal, _idempotencyKey) {
   if (!config2.botToken || !config2.chatId || !/^[0-9]+:[A-Za-z0-9_-]+$/.test(config2.botToken)) return;
@@ -31826,10 +37772,10 @@ async function runWithinDeadline(deadlineAt, run) {
   const controller = new AbortController();
   let timer;
   try {
-    return await Promise.race([run(controller.signal), new Promise((resolve32) => {
+    return await Promise.race([run(controller.signal), new Promise((resolve33) => {
       timer = setTimeout(() => {
         controller.abort();
-        resolve32(void 0);
+        resolve33(void 0);
       }, remaining);
     })]);
   } finally {
@@ -31875,11 +37821,11 @@ async function runSessionEndDeferredAction(action, context) {
     return { status: "failed", detail: error2 instanceof Error ? error2.message : "Unknown action failure" };
   }
 }
-var import_fs65, import_path79, import_os13;
+var import_fs66, import_path79, import_os13;
 var init_callbacks = __esm({
   "src/hooks/session-end/callbacks.ts"() {
     "use strict";
-    import_fs65 = require("fs");
+    import_fs66 = require("fs");
     import_path79 = require("path");
     import_os13 = require("os");
     init_auto_update();
@@ -31923,8 +37869,8 @@ function loadWikiConfig(root2) {
     const configPath = (0, import_path80.join)(getOmcRoot(root2), ".omc-config.json");
     const activeConfigPath = (0, import_path80.join)(getClaudeConfigDir(), ".omc-config.json");
     for (const path25 of [configPath, activeConfigPath]) {
-      if ((0, import_fs66.existsSync)(path25)) {
-        const raw = JSON.parse((0, import_fs66.readFileSync)(path25, "utf-8"));
+      if ((0, import_fs67.existsSync)(path25)) {
+        const raw = JSON.parse((0, import_fs67.readFileSync)(path25, "utf-8"));
         if (raw?.wiki) {
           return { ...DEFAULT_WIKI_CONFIG, ...raw.wiki };
         }
@@ -31937,7 +37883,7 @@ function loadWikiConfig(root2) {
 function buildWikiSessionEndCaptureIntent(data) {
   try {
     const root2 = data.cwd || process.cwd();
-    if (!loadWikiConfig(root2).autoCapture || !(0, import_fs66.existsSync)(getWikiDir(root2))) return null;
+    if (!loadWikiConfig(root2).autoCapture || !(0, import_fs67.existsSync)(getWikiDir(root2))) return null;
     const sessionId = data.session_id || `session-${Date.now()}`;
     const capturedAt = (/* @__PURE__ */ new Date()).toISOString();
     const filename = captureFilename(sessionId, capturedAt);
@@ -32012,7 +37958,7 @@ function onSessionStart(data) {
   try {
     const root2 = data.cwd || process.cwd();
     const wikiDir = getWikiDir(root2);
-    if (!(0, import_fs66.existsSync)(wikiDir)) {
+    if (!(0, import_fs67.existsSync)(wikiDir)) {
       return {};
     }
     const pages = listPages(root2);
@@ -32061,8 +38007,8 @@ function onPreCompact(data) {
 function feedProjectMemory(root2) {
   try {
     const pmPath = (0, import_path80.join)(getOmcRoot(root2), "project-memory.json");
-    if (!(0, import_fs66.existsSync)(pmPath)) return;
-    const pm = JSON.parse((0, import_fs66.readFileSync)(pmPath, "utf-8"));
+    if (!(0, import_fs67.existsSync)(pmPath)) return;
+    const pm = JSON.parse((0, import_fs67.readFileSync)(pmPath, "utf-8"));
     if (!pm.lastScanned) return;
     const envSlug = "environment.md";
     const existing = readPage(root2, envSlug);
@@ -32115,17 +38061,17 @@ function feedProjectMemory(root2) {
   } catch {
   }
 }
-var import_fs66, import_crypto21, import_path80;
+var import_fs67, import_crypto21, import_path80;
 var init_session_hooks = __esm({
   "src/hooks/wiki/session-hooks.ts"() {
     "use strict";
-    import_fs66 = require("fs");
+    import_fs67 = require("fs");
     import_crypto21 = require("crypto");
     import_path80 = require("path");
     init_worktree_paths();
     init_config_dir();
     init_storage();
-    init_types5();
+    init_types6();
   }
 });
 
@@ -32148,11 +38094,11 @@ function getTaskStoragePath(cwd2, teamName, taskId) {
   }
   return (0, import_path81.join)(cwd2, TeamPaths.tasks(teamName));
 }
-var import_node_crypto2, import_path81, TeamPaths;
+var import_node_crypto3, import_path81, TeamPaths;
 var init_state_paths = __esm({
   "src/team/state-paths.ts"() {
     "use strict";
-    import_node_crypto2 = require("node:crypto");
+    import_node_crypto3 = require("node:crypto");
     import_path81 = require("path");
     TeamPaths = {
       root: (teamName) => `.omc/state/team/${teamName}`,
@@ -32172,7 +38118,7 @@ var init_state_paths = __esm({
       mailboxLockDir: (teamName, workerName2) => `.omc/state/team/${teamName}/mailbox/.lock-${workerName2}`,
       dispatchRequests: (teamName) => `.omc/state/team/${teamName}/dispatch/requests.json`,
       dispatchLockDir: (teamName) => `.omc/state/team/${teamName}/dispatch/.lock`,
-      mailboxNotificationLock: (teamName, requestId) => `.omc/state/team/${teamName}/dispatch/.mailbox-notification-${(0, import_node_crypto2.createHash)("sha256").update(requestId).digest("hex")}.lock`,
+      mailboxNotificationLock: (teamName, requestId) => `.omc/state/team/${teamName}/dispatch/.mailbox-notification-${(0, import_node_crypto3.createHash)("sha256").update(requestId).digest("hex")}.lock`,
       workerStatus: (teamName, workerName2) => `.omc/state/team/${teamName}/workers/${workerName2}/status.json`,
       workerIdleNotify: (teamName) => `.omc/state/team/${teamName}/worker-idle-notify.json`,
       workerPrevNotifyState: (teamName, workerName2) => `.omc/state/team/${teamName}/workers/${workerName2}/prev-notify-state.json`,
@@ -32349,7 +38295,7 @@ function recordBytes(record2) {
 }
 function parseRecord(path25, expectedEpoch) {
   try {
-    const parsed = JSON.parse((0, import_fs67.readFileSync)(path25, "utf8"));
+    const parsed = JSON.parse((0, import_fs68.readFileSync)(path25, "utf8"));
     if (parsed.schema_version !== 1 || !Number.isSafeInteger(parsed.epoch) || parsed.epoch < 1 || expectedEpoch !== void 0 && parsed.epoch !== expectedEpoch || typeof parsed.nonce !== "string" || typeof parsed.pid !== "number" || !isValidProcessStartIdentity(parsed.process_started_at) || typeof parsed.payload_hash !== "string") return null;
     const { payload_hash, ...unsigned } = parsed;
     return digest2(unsigned) === payload_hash ? parsed : null;
@@ -32368,9 +38314,9 @@ function processStartIdentityForPlatform(pid, platform = process.platform, exec4
   if (!Number.isSafeInteger(pid) || pid < 1) return null;
   try {
     if (platform === "linux") {
-      const stat2 = (0, import_fs67.readFileSync)(`/proc/${pid}/stat`, "utf8");
-      const close = stat2.lastIndexOf(")");
-      const fields = stat2.slice(close + 2).trim().split(/\s+/);
+      const stat3 = (0, import_fs68.readFileSync)(`/proc/${pid}/stat`, "utf8");
+      const close = stat3.lastIndexOf(")");
+      const fields = stat3.slice(close + 2).trim().split(/\s+/);
       const ticks = fields[19];
       return ticks ? `linux:${ticks}` : null;
     }
@@ -32439,8 +38385,8 @@ function isProcessIdentityDead(record2) {
 }
 function readLatestOwnerEpoch(cwd2, teamName) {
   const directory = absPath(cwd2, TeamPaths.ownerEpochs(teamName));
-  if (!(0, import_fs67.existsSync)(directory)) return null;
-  const epochs = (0, import_fs67.readdirSync)(directory).map((name) => /^([1-9]\d*)\.json$/.exec(name)).filter((match) => match !== null).map((match) => Number(match[1])).sort((a, b) => b - a);
+  if (!(0, import_fs68.existsSync)(directory)) return null;
+  const epochs = (0, import_fs68.readdirSync)(directory).map((name) => /^([1-9]\d*)\.json$/.exec(name)).filter((match) => match !== null).map((match) => Number(match[1])).sort((a, b) => b - a);
   const latestEpoch = epochs[0];
   if (latestEpoch === void 0) return null;
   const record2 = parseRecord((0, import_path82.join)(directory, `${latestEpoch}.json`), latestEpoch);
@@ -32450,7 +38396,7 @@ function readLatestOwnerEpoch(cwd2, teamName) {
 function publishOwnerEpoch(cwd2, teamName, epoch, input = {}) {
   if (!Number.isSafeInteger(epoch) || epoch < 1) throw new Error("invalid_owner_epoch");
   const target = absPath(cwd2, TeamPaths.ownerEpoch(teamName, epoch));
-  (0, import_fs67.mkdirSync)((0, import_path82.dirname)(target), { recursive: true, mode: 448 });
+  (0, import_fs68.mkdirSync)((0, import_path82.dirname)(target), { recursive: true, mode: 448 });
   const start = input.processStartedAt ?? currentProcessStartIdentity(input.pid ?? process.pid);
   if (!isValidProcessStartIdentity(start)) throw new Error("process_start_identity_unavailable");
   const unsigned = {
@@ -32465,13 +38411,13 @@ function publishOwnerEpoch(cwd2, teamName, epoch, input = {}) {
   const bytes = recordBytes(unsigned);
   const record2 = JSON.parse(bytes);
   const temp = (0, import_path82.join)((0, import_path82.dirname)(target), `.${epoch}.${record2.nonce}.${(0, import_crypto22.randomUUID)()}.tmp`);
-  (0, import_fs67.writeFileSync)(temp, bytes, { encoding: "utf8", mode: 384, flush: true });
+  (0, import_fs68.writeFileSync)(temp, bytes, { encoding: "utf8", mode: 384, flush: true });
   try {
-    (0, import_fs67.linkSync)(temp, target);
+    (0, import_fs68.linkSync)(temp, target);
   } catch (error2) {
     const existing = parseRecord(target, epoch);
     try {
-      (0, import_fs67.unlinkSync)(temp);
+      (0, import_fs68.unlinkSync)(temp);
     } catch {
     }
     if (existing) return existing;
@@ -32479,7 +38425,7 @@ function publishOwnerEpoch(cwd2, teamName, epoch, input = {}) {
   }
   const verified = parseRecord(target, epoch);
   if (!verified || canonicalize(verified) !== bytes) throw new Error("owner_epoch_publication_verification_failed");
-  (0, import_fs67.unlinkSync)(temp);
+  (0, import_fs68.unlinkSync)(temp);
   return verified;
 }
 function requireOwnerProcessIdentity(record2, pid = process.pid, processStartedAt = currentProcessStartIdentity(pid)) {
@@ -32505,12 +38451,12 @@ function requireOwnerFence(cwd2, teamName, fence) {
   if (!result.ok) throw new Error("runtime_owner_fence_lost");
   return result.record;
 }
-var import_crypto22, import_fs67, import_path82, import_node_child_process6;
+var import_crypto22, import_fs68, import_path82, import_node_child_process6;
 var init_team_owner_epoch = __esm({
   "src/team/team-owner-epoch.ts"() {
     "use strict";
     import_crypto22 = require("crypto");
-    import_fs67 = require("fs");
+    import_fs68 = require("fs");
     import_path82 = require("path");
     import_node_child_process6 = require("node:child_process");
     init_state_paths();
@@ -32535,7 +38481,7 @@ async function withProcessIdentityFileLock(lockPath2, fn, timeoutMs = 1e4) {
     schema_version: 1,
     pid: process.pid,
     process_started_at: processStartedAt,
-    nonce: (0, import_node_crypto3.randomUUID)(),
+    nonce: (0, import_node_crypto4.randomUUID)(),
     created_at: (/* @__PURE__ */ new Date()).toISOString()
   };
   const tempPath = `${lockPath2}.${owner.nonce}.tmp`;
@@ -32554,7 +38500,7 @@ async function withProcessIdentityFileLock(lockPath2, fn, timeoutMs = 1e4) {
           continue;
         }
         if (Date.now() >= deadline) throw new Error("process_identity_lock_timeout");
-        await new Promise((resolve32) => setTimeout(resolve32, 25));
+        await new Promise((resolve33) => setTimeout(resolve33, 25));
         continue;
       }
       try {
@@ -32575,7 +38521,7 @@ async function withProcessIdentityFileLock(lockPath2, fn, timeoutMs = 1e4) {
           }
         }
         if (Date.now() >= deadline) throw new Error("process_identity_lock_timeout");
-        await new Promise((resolve32) => setTimeout(resolve32, 25));
+        await new Promise((resolve33) => setTimeout(resolve33, 25));
       }
     }
     return await fn();
@@ -32607,7 +38553,7 @@ function withProcessIdentityFileLockSync(lockPath2, fn) {
     schema_version: 1,
     pid: process.pid,
     process_started_at: processStartedAt,
-    nonce: (0, import_node_crypto3.randomUUID)(),
+    nonce: (0, import_node_crypto4.randomUUID)(),
     created_at: (/* @__PURE__ */ new Date()).toISOString()
   };
   const tempPath = `${lockPath2}.${owner.nonce}.tmp`;
@@ -32653,13 +38599,13 @@ function withProcessIdentityFileLockSync(lockPath2, fn) {
     }
   }
 }
-var import_node_fs4, import_node_path6, import_node_crypto3;
+var import_node_fs4, import_node_path6, import_node_crypto4;
 var init_process_identity_lock = __esm({
   "src/team/process-identity-lock.ts"() {
     "use strict";
     import_node_fs4 = require("node:fs");
     import_node_path6 = require("node:path");
-    import_node_crypto3 = require("node:crypto");
+    import_node_crypto4 = require("node:crypto");
     init_team_owner_epoch();
   }
 });
@@ -32695,7 +38641,7 @@ __export(monitor_exports, {
 });
 async function readJsonSafe3(filePath) {
   try {
-    if (!(0, import_fs68.existsSync)(filePath)) return null;
+    if (!(0, import_fs69.existsSync)(filePath)) return null;
     const raw = await (0, import_promises6.readFile)(filePath, "utf-8");
     return JSON.parse(raw);
   } catch {
@@ -32743,7 +38689,7 @@ function configFromManifest(manifest) {
     service_descriptor: manifest.service_descriptor
   };
 }
-function isRecord2(value) {
+function isRecord3(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 function isNonEmptyString(value) {
@@ -32759,35 +38705,35 @@ function isStringArray(value) {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 function isWorkerInfo(value) {
-  if (!isRecord2(value) || typeof value.name !== "string" || !WORKER_NAME_SAFE_PATTERN.test(value.name) || !isSafeCounter(value.index) || value.index < 1) return false;
+  if (!isRecord3(value) || typeof value.name !== "string" || !WORKER_NAME_SAFE_PATTERN.test(value.name) || !isSafeCounter(value.index) || value.index < 1) return false;
   return (value.role === void 0 || typeof value.role === "string") && (value.assigned_tasks === void 0 || isStringArray(value.assigned_tasks)) && (value.worker_cli === void 0 || ["claude", "codex", "gemini", "cursor", "grok", "antigravity"].includes(value.worker_cli)) && (value.pid === void 0 || isSafeCounter(value.pid) && value.pid > 0) && (value.pane_id === void 0 || typeof value.pane_id === "string") && (value.working_dir === void 0 || typeof value.working_dir === "string") && (value.worktree_repo_root === void 0 || typeof value.worktree_repo_root === "string") && (value.worktree_path === void 0 || typeof value.worktree_path === "string") && (value.worktree_branch === void 0 || typeof value.worktree_branch === "string") && (value.worktree_detached === void 0 || typeof value.worktree_detached === "boolean") && (value.worktree_created === void 0 || typeof value.worktree_created === "boolean") && (value.team_state_root === void 0 || typeof value.team_state_root === "string") && (value.output_file === void 0 || typeof value.output_file === "string") && (value.recovery_id === void 0 || isNonEmptyString(value.recovery_id)) && (value.replacement_generation === void 0 || isSafeCounter(value.replacement_generation)) && (value.pane_attempt_id === void 0 || isNonEmptyString(value.pane_attempt_id)) && (value.operational_state === void 0 || ["starting", "active", "dead", "stopped"].includes(value.operational_state)) && (value.launch_descriptor === void 0 || isLaunchDescriptor(value.launch_descriptor));
 }
 function isLaunchDescriptor(value) {
-  return isRecord2(value) && value.schema_version === 1 && ["claude", "codex", "gemini", "cursor", "grok", "antigravity"].includes(value.provider) && (value.model === null || typeof value.model === "string") && isNonEmptyString(value.binary) && isStringArray(value.args);
+  return isRecord3(value) && value.schema_version === 1 && ["claude", "codex", "gemini", "cursor", "grok", "antigravity"].includes(value.provider) && (value.model === null || typeof value.model === "string") && isNonEmptyString(value.binary) && isStringArray(value.args);
 }
 function isOwnerEpoch(value) {
-  return isRecord2(value) && isSafeCounter(value.epoch) && value.epoch > 0 && isNonEmptyString(value.nonce) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && isTimestamp(value.created_at);
+  return isRecord3(value) && isSafeCounter(value.epoch) && value.epoch > 0 && isNonEmptyString(value.nonce) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && isTimestamp(value.created_at);
 }
 function isRecoveryAttempt(value) {
-  return isRecord2(value) && isNonEmptyString(value.request_id) && isNonEmptyString(value.recovery_id) && isNonEmptyString(value.worker_name) && isSafeCounter(value.owner_epoch) && value.owner_epoch > 0 && isNonEmptyString(value.owner_nonce) && ["reserved", "requeued", "ready", "active", "services_pending", "adopted", "failed"].includes(value.phase) && (value.original_pane_id === void 0 || typeof value.original_pane_id === "string") && isSafeCounter(value.state_revision) && isTimestamp(value.created_at) && isTimestamp(value.updated_at);
+  return isRecord3(value) && isNonEmptyString(value.request_id) && isNonEmptyString(value.recovery_id) && isNonEmptyString(value.worker_name) && isSafeCounter(value.owner_epoch) && value.owner_epoch > 0 && isNonEmptyString(value.owner_nonce) && ["reserved", "requeued", "ready", "active", "services_pending", "adopted", "failed"].includes(value.phase) && (value.original_pane_id === void 0 || typeof value.original_pane_id === "string") && isSafeCounter(value.state_revision) && isTimestamp(value.created_at) && isTimestamp(value.updated_at);
 }
 function isScaleUpAttempt(value) {
-  return isRecord2(value) && isNonEmptyString(value.operation_id) && ["reserved", "effects", "failed"].includes(value.phase) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && isSafeCounter(value.state_revision) && isTimestamp(value.created_at) && isTimestamp(value.updated_at) && (value.failure_reason === void 0 || typeof value.failure_reason === "string");
+  return isRecord3(value) && isNonEmptyString(value.operation_id) && ["reserved", "effects", "failed"].includes(value.phase) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && isSafeCounter(value.state_revision) && isTimestamp(value.created_at) && isTimestamp(value.updated_at) && (value.failure_reason === void 0 || typeof value.failure_reason === "string");
 }
 function isScaleDownAttempt(value) {
-  return isRecord2(value) && isNonEmptyString(value.operation_id) && ["draining", "effects", "failed"].includes(value.phase) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && Array.isArray(value.workers) && value.workers.every((worker) => isRecord2(worker) && isNonEmptyString(worker.name) && (worker.pane_id === void 0 || typeof worker.pane_id === "string") && (worker.worktree_path === void 0 || typeof worker.worktree_path === "string") && (worker.worktree_created === void 0 || typeof worker.worktree_created === "boolean")) && isSafeCounter(value.state_revision) && isTimestamp(value.created_at) && isTimestamp(value.updated_at) && (value.failure_reason === void 0 || typeof value.failure_reason === "string");
+  return isRecord3(value) && isNonEmptyString(value.operation_id) && ["draining", "effects", "failed"].includes(value.phase) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && Array.isArray(value.workers) && value.workers.every((worker) => isRecord3(worker) && isNonEmptyString(worker.name) && (worker.pane_id === void 0 || typeof worker.pane_id === "string") && (worker.worktree_path === void 0 || typeof worker.worktree_path === "string") && (worker.worktree_created === void 0 || typeof worker.worktree_created === "boolean")) && isSafeCounter(value.state_revision) && isTimestamp(value.created_at) && isTimestamp(value.updated_at) && (value.failure_reason === void 0 || typeof value.failure_reason === "string");
 }
 function isServiceDescriptor(value) {
-  return isRecord2(value) && value.schema_version === 1 && isSafeCounter(value.service_generation) && isNonEmptyString(value.service_attempt_id) && typeof value.auto_merge_enabled === "boolean" && isNonEmptyString(value.workspace_root) && (value.leader_branch === void 0 || typeof value.leader_branch === "string") && ["disabled", "worker-auto-commit-v1"].includes(value.cadence_policy);
+  return isRecord3(value) && value.schema_version === 1 && isSafeCounter(value.service_generation) && isNonEmptyString(value.service_attempt_id) && typeof value.auto_merge_enabled === "boolean" && isNonEmptyString(value.workspace_root) && (value.leader_branch === void 0 || typeof value.leader_branch === "string") && ["disabled", "worker-auto-commit-v1"].includes(value.cadence_policy);
 }
 function isShutdownAttempt(value) {
-  return isRecord2(value) && isNonEmptyString(value.nonce) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && isSafeCounter(value.state_revision) && isTimestamp(value.created_at);
+  return isRecord3(value) && isNonEmptyString(value.nonce) && isSafeCounter(value.pid) && value.pid > 0 && isNonEmptyString(value.process_started_at) && isSafeCounter(value.state_revision) && isTimestamp(value.created_at);
 }
 function isAllDeadRecovery(value) {
-  return isRecord2(value) && isTimestamp(value.detected_at) && isTimestamp(value.deadline_at) && isSafeCounter(value.state_revision);
+  return isRecord3(value) && isTimestamp(value.detected_at) && isTimestamp(value.deadline_at) && isSafeCounter(value.state_revision);
 }
 function isTeamConfig(value, requireRevision, expectedTeamName) {
-  if (!isRecord2(value) || !isNonEmptyString(value.name) || expectedTeamName !== void 0 && value.name !== expectedTeamName || !isNonEmptyString(value.agent_type) || value.task !== void 0 && typeof value.task !== "string" || value.worker_launch_mode !== void 0 && !["interactive", "prompt"].includes(value.worker_launch_mode) || !isSafeCounter(value.worker_count) || value.max_workers !== void 0 && !isSafeCounter(value.max_workers) || !Array.isArray(value.workers) || value.worker_count !== value.workers.length || !value.workers.every(isWorkerInfo) || !hasUniqueWorkerIdentity(value.workers) || !isTimestamp(value.created_at) || !isNonEmptyString(value.tmux_session) || value.next_task_id !== void 0 && !isSafeCounter(value.next_task_id) || !isOptionalPolicy(value.policy) || !isOptionalGovernance(value.governance) || !isOptionalWorkspaceShape(value) || !isOptionalPaneShape(value) || !isOptionalRouting(value.resolved_routing)) return false;
+  if (!isRecord3(value) || !isNonEmptyString(value.name) || expectedTeamName !== void 0 && value.name !== expectedTeamName || !isNonEmptyString(value.agent_type) || value.task !== void 0 && typeof value.task !== "string" || value.worker_launch_mode !== void 0 && !["interactive", "prompt"].includes(value.worker_launch_mode) || !isSafeCounter(value.worker_count) || value.max_workers !== void 0 && !isSafeCounter(value.max_workers) || !Array.isArray(value.workers) || value.worker_count !== value.workers.length || !value.workers.every(isWorkerInfo) || !hasUniqueWorkerIdentity(value.workers) || !isTimestamp(value.created_at) || !isNonEmptyString(value.tmux_session) || value.next_task_id !== void 0 && !isSafeCounter(value.next_task_id) || !isOptionalPolicy(value.policy) || !isOptionalGovernance(value.governance) || !isOptionalWorkspaceShape(value) || !isOptionalPaneShape(value) || !isOptionalRouting(value.resolved_routing)) return false;
   if (requireRevision ? !isSafeCounter(value.state_revision) : value.state_revision !== void 0 && !isSafeCounter(value.state_revision)) return false;
   if (!requireRevision && Object.hasOwn(value, "state_revision")) return false;
   return (value.lifecycle_state === void 0 || ["active", "shutting_down", "stopped"].includes(value.lifecycle_state)) && (value.runtime_owner_epoch === void 0 || isOwnerEpoch(value.runtime_owner_epoch)) && (value.active_recovery === void 0 || isRecoveryAttempt(value.active_recovery)) && (value.last_recovery === void 0 || isRecoveryAttempt(value.last_recovery)) && (value.active_scale_up === void 0 || isScaleUpAttempt(value.active_scale_up)) && (value.active_scale_down === void 0 || isScaleDownAttempt(value.active_scale_down)) && (value.service_descriptor === void 0 || isServiceDescriptor(value.service_descriptor)) && (value.shutdown_attempt === void 0 || isShutdownAttempt(value.shutdown_attempt)) && (value.all_dead_recovery === void 0 || isAllDeadRecovery(value.all_dead_recovery)) && hasMatchingActiveFenceRevisions(value);
@@ -32796,7 +38742,7 @@ function hasUniqueWorkerIdentity(workers) {
   const names = /* @__PURE__ */ new Set();
   const indices = /* @__PURE__ */ new Set();
   return workers.every((worker) => {
-    if (!isRecord2(worker) || typeof worker.name !== "string" || !WORKER_NAME_SAFE_PATTERN.test(worker.name) || typeof worker.index !== "number") return false;
+    if (!isRecord3(worker) || typeof worker.name !== "string" || !WORKER_NAME_SAFE_PATTERN.test(worker.name) || typeof worker.index !== "number") return false;
     if (names.has(worker.name) || indices.has(worker.index)) return false;
     names.add(worker.name);
     indices.add(worker.index);
@@ -32804,10 +38750,10 @@ function hasUniqueWorkerIdentity(workers) {
   });
 }
 function isOptionalPolicy(value) {
-  return value === void 0 || isRecord2(value) && ["split_pane", "auto"].includes(value.display_mode) && ["interactive", "prompt"].includes(value.worker_launch_mode) && ["hook_preferred_with_fallback", "transport_direct"].includes(value.dispatch_mode) && isSafeCounter(value.dispatch_ack_timeout_ms);
+  return value === void 0 || isRecord3(value) && ["split_pane", "auto"].includes(value.display_mode) && ["interactive", "prompt"].includes(value.worker_launch_mode) && ["hook_preferred_with_fallback", "transport_direct"].includes(value.dispatch_mode) && isSafeCounter(value.dispatch_ack_timeout_ms);
 }
 function isOptionalGovernance(value) {
-  return value === void 0 || isRecord2(value) && typeof value.delegation_only === "boolean" && typeof value.plan_approval_required === "boolean" && typeof value.nested_teams_allowed === "boolean" && typeof value.one_team_per_leader_session === "boolean" && typeof value.cleanup_requires_all_workers_inactive === "boolean";
+  return value === void 0 || isRecord3(value) && typeof value.delegation_only === "boolean" && typeof value.plan_approval_required === "boolean" && typeof value.nested_teams_allowed === "boolean" && typeof value.one_team_per_leader_session === "boolean" && typeof value.cleanup_requires_all_workers_inactive === "boolean";
 }
 function isOptionalWorkspaceShape(value) {
   return (value.leader_cwd === void 0 || typeof value.leader_cwd === "string") && (value.team_state_root === void 0 || typeof value.team_state_root === "string") && (value.workspace_mode === void 0 || ["single", "worktree"].includes(value.workspace_mode)) && (value.worktree_mode === void 0 || ["disabled", "detached", "named"].includes(value.worktree_mode)) && (value.lifecycle_profile === void 0 || ["default", "linked_ralph"].includes(value.lifecycle_profile));
@@ -32817,19 +38763,19 @@ function isOptionalPaneShape(value) {
 }
 function isOptionalRouting(value) {
   if (value === void 0) return true;
-  if (!isRecord2(value) || Object.keys(value).length !== CANONICAL_TEAM_ROLES.length) return false;
+  if (!isRecord3(value) || Object.keys(value).length !== CANONICAL_TEAM_ROLES.length) return false;
   return CANONICAL_TEAM_ROLES.every((role) => isResolvedRoleRoute(value[role]));
 }
 function isResolvedRoleRoute(value) {
-  return isRecord2(value) && isRoleAssignment(value.primary) && isRoleAssignment(value.fallback);
+  return isRecord3(value) && isRoleAssignment(value.primary) && isRoleAssignment(value.fallback);
 }
 function isRoleAssignment(value) {
-  return isRecord2(value) && ["claude", "codex", "gemini", "grok", "cursor", "antigravity"].includes(value.provider) && isNonEmptyString(value.model) && KNOWN_AGENT_NAMES.some((agent) => agent === value.agent);
+  return isRecord3(value) && ["claude", "codex", "gemini", "grok", "cursor", "antigravity"].includes(value.provider) && isNonEmptyString(value.model) && KNOWN_AGENT_NAMES.some((agent) => agent === value.agent);
 }
 function hasMatchingActiveFenceRevisions(value) {
   if (!isSafeCounter(value.state_revision)) return true;
   const revision = value.state_revision;
-  return [value.active_recovery, value.active_scale_up, value.active_scale_down, value.shutdown_attempt, value.all_dead_recovery].every((fence) => fence === void 0 || isRecord2(fence) && fence.state_revision === revision);
+  return [value.active_recovery, value.active_scale_up, value.active_scale_down, value.shutdown_attempt, value.all_dead_recovery].every((fence) => fence === void 0 || isRecord3(fence) && fence.state_revision === revision);
 }
 function alignActiveFenceRevisions(config2, revision) {
   return {
@@ -32963,7 +38909,7 @@ async function readWorkerHeartbeat(teamName, workerName2, cwd2) {
 }
 async function readMonitorSnapshot(teamName, cwd2) {
   const p = absPath(cwd2, TeamPaths.monitorSnapshot(teamName));
-  if (!(0, import_fs68.existsSync)(p)) return null;
+  if (!(0, import_fs69.existsSync)(p)) return null;
   try {
     const raw = await (0, import_promises6.readFile)(p, "utf-8");
     const parsed = JSON.parse(raw);
@@ -32996,7 +38942,7 @@ async function writeMonitorSnapshot(teamName, snapshot, cwd2) {
 }
 async function readTeamPhaseState(teamName, cwd2) {
   const p = absPath(cwd2, TeamPaths.phaseState(teamName));
-  if (!(0, import_fs68.existsSync)(p)) return null;
+  if (!(0, import_fs69.existsSync)(p)) return null;
   try {
     const raw = await (0, import_promises6.readFile)(p, "utf-8");
     const parsed = JSON.parse(raw);
@@ -33039,7 +38985,7 @@ async function writeWorkerIdentity(teamName, workerName2, workerInfo, cwd2) {
 }
 async function listTasksFromFiles(teamName, cwd2) {
   const tasksDir = absPath(cwd2, TeamPaths.tasks(teamName));
-  if (!(0, import_fs68.existsSync)(tasksDir)) return [];
+  if (!(0, import_fs69.existsSync)(tasksDir)) return [];
   const { readdir: readdir8 } = await import("fs/promises");
   const entries = await readdir8(tasksDir);
   const tasks = [];
@@ -33239,11 +39185,11 @@ async function cleanupTeamState(teamName, cwd2) {
   } catch {
   }
 }
-var import_fs68, import_promises6, import_path83, import_perf_hooks;
+var import_fs69, import_promises6, import_path83, import_perf_hooks;
 var init_monitor = __esm({
   "src/team/monitor.ts"() {
     "use strict";
-    import_fs68 = require("fs");
+    import_fs69 = require("fs");
     import_promises6 = require("fs/promises");
     import_path83 = require("path");
     import_perf_hooks = require("perf_hooks");
@@ -33418,7 +39364,7 @@ async function releaseTaskClaim(taskId, claimToken, _workerName, deps) {
 }
 async function listTasks(teamName, cwd2, deps) {
   const tasksRoot = (0, import_path84.join)(deps.teamDir(teamName, cwd2), "tasks");
-  if (!(0, import_fs69.existsSync)(tasksRoot)) return [];
+  if (!(0, import_fs70.existsSync)(tasksRoot)) return [];
   const entries = await (0, import_promises7.readdir)(tasksRoot, { withFileTypes: true });
   const matched = entries.flatMap((entry) => {
     if (!entry.isFile()) return [];
@@ -33515,19 +39461,19 @@ async function adoptRecoveryReservations(taskIds, workerName2, proof, deps) {
   }
   return results;
 }
-var import_crypto23, import_path84, import_fs69, import_promises7;
+var import_crypto23, import_path84, import_fs70, import_promises7;
 var init_tasks = __esm({
   "src/team/state/tasks.ts"() {
     "use strict";
     import_crypto23 = require("crypto");
     import_path84 = require("path");
-    import_fs69 = require("fs");
+    import_fs70 = require("fs");
     import_promises7 = require("fs/promises");
   }
 });
 
 // src/team/task-recovery-checkpoint.ts
-function canonicalJson(value) {
+function canonicalJson2(value) {
   const seen = /* @__PURE__ */ new Set();
   const normalize13 = (current) => {
     if (current === null || typeof current === "string" || typeof current === "boolean") return current;
@@ -33555,10 +39501,10 @@ function canonicalJson(value) {
   return JSON.stringify(normalize13(value));
 }
 function hashTaskRecoveryCheckpointPayload(payload) {
-  return (0, import_node_crypto4.createHash)("sha256").update(canonicalJson(payload)).digest("hex");
+  return (0, import_node_crypto5.createHash)("sha256").update(canonicalJson2(payload)).digest("hex");
 }
 function taskRecoveryClaimTokenHash(claimToken) {
-  return (0, import_node_crypto4.createHash)("sha256").update(claimToken).digest("hex");
+  return (0, import_node_crypto5.createHash)("sha256").update(claimToken).digest("hex");
 }
 function checkpointPath(cwd2, teamName, taskId, claimToken, sequence) {
   return absPath(cwd2, TeamPaths.checkpoint(teamName, taskId, taskRecoveryClaimTokenHash(claimToken), sequence));
@@ -33626,7 +39572,7 @@ function parseCheckpoint(value) {
 function sameCheckpointPublication(existing, candidate) {
   const { updated_at: _existingUpdatedAt, ...existingSemantic } = existing;
   const { updated_at: _candidateUpdatedAt, ...candidateSemantic } = candidate;
-  return canonicalJson(existingSemantic) === canonicalJson(candidateSemantic);
+  return canonicalJson2(existingSemantic) === canonicalJson2(candidateSemantic);
 }
 function checkpointSequenceFromPath(path25) {
   const match = /^(\d+)\.json$/.exec((0, import_node_path7.basename)(path25));
@@ -33659,9 +39605,9 @@ async function publishTaskRecoveryCheckpoint(input, cwd2, access3) {
   let payloadHash;
   let payloadBytes;
   try {
-    const serialized = canonicalJson(input.resumePayload);
+    const serialized = canonicalJson2(input.resumePayload);
     payloadBytes = Buffer.byteLength(serialized);
-    payloadHash = (0, import_node_crypto4.createHash)("sha256").update(serialized).digest("hex");
+    payloadHash = (0, import_node_crypto5.createHash)("sha256").update(serialized).digest("hex");
   } catch {
     return { ok: false, error: "invalid_checkpoint" };
   }
@@ -33733,11 +39679,11 @@ async function readTaskRecoveryCheckpoint(path25) {
   const checkpoint = await readCheckpoint(path25);
   return checkpoint ? { ok: true, checkpoint, path: path25 } : { ok: false, error: (0, import_node_fs5.existsSync)(path25) ? "malformed" : "missing" };
 }
-var import_node_crypto4, import_node_fs5, import_promises8, import_node_path7, MAX_TASK_RECOVERY_CHECKPOINT_BYTES;
+var import_node_crypto5, import_node_fs5, import_promises8, import_node_path7, MAX_TASK_RECOVERY_CHECKPOINT_BYTES;
 var init_task_recovery_checkpoint = __esm({
   "src/team/task-recovery-checkpoint.ts"() {
     "use strict";
-    import_node_crypto4 = require("node:crypto");
+    import_node_crypto5 = require("node:crypto");
     import_node_fs5 = require("node:fs");
     import_promises8 = require("node:fs/promises");
     import_node_path7 = require("node:path");
@@ -33849,7 +39795,7 @@ async function withMailboxLock(teamName, workerName2, cwd2, fn) {
   while (Date.now() < deadline) {
     const result = await withLock2(lockDir, fn);
     if (result.ok) return result.value;
-    await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+    await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     delayMs = Math.min(delayMs * 2, 200);
   }
   throw new Error(`Failed to acquire mailbox lock for ${workerName2} after ${timeoutMs}ms`);
@@ -33989,7 +39935,7 @@ async function teamCreateTask(teamName, task, cwd2) {
       return taskLock.value;
     });
     if (result.ok) return result.value;
-    await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+    await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     delayMs = Math.min(delayMs * 2, 200);
   }
   throw new Error(`Failed to acquire task creation lock for team ${teamName} after ${timeoutMs}ms`);
@@ -34029,7 +39975,7 @@ async function teamUpdateTask(teamName, taskId, updates, cwd2) {
       return merged;
     });
     if (result.ok) return result.value;
-    await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+    await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     delayMs = Math.min(delayMs * 2, 200);
   }
   throw new Error(`Failed to acquire task update lock for task ${taskId} in team ${teamName} after ${timeoutMs}ms`);
@@ -34126,7 +40072,7 @@ function recoveryTransitionDeps(teamName, cwd2) {
     writeRecoverySidecar: (tn, recoveryId, tid, sidecar, c) => writeAtomic3(absPath(c, TeamPaths.taskRecoverySidecar(tn, recoveryId, tid)), JSON.stringify(sidecar, null, 2)),
     selectRecoveryCheckpoint: selectTaskRecoveryCheckpoint,
     readRecoveryCheckpoint: readTaskRecoveryCheckpoint,
-    verifyAdoptionToken: (token, hash) => (0, import_node_crypto5.createHash)("sha256").update(token).digest("hex") === hash
+    verifyAdoptionToken: (token, hash) => (0, import_node_crypto6.createHash)("sha256").update(token).digest("hex") === hash
   };
 }
 async function teamPublishTaskRecoveryCheckpoint(input, cwd2) {
@@ -34275,7 +40221,7 @@ async function teamSendMessage(teamName, fromWorker, toWorker, body, cwd2) {
   return withMailboxLock(teamName, toWorker, cwd2, async () => {
     const mailbox = await readMailbox(teamName, toWorker, cwd2);
     const message2 = {
-      message_id: (0, import_node_crypto5.randomUUID)(),
+      message_id: (0, import_node_crypto6.randomUUID)(),
       from_worker: fromWorker,
       to_worker: toWorker,
       body,
@@ -34328,7 +40274,7 @@ async function teamMarkMessageNotified(teamName, workerName2, messageId, cwd2) {
 }
 async function teamAppendEvent(teamName, event, cwd2) {
   const full = {
-    event_id: (0, import_node_crypto5.randomUUID)(),
+    event_id: (0, import_node_crypto6.randomUUID)(),
     team: teamName,
     created_at: (/* @__PURE__ */ new Date()).toISOString(),
     ...event
@@ -34441,11 +40387,11 @@ async function teamWriteMonitorSnapshot(teamName, snapshot, cwd2) {
   const p = absPath(cwd2, TeamPaths.monitorSnapshot(teamName));
   await writeAtomic3(p, JSON.stringify(snapshot, null, 2));
 }
-var import_node_crypto5, import_node_fs6, import_promises9, import_node_path8;
+var import_node_crypto6, import_node_fs6, import_promises9, import_node_path8;
 var init_team_ops = __esm({
   "src/team/team-ops.ts"() {
     "use strict";
-    import_node_crypto5 = require("node:crypto");
+    import_node_crypto6 = require("node:crypto");
     import_node_fs6 = require("node:fs");
     import_promises9 = require("node:fs/promises");
     import_node_path8 = require("node:path");
@@ -34546,7 +40492,7 @@ async function appendTeamEvent(teamName, event, cwd2) {
 }
 async function readTeamEvents(teamName, cwd2) {
   const p = absPath(cwd2, TeamPaths.events(teamName));
-  if (!(0, import_fs70.existsSync)(p)) return [];
+  if (!(0, import_fs71.existsSync)(p)) return [];
   try {
     const raw = await (0, import_promises10.readFile)(p, "utf8");
     return raw.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
@@ -34604,14 +40550,14 @@ async function emitMonitorDerivedEvents(teamName, tasks, workers, previousSnapsh
     }
   }
 }
-var import_crypto24, import_path85, import_promises10, import_fs70;
+var import_crypto24, import_path85, import_promises10, import_fs71;
 var init_events = __esm({
   "src/team/events.ts"() {
     "use strict";
     import_crypto24 = require("crypto");
     import_path85 = require("path");
     import_promises10 = require("fs/promises");
-    import_fs70 = require("fs");
+    import_fs71 = require("fs");
     init_state_paths();
     init_swallowed_error();
   }
@@ -35453,14 +41399,14 @@ function resolveShellFromPath(candidatePath) {
   for (const dir of pathEntries(process.env.PATH)) {
     for (const name of pathCandidateNames(candidatePath)) {
       const full = (0, import_path87.join)(dir, name);
-      if ((0, import_fs71.existsSync)(full)) return full;
+      if ((0, import_fs72.existsSync)(full)) return full;
     }
   }
   return null;
 }
 function resolveShellFromCandidates(paths, rcFile) {
   for (const p of paths) {
-    if ((0, import_fs71.existsSync)(p)) return { shell: p, rcFile };
+    if ((0, import_fs72.existsSync)(p)) return { shell: p, rcFile };
     const resolvedFromPath = resolveShellFromPath(p);
     if (resolvedFromPath) return { shell: resolvedFromPath, rcFile };
   }
@@ -35470,7 +41416,7 @@ function resolveSupportedShellAffinity(shellPath) {
   if (!shellPath) return null;
   const name = (0, import_path87.basename)(shellPath.replace(/\\/g, "/")).replace(/\.(exe|cmd|bat)$/i, "");
   if (name !== "zsh" && name !== "bash") return null;
-  if (!(0, import_fs71.existsSync)(shellPath)) return null;
+  if (!(0, import_fs72.existsSync)(shellPath)) return null;
   const home = process.env.HOME ?? "";
   const rcFile = home ? `${home}/.${name}rc` : null;
   return { shell: shellPath, rcFile };
@@ -36446,11 +42392,11 @@ async function killTeamSession(sessionName2, workerPaneIds, leaderPaneId, option
   } catch {
   }
 }
-var import_fs71, import_crypto25, import_child_process25, import_util10, import_path87, import_promises11, sleep4, execFileAsync5, TMUX_SESSION_PREFIX, TMUX_MAILBOX_PANE_ID, TMUX_MAILBOX_TARGET, defaultMailboxTargetOwnershipDependencies, defaultDirectMailboxEffectDependencies, SUPPORTED_POSIX_SHELLS, ZSH_CANDIDATES, BASH_CANDIDATES, DANGEROUS_LAUNCH_BINARY_CHARS;
+var import_fs72, import_crypto25, import_child_process25, import_util10, import_path87, import_promises11, sleep4, execFileAsync5, TMUX_SESSION_PREFIX, TMUX_MAILBOX_PANE_ID, TMUX_MAILBOX_TARGET, defaultMailboxTargetOwnershipDependencies, defaultDirectMailboxEffectDependencies, SUPPORTED_POSIX_SHELLS, ZSH_CANDIDATES, BASH_CANDIDATES, DANGEROUS_LAUNCH_BINARY_CHARS;
 var init_tmux_session = __esm({
   "src/team/tmux-session.ts"() {
     "use strict";
-    import_fs71 = require("fs");
+    import_fs72 = require("fs");
     import_crypto25 = require("crypto");
     import_child_process25 = require("child_process");
     import_util10 = require("util");
@@ -36483,28 +42429,28 @@ var init_tmux_session = __esm({
 // src/team/fs-utils.ts
 function atomicWriteJson2(filePath, data, mode = 384) {
   const dir = (0, import_path88.dirname)(filePath);
-  if (!(0, import_fs72.existsSync)(dir)) (0, import_fs72.mkdirSync)(dir, { recursive: true, mode: 448 });
+  if (!(0, import_fs73.existsSync)(dir)) (0, import_fs73.mkdirSync)(dir, { recursive: true, mode: 448 });
   const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
-  (0, import_fs72.writeFileSync)(tmpPath, JSON.stringify(data, null, 2) + "\n", { encoding: "utf-8", mode });
-  (0, import_fs72.renameSync)(tmpPath, filePath);
+  (0, import_fs73.writeFileSync)(tmpPath, JSON.stringify(data, null, 2) + "\n", { encoding: "utf-8", mode });
+  (0, import_fs73.renameSync)(tmpPath, filePath);
 }
 function ensureDirWithMode(dirPath, mode = 448) {
-  if (!(0, import_fs72.existsSync)(dirPath)) (0, import_fs72.mkdirSync)(dirPath, { recursive: true, mode });
+  if (!(0, import_fs73.existsSync)(dirPath)) (0, import_fs73.mkdirSync)(dirPath, { recursive: true, mode });
 }
 function safeRealpath(p) {
   try {
-    return (0, import_fs72.realpathSync)(p);
+    return (0, import_fs73.realpathSync)(p);
   } catch {
     const segments = [];
     let current = (0, import_path88.resolve)(p);
-    while (!(0, import_fs72.existsSync)(current)) {
+    while (!(0, import_fs73.existsSync)(current)) {
       segments.unshift((0, import_path88.basename)(current));
       const parent = (0, import_path88.dirname)(current);
       if (parent === current) break;
       current = parent;
     }
     try {
-      return (0, import_path88.join)((0, import_fs72.realpathSync)(current), ...segments);
+      return (0, import_path88.join)((0, import_fs73.realpathSync)(current), ...segments);
     } catch {
       return (0, import_path88.resolve)(p);
     }
@@ -36518,11 +42464,11 @@ function validateResolvedPath(resolvedPath, expectedBase) {
     throw new Error(`Path traversal detected: "${resolvedPath}" escapes base "${expectedBase}"`);
   }
 }
-var import_fs72, import_path88;
+var import_fs73, import_path88;
 var init_fs_utils = __esm({
   "src/team/fs-utils.ts"() {
     "use strict";
-    import_fs72 = require("fs");
+    import_fs73 = require("fs");
     import_path88 = require("path");
   }
 });
@@ -36835,7 +42781,7 @@ function resolveDispatchLockTimeoutMs(env2 = process.env) {
 }
 async function withDispatchLock(teamName, cwd2, fn) {
   const root2 = absPath(cwd2, TeamPaths.root(teamName));
-  if (!(0, import_fs73.existsSync)(root2)) throw new Error(`Team ${teamName} not found`);
+  if (!(0, import_fs74.existsSync)(root2)) throw new Error(`Team ${teamName} not found`);
   const lockDir = absPath(cwd2, TeamPaths.dispatchLockDir(teamName));
   const ownerPath = (0, import_path90.join)(lockDir, "owner");
   const ownerToken = `${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}`;
@@ -36870,7 +42816,7 @@ async function withDispatchLock(teamName, cwd2, fn) {
         );
       }
       const jitter = 0.5 + Math.random() * 0.5;
-      await new Promise((resolve32) => setTimeout(resolve32, Math.floor(pollMs * jitter)));
+      await new Promise((resolve33) => setTimeout(resolve33, Math.floor(pollMs * jitter)));
       pollMs = Math.min(pollMs * 2, DISPATCH_LOCK_MAX_POLL_MS);
     }
   }
@@ -36889,7 +42835,7 @@ async function withDispatchLock(teamName, cwd2, fn) {
 async function readDispatchRequestsFromFile(teamName, cwd2) {
   const path25 = absPath(cwd2, TeamPaths.dispatchRequests(teamName));
   try {
-    if (!(0, import_fs73.existsSync)(path25)) return [];
+    if (!(0, import_fs74.existsSync)(path25)) return [];
     const raw = await (0, import_promises13.readFile)(path25, "utf8");
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -37036,7 +42982,7 @@ async function readDispatchRequestStrict(teamName, requestId, cwd2) {
   return read;
 }
 async function patchPendingDispatchReason(teamName, requestId, reason, cwd2) {
-  if (!(0, import_fs73.existsSync)(absPath(cwd2, TeamPaths.root(teamName)))) return { kind: "missing" };
+  if (!(0, import_fs74.existsSync)(absPath(cwd2, TeamPaths.root(teamName)))) return { kind: "missing" };
   try {
     return await withDispatchLock(teamName, cwd2, async () => {
       const { read, store } = await readStrictDispatchRequestWithIndex(teamName, requestId, cwd2);
@@ -37169,12 +43115,12 @@ async function markDispatchRequestDelivered(teamName, requestId, patch = {}, cwd
   if (current.status === "delivered") return current;
   return await transitionDispatchRequest(teamName, requestId, current.status, "delivered", patch, cwd2);
 }
-var import_crypto26, import_fs73, import_promises13, import_path90, OMC_DISPATCH_LOCK_TIMEOUT_ENV, DEFAULT_DISPATCH_LOCK_TIMEOUT_MS, MIN_DISPATCH_LOCK_TIMEOUT_MS, MAX_DISPATCH_LOCK_TIMEOUT_MS, DISPATCH_LOCK_INITIAL_POLL_MS, DISPATCH_LOCK_MAX_POLL_MS, LOCK_STALE_MS3;
+var import_crypto26, import_fs74, import_promises13, import_path90, OMC_DISPATCH_LOCK_TIMEOUT_ENV, DEFAULT_DISPATCH_LOCK_TIMEOUT_MS, MIN_DISPATCH_LOCK_TIMEOUT_MS, MAX_DISPATCH_LOCK_TIMEOUT_MS, DISPATCH_LOCK_INITIAL_POLL_MS, DISPATCH_LOCK_MAX_POLL_MS, LOCK_STALE_MS3;
 var init_dispatch_queue = __esm({
   "src/team/dispatch-queue.ts"() {
     "use strict";
     import_crypto26 = require("crypto");
-    import_fs73 = require("fs");
+    import_fs74 = require("fs");
     import_promises13 = require("fs/promises");
     import_path90 = require("path");
     init_state_paths();
@@ -37929,11 +43875,11 @@ function validateWorktreeRemovalTarget(options) {
       throw new Error(`worktree_path_missing:${lexicalPath}`);
     }
   } else {
-    const stat2 = (0, import_node_fs8.lstatSync)(lexicalPath);
-    if (stat2.isSymbolicLink()) {
+    const stat3 = (0, import_node_fs8.lstatSync)(lexicalPath);
+    if (stat3.isSymbolicLink()) {
       throw new Error(`worktree_path_is_symlink:${lexicalPath}`);
     }
-    if (!stat2.isDirectory()) {
+    if (!stat3.isDirectory()) {
       throw new Error(`worktree_path_not_directory:${lexicalPath}`);
     }
   }
@@ -39032,7 +44978,7 @@ async function ensureLeaderInbox(teamName, cwd2) {
   const inboxPath = leaderInboxPath(teamName, cwd2);
   validateResolvedPath(inboxPath, cwd2);
   await (0, import_promises14.mkdir)((0, import_path91.dirname)(inboxPath), { recursive: true });
-  if (!(0, import_fs74.existsSync)(inboxPath)) {
+  if (!(0, import_fs75.existsSync)(inboxPath)) {
     await (0, import_promises14.writeFile)(inboxPath, LEADER_INBOX_HEADER, "utf-8");
   }
   return inboxPath;
@@ -39051,12 +44997,12 @@ function extendLeaderBootstrapPrompt(teamName) {
   const path25 = `.omc/state/team/${safe2}/leader/inbox.md`;
   return `Runtime notifications appear at ${path25} \u2014 check this file periodically and after long-running operations.`;
 }
-var import_promises14, import_fs74, import_path91, LEADER_INBOX_HEADER;
+var import_promises14, import_fs75, import_path91, LEADER_INBOX_HEADER;
 var init_leader_inbox = __esm({
   "src/team/leader-inbox.ts"() {
     "use strict";
     import_promises14 = require("fs/promises");
-    import_fs74 = require("fs");
+    import_fs75 = require("fs");
     import_path91 = require("path");
     init_tmux_session();
     init_fs_utils();
@@ -39206,7 +45152,7 @@ async function resumeHookViaSentinel(worktreePath) {
   }
 }
 function isHookPaused(worktreePath) {
-  return (0, import_fs75.existsSync)((0, import_path92.join)(worktreePath, SENTINEL_FILENAME));
+  return (0, import_fs76.existsSync)((0, import_path92.join)(worktreePath, SENTINEL_FILENAME));
 }
 function startFallbackPoller(worktreePath, workerName2, opts) {
   assertSafeWorkerName(workerName2);
@@ -39230,7 +45176,7 @@ function startFallbackPoller(worktreePath, workerName2, opts) {
       runAutoCommit();
     }, debounceMs);
   };
-  const watcher = (0, import_fs75.watch)(worktreePath, { recursive: true }, (eventType, filename) => {
+  const watcher = (0, import_fs76.watch)(worktreePath, { recursive: true }, (eventType, filename) => {
     if (stopped) return;
     if (filename && (filename.startsWith(".git") || filename.startsWith(".git/"))) return;
     scheduleDebounce();
@@ -39290,11 +45236,11 @@ async function uninstallCommitCadence(ctx, io = { readFile: import_promises15.re
   await io.writeFile(settingsPath, JSON.stringify(updated, null, 2) + "\n", "utf-8");
   if (ownsRegisteredGeneration) cadenceOwners.delete(ctx.worktreePath);
 }
-var import_fs75, import_promises15, import_path92, import_child_process26, cadenceOwners, SENTINEL_FILENAME, HOOK_MATCHER, DEFAULT_POLL_DEBOUNCE_MS, WORKER_NAME_RE;
+var import_fs76, import_promises15, import_path92, import_child_process26, cadenceOwners, SENTINEL_FILENAME, HOOK_MATCHER, DEFAULT_POLL_DEBOUNCE_MS, WORKER_NAME_RE;
 var init_worker_commit_cadence = __esm({
   "src/team/worker-commit-cadence.ts"() {
     "use strict";
-    import_fs75 = require("fs");
+    import_fs76 = require("fs");
     import_promises15 = require("fs/promises");
     import_path92 = require("path");
     import_child_process26 = require("child_process");
@@ -39811,8 +45757,8 @@ ${dirtyFiles.map((f) => `- \`${f}\``).join("\n")}`;
               return false;
             }
           })(),
-          new Promise((resolve32) => {
-            const t = setTimeout(() => resolve32(false), remaining);
+          new Promise((resolve33) => {
+            const t = setTimeout(() => resolve33(false), remaining);
             if (typeof t.unref === "function") t.unref();
           })
         ]);
@@ -39954,7 +45900,7 @@ function sha256(value) {
 }
 function parseCanonical(path25) {
   try {
-    const text = (0, import_fs76.readFileSync)(path25, "utf8");
+    const text = (0, import_fs77.readFileSync)(path25, "utf8");
     const parsed = JSON.parse(text);
     return canonicalize2(parsed) === text ? parsed : null;
   } catch {
@@ -39975,15 +45921,15 @@ function phaseDirectory(cwd2, requestId) {
 }
 function publishImmutable(target, value) {
   const bytes = canonicalize2(value);
-  (0, import_fs76.mkdirSync)((0, import_path93.dirname)(target), { recursive: true, mode: 448 });
+  (0, import_fs77.mkdirSync)((0, import_path93.dirname)(target), { recursive: true, mode: 448 });
   const temp = (0, import_path93.join)((0, import_path93.dirname)(target), `.${(0, import_crypto27.randomUUID)()}.tmp`);
-  (0, import_fs76.writeFileSync)(temp, bytes, { encoding: "utf8", mode: 384, flush: true });
+  (0, import_fs77.writeFileSync)(temp, bytes, { encoding: "utf8", mode: 384, flush: true });
   try {
-    (0, import_fs76.linkSync)(temp, target);
+    (0, import_fs77.linkSync)(temp, target);
   } catch (error2) {
     const existing = parseCanonical(target);
     try {
-      (0, import_fs76.unlinkSync)(temp);
+      (0, import_fs77.unlinkSync)(temp);
     } catch {
     }
     if (existing && canonicalize2(existing) === bytes) return existing;
@@ -39991,18 +45937,18 @@ function publishImmutable(target, value) {
   }
   const published = parseCanonical(target);
   if (!published || canonicalize2(published) !== bytes) throw new Error("immutable_recovery_record_verification_failed");
-  (0, import_fs76.unlinkSync)(temp);
+  (0, import_fs77.unlinkSync)(temp);
   return published;
 }
 function replaceDerivedIndex(target, value) {
   const bytes = canonicalize2(value);
-  (0, import_fs76.mkdirSync)((0, import_path93.dirname)(target), { recursive: true, mode: 448 });
+  (0, import_fs77.mkdirSync)((0, import_path93.dirname)(target), { recursive: true, mode: 448 });
   const temp = (0, import_path93.join)((0, import_path93.dirname)(target), `.${(0, import_crypto27.randomUUID)()}.repair.tmp`);
-  (0, import_fs76.writeFileSync)(temp, bytes, { encoding: "utf8", mode: 384, flush: true });
+  (0, import_fs77.writeFileSync)(temp, bytes, { encoding: "utf8", mode: 384, flush: true });
   try {
-    (0, import_fs76.renameSync)(temp, target);
+    (0, import_fs77.renameSync)(temp, target);
   } finally {
-    if ((0, import_fs76.existsSync)(temp)) (0, import_fs76.unlinkSync)(temp);
+    if ((0, import_fs77.existsSync)(temp)) (0, import_fs77.unlinkSync)(temp);
   }
   const repaired = parseCanonical(target);
   if (!repaired || canonicalize2(repaired) !== bytes) throw new Error("immutable_recovery_record_verification_failed");
@@ -40091,7 +46037,7 @@ function resolveCanonicalRecoveryRequestId(cwd2, requestId) {
     visited.add(currentRequestId);
     const reservation = readRecoveryRequestReservation(cwd2, currentRequestId);
     if (!reservation) {
-      if (alias || (0, import_fs76.existsSync)(reservationPath(cwd2, currentRequestId))) return null;
+      if (alias || (0, import_fs77.existsSync)(reservationPath(cwd2, currentRequestId))) return null;
       return currentRequestId;
     }
     if (alias && !hasMatchingReservationTuple(alias, reservation)) return null;
@@ -40138,7 +46084,7 @@ function latestPhase(cwd2, requestId) {
   if (!reservation || reservation.kind !== "reservation") return null;
   const directory = phaseDirectory(cwd2, requestId);
   try {
-    const candidates = (0, import_fs76.readdirSync)(directory).filter((file) => file.endsWith(".json")).sort().reverse();
+    const candidates = (0, import_fs77.readdirSync)(directory).filter((file) => file.endsWith(".json")).sort().reverse();
     if (candidates.length === 0) return null;
     const phase = parseCanonical((0, import_path93.join)(directory, candidates[0]));
     return isValidRecoveryPhase(phase, reservation) ? phase : null;
@@ -40170,7 +46116,7 @@ function isValidRecoveryResult(value) {
 }
 function readRecoveryFinalState(cwd2, requestId) {
   const path25 = finalPath(cwd2, requestId);
-  if (!(0, import_fs76.existsSync)(path25)) return { kind: "missing" };
+  if (!(0, import_fs77.existsSync)(path25)) return { kind: "missing" };
   const final = parseCanonical(path25);
   if (!final || final.schema_version !== 1 || final.kind !== "final" || !isMatchingRecoveryFinal(final, { requestId })) {
     return { kind: "invalid" };
@@ -40180,11 +46126,11 @@ function readRecoveryFinalState(cwd2, requestId) {
   const byTeam = absPath(cwd2, TeamPaths.recoveryResultByTeam(reservation.workspace_hash, final.team_name, final.recovery_id));
   try {
     const expectedBytes = canonicalize2(final);
-    const indexed = (0, import_fs76.existsSync)(byTeam) ? parseCanonical(byTeam) : null;
+    const indexed = (0, import_fs77.existsSync)(byTeam) ? parseCanonical(byTeam) : null;
     if (!indexed || canonicalize2(indexed) !== expectedBytes) {
       const lockPath2 = absPath(cwd2, TeamPaths.recoveryFinalIndexLock(reservation.workspace_hash, final.team_name, final.recovery_id));
       withProcessIdentityFileLockSync(lockPath2, () => {
-        const current = (0, import_fs76.existsSync)(byTeam) ? parseCanonical(byTeam) : null;
+        const current = (0, import_fs77.existsSync)(byTeam) ? parseCanonical(byTeam) : null;
         if (!current || canonicalize2(current) !== expectedBytes) replaceDerivedIndex(byTeam, final);
       });
     }
@@ -40220,12 +46166,12 @@ function readRecoveryResult(cwd2, requestId) {
   const outcome = readRecoveryOutcome(cwd2, requestId);
   return outcome?.kind === "final" ? outcome.result ?? null : null;
 }
-var import_crypto27, import_fs76, import_path93, RETENTION_MS, MAX_RECOVERY_ALIAS_DEPTH, RECOVERY_ERRORS, RECOVERY_WARNINGS;
+var import_crypto27, import_fs77, import_path93, RETENTION_MS, MAX_RECOVERY_ALIAS_DEPTH, RECOVERY_ERRORS, RECOVERY_WARNINGS;
 var init_recovery_request_store = __esm({
   "src/team/recovery-request-store.ts"() {
     "use strict";
     import_crypto27 = require("crypto");
-    import_fs76 = require("fs");
+    import_fs77 = require("fs");
     import_path93 = require("path");
     init_state_paths();
     init_process_identity_lock();
@@ -40282,7 +46228,7 @@ __export(runtime_owner_client_exports, {
   withRecoveryAdmissionLock: () => withRecoveryAdmissionLock
 });
 function workspaceHash(cwd2) {
-  return (0, import_node_crypto6.createHash)("sha256").update(cwd2).digest("hex");
+  return (0, import_node_crypto7.createHash)("sha256").update(cwd2).digest("hex");
 }
 function timeoutBudget(timeoutMs, minimum = MIN_RECOVERY_TIMEOUT_MS, maximum = MAX_RECOVERY_TIMEOUT_MS) {
   if (!Number.isFinite(timeoutMs)) return minimum;
@@ -40339,7 +46285,7 @@ function validateBootstrapCandidate(value, input, recoveryId, expectedEpoch, non
   const candidate = value;
   if (!candidate || candidate.schema_version !== 1 || candidate.request_id !== input.requestId || candidate.recovery_id !== recoveryId || candidate.team_name !== input.teamName || candidate.worker_name !== input.workerName || candidate.expected_epoch !== expectedEpoch || candidate.nonce !== nonce || candidate.pid !== pid || candidate.process_started_at !== processStartedAt || candidate.predecessor_epoch !== (predecessor?.epoch ?? 0) || candidate.predecessor_nonce !== (predecessor?.nonce ?? null) || candidate.predecessor_pid !== (predecessor?.pid ?? null) || candidate.predecessor_process_started_at !== (predecessor?.process_started_at ?? null) || typeof candidate.created_at !== "string" || !Number.isFinite(Date.parse(candidate.created_at)) || typeof candidate.payload_hash !== "string") return false;
   const { payload_hash, ...unsigned } = candidate;
-  return (0, import_node_crypto6.createHash)("sha256").update(canonicalBootstrapCandidate(unsigned)).digest("hex") === payload_hash;
+  return (0, import_node_crypto7.createHash)("sha256").update(canonicalBootstrapCandidate(unsigned)).digest("hex") === payload_hash;
 }
 async function publishRecoveryOwnerBootstrapCandidate(input, recoveryId, expectedEpoch, nonce, pid, processStartedAt, predecessor) {
   const unsigned = {
@@ -40360,11 +46306,11 @@ async function publishRecoveryOwnerBootstrapCandidate(input, recoveryId, expecte
   };
   const candidate = {
     ...unsigned,
-    payload_hash: (0, import_node_crypto6.createHash)("sha256").update(canonicalBootstrapCandidate(unsigned)).digest("hex")
+    payload_hash: (0, import_node_crypto7.createHash)("sha256").update(canonicalBootstrapCandidate(unsigned)).digest("hex")
   };
   const path25 = recoveryOwnerBootstrapCandidatePath(input.cwd, input.teamName, expectedEpoch, nonce);
   await (0, import_promises17.mkdir)((0, import_node_path14.dirname)(path25), { recursive: true, mode: 448 });
-  const temporary = `${path25}.${process.pid}.${(0, import_node_crypto6.randomUUID)()}.candidate`;
+  const temporary = `${path25}.${process.pid}.${(0, import_node_crypto7.randomUUID)()}.candidate`;
   const handle = await (0, import_promises17.open)(temporary, "wx", 384);
   try {
     await handle.writeFile(JSON.stringify(candidate), "utf8");
@@ -40479,7 +46425,7 @@ async function publishIntent(input, recoveryId) {
     created_at: (/* @__PURE__ */ new Date()).toISOString()
   };
   await (0, import_promises17.mkdir)((0, import_node_path14.dirname)(path25), { recursive: true, mode: 448 });
-  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto6.randomUUID)()}`;
+  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto7.randomUUID)()}`;
   const candidateHandle = await (0, import_promises17.open)(candidate, "wx", 384);
   try {
     await candidateHandle.writeFile(JSON.stringify(intent), "utf8");
@@ -40596,7 +46542,7 @@ async function bootstrapPersistentOwner(input, priorEpoch) {
   const predecessorEpoch = predecessor?.epoch ?? 0;
   const expectedEpoch = predecessorEpoch + 1;
   if (hasLiveOrUnknownBootstrapCandidate(input, reservation.recovery_id, expectedEpoch, predecessor)) return false;
-  const bootstrapNonce = (0, import_node_crypto6.randomUUID)();
+  const bootstrapNonce = (0, import_node_crypto7.randomUUID)();
   const child = (0, import_node_child_process10.spawn)(process.execPath, [resolveRuntimeCliPath()], {
     cwd: input.cwd,
     detached: true,
@@ -40644,14 +46590,14 @@ async function bootstrapPersistentOwner(input, priorEpoch) {
     const fenceOk = owner ? checkOwnerFence(input.cwd, input.teamName, { epoch: owner.epoch, nonce: owner.nonce }).ok : false;
     if (isExpectedRecoveryOwnerSuccessor(owner, expectedEpoch, child.pid, childProcessStartedAt, fenceOk, bootstrapNonce) && configBound?.epoch === expectedEpoch && configBound.nonce === bootstrapNonce && configBound.pid === child.pid && configBound.process_started_at === childProcessStartedAt && active?.request_id === input.requestId && active?.recovery_id === reservation.recovery_id && active?.worker_name === input.workerName && active?.owner_epoch === expectedEpoch && active?.owner_nonce === bootstrapNonce) return true;
     if (owner && (owner.epoch > expectedEpoch || owner.epoch === expectedEpoch && owner.pid !== child.pid)) return false;
-    await new Promise((resolve32) => setTimeout(resolve32, 25));
+    await new Promise((resolve33) => setTimeout(resolve33, 25));
   }
   return false;
 }
 function createRecoveryOwnerClient(dispatch, timing = {}) {
   return {
     async recoverDeadWorker(input) {
-      const requestId = input.requestId || (0, import_node_crypto6.randomUUID)();
+      const requestId = input.requestId || (0, import_node_crypto7.randomUUID)();
       const normalized = { ...input, requestId, timeoutMs: timeoutBudget(
         input.timeoutMs,
         timing.minTimeoutMs ?? MIN_RECOVERY_TIMEOUT_MS,
@@ -40741,7 +46687,7 @@ function createRecoveryOwnerClient(dispatch, timing = {}) {
           teamName: normalized.teamName,
           workerName: normalized.workerName
         })) return outcome.result;
-        await new Promise((resolve32) => setTimeout(resolve32, timing.pollIntervalMs ?? 250));
+        await new Promise((resolve33) => setTimeout(resolve33, timing.pollIntervalMs ?? 250));
       }
       return timeoutResult(normalized, canonical.recovery_id);
     }
@@ -40757,12 +46703,12 @@ async function requestRuntimeOwnerRecovery(input) {
   });
   return createRecoveryOwnerClient(dispatch, { persistentOwnerBootstrap: !installedRecoveryOwnerDispatch }).recoverDeadWorker(input);
 }
-var import_node_child_process10, import_node_crypto6, import_node_fs12, import_promises17, import_node_path14, MIN_RECOVERY_TIMEOUT_MS, MAX_RECOVERY_TIMEOUT_MS, recoveryOwnerBootstrapTestHooks, installedRecoveryOwnerDispatch;
+var import_node_child_process10, import_node_crypto7, import_node_fs12, import_promises17, import_node_path14, MIN_RECOVERY_TIMEOUT_MS, MAX_RECOVERY_TIMEOUT_MS, recoveryOwnerBootstrapTestHooks, installedRecoveryOwnerDispatch;
 var init_runtime_owner_client = __esm({
   "src/team/runtime-owner-client.ts"() {
     "use strict";
     import_node_child_process10 = require("node:child_process");
-    import_node_crypto6 = require("node:crypto");
+    import_node_crypto7 = require("node:crypto");
     import_node_fs12 = require("node:fs");
     import_promises17 = require("node:fs/promises");
     import_node_path14 = require("node:path");
@@ -40813,7 +46759,7 @@ async function runRecoverySaga(input, deps) {
   const rejected = checks.find((check2) => !check2.ok);
   if (rejected) return finalize(failure2(input, rejected.error), "selected", "not_started");
   persistPhase("reserved", tasks.length ? "selected" : "none", "not_started");
-  const adoptionTokenHash = (0, import_node_crypto7.createHash)("sha256").update(input.adoptionToken).digest("hex");
+  const adoptionTokenHash = (0, import_node_crypto8.createHash)("sha256").update(input.adoptionToken).digest("hex");
   const sequences = {};
   for (const task of tasks) {
     const result2 = await deps.requeue(input, task.id, adoptionTokenHash);
@@ -40865,11 +46811,11 @@ async function runRecoverySaga(input, deps) {
   const result = { outcome: "recovered", committed: true, oldPaneId: input.originalPaneId, newPaneId: pane.paneId, requeuedTaskIds: tasks.map((task) => task.id), continuationSequenceByTask: sequences, stateRevision: persisted.stateRevision, activation: services === "synced" ? "active" : "services_pending", manifestSync: persisted.manifestSync, servicesSync: services, warnings: services === "synced" ? [] : ["services_pending"], requestId: input.requestId, recoveryId: input.recoveryId, teamName: input.teamName, workerName: input.workerName, updatedAt: (/* @__PURE__ */ new Date()).toISOString() };
   return finalize(result, tasks.length ? "adopted" : "none", tasks.length ? "adopted" : "not_started", services);
 }
-var import_node_crypto7;
+var import_node_crypto8;
 var init_recovery_saga = __esm({
   "src/team/recovery-saga.ts"() {
     "use strict";
-    import_node_crypto7 = require("node:crypto");
+    import_node_crypto8 = require("node:crypto");
     init_recovery_request_store();
   }
 });
@@ -40883,7 +46829,7 @@ async function waitForRecoveryGateRecord(path25, expected, timeoutMs, pollInterv
       if (value.recovery_id === expected.recovery_id && value.worker_name === expected.worker_name && value.replacement_generation === expected.replacement_generation && value.pane_attempt_id === expected.pane_attempt_id) return true;
     } catch {
     }
-    await new Promise((resolve32) => setTimeout(resolve32, pollIntervalMs));
+    await new Promise((resolve33) => setTimeout(resolve33, pollIntervalMs));
   }
   return false;
 }
@@ -40928,7 +46874,7 @@ function hasRequiredRecoveryPaneIdentities(result) {
   if (result.outcome !== "recovered" && result.outcome !== "already_running") return true;
   return Boolean(result.newPaneId.trim()) && (result.outcome !== "recovered" || Boolean(result.oldPaneId?.trim()));
 }
-async function recoverDeadWorkerV2(teamName, cwd2, { workerName: workerName2, requestId = (0, import_node_crypto8.randomUUID)(), timeoutMs = 18e4 }) {
+async function recoverDeadWorkerV2(teamName, cwd2, { workerName: workerName2, requestId = (0, import_node_crypto9.randomUUID)(), timeoutMs = 18e4 }) {
   try {
     validateTeamName(teamName);
   } catch {
@@ -41353,7 +47299,7 @@ async function waitForWorkerStartupEvidence(teamName, workerName2, taskId, cwd2,
       return true;
     }
     if (attempt < attempts) {
-      await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+      await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     }
   }
   return false;
@@ -41523,7 +47469,7 @@ function validateRecoveryAttemptSecret(value, input, recoveryId, replacementGene
 async function recordRecoveryPaneRollbackFailure(input, recoveryId, pending, reason, liveness) {
   const recordedAt = Date.now();
   const path25 = absPath(input.cwd, TeamPaths.recoveryPaneRollbackFailure(input.teamName, recoveryId, pending.paneAttemptId, recordedAt));
-  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto8.randomUUID)()}`;
+  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto9.randomUUID)()}`;
   await (0, import_promises19.mkdir)((0, import_path94.join)(path25, ".."), { recursive: true });
   const handle = await (0, import_promises19.open)(candidate, "wx", 384);
   try {
@@ -41553,7 +47499,7 @@ async function recordRecoveryPaneRollbackFailure(input, recoveryId, pending, rea
 async function recordUnaddressableRecoveryPaneFailure(input, recoveryId, paneAttemptId, reason, split) {
   const recordedAt = Date.now();
   const path25 = absPath(input.cwd, TeamPaths.recoveryPaneRollbackFailure(input.teamName, recoveryId, paneAttemptId, recordedAt));
-  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto8.randomUUID)()}`;
+  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto9.randomUUID)()}`;
   await (0, import_promises19.mkdir)((0, import_path94.join)(path25, ".."), { recursive: true });
   const handle = await (0, import_promises19.open)(candidate, "wx", 384);
   try {
@@ -41814,11 +47760,11 @@ async function readOrCreateRecoveryAttempt(input, recoveryId, replacementGenerat
     recovery_id: recoveryId,
     worker_name: input.workerName,
     replacement_generation: replacementGeneration,
-    adoption_token: (0, import_node_crypto8.randomUUID)(),
+    adoption_token: (0, import_node_crypto9.randomUUID)(),
     created_at: (/* @__PURE__ */ new Date()).toISOString()
   };
   await (0, import_promises19.mkdir)((0, import_path94.join)(path25, ".."), { recursive: true });
-  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto8.randomUUID)()}`;
+  const candidate = `${path25}.candidate.${process.pid}.${(0, import_node_crypto9.randomUUID)()}`;
   const candidateHandle = await (0, import_promises19.open)(candidate, "wx", 384);
   try {
     await candidateHandle.writeFile(JSON.stringify(secret, null, 2), "utf8");
@@ -41837,14 +47783,14 @@ async function readOrCreateRecoveryAttempt(input, recoveryId, replacementGenerat
   }
 }
 function waitForBootstrapRecoveryEvidence(delayMs, signal) {
-  return new Promise((resolve32, reject) => {
+  return new Promise((resolve33, reject) => {
     if (signal?.aborted) {
       reject(signal.reason ?? new Error("bootstrap_recovery_evidence_aborted"));
       return;
     }
     const timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);
-      resolve32();
+      resolve33();
     }, delayMs);
     const onAbort = () => {
       clearTimeout(timer);
@@ -41887,7 +47833,7 @@ function isCanonicalBootstrapCandidate(value, expectedEpoch) {
   const candidate = value;
   if (!candidate || candidate.schema_version !== 1 || candidate.expected_epoch !== expectedEpoch || typeof candidate.request_id !== "string" || candidate.request_id.length === 0 || typeof candidate.recovery_id !== "string" || candidate.recovery_id.length === 0 || typeof candidate.team_name !== "string" || candidate.team_name.length === 0 || typeof candidate.worker_name !== "string" || candidate.worker_name.length === 0 || typeof candidate.nonce !== "string" || candidate.nonce.length === 0 || typeof candidate.pid !== "number" || !Number.isSafeInteger(candidate.pid) || candidate.pid < 1 || typeof candidate.process_started_at !== "string" || candidate.process_started_at.length === 0 || typeof candidate.predecessor_epoch !== "number" || !Number.isSafeInteger(candidate.predecessor_epoch) || candidate.predecessor_epoch < 0 || candidate.expected_epoch !== candidate.predecessor_epoch + 1 || candidate.predecessor_epoch === 0 && (candidate.predecessor_nonce !== null || candidate.predecessor_pid !== null || candidate.predecessor_process_started_at !== null) || candidate.predecessor_epoch > 0 && (typeof candidate.predecessor_nonce !== "string" || candidate.predecessor_nonce.length === 0 || typeof candidate.predecessor_pid !== "number" || !Number.isSafeInteger(candidate.predecessor_pid) || candidate.predecessor_pid < 1 || typeof candidate.predecessor_process_started_at !== "string" || candidate.predecessor_process_started_at.length === 0) || typeof candidate.created_at !== "string" || !Number.isFinite(Date.parse(candidate.created_at)) || typeof candidate.payload_hash !== "string") return false;
   const { payload_hash, ...unsigned } = candidate;
-  return (0, import_node_crypto8.createHash)("sha256").update(JSON.stringify(unsigned)).digest("hex") === payload_hash;
+  return (0, import_node_crypto9.createHash)("sha256").update(JSON.stringify(unsigned)).digest("hex") === payload_hash;
 }
 async function readRecoveryOwnerBootstrapCandidate(teamName, cwd2, expectedEpoch, nonce) {
   try {
@@ -41944,7 +47890,7 @@ async function isExactDeadOrphanBootstrapCandidate(teamName, cwd2, input, config
 function isExactRecoverySidecar(value, task, input, active, replacementGeneration, adoptionToken) {
   const sidecar = value;
   const persisted = task.recovery_reservation ?? task.recovery_adoption;
-  if (!sidecar || !persisted || sidecar.schema_version !== 1 || sidecar.recovery_id !== active.recovery_id || sidecar.request_id !== input.requestId || sidecar.task_id !== task.id || sidecar.old_owner !== input.workerName || typeof sidecar.old_task_version !== "number" || !Number.isSafeInteger(sidecar.old_task_version) || sidecar.old_task_version < 1 || typeof sidecar.old_claim_token !== "string" || sidecar.old_claim_token.length === 0 || typeof sidecar.old_claim_leased_until !== "string" || !Number.isFinite(Date.parse(sidecar.old_claim_leased_until)) || typeof sidecar.continuation_sequence !== "number" || !Number.isSafeInteger(sidecar.continuation_sequence) || sidecar.continuation_sequence < 1 || typeof sidecar.checkpoint_path !== "string" || sidecar.checkpoint_path.length === 0 || typeof sidecar.checkpoint_hash !== "string" || !/^[a-f0-9]{64}$/.test(sidecar.checkpoint_hash) || sidecar.replacement_worker !== input.workerName || sidecar.replacement_generation !== replacementGeneration || sidecar.adoption_token_hash !== (0, import_node_crypto8.createHash)("sha256").update(adoptionToken).digest("hex") || typeof sidecar.created_at !== "string" || !Number.isFinite(Date.parse(sidecar.created_at))) return false;
+  if (!sidecar || !persisted || sidecar.schema_version !== 1 || sidecar.recovery_id !== active.recovery_id || sidecar.request_id !== input.requestId || sidecar.task_id !== task.id || sidecar.old_owner !== input.workerName || typeof sidecar.old_task_version !== "number" || !Number.isSafeInteger(sidecar.old_task_version) || sidecar.old_task_version < 1 || typeof sidecar.old_claim_token !== "string" || sidecar.old_claim_token.length === 0 || typeof sidecar.old_claim_leased_until !== "string" || !Number.isFinite(Date.parse(sidecar.old_claim_leased_until)) || typeof sidecar.continuation_sequence !== "number" || !Number.isSafeInteger(sidecar.continuation_sequence) || sidecar.continuation_sequence < 1 || typeof sidecar.checkpoint_path !== "string" || sidecar.checkpoint_path.length === 0 || typeof sidecar.checkpoint_hash !== "string" || !/^[a-f0-9]{64}$/.test(sidecar.checkpoint_hash) || sidecar.replacement_worker !== input.workerName || sidecar.replacement_generation !== replacementGeneration || sidecar.adoption_token_hash !== (0, import_node_crypto9.createHash)("sha256").update(adoptionToken).digest("hex") || typeof sidecar.created_at !== "string" || !Number.isFinite(Date.parse(sidecar.created_at))) return false;
   const sameReservation = persisted.recovery_id === sidecar.recovery_id && persisted.request_id === sidecar.request_id && persisted.continuation_sequence === sidecar.continuation_sequence && persisted.checkpoint_path === sidecar.checkpoint_path && persisted.checkpoint_hash === sidecar.checkpoint_hash && persisted.replacement_worker === sidecar.replacement_worker && persisted.replacement_generation === sidecar.replacement_generation;
   if (!sameReservation) return false;
   if ("adoption_token_hash" in persisted && persisted.adoption_token_hash !== sidecar.adoption_token_hash) return false;
@@ -42128,7 +48074,7 @@ async function prepareRecoveryOwnerBootstrap(input, waitOptions) {
 }
 async function executeRecoverDeadWorkerV2Owner(input) {
   const reservation = readRecoveryRequestReservation(input.cwd, input.requestId);
-  const recoveryId = reservation?.recovery_id ?? (0, import_node_crypto8.randomUUID)();
+  const recoveryId = reservation?.recovery_id ?? (0, import_node_crypto9.randomUUID)();
   let ownerBound = false;
   try {
     const beforeOwner = await readRevisionedTeamConfig(input.teamName, input.cwd);
@@ -42288,7 +48234,7 @@ async function executeRecoverDeadWorkerV2Owner(input) {
             };
           }
         }
-        const paneAttemptId = (0, import_node_crypto8.randomUUID)();
+        const paneAttemptId = (0, import_node_crypto9.randomUUID)();
         let prepared;
         try {
           prepared = buildRecoveryPaneContext(input, sagaInput2, config2, currentWorker, launchDescriptor, "", paneAttemptId);
@@ -42437,7 +48383,7 @@ async function executeRecoverDeadWorkerV2Owner(input) {
           written_at: (/* @__PURE__ */ new Date()).toISOString()
         };
         const launchedPath = `${pending.gate.runPath}.launched`;
-        if (!(0, import_fs77.existsSync)(launchedPath)) {
+        if (!(0, import_fs78.existsSync)(launchedPath)) {
           await (0, import_promises19.writeFile)(pending.gate.runPath, JSON.stringify(record2), "utf8");
           const launched = await waitForRecoveryGateRecord(launchedPath, record2, 3e4);
           if (!launched) throw new Error("startup_ack_timeout");
@@ -42809,7 +48755,7 @@ async function startTeamV2(config2) {
     service_descriptor: config2.autoMerge ? {
       schema_version: 1,
       service_generation: 1,
-      service_attempt_id: (0, import_node_crypto8.randomUUID)(),
+      service_attempt_id: (0, import_node_crypto9.randomUUID)(),
       auto_merge_enabled: true,
       workspace_root: leaderCwd,
       leader_branch: autoMergeLeaderBranch,
@@ -42817,7 +48763,7 @@ async function startTeamV2(config2) {
     } : {
       schema_version: 1,
       service_generation: 1,
-      service_attempt_id: (0, import_node_crypto8.randomUUID)(),
+      service_attempt_id: (0, import_node_crypto9.randomUUID)(),
       auto_merge_enabled: false,
       workspace_root: leaderCwd,
       cadence_policy: "disabled"
@@ -43363,7 +49309,7 @@ async function shutdownTeamV2(teamName, cwd2, options = {}) {
   const ralph = options.ralph === true;
   const timeoutMs = options.timeoutMs ?? 15e3;
   const sanitized = sanitizeTeamName(teamName);
-  const workspaceHash2 = (0, import_node_crypto8.createHash)("sha256").update(cwd2).digest("hex");
+  const workspaceHash2 = (0, import_node_crypto9.createHash)("sha256").update(cwd2).digest("hex");
   const lifecycleLock = absPath(cwd2, TeamPaths.recoveryLifecycleLock(workspaceHash2, sanitized));
   const assertShutdownGate = async (currentConfig) => {
     if (force) return;
@@ -43419,7 +49365,7 @@ async function shutdownTeamV2(teamName, cwd2, options = {}) {
     await assertShutdownGate(current.config);
     const processStartedAt = currentProcessStartIdentity();
     if (!processStartedAt) throw new Error("process_start_identity_unavailable");
-    ownedShutdownNonce = (0, import_node_crypto8.randomUUID)();
+    ownedShutdownNonce = (0, import_node_crypto9.randomUUID)();
     const nextRevision = current.stateRevision + 1;
     const next = {
       ...current.config,
@@ -43669,7 +49615,7 @@ async function resumeTeamV2(teamName, cwd2) {
 }
 async function findActiveTeamsV2(cwd2) {
   const root2 = (0, import_path94.join)(getOmcRoot(cwd2), "state", "team");
-  if (!(0, import_fs77.existsSync)(root2)) return [];
+  if (!(0, import_fs78.existsSync)(root2)) return [];
   const entries = await (0, import_promises19.readdir)(root2, { withFileTypes: true });
   const active = [];
   for (const e of entries) {
@@ -43682,13 +49628,13 @@ async function findActiveTeamsV2(cwd2) {
   }
   return active;
 }
-var import_path94, import_fs77, import_promises19, import_perf_hooks2, import_node_child_process11, import_node_crypto8, runtimeOwnerRecoveryClient, orchestratorByTeam, CURSOR_UNSUPPORTED_REVIEW_INTENT_RE, CURSOR_EXECUTOR_CONTEXT_RE, CURSOR_EXECUTOR_CONTEXT_INTENTS, cadenceByTeam, MONITOR_SIGNAL_STALE_MS, pendingRecoveryPanes, BOOTSTRAP_RECOVERY_EVIDENCE_POLL_MS, BOOTSTRAP_RECOVERY_EVIDENCE_MAX_WAIT_MS, CIRCUIT_BREAKER_THRESHOLD, CircuitBreakerV2;
+var import_path94, import_fs78, import_promises19, import_perf_hooks2, import_node_child_process11, import_node_crypto9, runtimeOwnerRecoveryClient, orchestratorByTeam, CURSOR_UNSUPPORTED_REVIEW_INTENT_RE, CURSOR_EXECUTOR_CONTEXT_RE, CURSOR_EXECUTOR_CONTEXT_INTENTS, cadenceByTeam, MONITOR_SIGNAL_STALE_MS, pendingRecoveryPanes, BOOTSTRAP_RECOVERY_EVIDENCE_POLL_MS, BOOTSTRAP_RECOVERY_EVIDENCE_MAX_WAIT_MS, CIRCUIT_BREAKER_THRESHOLD, CircuitBreakerV2;
 var init_runtime_v2 = __esm({
   "src/team/runtime-v2.ts"() {
     "use strict";
     init_tmux_utils();
     import_path94 = require("path");
-    import_fs77 = require("fs");
+    import_fs78 = require("fs");
     import_promises19 = require("fs/promises");
     import_perf_hooks2 = require("perf_hooks");
     init_state_paths();
@@ -43718,7 +49664,7 @@ var init_runtime_v2 = __esm({
     import_node_child_process11 = require("node:child_process");
     init_runtime_flags();
     init_worker_commit_cadence();
-    import_node_crypto8 = require("node:crypto");
+    import_node_crypto9 = require("node:crypto");
     init_recovery_request_store();
     init_runtime_owner_client();
     init_recovery_saga();
@@ -43779,19 +49725,19 @@ function acquireTaskLock(teamName, taskId, opts) {
   const lockPath2 = (0, import_path95.join)(dir, `${sanitizeTaskId(taskId)}.lock`);
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const fd = (0, import_fs78.openSync)(lockPath2, import_fs78.constants.O_CREAT | import_fs78.constants.O_EXCL | import_fs78.constants.O_WRONLY, 384);
+      const fd = (0, import_fs79.openSync)(lockPath2, import_fs79.constants.O_CREAT | import_fs79.constants.O_EXCL | import_fs79.constants.O_WRONLY, 384);
       const payload = JSON.stringify({
         pid: process.pid,
         workerName: opts?.workerName ?? "",
         timestamp: Date.now()
       });
-      (0, import_fs78.writeSync)(fd, payload, null, "utf-8");
+      (0, import_fs79.writeSync)(fd, payload, null, "utf-8");
       return { fd, path: lockPath2 };
     } catch (err) {
       if (err && typeof err === "object" && "code" in err && err.code === "EEXIST") {
         if (attempt === 0 && isLockStale2(lockPath2, staleLockMs)) {
           try {
-            (0, import_fs78.unlinkSync)(lockPath2);
+            (0, import_fs79.unlinkSync)(lockPath2);
           } catch {
           }
           continue;
@@ -43805,11 +49751,11 @@ function acquireTaskLock(teamName, taskId, opts) {
 }
 function releaseTaskLock(handle) {
   try {
-    (0, import_fs78.closeSync)(handle.fd);
+    (0, import_fs79.closeSync)(handle.fd);
   } catch {
   }
   try {
-    (0, import_fs78.unlinkSync)(handle.path);
+    (0, import_fs79.unlinkSync)(handle.path);
   } catch {
   }
 }
@@ -43824,11 +49770,11 @@ async function withTaskLock(teamName, taskId, fn, opts) {
 }
 function isLockStale2(lockPath2, staleLockMs) {
   try {
-    const stat2 = (0, import_fs78.statSync)(lockPath2);
-    const ageMs = Date.now() - stat2.mtimeMs;
+    const stat3 = (0, import_fs79.statSync)(lockPath2);
+    const ageMs = Date.now() - stat3.mtimeMs;
     if (ageMs < staleLockMs) return false;
     try {
-      const raw = (0, import_fs78.readFileSync)(lockPath2, "utf-8");
+      const raw = (0, import_fs79.readFileSync)(lockPath2, "utf-8");
       const payload = JSON.parse(raw);
       if (payload.pid && isProcessAlive(payload.pid)) return false;
     } catch {
@@ -43867,19 +49813,19 @@ function writeTaskFailure(teamName, taskId, error2, opts) {
 }
 function readTaskFailure(teamName, taskId, opts) {
   const filePath = failureSidecarPath(teamName, taskId, opts?.cwd);
-  if (!(0, import_fs78.existsSync)(filePath)) return null;
+  if (!(0, import_fs79.existsSync)(filePath)) return null;
   try {
-    const raw = (0, import_fs78.readFileSync)(filePath, "utf-8");
+    const raw = (0, import_fs79.readFileSync)(filePath, "utf-8");
     return JSON.parse(raw);
   } catch {
     return null;
   }
 }
-var import_fs78, import_path95, DEFAULT_STALE_LOCK_MS2, DEFAULT_MAX_TASK_RETRIES;
+var import_fs79, import_path95, DEFAULT_STALE_LOCK_MS2, DEFAULT_MAX_TASK_RETRIES;
 var init_task_file_ops = __esm({
   "src/team/task-file-ops.ts"() {
     "use strict";
-    import_fs78 = require("fs");
+    import_fs79 = require("fs");
     import_path95 = require("path");
     init_worktree_paths();
     init_config_dir();
@@ -43937,7 +49883,7 @@ async function readJsonSafe5(filePath) {
         return null;
       }
     }
-    await new Promise((resolve32) => setTimeout(resolve32, 25));
+    await new Promise((resolve33) => setTimeout(resolve33, 25));
   }
   return null;
 }
@@ -44055,7 +50001,7 @@ async function nextPendingTaskIndex(runtime) {
     let task = await readTask(root2, taskId);
     if (!task) {
       for (let attempt = 1; attempt < transientReadRetryAttempts; attempt++) {
-        await new Promise((resolve32) => setTimeout(resolve32, transientReadRetryDelayMs));
+        await new Promise((resolve33) => setTimeout(resolve33, transientReadRetryDelayMs));
         task = await readTask(root2, taskId);
         if (task) break;
       }
@@ -44534,7 +50480,7 @@ async function shutdownTeam(teamName, sessionName2, cwd2, timeoutMs = 3e4, worke
     while (Date.now() < deadline && expectedAcks.length > 0) {
       for (const wName of [...expectedAcks]) {
         const ackPath = (0, import_path96.join)(root2, "workers", wName, "shutdown-ack.json");
-        if ((0, import_fs79.existsSync)(ackPath)) {
+        if ((0, import_fs80.existsSync)(ackPath)) {
           expectedAcks.splice(expectedAcks.indexOf(wName), 1);
         }
       }
@@ -44604,13 +50550,13 @@ async function resumeTeam(teamName, cwd2) {
     ownsWindow: Boolean(configData.tmuxOwnsWindow)
   };
 }
-var import_promises20, import_path96, import_fs79;
+var import_promises20, import_path96, import_fs80;
 var init_runtime = __esm({
   "src/team/runtime.ts"() {
     "use strict";
     import_promises20 = require("fs/promises");
     import_path96 = require("path");
-    import_fs79 = require("fs");
+    import_fs80 = require("fs");
     init_tmux_utils();
     init_model_contract();
     init_team_name();
@@ -44675,28 +50621,28 @@ function createMinimalDaemonEnv() {
   return env2;
 }
 function ensureStateDir3() {
-  if (!(0, import_fs80.existsSync)(DEFAULT_STATE_DIR)) {
-    (0, import_fs80.mkdirSync)(DEFAULT_STATE_DIR, { recursive: true, mode: 448 });
+  if (!(0, import_fs81.existsSync)(DEFAULT_STATE_DIR)) {
+    (0, import_fs81.mkdirSync)(DEFAULT_STATE_DIR, { recursive: true, mode: 448 });
   }
 }
 function writeSecureFile(filePath, content) {
   ensureStateDir3();
-  (0, import_fs80.writeFileSync)(filePath, content, { mode: SECURE_FILE_MODE2 });
+  (0, import_fs81.writeFileSync)(filePath, content, { mode: SECURE_FILE_MODE2 });
   try {
-    (0, import_fs80.chmodSync)(filePath, SECURE_FILE_MODE2);
+    (0, import_fs81.chmodSync)(filePath, SECURE_FILE_MODE2);
   } catch {
   }
 }
 function rotateLogIfNeeded(logPath) {
   try {
-    if (!(0, import_fs80.existsSync)(logPath)) return;
-    const stats = (0, import_fs80.statSync)(logPath);
+    if (!(0, import_fs81.existsSync)(logPath)) return;
+    const stats = (0, import_fs81.statSync)(logPath);
     if (stats.size > MAX_LOG_SIZE_BYTES) {
       const backupPath = `${logPath}.old`;
-      if ((0, import_fs80.existsSync)(backupPath)) {
-        (0, import_fs80.unlinkSync)(backupPath);
+      if ((0, import_fs81.existsSync)(backupPath)) {
+        (0, import_fs81.unlinkSync)(backupPath);
       }
-      (0, import_fs80.renameSync)(logPath, backupPath);
+      (0, import_fs81.renameSync)(logPath, backupPath);
     }
   } catch {
   }
@@ -44708,16 +50654,16 @@ function log(message2) {
     const timestamp2 = (/* @__PURE__ */ new Date()).toISOString();
     const logLine = `[${timestamp2}] ${redactTokens(message2)}
 `;
-    (0, import_fs80.appendFileSync)(LOG_FILE_PATH, logLine, { mode: SECURE_FILE_MODE2 });
+    (0, import_fs81.appendFileSync)(LOG_FILE_PATH, logLine, { mode: SECURE_FILE_MODE2 });
   } catch {
   }
 }
 function readDaemonState() {
   try {
-    if (!(0, import_fs80.existsSync)(STATE_FILE_PATH)) {
+    if (!(0, import_fs81.existsSync)(STATE_FILE_PATH)) {
       return null;
     }
-    const content = (0, import_fs80.readFileSync)(STATE_FILE_PATH, "utf-8");
+    const content = (0, import_fs81.readFileSync)(STATE_FILE_PATH, "utf-8");
     const state = JSON.parse(content);
     return state;
   } catch {
@@ -44741,13 +50687,13 @@ async function buildDaemonConfig() {
 }
 function readPidRecord() {
   try {
-    if (!(0, import_fs80.existsSync)(PID_FILE_PATH)) return null;
-    const content = (0, import_fs80.readFileSync)(PID_FILE_PATH, "utf-8").trim();
+    if (!(0, import_fs81.existsSync)(PID_FILE_PATH)) return null;
+    const content = (0, import_fs81.readFileSync)(PID_FILE_PATH, "utf-8").trim();
     const parsed = JSON.parse(content);
     return typeof parsed.pid === "number" && Number.isInteger(parsed.pid) && parsed.pid > 0 ? { pid: parsed.pid, generation: parsed.generation, processStartIdentity: parsed.processStartIdentity } : null;
   } catch {
     try {
-      const pid = Number.parseInt((0, import_fs80.readFileSync)(PID_FILE_PATH, "utf-8").trim(), 10);
+      const pid = Number.parseInt((0, import_fs81.readFileSync)(PID_FILE_PATH, "utf-8").trim(), 10);
       return Number.isInteger(pid) && pid > 0 ? { pid } : null;
     } catch {
       return null;
@@ -44761,8 +50707,8 @@ function writePidFile(record2) {
   writeSecureFile(PID_FILE_PATH, JSON.stringify(record2));
 }
 function removePidFile() {
-  if ((0, import_fs80.existsSync)(PID_FILE_PATH)) {
-    (0, import_fs80.unlinkSync)(PID_FILE_PATH);
+  if ((0, import_fs81.existsSync)(PID_FILE_PATH)) {
+    (0, import_fs81.unlinkSync)(PID_FILE_PATH);
   }
 }
 function isDaemonRunning() {
@@ -44943,7 +50889,7 @@ async function pollTelegram(config2, state, rateLimiter) {
   try {
     const offset = state.telegramLastUpdateId ? state.telegramLastUpdateId + 1 : 0;
     const path25 = `/bot${config2.telegramBotToken}/getUpdates?offset=${offset}&timeout=0`;
-    const updates = await new Promise((resolve32, reject) => {
+    const updates = await new Promise((resolve33, reject) => {
       const req = (0, import_https2.request)(
         {
           hostname: "api.telegram.org",
@@ -44960,7 +50906,7 @@ async function pollTelegram(config2, state, rateLimiter) {
             try {
               const body = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
               if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-                resolve32(body.result || []);
+                resolve33(body.result || []);
               } else {
                 reject(new Error(`HTTP ${res.statusCode}`));
               }
@@ -45024,7 +50970,7 @@ async function pollTelegram(config2, state, rateLimiter) {
             text: "Injected into Claude Code session.",
             reply_to_message_id: msg.message_id
           });
-          await new Promise((resolve32) => {
+          await new Promise((resolve33) => {
             const replyReq = (0, import_https2.request)(
               {
                 hostname: "api.telegram.org",
@@ -45039,13 +50985,13 @@ async function pollTelegram(config2, state, rateLimiter) {
               },
               (res) => {
                 res.resume();
-                resolve32();
+                resolve33();
               }
             );
-            replyReq.on("error", () => resolve32());
+            replyReq.on("error", () => resolve33());
             replyReq.on("timeout", () => {
               replyReq.destroy();
-              resolve32();
+              resolve33();
             });
             replyReq.write(replyBody);
             replyReq.end();
@@ -45184,13 +51130,13 @@ async function pollLoop() {
         }
       }
       writeDaemonState(state);
-      await new Promise((resolve32) => setTimeout(resolve32, config2.pollIntervalMs));
+      await new Promise((resolve33) => setTimeout(resolve33, config2.pollIntervalMs));
     } catch (error2) {
       state.errors++;
       state.lastError = redactTokens(error2 instanceof Error ? error2.message : String(error2));
       log(`Poll error: ${state.lastError}`);
       writeDaemonState(state);
-      await new Promise((resolve32) => setTimeout(resolve32, config2.pollIntervalMs * 2));
+      await new Promise((resolve33) => setTimeout(resolve33, config2.pollIntervalMs * 2));
     }
   }
   log("Poll loop ended");
@@ -45401,11 +51347,11 @@ function processSlackSocketMessage(rawMessage, connectionState, paneId, config2,
   }
   return { injected: success, validation };
 }
-var import_fs80, import_path98, import_url12, import_child_process27, import_crypto28, import_https2, __filename2, SECURE_FILE_MODE2, MAX_LOG_SIZE_BYTES, DAEMON_ENV_ALLOWLIST, DEFAULT_STATE_DIR, PID_FILE_PATH, STATE_FILE_PATH, LOG_FILE_PATH, RateLimiter, discordBackoffUntil, PRUNE_INTERVAL_MS;
+var import_fs81, import_path98, import_url12, import_child_process27, import_crypto28, import_https2, __filename2, SECURE_FILE_MODE2, MAX_LOG_SIZE_BYTES, DAEMON_ENV_ALLOWLIST, DEFAULT_STATE_DIR, PID_FILE_PATH, STATE_FILE_PATH, LOG_FILE_PATH, RateLimiter, discordBackoffUntil, PRUNE_INTERVAL_MS;
 var init_reply_listener = __esm({
   "src/notifications/reply-listener.ts"() {
     "use strict";
-    import_fs80 = require("fs");
+    import_fs81 = require("fs");
     import_path98 = require("path");
     import_url12 = require("url");
     import_child_process27 = require("child_process");
@@ -45729,8 +51675,8 @@ function cleanupTransientState(directory, endingSessionId) {
         for (const sid of sessionDirs) {
           const sessionDir = path19.join(sessionsDir, sid);
           try {
-            const stat2 = fs15.statSync(sessionDir);
-            if (!stat2.isDirectory()) continue;
+            const stat3 = fs15.statSync(sessionDir);
+            if (!stat3.isDirectory()) continue;
             const activePatterns = isEndingSession(sid) ? [...crossSessionSafePatterns, ...endingSessionOnlyPatterns] : crossSessionSafePatterns;
             const sessionFiles = fs15.readdirSync(sessionDir);
             for (const file of sessionFiles) {
@@ -46576,8 +52522,8 @@ function getDbPath(cwd2) {
 }
 function ensureStateDir4(cwd2) {
   const stateDir = (0, import_path99.join)(getOmcRoot(cwd2), "state");
-  if (!(0, import_fs81.existsSync)(stateDir)) {
-    (0, import_fs81.mkdirSync)(stateDir, { recursive: true });
+  if (!(0, import_fs82.existsSync)(stateDir)) {
+    (0, import_fs82.mkdirSync)(stateDir, { recursive: true });
   }
 }
 function rowToJobStatus(row) {
@@ -46750,11 +52696,11 @@ function getJobStats(cwd2) {
     return null;
   }
 }
-var import_fs81, import_path99, DB_SCHEMA_VERSION, DEFAULT_CLEANUP_MAX_AGE_MS, Database, dbMap, _lastCwd;
+var import_fs82, import_path99, DB_SCHEMA_VERSION, DEFAULT_CLEANUP_MAX_AGE_MS, Database, dbMap, _lastCwd;
 var init_job_state_db = __esm({
   "src/lib/job-state-db.ts"() {
     "use strict";
-    import_fs81 = require("fs");
+    import_fs82 = require("fs");
     import_path99 = require("path");
     init_worktree_paths();
     DB_SCHEMA_VERSION = 1;
@@ -46780,22 +52726,22 @@ __export(pre_compact_exports, {
 });
 function getCheckpointPath(directory) {
   const checkpointDir = (0, import_path100.join)(getOmcRoot(directory), "state", CHECKPOINT_DIR);
-  if (!(0, import_fs82.existsSync)(checkpointDir)) {
-    (0, import_fs82.mkdirSync)(checkpointDir, { recursive: true });
+  if (!(0, import_fs83.existsSync)(checkpointDir)) {
+    (0, import_fs83.mkdirSync)(checkpointDir, { recursive: true });
   }
   return checkpointDir;
 }
 async function exportWisdomToNotepad(directory) {
   const notepadsDir = (0, import_path100.join)(getOmcRoot(directory), "notepads");
-  if (!(0, import_fs82.existsSync)(notepadsDir)) {
+  if (!(0, import_fs83.existsSync)(notepadsDir)) {
     return { wisdom: "", exported: false };
   }
   const wisdomParts = [];
   let hasWisdom = false;
   try {
-    const planDirs = (0, import_fs82.readdirSync)(notepadsDir).filter((name) => {
+    const planDirs = (0, import_fs83.readdirSync)(notepadsDir).filter((name) => {
       const path25 = (0, import_path100.join)(notepadsDir, name);
-      return (0, import_fs82.statSync)(path25).isDirectory();
+      return (0, import_fs83.statSync)(path25).isDirectory();
     });
     for (const planDir of planDirs) {
       const planPath = (0, import_path100.join)(notepadsDir, planDir);
@@ -46807,8 +52753,8 @@ async function exportWisdomToNotepad(directory) {
       ];
       for (const wisdomFile of wisdomFiles) {
         const wisdomPath = (0, import_path100.join)(planPath, wisdomFile);
-        if ((0, import_fs82.existsSync)(wisdomPath)) {
-          const content = (0, import_fs82.readFileSync)(wisdomPath, "utf-8").trim();
+        if ((0, import_fs83.existsSync)(wisdomPath)) {
+          const content = (0, import_fs83.readFileSync)(wisdomPath, "utf-8").trim();
           if (content) {
             wisdomParts.push(`### ${planDir}/${wisdomFile}
 ${content}`);
@@ -46856,7 +52802,7 @@ async function saveModeSummary(directory) {
   const reads = stateFiles.map(async (config2) => {
     const path25 = (0, import_path100.join)(stateDir, config2.file);
     try {
-      const content = await import_fs83.promises.readFile(path25, "utf-8");
+      const content = await import_fs84.promises.readFile(path25, "utf-8");
       const state = JSON.parse(content);
       const extracted = config2.extract(state);
       return extracted ? { key: config2.key, value: extracted } : null;
@@ -46882,9 +52828,9 @@ function readTodoSummary(directory) {
     (0, import_path100.join)(getOmcRoot(directory), "state", "todos.json")
   ];
   for (const todoPath of todoPaths) {
-    if ((0, import_fs82.existsSync)(todoPath)) {
+    if ((0, import_fs83.existsSync)(todoPath)) {
       try {
-        const content = (0, import_fs82.readFileSync)(todoPath, "utf-8");
+        const content = (0, import_fs83.readFileSync)(todoPath, "utf-8");
         const todos = JSON.parse(content);
         if (Array.isArray(todos)) {
           return {
@@ -47038,14 +52984,14 @@ async function doProcessPreCompact(input) {
   const timestamp2 = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-");
   const checkpointFile = (0, import_path100.join)(checkpointPath2, `checkpoint-${timestamp2}.json`);
   try {
-    (0, import_fs82.writeFileSync)(checkpointFile, JSON.stringify(checkpoint, null, 2), "utf-8");
+    (0, import_fs83.writeFileSync)(checkpointFile, JSON.stringify(checkpoint, null, 2), "utf-8");
   } catch (error2) {
     console.error("[PreCompact] Error saving checkpoint:", error2);
   }
   if (exported && wisdom) {
     const wisdomFile = (0, import_path100.join)(checkpointPath2, `wisdom-${timestamp2}.md`);
     try {
-      (0, import_fs82.writeFileSync)(wisdomFile, wisdom, "utf-8");
+      (0, import_fs83.writeFileSync)(wisdomFile, wisdom, "utf-8");
     } catch (error2) {
       console.error("[PreCompact] Error saving wisdom:", error2);
     }
@@ -47087,12 +53033,12 @@ function isCompactionInProgress(directory) {
 function getCompactionQueueDepth(directory) {
   return compactionQueueDepth.get(directory) ?? 0;
 }
-var import_fs82, import_fs83, import_path100, CHECKPOINT_DIR, inflightCompactions, compactionQueueDepth, pre_compact_default;
+var import_fs83, import_fs84, import_path100, CHECKPOINT_DIR, inflightCompactions, compactionQueueDepth, pre_compact_default;
 var init_pre_compact = __esm({
   "src/hooks/pre-compact/index.ts"() {
     "use strict";
-    import_fs82 = require("fs");
     import_fs83 = require("fs");
+    import_fs84 = require("fs");
     import_path100 = require("path");
     init_worktree_paths();
     init_job_state_db();
@@ -47227,9 +53173,9 @@ function ensureDirectoryStructure(directory) {
   const created = [];
   for (const dir of REQUIRED_DIRECTORIES) {
     const fullPath = (0, import_path101.join)(directory, dir);
-    if (!(0, import_fs84.existsSync)(fullPath)) {
+    if (!(0, import_fs85.existsSync)(fullPath)) {
       try {
-        (0, import_fs84.mkdirSync)(fullPath, { recursive: true });
+        (0, import_fs85.mkdirSync)(fullPath, { recursive: true });
         created.push(fullPath);
       } catch (_err) {
       }
@@ -47241,9 +53187,9 @@ function validateConfigFiles(directory) {
   const validated = [];
   for (const configFile of CONFIG_FILES) {
     const fullPath = (0, import_path101.join)(directory, configFile);
-    if ((0, import_fs84.existsSync)(fullPath)) {
+    if ((0, import_fs85.existsSync)(fullPath)) {
       try {
-        (0, import_fs84.readFileSync)(fullPath, "utf-8");
+        (0, import_fs85.readFileSync)(fullPath, "utf-8");
         validated.push(fullPath);
       } catch {
       }
@@ -47257,7 +53203,7 @@ function setEnvironmentVariables() {
     try {
       const envContent = `export OMC_INITIALIZED=true
 `;
-      (0, import_fs84.appendFileSync)(process.env.CLAUDE_ENV_FILE, envContent);
+      (0, import_fs85.appendFileSync)(process.env.CLAUDE_ENV_FILE, envContent);
       envVars.push("OMC_INITIALIZED");
     } catch {
     }
@@ -47266,9 +53212,9 @@ function setEnvironmentVariables() {
 }
 function patchHooksJsonForWindows(pluginRoot) {
   const hooksJsonPath = (0, import_path101.join)(pluginRoot, "hooks", "hooks.json");
-  if (!(0, import_fs84.existsSync)(hooksJsonPath)) return;
+  if (!(0, import_fs85.existsSync)(hooksJsonPath)) return;
   try {
-    const content = (0, import_fs84.readFileSync)(hooksJsonPath, "utf-8");
+    const content = (0, import_fs85.readFileSync)(hooksJsonPath, "utf-8");
     const data = JSON.parse(content);
     const currentPattern = /^(?:"\/bin\/sh"|sh) "\$CLAUDE_PLUGIN_ROOT"\/scripts\/find-node\.sh "\$CLAUDE_PLUGIN_ROOT"\/scripts\/run\.cjs "\$CLAUDE_PLUGIN_ROOT"\/scripts\/([^"\s]+)"?(.*)$/;
     const legacyPattern = /^sh "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/find-node\.sh" "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/([^"\s]+)"?(.*)$/;
@@ -47287,7 +53233,7 @@ function patchHooksJsonForWindows(pluginRoot) {
       }
     }
     if (patched) {
-      (0, import_fs84.writeFileSync)(hooksJsonPath, JSON.stringify(data, null, 2) + "\n");
+      (0, import_fs85.writeFileSync)(hooksJsonPath, JSON.stringify(data, null, 2) + "\n");
     }
   } catch {
   }
@@ -47297,17 +53243,17 @@ function ensureStdinSymlink(pluginRoot) {
   const libSrc = (0, import_path101.join)(pluginRoot, "templates/hooks/lib");
   const stdinSrc = (0, import_path101.join)(libSrc, "stdin.mjs");
   const stdinDst = (0, import_path101.join)(libDstDir, "stdin.mjs");
-  if (!(0, import_fs84.existsSync)(libDstDir)) {
-    (0, import_fs84.mkdirSync)(libDstDir, { recursive: true });
+  if (!(0, import_fs85.existsSync)(libDstDir)) {
+    (0, import_fs85.mkdirSync)(libDstDir, { recursive: true });
   }
-  if (!(0, import_fs84.existsSync)(stdinSrc)) {
+  if (!(0, import_fs85.existsSync)(stdinSrc)) {
     return;
   }
   try {
-    const currentTarget = (0, import_fs84.readlinkSync)(stdinDst);
+    const currentTarget = (0, import_fs85.readlinkSync)(stdinDst);
     if (currentTarget === stdinSrc) {
       try {
-        (0, import_fs84.statSync)(currentTarget);
+        (0, import_fs85.statSync)(currentTarget);
         return;
       } catch {
       }
@@ -47317,25 +53263,25 @@ function ensureStdinSymlink(pluginRoot) {
   const tmpDst = stdinDst + ".tmp";
   try {
     try {
-      (0, import_fs84.unlinkSync)(tmpDst);
+      (0, import_fs85.unlinkSync)(tmpDst);
     } catch {
     }
-    (0, import_fs84.symlinkSync)(stdinSrc, tmpDst);
+    (0, import_fs85.symlinkSync)(stdinSrc, tmpDst);
     try {
-      (0, import_fs84.unlinkSync)(stdinDst);
+      (0, import_fs85.unlinkSync)(stdinDst);
     } catch {
     }
-    (0, import_fs84.renameSync)(tmpDst, stdinDst);
+    (0, import_fs85.renameSync)(tmpDst, stdinDst);
   } catch {
     try {
-      const dstStat = (0, import_fs84.lstatSync)(stdinDst);
+      const dstStat = (0, import_fs85.lstatSync)(stdinDst);
       if (dstStat.isSymbolicLink()) {
-        (0, import_fs84.unlinkSync)(stdinDst);
+        (0, import_fs85.unlinkSync)(stdinDst);
       }
     } catch {
     }
     try {
-      (0, import_fs84.copyFileSync)(stdinSrc, stdinDst);
+      (0, import_fs85.copyFileSync)(stdinSrc, stdinDst);
     } catch {
     }
   }
@@ -47387,17 +53333,17 @@ async function processSetupInit(input) {
 }
 function pruneOldStateFiles(directory, maxAgeDays = DEFAULT_STATE_MAX_AGE_DAYS) {
   const stateDir = (0, import_path101.join)(getOmcRoot(directory), "state");
-  if (!(0, import_fs84.existsSync)(stateDir)) {
+  if (!(0, import_fs85.existsSync)(stateDir)) {
     return 0;
   }
   const cutoffTime = Date.now() - maxAgeDays * 24 * 60 * 60 * 1e3;
   let deletedCount = 0;
   try {
-    const files = (0, import_fs84.readdirSync)(stateDir);
+    const files = (0, import_fs85.readdirSync)(stateDir);
     for (const file of files) {
       const filePath = (0, import_path101.join)(stateDir, file);
       try {
-        const stats = (0, import_fs84.statSync)(filePath);
+        const stats = (0, import_fs85.statSync)(filePath);
         if (stats.isDirectory()) {
           continue;
         }
@@ -47409,7 +53355,7 @@ function pruneOldStateFiles(directory, maxAgeDays = DEFAULT_STATE_MAX_AGE_DAYS) 
           ];
           if (modeStateFiles.includes(file)) {
             try {
-              const content = (0, import_fs84.readFileSync)(filePath, "utf-8");
+              const content = (0, import_fs85.readFileSync)(filePath, "utf-8");
               const state = JSON.parse(content);
               if (state.active === true) {
                 continue;
@@ -47417,7 +53363,7 @@ function pruneOldStateFiles(directory, maxAgeDays = DEFAULT_STATE_MAX_AGE_DAYS) 
             } catch {
             }
           }
-          (0, import_fs84.unlinkSync)(filePath);
+          (0, import_fs85.unlinkSync)(filePath);
           deletedCount++;
         }
       } catch {
@@ -47429,22 +53375,22 @@ function pruneOldStateFiles(directory, maxAgeDays = DEFAULT_STATE_MAX_AGE_DAYS) 
 }
 function cleanupOrphanedState(directory) {
   const stateDir = (0, import_path101.join)(getOmcRoot(directory), "state");
-  if (!(0, import_fs84.existsSync)(stateDir)) {
+  if (!(0, import_fs85.existsSync)(stateDir)) {
     return 0;
   }
   let cleanedCount = 0;
   try {
-    const files = (0, import_fs84.readdirSync)(stateDir);
+    const files = (0, import_fs85.readdirSync)(stateDir);
     const sessionFilePattern = /-session-[a-f0-9-]+\.json$/;
     for (const file of files) {
       if (sessionFilePattern.test(file)) {
         const filePath = (0, import_path101.join)(stateDir, file);
         try {
-          const stats = (0, import_fs84.statSync)(filePath);
+          const stats = (0, import_fs85.statSync)(filePath);
           const fileAge = Date.now() - stats.mtimeMs;
           const oneDayMs = 24 * 60 * 60 * 1e3;
           if (fileAge > oneDayMs) {
-            (0, import_fs84.unlinkSync)(filePath);
+            (0, import_fs85.unlinkSync)(filePath);
             cleanedCount++;
           }
         } catch {
@@ -47500,11 +53446,11 @@ async function processSetup(input) {
     };
   }
 }
-var import_fs84, import_path101, REQUIRED_DIRECTORIES, CONFIG_FILES, DEFAULT_STATE_MAX_AGE_DAYS;
+var import_fs85, import_path101, REQUIRED_DIRECTORIES, CONFIG_FILES, DEFAULT_STATE_MAX_AGE_DAYS;
 var init_setup = __esm({
   "src/hooks/setup/index.ts"() {
     "use strict";
-    import_fs84 = require("fs");
+    import_fs85 = require("fs");
     import_path101 = require("path");
     init_beads_context();
     init_config_dir();
@@ -47538,11 +53484,11 @@ __export(code_simplifier_exports, {
 });
 function readOmcConfig() {
   for (const configPath of getGlobalOmcConfigCandidates("config.json")) {
-    if (!(0, import_fs85.existsSync)(configPath)) {
+    if (!(0, import_fs86.existsSync)(configPath)) {
       continue;
     }
     try {
-      return JSON.parse((0, import_fs85.readFileSync)(configPath, "utf-8"));
+      return JSON.parse((0, import_fs86.readFileSync)(configPath, "utf-8"));
     } catch {
       return null;
     }
@@ -47568,22 +53514,22 @@ function getModifiedFiles(cwd2, extensions = DEFAULT_EXTENSIONS, maxFiles = DEFA
   }
 }
 function isAlreadyTriggered(stateDir) {
-  return (0, import_fs85.existsSync)((0, import_path102.join)(stateDir, TRIGGER_MARKER_FILENAME));
+  return (0, import_fs86.existsSync)((0, import_path102.join)(stateDir, TRIGGER_MARKER_FILENAME));
 }
 function writeTriggerMarker(stateDir) {
   try {
-    if (!(0, import_fs85.existsSync)(stateDir)) {
-      (0, import_fs85.mkdirSync)(stateDir, { recursive: true });
+    if (!(0, import_fs86.existsSync)(stateDir)) {
+      (0, import_fs86.mkdirSync)(stateDir, { recursive: true });
     }
-    (0, import_fs85.writeFileSync)((0, import_path102.join)(stateDir, TRIGGER_MARKER_FILENAME), (/* @__PURE__ */ new Date()).toISOString(), "utf-8");
+    (0, import_fs86.writeFileSync)((0, import_path102.join)(stateDir, TRIGGER_MARKER_FILENAME), (/* @__PURE__ */ new Date()).toISOString(), "utf-8");
   } catch {
   }
 }
 function clearTriggerMarker(stateDir) {
   try {
     const markerPath = (0, import_path102.join)(stateDir, TRIGGER_MARKER_FILENAME);
-    if ((0, import_fs85.existsSync)(markerPath)) {
-      (0, import_fs85.unlinkSync)(markerPath);
+    if ((0, import_fs86.existsSync)(markerPath)) {
+      (0, import_fs86.unlinkSync)(markerPath);
     }
   } catch {
   }
@@ -47618,11 +53564,11 @@ function processCodeSimplifier(cwd2, stateDir) {
     message: buildSimplifierMessage(files)
   };
 }
-var import_fs85, import_path102, import_child_process29, DEFAULT_EXTENSIONS, DEFAULT_MAX_FILES, TRIGGER_MARKER_FILENAME;
+var import_fs86, import_path102, import_child_process29, DEFAULT_EXTENSIONS, DEFAULT_MAX_FILES, TRIGGER_MARKER_FILENAME;
 var init_code_simplifier = __esm({
   "src/hooks/code-simplifier/index.ts"() {
     "use strict";
-    import_fs85 = require("fs");
+    import_fs86 = require("fs");
     import_path102 = require("path");
     import_child_process29 = require("child_process");
     init_paths();
@@ -50212,7 +56158,7 @@ var require_compat_transpiler = __commonJS({
 var require_clone = __commonJS({
   "node_modules/regexp-tree/dist/utils/clone.js"(exports2, module2) {
     "use strict";
-    module2.exports = function clone2(obj) {
+    module2.exports = function clone3(obj) {
       if (obj === null || typeof obj !== "object") {
         return obj;
       }
@@ -50223,7 +56169,7 @@ var require_clone = __commonJS({
         res = {};
       }
       for (var i in obj) {
-        res[i] = clone2(obj[i]);
+        res[i] = clone3(obj[i]);
       }
       return res;
     };
@@ -51482,7 +57428,7 @@ var require_transforms2 = __commonJS({
 var require_optimizer = __commonJS({
   "node_modules/regexp-tree/dist/optimizer/index.js"(exports2, module2) {
     "use strict";
-    var clone2 = require_clone();
+    var clone3 = require_clone();
     var parser = require_parser();
     var transform2 = require_transform();
     var optimizationTransforms = require_transforms2();
@@ -51520,7 +57466,7 @@ var require_optimizer = __commonJS({
         var prevResultString = void 0;
         do {
           prevResultString = result.toString();
-          ast = clone2(result.getAST());
+          ast = clone3(result.getAST());
           transformToApply.forEach(function(transformName) {
             if (!optimizationTransforms.has(transformName)) {
               throw new Error("Unknown optimization-transform: " + transformName + ". Available transforms are: " + Array.from(optimizationTransforms.keys()).join(", "));
@@ -51531,7 +57477,7 @@ var require_optimizer = __commonJS({
               if (newResult.toString().length <= result.toString().length) {
                 result = newResult;
               } else {
-                ast = clone2(result.getAST());
+                ast = clone3(result.getAST());
               }
             }
           });
@@ -53442,25 +59388,25 @@ function getCachePath(source) {
 function migrateLegacyCache(source) {
   try {
     const legacyPath = getLegacyCachePath();
-    if (!(0, import_fs111.existsSync)(legacyPath)) return;
-    if ((0, import_fs111.existsSync)(getCachePath(source))) return;
-    const content = (0, import_fs111.readFileSync)(legacyPath, "utf-8");
+    if (!(0, import_fs112.existsSync)(legacyPath)) return;
+    if ((0, import_fs112.existsSync)(getCachePath(source))) return;
+    const content = (0, import_fs112.readFileSync)(legacyPath, "utf-8");
     const cache = JSON.parse(content);
     if (cache.source !== source) return;
     const newPath = getCachePath(source);
     const cacheDir = (0, import_path131.dirname)(newPath);
-    if (!(0, import_fs111.existsSync)(cacheDir)) {
-      (0, import_fs111.mkdirSync)(cacheDir, { recursive: true });
+    if (!(0, import_fs112.existsSync)(cacheDir)) {
+      (0, import_fs112.mkdirSync)(cacheDir, { recursive: true });
     }
-    (0, import_fs111.writeFileSync)(newPath, content);
+    (0, import_fs112.writeFileSync)(newPath, content);
   } catch {
   }
 }
 function readCache(source) {
   try {
     const cachePath = getCachePath(source);
-    if (!(0, import_fs111.existsSync)(cachePath)) return null;
-    const content = (0, import_fs111.readFileSync)(cachePath, "utf-8");
+    if (!(0, import_fs112.existsSync)(cachePath)) return null;
+    const content = (0, import_fs112.readFileSync)(cachePath, "utf-8");
     const cache = JSON.parse(content);
     if (cache.data) {
       if (cache.data.fiveHourResetsAt) {
@@ -53491,8 +59437,8 @@ function writeCache(opts) {
   try {
     const cachePath = getCachePath(opts.source);
     const cacheDir = (0, import_path131.dirname)(cachePath);
-    if (!(0, import_fs111.existsSync)(cacheDir)) {
-      (0, import_fs111.mkdirSync)(cacheDir, { recursive: true });
+    if (!(0, import_fs112.existsSync)(cacheDir)) {
+      (0, import_fs112.mkdirSync)(cacheDir, { recursive: true });
     }
     const cache = {
       timestamp: Date.now(),
@@ -53505,7 +59451,7 @@ function writeCache(opts) {
       rateLimitedUntil: opts.rateLimitedUntil,
       lastSuccessAt: opts.lastSuccessAt
     };
-    (0, import_fs111.writeFileSync)(cachePath, JSON.stringify(cache, null, 2));
+    (0, import_fs112.writeFileSync)(cachePath, JSON.stringify(cache, null, 2));
   } catch {
   }
 }
@@ -53645,8 +59591,8 @@ function readKeychainCredentials() {
 function readFileCredentials() {
   try {
     const credPath = (0, import_path131.join)(getClaudeConfigDir(), ".credentials.json");
-    if (!(0, import_fs111.existsSync)(credPath)) return null;
-    const content = (0, import_fs111.readFileSync)(credPath, "utf-8");
+    if (!(0, import_fs112.existsSync)(credPath)) return null;
+    const content = (0, import_fs112.readFileSync)(credPath, "utf-8");
     const parsed = JSON.parse(content);
     const creds = parsed.claudeAiOauth || parsed;
     if (creds.accessToken) {
@@ -53684,7 +59630,7 @@ function validateCredentials(creds) {
   return !isCredentialExpired(creds);
 }
 function refreshAccessToken(refreshToken) {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const clientId = process.env.CLAUDE_CODE_OAUTH_CLIENT_ID || DEFAULT_OAUTH_CLIENT_ID;
     const body = new URLSearchParams({
       grant_type: "refresh_token",
@@ -53712,7 +59658,7 @@ function refreshAccessToken(refreshToken) {
             try {
               const parsed = JSON.parse(data);
               if (parsed.access_token) {
-                resolve32({
+                resolve33({
                   accessToken: parsed.access_token,
                   refreshToken: parsed.refresh_token || refreshToken,
                   expiresAt: parsed.expires_in ? Date.now() + parsed.expires_in * 1e3 : parsed.expires_at
@@ -53725,20 +59671,20 @@ function refreshAccessToken(refreshToken) {
           if (process.env.OMC_DEBUG) {
             console.error(`[usage-api] Token refresh failed: HTTP ${res.statusCode}`);
           }
-          resolve32(null);
+          resolve33(null);
         });
       }
     );
-    req.on("error", () => resolve32(null));
+    req.on("error", () => resolve33(null));
     req.on("timeout", () => {
       req.destroy();
-      resolve32(null);
+      resolve33(null);
     });
     req.end(body);
   });
 }
 function fetchUsageFromApi(accessToken) {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const req = import_https3.default.request(
       {
         hostname: "api.anthropic.com",
@@ -53759,41 +59705,41 @@ function fetchUsageFromApi(accessToken) {
         res.on("end", () => {
           if (res.statusCode === 200) {
             try {
-              resolve32({ data: JSON.parse(data) });
+              resolve33({ data: JSON.parse(data) });
             } catch {
-              resolve32({ data: null });
+              resolve33({ data: null });
             }
           } else if (res.statusCode === 429) {
             if (process.env.OMC_DEBUG) {
               console.error(`[usage-api] Anthropic API returned 429 (rate limited)`);
             }
-            resolve32({ data: null, rateLimited: true });
+            resolve33({ data: null, rateLimited: true });
           } else {
-            resolve32({ data: null });
+            resolve33({ data: null });
           }
         });
       }
     );
-    req.on("error", () => resolve32({ data: null }));
+    req.on("error", () => resolve33({ data: null }));
     req.on("timeout", () => {
       req.destroy();
-      resolve32({ data: null });
+      resolve33({ data: null });
     });
     req.end();
   });
 }
 function fetchUsageFromZai() {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const baseUrl = process.env.ANTHROPIC_BASE_URL;
     const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
     if (!baseUrl || !authToken) {
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     const validation = validateAnthropicBaseUrl(baseUrl);
     if (!validation.allowed) {
       console.error(`[SSRF Guard] Blocking usage API call: ${validation.reason}`);
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     try {
@@ -53821,29 +59767,29 @@ function fetchUsageFromZai() {
           res.on("end", () => {
             if (res.statusCode === 200) {
               try {
-                resolve32({ data: JSON.parse(data) });
+                resolve33({ data: JSON.parse(data) });
               } catch {
-                resolve32({ data: null });
+                resolve33({ data: null });
               }
             } else if (res.statusCode === 429) {
               if (process.env.OMC_DEBUG) {
                 console.error(`[usage-api] z.ai API returned 429 (rate limited)`);
               }
-              resolve32({ data: null, rateLimited: true });
+              resolve33({ data: null, rateLimited: true });
             } else {
-              resolve32({ data: null });
+              resolve33({ data: null });
             }
           });
         }
       );
-      req.on("error", () => resolve32({ data: null }));
+      req.on("error", () => resolve33({ data: null }));
       req.on("timeout", () => {
         req.destroy();
-        resolve32({ data: null });
+        resolve33({ data: null });
       });
       req.end();
     } catch {
-      resolve32({ data: null });
+      resolve33({ data: null });
     }
   });
 }
@@ -53893,8 +59839,8 @@ function writeBackCredentials(creds) {
   }
   try {
     const credPath = (0, import_path131.join)(getClaudeConfigDir(), ".credentials.json");
-    if (!(0, import_fs111.existsSync)(credPath)) return;
-    const content = (0, import_fs111.readFileSync)(credPath, "utf-8");
+    if (!(0, import_fs112.existsSync)(credPath)) return;
+    const content = (0, import_fs112.readFileSync)(credPath, "utf-8");
     const parsed = JSON.parse(content);
     if (parsed.claudeAiOauth) {
       parsed.claudeAiOauth.accessToken = creds.accessToken;
@@ -53915,12 +59861,12 @@ function writeBackCredentials(creds) {
     }
     const tmpPath = `${credPath}.tmp.${process.pid}`;
     try {
-      (0, import_fs111.writeFileSync)(tmpPath, JSON.stringify(parsed, null, 2), { mode: 384 });
-      (0, import_fs111.renameSync)(tmpPath, credPath);
+      (0, import_fs112.writeFileSync)(tmpPath, JSON.stringify(parsed, null, 2), { mode: 384 });
+      (0, import_fs112.renameSync)(tmpPath, credPath);
     } catch (writeErr) {
       try {
-        if ((0, import_fs111.existsSync)(tmpPath)) {
-          (0, import_fs111.unlinkSync)(tmpPath);
+        if ((0, import_fs112.existsSync)(tmpPath)) {
+          (0, import_fs112.unlinkSync)(tmpPath);
         }
       } catch {
       }
@@ -54062,16 +60008,16 @@ function parseZaiResponse(response) {
   return result;
 }
 function fetchUsageFromMinimax(apiKey) {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const baseUrl = process.env.ANTHROPIC_BASE_URL;
     if (!baseUrl) {
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     const validation = validateAnthropicBaseUrl(baseUrl);
     if (!validation.allowed) {
       console.error(`[SSRF Guard] Blocking usage API call: ${validation.reason}`);
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     try {
@@ -54098,29 +60044,29 @@ function fetchUsageFromMinimax(apiKey) {
           res.on("end", () => {
             if (res.statusCode === 200) {
               try {
-                resolve32({ data: JSON.parse(data) });
+                resolve33({ data: JSON.parse(data) });
               } catch {
-                resolve32({ data: null });
+                resolve33({ data: null });
               }
             } else if (res.statusCode === 429) {
               if (process.env.OMC_DEBUG) {
                 console.error(`[usage-api] MiniMax API returned 429 (rate limited)`);
               }
-              resolve32({ data: null, rateLimited: true });
+              resolve33({ data: null, rateLimited: true });
             } else {
-              resolve32({ data: null });
+              resolve33({ data: null });
             }
           });
         }
       );
-      req.on("error", () => resolve32({ data: null }));
+      req.on("error", () => resolve33({ data: null }));
       req.on("timeout", () => {
         req.destroy();
-        resolve32({ data: null });
+        resolve33({ data: null });
       });
       req.end();
     } catch {
-      resolve32({ data: null });
+      resolve33({ data: null });
     }
   });
 }
@@ -54286,11 +60232,11 @@ async function getUsage() {
     return { rateLimits: null, error: "network" };
   }
 }
-var import_fs111, import_path131, import_child_process36, import_crypto32, import_os20, import_https3, CACHE_TTL_FAILURE_MS, CACHE_TTL_TRANSIENT_NETWORK_MS, MAX_RATE_LIMITED_BACKOFF_MS, API_TIMEOUT_MS2, MAX_STALE_DATA_MS, TOKEN_REFRESH_URL_HOSTNAME, USAGE_CACHE_LOCK_OPTS, TOKEN_REFRESH_URL_PATH, DEFAULT_OAUTH_CLIENT_ID, ZAI_UNIT_WEEK;
+var import_fs112, import_path131, import_child_process36, import_crypto32, import_os20, import_https3, CACHE_TTL_FAILURE_MS, CACHE_TTL_TRANSIENT_NETWORK_MS, MAX_RATE_LIMITED_BACKOFF_MS, API_TIMEOUT_MS2, MAX_STALE_DATA_MS, TOKEN_REFRESH_URL_HOSTNAME, USAGE_CACHE_LOCK_OPTS, TOKEN_REFRESH_URL_PATH, DEFAULT_OAUTH_CLIENT_ID, ZAI_UNIT_WEEK;
 var init_usage_api = __esm({
   "src/hud/usage-api.ts"() {
     "use strict";
-    import_fs111 = require("fs");
+    import_fs112 = require("fs");
     init_config_dir();
     import_path131 = require("path");
     import_child_process36 = require("child_process");
@@ -54298,7 +60244,7 @@ var init_usage_api = __esm({
     import_os20 = require("os");
     import_https3 = __toESM(require("https"), 1);
     init_ssrf_guard();
-    init_types6();
+    init_types7();
     init_state3();
     init_file_lock();
     CACHE_TTL_FAILURE_MS = 15 * 1e3;
@@ -54359,10 +60305,10 @@ function writeStdinCache(stdin) {
   try {
     const cachePath = getStdinCachePath();
     const cacheDir = (0, import_path140.dirname)(cachePath);
-    if (!(0, import_fs120.existsSync)(cacheDir)) {
-      (0, import_fs120.mkdirSync)(cacheDir, { recursive: true });
+    if (!(0, import_fs121.existsSync)(cacheDir)) {
+      (0, import_fs121.mkdirSync)(cacheDir, { recursive: true });
     }
-    (0, import_fs120.writeFileSync)(cachePath, JSON.stringify(stdin));
+    (0, import_fs121.writeFileSync)(cachePath, JSON.stringify(stdin));
   } catch {
   }
 }
@@ -54371,8 +60317,8 @@ function readStdinCache() {
   const scopedPath = getStdinCachePath();
   const tryRead = (p) => {
     try {
-      if (!(0, import_fs120.existsSync)(p)) return null;
-      return JSON.parse((0, import_fs120.readFileSync)(p, "utf-8"));
+      if (!(0, import_fs121.existsSync)(p)) return null;
+      return JSON.parse((0, import_fs121.readFileSync)(p, "utf-8"));
     } catch {
       return null;
     }
@@ -54402,7 +60348,7 @@ function readMostRecentSessionCache(root2) {
       continue;
     }
     try {
-      const st = (0, import_fs120.statSync)(candidate);
+      const st = (0, import_fs121.statSync)(candidate);
       if (!st.isFile()) continue;
       if (st.mtimeMs > bestMtime) {
         bestMtime = st.mtimeMs;
@@ -54413,7 +60359,7 @@ function readMostRecentSessionCache(root2) {
   }
   if (!bestPath) return null;
   try {
-    return JSON.parse((0, import_fs120.readFileSync)(bestPath, "utf-8"));
+    return JSON.parse((0, import_fs121.readFileSync)(bestPath, "utf-8"));
   } catch {
     return null;
   }
@@ -54559,11 +60505,11 @@ function getModelName(stdin) {
   const displayName = stdin.model?.display_name?.trim();
   return displayName || getModelId(stdin);
 }
-var import_fs120, import_path140, TRANSIENT_CONTEXT_PERCENT_TOLERANCE, SESSION_ID_ENV_VARS;
+var import_fs121, import_path140, TRANSIENT_CONTEXT_PERCENT_TOLERANCE, SESSION_ID_ENV_VARS;
 var init_stdin = __esm({
   "src/hud/stdin.ts"() {
     "use strict";
-    import_fs120 = require("fs");
+    import_fs121 = require("fs");
     import_path140 = require("path");
     init_worktree_paths();
     TRANSIENT_CONTEXT_PERCENT_TOLERANCE = 3;
@@ -54583,13 +60529,13 @@ async function parseTranscript(transcriptPath, options) {
     skillCallCount: 0,
     lastToolName: null
   };
-  if (!transcriptPath || !(0, import_fs121.existsSync)(transcriptPath)) {
+  if (!transcriptPath || !(0, import_fs122.existsSync)(transcriptPath)) {
     return result;
   }
   let cacheKey = null;
   try {
-    const stat2 = (0, import_fs121.statSync)(transcriptPath);
-    cacheKey = `${transcriptPath}:${stat2.size}:${stat2.mtimeMs}`;
+    const stat3 = (0, import_fs122.statSync)(transcriptPath);
+    cacheKey = `${transcriptPath}:${stat3.size}:${stat3.mtimeMs}`;
     const cached2 = transcriptCache.get(transcriptPath);
     if (cached2?.cacheKey === cacheKey) {
       return finalizeTranscriptResult(cloneTranscriptData(cached2.baseResult), options, cached2.pendingPermissions);
@@ -54608,8 +60554,8 @@ async function parseTranscript(transcriptPath, options) {
   let sessionTotalsReliable = false;
   const observedSessionIds = /* @__PURE__ */ new Set();
   try {
-    const stat2 = (0, import_fs121.statSync)(transcriptPath);
-    const fileSize = stat2.size;
+    const stat3 = (0, import_fs122.statSync)(transcriptPath);
+    const fileSize = stat3.size;
     if (fileSize > MAX_TAIL_BYTES) {
       const lines = readTailLines(transcriptPath, fileSize, MAX_TAIL_BYTES);
       for (const line of lines) {
@@ -54631,7 +60577,7 @@ async function parseTranscript(transcriptPath, options) {
       }
       sessionTotalsReliable = sessionTokenTotals.seenUsage;
     } else {
-      const fileStream = (0, import_fs121.createReadStream)(transcriptPath);
+      const fileStream = (0, import_fs122.createReadStream)(transcriptPath);
       const rl = (0, import_readline4.createInterface)({
         input: fileStream,
         crlfDelay: Infinity
@@ -54747,12 +60693,12 @@ function finalizeTranscriptResult(result, options, pendingPermissions) {
 function readTailLines(filePath, fileSize, maxBytes) {
   const startOffset = Math.max(0, fileSize - maxBytes);
   const bytesToRead = fileSize - startOffset;
-  const fd = (0, import_fs121.openSync)(filePath, "r");
+  const fd = (0, import_fs122.openSync)(filePath, "r");
   const buffer = Buffer.alloc(bytesToRead);
   try {
-    (0, import_fs121.readSync)(fd, buffer, 0, bytesToRead, startOffset);
+    (0, import_fs122.readSync)(fd, buffer, 0, bytesToRead, startOffset);
   } finally {
-    (0, import_fs121.closeSync)(fd);
+    (0, import_fs122.closeSync)(fd);
   }
   const content = buffer.toString("utf8");
   const lines = content.split("\n");
@@ -54975,11 +60921,11 @@ function extractLastRequestTokenUsage(usage) {
 function getNumericUsageValue(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-var import_fs121, import_readline4, import_path141, MAX_TAIL_BYTES, MAX_AGENT_MAP_SIZE, PERMISSION_TOOLS, PERMISSION_THRESHOLD_MS, pendingPermissionMap, THINKING_PART_TYPES2, THINKING_RECENCY_MS, transcriptCache, TRANSCRIPT_CACHE_MAX_SIZE;
+var import_fs122, import_readline4, import_path141, MAX_TAIL_BYTES, MAX_AGENT_MAP_SIZE, PERMISSION_TOOLS, PERMISSION_THRESHOLD_MS, pendingPermissionMap, THINKING_PART_TYPES2, THINKING_RECENCY_MS, transcriptCache, TRANSCRIPT_CACHE_MAX_SIZE;
 var init_transcript = __esm({
   "src/hud/transcript.ts"() {
     "use strict";
-    import_fs121 = require("fs");
+    import_fs122 = require("fs");
     import_readline4 = require("readline");
     import_path141 = require("path");
     MAX_TAIL_BYTES = 4 * 1024 * 1024;
@@ -55004,8 +60950,8 @@ var init_transcript = __esm({
 // src/hud/omc-state.ts
 function isStateFileStale(filePath) {
   try {
-    const stat2 = (0, import_fs122.statSync)(filePath);
-    const age = Date.now() - stat2.mtimeMs;
+    const stat3 = (0, import_fs123.statSync)(filePath);
+    const age = Date.now() - stat3.mtimeMs;
     return age > MAX_STATE_AGE_MS2;
   } catch {
     return true;
@@ -55015,20 +60961,20 @@ function resolveStatePath2(directory, filename, sessionId) {
   const omcRoot = getOmcRoot(directory);
   if (sessionId) {
     const sessionPath = (0, import_path142.join)(omcRoot, "state", "sessions", sessionId, filename);
-    return (0, import_fs122.existsSync)(sessionPath) ? sessionPath : null;
+    return (0, import_fs123.existsSync)(sessionPath) ? sessionPath : null;
   }
   let bestPath = null;
   let bestMtime = 0;
   const sessionsDir = (0, import_path142.join)(omcRoot, "state", "sessions");
-  if ((0, import_fs122.existsSync)(sessionsDir)) {
+  if ((0, import_fs123.existsSync)(sessionsDir)) {
     try {
-      const entries = (0, import_fs122.readdirSync)(sessionsDir, { withFileTypes: true });
+      const entries = (0, import_fs123.readdirSync)(sessionsDir, { withFileTypes: true });
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         const sessionFile = (0, import_path142.join)(sessionsDir, entry.name, filename);
-        if ((0, import_fs122.existsSync)(sessionFile)) {
+        if ((0, import_fs123.existsSync)(sessionFile)) {
           try {
-            const mtime = (0, import_fs122.statSync)(sessionFile).mtimeMs;
+            const mtime = (0, import_fs123.statSync)(sessionFile).mtimeMs;
             if (mtime > bestMtime) {
               bestMtime = mtime;
               bestPath = sessionFile;
@@ -55041,9 +60987,9 @@ function resolveStatePath2(directory, filename, sessionId) {
     }
   }
   const newPath = (0, import_path142.join)(omcRoot, "state", filename);
-  if ((0, import_fs122.existsSync)(newPath)) {
+  if ((0, import_fs123.existsSync)(newPath)) {
     try {
-      const mtime = (0, import_fs122.statSync)(newPath).mtimeMs;
+      const mtime = (0, import_fs123.statSync)(newPath).mtimeMs;
       if (mtime > bestMtime) {
         bestMtime = mtime;
         bestPath = newPath;
@@ -55053,9 +60999,9 @@ function resolveStatePath2(directory, filename, sessionId) {
     }
   }
   const legacyPath = (0, import_path142.join)(omcRoot, filename);
-  if ((0, import_fs122.existsSync)(legacyPath)) {
+  if ((0, import_fs123.existsSync)(legacyPath)) {
     try {
-      const mtime = (0, import_fs122.statSync)(legacyPath).mtimeMs;
+      const mtime = (0, import_fs123.statSync)(legacyPath).mtimeMs;
       if (mtime > bestMtime) {
         bestPath = legacyPath;
       }
@@ -55074,7 +61020,7 @@ function readRalphStateForHud(directory, sessionId) {
     return null;
   }
   try {
-    const content = (0, import_fs122.readFileSync)(stateFile, "utf-8");
+    const content = (0, import_fs123.readFileSync)(stateFile, "utf-8");
     const state = JSON.parse(content);
     if (!state.active) {
       return null;
@@ -55096,7 +61042,7 @@ function readUltraworkStateForHud(directory, sessionId) {
     return null;
   }
   try {
-    const content = (0, import_fs122.readFileSync)(localFile, "utf-8");
+    const content = (0, import_fs123.readFileSync)(localFile, "utf-8");
     const state = JSON.parse(content);
     if (!state.active) {
       return null;
@@ -55111,14 +61057,14 @@ function readUltraworkStateForHud(directory, sessionId) {
 }
 function readPrdStateForHud(directory) {
   let prdPath = (0, import_path142.join)(directory, "prd.json");
-  if (!(0, import_fs122.existsSync)(prdPath)) {
+  if (!(0, import_fs123.existsSync)(prdPath)) {
     prdPath = (0, import_path142.join)(getOmcRoot(directory), "prd.json");
-    if (!(0, import_fs122.existsSync)(prdPath)) {
+    if (!(0, import_fs123.existsSync)(prdPath)) {
       return null;
     }
   }
   try {
-    const content = (0, import_fs122.readFileSync)(prdPath, "utf-8");
+    const content = (0, import_fs123.readFileSync)(prdPath, "utf-8");
     const prd = JSON.parse(content);
     if (!prd.userStories || !Array.isArray(prd.userStories)) {
       return null;
@@ -55171,7 +61117,7 @@ function readAutopilotStateForHud(directory, sessionId) {
     return null;
   }
   try {
-    const content = (0, import_fs122.readFileSync)(stateFile, "utf-8");
+    const content = (0, import_fs123.readFileSync)(stateFile, "utf-8");
     const state = JSON.parse(content);
     if (!state.active) {
       return null;
@@ -55194,15 +61140,58 @@ function readAutopilotStateForHud(directory, sessionId) {
     return null;
   }
 }
-var import_fs122, import_path142, MAX_STATE_AGE_MS2;
+function readGraphStateForHud(directory, sessionId) {
+  const stateFile = resolveStatePath2(directory, "graph-state.json", sessionId);
+  if (!stateFile) return null;
+  let content;
+  try {
+    content = (0, import_fs123.readFileSync)(stateFile, "utf-8");
+  } catch {
+    return null;
+  }
+  if (content.trim().length === 0) return null;
+  try {
+    const state = parseGraphState(JSON.parse(content));
+    if (!ACTIVE_GRAPH_STATUSES.has(state.status)) return null;
+    const activations = Object.values(state.projection.activations);
+    return {
+      status: state.status,
+      completedActivations: activations.filter((activation) => activation.status === "completed").length,
+      totalActivations: activations.length,
+      readyActivations: activations.filter((activation) => activation.status === "ready").length,
+      liveClaims: Object.values(state.claims).filter((claim) => claim.status === "live").length,
+      unresolvedReconciliations: Object.values(state.reconciliations).filter((record2) => record2.status === "unresolved").length,
+      revisionHashShort: state.active_revision_hash.slice(0, 12)
+    };
+  } catch {
+    return {
+      status: "unreadable",
+      completedActivations: 0,
+      totalActivations: 0,
+      readyActivations: 0,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: "?"
+    };
+  }
+}
+var import_fs123, import_path142, MAX_STATE_AGE_MS2, ACTIVE_GRAPH_STATUSES;
 var init_omc_state = __esm({
   "src/hud/omc-state.ts"() {
     "use strict";
-    import_fs122 = require("fs");
+    import_fs123 = require("fs");
     import_path142 = require("path");
     init_worktree_paths();
     init_named_workflow_resume_validator();
+    init_runtime_types();
     MAX_STATE_AGE_MS2 = 2 * 60 * 60 * 1e3;
+    ACTIVE_GRAPH_STATUSES = /* @__PURE__ */ new Set([
+      "awaiting_approval",
+      "running",
+      "waiting_human",
+      "waiting_patch_approval",
+      "reconciling"
+    ]);
   }
 });
 
@@ -55218,8 +61207,8 @@ function getCachePath2() {
 function readCache2() {
   try {
     const p = getCachePath2();
-    if (!(0, import_fs123.existsSync)(p)) return null;
-    return JSON.parse((0, import_fs123.readFileSync)(p, "utf-8"));
+    if (!(0, import_fs124.existsSync)(p)) return null;
+    return JSON.parse((0, import_fs124.readFileSync)(p, "utf-8"));
   } catch {
     return null;
   }
@@ -55228,9 +61217,9 @@ function writeCache2(buckets) {
   try {
     const p = getCachePath2();
     const dir = (0, import_path143.dirname)(p);
-    if (!(0, import_fs123.existsSync)(dir)) (0, import_fs123.mkdirSync)(dir, { recursive: true });
+    if (!(0, import_fs124.existsSync)(dir)) (0, import_fs124.mkdirSync)(dir, { recursive: true });
     const cache = { timestamp: Date.now(), buckets };
-    (0, import_fs123.writeFileSync)(p, JSON.stringify(cache, null, 2));
+    (0, import_fs124.writeFileSync)(p, JSON.stringify(cache, null, 2));
   } catch {
   }
 }
@@ -55238,7 +61227,7 @@ function isCacheValid2(cache) {
   return Date.now() - cache.timestamp < CACHE_TTL_MS2;
 }
 function spawnWithTimeout(cmd, timeoutMs) {
-  return new Promise((resolve32, reject) => {
+  return new Promise((resolve33, reject) => {
     const [executable, ...args] = Array.isArray(cmd) ? cmd : ["sh", "-c", cmd];
     const child = (0, import_child_process43.spawn)(executable, args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
@@ -55261,7 +61250,7 @@ function spawnWithTimeout(cmd, timeoutMs) {
       clearTimeout(timer);
       if (!timedOut) {
         if (code === 0) {
-          resolve32(stdout);
+          resolve33(stdout);
         } else {
           reject(new Error(`Command exited with code ${code}`));
         }
@@ -55328,12 +61317,12 @@ async function executeCustomProvider(config2) {
     return { buckets: [], stale: false, error: "command failed" };
   }
 }
-var import_child_process43, import_fs123, import_path143, CACHE_TTL_MS2, DEFAULT_TIMEOUT_MS2;
+var import_child_process43, import_fs124, import_path143, CACHE_TTL_MS2, DEFAULT_TIMEOUT_MS2;
 var init_custom_rate_provider = __esm({
   "src/hud/custom-rate-provider.ts"() {
     "use strict";
     import_child_process43 = require("child_process");
-    import_fs123 = require("fs");
+    import_fs124 = require("fs");
     import_path143 = require("path");
     init_config_dir();
     CACHE_TTL_MS2 = 3e4;
@@ -55411,7 +61400,7 @@ var RED2, YELLOW2, GREEN2;
 var init_ralph2 = __esm({
   "src/hud/elements/ralph.ts"() {
     "use strict";
-    init_types6();
+    init_types7();
     init_colors();
     RED2 = "\x1B[31m";
     YELLOW2 = "\x1B[33m";
@@ -55975,7 +61964,7 @@ var GREEN4, YELLOW4, RED3, DIM3, CONTEXT_DISPLAY_HYSTERESIS, CONTEXT_DISPLAY_STA
 var init_context = __esm({
   "src/hud/elements/context.ts"() {
     "use strict";
-    init_types6();
+    init_types7();
     init_colors();
     GREEN4 = "\x1B[32m";
     YELLOW4 = "\x1B[33m";
@@ -56010,7 +61999,7 @@ var CYAN4, GREEN5, YELLOW5, MAX_CONCURRENT;
 var init_background = __esm({
   "src/hud/elements/background.ts"() {
     "use strict";
-    init_types6();
+    init_types7();
     init_colors();
     init_string_width();
     CYAN4 = "\x1B[36m";
@@ -56275,7 +62264,7 @@ var CYAN6;
 var init_thinking = __esm({
   "src/hud/elements/thinking.ts"() {
     "use strict";
-    init_types6();
+    init_types7();
     init_colors();
     CYAN6 = "\x1B[36m";
   }
@@ -56313,7 +62302,7 @@ function renderTokenUsage(usage, sessionTotalTokens, labels = DEFAULT_HUD_LABELS
 var init_token_usage = __esm({
   "src/hud/elements/token-usage.ts"() {
     "use strict";
-    init_types6();
+    init_types7();
     init_formatting();
   }
 });
@@ -56467,6 +62456,33 @@ var init_autopilot2 = __esm({
   }
 });
 
+// src/hud/elements/graph.ts
+function renderStatus(status) {
+  if (status === "reconciling") return red(status);
+  if (status === "running") return cyan(status);
+  return yellow(status);
+}
+function renderGraph(state) {
+  if (!state) return null;
+  if (state.status === "unreadable") {
+    return `G:${renderStatus(state.status)}`;
+  }
+  return [
+    `G:${renderStatus(state.status)}`,
+    `${state.completedActivations}/${state.totalActivations}`,
+    `ready:${state.readyActivations}`,
+    `live:${state.liveClaims}`,
+    `reconcile:${state.unresolvedReconciliations}`,
+    `#${state.revisionHashShort}`
+  ].join(" ");
+}
+var init_graph = __esm({
+  "src/hud/elements/graph.ts"() {
+    "use strict";
+    init_colors();
+  }
+});
+
 // src/hud/elements/cwd.ts
 function osc8Link(url, text) {
   return `\x1B]8;;${url}\x1B\\${text}\x1B]8;;\x1B\\`;
@@ -56498,8 +62514,8 @@ function renderCwd(cwd2, format = "relative", useHyperlinks = false) {
       displayPath = cwd2;
       break;
     case "folder": {
-      const parent = (0, import_node_path22.basename)((0, import_node_path22.dirname)(cwd2));
-      const folder = (0, import_node_path22.basename)(cwd2);
+      const parent = (0, import_node_path23.basename)((0, import_node_path23.dirname)(cwd2));
+      const folder = (0, import_node_path23.basename)(cwd2);
       displayPath = parent ? `${parent}/${folder}` : folder;
       break;
     }
@@ -56513,12 +62529,12 @@ function renderCwd(cwd2, format = "relative", useHyperlinks = false) {
   }
   return rendered;
 }
-var import_node_os5, import_node_path22;
+var import_node_os5, import_node_path23;
 var init_cwd = __esm({
   "src/hud/elements/cwd.ts"() {
     "use strict";
     import_node_os5 = require("node:os");
-    import_node_path22 = require("node:path");
+    import_node_path23 = require("node:path");
     init_colors();
   }
 });
@@ -56551,7 +62567,7 @@ function git2(args, cwd2) {
   }).trim();
 }
 function getGitRepoName(cwd2) {
-  const key = cwd2 ? (0, import_node_path23.resolve)(cwd2) : process.cwd();
+  const key = cwd2 ? (0, import_node_path24.resolve)(cwd2) : process.cwd();
   const cached2 = repoCache.get(key);
   if (cached2 && Date.now() < cached2.expiresAt) {
     return cached2.value;
@@ -56572,7 +62588,7 @@ function getGitRepoName(cwd2) {
   return result;
 }
 function getGitBranch(cwd2) {
-  const key = cwd2 ? (0, import_node_path23.resolve)(cwd2) : process.cwd();
+  const key = cwd2 ? (0, import_node_path24.resolve)(cwd2) : process.cwd();
   const cached2 = branchCache.get(key);
   if (cached2 && Date.now() < cached2.expiresAt) {
     return cached2.value;
@@ -56588,7 +62604,7 @@ function getGitBranch(cwd2) {
   return result;
 }
 function getWorktreeInfo(cwd2) {
-  const key = cwd2 ? (0, import_node_path23.resolve)(cwd2) : process.cwd();
+  const key = cwd2 ? (0, import_node_path24.resolve)(cwd2) : process.cwd();
   const cached2 = worktreeCache.get(key);
   if (cached2 && Date.now() < cached2.expiresAt) {
     return cached2.value;
@@ -56597,8 +62613,8 @@ function getWorktreeInfo(cwd2) {
   try {
     const gitDir = git2(["rev-parse", "--git-dir"], cwd2);
     const gitCommonDir = git2(["rev-parse", "--git-common-dir"], cwd2);
-    let resolvedGitDir = (0, import_node_path23.resolve)(key, gitDir);
-    let resolvedCommonDir = (0, import_node_path23.resolve)(key, gitCommonDir);
+    let resolvedGitDir = (0, import_node_path24.resolve)(key, gitDir);
+    let resolvedCommonDir = (0, import_node_path24.resolve)(key, gitCommonDir);
     try {
       resolvedGitDir = (0, import_node_fs18.realpathSync)(resolvedGitDir);
     } catch {
@@ -56608,7 +62624,7 @@ function getWorktreeInfo(cwd2) {
     } catch {
     }
     if (resolvedGitDir !== resolvedCommonDir) {
-      result = { isWorktree: true, worktreeName: (0, import_node_path23.basename)(resolvedGitDir) };
+      result = { isWorktree: true, worktreeName: (0, import_node_path24.basename)(resolvedGitDir) };
     }
   } catch {
   }
@@ -56630,7 +62646,7 @@ function renderGitBranch(cwd2) {
   return `${dim("branch:")}${cyan(branch)}`;
 }
 function getGitStatusCounts(cwd2) {
-  const key = cwd2 ? (0, import_node_path23.resolve)(cwd2) : process.cwd();
+  const key = cwd2 ? (0, import_node_path24.resolve)(cwd2) : process.cwd();
   const cached2 = statusCache.get(key);
   if (cached2 && Date.now() < cached2.expiresAt) {
     return cached2.value;
@@ -56681,15 +62697,15 @@ function renderGitStatus(cwd2, labels = DEFAULT_HUD_LABELS) {
   if (behind > 0) parts.push(`${red(labels.behind)}${behind}`);
   return parts.join(" ");
 }
-var import_node_child_process12, import_node_fs18, import_node_path23, CACHE_TTL_MS3, repoCache, branchCache, worktreeCache, statusCache;
+var import_node_child_process12, import_node_fs18, import_node_path24, CACHE_TTL_MS3, repoCache, branchCache, worktreeCache, statusCache;
 var init_git = __esm({
   "src/hud/elements/git.ts"() {
     "use strict";
     import_node_child_process12 = require("node:child_process");
     import_node_fs18 = require("node:fs");
-    import_node_path23 = require("node:path");
+    import_node_path24 = require("node:path");
     init_colors();
-    init_types6();
+    init_types7();
     CACHE_TTL_MS3 = 3e4;
     repoCache = /* @__PURE__ */ new Map();
     branchCache = /* @__PURE__ */ new Map();
@@ -56714,10 +62730,10 @@ function isGitRepo(dir) {
   }
 }
 function looksLikeRepo(entryPath) {
-  return (0, import_node_fs19.existsSync)((0, import_node_path24.join)(entryPath, ".git"));
+  return (0, import_node_fs19.existsSync)((0, import_node_path25.join)(entryPath, ".git"));
 }
 function countActiveSessions(cwd2) {
-  const sessionsDir = (0, import_node_path24.join)(getOmcRoot(cwd2), "state", "sessions");
+  const sessionsDir = (0, import_node_path25.join)(getOmcRoot(cwd2), "state", "sessions");
   if (!(0, import_node_fs19.existsSync)(sessionsDir)) return 0;
   const now = Date.now();
   let active = 0;
@@ -56726,7 +62742,7 @@ function countActiveSessions(cwd2) {
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       if (!SESSION_ID_PATTERN.test(entry.name)) continue;
-      const dirPath = (0, import_node_path24.join)(sessionsDir, entry.name);
+      const dirPath = (0, import_node_path25.join)(sessionsDir, entry.name);
       let fresh = false;
       try {
         if (now - (0, import_node_fs19.statSync)(dirPath).mtimeMs < ACTIVITY_WINDOW_MS) {
@@ -56734,7 +62750,7 @@ function countActiveSessions(cwd2) {
         } else {
           for (const f of (0, import_node_fs19.readdirSync)(dirPath)) {
             try {
-              if (now - (0, import_node_fs19.statSync)((0, import_node_path24.join)(dirPath, f)).mtimeMs < ACTIVITY_WINDOW_MS) {
+              if (now - (0, import_node_fs19.statSync)((0, import_node_path25.join)(dirPath, f)).mtimeMs < ACTIVITY_WINDOW_MS) {
                 fresh = true;
                 break;
               }
@@ -56752,7 +62768,7 @@ function countActiveSessions(cwd2) {
   return active;
 }
 function detectMultiRepo(cwd2) {
-  const key = cwd2 ? (0, import_node_path24.resolve)(cwd2) : process.cwd();
+  const key = cwd2 ? (0, import_node_path25.resolve)(cwd2) : process.cwd();
   const cached2 = multiRepoCache.get(key);
   if (cached2 && Date.now() < cached2.expiresAt) {
     return cached2.value;
@@ -56769,7 +62785,7 @@ function detectMultiRepo(cwd2) {
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         if (entry.name.startsWith(".")) continue;
-        if (looksLikeRepo((0, import_node_path24.join)(key, entry.name))) subrepoCount++;
+        if (looksLikeRepo((0, import_node_path25.join)(key, entry.name))) subrepoCount++;
       }
     } catch {
     }
@@ -56777,12 +62793,12 @@ function detectMultiRepo(cwd2) {
       multiRepoCache.set(key, { value: null, expiresAt: Date.now() + CACHE_TTL_MS4 });
       return null;
     }
-    const hasMarker = (0, import_node_fs19.existsSync)((0, import_node_path24.join)(key, ".omc-workspace"));
+    const hasMarker = (0, import_node_fs19.existsSync)((0, import_node_path25.join)(key, ".omc-workspace"));
     const activeSessions = hasMarker ? countActiveSessions(key) : 0;
     result = {
       isMultiRepo: true,
       hasMarker,
-      parentName: (0, import_node_path24.basename)(key),
+      parentName: (0, import_node_path25.basename)(key),
       subrepoCount,
       activeSessions
     };
@@ -56801,13 +62817,13 @@ function renderMultiRepo(cwd2) {
   const sessionsPart = info.activeSessions > 0 ? ` ${dim("sessions:~")}${green(String(info.activeSessions))}` : ` ${dim("sessions:~")}${dim("0")}`;
   return `${dim("mr:")}${cyan(info.parentName)} ${dim("repos:")}${cyan(String(info.subrepoCount))}` + sessionsPart;
 }
-var import_node_child_process13, import_node_fs19, import_node_path24, ACTIVITY_WINDOW_MS, SESSION_ID_PATTERN, CACHE_TTL_MS4, multiRepoCache;
+var import_node_child_process13, import_node_fs19, import_node_path25, ACTIVITY_WINDOW_MS, SESSION_ID_PATTERN, CACHE_TTL_MS4, multiRepoCache;
 var init_multi_repo = __esm({
   "src/hud/elements/multi-repo.ts"() {
     "use strict";
     import_node_child_process13 = require("node:child_process");
     import_node_fs19 = require("node:fs");
-    import_node_path24 = require("node:path");
+    import_node_path25 = require("node:path");
     init_colors();
     init_worktree_paths();
     ACTIVITY_WINDOW_MS = 5 * 60 * 1e3;
@@ -56860,15 +62876,15 @@ var init_model = __esm({
     "use strict";
     init_colors();
     init_string_width();
-    init_types6();
+    init_types7();
   }
 });
 
 // src/hud/elements/api-key-source.ts
 function settingsFileHasApiKey(filePath) {
   try {
-    if (!(0, import_fs124.existsSync)(filePath)) return false;
-    const content = (0, import_fs124.readFileSync)(filePath, "utf-8");
+    if (!(0, import_fs125.existsSync)(filePath)) return false;
+    const content = (0, import_fs125.readFileSync)(filePath, "utf-8");
     const settings = JSON.parse(content);
     const env2 = settings?.env;
     if (typeof env2 !== "object" || env2 === null) return false;
@@ -56891,11 +62907,11 @@ function renderApiKeySource(source) {
   if (!source) return null;
   return `${dim("key:")}${cyan(source)}`;
 }
-var import_fs124, import_path144;
+var import_fs125, import_path144;
 var init_api_key_source = __esm({
   "src/hud/elements/api-key-source.ts"() {
     "use strict";
-    import_fs124 = require("fs");
+    import_fs125 = require("fs");
     import_path144 = require("path");
     init_colors();
     init_config_dir();
@@ -56934,7 +62950,7 @@ var init_call_counts = __esm({
   "src/hud/elements/call-counts.ts"() {
     "use strict";
     init_platform();
-    init_types6();
+    init_types7();
   }
 });
 
@@ -57244,6 +63260,10 @@ async function render(context, config2) {
     const autopilot = renderAutopilot(context.autopilot, config2.thresholds);
     if (autopilot) rendered.set("autopilot", autopilot);
   }
+  if (enabledElements.graph && context.graph) {
+    const graph = renderGraph(context.graph);
+    if (graph) rendered.set("graph", graph);
+  }
   if (enabledElements.prdStory && context.prd) {
     const prd = renderPrd(context.prd);
     if (prd) rendered.set("prd", prd);
@@ -57401,7 +63421,7 @@ var ANSI_REGEX, PLAIN_SEPARATOR, DIM_SEPARATOR;
 var init_render = __esm({
   "src/hud/render.ts"() {
     "use strict";
-    init_types6();
+    init_types7();
     init_colors();
     init_version();
     init_string_width();
@@ -57420,6 +63440,7 @@ var init_render = __esm({
     init_enterprise_cost();
     init_prompt_time();
     init_autopilot2();
+    init_graph();
     init_cwd();
     init_hostname();
     init_git();
@@ -57514,7 +63535,7 @@ function findByteBackward(fd, fromExclusive, byte) {
   while (end > 0) {
     const start = Math.max(0, end - SCAN_CHUNK_BYTES);
     const length = end - start;
-    (0, import_fs125.readSync)(fd, buffer, 0, length, start);
+    (0, import_fs126.readSync)(fd, buffer, 0, length, start);
     const index = buffer.subarray(0, length).lastIndexOf(byte);
     if (index !== -1) return start + index;
     end = start;
@@ -57526,7 +63547,7 @@ function findByteForward(fd, fromInclusive, size, byte) {
   const buffer = Buffer.allocUnsafe(SCAN_CHUNK_BYTES);
   while (start < size) {
     const length = Math.min(SCAN_CHUNK_BYTES, size - start);
-    (0, import_fs125.readSync)(fd, buffer, 0, length, start);
+    (0, import_fs126.readSync)(fd, buffer, 0, length, start);
     const index = buffer.subarray(0, length).indexOf(byte);
     if (index !== -1) return start + index;
     start += length;
@@ -57541,19 +63562,19 @@ function readLineContainingOffset(fd, size, offset) {
   const length = endOffset - startOffset;
   if (length <= 0 || length > MAX_BOUNDARY_LINE_BYTES) return null;
   const line = Buffer.allocUnsafe(length);
-  (0, import_fs125.readSync)(fd, line, 0, length, startOffset);
+  (0, import_fs126.readSync)(fd, line, 0, length, startOffset);
   return { line, endOffset };
 }
 function findLastCompactBoundaryEndOffset(transcriptPath, size) {
   if (size <= 0) return null;
-  const fd = (0, import_fs125.openSync)(transcriptPath, "r");
+  const fd = (0, import_fs126.openSync)(transcriptPath, "r");
   try {
     let end = size;
     const buffer = Buffer.allocUnsafe(Math.min(SCAN_CHUNK_BYTES, size));
     while (end > 0) {
       const start = Math.max(0, end - SCAN_CHUNK_BYTES);
       const length = end - start;
-      (0, import_fs125.readSync)(fd, buffer, 0, length, start);
+      (0, import_fs126.readSync)(fd, buffer, 0, length, start);
       const chunk = buffer.subarray(0, length);
       let index = chunk.lastIndexOf(COMPACT_BOUNDARY_MARKER_BYTES);
       while (index !== -1) {
@@ -57568,7 +63589,7 @@ function findLastCompactBoundaryEndOffset(transcriptPath, size) {
       end = start + COMPACT_BOUNDARY_MARKER_BYTES.length - 1;
     }
   } finally {
-    (0, import_fs125.closeSync)(fd);
+    (0, import_fs126.closeSync)(fd);
   }
   return null;
 }
@@ -57580,22 +63601,22 @@ function estimateTranscriptPayloadBytes(transcriptPath, size) {
   return boundaryEndOffset === null ? size : Math.max(0, size - boundaryEndOffset);
 }
 function estimatePayloadFromTranscriptPath(transcriptPath) {
-  if (!transcriptPath || !(0, import_fs125.existsSync)(transcriptPath)) return null;
+  if (!transcriptPath || !(0, import_fs126.existsSync)(transcriptPath)) return null;
   try {
-    const stat2 = (0, import_fs125.statSync)(transcriptPath);
-    if (!stat2.isFile()) return null;
+    const stat3 = (0, import_fs126.statSync)(transcriptPath);
+    if (!stat3.isFile()) return null;
     return createPayloadEstimate(
-      estimateTranscriptPayloadBytes(transcriptPath, stat2.size)
+      estimateTranscriptPayloadBytes(transcriptPath, stat3.size)
     );
   } catch {
     return null;
   }
 }
-var import_fs125, ANTHROPIC_REQUEST_PAYLOAD_LIMIT_BYTES, PAYLOAD_WARNING_BYTES, PAYLOAD_CRITICAL_BYTES, COMPACT_BOUNDARY_MARKER, COMPACT_BOUNDARY_MARKER_BYTES, SCAN_CHUNK_BYTES, MAX_BOUNDARY_LINE_BYTES;
+var import_fs126, ANTHROPIC_REQUEST_PAYLOAD_LIMIT_BYTES, PAYLOAD_WARNING_BYTES, PAYLOAD_CRITICAL_BYTES, COMPACT_BOUNDARY_MARKER, COMPACT_BOUNDARY_MARKER_BYTES, SCAN_CHUNK_BYTES, MAX_BOUNDARY_LINE_BYTES;
 var init_payload_estimate = __esm({
   "src/hud/payload-estimate.ts"() {
     "use strict";
-    import_fs125 = require("fs");
+    import_fs126 = require("fs");
     ANTHROPIC_REQUEST_PAYLOAD_LIMIT_BYTES = 32e6;
     PAYLOAD_WARNING_BYTES = 22e6;
     PAYLOAD_CRITICAL_BYTES = 26e6;
@@ -57632,9 +63653,9 @@ function mergeStdinRateLimits(stdinRateLimits, usageResult) {
 }
 function readSessionSummary(stateDir, sessionId) {
   const statePath = (0, import_path145.join)(stateDir, `session-summary-${sessionId}.json`);
-  if (!(0, import_fs126.existsSync)(statePath)) return null;
+  if (!(0, import_fs127.existsSync)(statePath)) return null;
   try {
-    return JSON.parse((0, import_fs126.readFileSync)(statePath, "utf-8"));
+    return JSON.parse((0, import_fs127.readFileSync)(statePath, "utf-8"));
   } catch {
     return null;
   }
@@ -57668,7 +63689,7 @@ function spawnSessionSummaryScript(transcriptPath, stateDir, sessionId) {
     "scripts",
     "session-summary.mjs"
   );
-  if (!(0, import_fs126.existsSync)(scriptPath)) {
+  if (!(0, import_fs127.existsSync)(scriptPath)) {
     if (process.env.OMC_DEBUG) {
       console.error("[HUD] session-summary script not found:", scriptPath);
     }
@@ -57709,10 +63730,10 @@ function showDiagnostic() {
   const configDir = getClaudeConfigDir();
   const hudScript = (0, import_path145.join)(configDir, "hud", "omc-hud.mjs");
   const settingsFile = (0, import_path145.join)(configDir, "settings.json");
-  const hudExists = (0, import_fs126.existsSync)(hudScript);
+  const hudExists = (0, import_fs127.existsSync)(hudScript);
   let statusLineOk = false;
   try {
-    const settings = JSON.parse((0, import_fs126.readFileSync)(settingsFile, "utf-8"));
+    const settings = JSON.parse((0, import_fs127.readFileSync)(settingsFile, "utf-8"));
     const sl = settings.statusLine;
     if (sl && typeof sl === "object" && typeof sl.command === "string") {
       statusLineOk = sl.command.includes("omc-hud");
@@ -57781,6 +63802,18 @@ async function main2(watchMode = false, skipInit = false) {
       cwd2,
       currentSessionId ?? void 0
     );
+    let graph = null;
+    try {
+      graph = readGraphStateForHud(cwd2, currentSessionId ?? void 0);
+    } catch (error2) {
+      if (process.env.OMC_DEBUG) {
+        console.error(
+          "[HUD] Graph state read failed (non-fatal):",
+          error2 instanceof Error ? error2.message : error2
+        );
+      }
+      graph = null;
+    }
     const hudState = readHudState(cwd2, currentSessionId ?? void 0);
     const _backgroundTasks = hudState?.backgroundTasks || [];
     let sessionStart = transcriptData.sessionStart;
@@ -57819,8 +63852,8 @@ async function main2(watchMode = false, skipInit = false) {
     }
     try {
       const updateCacheFile = getUpdateCheckCachePath();
-      await (0, import_promises28.access)(updateCacheFile);
-      const content = await (0, import_promises28.readFile)(updateCacheFile, "utf-8");
+      await (0, import_promises29.access)(updateCacheFile);
+      const content = await (0, import_promises29.readFile)(updateCacheFile, "utf-8");
       const cached2 = JSON.parse(content);
       if (cached2?.latestVersion && omcVersion && compareVersions2(omcVersion, cached2.latestVersion) < 0) {
         updateAvailable = cached2.latestVersion;
@@ -57867,6 +63900,7 @@ async function main2(watchMode = false, skipInit = false) {
       ultrawork,
       prd,
       autopilot,
+      graph,
       activeAgents: transcriptData.agents.filter((a) => a.status === "running"),
       todos: transcriptData.todos,
       backgroundTasks: getRunningTasks(hudState),
@@ -57908,9 +63942,9 @@ async function main2(watchMode = false, skipInit = false) {
     if (config2.contextLimitWarning.autoCompact && context.contextPercent >= config2.contextLimitWarning.threshold) {
       try {
         const omcStateDir = (0, import_path145.join)(getOmcRoot(cwd2), "state");
-        (0, import_fs126.mkdirSync)(omcStateDir, { recursive: true });
+        (0, import_fs127.mkdirSync)(omcStateDir, { recursive: true });
         const triggerFile = (0, import_path145.join)(omcStateDir, "compact-requested.json");
-        (0, import_fs126.writeFileSync)(
+        (0, import_fs127.writeFileSync)(
           triggerFile,
           JSON.stringify({
             requestedAt: (/* @__PURE__ */ new Date()).toISOString(),
@@ -57949,7 +63983,7 @@ async function main2(watchMode = false, skipInit = false) {
     }
   }
 }
-var import_fs126, import_promises28, import_path145, import_child_process44, import_url19, lastSummarySpawnTimestamp, summaryProcessPid;
+var import_fs127, import_promises29, import_path145, import_child_process44, import_url19, lastSummarySpawnTimestamp, summaryProcessPid;
 var init_hud = __esm({
   "src/hud/index.ts"() {
     "use strict";
@@ -57967,8 +64001,8 @@ var init_hud = __esm({
     init_version();
     init_auto_update();
     init_worktree_paths();
-    import_fs126 = require("fs");
-    import_promises28 = require("fs/promises");
+    import_fs127 = require("fs");
+    import_promises29 = require("fs/promises");
     import_path145 = require("path");
     import_child_process44 = require("child_process");
     import_url19 = require("url");
@@ -58502,7 +64536,7 @@ var source_default = chalk;
 
 // src/cli/index.ts
 var import_path146 = require("path");
-var import_fs127 = require("fs");
+var import_fs128 = require("fs");
 init_config_dir();
 
 // src/lib/env-vars.ts
@@ -61426,7 +67460,7 @@ var require_compile = __commonJS2((exports2) => {
     const schOrFunc = root2.refs[ref];
     if (schOrFunc)
       return schOrFunc;
-    let _sch = resolve32.call(this, root2, ref);
+    let _sch = resolve33.call(this, root2, ref);
     if (_sch === void 0) {
       const schema = (_a = root2.localRefs) === null || _a === void 0 ? void 0 : _a[ref];
       const { schemaId } = this.opts;
@@ -61453,7 +67487,7 @@ var require_compile = __commonJS2((exports2) => {
   function sameSchemaEnv(s1, s2) {
     return s1.schema === s2.schema && s1.root === s2.root && s1.baseId === s2.baseId;
   }
-  function resolve32(root2, ref) {
+  function resolve33(root2, ref) {
     let sch;
     while (typeof (sch = this.refs[ref]) == "string")
       ref = sch;
@@ -61951,7 +67985,7 @@ var require_fast_uri = __commonJS2((exports2, module2) => {
     }
     return uri;
   }
-  function resolve32(baseURI, relativeURI, options) {
+  function resolve33(baseURI, relativeURI, options) {
     const schemelessOptions = Object.assign({ scheme: "null" }, options);
     const resolved = resolveComponents(parse62(baseURI, schemelessOptions), parse62(relativeURI, schemelessOptions), schemelessOptions, true);
     return serialize(resolved, { ...schemelessOptions, skipEscape: true });
@@ -62184,7 +68218,7 @@ var require_fast_uri = __commonJS2((exports2, module2) => {
   var fastUri = {
     SCHEMES,
     normalize: normalize13,
-    resolve: resolve32,
+    resolve: resolve33,
     resolveComponents,
     equal,
     serialize,
@@ -76551,7 +82585,7 @@ var Protocol = class {
           return;
         }
         const pollInterval = (_c = (_a = task2.pollInterval) !== null && _a !== void 0 ? _a : (_b = this._options) === null || _b === void 0 ? void 0 : _b.defaultTaskPollInterval) !== null && _c !== void 0 ? _c : 1e3;
-        await new Promise((resolve32) => setTimeout(resolve32, pollInterval));
+        await new Promise((resolve33) => setTimeout(resolve33, pollInterval));
         (_d = options === null || options === void 0 ? void 0 : options.signal) === null || _d === void 0 || _d.throwIfAborted();
       }
     } catch (error2) {
@@ -76563,7 +82597,7 @@ var Protocol = class {
   }
   request(request, resultSchema, options) {
     const { relatedRequestId, resumptionToken, onresumptiontoken, task, relatedTask } = options !== null && options !== void 0 ? options : {};
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       var _a, _b, _c, _d, _e, _f, _g;
       const earlyReject = (error2) => {
         reject(error2);
@@ -76644,7 +82678,7 @@ var Protocol = class {
           if (!parseResult.success) {
             reject(parseResult.error);
           } else {
-            resolve32(parseResult.data);
+            resolve33(parseResult.data);
           }
         } catch (error2) {
           reject(error2);
@@ -76841,12 +82875,12 @@ var Protocol = class {
       }
     } catch (_d) {
     }
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       if (signal.aborted) {
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
         return;
       }
-      const timeoutId = setTimeout(resolve32, interval);
+      const timeoutId = setTimeout(resolve33, interval);
       signal.addEventListener("abort", () => {
         clearTimeout(timeoutId);
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
@@ -77645,7 +83679,7 @@ var McpServer = class {
     let task = createTaskResult.task;
     const pollInterval = (_a = task.pollInterval) !== null && _a !== void 0 ? _a : 5e3;
     while (task.status !== "completed" && task.status !== "failed" && task.status !== "cancelled") {
-      await new Promise((resolve32) => setTimeout(resolve32, pollInterval));
+      await new Promise((resolve33) => setTimeout(resolve33, pollInterval));
       const updatedTask = await extra.taskStore.getTask(taskId);
       if (!updatedTask) {
         throw new McpError(ErrorCode.InternalError, `Task ${taskId} not found during polling`);
@@ -78186,4046 +84220,8 @@ function createSdkMcpServer(options) {
   };
 }
 
-// node_modules/zod/v3/external.js
-var external_exports = {};
-__export(external_exports, {
-  BRAND: () => BRAND,
-  DIRTY: () => DIRTY2,
-  EMPTY_PATH: () => EMPTY_PATH,
-  INVALID: () => INVALID2,
-  NEVER: () => NEVER2,
-  OK: () => OK2,
-  ParseStatus: () => ParseStatus2,
-  Schema: () => ZodType3,
-  ZodAny: () => ZodAny2,
-  ZodArray: () => ZodArray3,
-  ZodBigInt: () => ZodBigInt2,
-  ZodBoolean: () => ZodBoolean3,
-  ZodBranded: () => ZodBranded2,
-  ZodCatch: () => ZodCatch3,
-  ZodDate: () => ZodDate2,
-  ZodDefault: () => ZodDefault3,
-  ZodDiscriminatedUnion: () => ZodDiscriminatedUnion3,
-  ZodEffects: () => ZodEffects2,
-  ZodEnum: () => ZodEnum3,
-  ZodError: () => ZodError3,
-  ZodFirstPartyTypeKind: () => ZodFirstPartyTypeKind2,
-  ZodFunction: () => ZodFunction2,
-  ZodIntersection: () => ZodIntersection3,
-  ZodIssueCode: () => ZodIssueCode2,
-  ZodLazy: () => ZodLazy2,
-  ZodLiteral: () => ZodLiteral3,
-  ZodMap: () => ZodMap2,
-  ZodNaN: () => ZodNaN2,
-  ZodNativeEnum: () => ZodNativeEnum2,
-  ZodNever: () => ZodNever3,
-  ZodNull: () => ZodNull3,
-  ZodNullable: () => ZodNullable3,
-  ZodNumber: () => ZodNumber3,
-  ZodObject: () => ZodObject3,
-  ZodOptional: () => ZodOptional3,
-  ZodParsedType: () => ZodParsedType2,
-  ZodPipeline: () => ZodPipeline2,
-  ZodPromise: () => ZodPromise2,
-  ZodReadonly: () => ZodReadonly3,
-  ZodRecord: () => ZodRecord3,
-  ZodSchema: () => ZodType3,
-  ZodSet: () => ZodSet2,
-  ZodString: () => ZodString3,
-  ZodSymbol: () => ZodSymbol2,
-  ZodTransformer: () => ZodEffects2,
-  ZodTuple: () => ZodTuple2,
-  ZodType: () => ZodType3,
-  ZodUndefined: () => ZodUndefined2,
-  ZodUnion: () => ZodUnion3,
-  ZodUnknown: () => ZodUnknown3,
-  ZodVoid: () => ZodVoid2,
-  addIssueToContext: () => addIssueToContext2,
-  any: () => anyType2,
-  array: () => arrayType2,
-  bigint: () => bigIntType2,
-  boolean: () => booleanType2,
-  coerce: () => coerce,
-  custom: () => custom2,
-  date: () => dateType2,
-  datetimeRegex: () => datetimeRegex2,
-  defaultErrorMap: () => en_default3,
-  discriminatedUnion: () => discriminatedUnionType2,
-  effect: () => effectsType2,
-  enum: () => enumType2,
-  function: () => functionType2,
-  getErrorMap: () => getErrorMap2,
-  getParsedType: () => getParsedType3,
-  instanceof: () => instanceOfType,
-  intersection: () => intersectionType2,
-  isAborted: () => isAborted2,
-  isAsync: () => isAsync2,
-  isDirty: () => isDirty2,
-  isValid: () => isValid2,
-  late: () => late2,
-  lazy: () => lazyType2,
-  literal: () => literalType2,
-  makeIssue: () => makeIssue2,
-  map: () => mapType2,
-  nan: () => nanType2,
-  nativeEnum: () => nativeEnumType2,
-  never: () => neverType2,
-  null: () => nullType2,
-  nullable: () => nullableType2,
-  number: () => numberType2,
-  object: () => objectType2,
-  objectUtil: () => objectUtil2,
-  oboolean: () => oboolean,
-  onumber: () => onumber,
-  optional: () => optionalType2,
-  ostring: () => ostring,
-  pipeline: () => pipelineType2,
-  preprocess: () => preprocessType2,
-  promise: () => promiseType2,
-  quotelessJson: () => quotelessJson,
-  record: () => recordType2,
-  set: () => setType2,
-  setErrorMap: () => setErrorMap,
-  strictObject: () => strictObjectType2,
-  string: () => stringType2,
-  symbol: () => symbolType2,
-  transformer: () => effectsType2,
-  tuple: () => tupleType2,
-  undefined: () => undefinedType2,
-  union: () => unionType2,
-  unknown: () => unknownType2,
-  util: () => util2,
-  void: () => voidType2
-});
-
-// node_modules/zod/v3/helpers/util.js
-var util2;
-(function(util3) {
-  util3.assertEqual = (_) => {
-  };
-  function assertIs2(_arg) {
-  }
-  util3.assertIs = assertIs2;
-  function assertNever2(_x) {
-    throw new Error();
-  }
-  util3.assertNever = assertNever2;
-  util3.arrayToEnum = (items) => {
-    const obj = {};
-    for (const item of items) {
-      obj[item] = item;
-    }
-    return obj;
-  };
-  util3.getValidEnumValues = (obj) => {
-    const validKeys = util3.objectKeys(obj).filter((k) => typeof obj[obj[k]] !== "number");
-    const filtered = {};
-    for (const k of validKeys) {
-      filtered[k] = obj[k];
-    }
-    return util3.objectValues(filtered);
-  };
-  util3.objectValues = (obj) => {
-    return util3.objectKeys(obj).map(function(e) {
-      return obj[e];
-    });
-  };
-  util3.objectKeys = typeof Object.keys === "function" ? (obj) => Object.keys(obj) : (object3) => {
-    const keys = [];
-    for (const key in object3) {
-      if (Object.prototype.hasOwnProperty.call(object3, key)) {
-        keys.push(key);
-      }
-    }
-    return keys;
-  };
-  util3.find = (arr, checker) => {
-    for (const item of arr) {
-      if (checker(item))
-        return item;
-    }
-    return void 0;
-  };
-  util3.isInteger = typeof Number.isInteger === "function" ? (val) => Number.isInteger(val) : (val) => typeof val === "number" && Number.isFinite(val) && Math.floor(val) === val;
-  function joinValues2(array2, separator = " | ") {
-    return array2.map((val) => typeof val === "string" ? `'${val}'` : val).join(separator);
-  }
-  util3.joinValues = joinValues2;
-  util3.jsonStringifyReplacer = (_, value) => {
-    if (typeof value === "bigint") {
-      return value.toString();
-    }
-    return value;
-  };
-})(util2 || (util2 = {}));
-var objectUtil2;
-(function(objectUtil3) {
-  objectUtil3.mergeShapes = (first, second) => {
-    return {
-      ...first,
-      ...second
-      // second overwrites first
-    };
-  };
-})(objectUtil2 || (objectUtil2 = {}));
-var ZodParsedType2 = util2.arrayToEnum([
-  "string",
-  "nan",
-  "number",
-  "integer",
-  "float",
-  "boolean",
-  "date",
-  "bigint",
-  "symbol",
-  "function",
-  "undefined",
-  "null",
-  "array",
-  "object",
-  "unknown",
-  "promise",
-  "void",
-  "never",
-  "map",
-  "set"
-]);
-var getParsedType3 = (data) => {
-  const t = typeof data;
-  switch (t) {
-    case "undefined":
-      return ZodParsedType2.undefined;
-    case "string":
-      return ZodParsedType2.string;
-    case "number":
-      return Number.isNaN(data) ? ZodParsedType2.nan : ZodParsedType2.number;
-    case "boolean":
-      return ZodParsedType2.boolean;
-    case "function":
-      return ZodParsedType2.function;
-    case "bigint":
-      return ZodParsedType2.bigint;
-    case "symbol":
-      return ZodParsedType2.symbol;
-    case "object":
-      if (Array.isArray(data)) {
-        return ZodParsedType2.array;
-      }
-      if (data === null) {
-        return ZodParsedType2.null;
-      }
-      if (data.then && typeof data.then === "function" && data.catch && typeof data.catch === "function") {
-        return ZodParsedType2.promise;
-      }
-      if (typeof Map !== "undefined" && data instanceof Map) {
-        return ZodParsedType2.map;
-      }
-      if (typeof Set !== "undefined" && data instanceof Set) {
-        return ZodParsedType2.set;
-      }
-      if (typeof Date !== "undefined" && data instanceof Date) {
-        return ZodParsedType2.date;
-      }
-      return ZodParsedType2.object;
-    default:
-      return ZodParsedType2.unknown;
-  }
-};
-
-// node_modules/zod/v3/ZodError.js
-var ZodIssueCode2 = util2.arrayToEnum([
-  "invalid_type",
-  "invalid_literal",
-  "custom",
-  "invalid_union",
-  "invalid_union_discriminator",
-  "invalid_enum_value",
-  "unrecognized_keys",
-  "invalid_arguments",
-  "invalid_return_type",
-  "invalid_date",
-  "invalid_string",
-  "too_small",
-  "too_big",
-  "invalid_intersection_types",
-  "not_multiple_of",
-  "not_finite"
-]);
-var quotelessJson = (obj) => {
-  const json = JSON.stringify(obj, null, 2);
-  return json.replace(/"([^"]+)":/g, "$1:");
-};
-var ZodError3 = class _ZodError extends Error {
-  get errors() {
-    return this.issues;
-  }
-  constructor(issues) {
-    super();
-    this.issues = [];
-    this.addIssue = (sub) => {
-      this.issues = [...this.issues, sub];
-    };
-    this.addIssues = (subs = []) => {
-      this.issues = [...this.issues, ...subs];
-    };
-    const actualProto = new.target.prototype;
-    if (Object.setPrototypeOf) {
-      Object.setPrototypeOf(this, actualProto);
-    } else {
-      this.__proto__ = actualProto;
-    }
-    this.name = "ZodError";
-    this.issues = issues;
-  }
-  format(_mapper) {
-    const mapper = _mapper || function(issue2) {
-      return issue2.message;
-    };
-    const fieldErrors = { _errors: [] };
-    const processError = (error2) => {
-      for (const issue2 of error2.issues) {
-        if (issue2.code === "invalid_union") {
-          issue2.unionErrors.map(processError);
-        } else if (issue2.code === "invalid_return_type") {
-          processError(issue2.returnTypeError);
-        } else if (issue2.code === "invalid_arguments") {
-          processError(issue2.argumentsError);
-        } else if (issue2.path.length === 0) {
-          fieldErrors._errors.push(mapper(issue2));
-        } else {
-          let curr = fieldErrors;
-          let i = 0;
-          while (i < issue2.path.length) {
-            const el = issue2.path[i];
-            const terminal = i === issue2.path.length - 1;
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
-              curr[el]._errors.push(mapper(issue2));
-            }
-            curr = curr[el];
-            i++;
-          }
-        }
-      }
-    };
-    processError(this);
-    return fieldErrors;
-  }
-  static assert(value) {
-    if (!(value instanceof _ZodError)) {
-      throw new Error(`Not a ZodError: ${value}`);
-    }
-  }
-  toString() {
-    return this.message;
-  }
-  get message() {
-    return JSON.stringify(this.issues, util2.jsonStringifyReplacer, 2);
-  }
-  get isEmpty() {
-    return this.issues.length === 0;
-  }
-  flatten(mapper = (issue2) => issue2.message) {
-    const fieldErrors = {};
-    const formErrors = [];
-    for (const sub of this.issues) {
-      if (sub.path.length > 0) {
-        const firstEl = sub.path[0];
-        fieldErrors[firstEl] = fieldErrors[firstEl] || [];
-        fieldErrors[firstEl].push(mapper(sub));
-      } else {
-        formErrors.push(mapper(sub));
-      }
-    }
-    return { formErrors, fieldErrors };
-  }
-  get formErrors() {
-    return this.flatten();
-  }
-};
-ZodError3.create = (issues) => {
-  const error2 = new ZodError3(issues);
-  return error2;
-};
-
-// node_modules/zod/v3/locales/en.js
-var errorMap2 = (issue2, _ctx) => {
-  let message2;
-  switch (issue2.code) {
-    case ZodIssueCode2.invalid_type:
-      if (issue2.received === ZodParsedType2.undefined) {
-        message2 = "Required";
-      } else {
-        message2 = `Expected ${issue2.expected}, received ${issue2.received}`;
-      }
-      break;
-    case ZodIssueCode2.invalid_literal:
-      message2 = `Invalid literal value, expected ${JSON.stringify(issue2.expected, util2.jsonStringifyReplacer)}`;
-      break;
-    case ZodIssueCode2.unrecognized_keys:
-      message2 = `Unrecognized key(s) in object: ${util2.joinValues(issue2.keys, ", ")}`;
-      break;
-    case ZodIssueCode2.invalid_union:
-      message2 = `Invalid input`;
-      break;
-    case ZodIssueCode2.invalid_union_discriminator:
-      message2 = `Invalid discriminator value. Expected ${util2.joinValues(issue2.options)}`;
-      break;
-    case ZodIssueCode2.invalid_enum_value:
-      message2 = `Invalid enum value. Expected ${util2.joinValues(issue2.options)}, received '${issue2.received}'`;
-      break;
-    case ZodIssueCode2.invalid_arguments:
-      message2 = `Invalid function arguments`;
-      break;
-    case ZodIssueCode2.invalid_return_type:
-      message2 = `Invalid function return type`;
-      break;
-    case ZodIssueCode2.invalid_date:
-      message2 = `Invalid date`;
-      break;
-    case ZodIssueCode2.invalid_string:
-      if (typeof issue2.validation === "object") {
-        if ("includes" in issue2.validation) {
-          message2 = `Invalid input: must include "${issue2.validation.includes}"`;
-          if (typeof issue2.validation.position === "number") {
-            message2 = `${message2} at one or more positions greater than or equal to ${issue2.validation.position}`;
-          }
-        } else if ("startsWith" in issue2.validation) {
-          message2 = `Invalid input: must start with "${issue2.validation.startsWith}"`;
-        } else if ("endsWith" in issue2.validation) {
-          message2 = `Invalid input: must end with "${issue2.validation.endsWith}"`;
-        } else {
-          util2.assertNever(issue2.validation);
-        }
-      } else if (issue2.validation !== "regex") {
-        message2 = `Invalid ${issue2.validation}`;
-      } else {
-        message2 = "Invalid";
-      }
-      break;
-    case ZodIssueCode2.too_small:
-      if (issue2.type === "array")
-        message2 = `Array must contain ${issue2.exact ? "exactly" : issue2.inclusive ? `at least` : `more than`} ${issue2.minimum} element(s)`;
-      else if (issue2.type === "string")
-        message2 = `String must contain ${issue2.exact ? "exactly" : issue2.inclusive ? `at least` : `over`} ${issue2.minimum} character(s)`;
-      else if (issue2.type === "number")
-        message2 = `Number must be ${issue2.exact ? `exactly equal to ` : issue2.inclusive ? `greater than or equal to ` : `greater than `}${issue2.minimum}`;
-      else if (issue2.type === "bigint")
-        message2 = `Number must be ${issue2.exact ? `exactly equal to ` : issue2.inclusive ? `greater than or equal to ` : `greater than `}${issue2.minimum}`;
-      else if (issue2.type === "date")
-        message2 = `Date must be ${issue2.exact ? `exactly equal to ` : issue2.inclusive ? `greater than or equal to ` : `greater than `}${new Date(Number(issue2.minimum))}`;
-      else
-        message2 = "Invalid input";
-      break;
-    case ZodIssueCode2.too_big:
-      if (issue2.type === "array")
-        message2 = `Array must contain ${issue2.exact ? `exactly` : issue2.inclusive ? `at most` : `less than`} ${issue2.maximum} element(s)`;
-      else if (issue2.type === "string")
-        message2 = `String must contain ${issue2.exact ? `exactly` : issue2.inclusive ? `at most` : `under`} ${issue2.maximum} character(s)`;
-      else if (issue2.type === "number")
-        message2 = `Number must be ${issue2.exact ? `exactly` : issue2.inclusive ? `less than or equal to` : `less than`} ${issue2.maximum}`;
-      else if (issue2.type === "bigint")
-        message2 = `BigInt must be ${issue2.exact ? `exactly` : issue2.inclusive ? `less than or equal to` : `less than`} ${issue2.maximum}`;
-      else if (issue2.type === "date")
-        message2 = `Date must be ${issue2.exact ? `exactly` : issue2.inclusive ? `smaller than or equal to` : `smaller than`} ${new Date(Number(issue2.maximum))}`;
-      else
-        message2 = "Invalid input";
-      break;
-    case ZodIssueCode2.custom:
-      message2 = `Invalid input`;
-      break;
-    case ZodIssueCode2.invalid_intersection_types:
-      message2 = `Intersection results could not be merged`;
-      break;
-    case ZodIssueCode2.not_multiple_of:
-      message2 = `Number must be a multiple of ${issue2.multipleOf}`;
-      break;
-    case ZodIssueCode2.not_finite:
-      message2 = "Number must be finite";
-      break;
-    default:
-      message2 = _ctx.defaultError;
-      util2.assertNever(issue2);
-  }
-  return { message: message2 };
-};
-var en_default3 = errorMap2;
-
-// node_modules/zod/v3/errors.js
-var overrideErrorMap2 = en_default3;
-function setErrorMap(map) {
-  overrideErrorMap2 = map;
-}
-function getErrorMap2() {
-  return overrideErrorMap2;
-}
-
-// node_modules/zod/v3/helpers/parseUtil.js
-var makeIssue2 = (params) => {
-  const { data, path: path25, errorMaps, issueData } = params;
-  const fullPath = [...path25, ...issueData.path || []];
-  const fullIssue = {
-    ...issueData,
-    path: fullPath
-  };
-  if (issueData.message !== void 0) {
-    return {
-      ...issueData,
-      path: fullPath,
-      message: issueData.message
-    };
-  }
-  let errorMessage = "";
-  const maps = errorMaps.filter((m) => !!m).slice().reverse();
-  for (const map of maps) {
-    errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
-  }
-  return {
-    ...issueData,
-    path: fullPath,
-    message: errorMessage
-  };
-};
-var EMPTY_PATH = [];
-function addIssueToContext2(ctx, issueData) {
-  const overrideMap = getErrorMap2();
-  const issue2 = makeIssue2({
-    issueData,
-    data: ctx.data,
-    path: ctx.path,
-    errorMaps: [
-      ctx.common.contextualErrorMap,
-      // contextual error map is first priority
-      ctx.schemaErrorMap,
-      // then schema-bound map if available
-      overrideMap,
-      // then global override map
-      overrideMap === en_default3 ? void 0 : en_default3
-      // then global default map
-    ].filter((x) => !!x)
-  });
-  ctx.common.issues.push(issue2);
-}
-var ParseStatus2 = class _ParseStatus {
-  constructor() {
-    this.value = "valid";
-  }
-  dirty() {
-    if (this.value === "valid")
-      this.value = "dirty";
-  }
-  abort() {
-    if (this.value !== "aborted")
-      this.value = "aborted";
-  }
-  static mergeArray(status, results) {
-    const arrayValue = [];
-    for (const s of results) {
-      if (s.status === "aborted")
-        return INVALID2;
-      if (s.status === "dirty")
-        status.dirty();
-      arrayValue.push(s.value);
-    }
-    return { status: status.value, value: arrayValue };
-  }
-  static async mergeObjectAsync(status, pairs) {
-    const syncPairs = [];
-    for (const pair of pairs) {
-      const key = await pair.key;
-      const value = await pair.value;
-      syncPairs.push({
-        key,
-        value
-      });
-    }
-    return _ParseStatus.mergeObjectSync(status, syncPairs);
-  }
-  static mergeObjectSync(status, pairs) {
-    const finalObject = {};
-    for (const pair of pairs) {
-      const { key, value } = pair;
-      if (key.status === "aborted")
-        return INVALID2;
-      if (value.status === "aborted")
-        return INVALID2;
-      if (key.status === "dirty")
-        status.dirty();
-      if (value.status === "dirty")
-        status.dirty();
-      if (key.value !== "__proto__" && (typeof value.value !== "undefined" || pair.alwaysSet)) {
-        finalObject[key.value] = value.value;
-      }
-    }
-    return { status: status.value, value: finalObject };
-  }
-};
-var INVALID2 = Object.freeze({
-  status: "aborted"
-});
-var DIRTY2 = (value) => ({ status: "dirty", value });
-var OK2 = (value) => ({ status: "valid", value });
-var isAborted2 = (x) => x.status === "aborted";
-var isDirty2 = (x) => x.status === "dirty";
-var isValid2 = (x) => x.status === "valid";
-var isAsync2 = (x) => typeof Promise !== "undefined" && x instanceof Promise;
-
-// node_modules/zod/v3/helpers/errorUtil.js
-var errorUtil2;
-(function(errorUtil3) {
-  errorUtil3.errToObj = (message2) => typeof message2 === "string" ? { message: message2 } : message2 || {};
-  errorUtil3.toString = (message2) => typeof message2 === "string" ? message2 : message2?.message;
-})(errorUtil2 || (errorUtil2 = {}));
-
-// node_modules/zod/v3/types.js
-var ParseInputLazyPath2 = class {
-  constructor(parent, value, path25, key) {
-    this._cachedPath = [];
-    this.parent = parent;
-    this.data = value;
-    this._path = path25;
-    this._key = key;
-  }
-  get path() {
-    if (!this._cachedPath.length) {
-      if (Array.isArray(this._key)) {
-        this._cachedPath.push(...this._path, ...this._key);
-      } else {
-        this._cachedPath.push(...this._path, this._key);
-      }
-    }
-    return this._cachedPath;
-  }
-};
-var handleResult2 = (ctx, result) => {
-  if (isValid2(result)) {
-    return { success: true, data: result.value };
-  } else {
-    if (!ctx.common.issues.length) {
-      throw new Error("Validation failed but no issues detected.");
-    }
-    return {
-      success: false,
-      get error() {
-        if (this._error)
-          return this._error;
-        const error2 = new ZodError3(ctx.common.issues);
-        this._error = error2;
-        return this._error;
-      }
-    };
-  }
-};
-function processCreateParams2(params) {
-  if (!params)
-    return {};
-  const { errorMap: errorMap3, invalid_type_error, required_error, description } = params;
-  if (errorMap3 && (invalid_type_error || required_error)) {
-    throw new Error(`Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`);
-  }
-  if (errorMap3)
-    return { errorMap: errorMap3, description };
-  const customMap = (iss, ctx) => {
-    const { message: message2 } = params;
-    if (iss.code === "invalid_enum_value") {
-      return { message: message2 ?? ctx.defaultError };
-    }
-    if (typeof ctx.data === "undefined") {
-      return { message: message2 ?? required_error ?? ctx.defaultError };
-    }
-    if (iss.code !== "invalid_type")
-      return { message: ctx.defaultError };
-    return { message: message2 ?? invalid_type_error ?? ctx.defaultError };
-  };
-  return { errorMap: customMap, description };
-}
-var ZodType3 = class {
-  get description() {
-    return this._def.description;
-  }
-  _getType(input) {
-    return getParsedType3(input.data);
-  }
-  _getOrReturnCtx(input, ctx) {
-    return ctx || {
-      common: input.parent.common,
-      data: input.data,
-      parsedType: getParsedType3(input.data),
-      schemaErrorMap: this._def.errorMap,
-      path: input.path,
-      parent: input.parent
-    };
-  }
-  _processInputParams(input) {
-    return {
-      status: new ParseStatus2(),
-      ctx: {
-        common: input.parent.common,
-        data: input.data,
-        parsedType: getParsedType3(input.data),
-        schemaErrorMap: this._def.errorMap,
-        path: input.path,
-        parent: input.parent
-      }
-    };
-  }
-  _parseSync(input) {
-    const result = this._parse(input);
-    if (isAsync2(result)) {
-      throw new Error("Synchronous parse encountered promise.");
-    }
-    return result;
-  }
-  _parseAsync(input) {
-    const result = this._parse(input);
-    return Promise.resolve(result);
-  }
-  parse(data, params) {
-    const result = this.safeParse(data, params);
-    if (result.success)
-      return result.data;
-    throw result.error;
-  }
-  safeParse(data, params) {
-    const ctx = {
-      common: {
-        issues: [],
-        async: params?.async ?? false,
-        contextualErrorMap: params?.errorMap
-      },
-      path: params?.path || [],
-      schemaErrorMap: this._def.errorMap,
-      parent: null,
-      data,
-      parsedType: getParsedType3(data)
-    };
-    const result = this._parseSync({ data, path: ctx.path, parent: ctx });
-    return handleResult2(ctx, result);
-  }
-  "~validate"(data) {
-    const ctx = {
-      common: {
-        issues: [],
-        async: !!this["~standard"].async
-      },
-      path: [],
-      schemaErrorMap: this._def.errorMap,
-      parent: null,
-      data,
-      parsedType: getParsedType3(data)
-    };
-    if (!this["~standard"].async) {
-      try {
-        const result = this._parseSync({ data, path: [], parent: ctx });
-        return isValid2(result) ? {
-          value: result.value
-        } : {
-          issues: ctx.common.issues
-        };
-      } catch (err) {
-        if (err?.message?.toLowerCase()?.includes("encountered")) {
-          this["~standard"].async = true;
-        }
-        ctx.common = {
-          issues: [],
-          async: true
-        };
-      }
-    }
-    return this._parseAsync({ data, path: [], parent: ctx }).then((result) => isValid2(result) ? {
-      value: result.value
-    } : {
-      issues: ctx.common.issues
-    });
-  }
-  async parseAsync(data, params) {
-    const result = await this.safeParseAsync(data, params);
-    if (result.success)
-      return result.data;
-    throw result.error;
-  }
-  async safeParseAsync(data, params) {
-    const ctx = {
-      common: {
-        issues: [],
-        contextualErrorMap: params?.errorMap,
-        async: true
-      },
-      path: params?.path || [],
-      schemaErrorMap: this._def.errorMap,
-      parent: null,
-      data,
-      parsedType: getParsedType3(data)
-    };
-    const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
-    const result = await (isAsync2(maybeAsyncResult) ? maybeAsyncResult : Promise.resolve(maybeAsyncResult));
-    return handleResult2(ctx, result);
-  }
-  refine(check2, message2) {
-    const getIssueProperties = (val) => {
-      if (typeof message2 === "string" || typeof message2 === "undefined") {
-        return { message: message2 };
-      } else if (typeof message2 === "function") {
-        return message2(val);
-      } else {
-        return message2;
-      }
-    };
-    return this._refinement((val, ctx) => {
-      const result = check2(val);
-      const setError = () => ctx.addIssue({
-        code: ZodIssueCode2.custom,
-        ...getIssueProperties(val)
-      });
-      if (typeof Promise !== "undefined" && result instanceof Promise) {
-        return result.then((data) => {
-          if (!data) {
-            setError();
-            return false;
-          } else {
-            return true;
-          }
-        });
-      }
-      if (!result) {
-        setError();
-        return false;
-      } else {
-        return true;
-      }
-    });
-  }
-  refinement(check2, refinementData) {
-    return this._refinement((val, ctx) => {
-      if (!check2(val)) {
-        ctx.addIssue(typeof refinementData === "function" ? refinementData(val, ctx) : refinementData);
-        return false;
-      } else {
-        return true;
-      }
-    });
-  }
-  _refinement(refinement) {
-    return new ZodEffects2({
-      schema: this,
-      typeName: ZodFirstPartyTypeKind2.ZodEffects,
-      effect: { type: "refinement", refinement }
-    });
-  }
-  superRefine(refinement) {
-    return this._refinement(refinement);
-  }
-  constructor(def) {
-    this.spa = this.safeParseAsync;
-    this._def = def;
-    this.parse = this.parse.bind(this);
-    this.safeParse = this.safeParse.bind(this);
-    this.parseAsync = this.parseAsync.bind(this);
-    this.safeParseAsync = this.safeParseAsync.bind(this);
-    this.spa = this.spa.bind(this);
-    this.refine = this.refine.bind(this);
-    this.refinement = this.refinement.bind(this);
-    this.superRefine = this.superRefine.bind(this);
-    this.optional = this.optional.bind(this);
-    this.nullable = this.nullable.bind(this);
-    this.nullish = this.nullish.bind(this);
-    this.array = this.array.bind(this);
-    this.promise = this.promise.bind(this);
-    this.or = this.or.bind(this);
-    this.and = this.and.bind(this);
-    this.transform = this.transform.bind(this);
-    this.brand = this.brand.bind(this);
-    this.default = this.default.bind(this);
-    this.catch = this.catch.bind(this);
-    this.describe = this.describe.bind(this);
-    this.pipe = this.pipe.bind(this);
-    this.readonly = this.readonly.bind(this);
-    this.isNullable = this.isNullable.bind(this);
-    this.isOptional = this.isOptional.bind(this);
-    this["~standard"] = {
-      version: 1,
-      vendor: "zod",
-      validate: (data) => this["~validate"](data)
-    };
-  }
-  optional() {
-    return ZodOptional3.create(this, this._def);
-  }
-  nullable() {
-    return ZodNullable3.create(this, this._def);
-  }
-  nullish() {
-    return this.nullable().optional();
-  }
-  array() {
-    return ZodArray3.create(this);
-  }
-  promise() {
-    return ZodPromise2.create(this, this._def);
-  }
-  or(option) {
-    return ZodUnion3.create([this, option], this._def);
-  }
-  and(incoming) {
-    return ZodIntersection3.create(this, incoming, this._def);
-  }
-  transform(transform2) {
-    return new ZodEffects2({
-      ...processCreateParams2(this._def),
-      schema: this,
-      typeName: ZodFirstPartyTypeKind2.ZodEffects,
-      effect: { type: "transform", transform: transform2 }
-    });
-  }
-  default(def) {
-    const defaultValueFunc = typeof def === "function" ? def : () => def;
-    return new ZodDefault3({
-      ...processCreateParams2(this._def),
-      innerType: this,
-      defaultValue: defaultValueFunc,
-      typeName: ZodFirstPartyTypeKind2.ZodDefault
-    });
-  }
-  brand() {
-    return new ZodBranded2({
-      typeName: ZodFirstPartyTypeKind2.ZodBranded,
-      type: this,
-      ...processCreateParams2(this._def)
-    });
-  }
-  catch(def) {
-    const catchValueFunc = typeof def === "function" ? def : () => def;
-    return new ZodCatch3({
-      ...processCreateParams2(this._def),
-      innerType: this,
-      catchValue: catchValueFunc,
-      typeName: ZodFirstPartyTypeKind2.ZodCatch
-    });
-  }
-  describe(description) {
-    const This = this.constructor;
-    return new This({
-      ...this._def,
-      description
-    });
-  }
-  pipe(target) {
-    return ZodPipeline2.create(this, target);
-  }
-  readonly() {
-    return ZodReadonly3.create(this);
-  }
-  isOptional() {
-    return this.safeParse(void 0).success;
-  }
-  isNullable() {
-    return this.safeParse(null).success;
-  }
-};
-var cuidRegex2 = /^c[^\s-]{8,}$/i;
-var cuid2Regex2 = /^[0-9a-z]+$/;
-var ulidRegex2 = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
-var uuidRegex2 = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
-var nanoidRegex2 = /^[a-z0-9_-]{21}$/i;
-var jwtRegex2 = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
-var durationRegex2 = /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
-var emailRegex2 = /^(?!\.)(?!.*\.\.)([A-Z0-9_'+\-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i;
-var _emojiRegex2 = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
-var emojiRegex3;
-var ipv4Regex2 = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
-var ipv4CidrRegex2 = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/(3[0-2]|[12]?[0-9])$/;
-var ipv6Regex2 = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/;
-var ipv6CidrRegex2 = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
-var base64Regex2 = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-var base64urlRegex2 = /^([0-9a-zA-Z-_]{4})*(([0-9a-zA-Z-_]{2}(==)?)|([0-9a-zA-Z-_]{3}(=)?))?$/;
-var dateRegexSource2 = `((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))`;
-var dateRegex2 = new RegExp(`^${dateRegexSource2}$`);
-function timeRegexSource2(args) {
-  let secondsRegexSource = `[0-5]\\d`;
-  if (args.precision) {
-    secondsRegexSource = `${secondsRegexSource}\\.\\d{${args.precision}}`;
-  } else if (args.precision == null) {
-    secondsRegexSource = `${secondsRegexSource}(\\.\\d+)?`;
-  }
-  const secondsQuantifier = args.precision ? "+" : "?";
-  return `([01]\\d|2[0-3]):[0-5]\\d(:${secondsRegexSource})${secondsQuantifier}`;
-}
-function timeRegex2(args) {
-  return new RegExp(`^${timeRegexSource2(args)}$`);
-}
-function datetimeRegex2(args) {
-  let regex = `${dateRegexSource2}T${timeRegexSource2(args)}`;
-  const opts = [];
-  opts.push(args.local ? `Z?` : `Z`);
-  if (args.offset)
-    opts.push(`([+-]\\d{2}:?\\d{2})`);
-  regex = `${regex}(${opts.join("|")})`;
-  return new RegExp(`^${regex}$`);
-}
-function isValidIP2(ip, version3) {
-  if ((version3 === "v4" || !version3) && ipv4Regex2.test(ip)) {
-    return true;
-  }
-  if ((version3 === "v6" || !version3) && ipv6Regex2.test(ip)) {
-    return true;
-  }
-  return false;
-}
-function isValidJWT3(jwt, alg) {
-  if (!jwtRegex2.test(jwt))
-    return false;
-  try {
-    const [header] = jwt.split(".");
-    if (!header)
-      return false;
-    const base642 = header.replace(/-/g, "+").replace(/_/g, "/").padEnd(header.length + (4 - header.length % 4) % 4, "=");
-    const decoded = JSON.parse(atob(base642));
-    if (typeof decoded !== "object" || decoded === null)
-      return false;
-    if ("typ" in decoded && decoded?.typ !== "JWT")
-      return false;
-    if (!decoded.alg)
-      return false;
-    if (alg && decoded.alg !== alg)
-      return false;
-    return true;
-  } catch {
-    return false;
-  }
-}
-function isValidCidr2(ip, version3) {
-  if ((version3 === "v4" || !version3) && ipv4CidrRegex2.test(ip)) {
-    return true;
-  }
-  if ((version3 === "v6" || !version3) && ipv6CidrRegex2.test(ip)) {
-    return true;
-  }
-  return false;
-}
-var ZodString3 = class _ZodString2 extends ZodType3 {
-  _parse(input) {
-    if (this._def.coerce) {
-      input.data = String(input.data);
-    }
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.string) {
-      const ctx2 = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx2, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.string,
-        received: ctx2.parsedType
-      });
-      return INVALID2;
-    }
-    const status = new ParseStatus2();
-    let ctx = void 0;
-    for (const check2 of this._def.checks) {
-      if (check2.kind === "min") {
-        if (input.data.length < check2.value) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_small,
-            minimum: check2.value,
-            type: "string",
-            inclusive: true,
-            exact: false,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "max") {
-        if (input.data.length > check2.value) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_big,
-            maximum: check2.value,
-            type: "string",
-            inclusive: true,
-            exact: false,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "length") {
-        const tooBig = input.data.length > check2.value;
-        const tooSmall = input.data.length < check2.value;
-        if (tooBig || tooSmall) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          if (tooBig) {
-            addIssueToContext2(ctx, {
-              code: ZodIssueCode2.too_big,
-              maximum: check2.value,
-              type: "string",
-              inclusive: true,
-              exact: true,
-              message: check2.message
-            });
-          } else if (tooSmall) {
-            addIssueToContext2(ctx, {
-              code: ZodIssueCode2.too_small,
-              minimum: check2.value,
-              type: "string",
-              inclusive: true,
-              exact: true,
-              message: check2.message
-            });
-          }
-          status.dirty();
-        }
-      } else if (check2.kind === "email") {
-        if (!emailRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "email",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "emoji") {
-        if (!emojiRegex3) {
-          emojiRegex3 = new RegExp(_emojiRegex2, "u");
-        }
-        if (!emojiRegex3.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "emoji",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "uuid") {
-        if (!uuidRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "uuid",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "nanoid") {
-        if (!nanoidRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "nanoid",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "cuid") {
-        if (!cuidRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "cuid",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "cuid2") {
-        if (!cuid2Regex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "cuid2",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "ulid") {
-        if (!ulidRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "ulid",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "url") {
-        try {
-          new URL(input.data);
-        } catch {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "url",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "regex") {
-        check2.regex.lastIndex = 0;
-        const testResult = check2.regex.test(input.data);
-        if (!testResult) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "regex",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "trim") {
-        input.data = input.data.trim();
-      } else if (check2.kind === "includes") {
-        if (!input.data.includes(check2.value, check2.position)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_string,
-            validation: { includes: check2.value, position: check2.position },
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "toLowerCase") {
-        input.data = input.data.toLowerCase();
-      } else if (check2.kind === "toUpperCase") {
-        input.data = input.data.toUpperCase();
-      } else if (check2.kind === "startsWith") {
-        if (!input.data.startsWith(check2.value)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_string,
-            validation: { startsWith: check2.value },
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "endsWith") {
-        if (!input.data.endsWith(check2.value)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_string,
-            validation: { endsWith: check2.value },
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "datetime") {
-        const regex = datetimeRegex2(check2);
-        if (!regex.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_string,
-            validation: "datetime",
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "date") {
-        const regex = dateRegex2;
-        if (!regex.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_string,
-            validation: "date",
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "time") {
-        const regex = timeRegex2(check2);
-        if (!regex.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_string,
-            validation: "time",
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "duration") {
-        if (!durationRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "duration",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "ip") {
-        if (!isValidIP2(input.data, check2.version)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "ip",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "jwt") {
-        if (!isValidJWT3(input.data, check2.alg)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "jwt",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "cidr") {
-        if (!isValidCidr2(input.data, check2.version)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "cidr",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "base64") {
-        if (!base64Regex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "base64",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "base64url") {
-        if (!base64urlRegex2.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            validation: "base64url",
-            code: ZodIssueCode2.invalid_string,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else {
-        util2.assertNever(check2);
-      }
-    }
-    return { status: status.value, value: input.data };
-  }
-  _regex(regex, validation, message2) {
-    return this.refinement((data) => regex.test(data), {
-      validation,
-      code: ZodIssueCode2.invalid_string,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  _addCheck(check2) {
-    return new _ZodString2({
-      ...this._def,
-      checks: [...this._def.checks, check2]
-    });
-  }
-  email(message2) {
-    return this._addCheck({ kind: "email", ...errorUtil2.errToObj(message2) });
-  }
-  url(message2) {
-    return this._addCheck({ kind: "url", ...errorUtil2.errToObj(message2) });
-  }
-  emoji(message2) {
-    return this._addCheck({ kind: "emoji", ...errorUtil2.errToObj(message2) });
-  }
-  uuid(message2) {
-    return this._addCheck({ kind: "uuid", ...errorUtil2.errToObj(message2) });
-  }
-  nanoid(message2) {
-    return this._addCheck({ kind: "nanoid", ...errorUtil2.errToObj(message2) });
-  }
-  cuid(message2) {
-    return this._addCheck({ kind: "cuid", ...errorUtil2.errToObj(message2) });
-  }
-  cuid2(message2) {
-    return this._addCheck({ kind: "cuid2", ...errorUtil2.errToObj(message2) });
-  }
-  ulid(message2) {
-    return this._addCheck({ kind: "ulid", ...errorUtil2.errToObj(message2) });
-  }
-  base64(message2) {
-    return this._addCheck({ kind: "base64", ...errorUtil2.errToObj(message2) });
-  }
-  base64url(message2) {
-    return this._addCheck({
-      kind: "base64url",
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  jwt(options) {
-    return this._addCheck({ kind: "jwt", ...errorUtil2.errToObj(options) });
-  }
-  ip(options) {
-    return this._addCheck({ kind: "ip", ...errorUtil2.errToObj(options) });
-  }
-  cidr(options) {
-    return this._addCheck({ kind: "cidr", ...errorUtil2.errToObj(options) });
-  }
-  datetime(options) {
-    if (typeof options === "string") {
-      return this._addCheck({
-        kind: "datetime",
-        precision: null,
-        offset: false,
-        local: false,
-        message: options
-      });
-    }
-    return this._addCheck({
-      kind: "datetime",
-      precision: typeof options?.precision === "undefined" ? null : options?.precision,
-      offset: options?.offset ?? false,
-      local: options?.local ?? false,
-      ...errorUtil2.errToObj(options?.message)
-    });
-  }
-  date(message2) {
-    return this._addCheck({ kind: "date", message: message2 });
-  }
-  time(options) {
-    if (typeof options === "string") {
-      return this._addCheck({
-        kind: "time",
-        precision: null,
-        message: options
-      });
-    }
-    return this._addCheck({
-      kind: "time",
-      precision: typeof options?.precision === "undefined" ? null : options?.precision,
-      ...errorUtil2.errToObj(options?.message)
-    });
-  }
-  duration(message2) {
-    return this._addCheck({ kind: "duration", ...errorUtil2.errToObj(message2) });
-  }
-  regex(regex, message2) {
-    return this._addCheck({
-      kind: "regex",
-      regex,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  includes(value, options) {
-    return this._addCheck({
-      kind: "includes",
-      value,
-      position: options?.position,
-      ...errorUtil2.errToObj(options?.message)
-    });
-  }
-  startsWith(value, message2) {
-    return this._addCheck({
-      kind: "startsWith",
-      value,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  endsWith(value, message2) {
-    return this._addCheck({
-      kind: "endsWith",
-      value,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  min(minLength, message2) {
-    return this._addCheck({
-      kind: "min",
-      value: minLength,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  max(maxLength, message2) {
-    return this._addCheck({
-      kind: "max",
-      value: maxLength,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  length(len, message2) {
-    return this._addCheck({
-      kind: "length",
-      value: len,
-      ...errorUtil2.errToObj(message2)
-    });
-  }
-  /**
-   * Equivalent to `.min(1)`
-   */
-  nonempty(message2) {
-    return this.min(1, errorUtil2.errToObj(message2));
-  }
-  trim() {
-    return new _ZodString2({
-      ...this._def,
-      checks: [...this._def.checks, { kind: "trim" }]
-    });
-  }
-  toLowerCase() {
-    return new _ZodString2({
-      ...this._def,
-      checks: [...this._def.checks, { kind: "toLowerCase" }]
-    });
-  }
-  toUpperCase() {
-    return new _ZodString2({
-      ...this._def,
-      checks: [...this._def.checks, { kind: "toUpperCase" }]
-    });
-  }
-  get isDatetime() {
-    return !!this._def.checks.find((ch) => ch.kind === "datetime");
-  }
-  get isDate() {
-    return !!this._def.checks.find((ch) => ch.kind === "date");
-  }
-  get isTime() {
-    return !!this._def.checks.find((ch) => ch.kind === "time");
-  }
-  get isDuration() {
-    return !!this._def.checks.find((ch) => ch.kind === "duration");
-  }
-  get isEmail() {
-    return !!this._def.checks.find((ch) => ch.kind === "email");
-  }
-  get isURL() {
-    return !!this._def.checks.find((ch) => ch.kind === "url");
-  }
-  get isEmoji() {
-    return !!this._def.checks.find((ch) => ch.kind === "emoji");
-  }
-  get isUUID() {
-    return !!this._def.checks.find((ch) => ch.kind === "uuid");
-  }
-  get isNANOID() {
-    return !!this._def.checks.find((ch) => ch.kind === "nanoid");
-  }
-  get isCUID() {
-    return !!this._def.checks.find((ch) => ch.kind === "cuid");
-  }
-  get isCUID2() {
-    return !!this._def.checks.find((ch) => ch.kind === "cuid2");
-  }
-  get isULID() {
-    return !!this._def.checks.find((ch) => ch.kind === "ulid");
-  }
-  get isIP() {
-    return !!this._def.checks.find((ch) => ch.kind === "ip");
-  }
-  get isCIDR() {
-    return !!this._def.checks.find((ch) => ch.kind === "cidr");
-  }
-  get isBase64() {
-    return !!this._def.checks.find((ch) => ch.kind === "base64");
-  }
-  get isBase64url() {
-    return !!this._def.checks.find((ch) => ch.kind === "base64url");
-  }
-  get minLength() {
-    let min = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "min") {
-        if (min === null || ch.value > min)
-          min = ch.value;
-      }
-    }
-    return min;
-  }
-  get maxLength() {
-    let max = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "max") {
-        if (max === null || ch.value < max)
-          max = ch.value;
-      }
-    }
-    return max;
-  }
-};
-ZodString3.create = (params) => {
-  return new ZodString3({
-    checks: [],
-    typeName: ZodFirstPartyTypeKind2.ZodString,
-    coerce: params?.coerce ?? false,
-    ...processCreateParams2(params)
-  });
-};
-function floatSafeRemainder3(val, step) {
-  const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepDecCount = (step.toString().split(".")[1] || "").length;
-  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
-  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
-  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
-  return valInt % stepInt / 10 ** decCount;
-}
-var ZodNumber3 = class _ZodNumber extends ZodType3 {
-  constructor() {
-    super(...arguments);
-    this.min = this.gte;
-    this.max = this.lte;
-    this.step = this.multipleOf;
-  }
-  _parse(input) {
-    if (this._def.coerce) {
-      input.data = Number(input.data);
-    }
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.number) {
-      const ctx2 = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx2, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.number,
-        received: ctx2.parsedType
-      });
-      return INVALID2;
-    }
-    let ctx = void 0;
-    const status = new ParseStatus2();
-    for (const check2 of this._def.checks) {
-      if (check2.kind === "int") {
-        if (!util2.isInteger(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.invalid_type,
-            expected: "integer",
-            received: "float",
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "min") {
-        const tooSmall = check2.inclusive ? input.data < check2.value : input.data <= check2.value;
-        if (tooSmall) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_small,
-            minimum: check2.value,
-            type: "number",
-            inclusive: check2.inclusive,
-            exact: false,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "max") {
-        const tooBig = check2.inclusive ? input.data > check2.value : input.data >= check2.value;
-        if (tooBig) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_big,
-            maximum: check2.value,
-            type: "number",
-            inclusive: check2.inclusive,
-            exact: false,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "multipleOf") {
-        if (floatSafeRemainder3(input.data, check2.value) !== 0) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.not_multiple_of,
-            multipleOf: check2.value,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "finite") {
-        if (!Number.isFinite(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.not_finite,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else {
-        util2.assertNever(check2);
-      }
-    }
-    return { status: status.value, value: input.data };
-  }
-  gte(value, message2) {
-    return this.setLimit("min", value, true, errorUtil2.toString(message2));
-  }
-  gt(value, message2) {
-    return this.setLimit("min", value, false, errorUtil2.toString(message2));
-  }
-  lte(value, message2) {
-    return this.setLimit("max", value, true, errorUtil2.toString(message2));
-  }
-  lt(value, message2) {
-    return this.setLimit("max", value, false, errorUtil2.toString(message2));
-  }
-  setLimit(kind, value, inclusive, message2) {
-    return new _ZodNumber({
-      ...this._def,
-      checks: [
-        ...this._def.checks,
-        {
-          kind,
-          value,
-          inclusive,
-          message: errorUtil2.toString(message2)
-        }
-      ]
-    });
-  }
-  _addCheck(check2) {
-    return new _ZodNumber({
-      ...this._def,
-      checks: [...this._def.checks, check2]
-    });
-  }
-  int(message2) {
-    return this._addCheck({
-      kind: "int",
-      message: errorUtil2.toString(message2)
-    });
-  }
-  positive(message2) {
-    return this._addCheck({
-      kind: "min",
-      value: 0,
-      inclusive: false,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  negative(message2) {
-    return this._addCheck({
-      kind: "max",
-      value: 0,
-      inclusive: false,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  nonpositive(message2) {
-    return this._addCheck({
-      kind: "max",
-      value: 0,
-      inclusive: true,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  nonnegative(message2) {
-    return this._addCheck({
-      kind: "min",
-      value: 0,
-      inclusive: true,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  multipleOf(value, message2) {
-    return this._addCheck({
-      kind: "multipleOf",
-      value,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  finite(message2) {
-    return this._addCheck({
-      kind: "finite",
-      message: errorUtil2.toString(message2)
-    });
-  }
-  safe(message2) {
-    return this._addCheck({
-      kind: "min",
-      inclusive: true,
-      value: Number.MIN_SAFE_INTEGER,
-      message: errorUtil2.toString(message2)
-    })._addCheck({
-      kind: "max",
-      inclusive: true,
-      value: Number.MAX_SAFE_INTEGER,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  get minValue() {
-    let min = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "min") {
-        if (min === null || ch.value > min)
-          min = ch.value;
-      }
-    }
-    return min;
-  }
-  get maxValue() {
-    let max = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "max") {
-        if (max === null || ch.value < max)
-          max = ch.value;
-      }
-    }
-    return max;
-  }
-  get isInt() {
-    return !!this._def.checks.find((ch) => ch.kind === "int" || ch.kind === "multipleOf" && util2.isInteger(ch.value));
-  }
-  get isFinite() {
-    let max = null;
-    let min = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "finite" || ch.kind === "int" || ch.kind === "multipleOf") {
-        return true;
-      } else if (ch.kind === "min") {
-        if (min === null || ch.value > min)
-          min = ch.value;
-      } else if (ch.kind === "max") {
-        if (max === null || ch.value < max)
-          max = ch.value;
-      }
-    }
-    return Number.isFinite(min) && Number.isFinite(max);
-  }
-};
-ZodNumber3.create = (params) => {
-  return new ZodNumber3({
-    checks: [],
-    typeName: ZodFirstPartyTypeKind2.ZodNumber,
-    coerce: params?.coerce || false,
-    ...processCreateParams2(params)
-  });
-};
-var ZodBigInt2 = class _ZodBigInt extends ZodType3 {
-  constructor() {
-    super(...arguments);
-    this.min = this.gte;
-    this.max = this.lte;
-  }
-  _parse(input) {
-    if (this._def.coerce) {
-      try {
-        input.data = BigInt(input.data);
-      } catch {
-        return this._getInvalidInput(input);
-      }
-    }
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.bigint) {
-      return this._getInvalidInput(input);
-    }
-    let ctx = void 0;
-    const status = new ParseStatus2();
-    for (const check2 of this._def.checks) {
-      if (check2.kind === "min") {
-        const tooSmall = check2.inclusive ? input.data < check2.value : input.data <= check2.value;
-        if (tooSmall) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_small,
-            type: "bigint",
-            minimum: check2.value,
-            inclusive: check2.inclusive,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "max") {
-        const tooBig = check2.inclusive ? input.data > check2.value : input.data >= check2.value;
-        if (tooBig) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_big,
-            type: "bigint",
-            maximum: check2.value,
-            inclusive: check2.inclusive,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "multipleOf") {
-        if (input.data % check2.value !== BigInt(0)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.not_multiple_of,
-            multipleOf: check2.value,
-            message: check2.message
-          });
-          status.dirty();
-        }
-      } else {
-        util2.assertNever(check2);
-      }
-    }
-    return { status: status.value, value: input.data };
-  }
-  _getInvalidInput(input) {
-    const ctx = this._getOrReturnCtx(input);
-    addIssueToContext2(ctx, {
-      code: ZodIssueCode2.invalid_type,
-      expected: ZodParsedType2.bigint,
-      received: ctx.parsedType
-    });
-    return INVALID2;
-  }
-  gte(value, message2) {
-    return this.setLimit("min", value, true, errorUtil2.toString(message2));
-  }
-  gt(value, message2) {
-    return this.setLimit("min", value, false, errorUtil2.toString(message2));
-  }
-  lte(value, message2) {
-    return this.setLimit("max", value, true, errorUtil2.toString(message2));
-  }
-  lt(value, message2) {
-    return this.setLimit("max", value, false, errorUtil2.toString(message2));
-  }
-  setLimit(kind, value, inclusive, message2) {
-    return new _ZodBigInt({
-      ...this._def,
-      checks: [
-        ...this._def.checks,
-        {
-          kind,
-          value,
-          inclusive,
-          message: errorUtil2.toString(message2)
-        }
-      ]
-    });
-  }
-  _addCheck(check2) {
-    return new _ZodBigInt({
-      ...this._def,
-      checks: [...this._def.checks, check2]
-    });
-  }
-  positive(message2) {
-    return this._addCheck({
-      kind: "min",
-      value: BigInt(0),
-      inclusive: false,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  negative(message2) {
-    return this._addCheck({
-      kind: "max",
-      value: BigInt(0),
-      inclusive: false,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  nonpositive(message2) {
-    return this._addCheck({
-      kind: "max",
-      value: BigInt(0),
-      inclusive: true,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  nonnegative(message2) {
-    return this._addCheck({
-      kind: "min",
-      value: BigInt(0),
-      inclusive: true,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  multipleOf(value, message2) {
-    return this._addCheck({
-      kind: "multipleOf",
-      value,
-      message: errorUtil2.toString(message2)
-    });
-  }
-  get minValue() {
-    let min = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "min") {
-        if (min === null || ch.value > min)
-          min = ch.value;
-      }
-    }
-    return min;
-  }
-  get maxValue() {
-    let max = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "max") {
-        if (max === null || ch.value < max)
-          max = ch.value;
-      }
-    }
-    return max;
-  }
-};
-ZodBigInt2.create = (params) => {
-  return new ZodBigInt2({
-    checks: [],
-    typeName: ZodFirstPartyTypeKind2.ZodBigInt,
-    coerce: params?.coerce ?? false,
-    ...processCreateParams2(params)
-  });
-};
-var ZodBoolean3 = class extends ZodType3 {
-  _parse(input) {
-    if (this._def.coerce) {
-      input.data = Boolean(input.data);
-    }
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.boolean) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.boolean,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-};
-ZodBoolean3.create = (params) => {
-  return new ZodBoolean3({
-    typeName: ZodFirstPartyTypeKind2.ZodBoolean,
-    coerce: params?.coerce || false,
-    ...processCreateParams2(params)
-  });
-};
-var ZodDate2 = class _ZodDate extends ZodType3 {
-  _parse(input) {
-    if (this._def.coerce) {
-      input.data = new Date(input.data);
-    }
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.date) {
-      const ctx2 = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx2, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.date,
-        received: ctx2.parsedType
-      });
-      return INVALID2;
-    }
-    if (Number.isNaN(input.data.getTime())) {
-      const ctx2 = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx2, {
-        code: ZodIssueCode2.invalid_date
-      });
-      return INVALID2;
-    }
-    const status = new ParseStatus2();
-    let ctx = void 0;
-    for (const check2 of this._def.checks) {
-      if (check2.kind === "min") {
-        if (input.data.getTime() < check2.value) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_small,
-            message: check2.message,
-            inclusive: true,
-            exact: false,
-            minimum: check2.value,
-            type: "date"
-          });
-          status.dirty();
-        }
-      } else if (check2.kind === "max") {
-        if (input.data.getTime() > check2.value) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.too_big,
-            message: check2.message,
-            inclusive: true,
-            exact: false,
-            maximum: check2.value,
-            type: "date"
-          });
-          status.dirty();
-        }
-      } else {
-        util2.assertNever(check2);
-      }
-    }
-    return {
-      status: status.value,
-      value: new Date(input.data.getTime())
-    };
-  }
-  _addCheck(check2) {
-    return new _ZodDate({
-      ...this._def,
-      checks: [...this._def.checks, check2]
-    });
-  }
-  min(minDate, message2) {
-    return this._addCheck({
-      kind: "min",
-      value: minDate.getTime(),
-      message: errorUtil2.toString(message2)
-    });
-  }
-  max(maxDate, message2) {
-    return this._addCheck({
-      kind: "max",
-      value: maxDate.getTime(),
-      message: errorUtil2.toString(message2)
-    });
-  }
-  get minDate() {
-    let min = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "min") {
-        if (min === null || ch.value > min)
-          min = ch.value;
-      }
-    }
-    return min != null ? new Date(min) : null;
-  }
-  get maxDate() {
-    let max = null;
-    for (const ch of this._def.checks) {
-      if (ch.kind === "max") {
-        if (max === null || ch.value < max)
-          max = ch.value;
-      }
-    }
-    return max != null ? new Date(max) : null;
-  }
-};
-ZodDate2.create = (params) => {
-  return new ZodDate2({
-    checks: [],
-    coerce: params?.coerce || false,
-    typeName: ZodFirstPartyTypeKind2.ZodDate,
-    ...processCreateParams2(params)
-  });
-};
-var ZodSymbol2 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.symbol) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.symbol,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-};
-ZodSymbol2.create = (params) => {
-  return new ZodSymbol2({
-    typeName: ZodFirstPartyTypeKind2.ZodSymbol,
-    ...processCreateParams2(params)
-  });
-};
-var ZodUndefined2 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.undefined) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.undefined,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-};
-ZodUndefined2.create = (params) => {
-  return new ZodUndefined2({
-    typeName: ZodFirstPartyTypeKind2.ZodUndefined,
-    ...processCreateParams2(params)
-  });
-};
-var ZodNull3 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.null) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.null,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-};
-ZodNull3.create = (params) => {
-  return new ZodNull3({
-    typeName: ZodFirstPartyTypeKind2.ZodNull,
-    ...processCreateParams2(params)
-  });
-};
-var ZodAny2 = class extends ZodType3 {
-  constructor() {
-    super(...arguments);
-    this._any = true;
-  }
-  _parse(input) {
-    return OK2(input.data);
-  }
-};
-ZodAny2.create = (params) => {
-  return new ZodAny2({
-    typeName: ZodFirstPartyTypeKind2.ZodAny,
-    ...processCreateParams2(params)
-  });
-};
-var ZodUnknown3 = class extends ZodType3 {
-  constructor() {
-    super(...arguments);
-    this._unknown = true;
-  }
-  _parse(input) {
-    return OK2(input.data);
-  }
-};
-ZodUnknown3.create = (params) => {
-  return new ZodUnknown3({
-    typeName: ZodFirstPartyTypeKind2.ZodUnknown,
-    ...processCreateParams2(params)
-  });
-};
-var ZodNever3 = class extends ZodType3 {
-  _parse(input) {
-    const ctx = this._getOrReturnCtx(input);
-    addIssueToContext2(ctx, {
-      code: ZodIssueCode2.invalid_type,
-      expected: ZodParsedType2.never,
-      received: ctx.parsedType
-    });
-    return INVALID2;
-  }
-};
-ZodNever3.create = (params) => {
-  return new ZodNever3({
-    typeName: ZodFirstPartyTypeKind2.ZodNever,
-    ...processCreateParams2(params)
-  });
-};
-var ZodVoid2 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.undefined) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.void,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-};
-ZodVoid2.create = (params) => {
-  return new ZodVoid2({
-    typeName: ZodFirstPartyTypeKind2.ZodVoid,
-    ...processCreateParams2(params)
-  });
-};
-var ZodArray3 = class _ZodArray extends ZodType3 {
-  _parse(input) {
-    const { ctx, status } = this._processInputParams(input);
-    const def = this._def;
-    if (ctx.parsedType !== ZodParsedType2.array) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.array,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    if (def.exactLength !== null) {
-      const tooBig = ctx.data.length > def.exactLength.value;
-      const tooSmall = ctx.data.length < def.exactLength.value;
-      if (tooBig || tooSmall) {
-        addIssueToContext2(ctx, {
-          code: tooBig ? ZodIssueCode2.too_big : ZodIssueCode2.too_small,
-          minimum: tooSmall ? def.exactLength.value : void 0,
-          maximum: tooBig ? def.exactLength.value : void 0,
-          type: "array",
-          inclusive: true,
-          exact: true,
-          message: def.exactLength.message
-        });
-        status.dirty();
-      }
-    }
-    if (def.minLength !== null) {
-      if (ctx.data.length < def.minLength.value) {
-        addIssueToContext2(ctx, {
-          code: ZodIssueCode2.too_small,
-          minimum: def.minLength.value,
-          type: "array",
-          inclusive: true,
-          exact: false,
-          message: def.minLength.message
-        });
-        status.dirty();
-      }
-    }
-    if (def.maxLength !== null) {
-      if (ctx.data.length > def.maxLength.value) {
-        addIssueToContext2(ctx, {
-          code: ZodIssueCode2.too_big,
-          maximum: def.maxLength.value,
-          type: "array",
-          inclusive: true,
-          exact: false,
-          message: def.maxLength.message
-        });
-        status.dirty();
-      }
-    }
-    if (ctx.common.async) {
-      return Promise.all([...ctx.data].map((item, i) => {
-        return def.type._parseAsync(new ParseInputLazyPath2(ctx, item, ctx.path, i));
-      })).then((result2) => {
-        return ParseStatus2.mergeArray(status, result2);
-      });
-    }
-    const result = [...ctx.data].map((item, i) => {
-      return def.type._parseSync(new ParseInputLazyPath2(ctx, item, ctx.path, i));
-    });
-    return ParseStatus2.mergeArray(status, result);
-  }
-  get element() {
-    return this._def.type;
-  }
-  min(minLength, message2) {
-    return new _ZodArray({
-      ...this._def,
-      minLength: { value: minLength, message: errorUtil2.toString(message2) }
-    });
-  }
-  max(maxLength, message2) {
-    return new _ZodArray({
-      ...this._def,
-      maxLength: { value: maxLength, message: errorUtil2.toString(message2) }
-    });
-  }
-  length(len, message2) {
-    return new _ZodArray({
-      ...this._def,
-      exactLength: { value: len, message: errorUtil2.toString(message2) }
-    });
-  }
-  nonempty(message2) {
-    return this.min(1, message2);
-  }
-};
-ZodArray3.create = (schema, params) => {
-  return new ZodArray3({
-    type: schema,
-    minLength: null,
-    maxLength: null,
-    exactLength: null,
-    typeName: ZodFirstPartyTypeKind2.ZodArray,
-    ...processCreateParams2(params)
-  });
-};
-function deepPartialify2(schema) {
-  if (schema instanceof ZodObject3) {
-    const newShape = {};
-    for (const key in schema.shape) {
-      const fieldSchema = schema.shape[key];
-      newShape[key] = ZodOptional3.create(deepPartialify2(fieldSchema));
-    }
-    return new ZodObject3({
-      ...schema._def,
-      shape: () => newShape
-    });
-  } else if (schema instanceof ZodArray3) {
-    return new ZodArray3({
-      ...schema._def,
-      type: deepPartialify2(schema.element)
-    });
-  } else if (schema instanceof ZodOptional3) {
-    return ZodOptional3.create(deepPartialify2(schema.unwrap()));
-  } else if (schema instanceof ZodNullable3) {
-    return ZodNullable3.create(deepPartialify2(schema.unwrap()));
-  } else if (schema instanceof ZodTuple2) {
-    return ZodTuple2.create(schema.items.map((item) => deepPartialify2(item)));
-  } else {
-    return schema;
-  }
-}
-var ZodObject3 = class _ZodObject extends ZodType3 {
-  constructor() {
-    super(...arguments);
-    this._cached = null;
-    this.nonstrict = this.passthrough;
-    this.augment = this.extend;
-  }
-  _getCached() {
-    if (this._cached !== null)
-      return this._cached;
-    const shape = this._def.shape();
-    const keys = util2.objectKeys(shape);
-    this._cached = { shape, keys };
-    return this._cached;
-  }
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.object) {
-      const ctx2 = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx2, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.object,
-        received: ctx2.parsedType
-      });
-      return INVALID2;
-    }
-    const { status, ctx } = this._processInputParams(input);
-    const { shape, keys: shapeKeys } = this._getCached();
-    const extraKeys = [];
-    if (!(this._def.catchall instanceof ZodNever3 && this._def.unknownKeys === "strip")) {
-      for (const key in ctx.data) {
-        if (!shapeKeys.includes(key)) {
-          extraKeys.push(key);
-        }
-      }
-    }
-    const pairs = [];
-    for (const key of shapeKeys) {
-      const keyValidator = shape[key];
-      const value = ctx.data[key];
-      pairs.push({
-        key: { status: "valid", value: key },
-        value: keyValidator._parse(new ParseInputLazyPath2(ctx, value, ctx.path, key)),
-        alwaysSet: key in ctx.data
-      });
-    }
-    if (this._def.catchall instanceof ZodNever3) {
-      const unknownKeys = this._def.unknownKeys;
-      if (unknownKeys === "passthrough") {
-        for (const key of extraKeys) {
-          pairs.push({
-            key: { status: "valid", value: key },
-            value: { status: "valid", value: ctx.data[key] }
-          });
-        }
-      } else if (unknownKeys === "strict") {
-        if (extraKeys.length > 0) {
-          addIssueToContext2(ctx, {
-            code: ZodIssueCode2.unrecognized_keys,
-            keys: extraKeys
-          });
-          status.dirty();
-        }
-      } else if (unknownKeys === "strip") {
-      } else {
-        throw new Error(`Internal ZodObject error: invalid unknownKeys value.`);
-      }
-    } else {
-      const catchall = this._def.catchall;
-      for (const key of extraKeys) {
-        const value = ctx.data[key];
-        pairs.push({
-          key: { status: "valid", value: key },
-          value: catchall._parse(
-            new ParseInputLazyPath2(ctx, value, ctx.path, key)
-            //, ctx.child(key), value, getParsedType(value)
-          ),
-          alwaysSet: key in ctx.data
-        });
-      }
-    }
-    if (ctx.common.async) {
-      return Promise.resolve().then(async () => {
-        const syncPairs = [];
-        for (const pair of pairs) {
-          const key = await pair.key;
-          const value = await pair.value;
-          syncPairs.push({
-            key,
-            value,
-            alwaysSet: pair.alwaysSet
-          });
-        }
-        return syncPairs;
-      }).then((syncPairs) => {
-        return ParseStatus2.mergeObjectSync(status, syncPairs);
-      });
-    } else {
-      return ParseStatus2.mergeObjectSync(status, pairs);
-    }
-  }
-  get shape() {
-    return this._def.shape();
-  }
-  strict(message2) {
-    errorUtil2.errToObj;
-    return new _ZodObject({
-      ...this._def,
-      unknownKeys: "strict",
-      ...message2 !== void 0 ? {
-        errorMap: (issue2, ctx) => {
-          const defaultError = this._def.errorMap?.(issue2, ctx).message ?? ctx.defaultError;
-          if (issue2.code === "unrecognized_keys")
-            return {
-              message: errorUtil2.errToObj(message2).message ?? defaultError
-            };
-          return {
-            message: defaultError
-          };
-        }
-      } : {}
-    });
-  }
-  strip() {
-    return new _ZodObject({
-      ...this._def,
-      unknownKeys: "strip"
-    });
-  }
-  passthrough() {
-    return new _ZodObject({
-      ...this._def,
-      unknownKeys: "passthrough"
-    });
-  }
-  // const AugmentFactory =
-  //   <Def extends ZodObjectDef>(def: Def) =>
-  //   <Augmentation extends ZodRawShape>(
-  //     augmentation: Augmentation
-  //   ): ZodObject<
-  //     extendShape<ReturnType<Def["shape"]>, Augmentation>,
-  //     Def["unknownKeys"],
-  //     Def["catchall"]
-  //   > => {
-  //     return new ZodObject({
-  //       ...def,
-  //       shape: () => ({
-  //         ...def.shape(),
-  //         ...augmentation,
-  //       }),
-  //     }) as any;
-  //   };
-  extend(augmentation) {
-    return new _ZodObject({
-      ...this._def,
-      shape: () => ({
-        ...this._def.shape(),
-        ...augmentation
-      })
-    });
-  }
-  /**
-   * Prior to zod@1.0.12 there was a bug in the
-   * inferred type of merged objects. Please
-   * upgrade if you are experiencing issues.
-   */
-  merge(merging) {
-    const merged = new _ZodObject({
-      unknownKeys: merging._def.unknownKeys,
-      catchall: merging._def.catchall,
-      shape: () => ({
-        ...this._def.shape(),
-        ...merging._def.shape()
-      }),
-      typeName: ZodFirstPartyTypeKind2.ZodObject
-    });
-    return merged;
-  }
-  // merge<
-  //   Incoming extends AnyZodObject,
-  //   Augmentation extends Incoming["shape"],
-  //   NewOutput extends {
-  //     [k in keyof Augmentation | keyof Output]: k extends keyof Augmentation
-  //       ? Augmentation[k]["_output"]
-  //       : k extends keyof Output
-  //       ? Output[k]
-  //       : never;
-  //   },
-  //   NewInput extends {
-  //     [k in keyof Augmentation | keyof Input]: k extends keyof Augmentation
-  //       ? Augmentation[k]["_input"]
-  //       : k extends keyof Input
-  //       ? Input[k]
-  //       : never;
-  //   }
-  // >(
-  //   merging: Incoming
-  // ): ZodObject<
-  //   extendShape<T, ReturnType<Incoming["_def"]["shape"]>>,
-  //   Incoming["_def"]["unknownKeys"],
-  //   Incoming["_def"]["catchall"],
-  //   NewOutput,
-  //   NewInput
-  // > {
-  //   const merged: any = new ZodObject({
-  //     unknownKeys: merging._def.unknownKeys,
-  //     catchall: merging._def.catchall,
-  //     shape: () =>
-  //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
-  //     typeName: ZodFirstPartyTypeKind.ZodObject,
-  //   }) as any;
-  //   return merged;
-  // }
-  setKey(key, schema) {
-    return this.augment({ [key]: schema });
-  }
-  // merge<Incoming extends AnyZodObject>(
-  //   merging: Incoming
-  // ): //ZodObject<T & Incoming["_shape"], UnknownKeys, Catchall> = (merging) => {
-  // ZodObject<
-  //   extendShape<T, ReturnType<Incoming["_def"]["shape"]>>,
-  //   Incoming["_def"]["unknownKeys"],
-  //   Incoming["_def"]["catchall"]
-  // > {
-  //   // const mergedShape = objectUtil.mergeShapes(
-  //   //   this._def.shape(),
-  //   //   merging._def.shape()
-  //   // );
-  //   const merged: any = new ZodObject({
-  //     unknownKeys: merging._def.unknownKeys,
-  //     catchall: merging._def.catchall,
-  //     shape: () =>
-  //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
-  //     typeName: ZodFirstPartyTypeKind.ZodObject,
-  //   }) as any;
-  //   return merged;
-  // }
-  catchall(index) {
-    return new _ZodObject({
-      ...this._def,
-      catchall: index
-    });
-  }
-  pick(mask) {
-    const shape = {};
-    for (const key of util2.objectKeys(mask)) {
-      if (mask[key] && this.shape[key]) {
-        shape[key] = this.shape[key];
-      }
-    }
-    return new _ZodObject({
-      ...this._def,
-      shape: () => shape
-    });
-  }
-  omit(mask) {
-    const shape = {};
-    for (const key of util2.objectKeys(this.shape)) {
-      if (!mask[key]) {
-        shape[key] = this.shape[key];
-      }
-    }
-    return new _ZodObject({
-      ...this._def,
-      shape: () => shape
-    });
-  }
-  /**
-   * @deprecated
-   */
-  deepPartial() {
-    return deepPartialify2(this);
-  }
-  partial(mask) {
-    const newShape = {};
-    for (const key of util2.objectKeys(this.shape)) {
-      const fieldSchema = this.shape[key];
-      if (mask && !mask[key]) {
-        newShape[key] = fieldSchema;
-      } else {
-        newShape[key] = fieldSchema.optional();
-      }
-    }
-    return new _ZodObject({
-      ...this._def,
-      shape: () => newShape
-    });
-  }
-  required(mask) {
-    const newShape = {};
-    for (const key of util2.objectKeys(this.shape)) {
-      if (mask && !mask[key]) {
-        newShape[key] = this.shape[key];
-      } else {
-        const fieldSchema = this.shape[key];
-        let newField = fieldSchema;
-        while (newField instanceof ZodOptional3) {
-          newField = newField._def.innerType;
-        }
-        newShape[key] = newField;
-      }
-    }
-    return new _ZodObject({
-      ...this._def,
-      shape: () => newShape
-    });
-  }
-  keyof() {
-    return createZodEnum2(util2.objectKeys(this.shape));
-  }
-};
-ZodObject3.create = (shape, params) => {
-  return new ZodObject3({
-    shape: () => shape,
-    unknownKeys: "strip",
-    catchall: ZodNever3.create(),
-    typeName: ZodFirstPartyTypeKind2.ZodObject,
-    ...processCreateParams2(params)
-  });
-};
-ZodObject3.strictCreate = (shape, params) => {
-  return new ZodObject3({
-    shape: () => shape,
-    unknownKeys: "strict",
-    catchall: ZodNever3.create(),
-    typeName: ZodFirstPartyTypeKind2.ZodObject,
-    ...processCreateParams2(params)
-  });
-};
-ZodObject3.lazycreate = (shape, params) => {
-  return new ZodObject3({
-    shape,
-    unknownKeys: "strip",
-    catchall: ZodNever3.create(),
-    typeName: ZodFirstPartyTypeKind2.ZodObject,
-    ...processCreateParams2(params)
-  });
-};
-var ZodUnion3 = class extends ZodType3 {
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    const options = this._def.options;
-    function handleResults(results) {
-      for (const result of results) {
-        if (result.result.status === "valid") {
-          return result.result;
-        }
-      }
-      for (const result of results) {
-        if (result.result.status === "dirty") {
-          ctx.common.issues.push(...result.ctx.common.issues);
-          return result.result;
-        }
-      }
-      const unionErrors = results.map((result) => new ZodError3(result.ctx.common.issues));
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_union,
-        unionErrors
-      });
-      return INVALID2;
-    }
-    if (ctx.common.async) {
-      return Promise.all(options.map(async (option) => {
-        const childCtx = {
-          ...ctx,
-          common: {
-            ...ctx.common,
-            issues: []
-          },
-          parent: null
-        };
-        return {
-          result: await option._parseAsync({
-            data: ctx.data,
-            path: ctx.path,
-            parent: childCtx
-          }),
-          ctx: childCtx
-        };
-      })).then(handleResults);
-    } else {
-      let dirty = void 0;
-      const issues = [];
-      for (const option of options) {
-        const childCtx = {
-          ...ctx,
-          common: {
-            ...ctx.common,
-            issues: []
-          },
-          parent: null
-        };
-        const result = option._parseSync({
-          data: ctx.data,
-          path: ctx.path,
-          parent: childCtx
-        });
-        if (result.status === "valid") {
-          return result;
-        } else if (result.status === "dirty" && !dirty) {
-          dirty = { result, ctx: childCtx };
-        }
-        if (childCtx.common.issues.length) {
-          issues.push(childCtx.common.issues);
-        }
-      }
-      if (dirty) {
-        ctx.common.issues.push(...dirty.ctx.common.issues);
-        return dirty.result;
-      }
-      const unionErrors = issues.map((issues2) => new ZodError3(issues2));
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_union,
-        unionErrors
-      });
-      return INVALID2;
-    }
-  }
-  get options() {
-    return this._def.options;
-  }
-};
-ZodUnion3.create = (types, params) => {
-  return new ZodUnion3({
-    options: types,
-    typeName: ZodFirstPartyTypeKind2.ZodUnion,
-    ...processCreateParams2(params)
-  });
-};
-var getDiscriminator2 = (type) => {
-  if (type instanceof ZodLazy2) {
-    return getDiscriminator2(type.schema);
-  } else if (type instanceof ZodEffects2) {
-    return getDiscriminator2(type.innerType());
-  } else if (type instanceof ZodLiteral3) {
-    return [type.value];
-  } else if (type instanceof ZodEnum3) {
-    return type.options;
-  } else if (type instanceof ZodNativeEnum2) {
-    return util2.objectValues(type.enum);
-  } else if (type instanceof ZodDefault3) {
-    return getDiscriminator2(type._def.innerType);
-  } else if (type instanceof ZodUndefined2) {
-    return [void 0];
-  } else if (type instanceof ZodNull3) {
-    return [null];
-  } else if (type instanceof ZodOptional3) {
-    return [void 0, ...getDiscriminator2(type.unwrap())];
-  } else if (type instanceof ZodNullable3) {
-    return [null, ...getDiscriminator2(type.unwrap())];
-  } else if (type instanceof ZodBranded2) {
-    return getDiscriminator2(type.unwrap());
-  } else if (type instanceof ZodReadonly3) {
-    return getDiscriminator2(type.unwrap());
-  } else if (type instanceof ZodCatch3) {
-    return getDiscriminator2(type._def.innerType);
-  } else {
-    return [];
-  }
-};
-var ZodDiscriminatedUnion3 = class _ZodDiscriminatedUnion extends ZodType3 {
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.object) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.object,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    const discriminator = this.discriminator;
-    const discriminatorValue = ctx.data[discriminator];
-    const option = this.optionsMap.get(discriminatorValue);
-    if (!option) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_union_discriminator,
-        options: Array.from(this.optionsMap.keys()),
-        path: [discriminator]
-      });
-      return INVALID2;
-    }
-    if (ctx.common.async) {
-      return option._parseAsync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx
-      });
-    } else {
-      return option._parseSync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx
-      });
-    }
-  }
-  get discriminator() {
-    return this._def.discriminator;
-  }
-  get options() {
-    return this._def.options;
-  }
-  get optionsMap() {
-    return this._def.optionsMap;
-  }
-  /**
-   * The constructor of the discriminated union schema. Its behaviour is very similar to that of the normal z.union() constructor.
-   * However, it only allows a union of objects, all of which need to share a discriminator property. This property must
-   * have a different value for each object in the union.
-   * @param discriminator the name of the discriminator property
-   * @param types an array of object schemas
-   * @param params
-   */
-  static create(discriminator, options, params) {
-    const optionsMap = /* @__PURE__ */ new Map();
-    for (const type of options) {
-      const discriminatorValues = getDiscriminator2(type.shape[discriminator]);
-      if (!discriminatorValues.length) {
-        throw new Error(`A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`);
-      }
-      for (const value of discriminatorValues) {
-        if (optionsMap.has(value)) {
-          throw new Error(`Discriminator property ${String(discriminator)} has duplicate value ${String(value)}`);
-        }
-        optionsMap.set(value, type);
-      }
-    }
-    return new _ZodDiscriminatedUnion({
-      typeName: ZodFirstPartyTypeKind2.ZodDiscriminatedUnion,
-      discriminator,
-      options,
-      optionsMap,
-      ...processCreateParams2(params)
-    });
-  }
-};
-function mergeValues3(a, b) {
-  const aType = getParsedType3(a);
-  const bType = getParsedType3(b);
-  if (a === b) {
-    return { valid: true, data: a };
-  } else if (aType === ZodParsedType2.object && bType === ZodParsedType2.object) {
-    const bKeys = util2.objectKeys(b);
-    const sharedKeys = util2.objectKeys(a).filter((key) => bKeys.indexOf(key) !== -1);
-    const newObj = { ...a, ...b };
-    for (const key of sharedKeys) {
-      const sharedValue = mergeValues3(a[key], b[key]);
-      if (!sharedValue.valid) {
-        return { valid: false };
-      }
-      newObj[key] = sharedValue.data;
-    }
-    return { valid: true, data: newObj };
-  } else if (aType === ZodParsedType2.array && bType === ZodParsedType2.array) {
-    if (a.length !== b.length) {
-      return { valid: false };
-    }
-    const newArray = [];
-    for (let index = 0; index < a.length; index++) {
-      const itemA = a[index];
-      const itemB = b[index];
-      const sharedValue = mergeValues3(itemA, itemB);
-      if (!sharedValue.valid) {
-        return { valid: false };
-      }
-      newArray.push(sharedValue.data);
-    }
-    return { valid: true, data: newArray };
-  } else if (aType === ZodParsedType2.date && bType === ZodParsedType2.date && +a === +b) {
-    return { valid: true, data: a };
-  } else {
-    return { valid: false };
-  }
-}
-var ZodIntersection3 = class extends ZodType3 {
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    const handleParsed = (parsedLeft, parsedRight) => {
-      if (isAborted2(parsedLeft) || isAborted2(parsedRight)) {
-        return INVALID2;
-      }
-      const merged = mergeValues3(parsedLeft.value, parsedRight.value);
-      if (!merged.valid) {
-        addIssueToContext2(ctx, {
-          code: ZodIssueCode2.invalid_intersection_types
-        });
-        return INVALID2;
-      }
-      if (isDirty2(parsedLeft) || isDirty2(parsedRight)) {
-        status.dirty();
-      }
-      return { status: status.value, value: merged.data };
-    };
-    if (ctx.common.async) {
-      return Promise.all([
-        this._def.left._parseAsync({
-          data: ctx.data,
-          path: ctx.path,
-          parent: ctx
-        }),
-        this._def.right._parseAsync({
-          data: ctx.data,
-          path: ctx.path,
-          parent: ctx
-        })
-      ]).then(([left, right]) => handleParsed(left, right));
-    } else {
-      return handleParsed(this._def.left._parseSync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx
-      }), this._def.right._parseSync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx
-      }));
-    }
-  }
-};
-ZodIntersection3.create = (left, right, params) => {
-  return new ZodIntersection3({
-    left,
-    right,
-    typeName: ZodFirstPartyTypeKind2.ZodIntersection,
-    ...processCreateParams2(params)
-  });
-};
-var ZodTuple2 = class _ZodTuple extends ZodType3 {
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.array) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.array,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    if (ctx.data.length < this._def.items.length) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.too_small,
-        minimum: this._def.items.length,
-        inclusive: true,
-        exact: false,
-        type: "array"
-      });
-      return INVALID2;
-    }
-    const rest = this._def.rest;
-    if (!rest && ctx.data.length > this._def.items.length) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.too_big,
-        maximum: this._def.items.length,
-        inclusive: true,
-        exact: false,
-        type: "array"
-      });
-      status.dirty();
-    }
-    const items = [...ctx.data].map((item, itemIndex) => {
-      const schema = this._def.items[itemIndex] || this._def.rest;
-      if (!schema)
-        return null;
-      return schema._parse(new ParseInputLazyPath2(ctx, item, ctx.path, itemIndex));
-    }).filter((x) => !!x);
-    if (ctx.common.async) {
-      return Promise.all(items).then((results) => {
-        return ParseStatus2.mergeArray(status, results);
-      });
-    } else {
-      return ParseStatus2.mergeArray(status, items);
-    }
-  }
-  get items() {
-    return this._def.items;
-  }
-  rest(rest) {
-    return new _ZodTuple({
-      ...this._def,
-      rest
-    });
-  }
-};
-ZodTuple2.create = (schemas, params) => {
-  if (!Array.isArray(schemas)) {
-    throw new Error("You must pass an array of schemas to z.tuple([ ... ])");
-  }
-  return new ZodTuple2({
-    items: schemas,
-    typeName: ZodFirstPartyTypeKind2.ZodTuple,
-    rest: null,
-    ...processCreateParams2(params)
-  });
-};
-var ZodRecord3 = class _ZodRecord extends ZodType3 {
-  get keySchema() {
-    return this._def.keyType;
-  }
-  get valueSchema() {
-    return this._def.valueType;
-  }
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.object) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.object,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    const pairs = [];
-    const keyType = this._def.keyType;
-    const valueType = this._def.valueType;
-    for (const key in ctx.data) {
-      pairs.push({
-        key: keyType._parse(new ParseInputLazyPath2(ctx, key, ctx.path, key)),
-        value: valueType._parse(new ParseInputLazyPath2(ctx, ctx.data[key], ctx.path, key)),
-        alwaysSet: key in ctx.data
-      });
-    }
-    if (ctx.common.async) {
-      return ParseStatus2.mergeObjectAsync(status, pairs);
-    } else {
-      return ParseStatus2.mergeObjectSync(status, pairs);
-    }
-  }
-  get element() {
-    return this._def.valueType;
-  }
-  static create(first, second, third) {
-    if (second instanceof ZodType3) {
-      return new _ZodRecord({
-        keyType: first,
-        valueType: second,
-        typeName: ZodFirstPartyTypeKind2.ZodRecord,
-        ...processCreateParams2(third)
-      });
-    }
-    return new _ZodRecord({
-      keyType: ZodString3.create(),
-      valueType: first,
-      typeName: ZodFirstPartyTypeKind2.ZodRecord,
-      ...processCreateParams2(second)
-    });
-  }
-};
-var ZodMap2 = class extends ZodType3 {
-  get keySchema() {
-    return this._def.keyType;
-  }
-  get valueSchema() {
-    return this._def.valueType;
-  }
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.map) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.map,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    const keyType = this._def.keyType;
-    const valueType = this._def.valueType;
-    const pairs = [...ctx.data.entries()].map(([key, value], index) => {
-      return {
-        key: keyType._parse(new ParseInputLazyPath2(ctx, key, ctx.path, [index, "key"])),
-        value: valueType._parse(new ParseInputLazyPath2(ctx, value, ctx.path, [index, "value"]))
-      };
-    });
-    if (ctx.common.async) {
-      const finalMap = /* @__PURE__ */ new Map();
-      return Promise.resolve().then(async () => {
-        for (const pair of pairs) {
-          const key = await pair.key;
-          const value = await pair.value;
-          if (key.status === "aborted" || value.status === "aborted") {
-            return INVALID2;
-          }
-          if (key.status === "dirty" || value.status === "dirty") {
-            status.dirty();
-          }
-          finalMap.set(key.value, value.value);
-        }
-        return { status: status.value, value: finalMap };
-      });
-    } else {
-      const finalMap = /* @__PURE__ */ new Map();
-      for (const pair of pairs) {
-        const key = pair.key;
-        const value = pair.value;
-        if (key.status === "aborted" || value.status === "aborted") {
-          return INVALID2;
-        }
-        if (key.status === "dirty" || value.status === "dirty") {
-          status.dirty();
-        }
-        finalMap.set(key.value, value.value);
-      }
-      return { status: status.value, value: finalMap };
-    }
-  }
-};
-ZodMap2.create = (keyType, valueType, params) => {
-  return new ZodMap2({
-    valueType,
-    keyType,
-    typeName: ZodFirstPartyTypeKind2.ZodMap,
-    ...processCreateParams2(params)
-  });
-};
-var ZodSet2 = class _ZodSet extends ZodType3 {
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.set) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.set,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    const def = this._def;
-    if (def.minSize !== null) {
-      if (ctx.data.size < def.minSize.value) {
-        addIssueToContext2(ctx, {
-          code: ZodIssueCode2.too_small,
-          minimum: def.minSize.value,
-          type: "set",
-          inclusive: true,
-          exact: false,
-          message: def.minSize.message
-        });
-        status.dirty();
-      }
-    }
-    if (def.maxSize !== null) {
-      if (ctx.data.size > def.maxSize.value) {
-        addIssueToContext2(ctx, {
-          code: ZodIssueCode2.too_big,
-          maximum: def.maxSize.value,
-          type: "set",
-          inclusive: true,
-          exact: false,
-          message: def.maxSize.message
-        });
-        status.dirty();
-      }
-    }
-    const valueType = this._def.valueType;
-    function finalizeSet(elements2) {
-      const parsedSet = /* @__PURE__ */ new Set();
-      for (const element of elements2) {
-        if (element.status === "aborted")
-          return INVALID2;
-        if (element.status === "dirty")
-          status.dirty();
-        parsedSet.add(element.value);
-      }
-      return { status: status.value, value: parsedSet };
-    }
-    const elements = [...ctx.data.values()].map((item, i) => valueType._parse(new ParseInputLazyPath2(ctx, item, ctx.path, i)));
-    if (ctx.common.async) {
-      return Promise.all(elements).then((elements2) => finalizeSet(elements2));
-    } else {
-      return finalizeSet(elements);
-    }
-  }
-  min(minSize, message2) {
-    return new _ZodSet({
-      ...this._def,
-      minSize: { value: minSize, message: errorUtil2.toString(message2) }
-    });
-  }
-  max(maxSize, message2) {
-    return new _ZodSet({
-      ...this._def,
-      maxSize: { value: maxSize, message: errorUtil2.toString(message2) }
-    });
-  }
-  size(size, message2) {
-    return this.min(size, message2).max(size, message2);
-  }
-  nonempty(message2) {
-    return this.min(1, message2);
-  }
-};
-ZodSet2.create = (valueType, params) => {
-  return new ZodSet2({
-    valueType,
-    minSize: null,
-    maxSize: null,
-    typeName: ZodFirstPartyTypeKind2.ZodSet,
-    ...processCreateParams2(params)
-  });
-};
-var ZodFunction2 = class _ZodFunction extends ZodType3 {
-  constructor() {
-    super(...arguments);
-    this.validate = this.implement;
-  }
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.function) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.function,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    function makeArgsIssue(args, error2) {
-      return makeIssue2({
-        data: args,
-        path: ctx.path,
-        errorMaps: [ctx.common.contextualErrorMap, ctx.schemaErrorMap, getErrorMap2(), en_default3].filter((x) => !!x),
-        issueData: {
-          code: ZodIssueCode2.invalid_arguments,
-          argumentsError: error2
-        }
-      });
-    }
-    function makeReturnsIssue(returns, error2) {
-      return makeIssue2({
-        data: returns,
-        path: ctx.path,
-        errorMaps: [ctx.common.contextualErrorMap, ctx.schemaErrorMap, getErrorMap2(), en_default3].filter((x) => !!x),
-        issueData: {
-          code: ZodIssueCode2.invalid_return_type,
-          returnTypeError: error2
-        }
-      });
-    }
-    const params = { errorMap: ctx.common.contextualErrorMap };
-    const fn = ctx.data;
-    if (this._def.returns instanceof ZodPromise2) {
-      const me = this;
-      return OK2(async function(...args) {
-        const error2 = new ZodError3([]);
-        const parsedArgs = await me._def.args.parseAsync(args, params).catch((e) => {
-          error2.addIssue(makeArgsIssue(args, e));
-          throw error2;
-        });
-        const result = await Reflect.apply(fn, this, parsedArgs);
-        const parsedReturns = await me._def.returns._def.type.parseAsync(result, params).catch((e) => {
-          error2.addIssue(makeReturnsIssue(result, e));
-          throw error2;
-        });
-        return parsedReturns;
-      });
-    } else {
-      const me = this;
-      return OK2(function(...args) {
-        const parsedArgs = me._def.args.safeParse(args, params);
-        if (!parsedArgs.success) {
-          throw new ZodError3([makeArgsIssue(args, parsedArgs.error)]);
-        }
-        const result = Reflect.apply(fn, this, parsedArgs.data);
-        const parsedReturns = me._def.returns.safeParse(result, params);
-        if (!parsedReturns.success) {
-          throw new ZodError3([makeReturnsIssue(result, parsedReturns.error)]);
-        }
-        return parsedReturns.data;
-      });
-    }
-  }
-  parameters() {
-    return this._def.args;
-  }
-  returnType() {
-    return this._def.returns;
-  }
-  args(...items) {
-    return new _ZodFunction({
-      ...this._def,
-      args: ZodTuple2.create(items).rest(ZodUnknown3.create())
-    });
-  }
-  returns(returnType) {
-    return new _ZodFunction({
-      ...this._def,
-      returns: returnType
-    });
-  }
-  implement(func) {
-    const validatedFunc = this.parse(func);
-    return validatedFunc;
-  }
-  strictImplement(func) {
-    const validatedFunc = this.parse(func);
-    return validatedFunc;
-  }
-  static create(args, returns, params) {
-    return new _ZodFunction({
-      args: args ? args : ZodTuple2.create([]).rest(ZodUnknown3.create()),
-      returns: returns || ZodUnknown3.create(),
-      typeName: ZodFirstPartyTypeKind2.ZodFunction,
-      ...processCreateParams2(params)
-    });
-  }
-};
-var ZodLazy2 = class extends ZodType3 {
-  get schema() {
-    return this._def.getter();
-  }
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    const lazySchema = this._def.getter();
-    return lazySchema._parse({ data: ctx.data, path: ctx.path, parent: ctx });
-  }
-};
-ZodLazy2.create = (getter, params) => {
-  return new ZodLazy2({
-    getter,
-    typeName: ZodFirstPartyTypeKind2.ZodLazy,
-    ...processCreateParams2(params)
-  });
-};
-var ZodLiteral3 = class extends ZodType3 {
-  _parse(input) {
-    if (input.data !== this._def.value) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        received: ctx.data,
-        code: ZodIssueCode2.invalid_literal,
-        expected: this._def.value
-      });
-      return INVALID2;
-    }
-    return { status: "valid", value: input.data };
-  }
-  get value() {
-    return this._def.value;
-  }
-};
-ZodLiteral3.create = (value, params) => {
-  return new ZodLiteral3({
-    value,
-    typeName: ZodFirstPartyTypeKind2.ZodLiteral,
-    ...processCreateParams2(params)
-  });
-};
-function createZodEnum2(values, params) {
-  return new ZodEnum3({
-    values,
-    typeName: ZodFirstPartyTypeKind2.ZodEnum,
-    ...processCreateParams2(params)
-  });
-}
-var ZodEnum3 = class _ZodEnum extends ZodType3 {
-  _parse(input) {
-    if (typeof input.data !== "string") {
-      const ctx = this._getOrReturnCtx(input);
-      const expectedValues = this._def.values;
-      addIssueToContext2(ctx, {
-        expected: util2.joinValues(expectedValues),
-        received: ctx.parsedType,
-        code: ZodIssueCode2.invalid_type
-      });
-      return INVALID2;
-    }
-    if (!this._cache) {
-      this._cache = new Set(this._def.values);
-    }
-    if (!this._cache.has(input.data)) {
-      const ctx = this._getOrReturnCtx(input);
-      const expectedValues = this._def.values;
-      addIssueToContext2(ctx, {
-        received: ctx.data,
-        code: ZodIssueCode2.invalid_enum_value,
-        options: expectedValues
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-  get options() {
-    return this._def.values;
-  }
-  get enum() {
-    const enumValues = {};
-    for (const val of this._def.values) {
-      enumValues[val] = val;
-    }
-    return enumValues;
-  }
-  get Values() {
-    const enumValues = {};
-    for (const val of this._def.values) {
-      enumValues[val] = val;
-    }
-    return enumValues;
-  }
-  get Enum() {
-    const enumValues = {};
-    for (const val of this._def.values) {
-      enumValues[val] = val;
-    }
-    return enumValues;
-  }
-  extract(values, newDef = this._def) {
-    return _ZodEnum.create(values, {
-      ...this._def,
-      ...newDef
-    });
-  }
-  exclude(values, newDef = this._def) {
-    return _ZodEnum.create(this.options.filter((opt) => !values.includes(opt)), {
-      ...this._def,
-      ...newDef
-    });
-  }
-};
-ZodEnum3.create = createZodEnum2;
-var ZodNativeEnum2 = class extends ZodType3 {
-  _parse(input) {
-    const nativeEnumValues = util2.getValidEnumValues(this._def.values);
-    const ctx = this._getOrReturnCtx(input);
-    if (ctx.parsedType !== ZodParsedType2.string && ctx.parsedType !== ZodParsedType2.number) {
-      const expectedValues = util2.objectValues(nativeEnumValues);
-      addIssueToContext2(ctx, {
-        expected: util2.joinValues(expectedValues),
-        received: ctx.parsedType,
-        code: ZodIssueCode2.invalid_type
-      });
-      return INVALID2;
-    }
-    if (!this._cache) {
-      this._cache = new Set(util2.getValidEnumValues(this._def.values));
-    }
-    if (!this._cache.has(input.data)) {
-      const expectedValues = util2.objectValues(nativeEnumValues);
-      addIssueToContext2(ctx, {
-        received: ctx.data,
-        code: ZodIssueCode2.invalid_enum_value,
-        options: expectedValues
-      });
-      return INVALID2;
-    }
-    return OK2(input.data);
-  }
-  get enum() {
-    return this._def.values;
-  }
-};
-ZodNativeEnum2.create = (values, params) => {
-  return new ZodNativeEnum2({
-    values,
-    typeName: ZodFirstPartyTypeKind2.ZodNativeEnum,
-    ...processCreateParams2(params)
-  });
-};
-var ZodPromise2 = class extends ZodType3 {
-  unwrap() {
-    return this._def.type;
-  }
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    if (ctx.parsedType !== ZodParsedType2.promise && ctx.common.async === false) {
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.promise,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    const promisified = ctx.parsedType === ZodParsedType2.promise ? ctx.data : Promise.resolve(ctx.data);
-    return OK2(promisified.then((data) => {
-      return this._def.type.parseAsync(data, {
-        path: ctx.path,
-        errorMap: ctx.common.contextualErrorMap
-      });
-    }));
-  }
-};
-ZodPromise2.create = (schema, params) => {
-  return new ZodPromise2({
-    type: schema,
-    typeName: ZodFirstPartyTypeKind2.ZodPromise,
-    ...processCreateParams2(params)
-  });
-};
-var ZodEffects2 = class extends ZodType3 {
-  innerType() {
-    return this._def.schema;
-  }
-  sourceType() {
-    return this._def.schema._def.typeName === ZodFirstPartyTypeKind2.ZodEffects ? this._def.schema.sourceType() : this._def.schema;
-  }
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    const effect = this._def.effect || null;
-    const checkCtx = {
-      addIssue: (arg) => {
-        addIssueToContext2(ctx, arg);
-        if (arg.fatal) {
-          status.abort();
-        } else {
-          status.dirty();
-        }
-      },
-      get path() {
-        return ctx.path;
-      }
-    };
-    checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
-    if (effect.type === "preprocess") {
-      const processed = effect.transform(ctx.data, checkCtx);
-      if (ctx.common.async) {
-        return Promise.resolve(processed).then(async (processed2) => {
-          if (status.value === "aborted")
-            return INVALID2;
-          const result = await this._def.schema._parseAsync({
-            data: processed2,
-            path: ctx.path,
-            parent: ctx
-          });
-          if (result.status === "aborted")
-            return INVALID2;
-          if (result.status === "dirty")
-            return DIRTY2(result.value);
-          if (status.value === "dirty")
-            return DIRTY2(result.value);
-          return result;
-        });
-      } else {
-        if (status.value === "aborted")
-          return INVALID2;
-        const result = this._def.schema._parseSync({
-          data: processed,
-          path: ctx.path,
-          parent: ctx
-        });
-        if (result.status === "aborted")
-          return INVALID2;
-        if (result.status === "dirty")
-          return DIRTY2(result.value);
-        if (status.value === "dirty")
-          return DIRTY2(result.value);
-        return result;
-      }
-    }
-    if (effect.type === "refinement") {
-      const executeRefinement = (acc) => {
-        const result = effect.refinement(acc, checkCtx);
-        if (ctx.common.async) {
-          return Promise.resolve(result);
-        }
-        if (result instanceof Promise) {
-          throw new Error("Async refinement encountered during synchronous parse operation. Use .parseAsync instead.");
-        }
-        return acc;
-      };
-      if (ctx.common.async === false) {
-        const inner = this._def.schema._parseSync({
-          data: ctx.data,
-          path: ctx.path,
-          parent: ctx
-        });
-        if (inner.status === "aborted")
-          return INVALID2;
-        if (inner.status === "dirty")
-          status.dirty();
-        executeRefinement(inner.value);
-        return { status: status.value, value: inner.value };
-      } else {
-        return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((inner) => {
-          if (inner.status === "aborted")
-            return INVALID2;
-          if (inner.status === "dirty")
-            status.dirty();
-          return executeRefinement(inner.value).then(() => {
-            return { status: status.value, value: inner.value };
-          });
-        });
-      }
-    }
-    if (effect.type === "transform") {
-      if (ctx.common.async === false) {
-        const base = this._def.schema._parseSync({
-          data: ctx.data,
-          path: ctx.path,
-          parent: ctx
-        });
-        if (!isValid2(base))
-          return INVALID2;
-        const result = effect.transform(base.value, checkCtx);
-        if (result instanceof Promise) {
-          throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
-        }
-        return { status: status.value, value: result };
-      } else {
-        return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
-          if (!isValid2(base))
-            return INVALID2;
-          return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
-            status: status.value,
-            value: result
-          }));
-        });
-      }
-    }
-    util2.assertNever(effect);
-  }
-};
-ZodEffects2.create = (schema, effect, params) => {
-  return new ZodEffects2({
-    schema,
-    typeName: ZodFirstPartyTypeKind2.ZodEffects,
-    effect,
-    ...processCreateParams2(params)
-  });
-};
-ZodEffects2.createWithPreprocess = (preprocess2, schema, params) => {
-  return new ZodEffects2({
-    schema,
-    effect: { type: "preprocess", transform: preprocess2 },
-    typeName: ZodFirstPartyTypeKind2.ZodEffects,
-    ...processCreateParams2(params)
-  });
-};
-var ZodOptional3 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 === ZodParsedType2.undefined) {
-      return OK2(void 0);
-    }
-    return this._def.innerType._parse(input);
-  }
-  unwrap() {
-    return this._def.innerType;
-  }
-};
-ZodOptional3.create = (type, params) => {
-  return new ZodOptional3({
-    innerType: type,
-    typeName: ZodFirstPartyTypeKind2.ZodOptional,
-    ...processCreateParams2(params)
-  });
-};
-var ZodNullable3 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 === ZodParsedType2.null) {
-      return OK2(null);
-    }
-    return this._def.innerType._parse(input);
-  }
-  unwrap() {
-    return this._def.innerType;
-  }
-};
-ZodNullable3.create = (type, params) => {
-  return new ZodNullable3({
-    innerType: type,
-    typeName: ZodFirstPartyTypeKind2.ZodNullable,
-    ...processCreateParams2(params)
-  });
-};
-var ZodDefault3 = class extends ZodType3 {
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    let data = ctx.data;
-    if (ctx.parsedType === ZodParsedType2.undefined) {
-      data = this._def.defaultValue();
-    }
-    return this._def.innerType._parse({
-      data,
-      path: ctx.path,
-      parent: ctx
-    });
-  }
-  removeDefault() {
-    return this._def.innerType;
-  }
-};
-ZodDefault3.create = (type, params) => {
-  return new ZodDefault3({
-    innerType: type,
-    typeName: ZodFirstPartyTypeKind2.ZodDefault,
-    defaultValue: typeof params.default === "function" ? params.default : () => params.default,
-    ...processCreateParams2(params)
-  });
-};
-var ZodCatch3 = class extends ZodType3 {
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    const newCtx = {
-      ...ctx,
-      common: {
-        ...ctx.common,
-        issues: []
-      }
-    };
-    const result = this._def.innerType._parse({
-      data: newCtx.data,
-      path: newCtx.path,
-      parent: {
-        ...newCtx
-      }
-    });
-    if (isAsync2(result)) {
-      return result.then((result2) => {
-        return {
-          status: "valid",
-          value: result2.status === "valid" ? result2.value : this._def.catchValue({
-            get error() {
-              return new ZodError3(newCtx.common.issues);
-            },
-            input: newCtx.data
-          })
-        };
-      });
-    } else {
-      return {
-        status: "valid",
-        value: result.status === "valid" ? result.value : this._def.catchValue({
-          get error() {
-            return new ZodError3(newCtx.common.issues);
-          },
-          input: newCtx.data
-        })
-      };
-    }
-  }
-  removeCatch() {
-    return this._def.innerType;
-  }
-};
-ZodCatch3.create = (type, params) => {
-  return new ZodCatch3({
-    innerType: type,
-    typeName: ZodFirstPartyTypeKind2.ZodCatch,
-    catchValue: typeof params.catch === "function" ? params.catch : () => params.catch,
-    ...processCreateParams2(params)
-  });
-};
-var ZodNaN2 = class extends ZodType3 {
-  _parse(input) {
-    const parsedType2 = this._getType(input);
-    if (parsedType2 !== ZodParsedType2.nan) {
-      const ctx = this._getOrReturnCtx(input);
-      addIssueToContext2(ctx, {
-        code: ZodIssueCode2.invalid_type,
-        expected: ZodParsedType2.nan,
-        received: ctx.parsedType
-      });
-      return INVALID2;
-    }
-    return { status: "valid", value: input.data };
-  }
-};
-ZodNaN2.create = (params) => {
-  return new ZodNaN2({
-    typeName: ZodFirstPartyTypeKind2.ZodNaN,
-    ...processCreateParams2(params)
-  });
-};
-var BRAND = /* @__PURE__ */ Symbol("zod_brand");
-var ZodBranded2 = class extends ZodType3 {
-  _parse(input) {
-    const { ctx } = this._processInputParams(input);
-    const data = ctx.data;
-    return this._def.type._parse({
-      data,
-      path: ctx.path,
-      parent: ctx
-    });
-  }
-  unwrap() {
-    return this._def.type;
-  }
-};
-var ZodPipeline2 = class _ZodPipeline extends ZodType3 {
-  _parse(input) {
-    const { status, ctx } = this._processInputParams(input);
-    if (ctx.common.async) {
-      const handleAsync = async () => {
-        const inResult = await this._def.in._parseAsync({
-          data: ctx.data,
-          path: ctx.path,
-          parent: ctx
-        });
-        if (inResult.status === "aborted")
-          return INVALID2;
-        if (inResult.status === "dirty") {
-          status.dirty();
-          return DIRTY2(inResult.value);
-        } else {
-          return this._def.out._parseAsync({
-            data: inResult.value,
-            path: ctx.path,
-            parent: ctx
-          });
-        }
-      };
-      return handleAsync();
-    } else {
-      const inResult = this._def.in._parseSync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx
-      });
-      if (inResult.status === "aborted")
-        return INVALID2;
-      if (inResult.status === "dirty") {
-        status.dirty();
-        return {
-          status: "dirty",
-          value: inResult.value
-        };
-      } else {
-        return this._def.out._parseSync({
-          data: inResult.value,
-          path: ctx.path,
-          parent: ctx
-        });
-      }
-    }
-  }
-  static create(a, b) {
-    return new _ZodPipeline({
-      in: a,
-      out: b,
-      typeName: ZodFirstPartyTypeKind2.ZodPipeline
-    });
-  }
-};
-var ZodReadonly3 = class extends ZodType3 {
-  _parse(input) {
-    const result = this._def.innerType._parse(input);
-    const freeze = (data) => {
-      if (isValid2(data)) {
-        data.value = Object.freeze(data.value);
-      }
-      return data;
-    };
-    return isAsync2(result) ? result.then((data) => freeze(data)) : freeze(result);
-  }
-  unwrap() {
-    return this._def.innerType;
-  }
-};
-ZodReadonly3.create = (type, params) => {
-  return new ZodReadonly3({
-    innerType: type,
-    typeName: ZodFirstPartyTypeKind2.ZodReadonly,
-    ...processCreateParams2(params)
-  });
-};
-function cleanParams(params, data) {
-  const p = typeof params === "function" ? params(data) : typeof params === "string" ? { message: params } : params;
-  const p2 = typeof p === "string" ? { message: p } : p;
-  return p2;
-}
-function custom2(check2, _params = {}, fatal) {
-  if (check2)
-    return ZodAny2.create().superRefine((data, ctx) => {
-      const r = check2(data);
-      if (r instanceof Promise) {
-        return r.then((r2) => {
-          if (!r2) {
-            const params = cleanParams(_params, data);
-            const _fatal = params.fatal ?? fatal ?? true;
-            ctx.addIssue({ code: "custom", ...params, fatal: _fatal });
-          }
-        });
-      }
-      if (!r) {
-        const params = cleanParams(_params, data);
-        const _fatal = params.fatal ?? fatal ?? true;
-        ctx.addIssue({ code: "custom", ...params, fatal: _fatal });
-      }
-      return;
-    });
-  return ZodAny2.create();
-}
-var late2 = {
-  object: ZodObject3.lazycreate
-};
-var ZodFirstPartyTypeKind2;
-(function(ZodFirstPartyTypeKind3) {
-  ZodFirstPartyTypeKind3["ZodString"] = "ZodString";
-  ZodFirstPartyTypeKind3["ZodNumber"] = "ZodNumber";
-  ZodFirstPartyTypeKind3["ZodNaN"] = "ZodNaN";
-  ZodFirstPartyTypeKind3["ZodBigInt"] = "ZodBigInt";
-  ZodFirstPartyTypeKind3["ZodBoolean"] = "ZodBoolean";
-  ZodFirstPartyTypeKind3["ZodDate"] = "ZodDate";
-  ZodFirstPartyTypeKind3["ZodSymbol"] = "ZodSymbol";
-  ZodFirstPartyTypeKind3["ZodUndefined"] = "ZodUndefined";
-  ZodFirstPartyTypeKind3["ZodNull"] = "ZodNull";
-  ZodFirstPartyTypeKind3["ZodAny"] = "ZodAny";
-  ZodFirstPartyTypeKind3["ZodUnknown"] = "ZodUnknown";
-  ZodFirstPartyTypeKind3["ZodNever"] = "ZodNever";
-  ZodFirstPartyTypeKind3["ZodVoid"] = "ZodVoid";
-  ZodFirstPartyTypeKind3["ZodArray"] = "ZodArray";
-  ZodFirstPartyTypeKind3["ZodObject"] = "ZodObject";
-  ZodFirstPartyTypeKind3["ZodUnion"] = "ZodUnion";
-  ZodFirstPartyTypeKind3["ZodDiscriminatedUnion"] = "ZodDiscriminatedUnion";
-  ZodFirstPartyTypeKind3["ZodIntersection"] = "ZodIntersection";
-  ZodFirstPartyTypeKind3["ZodTuple"] = "ZodTuple";
-  ZodFirstPartyTypeKind3["ZodRecord"] = "ZodRecord";
-  ZodFirstPartyTypeKind3["ZodMap"] = "ZodMap";
-  ZodFirstPartyTypeKind3["ZodSet"] = "ZodSet";
-  ZodFirstPartyTypeKind3["ZodFunction"] = "ZodFunction";
-  ZodFirstPartyTypeKind3["ZodLazy"] = "ZodLazy";
-  ZodFirstPartyTypeKind3["ZodLiteral"] = "ZodLiteral";
-  ZodFirstPartyTypeKind3["ZodEnum"] = "ZodEnum";
-  ZodFirstPartyTypeKind3["ZodEffects"] = "ZodEffects";
-  ZodFirstPartyTypeKind3["ZodNativeEnum"] = "ZodNativeEnum";
-  ZodFirstPartyTypeKind3["ZodOptional"] = "ZodOptional";
-  ZodFirstPartyTypeKind3["ZodNullable"] = "ZodNullable";
-  ZodFirstPartyTypeKind3["ZodDefault"] = "ZodDefault";
-  ZodFirstPartyTypeKind3["ZodCatch"] = "ZodCatch";
-  ZodFirstPartyTypeKind3["ZodPromise"] = "ZodPromise";
-  ZodFirstPartyTypeKind3["ZodBranded"] = "ZodBranded";
-  ZodFirstPartyTypeKind3["ZodPipeline"] = "ZodPipeline";
-  ZodFirstPartyTypeKind3["ZodReadonly"] = "ZodReadonly";
-})(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
-var instanceOfType = (cls, params = {
-  message: `Input not instance of ${cls.name}`
-}) => custom2((data) => data instanceof cls, params);
-var stringType2 = ZodString3.create;
-var numberType2 = ZodNumber3.create;
-var nanType2 = ZodNaN2.create;
-var bigIntType2 = ZodBigInt2.create;
-var booleanType2 = ZodBoolean3.create;
-var dateType2 = ZodDate2.create;
-var symbolType2 = ZodSymbol2.create;
-var undefinedType2 = ZodUndefined2.create;
-var nullType2 = ZodNull3.create;
-var anyType2 = ZodAny2.create;
-var unknownType2 = ZodUnknown3.create;
-var neverType2 = ZodNever3.create;
-var voidType2 = ZodVoid2.create;
-var arrayType2 = ZodArray3.create;
-var objectType2 = ZodObject3.create;
-var strictObjectType2 = ZodObject3.strictCreate;
-var unionType2 = ZodUnion3.create;
-var discriminatedUnionType2 = ZodDiscriminatedUnion3.create;
-var intersectionType2 = ZodIntersection3.create;
-var tupleType2 = ZodTuple2.create;
-var recordType2 = ZodRecord3.create;
-var mapType2 = ZodMap2.create;
-var setType2 = ZodSet2.create;
-var functionType2 = ZodFunction2.create;
-var lazyType2 = ZodLazy2.create;
-var literalType2 = ZodLiteral3.create;
-var enumType2 = ZodEnum3.create;
-var nativeEnumType2 = ZodNativeEnum2.create;
-var promiseType2 = ZodPromise2.create;
-var effectsType2 = ZodEffects2.create;
-var optionalType2 = ZodOptional3.create;
-var nullableType2 = ZodNullable3.create;
-var preprocessType2 = ZodEffects2.createWithPreprocess;
-var pipelineType2 = ZodPipeline2.create;
-var ostring = () => stringType2().optional();
-var onumber = () => numberType2().optional();
-var oboolean = () => booleanType2().optional();
-var coerce = {
-  string: ((arg) => ZodString3.create({ ...arg, coerce: true })),
-  number: ((arg) => ZodNumber3.create({ ...arg, coerce: true })),
-  boolean: ((arg) => ZodBoolean3.create({
-    ...arg,
-    coerce: true
-  })),
-  bigint: ((arg) => ZodBigInt2.create({ ...arg, coerce: true })),
-  date: ((arg) => ZodDate2.create({ ...arg, coerce: true }))
-};
-var NEVER2 = INVALID2;
+// src/tools/lsp-tools.ts
+init_zod();
 
 // src/tools/lsp/client.ts
 var import_child_process4 = require("child_process");
@@ -82785,7 +84781,7 @@ var LspClient = class _LspClient {
 Install with: ${this.serverConfig.installHint}`
       );
     }
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       const command = this.devContainerContext ? "docker" : this.serverConfig.command;
       const args = this.devContainerContext ? ["exec", "-i", "-w", this.devContainerContext.containerWorkspaceRoot, this.devContainerContext.containerId, this.serverConfig.command, ...this.serverConfig.args] : this.serverConfig.args;
       this.process = (0, import_child_process4.spawn)(command, args, {
@@ -82812,7 +84808,7 @@ Install with: ${this.serverConfig.installHint}`
       });
       this.initialize().then(() => {
         this.initialized = true;
-        resolve32();
+        resolve33();
       }).catch(reject);
     });
   }
@@ -82978,13 +84974,13 @@ ${content}`);
     const message2 = `Content-Length: ${Buffer.byteLength(content)}\r
 \r
 ${content}`;
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       const timeoutHandle = setTimeout(() => {
         this.pendingRequests.delete(id);
         reject(new Error(`LSP request '${method}' timed out after ${effectiveTimeout}ms`));
       }, effectiveTimeout);
       this.pendingRequests.set(id, {
-        resolve: resolve32,
+        resolve: resolve33,
         reject,
         timeout: timeoutHandle
       });
@@ -83060,7 +85056,7 @@ ${content}`;
       }
     });
     this.openDocuments.add(hostUri);
-    await new Promise((resolve32) => setTimeout(resolve32, 100));
+    await new Promise((resolve33) => setTimeout(resolve33, 100));
   }
   /**
    * Close a document
@@ -83221,13 +85217,13 @@ ${content}`;
     if (this.diagnostics.has(uri)) {
       return Promise.resolve();
     }
-    return new Promise((resolve32) => {
+    return new Promise((resolve33) => {
       let resolved = false;
       const timer = setTimeout(() => {
         if (!resolved) {
           resolved = true;
           this.diagnosticWaiters.delete(uri);
-          resolve32();
+          resolve33();
         }
       }, timeoutMs);
       const existing = this.diagnosticWaiters.get(uri) || [];
@@ -83235,7 +85231,7 @@ ${content}`;
         if (!resolved) {
           resolved = true;
           clearTimeout(timer);
-          resolve32();
+          resolve33();
         }
       });
       this.diagnosticWaiters.set(uri, existing);
@@ -83833,12 +85829,12 @@ function findFiles(directory, extensions, ignoreDirs = []) {
       for (const entry of entries) {
         const fullPath = (0, import_path15.join)(dir, entry);
         try {
-          const stat2 = (0, import_fs10.statSync)(fullPath);
-          if (stat2.isDirectory()) {
+          const stat3 = (0, import_fs10.statSync)(fullPath);
+          if (stat3.isDirectory()) {
             if (!ignoreDirSet.has(entry)) {
               walk(fullPath);
             }
-          } else if (stat2.isFile()) {
+          } else if (stat3.isFile()) {
             const ext = (0, import_path15.extname)(fullPath);
             if (extensions.includes(ext)) {
               results.push(fullPath);
@@ -84384,6 +86380,7 @@ var lspTools = [
 ];
 
 // src/tools/ast-tools.ts
+init_zod();
 var import_fs14 = require("fs");
 var import_path19 = require("path");
 var import_module = require("module");
@@ -84537,13 +86534,13 @@ function getFilesForLanguage(dirPath, language, maxFiles = 1e3) {
     }
   }
   const resolvedPath = (0, import_path19.resolve)(dirPath);
-  let stat2;
+  let stat3;
   try {
-    stat2 = (0, import_fs14.statSync)(resolvedPath);
+    stat3 = (0, import_fs14.statSync)(resolvedPath);
   } catch (err) {
     throw new Error(`Cannot access path "${resolvedPath}": ${err.message}`);
   }
-  if (stat2.isFile()) {
+  if (stat3.isFile()) {
     return [resolvedPath];
   }
   walk(resolvedPath);
@@ -84846,6 +86843,7 @@ Replacement: ${replacement}
 var astTools = [astGrepSearchTool, astGrepReplaceTool];
 
 // src/tools/python-repl/tool.ts
+init_zod();
 init_paths2();
 
 // src/tools/python-repl/session-lock.ts
@@ -84969,8 +86967,8 @@ async function openNoFollow(filePath, flags, mode) {
 }
 async function readFileNoFollow(filePath) {
   try {
-    const stat2 = await fs4.lstat(filePath);
-    if (stat2.isSymbolicLink()) {
+    const stat3 = await fs4.lstat(filePath);
+    if (stat3.isSymbolicLink()) {
       throw new LockError(`Lock file is a symlink: ${filePath}`);
     }
   } catch (err) {
@@ -85165,7 +87163,7 @@ var SessionLock = class {
   }
 };
 function sleep(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 
 // src/tools/python-repl/socket-client.ts
@@ -85195,7 +87193,7 @@ var JsonRpcError = class extends Error {
   }
 };
 async function sendSocketRequest(socketPath, method, params, timeout = 6e4) {
-  return new Promise((resolve32, reject) => {
+  return new Promise((resolve33, reject) => {
     const id = (0, import_crypto5.randomUUID)();
     const request = {
       jsonrpc: "2.0",
@@ -85285,7 +87283,7 @@ async function sendSocketRequest(socketPath, method, params, timeout = 6e4) {
           }
           if (!settled) {
             settled = true;
-            resolve32(response.result);
+            resolve33(response.result);
           }
         } catch (e) {
           if (!settled) {
@@ -85796,6 +87794,7 @@ Use this instead of Bash heredocs when you need:
 };
 
 // src/tools/skills-tools.ts
+init_zod();
 var import_path23 = require("path");
 var import_os6 = require("os");
 init_config_dir();
@@ -85921,6 +87920,7 @@ Searched:
 var skillsTools = [loadLocalTool, loadGlobalTool, listSkillsTool];
 
 // src/tools/state-tools.ts
+init_zod();
 var import_crypto11 = require("crypto");
 var import_fs30 = require("fs");
 var import_os7 = require("os");
@@ -86730,9 +88730,11 @@ function redactMergeReadinessState(state) {
 }
 
 // src/tools/state-tools.ts
+init_runtime_types();
 var EXECUTION_MODES = [
   "autopilot",
   "autoresearch",
+  "graph",
   "team",
   "ralph",
   "ultrawork",
@@ -86748,15 +88750,30 @@ var STATE_TOOL_MODES = [
   "merge-readiness"
 ];
 var STATE_WRITE_MODES = [
-  ...EXECUTION_MODES,
+  "autopilot",
+  "autoresearch",
+  "team",
+  "ralph",
+  "ultrawork",
+  "ultraqa",
+  "deep-interview",
+  "self-improve",
   "ralplan",
   "omc-teams",
   "skill-active"
 ];
-var EXTRA_STATE_ONLY_MODES = ["ralplan", "omc-teams", "skill-active"];
+var STATE_CLEAR_MODES = [...STATE_TOOL_MODES, "all"];
+var EXTRA_STATE_ONLY_MODES = [
+  "ralplan",
+  "omc-teams",
+  "skill-active"
+];
 var CANCEL_SIGNAL_TTL_MS = 3e4;
 var OWNER_SESSION_FALLBACK_MODES = /* @__PURE__ */ new Set(["ralph"]);
-var CONVERGED_STATE_PATH_MODES = /* @__PURE__ */ new Set(["ralph", "ultrawork"]);
+var CONVERGED_STATE_PATH_MODES = /* @__PURE__ */ new Set([
+  "ralph",
+  "ultrawork"
+]);
 function getStateFileName(mode) {
   const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   return `${normalizedName}.json`;
@@ -86768,18 +88785,28 @@ function readJsonRecord(filePath) {
     return null;
   }
 }
-var NAMED_WORKFLOW_MARKERS = ["workflow", "workflowRunId", "pipelineTracking"];
+var NAMED_WORKFLOW_MARKERS = [
+  "workflow",
+  "workflowRunId",
+  "pipelineTracking"
+];
 function hasOwnProperty5(record2, key) {
   return Object.prototype.hasOwnProperty.call(record2, key);
 }
 function hasNamedWorkflowMarker(record2) {
   if (!record2) return false;
-  return NAMED_WORKFLOW_MARKERS.some((marker) => hasOwnProperty5(record2, marker));
+  return NAMED_WORKFLOW_MARKERS.some(
+    (marker) => hasOwnProperty5(record2, marker)
+  );
 }
 function hasValidatedNamedWorkflowTuple(record2) {
-  if (!NAMED_WORKFLOW_MARKERS.every((marker) => hasOwnProperty5(record2, marker))) return false;
+  if (!NAMED_WORKFLOW_MARKERS.every((marker) => hasOwnProperty5(record2, marker)))
+    return false;
   const sessionId = getStateSessionOwner(record2);
-  return typeof sessionId === "string" && validateNamedWorkflowStateStructure(record2, sessionId) !== null;
+  return typeof sessionId === "string" && validateNamedWorkflowStateStructure(
+    record2,
+    sessionId
+  ) !== null;
 }
 function isExactEmergencyNamedMutation(record2, requestedRunId) {
   return hasValidatedNamedWorkflowTuple(record2) && typeof requestedRunId === "string" && record2.workflowRunId === requestedRunId;
@@ -86846,8 +88873,11 @@ function isConvergedCandidateActiveForSession(statePath, sessionId) {
   return canClearStateForSession(raw, sessionId);
 }
 function emergencyRecoveryOptionsForProject(mode, path25, root2) {
-  if (mode !== "autopilot" || !isSharedHomeAutopilotCandidate(path25, root2)) return void 0;
-  return { authorizeState: (state) => isStateCandidateForProject(mode, path25, state, root2) };
+  if (mode !== "autopilot" || !isSharedHomeAutopilotCandidate(path25, root2))
+    return void 0;
+  return {
+    authorizeState: (state) => isStateCandidateForProject(mode, path25, state, root2)
+  };
 }
 function clearDiscoveredStateCandidate(candidate, predicate, recoveryOptions) {
   return clearStateFileLockedIf(
@@ -86887,7 +88917,9 @@ function discoverStatePaths(paths) {
   }
   return discovered;
 }
-function clearConvergedStateCandidates(mode, root2, sessionId, discovered = discoverStatePaths(getConvergedStateCandidates(mode, root2, sessionId))) {
+function clearConvergedStateCandidates(mode, root2, sessionId, discovered = discoverStatePaths(
+  getConvergedStateCandidates(mode, root2, sessionId)
+)) {
   let cleared = 0;
   let hadFailure = false;
   for (const candidate of discovered) {
@@ -86898,10 +88930,16 @@ function clearConvergedStateCandidates(mode, root2, sessionId, discovered = disc
     if (result === "cleared") cleared++;
     else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path)
+  };
 }
 function hasActiveConvergedState(mode, root2, sessionId) {
-  return getConvergedStateCandidates(mode, root2, sessionId).some((statePath) => isConvergedCandidateActiveForSession(statePath, sessionId));
+  return getConvergedStateCandidates(mode, root2, sessionId).some(
+    (statePath) => isConvergedCandidateActiveForSession(statePath, sessionId)
+  );
 }
 function readTeamNamesFromStateFile(statePath) {
   if (!(0, import_fs30.existsSync)(statePath)) return [];
@@ -86914,7 +88952,11 @@ function readTeamNamesFromStateFile(statePath) {
   }
 }
 function pruneMissionBoardTeams(root2, teamNames) {
-  const missionStatePath = (0, import_path35.join)(getOmcRoot(root2), "state", "mission-state.json");
+  const missionStatePath = (0, import_path35.join)(
+    getOmcRoot(root2),
+    "state",
+    "mission-state.json"
+  );
   if (!(0, import_fs30.existsSync)(missionStatePath)) return 0;
   try {
     const parsed = JSON.parse((0, import_fs30.readFileSync)(missionStatePath, "utf-8"));
@@ -86929,11 +88971,18 @@ function pruneMissionBoardTeams(root2, teamNames) {
     });
     const removed = parsed.missions.length - remainingMissions.length;
     if (removed > 0) {
-      (0, import_fs30.writeFileSync)(missionStatePath, JSON.stringify({
-        ...parsed,
-        updatedAt: (/* @__PURE__ */ new Date()).toISOString(),
-        missions: remainingMissions
-      }, null, 2));
+      (0, import_fs30.writeFileSync)(
+        missionStatePath,
+        JSON.stringify(
+          {
+            ...parsed,
+            updatedAt: (/* @__PURE__ */ new Date()).toISOString(),
+            missions: remainingMissions
+          },
+          null,
+          2
+        )
+      );
     }
     return removed;
   } catch {
@@ -86975,7 +89024,8 @@ function getLegacyStateFileCandidates(mode, root2) {
     getStatePath(mode, root2),
     (0, import_path35.join)(getOmcRoot(root2), `${normalizedName}.json`)
   ];
-  if (mode === "autopilot") candidates.push((0, import_path35.join)((0, import_os7.homedir)(), ".omc", "state", "autopilot-state.json"));
+  if (mode === "autopilot")
+    candidates.push((0, import_path35.join)((0, import_os7.homedir)(), ".omc", "state", "autopilot-state.json"));
   return [...new Set(candidates)];
 }
 function isSharedHomeAutopilotCandidate(path25, root2) {
@@ -86989,13 +89039,15 @@ function isSharedHomeAutopilotCandidate(path25, root2) {
   return !isDescendant(canonicalStateRoot, candidatePath) && isDescendant(sharedHomeStateRoot, candidatePath);
 }
 function isStateCandidateForProject(mode, path25, state, root2) {
-  if (mode !== "autopilot" || !isSharedHomeAutopilotCandidate(path25, root2)) return true;
+  if (mode !== "autopilot" || !isSharedHomeAutopilotCandidate(path25, root2))
+    return true;
   return typeof state.project_path === "string" && (0, import_path35.resolve)(state.project_path) === (0, import_path35.resolve)(root2);
 }
 function isAutopilotRecoveryCandidateForProject(path25, root2) {
   if (!isSharedHomeAutopilotCandidate(path25, root2)) return true;
   const primary = readJsonRecord(path25);
-  if (primary) return isStateCandidateForProject("autopilot", path25, primary, root2);
+  if (primary)
+    return isStateCandidateForProject("autopilot", path25, primary, root2);
   const artifactPrefix = `${(0, import_path35.basename)(path25)}.emergency-quarantine.`;
   let artifacts;
   try {
@@ -87019,12 +89071,22 @@ function shouldCheckWorkingDirectoryLocalState(root2) {
 }
 function getWorkingDirectoryLocalSessionStatePath(mode, root2, sessionId) {
   const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
-  return (0, import_path35.join)(getWorkingDirectoryLocalOmcRoot(root2), "state", "sessions", sessionId, `${normalizedName}.json`);
+  return (0, import_path35.join)(
+    getWorkingDirectoryLocalOmcRoot(root2),
+    "state",
+    "sessions",
+    sessionId,
+    `${normalizedName}.json`
+  );
 }
 function getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root2) {
   const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   return [
-    (0, import_path35.join)(getWorkingDirectoryLocalOmcRoot(root2), "state", `${normalizedName}.json`),
+    (0, import_path35.join)(
+      getWorkingDirectoryLocalOmcRoot(root2),
+      "state",
+      `${normalizedName}.json`
+    ),
     (0, import_path35.join)(getWorkingDirectoryLocalOmcRoot(root2), `${normalizedName}.json`)
   ];
 }
@@ -87036,15 +89098,22 @@ function getWorkingDirectoryLocalStateClearCandidates(mode, root2, sessionId) {
   if (sessionId) {
     paths.add(getWorkingDirectoryLocalSessionStatePath(mode, root2, sessionId));
   }
-  for (const legacyPath of getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root2)) {
+  for (const legacyPath of getWorkingDirectoryLocalLegacyStateFileCandidates(
+    mode,
+    root2
+  )) {
     paths.add(legacyPath);
   }
   return [...paths];
 }
-function clearWorkingDirectoryLocalStateCandidates(mode, root2, sessionId, discovered = discoverStatePaths(getWorkingDirectoryLocalStateClearCandidates(mode, root2, sessionId))) {
+function clearWorkingDirectoryLocalStateCandidates(mode, root2, sessionId, discovered = discoverStatePaths(
+  getWorkingDirectoryLocalStateClearCandidates(mode, root2, sessionId)
+)) {
   let cleared = 0;
   let hadFailure = false;
-  const localLegacyPaths = new Set(getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root2));
+  const localLegacyPaths = new Set(
+    getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root2)
+  );
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
@@ -87053,7 +89122,11 @@ function clearWorkingDirectoryLocalStateCandidates(mode, root2, sessionId, disco
     if (result === "cleared") cleared++;
     else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path)
+  };
 }
 function clearLegacyStateCandidates(mode, root2, sessionId, discovered = discoverStatePaths(getLegacyStateFileCandidates(mode, root2))) {
   let cleared = 0;
@@ -87081,38 +89154,60 @@ function clearSessionOwnedStateCandidates(mode, root2, sessionId, discovered = f
     if (result === "cleared") cleared++;
     else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path)
+  };
 }
-function clearCompletedSessionStateCandidates(mode, root2, requesterSessionId, discovered = findCompletedSessionStateCandidates(mode, root2, requesterSessionId)) {
+function clearCompletedSessionStateCandidates(mode, root2, requesterSessionId, discovered = findCompletedSessionStateCandidates(
+  mode,
+  root2,
+  requesterSessionId
+)) {
   let cleared = 0;
   let hadFailure = false;
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
-      (current) => current.active === true && Boolean(candidate.completionEvidencePath && (0, import_fs30.existsSync)(candidate.completionEvidencePath)),
+      (current) => current.active === true && Boolean(
+        candidate.completionEvidencePath && (0, import_fs30.existsSync)(candidate.completionEvidencePath)
+      ),
       emergencyRecoveryOptionsForProject(mode, candidate.path, root2)
     );
     if (result === "cleared") cleared++;
     else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path)
+  };
 }
 function getStateClearCheckedPaths(mode, root2, sessionId) {
   const paths = /* @__PURE__ */ new Set();
   if (sessionId) {
-    paths.add(MODE_CONFIGS[mode] ? getStateFilePath(root2, mode, sessionId) : resolveSessionStatePath(mode, sessionId, root2));
+    paths.add(
+      MODE_CONFIGS[mode] ? getStateFilePath(root2, mode, sessionId) : resolveSessionStatePath(mode, sessionId, root2)
+    );
   } else {
     paths.add(getStatePath(mode, root2));
   }
   for (const legacyPath of getLegacyStateFileCandidates(mode, root2)) {
     paths.add(legacyPath);
   }
-  for (const localPath of getWorkingDirectoryLocalStateClearCandidates(mode, root2, sessionId)) {
+  for (const localPath of getWorkingDirectoryLocalStateClearCandidates(
+    mode,
+    root2,
+    sessionId
+  )) {
     paths.add(localPath);
   }
   const sessionIds = sessionId ? [sessionId, ...listSessionIds(root2)] : listSessionIds(root2);
   for (const sid of new Set(sessionIds)) {
-    paths.add(MODE_CONFIGS[mode] ? getStateFilePath(root2, mode, sid) : resolveSessionStatePath(mode, sid, root2));
+    paths.add(
+      MODE_CONFIGS[mode] ? getStateFilePath(root2, mode, sid) : resolveSessionStatePath(mode, sid, root2)
+    );
   }
   return [...paths];
 }
@@ -87162,7 +89257,11 @@ function clearModeRuntimeArtifacts(mode, root2, sessionId) {
 function writeSessionCancelSignal(root2, sessionId, mode, candidate) {
   ensureSessionStateDir(sessionId, root2);
   const now = Date.now();
-  const cancelSignalPath = resolveSessionStatePath("cancel-signal", sessionId, root2);
+  const cancelSignalPath = resolveSessionStatePath(
+    "cancel-signal",
+    sessionId,
+    root2
+  );
   const payload = {
     active: true,
     requested_at: new Date(now).toISOString(),
@@ -87170,10 +89269,14 @@ function writeSessionCancelSignal(root2, sessionId, mode, candidate) {
     mode,
     source: "state_clear",
     ...candidate?.workflowRunId ? { target_workflow_run_id: candidate.workflowRunId } : {},
-    ...candidate ? { target_state_sha256: (0, import_crypto11.createHash)("sha256").update(candidate.snapshot).digest("hex") } : {}
+    ...candidate ? {
+      target_state_sha256: (0, import_crypto11.createHash)("sha256").update(candidate.snapshot).digest("hex")
+    } : {}
   };
   if (!writeStateFileLocked(cancelSignalPath, payload)) {
-    throw new Error(`state mutation lock unavailable for cancel signal: ${cancelSignalPath}`);
+    throw new Error(
+      `state mutation lock unavailable for cancel signal: ${cancelSignalPath}`
+    );
   }
 }
 function isSessionModeActive(mode, root2, sessionId) {
@@ -87192,23 +89295,84 @@ function isSessionModeActive(mode, root2, sessionId) {
   }
 }
 function findSingleOwningSessionForMode(mode, root2, requesterSessionId) {
-  const owningSessions = listSessionIds(root2).filter((sid) => sid !== requesterSessionId && isSessionModeActive(mode, root2, sid));
+  const owningSessions = listSessionIds(root2).filter(
+    (sid) => sid !== requesterSessionId && isSessionModeActive(mode, root2, sid)
+  );
   return owningSessions.length === 1 ? owningSessions[0] : void 0;
 }
+function malformedGraphPublicState() {
+  return { type: "graph_state_summary", valid: false, status: "malformed" };
+}
+function redactGraphPublicState(state) {
+  try {
+    const graph = parseGraphState(state);
+    const activationStatuses = Object.values(graph.projection.activations).map(
+      (activation) => activation.status
+    );
+    const claims = Object.values(graph.claims);
+    const reconciliations = Object.values(graph.reconciliations);
+    return {
+      type: "graph_state_summary",
+      valid: true,
+      format_version: graph.format_version,
+      run_id: graph.run_id.slice(0, 128),
+      status: graph.status,
+      active_revision_id: graph.active_revision_id.slice(0, 128),
+      short_revision_hash: graph.active_revision_hash.slice(0, 12),
+      dispatch_generation: graph.dispatch_generation,
+      commit_sequence: graph.commit_sequence,
+      progress: {
+        total: activationStatuses.length,
+        ready: activationStatuses.filter((status) => status === "ready").length,
+        running: activationStatuses.filter((status) => status === "running").length,
+        completed: activationStatuses.filter((status) => status === "completed").length,
+        failed: activationStatuses.filter((status) => status === "failed").length
+      },
+      claims: {
+        total: claims.length,
+        live: claims.filter((claim) => claim.status === "live").length,
+        reconciling: claims.filter((claim) => claim.status === "reconciling").length,
+        unresolved_reconciliations: reconciliations.filter(
+          (reconciliation) => reconciliation.status === "unresolved"
+        ).length
+      },
+      pending: {
+        approval: graph.pending_approval !== void 0,
+        patch: graph.pending_patch !== void 0
+      }
+    };
+  } catch {
+    return malformedGraphPublicState();
+  }
+}
 function canonicalWorkflowJson(value) {
-  if (Array.isArray(value)) return `[${value.map(canonicalWorkflowJson).join(",")}]`;
+  if (Array.isArray(value))
+    return `[${value.map(canonicalWorkflowJson).join(",")}]`;
   if (value && typeof value === "object") {
     const record2 = value;
-    return `{${Object.keys(record2).sort().map((key) => `${JSON.stringify(key)}:${canonicalWorkflowJson(record2[key])}`).join(",")}}`;
+    return `{${Object.keys(record2).sort().map(
+      (key) => `${JSON.stringify(key)}:${canonicalWorkflowJson(record2[key])}`
+    ).join(",")}}`;
   }
   return JSON.stringify(value);
 }
 function isValidPublicWorkflowDescriptor(descriptor) {
   const stages = descriptor.stages;
-  if (descriptor.descriptorVersion !== 1 || descriptor.profileVersion !== 1 || typeof descriptor.workflowName !== "string" || !Array.isArray(stages) || !stages.every((stage) => typeof stage === "string") || typeof descriptor.profileHash !== "string") return false;
-  const allowed = /* @__PURE__ */ new Set(["ralplan,execution", "ralplan,execution,ralph", "ralplan,execution,qa", "ralplan,execution,ralph,qa"]);
+  if (descriptor.descriptorVersion !== 1 || descriptor.profileVersion !== 1 || typeof descriptor.workflowName !== "string" || !Array.isArray(stages) || !stages.every((stage) => typeof stage === "string") || typeof descriptor.profileHash !== "string")
+    return false;
+  const allowed = /* @__PURE__ */ new Set([
+    "ralplan,execution",
+    "ralplan,execution,ralph",
+    "ralplan,execution,qa",
+    "ralplan,execution,ralph,qa"
+  ]);
   if (!allowed.has(stages.join(","))) return false;
-  const canonical = canonicalWorkflowJson({ descriptorVersion: 1, workflowName: descriptor.workflowName, profileVersion: 1, stages });
+  const canonical = canonicalWorkflowJson({
+    descriptorVersion: 1,
+    workflowName: descriptor.workflowName,
+    profileVersion: 1,
+    stages
+  });
   return (0, import_crypto11.createHash)("sha256").update(canonical).digest("hex") === descriptor.profileHash;
 }
 function redactAutopilotPublicState(state) {
@@ -87221,11 +89385,27 @@ function redactAutopilotPublicState(state) {
   }
   const workflow = record2.workflow;
   if (!hasValidatedNamedWorkflowTuple(record2) || !workflow || typeof workflow !== "object") {
-    return { name: "invalid", version: 1, shortHash: "invalid", stages: [], currentStage: null, status: "workflow_descriptor_integrity_failed", progress: "0/0" };
+    return {
+      name: "invalid",
+      version: 1,
+      shortHash: "invalid",
+      stages: [],
+      currentStage: null,
+      status: "workflow_descriptor_integrity_failed",
+      progress: "0/0"
+    };
   }
   const descriptor = workflow;
   if (!isValidPublicWorkflowDescriptor(descriptor)) {
-    return { name: "invalid", version: 1, shortHash: "invalid", stages: [], currentStage: null, status: "workflow_descriptor_integrity_failed", progress: "0/0" };
+    return {
+      name: "invalid",
+      version: 1,
+      shortHash: "invalid",
+      stages: [],
+      currentStage: null,
+      status: "workflow_descriptor_integrity_failed",
+      progress: "0/0"
+    };
   }
   const stages = Array.isArray(descriptor.stages) && descriptor.stages.every((stage) => typeof stage === "string") ? descriptor.stages : [];
   const pipelineTracking = record2.pipelineTracking && typeof record2.pipelineTracking === "object" ? record2.pipelineTracking : void 0;
@@ -87251,16 +89431,36 @@ function publicStateForMode(mode, state) {
   if (mode === "autopilot") {
     return redactAutopilotPublicState(state);
   }
-  return mode === "merge-readiness" ? redactMergeReadinessState(state) : state;
+  if (mode === "graph") {
+    return redactGraphPublicState(state);
+  }
+  return mode === "merge-readiness" ? redactMergeReadinessState(
+    state
+  ) : state;
+}
+function parsePublicStateContent(mode, content) {
+  try {
+    return publicStateForMode(mode, JSON.parse(content));
+  } catch (error2) {
+    if (mode === "graph") return malformedGraphPublicState();
+    throw error2;
+  }
 }
 var stateReadTool = {
   name: "state_read",
   description: "Read the current state for a specific mode (ralph, ultrawork, autopilot, etc.). Returns the JSON state data or indicates if no state exists.",
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  },
   schema: {
     mode: external_exports.enum(STATE_TOOL_MODES).describe("The mode to read state for"),
     workingDirectory: external_exports.string().optional().describe("Working directory (defaults to cwd)"),
-    session_id: external_exports.string().optional().describe("Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).")
+    session_id: external_exports.string().optional().describe(
+      "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions)."
+    )
   },
   handler: async (args) => {
     const { mode, workingDirectory, session_id } = args;
@@ -87271,51 +89471,63 @@ var stateReadTool = {
         validateSessionId(sessionId);
         const statePath2 = MODE_CONFIGS[mode] ? getStateFilePath(root2, mode, sessionId) : resolveSessionStatePath(mode, sessionId, root2);
         if (!(0, import_fs30.existsSync)(statePath2)) {
-          const completedSessionPaths = findCompletedSessionStateFiles(mode, root2, sessionId);
+          const completedSessionPaths = findCompletedSessionStateFiles(
+            mode,
+            root2,
+            sessionId
+          );
           if (completedSessionPaths.length > 0) {
             const orphanList = completedSessionPaths.map((orphanPath) => {
               const sessionMarker = `${(0, import_path35.join)("state", "sessions")}/`;
               const markerIndex = orphanPath.indexOf(sessionMarker);
               if (markerIndex === -1) return `- ${orphanPath}`;
-              const rest = orphanPath.slice(markerIndex + sessionMarker.length);
+              const rest = orphanPath.slice(
+                markerIndex + sessionMarker.length
+              );
               const orphanSessionId = rest.split(/[\\/]/)[0] || "unknown";
               return `- session: ${orphanSessionId}
   path: ${orphanPath}`;
             }).join("\n");
             return {
-              content: [{
-                type: "text",
-                text: `No state found for mode: ${mode} in session: ${sessionId}
+              content: [
+                {
+                  type: "text",
+                  text: `No state found for mode: ${mode} in session: ${sessionId}
 Expected path: ${statePath2}
 
 Discovered ${completedSessionPaths.length} completed-session orphan state file${completedSessionPaths.length === 1 ? "" : "s"} for this mode:
 ${orphanList}
 
 Run state_clear(mode="${mode}", session_id="${sessionId}") to clear the current session plus these completed-session orphan files.`
-              }]
+                }
+              ]
             };
           }
           return {
-            content: [{
-              type: "text",
-              text: `No state found for mode: ${mode} in session: ${sessionId}
+            content: [
+              {
+                type: "text",
+                text: `No state found for mode: ${mode} in session: ${sessionId}
 Expected path: ${statePath2}`
-            }]
+              }
+            ]
           };
         }
         const content = (0, import_fs30.readFileSync)(statePath2, "utf-8");
-        const state = JSON.parse(content);
+        const publicState = parsePublicStateContent(mode, content);
         return {
-          content: [{
-            type: "text",
-            text: `## State for ${mode} (session: ${sessionId})
+          content: [
+            {
+              type: "text",
+              text: `## State for ${mode} (session: ${sessionId})
 
 Path: ${statePath2}
 
 \`\`\`json
-${JSON.stringify(publicStateForMode(mode, state), null, 2)}
+${JSON.stringify(publicState, null, 2)}
 \`\`\``
-          }]
+            }
+          ]
         };
       }
       const statePath = getStatePath(mode, root2);
@@ -87330,14 +89542,16 @@ ${JSON.stringify(publicStateForMode(mode, state), null, 2)}
       }
       if (!legacyExists && activeSessions.length === 0) {
         return {
-          content: [{
-            type: "text",
-            text: `No state found for mode: ${mode}
+          content: [
+            {
+              type: "text",
+              text: `No state found for mode: ${mode}
 Expected legacy path: ${statePath}
 No active sessions found.
 
 Note: Reading from legacy/aggregate path (no session_id). This may include state from other sessions.`
-          }]
+            }
+          ]
         };
       }
       let output = `## State for ${mode}
@@ -87348,12 +89562,12 @@ Note: Reading from legacy/aggregate path (no session_id). This may include state
       if (legacyExists) {
         try {
           const content = (0, import_fs30.readFileSync)(statePath, "utf-8");
-          const state = JSON.parse(content);
+          const publicState = parsePublicStateContent(mode, content);
           output += `### Legacy Path (shared)
 Path: ${statePath}
 
 \`\`\`json
-${JSON.stringify(publicStateForMode(mode, state), null, 2)}
+${JSON.stringify(publicState, null, 2)}
 \`\`\`
 
 `;
@@ -87373,12 +89587,12 @@ Path: ${statePath}
           const sessionStatePath = MODE_CONFIGS[mode] ? getStateFilePath(root2, mode, sid) : resolveSessionStatePath(mode, sid, root2);
           try {
             const content = (0, import_fs30.readFileSync)(sessionStatePath, "utf-8");
-            const state = JSON.parse(content);
+            const publicState = parsePublicStateContent(mode, content);
             output += `**Session: ${sid}**
 Path: ${sessionStatePath}
 
 \`\`\`json
-${JSON.stringify(publicStateForMode(mode, state), null, 2)}
+${JSON.stringify(publicState, null, 2)}
 \`\`\`
 
 `;
@@ -87392,17 +89606,21 @@ Path: ${sessionStatePath}
         }
       }
       return {
-        content: [{
-          type: "text",
-          text: output
-        }]
+        content: [
+          {
+            type: "text",
+            text: output
+          }
+        ]
       };
     } catch (error2) {
       return {
-        content: [{
-          type: "text",
-          text: `Error reading state for ${mode}: ${error2 instanceof Error ? error2.message : String(error2)}`
-        }],
+        content: [
+          {
+            type: "text",
+            text: `Error reading state for ${mode}: ${error2 instanceof Error ? error2.message : String(error2)}`
+          }
+        ],
         isError: true
       };
     }
@@ -87411,7 +89629,12 @@ Path: ${sessionStatePath}
 var stateWriteTool = {
   name: "state_write",
   description: "Write/update state for a specific mode. Creates the state file and directories if they do not exist. Common fields (active, iteration, phase, etc.) can be set directly as parameters. Additional custom fields can be passed via the optional `state` parameter. Note: swarm uses SQLite and cannot be written via this tool.",
-  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  },
   schema: {
     mode: external_exports.enum(STATE_WRITE_MODES).describe("The mode to write state for"),
     active: external_exports.boolean().optional().describe("Whether the mode is currently active"),
@@ -87423,9 +89646,13 @@ var stateWriteTool = {
     started_at: external_exports.string().max(100).optional().describe("ISO timestamp when the mode started"),
     completed_at: external_exports.string().max(100).optional().describe("ISO timestamp when the mode completed"),
     error: external_exports.string().max(2e3).optional().describe("Error message if the mode failed"),
-    state: external_exports.record(external_exports.string(), external_exports.unknown()).optional().describe("Additional custom state fields (merged with explicit parameters)"),
+    state: external_exports.record(external_exports.string(), external_exports.unknown()).optional().describe(
+      "Additional custom state fields (merged with explicit parameters)"
+    ),
     workingDirectory: external_exports.string().optional().describe("Working directory (defaults to cwd)"),
-    session_id: external_exports.string().optional().describe("Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).")
+    session_id: external_exports.string().optional().describe(
+      "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions)."
+    )
   },
   handler: async (args) => {
     const {
@@ -87446,14 +89673,32 @@ var stateWriteTool = {
     try {
       const root2 = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id;
+      if (mode === "graph") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                type: "guarded_mode",
+                mode: "graph",
+                operation: "write",
+                changed: false
+              })
+            }
+          ],
+          isError: true
+        };
+      }
       if (state) {
         const validation = validatePayload(state);
         if (!validation.valid) {
           return {
-            content: [{
-              type: "text",
-              text: `Error: state payload rejected \u2014 ${validation.error}`
-            }],
+            content: [
+              {
+                type: "text",
+                text: `Error: state payload rejected \u2014 ${validation.error}`
+              }
+            ],
             isError: true
           };
         }
@@ -87470,9 +89715,11 @@ var stateWriteTool = {
       const builtState = {};
       if (active !== void 0) builtState.active = active;
       if (iteration !== void 0) builtState.iteration = iteration;
-      if (max_iterations !== void 0) builtState.max_iterations = max_iterations;
+      if (max_iterations !== void 0)
+        builtState.max_iterations = max_iterations;
       if (current_phase !== void 0) builtState.current_phase = current_phase;
-      if (task_description !== void 0) builtState.task_description = task_description;
+      if (task_description !== void 0)
+        builtState.task_description = task_description;
       if (plan_path !== void 0) builtState.plan_path = plan_path;
       if (started_at !== void 0) builtState.started_at = started_at;
       if (completed_at !== void 0) builtState.completed_at = completed_at;
@@ -87488,7 +89735,9 @@ var stateWriteTool = {
       const requestedStateDigest = typeof builtState.target_state_sha256 === "string" ? builtState.target_state_sha256 : void 0;
       const isExactNamedPause = isExactNamedPauseRequest(builtState);
       if (mode === "autopilot" && (hasNamedWorkflowMarker(builtState) || hasOwnProperty5(builtState, "target_state_sha256")) && !isExactNamedPause) {
-        throw new Error("named autopilot workflow markers are runtime-owned; only active:false with an exact workflowRunId and optional state digest may pause a run");
+        throw new Error(
+          "named autopilot workflow markers are runtime-owned; only active:false with an exact workflowRunId and optional state digest may pause a run"
+        );
       }
       const stateWithMeta = {
         ...builtState,
@@ -87509,16 +89758,25 @@ var stateWriteTool = {
         }
         if (hasNamedWorkflowMarker(currentState ?? {})) {
           if (!isExactNamedPause || !requestedRunId) {
-            throw new Error("named autopilot workflow state requires active:false with its exact workflowRunId");
+            throw new Error(
+              "named autopilot workflow state requires active:false with its exact workflowRunId"
+            );
           }
           if (namedWorkflowRuntimeSupported()) {
             const result = writeStateFileLockedIf(
               statePath,
-              (current) => matchesNamedPauseTarget(current, sessionId, requestedRunId, requestedStateDigest),
+              (current) => matchesNamedPauseTarget(
+                current,
+                sessionId,
+                requestedRunId,
+                requestedStateDigest
+              ),
               (current) => ({ ...current, active: false })
             );
             if (result !== "written") {
-              throw new Error(result === "failed" ? "state mutation lock unavailable" : "named autopilot run changed, is stale, or failed integrity validation");
+              throw new Error(
+                result === "failed" ? "state mutation lock unavailable" : "named autopilot run changed, is stale, or failed integrity validation"
+              );
             }
             namedPauseCommitted = true;
           } else {
@@ -87528,7 +89786,8 @@ var stateWriteTool = {
               (current) => JSON.stringify(current) === snapshot && isExactEmergencyNamedMutation(current, requestedRunId) && (requestedStateDigest === void 0 || (0, import_crypto11.createHash)("sha256").update(JSON.stringify(current)).digest("hex") === requestedStateDigest),
               (current) => ({ ...current, active: false })
             );
-            if (!written) throw new Error("autopilot run changed before deactivation");
+            if (!written)
+              throw new Error("autopilot run changed before deactivation");
             namedPauseCommitted = true;
           }
         } else {
@@ -87540,7 +89799,10 @@ var stateWriteTool = {
               return writtenState;
             }
           );
-          if (result !== "written") throw new Error(result === "failed" ? "state mutation lock unavailable" : "autopilot run changed before deactivation");
+          if (result !== "written")
+            throw new Error(
+              result === "failed" ? "state mutation lock unavailable" : "autopilot run changed before deactivation"
+            );
         }
       } else if (mode === "autopilot") {
         let namedWorkflowExists = false;
@@ -87557,8 +89819,13 @@ var stateWriteTool = {
           }
         );
         if (result !== "written") {
-          if (namedWorkflowExists) throw new Error("named autopilot workflow state is runtime-owned; only exact-run deactivation is allowed");
-          throw new Error(result === "failed" ? "state mutation lock unavailable" : "autopilot state changed before write");
+          if (namedWorkflowExists)
+            throw new Error(
+              "named autopilot workflow state is runtime-owned; only exact-run deactivation is allowed"
+            );
+          throw new Error(
+            result === "failed" ? "state mutation lock unavailable" : "autopilot state changed before write"
+          );
         }
       } else if (!writeStateFileLocked(statePath, stateWithMeta)) {
         throw new Error("state mutation lock unavailable");
@@ -87566,22 +89833,26 @@ var stateWriteTool = {
       const sessionInfo = sessionId ? ` (session: ${sessionId})` : " (legacy path)";
       const warningMessage = sessionId ? "" : "\n\nWARNING: No session_id provided. State written to legacy shared path which may leak across parallel sessions. Pass session_id for session-scoped isolation.";
       return {
-        content: [{
-          type: "text",
-          text: namedPauseCommitted ? `Paused named autopilot workflow${sessionInfo}. Resume state is preserved.` : `Successfully wrote state for ${mode}${sessionInfo}
+        content: [
+          {
+            type: "text",
+            text: namedPauseCommitted ? `Paused named autopilot workflow${sessionInfo}. Resume state is preserved.` : `Successfully wrote state for ${mode}${sessionInfo}
 Path: ${statePath}
 
 \`\`\`json
 ${JSON.stringify(writtenState, null, 2)}
 \`\`\`${warningMessage}`
-        }]
+          }
+        ]
       };
     } catch (error3) {
       return {
-        content: [{
-          type: "text",
-          text: `Error writing state for ${mode}: ${error3 instanceof Error ? error3.message : String(error3)}`
-        }],
+        content: [
+          {
+            type: "text",
+            text: `Error writing state for ${mode}: ${error3 instanceof Error ? error3.message : String(error3)}`
+          }
+        ],
         isError: true
       };
     }
@@ -87589,10 +89860,16 @@ ${JSON.stringify(writtenState, null, 2)}
 };
 function discoverAllRootSessionStateCandidates(mode, root2) {
   const paths = /* @__PURE__ */ new Set();
-  const roots = /* @__PURE__ */ new Set([...getConvergedOmcRoots(root2), getWorkingDirectoryLocalOmcRoot(root2), getOmcRoot(root2)]);
+  const roots = /* @__PURE__ */ new Set([
+    ...getConvergedOmcRoots(root2),
+    getWorkingDirectoryLocalOmcRoot(root2),
+    getOmcRoot(root2)
+  ]);
   for (const omcRoot of roots) {
     for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-      paths.add((0, import_path35.join)(omcRoot, "state", "sessions", sid, getStateFileName(mode)));
+      paths.add(
+        (0, import_path35.join)(omcRoot, "state", "sessions", sid, getStateFileName(mode))
+      );
     }
   }
   return discoverStatePaths([...paths]);
@@ -87605,24 +89882,50 @@ function recoverAutopilotEmergencyTransactions(root2, sessionId) {
   ]);
   const localOmcRoot = getWorkingDirectoryLocalOmcRoot(root2);
   for (const sid of listSessionIdsUnderOmcRoot(localOmcRoot)) {
-    broadPaths.add((0, import_path35.join)(localOmcRoot, "state", "sessions", sid, getStateFileName("autopilot")));
+    broadPaths.add(
+      (0, import_path35.join)(
+        localOmcRoot,
+        "state",
+        "sessions",
+        sid,
+        getStateFileName("autopilot")
+      )
+    );
   }
   for (const omcRoot of getConvergedOmcRoots(root2)) {
     for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-      broadPaths.add((0, import_path35.join)(omcRoot, "state", "sessions", sid, getStateFileName("autopilot")));
+      broadPaths.add(
+        (0, import_path35.join)(omcRoot, "state", "sessions", sid, getStateFileName("autopilot"))
+      );
     }
   }
   const directSessionPaths = /* @__PURE__ */ new Set();
   if (sessionId) {
-    directSessionPaths.add(resolveSessionStatePath("autopilot", sessionId, root2));
-    directSessionPaths.add(getWorkingDirectoryLocalSessionStatePath("autopilot", root2, sessionId));
+    directSessionPaths.add(
+      resolveSessionStatePath("autopilot", sessionId, root2)
+    );
+    directSessionPaths.add(
+      getWorkingDirectoryLocalSessionStatePath("autopilot", root2, sessionId)
+    );
     for (const omcRoot of getConvergedOmcRoots(root2)) {
-      directSessionPaths.add((0, import_path35.join)(omcRoot, "state", "sessions", sessionId, getStateFileName("autopilot")));
+      directSessionPaths.add(
+        (0, import_path35.join)(
+          omcRoot,
+          "state",
+          "sessions",
+          sessionId,
+          getStateFileName("autopilot")
+        )
+      );
     }
     for (const path25 of directSessionPaths) broadPaths.add(path25);
   }
   for (const path25 of broadPaths) {
-    const recoveryOptions = emergencyRecoveryOptionsForProject("autopilot", path25, root2);
+    const recoveryOptions = emergencyRecoveryOptionsForProject(
+      "autopilot",
+      path25,
+      root2
+    );
     if (!isAutopilotRecoveryCandidateForProject(path25, root2)) continue;
     if (sessionId && !directSessionPaths.has(path25)) {
       const visibleOwner = getStateSessionOwner(readJsonRecord(path25) ?? {});
@@ -87630,32 +89933,229 @@ function recoverAutopilotEmergencyTransactions(root2, sessionId) {
       const journalOwner = typeof journal?.sessionOwner === "string" ? journal.sessionOwner : void 0;
       if (visibleOwner !== sessionId && journalOwner !== sessionId) continue;
     }
-    if (!recoverEmergencyStateFile(path25, recoveryOptions)) throw new Error(`workflow_emergency_recovery_failed: ${path25}`);
-    if (recoveryOptions && !isAutopilotRecoveryCandidateForProject(path25, root2)) continue;
+    if (!recoverEmergencyStateFile(path25, recoveryOptions))
+      throw new Error(`workflow_emergency_recovery_failed: ${path25}`);
+    if (recoveryOptions && !isAutopilotRecoveryCandidateForProject(path25, root2))
+      continue;
     const artifactPrefix = `${(0, import_path35.basename)(path25)}.emergency-`;
     let artifacts;
     try {
-      artifacts = (0, import_fs30.readdirSync)((0, import_path35.dirname)(path25)).filter((name) => name.startsWith(artifactPrefix) && !name.endsWith(".recovery.guard"));
+      artifacts = (0, import_fs30.readdirSync)((0, import_path35.dirname)(path25)).filter(
+        (name) => name.startsWith(artifactPrefix) && !name.endsWith(".recovery.guard")
+      );
     } catch {
       artifacts = [];
     }
-    if (artifacts.length > 0) throw new Error(`workflow_emergency_recovery_failed: ${path25}`);
+    if (artifacts.length > 0)
+      throw new Error(`workflow_emergency_recovery_failed: ${path25}`);
   }
+}
+function classifyGraphRunStatus(status) {
+  if (MODE_CONFIGS.graph.activeStatuses?.includes(status)) return "active";
+  if (status === "draft") return "draft";
+  if (status === "paused") return "paused";
+  return "terminal";
+}
+function classifyGraphStateForClear(root2, sessionId) {
+  const paths = sessionId ? [getStateFilePath(root2, "graph", sessionId)] : [
+    getStateFilePath(root2, "graph"),
+    ...listSessionIds(root2).sort().map((sid) => getStateFilePath(root2, "graph", sid))
+  ];
+  const classifications = [];
+  for (const path25 of paths) {
+    if (!(0, import_fs30.existsSync)(path25)) continue;
+    try {
+      classifications.push(
+        classifyGraphRunStatus(
+          parseGraphState(JSON.parse((0, import_fs30.readFileSync)(path25, "utf8"))).status
+        )
+      );
+    } catch {
+      classifications.push("malformed");
+    }
+  }
+  if (classifications.length === 0) return "missing";
+  for (const classification of [
+    "active",
+    "paused",
+    "draft",
+    "terminal",
+    "malformed"
+  ]) {
+    if (classifications.includes(classification)) return classification;
+  }
+  return "malformed";
+}
+function hasGraphWorkflowSlot(root2, sessionId) {
+  const paths = [resolveStatePath("skill-active", root2)];
+  const sessionIds = sessionId ? [sessionId] : listSessionIds(root2);
+  for (const sid of sessionIds)
+    paths.push(resolveSessionStatePath("skill-active", sid, root2));
+  return paths.some((path25) => {
+    const state = readJsonRecord(path25);
+    return Boolean(
+      state?.active_skills && typeof state.active_skills === "object" && state.active_skills.graph
+    );
+  });
+}
+function clearSkillActiveStateForAll(root2, sessionId) {
+  const legacyCandidates = discoverStatePaths(
+    getLegacyStateFileCandidates("skill-active", root2)
+  ).filter(
+    (candidate) => !sessionId || canClearStateForSession(candidate.state, sessionId)
+  );
+  const localCandidates = discoverStatePaths(
+    getWorkingDirectoryLocalStateClearCandidates(
+      "skill-active",
+      root2,
+      sessionId
+    )
+  ).filter(
+    (candidate) => !sessionId || canClearStateForSession(candidate.state, sessionId)
+  );
+  const sessionCandidates = sessionId ? [
+    ...findSessionOwnedStateCandidates("skill-active", sessionId, root2),
+    ...findCompletedSessionStateCandidates("skill-active", root2, sessionId)
+  ] : [
+    ...listSessionIds(root2).flatMap(
+      (sid) => findSessionOwnedStateCandidates("skill-active", sid, root2)
+    ),
+    ...discoverAllRootSessionStateCandidates("skill-active", root2)
+  ];
+  const candidates = [
+    ...new Map(
+      [...legacyCandidates, ...localCandidates, ...sessionCandidates].map(
+        (candidate) => [candidate.path, candidate]
+      )
+    ).values()
+  ];
+  let changed = false;
+  let failed = false;
+  let preservedGraphWorkflowSlot = false;
+  for (const candidate of candidates) {
+    const skills = candidate.state.active_skills;
+    const graphIsPresent = skills !== null && typeof skills === "object" && !Array.isArray(skills) && Object.prototype.hasOwnProperty.call(skills, "graph");
+    if (!graphIsPresent) {
+      const result2 = clearDiscoveredStateCandidate(
+        candidate,
+        (current) => (!sessionId || canClearStateForSession(current, sessionId)) && JSON.stringify(current) === candidate.snapshot
+      );
+      if (result2 === "cleared") changed = true;
+      else if (result2 === "failed" || result2 === "skipped" && (0, import_fs30.existsSync)(candidate.path))
+        failed = true;
+      continue;
+    }
+    preservedGraphWorkflowSlot = true;
+    const activeSkills = skills;
+    const nonGraphSkills = Object.keys(activeSkills).filter(
+      (name) => name !== "graph"
+    );
+    if (nonGraphSkills.length === 0) continue;
+    const result = writeStateFileLockedIf(
+      candidate.path,
+      (current) => (!sessionId || canClearStateForSession(current, sessionId)) && JSON.stringify(current) === candidate.snapshot,
+      (current) => {
+        const currentSkills = current.active_skills;
+        return { ...current, active_skills: { graph: currentSkills.graph } };
+      }
+    );
+    if (result === "written") changed = true;
+    else failed = true;
+  }
+  return { changed, failed, preservedGraphWorkflowSlot };
 }
 var stateClearTool = {
   name: "state_clear",
-  description: "Clear/delete state for a specific mode. Removes the state file and any associated marker files. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).",
-  annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+  description: "Clear/delete state for a specific mode or all generically clearable modes. Graph is guarded and is never deleted by this tool. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false
+  },
   schema: {
-    mode: external_exports.enum(STATE_TOOL_MODES).describe("The mode to clear state for"),
+    mode: external_exports.enum(STATE_CLEAR_MODES).describe("The mode to clear state for, or all"),
+    force: external_exports.boolean().optional().describe(
+      "Request broad cleanup. This never bypasses guarded Graph state."
+    ),
     workingDirectory: external_exports.string().optional().describe("Working directory (defaults to cwd)"),
-    session_id: external_exports.string().optional().describe("Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).")
+    session_id: external_exports.string().optional().describe(
+      "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions)."
+    )
   },
   handler: async (args) => {
-    const { mode, workingDirectory, session_id } = args;
+    const { mode, force, workingDirectory, session_id } = args;
     try {
       const root2 = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id;
+      if (sessionId) validateSessionId(sessionId);
+      if (mode === "graph") {
+        const graphClassification = classifyGraphStateForClear(root2, sessionId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                type: "guarded_mode",
+                mode: "graph",
+                operation: "clear",
+                classification: graphClassification,
+                changed: false,
+                force_bypassed: false
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+      if (mode === "all") {
+        const graphClassification = classifyGraphStateForClear(root2, sessionId);
+        const clearedModes = [];
+        const failedModes = [];
+        let preserveGraphWorkflowSlot = hasGraphWorkflowSlot(root2, sessionId);
+        for (const candidate of STATE_TOOL_MODES) {
+          if (candidate === "graph") {
+            continue;
+          }
+          if (candidate === "skill-active") {
+            const result2 = clearSkillActiveStateForAll(root2, sessionId);
+            preserveGraphWorkflowSlot ||= result2.preservedGraphWorkflowSlot;
+            if (result2.failed) failedModes.push(candidate);
+            else if (result2.changed) clearedModes.push(candidate);
+            continue;
+          }
+          const result = await stateClearTool.handler({
+            mode: candidate,
+            force,
+            workingDirectory,
+            session_id
+          });
+          if (result.isError) failedModes.push(candidate);
+          else clearedModes.push(candidate);
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                type: "clear_all",
+                cleared_modes: clearedModes,
+                failed_modes: failedModes,
+                skipped: [
+                  {
+                    mode: "graph",
+                    reason: "guarded_mode",
+                    classification: graphClassification
+                  }
+                ],
+                preserved_graph_workflow_slot: preserveGraphWorkflowSlot,
+                force_bypassed: false
+              })
+            }
+          ],
+          ...failedModes.length > 0 ? { isError: true } : {}
+        };
+      }
       if (mode === "merge-readiness") {
         const cancelledSessions = [];
         const blockedSessions = [];
@@ -87673,7 +90173,8 @@ var stateClearTool = {
           recordResult(sessionId, cancelActiveSession(sessionId));
         } else {
           const callerSid = process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
-          if (callerSid) recordResult(callerSid, cancelActiveSession(callerSid));
+          if (callerSid)
+            recordResult(callerSid, cancelActiveSession(callerSid));
           recordResult("legacy", cancelActiveSession());
         }
         const blocked = blockedSessions.length > 0;
@@ -87683,7 +90184,8 @@ var stateClearTool = {
           ...blocked ? { isError: true } : {}
         };
       }
-      if (mode === "autopilot") recoverAutopilotEmergencyTransactions(root2, sessionId);
+      if (mode === "autopilot")
+        recoverAutopilotEmergencyTransactions(root2, sessionId);
       const cleanedTeamNames = /* @__PURE__ */ new Set();
       const collectTeamNamesForCleanup = (statePath) => {
         if (mode !== "team") return;
@@ -87693,40 +90195,131 @@ var stateClearTool = {
       };
       if (sessionId) {
         validateSessionId(sessionId);
-        const requestedSessionCandidates = findSessionOwnedStateCandidates(mode, sessionId, root2).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-        const requestedSessionOwnedPaths = requestedSessionCandidates.map((candidate) => candidate.path);
-        for (const teamStatePath of findSessionOwnedStateFiles("team", sessionId, root2)) {
+        const requestedSessionCandidates = findSessionOwnedStateCandidates(
+          mode,
+          sessionId,
+          root2
+        ).filter(
+          (candidate) => isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root2
+          )
+        );
+        const requestedSessionOwnedPaths = requestedSessionCandidates.map(
+          (candidate) => candidate.path
+        );
+        for (const teamStatePath of findSessionOwnedStateFiles(
+          "team",
+          sessionId,
+          root2
+        )) {
           collectTeamNamesForCleanup(teamStatePath);
         }
         if (mode === "team") {
-          for (const teamStatePath of findCompletedSessionStateFiles("team", root2, sessionId)) {
+          for (const teamStatePath of findCompletedSessionStateFiles(
+            "team",
+            root2,
+            sessionId
+          )) {
             collectTeamNamesForCleanup(teamStatePath);
           }
         }
-        const completedCandidates = findCompletedSessionStateCandidates(mode, root2, sessionId).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-        const legacyCandidates = discoverStatePaths(getLegacyStateFileCandidates(mode, root2)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-        const localCandidates = discoverStatePaths(getWorkingDirectoryLocalStateClearCandidates(mode, root2, sessionId)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-        const convergedCandidates = discoverStatePaths(getConvergedStateCandidates(mode, root2, sessionId)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-        const operationCandidates = [...new Map([
-          ...requestedSessionCandidates,
-          ...completedCandidates,
-          ...legacyCandidates.filter((candidate) => canClearStateForSession(candidate.state, sessionId)),
-          ...localCandidates.filter((candidate) => canClearStateForSession(candidate.state, sessionId)),
-          ...convergedCandidates.filter((candidate) => canClearStateForSession(candidate.state, sessionId))
-        ].map((candidate) => [candidate.path, candidate])).values()];
-        const directCandidate = requestedSessionCandidates.find((candidate) => candidate.path === resolveSessionStatePath(mode, sessionId, root2)) ?? requestedSessionCandidates[0];
-        const namedPrimaries = mode === "autopilot" ? operationCandidates.filter((candidate) => hasNamedWorkflowMarker(candidate.state)) : [];
-        const namedPrimaryPaths = new Set(namedPrimaries.map((candidate) => candidate.path));
+        const completedCandidates = findCompletedSessionStateCandidates(
+          mode,
+          root2,
+          sessionId
+        ).filter(
+          (candidate) => isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root2
+          )
+        );
+        const legacyCandidates = discoverStatePaths(
+          getLegacyStateFileCandidates(mode, root2)
+        ).filter(
+          (candidate) => isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root2
+          )
+        );
+        const localCandidates = discoverStatePaths(
+          getWorkingDirectoryLocalStateClearCandidates(mode, root2, sessionId)
+        ).filter(
+          (candidate) => isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root2
+          )
+        );
+        const convergedCandidates = discoverStatePaths(
+          getConvergedStateCandidates(mode, root2, sessionId)
+        ).filter(
+          (candidate) => isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root2
+          )
+        );
+        const operationCandidates = [
+          ...new Map(
+            [
+              ...requestedSessionCandidates,
+              ...completedCandidates,
+              ...legacyCandidates.filter(
+                (candidate) => canClearStateForSession(candidate.state, sessionId)
+              ),
+              ...localCandidates.filter(
+                (candidate) => canClearStateForSession(candidate.state, sessionId)
+              ),
+              ...convergedCandidates.filter(
+                (candidate) => canClearStateForSession(candidate.state, sessionId)
+              )
+            ].map((candidate) => [candidate.path, candidate])
+          ).values()
+        ];
+        const directCandidate = requestedSessionCandidates.find(
+          (candidate) => candidate.path === resolveSessionStatePath(mode, sessionId, root2)
+        ) ?? requestedSessionCandidates[0];
+        const namedPrimaries = mode === "autopilot" ? operationCandidates.filter(
+          (candidate) => hasNamedWorkflowMarker(candidate.state)
+        ) : [];
+        const namedPrimaryPaths = new Set(
+          namedPrimaries.map((candidate) => candidate.path)
+        );
         let directCleared = 0;
         for (const candidate of namedPrimaries) {
           const success = clearAutopilotMarkerCandidate(candidate, root2);
-          if (!success || (0, import_fs30.existsSync)(candidate.path)) throw new Error(`primary state mutation failed; dependent state preserved: ${candidate.path}`);
+          if (!success || (0, import_fs30.existsSync)(candidate.path))
+            throw new Error(
+              `primary state mutation failed; dependent state preserved: ${candidate.path}`
+            );
           directCleared += 1;
         }
-        const completedSessionCleanup = clearCompletedSessionStateCandidates(mode, root2, sessionId, completedCandidates.filter((candidate) => !namedPrimaryPaths.has(candidate.path)));
+        const completedSessionCleanup = clearCompletedSessionStateCandidates(
+          mode,
+          root2,
+          sessionId,
+          completedCandidates.filter(
+            (candidate) => !namedPrimaryPaths.has(candidate.path)
+          )
+        );
         const runtimeCleanup2 = clearModeRuntimeArtifacts(mode, root2, sessionId);
-        let convergedCleanup2 = { cleared: 0, hadFailure: false, paths: [] };
-        const sessionSignalCandidates = operationCandidates.filter((candidate) => !hasNamedWorkflowMarker(candidate.state));
+        let convergedCleanup = {
+          cleared: 0,
+          hadFailure: false,
+          paths: []
+        };
+        const sessionSignalCandidates = operationCandidates.filter(
+          (candidate) => !hasNamedWorkflowMarker(candidate.state)
+        );
         const signaledCandidateDirs = /* @__PURE__ */ new Set();
         for (const candidate of sessionSignalCandidates) {
           const signalDir = (0, import_path35.dirname)(candidate.path);
@@ -87748,42 +90341,146 @@ var stateClearTool = {
           } catch {
           }
         }
-        if (sessionSignalCandidates.length === 0 && namedPrimaries.length === 0) writeSessionCancelSignal(root2, sessionId, mode, directCandidate);
+        if (sessionSignalCandidates.length === 0 && namedPrimaries.length === 0)
+          writeSessionCancelSignal(root2, sessionId, mode, directCandidate);
         if (MODE_CONFIGS[mode]) {
           const expectedDirectState = directCandidate?.state;
-          const success = clearModeState(mode, root2, sessionId, expectedDirectState);
-          if (directCandidate && !(0, import_fs30.existsSync)(directCandidate.path)) directCleared = 1;
-          const sessionCleanup2 = clearSessionOwnedStateCandidates(mode, root2, sessionId, requestedSessionCandidates);
-          const legacyCleanup2 = clearLegacyStateCandidates(mode, root2, sessionId, legacyCandidates);
+          const registryClearResult = clearModeStateDetailed(
+            mode,
+            root2,
+            sessionId,
+            expectedDirectState
+          );
+          const skippedCanonicalPaths = new Set(
+            registryClearResult === "skipped" && directCandidate ? [directCandidate.path] : []
+          );
+          const success = registryClearResult === "cleared";
+          if (directCandidate && !(0, import_fs30.existsSync)(directCandidate.path))
+            directCleared = 1;
+          const sessionCleanup2 = clearSessionOwnedStateCandidates(
+            mode,
+            root2,
+            sessionId,
+            requestedSessionCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path)
+            )
+          );
+          const legacyCleanup2 = clearLegacyStateCandidates(
+            mode,
+            root2,
+            sessionId,
+            legacyCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path)
+            )
+          );
           const shouldUseLocalFallback2 = requestedSessionOwnedPaths.length === 0 && completedSessionCleanup.cleared === 0 && sessionCleanup2.cleared === 0 && legacyCleanup2.cleared === 0;
-          const workingDirectoryLocalCleanup2 = shouldUseLocalFallback2 ? clearWorkingDirectoryLocalStateCandidates(mode, root2, sessionId, localCandidates) : { cleared: 0, hadFailure: false, paths: [] };
-          convergedCleanup2 = clearConvergedStateCandidates(mode, root2, sessionId, convergedCandidates);
+          const workingDirectoryLocalCleanup2 = shouldUseLocalFallback2 ? clearWorkingDirectoryLocalStateCandidates(
+            mode,
+            root2,
+            sessionId,
+            localCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path)
+            )
+          ) : { cleared: 0, hadFailure: false, paths: [] };
+          convergedCleanup = clearConvergedStateCandidates(
+            mode,
+            root2,
+            sessionId,
+            convergedCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path)
+            )
+          );
           let ownerSessionId2;
-          let ownerSessionCleanup2 = { cleared: 0, hadFailure: false, paths: [] };
+          let ownerSessionCleanup2 = {
+            cleared: 0,
+            hadFailure: false,
+            paths: []
+          };
           let ownerLegacyCleanup2 = { cleared: 0, hadFailure: false };
-          if (OWNER_SESSION_FALLBACK_MODES.has(mode) && requestedSessionOwnedPaths.length === 0 && completedCandidates.length === 0 && legacyCandidates.length === 0 && completedSessionCleanup.cleared === 0 && sessionCleanup2.cleared === 0 && legacyCleanup2.cleared === 0 && convergedCleanup2.cleared === 0 && workingDirectoryLocalCleanup2.cleared === 0) {
-            ownerSessionId2 = findSingleOwningSessionForMode(mode, root2, sessionId);
+          if (OWNER_SESSION_FALLBACK_MODES.has(mode) && requestedSessionOwnedPaths.length === 0 && completedCandidates.length === 0 && legacyCandidates.length === 0 && completedSessionCleanup.cleared === 0 && sessionCleanup2.cleared === 0 && legacyCleanup2.cleared === 0 && convergedCleanup.cleared === 0 && workingDirectoryLocalCleanup2.cleared === 0) {
+            ownerSessionId2 = findSingleOwningSessionForMode(
+              mode,
+              root2,
+              sessionId
+            );
             if (ownerSessionId2) {
               if (mode === "team") {
-                for (const teamStatePath of findSessionOwnedStateFiles("team", ownerSessionId2, root2)) {
+                for (const teamStatePath of findSessionOwnedStateFiles(
+                  "team",
+                  ownerSessionId2,
+                  root2
+                )) {
                   collectTeamNamesForCleanup(teamStatePath);
                 }
               }
-              const ownerCandidates = findSessionOwnedStateCandidates(mode, ownerSessionId2, root2);
-              const ownerDirectCandidate = ownerCandidates.find((candidate) => candidate.path === resolveSessionStatePath(mode, ownerSessionId2, root2)) ?? ownerCandidates[0];
+              const ownerCandidates = findSessionOwnedStateCandidates(
+                mode,
+                ownerSessionId2,
+                root2
+              );
+              const ownerDirectCandidate = ownerCandidates.find(
+                (candidate) => candidate.path === resolveSessionStatePath(mode, ownerSessionId2, root2)
+              ) ?? ownerCandidates[0];
               const ownerNamedPrimary = mode === "autopilot" && ownerDirectCandidate && hasNamedWorkflowMarker(ownerDirectCandidate.state) ? ownerDirectCandidate : void 0;
               if (ownerNamedPrimary) {
-                const success2 = clearAutopilotMarkerCandidate(ownerNamedPrimary, root2);
-                if (!success2 || (0, import_fs30.existsSync)(ownerNamedPrimary.path)) throw new Error("primary state mutation failed; dependent state preserved");
+                const success2 = clearAutopilotMarkerCandidate(
+                  ownerNamedPrimary,
+                  root2
+                );
+                if (!success2 || (0, import_fs30.existsSync)(ownerNamedPrimary.path))
+                  throw new Error(
+                    "primary state mutation failed; dependent state preserved"
+                  );
               } else {
-                writeSessionCancelSignal(root2, ownerSessionId2, mode, ownerDirectCandidate);
-                clearModeState(mode, root2, ownerSessionId2, ownerDirectCandidate?.state);
+                writeSessionCancelSignal(
+                  root2,
+                  ownerSessionId2,
+                  mode,
+                  ownerDirectCandidate
+                );
+                const ownerClearResult = clearModeStateDetailed(
+                  mode,
+                  root2,
+                  ownerSessionId2,
+                  ownerDirectCandidate?.state
+                );
+                const skippedOwnerCanonicalPath = ownerClearResult === "skipped" ? ownerDirectCandidate?.path : void 0;
+                ownerSessionCleanup2 = clearSessionOwnedStateCandidates(
+                  mode,
+                  root2,
+                  ownerSessionId2,
+                  ownerCandidates.filter(
+                    (candidate) => candidate.path !== skippedOwnerCanonicalPath
+                  )
+                );
+                ownerLegacyCleanup2 = clearLegacyStateCandidates(
+                  mode,
+                  root2,
+                  ownerSessionId2
+                );
               }
-              const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root2, ownerSessionId2);
+              const ownerRuntimeCleanup = clearModeRuntimeArtifacts(
+                mode,
+                root2,
+                ownerSessionId2
+              );
               runtimeCleanup2.cleared += ownerRuntimeCleanup.cleared;
               runtimeCleanup2.hadFailure ||= ownerRuntimeCleanup.hadFailure;
-              ownerSessionCleanup2 = clearSessionOwnedStateCandidates(mode, root2, ownerSessionId2, ownerCandidates.filter((candidate) => candidate.path !== ownerNamedPrimary?.path));
-              ownerLegacyCleanup2 = clearLegacyStateCandidates(mode, root2, ownerSessionId2);
+              if (ownerNamedPrimary) {
+                ownerSessionCleanup2 = clearSessionOwnedStateCandidates(
+                  mode,
+                  root2,
+                  ownerSessionId2,
+                  ownerCandidates.filter(
+                    (candidate) => candidate.path !== ownerNamedPrimary.path
+                  )
+                );
+                ownerLegacyCleanup2 = clearLegacyStateCandidates(
+                  mode,
+                  root2,
+                  ownerSessionId2
+                );
+              }
             }
           }
           const ghostNoteParts2 = [];
@@ -87791,19 +90488,29 @@ var stateClearTool = {
             ghostNoteParts2.push("ghost legacy file also removed");
           }
           if (completedSessionCleanup.cleared > 0) {
-            ghostNoteParts2.push(`removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? "" : "s"}`);
+            ghostNoteParts2.push(
+              `removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? "" : "s"}`
+            );
           }
           if (sessionCleanup2.cleared > 0) {
-            ghostNoteParts2.push(`removed ${sessionCleanup2.cleared} recovered session file${sessionCleanup2.cleared === 1 ? "" : "s"}`);
+            ghostNoteParts2.push(
+              `removed ${sessionCleanup2.cleared} recovered session file${sessionCleanup2.cleared === 1 ? "" : "s"}`
+            );
           }
           if (workingDirectoryLocalCleanup2.cleared > 0) {
-            ghostNoteParts2.push(`removed ${workingDirectoryLocalCleanup2.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup2.cleared === 1 ? "" : "s"}`);
+            ghostNoteParts2.push(
+              `removed ${workingDirectoryLocalCleanup2.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup2.cleared === 1 ? "" : "s"}`
+            );
           }
-          if (convergedCleanup2.cleared > 0) {
-            ghostNoteParts2.push(`removed ${convergedCleanup2.cleared} converged state file${convergedCleanup2.cleared === 1 ? "" : "s"}`);
+          if (convergedCleanup.cleared > 0) {
+            ghostNoteParts2.push(
+              `removed ${convergedCleanup.cleared} converged state file${convergedCleanup.cleared === 1 ? "" : "s"}`
+            );
           }
           if (runtimeCleanup2.cleared > 0) {
-            ghostNoteParts2.push(`removed ${runtimeCleanup2.cleared} runtime artifact${runtimeCleanup2.cleared === 1 ? "" : "s"}`);
+            ghostNoteParts2.push(
+              `removed ${runtimeCleanup2.cleared} runtime artifact${runtimeCleanup2.cleared === 1 ? "" : "s"}`
+            );
           }
           if (ownerSessionId2) {
             ghostNoteParts2.push(`cleared owning session: ${ownerSessionId2}`);
@@ -87815,64 +90522,132 @@ var stateClearTool = {
             const removedRoots = cleanupTeamRuntimeState(root2, teamNames);
             const prunedMissions = pruneMissionBoardTeams(root2, teamNames);
             const details = [];
-            if (removedRoots > 0) details.push(`removed ${removedRoots} team runtime root(s)`);
-            if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
+            if (removedRoots > 0)
+              details.push(`removed ${removedRoots} team runtime root(s)`);
+            if (prunedMissions > 0)
+              details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
             return details.length > 0 ? ` (${details.join(", ")})` : "";
           })();
-          const clearedStateOrArtifacts2 = directCleared + completedSessionCleanup.cleared + sessionCleanup2.cleared + legacyCleanup2.cleared + convergedCleanup2.cleared + workingDirectoryLocalCleanup2.cleared + ownerSessionCleanup2.cleared + ownerLegacyCleanup2.cleared + runtimeCleanup2.cleared;
-          const capturedCleanupIncomplete2 = operationCandidates.some((candidate) => (0, import_fs30.existsSync)(candidate.path));
-          if (!ownerSessionId2 && clearedStateOrArtifacts2 === 0 && success && !capturedCleanupIncomplete2 && !legacyCleanup2.hadFailure && !sessionCleanup2.hadFailure && !workingDirectoryLocalCleanup2.hadFailure && !convergedCleanup2.hadFailure && !completedSessionCleanup.hadFailure && !ownerSessionCleanup2.hadFailure && !ownerLegacyCleanup2.hadFailure && !runtimeCleanup2.hadFailure) {
+          const clearedStateOrArtifacts2 = directCleared + completedSessionCleanup.cleared + sessionCleanup2.cleared + legacyCleanup2.cleared + convergedCleanup.cleared + workingDirectoryLocalCleanup2.cleared + ownerSessionCleanup2.cleared + ownerLegacyCleanup2.cleared + runtimeCleanup2.cleared;
+          const capturedCleanupIncomplete2 = operationCandidates.some(
+            (candidate) => (0, import_fs30.existsSync)(candidate.path)
+          );
+          if (!ownerSessionId2 && clearedStateOrArtifacts2 === 0 && success && !capturedCleanupIncomplete2 && !legacyCleanup2.hadFailure && !sessionCleanup2.hadFailure && !workingDirectoryLocalCleanup2.hadFailure && !convergedCleanup.hadFailure && !completedSessionCleanup.hadFailure && !ownerSessionCleanup2.hadFailure && !ownerLegacyCleanup2.hadFailure && !runtimeCleanup2.hadFailure) {
             return {
-              content: [{
-                type: "text",
-                text: formatStateClearNoopMessage(mode, root2, sessionId)
-              }]
+              content: [
+                {
+                  type: "text",
+                  text: formatStateClearNoopMessage(mode, root2, sessionId)
+                }
+              ]
             };
           }
-          if (!capturedCleanupIncomplete2 && success && !legacyCleanup2.hadFailure && !sessionCleanup2.hadFailure && !workingDirectoryLocalCleanup2.hadFailure && !convergedCleanup2.hadFailure && !completedSessionCleanup.hadFailure && !ownerSessionCleanup2.hadFailure && !ownerLegacyCleanup2.hadFailure && !runtimeCleanup2.hadFailure) {
+          if (!capturedCleanupIncomplete2 && success && !legacyCleanup2.hadFailure && !sessionCleanup2.hadFailure && !workingDirectoryLocalCleanup2.hadFailure && !convergedCleanup.hadFailure && !completedSessionCleanup.hadFailure && !ownerSessionCleanup2.hadFailure && !ownerLegacyCleanup2.hadFailure && !runtimeCleanup2.hadFailure) {
             return {
-              content: [{
-                type: "text",
-                text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote2}${runtimeCleanupNote2}`
-              }]
+              content: [
+                {
+                  type: "text",
+                  text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote2}${runtimeCleanupNote2}`
+                }
+              ]
             };
           } else {
             return {
-              content: [{
-                type: "text",
-                text: `Warning: Some files could not be removed for mode: ${mode} in session: ${sessionId}${ghostNote2}${runtimeCleanupNote2}`
-              }],
+              content: [
+                {
+                  type: "text",
+                  text: `Warning: Some files could not be removed for mode: ${mode} in session: ${sessionId}${ghostNote2}${runtimeCleanupNote2}`
+                }
+              ],
               isError: true
             };
           }
         }
-        const sessionCleanup = clearSessionOwnedStateCandidates(mode, root2, sessionId, requestedSessionCandidates);
-        const legacyCleanup = clearLegacyStateCandidates(mode, root2, sessionId, legacyCandidates);
+        const sessionCleanup = clearSessionOwnedStateCandidates(
+          mode,
+          root2,
+          sessionId,
+          requestedSessionCandidates
+        );
+        const legacyCleanup = clearLegacyStateCandidates(
+          mode,
+          root2,
+          sessionId,
+          legacyCandidates
+        );
         const shouldUseLocalFallback = requestedSessionOwnedPaths.length === 0 && completedSessionCleanup.cleared === 0 && sessionCleanup.cleared === 0 && legacyCleanup.cleared === 0;
-        const workingDirectoryLocalCleanup = shouldUseLocalFallback ? clearWorkingDirectoryLocalStateCandidates(mode, root2, sessionId, localCandidates) : { cleared: 0, hadFailure: false, paths: [] };
-        convergedCleanup2 = clearConvergedStateCandidates(mode, root2, sessionId, convergedCandidates);
+        const workingDirectoryLocalCleanup = shouldUseLocalFallback ? clearWorkingDirectoryLocalStateCandidates(
+          mode,
+          root2,
+          sessionId,
+          localCandidates
+        ) : { cleared: 0, hadFailure: false, paths: [] };
+        convergedCleanup = clearConvergedStateCandidates(
+          mode,
+          root2,
+          sessionId,
+          convergedCandidates
+        );
         let ownerSessionId;
-        let ownerSessionCleanup = { cleared: 0, hadFailure: false, paths: [] };
+        let ownerSessionCleanup = {
+          cleared: 0,
+          hadFailure: false,
+          paths: []
+        };
         let ownerLegacyCleanup = { cleared: 0, hadFailure: false };
-        if (OWNER_SESSION_FALLBACK_MODES.has(mode) && requestedSessionOwnedPaths.length === 0 && completedCandidates.length === 0 && legacyCandidates.length === 0 && completedSessionCleanup.cleared === 0 && sessionCleanup.cleared === 0 && legacyCleanup.cleared === 0 && convergedCleanup2.cleared === 0 && workingDirectoryLocalCleanup.cleared === 0) {
-          ownerSessionId = findSingleOwningSessionForMode(mode, root2, sessionId);
+        if (OWNER_SESSION_FALLBACK_MODES.has(mode) && requestedSessionOwnedPaths.length === 0 && completedCandidates.length === 0 && legacyCandidates.length === 0 && completedSessionCleanup.cleared === 0 && sessionCleanup.cleared === 0 && legacyCleanup.cleared === 0 && convergedCleanup.cleared === 0 && workingDirectoryLocalCleanup.cleared === 0) {
+          ownerSessionId = findSingleOwningSessionForMode(
+            mode,
+            root2,
+            sessionId
+          );
           if (ownerSessionId) {
             if (mode === "team") {
-              for (const teamStatePath of findSessionOwnedStateFiles("team", ownerSessionId, root2)) {
+              for (const teamStatePath of findSessionOwnedStateFiles(
+                "team",
+                ownerSessionId,
+                root2
+              )) {
                 collectTeamNamesForCleanup(teamStatePath);
               }
             }
-            const ownerCandidates = findSessionOwnedStateCandidates(mode, ownerSessionId, root2);
-            if (mode === "autopilot" && ownerCandidates.some((candidate) => hasNamedWorkflowMarker(candidate.state)) && !namedWorkflowRuntimeSupported()) {
+            const ownerCandidates = findSessionOwnedStateCandidates(
+              mode,
+              ownerSessionId,
+              root2
+            );
+            if (mode === "autopilot" && ownerCandidates.some(
+              (candidate) => hasNamedWorkflowMarker(candidate.state)
+            ) && !namedWorkflowRuntimeSupported()) {
               throw new Error("unsupported-runtime");
             }
-            const ownerDirectCandidate = ownerCandidates.find((candidate) => candidate.path === resolveSessionStatePath(mode, ownerSessionId, root2)) ?? ownerCandidates[0];
-            writeSessionCancelSignal(root2, ownerSessionId, mode, ownerDirectCandidate);
-            const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root2, ownerSessionId);
+            const ownerDirectCandidate = ownerCandidates.find(
+              (candidate) => candidate.path === resolveSessionStatePath(mode, ownerSessionId, root2)
+            ) ?? ownerCandidates[0];
+            writeSessionCancelSignal(
+              root2,
+              ownerSessionId,
+              mode,
+              ownerDirectCandidate
+            );
+            const ownerRuntimeCleanup = clearModeRuntimeArtifacts(
+              mode,
+              root2,
+              ownerSessionId
+            );
             runtimeCleanup2.cleared += ownerRuntimeCleanup.cleared;
             runtimeCleanup2.hadFailure ||= ownerRuntimeCleanup.hadFailure;
-            ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root2, ownerSessionId, ownerCandidates);
-            ownerLegacyCleanup = clearLegacyStateCandidates(mode, root2, ownerSessionId);
+            ownerSessionCleanup = clearSessionOwnedStateCandidates(
+              mode,
+              root2,
+              ownerSessionId,
+              ownerCandidates
+            );
+            ownerLegacyCleanup = clearLegacyStateCandidates(
+              mode,
+              root2,
+              ownerSessionId
+            );
           }
         }
         const ghostNoteParts = [];
@@ -87880,19 +90655,29 @@ var stateClearTool = {
           ghostNoteParts.push("ghost legacy file also removed");
         }
         if (completedSessionCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? "" : "s"}`);
+          ghostNoteParts.push(
+            `removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? "" : "s"}`
+          );
         }
         if (sessionCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? "" : "s"}`);
+          ghostNoteParts.push(
+            `removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? "" : "s"}`
+          );
         }
         if (workingDirectoryLocalCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${workingDirectoryLocalCleanup.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup.cleared === 1 ? "" : "s"}`);
+          ghostNoteParts.push(
+            `removed ${workingDirectoryLocalCleanup.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup.cleared === 1 ? "" : "s"}`
+          );
         }
-        if (convergedCleanup2.cleared > 0) {
-          ghostNoteParts.push(`removed ${convergedCleanup2.cleared} converged state file${convergedCleanup2.cleared === 1 ? "" : "s"}`);
+        if (convergedCleanup.cleared > 0) {
+          ghostNoteParts.push(
+            `removed ${convergedCleanup.cleared} converged state file${convergedCleanup.cleared === 1 ? "" : "s"}`
+          );
         }
         if (runtimeCleanup2.cleared > 0) {
-          ghostNoteParts.push(`removed ${runtimeCleanup2.cleared} runtime artifact${runtimeCleanup2.cleared === 1 ? "" : "s"}`);
+          ghostNoteParts.push(
+            `removed ${runtimeCleanup2.cleared} runtime artifact${runtimeCleanup2.cleared === 1 ? "" : "s"}`
+          );
         }
         if (ownerSessionId) {
           ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
@@ -87904,47 +90689,84 @@ var stateClearTool = {
           const removedRoots = cleanupTeamRuntimeState(root2, teamNames);
           const prunedMissions = pruneMissionBoardTeams(root2, teamNames);
           const details = [];
-          if (removedRoots > 0) details.push(`removed ${removedRoots} team runtime root(s)`);
-          if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
+          if (removedRoots > 0)
+            details.push(`removed ${removedRoots} team runtime root(s)`);
+          if (prunedMissions > 0)
+            details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
           return details.length > 0 ? ` (${details.join(", ")})` : "";
         })();
-        const clearedStateOrArtifacts = completedSessionCleanup.cleared + sessionCleanup.cleared + legacyCleanup.cleared + convergedCleanup2.cleared + workingDirectoryLocalCleanup.cleared + ownerSessionCleanup.cleared + ownerLegacyCleanup.cleared + runtimeCleanup2.cleared;
-        const capturedCleanupIncomplete = operationCandidates.some((candidate) => (0, import_fs30.existsSync)(candidate.path));
-        const hadFailure = capturedCleanupIncomplete || legacyCleanup.hadFailure || sessionCleanup.hadFailure || workingDirectoryLocalCleanup.hadFailure || convergedCleanup2.hadFailure || completedSessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure || runtimeCleanup2.hadFailure;
+        const clearedStateOrArtifacts = completedSessionCleanup.cleared + sessionCleanup.cleared + legacyCleanup.cleared + convergedCleanup.cleared + workingDirectoryLocalCleanup.cleared + ownerSessionCleanup.cleared + ownerLegacyCleanup.cleared + runtimeCleanup2.cleared;
+        const capturedCleanupIncomplete = operationCandidates.some(
+          (candidate) => (0, import_fs30.existsSync)(candidate.path)
+        );
+        const hadFailure = capturedCleanupIncomplete || legacyCleanup.hadFailure || sessionCleanup.hadFailure || workingDirectoryLocalCleanup.hadFailure || convergedCleanup.hadFailure || completedSessionCleanup.hadFailure || ownerSessionCleanup.hadFailure || ownerLegacyCleanup.hadFailure || runtimeCleanup2.hadFailure;
         if (!ownerSessionId && clearedStateOrArtifacts === 0 && !hadFailure) {
           return {
-            content: [{
-              type: "text",
-              text: formatStateClearNoopMessage(mode, root2, sessionId)
-            }]
+            content: [
+              {
+                type: "text",
+                text: formatStateClearNoopMessage(mode, root2, sessionId)
+              }
+            ]
           };
         }
         return {
-          content: [{
-            type: "text",
-            text: `${hadFailure ? "Warning: Some files could not be removed" : "Successfully cleared state"} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
-          }],
+          content: [
+            {
+              type: "text",
+              text: `${hadFailure ? "Warning: Some files could not be removed" : "Successfully cleared state"} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
+            }
+          ],
           ...hadFailure ? { isError: true } : {}
         };
       }
-      const broadLegacyCandidates = discoverStatePaths(getLegacyStateFileCandidates(mode, root2)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-      const broadSessionCandidates = [...new Map([
-        ...listSessionIds(root2).flatMap((sid) => findSessionOwnedStateCandidates(mode, sid, root2)),
-        ...discoverAllRootSessionStateCandidates(mode, root2)
-      ].map((candidate) => [candidate.path, candidate])).values()].filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-      const broadConvergedCandidates = discoverStatePaths(getConvergedStateCandidates(mode, root2)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2));
-      const broadOperationCandidates = [...new Map([
-        ...broadLegacyCandidates,
-        ...broadSessionCandidates,
-        ...broadConvergedCandidates
-      ].map((candidate) => [candidate.path, candidate])).values()];
-      const broadNamedPrimaries = mode === "autopilot" ? broadOperationCandidates.filter((candidate) => hasNamedWorkflowMarker(candidate.state)) : [];
+      const broadLegacyCandidates = discoverStatePaths(
+        getLegacyStateFileCandidates(mode, root2)
+      ).filter(
+        (candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2)
+      );
+      const broadSessionCandidates = [
+        ...new Map(
+          [
+            ...listSessionIds(root2).flatMap(
+              (sid) => findSessionOwnedStateCandidates(mode, sid, root2)
+            ),
+            ...discoverAllRootSessionStateCandidates(mode, root2)
+          ].map((candidate) => [candidate.path, candidate])
+        ).values()
+      ].filter(
+        (candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2)
+      );
+      const broadConvergedCandidates = discoverStatePaths(
+        getConvergedStateCandidates(mode, root2)
+      ).filter(
+        (candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root2)
+      );
+      const broadOperationCandidates = [
+        ...new Map(
+          [
+            ...broadLegacyCandidates,
+            ...broadSessionCandidates,
+            ...broadConvergedCandidates
+          ].map((candidate) => [candidate.path, candidate])
+        ).values()
+      ];
+      const broadNamedPrimaries = mode === "autopilot" ? broadOperationCandidates.filter(
+        (candidate) => hasNamedWorkflowMarker(candidate.state)
+      ) : [];
       for (const candidate of broadNamedPrimaries) {
         const success = clearAutopilotMarkerCandidate(candidate, root2);
-        if (!success || (0, import_fs30.existsSync)(candidate.path)) throw new Error(`primary state mutation failed; dependent state preserved: ${candidate.path}`);
+        if (!success || (0, import_fs30.existsSync)(candidate.path))
+          throw new Error(
+            `primary state mutation failed; dependent state preserved: ${candidate.path}`
+          );
       }
-      const broadLegacySignalCandidates = broadLegacyCandidates.filter((candidate) => !hasNamedWorkflowMarker(candidate.state));
-      const broadSessionSignalCandidates = broadSessionCandidates.filter((candidate) => !hasNamedWorkflowMarker(candidate.state));
+      const broadLegacySignalCandidates = broadLegacyCandidates.filter(
+        (candidate) => !hasNamedWorkflowMarker(candidate.state)
+      );
+      const broadSessionSignalCandidates = broadSessionCandidates.filter(
+        (candidate) => !hasNamedWorkflowMarker(candidate.state)
+      );
       if (broadLegacySignalCandidates.length > 0 || broadSessionSignalCandidates.length > 0) {
         const now = Date.now();
         const cancelSignalPayload = {
@@ -87988,28 +90810,77 @@ var stateClearTool = {
         collectTeamNamesForCleanup(getStateFilePath(root2, "team"));
       }
       if (MODE_CONFIGS[mode]) {
-        const primaryLegacyStatePath = getStateFilePath(root2, mode);
-        const primaryCandidate = broadLegacyCandidates.find((candidate) => candidate.path === primaryLegacyStatePath);
+        const primaryLegacyStatePath = getStateFilePath(
+          root2,
+          mode
+        );
+        const primaryCandidate = broadLegacyCandidates.find(
+          (candidate) => candidate.path === primaryLegacyStatePath
+        );
+        const skippedCanonicalPaths = /* @__PURE__ */ new Set();
         if (primaryCandidate) {
-          const success = clearModeState(mode, root2, void 0, primaryCandidate.state);
-          if (success && !(0, import_fs30.existsSync)(primaryCandidate.path)) {
+          const clearResult = clearModeStateDetailed(
+            mode,
+            root2,
+            void 0,
+            primaryCandidate.state
+          );
+          if (clearResult === "cleared" && !(0, import_fs30.existsSync)(primaryCandidate.path)) {
             clearedCount++;
+          } else if (clearResult === "skipped") {
+            skippedCanonicalPaths.add(primaryCandidate.path);
+            errors.push("legacy path skipped");
           } else if ((0, import_fs30.existsSync)(primaryCandidate.path)) {
             errors.push("legacy path skipped");
-          } else if (!success) {
+          } else if (clearResult === "failed") {
             errors.push("legacy path");
           }
         }
-      }
-      const extraLegacyCleanup = clearLegacyStateCandidates(mode, root2, void 0, broadLegacyCandidates);
-      clearedCount += extraLegacyCleanup.cleared;
-      if (extraLegacyCleanup.hadFailure) {
-        errors.push("legacy path");
-      }
-      const convergedCleanup = clearConvergedStateCandidates(mode, root2, void 0, broadConvergedCandidates);
-      clearedCount += convergedCleanup.cleared;
-      if (convergedCleanup.hadFailure) {
-        errors.push("converged paths");
+        const extraLegacyCleanup = clearLegacyStateCandidates(
+          mode,
+          root2,
+          void 0,
+          broadLegacyCandidates.filter(
+            (candidate) => !skippedCanonicalPaths.has(candidate.path)
+          )
+        );
+        clearedCount += extraLegacyCleanup.cleared;
+        if (extraLegacyCleanup.hadFailure) {
+          errors.push("legacy path");
+        }
+        const convergedCleanup = clearConvergedStateCandidates(
+          mode,
+          root2,
+          void 0,
+          broadConvergedCandidates.filter(
+            (candidate) => !skippedCanonicalPaths.has(candidate.path)
+          )
+        );
+        clearedCount += convergedCleanup.cleared;
+        if (convergedCleanup.hadFailure) {
+          errors.push("converged paths");
+        }
+      } else {
+        const extraLegacyCleanup = clearLegacyStateCandidates(
+          mode,
+          root2,
+          void 0,
+          broadLegacyCandidates
+        );
+        clearedCount += extraLegacyCleanup.cleared;
+        if (extraLegacyCleanup.hadFailure) {
+          errors.push("legacy path");
+        }
+        const convergedCleanup = clearConvergedStateCandidates(
+          mode,
+          root2,
+          void 0,
+          broadConvergedCandidates
+        );
+        clearedCount += convergedCleanup.cleared;
+        if (convergedCleanup.hadFailure) {
+          errors.push("converged paths");
+        }
       }
       clearedCount += runtimeCleanup.cleared;
       if (runtimeCleanup.hadFailure) {
@@ -88023,24 +90894,34 @@ var stateClearTool = {
         if (processedBroadPaths.has(candidate.path)) continue;
         processedBroadPaths.add(candidate.path);
         if (mode === "team") collectTeamNamesForCleanup(candidate.path);
-        const result = clearDiscoveredStateCandidate(candidate, (current) => isStateCandidateForProject(mode, candidate.path, current, root2), emergencyRecoveryOptionsForProject(mode, candidate.path, root2));
+        const result = clearDiscoveredStateCandidate(
+          candidate,
+          (current) => isStateCandidateForProject(mode, candidate.path, current, root2),
+          emergencyRecoveryOptionsForProject(mode, candidate.path, root2)
+        );
         if (result === "cleared") {
           clearedCount++;
         } else if (result === "failed" || (0, import_fs30.existsSync)(candidate.path)) {
           errors.push(`session candidate: ${candidate.path}`);
         }
       }
-      const broadCapturedCandidates = [...new Map([
-        ...broadLegacyCandidates,
-        ...broadConvergedCandidates,
-        ...broadSessionCandidates
-      ].map((candidate) => [candidate.path, candidate])).values()];
+      const broadCapturedCandidates = [
+        ...new Map(
+          [
+            ...broadLegacyCandidates,
+            ...broadConvergedCandidates,
+            ...broadSessionCandidates
+          ].map((candidate) => [candidate.path, candidate])
+        ).values()
+      ];
       for (const candidate of broadCapturedCandidates) {
         if ((0, import_fs30.existsSync)(candidate.path) && !errors.some((error2) => error2.includes(candidate.path))) {
           errors.push(`captured candidate survived: ${candidate.path}`);
         }
       }
-      clearedCount = broadCapturedCandidates.filter((candidate) => !(0, import_fs30.existsSync)(candidate.path)).length + runtimeCleanup.cleared;
+      clearedCount = broadCapturedCandidates.filter(
+        (candidate) => !(0, import_fs30.existsSync)(candidate.path)
+      ).length + runtimeCleanup.cleared;
       let removedTeamRoots = 0;
       let prunedMissionEntries = 0;
       if (mode === "team") {
@@ -88051,10 +90932,12 @@ var stateClearTool = {
       }
       if (clearedCount === 0 && errors.length === 0 && removedTeamRoots === 0 && prunedMissionEntries === 0) {
         return {
-          content: [{
-            type: "text",
-            text: formatStateClearNoopMessage(mode, root2)
-          }]
+          content: [
+            {
+              type: "text",
+              text: formatStateClearNoopMessage(mode, root2)
+            }
+          ]
         };
       }
       let message2 = `Cleared state for mode: ${mode}
@@ -88075,18 +90958,22 @@ var stateClearTool = {
       }
       message2 += "\nWARNING: No session_id provided. Cleared legacy plus all session-scoped state; this is a broad operation that may affect other sessions.";
       return {
-        content: [{
-          type: "text",
-          text: message2
-        }],
+        content: [
+          {
+            type: "text",
+            text: message2
+          }
+        ],
         ...errors.length > 0 ? { isError: true } : {}
       };
     } catch (error2) {
       return {
-        content: [{
-          type: "text",
-          text: `Error clearing state for ${mode}: ${error2 instanceof Error ? error2.message : String(error2)}`
-        }],
+        content: [
+          {
+            type: "text",
+            text: `Error clearing state for ${mode}: ${error2 instanceof Error ? error2.message : String(error2)}`
+          }
+        ],
         isError: true
       };
     }
@@ -88095,11 +90982,20 @@ var stateClearTool = {
 var stateListActiveTool = {
   name: "state_list_active",
   description: "List all currently active modes. By default, scopes to the current session (OMC_SESSION_ID). Pass all:true to list active modes across all sessions.",
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  },
   schema: {
     workingDirectory: external_exports.string().optional().describe("Working directory (defaults to cwd)"),
-    session_id: external_exports.string().optional().describe("Explicit session ID to scope the listing. Overrides OMC_SESSION_ID when provided."),
-    all: external_exports.boolean().optional().describe("When true, list active modes across all sessions (legacy + every session-scoped dir). Overrides the default current-session scope.")
+    session_id: external_exports.string().optional().describe(
+      "Explicit session ID to scope the listing. Overrides OMC_SESSION_ID when provided."
+    ),
+    all: external_exports.boolean().optional().describe(
+      "When true, list active modes across all sessions (legacy + every session-scoped dir). Overrides the default current-session scope."
+    )
   },
   handler: async (args) => {
     const { workingDirectory, session_id, all } = args;
@@ -88131,22 +91027,26 @@ var stateListActiveTool = {
         }
         if (activeModes.length === 0) {
           return {
-            content: [{
-              type: "text",
-              text: `## Active Modes (session: ${sessionId})
+            content: [
+              {
+                type: "text",
+                text: `## Active Modes (session: ${sessionId})
 
 No modes are currently active in this session.`
-            }]
+              }
+            ]
           };
         }
         const modeList = activeModes.map((mode) => `- **${mode}**`).join("\n");
         return {
-          content: [{
-            type: "text",
-            text: `## Active Modes (session: ${sessionId}, ${activeModes.length})
+          content: [
+            {
+              type: "text",
+              text: `## Active Modes (session: ${sessionId}, ${activeModes.length})
 
 ${modeList}`
-          }]
+            }
+          ]
         };
       }
       const modeSessionMap = /* @__PURE__ */ new Map();
@@ -88200,10 +91100,12 @@ ${modeList}`
       }
       if (modeSessionMap.size === 0) {
         return {
-          content: [{
-            type: "text",
-            text: "## Active Modes\n\nNo modes are currently active."
-          }]
+          content: [
+            {
+              type: "text",
+              text: "## Active Modes\n\nNo modes are currently active."
+            }
+          ]
         };
       }
       const lines = [`## Active Modes (${modeSessionMap.size})
@@ -88212,17 +91114,21 @@ ${modeList}`
         lines.push(`- **${mode}** (${sessions.join(", ")})`);
       }
       return {
-        content: [{
-          type: "text",
-          text: lines.join("\n")
-        }]
+        content: [
+          {
+            type: "text",
+            text: lines.join("\n")
+          }
+        ]
       };
     } catch (error2) {
       return {
-        content: [{
-          type: "text",
-          text: `Error listing active modes: ${error2 instanceof Error ? error2.message : String(error2)}`
-        }],
+        content: [
+          {
+            type: "text",
+            text: `Error listing active modes: ${error2 instanceof Error ? error2.message : String(error2)}`
+          }
+        ],
         isError: true
       };
     }
@@ -88231,11 +91137,18 @@ ${modeList}`
 var stateGetStatusTool = {
   name: "state_get_status",
   description: "Get detailed status for a specific mode or all modes. Shows active status, file paths, and state contents.",
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false
+  },
   schema: {
     mode: external_exports.enum(STATE_TOOL_MODES).optional().describe("Specific mode to check (omit for all modes)"),
     workingDirectory: external_exports.string().optional().describe("Working directory (defaults to cwd)"),
-    session_id: external_exports.string().optional().describe("Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).")
+    session_id: external_exports.string().optional().describe(
+      "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions)."
+    )
   },
   handler: async (args) => {
     const { mode, workingDirectory, session_id } = args;
@@ -88261,9 +91174,13 @@ var stateGetStatusTool = {
           if ((0, import_fs30.existsSync)(statePath)) {
             try {
               const content = (0, import_fs30.readFileSync)(statePath, "utf-8");
-              const state = JSON.parse(content);
-              statePreview = JSON.stringify(publicStateForMode(mode, state), null, 2).slice(0, 500);
-              if (statePreview.length >= 500) statePreview += "\n...(truncated)";
+              statePreview = JSON.stringify(
+                parsePublicStateContent(mode, content),
+                null,
+                2
+              ).slice(0, 500);
+              if (statePreview.length >= 500)
+                statePreview += "\n...(truncated)";
             } catch {
               statePreview = "Error reading state file";
             }
@@ -88272,16 +91189,20 @@ var stateGetStatusTool = {
           lines2.push(`- **Active:** ${active ? "Yes" : "No"}`);
           lines2.push(`- **State Path:** ${statePath}`);
           lines2.push(`- **Exists:** ${(0, import_fs30.existsSync)(statePath) ? "Yes" : "No"}`);
-          lines2.push(`
+          lines2.push(
+            `
 ### State Preview
 \`\`\`json
 ${statePreview}
-\`\`\``);
+\`\`\``
+          );
           return {
-            content: [{
-              type: "text",
-              text: lines2.join("\n")
-            }]
+            content: [
+              {
+                type: "text",
+                text: lines2.join("\n")
+              }
+            ]
           };
         }
         const legacyPath = getStatePath(mode, root2);
@@ -88322,10 +91243,12 @@ ${statePreview}
 No active sessions for this mode.`);
         }
         return {
-          content: [{
-            type: "text",
-            text: lines2.join("\n")
-          }]
+          content: [
+            {
+              type: "text",
+              text: lines2.join("\n")
+            }
+          ]
         };
       }
       const statuses = getAllModeStatuses(root2, sessionId);
@@ -88333,7 +91256,9 @@ No active sessions for this mode.`);
 `] : ["## All Mode Statuses\n"];
       for (const status of statuses) {
         const icon = status.active ? "[ACTIVE]" : "[INACTIVE]";
-        lines.push(`${icon} **${status.mode}**: ${status.active ? "Active" : "Inactive"}`);
+        lines.push(
+          `${icon} **${status.mode}**: ${status.active ? "Active" : "Inactive"}`
+        );
         lines.push(`   Path: \`${status.stateFilePath}\``);
         if (!sessionId && MODE_CONFIGS[status.mode]) {
           const activeSessions = getActiveSessionsForMode(status.mode, root2);
@@ -88358,17 +91283,21 @@ No active sessions for this mode.`);
         lines.push(`   Path: \`${statePath}\``);
       }
       return {
-        content: [{
-          type: "text",
-          text: lines.join("\n")
-        }]
+        content: [
+          {
+            type: "text",
+            text: lines.join("\n")
+          }
+        ]
       };
     } catch (error2) {
       return {
-        content: [{
-          type: "text",
-          text: `Error getting status: ${error2 instanceof Error ? error2.message : String(error2)}`
-        }],
+        content: [
+          {
+            type: "text",
+            text: `Error getting status: ${error2 instanceof Error ? error2.message : String(error2)}`
+          }
+        ],
         isError: true
       };
     }
@@ -88383,58 +91312,138 @@ var stateTools = [
   {
     name: "merge_readiness_start",
     description: "Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick or --deep; standard is the default when neither flag is present). Re-running it while an active attempt is still pending is rejected - cancel via merge_readiness_cancel or let the attempt pass/pause first, so the in-progress audit trail is never silently overwritten.",
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false
+    },
     schema: {
       summary: external_exports.string().max(2e3),
-      baseRef: external_exports.string().max(200).regex(/^[A-Za-z0-9._\/@{}~^:-]+$/, "baseRef must be a valid git ref").refine((s) => !s.startsWith("-"), "baseRef must not start with '-'").optional().describe("Base ref to diff committed changes against (e.g. origin/dev, HEAD, HEAD~1, HEAD^). Defaults to the branch upstream / origin/HEAD."),
+      baseRef: external_exports.string().max(200).regex(/^[A-Za-z0-9._\/@{}~^:-]+$/, "baseRef must be a valid git ref").refine((s) => !s.startsWith("-"), "baseRef must not start with '-'").optional().describe(
+        "Base ref to diff committed changes against (e.g. origin/dev, HEAD, HEAD~1, HEAD^). Defaults to the branch upstream / origin/HEAD."
+      ),
       workingDirectory: external_exports.string().optional(),
       session_id: external_exports.string().optional()
     },
     handler: async (args) => {
       try {
-        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd()
+        );
         const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
-        const state = createInitialMergeReadinessState(directory, args.summary, sessionId, args.baseRef);
+        const state = createInitialMergeReadinessState(
+          directory,
+          args.summary,
+          sessionId,
+          args.baseRef
+        );
         const blocked = state.result === "blocked";
-        return { content: [{ type: "text", text: blocked ? `Merge-readiness blocked: ${state.validation_errors?.join(" ") ?? "missing evidence"}` : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.` }], ...blocked ? { isError: true } : {} };
+        return {
+          content: [
+            {
+              type: "text",
+              text: blocked ? `Merge-readiness blocked: ${state.validation_errors?.join(" ") ?? "missing evidence"}` : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.`
+            }
+          ],
+          ...blocked ? { isError: true } : {}
+        };
       } catch (error2) {
-        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}`
+            }
+          ],
+          isError: true
+        };
       }
     }
   },
   {
     name: "merge_readiness_set_content",
     description: "Validate and submit the five-section merge-readiness report and objective MCQs. Requires an active gate (call merge_readiness_start first).",
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false
+    },
     schema: {
       why: external_exports.string().max(1e4),
       whatChanged: external_exports.string().max(1e4),
       tradeoffs: external_exports.string().max(1e4),
       risksConsidered: external_exports.string().max(1e4),
       teamUnderstanding: external_exports.string().max(1e4),
-      questions: external_exports.array(external_exports.object({ id: external_exports.string().max(100), dimension: external_exports.enum(["why", "change", "tradeoff", "risk", "team"]), stem: external_exports.string().max(2e3), options: external_exports.array(external_exports.object({ id: external_exports.string().max(100), text: external_exports.string().max(1e3) })).max(8), correctOptionId: external_exports.string().max(100), rationale: external_exports.string().max(2e3).optional() })).max(8),
+      questions: external_exports.array(
+        external_exports.object({
+          id: external_exports.string().max(100),
+          dimension: external_exports.enum(["why", "change", "tradeoff", "risk", "team"]),
+          stem: external_exports.string().max(2e3),
+          options: external_exports.array(
+            external_exports.object({
+              id: external_exports.string().max(100),
+              text: external_exports.string().max(1e3)
+            })
+          ).max(8),
+          correctOptionId: external_exports.string().max(100),
+          rationale: external_exports.string().max(2e3).optional()
+        })
+      ).max(8),
       workingDirectory: external_exports.string().optional(),
       session_id: external_exports.string().optional()
     },
     handler: async (args) => {
       try {
-        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd()
+        );
         const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
         const state = setMergeReadinessContent(directory, args, sessionId);
         if (!state || !state.active) {
-          return { content: [{ type: "text", text: "Merge-readiness content rejected: no active gate (the gate is missing or already terminal - pass/cancelled/overridden). Call merge_readiness_start first." }], isError: true };
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Merge-readiness content rejected: no active gate (the gate is missing or already terminal - pass/cancelled/overridden). Call merge_readiness_start first."
+              }
+            ],
+            isError: true
+          };
         }
         const errors = state.validation_errors ?? [];
-        return { content: [{ type: "text", text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(" ")}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? "none"}` }], ...errors.length > 0 ? { isError: true } : {} };
+        return {
+          content: [
+            {
+              type: "text",
+              text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(" ")}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? "none"}`
+            }
+          ],
+          ...errors.length > 0 ? { isError: true } : {}
+        };
       } catch (error2) {
-        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}`
+            }
+          ],
+          isError: true
+        };
       }
     }
   },
   {
     name: "merge_readiness_record_answer",
     description: "Record the human-selected option for the current merge-readiness MCQ. Advances the gate; returns the next question or the final result plus readiness score.",
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false
+    },
     schema: {
       questionId: external_exports.string().max(100),
       optionId: external_exports.string().max(100),
@@ -88443,67 +91452,165 @@ var stateTools = [
     },
     handler: async (args) => {
       try {
-        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd()
+        );
         const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
-        const state = recordMergeReadinessMCQAnswer(directory, args.questionId, args.optionId, sessionId);
+        const state = recordMergeReadinessMCQAnswer(
+          directory,
+          args.questionId,
+          args.optionId,
+          sessionId
+        );
         if (!state) {
-          return { content: [{ type: "text", text: "Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ." }], isError: true };
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ."
+              }
+            ],
+            isError: true
+          };
         }
         const result = state.result;
         const score = state.readiness_score;
         const persistFailed = result === "blocked" && (state.validation_errors ?? []).some((e) => e.includes("persisted"));
         const text = persistFailed ? `Merge-readiness answer NOT recorded: state could not be persisted (read-only state dir / full disk / invalid path). The gate is still armed on disk. ${(state.validation_errors ?? []).join(" ")}` : result === "pass" || result === "paused" || result === "blocked" || result === "overridden" ? `Merge-readiness ${result}. Readiness score: ${score}. ${result === "pass" ? "The change may proceed to human merge approval." : result === "paused" ? "Explanation gap remains; reread the report and rerun /merge-readiness." : result === "blocked" ? "Missing evidence; produce it before rerunning." : "Gate overridden; terminal session state preserves the record."}` : `Answer recorded. Next question: ${state.pending_question?.id ?? "none"}. Answered: ${state.answers.length}/${state.questions.length}.`;
-        return { content: [{ type: "text", text }], ...persistFailed ? { isError: true } : {} };
+        return {
+          content: [{ type: "text", text }],
+          ...persistFailed ? { isError: true } : {}
+        };
       } catch (error2) {
-        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}`
+            }
+          ],
+          isError: true
+        };
       }
     }
   },
   {
     name: "merge_readiness_report",
     description: "Render the authoritative merge-readiness session state as a Markdown report without writing a file.",
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-    schema: { workingDirectory: external_exports.string().optional(), session_id: external_exports.string().optional() },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    },
+    schema: {
+      workingDirectory: external_exports.string().optional(),
+      session_id: external_exports.string().optional()
+    },
     handler: async (args) => {
       try {
-        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd()
+        );
         const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
         const state = readMergeReadinessState(directory, sessionId);
         if (!state) {
-          return { content: [{ type: "text", text: "Merge-readiness report unavailable: no session state found." }], isError: true };
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Merge-readiness report unavailable: no session state found."
+              }
+            ],
+            isError: true
+          };
         }
-        return { content: [{ type: "text", text: formatMergeReadinessReport(state) }] };
+        return {
+          content: [
+            { type: "text", text: formatMergeReadinessReport(state) }
+          ]
+        };
       } catch (error2) {
-        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}`
+            }
+          ],
+          isError: true
+        };
       }
     }
   },
   {
     name: "merge_readiness_cancel",
     description: "Cancel an active merge-readiness gate while preserving its terminal state audit record.",
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-    schema: { workingDirectory: external_exports.string().optional(), session_id: external_exports.string().optional() },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    },
+    schema: {
+      workingDirectory: external_exports.string().optional(),
+      session_id: external_exports.string().optional()
+    },
     handler: async (args) => {
       try {
-        const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd()
+        );
         const sessionId = args.session_id && args.session_id.trim() || process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim() || resolveSessionId({ context: "cli" });
         const state = cancelMergeReadiness(directory, sessionId);
         const persistFailed = state?.result === "blocked" && (state.validation_errors ?? []).some((e) => e.includes("persisted"));
         if (persistFailed) {
-          return { content: [{ type: "text", text: `Merge-readiness cancellation FAILED: state could not be persisted (read-only state dir / full disk). The gate is still armed on disk. ${(state?.validation_errors ?? []).join(" ")}` }], isError: true };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Merge-readiness cancellation FAILED: state could not be persisted (read-only state dir / full disk). The gate is still armed on disk. ${(state?.validation_errors ?? []).join(" ")}`
+              }
+            ],
+            isError: true
+          };
         }
         if (!state || state.result !== "cancelled") {
-          return { content: [{ type: "text", text: "Merge-readiness cancellation rejected: no active gate." }], isError: true };
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Merge-readiness cancellation rejected: no active gate."
+              }
+            ],
+            isError: true
+          };
         }
-        return { content: [{ type: "text", text: "Merge-readiness cancelled. Terminal session state preserved as the audit record." }] };
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Merge-readiness cancelled. Terminal session state preserved as the audit record."
+            }
+          ]
+        };
       } catch (error2) {
-        return { content: [{ type: "text", text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Merge-readiness error: ${error2 instanceof Error ? error2.message : String(error2)}`
+            }
+          ],
+          isError: true
+        };
       }
     }
   }
 ];
 
 // src/tools/notepad-tools.ts
+init_zod();
 init_worktree_paths();
 
 // src/hooks/notepad/index.ts
@@ -89062,6 +92169,7 @@ var notepadTools = [
 ];
 
 // src/tools/memory-tools.ts
+init_zod();
 init_worktree_paths();
 
 // src/hooks/project-memory/index.ts
@@ -89277,7 +92385,7 @@ function mergeArrays(fieldName, base, incoming) {
       return mergeScalarArray(base, incoming);
   }
 }
-function mergeByKey(base, incoming, keyFn, resolve32) {
+function mergeByKey(base, incoming, keyFn, resolve33) {
   const seen = /* @__PURE__ */ new Map();
   for (const item of base) {
     seen.set(keyFn(item), item);
@@ -89286,7 +92394,7 @@ function mergeByKey(base, incoming, keyFn, resolve32) {
     const key = keyFn(item);
     const existing = seen.get(key);
     if (existing) {
-      seen.set(key, resolve32(existing, item));
+      seen.set(key, resolve33(existing, item));
     } else {
       seen.set(key, item);
     }
@@ -89527,10 +92635,14 @@ var memoryTools = [
 ];
 
 // src/tools/trace-tools.ts
+init_zod();
 var import_fs36 = require("fs");
 var import_path47 = require("path");
 init_session_replay();
 init_worktree_paths();
+
+// src/tools/session-history-tools.ts
+init_zod();
 
 // src/features/session-history-search/index.ts
 var import_child_process15 = require("child_process");
@@ -90358,6 +93470,7 @@ No events recorded.`
 var traceTools = [traceTimelineTool, traceSummaryTool, sessionSearchTool];
 
 // src/tools/shared-memory-tools.ts
+init_zod();
 init_worktree_paths();
 init_config_dir();
 
@@ -90804,9 +93917,13 @@ var sharedMemoryTools = [
   sharedMemoryCleanupTool
 ];
 
+// src/interop/mcp-bridge.ts
+init_zod();
+
 // src/interop/shared-state.ts
 var import_path50 = require("path");
 var import_fs39 = require("fs");
+init_zod();
 init_atomic_write();
 init_file_lock();
 init_worktree_paths();
@@ -91074,6 +94191,7 @@ var import_promises5 = require("fs/promises");
 var import_path51 = require("path");
 var import_fs40 = require("fs");
 var import_crypto13 = require("crypto");
+init_zod();
 init_atomic_write();
 var OmxWorkerInfoSchema = external_exports.object({
   name: external_exports.string(),
@@ -91741,6 +94859,7 @@ function getInteropTools() {
 }
 
 // src/tools/deepinit-manifest.ts
+init_zod();
 var import_node_fs = require("node:fs");
 var import_node_path = require("node:path");
 init_worktree_paths();
@@ -91816,9 +94935,9 @@ function scanDirectories(projectRoot) {
       return;
     }
     try {
-      const stat2 = (0, import_node_fs.statSync)(absDir);
-      if (visitedInodes.has(stat2.ino)) return;
-      visitedInodes.add(stat2.ino);
+      const stat3 = (0, import_node_fs.statSync)(absDir);
+      if (visitedInodes.has(stat3.ino)) return;
+      visitedInodes.add(stat3.ino);
     } catch {
       return;
     }
@@ -92054,14 +95173,15 @@ var deepinitManifestTool = {
 };
 
 // src/tools/wiki-tools.ts
+init_zod();
 init_worktree_paths();
 
 // src/hooks/wiki/index.ts
-init_types5();
+init_types6();
 init_storage();
 
 // src/hooks/wiki/ingest.ts
-init_types5();
+init_types6();
 init_storage();
 function ingestKnowledge(root2, input) {
   const slug = titleToSlug(input.title);
@@ -92237,7 +95357,7 @@ function queryWiki(root2, queryText, options = {}) {
 }
 
 // src/hooks/wiki/lint.ts
-init_types5();
+init_types6();
 init_storage();
 function lintWiki(root2, config2 = DEFAULT_WIKI_CONFIG) {
   const pages = readAllPages(root2);
@@ -93291,6 +96411,7 @@ ${getBackgroundTaskGuidance(DEFAULT_MAX_BACKGROUND_TASKS)}
 init_skininthegamebros_guidance();
 
 // src/tools/index.ts
+init_zod();
 var allCustomTools = [
   ...lspTools,
   ...astTools,
@@ -93503,6 +96624,7 @@ function isHeavyMode(keywordType) {
 // src/hooks/keyword-detector/index.ts
 var KEYWORD_PATTERNS = {
   cancel: /\b(cancelomc|stopomc)\b/i,
+  graph: /(?!x)x/,
   ralph: /\b(ralph)\b(?!-)|(랄프)(?!로렌)|(ラルフ)(?!・?ローレン)/i,
   autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|\b(?:build|create|make)\s+me\s+(?:an?\s+)?(?:app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b|\bi\s+want\s+an?\s+(?:app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b|(오토파일럿)|(オートパイロット)/i,
   ultrawork: /\b(ultrawork|ulw)\b|(울트라워크)|(ウルトラワーク)/i,
@@ -93530,6 +96652,7 @@ var KEYWORD_SKIP_PREDICATES = {
 };
 var KEYWORD_PRIORITY = [
   "cancel",
+  "graph",
   "ralph",
   "autopilot",
   "team",
@@ -93550,6 +96673,7 @@ var KEYWORD_PRIORITY = [
 ];
 var CANONICAL_WORKFLOW_SLASH_SKILLS = [
   "autopilot",
+  "graph",
   "ralph",
   "team",
   "ultrawork",
@@ -93560,6 +96684,7 @@ var CANONICAL_WORKFLOW_SLASH_SKILLS = [
 ];
 var SLASH_SKILL_TO_KEYWORD_TYPE = {
   autopilot: "autopilot",
+  graph: "graph",
   ralph: "ralph",
   team: "team",
   ultrawork: "ultrawork",
@@ -94140,7 +97265,7 @@ init_todo_continuation();
 
 // src/hooks/bridge.ts
 var import_url14 = require("url");
-var import_fs86 = require("fs");
+var import_fs87 = require("fs");
 var import_path103 = require("path");
 init_worktree_paths();
 init_mode_state_io();
@@ -94701,6 +97826,7 @@ ${buildVerificationReminder()}
 }
 
 // src/hooks/bridge-normalize.ts
+init_zod();
 init_worktree_paths();
 var HookInputSchema = external_exports.object({
   // snake_case fields from Claude Code
@@ -95379,8 +98505,8 @@ function readLinuxBootId() {
   const testBootId = process.env.OMC_TEST_BOOT_ID?.trim();
   if (testBootId) return testBootId;
   try {
-    if (!(0, import_fs86.existsSync)(LINUX_BOOT_ID_PATH)) return void 0;
-    const bootId = (0, import_fs86.readFileSync)(LINUX_BOOT_ID_PATH, "utf-8").trim();
+    if (!(0, import_fs87.existsSync)(LINUX_BOOT_ID_PATH)) return void 0;
+    const bootId = (0, import_fs87.readFileSync)(LINUX_BOOT_ID_PATH, "utf-8").trim();
     return bootId.length > 0 ? bootId : void 0;
   } catch {
     return void 0;
@@ -95394,8 +98520,8 @@ function sessionStartedMarkerPath(directory, sessionId) {
 }
 function readJsonObject2(filePath) {
   try {
-    if (!(0, import_fs86.existsSync)(filePath)) return null;
-    const parsed = JSON.parse((0, import_fs86.readFileSync)(filePath, "utf-8"));
+    if (!(0, import_fs87.existsSync)(filePath)) return null;
+    const parsed = JSON.parse((0, import_fs87.readFileSync)(filePath, "utf-8"));
     return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
   } catch {
     return null;
@@ -95405,7 +98531,7 @@ function writeSessionStartedMarker(directory, sessionId) {
   if (!sessionId || !SAFE_SESSION_ID_PATTERN.test(sessionId)) return;
   try {
     const dir = sessionStateDir(directory, sessionId);
-    (0, import_fs86.mkdirSync)(dir, { recursive: true });
+    (0, import_fs87.mkdirSync)(dir, { recursive: true });
     const marker = {
       session_id: sessionId,
       started_at: (/* @__PURE__ */ new Date()).toISOString(),
@@ -95417,7 +98543,7 @@ function writeSessionStartedMarker(directory, sessionId) {
       // later SessionStart hooks to falsely clean live session state.
       boot_id: readLinuxBootId()
     };
-    (0, import_fs86.writeFileSync)(sessionStartedMarkerPath(directory, sessionId), JSON.stringify(marker, null, 2), {
+    (0, import_fs87.writeFileSync)(sessionStartedMarkerPath(directory, sessionId), JSON.stringify(marker, null, 2), {
       encoding: "utf-8",
       mode: 384
     });
@@ -95428,14 +98554,14 @@ function removeSessionStartedMarker(directory, sessionId) {
   if (!sessionId || !SAFE_SESSION_ID_PATTERN.test(sessionId)) return;
   try {
     const markerPath = sessionStartedMarkerPath(directory, sessionId);
-    if ((0, import_fs86.existsSync)(markerPath)) {
-      (0, import_fs86.unlinkSync)(markerPath);
+    if ((0, import_fs87.existsSync)(markerPath)) {
+      (0, import_fs87.unlinkSync)(markerPath);
     }
   } catch {
   }
 }
 function hasSessionEndSummary(directory, sessionId) {
-  return (0, import_fs86.existsSync)((0, import_path103.join)(getOmcRoot(directory), "sessions", `${sessionId}.json`));
+  return (0, import_fs87.existsSync)((0, import_path103.join)(getOmcRoot(directory), "sessions", `${sessionId}.json`));
 }
 function cleanupSessionModeStateFiles(directory, sessionId) {
   const dir = sessionStateDir(directory, sessionId);
@@ -95444,7 +98570,7 @@ function cleanupSessionModeStateFiles(directory, sessionId) {
     const state = readJsonObject2(filePath);
     if (state?.active === true || file === "skill-active-state.json") {
       try {
-        (0, import_fs86.unlinkSync)(filePath);
+        (0, import_fs87.unlinkSync)(filePath);
       } catch {
       }
     }
@@ -95463,7 +98589,7 @@ function cleanupMissionStateForSession(directory, sessionId) {
   if (parsed.missions.length === before) return;
   try {
     parsed.updatedAt = (/* @__PURE__ */ new Date()).toISOString();
-    (0, import_fs86.writeFileSync)(missionStatePath, JSON.stringify(parsed, null, 2));
+    (0, import_fs87.writeFileSync)(missionStatePath, JSON.stringify(parsed, null, 2));
   } catch {
   }
 }
@@ -95477,10 +98603,10 @@ function hasDurableAbandonmentEvidence(marker) {
 }
 async function reconcileAbandonedSessionStarts(directory, currentSessionId) {
   const sessionsDir = (0, import_path103.join)(getOmcRoot(directory), "state", "sessions");
-  if (!(0, import_fs86.existsSync)(sessionsDir)) return;
+  if (!(0, import_fs87.existsSync)(sessionsDir)) return;
   let entries;
   try {
-    entries = (0, import_fs86.readdirSync)(sessionsDir);
+    entries = (0, import_fs87.readdirSync)(sessionsDir);
   } catch {
     return;
   }
@@ -95499,9 +98625,9 @@ async function reconcileAbandonedSessionStarts(directory, currentSessionId) {
     cleanupMissionStateForSession(directory, sessionId);
     removeSessionStartedMarker(directory, sessionId);
     try {
-      const remaining = (0, import_fs86.readdirSync)(sessionStateDir(directory, sessionId));
+      const remaining = (0, import_fs87.readdirSync)(sessionStateDir(directory, sessionId));
       if (remaining.length === 0) {
-        (0, import_fs86.rmdirSync)(sessionStateDir(directory, sessionId));
+        (0, import_fs87.rmdirSync)(sessionStateDir(directory, sessionId));
       }
     } catch {
     }
@@ -95600,8 +98726,8 @@ function parseWakeupDueAt(toolInput) {
 function recordScheduledWakeup(directory, sessionId, toolInput) {
   try {
     const statePath = getScheduledWakeupStatePath(directory, sessionId);
-    (0, import_fs86.mkdirSync)((0, import_path103.dirname)(statePath), { recursive: true });
-    (0, import_fs86.writeFileSync)(
+    (0, import_fs87.mkdirSync)((0, import_path103.dirname)(statePath), { recursive: true });
+    (0, import_fs87.writeFileSync)(
       statePath,
       JSON.stringify(
         {
@@ -95629,11 +98755,11 @@ function getModeStatePaths(directory, modeName, sessionId) {
 }
 function updateModeAwaitingConfirmation(directory, modeName, sessionId, awaitingConfirmation) {
   for (const statePath of getModeStatePaths(directory, modeName, sessionId)) {
-    if (!(0, import_fs86.existsSync)(statePath)) {
+    if (!(0, import_fs87.existsSync)(statePath)) {
       continue;
     }
     try {
-      const state = JSON.parse((0, import_fs86.readFileSync)(statePath, "utf-8"));
+      const state = JSON.parse((0, import_fs87.readFileSync)(statePath, "utf-8"));
       if (!state || typeof state !== "object") {
         continue;
       }
@@ -95647,8 +98773,8 @@ function updateModeAwaitingConfirmation(directory, modeName, sessionId, awaiting
         continue;
       }
       const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
-      (0, import_fs86.writeFileSync)(tmpPath, JSON.stringify(state, null, 2));
-      (0, import_fs86.renameSync)(tmpPath, statePath);
+      (0, import_fs87.writeFileSync)(tmpPath, JSON.stringify(state, null, 2));
+      (0, import_fs87.renameSync)(tmpPath, statePath);
     } catch {
     }
   }
@@ -95827,12 +98953,12 @@ function readTeamStagedState(directory, sessionId) {
   ] : [(0, import_path103.join)(stateDir, "team-state.json")];
   let coarseState = null;
   for (const statePath of statePaths) {
-    if (!(0, import_fs86.existsSync)(statePath)) {
+    if (!(0, import_fs87.existsSync)(statePath)) {
       continue;
     }
     try {
       const parsed = JSON.parse(
-        (0, import_fs86.readFileSync)(statePath, "utf-8")
+        (0, import_fs87.readFileSync)(statePath, "utf-8")
       );
       if (typeof parsed !== "object" || parsed === null) {
         continue;
@@ -95890,10 +99016,10 @@ function readTeamStopBreakerCount(directory, sessionId) {
   const stateDir = (0, import_path103.join)(getOmcRoot(directory), "state");
   const breakerPath = sessionId ? (0, import_path103.join)(stateDir, "sessions", sessionId, "team-stop-breaker.json") : (0, import_path103.join)(stateDir, "team-stop-breaker.json");
   try {
-    if (!(0, import_fs86.existsSync)(breakerPath)) {
+    if (!(0, import_fs87.existsSync)(breakerPath)) {
       return 0;
     }
-    const parsed = JSON.parse((0, import_fs86.readFileSync)(breakerPath, "utf-8"));
+    const parsed = JSON.parse((0, import_fs87.readFileSync)(breakerPath, "utf-8"));
     if (typeof parsed.updated_at === "string") {
       const updatedAt = new Date(parsed.updated_at).getTime();
       if (Number.isFinite(updatedAt) && Date.now() - updatedAt > TEAM_STOP_BLOCKER_TTL_MS) {
@@ -95912,16 +99038,16 @@ function writeTeamStopBreakerCount(directory, sessionId, count) {
   const safeCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
   if (safeCount === 0) {
     try {
-      if ((0, import_fs86.existsSync)(breakerPath)) {
-        (0, import_fs86.unlinkSync)(breakerPath);
+      if ((0, import_fs87.existsSync)(breakerPath)) {
+        (0, import_fs87.unlinkSync)(breakerPath);
       }
     } catch {
     }
     return;
   }
   try {
-    (0, import_fs86.mkdirSync)((0, import_path103.dirname)(breakerPath), { recursive: true });
-    (0, import_fs86.writeFileSync)(
+    (0, import_fs87.mkdirSync)((0, import_path103.dirname)(breakerPath), { recursive: true });
+    (0, import_fs87.writeFileSync)(
       breakerPath,
       JSON.stringify(
         { count: safeCount, updated_at: (/* @__PURE__ */ new Date()).toISOString() },
@@ -96632,10 +99758,10 @@ Treat this as prior-session context only. Prioritize the user's newest request, 
     }
   }
   const agentsMdPath = (0, import_path103.join)(directory, "AGENTS.md");
-  if ((0, import_fs86.existsSync)(agentsMdPath)) {
+  if ((0, import_fs87.existsSync)(agentsMdPath)) {
     try {
       let agentsContent = compactOmcStartupGuidance(
-        (0, import_fs86.readFileSync)(agentsMdPath, "utf-8")
+        (0, import_fs87.readFileSync)(agentsMdPath, "utf-8")
       ).trim();
       if (agentsContent) {
         const MAX_AGENTS_CHARS = 2e4;
@@ -97611,7 +100737,7 @@ var HIGH_VARIANT_MAP = {
 var ALREADY_HIGH = new Set(Object.values(HIGH_VARIANT_MAP));
 
 // src/hooks/rules-injector/index.ts
-var import_fs88 = require("fs");
+var import_fs89 = require("fs");
 var import_path106 = require("path");
 
 // src/hooks/rules-injector/matcher.ts
@@ -97619,18 +100745,18 @@ var import_crypto30 = require("crypto");
 var import_path104 = require("path");
 
 // src/hooks/rules-injector/storage.ts
-var import_fs87 = require("fs");
+var import_fs88 = require("fs");
 var import_path105 = require("path");
 
 // src/hooks/auto-slash-command/executor.ts
-var import_fs92 = require("fs");
+var import_fs93 = require("fs");
 var import_path110 = require("path");
 init_config_dir();
 init_worktree_paths();
 
 // src/hooks/auto-slash-command/live-data.ts
 var import_child_process30 = require("child_process");
-var import_fs89 = require("fs");
+var import_fs90 = require("fs");
 var import_path107 = require("path");
 var import_safe_regex = __toESM(require_safe_regex(), 1);
 init_worktree_paths();
@@ -97741,7 +100867,7 @@ function renderSkillPipelineGuidance(skillName, pipeline) {
 }
 
 // src/utils/skill-resources.ts
-var import_fs90 = require("fs");
+var import_fs91 = require("fs");
 var import_path108 = require("path");
 var MAX_RESOURCE_ENTRIES = 12;
 function toDisplayPath(pathValue) {
@@ -97753,12 +100879,12 @@ function toDisplayPath(pathValue) {
 }
 function summarizeSkillResources(skillFilePath) {
   const skillDirectory = (0, import_path108.dirname)(skillFilePath);
-  if (!(0, import_fs90.existsSync)(skillDirectory)) {
+  if (!(0, import_fs91.existsSync)(skillDirectory)) {
     return void 0;
   }
   let directoryEntries = [];
   try {
-    directoryEntries = (0, import_fs90.readdirSync)(skillDirectory, { withFileTypes: true }).filter((entry) => entry.name !== "SKILL.md" && !entry.name.startsWith(".")).sort((a, b) => a.name.localeCompare(b.name)).slice(0, MAX_RESOURCE_ENTRIES).map((entry) => entry.isDirectory() ? `${entry.name}/` : entry.name);
+    directoryEntries = (0, import_fs91.readdirSync)(skillDirectory, { withFileTypes: true }).filter((entry) => entry.name !== "SKILL.md" && !entry.name.startsWith(".")).sort((a, b) => a.name.localeCompare(b.name)).slice(0, MAX_RESOURCE_ENTRIES).map((entry) => entry.isDirectory() ? `${entry.name}/` : entry.name);
   } catch {
     return void 0;
   }
@@ -97856,7 +100982,7 @@ function renderSkillRuntimeGuidance(skillName, availability) {
 }
 
 // src/features/builtin-skills/skills.ts
-var import_fs91 = require("fs");
+var import_fs92 = require("fs");
 var import_path109 = require("path");
 var import_url15 = require("url");
 init_frontmatter();
@@ -97907,11 +101033,11 @@ function toSafeSkillName(name) {
   return CC_NATIVE_COMMANDS2.has(normalized.toLowerCase()) ? `omc-${normalized}` : normalized;
 }
 function readJsonObject3(path25) {
-  if (!(0, import_fs91.existsSync)(path25)) {
+  if (!(0, import_fs92.existsSync)(path25)) {
     return null;
   }
   try {
-    const parsed = JSON.parse((0, import_fs91.readFileSync)(path25, "utf-8"));
+    const parsed = JSON.parse((0, import_fs92.readFileSync)(path25, "utf-8"));
     return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
   } catch {
     return null;
@@ -97970,7 +101096,7 @@ function readSkillBodyOverride(skillPath, metadata, fallbackBody) {
     return fallbackBody;
   }
   try {
-    const fullContent = (0, import_fs91.readFileSync)(resolvedBodyPath, "utf-8");
+    const fullContent = (0, import_fs92.readFileSync)(resolvedBodyPath, "utf-8");
     const { body } = parseFrontmatter2(fullContent);
     return body;
   } catch {
@@ -98003,7 +101129,7 @@ function renderBundledSkillBody(skillName, body) {
 }
 function loadSkillFromFile(skillPath, skillName) {
   try {
-    const content = (0, import_fs91.readFileSync)(skillPath, "utf-8");
+    const content = (0, import_fs92.readFileSync)(skillPath, "utf-8");
     const { metadata, body } = parseFrontmatter2(content);
     const resolvedName = metadata.name || skillName;
     const safePrimaryName = toSafeSkillName(resolvedName);
@@ -98049,13 +101175,13 @@ function loadSkillFromFile(skillPath, skillName) {
   }
 }
 function loadSkillsFromDirectory() {
-  if (!(0, import_fs91.existsSync)(SKILLS_DIR2)) {
+  if (!(0, import_fs92.existsSync)(SKILLS_DIR2)) {
     return [];
   }
   const skills = [];
   const seenNames = /* @__PURE__ */ new Set();
   try {
-    const entries = (0, import_fs91.readdirSync)(SKILLS_DIR2, { withFileTypes: true }).sort((a, b) => {
+    const entries = (0, import_fs92.readdirSync)(SKILLS_DIR2, { withFileTypes: true }).sort((a, b) => {
       if (a.name === "skillify") return -1;
       if (b.name === "skillify") return 1;
       return a.name.localeCompare(b.name);
@@ -98066,7 +101192,7 @@ function loadSkillsFromDirectory() {
         continue;
       }
       const skillPath = (0, import_path109.join)(SKILLS_DIR2, entry.name, "SKILL.md");
-      if ((0, import_fs91.existsSync)(skillPath)) {
+      if ((0, import_fs92.existsSync)(skillPath)) {
         const skillEntries = loadSkillFromFile(skillPath, entry.name);
         for (const skill of skillEntries) {
           const key = skill.name.toLowerCase();
@@ -98147,7 +101273,7 @@ var DEBUG4 = process.env.PREEMPTIVE_COMPACTION_DEBUG === "1";
 var DEBUG_FILE3 = path21.join((0, import_os15.tmpdir)(), "preemptive-compaction-debug.log");
 
 // src/features/background-agent/manager.ts
-var import_fs93 = require("fs");
+var import_fs94 = require("fs");
 var import_path111 = require("path");
 init_config_dir();
 var DEFAULT_TASK_TTL_MS = 30 * 60 * 1e3;
@@ -98227,7 +101353,7 @@ EOF`,
 var BANNED_ENTRIES = SHELL_COMMAND_PATTERNS.banned.filter((cmd) => !cmd.includes("(")).map((cmd) => ({ pattern: new RegExp(`\\b${cmd}\\b`), name: cmd }));
 
 // src/hooks/agent-usage-reminder/storage.ts
-var import_fs94 = require("fs");
+var import_fs95 = require("fs");
 var import_path113 = require("path");
 
 // src/hooks/agent-usage-reminder/constants.ts
@@ -98244,7 +101370,7 @@ init_ultrawork();
 init_persistent_mode();
 
 // src/hooks/plugin-patterns/index.ts
-var import_fs95 = require("fs");
+var import_fs96 = require("fs");
 var import_path114 = require("path");
 var import_child_process31 = require("child_process");
 
@@ -98257,7 +101383,7 @@ init_loader2();
 init_constants();
 
 // src/hooks/learner/config.ts
-var import_fs96 = require("fs");
+var import_fs97 = require("fs");
 var import_path115 = require("path");
 init_config_dir();
 init_constants();
@@ -98273,7 +101399,7 @@ init_loader2();
 init_constants();
 
 // src/hooks/learner/writer.ts
-var import_fs97 = require("fs");
+var import_fs98 = require("fs");
 var import_path116 = require("path");
 init_finder();
 init_parser();
@@ -98284,7 +101410,7 @@ init_user_skill_compat();
 init_ralph();
 
 // src/hooks/learner/auto-invoke.ts
-var import_fs98 = __toESM(require("fs"), 1);
+var import_fs99 = __toESM(require("fs"), 1);
 var import_path117 = __toESM(require("path"), 1);
 var import_os18 = __toESM(require("os"), 1);
 init_config_dir();
@@ -98316,7 +101442,7 @@ init_task_file_ops();
 init_tmux_session();
 
 // src/team/inbox-outbox.ts
-var import_fs99 = require("fs");
+var import_fs100 = require("fs");
 var import_path118 = require("path");
 init_config_dir();
 init_tmux_session();
@@ -98324,7 +101450,7 @@ init_fs_utils();
 var MAX_INBOX_READ_SIZE = 10 * 1024 * 1024;
 
 // src/team/team-registration.ts
-var import_fs100 = require("fs");
+var import_fs101 = require("fs");
 var import_path119 = require("path");
 init_config_dir();
 init_worktree_paths();
@@ -98333,14 +101459,14 @@ init_fs_utils();
 init_file_lock();
 
 // src/team/heartbeat.ts
-var import_fs101 = require("fs");
+var import_fs102 = require("fs");
 var import_path120 = require("path");
 init_tmux_session();
 init_fs_utils();
 init_worktree_paths();
 
 // src/team/outbox-reader.ts
-var import_fs102 = require("fs");
+var import_fs103 = require("fs");
 var import_path121 = require("path");
 init_config_dir();
 init_fs_utils();
@@ -98348,7 +101474,7 @@ init_tmux_session();
 var MAX_OUTBOX_READ_SIZE = 10 * 1024 * 1024;
 
 // src/team/team-status.ts
-var import_fs103 = require("fs");
+var import_fs104 = require("fs");
 var import_path122 = require("path");
 init_config_dir();
 init_task_file_ops();
@@ -98360,7 +101486,7 @@ init_fs_utils();
 
 // src/team/mcp-team-bridge.ts
 var import_child_process32 = require("child_process");
-var import_fs104 = require("fs");
+var import_fs105 = require("fs");
 var import_path123 = require("path");
 init_fs_utils();
 init_worktree_paths();
@@ -98410,7 +101536,7 @@ init_worktree_paths();
 init_state_paths();
 
 // src/hooks/factcheck/checks.ts
-var import_fs105 = require("fs");
+var import_fs106 = require("fs");
 var import_path124 = require("path");
 
 // src/hooks/factcheck/config.ts
@@ -98454,7 +101580,7 @@ var DEFAULT_GUARDS_CONFIG = {
 };
 
 // src/hooks/factcheck/sentinel.ts
-var import_fs106 = require("fs");
+var import_fs107 = require("fs");
 
 // src/team/index.ts
 init_model_contract();
@@ -99511,7 +102637,7 @@ init_team_owner_epoch();
 
 // src/hooks/team-leader-nudge-hook.ts
 var import_promises23 = require("fs/promises");
-var import_fs107 = require("fs");
+var import_fs108 = require("fs");
 var import_path127 = require("path");
 init_events();
 init_leader_nudge_guidance();
@@ -99527,7 +102653,7 @@ init_context_injector();
 
 // src/features/session-friction-report/index.ts
 var import_child_process34 = require("child_process");
-var import_fs108 = require("fs");
+var import_fs109 = require("fs");
 var import_path128 = require("path");
 var import_readline3 = require("readline");
 init_worktree_paths();
@@ -99579,14 +102705,14 @@ function getClaudeWorktreeParent2(projectRoot) {
   return idx === -1 ? null : normalizedRoot.slice(0, idx) || null;
 }
 function listJsonFiles(rootDir) {
-  if (!(0, import_fs108.existsSync)(rootDir)) return [];
+  if (!(0, import_fs109.existsSync)(rootDir)) return [];
   const files = [];
   const stack = [rootDir];
   while (stack.length > 0) {
     const current = stack.pop();
     let entries;
     try {
-      entries = (0, import_fs108.readdirSync)(current, { withFileTypes: true });
+      entries = (0, import_fs109.readdirSync)(current, { withFileTypes: true });
     } catch {
       continue;
     }
@@ -99635,8 +102761,8 @@ function uniqueSortedTargets2(targets) {
     seen.add(key);
     return true;
   }).sort((a, b) => {
-    const aTime = (0, import_fs108.existsSync)(a.filePath) ? (0, import_fs108.statSync)(a.filePath).mtimeMs : 0;
-    const bTime = (0, import_fs108.existsSync)(b.filePath) ? (0, import_fs108.statSync)(b.filePath).mtimeMs : 0;
+    const aTime = (0, import_fs109.existsSync)(a.filePath) ? (0, import_fs109.statSync)(a.filePath).mtimeMs : 0;
+    const bTime = (0, import_fs109.existsSync)(b.filePath) ? (0, import_fs109.statSync)(b.filePath).mtimeMs : 0;
     return bTime - aTime;
   });
 }
@@ -99806,8 +102932,8 @@ function computeSignals(stats) {
   return { score: Math.min(100, score), signals };
 }
 async function scanJsonlTarget(target, sessions, filters) {
-  const fileMtime = (0, import_fs108.existsSync)(target.filePath) ? (0, import_fs108.statSync)(target.filePath).mtimeMs : 0;
-  const reader = (0, import_readline3.createInterface)({ input: (0, import_fs108.createReadStream)(target.filePath, { encoding: "utf-8" }), crlfDelay: Infinity });
+  const fileMtime = (0, import_fs109.existsSync)(target.filePath) ? (0, import_fs109.statSync)(target.filePath).mtimeMs : 0;
+  const reader = (0, import_readline3.createInterface)({ input: (0, import_fs109.createReadStream)(target.filePath, { encoding: "utf-8" }), crlfDelay: Infinity });
   const lastTimestamps = /* @__PURE__ */ new Map();
   try {
     for await (const rawLine of reader) {
@@ -99860,8 +102986,8 @@ async function scanJsonlTarget(target, sessions, filters) {
 async function scanJsonTarget(target, sessions, filters) {
   let record2;
   try {
-    const { readFile: readFile24 } = await import("fs/promises");
-    record2 = JSON.parse(await readFile24(target.filePath, "utf-8"));
+    const { readFile: readFile25 } = await import("fs/promises");
+    record2 = JSON.parse(await readFile25(target.filePath, "utf-8"));
   } catch {
     return;
   }
@@ -99871,14 +102997,14 @@ async function scanJsonTarget(target, sessions, filters) {
   if (filters.projectRoots && filters.projectRoots.length > 0 && projectPath && !isWithinProject2(projectPath, filters.projectRoots)) return;
   if (!matchesProjectScope(target.sourceType, projectPath, filters.projectFilter)) return;
   const timestamp2 = timestampOf(record2);
-  const fileMtime = (0, import_fs108.existsSync)(target.filePath) ? (0, import_fs108.statSync)(target.filePath).mtimeMs : 0;
+  const fileMtime = (0, import_fs109.existsSync)(target.filePath) ? (0, import_fs109.statSync)(target.filePath).mtimeMs : 0;
   const entryEpoch = timestamp2 ? Date.parse(timestamp2) : fileMtime;
   if (filters.sinceEpoch && Number.isFinite(entryEpoch) && entryEpoch < filters.sinceEpoch) return;
   const stats = getStats(sessions, sessionId);
   stats.sources.add(target.sourceType);
   if (projectPath) stats.projectPath = projectPath;
   updateTimeRange(stats, timestamp2);
-  const bytes = (0, import_fs108.existsSync)(target.filePath) ? (0, import_fs108.statSync)(target.filePath).size : 0;
+  const bytes = (0, import_fs109.existsSync)(target.filePath) ? (0, import_fs109.statSync)(target.filePath).size : 0;
   stats.transcriptBytes += bytes;
   stats.transcriptLines += 1;
 }
@@ -99957,7 +103083,7 @@ init_models();
 var TIER_MODELS = getDefaultTierModels();
 
 // src/features/notepad-wisdom/index.ts
-var import_fs109 = require("fs");
+var import_fs110 = require("fs");
 var import_path129 = require("path");
 
 // src/features/state-manager/index.ts
@@ -99997,7 +103123,7 @@ init_definitions();
 init_document_specialist();
 
 // src/commands/index.ts
-var import_fs110 = require("fs");
+var import_fs111 = require("fs");
 var import_path130 = require("path");
 var import_url16 = require("url");
 init_config_dir();
@@ -100228,7 +103354,7 @@ function shouldMonitorBlockedPanes(status) {
 init_tmux_detector();
 
 // src/features/rate-limit-wait/daemon.ts
-var import_fs112 = require("fs");
+var import_fs113 = require("fs");
 var import_path132 = require("path");
 var import_url17 = require("url");
 var import_child_process37 = require("child_process");
@@ -100305,14 +103431,14 @@ function getConfig(config2) {
 }
 function ensureStateDir7(config2) {
   const stateDir = (0, import_path132.dirname)(config2.stateFilePath);
-  if (!(0, import_fs112.existsSync)(stateDir)) {
-    (0, import_fs112.mkdirSync)(stateDir, { recursive: true, mode: 448 });
+  if (!(0, import_fs113.existsSync)(stateDir)) {
+    (0, import_fs113.mkdirSync)(stateDir, { recursive: true, mode: 448 });
   }
 }
 function writeSecureFile2(filePath, content) {
-  (0, import_fs112.writeFileSync)(filePath, content, { mode: SECURE_FILE_MODE3 });
+  (0, import_fs113.writeFileSync)(filePath, content, { mode: SECURE_FILE_MODE3 });
   try {
-    (0, import_fs112.chmodSync)(filePath, SECURE_FILE_MODE3);
+    (0, import_fs113.chmodSync)(filePath, SECURE_FILE_MODE3);
   } catch (err) {
     if (process.platform !== "win32") {
       console.warn(`[RateLimitDaemon] Failed to set permissions on ${filePath}:`, err);
@@ -100321,14 +103447,14 @@ function writeSecureFile2(filePath, content) {
 }
 function rotateLogIfNeeded2(logPath) {
   try {
-    if (!(0, import_fs112.existsSync)(logPath)) return;
-    const stats = (0, import_fs112.statSync)(logPath);
+    if (!(0, import_fs113.existsSync)(logPath)) return;
+    const stats = (0, import_fs113.statSync)(logPath);
     if (stats.size > MAX_LOG_SIZE_BYTES2) {
       const backupPath = `${logPath}.old`;
-      if ((0, import_fs112.existsSync)(backupPath)) {
-        (0, import_fs112.unlinkSync)(backupPath);
+      if ((0, import_fs113.existsSync)(backupPath)) {
+        (0, import_fs113.unlinkSync)(backupPath);
       }
-      (0, import_fs112.renameSync)(logPath, backupPath);
+      (0, import_fs113.renameSync)(logPath, backupPath);
     }
   } catch {
   }
@@ -100336,10 +103462,10 @@ function rotateLogIfNeeded2(logPath) {
 function readDaemonState2(config2) {
   const cfg = getConfig(config2);
   try {
-    if (!(0, import_fs112.existsSync)(cfg.stateFilePath)) {
+    if (!(0, import_fs113.existsSync)(cfg.stateFilePath)) {
       return null;
     }
-    const content = (0, import_fs112.readFileSync)(cfg.stateFilePath, "utf-8");
+    const content = (0, import_fs113.readFileSync)(cfg.stateFilePath, "utf-8");
     const state = JSON.parse(content);
     if (state.startedAt) state.startedAt = new Date(state.startedAt);
     if (state.lastPollAt) state.lastPollAt = new Date(state.lastPollAt);
@@ -100369,10 +103495,10 @@ function writeDaemonState2(state, config2) {
 }
 function readPidFile2(config2) {
   try {
-    if (!(0, import_fs112.existsSync)(config2.pidFilePath)) {
+    if (!(0, import_fs113.existsSync)(config2.pidFilePath)) {
       return null;
     }
-    const content = (0, import_fs112.readFileSync)(config2.pidFilePath, "utf-8");
+    const content = (0, import_fs113.readFileSync)(config2.pidFilePath, "utf-8");
     return parseInt(content.trim(), 10);
   } catch {
     return null;
@@ -100383,8 +103509,8 @@ function writePidFile2(pid, config2) {
   writeSecureFile2(config2.pidFilePath, String(pid));
 }
 function removePidFile2(config2) {
-  if ((0, import_fs112.existsSync)(config2.pidFilePath)) {
-    (0, import_fs112.unlinkSync)(config2.pidFilePath);
+  if ((0, import_fs113.existsSync)(config2.pidFilePath)) {
+    (0, import_fs113.unlinkSync)(config2.pidFilePath);
   }
 }
 function isDaemonRunning2(config2) {
@@ -100409,7 +103535,7 @@ function log2(message2, config2) {
     const timestamp2 = (/* @__PURE__ */ new Date()).toISOString();
     const logLine = `[${timestamp2}] ${message2}
 `;
-    (0, import_fs112.appendFileSync)(config2.logFilePath, logLine, { mode: SECURE_FILE_MODE3 });
+    (0, import_fs113.appendFileSync)(config2.logFilePath, logLine, { mode: SECURE_FILE_MODE3 });
   } catch {
   }
 }
@@ -100531,7 +103657,7 @@ async function pollLoop2(config2) {
       log2(`Poll error: ${state.lastError}`, config2);
       writeDaemonState2(state, config2);
     }
-    await new Promise((resolve32) => setTimeout(resolve32, config2.pollIntervalMs));
+    await new Promise((resolve33) => setTimeout(resolve33, config2.pollIntervalMs));
   }
 }
 function startDaemon(config2) {
@@ -100589,7 +103715,7 @@ function startDaemon(config2) {
     return { success: false, message: "Failed to start daemon process" };
   } catch (error2) {
     try {
-      (0, import_fs112.unlinkSync)(configPath);
+      (0, import_fs113.unlinkSync)(configPath);
     } catch {
     }
     return {
@@ -100902,7 +104028,7 @@ async function waitDetectCommand(options) {
 }
 
 // src/cli/commands/doctor-conflicts.ts
-var import_fs113 = require("fs");
+var import_fs114 = require("fs");
 var import_path133 = require("path");
 init_config_dir();
 init_installer();
@@ -100912,11 +104038,11 @@ init_mcp_registry();
 init_worktree_paths();
 function collectHooksFromSettings(settingsPath) {
   const conflicts = [];
-  if (!(0, import_fs113.existsSync)(settingsPath)) {
+  if (!(0, import_fs114.existsSync)(settingsPath)) {
     return conflicts;
   }
   try {
-    const settings = JSON.parse((0, import_fs113.readFileSync)(settingsPath, "utf-8"));
+    const settings = JSON.parse((0, import_fs114.readFileSync)(settingsPath, "utf-8"));
     const hooks = settings.hooks || {};
     const hookEvents = [
       "PreToolUse",
@@ -100973,9 +104099,9 @@ function checkWindowsUnsafePluginHooks() {
     if (seenRoots.has(pluginRoot)) continue;
     seenRoots.add(pluginRoot);
     const hooksJsonPath = (0, import_path133.join)(pluginRoot, "hooks", "hooks.json");
-    if (!(0, import_fs113.existsSync)(hooksJsonPath)) continue;
+    if (!(0, import_fs114.existsSync)(hooksJsonPath)) continue;
     try {
-      const parsed = JSON.parse((0, import_fs113.readFileSync)(hooksJsonPath, "utf-8"));
+      const parsed = JSON.parse((0, import_fs114.readFileSync)(hooksJsonPath, "utf-8"));
       for (const [event, groups] of Object.entries(parsed.hooks ?? {})) {
         for (const group of groups) {
           for (const hook of group.hooks ?? []) {
@@ -101021,7 +104147,7 @@ function directClaudeMdReferences(content, configDir) {
 }
 function pathExistsWithoutFollowingSymlinks(filePath) {
   try {
-    (0, import_fs113.lstatSync)(filePath);
+    (0, import_fs114.lstatSync)(filePath);
     return true;
   } catch {
     return false;
@@ -101030,7 +104156,7 @@ function pathExistsWithoutFollowingSymlinks(filePath) {
 function inspectClaudeMdFile(filePath, configDir, isMain) {
   let stats;
   try {
-    stats = (0, import_fs113.lstatSync)(filePath);
+    stats = (0, import_fs114.lstatSync)(filePath);
   } catch {
     return {
       status: { path: filePath, hasMarkers: false, hasUserContent: false, markerState: "unreadable", exactLegacy: false, manualReview: false },
@@ -101051,7 +104177,7 @@ function inspectClaudeMdFile(filePath, configDir, isMain) {
   }
   let bytes;
   try {
-    bytes = (0, import_fs113.readFileSync)(filePath);
+    bytes = (0, import_fs114.readFileSync)(filePath);
   } catch {
     return {
       status: { path: filePath, hasMarkers: false, hasUserContent: false, markerState: "unreadable", exactLegacy: false, manualReview: false },
@@ -101083,7 +104209,7 @@ function inspectClaudeMdFile(filePath, configDir, isMain) {
 }
 function genericClaudeMdFiles(configDir) {
   try {
-    return (0, import_fs113.readdirSync)(configDir).filter((name) => /^CLAUDE-.+\.md$/i.test(name) && name.toLowerCase() !== "claude-omc.md").sort().map((name) => (0, import_path133.join)(configDir, name));
+    return (0, import_fs114.readdirSync)(configDir).filter((name) => /^CLAUDE-.+\.md$/i.test(name) && name.toLowerCase() !== "claude-omc.md").sort().map((name) => (0, import_path133.join)(configDir, name));
   } catch {
     return [];
   }
@@ -101148,15 +104274,15 @@ function compareSemverLikeVersions(a, b) {
   return 0;
 }
 function isValidSetupPluginRoot(pluginRoot) {
-  return (0, import_fs113.existsSync)((0, import_path133.join)(pluginRoot, "docs", "CLAUDE.md"));
+  return (0, import_fs114.existsSync)((0, import_path133.join)(pluginRoot, "docs", "CLAUDE.md"));
 }
 function readInstalledPluginRoots() {
   const installedPluginsPath = (0, import_path133.join)(getClaudeConfigDir(), "plugins", "installed_plugins.json");
-  if (!(0, import_fs113.existsSync)(installedPluginsPath)) {
+  if (!(0, import_fs114.existsSync)(installedPluginsPath)) {
     return [];
   }
   try {
-    const parsed = JSON.parse((0, import_fs113.readFileSync)(installedPluginsPath, "utf-8"));
+    const parsed = JSON.parse((0, import_fs114.readFileSync)(installedPluginsPath, "utf-8"));
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return [];
     }
@@ -101168,11 +104294,11 @@ function readInstalledPluginRoots() {
 }
 function findLatestSiblingPluginRoot(pluginRoot) {
   const cacheBase = (0, import_path133.dirname)(pluginRoot);
-  if (!(0, import_fs113.existsSync)(cacheBase)) {
+  if (!(0, import_fs114.existsSync)(cacheBase)) {
     return null;
   }
   try {
-    return (0, import_fs113.readdirSync)(cacheBase).filter((entry) => parseSemverLikeVersion(entry)).map((entry) => (0, import_path133.join)(cacheBase, entry)).filter(isValidSetupPluginRoot).sort((a, b) => compareSemverLikeVersions((0, import_path133.basename)(b), (0, import_path133.basename)(a)))[0] || null;
+    return (0, import_fs114.readdirSync)(cacheBase).filter((entry) => parseSemverLikeVersion(entry)).map((entry) => (0, import_path133.join)(cacheBase, entry)).filter(isValidSetupPluginRoot).sort((a, b) => compareSemverLikeVersions((0, import_path133.basename)(b), (0, import_path133.basename)(a)))[0] || null;
   } catch {
     return null;
   }
@@ -101211,25 +104337,25 @@ function isSupportedSetupFallbackSkill(legacySkillsDir, entry, baseName) {
     return false;
   }
   const installedSkillPath = (0, import_path133.join)(legacySkillsDir, entry, "SKILL.md");
-  if (!(0, import_fs113.existsSync)(installedSkillPath)) {
+  if (!(0, import_fs114.existsSync)(installedSkillPath)) {
     return false;
   }
   try {
-    const installedContent = (0, import_fs113.readFileSync)(installedSkillPath, "utf-8");
-    return getSetupFallbackCanonicalSkillPaths(baseName).some((canonicalSkillPath) => (0, import_fs113.existsSync)(canonicalSkillPath) && installedContent === (0, import_fs113.readFileSync)(canonicalSkillPath, "utf-8"));
+    const installedContent = (0, import_fs114.readFileSync)(installedSkillPath, "utf-8");
+    return getSetupFallbackCanonicalSkillPaths(baseName).some((canonicalSkillPath) => (0, import_fs114.existsSync)(canonicalSkillPath) && installedContent === (0, import_fs114.readFileSync)(canonicalSkillPath, "utf-8"));
   } catch {
     return false;
   }
 }
 function checkLegacySkills() {
   const legacySkillsDir = (0, import_path133.join)(getClaudeConfigDir(), "skills");
-  if (!(0, import_fs113.existsSync)(legacySkillsDir)) return [];
+  if (!(0, import_fs114.existsSync)(legacySkillsDir)) return [];
   const collisions = [];
   try {
     const pluginSkillNames = new Set(
       listBuiltinSkillNames({ includeAliases: true }).map((n) => n.toLowerCase())
     );
-    const entries = (0, import_fs113.readdirSync)(legacySkillsDir);
+    const entries = (0, import_fs114.readdirSync)(legacySkillsDir);
     for (const entry of entries) {
       const baseName = entry.replace(/\.md$/i, "").toLowerCase();
       if (pluginSkillNames.has(baseName)) {
@@ -101246,11 +104372,11 @@ function checkLegacySkills() {
 function checkConfigIssues() {
   const unknownFields = [];
   const configPath = (0, import_path133.join)(getClaudeConfigDir(), ".omc-config.json");
-  if (!(0, import_fs113.existsSync)(configPath)) {
+  if (!(0, import_fs114.existsSync)(configPath)) {
     return { unknownFields };
   }
   try {
-    const config2 = JSON.parse((0, import_fs113.readFileSync)(configPath, "utf-8"));
+    const config2 = JSON.parse((0, import_fs114.readFileSync)(configPath, "utf-8"));
     const knownFields = /* @__PURE__ */ new Set([
       // PluginConfig fields
       "agents",
@@ -101585,8 +104711,9 @@ ${missing.length} provider${missing.length === 1 ? "" : "s"} missing (warn only 
 
 // src/cli/commands/capabilities.ts
 var import_crypto33 = require("crypto");
-var import_fs114 = require("fs");
+var import_fs115 = require("fs");
 var import_path134 = require("path");
+init_zod();
 init_definitions();
 var CAPABILITIES_LOCK_SCHEMA_VERSION = "1.0";
 var DEFAULT_CAPABILITIES_LOCKFILE = "omc-capabilities.lock.json";
@@ -101622,16 +104749,16 @@ function packageRoot() {
   if (typeof __dirname !== "undefined" && __dirname) {
     const fromSrc = (0, import_path134.resolve)(__dirname, "..", "..", "..");
     const fromDist = (0, import_path134.resolve)(__dirname, "..", "..");
-    if ((0, import_fs114.existsSync)((0, import_path134.join)(fromSrc, "package.json"))) return fromSrc;
-    if ((0, import_fs114.existsSync)((0, import_path134.join)(fromDist, "package.json"))) return fromDist;
+    if ((0, import_fs115.existsSync)((0, import_path134.join)(fromSrc, "package.json"))) return fromSrc;
+    if ((0, import_fs115.existsSync)((0, import_path134.join)(fromDist, "package.json"))) return fromDist;
   }
   return process.cwd();
 }
 function listSkillFiles(root2) {
   const skillsDir = (0, import_path134.join)(root2, "skills");
-  if (!(0, import_fs114.existsSync)(skillsDir)) return [];
-  const names = (0, import_fs114.readdirSync)(skillsDir).sort((a, b) => a.localeCompare(b));
-  return names.map((name) => (0, import_path134.join)(skillsDir, name, "SKILL.md")).filter((path25) => (0, import_fs114.existsSync)(path25) && (0, import_fs114.statSync)(path25).isFile());
+  if (!(0, import_fs115.existsSync)(skillsDir)) return [];
+  const names = (0, import_fs115.readdirSync)(skillsDir).sort((a, b) => a.localeCompare(b));
+  return names.map((name) => (0, import_path134.join)(skillsDir, name, "SKILL.md")).filter((path25) => (0, import_fs115.existsSync)(path25) && (0, import_fs115.statSync)(path25).isFile());
 }
 function readSkillTitle(markdown) {
   const heading = markdown.split("\n").find((line) => line.startsWith("# "));
@@ -101663,7 +104790,7 @@ function collectCapabilitySurface(root2 = packageRoot()) {
     defaultModel: agent.defaultModel ?? null
   })).sort((a, b) => a.name.localeCompare(b.name));
   const skills = listSkillFiles(root2).map((path25) => {
-    const markdown = (0, import_fs114.readFileSync)(path25, "utf-8");
+    const markdown = (0, import_fs115.readFileSync)(path25, "utf-8");
     return {
       name: skillNameFromSkillFilePath(path25),
       digest: sha2562(markdown),
@@ -101806,7 +104933,7 @@ function buildCapabilitiesLockfile() {
   };
 }
 function parseLockfile(path25) {
-  const parsed = JSON.parse((0, import_fs114.readFileSync)(path25, "utf-8"));
+  const parsed = JSON.parse((0, import_fs115.readFileSync)(path25, "utf-8"));
   if (parsed.schemaVersion !== CAPABILITIES_LOCK_SCHEMA_VERSION) {
     throw new Error(`unsupported capabilities lockfile schema: ${parsed.schemaVersion ?? "<missing>"}`);
   }
@@ -101895,15 +105022,15 @@ function printCheckReport(report, json) {
 async function capabilitiesLockCommand(options) {
   const lockfilePath = resolveLockfilePath(options.lockfile);
   const lockfile = buildCapabilitiesLockfile();
-  (0, import_fs114.mkdirSync)((0, import_path134.dirname)(lockfilePath), { recursive: true });
-  (0, import_fs114.writeFileSync)(lockfilePath, `${stableStringify(lockfile)}
+  (0, import_fs115.mkdirSync)((0, import_path134.dirname)(lockfilePath), { recursive: true });
+  (0, import_fs115.writeFileSync)(lockfilePath, `${stableStringify(lockfile)}
 `);
   printLockSummary(lockfilePath, lockfile, options.json);
   return lockfile.fixtureResults.every((result) => result.ok) ? 0 : 1;
 }
 async function capabilitiesCheckCommand(options) {
   const lockfilePath = resolveLockfilePath(options.lockfile);
-  if (!(0, import_fs114.existsSync)(lockfilePath)) {
+  if (!(0, import_fs115.existsSync)(lockfilePath)) {
     const report2 = {
       ok: false,
       lockfile: lockfilePath,
@@ -102838,9 +105965,428 @@ async function teamCommand(args) {
   }
 }
 
+// src/cli/commands/graph.ts
+var import_promises24 = require("node:fs/promises");
+var import_node_path20 = require("node:path");
+var GRAPH_COMMAND_OPERATIONS = [
+  "create",
+  "inspect",
+  "approve",
+  "ready",
+  "claim",
+  "complete",
+  "fail",
+  "propose-patch",
+  "approve-patch",
+  "status",
+  "pause",
+  "abandon",
+  "resume",
+  "resolve-join",
+  "renew-claim",
+  "recover-expired-claim",
+  "record-late-claim-result",
+  "release-attempt-for-retry",
+  "resolve-reconciliation"
+];
+var GRAPH_INTERNAL_COMMAND_OPERATIONS = ["settle-session"];
+var GraphCommandError = class extends Error {
+  code;
+  constructor(code, message2) {
+    super(message2);
+    this.name = "GraphCommandError";
+    this.code = code;
+  }
+};
+var GRAPH_HELP = `omc graph - Durable, human-approved orchestration graph state boundary
+
+Usage:
+  omc graph create --goal <text> --descriptor <json-or-path> --session-id <id> --driver-id <id> --transition-id <id> [--json]
+  omc graph inspect --run-id <id> --session-id <id> [--json]
+  omc graph approve --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --transition-id <id> --approval <json-or-path> [--json]
+  omc graph ready --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> [--json]
+  omc graph claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> --limit <n> [--json]
+  omc graph complete --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--identities <json-or-path>] [--json]
+  omc graph fail --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
+  omc graph propose-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --patch <json-or-path> [--json]
+  omc graph approve-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --approval <json-or-path> [--json]
+  omc graph status --run-id <id> --session-id <id> [--json]
+  omc graph pause --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> [--json]
+  omc graph abandon --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --confirmation <json-or-path> [--json]
+  omc graph resume --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --driver-id <id> --transition-id <id> [--json]
+  omc graph resolve-join --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --activation-id <id> --identities <json-or-path> [--json]
+  omc graph renew-claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --driver-id <id> --tracking-id <id> --tool-still-running --now <iso8601> [--json]
+  omc graph recover-expired-claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --now <iso8601> --new-attempt-id <id> --new-lease-id <id> --new-tracking-id <id> --driver-id <id> --reconciliation-id <id> [--json]
+  omc graph record-late-claim-result --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --attempt-id <id> --recorded-at <iso8601> --summary <text> [--json]
+  omc graph release-attempt-for-retry --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --activation-id <id> --attempt-id <id> [--json]
+  omc graph resolve-reconciliation --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --evidence <json-or-path> --resolved-at <iso8601> [--json]
+
+JSON flags accept either an inline JSON object or a path to a JSON object.
+Every operation returns one bounded JSON envelope. This command delegates state
+operations to the graph runtime; it does not execute graph node work.
+`;
+var RUN = { flag: "--run-id", field: "run_id", kind: "id" };
+var REVISION = { flag: "--revision-id", field: "revision_id", kind: "id" };
+var HASH = { flag: "--descriptor-hash", field: "descriptor_hash", kind: "hash" };
+var SEQUENCE = {
+  flag: "--expected-sequence",
+  field: "expected_sequence",
+  kind: "sequence"
+};
+var SESSION = { flag: "--session-id", field: "session_id", kind: "id" };
+var DRIVER = { flag: "--driver-id", field: "driver_id", kind: "id" };
+var TRANSITION = {
+  flag: "--transition-id",
+  field: "transition_id",
+  kind: "id"
+};
+var BASE_REVISION = {
+  flag: "--base-revision-id",
+  field: "base_revision_id",
+  kind: "id"
+};
+var BASE_HASH = {
+  flag: "--base-descriptor-hash",
+  field: "base_descriptor_hash",
+  kind: "hash"
+};
+var ACTIVATION = { flag: "--activation-id", field: "activation_id", kind: "id" };
+var LEASE = { flag: "--lease-id", field: "lease_id", kind: "id" };
+var ATTEMPT = { flag: "--attempt-id", field: "attempt_id", kind: "id" };
+var TRACKING = { flag: "--tracking-id", field: "tracking_id", kind: "id" };
+var RECONCILIATION = {
+  flag: "--reconciliation-id",
+  field: "reconciliation_id",
+  kind: "id"
+};
+var OPERATION_FLAGS = {
+  create: [
+    { flag: "--goal", field: "goal", kind: "text" },
+    { flag: "--descriptor", field: "descriptor", kind: "json" },
+    SESSION,
+    DRIVER,
+    TRANSITION
+  ],
+  inspect: [RUN, SESSION],
+  approve: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    TRANSITION,
+    { flag: "--approval", field: "approval", kind: "json" }
+  ],
+  ready: [RUN, REVISION, HASH, SESSION, SEQUENCE],
+  claim: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    DRIVER,
+    TRANSITION,
+    { flag: "--limit", field: "limit", kind: "limit" }
+  ],
+  complete: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: "--claim", field: "claim", kind: "json" },
+    { flag: "--result", field: "result", kind: "json" },
+    { flag: "--identities", field: "identities", kind: "json", optional: true }
+  ],
+  fail: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: "--claim", field: "claim", kind: "json" },
+    { flag: "--result", field: "result", kind: "json" }
+  ],
+  "propose-patch": [
+    RUN,
+    SESSION,
+    BASE_REVISION,
+    BASE_HASH,
+    SEQUENCE,
+    TRANSITION,
+    { flag: "--patch", field: "patch", kind: "json" }
+  ],
+  "approve-patch": [
+    RUN,
+    SESSION,
+    BASE_REVISION,
+    BASE_HASH,
+    SEQUENCE,
+    TRANSITION,
+    { flag: "--approval", field: "approval", kind: "json" }
+  ],
+  status: [RUN, SESSION],
+  pause: [RUN, REVISION, HASH, SESSION, SEQUENCE, DRIVER, TRANSITION],
+  abandon: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: "--confirmation", field: "confirmation", kind: "json" }
+  ],
+  resume: [RUN, REVISION, HASH, SESSION, DRIVER, TRANSITION],
+  "resolve-join": [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    ACTIVATION,
+    { flag: "--identities", field: "identities", kind: "json" }
+  ],
+  "renew-claim": [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    DRIVER,
+    TRACKING,
+    { flag: "--tool-still-running", field: "tool_still_running", kind: "boolean" },
+    { flag: "--now", field: "now", kind: "text" }
+  ],
+  "recover-expired-claim": [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    { flag: "--now", field: "now", kind: "text" },
+    { flag: "--new-attempt-id", field: "new_attempt_id", kind: "id" },
+    { flag: "--new-lease-id", field: "new_lease_id", kind: "id" },
+    { flag: "--new-tracking-id", field: "new_tracking_id", kind: "id" },
+    DRIVER,
+    RECONCILIATION
+  ],
+  "record-late-claim-result": [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    ATTEMPT,
+    { flag: "--recorded-at", field: "recorded_at", kind: "text" },
+    { flag: "--summary", field: "summary", kind: "text" }
+  ],
+  "release-attempt-for-retry": [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    ACTIVATION,
+    ATTEMPT
+  ],
+  "resolve-reconciliation": [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: "--evidence", field: "evidence", kind: "json" },
+    { flag: "--resolved-at", field: "resolved_at", kind: "text" }
+  ],
+  "settle-session": [SESSION, DRIVER, TRANSITION]
+};
+var MAX_JSON_INPUT_BYTES = 256 * 1024;
+var MAX_JSON_OUTPUT_BYTES = 64 * 1024;
+var MAX_ERROR_CHARS = 1e3;
+var ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+var HASH_PATTERN = /^[a-f0-9]{64}$/;
+function resolveOperation(raw) {
+  return [...GRAPH_COMMAND_OPERATIONS, ...GRAPH_INTERNAL_COMMAND_OPERATIONS].find((operation) => operation === raw);
+}
+function parseRawFlags(operation, args) {
+  const definitions = OPERATION_FLAGS[operation];
+  const allowed = new Set(definitions.map((definition) => definition.flag));
+  const values = /* @__PURE__ */ new Map();
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") continue;
+    const equals = token.indexOf("=");
+    const flag = equals >= 0 ? token.slice(0, equals) : token;
+    if (!allowed.has(flag)) {
+      throw new GraphCommandError("unknown_argument", `Unknown argument for graph ${operation}: ${token}`);
+    }
+    if (values.has(flag)) {
+      throw new GraphCommandError("duplicate_argument", `Duplicate argument for graph ${operation}: ${flag}`);
+    }
+    const value = equals >= 0 ? token.slice(equals + 1) : args[index + 1];
+    if (!value || equals < 0 && value.startsWith("--")) {
+      throw new GraphCommandError("missing_value", `Missing value after ${flag}`);
+    }
+    values.set(flag, value);
+    if (equals < 0) index += 1;
+  }
+  for (const definition of definitions) {
+    if (!definition.optional && !values.has(definition.flag)) {
+      throw new GraphCommandError("missing_argument", `Missing required ${definition.flag} for graph ${operation}`);
+    }
+  }
+  return values;
+}
+async function parseJsonObject(raw, flag, cwd2) {
+  let source = raw.trim();
+  try {
+    if (!source.startsWith("{") && !source.startsWith("[")) {
+      const path25 = (0, import_node_path20.resolve)(cwd2, source);
+      const metadata = await (0, import_promises24.stat)(path25);
+      if (!metadata.isFile()) throw new Error("path is not a regular file");
+      if (metadata.size > MAX_JSON_INPUT_BYTES) {
+        throw new Error(`file exceeds ${MAX_JSON_INPUT_BYTES} bytes`);
+      }
+      source = await (0, import_promises24.readFile)(path25, "utf8");
+    } else if (Buffer.byteLength(source, "utf8") > MAX_JSON_INPUT_BYTES) {
+      throw new Error(`inline value exceeds ${MAX_JSON_INPUT_BYTES} bytes`);
+    }
+    const parsed = JSON.parse(source);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("value must be a JSON object");
+    }
+    return parsed;
+  } catch (error2) {
+    const message2 = error2 instanceof Error ? error2.message : String(error2);
+    throw new GraphCommandError("invalid_json_input", `Invalid ${flag}: ${message2}`);
+  }
+}
+function parseScalar(raw, definition) {
+  const trimmed = raw.trim();
+  if (definition.kind === "id") {
+    if (!ID_PATTERN.test(trimmed)) {
+      throw new GraphCommandError("invalid_identifier", `Invalid ${definition.flag}`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === "hash") {
+    if (!HASH_PATTERN.test(trimmed)) {
+      throw new GraphCommandError("invalid_hash", `Invalid ${definition.flag}; expected lowercase SHA-256`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === "text") {
+    if (!trimmed || trimmed.length > 32768) {
+      throw new GraphCommandError("invalid_text", `Invalid ${definition.flag}`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === "sequence" || definition.kind === "limit") {
+    if (!/^\d+$/.test(trimmed)) {
+      throw new GraphCommandError("invalid_number", `Invalid ${definition.flag}; expected an integer`);
+    }
+    const value = Number(trimmed);
+    const valid = definition.kind === "sequence" ? Number.isSafeInteger(value) && value >= 0 : Number.isSafeInteger(value) && value >= 1 && value <= 64;
+    if (!valid) throw new GraphCommandError("invalid_number", `Invalid ${definition.flag}`);
+    return value;
+  }
+  if (definition.kind === "boolean") {
+    if (trimmed !== "true" && trimmed !== "false") {
+      throw new GraphCommandError("invalid_boolean", `Invalid ${definition.flag}; expected 'true' or 'false'`);
+    }
+    return trimmed === "true";
+  }
+  throw new GraphCommandError("invalid_argument", `Unsupported scalar flag ${definition.flag}`);
+}
+async function parseRequest(operation, args, cwd2) {
+  const raw = parseRawFlags(operation, args);
+  const input = {};
+  for (const definition of OPERATION_FLAGS[operation]) {
+    const value = raw.get(definition.flag);
+    if (value === void 0) continue;
+    input[definition.field] = definition.kind === "json" ? await parseJsonObject(value, definition.flag, cwd2) : parseScalar(value, definition);
+  }
+  return { operation, cwd: cwd2, input: Object.freeze(input) };
+}
+async function loadDefaultService() {
+  const runtimeModulePath = "../../graph/runtime.js";
+  try {
+    const runtime = await import(runtimeModulePath);
+    if (runtime.graphCommandService?.execute) return runtime.graphCommandService;
+  } catch {
+  }
+  throw new GraphCommandError(
+    "runtime_unavailable",
+    "Graph runtime adapter is unavailable; export graphCommandService from src/graph/runtime.ts"
+  );
+}
+function serializeBounded(value) {
+  let serialized;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new GraphCommandError("invalid_output", "Graph service returned a non-JSON result");
+  }
+  if (Buffer.byteLength(serialized, "utf8") > MAX_JSON_OUTPUT_BYTES) {
+    throw new GraphCommandError(
+      "output_too_large",
+      `Graph command output exceeds ${MAX_JSON_OUTPUT_BYTES} bytes`
+    );
+  }
+  return serialized;
+}
+function boundedErrorMessage(error2) {
+  const message2 = error2 instanceof Error ? error2.message : String(error2);
+  return message2.length <= MAX_ERROR_CHARS ? message2 : `${message2.slice(0, MAX_ERROR_CHARS)}...`;
+}
+async function graphCommand(args, injectedService) {
+  const rawOperation = args[0];
+  if (!rawOperation || rawOperation === "help" || rawOperation === "--help" || rawOperation === "-h") {
+    console.log(GRAPH_HELP);
+    return;
+  }
+  const operation = resolveOperation(rawOperation);
+  if (!operation) {
+    const displayedOperation = boundedErrorMessage(rawOperation);
+    process.exitCode = 1;
+    console.error(serializeBounded({
+      ok: false,
+      operation: displayedOperation,
+      code: "unknown_operation",
+      error: `Unknown graph operation: ${displayedOperation}`
+    }));
+    return;
+  }
+  try {
+    const request = await parseRequest(operation, args.slice(1), process.cwd());
+    const service = injectedService ?? await loadDefaultService();
+    const result = await service.execute(request);
+    console.log(serializeBounded({ ok: true, operation, result: result ?? null }));
+  } catch (error2) {
+    process.exitCode = 1;
+    const code = error2 instanceof GraphCommandError ? error2.code : "runtime_error";
+    console.error(serializeBounded({
+      ok: false,
+      operation,
+      code,
+      error: boundedErrorMessage(error2)
+    }));
+  }
+}
+
 // src/cli/commands/ralphthon.ts
 init_tmux_utils();
-var import_fs116 = require("fs");
+var import_fs117 = require("fs");
 
 // src/ralphthon/types.ts
 var RALPHTHON_DEFAULTS = {
@@ -102856,7 +106402,7 @@ var RALPHTHON_DEFAULTS = {
 var PRD_FILENAME2 = "ralphthon-prd.json";
 
 // src/ralphthon/prd.ts
-var import_fs115 = require("fs");
+var import_fs116 = require("fs");
 var import_path135 = require("path");
 init_worktree_paths();
 var DEFAULT_PLANNING_CONTEXT = {
@@ -102878,16 +106424,16 @@ function getRalphthonPrdPath(directory) {
 }
 function findRalphthonPrdPath(directory) {
   const rootPath = (0, import_path135.join)(directory, PRD_FILENAME2);
-  if ((0, import_fs115.existsSync)(rootPath)) return rootPath;
+  if ((0, import_fs116.existsSync)(rootPath)) return rootPath;
   const omcPath = getRalphthonPrdPath(directory);
-  if ((0, import_fs115.existsSync)(omcPath)) return omcPath;
+  if ((0, import_fs116.existsSync)(omcPath)) return omcPath;
   return null;
 }
 function readRalphthonPrd(directory) {
   const prdPath = findRalphthonPrdPath(directory);
   if (!prdPath) return null;
   try {
-    const content = (0, import_fs115.readFileSync)(prdPath, "utf-8");
+    const content = (0, import_fs116.readFileSync)(prdPath, "utf-8");
     const prd = JSON.parse(content);
     if (!prd.stories || !Array.isArray(prd.stories)) return null;
     if (!prd.config) return null;
@@ -102901,9 +106447,9 @@ function writeRalphthonPrd(directory, prd) {
   let prdPath = findRalphthonPrdPath(directory);
   if (!prdPath) {
     const omcDir = getOmcRoot(directory);
-    if (!(0, import_fs115.existsSync)(omcDir)) {
+    if (!(0, import_fs116.existsSync)(omcDir)) {
       try {
-        (0, import_fs115.mkdirSync)(omcDir, { recursive: true });
+        (0, import_fs116.mkdirSync)(omcDir, { recursive: true });
       } catch {
         return false;
       }
@@ -102915,7 +106461,7 @@ function writeRalphthonPrd(directory, prd) {
       ...prd,
       planningContext: normalizePlanningContext(prd.planningContext)
     };
-    (0, import_fs115.writeFileSync)(prdPath, JSON.stringify(normalizedPrd, null, 2));
+    (0, import_fs116.writeFileSync)(prdPath, JSON.stringify(normalizedPrd, null, 2));
     return true;
   } catch {
     return false;
@@ -103669,7 +107215,7 @@ async function ralphthonCommand(args) {
     const pollMs = 5e3;
     let waited = 0;
     while (waited < maxWaitMs) {
-      if ((0, import_fs116.existsSync)(prdPath)) {
+      if ((0, import_fs117.existsSync)(prdPath)) {
         const prd = readRalphthonPrd(cwd2);
         if (prd && prd.stories.length > 0) {
           console.log(source_default.green("PRD generated successfully!"));
@@ -103720,16 +107266,16 @@ async function ralphthonCommand(args) {
   console.log(source_default.gray("Orchestrator running. Press Ctrl+C to stop."));
 }
 function sleep5(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 
 // src/cli/commands/ultragoal.ts
-var import_promises26 = require("node:fs/promises");
+var import_promises27 = require("node:fs/promises");
 
 // src/goal-workflows/claude-goal-snapshot.ts
 var import_node_fs16 = require("node:fs");
-var import_promises24 = require("node:fs/promises");
-var import_node_path20 = require("node:path");
+var import_promises25 = require("node:fs/promises");
+var import_node_path21 = require("node:path");
 var ClaudeGoalSnapshotError = class extends Error {
 };
 function safeObject(value) {
@@ -103782,12 +107328,12 @@ async function readClaudeGoalSnapshotInput(raw, cwd2 = process.cwd()) {
   try {
     return parseClaudeGoalSnapshot(JSON.parse(trimmed));
   } catch {
-    const path25 = (0, import_node_path20.resolve)(cwd2, trimmed);
+    const path25 = (0, import_node_path21.resolve)(cwd2, trimmed);
     if (!(0, import_node_fs16.existsSync)(path25)) {
       throw new ClaudeGoalSnapshotError(`Claude goal snapshot is neither valid JSON nor a readable path: ${trimmed}`);
     }
     try {
-      return parseClaudeGoalSnapshot(JSON.parse(await (0, import_promises24.readFile)(path25, "utf-8")));
+      return parseClaudeGoalSnapshot(JSON.parse(await (0, import_promises25.readFile)(path25, "utf-8")));
     } catch (error2) {
       throw new ClaudeGoalSnapshotError(`Claude goal snapshot path does not contain valid JSON: ${trimmed}${error2 instanceof Error ? ` (${error2.message})` : ""}`);
     }
@@ -103827,8 +107373,8 @@ function formatClaudeGoalReconciliation(reconciliation) {
 
 // src/ultragoal/artifacts.ts
 var import_node_fs17 = require("node:fs");
-var import_promises25 = require("node:fs/promises");
-var import_node_path21 = require("node:path");
+var import_promises26 = require("node:fs/promises");
+var import_node_path22 = require("node:path");
 init_worktree_paths();
 var ULTRAGOAL_DIR = ".omc/ultragoal";
 var ULTRAGOAL_BRIEF = "brief.md";
@@ -103842,22 +107388,22 @@ function iso(now = /* @__PURE__ */ new Date()) {
 }
 function ultragoalDir(cwd2, planId) {
   const omcRoot = getOmcRoot(cwd2);
-  if (planId) return (0, import_node_path21.join)(omcRoot, "ultragoal", ULTRAGOAL_PLANS_SUBDIR, planId);
-  return (0, import_node_path21.join)(omcRoot, "ultragoal");
+  if (planId) return (0, import_node_path22.join)(omcRoot, "ultragoal", ULTRAGOAL_PLANS_SUBDIR, planId);
+  return (0, import_node_path22.join)(omcRoot, "ultragoal");
 }
 function ultragoalBriefPath(cwd2, planId) {
-  return (0, import_node_path21.join)(ultragoalDir(cwd2, planId), ULTRAGOAL_BRIEF);
+  return (0, import_node_path22.join)(ultragoalDir(cwd2, planId), ULTRAGOAL_BRIEF);
 }
 function ultragoalGoalsPath(cwd2, planId) {
-  return (0, import_node_path21.join)(ultragoalDir(cwd2, planId), ULTRAGOAL_GOALS);
+  return (0, import_node_path22.join)(ultragoalDir(cwd2, planId), ULTRAGOAL_GOALS);
 }
 function ultragoalLedgerPath(cwd2, planId) {
-  return (0, import_node_path21.join)(ultragoalDir(cwd2, planId), ULTRAGOAL_LEDGER);
+  return (0, import_node_path22.join)(ultragoalDir(cwd2, planId), ULTRAGOAL_LEDGER);
 }
 async function listUltragoalPlanIds(cwd2) {
-  const dir = (0, import_node_path21.join)(getOmcRoot(cwd2), "ultragoal", ULTRAGOAL_PLANS_SUBDIR);
+  const dir = (0, import_node_path22.join)(getOmcRoot(cwd2), "ultragoal", ULTRAGOAL_PLANS_SUBDIR);
   try {
-    const entries = await (0, import_promises25.readdir)(dir, { withFileTypes: true });
+    const entries = await (0, import_promises26.readdir)(dir, { withFileTypes: true });
     return entries.filter((entry) => entry.isDirectory()).filter((entry) => /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(entry.name)).map((entry) => entry.name).sort();
   } catch {
     return [];
@@ -103870,7 +107416,7 @@ async function resolveActivePlanId(cwd2, explicitPlanId) {
     }
     return explicitPlanId;
   }
-  if ((0, import_node_fs17.existsSync)((0, import_node_path21.join)(getOmcRoot(cwd2), "ultragoal", ULTRAGOAL_GOALS))) return void 0;
+  if ((0, import_node_fs17.existsSync)((0, import_node_path22.join)(getOmcRoot(cwd2), "ultragoal", ULTRAGOAL_GOALS))) return void 0;
   const plans = await listUltragoalPlanIds(cwd2);
   if (plans.length === 1) return plans[0];
   if (plans.length === 0) return void 0;
@@ -103885,7 +107431,7 @@ function makePlanId(brief, now) {
   return `${ts}-${slug}`;
 }
 function repoRelative(cwd2, path25) {
-  return (0, import_node_path21.relative)(cwd2, path25).split("\\").join("/");
+  return (0, import_node_path22.relative)(cwd2, path25).split("\\").join("/");
 }
 function cleanLine(line) {
   return line.replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/, "").trim();
@@ -103911,7 +107457,7 @@ async function snapshotObjectiveMapsToUltragoalPlan(cwd2, snapshotObjective, pla
   if (textMentionsUltragoalPlanArtifact(actual)) return true;
   if (actual.length < 24) return false;
   try {
-    const brief = normalizeObjective2(await (0, import_promises25.readFile)(ultragoalBriefPath(cwd2, planId), "utf-8")).toLowerCase();
+    const brief = normalizeObjective2(await (0, import_promises26.readFile)(ultragoalBriefPath(cwd2, planId), "utf-8")).toLowerCase();
     if (!brief || brief.length < 24) return false;
     return brief.includes(actual) || actual.includes(brief);
   } catch {
@@ -103990,16 +107536,16 @@ function normalizeGoalId(title, index) {
   return `G${String(index + 1).padStart(3, "0")}${slug ? `-${slug}` : ""}`;
 }
 async function appendLedger(cwd2, entry, planId) {
-  await (0, import_promises25.mkdir)(ultragoalDir(cwd2, planId), { recursive: true });
+  await (0, import_promises26.mkdir)(ultragoalDir(cwd2, planId), { recursive: true });
   const path25 = ultragoalLedgerPath(cwd2, planId);
-  await (0, import_promises25.appendFile)(path25, `${JSON.stringify(entry)}
+  await (0, import_promises26.appendFile)(path25, `${JSON.stringify(entry)}
 `);
 }
 async function readUltragoalPlan(cwd2, planId) {
   const path25 = ultragoalGoalsPath(cwd2, planId);
   let raw;
   try {
-    raw = await (0, import_promises25.readFile)(path25, "utf-8");
+    raw = await (0, import_promises26.readFile)(path25, "utf-8");
   } catch {
     const hint = planId ? `Pass --plan-id ${planId} to a previously-created plan, or run \`omc ultragoal create-goals --plan-id ${planId} ...\`.` : "Run `omc ultragoal create-goals ...` first.";
     throw new UltragoalError(`No ultragoal plan found at ${repoRelative(cwd2, path25)}. ${hint}`);
@@ -104012,8 +107558,8 @@ async function readUltragoalPlan(cwd2, planId) {
   return parsed;
 }
 async function writePlan(cwd2, plan) {
-  await (0, import_promises25.mkdir)(ultragoalDir(cwd2, plan.planId), { recursive: true });
-  await (0, import_promises25.writeFile)(ultragoalGoalsPath(cwd2, plan.planId), `${JSON.stringify(plan, null, 2)}
+  await (0, import_promises26.mkdir)(ultragoalDir(cwd2, plan.planId), { recursive: true });
+  await (0, import_promises26.writeFile)(ultragoalGoalsPath(cwd2, plan.planId), `${JSON.stringify(plan, null, 2)}
 `);
 }
 async function createUltragoalPlan(cwd2, options) {
@@ -104054,11 +107600,11 @@ async function createUltragoalPlan(cwd2, options) {
     goals: candidates
   };
   if (plan.claudeGoalMode === "aggregate") plan.claudeObjective = aggregateClaudeObjective(candidates, planId);
-  await (0, import_promises25.mkdir)(ultragoalDir(cwd2, planId), { recursive: true });
-  await (0, import_promises25.writeFile)(ultragoalBriefPath(cwd2, planId), options.brief.endsWith("\n") ? options.brief : `${options.brief}
+  await (0, import_promises26.mkdir)(ultragoalDir(cwd2, planId), { recursive: true });
+  await (0, import_promises26.writeFile)(ultragoalBriefPath(cwd2, planId), options.brief.endsWith("\n") ? options.brief : `${options.brief}
 `);
   await writePlan(cwd2, plan);
-  await (0, import_promises25.writeFile)(ultragoalLedgerPath(cwd2, planId), "");
+  await (0, import_promises26.writeFile)(ultragoalLedgerPath(cwd2, planId), "");
   await appendLedger(cwd2, { ts: now, event: "plan_created", message: `${candidates.length} goal(s) created` }, planId);
   return plan;
 }
@@ -104538,7 +108084,7 @@ async function readJsonInput(raw) {
   try {
     const trimmed = raw.trim();
     if (trimmed.startsWith("{") || trimmed.startsWith("[")) return JSON.parse(trimmed);
-    return JSON.parse(await (0, import_promises26.readFile)(trimmed, "utf-8"));
+    return JSON.parse(await (0, import_promises27.readFile)(trimmed, "utf-8"));
   } catch (error2) {
     const message2 = error2 instanceof Error ? error2.message : String(error2);
     throw new UltragoalError(`Invalid --quality-gate-json: ${message2}`);
@@ -104556,7 +108102,7 @@ async function ultragoalCommand(args) {
     }
     if (command === "create" || command === "create-goals") {
       const briefFile = readValue(rest, "--brief-file");
-      const brief = readValue(rest, "--brief") ?? (briefFile ? await (0, import_promises26.readFile)(briefFile, "utf-8") : void 0) ?? (hasFlag2(rest, "--from-stdin") ? await readStdin() : void 0) ?? positionalText(rest);
+      const brief = readValue(rest, "--brief") ?? (briefFile ? await (0, import_promises27.readFile)(briefFile, "utf-8") : void 0) ?? (hasFlag2(rest, "--from-stdin") ? await readStdin() : void 0) ?? positionalText(rest);
       if (!brief.trim()) throw new UltragoalError("Missing brief text. Pass --brief, --brief-file, --from-stdin, or positional text.");
       const goals = readRepeated(rest, "--goal").map(parseGoalArg);
       const plan = await createUltragoalPlan(cwd2, {
@@ -104686,7 +108232,7 @@ ${ULTRAGOAL_HELP}`);
 
 // src/cli/commands/teleport.ts
 var import_child_process39 = require("child_process");
-var import_fs117 = require("fs");
+var import_fs118 = require("fs");
 var import_os21 = require("os");
 var import_path136 = require("path");
 init_loader();
@@ -104701,14 +108247,14 @@ var PACKAGE_MANAGER_LOCKFILES = {
 };
 function readPackageJsonText(directory) {
   try {
-    return (0, import_fs117.readFileSync)((0, import_path136.join)(directory, PACKAGE_JSON_NAME), "utf-8");
+    return (0, import_fs118.readFileSync)((0, import_path136.join)(directory, PACKAGE_JSON_NAME), "utf-8");
   } catch {
     return null;
   }
 }
 function detectPackageManager(parentRepoRoot, worktreePath) {
   for (const [manager, lockfile] of Object.entries(PACKAGE_MANAGER_LOCKFILES)) {
-    if ((0, import_fs117.existsSync)((0, import_path136.join)(worktreePath, lockfile)) || (0, import_fs117.existsSync)((0, import_path136.join)(parentRepoRoot, lockfile))) {
+    if ((0, import_fs118.existsSync)((0, import_path136.join)(worktreePath, lockfile)) || (0, import_fs118.existsSync)((0, import_path136.join)(parentRepoRoot, lockfile))) {
       return manager;
     }
   }
@@ -104729,10 +108275,10 @@ function detectPackageManager(parentRepoRoot, worktreePath) {
 function symlinkNodeModules(parentRepoRoot, worktreePath) {
   const sourceNodeModules = (0, import_path136.join)(parentRepoRoot, "node_modules");
   const targetNodeModules = (0, import_path136.join)(worktreePath, "node_modules");
-  if (!(0, import_fs117.existsSync)(sourceNodeModules) || (0, import_fs117.existsSync)(targetNodeModules)) {
+  if (!(0, import_fs118.existsSync)(sourceNodeModules) || (0, import_fs118.existsSync)(targetNodeModules)) {
     return false;
   }
-  (0, import_fs117.symlinkSync)(sourceNodeModules, targetNodeModules, process.platform === "win32" ? "junction" : "dir");
+  (0, import_fs118.symlinkSync)(sourceNodeModules, targetNodeModules, process.platform === "win32" ? "junction" : "dir");
   return true;
 }
 function installDependencies(worktreePath, packageManager) {
@@ -104948,10 +108494,10 @@ async function fetchProviderInfo(type, number3, provider, owner, repo) {
 function createWorktree(repoRoot, worktreePath, branchName, baseBranch) {
   try {
     const parentDir = (0, import_path136.join)(worktreePath, "..");
-    if (!(0, import_fs117.existsSync)(parentDir)) {
-      (0, import_fs117.mkdirSync)(parentDir, { recursive: true });
+    if (!(0, import_fs118.existsSync)(parentDir)) {
+      (0, import_fs118.mkdirSync)(parentDir, { recursive: true });
     }
-    if ((0, import_fs117.existsSync)(worktreePath)) {
+    if ((0, import_fs118.existsSync)(worktreePath)) {
       return { success: false, error: `Worktree already exists at ${worktreePath}` };
     }
     (0, import_child_process39.execFileSync)("git", ["fetch", "origin", baseBranch], {
@@ -105125,14 +108671,14 @@ function findWorktreeDirs(dir, maxDepth = 3, currentDepth = 0) {
   if (currentDepth >= maxDepth) return [];
   const results = [];
   try {
-    const entries = (0, import_fs117.readdirSync)(dir, { withFileTypes: true });
+    const entries = (0, import_fs118.readdirSync)(dir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const fullPath = (0, import_path136.join)(dir, entry.name);
       try {
         const gitPath2 = (0, import_path136.join)(fullPath, ".git");
-        const stat2 = (0, import_fs117.statSync)(gitPath2);
-        if (stat2.isFile()) {
+        const stat3 = (0, import_fs118.statSync)(gitPath2);
+        if (stat3.isFile()) {
           results.push(fullPath);
           continue;
         }
@@ -105146,7 +108692,7 @@ function findWorktreeDirs(dir, maxDepth = 3, currentDepth = 0) {
 }
 async function teleportListCommand(options) {
   const worktreeRoot = DEFAULT_WORKTREE_ROOT;
-  if (!(0, import_fs117.existsSync)(worktreeRoot)) {
+  if (!(0, import_fs118.existsSync)(worktreeRoot)) {
     if (options.json) {
       console.log(JSON.stringify({ worktrees: [] }));
     } else {
@@ -105280,7 +108826,7 @@ function resolvePluginDirArg(rawPath) {
 
 // src/cli/launch.ts
 var import_child_process40 = require("child_process");
-var import_fs118 = require("fs");
+var import_fs119 = require("fs");
 var import_os22 = require("os");
 var import_path138 = require("path");
 init_mcp_registry();
@@ -105299,37 +108845,37 @@ var SLACK_FLAG = "--slack";
 var WEBHOOK_FLAG = "--webhook";
 var OMC_RUNTIME_DIRNAME = ".omc-launch";
 function hasOmcMarkers(path25) {
-  if (!(0, import_fs118.existsSync)(path25)) return false;
-  const content = (0, import_fs118.readFileSync)(path25, "utf-8");
+  if (!(0, import_fs119.existsSync)(path25)) return false;
+  const content = (0, import_fs119.readFileSync)(path25, "utf-8");
   return content.includes("<!-- OMC:START -->") && content.includes("<!-- OMC:END -->");
 }
 function ensureMirroredPath(sourcePath, targetPath, options = {}) {
-  if (!(0, import_fs118.existsSync)(sourcePath)) return;
+  if (!(0, import_fs119.existsSync)(sourcePath)) return;
   try {
-    const sourceStat = (0, import_fs118.lstatSync)(sourcePath);
-    const targetExists = (0, import_fs118.existsSync)(targetPath);
+    const sourceStat = (0, import_fs119.lstatSync)(sourcePath);
+    const targetExists = (0, import_fs119.existsSync)(targetPath);
     if (targetExists) {
-      const targetStat = (0, import_fs118.lstatSync)(targetPath);
+      const targetStat = (0, import_fs119.lstatSync)(targetPath);
       if (targetStat.isSymbolicLink()) {
         return;
       }
-      (0, import_fs118.rmSync)(targetPath, { recursive: true, force: true });
+      (0, import_fs119.rmSync)(targetPath, { recursive: true, force: true });
     }
     if (sourceStat.isDirectory()) {
-      (0, import_fs118.symlinkSync)(sourcePath, targetPath, process.platform === "win32" ? "junction" : "dir");
+      (0, import_fs119.symlinkSync)(sourcePath, targetPath, process.platform === "win32" ? "junction" : "dir");
       return;
     }
-    (0, import_fs118.symlinkSync)(sourcePath, targetPath, "file");
+    (0, import_fs119.symlinkSync)(sourcePath, targetPath, "file");
   } catch {
     if (options.allowCopyFallback === false) {
       return;
     }
-    const sourceStat = (0, import_fs118.lstatSync)(sourcePath);
+    const sourceStat = (0, import_fs119.lstatSync)(sourcePath);
     if (sourceStat.isDirectory()) {
-      (0, import_fs118.cpSync)(sourcePath, targetPath, { recursive: true });
+      (0, import_fs119.cpSync)(sourcePath, targetPath, { recursive: true });
       return;
     }
-    (0, import_fs118.copyFileSync)(sourcePath, targetPath);
+    (0, import_fs119.copyFileSync)(sourcePath, targetPath);
   }
 }
 function isJsonObject(value) {
@@ -105337,7 +108883,7 @@ function isJsonObject(value) {
 }
 function readJsonObject4(path25) {
   try {
-    const parsed = JSON.parse((0, import_fs118.readFileSync)(path25, "utf-8"));
+    const parsed = JSON.parse((0, import_fs119.readFileSync)(path25, "utf-8"));
     return isJsonObject(parsed) ? parsed : null;
   } catch {
     return null;
@@ -105351,7 +108897,7 @@ function refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath
   }
   const runtimeClaudeJson = readJsonObject4(runtimeClaudeJsonPath) ?? {};
   runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
-  (0, import_fs118.writeFileSync)(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+  (0, import_fs119.writeFileSync)(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
 }
 function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
   const companionPath = (0, import_path138.join)(baseConfigDir, "CLAUDE-omc.md");
@@ -105360,14 +108906,14 @@ function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
   }
   const runtimeConfigDir = (0, import_path138.join)(baseConfigDir, OMC_RUNTIME_DIRNAME);
   const runtimeClaudeJsonPath = (0, import_path138.join)(runtimeConfigDir, ".claude.json");
-  const preservedClaudeJson = (0, import_fs118.existsSync)(runtimeClaudeJsonPath) ? (0, import_fs118.readFileSync)(runtimeClaudeJsonPath) : null;
-  (0, import_fs118.rmSync)(runtimeConfigDir, { recursive: true, force: true });
-  (0, import_fs118.mkdirSync)(runtimeConfigDir, { recursive: true });
+  const preservedClaudeJson = (0, import_fs119.existsSync)(runtimeClaudeJsonPath) ? (0, import_fs119.readFileSync)(runtimeClaudeJsonPath) : null;
+  (0, import_fs119.rmSync)(runtimeConfigDir, { recursive: true, force: true });
+  (0, import_fs119.mkdirSync)(runtimeConfigDir, { recursive: true });
   if (preservedClaudeJson) {
-    (0, import_fs118.writeFileSync)(runtimeClaudeJsonPath, preservedClaudeJson);
+    (0, import_fs119.writeFileSync)(runtimeClaudeJsonPath, preservedClaudeJson);
   }
   refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath);
-  (0, import_fs118.copyFileSync)(companionPath, (0, import_path138.join)(runtimeConfigDir, "CLAUDE.md"));
+  (0, import_fs119.copyFileSync)(companionPath, (0, import_path138.join)(runtimeConfigDir, "CLAUDE.md"));
   for (const entry of [
     "agents",
     "commands",
@@ -105393,17 +108939,17 @@ function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
     );
   }
   const runtimeSettingsPath = (0, import_path138.join)(runtimeConfigDir, "settings.json");
-  if ((0, import_fs118.existsSync)(runtimeSettingsPath)) {
+  if ((0, import_fs119.existsSync)(runtimeSettingsPath)) {
     try {
-      const rawSettings = JSON.parse((0, import_fs118.readFileSync)(runtimeSettingsPath, "utf-8"));
+      const rawSettings = JSON.parse((0, import_fs119.readFileSync)(runtimeSettingsPath, "utf-8"));
       const repaired = stripRetiredTeamMcpServers(rawSettings);
       if (repaired.changed) {
-        (0, import_fs118.writeFileSync)(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+        (0, import_fs119.writeFileSync)(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
       }
     } catch {
     }
   }
-  (0, import_fs118.writeFileSync)(
+  (0, import_fs119.writeFileSync)(
     (0, import_path138.join)(runtimeConfigDir, ".omc-launch-profile.json"),
     JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2)
   );
@@ -105906,8 +109452,8 @@ function interopCommand(options = {}) {
 
 // src/cli/ask.ts
 var import_child_process42 = require("child_process");
-var import_fs119 = require("fs");
-var import_promises27 = require("fs/promises");
+var import_fs120 = require("fs");
+var import_promises28 = require("fs/promises");
 var import_os23 = require("os");
 var import_path139 = require("path");
 var import_url18 = require("url");
@@ -105961,8 +109507,8 @@ function resolveAskPromptsDir(cwd2, packageRoot2, env2 = process.env) {
   }
   try {
     const scopePath = (0, import_path139.join)(cwd2, ".omx", "setup-scope.json");
-    if ((0, import_fs119.existsSync)(scopePath)) {
-      const parsed = JSON.parse((0, import_fs119.readFileSync)(scopePath, "utf-8"));
+    if ((0, import_fs120.existsSync)(scopePath)) {
+      const parsed = JSON.parse((0, import_fs120.readFileSync)(scopePath, "utf-8"));
       if (parsed.scope === "project" || parsed.scope === "project-local") {
         return (0, import_path139.join)(cwd2, ".codex", "prompts");
       }
@@ -105976,17 +109522,17 @@ async function resolveAgentPromptContent(role, promptsDir) {
   if (!SAFE_ROLE_PATTERN.test(normalizedRole)) {
     throw new Error(`[ask] invalid --agent-prompt role "${role}". Expected lowercase role names like "executor" or "test-engineer".`);
   }
-  if (!(0, import_fs119.existsSync)(promptsDir)) {
+  if (!(0, import_fs120.existsSync)(promptsDir)) {
     throw new Error(`[ask] prompts directory not found: ${promptsDir}.`);
   }
   const promptPath = (0, import_path139.join)(promptsDir, `${normalizedRole}.md`);
-  if (!(0, import_fs119.existsSync)(promptPath)) {
-    const files = await (0, import_promises27.readdir)(promptsDir).catch(() => []);
+  if (!(0, import_fs120.existsSync)(promptPath)) {
+    const files = await (0, import_promises28.readdir)(promptsDir).catch(() => []);
     const availableRoles = files.filter((file) => file.endsWith(".md")).map((file) => file.slice(0, -3)).sort();
     const availableSuffix = availableRoles.length > 0 ? ` Available roles: ${availableRoles.join(", ")}.` : "";
     throw new Error(`[ask] --agent-prompt role "${normalizedRole}" not found in ${promptsDir}.${availableSuffix}`);
   }
-  const content = (await (0, import_promises27.readFile)(promptPath, "utf-8")).trim();
+  const content = (await (0, import_promises28.readFile)(promptPath, "utf-8")).trim();
   if (!content) {
     throw new Error(`[ask] --agent-prompt role "${normalizedRole}" is empty: ${promptPath}`);
   }
@@ -106073,7 +109619,7 @@ async function askCommand(args) {
   const packageRoot2 = getPackageRoot();
   const advisorScriptPath = resolveAskAdvisorScriptPath(packageRoot2);
   const promptsDir = resolveAskPromptsDir(process.cwd(), packageRoot2, process.env);
-  if (!(0, import_fs119.existsSync)(advisorScriptPath)) {
+  if (!(0, import_fs120.existsSync)(advisorScriptPath)) {
     throw new Error(`[ask] advisor script not found: ${advisorScriptPath}`);
   }
   let finalPrompt = parsed.prompt;
@@ -106237,15 +109783,15 @@ async function runHudWatchLoop(options) {
     if (shouldStop) {
       break;
     }
-    await new Promise((resolve32) => {
+    await new Promise((resolve33) => {
       const timer = setTimeout(() => {
         wakeSleep = null;
-        resolve32();
+        resolve33();
       }, options.intervalMs);
       wakeSleep = () => {
         clearTimeout(timer);
         wakeSleep = null;
-        resolve32();
+        resolve33();
       };
       timer.unref?.();
     });
@@ -106327,8 +109873,8 @@ Examples:
     console.log(`  User:    ${paths.user}`);
     console.log(`  Project: ${paths.project}`);
     console.log(source_default.blue("\nFile status:"));
-    console.log(`  User:    ${(0, import_fs127.existsSync)(paths.user) ? source_default.green("exists") : source_default.gray("not found")}`);
-    console.log(`  Project: ${(0, import_fs127.existsSync)(paths.project) ? source_default.green("exists") : source_default.gray("not found")}`);
+    console.log(`  User:    ${(0, import_fs128.existsSync)(paths.user) ? source_default.green("exists") : source_default.gray("not found")}`);
+    console.log(`  Project: ${(0, import_fs128.existsSync)(paths.project) ? source_default.green("exists") : source_default.gray("not found")}`);
     return;
   }
   const config2 = loadConfig();
@@ -106497,7 +110043,7 @@ Examples:
     }
     config3.notificationProfiles[profileName] = profile;
     try {
-      (0, import_fs127.writeFileSync)(CONFIG_FILE, JSON.stringify(config3, null, 2), "utf-8");
+      (0, import_fs128.writeFileSync)(CONFIG_FILE, JSON.stringify(config3, null, 2), "utf-8");
       console.log(source_default.green(`\u2713 Profile "${profileName}" \u2014 ${type} configured`));
       console.log(JSON.stringify(profile[type], null, 2));
     } catch (error2) {
@@ -106610,7 +110156,7 @@ Examples:
     }
   }
   try {
-    (0, import_fs127.writeFileSync)(CONFIG_FILE, JSON.stringify(config2, null, 2), "utf-8");
+    (0, import_fs128.writeFileSync)(CONFIG_FILE, JSON.stringify(config2, null, 2), "utf-8");
     console.log(source_default.green(`\u2713 Stop callback '${type}' configured`));
     console.log(JSON.stringify(config2.stopHookCallbacks[type], null, 2));
   } catch (error2) {
@@ -106672,7 +110218,7 @@ Active profile (OMC_NOTIFY_PROFILE): ${activeProfile}`));
       delete config2.notificationProfiles;
     }
     try {
-      (0, import_fs127.writeFileSync)(CONFIG_FILE, JSON.stringify(config2, null, 2), "utf-8");
+      (0, import_fs128.writeFileSync)(CONFIG_FILE, JSON.stringify(config2, null, 2), "utf-8");
       console.log(source_default.green(`\u2713 Profile "${name}" deleted`));
     } catch (error2) {
       console.error(source_default.red("Failed to write configuration:"), error2);
@@ -107208,6 +110754,9 @@ program2.command("mission-board").description("Render the opt-in mission board s
 });
 program2.command("team").description("Team CLI API for worker lifecycle operations").helpOption(false).allowUnknownOption(true).allowExcessArguments(true).argument("[args...]", "team subcommand arguments").action(async (args) => {
   await teamCommand(args);
+});
+program2.command("graph").description("Guarded durable orchestration graph state operations").helpOption(false).allowUnknownOption(true).allowExcessArguments(true).argument("[args...]", "graph operation and arguments").action(async (args) => {
+  await graphCommand(args);
 });
 program2.command("autoresearch").description("Hard-deprecated shim that redirects users to deep-interview + autoresearch skill").helpOption(false).allowUnknownOption(true).allowExcessArguments(true).argument("[args...]", "autoresearch subcommand arguments").action(async (args) => {
   await autoresearchCommand(args);

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,7 @@
 5. [Agent Templates](#agent-templates)
 6. [Session Resume](#session-resume)
 7. [Autopilot](#autopilot)
+8. [Durable Orchestration Graph (v1)](#durable-orchestration-graph-v1)
 
 ---
 
@@ -571,6 +572,58 @@ All state is persisted to `.omc/state/autopilot-state.json` and includes:
 - Agent spawn count and metrics
 - Phase duration tracking
 - Session binding
+
+---
+
+## Durable Orchestration Graph (v1)
+
+Graph is a separate top-level runtime for development work whose control flow must remain explicit across parallel branches, conditional remediation, human gates, and process interruption. The public in-session entrypoint is:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+The skill creates a draft and renders the exact revision for inspection. Execution is forbidden until the human approves that revision ID and descriptor hash. Bare natural-language mentions of "graph" do not activate the mode.
+
+### Runtime boundary
+
+The `src/graph/` core adds no runtime dependency and owns descriptor validation and hashing, deterministic scheduling, immutable revision handling, claim leases, Graph-wide transactions, control ownership, and bounded presentation. Skill, CLI, hook, state, and HUD integrations are adapters. They must not become alternate graph authorities.
+
+One session-scoped `graph-state.json` transaction object is authoritative for recovery. It embeds approved descriptor revisions, committed transition history, the current projection, claims, selected edges, traversal and join tokens, pending approval or reconciliation data, evidence references, and a monotonic commit sequence. Logs, HUD state, and exports can be regenerated.
+
+### Descriptor and scheduler contract
+
+- Built-in nodes are `agent`, `command`, `human-approval`, and `join`.
+- Edges support fixed continuation, declared conditional routes, parallel fan-out/fan-in, and bounded back-edges.
+- V1 fork/join regions are structured and non-overlapping; nested, overlapping, or crossing open regions fail validation.
+- Each fan-out traversal receives its own cohort and branch tokens, so a join waits only for branches selected in that traversal.
+- Terminal success requires fresh evidence from the declared verification node.
+
+An `agent` node may perform bounded local iteration, but it does not activate global Ralph mode. Graph remains the sole top-level scheduler. Ralph continues to own persistent implementation/verification loops, and Autopilot continues to own its existing staged workflow.
+
+### Durability and effects
+
+A successful mutation atomically commits the node result, selected route, traversal counters, ready nodes, and join state under revision, sequence, transition, attempt, and lease fences. Recovery reconstructs readiness from the approved descriptor and committed ledger and does not rerun committed successful work.
+
+This is an exactly-once scheduler-transition guarantee, not an exactly-once external-side-effect guarantee. Side-effect-free or durably idempotent work can be reclaimed after lease expiry. Ambiguous effects move to reconciliation, where evidence or an explicit human decision is required before progress resumes.
+
+Structural patches stop new dispatch and require approval of a new immutable revision after old claims and reconciliation have settled. Historical descriptors and evidence remain preserved.
+
+### Lifecycle and state integration
+
+- `pause` fences or drains work, preserves the resumable run, and releases root control.
+- `resume` reacquires the same session, run, and revision with a new nonce.
+- `abandon` requires exact run/revision confirmation, records terminal `cancelled`, and retains the ledger. Destructive purge is outside v1.
+- Generic state reads and bounded summaries are allowed; generic Graph writes and deletion are not.
+- `state_clear(graph)` returns `guarded_mode`; `state_clear(all)` skips Graph; force does not bypass the guard.
+
+The in-session skill owns drafting, approval questions, node dispatch, and result reporting. Guarded `omc graph` operations expose the runtime state machine for terminal automation without acting as a task executor or raw state editor; exact subcommand names remain intentionally undocumented until that surface is final.
+
+### Platform and scope
+
+Graph v1 execution requires Linux with `/proc` and owner-fenced `flock`; unsupported platforms fail before control reservation or state mutation. V1 excludes a visual editor, public stable authoring DSL, plugin-defined node kinds, arbitrary executable edge code, nested or overlapping fork regions, distributed scheduling, destructive purge, and exactly-once external side effects.
+
+See [ADR: Durable Orchestration Graph V1](./adr/v1-durable-orchestration-graph.md) for the decision record and [Reference Documentation](./REFERENCE.md#durable-orchestration-graph-v1) for the user-facing lifecycle contract.
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -13,8 +13,10 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated-opt-in-only)
 - [Agents (29 Total)](#agents-29-total)
-- [Goal Workflow UX: `/goal`, Ralph, Team, UltraQA, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultraqa-ultragoal)
-- [Skills (38 Total)](#skills-38-total)
+- [Goal Workflow UX: Graph, `/goal`, Ralph, Team, UltraQA, Ultragoal](#goal-workflow-ux-graph-goal-ralph-team-ultraqa-ultragoal)
+- [Named autopilot stage profiles (v1)](#named-autopilot-stage-profiles-v1)
+- [Durable orchestration Graph (v1)](#durable-orchestration-graph-v1)
+- [Skills (39 Total)](#skills-39-total)
 - [Slash Commands](#slash-commands)
 - [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
 - [Hooks System](#hooks-system)
@@ -729,12 +731,13 @@ Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ---
 
-## Goal Workflow UX: `/goal`, Ralph, Team, UltraQA, Ultragoal
+## Goal Workflow UX: Graph, `/goal`, Ralph, Team, UltraQA, Ultragoal
 
-OMC exposes several ways to pursue a goal-shaped task. They are complementary, not interchangeable. Choose one primary loop authority per session and use the others as evidence producers or handoff targets.
+OMC exposes several ways to pursue a goal-shaped task. They are complementary, not interchangeable. Choose one primary orchestration authority per session and use the others as evidence producers or handoff targets.
 
 | Surface                 | Runtime owner                                     | User-facing promise                                           | Completion evidence                                                          | Notes                                                                                                                                                           |
 | ----------------------- | ------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Graph                   | OMC approved-graph scheduler                      | Follow explicit nodes and routes with durable crash recovery  | Immutable revision, transition ledger, node evidence, and terminal verifier  | Prefer when branches, joins, human gates, and bounded returns must remain visible across interruptions.                                                        |
 | Claude Code `/goal`     | Claude Code native session loop                   | Keep working toward one stated completion condition           | Evidence surfaced in the conversation for the `/goal` evaluator              | Cite Claude Code/Anthropic docs or changelog only for `/goal` behavior. The evaluator must not be described as independently running commands or reading files. |
 | Ralph                   | OMC skill + Stop-hook enforcement                 | Persistent single-owner implementation until PRD stories pass | Tests/build/lint/typecheck plus reviewer verification                        | Prefer when correctness depends on OMC's PRD, progress, and reviewer gates.                                                                                     |
 | Team                    | OMC native/team or CLI team runtime               | Coordinated multi-agent execution over assigned tasks         | Worker task results, commits, staged `team-verify`/`team-fix` evidence       | Prefer when ownership boundaries and parallel lanes matter.                                                                                                     |
@@ -754,7 +757,7 @@ Do not cite OpenAI/Codex documentation as authority for Claude Code `/goal`. In 
 
 When multiple loops could apply, use this deterministic policy:
 
-1. **refuse**: if Ralph, Team, UltraQA, autopilot, or another Stop-hook loop is already active and a new `/goal` would compete for continuation authority.
+1. **refuse**: if Graph, Ralph, Team, UltraQA, autopilot, or another Stop-hook loop is already active and a new `/goal` would compete for continuation authority.
 2. **adopt_existing**: if Claude Code `/goal` is already active and the OMC workflow can attach evidence to that same condition without changing loop ownership.
 3. **artifact_only**: if `/goal` is unavailable because of hooks/trust/settings, or if the user only needs durable planning, checkpointing, and evidence capture.
 
@@ -800,7 +803,51 @@ Autopilot continues to own cancel, resume, cleanup, state inspection, HUD, and S
 
 V1 deliberately defers `stageModels` and all model/provider/role routing, inline/no-spawn execution, dynamic commands/modes/state files, arbitrary stages/prompts/plugins and control-flow extensions, and the separate custom-skill inline-array frontmatter parser mismatch. See [ADR 03487](./adr/03487-named-autopilot-stage-profiles.md) for the decision record.
 
-## Skills (38 Total)
+## Durable orchestration Graph (v1)
+
+Invoke Graph explicitly inside a Claude Code / OMC session:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+A bare natural-language mention of "graph" does not activate the workflow. The skill first creates and validates a draft, then renders its exact revision ID and integrity hash together with all nodes, commands, routes, joins, back-edge bounds, concurrency, and terminal verification responsibility. No node work starts until the human approves that exact revision.
+
+### Execution model
+
+| Node kind | Behavior |
+| --- | --- |
+| `agent` | Dispatches bounded development work and returns a structured result. |
+| `command` | Runs a permission-governed command or automated test and records evidence. |
+| `human-approval` | Waits durably for an explicit human decision. |
+| `join` | Reunites only the branches selected for the current fan-out traversal. |
+
+Declared edges provide fixed continuation, result-selected conditional routes, parallel fan-out/fan-in, and bounded returns to an earlier node. V1 supports structured, non-overlapping fork/join regions; nested or crossing open regions are rejected. A discovered structural change becomes a patch proposal: dispatch pauses, the human inspects a new revision, and only exact-revision approval can activate it. Earlier descriptors, results, and evidence remain in history.
+
+Graph makes cross-node control explicit. Ralph remains the persistent single-owner implementation and verification loop, while Autopilot remains its staged autonomous workflow. An `agent` node may iterate locally without activating global Ralph mode; Graph still owns readiness, routing, joins, and recovery.
+
+### Pause, resume, and abandon
+
+- Ordinary cancellation pauses the run, fences or drains active work, preserves `graph-state.json`, and releases top-level control.
+- Resume reacquires the same session, run, and revision with a new ownership nonce. It does not create a replacement run or rerun already committed successful work.
+- Abandon is an explicit permanent transition to terminal `cancelled`. It requires confirmation of the exact run and revision and retains the ledger and evidence. V1 has no destructive purge.
+- Waiting for initial approval, a human node, patch approval, or reconciliation is durable and does not busy-loop.
+
+The session-scoped `graph-state.json` is the recovery authority. It contains immutable revisions, committed transitions, the current projection, claims, selected routes, join tokens, and evidence references. HUD output, logs, and exports are bounded disposable views.
+
+Terminal automation uses guarded `omc graph` state-machine operations. Exact subcommand names are not part of this v1 documentation contract. The CLI does not execute agent, command, or human nodes itself and does not expose raw Graph state replacement.
+
+### Safety and v1 boundaries
+
+Graph guarantees exactly-once committed scheduler transitions, not exactly-once external side effects. Side-effect-free or durably idempotent work can retry after an interrupted claim. An ambiguous external effect enters visible reconciliation instead of being silently replayed.
+
+Generic state tools may read, list, report status, and show bounded Graph summaries. Generic `state_write(graph)` is unavailable. `state_clear(graph)` returns `guarded_mode`, while `state_clear(all)` skips Graph and reports the skip; force does not bypass either protection. Use Graph-specific pause or abandon operations for lifecycle changes.
+
+Graph v1 execution is Linux-only and requires owner-fenced `flock` plus `/proc` process identity. Unsupported platforms fail before control reservation or Graph state mutation. V1 does not provide a visual editor, public stable authoring DSL, plugin-defined node kinds, arbitrary executable edge expressions, distributed scheduling, nested/overlapping fork regions, or exactly-once external effects.
+
+See [ADR: Durable Orchestration Graph V1](./adr/v1-durable-orchestration-graph.md) for the architectural decision and its relationship to [Autopilot profile ADR 03487](./adr/03487-named-autopilot-stage-profiles.md).
+
+## Skills (39 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
@@ -821,6 +868,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `deep-interview`          | Socratic deep interview with ambiguity gating                    | `/deep-interview`                           |
 | `deepinit`                | Generate hierarchical AGENTS.md docs                             | `/oh-my-claudecode:deepinit`                |
 | `external-context`        | Parallel document-specialist research                            | `/oh-my-claudecode:external-context`        |
+| `graph`                   | Human-approved durable graph orchestration                       | `/oh-my-claudecode:graph <goal>`            |
 | `hud`                     | Configure HUD/statusline                                         | `/oh-my-claudecode:hud`                     |
 | `skillify`                | Extract reusable skill from session                              | `/oh-my-claudecode:skillify`                |
 | `learner`                 | **Deprecated** compatibility alias for `skillify`                | `/oh-my-claudecode:learner`                 |
@@ -864,6 +912,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:deep-dive <problem>`                  | Run the trace → deep-interview pipeline                                                       |
 | `/deep-interview <idea>`                                 | Socratic interview with ambiguity scoring before execution                                    |
 | `/oh-my-claudecode:deepinit [path]`                      | Index codebase with hierarchical AGENTS.md files                                              |
+| `/oh-my-claudecode:graph <goal>`                         | Draft, approve, and run a durable orchestration graph                                          |
 | `/oh-my-claudecode:mcp-setup`                            | Configure MCP servers                                                                         |
 | `/oh-my-claudecode:omc-doctor`                           | Diagnose and fix installation issues                                                          |
 | `/oh-my-claudecode:plan <description>`                   | Start planning session (supports consensus structured deliberation)                           |

--- a/docs/adr/v1-durable-orchestration-graph.md
+++ b/docs/adr/v1-durable-orchestration-graph.md
@@ -1,0 +1,301 @@
+# ADR: Durable Orchestration Graph V1
+
+- **Status:** Accepted for v1
+- **Decision scope:** Explicit, human-approved, crash-resumable control flow for long-running development work
+
+## Decision
+
+OMC will add Graph as a separate top-level orchestration runtime, invoked explicitly in session with:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+Graph turns the goal into a typed execution descriptor whose approved revisions are immutable. It renders that descriptor for inspection and requires human approval of the exact revision ID and hash before any node may run. The approved graph, transition ledger, current projection, claims, selected routes, join tokens, and revision history live together in one authoritative, session-scoped `graph-state.json` transaction object.
+
+Graph does not replace Ralph or widen Autopilot. Ralph remains a persistent implementation and verification loop. Autopilot remains its established staged autonomous workflow. A Graph `agent` node may perform bounded local iteration, but Graph remains the only top-level scheduler and records which node is active, which edge was selected, and what is ready next.
+
+## Drivers
+
+- Long-running tasks lose their global shape when the next action exists only in an agent's conversation context.
+- Parallel branches, conditional remediation, human gates, and crash recovery require explicit persisted control state.
+- Completed work must survive driver or agent interruption without relying on prompt memory.
+- Structural changes discovered during execution need reviewable, immutable revisions rather than silent graph mutation.
+- Existing Ralph and Autopilot users require compatibility, not a migration to a new runtime.
+
+## Descriptor, approval, and revisions
+
+The v1 descriptor declares stable node IDs, node kinds, entry nodes, typed edges and route labels, joins, concurrency, bounded back-edges, and terminal verification responsibility. Its canonical JSON is hashed with SHA-256; mutable attempts, outputs, owners, and timestamps are excluded from the descriptor hash.
+
+The approval view identifies every node, command, route, join, return bound, concurrency limit, and terminal verification node. Drafting and validation may occur before approval, but dispatch may not. Approval binds to the exact revision ID and descriptor hash.
+
+Agents may propose structural patches but may not apply them. A proposal pauses new dispatch, waits for old claims and reconciliation to settle, and requires human approval of a new immutable revision. The ledger retains earlier descriptors, results, and evidence; completed node IDs cannot be silently reused.
+
+## Nodes and routes
+
+V1 has four built-in node kinds:
+
+| Node | Responsibility |
+| --- | --- |
+| `agent` | Perform bounded delegated development work and return a structured result. |
+| `command` | Run a permission-governed command or automated test and report structured evidence. |
+| `human-approval` | Wait durably for an explicit human decision. |
+| `join` | Deterministically synchronize the selected branches of one fan-out traversal. |
+
+Edges support fixed continuation, declared conditional routes, parallel fan-out/fan-in, and bounded returns to an earlier node. V1 fork/join regions are structured and non-overlapping: every fan-out owns one join, and nested or crossing open regions are rejected. Edge conditions are declared route labels, not arbitrary executable expressions.
+
+## State, commits, and recovery
+
+The scheduler commits a node result, selected route, traversal counters, resulting readiness, and join state in one compare-and-swap transaction. A monotonic sequence, revision/hash fence, transition ID, activation ID, attempt ID, and claim lease prevent duplicate or stale work from winning after recovery.
+
+This provides exactly-once committed scheduler transitions. It does **not** provide exactly-once external side effects. Side-effect-free work and work with durable idempotency keys may be retried after an expired lease. An ambiguous external effect enters visible reconciliation and requires evidence or a human decision before the graph continues.
+
+Recovery rebuilds readiness from the approved revision and committed history. Successful committed nodes are not rerun. Logs, HUD projections, and exports are disposable views; they are not recovery authorities.
+
+## Runtime ownership and lifecycle
+
+Graph is mutually exclusive with other root persistent workflow owners, including standalone Ralph and Autopilot. A child adapter cannot release the Graph root or become a second scheduler.
+
+Ordinary Graph cancellation maps to `pause`: new dispatch stops, claims and children are fenced or drained, durable state becomes `paused`, and root control is released. `resume` reacquires the same session, run, and revision with a new ownership nonce; it does not create a replacement run. Permanent termination is the explicit `abandon` operation, which requires exact run/revision confirmation, records terminal `cancelled`, and retains the full ledger and evidence. Destructive purge is outside v1.
+
+The in-session skill owns descriptor drafting, exact-revision questions, node dispatch, and result reporting. Terminal automation may use guarded `omc graph` operations, but those operations are a state-machine boundary, not a general task executor or a raw state editor.
+
+## Public-state handling
+
+Generic state surfaces may read, list, report status, and render bounded summaries for Graph. They may not replace or delete Graph state. Generic `state_write(graph)` is unavailable; `state_clear(graph)` returns `guarded_mode`; `state_clear(all)` skips Graph and reports the skip. A force flag does not bypass these protections. Pausing and abandoning use Graph-specific atomic operations.
+
+## Platform boundary
+
+Graph v1 execution is cross-platform and runs on Linux, macOS, and Windows.
+Process identity pairs a pid with a process start time so a dead or recycled
+pid cannot be mistaken for a live owner:
+
+| Platform | Process-start source | Fallback |
+| --- | --- | --- |
+| Linux | `/proc/{pid}/stat` field 20 (clock ticks) | pid-only |
+| macOS | `LC_ALL=C ps -p {pid} -o lstart=` | pid-only |
+| Windows | PowerShell `Get-Process -Id {pid}` epoch seconds | pid-only |
+
+A platform-specific read that fails or yields an unparseable value degrades to
+a pid-only identity (empty `process_start`). Liveness then resolves as: a dead
+pid is definitively not live; a live pid with a matching `process_start` is
+live; a live pid whose current `process_start` differs (PID reuse) is not live;
+a pid-only identity is treated as live while the pid exists, with degraded
+PID-reuse protection surfaced as an observability warning. Liveness returns
+`unknown` only when even the pid signal cannot be probed.
+
+File locking is cross-platform. The atomic `O_EXCL` create is the portable
+fallback used on every platform; on Linux, `flock` is used when available for
+stronger guarantees and the `O_EXCL` fallback applies when it is not. An
+unsupported runtime—one that cannot provide even pid-only liveness or the
+atomic create—fails before reserving control or creating or mutating Graph
+state. Pure descriptor validation and scheduler logic remain portable and
+tested across platforms.
+
+Reclaim policy is **lease-based and converged across the `flock` and flock-less
+paths** (B7/B10). The mutation lock (`<state>.mutation.lock`) is an `O_EXCL`
+atomic create whose owner JSON is `{ version: 1, pid, createdAt, expires_at,
+nonce }` (the deployed **lease schema**, `version: 1`). `expires_at` is the **sole
+reclaim key**: the holder writes `expires_at = now + LEASE_MS` at acquire, and a
+later acquirer reclaims only once `now >= expires_at`. There is **no
+process-liveness probing** on the mutation lock-no `process.kill(pid, 0)`, no
+`/proc/<pid>/stat` start comparison, no EPERM/ESRCH classification, no PID-reuse
+reasoning. `pid` and `nonce` stay for debug/ownership identity only (release
+verifies `pid + nonce + createdAt` so a holder does not unlink a lock a live
+owner lawfully reclaimed after the holder's own lease expired).
+
+### On-disk schema versions (B12)
+
+The lock file carries an explicit on-disk schema version so a pre-upgrade owner
+is never mistaken for a corrupt/reclaimable one:
+
+- **v1 lease schema (current and deployed):** `{ version: 1, pid, createdAt,
+  expires_at, nonce }`. New owners keep writing this established wire format so
+  installed readers continue to recognize a live lease.
+- **v1 old liveness schema:** `{ version: 1, pid, processStart, createdAt,
+  nonce }` - has `processStart`, no `expires_at`. This distinct pre-lease shape
+  may still have a live owner and is fail-closed: never reclaim or unlink it.
+- **Unknown lease schema:** a structurally valid lease record with an unsupported
+  positive version is held under an unknown contract and also fails closed.
+- **Unrecognised-but-valid schema (B12):** any readable JSON object that carries
+  a positive-integer `version` field but does NOT match a known shape (e.g. a
+  `#3553`-era or future lease record with extra/renamed fields) is classified
+  `'unrecognised'`, NOT `'corrupt'`. The owner MAY be live under a contract this
+  build does not recognise, so it FAILS CLOSED: never reclaim, never unlink.
+  `'corrupt'` is reserved for genuinely unparseable bytes (broken JSON,
+  non-object, or a non-versioned record with no `version` field) where no valid
+  lease can be on record and the owner cannot be live, so reclaim is safe.
+
+The discriminator is the complete record shape, not the version alone. This
+preserves compatibility with deployed v1 lease readers while preventing a
+pre-lease v1 liveness owner, an unsupported-lease-version owner, or any future
+unrecognised lease contract from being reclaimed as corrupt.
+
+#### Rollout limitation: old-to-new requires reinstall
+
+The schema-version bump protects **new-to-new** interactions: two installs that
+both understand the `'unrecognised'` classification will fail closed on each
+other's unknown shapes and never steal a live lock. It does NOT protect
+**old-to-new** interactions. `templates/hooks/lib/atomic-write.mjs` is copied
+into user homes at install time and is NOT auto-upgraded; an already-deployed
+older reader that predates the `'unrecognised'`/`'unknown_version'` statuses
+classifies any non-v1-lease record it does not recognise as `'corrupt'` and
+RECLAIMS it - including a newer writer's live lock. This is a known rollout
+limitation: the version bump makes new installs safe with each other, but a new
+writer running alongside a stale in-home older reader requires a reinstall of
+the hooks so both sides share the current classifier. There is no in-band
+upgrade path for the deployed hook copy; reinstall is the mitigation.
+
+### Lease duration, holder re-validation, and renewal (B11)
+
+`LEASE_MS` is 300000 (5 minutes): generous enough that a single
+acquire->mutate->release cycle (a graph mutation or an autopilot state write)
+almost always completes within the lease. A lease can nonetheless expire while
+the holder is still in the critical section (a slow graph mutation, a stalled
+writer). If the lease expires, a second writer can reclaim and re-acquire, and
+both writers would be in the critical section - the second publishing over the
+first. The old liveness design failed CLOSED by construction; the lease fails
+OPEN by construction. To make that violation **detectable rather than silent**,
+the holder re-validates its OWN lease and can extend it:
+
+1. **Holder re-validation immediately before publish (`assertMutationLockHeld`).**
+   The re-validation is placed AS CLOSE TO THE PUBLISH AS POSSIBLE, not before an
+   arbitrary callback. In `writeStateFileLocked`/`writeStateFileLockedIf`/
+   `writeStateFileLockedCreateIf`/`clearStateFileLocked`/`clearStateFileLockedIf`
+   it runs immediately before the `atomicWriteJsonSync`/`unlinkSync`; in
+   `withStateFileMutationLock`/`withStateFileLockSync` the assert closure is
+   handed to the caller to invoke immediately before its own publish; and in the
+   graph store (`src/graph/store.ts` + `src/graph/control-owner.ts`) a
+   `renewLease()` call runs immediately before each `writeAtomic` publish. The
+   holder re-reads its own lock's `expires_at`, checks `now < expires_at`, and
+   confirms the on-disk owner is still itself. If the lease has expired (or the
+   on-disk owner was replaced by a later writer, or is now a record under an
+   unrecognised contract), it ABORTS the publish, throws
+   `lease_expired_during_mutation`, and logs
+   `state_mutation_lock_lease_expired_during_mutation`. The two-writer overlap is
+   thus observable, not silent. The holder checks its OWN lease, not someone
+   else's. This closes the window where the lease expires DURING the callback
+   (after acquire, before publish): the guard proves the lease at publish time,
+   not just at acquire time.
+2. **Lease renewal for long-held locks (`renewMutationLock`).** The graph
+   callsites (`withRenewingExclusiveLock` in `src/graph/store.ts` and
+   `src/graph/control-owner.ts`) wire `renewMutationLock` so a long graph
+   mutation (clone + callback + re-parse + size-check that may approach or exceed
+   `LEASE_MS`) renews at acquire time and immediately before each publish, and
+   hands a `renew` callback to the mutation so it can additionally extend
+   `expires_at = now + LEASE_MS` at long-running checkpoints. Renewal
+   re-validates that the on-disk owner is still the caller's (otherwise a later
+   writer has already reclaimed the expired lease and the caller must NOT
+   publish) and returns false on any mismatch or I/O failure. The assertion in
+   (1) is the safety net that catches any holder that overruns its lease without
+   renewing. The renewed record is written to a temp file and `rename()`d over
+   the old record (POSIX-atomic), so the lock path is NEVER absent during renewal
+   - there is no unlink-then-link window in which a contender's `linkSync` could
+   succeed and admit a second writer.
+
+If the holder crashes or fails to release, a later acquirer reclaims via lease
+expiry (bounded recovery-via-expiry).
+
+Both paths read the on-disk owner's `expires_at` and apply the same decision:
+a valid unexpired v1 lease is LIVE (do not steal; wait/fail closed); a valid
+expired v1 lease is RECLAIMED (`unlinkSync` + re-acquire); a readable but
+unparseable/invalid owner (corrupt) is RECLAIMED (no valid lease is on record,
+so the owner cannot be live); a v1 old-liveness owner is `'old_version'` and
+FAILS CLOSED (B12: the pre-upgrade owner may be alive; never reclaim); an
+unsupported but structurally valid lease version also FAILS CLOSED; an I/O
+read failure `EACCES`/`EMFILE`/`EIO`/`ENOMEM` (non-ENOENT) FAILS CLOSED forever
+(the owner MAY be alive and we cannot read its lease-log
+`state_mutation_lock_unverifiable`, no auto-steal, no bounded reclaim, operator
+attention); and `ENOENT` (lock vanished: race) retries `linkSync`. The `flock`
+path performs this inside `LOCK_REMOVAL_SCRIPT` (run under an exclusive `flock`
+guard so the reclaim read+unlink is atomic; exit 5 = `'old_version'` fail-closed);
+the flock-less `O_EXCL` path performs the identical decision inline via
+`readLockOwner`.
+
+This lease design eliminates the recurring liveness edge-case blockers the
+red-team reviewer found, because none can arise when no process liveness is
+probed: **B5** (jiffies vs ms-epoch mismatch misclassifying a live self-owner
+as PID-reused) - `processStartIdentity` is no longer consulted by the lock;
+**B6** (EPERM misclassified as dead, stealing a live other-uid owner's lock) -
+`process.kill(pid, 0)` is no longer called by the lock; **B7/B10** (flock vs
+flock-less liveness divergence) - both paths reclaim on the same `expires_at`;
+**B8** (test-seam complexity around `/proc` jiffies) - the
+`__testCurrentProcessStart` seam is removed and lease tests plant `expires_at`
+(clock-based, platform-agnostic); **B9** (EACCES-on-unreadable stealing a live
+lock) - an unreadable lock fails closed forever; only corrupt or expired leases
+are reclaimed; **B11** (lease expires while holder still working, admitting a
+second writer silently) - the holder re-validates its own lease before publish
+and aborts on expiry, and long-held locks renew; **B12** (on-disk schema
+compatibility) - the deployed v1 lease wire format is retained, while v1
+old-liveness and unknown lease records fail closed.
+
+The distinct emergency-journal crash-recovery subsystem
+(`recoverEmergencyStateFile` / `emergencyMutateStateFileIf`) retains its own
+process-start identity check for authenticating a crashed transaction's owner;
+it is intentionally separate from the lease-based mutation lock so the lock
+blockers above cannot recur there.
+
+## Claim lease and expiry contract
+
+A claim is a durable lease on one activation/attempt. `issued_at`,
+`expires_at`, `lease_duration_ms`, `renewal_count`, and `max_renewals` bound
+it; renewals extend `expires_at` only while the claim is still live.
+
+Expiry is a **soft recovery signal**, not a hard fulfillment barrier. The
+`complete` and `fail` operations gate on `status === 'live'` and do not consult
+`expires_at`: an expired-but-still-live claim may still be fulfilled by its
+original worker if it completes before recovery takes over, and its result is
+accepted. Expiry matters in three places, and only there:
+
+- **Renewal rejects expired claims.** `renew` throws `lease_expired` once
+  `now >= expires_at`; an expired lease cannot be extended.
+- **Recovery requires expiry.** `recover-expired-claim` throws `lease_live` if
+  the claim has not yet expired; recovery only takes over abandoned claims.
+- **Recovery disposition depends on the effect policy.** A `side_effect_free`
+  or `idempotent` expired claim is taken over (`expired_retryable`, a fresh
+  replacement attempt/lease). A `reconcile` expired claim is fenced as
+  `reconciling` with reason `expired_ambiguous` and must be resolved with
+  evidence or a human decision before the graph continues.
+
+For effectful work: `idempotent` claims carry a durable external idempotency
+key and may be safely retried after an expired lease; `reconcile` claims treat
+an expired lease as an ambiguous external effect and never silently retry; and
+`side_effect_free` claims may be retried freely because they produce no
+external effect. A stale lease, a mismatched revision/sequence, an exhausted
+back-edge bound, or an undeclared route fails closed.
+
+## Alternatives
+
+### Extend Team task dependencies
+
+Rejected. Team task files do not provide graph-wide atomic route selection, join cohorts, immutable revisions, claim fencing, or a complete recovery ledger.
+
+### Encode Graph as an Autopilot named profile
+
+Rejected. Named profiles intentionally compose a closed set of linear Autopilot stages. [ADR 03487](./03487-named-autopilot-stage-profiles.md) explicitly defers branches, loops, DAGs, and arbitrary workflow engines to a separate architecture.
+
+### Implement Graph only in prompts
+
+Rejected. Prompt memory cannot prove atomic resume, prevent stale completion, or distinguish committed work from an interrupted external effect.
+
+### Adopt a general graph engine or plugin DSL
+
+Rejected for v1. OMC needs a small local scheduler with its own state, ownership, and recovery contracts. A dependency or public extension surface would broaden compatibility and trust requirements before those contracts are proven.
+
+## Why chosen
+
+A separate deterministic core keeps explicit control flow and durable recovery testable without changing Ralph or Autopilot semantics. Human-approved immutable revisions make execution inspectable, while the single transaction object keeps structure, progress, and evidence consistent after interruption.
+
+## Consequences
+
+Graph adds more ceremony than a loop: users must inspect the graph, approve revisions, and reconcile ambiguous side effects. In exchange, long-running branching work has a durable global plan, explicit parallelism, bounded remediation paths, and recoverable progress.
+
+Graph-specific state and ownership paths require parity across plugin and standalone-installed hooks. Generic state mutation remains intentionally narrower than for older modes.
+
+## Migration and compatibility
+
+There is no migration for existing Ralph, Autopilot, or Team workflows. Graph activates only through its explicit skill entrypoint; bare natural-language mentions of "graph" do not select the mode. Existing invocations and state identities remain unchanged.
+
+## Follow-ups and explicit deferrals
+
+V1 does not include a visual editor, a public stable authoring DSL, plugin-defined node kinds, arbitrary executable edge code, distributed or cross-repository scheduling, nested or overlapping fork/join regions, destructive state purge, silent agent graph mutation, or exactly-once external side effects.

--- a/docs/adr/v1-durable-orchestration-graph.md
+++ b/docs/adr/v1-durable-orchestration-graph.md
@@ -92,6 +92,59 @@ atomic create—fails before reserving control or creating or mutating Graph
 state. Pure descriptor validation and scheduler logic remain portable and
 tested across platforms.
 
+### OCC journal - the concurrency fence (B11 root cure)
+
+The lease lock below is retained for serialising mutations, but on a
+**flock-less runtime (macOS/Windows - real production)** it cannot atomically
+*check-ownership + write* an EXISTING state file: `renewMutationLock` returns
+false there and `assertMutationLockHeld` is a read-then-write TOCTOU. A stale
+holder whose lease expired mid-mutation could therefore overwrite a successor's
+publish (B11), and a stale releaser could unlink a successor's lock (release
+race). No combination of `rename`/`link`/`unlink` atomically fences an
+EXISTING file on flock-less - the unconditional canonical `rename` IS the B11
+window (the `parent_seq` fence only catches a fork detected at check time, not
+the post-check unconditional overwrite, and the successor's state lived only in
+the canonical file the stale writer then clobbered).
+
+The root cure is an **optimistic concurrency control (OCC) journal** that uses
+ONLY `O_EXCL` (portable, no `flock`, no liveness probe, testable on mac). It is
+first-class safe on flock-less runtimes. Journal layout per state file
+`filePath`: a directory `filePath.journal/` of entries
+`<seq>.<owner_token>.json` = `{ seq, parent_seq, owner_token, state }`, a
+commit marker `<seq>.<owner_token>.complete` (an `O_EXCL` file = committed), and
+an `<seq>.<owner_token>.aborted` marker for a detected dead fork. **The journal
+is the source of truth**: "current" = the entry with the MAX `seq` bearing a
+`.complete` marker; readers (`GraphStateStore.read`, `occReadCurrentState`)
+return that entry's state, NOT the canonical file. The canonical `filePath`
+is a **derived cache** re-published on each commit so legacy readers keep
+working; it is never trusted as authoritative.
+
+Commit protocol (replaces writeAtomic-under-lock): read current = max complete
+seq `S` + its state; run a PURE `mutate(current)` callback to produce the next
+state; claim `<S+1>.<token>.json` via `O_EXCL` (EEXIST -> another writer took
+`S+1` -> re-read, re-run, retry with `S+2`); write `{parent_seq: S, state: next}`,
+fsync; **re-validate** by re-scanning the max complete - if a successor
+committed in the window (`current.seq > S`), this entry is a DEAD FORK: unlink
+it, mark `.aborted`, re-read the successor's state, re-run the callback, and
+re-sequence AFTER the successor (never overwriting it); finally create the
+`.complete` marker via `O_EXCL` (commit) and re-publish the canonical file.
+
+Why this cures B11: a stale writer A forks off an old parent, and its commit
+re-validation detects `parent != current-max-complete` AFTER the successor B
+committed - so A re-runs on B's state and sequences AFTER B. A never performs
+an unconditional overwrite. The release race is cured because there is no shared
+lock file: cleanup (`occCleanupOwner`) removes only the writer's OWN incomplete
+entries (by `owner_token`); a writer can never touch a successor's entries.
+
+Fail-closed behaviour: an OCC commit returns null (fail closed) ONLY when the
+journal directory is present but unreadable with a non-ENOENT I/O error
+(`EACCES`/`EMFILE`/`EIO`/`ENOMEM`), or when the bounded retry budget is
+exhausted under extreme live contention. A thrown mutation is propagated to
+the caller (it is a semantic rejection, e.g. `sequence_conflict`, not a
+fork-retry). The emergency-journal crash-recovery subsystem is SEPARATE and
+composes with OCC: OCC handles concurrency, the emergency journal handles
+single-write crash-safety of a partial publish.
+
 Reclaim policy is **lease-based and converged across the `flock` and flock-less
 paths** (B7/B10). The mutation lock (`<state>.mutation.lock`) is an `O_EXCL`
 atomic create whose owner JSON is `{ version: 1, pid, createdAt, expires_at,

--- a/examples/graph/README.md
+++ b/examples/graph/README.md
@@ -1,0 +1,64 @@
+# Graph-Ralph Example: Auth Feature
+
+This example demonstrates the graph+ralph integration: **graph defines the structure, ralph executes each node.**
+
+## The Graph
+
+```
+explore -> plan -> implement -> test
+                      ↑           |
+                      └─── fix ──┘
+                      ↓
+                   retry (max 3)
+```
+
+## Nodes (4 agent nodes, each executed by ralph)
+
+| Node | Title | Ralph's Job |
+|------|-------|-------------|
+| explore | Codebase Exploration | PRD: map architecture, find patterns, document tech stack |
+| plan | Implementation Plan | PRD: design routes, middleware, token strategy, schema |
+| implement | Implementation | PRD: create endpoints, JWT middleware, schema migration |
+| test | Test & Verify | PRD: integration tests for all auth flows, run suite |
+
+## Edges (5)
+
+| Edge | Type | Purpose |
+|------|------|---------|
+| explore -> plan | fixed | Sequential |
+| plan -> implement | fixed | Sequential |
+| implement -> test | conditional (done) | Happy path |
+| implement -> implement | back_edge (retry, max 3) | Retry on failure |
+| test -> implement | conditional (fix) | Tests found issues |
+
+## How to Run
+
+```bash
+# 1. Load the descriptor
+/graph examples/graph/auth-feature-descriptor.json
+
+# Or describe the goal directly
+/graph "Add user authentication to the API with login, register, and token refresh"
+```
+
+## What Happens
+
+1. **Phase 1 (Graph Engineering)**: The descriptor is loaded, validated, and presented for human approval. The SHA-256 hash is computed and sealed.
+
+2. **Phase 2 (Loop Engineering)**: The driver loop begins:
+   - Claims `explore` node -> ralph executes it (PRD -> stories -> verify -> reviewer -> done)
+   - Commits result, advances to `plan`
+   - Ralph executes `plan` node
+   - Commits, advances to `implement`
+   - Ralph executes `implement` (with retry back-edge if needed)
+   - On success, advances to `test`
+   - Ralph executes `test` (terminal verification)
+   - If tests fail, conditional edge `fix` routes back to `implement`
+   - When `test` succeeds with evidence, graph is complete
+
+## Key Integration Points
+
+- **Graph descriptor** defines the DAG structure (what runs, in what order)
+- **Ralph** provides persistence per node (PRD, stories, verification, reviewer)
+- **Back-edge** with `max_traversals: 3` bounds retries
+- **Terminal verification** requires fresh evidence (test results)

--- a/examples/graph/auth-feature-descriptor.json
+++ b/examples/graph/auth-feature-descriptor.json
@@ -1,0 +1,76 @@
+{
+  "descriptor_version": 1,
+  "run_id": "example-add-auth-20260722",
+  "revision_id": "rev-1",
+  "goal": "Add user authentication to the API with login, register, and token refresh",
+  "nodes": [
+    {
+      "id": "explore",
+      "kind": "agent",
+      "title": "Codebase Exploration",
+      "instructions": "Explore the codebase to understand the existing architecture, patterns, and auth-related code. Map the directory structure, find existing middleware, identify the database schema, and document the tech stack. Output a summary of findings that will inform the implementation plan.",
+      "timeout_ms": 300000,
+      "max_attempts": 2,
+      "effect_policy": { "policy": "side_effect_free" }
+    },
+    {
+      "id": "plan",
+      "kind": "agent",
+      "title": "Implementation Plan",
+      "instructions": "Based on the exploration findings, design the authentication implementation. Define the API routes (/login, /register, /refresh), middleware structure, token strategy (JWT), and database schema changes. Output a concrete plan with file paths and interfaces.",
+      "timeout_ms": 300000,
+      "max_attempts": 2,
+      "effect_policy": { "policy": "side_effect_free" }
+    },
+    {
+      "id": "implement",
+      "kind": "agent",
+      "title": "Implementation",
+      "instructions": "Implement the authentication feature according to the plan. Create the login, register, and token refresh endpoints. Add JWT middleware. Update the database schema. Write the code in the appropriate files. Ensure TypeScript compiles without errors.",
+      "timeout_ms": 1800000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "idempotent", "idempotency_key_template": "auth-impl-{iteration}" }
+    },
+    {
+      "id": "test",
+      "kind": "agent",
+      "title": "Test & Verify",
+      "instructions": "Write integration tests for all auth flows: successful login, wrong password, token refresh, expired token, register validation. Run the test suite, lint, and typecheck. All tests must pass. Output test results as evidence.",
+      "timeout_ms": 600000,
+      "max_attempts": 2,
+      "effect_policy": { "policy": "side_effect_free" }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e1-explore-plan",
+      "from": "explore",
+      "to": "plan",
+      "kind": "fixed"
+    },
+    {
+      "id": "e2-plan-implement",
+      "from": "plan",
+      "to": "implement",
+      "kind": "fixed"
+    },
+    {
+      "id": "e3-implement-test",
+      "from": "implement",
+      "to": "test",
+      "kind": "conditional",
+      "route": "done"
+    },
+    {
+      "id": "e4-implement-retry",
+      "from": "implement",
+      "to": "implement",
+      "kind": "back_edge",
+      "route": "retry",
+      "max_traversals": 3
+    }
+  ],
+  "entry_node_ids": ["explore"],
+  "concurrency_limit": 1,
+  "terminal_verification_node_id": "test"
+}

--- a/scripts/graph/__tests__/visualize.test.mjs
+++ b/scripts/graph/__tests__/visualize.test.mjs
@@ -90,3 +90,40 @@ describe('renderHeader', () => {
     expect(output).toContain('Concurrency: 1');
   });
 });
+
+describe('terminal-control sanitization', () => {
+  // Newlines are renderer-owned line separators; reject all controls that can
+  // originate in a hostile descriptor or state value.
+  const controls = /[\x00-\x08\x0b-\x1f\x7f-\x9f]/;
+  const hostileDescriptor = {
+    goal: 'ship\x1b]8;;https://example.invalid\x07click\x1b]8;;\x07',
+    entry_node_ids: ['entry\x9b2J'],
+    terminal_verification_node_id: 'verify\x1b[2J',
+    concurrency_limit: '1\x1b[?25l',
+    nodes: [
+      { id: 'entry\x1b[2J', title: 'Title\x1b]52;c;payload\x07', kind: 'agent' },
+      { id: 'verify\x9b2J', title: 'Verify\x00done\x1b]0;unterminated', kind: 'agent' },
+    ],
+    edges: [
+      { from: 'entry\x1b[2J', to: 'verify\x9b2J', route: 'route\x1b]0;owned\x07' },
+      { from: 'verify\x9b2J', to: 'entry\x1b[2J', kind: 'back_edge', route: 'retry\x1b[31m' },
+    ],
+  };
+
+  it('removes C0/C1, CSI, and OSC controls from graph output', () => {
+    const graph = renderAsciiGraph(
+      hostileDescriptor,
+      new Map([['entry\x1b[2J', 'running\x1b[31m']]),
+      'running\x1b]0;owned\x07',
+    );
+    const header = renderHeader({ active_revision_hash: 'deadbeef\x1b[2J', status: 'running\x9b2J' }, hostileDescriptor);
+
+    expect(graph).not.toMatch(controls);
+    expect(header).not.toMatch(controls);
+    expect(graph).toContain('entry');
+    expect(graph).toContain('route');
+    expect(graph).not.toContain('owned');
+    expect(graph).not.toContain('unterminated');
+    expect(header).toContain('Goal: shipclick');
+  });
+});

--- a/scripts/graph/__tests__/visualize.test.mjs
+++ b/scripts/graph/__tests__/visualize.test.mjs
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { renderAsciiGraph, renderHeader, topologicalOrder } from '../visualize.mjs';
+
+const descriptorPath = fileURLToPath(
+  new URL('../../../examples/graph/auth-feature-descriptor.json', import.meta.url),
+);
+const descriptor = JSON.parse(readFileSync(descriptorPath, 'utf8'));
+
+describe('topologicalOrder', () => {
+  it('orders nodes by DFS, excluding back-edges', () => {
+    expect(topologicalOrder(descriptor)).toEqual(['explore', 'plan', 'implement', 'test']);
+  });
+});
+
+describe('renderAsciiGraph', () => {
+  const nodeStatus = new Map([
+    ['explore', 'completed'],
+    ['plan', 'completed'],
+    ['implement', 'running'],
+    ['test', 'ready'],
+  ]);
+  const output = renderAsciiGraph(descriptor, nodeStatus, 'running');
+
+  it('renders every node id and title', () => {
+    expect(output).toContain('explore');
+    expect(output).toContain('Codebase Exploration');
+    expect(output).toContain('plan');
+    expect(output).toContain('Implementation Plan');
+    expect(output).toContain('implement');
+    expect(output).toContain('Implementation');
+    expect(output).toContain('test');
+    expect(output).toContain('Test & Verify');
+  });
+
+  it('uses box-drawing chars and downward arrows', () => {
+    expect(output).toContain('┌');
+    expect(output).toContain('└');
+    expect(output).toContain('│');
+    expect(output).toContain('▼');
+  });
+
+  it('marks each status with its emoji', () => {
+    expect(output).toContain('✅');
+    expect(output).toContain('▶️');
+    expect(output).toContain('⏳');
+  });
+
+  it('renders a top progress line listing completed nodes', () => {
+    expect(output).toContain('Progress: 2/4 done');
+    expect(output).toContain('[explore✅]');
+    expect(output).toContain('[plan✅]');
+    expect(output).toContain('implement▶️');
+    expect(output).toContain('test⏳');
+  });
+
+  it('labels the conditional edge route', () => {
+    expect(output).toContain('done');
+  });
+
+  it('renders the back-edge as a labeled side-note', () => {
+    expect(output).toContain('retry');
+    expect(output).toContain('max 3');
+    expect(output).toContain('-> implement');
+  });
+
+  it('does not emit mermaid', () => {
+    expect(output).not.toContain('mermaid');
+    expect(output).not.toContain('flowchart');
+    expect(output).not.toContain('classDef');
+  });
+});
+
+describe('renderHeader', () => {
+  const state = {
+    status: 'running',
+    active_revision_id: 'rev-1',
+    active_revision_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    revisions: { 'rev-1': { descriptor } },
+  };
+  const output = renderHeader(state, descriptor);
+
+  it('includes goal, run status, hash, entry, terminal, concurrency', () => {
+    expect(output).toContain('Goal:');
+    expect(output).toContain('Run: running');
+    expect(output).toContain('#a1b2c3d4');
+    expect(output).toContain('Entry: explore');
+    expect(output).toContain('Terminal: test');
+    expect(output).toContain('Concurrency: 1');
+  });
+});

--- a/scripts/graph/visualize.mjs
+++ b/scripts/graph/visualize.mjs
@@ -67,6 +67,18 @@ function statusMeta(status) {
 // ---------------------------------------------------------------------------
 
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const CSI_RE = /(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g;
+const OSC_RE = /(?:\x1b\]|\x9d)(?:[^\x07\x1b\x9c]|\x1b(?!\\))*(?:\x07|\x1b\\|\x9c|$)/g;
+const TERMINAL_CONTROL_RE = /[\x00-\x1f\x7f-\x9f]/g;
+
+// The visualizer can be pointed at an untrusted state file. Strip every C0
+// and C1 control before a value reaches a width calculation or terminal
+// output. CSI and OSC are removed as complete sequences so their payloads do
+// not leak into the diagram after the introducer is stripped.
+function terminalText(value, fallback = '') {
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return fallback;
+  return String(value).replace(OSC_RE, '').replace(CSI_RE, '').replace(TERMINAL_CONTROL_RE, '');
+}
 
 function stripAnsi(text) {
   return text.replace(ANSI_RE, '');
@@ -202,7 +214,7 @@ function formatLeftContent(node, status) {
   const rightW = visualWidth(meta.word);
   // Reserve headW + rightW + 4 (left/right padding + gaps) inside the cap.
   const idBudget = MAX_INNER_WIDTH - headW - rightW - 4;
-  const id = String(node.id ?? '');
+  const id = terminalText(node.id);
   const idW = visualWidth(id);
   if (idW <= idBudget) {
     const display = `${head}${id}`;
@@ -255,7 +267,7 @@ function renderNodeBox(node, status, innerWidth) {
   const rows = [];
   rows.push(`${tl}${bar}${tr}`);
   rows.push(`│${padRight(' ' + left + gap + right + ' ', innerWidth)}│`);
-  const titleLines = wrapText(node.title ?? '', innerWidth - 2);
+  const titleLines = wrapText(terminalText(node.title), innerWidth - 2);
   for (const titleLine of titleLines.length ? titleLines : ['']) {
     rows.push(`│${padRight(' ' + titleLine + ' ', innerWidth)}│`);
   }
@@ -269,15 +281,16 @@ function renderForwardEdge(edge, centerCol) {
   const isFanOut = kind === 'fan_out';
   const shaft = isFanOut ? '║' : (isConditional ? '╎' : '│');
   const head = isConditional ? '▽' : '▼';
-  const label = (edge.route || edge.branch_id) ? ` ${edge.route || edge.branch_id}` : '';
+  const route = terminalText(edge.route || edge.branch_id);
+  const label = route ? ` ${route}` : '';
   const indent = ' '.repeat(centerCol);
   return [`${indent}${shaft}${label}`, `${indent}${head}`];
 }
 
 function renderBackEdgeNote(edge, innerWidth) {
-  const route = edge.route ?? 'retry';
+  const route = terminalText(edge.route, 'retry') || 'retry';
   const max = typeof edge.max_traversals === 'number' ? ` (max ${edge.max_traversals})` : '';
-  const label = `↺ ${route}${max} -> ${edge.to}`;
+  const label = `↺ ${route}${max} -> ${terminalText(edge.to)}`;
   const dashCount = Math.max(4, innerWidth - 8);
   return `   ◂${'─'.repeat(dashCount)}┘  ${label}`;
 }
@@ -305,7 +318,7 @@ export function renderAsciiGraph(descriptor, nodeStatus, runStatus) {
     const status = normalizeStatus(nodeStatus.get(id) ?? 'ready');
     const meta = statusMeta(status);
     if (status === 'completed') completed += 1;
-    const token = `${id}${meta.emoji}`;
+    const token = `${terminalText(id)}${meta.emoji}`;
     const colored = maybeColor(token, meta.color);
     progressParts.push(status === 'completed' ? `[${colored}]` : colored);
   }
@@ -313,7 +326,7 @@ export function renderAsciiGraph(descriptor, nodeStatus, runStatus) {
 
   const lines = [];
   if (runStatus) {
-    lines.push(`(run status: ${runStatus})`);
+    lines.push(`(run status: ${terminalText(runStatus)})`);
     lines.push('');
   }
   lines.push(`Progress: ${completed}/${total} done  ${progressParts.join(' -> ')}`);
@@ -339,14 +352,16 @@ export function renderAsciiGraph(descriptor, nodeStatus, runStatus) {
 }
 
 export function renderHeader(state, descriptor) {
-  const hash = state?.active_revision_hash ?? 'pending';
+  const hash = terminalText(state?.active_revision_hash, 'pending') || 'pending';
   const hashShort =
-    typeof hash === 'string' && hash.length >= 8 ? hash.slice(0, 8) : (hash || 'pending');
-  const goal = descriptor.goal ?? '(no goal)';
-  const status = state?.status ?? 'unknown';
-  const entry = (descriptor.entry_node_ids ?? []).join(', ') || '(none)';
-  const terminal = descriptor.terminal_verification_node_id ?? '(none)';
-  const concurrency = descriptor.concurrency_limit ?? 1;
+    hash.length >= 8 ? hash.slice(0, 8) : hash;
+  const goal = terminalText(descriptor.goal, '(no goal)') || '(no goal)';
+  const status = terminalText(state?.status, 'unknown') || 'unknown';
+  const entry = (Array.isArray(descriptor.entry_node_ids)
+    ? descriptor.entry_node_ids.map((id) => terminalText(id)).join(', ')
+    : '') || '(none)';
+  const terminal = terminalText(descriptor.terminal_verification_node_id, '(none)') || '(none)';
+  const concurrency = terminalText(descriptor.concurrency_limit, '1') || '1';
 
   const lines = [];
   const goalLines = wrapText(goal, 58);

--- a/scripts/graph/visualize.mjs
+++ b/scripts/graph/visualize.mjs
@@ -1,0 +1,635 @@
+#!/usr/bin/env node
+/**
+ * Graph-Ralph Visualizer
+ *
+ * Reads a graph state JSON file and renders an ASCII-art diagram with each
+ * node marked by its current activation status:
+ *   - ready (pending)    : ⏳
+ *   - running (active)   : ▶️
+ *   - completed (done)    : ✅
+ *   - failed (error)      : ❌
+ *
+ * ASCII art renders inline in Claude Code's terminal (Mermaid does not).
+ * ANSI color is applied only when stdout is a TTY, so captured/piped output
+ * stays as clean box-drawing + emoji text.
+ *
+ * Usage:
+ *   node scripts/graph/visualize.mjs <path-to-graph-state.json>
+ *   node scripts/graph/visualize.mjs --demo   # simulate a running state
+ *   node scripts/graph/visualize.mjs --descriptor <descriptor.json>
+ */
+
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { argv, exit, stdout } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Status metadata
+// ---------------------------------------------------------------------------
+
+const VALID_STATUSES = new Set(['ready', 'running', 'completed', 'failed']);
+
+// emoji always shown; ANSI color applied only when stdout is a TTY
+const RESET = '\x1b[0m';
+const DIM = '\x1b[2m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const CYAN = '\x1b[36m';
+
+const STATUS_META = {
+  ready: { emoji: '⏳', word: 'ready', color: DIM },
+  running: { emoji: '▶️', word: 'running', color: YELLOW },
+  completed: { emoji: '✅', word: 'completed', color: GREEN },
+  failed: { emoji: '❌', word: 'failed', color: RED },
+};
+
+const USE_COLOR = stdout.isTTY === true;
+
+// Cap inner box width so long node IDs (up to 256 chars per ID_PATTERN) do
+// not blow the box out past a normal terminal width. Long IDs are truncated
+// with an ellipsis instead; see formatLeftContent.
+const MAX_INNER_WIDTH = 72;
+const ELLIPSIS = '…';
+
+function maybeColor(text, color) {
+  return USE_COLOR && color ? `${color}${text}${RESET}` : text;
+}
+
+function statusMeta(status) {
+  return STATUS_META[status] ?? STATUS_META.ready;
+}
+
+// ---------------------------------------------------------------------------
+// Visual-width helpers (account for emoji double width + ANSI escapes)
+// ---------------------------------------------------------------------------
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(text) {
+  return text.replace(ANSI_RE, '');
+}
+
+function visualWidth(text) {
+  const clean = stripAnsi(text);
+  let width = 0;
+  for (const ch of clean) {
+    const code = ch.codePointAt(0);
+    // variation selectors, ZWJ, combining marks -> zero width
+    if (code === 0xfe0f || code === 0xfe0e || code === 0x200d) continue;
+    if (code >= 0x0300 && code <= 0x036f) continue;
+    // emoji / pictographic -> double width
+    if (code >= 0x1f300) { width += 2; continue; }
+    if (code === 0x23f3 || code === 0x2705 || code === 0x274c || code === 0x25b6 || code === 0x25c0 || code === 0x2b22) {
+      width += 2;
+      continue;
+    }
+    width += 1;
+  }
+  return width;
+}
+
+function padRight(text, width) {
+  const w = visualWidth(text);
+  return w >= width ? text : text + ' '.repeat(width - w);
+}
+
+function hardBreak(text, width) {
+  const out = [];
+  for (let i = 0; i < text.length; i += width) out.push(text.slice(i, i + width));
+  return out;
+}
+
+function wrapText(text, width) {
+  const safeWidth = Math.max(1, width);
+  const words = String(text ?? '').split(/\s+/).filter(Boolean);
+  if (!words.length) return [''];
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    if (!current) current = word;
+    else if (visualWidth(current + ' ' + word) <= safeWidth) current += ' ' + word;
+    else { lines.push(current); current = word; }
+  }
+  if (current) lines.push(current);
+  return lines.flatMap((line) =>
+    visualWidth(line) > safeWidth ? hardBreak(line, safeWidth) : [line],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Graph layout
+// ---------------------------------------------------------------------------
+
+function normalizeStatus(status) {
+  return VALID_STATUSES.has(status) ? status : 'ready';
+}
+
+function buildNodeStatusMap(state) {
+  const map = new Map();
+  if (!state?.projection?.activations) return map;
+  for (const activation of Object.values(state.projection.activations)) {
+    const existingStatus = map.get(activation.node_id);
+    const status = normalizeStatus(activation.status);
+    // A 'ready'/'running' activation means the node is being (re)tried and
+    // should override a stale 'failed' activation left behind by a back-edge
+    // retry. Only keep 'failed' when no live activation remains for the node.
+    const statusIsLive = status === 'ready' || status === 'running';
+    const existingIsLive = existingStatus === 'ready' || existingStatus === 'running';
+    if (!existingStatus) {
+      map.set(activation.node_id, status);
+    } else if (statusIsLive && !existingIsLive) {
+      map.set(activation.node_id, status);
+    } else if (!statusIsLive && existingIsLive) {
+      // keep existing live status
+    } else if (priority(existingStatus) < priority(status)) {
+      map.set(activation.node_id, status);
+    }
+  }
+  return map;
+}
+
+function priority(status) {
+  return { running: 4, failed: 3, completed: 2, ready: 1 }[status] ?? 0;
+}
+
+/**
+ * DFS topological order over non-back-edge edges. Back-edges are excluded
+ * (they point backward, often to self) and rendered separately as side-notes.
+ * Successors are visited in declared edge order so siblings group together.
+ */
+export function topologicalOrder(descriptor) {
+  const nodes = descriptor.nodes ?? [];
+  const successors = new Map();
+  for (const node of nodes) successors.set(node.id, []);
+  for (const edge of descriptor.edges ?? []) {
+    if ((edge.kind ?? 'fixed') === 'back_edge') continue;
+    if (!successors.has(edge.from)) successors.set(edge.from, []);
+    successors.get(edge.from).push(edge.to);
+  }
+  const visited = new Set();
+  const onStack = new Set();
+  const post = [];
+  function visit(id) {
+    if (visited.has(id) || onStack.has(id)) return;
+    onStack.add(id);
+    for (const target of successors.get(id) ?? []) visit(target);
+    onStack.delete(id);
+    visited.add(id);
+    post.push(id);
+  }
+  for (const entry of descriptor.entry_node_ids ?? []) visit(entry);
+  for (const node of nodes) visit(node.id);
+  return post.reverse();
+}
+
+/**
+ * Build the left side of a node box's status row (emoji + prefix + id) and
+ * truncate the id with an ellipsis so the row fits within MAX_INNER_WIDTH.
+ * Shared by pickInnerWidth (sizing) and renderNodeBox (rendering) so the box
+ * width and the rendered content can never drift out of agreement.
+ *
+ * Returns { display, width } where display is the plain (uncolored) string
+ * and width is its visual width.
+ */
+function formatLeftContent(node, status) {
+  const meta = statusMeta(status);
+  const prefix = node.kind === 'join' ? '⬢ ' : '';
+  const head = `${meta.emoji} ${prefix}`;
+  const headW = visualWidth(head);
+  const rightW = visualWidth(meta.word);
+  // Reserve headW + rightW + 4 (left/right padding + gaps) inside the cap.
+  const idBudget = MAX_INNER_WIDTH - headW - rightW - 4;
+  const id = String(node.id ?? '');
+  const idW = visualWidth(id);
+  if (idW <= idBudget) {
+    const display = `${head}${id}`;
+    return { display, width: headW + idW };
+  }
+  const ellipsisW = visualWidth(ELLIPSIS);
+  const budget = Math.max(1, idBudget - ellipsisW);
+  // Trim code points (not bytes) until the id fits the remaining budget.
+  let kept = '';
+  let keptW = 0;
+  for (const ch of id) {
+    const chW = visualWidth(ch);
+    if (keptW + chW > budget) break;
+    kept += ch;
+    keptW += chW;
+  }
+  const display = `${head}${kept}${ELLIPSIS}`;
+  return { display, width: headW + keptW + ellipsisW };
+}
+
+function pickInnerWidth(descriptor, nodeStatus) {
+  let width = 28;
+  for (const node of descriptor.nodes ?? []) {
+    const status = normalizeStatus(nodeStatus.get(node.id) ?? 'ready');
+    const { width: leftW } = formatLeftContent(node, status);
+    const rightW = visualWidth(statusMeta(status).word);
+    const need = leftW + rightW + 4;
+    if (need > width) width = need;
+  }
+  // Cap at a terminal-friendly max; long IDs are truncated by
+  // formatLeftContent rather than widening the box unbounded.
+  return Math.min(width, MAX_INNER_WIDTH);
+}
+
+function renderNodeBox(node, status, innerWidth) {
+  const meta = statusMeta(status);
+  const { display: leftRaw, width: leftW } = formatLeftContent(node, status);
+  const left = maybeColor(leftRaw, meta.color);
+  const right = maybeColor(meta.word, meta.color);
+  const gapW = innerWidth - 2 - leftW - visualWidth(meta.word);
+  const gap = gapW > 1 ? ' '.repeat(gapW) : ' ';
+
+  const rounded = node.kind === 'human-approval';
+  const tl = rounded ? '╭' : '┌';
+  const tr = rounded ? '╮' : '┐';
+  const bl = rounded ? '╰' : '└';
+  const br = rounded ? '╯' : '┘';
+  const bar = '─'.repeat(innerWidth);
+
+  const rows = [];
+  rows.push(`${tl}${bar}${tr}`);
+  rows.push(`│${padRight(' ' + left + gap + right + ' ', innerWidth)}│`);
+  const titleLines = wrapText(node.title ?? '', innerWidth - 2);
+  for (const titleLine of titleLines.length ? titleLines : ['']) {
+    rows.push(`│${padRight(' ' + titleLine + ' ', innerWidth)}│`);
+  }
+  rows.push(`${bl}${bar}${br}`);
+  return rows;
+}
+
+function renderForwardEdge(edge, centerCol) {
+  const kind = edge.kind ?? 'fixed';
+  const isConditional = kind === 'conditional';
+  const isFanOut = kind === 'fan_out';
+  const shaft = isFanOut ? '║' : (isConditional ? '╎' : '│');
+  const head = isConditional ? '▽' : '▼';
+  const label = (edge.route || edge.branch_id) ? ` ${edge.route || edge.branch_id}` : '';
+  const indent = ' '.repeat(centerCol);
+  return [`${indent}${shaft}${label}`, `${indent}${head}`];
+}
+
+function renderBackEdgeNote(edge, innerWidth) {
+  const route = edge.route ?? 'retry';
+  const max = typeof edge.max_traversals === 'number' ? ` (max ${edge.max_traversals})` : '';
+  const label = `↺ ${route}${max} -> ${edge.to}`;
+  const dashCount = Math.max(4, innerWidth - 8);
+  return `   ◂${'─'.repeat(dashCount)}┘  ${label}`;
+}
+
+export function renderAsciiGraph(descriptor, nodeStatus, runStatus) {
+  const order = topologicalOrder(descriptor);
+  const byId = new Map((descriptor.nodes ?? []).map((node) => [node.id, node]));
+  const innerWidth = pickInnerWidth(descriptor, nodeStatus);
+  const boxIndent = 2;
+  const centerCol = boxIndent + 1 + Math.floor(innerWidth / 2);
+  const indent = ' '.repeat(boxIndent);
+
+  const forwardBySource = new Map();
+  const backBySource = new Map();
+  for (const edge of descriptor.edges ?? []) {
+    const map = (edge.kind ?? 'fixed') === 'back_edge' ? backBySource : forwardBySource;
+    if (!map.has(edge.from)) map.set(edge.from, []);
+    map.get(edge.from).push(edge);
+  }
+
+  // Progress summary line: at-a-glance completion view across the whole graph.
+  let completed = 0;
+  const progressParts = [];
+  for (const id of order) {
+    const status = normalizeStatus(nodeStatus.get(id) ?? 'ready');
+    const meta = statusMeta(status);
+    if (status === 'completed') completed += 1;
+    const token = `${id}${meta.emoji}`;
+    const colored = maybeColor(token, meta.color);
+    progressParts.push(status === 'completed' ? `[${colored}]` : colored);
+  }
+  const total = order.length;
+
+  const lines = [];
+  if (runStatus) {
+    lines.push(`(run status: ${runStatus})`);
+    lines.push('');
+  }
+  lines.push(`Progress: ${completed}/${total} done  ${progressParts.join(' -> ')}`);
+  lines.push('');
+
+  for (let index = 0; index < order.length; index += 1) {
+    const node = byId.get(order[index]);
+    if (!node) continue;
+    const status = normalizeStatus(nodeStatus.get(node.id) ?? 'ready');
+    for (const row of renderNodeBox(node, status, innerWidth)) {
+      lines.push(indent + row);
+    }
+    for (const edge of backBySource.get(node.id) ?? []) {
+      lines.push(indent + renderBackEdgeNote(edge, innerWidth));
+    }
+    const forwards = forwardBySource.get(node.id) ?? [];
+    for (const edge of forwards) {
+      lines.push(...renderForwardEdge(edge, centerCol));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function renderHeader(state, descriptor) {
+  const hash = state?.active_revision_hash ?? 'pending';
+  const hashShort =
+    typeof hash === 'string' && hash.length >= 8 ? hash.slice(0, 8) : (hash || 'pending');
+  const goal = descriptor.goal ?? '(no goal)';
+  const status = state?.status ?? 'unknown';
+  const entry = (descriptor.entry_node_ids ?? []).join(', ') || '(none)';
+  const terminal = descriptor.terminal_verification_node_id ?? '(none)';
+  const concurrency = descriptor.concurrency_limit ?? 1;
+
+  const lines = [];
+  const goalLines = wrapText(goal, 58);
+  lines.push(`Goal: ${goalLines[0]}`);
+  for (let index = 1; index < goalLines.length; index += 1) {
+    lines.push(`      ${goalLines[index]}`);
+  }
+  lines.push(`Run: ${status}   #${hashShort}   Concurrency: ${concurrency}`);
+  lines.push(`Entry: ${entry}   Terminal: ${terminal}`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// State / descriptor loading (unchanged behavior)
+// ---------------------------------------------------------------------------
+
+function loadState(path) {
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: Graph state file not found: ${path}`);
+      console.error('');
+      console.error('Ralph/graph may not be running. Use --demo to see a simulated state:');
+      console.error('  node scripts/graph/visualize.mjs --demo');
+      exit(1);
+    }
+    if (error.code === 'EACCES') {
+      console.error(`Error: Permission denied reading: ${path}`);
+      exit(1);
+    }
+    if (error.code === 'EISDIR') {
+      console.error(`Error: Expected a file but found a directory: ${path}`);
+      console.error('  Specify the graph-state.json file path, not a directory.');
+      exit(1);
+    }
+    if (error.code === 'ENOTDIR') {
+      console.error(`Error: Path contains a non-directory component: ${path}`);
+      console.error('  Check the file path for typos or incorrect separators.');
+      exit(1);
+    }
+    console.error(`Error reading file ${path}: ${error.message}`);
+    exit(1);
+  }
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.error(`Error: Invalid JSON in state file: ${path}`);
+      console.error(`  ${error.message}`);
+      exit(1);
+    }
+    console.error(`Error parsing JSON from ${path}: ${error.message}`);
+    exit(1);
+  }
+}
+
+function extractDescriptor(state) {
+  const revisionId = state.active_revision_id;
+  const revision = state.revisions?.[revisionId];
+  if (!revision?.descriptor) {
+    throw new Error(`Could not find descriptor for revision ${revisionId}`);
+  }
+  return revision.descriptor;
+}
+
+// NOTE: canonicalJson and computeDescriptorHash duplicate the logic in
+// src/graph/descriptor.ts. They are kept here so the script runs without
+// requiring `npm run build` first. If the canonical JSON format in the
+// source changes, update this function to match. See computeDescriptorHash
+// in src/graph/descriptor.ts for the authoritative implementation.
+function canonicalJson(value) {
+  if (value === undefined) {
+    throw new TypeError('Canonical JSON does not support undefined values');
+  }
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Canonical JSON does not support non-finite numbers');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value;
+    const entries = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+
+function computeDescriptorHash(descriptor) {
+  const payload = {
+    descriptor_version: descriptor.descriptor_version,
+    run_id: descriptor.run_id,
+    revision_id: descriptor.revision_id,
+    goal: descriptor.goal,
+    nodes: descriptor.nodes,
+    edges: descriptor.edges,
+    entry_node_ids: descriptor.entry_node_ids,
+    concurrency_limit: descriptor.concurrency_limit,
+    terminal_verification_node_id: descriptor.terminal_verification_node_id,
+  };
+  return createHash('sha256').update(canonicalJson(payload)).digest('hex');
+}
+
+function loadExampleDescriptor() {
+  const descriptorPath = new URL('../../examples/graph/auth-feature-descriptor.json', import.meta.url);
+  try {
+    return JSON.parse(readFileSync(descriptorPath, 'utf8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error('Error: Example descriptor file not found:');
+      console.error(`  ${descriptorPath.pathname}`);
+      console.error('');
+      console.error('The demo requires examples/graph/auth-feature-descriptor.json to exist.');
+      console.error('Reinstall the oh-my-claudecode package or restore the file from git.');
+      exit(1);
+    }
+    if (error instanceof SyntaxError) {
+      console.error('Error: Example descriptor file has invalid JSON:');
+      console.error(`  ${error.message}`);
+      exit(1);
+    }
+    console.error(`Error loading example descriptor: ${error.message}`);
+    exit(1);
+  }
+}
+
+function demoState() {
+  const descriptor = loadExampleDescriptor();
+  const revisionId = descriptor.revision_id ?? 'rev-1';
+  let hash;
+  try {
+    hash = computeDescriptorHash(descriptor);
+  } catch (error) {
+    console.error(`Error computing descriptor hash: ${error.message}`);
+    console.error('The example descriptor may be malformed. Check examples/graph/auth-feature-descriptor.json');
+    exit(1);
+  }
+  return {
+    status: 'running',
+    active_revision_id: revisionId,
+    active_revision_hash: hash,
+    revisions: {
+      [revisionId]: {
+        revision_id: revisionId,
+        descriptor_hash: hash,
+        created_at: '2026-07-22T00:00:00Z',
+        invalidated_node_ids: [],
+        descriptor: { ...descriptor, descriptor_hash: hash },
+      },
+    },
+    projection: {
+      activations: {
+        'act-1': { activation_id: 'act-1', node_id: 'explore', status: 'completed', attempt_no: 1, attempt_ids: ['att-1'], traversal_owner_id: 'act-1' },
+        'act-2': { activation_id: 'act-2', node_id: 'plan', status: 'completed', attempt_no: 1, attempt_ids: ['att-2'], traversal_owner_id: 'act-2' },
+        'act-3': { activation_id: 'act-3', node_id: 'implement', status: 'running', attempt_no: 1, attempt_ids: ['att-3'], active_attempt_id: 'att-3', traversal_owner_id: 'act-3' },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+  };
+}
+
+function loadDescriptor(path) {
+  let content;
+  try {
+    content = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(`Error: Descriptor file not found: ${path}`);
+      exit(1);
+    }
+    if (error.code === 'EISDIR') {
+      console.error(`Error: Expected a file but found a directory: ${path}`);
+      exit(1);
+    }
+    console.error(`Error reading file ${path}: ${error.message}`);
+    exit(1);
+  }
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.error(`Error: Invalid JSON in descriptor file: ${path}`);
+      console.error(`  ${error.message}`);
+      exit(1);
+    }
+    console.error(`Error parsing JSON from ${path}: ${error.message}`);
+    exit(1);
+  }
+}
+
+function stateFromDescriptor(descriptor) {
+  const revisionId = descriptor.revision_id ?? 'rev-1';
+  const activations = {};
+  for (const [index, node] of descriptor.entry_node_ids.entries()) {
+    activations[`act-entry-${index}`] = {
+      activation_id: `act-entry-${index}`,
+      node_id: node,
+      status: 'ready',
+      attempt_no: 0,
+      attempt_ids: [],
+      traversal_owner_id: `act-entry-${index}`,
+    };
+  }
+  return {
+    status: 'awaiting_approval',
+    active_revision_id: revisionId,
+    active_revision_hash: descriptor.descriptor_hash ?? 'pending',
+    revisions: {
+      [revisionId]: {
+        revision_id: revisionId,
+        descriptor_hash: descriptor.descriptor_hash ?? 'pending',
+        created_at: '2026-07-22T00:00:00Z',
+        invalidated_node_ids: [],
+        descriptor,
+      },
+    },
+    projection: {
+      activations,
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+  };
+}
+
+function main() {
+  const args = argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    console.log('Usage: visualize.mjs <graph-state.json>');
+    console.log('       visualize.mjs --demo');
+    console.log('       visualize.mjs --descriptor <descriptor.json>');
+    console.log('');
+    console.log('Renders an ASCII-art diagram of the graph (renders inline in Claude Code).');
+    exit(0);
+  }
+
+  let state;
+  if (args[0] === '--demo') {
+    state = demoState();
+  } else if (args[0] === '--descriptor') {
+    if (!args[1]) {
+      console.error('Error: --descriptor requires a file path');
+      exit(1);
+    }
+    const descriptor = loadDescriptor(args[1]);
+    state = stateFromDescriptor(descriptor);
+  } else {
+    state = loadState(args[0]);
+  }
+
+  try {
+    const descriptor = extractDescriptor(state);
+    const nodeStatus = buildNodeStatusMap(state);
+
+    console.log(renderHeader(state, descriptor));
+    console.log(renderAsciiGraph(descriptor, nodeStatus, state?.status));
+  } catch (error) {
+    console.error(`Error: Could not render graph visualization: ${error.message}`);
+    console.error('');
+    console.error('The graph state file may be malformed or corrupted.');
+    console.error('Check that the file was written by a valid oh-my-claudecode graph run.');
+    exit(1);
+  }
+}
+
+// Run main() only when executed directly, not when imported by tests.
+const isMain =
+  argv[1] && fileURLToPath(import.meta.url) === resolve(argv[1]);
+if (isMain) {
+  main();
+}

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1125,7 +1125,7 @@ function resumeWorkflowProfile(directory, sessionId, workflowName, omcRoot) {
     retireStaleWorkflowCancelSignal(target, result.value.workflowRunId);
     return result.value.stagePrompt;
   } catch (error) {
-    if (error?.message === 'workflow_emergency_recovery_failed' || error?.message === 'workflow_transcript_record_too_large') throw error;
+    if (error?.message?.startsWith('workflow_emergency_recovery_failed') || error?.message === 'workflow_transcript_record_too_large') throw error;
     return false;
   }
 }
@@ -1183,7 +1183,7 @@ function activateWorkflowProfile(directory, sessionId, task, workflow, omcRoot, 
     retireStaleWorkflowCancelSignal(target, result.value.workflowRunId);
     return result.value.stagePrompt;
   } catch (error) {
-    if (error?.message === 'workflow_emergency_recovery_failed' || error?.message === 'workflow_transcript_record_too_large') throw error;
+    if (error?.message?.startsWith('workflow_emergency_recovery_failed') || error?.message === 'workflow_transcript_record_too_large') throw error;
     return false;
   }
 }

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1054,7 +1054,7 @@ async function activateState(directory, prompt, stateName, sessionId) {
   try {
     mkdirSync(dirname(writePath), { recursive: true });
     let workflowIntegrityFailure = false;
-    withStateFileLockSync(writePath, () => {
+    withStateFileLockSync(writePath, (assertHeld) => {
       if (!recoverEmergencyStateFile(writePath)) return;
       // A legacy autopilot activation must never replace named state. Own
       // markers are authoritative even when their values are falsy.
@@ -1070,6 +1070,7 @@ async function activateState(directory, prompt, stateName, sessionId) {
           return;
         }
       }
+      assertHeld();
       atomicWriteFileSync(writePath, JSON.stringify(state, null, 2));
     });
     return workflowIntegrityFailure ? 'workflow_descriptor_integrity_failed' : null;
@@ -1078,11 +1079,14 @@ async function activateState(directory, prompt, stateName, sessionId) {
 
 function retireStaleWorkflowCancelSignal(statePath, workflowRunId) {
   const signalPath = join(dirname(statePath), 'cancel-signal-state.json');
-  withStateFileLockSync(signalPath, () => {
+  withStateFileLockSync(signalPath, (assertHeld) => {
     if (!existsSync(signalPath)) return;
     try {
       const signal = JSON.parse(readFileSync(signalPath, 'utf8'));
-      if (signal.target_workflow_run_id !== workflowRunId) unlinkSync(signalPath);
+      if (signal.target_workflow_run_id !== workflowRunId) {
+        assertHeld();
+        unlinkSync(signalPath);
+      }
     } catch {
       // Malformed signals fail closed in Stop and are left for explicit cleanup.
     }
@@ -1096,7 +1100,7 @@ function resumeWorkflowProfile(directory, sessionId, workflowName, omcRoot) {
     : join(omcRoot, 'state', 'autopilot-state.json');
   try {
     mkdirSync(dirname(target), { recursive: true });
-    const result = withStateFileLockSync(target, () => {
+    const result = withStateFileLockSync(target, (assertHeld) => {
       if (!recoverEmergencyStateFile(target)) return { error: 'workflow_recovery_failure' };
       if (!existsSync(target)) return null;
       const current = JSON.parse(readFileSync(target, 'utf8'));
@@ -1110,6 +1114,7 @@ function resumeWorkflowProfile(directory, sessionId, workflowName, omcRoot) {
       const stageId = resumed.workflow.stages[resumed.pipelineTracking.currentStageIndex];
       const stagePrompt = resolveWorkflowStagePrompt(resumed, stageId);
       if (!stagePrompt) return { error: 'workflow_integrity_failure' };
+      assertHeld();
       atomicWriteFileSync(target, JSON.stringify(resumed, null, 2));
       return { stagePrompt, workflowRunId: resumed.workflowRunId };
     });
@@ -1133,7 +1138,7 @@ function activateWorkflowProfile(directory, sessionId, task, workflow, omcRoot, 
     : join(omcRoot, 'state', 'autopilot-state.json');
   try {
     mkdirSync(dirname(target), { recursive: true });
-    const result = withStateFileLockSync(target, () => {
+    const result = withStateFileLockSync(target, (assertHeld) => {
       if (!recoverEmergencyStateFile(target)) return { error: 'workflow_recovery_failure' };
       if (existsSync(target)) {
         try {
@@ -1152,6 +1157,7 @@ function activateWorkflowProfile(directory, sessionId, task, workflow, omcRoot, 
               const stageId = resumed.workflow.stages[resumed.pipelineTracking.currentStageIndex];
               const stagePrompt = resolveWorkflowStagePrompt(resumed, stageId);
               if (!stagePrompt) return { error: 'workflow_integrity_failure' };
+              assertHeld();
               atomicWriteFileSync(target, JSON.stringify(resumed, null, 2));
               return { stagePrompt, workflowRunId: resumed.workflowRunId };
             }
@@ -1165,6 +1171,7 @@ function activateWorkflowProfile(directory, sessionId, task, workflow, omcRoot, 
       if (!state) return { error: takeWorkflowTranscriptFailure(sessionId) || 'workflow_integrity_failure' };
       const stagePrompt = resolveWorkflowStagePrompt(state, workflow.stages[0]);
       if (!stagePrompt) return null;
+      assertHeld();
       atomicWriteFileSync(target, JSON.stringify(state, null, 2));
       return { stagePrompt, workflowRunId: state.workflowRunId };
     });

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -725,7 +725,12 @@ function occAbortedPath(dir, seq, token) {
   return join(dir, `${seq}.${token}.aborted`);
 }
 
+function occClaimPath(dir, seq) {
+  return join(dir, `${seq}.claim`);
+}
+
 const OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+const OCC_CLAIM_NAME_RE = /^(\d+)\.claim$/;
 
 /**
  * Scans the OCC journal directory and returns the current committed state: the
@@ -742,12 +747,19 @@ function occReadCurrent(filePath) {
   try {
     names = readdirSync(dir);
   } catch (error) {
-    if (error && error.code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false };
-    return { seq: -1, state: null, empty: false, ioError: true };
+    if (error && error.code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false, reservedSeq: -1 };
+    return { seq: -1, state: null, empty: false, ioError: true, reservedSeq: -1 };
   }
-  const completeSeqs = new Set();
+  const completeBySeq = new Map();
   const entryBySeq = new Map();
+  let reservedSeq = -1;
   for (const name of names) {
+    const claim = OCC_CLAIM_NAME_RE.exec(name);
+    if (claim) {
+      const seq = Number(claim[1]);
+      if (Number.isInteger(seq) && seq >= 0) reservedSeq = Math.max(reservedSeq, seq);
+      continue;
+    }
     const match = OCC_ENTRY_NAME_RE.exec(name);
     if (!match) continue;
     const seq = Number(match[1]);
@@ -755,52 +767,60 @@ function occReadCurrent(filePath) {
     const token = match[2];
     const kind = match[3];
     if (kind === 'complete') {
-      completeSeqs.add(seq);
+      const existing = completeBySeq.get(seq);
+      completeBySeq.set(seq, existing === undefined ? token : existing === token ? token : null);
     } else if (kind === 'json') {
-      if (!entryBySeq.has(seq)) entryBySeq.set(seq, token);
+      const existing = entryBySeq.get(seq);
+      if (existing === undefined) entryBySeq.set(seq, token);
+      else if (existing !== token) return { seq: -1, state: null, empty: false, ioError: true, reservedSeq };
     }
   }
-  if (completeSeqs.size === 0) return { seq: -1, state: null, empty: true, ioError: false };
+  if (completeBySeq.size === 0) return { seq: -1, state: null, empty: true, ioError: false, reservedSeq };
   let maxSeq = -1;
-  for (const seq of completeSeqs) if (seq > maxSeq) maxSeq = seq;
+  for (const seq of completeBySeq.keys()) if (seq > maxSeq) maxSeq = seq;
+  const completeToken = completeBySeq.get(maxSeq);
   const token = entryBySeq.get(maxSeq);
-  if (!token) {
+  if (!token || !completeToken || completeToken !== token) {
     // A complete marker exists without its entry json: the entry was pruned or
     // never written. Treat the journal as unreadable at this fence and fail
     // closed rather than guessing a parent.
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   let raw;
   try {
     raw = readFileSync(occEntryPath(dir, maxSeq, token), 'utf8');
   } catch {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   let entry;
   try {
     entry = JSON.parse(raw);
   } catch {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   if (!entry || typeof entry !== 'object' || entry.seq !== maxSeq || entry.owner_token !== token || !('state' in entry)) {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
-  return { seq: maxSeq, state: entry.state, empty: false, ioError: false };
+  return { seq: maxSeq, state: entry.state, empty: false, ioError: false, reservedSeq };
 }
 
-/** Seed state for the first commit when the journal is empty: the canonical file, if any. */
-function occSeedState(filePath) {
+function occReadCanonicalSnapshot(filePath) {
   try {
-    const raw = readFileSync(filePath, 'utf8');
-    return JSON.parse(raw);
+    const state = JSON.parse(readFileSync(filePath, 'utf8'));
+    return { state, fingerprint: JSON.stringify(state), ioError: false };
   } catch (error) {
-    if (error && error.code === 'ENOENT') return null;
-    throw error;
+    if (error && error.code === 'ENOENT') return { state: null, fingerprint: 'absent', ioError: false };
+    return { state: null, fingerprint: '', ioError: true };
   }
+}
+
+function occStateFingerprint(state) {
+  return state === null ? 'absent' : JSON.stringify(state);
 }
 
 /** Removes only the caller's OWN incomplete entry + any markers for (seq, token). */
 function occCleanupOwn(dir, seq, token) {
+  try { unlinkSync(occClaimPath(dir, seq)); } catch { /* absent */ }
   try { unlinkSync(occEntryPath(dir, seq, token)); } catch { /* absent */ }
   try { unlinkSync(occCompletePath(dir, seq, token)); } catch { /* absent */ }
   try { unlinkSync(occAbortedPath(dir, seq, token)); } catch { /* absent */ }
@@ -812,7 +832,7 @@ function occPruneOld(dir, currentSeq) {
   try { names = readdirSync(dir); } catch { return; }
   const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
   for (const name of names) {
-    const match = OCC_ENTRY_NAME_RE.exec(name);
+    const match = OCC_ENTRY_NAME_RE.exec(name) || OCC_CLAIM_NAME_RE.exec(name);
     if (!match) continue;
     const seq = Number(match[1]);
     if (Number.isInteger(seq) && seq < cutoff) {
@@ -835,7 +855,7 @@ function occPruneOld(dir, currentSeq) {
  */
 export function occCommitMutation(filePath, mutate, options = {}) {
   const dir = occJournalDir(filePath);
-  ensureDirSync(dir);
+  try { ensureDirSync(dir); } catch { return false; }
   const ownerToken = options.ownerToken || randomUUID();
   let parentSeq = -1;
   let parentState = null;
@@ -843,35 +863,41 @@ export function occCommitMutation(filePath, mutate, options = {}) {
   for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
     const current = occReadCurrent(filePath);
     if (current.ioError) return false; // fail closed: cannot fence without reading
+    const canonical = occReadCanonicalSnapshot(filePath);
+    if (canonical.ioError) return false;
     if (current.empty) {
       parentSeq = -1;
-      parentState = occSeedState(filePath);
+      parentState = canonical.state;
     } else {
       parentSeq = current.seq;
-      parentState = current.state;
+      parentState = occStateFingerprint(current.state) === canonical.fingerprint ? current.state : canonical.state;
     }
     let produced;
     produced = mutate(parentState, ownerToken);
     if (produced === null || produced === undefined) return false; // cancelled, no commit
     next = produced;
-    const seq = parentSeq + 1;
+    const seq = Math.max(parentSeq, current.reservedSeq) + 1;
     const entryPath = occEntryPath(dir, seq, ownerToken);
     let fd;
-    let claimed = false;
     try {
+      fd = openSync(occClaimPath(dir, seq), 'wx', 0o600);
+      writeAllSync(fd, ownerToken, 'occ sequence claim');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
       fd = openSync(entryPath, 'wx', 0o600);
       const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
       writeAllSync(fd, JSON.stringify(entry), 'occ journal entry');
       fsyncSync(fd);
       closeSync(fd);
       fd = undefined;
-      claimed = true;
     } catch (error) {
       if (fd !== undefined) { try { closeSync(fd); } catch {} }
       if (error && error.code === 'EEXIST') {
         // Another writer already claimed this seq. Re-read and retry with seq+1.
         continue;
       }
+      occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
     // Test seam (B11 probe): when a pause hook is registered for this filePath,
@@ -896,6 +922,19 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       // mark the fork as aborted so it is distinguishable from a live claim
       try { openSync(occAbortedPath(dir, seq, ownerToken), 'wx', 0o600); } catch { /* already marked */ }
       continue; // re-run mutate on the successor's state
+    }
+    try { options.assertHeld?.(); } catch {
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    const canonicalFence = occReadCanonicalSnapshot(filePath);
+    if (canonicalFence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    if (canonicalFence.fingerprint !== canonical.fingerprint) {
+      occCleanupOwn(dir, seq, ownerToken);
+      continue;
     }
     // COMMIT: create the .complete marker via O_EXCL.
     let markerFd;

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -806,11 +806,12 @@ function occReadCurrent(filePath) {
 
 function occReadCanonicalSnapshot(filePath) {
   try {
-    const state = JSON.parse(readFileSync(filePath, 'utf8'));
-    return { state, fingerprint: JSON.stringify(state), ioError: false };
+    const raw = readFileSync(filePath, 'utf8');
+    const state = JSON.parse(raw);
+    return { state, contentFingerprint: stateDigest(raw), stateFingerprint: JSON.stringify(state), ioError: false };
   } catch (error) {
-    if (error && error.code === 'ENOENT') return { state: null, fingerprint: 'absent', ioError: false };
-    return { state: null, fingerprint: '', ioError: true };
+    if (error && error.code === 'ENOENT') return { state: null, contentFingerprint: 'absent', stateFingerprint: 'absent', ioError: false };
+    return { state: null, contentFingerprint: '', stateFingerprint: '', ioError: true };
   }
 }
 
@@ -870,7 +871,16 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       parentState = canonical.state;
     } else {
       parentSeq = current.seq;
-      parentState = occStateFingerprint(current.state) === canonical.fingerprint ? current.state : canonical.state;
+      if (!options.skipCanonicalReconciliation && occStateFingerprint(current.state) !== canonical.stateFingerprint) {
+        const reconciled = occCommitMutation(
+          filePath,
+          () => ({ state: canonical.state, result: true }),
+          { assertHeld: options.assertHeld, suppressCanonicalRepublish: true, skipCanonicalReconciliation: true },
+        );
+        if (!reconciled) return false;
+        continue;
+      }
+      parentState = current.state;
     }
     let produced;
     produced = mutate(parentState, ownerToken);
@@ -932,7 +942,7 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
-    if (canonicalFence.fingerprint !== canonical.fingerprint) {
+    if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
       occCleanupOwn(dir, seq, ownerToken);
       continue;
     }
@@ -956,11 +966,13 @@ export function occCommitMutation(filePath, mutate, options = {}) {
     // entry is now NOT the max, it remains a valid committed ancestor: leave it.
     occPruneOld(dir, seq);
     // Re-publish the canonical file so legacy readers see the latest state.
-    try {
-      atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
-    } catch {
-      // The journal IS the source of truth; a failed canonical re-publish is
-      // non-fatal (the committed entry already advances current). Return true.
+    if (!options.suppressCanonicalRepublish) {
+      try {
+        atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
+      } catch {
+        // The journal commit remains durable. A later writer reconciles the
+        // compatibility file before evaluating its mutation.
+      }
     }
     return true;
   }
@@ -971,10 +983,9 @@ export function occCommitMutation(filePath, mutate, options = {}) {
 export function occReadCurrentState(filePath) {
   const current = occReadCurrent(filePath);
   if (current.ioError) return null;
-  if (current.empty) {
-    try { return JSON.parse(readFileSync(filePath, 'utf8')); } catch { return null; }
-  }
-  return current.state;
+  if (!current.empty) return current.state;
+  const canonical = occReadCanonicalSnapshot(filePath);
+  return canonical.ioError ? null : canonical.state;
 }
 
 /** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -866,20 +866,24 @@ export function occCommitMutation(filePath, mutate, options = {}) {
     if (current.ioError) return false; // fail closed: cannot fence without reading
     const canonical = occReadCanonicalSnapshot(filePath);
     if (canonical.ioError) return false;
+    if (options.expectedCanonicalContentFingerprint !== undefined &&
+      canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      return false;
+    }
     if (current.empty) {
       parentSeq = -1;
-      parentState = canonical.state;
+      // An authenticated external publisher supplies the source it captured
+      // before cache publication. Never infer that parent from post-publish
+      // canonical bytes.
+      parentState = Object.prototype.hasOwnProperty.call(options, 'authenticatedExternalParent')
+        ? options.authenticatedExternalParent
+        : canonical.state;
     } else {
       parentSeq = current.seq;
-      if (!options.skipCanonicalReconciliation && occStateFingerprint(current.state) !== canonical.stateFingerprint) {
-        const reconciled = occCommitMutation(
-          filePath,
-          () => ({ state: canonical.state, result: true }),
-          { assertHeld: options.assertHeld, suppressCanonicalRepublish: true, skipCanonicalReconciliation: true },
-        );
-        if (!reconciled) return false;
-        continue;
-      }
+      // A committed journal head is authoritative. `filePath` is only a
+      // compatibility cache and may be stale or written by an older install;
+      // it must never be silently promoted into a new journal generation.
       parentState = current.state;
     }
     let produced;
@@ -942,6 +946,12 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
+    if (options.expectedCanonicalContentFingerprint !== undefined &&
+      canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
     if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
       occCleanupOwn(dir, seq, ownerToken);
       continue;
@@ -970,8 +980,8 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       try {
         atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
       } catch {
-        // The journal commit remains durable. A later writer reconciles the
-        // compatibility file before evaluating its mutation.
+        // The journal commit remains durable. A later writer re-publishes its
+        // authoritative head; cache bytes are never journal input.
       }
     }
     return true;

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -667,6 +667,301 @@ export function withStateFileLockSync(filePath, callback, requireExclusive = fal
   }
 }
 
+// ===========================================================================
+// OCC (optimistic concurrency control) journal - root cure for B11.
+//
+// The lease lock above cannot atomically (check-ownership + write) an EXISTING
+// state file on a flock-less runtime (macOS/Windows): renewMutationLock returns
+// false there and assertMutationLockHeld is a read-then-write TOCTOU, so a
+// stale holder whose lease expired mid-mutation can overwrite a successor's
+// publish (B11), and a stale releaser can unlink a successor's lock (release
+// race). No combination of rename/link/unlink atomically fences an EXISTING file
+// on flock-less. OCC fixes it using ONLY O_EXCL (portable, no flock, no
+// liveness probe, testable on mac): every mutation sequences a NEW journal
+// entry under an O_EXCL name and validates its parent against the current
+// committed sequence; a stale writer that forks off an old parent is DETECTED
+// and re-sequenced AFTER its successor instead of overwriting it. There is no
+// shared lock to unlink - cleanup only ever touches the writer's OWN entries.
+//
+// Journal layout per state file `filePath`:
+//   dir:        filePath.journal/
+//   entry:      <seq>.<owner_token>.json        = { seq, parent_seq, owner_token, state }
+//   commit:     <seq>.<owner_token>.complete    (O_EXCL file = committed)
+//   aborted:    <seq>.<owner_token>.aborted     (marker for a detected dead fork)
+// "current" = the entry with the MAX seq bearing a .complete marker. Readers
+// scan the directory for the max complete seq (small N; entries with seq <
+// current - K are pruned, K=8) and read that entry's state. The canonical
+// `filePath` is re-published (atomicWriteFileSync) right after each commit so
+// existing readers that do not understand the journal keep working.
+// ===========================================================================
+
+/** Prune window: keep entries whose seq >= currentSeq - OCC_JOURNAL_PRUNE_BEHIND. */
+const OCC_JOURNAL_PRUNE_BEHIND = 8;
+/** Bounded O_EXCL claim retries per commit attempt (defends against live contention). */
+const OCC_JOURNAL_MAX_RETRIES = 50;
+
+/**
+ * Test seam for the deterministic B11 probe (stale-holder-publishes-after-reclaim).
+ * When `pauseAfterClaim` is set, `occCommitMutation` invokes its `fn` AFTER
+ * claiming an entry and BEFORE the fence revalidation, letting a test
+ * deschedule writer A, commit writer B fully, then resume A so A must detect
+ * its fork. Unused in production (the hook object stays empty).
+ */
+export const OCC_TEST_HOOKS = { pauseAfterClaim: null };
+
+function occJournalDir(filePath) {
+  return `${filePath}.journal`;
+}
+
+function occEntryPath(dir, seq, token) {
+  return join(dir, `${seq}.${token}.json`);
+}
+
+function occCompletePath(dir, seq, token) {
+  return join(dir, `${seq}.${token}.complete`);
+}
+
+function occAbortedPath(dir, seq, token) {
+  return join(dir, `${seq}.${token}.aborted`);
+}
+
+const OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+
+/**
+ * Scans the OCC journal directory and returns the current committed state: the
+ * entry with the maximum `seq` that bears a `.complete` marker. Returns
+ * { seq: -1, state: null, empty: true } when no committed entry exists yet (the
+ * journal is empty). Returns null (current=null, ioError=true) ONLY when the
+ * journal directory is present but unreadable with a non-ENOENT I/O error - in
+ * that case the caller FAILS CLOSED (operator attention): an OCC commit cannot
+ * proceed safely without being able to read the committed sequence fence.
+ */
+function occReadCurrent(filePath) {
+  const dir = occJournalDir(filePath);
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false };
+    return { seq: -1, state: null, empty: false, ioError: true };
+  }
+  const completeSeqs = new Set();
+  const entryBySeq = new Map();
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (!Number.isInteger(seq) || seq < 0) continue;
+    const token = match[2];
+    const kind = match[3];
+    if (kind === 'complete') {
+      completeSeqs.add(seq);
+    } else if (kind === 'json') {
+      if (!entryBySeq.has(seq)) entryBySeq.set(seq, token);
+    }
+  }
+  if (completeSeqs.size === 0) return { seq: -1, state: null, empty: true, ioError: false };
+  let maxSeq = -1;
+  for (const seq of completeSeqs) if (seq > maxSeq) maxSeq = seq;
+  const token = entryBySeq.get(maxSeq);
+  if (!token) {
+    // A complete marker exists without its entry json: the entry was pruned or
+    // never written. Treat the journal as unreadable at this fence and fail
+    // closed rather than guessing a parent.
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  let raw;
+  try {
+    raw = readFileSync(occEntryPath(dir, maxSeq, token), 'utf8');
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  let entry;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  if (!entry || typeof entry !== 'object' || entry.seq !== maxSeq || entry.owner_token !== token || !('state' in entry)) {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  return { seq: maxSeq, state: entry.state, empty: false, ioError: false };
+}
+
+/** Seed state for the first commit when the journal is empty: the canonical file, if any. */
+function occSeedState(filePath) {
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+/** Removes only the caller's OWN incomplete entry + any markers for (seq, token). */
+function occCleanupOwn(dir, seq, token) {
+  try { unlinkSync(occEntryPath(dir, seq, token)); } catch { /* absent */ }
+  try { unlinkSync(occCompletePath(dir, seq, token)); } catch { /* absent */ }
+  try { unlinkSync(occAbortedPath(dir, seq, token)); } catch { /* absent */ }
+}
+
+/** Prunes committed entries older than currentSeq - K (keeps the history tail bounded). */
+function occPruneOld(dir, currentSeq) {
+  let names;
+  try { names = readdirSync(dir); } catch { return; }
+  const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (Number.isInteger(seq) && seq < cutoff) {
+      try { unlinkSync(join(dir, name)); } catch { /* race; ignore */ }
+    }
+  }
+}
+
+/**
+ * OCC commit protocol (replaces writeAtomic-under-lock for concurrency fencing).
+ *
+ * `mutate(currentState)` is PURE: it returns the next state (or `null` /
+ * `undefined` to cancel without committing). The wrapper handles claim,
+ * parent-validation, commit, re-publication, and retry. Returns:
+ *   - true on a committed mutation (current advanced),
+ *   - false if every retry forked (extremely live contention) or on a journal-
+ *     directory I/O error (fail closed) or a thrown mutation.
+ *
+ * The graph store passes `{next, result}` callbacks; this wrapper is generic.
+ */
+export function occCommitMutation(filePath, mutate, options = {}) {
+  const dir = occJournalDir(filePath);
+  ensureDirSync(dir);
+  const ownerToken = options.ownerToken || randomUUID();
+  let parentSeq = -1;
+  let parentState = null;
+  let next = null;
+  for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
+    const current = occReadCurrent(filePath);
+    if (current.ioError) return false; // fail closed: cannot fence without reading
+    if (current.empty) {
+      parentSeq = -1;
+      parentState = occSeedState(filePath);
+    } else {
+      parentSeq = current.seq;
+      parentState = current.state;
+    }
+    let produced;
+    produced = mutate(parentState, ownerToken);
+    if (produced === null || produced === undefined) return false; // cancelled, no commit
+    next = produced;
+    const seq = parentSeq + 1;
+    const entryPath = occEntryPath(dir, seq, ownerToken);
+    let fd;
+    let claimed = false;
+    try {
+      fd = openSync(entryPath, 'wx', 0o600);
+      const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
+      writeAllSync(fd, JSON.stringify(entry), 'occ journal entry');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
+      claimed = true;
+    } catch (error) {
+      if (fd !== undefined) { try { closeSync(fd); } catch {} }
+      if (error && error.code === 'EEXIST') {
+        // Another writer already claimed this seq. Re-read and retry with seq+1.
+        continue;
+      }
+      return false;
+    }
+    // Test seam (B11 probe): when a pause hook is registered for this filePath,
+    // invoke it AFTER the entry is claimed but BEFORE the fence revalidation.
+    // This deterministically forces the stale-holder-publishes-after-reclaim
+    // interleaving: A claims, yields here, B commits fully, A resumes and must
+    // detect the fork. No-op in production (no hook registered).
+    if (OCC_TEST_HOOKS.pauseAfterClaim && OCC_TEST_HOOKS.pauseAfterClaim.filePath === filePath) {
+      try { OCC_TEST_HOOKS.pauseAfterClaim.fn(seq, ownerToken, parentSeq); } catch { /* test seam; ignore */ }
+    }
+    // RE-VALIDATE (the fence): re-scan the current committed max. If a successor
+    // committed in the window (current.seq > parentSeq), this entry is a DEAD
+    // FORK off a stale parent: mark it aborted, re-run the mutation on the
+    // successor's state, and re-sequence AFTER it. It NEVER overwrites.
+    const fence = occReadCurrent(filePath);
+    if (fence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    if (!fence.empty && fence.seq > parentSeq) {
+      try { unlinkSync(occEntryPath(dir, seq, ownerToken)); } catch { /* absent */ }
+      // mark the fork as aborted so it is distinguishable from a live claim
+      try { openSync(occAbortedPath(dir, seq, ownerToken), 'wx', 0o600); } catch { /* already marked */ }
+      continue; // re-run mutate on the successor's state
+    }
+    // COMMIT: create the .complete marker via O_EXCL.
+    let markerFd;
+    try {
+      markerFd = openSync(occCompletePath(dir, seq, ownerToken), 'wx', 0o600);
+      fsyncSync(markerFd);
+      closeSync(markerFd);
+    } catch (error) {
+      // A .complete marker already exists for this (seq, token): impossible for
+      // a fresh token; treat as a fork and retry.
+      if (markerFd !== undefined) { try { closeSync(markerFd); } catch {} }
+      occCleanupOwn(dir, seq, ownerToken);
+      if (error && error.code === 'EEXIST') continue;
+      return false;
+    }
+    // Re-validate this seq is still the max complete (else a successor committed
+    // between our fence read and our marker; we still committed a valid child of
+    // `parentSeq`, which is fine - the successor simply sequences ahead). If our
+    // entry is now NOT the max, it remains a valid committed ancestor: leave it.
+    occPruneOld(dir, seq);
+    // Re-publish the canonical file so legacy readers see the latest state.
+    try {
+      atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
+    } catch {
+      // The journal IS the source of truth; a failed canonical re-publish is
+      // non-fatal (the committed entry already advances current). Return true.
+    }
+    return true;
+  }
+  return false; // exhausted retries under extreme live contention
+}
+
+/** Reads the current committed state via the OCC journal (test + reader surface). */
+export function occReadCurrentState(filePath) {
+  const current = occReadCurrent(filePath);
+  if (current.ioError) return null;
+  if (current.empty) {
+    try { return JSON.parse(readFileSync(filePath, 'utf8')); } catch { return null; }
+  }
+  return current.state;
+}
+
+/** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */
+export function occCleanupOwner(filePath, ownerToken) {
+  const dir = occJournalDir(filePath);
+  let names;
+  try { names = readdirSync(dir); } catch { return; }
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    if (match[2] !== ownerToken) continue; // never touch another writer's entries
+    const seq = Number(match[1]);
+    const kind = match[3];
+    // Only remove entries that lack a .complete marker (incomplete forks).
+    if (kind === 'json' || kind === 'aborted') {
+      const hasComplete = names.some((other) => {
+        const om = OCC_ENTRY_NAME_RE.exec(other);
+        return om && om[1] === match[1] && om[2] === ownerToken && om[3] === 'complete';
+      });
+      if (!hasComplete) {
+        try { unlinkSync(join(dir, name)); } catch { /* race */ }
+      }
+    }
+  }
+}
+
 /** Recover an interrupted exact emergency state mutation without touching replacements. */
 function stateDigest(raw) {
   return createHash('sha256').update(raw).digest('hex');

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -863,14 +863,13 @@ export function occCommitMutation(filePath, mutate, options = {}) {
   let next = null;
   for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
     const current = occReadCurrent(filePath);
-    if (current.ioError) return false; // fail closed: cannot fence without reading
     const canonical = occReadCanonicalSnapshot(filePath);
-    if (canonical.ioError) return false;
     if (options.expectedCanonicalContentFingerprint !== undefined &&
       canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
       options.onCanonicalCompareFailed?.();
       return false;
     }
+    if (current.ioError || canonical.ioError) return false; // fail closed: cannot fence without reading
     if (current.empty) {
       parentSeq = -1;
       // An authenticated external publisher supplies the source it captured
@@ -942,13 +941,13 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       return false;
     }
     const canonicalFence = occReadCanonicalSnapshot(filePath);
-    if (canonicalFence.ioError) {
-      occCleanupOwn(dir, seq, ownerToken);
-      return false;
-    }
     if (options.expectedCanonicalContentFingerprint !== undefined &&
       canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
       options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    if (canonicalFence.ioError) {
       occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
@@ -1421,7 +1420,7 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
       if (intent === 'publish' && digest(payloadPath) !== intendedDigest) return false;
       if (!owned()) return false;
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
-        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) removeOwnedEmergencyArtifacts(journalPath, journal, true);
+        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) return removeOwnedEmergencyArtifacts(journalPath, journal, true);
         return false;
       }
       journal.phase = 'quarantined';

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -1035,8 +1035,11 @@ function sameEmergencyOwner(left, right) {
   return left.pid === right.pid && left.processStart === right.processStart && left.nonce === right.nonce;
 }
 
-/** Unknown process identity is treated as live; only an exact start identity proves ownership. */
+/** Unknown process identity is treated as live: stealing a claim is never safe. */
 function isEmergencyOwnerLive(owner) {
+  // Deterministic crash injection relinquishes ownership with this sentinel.
+  // It is test-only; real unknown process identities remain fail-closed.
+  if (process.env.NODE_ENV === 'test' && owner.pid === 999999999 && owner.processStart === 'abandoned') return false;
   const currentStart = processStartIdentity(owner.pid);
   return currentStart !== 'absent' && (currentStart === null || currentStart === owner.processStart);
 }
@@ -1420,7 +1423,17 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
       if (intent === 'publish' && digest(payloadPath) !== intendedDigest) return false;
       if (!owned()) return false;
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
-        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+        // A replacement appeared DURING capture, before the original was durably
+        // quarantined and unlinked. The emergency no longer applies to this
+        // generation: abort so the caller surfaces the recovery failure, while
+        // cleaning up the partial transaction so no ownerless artifact remains.
+        // This mirrors the live emergencyMutateStateFileIf capture-failure path.
+        // A quarantine that capture created before detecting the replacement is
+        // removed; the replacement wins and is never sequenced through OCC.
+        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) {
+          removeOwnedEmergencyArtifacts(journalPath, journal, true);
+          return false;
+        }
         return false;
       }
       journal.phase = 'quarantined';

--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -105,45 +105,166 @@ export function atomicWriteFileSync(filePath, content) {
   }
 }
 
+// Keep emitting the deployed v1 lease wire format. Older readers classify a
+// different version as corrupt and can otherwise reclaim a live current lock.
 const LOCK_SCHEMA_VERSION = 1;
-function flockPath() { return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null; }
+const LOCK_OLD_SCHEMA_VERSION = 1;
+/** Pre-upgrade (v1) liveness-schema key set: has `processStart`, no `expires_at`. */
+const LOCK_OLD_OWNER_KEYS = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
+/**
+ * Lease duration (ms) for a mutation lock. Generous enough that a single
+ * acquire->mutate->release cycle (graph mutation or autopilot state write)
+ * almost always completes within the lease. As a SAFETY NET against a holder
+ * whose critical section overruns the lease (B11: the lease would otherwise
+ * expire mid-mutation and admit a second writer), the holder re-validates its
+ * OWN lease immediately before publishing (see assertMutationLockHeld) and
+ * aborts with `lease_expired_during_mutation` if it has expired. Long-held
+ * locks (e.g. a slow graph mutation) SHOULD additionally call renewMutationLock
+ * periodically to extend `expires_at` while still working, so the lease does
+ * not expire under them. If the holder crashes or fails to release, a later
+ * acquirer reclaims once `now >= expires_at`.
+ */
+const LOCK_LEASE_MS = 300000; // 5 minutes
+
+/**
+ * Returns the current wall-clock ms. Centralised so tests can mock time by
+ * planting `expires_at` values; production reads `Date.now()`.
+ */
+function leaseNow() {
+  return Date.now();
+}
+
+function flockPath() {
+  // B8 test seam: OMC_TEST_FORCE_FLOCKLESS=1 (NODE_ENV=test only) forces the
+  // flock-less linkSync branch on a host that actually has flock (Linux CI),
+  // so the flock-less acquire/reclaim/release code is exercised there. Unlike
+  // OMC_TEST_FLOCK_AVAILABLE=0 it does NOT trip lockingDisabledForTest(), so
+  // exclusive locking stays enabled and the real flock-less path runs.
+  if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FORCE_FLOCKLESS === '1') return null;
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null;
+}
+/**
+ * True only when the test harness explicitly simulates a runtime with NO
+ * locking primitives whatsoever (OMC_TEST_FLOCK_AVAILABLE=0). Distinct from a
+ * real flock-less runtime (Windows/macOS): there, linkSync-based O_EXCL locking
+ * is still a valid mutual-exclusion mechanism and may be used. Under the test
+ * simulation, exclusive locks must remain unavailable (return null) so callers
+ * fail closed - the same contract the dev branch established. Mirrors
+ * lockingDisabledForTest() in src/lib/mode-state-io.ts.
+ */
+function lockingDisabledForTest() {
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0';
+}
+// Lease-based mutation lock reclaim script (runs under an exclusive `flock` guard
+// on `${lockPath}.reclaim.guard` so the reclaim read+unlink is atomic w.r.t.
+// other reclaimers). The script reads the on-disk owner and decides:
+//   exit 0 -> lock was reclaimable (expired lease OR corrupt) and has been
+//             unlinked; the caller should retry linkSync to acquire.
+//   exit 2 -> lock has a VALID, UNEXPIRED v1 lease (live owner); do NOT reclaim.
+//   exit 3 -> the lock could not be read with a non-ENOENT I/O error
+//             (EACCES/EMFILE/EIO/ENOMEM): the owner MAY be alive and we just
+//             cannot read its lease. FAIL CLOSED (no steal). Operator attention.
+//   exit 4 -> owner replaced between read and unlink (TOCTOU); caller retries.
+//   exit 5 -> the on-disk owner is a v1 (old-liveness contract) record
+//             (has processStart, no expires_at). The old owner MAY be alive; we
+//             do NOT reclaim it and do NOT unlink. FAIL CLOSED (B12). The caller
+//             fails closed (wait / return null). Operator attention.
+//   exit 6 -> lock is a structurally valid lease record with an unsupported
+//             version. It may be live under another contract; fail closed.
+// For `release` the script unlinks only if the on-disk owner exactly matches the
+// expected owner (pid + nonce + createdAt); a mismatched owner (or a v1 owner,
+// or a corrupt owner) is left in place.
 const LOCK_REMOVAL_SCRIPT = String.raw`
 const fs = require('fs');
-const [operation, lockPath, expectedRaw] = process.argv.slice(1);
-const keys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
+const [operation, lockPath, expectedRaw, renewalPath] = process.argv.slice(1);
+const leaseKeys = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'];
+const oldKeys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
 function readOwner() {
+  let raw;
   try {
-    const value = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    raw = fs.readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return 'absent';
+    return 'io_error';
+  }
+  try {
+    const value = JSON.parse(raw);
     const actual = Object.keys(value).sort();
-    if (actual.length !== keys.length || !actual.every((key, index) => key === keys[index]) || value.version !== 1 || !Number.isSafeInteger(value.pid) || value.pid <= 0 || typeof value.processStart !== 'string' || !/^\d+$/.test(value.processStart) || typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt)) || typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return null;
-    return value;
-  } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); return null; }
+    // v1 lease schema (the deployed current contract): expires_at, no processStart.
+    const leaseShaped = actual.length === leaseKeys.length && actual.every((key, index) => key === leaseKeys[index]) && Number.isSafeInteger(value.version) && value.version > 0 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.expires_at === 'string' && Number.isFinite(Date.parse(value.expires_at)) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce);
+    if (leaseShaped && value.version === 1) return value;
+    // v1 old-liveness schema (pre-upgrade contract): version 1, processStart, no
+    // expires_at. NOT corrupt - it is a live lock held under the old contract. The
+    // old owner may be alive; FAIL CLOSED (B12): never unlink, never reclaim.
+    if (actual.length === oldKeys.length && actual.every((key, index) => key === oldKeys[index]) && value.version === 1 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.processStart === 'string' && /^\d+$/.test(value.processStart) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce)) return 'old_version';
+    if (leaseShaped) return 'unknown_version';
+    // B12: a structurally-valid versioned object under a shape we don't recognise
+    // (e.g. a future lease with extra/renamed fields) MAY be a live owner. FAIL
+    // CLOSED (unknown_version -> exit 6): never unlink, never reclaim. Reserve
+    // 'corrupt' for genuinely unparseable / non-versioned garbage.
+    if (value && typeof value === 'object' && !Array.isArray(value) && Number.isSafeInteger(value.version) && value.version > 0) return 'unknown_version';
+    return 'corrupt';
+  } catch (error) { return 'corrupt'; }
 }
-const owner = readOwner();
-if (!owner) process.exit(3);
 if (operation === 'release') {
   let expected;
   try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
-  if (owner.pid !== expected.pid || owner.processStart !== expected.processStart || owner.nonce !== expected.nonce) process.exit(4);
-  try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(0);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5); // not ours; leave the old-contract lock in place
+  if (current === 'unknown_version') process.exit(6); // not ours; leave the unsupported-contract lock in place
+  if (current === 'corrupt') process.exit(3);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); }
 }
-if (process.platform !== 'linux') process.exit(3);
-let currentStart;
-try {
-  const stat = fs.readFileSync('/proc/' + owner.pid + '/stat', 'utf8');
-  const end = stat.lastIndexOf(')');
-  const fields = end >= 0 ? stat.slice(end + 2).trim().split(/\s+/) : [];
-  currentStart = fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
-} catch (error) { currentStart = error && error.code === 'ENOENT' ? 'absent' : null; }
-if (currentStart === null) process.exit(3);
-if (currentStart !== 'absent' && currentStart === owner.processStart) process.exit(2);
-try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+if (operation === 'renew') {
+  let expected;
+  try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(4);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5);
+  if (current === 'unknown_version') process.exit(6);
+  if (current === 'corrupt') process.exit(4);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  if (Date.now() >= Date.parse(current.expires_at)) process.exit(2);
+  try { fs.renameSync(renewalPath, lockPath); process.exit(0); } catch { process.exit(3); }
+}
+const current = readOwner();
+if (current === 'absent') process.exit(0);
+if (current === 'io_error') process.exit(3);
+if (current === 'old_version') process.exit(5); // old-contract owner may be live; FAIL CLOSED (B12)
+if (current === 'unknown_version') process.exit(6); // unknown-contract owner may be live; FAIL CLOSED
+if (current === 'corrupt') { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+if (Date.now() >= Date.parse(current.expires_at)) { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+process.exit(2);
 `;
+
+// ---------------------------------------------------------------------------
+// Emergency-journal process identity (NOT used by the mutation lock).
+//
+// The mutation lock is LEASE-based (see freshLockOwner/readLockOwner above) and
+// does NOT probe process liveness. This processStartIdentity helper is retained
+// exclusively for the EMERGENCY JOURNAL subsystem (recoverEmergencyStateFile /
+// emergencyMutateStateFileIf and their recovery-claim script), which still
+// authenticates a crashed transaction's owner by process-start identity. It is
+// intentionally kept separate from the lease lock so the mutation-lock blockers
+// (B5/B6/B7/B8/B9/B10) cannot recur via the emergency path's liveness probe.
+// ---------------------------------------------------------------------------
+let cachedSelfProcessStart;
+
+function selfProcessStart() {
+  if (cachedSelfProcessStart === undefined) {
+    cachedSelfProcessStart = String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1000)));
+  }
+  return cachedSelfProcessStart;
+}
 
 function processStartIdentity(pid) {
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_EMERGENCY_PROCESS_START_UNKNOWN_PID === String(pid)) return null;
   if (!Number.isSafeInteger(pid) || pid <= 0) return null;
-  if (process.platform !== 'linux') return pid === process.pid ? String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1000))) : null;
+  if (process.platform !== 'linux') return pid === process.pid ? selfProcessStart() : null;
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
     const end = stat.lastIndexOf(')');
@@ -152,6 +273,25 @@ function processStartIdentity(pid) {
     return fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
   } catch (error) { return error?.code === 'ENOENT' ? 'absent' : null; }
 }
+
+/**
+ * Computes the owner record written to a freshly acquired lock file. The lease
+ * expires_at = now + LOCK_LEASE_MS; it is the ONLY reclaim key (no process
+ * liveness is probed). pid + nonce + createdAt stay for debug/ownership identity
+ * (release verifies them to avoid unlinking a lock a live owner lawfully
+ * reclaimed and re-acquired).
+ */
+function freshLockOwner() {
+  const now = leaseNow();
+  return {
+    version: LOCK_SCHEMA_VERSION,
+    pid: process.pid,
+    createdAt: new Date(now).toISOString(),
+    expires_at: new Date(now + LOCK_LEASE_MS).toISOString(),
+    nonce: randomUUID(),
+  };
+}
+
 function guardedLockRemoval(lockPath, operation, owner) {
   const flock = flockPath();
   if (!flock) return 'unverifiable';
@@ -159,19 +299,30 @@ function guardedLockRemoval(lockPath, operation, owner) {
   if (result.status === 0) return 'retry';
   if (result.status === 2) return 'live';
   if (result.status === 4) return 'replaced';
+  if (result.status === 5) return 'old_version';
+  if (result.status === 6) return 'unknown_version';
   return 'unverifiable';
+}
+
+/** Compares and replaces a lease while holding the reclaimer's guard. */
+function guardedLockRenewal(lockPath, owner, renewalPath) {
+  const flock = flockPath();
+  if (!flock) return false;
+  const result = spawnSync(flock, ['-x', `${lockPath}.reclaim.guard`, process.execPath, '-e', LOCK_REMOVAL_SCRIPT, 'renew', lockPath, JSON.stringify(owner), renewalPath], { stdio: 'ignore', timeout: 2000 });
+  return result.status === 0;
 }
 
 function acquireLockAt(lockPath, attempts = 50, requireExclusive = false) {
   ensureDirSync(dirname(lockPath));
-  if (!flockPath()) return requireExclusive ? null : { unlocked: true };
-  const processStart = processStartIdentity(process.pid);
-  if (!processStart || processStart === 'absent') {
-    console.error(`[omc-lock] state_mutation_lock_owner_unverifiable: ${lockPath}`);
-    return null;
-  }
+  const hasFlock = !!flockPath();
+  // Under the explicit test no-locking simulation, exclusive locks are
+  // unavailable (fail closed), matching the dev contract. On real flock-less
+  // runtimes (Windows/macOS) we still fall through to linkSync-based locking.
+  if (lockingDisabledForTest()) return requireExclusive ? null : { unlocked: true };
+  if (!hasFlock && !requireExclusive) return { unlocked: true };
+  // No process-liveness probe: the lease (expires_at) is the sole reclaim key.
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const owner = { version: LOCK_SCHEMA_VERSION, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() };
+    const owner = freshLockOwner();
     const tempPath = `${lockPath}.${process.pid}.${owner.nonce}.tmp`;
     let fd;
     try {
@@ -185,12 +336,60 @@ function acquireLockAt(lockPath, attempts = 50, requireExclusive = false) {
       if (fd !== undefined) { try { closeSync(fd); } catch {} }
       try { unlinkSync(tempPath); } catch {}
       if (error?.code !== 'EEXIST') return null;
-      const disposition = guardedLockRemoval(lockPath, 'reclaim');
-      if (disposition === 'unverifiable') {
-        console.error(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
-        return null;
+      // A lock already exists. Decide reclaim by LEASE, not process liveness.
+      // Both the flock and flock-less paths use the SAME policy (B7/B10
+      // convergence): reclaim only when the lease is expired or the owner JSON
+      // is corrupt; a valid unexpired lease blocks (fail closed); an I/O-
+      // unreadable lock fails closed forever (B9: the owner MAY be alive).
+      if (hasFlock) {
+        const disposition = guardedLockRemoval(lockPath, 'reclaim');
+        if (disposition === 'unverifiable') {
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
+          return null;
+        }
+        if (disposition === 'old_version' || disposition === 'unknown_version' || disposition === 'unrecognised') {
+          // v1 old-liveness contract owner, an unsupported-lease-version owner,
+          // OR a structurally-valid versioned owner under a shape we don't
+          // recognise: the owner MAY be alive under a contract we don't know.
+          // FAIL CLOSED (B12): never reclaim, never steal. Surface it so an
+          // operator can intervene; bail rather than spin forever.
+          console.error(`[omc-lock] state_mutation_lock_${disposition}: ${lockPath}`);
+          return null;
+        }
+        if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        // 'retry' (reclaimed) or 'replaced' (TOCTOU): loop and re-attempt linkSync.
+      } else {
+        const current = readLockOwner(lockPath);
+        if (current === 'absent') {
+          // Lock vanished between EEXIST and read (race): retry linkSync.
+        } else if (current === null) {
+          // I/O read failure (EACCES/EMFILE/EIO/ENOMEM) on a possibly-live
+          // lock. The owner MAY be alive; we just cannot read its lease. FAIL
+          // CLOSED (B9): no steal, no bounded reclaim, no wedge-escape. Log so
+          // the event is observable for operator attention.
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        } else if (current === 'old_version' || current === 'unknown_version' || current === 'unrecognised') {
+          // v1 old-liveness contract owner (processStart, no expires_at), an
+          // exact-lease-shape owner under an unsupported version, OR a
+          // structurally-valid versioned owner under a shape we don't recognise:
+          // the owner MAY be alive under a contract we don't know. FAIL CLOSED
+          // (B12): do NOT unlink, do NOT steal. Surface it; bail rather than spin.
+          console.error(`[omc-lock] state_mutation_lock_${current}: ${lockPath}`);
+          return null;
+        } else if (current === 'corrupt') {
+          // Readable but unparseable/invalid owner JSON: no valid lease is on
+          // record, so the owner cannot be live. RECLAIM (unlink) and retry.
+          try { unlinkSync(lockPath); } catch { /* race; retry linkSync */ }
+        } else if (leaseNow() >= Date.parse(current.expires_at)) {
+          // Valid owner whose lease has EXPIRED: the holder crashed or failed
+          // to release. RECLAIM (unlink) and retry.
+          try { unlinkSync(lockPath); } catch { /* race; retry linkSync */ }
+        } else {
+          // Valid owner with an unexpired lease: LIVE. Do NOT steal; wait.
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        }
       }
-      if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
   }
   return null;
@@ -200,17 +399,269 @@ export function acquireStateFileLockSync(filePath, attempts = 50, requireExclusi
   return acquireLockAt(`${filePath}.mutation.lock`, attempts, requireExclusive);
 }
 
+function sameLockOwner(left, right) {
+  return left.pid === right.pid && left.nonce === right.nonce && left.createdAt === right.createdAt;
+}
+
+const LOCK_OWNER_KEYS = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'];
+
+/**
+ * True when `value` matches the pre-upgrade v1 LIVENESS-schema owner shape
+ * (`processStart` present, no `expires_at`, version 1). Such a record is a lock
+ * held under the OLD contract; the owner may still be alive. It is NOT corrupt
+ * and must NEVER be reclaimed (B12). Distinct from a corrupt/malformed record.
+ */
+function isOldLivenessOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  if (actual.length !== LOCK_OLD_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OLD_OWNER_KEYS[index])) return false;
+  if (value.version !== LOCK_OLD_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) return false;
+  if (typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt))) return false;
+  if (typeof value.processStart !== 'string' || !/^\d+$/.test(value.processStart)) return false;
+  if (typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return false;
+  return true;
+}
+
+/**
+ * Validates a parsed object as a lease-based (v1) lock owner using the SAME checks
+ * the flock path's LOCK_REMOVAL_SCRIPT enforces: exact key set, version===1,
+ * positive integer pid, parseable createdAt, parseable expires_at (the lease
+ * reclaim key), and a 36-char UUID nonce. pid is kept for debug/ownership
+ * identity and is NOT probed for liveness. Returns the owner or null. A v1
+ * old-liveness record is NOT null here; use isOldLivenessOwner to detect it.
+ * Single owner validator (B4: folded the two divergent validators into one).
+ */
+function validateLockOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const actual = Object.keys(value).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return null;
+  if (value.version !== LOCK_SCHEMA_VERSION) return null;
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) return null;
+  if (typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt))) return null;
+  if (typeof value.expires_at !== 'string' || !Number.isFinite(Date.parse(value.expires_at))) return null;
+  if (typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return null;
+  return value;
+}
+
+function isUnknownLeaseOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return false;
+  if (!Number.isSafeInteger(value.version) || value.version <= 0 || value.version === LOCK_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) return false;
+  if (typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt))) return false;
+  if (typeof value.expires_at !== 'string' || !Number.isFinite(Date.parse(value.expires_at))) return false;
+  return typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce);
+}
+
+/**
+ * True when `value` is a structurally-valid-but-UNRECOGNISED versioned owner: a
+ * JSON object that carries a positive-integer `version` field but does NOT
+ * match any schema this build knows (v1 lease, v1 old-liveness, or the exact
+ * 5-key unknown-lease shape handled by `isUnknownLeaseOwner`). Such a record
+ * may be a live lock held under a future contract whose shape we don't
+ * recognise (B12: e.g. a #3553-era or v2 lease with extra/renamed fields). It
+ * is NOT corrupt (the bytes are valid) and must NEVER be reclaimed: reclaiming
+ * it would destroy a live owner's lock. Callers FAIL CLOSED on it. Reserve
+ * `'corrupt'` for genuinely unparseable bytes / non-versioned garbage.
+ */
+function isUnrecognisedVersionedOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  if (!Number.isSafeInteger(value.version) || value.version <= 0) return false;
+  // Anything versioned we didn't recognise above is an unknown contract. This
+  // intentionally includes records with extra/missing fields relative to the
+  // known key sets, so a future-schema live owner is never stolen as 'corrupt'.
+  return true;
+}
+
+/**
+ * Reads and validates the on-disk lease owner. Returns:
+ *  - the validated v1 lease owner on success,
+ *  - 'absent' when the lock file does not exist (ENOENT),
+ *  - 'corrupt' when the file is readable but genuinely unparseable/invalid
+ *    (broken JSON, non-object, or a non-versioned record with no `version`):
+ *    no valid lease is on record and the owner cannot be live, so reclaim.
+ *  - 'old_version' when the file is a readable v1 old-liveness-schema record
+ *    (processStart, no expires_at): a lock held under the OLD contract whose
+ *    owner may be alive. Callers FAIL CLOSED on it (B12): never reclaim.
+ *  - 'unknown_version' when the file is the exact v1-lease key set under a
+ *    different positive version (unsupported contract). FAIL CLOSED (B12).
+ *  - 'unrecognised' when the file is a structurally-valid versioned JSON object
+ *    under a shape this build does not recognise (e.g. a future lease with
+ *    extra/renamed fields). The owner MAY be live; FAIL CLOSED (B12): never
+ *    reclaim, never unlink. Distinct from 'corrupt' (genuinely bad bytes).
+ *  - null when the read itself failed with a non-ENOENT I/O error
+ *    (EACCES/EMFILE/EIO/ENOMEM) - the owner MAY be alive; callers fail closed.
+ * The 6-way result lets the caller fail closed on an unreadable lock (B9), an
+ * old-contract lock (B12), or an unrecognised-but-valid lock (B12); reclaim
+ * only a genuinely corrupt lock; and block on a valid unexpired lease.
+ */
+function readLockOwner(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') return 'absent';
+    return null; // I/O failure - may be a live lock we cannot read
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 'corrupt'; // readable but unparseable JSON - no valid lease
+  }
+  if (isOldLivenessOwner(parsed)) return 'old_version';
+  if (isUnknownLeaseOwner(parsed)) return 'unknown_version';
+  const owner = validateLockOwner(parsed);
+  if (owner !== null) return owner;
+  // B12: a versioned object we don't recognise may be a live owner under a
+  // future contract. Fail closed (never unlink) instead of stealing it as
+  // 'corrupt'. Only non-versioned / non-object garbage stays 'corrupt'.
+  if (isUnrecognisedVersionedOwner(parsed)) return 'unrecognised';
+  return 'corrupt';
+}
+
 export function releaseStateFileLockSync(lock) {
   if (!lock || lock.unlocked) return;
   try { closeSync(lock.fd); } catch {}
-  guardedLockRemoval(lock.lockPath, 'release', lock.owner);
+  if (flockPath()) {
+    // Flock path: the guarded removal script unlinks only if the on-disk owner
+    // exactly matches ours (pid + nonce + createdAt); a mismatched owner is a
+    // live owner that lawfully reclaimed after our lease expired, so we leave
+    // it in place (the script exits 4 and we log).
+    const disposition = guardedLockRemoval(lock.lockPath, 'release', lock.owner);
+    if (disposition === 'replaced' || disposition === 'old_version') {
+      console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.lockPath}`);
+    }
+    return;
+  }
+  // flock-less runtime (macOS/Windows) or the explicit test simulation: the
+  // holder releases its OWN lock. Re-validate immediately before unlink to close
+  // the TOCTOU window between readLockOwner and unlinkSync: if the on-disk owner
+  // no longer matches (our lease expired and a later acquirer reclaimed it, or a
+  // concurrent release raced), leave the live owner's lock in place and log.
+  const current = readLockOwner(lock.lockPath);
+  if (current === 'absent') return; // already released
+  if (current === null) return; // unreadable - do not unlink what we cannot verify
+  if (current === 'old_version' || current === 'unknown_version' || current === 'unrecognised') {
+    // The on-disk lock is now a record under a contract we don't recognise
+    // (v1 old-liveness, an unsupported lease version, or an unrecognised
+    // versioned shape - e.g. a pre-upgrade owner or a future-schema owner that
+    // reclaimed after our lease expired). It is NOT ours; leave it in place
+    // (B12) - never unlink an owner whose schema we cannot verify.
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.lockPath}`);
+    return;
+  }
+  if (current !== 'corrupt' && sameLockOwner(current, lock.owner)) {
+    try { unlinkSync(lock.lockPath); } catch { /* race or already removed */ }
+  } else {
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.lockPath}`);
+  }
+}
+
+/**
+ * Re-validates that the holder's OWN lease is still live (B11). Re-reads the
+ * on-disk owner at `lock.lockPath` and confirms (a) it is still our lock
+ * (`sameLockOwner`: pid + nonce + createdAt) and (b) `now < expires_at`. If the
+ * lease has expired while we were still in the critical section, a second writer
+ * may already have reclaimed and re-acquired the lock; publishing now would
+ * silently overwrite that writer's work. To make that violation DETECTABLE
+ * rather than silent, this throws `lease_expired_during_mutation` and logs the
+ * two-writer overlap. Call this immediately BEFORE publishing under a lock whose
+ * critical section may approach LEASE_MS; withStateFileLockSync does so
+ * automatically before invoking the callback.
+ *
+ * Note: this is the holder checking ITS OWN lease, not someone else's. A holder
+ * that overruns its lease is the bug; this is the safety net that catches it.
+ */
+export function assertMutationLockHeld(lock) {
+  if (!lock || lock.unlocked) return;
+  const current = readLockOwner(lock.lockPath);
+  if (current === 'absent' || current === 'old_version' || current === 'unknown_version' || current === 'unrecognised' || current === 'corrupt' || current === null) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.lockPath}`);
+    throw new Error(`lease_expired_during_mutation: holder's lock is no longer live at ${lock.lockPath}`);
+  }
+  if (!sameLockOwner(current, lock.owner)) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.lockPath}`);
+    throw new Error(`lease_expired_during_mutation: on-disk owner replaced at ${lock.lockPath}`);
+  }
+  if (leaseNow() >= Date.parse(current.expires_at)) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.lockPath}`);
+    throw new Error(`lease_expired_during_mutation: holder's lease expired before publish at ${lock.lockPath}`);
+  }
+}
+
+/**
+ * Extends the holder's lease by re-writing `expires_at = now + LEASE_MS` while
+ * still holding the lock (B11). For long critical sections (e.g. a slow graph
+ * mutation that may approach or exceed LEASE_MS), callers should renew
+ * periodically so the lease does not expire under them and admit a second
+ * writer. Renewal re-validates that the on-disk owner is still ours (otherwise a
+ * later writer has already reclaimed our expired lease and we must NOT publish);
+ * on owner mismatch or I/O failure it returns false and the caller should abort.
+ * Returns true on a successful renewal. No-op (returns true) for unlocked locks.
+ */
+export function renewMutationLock(lock) {
+  if (!lock || lock.unlocked) return true;
+  // A read followed by rename is not a path-level CAS. Without the shared
+  // reclaimer guard there is no portable safe replacement, so fail closed.
+  if (!flockPath()) return false;
+  const current = readLockOwner(lock.lockPath);
+  if (current === 'absent' || current === 'old_version' || current === 'unknown_version' || current === 'unrecognised' || current === 'corrupt' || current === null) return false;
+  if (!sameLockOwner(current, lock.owner)) return false; // someone else owns it now
+  if (leaseNow() >= Date.parse(current.expires_at)) return false;
+  const renewedExpiresAt = new Date(leaseNow() + LOCK_LEASE_MS).toISOString();
+  const tempPath = `${lock.lockPath}.${process.pid}.${lock.owner.nonce}.renew.tmp`;
+  let fd;
+  try {
+    const renewed = { ...lock.owner, expires_at: renewedExpiresAt };
+    fd = openSync(tempPath, 'wx', 0o600);
+    writeAllSync(fd, JSON.stringify(renewed), 'lock renewal publication');
+    fsyncSync(fd);
+    // Repeat identity and expiry validation under the same guard reclaimers
+    // use, then replace atomically. This cannot overwrite a later owner.
+    if (!guardedLockRenewal(lock.lockPath, lock.owner, tempPath)) return false;
+    lock.owner = renewed;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) { try { closeSync(fd); } catch {} }
+    try { unlinkSync(tempPath); } catch {}
+  }
+}
+
+/**
+ * Reports whether `renewMutationLock` can actually extend the lease for `lock`
+ * on the current runtime (B11). On a flock-capable runtime it returns true; on
+ * a flock-less runtime (macOS/Windows) it returns false, because a portable
+ * atomic rename-over-the-live-lock is unavailable without the shared reclaimer
+ * guard, so `renewMutationLock` returns false there regardless of whether the
+ * lock is still held. Unlocked locks are trivially "supported" (renewal is a
+ * no-op that returns true).
+ *
+ * Callers that gate on renewal failure should use this to distinguish
+ * "renewal unsupported on this runtime" (the lock is NOT lost - it is still
+ * held via the O_EXCL linkSync and its lease is still valid for LEASE_MS; the
+ * holder should NO-OP, relying on `assertMutationLockHeld` before publish as the
+ * safety net) from "renewal attempted on a supported runtime and failed" (the
+ * lock WAS lost - owner replaced / lease expired / I/O error - and the caller
+ * must abort). Treating the unsupported case as `lock_lost` would break every
+ * mutation on macOS/Windows.
+ */
+export function mutationLockRenewalSupported(lock) {
+  if (!lock || lock.unlocked) return true;
+  return !!flockPath();
 }
 
 export function withStateFileLockSync(filePath, callback, requireExclusive = false) {
   const lock = acquireStateFileLockSync(filePath, 50, requireExclusive);
   if (!lock) return { acquired: false, value: undefined };
   try {
-    return { acquired: true, value: callback() };
+    // Callers with a publication inside the callback invoke this immediately
+    // before it. Zero-argument callbacks remain source-compatible.
+    return { acquired: true, value: callback(() => assertMutationLockHeld(lock)) };
   } finally {
     releaseStateFileLockSync(lock);
   }

--- a/scripts/lib/graph-session-settlement.mjs
+++ b/scripts/lib/graph-session-settlement.mjs
@@ -32,7 +32,13 @@ export async function settleGraphSessionEnd(input) {
 
   try {
     const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
-    if (!existsSync(writePath)) return;
+    // Under OCC (B11 root cure) the journal dir `${writePath}.journal` is the
+    // authoritative state location; the canonical `writePath` file is a derived
+    // cache that may be absent (e.g. not re-published, or cleared) while the
+    // journal still holds state with live claims requiring settlement. Gate on
+    // the journal dir, not the canonical cache, so SessionEnd does not skip
+    // settle when the canonical is absent but journal authority still requires it.
+    if (!existsSync(`${writePath}.journal`)) return;
     spawnSync('omc', [
       'graph',
       'settle-session',

--- a/scripts/lib/graph-session-settlement.mjs
+++ b/scripts/lib/graph-session-settlement.mjs
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { resolveSessionStatePathsForHook } from './state-root.mjs';
+
+const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const SETTLE_TIMEOUT_MS = 2_000;
+
+function transitionId(sessionId, graphPath) {
+  const nonce = `${process.hrtime.bigint()}-${Math.random().toString(36).slice(2)}`;
+  const digest = createHash('sha256')
+    .update(`${sessionId}\0${graphPath}\0${nonce}`)
+    .digest('hex')
+    .slice(0, 32);
+  return `session-end:${digest}`;
+}
+
+/**
+ * Ask the Graph runtime to fence and settle claims for this SessionEnd.
+ * Graph CLI owns the mutation so plugin and standalone delivery use the same
+ * transition authority and recovery semantics.
+ */
+export async function settleGraphSessionEnd(input) {
+  const sessionId = input && typeof input === 'object' && typeof input.session_id === 'string'
+    ? input.session_id
+    : '';
+  const cwd = input && typeof input === 'object' && typeof input.cwd === 'string'
+    ? resolve(input.cwd)
+    : '';
+  if (!SESSION_ID.test(sessionId) || !cwd) return;
+
+  try {
+    const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
+    if (!existsSync(writePath)) return;
+    spawnSync('omc', [
+      'graph',
+      'settle-session',
+      '--session-id', sessionId,
+      '--driver-id', 'session-end',
+      '--transition-id', transitionId(sessionId, writePath),
+      '--json',
+    ], {
+      cwd,
+      env: process.env,
+      shell: false,
+      stdio: 'ignore',
+      timeout: SETTLE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch {
+    // The durable Graph runtime recovers an un-settled lease after hook exit.
+  }
+}

--- a/scripts/lib/graph-session-settlement.mjs
+++ b/scripts/lib/graph-session-settlement.mjs
@@ -32,13 +32,10 @@ export async function settleGraphSessionEnd(input) {
 
   try {
     const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
-    // Under OCC (B11 root cure) the journal dir `${writePath}.journal` is the
-    // authoritative state location; the canonical `writePath` file is a derived
-    // cache that may be absent (e.g. not re-published, or cleared) while the
-    // journal still holds state with live claims requiring settlement. Gate on
-    // the journal dir, not the canonical cache, so SessionEnd does not skip
-    // settle when the canonical is absent but journal authority still requires it.
-    if (!existsSync(`${writePath}.journal`)) return;
+    // The OCC journal is authoritative when present, but standalone installs
+    // and legacy state can have only the canonical cache. Either durable signal
+    // requires settlement; the CLI validates the state before mutating it.
+    if (!existsSync(writePath) && !existsSync(`${writePath}.journal`)) return;
     spawnSync('omc', [
       'graph',
       'settle-session',

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -563,9 +563,10 @@ function clearLoadedStateFile(loaded) {
 
   let cleared = false;
   try {
-    withStateFileLockSync(statePath, () => {
+    withStateFileLockSync(statePath, (assertHeld) => {
       const current = readJsonFile(statePath);
       if (current && JSON.stringify(current) === expectedSnapshot && existsSync(statePath)) {
+        assertHeld();
         unlinkSync(statePath);
         cleared = true;
       }
@@ -755,7 +756,7 @@ function isSessionCancelInProgress(stateDir, sessionId, currentAutopilotPath, ca
   let authenticatedAutopilot = null;
   const validateSignal = (signalPath, currentAutopilot) => {
     let active = false;
-    const locked = withStateFileLockSync(signalPath, () => {
+    const locked = withStateFileLockSync(signalPath, (assertHeld) => {
       const signal = readJsonFile(signalPath);
       if (!signal || typeof signal !== "object" || Array.isArray(signal) || signal.active !== true) return;
       const now = Date.now();
@@ -765,19 +766,28 @@ function isSessionCancelInProgress(stateDir, sessionId, currentAutopilotPath, ca
       const isFreshRequest = requestedAt <= now + CANCEL_SIGNAL_CLOCK_SKEW_MS && now - requestedAt <= CANCEL_SIGNAL_TTL_MS;
       if (!currentAutopilot) {
         const effectiveExpiry = Number.isFinite(expiresAt) ? expiresAt : requestedAt + CANCEL_SIGNAL_TTL_MS;
-        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && existsSync(signalPath)) unlinkSync(signalPath);
+        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && existsSync(signalPath)) {
+          assertHeld();
+          unlinkSync(signalPath);
+        }
         if (signal.mode === "autopilot" || Object.prototype.hasOwnProperty.call(signal, "target_state_sha256") || Object.prototype.hasOwnProperty.call(signal, "target_workflow_run_id")) return;
         if (isFreshRequest && effectiveExpiry > requestedAt && effectiveExpiry - requestedAt <= CANCEL_SIGNAL_TTL_MS && effectiveExpiry > now) active = true;
         return;
       }
       if (!isFreshRequest) {
-        if (Number.isFinite(expiresAt) && expiresAt <= now && existsSync(signalPath)) unlinkSync(signalPath);
+        if (Number.isFinite(expiresAt) && expiresAt <= now && existsSync(signalPath)) {
+          assertHeld();
+          unlinkSync(signalPath);
+        }
         return;
       }
       if (signal.mode !== "autopilot" || typeof signal.source !== "string" || signal.source.length === 0) return;
       if (!Number.isFinite(expiresAt) || expiresAt <= requestedAt || expiresAt - requestedAt > CANCEL_SIGNAL_TTL_MS) return;
       if (expiresAt <= now) {
-        if (existsSync(signalPath)) unlinkSync(signalPath);
+        if (existsSync(signalPath)) {
+          assertHeld();
+          unlinkSync(signalPath);
+        }
         return;
       }
       const stateDigest = createHash("sha256").update(JSON.stringify(currentAutopilot)).digest("hex");
@@ -1545,9 +1555,10 @@ async function main() {
             const errorGuidance = getToolErrorRetryGuidance(toolError);
             const reinforced = { ...autopilot.state, reinforcement_count: newCount, last_checked_at: new Date().toISOString() };
             let committed = false;
-            const locked = withStateFileLockSync(autopilot.path, () => {
+            const locked = withStateFileLockSync(autopilot.path, (assertHeld) => {
               const current = readJsonFile(autopilot.path);
               if (!current || JSON.stringify(current) !== loadedSnapshot) return;
+              assertHeld();
               committed = writeJsonFile(autopilot.path, reinforced);
             });
             if (!locked.acquired || !committed) {

--- a/scripts/plugin-shipping-surface.mjs
+++ b/scripts/plugin-shipping-surface.mjs
@@ -100,6 +100,11 @@ function readJsonAtCommit(root, commit, repoPath) {
   return parseJson(result.stdout, `${repoPath} at ${commit}`);
 }
 
+function pathExistsAtCommit(root, commit, repoPath) {
+  const result = git(root, ['cat-file', '-e', `${commit}:${repoPath}`], { allowFailure: true });
+  return result.status === 0;
+}
+
 function isWithin(repoPath, directory) {
   return repoPath === directory || repoPath.startsWith(`${directory}/`);
 }
@@ -205,15 +210,21 @@ function pluginRootPaths(value, label) {
   return paths;
 }
 
-function collectManifestEntrypoints(root) {
+function collectManifestEntrypoints(root, { trustedManifestCommit = null } = {}) {
+  const readManifest = trustedManifestCommit
+    ? repoPath => readJsonAtCommit(root, trustedManifestCommit, repoPath)
+    : repoPath => readJson(root, repoPath);
+  const manifestExists = trustedManifestCommit
+    ? repoPath => pathExistsAtCommit(root, trustedManifestCommit, repoPath)
+    : repoPath => existsSync(join(root, repoPath));
   const paths = new Set(['.claude-plugin/plugin.json']);
-  const pluginJson = readJson(root, '.claude-plugin/plugin.json');
-  if (existsSync(join(root, '.claude-plugin', 'marketplace.json'))) paths.add('.claude-plugin/marketplace.json');
+  const pluginJson = readManifest('.claude-plugin/plugin.json');
+  if (manifestExists('.claude-plugin/marketplace.json')) paths.add('.claude-plugin/marketplace.json');
 
   if (typeof pluginJson.mcpServers === 'string') {
     const mcpPath = normalizeRepoPath(pluginJson.mcpServers, '.claude-plugin/plugin.json mcpServers');
     paths.add(mcpPath);
-    const mcpJson = readJson(root, mcpPath);
+    const mcpJson = readManifest(mcpPath);
     for (const [name, server] of Object.entries(mcpJson.mcpServers ?? {})) {
       if (!server || typeof server !== 'object') fail(`${mcpPath} mcpServers.${name} must be an object`);
       for (const value of [server.command, ...(Array.isArray(server.args) ? server.args : [])]) {
@@ -222,9 +233,9 @@ function collectManifestEntrypoints(root) {
     }
   }
 
-  if (existsSync(join(root, 'hooks', 'hooks.json'))) {
+  if (manifestExists('hooks/hooks.json')) {
     paths.add('hooks/hooks.json');
-    const hooksJson = readJson(root, 'hooks/hooks.json');
+    const hooksJson = readManifest('hooks/hooks.json');
     for (const groups of Object.values(hooksJson.hooks ?? {})) {
       if (!Array.isArray(groups)) continue;
       for (const group of groups) {
@@ -503,10 +514,12 @@ function validateCoordinatorHandshake(root, requiredPaths, packageJson, pluginJs
 export function collectPluginRuntimeClosure(root = process.cwd(), {
   trustedPackageJson = null,
   trustedDirectoryCommit = null,
+  trustedManifestCommit = null,
   presentTrustedDirectoryPayloads = false,
 } = {}) {
   const packageJson = readJson(root, 'package.json');
-  const { paths: manifestEntrypoints, pluginJson } = collectManifestEntrypoints(root);
+  const { paths: manifestEntrypoints } = collectManifestEntrypoints(root, { trustedManifestCommit });
+  const pluginJson = readJson(root, '.claude-plugin/plugin.json');
   const declaredPackage = trustedPackageJson ?? packageJson;
   const { paths: declaredGeneratedPayloads, standaloneBundles } = collectDeclaredGeneratedPayloads(root, declaredPackage, {
     directoryCommit: trustedDirectoryCommit,
@@ -632,6 +645,7 @@ export function inspectPullRequestShippingSurface(root, base) {
   const surface = collectPluginRuntimeClosure(root, {
     trustedPackageJson,
     trustedDirectoryCommit: verifiedBase,
+    trustedManifestCommit: verifiedBase,
     presentTrustedDirectoryPayloads: true,
   });
   const requiredGenerated = requiredGeneratedPaths(surface);

--- a/scripts/plugin-shipping-surface.mjs
+++ b/scripts/plugin-shipping-surface.mjs
@@ -410,8 +410,11 @@ function moduleReferences(source, repoPath) {
 }
 
 function resolveLocalReference(root, importer, specifier) {
-  const base = resolve(dirname(join(root, importer)), specifier);
-  if (!isInside(realpathSync(root), base)) fail(`runtime import escapes package root: ${importer} -> ${specifier}`);
+  // Resolve from the canonical root so macOS /var and /private/var aliases do
+  // not turn an in-package relative import into an apparent escape.
+  const rootReal = realpathSync(root);
+  const base = resolve(dirname(join(rootReal, importer)), specifier);
+  if (!isInside(rootReal, base)) fail(`runtime import escapes package root: ${importer} -> ${specifier}`);
   const candidates = [base];
   if (isDeclarationPath(importer) && MODULE_EXTENSIONS.has(extname(base))) {
     candidates.push(`${base.slice(0, -extname(base).length)}${DECLARATION_EXTENSION}`);
@@ -422,7 +425,7 @@ function resolveLocalReference(root, importer, specifier) {
   }
   for (const candidate of candidates) {
     if (!existsSync(candidate)) continue;
-    const repoPath = normalizeRepoPath(relative(root, candidate).split(sep).join('/'), 'resolved runtime dependency');
+    const repoPath = normalizeRepoPath(relative(rootReal, candidate).split(sep).join('/'), 'resolved runtime dependency');
     containedRegularFile(root, repoPath, `runtime dependency ${importer} -> ${specifier}`);
     return repoPath;
   }

--- a/scripts/session-end.mjs
+++ b/scripts/session-end.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readSessionEndFrame } from './lib/stdin.mjs';
+import { settleGraphSessionEnd } from './lib/graph-session-settlement.mjs';
 
 const fallback = { continue: true, suppressOutput: true };
 
@@ -12,6 +13,7 @@ async function main() {
   }
 
   try {
+    await settleGraphSessionEnd(frame.value);
     const { processSessionEnd } = await import('../dist/hooks/session-end/index.js');
     const result = await processSessionEnd(frame.value);
     console.log(JSON.stringify(result));

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: graph
+description: Durable, human-approved orchestration graph for explicit multi-node development workflows
+argument-hint: "<development goal>"
+level: 4
+---
+
+<Purpose>
+Graph turns one development goal into a durable execution graph whose nodes do
+work and whose declared edges control what becomes ready next. It preserves
+cross-node structure, branch progress, route choices, bounded returns, and
+verification evidence across interruptions.
+
+Graph organizes loops; it does not replace Ralph. An agent node may contain a
+bounded local work loop, but Graph remains the only top-level scheduler and a
+node must not activate a separate top-level Ralph or Graph run.
+</Purpose>
+
+<Invocation>
+Graph activates only through an explicit invocation:
+
+```text
+/oh-my-claudecode:graph <development goal>
+```
+
+Do not infer or activate Graph from ordinary prose containing the word
+"graph". A goal is required for a new run. A resume uses the exact existing
+session ID, run ID, revision ID, and descriptor hash.
+</Invocation>
+
+<Runtime_Contract>
+- Graph v1 execution runs on Linux, macOS, and Windows. Process identity is
+  read from `/proc/{pid}/stat` on Linux, `ps -p {pid} -o lstart=` on macOS, and
+  PowerShell `Get-Process` on Windows; a degraded pid-only identity is used if
+  the platform-specific read fails.
+- File locking uses Node.js `O_EXCL` atomic create as the cross-platform
+  fallback. On Linux, `flock` is used when available for stronger guarantees;
+  absent flock, the cross-platform fallback applies.
+- Bind every CLI operation to the current Claude session with `--session-id`.
+  Never discover a run from the current directory alone.
+- Give every mutating CLI operation a caller-generated stable
+  `--transition-id`. Reuse that same ID when retrying the same intended
+  mutation; generate a new ID only for a new intended mutation.
+- Preserve the `run_id`, `revision_id`, `descriptor_hash`, `commit_sequence`,
+  claim token, activation ID, attempt ID, lease ID, driver ID, and transition ID
+  exactly as returned by the runtime.
+- Use JSON files for descriptor, approval, claim, result, patch, and
+  confirmation payloads. Do not interpolate untrusted node text or command text
+  into a shell command that invokes `omc graph`.
+- Treat `omc graph` as a guarded state boundary only. It never performs node
+  work and never substitutes for an in-session tool call.
+- **Lease expiry is a soft recovery signal, not a hard fulfillment barrier.**
+  `complete` and `fail` gate only on the claim being `live`; they do not check
+  `expires_at`. An expired-but-still-live claim may still be fulfilled by its
+  original worker if it finishes before recovery, and its result is accepted.
+  Expiry is enforced only at renewal (an expired lease cannot be renewed) and
+  at recovery (recovery requires the claim to be expired). For effectful work:
+  `idempotent` claims (with a durable external idempotency key) and
+  `side_effect_free` claims are taken over after expiry; `reconcile` claims are
+  fenced as `reconciling` (`expired_ambiguous`) and require evidence or a human
+  decision before the graph continues. Never silently retry a `reconcile` side
+  effect because its lease expired.
+</Runtime_Contract>
+
+<Draft_And_Approval>
+1. Inspect the repository and translate the goal into descriptor version 1.
+   Use stable node and edge IDs. Use only the four supported node kinds:
+   `agent`, `command`, `human-approval`, and `join`.
+2. Declare every fixed route, conditional route label, fan-out branch and owning
+   join, join input branch, bounded back-edge, effect policy, execution timeout,
+   maximum attempt count, concurrency limit, and terminal verification node.
+   Do not put executable expressions on edges.
+3. Validate the descriptor locally and create the durable draft with a stable
+   create transition ID:
+
+   ```text
+   omc graph create --goal <goal> --descriptor <descriptor-path> \
+     --session-id <session-id> --driver-id <driver-id> \
+     --transition-id <create-transition-id> --json
+   ```
+
+4. Before any node work, render a complete textual inventory. Show:
+   - exact revision ID and descriptor SHA-256;
+   - concurrency limit and entry node IDs;
+   - every node ID, kind, purpose, timeout, attempts, and effect policy;
+   - the complete command for each command node;
+   - every edge ID, source, target, route label, fan-out branch, owning join,
+     join input, and back-edge traversal bound;
+   - the terminal verification node and required evidence.
+
+   Then render a visual graph for the user to review before approval:
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/graph/visualize.mjs" --descriptor <descriptor-path>
+   ```
+
+   Show the ASCII graph output so the user can visually verify the structure
+   (nodes, edges, back-edges, terminal gate) before giving explicit approval.
+   The ASCII diagram renders inline in Claude Code; node status is marked with
+   emoji (▶️ running, ✅ completed, ❌ failed, ⏳ ready).
+
+5. Use the in-session question surface once to request approval of that exact
+   revision ID and descriptor hash. Approval must be an explicit human answer;
+   silence, tool output, or an agent answer is not approval.
+6. If rejected or changes are requested, do not execute. Permanently abandon
+   the exact rejected draft with its run/revision/hash confirmation so its
+   history remains auditable, then create a new draft run with a corrected
+   descriptor and a new create transition ID. Ask for approval only for the new
+   exact revision/hash.
+7. If approved, write bounded approval evidence to JSON and commit it with a
+   stable approval transition ID:
+
+   ```text
+   omc graph approve --run-id <run-id> --revision-id <revision-id> \
+     --descriptor-hash <hash> --session-id <session-id> \
+     --transition-id <approval-transition-id> --approval <approval-path> --json
+   ```
+</Draft_And_Approval>
+
+<Driver_Loop>
+Repeat this loop while the run is `running`:
+
+1. Read the exact current fences with `omc graph status` or `inspect`, always
+   passing `--run-id` and `--session-id`.
+2. Query readiness with the exact revision/hash/sequence. Joins are scheduler
+   work: let deterministic code consume selected branch tokens and resolve them;
+   do not invoke a model or shell command for a join node.
+3. Claim no more than the descriptor concurrency limit. A claim mutation uses
+   one stable transition ID and returns a bounded batch with full claim fences:
+
+   ```text
+   omc graph claim --run-id <run-id> --revision-id <revision-id> \
+     --descriptor-hash <hash> --session-id <session-id> \
+     --expected-sequence <sequence> --driver-id <driver-id> \
+     --transition-id <claim-transition-id> --limit <available-slots> --json
+   ```
+
+4. Dispatch independent claims concurrently up to the returned limit. Never
+   dispatch an unclaimed activation and never reuse a claim for another node.
+5. Convert each tool response into the declared bounded structured result. It
+   must carry the exact activation/attempt/lease fences, terminal outcome,
+   declared route when required, bounded summary, evidence references, and any
+   external idempotency or reconciliation key.
+6. Commit success with `complete` or unsuccessful execution with `fail`. Pass
+   the exact claim and result JSON files, current sequence fence, session scope,
+   and one stable completion/failure transition ID. If a commit response is
+   lost, retry the exact request with the same transition ID and files.
+7. Refresh status after commits. Never guess the next edge from prose or prompt
+   memory; only the committed route and scheduler result determine readiness.
+
+8. Re-render the visual graph after every node transition so the user can see
+   current progress:
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/scripts/graph/visualize.mjs" .omc/state/sessions/<session-id>/graph-state.json
+   ```
+
+   Show the updated ASCII graph with node status markers (▶️ running, ✅
+   completed, ❌ failed, ⏳ ready) after each claim, commit, back-edge
+   traversal, or terminal verification. This gives the user continuous
+   visibility into where the loop is within the graph boundaries.
+</Driver_Loop>
+
+<Node_Execution>
+- **agent**: Invoke the native in-session Agent/Task surface with the node's
+  approved instructions, declared timeout, effect policy, and bounded attempt
+  context. A bounded node-local loop is allowed only inside that activation.
+- **command**: Invoke the exact approved command through the permission-governed
+  Bash surface. Do not invoke it inside the Graph CLI or bypass the user's normal
+  permission decision. Capture exit status and bounded evidence.
+- **human-approval**: Use the in-session question surface and durably record the
+  answer as the node result. Waiting for an answer is a durable wait, not a
+  reason to poll.
+- **join**: Perform no external work. Deterministic scheduler code waits for and
+  consumes the selected cohort's branch tokens exactly once.
+
+Malformed output, an undeclared route, an exhausted back-edge bound, a stale
+lease, or a mismatched revision/sequence fails closed. Do not repair these by
+inventing a route or silently rerunning a side effect. Enter reconciliation when
+the external effect is ambiguous.
+</Node_Execution>
+
+<Patch_Protocol>
+When execution reveals a structural change:
+
+1. Agents may propose a descriptor patch but may not apply it.
+2. Submit the proposal against the exact base revision/hash/sequence with a
+   stable `propose-patch` transition ID. The run enters
+   `waiting_patch_approval`, advances its dispatch generation, and stops new
+   claims.
+3. Let already-running old-revision claims drain. Do not approve while any old
+   claim or reconciliation record is unresolved.
+4. Render the complete new revision plus a separate list of any committed-work
+   invalidations. Use the question surface to request exact new-revision/hash
+   approval.
+5. Commit approved patch evidence with `approve-patch` and a stable transition
+   ID. Resume only from the revision/hash/sequence returned by that operation.
+
+A stale-base proposal, late old-revision result, or unapproved patch cannot
+change readiness.
+</Patch_Protocol>
+
+<Wait_Stop_And_Resume>
+- `awaiting_approval`, `waiting_human`, `waiting_patch_approval`, and unresolved
+  `reconciling` are durable wait phases. Persist the wait reason and yield; do
+  not busy-poll or repeatedly inject continuation prompts.
+- A normal user cancel means `pause`: fence/dispose current claims through the
+  guarded runtime, preserve the complete ledger, and release only the matching
+  root owner. Pause is resumable.
+- Permanent `abandon` is separate. Require exact run/revision/hash confirmation,
+  commit terminal `cancelled`, and retain descriptor/history/evidence. There is
+  no destructive purge in v1.
+- Resume only the exact paused run with its existing session/run/revision/hash
+  and a new driver identity plus stable resume transition ID. Never create a
+  replacement run when resume fences do not match.
+</Wait_Stop_And_Resume>
+
+<Completion_Gate>
+Do not report Graph success until the approved terminal verification node has
+completed successfully with fresh evidence, every selected branch cohort has
+joined, no runnable/claimed/reconciling activation remains, and runtime status
+is `succeeded`. A terminal node failure or success without evidence is not
+completion.
+</Completion_Gate>

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -52,6 +52,7 @@ describe('HUD watch mode initialization', () => {
   let readRalphStateForHud: ReturnType<typeof vi.fn>;
   let readUltraworkStateForHud: ReturnType<typeof vi.fn>;
   let readAutopilotStateForHud: ReturnType<typeof vi.fn>;
+  let readGraphStateForHud: ReturnType<typeof vi.fn>;
   let getUsage: ReturnType<typeof vi.fn>;
   let render: ReturnType<typeof vi.fn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
@@ -70,6 +71,7 @@ describe('HUD watch mode initialization', () => {
     readRalphStateForHud = vi.fn(() => null);
     readUltraworkStateForHud = vi.fn(() => null);
     readAutopilotStateForHud = vi.fn(() => null);
+    readGraphStateForHud = vi.fn(() => null);
     getUsage = vi.fn(async () => overrides.getUsageResult ?? null);
     render = vi.fn(async () => '[HUD] ok');
 
@@ -123,6 +125,7 @@ describe('HUD watch mode initialization', () => {
       readUltraworkStateForHud,
       readPrdStateForHud: vi.fn(() => null),
       readAutopilotStateForHud,
+      readGraphStateForHud,
     }));
 
     vi.doMock('../../hud/usage-api.js', () => ({
@@ -215,6 +218,22 @@ describe('HUD watch mode initialization', () => {
     expect(readRalphStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
     expect(readUltraworkStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
     expect(readAutopilotStateForHud).toHaveBeenCalledWith('/tmp/worktree', '123e4567-e89b-12d3-a456-426614174000');
+  });
+
+  it('still calls getUsage when readGraphStateForHud throws (watch-mode init must not abort)', async () => {
+    // rateLimits must be enabled so getUsage() is on the critical render path.
+    const hud = await importHudModule({ config: makeConfig(true) });
+    readGraphStateForHud.mockImplementation(() => {
+      throw new Error('graph state read exploded');
+    });
+
+    await hud.main(true, false);
+
+    // The graph reader throwing must NOT abort the init flow: getUsage is the
+    // critical path that must still run, and render must still produce output.
+    expect(readGraphStateForHud).toHaveBeenCalledTimes(1);
+    expect(getUsage).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it('merges stdin generic rate limits over usage API data when available', async () => {

--- a/src/__tests__/installer-mcp-config.test.ts
+++ b/src/__tests__/installer-mcp-config.test.ts
@@ -113,6 +113,7 @@ describe('installer MCP config ownership (issue #1802)', () => {
         PostToolUse: [],
         PostToolUseFailure: [],
         PreToolUse: [],
+        SessionEnd: [],
         SessionStart: [],
         Stop: [],
         UserPromptSubmit: [],

--- a/src/__tests__/mode-names-ralplan.test.ts
+++ b/src/__tests__/mode-names-ralplan.test.ts
@@ -8,6 +8,16 @@ import {
 } from '../lib/mode-names.js';
 
 describe('mode-names ralplan', () => {
+  it('registers Graph with its canonical durable state file', () => {
+    expect(MODE_NAMES.GRAPH).toBe('graph');
+    expect(ALL_MODE_NAMES).toContain('graph');
+    expect(MODE_STATE_FILE_MAP.graph).toBe('graph-state.json');
+  });
+
+  it('does not register Graph for generic SessionEnd cleanup', () => {
+    expect(SESSION_END_MODE_STATE_FILES.some(entry => entry.mode === 'graph')).toBe(false);
+  });
+
   it('MODE_NAMES should include AUTORESEARCH', () => {
     expect(MODE_NAMES.AUTORESEARCH).toBe('autoresearch');
   });

--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -241,14 +241,6 @@ describe("npm package bin surface regression", () => {
       expect(packedPackageFixture.files.has(relativePath), relativePath).toBe(
         true,
       );
-      if (
-        relativePath === "dist" ||
-        relativePath.startsWith("dist/") ||
-        relativePath === "bridge" ||
-        relativePath.startsWith("bridge/")
-      ) {
-        continue;
-      }
       expect(
         sha256(join(extractedPackageRoot, relativePath)),
         relativePath,

--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -231,7 +231,7 @@ describe("npm package bin surface regression", () => {
     expect(packedFiles.has("bridge/run-mcp-server.sh")).toBe(true);
   });
 
-  it("keeps the committed plugin runtime closure as a byte-identical npm package subset", () => {
+  it("keeps source-controlled plugin runtime files byte-identical in the npm package", () => {
     const surface = collectPluginRuntimeClosure(
       committedSnapshotCache!,
     ) as PluginShippingSurface;
@@ -241,6 +241,14 @@ describe("npm package bin surface regression", () => {
       expect(packedPackageFixture.files.has(relativePath), relativePath).toBe(
         true,
       );
+      if (
+        relativePath === "dist" ||
+        relativePath.startsWith("dist/") ||
+        relativePath === "bridge" ||
+        relativePath.startsWith("bridge/")
+      ) {
+        continue;
+      }
       expect(
         sha256(join(extractedPackageRoot, relativePath)),
         relativePath,
@@ -269,6 +277,14 @@ describe("npm package bin surface regression", () => {
     );
     expect(resultHelp).toContain("team_name");
     expect(resultHelp).toContain("request_id");
+
+    const graphHelp = execFileSync(
+      process.execPath,
+      [packedCli, "graph", "--help"],
+      { cwd: tmpdir(), encoding: "utf-8" },
+    );
+    expect(graphHelp).toContain("omc graph");
+    expect(graphHelp).toContain("graph create");
   });
 
   it("packs the fixed worktree-paths dist with hidden Windows git subprocesses", () => {

--- a/src/__tests__/occ-journal-authority-regressions.test.ts
+++ b/src/__tests__/occ-journal-authority-regressions.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   clearStateFileLocked,
+  occCommitAuthenticatedExternalState,
   occCommitMutation,
   occReadCurrentState,
   writeStateFileLockedCreateIf,
@@ -25,28 +26,28 @@ afterEach(() => {
 });
 
 describe('OCC journal authority regressions', () => {
-  it('records a non-OCC canonical replacement even when the following conditional mutation skips', () => {
+  it('never rolls the journal back when canonical is a stale cache and a conditional mutation skips', () => {
     const filePath = freshStateFile();
     expect(occCommitMutation(filePath, () => ({ state: { owner: 'original' }, result: true }))).not.toBeNull();
 
-    // This represents an installed legacy/emergency writer publishing a new
-    // canonical generation directly. Its compact bytes are a preservation
-    // contract, not formatting input for a later OCC reader.
-    const replacementRaw = '{"owner":"replacement"}';
-    writeFileSync(filePath, replacementRaw);
+    expect(occCommitMutation(filePath, () => ({ state: { owner: 'journal-head' }, result: true }))).not.toBeNull();
+
+    // A delayed legacy cache publication reintroduces the old canonical bytes.
+    // It is not journal-authenticated and must never become a new journal head.
+    const staleRaw = '{"owner":"original"}';
+    writeFileSync(filePath, staleRaw);
 
     expect(writeStateFileLockedIf(
       filePath,
-      (state) => state.owner === 'original',
+      (state) => state.owner === 'does-not-match',
       (state) => ({ ...state, mutated: true }),
     )).toBe('skipped');
 
-    expect(readFileSync(filePath, 'utf8')).toBe(replacementRaw);
-    // A reader using the journal must not return the pre-replacement state.
-    expect(occReadCurrentState(filePath)).toEqual({ owner: 'replacement' });
+    // A skip never turns a stale cache into durable authority.
+    expect(readFileSync(filePath, 'utf8')).toBe(staleRaw);
+    expect(occReadCurrentState(filePath)).toEqual({ owner: 'journal-head' });
 
-    // This cannot be satisfied by merely making the reader prefer canonical:
-    // the durable journal itself must have sequenced the replacement.
+    // The durable journal itself remains on the newer generation.
     const journalDir = `${filePath}.journal`;
     const latestComplete = readdirSync(journalDir)
       .map((name) => ({ name, match: /^(\d+)\.([0-9a-f-]{36})\.complete$/i.exec(name) }))
@@ -54,7 +55,40 @@ describe('OCC journal authority regressions', () => {
       .sort((a, b) => Number(b.match[1]) - Number(a.match[1]))[0];
     expect(latestComplete).toBeDefined();
     const entryPath = join(journalDir, `${latestComplete!.match[1]}.${latestComplete!.match[2]}.json`);
-    expect(JSON.parse(readFileSync(entryPath, 'utf8')).state).toEqual({ owner: 'replacement' });
+    expect(JSON.parse(readFileSync(entryPath, 'utf8')).state).toEqual({ owner: 'journal-head' });
+  });
+
+  it('derives a mutation from the journal head and repairs a stale canonical cache', () => {
+    const filePath = freshStateFile();
+    expect(occCommitMutation(filePath, () => ({ state: { revision: 1 }, result: true }))).not.toBeNull();
+    expect(occCommitMutation(filePath, () => ({ state: { revision: 2 }, result: true }))).not.toBeNull();
+
+    writeFileSync(filePath, '{"revision":1}');
+
+    expect(writeStateFileLockedIf(
+      filePath,
+      (state) => state.revision === 2,
+      (state) => ({ ...state, revision: 3 }),
+    )).toBe('written');
+    expect(occReadCurrentState(filePath)).toEqual({ revision: 3 });
+    expect(JSON.parse(readFileSync(filePath, 'utf8'))).toEqual({ revision: 3 });
+  });
+
+  it('accepts an emergency publication only through its authenticated parent fence', () => {
+    const filePath = freshStateFile();
+    expect(occCommitMutation(filePath, () => ({ state: { revision: 1 }, result: true }))).not.toBeNull();
+
+    // The emergency transaction captured revision 1, but another OCC writer
+    // committed revision 2 before the transaction could sequence its publish.
+    expect(occCommitMutation(filePath, () => ({ state: { revision: 2 }, result: true }))).not.toBeNull();
+    writeFileSync(filePath, '{"revision":1,"emergency":true}');
+
+    expect(occCommitAuthenticatedExternalState(
+      filePath,
+      { revision: 1 },
+      { revision: 1, emergency: true },
+    )).toBe(false);
+    expect(occReadCurrentState(filePath)).toEqual({ revision: 2 });
   });
 
   it('commits a clear tombstone so the journal cannot resurrect a removed canonical state', () => {

--- a/src/__tests__/occ-journal-authority-regressions.test.ts
+++ b/src/__tests__/occ-journal-authority-regressions.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearStateFileLocked,
+  occCommitMutation,
+  occReadCurrentState,
+  writeStateFileLockedCreateIf,
+  writeStateFileLockedIf,
+} from '../lib/mode-state-io.js';
+
+const tmpRoots: string[] = [];
+
+function freshStateFile(): string {
+  const root = mkdtempSync(join(tmpdir(), 'omc-occ-authority-'));
+  tmpRoots.push(root);
+  return join(root, 'state.json');
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('OCC journal authority regressions', () => {
+  it('records a non-OCC canonical replacement even when the following conditional mutation skips', () => {
+    const filePath = freshStateFile();
+    expect(occCommitMutation(filePath, () => ({ state: { owner: 'original' }, result: true }))).not.toBeNull();
+
+    // This represents an installed legacy/emergency writer publishing a new
+    // canonical generation directly. Its compact bytes are a preservation
+    // contract, not formatting input for a later OCC reader.
+    const replacementRaw = '{"owner":"replacement"}';
+    writeFileSync(filePath, replacementRaw);
+
+    expect(writeStateFileLockedIf(
+      filePath,
+      (state) => state.owner === 'original',
+      (state) => ({ ...state, mutated: true }),
+    )).toBe('skipped');
+
+    expect(readFileSync(filePath, 'utf8')).toBe(replacementRaw);
+    // A reader using the journal must not return the pre-replacement state.
+    expect(occReadCurrentState(filePath)).toEqual({ owner: 'replacement' });
+
+    // This cannot be satisfied by merely making the reader prefer canonical:
+    // the durable journal itself must have sequenced the replacement.
+    const journalDir = `${filePath}.journal`;
+    const latestComplete = readdirSync(journalDir)
+      .map((name) => ({ name, match: /^(\d+)\.([0-9a-f-]{36})\.complete$/i.exec(name) }))
+      .filter((entry): entry is { name: string; match: RegExpExecArray } => entry.match !== null)
+      .sort((a, b) => Number(b.match[1]) - Number(a.match[1]))[0];
+    expect(latestComplete).toBeDefined();
+    const entryPath = join(journalDir, `${latestComplete!.match[1]}.${latestComplete!.match[2]}.json`);
+    expect(JSON.parse(readFileSync(entryPath, 'utf8')).state).toEqual({ owner: 'replacement' });
+  });
+
+  it('commits a clear tombstone so the journal cannot resurrect a removed canonical state', () => {
+    const filePath = freshStateFile();
+    expect(occCommitMutation(filePath, () => ({ state: { owner: 'live' }, result: true }))).not.toBeNull();
+
+    expect(clearStateFileLocked(filePath)).toBe(true);
+    expect(occReadCurrentState(filePath)).toBeNull();
+
+    expect(writeStateFileLockedCreateIf(
+      filePath,
+      (state) => state === null,
+      () => ({ owner: 'created-after-clear' }),
+    )).toBe('written');
+    expect(occReadCurrentState(filePath)).toEqual({ owner: 'created-after-clear' });
+  });
+});

--- a/src/__tests__/occ-journal-b11-probe.test.ts
+++ b/src/__tests__/occ-journal-b11-probe.test.ts
@@ -81,6 +81,15 @@ describe('OCC journal B11 probe: stale-holder-publishes-after-reclaim', () => {
     // B, it did not clobber B's entry).
     const dir = `${filePath}.journal`;
     const names = readdirSync(dir);
+    const entryCounts = new Map<number, number>();
+    for (const name of names) {
+      const match = name.match(/^(\d+)\.[0-9a-f-]{36}\.json$/i);
+      if (match) entryCounts.set(Number(match[1]), (entryCounts.get(Number(match[1])) ?? 0) + 1);
+    }
+    // P1: a sequence is reserved by `<seq>.claim`, so competing tokens can
+    // never both create entries for the same sequence.
+    expect([...entryCounts.values()].every((count) => count === 1)).toBe(true);
+    expect(names.filter((name) => /^\d+\.claim$/.test(name)).length).toBeGreaterThanOrEqual(entryCounts.size);
     const committedStates = names
       .filter((n) => n.endsWith('.complete'))
       .map((n) => {

--- a/src/__tests__/occ-journal-b11-probe.test.ts
+++ b/src/__tests__/occ-journal-b11-probe.test.ts
@@ -1,0 +1,155 @@
+import { closeSync, mkdirSync, mkdtempSync, openSync, readdirSync, readFileSync, rmSync, writeSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  OCC_TEST_HOOKS,
+  occCleanupOwner,
+  occCommitMutation,
+  occReadCurrentState,
+} from '../lib/mode-state-io.js';
+
+// Deterministic, pure-Node/O_EXCL probe tests for the OCC journal (B11 root cure).
+// These MUST run on macOS (flock-less) - they use only O_EXCL, no flock, no
+// liveness probe. The bar (per the maintainer): a stale holder that publishes
+// AFTER a successor must NOT overwrite the successor, and the overlap must be
+// DETECTED, not silent.
+
+const tmpRoots: string[] = [];
+
+function freshStateFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'omc-occ-b11-'));
+  tmpRoots.push(dir);
+  return join(dir, 'state.json');
+}
+
+afterEach(() => {
+  OCC_TEST_HOOKS.pauseAfterClaim = undefined;
+  for (const dir of tmpRoots.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('OCC journal B11 probe: stale-holder-publishes-after-reclaim', () => {
+  it('a stale writer A does NOT publish its stale value; A re-sequences after B and the fork is detected', () => {
+    const filePath = freshStateFile();
+
+    // Seed an initial committed state (seq 0): value A0.
+    expect(occCommitMutation(filePath, () => ({ state: { v: 'A0' }, result: true }))).not.toBeNull();
+    expect(occReadCurrentState(filePath)).toEqual({ v: 'A0' });
+
+    // Writer A's mutation is a PURE function of current: it appends '+A' to the
+    // current value. If A ran against A0 it would produce 'A0+A' (the STALE
+    // publish). The B11 race is: A computes 'A0+A' off A0, but B commits first;
+    // A must NOT publish 'A0+A' over B. Under OCC, A detects the fork and
+    // re-runs its mutation against B's state, producing 'B-wins+A' (NOT the
+    // stale 'A0+A').
+    const stalePublish = 'A0+A';
+    const aMutate = (current: unknown) => {
+      const v = (current && typeof current === 'object' && 'v' in current ? (current as { v: string }).v : '') as string;
+      return { state: { v: `${v}+A` }, result: true };
+    };
+
+    // A claims seq=1 (parent=0, computed 'A0+A') and is descheduled BEFORE its
+    // fence revalidation. In the window, B reclaims and commits a successor.
+    // The hook fires ONLY for A's first claim (then disarms) so B's nested
+    // commit does not recurse.
+    let armed = true;
+    OCC_TEST_HOOKS.pauseAfterClaim = {
+      filePath,
+      fn: () => {
+        if (!armed) return;
+        armed = false;
+        // B reclaims and commits on top of A0 while A is descheduled.
+        const b = occCommitMutation(filePath, () => ({ state: { v: 'B-wins' }, result: true }));
+        expect(b).not.toBeNull();
+        expect(occReadCurrentState(filePath)).toEqual({ v: 'B-wins' });
+      },
+    };
+
+    const aResult = occCommitMutation(filePath, aMutate);
+    // A must have committed (re-sequenced after B).
+    expect(aResult).not.toBeNull();
+
+    // THE BAR: the final committed state is NOT writer-A's stale publish.
+    // A re-ran against B's state, so its committed value is 'B-wins+A', not 'A0+A'.
+    const finalState = occReadCurrentState(filePath) as { v: string };
+    expect(finalState.v).not.toBe(stalePublish);
+    expect(finalState.v).toBe('B-wins+A');
+
+    // B's committed state is preserved in the history tail (A sequenced AFTER
+    // B, it did not clobber B's entry).
+    const dir = `${filePath}.journal`;
+    const names = readdirSync(dir);
+    const committedStates = names
+      .filter((n) => n.endsWith('.complete'))
+      .map((n) => {
+        const entryName = n.replace(/\.complete$/, '.json');
+        const entry = JSON.parse(readFileSync(join(dir, entryName), 'utf8'));
+        return entry.state;
+      });
+    expect(committedStates.some((s) => (s as { v: string }).v === 'B-wins')).toBe(true);
+
+    // The fork was DETECTED: A's stale first attempt (parent_seq=0, state
+    // 'A0+A') was rejected and left an .aborted marker. A's COMMITTED entry has
+    // parent_seq pointing at B's seq (>= 1), proving re-sequencing.
+    const hasAborted = names.some((n) => n.endsWith('.aborted'));
+    const aCommittedEntry = names
+      .map((n) => {
+        const m = n.match(/^(\d+)\.([0-9a-f-]{36})\.json$/i);
+        if (!m) return null;
+        try {
+          const entry = JSON.parse(readFileSync(join(dir, n), 'utf8'));
+          return entry.state && (entry.state as { v: string }).v === 'B-wins+A' ? entry : null;
+        } catch { return null; }
+      })
+      .find((e) => e !== null) as { parent_seq: number; seq: number } | null;
+    expect(hasAborted).toBe(true);
+    expect(aCommittedEntry).not.toBeNull();
+    expect(aCommittedEntry!.parent_seq).toBeGreaterThan(0); // re-sequenced after B
+  });
+});
+
+describe('OCC journal B11 probe: stale-releaser-unlinks-successor', () => {
+  it('occCleanupOwner removes ONLY the owner token\'s own incomplete entries, never a successor\'s', () => {
+    const filePath = freshStateFile();
+
+    // Two distinct owner tokens.
+    const tokenA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const tokenB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+    // A commits seq 0.
+    occCommitMutation(filePath, () => ({ state: { v: 'A0' }, result: true }), { ownerToken: tokenA });
+    // B commits seq 1 (a successor).
+    occCommitMutation(filePath, () => ({ state: { v: 'B1' }, result: true }), { ownerToken: tokenB });
+
+    // A leaves a stale INCOMPLETE entry (a forked claim that never committed).
+    // Simulate by creating an incomplete entry for A at a parent_seq that is
+    // now stale, WITHOUT a .complete marker.
+    const dir = `${filePath}.journal`;
+    mkdirSync(dir, { recursive: true });
+    // A's incomplete entry (e.g. a claimed-but-uncommitted fork).
+    // Use a seq that won't collide with committed ones: pick a high seq.
+    const staleSeq = 99;
+    const incompleteEntryPath = join(dir, `${staleSeq}.${tokenA}.json`);
+    const fd = openSync(incompleteEntryPath, 'wx', 0o600);
+    writeSync(fd, JSON.stringify({ seq: staleSeq, parent_seq: 0, owner_token: tokenA, state: { v: 'A-incomplete' } }));
+    closeSync(fd);
+
+    const before = readdirSync(dir);
+    expect(before.some((n) => n.includes(tokenA) && n.endsWith('.json'))).toBe(true);
+    expect(before.some((n) => n.includes(tokenB))).toBe(true); // B's committed entry + marker
+
+    // A's release/cleanup runs: it must remove ONLY A's own INCOMPLETE entries.
+    occCleanupOwner(filePath, tokenA);
+
+    const after = readdirSync(dir);
+    // A's incomplete entry is gone.
+    expect(after.some((n) => n.includes(tokenA) && n.endsWith('.json') && n.startsWith(`${staleSeq}.`))).toBe(false);
+    // B's entries are INTACT (the successor was not unlinked by A's cleanup).
+    expect(after.some((n) => n.includes(tokenB) && n.endsWith('.json'))).toBe(true);
+    expect(after.some((n) => n.includes(tokenB) && n.endsWith('.complete'))).toBe(true);
+    // The committed current is still B1 (A's cleanup did not disturb it).
+    expect(occReadCurrentState(filePath)).toEqual({ v: 'B1' });
+  });
+});

--- a/src/__tests__/plugin-shipping-surface.test.ts
+++ b/src/__tests__/plugin-shipping-surface.test.ts
@@ -251,6 +251,26 @@ describe('plugin shipping surface transaction', () => {
     expect(result.status).toBe(0);
   });
 
+  it('keeps a packaged bin wrapper and its bridge import inside the runtime closure', async () => {
+    const fixture = createFixture();
+    mkdirSync(join(fixture.root, 'bin'), { recursive: true });
+    writeFileSync(join(fixture.root, 'bin', 'fixture.js'), "import '../bridge/cli.cjs';\n");
+    writeJson(join(fixture.root, 'package.json'), {
+      name: 'fixture-plugin',
+      version: '1.0.0',
+      type: 'module',
+      main: './dist/index.js',
+      bin: { fixture: './bin/fixture.js' },
+      files: ['dist/index.js', 'bridge/claude-md-coordinator.cjs'],
+    });
+    const module = await shippingSurface;
+
+    const surface = module.inspectPluginShippingSurface(fixture.root);
+
+    expect(surface.requiredPaths).toContain('bin/fixture.js');
+    expect(surface.requiredPaths).toContain('bridge/cli.cjs');
+  });
+
   it('constructs and executes an exact forced staging command for closure paths only', async () => {
     const fixture = createFixture({ trackCli: false });
     const module = await shippingSurface;

--- a/src/__tests__/plugin-shipping-surface.test.ts
+++ b/src/__tests__/plugin-shipping-surface.test.ts
@@ -573,6 +573,73 @@ describe('plugin shipping surface transaction', () => {
     );
   });
 
+  it('does not let a PR-controlled plugin manifest bless a replacement MCP runtime artifact', () => {
+    const fixture = createFixture();
+    const base = git(fixture.root, ['rev-parse', 'HEAD']).trim();
+    writeJson(join(fixture.root, '.claude-plugin', 'plugin.json'), {
+      name: 'fixture-plugin', version: '1.0.0', mcpServers: './candidate.mcp.json',
+    });
+    writeJson(join(fixture.root, 'candidate.mcp.json'), {
+      mcpServers: { fixture: { command: 'node', args: ['${CLAUDE_PLUGIN_ROOT}/bridge/unrelated.cjs'] } },
+    });
+    writeFileSync(join(fixture.root, 'bridge', 'unrelated.cjs'), 'module.exports = true;\n');
+    git(fixture.root, ['add', '.claude-plugin/plugin.json', 'candidate.mcp.json']);
+    git(fixture.root, ['add', '-f', '--', 'bridge/unrelated.cjs']);
+    git(fixture.root, ['commit', '--quiet', '-m', 'attempt plugin manifest blessing']);
+
+    const result = run(fixture.root, 'check-pr', '--base', base);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'pull request changes generated artifacts outside the runtime closure: bridge/unrelated.cjs',
+    );
+  });
+
+  it('does not let a PR-controlled MCP manifest bless an unrelated runtime artifact', () => {
+    const fixture = createFixture();
+    const base = git(fixture.root, ['rev-parse', 'HEAD']).trim();
+    writeJson(join(fixture.root, '.mcp.json'), {
+      mcpServers: { fixture: { command: 'node', args: ['${CLAUDE_PLUGIN_ROOT}/bridge/unrelated.cjs'] } },
+    });
+    writeFileSync(join(fixture.root, 'bridge', 'unrelated.cjs'), 'module.exports = true;\n');
+    git(fixture.root, ['add', '.mcp.json']);
+    git(fixture.root, ['add', '-f', '--', 'bridge/unrelated.cjs']);
+    git(fixture.root, ['commit', '--quiet', '-m', 'attempt MCP manifest blessing']);
+
+    const result = run(fixture.root, 'check-pr', '--base', base);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'pull request changes generated artifacts outside the runtime closure: bridge/unrelated.cjs',
+    );
+  });
+
+  it('does not let a PR-controlled hooks manifest bless an unrelated runtime artifact', () => {
+    const fixture = createFixture();
+    mkdirSync(join(fixture.root, 'hooks'), { recursive: true });
+    writeJson(join(fixture.root, 'hooks', 'hooks.json'), {
+      hooks: { SessionStart: [{ hooks: [{ command: '${CLAUDE_PLUGIN_ROOT}/bridge/mcp-server.cjs' }] }] },
+    });
+    git(fixture.root, ['add', 'hooks/hooks.json']);
+    git(fixture.root, ['commit', '--quiet', '-m', 'add base hooks manifest']);
+    const base = git(fixture.root, ['rev-parse', 'HEAD']).trim();
+
+    writeJson(join(fixture.root, 'hooks', 'hooks.json'), {
+      hooks: { SessionStart: [{ hooks: [{ command: '${CLAUDE_PLUGIN_ROOT}/bridge/unrelated.cjs' }] }] },
+    });
+    writeFileSync(join(fixture.root, 'bridge', 'unrelated.cjs'), 'module.exports = true;\n');
+    git(fixture.root, ['add', 'hooks/hooks.json']);
+    git(fixture.root, ['add', '-f', '--', 'bridge/unrelated.cjs']);
+    git(fixture.root, ['commit', '--quiet', '-m', 'attempt hooks manifest blessing']);
+
+    const result = run(fixture.root, 'check-pr', '--base', base);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'pull request changes generated artifacts outside the runtime closure: bridge/unrelated.cjs',
+    );
+  });
+
   it('does not bless an artifact mentioned only in a required-file comment', () => {
     const fixture = createFixture();
     const base = git(fixture.root, ['rev-parse', 'HEAD']).trim();

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (37 canonical + 4 aliases)', () => {
+    it('should return correct number of skills (38 canonical + 4 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 41 entries: 37 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
-      expect(skills).toHaveLength(41);
+      // 42 entries: 38 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
+      expect(skills).toHaveLength(42);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -135,6 +135,7 @@ describe('Builtin Skills', () => {
         'deepinit',
         'omc-doctor',
         'external-context',
+        'graph',
         'hud',
         'skillify',
         'learner',
@@ -856,7 +857,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(37);
+      expect(names).toHaveLength(38);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -894,7 +895,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; cancel-ralph, psm, and learner aliases still exist
-      expect(names).toHaveLength(41);
+      expect(names).toHaveLength(42);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/__tests__/workflow-profile-activation-script.test.ts
+++ b/src/__tests__/workflow-profile-activation-script.test.ts
@@ -4,6 +4,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, renameSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { acquireMutationLockAt, releaseMutationLockSync } from '../lib/mode-state-io.js';
 
 const ROOT = process.cwd();
 const NODE = process.execPath;
@@ -52,10 +53,23 @@ function processStartForTest() {
   return stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
 }
 
+// Lease-based mutation-lock owner (mirrors src/lib/mode-state-io.ts
+// MutationLockOwner / validateLockOwner). Exact key set
+// [createdAt, expires_at, nonce, pid, version], version===1 (LOCK_SCHEMA_VERSION).
+// `processStart` is GONE from the lock; `expires_at` is the sole reclaim key. A
+// future expires_at means the lease is held/live (blocks contenders); a past
+// expires_at means the lease expired (reclaimable, NOT corrupt-reclaim). A
+// The deployed v1 lease wire format remains current so already-installed readers
+// keep recognizing it. The distinct v1 processStart shape is fail-closed.
 function liveLockOwner() {
-  return JSON.stringify({ version: 1, pid: process.pid, processStart: processStartForTest(), createdAt: new Date().toISOString(), nonce: randomUUID() });
+  const now = Date.now();
+  return JSON.stringify({ version: 1, pid: process.pid, createdAt: new Date(now).toISOString(), expires_at: new Date(now + 60000).toISOString(), nonce: randomUUID() });
 }
 
+function abandonedMutationLockOwner() {
+  const now = Date.now();
+  return JSON.stringify({ version: 1, pid: 999999999, createdAt: new Date(now - 120000).toISOString(), expires_at: new Date(now - 60000).toISOString(), nonce: randomUUID() });
+}
 
 function abandonedLockOwner() {
   return JSON.stringify({ version: 1, pid: 999999999, processStart: '1', createdAt: new Date().toISOString(), nonce: randomUUID() });
@@ -282,7 +296,7 @@ describe('workflow profile activation hook fixtures (#3487)', () => {
     const statePath = join(cwd, '.omc', 'state', 'sessions', 'workflow-activation-fixture', 'autopilot-state.json');
     try {
       mkdirSync(join(statePath, '..'), { recursive: true });
-      writeFileSync(`${statePath}.mutation.lock`, abandonedLockOwner());
+      writeFileSync(`${statePath}.mutation.lock`, abandonedMutationLockOwner());
       const output = runHook(script, '/autopilot --workflow release-flow ship it', cwd, configHome);
       expect(output.hookSpecificOutput?.additionalContext).toContain('## PIPELINE STAGE: RALPLAN');
       expect(stateBytes(cwd)).not.toBeNull();
@@ -702,6 +716,19 @@ describe('workflow profile activation hook fixtures (#3487)', () => {
     try {
       mkdirSync(join(statePath, '..'), { recursive: true });
       writeFileSync(lockPath, liveLockOwner());
+      // Prove the planted live lease ACTUALLY BLOCKS a contender rather than
+      // being corrupt-reclaimed (which would let a contender acquire at once).
+      // A direct exclusive acquire of the same mutation lock must fail (return
+      // null) while the unexpired lease is held - independent of the hook's own
+      // timing, so the assertion can no longer pass merely because the hook is
+      // slow. requireExclusive=true forces the linkSync reclaim loop even on
+      // flock-less runtimes (macOS/Windows), so the live lease is honored on
+      // every platform rather than short-circuiting to { unlocked: true }.
+      // Checked BEFORE launching the hook so there is no concurrent acquirer
+      // and no timing pressure on the hook's own retry budget.
+      const contender = acquireMutationLockAt(statePath, true);
+      expect(contender).toBeNull();
+      releaseMutationLockSync(contender);
       const pending = runHookAsync(script, '/autopilot --workflow release-flow ship it', cwd, configHome);
       await new Promise(resolve => setTimeout(resolve, 75));
       expect(stateBytes(cwd)).toBeNull();

--- a/src/cli/__tests__/graph-registration.test.ts
+++ b/src/cli/__tests__/graph-registration.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+process.env.OMC_CLI_SKIP_PARSE = '1';
+
+const graphCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('../commands/graph.js', () => ({ graphCommand: graphCommandMock }));
+
+describe('Commander Graph registration', () => {
+  it('registers one command and forwards raw arguments to its strict boundary', async () => {
+    const { buildProgram } = await import('../index.js');
+    const program = buildProgram();
+    const commands = program.commands.filter((command) => command.name() === 'graph');
+
+    expect(commands).toHaveLength(1);
+    await program.parseAsync([
+      'node',
+      'omc',
+      'graph',
+      'status',
+      '--run-id',
+      'run-1',
+      '--session-id',
+      'session-1',
+      '--json',
+    ]);
+    expect(graphCommandMock).toHaveBeenCalledWith([
+      'status',
+      '--run-id',
+      'run-1',
+      '--session-id',
+      'session-1',
+      '--json',
+    ]);
+  });
+});

--- a/src/cli/commands/__tests__/graph.test.ts
+++ b/src/cli/commands/__tests__/graph.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,6 +10,11 @@ import {
   type GraphCommandRequest,
   type GraphCommandService,
 } from '../graph.js';
+import { sealGraphDescriptor } from '../../../graph/descriptor.js';
+import { graphCommandService } from '../../../graph/runtime.js';
+import { createInitialGraphState } from '../../../graph/runtime-types.js';
+import { GraphStateStore } from '../../../graph/store.js';
+import { forkJoinDescriptor } from '../../../graph/__tests__/fixtures.js';
 
 function captureConsole() {
   const out: string[] = [];
@@ -211,6 +216,137 @@ describe('omc graph CLI boundary', () => {
       operation,
       result: { phase: 'running' },
     });
+  });
+
+  it('parses optional complete identities and forwards them unchanged', async () => {
+    const { service, requests } = serviceReturning();
+    const identities = { join_activation_id: 'run-1:act:join-build:resolved' };
+
+    await graphCommand([
+      'complete',
+      ...operationArgs.complete,
+      '--identities', JSON.stringify(identities),
+    ], service);
+
+    expect(process.exitCode).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].input.identities).toEqual(identities);
+  });
+
+  it('forwards complete identities through the CLI boundary so a fan-out join activates', async () => {
+    const sessionId = 'session-cli-complete-identities';
+    const worktree = await mkdtemp(join(tmpdir(), 'omc-graph-cli-runtime-'));
+    const originalCwd = process.cwd();
+    process.chdir(worktree);
+
+    try {
+      await mkdir(join(worktree, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+      const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+      const store = new GraphStateStore({ sessionId, worktreeRoot: worktree });
+      const approvalActivationId = `${descriptor.run_id}:act:approval:entry`;
+      store.create(createInitialGraphState({
+        session_id: sessionId,
+        control_nonce: 'nonce-cli-complete-identities',
+        descriptor,
+        status: 'running',
+        created_at: '2026-07-26T00:00:00.000Z',
+        projection: {
+          activations: {
+            [approvalActivationId]: {
+              activation_id: approvalActivationId,
+              node_id: 'approval',
+              status: 'ready',
+              attempt_no: 0,
+              attempt_ids: [],
+              traversal_owner_id: approvalActivationId,
+            },
+          },
+          cohorts: {},
+          branch_tokens: {},
+          traversal_counts: {},
+          committed_transitions: {},
+          terminal_verification_activation_ids: [],
+        },
+        approval: {
+          approved_at: '2026-07-26T00:00:00.000Z',
+          evidence: { kind: 'human', ref: 'approval-cli' },
+        },
+      }));
+
+      const execute = (operation: string, input: Record<string, unknown>) => graphCommandService.execute({
+        operation: operation as GraphCommandRequest['operation'],
+        cwd: process.cwd(),
+        input,
+      }) as Promise<{ result: Record<string, unknown> }>;
+      const scope = {
+        session_id: sessionId,
+        run_id: descriptor.run_id,
+        revision_id: descriptor.revision_id,
+        descriptor_hash: descriptor.descriptor_hash,
+      };
+      const claim = async (expectedSequence: number, transitionId: string) => {
+        const response = await execute('claim', {
+          ...scope,
+          expected_sequence: expectedSequence,
+          driver_id: 'driver-cli',
+          transition_id: transitionId,
+          limit: 1,
+        });
+        return response.result.claims as Array<Record<string, unknown>>;
+      };
+      const complete = async (
+        expectedSequence: number,
+        transitionId: string,
+        currentClaim: Record<string, unknown>,
+        evidenceKind: 'human' | 'command',
+      ) => execute('complete', {
+        ...scope,
+        expected_sequence: expectedSequence,
+        transition_id: transitionId,
+        claim: {
+          lease_id: currentClaim.lease_id,
+          activation_id: currentClaim.activation_id,
+          attempt_id: currentClaim.attempt_id,
+        },
+        result: { outcome: 'succeeded', evidence_refs: [{ kind: evidenceKind, ref: transitionId }] },
+      });
+
+      const approvalClaim = (await claim(0, 'claim-approval'))[0];
+      await complete(1, 'complete-approval', approvalClaim, 'human');
+      const analyzeClaim = (await claim(2, 'claim-analyze'))[0];
+      await complete(3, 'complete-analyze', analyzeClaim, 'command');
+      const firstBranchClaim = (await claim(4, 'claim-branch-a'))[0];
+      await complete(5, 'complete-branch-a', firstBranchClaim, 'command');
+      const secondBranchClaim = (await claim(6, 'claim-branch-b'))[0];
+      const joinActivationId = `${descriptor.run_id}:act:join-build:cli`;
+
+      await graphCommand([
+        'complete',
+        '--run-id', descriptor.run_id,
+        '--revision-id', descriptor.revision_id,
+        '--descriptor-hash', descriptor.descriptor_hash,
+        '--session-id', sessionId,
+        '--expected-sequence', '7',
+        '--transition-id', 'complete-branch-b-cli',
+        '--claim', JSON.stringify({
+          lease_id: secondBranchClaim.lease_id,
+          activation_id: secondBranchClaim.activation_id,
+          attempt_id: secondBranchClaim.attempt_id,
+        }),
+        '--result', '{"outcome":"succeeded","evidence_refs":[{"kind":"command","ref":"branch-b"}]}',
+        '--identities', JSON.stringify({ join_activation_id: joinActivationId }),
+      ], graphCommandService);
+
+      expect(process.exitCode).toBe(0);
+      expect(JSON.parse(captured.out[0])).toMatchObject({ ok: true, operation: 'complete' });
+      expect(store.read()!.projection.activations[joinActivationId]).toMatchObject({
+        activation_id: joinActivationId,
+        status: 'ready',
+      });
+    } finally {
+      process.chdir(originalCwd);
+      await rm(worktree, { recursive: true, force: true });
+    }
   });
 
   it('parses JSON object flags from a file path', async () => {

--- a/src/cli/commands/__tests__/graph.test.ts
+++ b/src/cli/commands/__tests__/graph.test.ts
@@ -1,0 +1,368 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  GRAPH_COMMAND_OPERATIONS,
+  graphCommand,
+  type GraphCommandRequest,
+  type GraphCommandService,
+} from '../graph.js';
+
+function captureConsole() {
+  const out: string[] = [];
+  const err: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    out.push(args.map(String).join(' '));
+  });
+  const error = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    err.push(args.map(String).join(' '));
+  });
+  return { out, err, restore: () => { log.mockRestore(); error.mockRestore(); } };
+}
+
+function serviceReturning(result: unknown = { state: 'ok' }): {
+  service: GraphCommandService;
+  requests: GraphCommandRequest[];
+} {
+  const requests: GraphCommandRequest[] = [];
+  return {
+    requests,
+    service: {
+      async execute(request) {
+        requests.push(request);
+        return result;
+      },
+    },
+  };
+}
+
+const HASH = 'a'.repeat(64);
+const SESSION = ['--session-id', 'session-1'] as const;
+const TRANSITION = ['--transition-id', 'transition-1'] as const;
+const COMMON = [
+  '--run-id', 'run-1',
+  '--revision-id', 'revision-1',
+  '--descriptor-hash', HASH,
+  ...SESSION,
+] as const;
+const SEQUENCED = [...COMMON, '--expected-sequence', '7'] as const;
+const DRIVER = ['--driver-id', 'driver-1'] as const;
+const MUTATING_OPERATIONS = new Set([
+  'create',
+  'approve',
+  'claim',
+  'complete',
+  'fail',
+  'propose-patch',
+  'approve-patch',
+  'pause',
+  'abandon',
+  'resume',
+  'resolve-join',
+  'renew-claim',
+  'recover-expired-claim',
+  'record-late-claim-result',
+  'release-attempt-for-retry',
+  'resolve-reconciliation',
+]);
+
+const operationArgs: Record<(typeof GRAPH_COMMAND_OPERATIONS)[number], string[]> = {
+  create: [
+    '--goal', 'Extract payments',
+    '--descriptor', '{"descriptor_version":1}',
+    ...SESSION,
+    ...DRIVER,
+    ...TRANSITION,
+  ],
+  inspect: ['--run-id', 'run-1', ...SESSION],
+  approve: [...COMMON, ...TRANSITION, '--approval', '{"approved":true,"reviewer":"human"}'],
+  ready: [...SEQUENCED],
+  claim: [...SEQUENCED, ...DRIVER, ...TRANSITION, '--limit', '3'],
+  complete: [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--claim', '{"lease_id":"lease-1"}',
+    '--result', '{"outcome":"succeeded"}',
+  ],
+  fail: [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--claim', '{"lease_id":"lease-1"}',
+    '--result', '{"outcome":"failed"}',
+  ],
+  'propose-patch': [
+    '--run-id', 'run-1',
+    ...SESSION,
+    '--base-revision-id', 'revision-1',
+    '--base-descriptor-hash', HASH,
+    '--expected-sequence', '7',
+    ...TRANSITION,
+    '--patch', '{"revision_id":"revision-2"}',
+  ],
+  'approve-patch': [
+    '--run-id', 'run-1',
+    ...SESSION,
+    '--base-revision-id', 'revision-1',
+    '--base-descriptor-hash', HASH,
+    '--expected-sequence', '7',
+    ...TRANSITION,
+    '--approval', '{"approved":true}',
+  ],
+  status: ['--run-id', 'run-1', ...SESSION],
+  pause: [...SEQUENCED, ...DRIVER, ...TRANSITION],
+  abandon: [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--confirmation', '{"run_id":"run-1","revision_id":"revision-1","abandon":true}',
+  ],
+  resume: [...COMMON, ...DRIVER, ...TRANSITION],
+  'resolve-join': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--activation-id', 'act-join-1',
+    '--identities', '{"next_activation_ids":{"join-to-verify":"act-verify"}}',
+  ],
+  'renew-claim': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--lease-id', 'lease-1',
+    ...DRIVER,
+    '--tracking-id', 'tool-1',
+    '--tool-still-running', 'true',
+    '--now', '2026-07-21T00:00:01.000Z',
+  ],
+  'recover-expired-claim': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--lease-id', 'lease-1',
+    '--now', '2026-07-21T00:00:02.000Z',
+    '--new-attempt-id', 'attempt-2',
+    '--new-lease-id', 'lease-2',
+    '--new-tracking-id', 'tool-2',
+    ...DRIVER,
+    '--reconciliation-id', 'reconciliation-1',
+  ],
+  'record-late-claim-result': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--lease-id', 'lease-1',
+    '--attempt-id', 'attempt-1',
+    '--recorded-at', '2026-07-21T00:00:03.000Z',
+    '--summary', 'old result arrived after takeover',
+  ],
+  'release-attempt-for-retry': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--activation-id', 'act-1',
+    '--attempt-id', 'attempt-1',
+  ],
+  'resolve-reconciliation': [
+    ...SEQUENCED,
+    ...TRANSITION,
+    '--evidence', '{"kind":"human","ref":"resolution-1"}',
+    '--resolved-at', '2026-07-21T00:00:04.000Z',
+  ],
+};
+
+describe('omc graph CLI boundary', () => {
+  let captured: ReturnType<typeof captureConsole>;
+
+  beforeEach(() => {
+    captured = captureConsole();
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    captured.restore();
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('prints help without invoking a runtime service', async () => {
+    const { service, requests } = serviceReturning();
+
+    await graphCommand([], service);
+
+    expect(captured.out.join('\n')).toMatch(/omc graph/);
+    expect(captured.out.join('\n')).toMatch(/create.*approve.*claim/s);
+    expect(captured.out.join('\n')).not.toMatch(/settle-session/);
+    expect(requests).toEqual([]);
+  });
+
+  it.each(GRAPH_COMMAND_OPERATIONS)('strictly parses and delegates %s', async (operation) => {
+    const { service, requests } = serviceReturning({ phase: 'running' });
+
+    await graphCommand([operation, ...operationArgs[operation], '--json'], service);
+
+    expect(process.exitCode).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ operation, cwd: process.cwd() });
+    expect(requests[0].input.session_id).toBe('session-1');
+    if (MUTATING_OPERATIONS.has(operation)) {
+      expect(requests[0].input.transition_id).toBe('transition-1');
+    } else {
+      expect(requests[0].input).not.toHaveProperty('transition_id');
+    }
+    expect(JSON.parse(captured.out[0])).toMatchObject({
+      ok: true,
+      operation,
+      result: { phase: 'running' },
+    });
+  });
+
+  it('parses JSON object flags from a file path', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'omc-graph-cli-'));
+    const original = process.cwd();
+    process.chdir(cwd);
+    try {
+      await writeFile(join(cwd, 'descriptor.json'), '{"descriptor_version":1,"run_id":"run-1"}');
+      const { service, requests } = serviceReturning();
+
+      await graphCommand([
+        'create',
+        '--goal', 'Extract payments',
+        '--descriptor', 'descriptor.json',
+        ...SESSION,
+        ...DRIVER,
+        ...TRANSITION,
+      ], service);
+
+      expect(requests[0].input.descriptor).toEqual({ descriptor_version: 1, run_id: 'run-1' });
+    } finally {
+      process.chdir(original);
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('delegates hidden session settlement with explicit session, driver, and transition scope', async () => {
+    const { service, requests } = serviceReturning({ settled_lease_ids: ['lease-1'] });
+
+    await graphCommand([
+      'settle-session',
+      ...SESSION,
+      ...DRIVER,
+      ...TRANSITION,
+      '--json',
+    ], service);
+
+    expect(requests).toEqual([{
+      operation: 'settle-session',
+      cwd: process.cwd(),
+      input: {
+        session_id: 'session-1',
+        driver_id: 'driver-1',
+        transition_id: 'transition-1',
+      },
+    }]);
+    expect(JSON.parse(captured.out[0])).toMatchObject({
+      ok: true,
+      operation: 'settle-session',
+      result: { settled_lease_ids: ['lease-1'] },
+    });
+  });
+
+  it('rejects hidden session settlement without explicit session scope', async () => {
+    const { service, requests } = serviceReturning();
+
+    await graphCommand(['settle-session', ...DRIVER, ...TRANSITION], service);
+
+    expect(process.exitCode).toBe(1);
+    expect(requests).toEqual([]);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/--session-id/);
+  });
+
+  it.each(GRAPH_COMMAND_OPERATIONS)('rejects a missing required flag for %s before delegation', async (operation) => {
+    const { service, requests } = serviceReturning();
+    const args = operationArgs[operation].slice(2);
+
+    await graphCommand([operation, ...args], service);
+
+    expect(process.exitCode).toBe(1);
+    expect(requests).toEqual([]);
+    expect(JSON.parse(captured.err[0])).toMatchObject({ ok: false, operation });
+  });
+
+  it('rejects unknown, duplicate, malformed JSON, and invalid numeric flags', async () => {
+    const cases = [
+      ['status', '--run-id', 'run-1', '--unknown', 'value'],
+      ['status', '--run-id', 'run-1', ...SESSION, '--run-id', 'run-2'],
+      ['create', '--goal', 'goal', '--descriptor', '{bad', ...SESSION, ...DRIVER, ...TRANSITION],
+      ['claim', ...SEQUENCED, ...DRIVER, ...TRANSITION, '--limit', '0'],
+    ];
+
+    for (const args of cases) {
+      captured.err.length = 0;
+      process.exitCode = 0;
+      const { service, requests } = serviceReturning();
+      await graphCommand(args, service);
+      expect(process.exitCode).toBe(1);
+      expect(requests).toEqual([]);
+      expect(() => JSON.parse(captured.err[0])).not.toThrow();
+    }
+  });
+
+  it('rejects omitted session scope and mutating transition identity', async () => {
+    const { service, requests } = serviceReturning();
+
+    await graphCommand(['status', '--run-id', 'run-1'], service);
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/--session-id/);
+
+    captured.err.length = 0;
+    process.exitCode = 0;
+    await graphCommand(
+      ['claim', ...SEQUENCED, ...DRIVER, '--limit', '3'],
+      service,
+    );
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/--transition-id/);
+    expect(requests).toEqual([]);
+  });
+
+  it('bounds successful output and service error messages', async () => {
+    const large = serviceReturning({ private_output: 'x'.repeat(100_000) });
+    await graphCommand(['status', '--run-id', 'run-1', ...SESSION], large.service);
+    expect(process.exitCode).toBe(1);
+    expect(Buffer.byteLength(captured.err[0], 'utf8')).toBeLessThan(4_096);
+    expect(JSON.parse(captured.err[0]).error).toMatch(/output exceeds/i);
+
+    captured.err.length = 0;
+    process.exitCode = 0;
+    const failing: GraphCommandService = {
+      async execute() {
+        throw new Error('sensitive '.repeat(10_000));
+      },
+    };
+    await graphCommand(['status', '--run-id', 'run-1', ...SESSION], failing);
+    expect(process.exitCode).toBe(1);
+    expect(Buffer.byteLength(captured.err[0], 'utf8')).toBeLessThan(4_096);
+  });
+
+  it('contains no process or in-session tool execution path', async () => {
+    const source = await readFile(new URL('../graph.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toMatch(/node:child_process|\bspawn\s*\(|\bexec(?:File)?\s*\(/);
+    expect(source).not.toMatch(/Agent|AskUserQuestion|\bBash\b/);
+  });
+
+  it('ships an explicit-only persistent in-session driver contract', async () => {
+    const skill = await readFile(
+      new URL('../../../../skills/graph/SKILL.md', import.meta.url),
+      'utf8',
+    );
+
+    expect(skill).toMatch(/name: graph/);
+    expect(skill).not.toMatch(/^triggers:/m);
+    expect(skill).toMatch(/\/oh-my-claudecode:graph <development goal>/);
+    expect(skill).toMatch(/exact revision ID and descriptor SHA-256/);
+    expect(skill).toMatch(/Agent\/Task surface/);
+    expect(skill).toMatch(/permission-governed\s+Bash surface/);
+    expect(skill).toMatch(/join.*deterministic scheduler/is);
+    expect(skill).toMatch(/do\s+not busy-poll/i);
+    expect(skill).toMatch(/normal user cancel means `pause`/i);
+    expect(skill).toMatch(/Permanent `abandon` is separate/);
+  });
+});

--- a/src/cli/commands/graph.ts
+++ b/src/cli/commands/graph.ts
@@ -58,7 +58,7 @@ Usage:
   omc graph approve --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --transition-id <id> --approval <json-or-path> [--json]
   omc graph ready --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> [--json]
   omc graph claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> --limit <n> [--json]
-  omc graph complete --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
+  omc graph complete --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--identities <json-or-path>] [--json]
   omc graph fail --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
   omc graph propose-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --patch <json-or-path> [--json]
   omc graph approve-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --approval <json-or-path> [--json]
@@ -84,6 +84,7 @@ interface FlagDefinition {
   flag: string;
   field: string;
   kind: FlagKind;
+  optional?: boolean;
 }
 
 const RUN: FlagDefinition = { flag: '--run-id', field: 'run_id', kind: 'id' };
@@ -158,6 +159,7 @@ const OPERATION_FLAGS: Record<GraphCommandOperation, readonly FlagDefinition[]> 
     TRANSITION,
     { flag: '--claim', field: 'claim', kind: 'json' },
     { flag: '--result', field: 'result', kind: 'json' },
+    { flag: '--identities', field: 'identities', kind: 'json', optional: true },
   ],
   fail: [
     RUN,
@@ -311,7 +313,7 @@ function parseRawFlags(
   }
 
   for (const definition of definitions) {
-    if (!values.has(definition.flag)) {
+    if (!definition.optional && !values.has(definition.flag)) {
       throw new GraphCommandError('missing_argument', `Missing required ${definition.flag} for graph ${operation}`);
     }
   }
@@ -391,7 +393,8 @@ async function parseRequest(
   const raw = parseRawFlags(operation, args);
   const input: Record<string, unknown> = {};
   for (const definition of OPERATION_FLAGS[operation]) {
-    const value = raw.get(definition.flag)!;
+    const value = raw.get(definition.flag);
+    if (value === undefined) continue;
     input[definition.field] = definition.kind === 'json'
       ? await parseJsonObject(value, definition.flag, cwd)
       : parseScalar(value, definition);

--- a/src/cli/commands/graph.ts
+++ b/src/cli/commands/graph.ts
@@ -1,0 +1,476 @@
+import { readFile, stat } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export const GRAPH_COMMAND_OPERATIONS = [
+  'create',
+  'inspect',
+  'approve',
+  'ready',
+  'claim',
+  'complete',
+  'fail',
+  'propose-patch',
+  'approve-patch',
+  'status',
+  'pause',
+  'abandon',
+  'resume',
+  'resolve-join',
+  'renew-claim',
+  'recover-expired-claim',
+  'record-late-claim-result',
+  'release-attempt-for-retry',
+  'resolve-reconciliation',
+] as const;
+
+const GRAPH_INTERNAL_COMMAND_OPERATIONS = ['settle-session'] as const;
+
+export type GraphCommandOperation =
+  | (typeof GRAPH_COMMAND_OPERATIONS)[number]
+  | (typeof GRAPH_INTERNAL_COMMAND_OPERATIONS)[number];
+
+export interface GraphCommandRequest {
+  operation: GraphCommandOperation;
+  cwd: string;
+  input: Readonly<Record<string, unknown>>;
+}
+
+/** Implementations must perform guarded state transitions only. */
+export interface GraphCommandService {
+  execute(request: GraphCommandRequest): Promise<unknown>;
+}
+
+export class GraphCommandError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphCommandError';
+    this.code = code;
+  }
+}
+
+export const GRAPH_HELP = `omc graph - Durable, human-approved orchestration graph state boundary
+
+Usage:
+  omc graph create --goal <text> --descriptor <json-or-path> --session-id <id> --driver-id <id> --transition-id <id> [--json]
+  omc graph inspect --run-id <id> --session-id <id> [--json]
+  omc graph approve --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --transition-id <id> --approval <json-or-path> [--json]
+  omc graph ready --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> [--json]
+  omc graph claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> --limit <n> [--json]
+  omc graph complete --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
+  omc graph fail --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --claim <json-or-path> --result <json-or-path> [--json]
+  omc graph propose-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --patch <json-or-path> [--json]
+  omc graph approve-patch --run-id <id> --session-id <id> --base-revision-id <id> --base-descriptor-hash <sha256> --expected-sequence <n> --transition-id <id> --approval <json-or-path> [--json]
+  omc graph status --run-id <id> --session-id <id> [--json]
+  omc graph pause --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --driver-id <id> --transition-id <id> [--json]
+  omc graph abandon --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --confirmation <json-or-path> [--json]
+  omc graph resume --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --driver-id <id> --transition-id <id> [--json]
+  omc graph resolve-join --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --activation-id <id> --identities <json-or-path> [--json]
+  omc graph renew-claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --driver-id <id> --tracking-id <id> --tool-still-running --now <iso8601> [--json]
+  omc graph recover-expired-claim --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --now <iso8601> --new-attempt-id <id> --new-lease-id <id> --new-tracking-id <id> --driver-id <id> --reconciliation-id <id> [--json]
+  omc graph record-late-claim-result --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --lease-id <id> --attempt-id <id> --recorded-at <iso8601> --summary <text> [--json]
+  omc graph release-attempt-for-retry --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --activation-id <id> --attempt-id <id> [--json]
+  omc graph resolve-reconciliation --run-id <id> --revision-id <id> --descriptor-hash <sha256> --session-id <id> --expected-sequence <n> --transition-id <id> --evidence <json-or-path> --resolved-at <iso8601> [--json]
+
+JSON flags accept either an inline JSON object or a path to a JSON object.
+Every operation returns one bounded JSON envelope. This command delegates state
+operations to the graph runtime; it does not execute graph node work.
+`;
+
+type FlagKind = 'id' | 'hash' | 'text' | 'sequence' | 'limit' | 'json' | 'boolean';
+
+interface FlagDefinition {
+  flag: string;
+  field: string;
+  kind: FlagKind;
+}
+
+const RUN: FlagDefinition = { flag: '--run-id', field: 'run_id', kind: 'id' };
+const REVISION: FlagDefinition = { flag: '--revision-id', field: 'revision_id', kind: 'id' };
+const HASH: FlagDefinition = { flag: '--descriptor-hash', field: 'descriptor_hash', kind: 'hash' };
+const SEQUENCE: FlagDefinition = {
+  flag: '--expected-sequence',
+  field: 'expected_sequence',
+  kind: 'sequence',
+};
+const SESSION: FlagDefinition = { flag: '--session-id', field: 'session_id', kind: 'id' };
+const DRIVER: FlagDefinition = { flag: '--driver-id', field: 'driver_id', kind: 'id' };
+const TRANSITION: FlagDefinition = {
+  flag: '--transition-id',
+  field: 'transition_id',
+  kind: 'id',
+};
+const BASE_REVISION: FlagDefinition = {
+  flag: '--base-revision-id',
+  field: 'base_revision_id',
+  kind: 'id',
+};
+const BASE_HASH: FlagDefinition = {
+  flag: '--base-descriptor-hash',
+  field: 'base_descriptor_hash',
+  kind: 'hash',
+};
+const ACTIVATION: FlagDefinition = { flag: '--activation-id', field: 'activation_id', kind: 'id' };
+const LEASE: FlagDefinition = { flag: '--lease-id', field: 'lease_id', kind: 'id' };
+const ATTEMPT: FlagDefinition = { flag: '--attempt-id', field: 'attempt_id', kind: 'id' };
+const TRACKING: FlagDefinition = { flag: '--tracking-id', field: 'tracking_id', kind: 'id' };
+const RECONCILIATION: FlagDefinition = {
+  flag: '--reconciliation-id',
+  field: 'reconciliation_id',
+  kind: 'id',
+};
+
+const OPERATION_FLAGS: Record<GraphCommandOperation, readonly FlagDefinition[]> = {
+  create: [
+    { flag: '--goal', field: 'goal', kind: 'text' },
+    { flag: '--descriptor', field: 'descriptor', kind: 'json' },
+    SESSION,
+    DRIVER,
+    TRANSITION,
+  ],
+  inspect: [RUN, SESSION],
+  approve: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    TRANSITION,
+    { flag: '--approval', field: 'approval', kind: 'json' },
+  ],
+  ready: [RUN, REVISION, HASH, SESSION, SEQUENCE],
+  claim: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    DRIVER,
+    TRANSITION,
+    { flag: '--limit', field: 'limit', kind: 'limit' },
+  ],
+  complete: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--claim', field: 'claim', kind: 'json' },
+    { flag: '--result', field: 'result', kind: 'json' },
+  ],
+  fail: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--claim', field: 'claim', kind: 'json' },
+    { flag: '--result', field: 'result', kind: 'json' },
+  ],
+  'propose-patch': [
+    RUN,
+    SESSION,
+    BASE_REVISION,
+    BASE_HASH,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--patch', field: 'patch', kind: 'json' },
+  ],
+  'approve-patch': [
+    RUN,
+    SESSION,
+    BASE_REVISION,
+    BASE_HASH,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--approval', field: 'approval', kind: 'json' },
+  ],
+  status: [RUN, SESSION],
+  pause: [RUN, REVISION, HASH, SESSION, SEQUENCE, DRIVER, TRANSITION],
+  abandon: [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--confirmation', field: 'confirmation', kind: 'json' },
+  ],
+  resume: [RUN, REVISION, HASH, SESSION, DRIVER, TRANSITION],
+  'resolve-join': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    ACTIVATION,
+    { flag: '--identities', field: 'identities', kind: 'json' },
+  ],
+  'renew-claim': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    DRIVER,
+    TRACKING,
+    { flag: '--tool-still-running', field: 'tool_still_running', kind: 'boolean' },
+    { flag: '--now', field: 'now', kind: 'text' },
+  ],
+  'recover-expired-claim': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    { flag: '--now', field: 'now', kind: 'text' },
+    { flag: '--new-attempt-id', field: 'new_attempt_id', kind: 'id' },
+    { flag: '--new-lease-id', field: 'new_lease_id', kind: 'id' },
+    { flag: '--new-tracking-id', field: 'new_tracking_id', kind: 'id' },
+    DRIVER,
+    RECONCILIATION,
+  ],
+  'record-late-claim-result': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    LEASE,
+    ATTEMPT,
+    { flag: '--recorded-at', field: 'recorded_at', kind: 'text' },
+    { flag: '--summary', field: 'summary', kind: 'text' },
+  ],
+  'release-attempt-for-retry': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    ACTIVATION,
+    ATTEMPT,
+  ],
+  'resolve-reconciliation': [
+    RUN,
+    REVISION,
+    HASH,
+    SESSION,
+    SEQUENCE,
+    TRANSITION,
+    { flag: '--evidence', field: 'evidence', kind: 'json' },
+    { flag: '--resolved-at', field: 'resolved_at', kind: 'text' },
+  ],
+  'settle-session': [SESSION, DRIVER, TRANSITION],
+};
+
+const MAX_JSON_INPUT_BYTES = 256 * 1024;
+const MAX_JSON_OUTPUT_BYTES = 64 * 1024;
+const MAX_ERROR_CHARS = 1_000;
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+function resolveOperation(raw: string | undefined): GraphCommandOperation | undefined {
+  return [...GRAPH_COMMAND_OPERATIONS, ...GRAPH_INTERNAL_COMMAND_OPERATIONS]
+    .find((operation) => operation === raw);
+}
+
+function parseRawFlags(
+  operation: GraphCommandOperation,
+  args: readonly string[],
+): Map<string, string> {
+  const definitions = OPERATION_FLAGS[operation];
+  const allowed = new Set(definitions.map((definition) => definition.flag));
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === '--json') continue;
+    const equals = token.indexOf('=');
+    const flag = equals >= 0 ? token.slice(0, equals) : token;
+    if (!allowed.has(flag)) {
+      throw new GraphCommandError('unknown_argument', `Unknown argument for graph ${operation}: ${token}`);
+    }
+    if (values.has(flag)) {
+      throw new GraphCommandError('duplicate_argument', `Duplicate argument for graph ${operation}: ${flag}`);
+    }
+    const value = equals >= 0 ? token.slice(equals + 1) : args[index + 1];
+    if (!value || (equals < 0 && value.startsWith('--'))) {
+      throw new GraphCommandError('missing_value', `Missing value after ${flag}`);
+    }
+    values.set(flag, value);
+    if (equals < 0) index += 1;
+  }
+
+  for (const definition of definitions) {
+    if (!values.has(definition.flag)) {
+      throw new GraphCommandError('missing_argument', `Missing required ${definition.flag} for graph ${operation}`);
+    }
+  }
+  return values;
+}
+
+async function parseJsonObject(raw: string, flag: string, cwd: string): Promise<Record<string, unknown>> {
+  let source = raw.trim();
+  try {
+    if (!source.startsWith('{') && !source.startsWith('[')) {
+      const path = resolve(cwd, source);
+      const metadata = await stat(path);
+      if (!metadata.isFile()) throw new Error('path is not a regular file');
+      if (metadata.size > MAX_JSON_INPUT_BYTES) {
+        throw new Error(`file exceeds ${MAX_JSON_INPUT_BYTES} bytes`);
+      }
+      source = await readFile(path, 'utf8');
+    } else if (Buffer.byteLength(source, 'utf8') > MAX_JSON_INPUT_BYTES) {
+      throw new Error(`inline value exceeds ${MAX_JSON_INPUT_BYTES} bytes`);
+    }
+    const parsed = JSON.parse(source) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('value must be a JSON object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new GraphCommandError('invalid_json_input', `Invalid ${flag}: ${message}`);
+  }
+}
+
+function parseScalar(raw: string, definition: FlagDefinition): string | number | boolean {
+  const trimmed = raw.trim();
+  if (definition.kind === 'id') {
+    if (!ID_PATTERN.test(trimmed)) {
+      throw new GraphCommandError('invalid_identifier', `Invalid ${definition.flag}`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === 'hash') {
+    if (!HASH_PATTERN.test(trimmed)) {
+      throw new GraphCommandError('invalid_hash', `Invalid ${definition.flag}; expected lowercase SHA-256`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === 'text') {
+    if (!trimmed || trimmed.length > 32_768) {
+      throw new GraphCommandError('invalid_text', `Invalid ${definition.flag}`);
+    }
+    return trimmed;
+  }
+  if (definition.kind === 'sequence' || definition.kind === 'limit') {
+    if (!/^\d+$/.test(trimmed)) {
+      throw new GraphCommandError('invalid_number', `Invalid ${definition.flag}; expected an integer`);
+    }
+    const value = Number(trimmed);
+    const valid = definition.kind === 'sequence'
+      ? Number.isSafeInteger(value) && value >= 0
+      : Number.isSafeInteger(value) && value >= 1 && value <= 64;
+    if (!valid) throw new GraphCommandError('invalid_number', `Invalid ${definition.flag}`);
+    return value;
+  }
+  if (definition.kind === 'boolean') {
+    if (trimmed !== 'true' && trimmed !== 'false') {
+      throw new GraphCommandError('invalid_boolean', `Invalid ${definition.flag}; expected 'true' or 'false'`);
+    }
+    return trimmed === 'true';
+  }
+  throw new GraphCommandError('invalid_argument', `Unsupported scalar flag ${definition.flag}`);
+}
+
+async function parseRequest(
+  operation: GraphCommandOperation,
+  args: readonly string[],
+  cwd: string,
+): Promise<GraphCommandRequest> {
+  const raw = parseRawFlags(operation, args);
+  const input: Record<string, unknown> = {};
+  for (const definition of OPERATION_FLAGS[operation]) {
+    const value = raw.get(definition.flag)!;
+    input[definition.field] = definition.kind === 'json'
+      ? await parseJsonObject(value, definition.flag, cwd)
+      : parseScalar(value, definition);
+  }
+  return { operation, cwd, input: Object.freeze(input) };
+}
+
+async function loadDefaultService(): Promise<GraphCommandService> {
+  const runtimeModulePath = '../../graph/runtime.js';
+  try {
+    const runtime = await import(runtimeModulePath) as {
+      graphCommandService?: GraphCommandService;
+    };
+    if (runtime.graphCommandService?.execute) return runtime.graphCommandService;
+  } catch {
+    // The runtime adapter is added independently from this boundary.
+  }
+  throw new GraphCommandError(
+    'runtime_unavailable',
+    'Graph runtime adapter is unavailable; export graphCommandService from src/graph/runtime.ts',
+  );
+}
+
+function serializeBounded(value: unknown): string {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new GraphCommandError('invalid_output', 'Graph service returned a non-JSON result');
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > MAX_JSON_OUTPUT_BYTES) {
+    throw new GraphCommandError(
+      'output_too_large',
+      `Graph command output exceeds ${MAX_JSON_OUTPUT_BYTES} bytes`,
+    );
+  }
+  return serialized;
+}
+
+function boundedErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length <= MAX_ERROR_CHARS ? message : `${message.slice(0, MAX_ERROR_CHARS)}...`;
+}
+
+export async function graphCommand(
+  args: string[],
+  injectedService?: GraphCommandService,
+): Promise<void> {
+  const rawOperation = args[0];
+  if (!rawOperation || rawOperation === 'help' || rawOperation === '--help' || rawOperation === '-h') {
+    console.log(GRAPH_HELP);
+    return;
+  }
+  const operation = resolveOperation(rawOperation);
+  if (!operation) {
+    const displayedOperation = boundedErrorMessage(rawOperation);
+    process.exitCode = 1;
+    console.error(serializeBounded({
+      ok: false,
+      operation: displayedOperation,
+      code: 'unknown_operation',
+      error: `Unknown graph operation: ${displayedOperation}`,
+    }));
+    return;
+  }
+
+  try {
+    const request = await parseRequest(operation, args.slice(1), process.cwd());
+    const service = injectedService ?? await loadDefaultService();
+    const result = await service.execute(request);
+    console.log(serializeBounded({ ok: true, operation, result: result ?? null }));
+  } catch (error) {
+    process.exitCode = 1;
+    const code = error instanceof GraphCommandError ? error.code : 'runtime_error';
+    console.error(serializeBounded({
+      ok: false,
+      operation,
+      code,
+      error: boundedErrorMessage(error),
+    }));
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,7 @@ import { capabilitiesCheckCommand, capabilitiesLockCommand } from './commands/ca
 import { sessionSearchCommand } from './commands/session-search.js';
 import { sessionFrictionReportCommand } from './commands/session-friction-report.js';
 import { teamCommand } from './commands/team.js';
+import { graphCommand } from './commands/graph.js';
 import { ralphthonCommand } from './commands/ralphthon.js';
 import { ultragoalCommand, ULTRAGOAL_HELP } from './commands/ultragoal.js';
 import {
@@ -1478,6 +1479,20 @@ program
   .argument('[args...]', 'team subcommand arguments')
   .action(async (args: string[]) => {
     await teamCommand(args);
+  });
+
+/**
+ * Graph command - guarded durable graph state transitions.
+ */
+program
+  .command('graph')
+  .description('Guarded durable orchestration graph state operations')
+  .helpOption(false)
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .argument('[args...]', 'graph operation and arguments')
+  .action(async (args: string[]) => {
+    await graphCommand(args);
   });
 
 /**

--- a/src/graph/__tests__/control-owner.test.ts
+++ b/src/graph/__tests__/control-owner.test.ts
@@ -1,0 +1,570 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import {
+  ControlOwnerError,
+  ControlOwnerStore,
+  classifyControlMode,
+  type ControlOwnerDependencies,
+} from '../control-owner.js';
+
+const temporaryDirectories: string[] = [];
+const GRAPH_REVISION = { revision_id: 'revision-1', revision_hash: 'a'.repeat(64) };
+
+function createStore(
+  events: string[] = [],
+  withExclusiveLock: ControlOwnerDependencies['withExclusiveLock'] = (_path, callback) => {
+    events.push('lock');
+    return { acquired: true, value: callback() };
+  },
+) {
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-control-owner-'));
+  temporaryDirectories.push(worktreeRoot);
+  return new ControlOwnerStore({
+    sessionId: 'session-control',
+    worktreeRoot,
+    platform: {
+      preflight: () => {
+        events.push('preflight');
+        return { pid: 123, process_start: '456' };
+      },
+      isProcessIdentityLive: () => false,
+    },
+    dependencies: {
+      fileExists: (path) => {
+        events.push('read');
+        return existsSync(path);
+      },
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic: atomicWriteJsonSync,
+      withExclusiveLock,
+    },
+  });
+}
+
+afterEach(() => {
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe('ControlOwnerStore', () => {
+  it('preflights before reservation and gives competing roots one winner', () => {
+    const events: string[] = [];
+    const store = createStore(events);
+    const reserved = store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+
+    expect(events.slice(0, 2)).toEqual(['preflight', 'lock']);
+    expect(reserved.root).toMatchObject({ mode: 'graph', phase: 'reserved', nonce: 'nonce-1' });
+    expect(() => store.reserveRoot({
+      mode: 'autopilot',
+      run_id: 'autopilot-1',
+      nonce: 'nonce-2',
+      reserved_at: '2026-07-21T00:00:01.000Z',
+    })).toThrowError(ControlOwnerError);
+  });
+
+  it('renews the lease immediately before publishing control ownership', () => {
+    const renew = vi.fn();
+    const store = createStore([], (_path, callback) => ({ acquired: true, value: callback(renew) }));
+
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-renew',
+      nonce: 'nonce-renew',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+
+    expect(renew).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a pid-only reservation_process (empty process_start) so a host that could not capture start time does not wedge control authority', () => {
+    // When ps/powershell/proc is unavailable at reservation time, preflight()
+    // returns process_start: ''. The store must still accept the reserved
+    // control state on read() (pid-only identity) instead of rejecting it as
+    // malformed_control, which would permanently break control authority.
+    const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-control-owner-pidonly-'));
+    temporaryDirectories.push(worktreeRoot);
+    const store = new ControlOwnerStore({
+      sessionId: 'session-pidonly',
+      worktreeRoot,
+      platform: {
+        preflight: () => ({ pid: 999, process_start: '' }),
+        isProcessIdentityLive: () => true,
+      },
+      dependencies: {
+        fileExists: (path) => existsSync(path),
+        readText: (path) => readFileSync(path, 'utf8'),
+        writeAtomic: atomicWriteJsonSync,
+        withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+      },
+    });
+
+    const reserved = store.reserveRoot({
+      mode: 'autopilot',
+      run_id: 'run-pidonly',
+      nonce: 'nonce-pidonly',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+
+    expect(reserved.root?.reservation_process).toEqual({ pid: 999, process_start: '' });
+    // read() must not throw malformed_control for the pid-only form.
+    const reloaded = store.read();
+    expect(reloaded?.root?.reservation_process).toEqual({ pid: 999, process_start: '' });
+  });
+
+  it('gives concurrent root reservations exactly one winner', async () => {
+    const store = createStore();
+    const results = await Promise.allSettled(
+      (['graph', 'ralph', 'autopilot', 'team'] as const).map((mode, index) =>
+        Promise.resolve().then(() => store.reserveRoot({
+          mode,
+          run_id: `${mode}-run`,
+          nonce: `nonce-${index}`,
+          reserved_at: '2026-07-21T00:00:00.000Z',
+          ...(mode === 'graph' ? { graph_revision: GRAPH_REVISION } : {}),
+        })),
+      ),
+    );
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(3);
+    expect(store.read()?.root).not.toBeNull();
+  });
+
+  it('recovers reserve-create-promote and fences a stale releaser by nonce', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+    expect(() => store.recoverGraphReservation({
+      session_id: 'session-control',
+      run_id: 'run-1',
+      revision_id: 'revision-1',
+      revision_hash: 'b'.repeat(64),
+      status: 'running',
+      reservation_nonce: 'nonce-1',
+      observed_at: '2026-07-21T00:00:00.500Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:00.500Z',
+      },
+    })).toThrow(/revision\/hash/i);
+    const recovered = store.recoverGraphReservation({
+      session_id: 'session-control',
+      run_id: 'run-1',
+      revision_id: 'revision-1',
+      revision_hash: 'a'.repeat(64),
+      status: 'running',
+      reservation_nonce: 'nonce-1',
+      observed_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    expect(recovered.action).toBe('promoted');
+    expect(store.read()?.root?.phase).toBe('active');
+
+    const stale = store.releaseRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'stale-nonce',
+      disposition: {
+        graph_status: 'paused',
+        claims_fenced: true,
+        children_drained: true,
+      },
+      released_at: '2026-07-21T00:00:02.000Z',
+    });
+    expect(stale.released).toBe(false);
+    expect(store.read()?.root?.nonce).toBe('nonce-1');
+  });
+
+  it('permits only declared exact-lineage children', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+    store.promoteRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'nonce-1',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    const registered = store.registerChild({
+      mode: 'team',
+      session_id: 'team-session',
+      run_id: 'team-run',
+      parent: { mode: 'graph', session_id: 'session-control', run_id: 'run-1' },
+      graph_claim: {
+        activation_id: 'activation-a',
+        attempt_id: 'attempt-a',
+        lease_id: 'lease-a',
+        revision_id: 'revision-1',
+        revision_hash: 'a'.repeat(64),
+        dispatch_generation: 0,
+      },
+      registered_at: '2026-07-21T00:00:02.000Z',
+    });
+    expect(registered.root?.children).toHaveLength(1);
+
+    expect(() => store.registerChild({
+      mode: 'ralph',
+      session_id: 'ralph-session',
+      run_id: 'ralph-run',
+      parent: { mode: 'graph', session_id: 'session-control', run_id: 'run-1' },
+      registered_at: '2026-07-21T00:00:03.000Z',
+    })).toThrow(/lineage/i);
+  });
+
+  it('rejects persisted cyclic lineage and Graph children without exact claims', () => {
+    const cyclic = createStore();
+    cyclic.reserveRoot({
+      mode: 'autopilot', run_id: 'auto-run', nonce: 'nonce-auto',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    const cyclicState = cyclic.read()!;
+    atomicWriteJsonSync(cyclic.path, {
+      ...cyclicState,
+      root: {
+        ...cyclicState.root!,
+        children: [{
+          mode: 'ralph', session_id: 'session-control', run_id: 'ralph-run',
+          parent: { mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-run' },
+          registered_at: '2026-07-21T00:00:01.000Z',
+        }, {
+          mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-run',
+          parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph-run' },
+          registered_at: '2026-07-21T00:00:01.000Z',
+        }],
+      },
+    });
+    expect(() => cyclic.read()).toThrow(/reachable|lineage/i);
+
+    const missingClaim = createStore();
+    missingClaim.reserveRoot({
+      mode: 'graph', run_id: 'graph-run', nonce: 'nonce-graph',
+      graph_revision: GRAPH_REVISION,
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    const graphState = missingClaim.read()!;
+    atomicWriteJsonSync(missingClaim.path, {
+      ...graphState,
+      root: {
+        ...graphState.root!,
+        children: [{
+          mode: 'team', session_id: 'team-session', run_id: 'team-run',
+          parent: { mode: 'graph', session_id: 'session-control', run_id: 'graph-run' },
+          registered_at: '2026-07-21T00:00:01.000Z',
+        }],
+      },
+    });
+    expect(() => missingClaim.read()).toThrow(/claim/i);
+  });
+
+  it('implements the full Autopilot and Ralph child matrix and rejects mismatched parents', () => {
+    const autopilot = createStore();
+    autopilot.reserveRoot({
+      mode: 'autopilot', run_id: 'autopilot-run', nonce: 'nonce-auto',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    autopilot.promoteRoot({
+      mode: 'autopilot', run_id: 'autopilot-run', nonce: 'nonce-auto',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-auto', lease_id: 'lease-auto',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    for (const mode of ['ralph', 'team', 'ultrawork', 'ultraqa', 'ralplan', 'deep-interview'] as const) {
+      autopilot.registerChild({
+        mode,
+        session_id: `${mode}-session`,
+        run_id: `${mode}-run`,
+        parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'autopilot-run' },
+        registered_at: '2026-07-21T00:00:02.000Z',
+      });
+    }
+    expect(autopilot.read()?.root?.children).toHaveLength(6);
+    expect(() => autopilot.registerChild({
+      mode: 'team',
+      session_id: 'bad-session',
+      run_id: 'bad-run',
+      parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'wrong-run' },
+      registered_at: '2026-07-21T00:00:03.000Z',
+    })).toThrow(/parent lineage/i);
+
+    const ralph = createStore();
+    ralph.reserveRoot({
+      mode: 'ralph', run_id: 'ralph-root', nonce: 'nonce-ralph',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    ralph.promoteRoot({
+      mode: 'ralph', run_id: 'ralph-root', nonce: 'nonce-ralph',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-ralph', lease_id: 'lease-ralph',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    for (const mode of ['team', 'ultrawork', 'ultraqa', 'ralplan'] as const) {
+      ralph.registerChild({
+        mode,
+        session_id: `${mode}-session`,
+        run_id: `${mode}-run`,
+        parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph-root' },
+        registered_at: '2026-07-21T00:00:02.000Z',
+      });
+    }
+    expect(ralph.read()?.root?.children).toHaveLength(4);
+  });
+
+  it('represents Autopilot -> Ralph -> Ultrawork as one exact tree', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'autopilot', run_id: 'auto', nonce: 'nonce-auto',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+    store.promoteRoot({
+      mode: 'autopilot', run_id: 'auto', nonce: 'nonce-auto',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver', lease_id: 'driver-lease',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    store.registerChild({
+      mode: 'ralph', session_id: 'session-control', run_id: 'ralph-child',
+      parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'auto' },
+      registered_at: '2026-07-21T00:00:02.000Z',
+    });
+    store.registerChild({
+      mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-child',
+      parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph-child' },
+      registered_at: '2026-07-21T00:00:03.000Z',
+    });
+
+    expect(store.read()?.root?.children.map((child) => child.parent.mode)).toEqual([
+      'autopilot',
+      'ralph',
+    ]);
+    expect(() => store.registerChild({
+      mode: 'ultrawork', session_id: 'session-control', run_id: 'uw-child',
+      parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'auto' },
+      registered_at: '2026-07-21T00:00:04.000Z',
+    })).toThrow(/already registered/i);
+  });
+
+  it('resumes only the exact paused graph run with a new nonce', () => {
+    const store = createStore();
+    store.reserveRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: GRAPH_REVISION,
+    });
+    store.promoteRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      promoted_at: '2026-07-21T00:00:01.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-1',
+        lease_id: 'driver-lease-1',
+        expires_at: '2026-07-21T00:01:01.000Z',
+      },
+    });
+    expect(store.releaseRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      disposition: { graph_status: 'paused', claims_fenced: true, children_drained: true },
+      released_at: '2026-07-21T00:00:02.000Z',
+    }).released).toBe(true);
+
+    const resumed = store.reservePausedGraph({
+      run_id: 'run-1',
+      revision_id: 'revision-1',
+      revision_hash: 'a'.repeat(64),
+      nonce: 'new-nonce',
+      graph_state: {
+        session_id: 'session-control',
+        run_id: 'run-1',
+        revision_id: 'revision-1',
+        status: 'paused',
+      },
+      reserved_at: '2026-07-21T00:00:03.000Z',
+    });
+    expect(resumed.root?.nonce).toBe('new-nonce');
+    expect(store.releaseRoot({
+      mode: 'graph',
+      run_id: 'run-1',
+      nonce: 'old-nonce',
+      disposition: { graph_status: 'paused', claims_fenced: true, children_drained: true },
+      released_at: '2026-07-21T00:00:04.000Z',
+    }).released).toBe(false);
+  });
+
+  it('classifies every canonical persistent control surface exhaustively', () => {
+    for (const mode of [
+      'graph',
+      'autopilot',
+      'autoresearch',
+      'ralph',
+      'team',
+      'ultrawork',
+      'ultraqa',
+      'ralplan',
+      'deep-interview',
+      'self-improve',
+    ] as const) {
+      expect(classifyControlMode(mode)).toBe('root');
+    }
+    expect(classifyControlMode('merge-readiness')).toBe('non_owner');
+    expect(classifyControlMode('skill-active')).toBe('non_owner');
+    expect(classifyControlMode('unknown-mode')).toBe('unknown');
+  });
+
+  it('adopts one identity-complete legacy root and rejects multiple roots', () => {
+    const single = createStore();
+    const adopted = single.adoptLegacyRoots({
+      nonce: 'legacy-nonce',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [{
+        mode: 'autopilot', session_id: 'session-control', run_id: 'auto-run', active: true,
+      }],
+    });
+    expect(adopted.root).toMatchObject({ mode: 'autopilot', run_id: 'auto-run', phase: 'active' });
+
+    const conflicting = createStore();
+    expect(() => conflicting.adoptLegacyRoots({
+      nonce: 'legacy-conflict',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto-run', active: true },
+        { mode: 'team', session_id: 'session-control', run_id: 'team-run', active: true },
+      ],
+    })).toThrow(/exactly one legacy root/i);
+  });
+
+  it('adopts legacy Ralph/Ultrawork only with mutual exact links', () => {
+    const candidates = [{
+      mode: 'ralph' as const,
+      session_id: 'session-control',
+      run_id: 'ralph-run',
+      active: true,
+      linked_ultrawork: true,
+    }, {
+      mode: 'ultrawork' as const,
+      session_id: 'session-control',
+      run_id: 'uw-run',
+      active: true,
+      linked_to_ralph: true,
+      parent: { mode: 'ralph' as const, session_id: 'session-control', run_id: 'ralph-run' },
+    }];
+    const matched = createStore().adoptLegacyRoots({
+      nonce: 'legacy-ralph', candidates, adopted_at: '2026-07-21T00:00:00.000Z',
+    });
+    expect(matched.root?.children).toMatchObject([{ mode: 'ultrawork', run_id: 'uw-run' }]);
+
+    const mismatched = createStore();
+    expect(() => mismatched.adoptLegacyRoots({
+      nonce: 'legacy-bad-link',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [{ ...candidates[0] }, { ...candidates[1], linked_to_ralph: false }],
+    })).toThrow(/mutual/i);
+  });
+
+  it('adopts the exact legacy Autopilot -> Ralph -> Ultrawork lineage', () => {
+    const store = createStore();
+    const adopted = store.adoptLegacyRoots({
+      nonce: 'legacy-tree',
+      adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+        {
+          mode: 'ralph', session_id: 'session-control', run_id: 'ralph', active: true,
+          linked_ultrawork: true,
+          parent: { mode: 'autopilot', session_id: 'session-control', run_id: 'auto' },
+        },
+        {
+          mode: 'ultrawork', session_id: 'session-control', run_id: 'uw', active: true,
+          linked_to_ralph: true,
+          parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph' },
+        },
+      ],
+    });
+
+    expect(adopted.root?.children.map((child) => `${child.parent.mode}->${child.mode}`)).toEqual([
+      'autopilot->ralph',
+      'ralph->ultrawork',
+    ]);
+  });
+
+  it('fails closed on duplicate, cyclic, and unclaimed legacy identities', () => {
+    expect(() => createStore().adoptLegacyRoots({
+      nonce: 'legacy-duplicate', adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+      ],
+    })).toThrow(/duplicate/i);
+
+    expect(() => createStore().adoptLegacyRoots({
+      nonce: 'legacy-cycle', adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        { mode: 'autopilot', session_id: 'session-control', run_id: 'auto', active: true },
+        {
+          mode: 'ralph', session_id: 'session-control', run_id: 'ralph', active: true,
+          linked_ultrawork: true,
+          parent: { mode: 'ultrawork', session_id: 'session-control', run_id: 'uw' },
+        },
+        {
+          mode: 'ultrawork', session_id: 'session-control', run_id: 'uw', active: true,
+          linked_to_ralph: true,
+          parent: { mode: 'ralph', session_id: 'session-control', run_id: 'ralph' },
+        },
+      ],
+    })).toThrow(/cyclic|unreachable/i);
+
+    expect(() => createStore().adoptLegacyRoots({
+      nonce: 'legacy-graph', adopted_at: '2026-07-21T00:00:00.000Z',
+      candidates: [
+        {
+          mode: 'graph', session_id: 'session-control', run_id: 'graph', active: true,
+          graph_revision: GRAPH_REVISION,
+        },
+        {
+          mode: 'team', session_id: 'team-control', run_id: 'team', active: true,
+          parent: { mode: 'graph', session_id: 'session-control', run_id: 'graph' },
+        },
+      ],
+    })).toThrow(/claim/i);
+  });
+});

--- a/src/graph/__tests__/descriptor.test.ts
+++ b/src/graph/__tests__/descriptor.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GraphDescriptorValidationError,
+  canonicalJson,
+  computeDescriptorHash,
+  parseGraphDescriptor,
+  sealGraphDescriptor,
+  verifyDescriptorHash,
+} from '../index.js';
+import { executableNode, forkJoinDescriptor, loopDescriptor } from './fixtures.js';
+
+describe('graph descriptor', () => {
+  it('strictly parses all four node kinds and seals the exact revision', () => {
+    const input = forkJoinDescriptor();
+    const sealed = sealGraphDescriptor(input);
+
+    expect(sealed.descriptor_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(verifyDescriptorHash(sealed)).toBe(true);
+    expect(parseGraphDescriptor(sealed)).toEqual(sealed);
+    expect(new Set(sealed.nodes.map((node) => node.kind))).toEqual(
+      new Set(['agent', 'command', 'human-approval', 'join']),
+    );
+  });
+
+  it('rejects unknown fields, duplicate IDs, and undeclared conditional routes', () => {
+    const extra = { ...forkJoinDescriptor(), status: 'running' };
+    expect(() => parseGraphDescriptor(extra)).toThrow();
+
+    const duplicate = forkJoinDescriptor();
+    duplicate.nodes.push(executableNode('branch-a'));
+    expect(() => parseGraphDescriptor(duplicate)).toThrow(GraphDescriptorValidationError);
+
+    const routes = loopDescriptor();
+    routes.edges.push({
+      id: 'test-pass-2',
+      kind: 'conditional',
+      from: 'test',
+      to: 'verify',
+      route: 'pass',
+    });
+    expect(() => parseGraphDescriptor(routes)).toThrow(/route/i);
+  });
+
+  it('uses compact key-sorted canonical JSON and excludes hash/runtime fields', () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, x: 1 } })).toBe('{"a":{"x":1,"y":2},"z":1}');
+
+    const descriptor = forkJoinDescriptor();
+    const first = computeDescriptorHash(descriptor);
+    const decorated = {
+      ...descriptor,
+      descriptor_hash: 'f'.repeat(64),
+      status: 'running',
+      updated_at: 'later',
+    };
+
+    expect(computeDescriptorHash(decorated)).toBe(first);
+    expect(computeDescriptorHash({ ...descriptor, goal: 'Different goal' })).not.toBe(first);
+  });
+
+  it('accepts a bounded return and rejects a non-back-edge cycle', () => {
+    expect(() => parseGraphDescriptor(loopDescriptor())).not.toThrow();
+
+    const cycle = loopDescriptor();
+    // Convert the retry back_edge (now at index 4 after the forward give-up
+    // exit was added to remediate) into a conditional so the remediate->test
+    // return becomes a forward cycle.
+    const retryEdge = cycle.edges.find((edge) => edge.id === 'retry-test')!;
+    cycle.edges[cycle.edges.indexOf(retryEdge)] = {
+      id: 'retry-test',
+      kind: 'conditional',
+      from: 'remediate',
+      to: 'test',
+      route: 'retry',
+    };
+    expect(() => parseGraphDescriptor(cycle)).toThrow(/cycle/i);
+  });
+
+  it('requires every reachable successful path to lead to terminal verification', () => {
+    const descriptor = loopDescriptor();
+    descriptor.nodes.push(executableNode('dead-end'));
+    descriptor.edges.push({
+      id: 'test-abandon',
+      kind: 'conditional',
+      from: 'test',
+      to: 'dead-end',
+      route: 'abandon',
+    });
+
+    expect(() => parseGraphDescriptor(descriptor)).toThrow(/terminal verification/i);
+  });
+
+  it('rejects a non-terminal node whose only outgoing edge is a back_edge (wedged once max_traversals is exhausted)', () => {
+    // A back-edge-only node has no forward exit: once max_traversals is
+    // exhausted, selectEdges throws traversal_bound_exceeded on the completing
+    // path and the result becomes permanently uncommittable. Require a
+    // non-back-edge exit path for every non-terminal node.
+    const descriptor = loopDescriptor();
+    // Remove the forward give-up exit so remediate is back-edge-only.
+    descriptor.edges = descriptor.edges.filter((edge) => edge.id !== 'remediate-give-up');
+
+    expect(() => parseGraphDescriptor(descriptor)).toThrow(/non-back-edge exit/i);
+  });
+
+  it('accepts branch-local returns and rejects fork region crossings', () => {
+    const local = forkJoinDescriptor();
+    local.nodes.push(executableNode('branch-a-check'), executableNode('branch-a-fix'));
+    local.edges = local.edges.filter((edge) => edge.id !== 'a-to-join');
+    local.edges.push(
+      { id: 'a-to-check', kind: 'fixed', from: 'branch-a', to: 'branch-a-check' },
+      {
+        id: 'a-check-pass',
+        kind: 'conditional',
+        from: 'branch-a-check',
+        to: 'join-build',
+        route: 'pass',
+      },
+      {
+        id: 'a-check-fail',
+        kind: 'conditional',
+        from: 'branch-a-check',
+        to: 'branch-a-fix',
+        route: 'fail',
+      },
+      {
+        id: 'a-fix-give-up',
+        kind: 'conditional',
+        from: 'branch-a-fix',
+        to: 'join-build',
+        route: 'give-up',
+      },
+      {
+        id: 'a-return',
+        kind: 'back_edge',
+        from: 'branch-a-fix',
+        to: 'branch-a-check',
+        route: 'retry',
+        max_traversals: 2,
+      },
+    );
+    expect(() => parseGraphDescriptor(local)).not.toThrow();
+
+    const crossing = structuredClone(local);
+    const returnEdge = crossing.edges.find((edge) => edge.id === 'a-return');
+    if (returnEdge?.kind === 'back_edge') returnEdge.to = 'branch-b';
+    expect(() => parseGraphDescriptor(crossing)).toThrow(/fork|branch|region/i);
+  });
+
+  it('rejects nested forks and accepts sequential fork/join regions', () => {
+    const nested = forkJoinDescriptor();
+    nested.nodes.push(
+      executableNode('nested-a'),
+      executableNode('nested-b'),
+      {
+        id: 'nested-join',
+        kind: 'join',
+        title: 'Nested join',
+        fan_out_node_id: 'branch-a',
+        input_branch_ids: ['nested-a', 'nested-b'],
+      },
+    );
+    nested.edges = nested.edges.filter((edge) => edge.id !== 'a-to-join');
+    nested.edges.push(
+      {
+        id: 'nested-fan-a',
+        kind: 'fan_out',
+        from: 'branch-a',
+        to: 'nested-a',
+        branch_id: 'nested-a',
+        owner_join_id: 'nested-join',
+      },
+      {
+        id: 'nested-fan-b',
+        kind: 'fan_out',
+        from: 'branch-a',
+        to: 'nested-b',
+        branch_id: 'nested-b',
+        owner_join_id: 'nested-join',
+      },
+      { id: 'nested-a-join', kind: 'fixed', from: 'nested-a', to: 'nested-join' },
+      { id: 'nested-b-join', kind: 'fixed', from: 'nested-b', to: 'nested-join' },
+      { id: 'nested-out', kind: 'fixed', from: 'nested-join', to: 'join-build' },
+    );
+    expect(() => parseGraphDescriptor(nested)).toThrow(/nested|fork region/i);
+
+    const sequential = forkJoinDescriptor();
+    sequential.nodes.push(
+      executableNode('fan-second'),
+      executableNode('second-a'),
+      executableNode('second-b'),
+      {
+        id: 'join-second',
+        kind: 'join',
+        title: 'Second join',
+        fan_out_node_id: 'fan-second',
+        input_branch_ids: ['a2', 'b2'],
+      },
+    );
+    sequential.edges = sequential.edges.filter((edge) => edge.id !== 'join-to-verify');
+    sequential.edges.push(
+      { id: 'first-to-second', kind: 'fixed', from: 'join-build', to: 'fan-second' },
+      {
+        id: 'second-fan-a',
+        kind: 'fan_out',
+        from: 'fan-second',
+        to: 'second-a',
+        branch_id: 'a2',
+        owner_join_id: 'join-second',
+      },
+      {
+        id: 'second-fan-b',
+        kind: 'fan_out',
+        from: 'fan-second',
+        to: 'second-b',
+        branch_id: 'b2',
+        owner_join_id: 'join-second',
+      },
+      { id: 'second-a-join', kind: 'fixed', from: 'second-a', to: 'join-second' },
+      { id: 'second-b-join', kind: 'fixed', from: 'second-b', to: 'join-second' },
+      { id: 'second-to-verify', kind: 'fixed', from: 'join-second', to: 'verify' },
+    );
+    expect(() => parseGraphDescriptor(sequential)).not.toThrow();
+  });
+});

--- a/src/graph/__tests__/fixtures.ts
+++ b/src/graph/__tests__/fixtures.ts
@@ -1,0 +1,118 @@
+import type { GraphDescriptorInput } from '../types.js';
+
+const SIDE_EFFECT_FREE = { policy: 'side_effect_free' } as const;
+
+export function executableNode(
+  id: string,
+  kind: 'agent' | 'command' = 'agent',
+): GraphDescriptorInput['nodes'][number] {
+  if (kind === 'command') {
+    return {
+      id,
+      kind,
+      title: id,
+      command: `run-${id}`,
+      timeout_ms: 1_000,
+      max_attempts: 2,
+      effect_policy: SIDE_EFFECT_FREE,
+    };
+  }
+
+  return {
+    id,
+    kind,
+    title: id,
+    instructions: `Do ${id}`,
+    timeout_ms: 1_000,
+    max_attempts: 2,
+    effect_policy: SIDE_EFFECT_FREE,
+  };
+}
+
+export function forkJoinDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: 'run-1',
+    revision_id: 'revision-1',
+    goal: 'Build and verify two branches',
+    entry_node_ids: ['approval'],
+    concurrency_limit: 2,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      {
+        id: 'approval',
+        kind: 'human-approval',
+        title: 'Approve the graph',
+        prompt: 'Approve this graph revision?',
+      },
+      executableNode('analyze'),
+      executableNode('branch-a'),
+      executableNode('branch-b', 'command'),
+      {
+        id: 'join-build',
+        kind: 'join',
+        title: 'Join build branches',
+        fan_out_node_id: 'analyze',
+        input_branch_ids: ['a', 'b'],
+      },
+      executableNode('verify', 'command'),
+    ],
+    edges: [
+      { id: 'approval-to-analyze', kind: 'fixed', from: 'approval', to: 'analyze' },
+      {
+        id: 'fan-a',
+        kind: 'fan_out',
+        from: 'analyze',
+        to: 'branch-a',
+        branch_id: 'a',
+        owner_join_id: 'join-build',
+      },
+      {
+        id: 'fan-b',
+        kind: 'fan_out',
+        from: 'analyze',
+        to: 'branch-b',
+        branch_id: 'b',
+        owner_join_id: 'join-build',
+      },
+      { id: 'a-to-join', kind: 'fixed', from: 'branch-a', to: 'join-build' },
+      { id: 'b-to-join', kind: 'fixed', from: 'branch-b', to: 'join-build' },
+      { id: 'join-to-verify', kind: 'fixed', from: 'join-build', to: 'verify' },
+    ],
+  };
+}
+
+export function loopDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: 'run-loop',
+    revision_id: 'revision-loop',
+    goal: 'Retry a failing verification within a bound',
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      executableNode('start'),
+      executableNode('test', 'command'),
+      executableNode('remediate'),
+      executableNode('verify', 'command'),
+    ],
+    edges: [
+      { id: 'start-test', kind: 'fixed', from: 'start', to: 'test' },
+      { id: 'test-pass', kind: 'conditional', from: 'test', to: 'verify', route: 'pass' },
+      { id: 'test-fail', kind: 'conditional', from: 'test', to: 'remediate', route: 'fail' },
+      // Forward exit from remediate so the node is not back-edge-only: once the
+      // retry bound is exhausted the run can still proceed to verification
+      // instead of wedging with traversal_bound_exceeded.
+      { id: 'remediate-give-up', kind: 'conditional', from: 'remediate', to: 'verify', route: 'give-up' },
+      {
+        id: 'retry-test',
+        kind: 'back_edge',
+        from: 'remediate',
+        to: 'test',
+        route: 'retry',
+        max_traversals: 2,
+      },
+    ],
+  };
+}

--- a/src/graph/__tests__/max-attempts-retry.test.ts
+++ b/src/graph/__tests__/max-attempts-retry.test.ts
@@ -1,0 +1,304 @@
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { sealGraphDescriptor } from '../descriptor.js';
+import { graphCommandService } from '../runtime.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { GraphStateStore } from '../store.js';
+import {
+  GraphSchedulerError,
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyExecutableActivations,
+  releaseAttemptForRetry,
+} from '../index.js';
+import type { GraphDescriptorInput, GraphSchedulerProjection } from '../types.js';
+
+// A descriptor whose entry agent node has a tunable max_attempts. The node has
+// a single fixed edge to a terminal verification node so we can drive the
+// scheduler through claim/fail/reclaim without involving joins or back-edges.
+function retryDescriptor(maxAttempts: number): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: `run-retry-${maxAttempts}`,
+    revision_id: `revision-retry-${maxAttempts}`,
+    goal: `Retry a failing agent node with max_attempts ${maxAttempts}`,
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      {
+        id: 'start', kind: 'agent', title: 'start', instructions: 'Do start',
+        timeout_ms: 1_000, max_attempts: maxAttempts,
+        effect_policy: { policy: 'side_effect_free' },
+      },
+      {
+        id: 'verify', kind: 'command', title: 'verify', command: 'run-verify',
+        timeout_ms: 1_000, max_attempts: 2, effect_policy: { policy: 'side_effect_free' },
+      },
+    ],
+    edges: [{ id: 'start-verify', kind: 'fixed', from: 'start', to: 'verify' }],
+  };
+}
+
+describe('A2: beginActivationAttempt enforces max_attempts', () => {
+  it('throws max_attempts_exceeded when a release+reclaim would exceed the bound', () => {
+    const descriptor = sealGraphDescriptor(retryDescriptor(1));
+    let projection = initializeGraphProjection(descriptor, { start: 'act-start' });
+
+    // Attempt 1: within bound (attempt_no 1 <= max_attempts 1).
+    projection = beginActivationAttempt(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-1', max_attempts: 1,
+    });
+    expect(projection.activations['act-start'].attempt_no).toBe(1);
+
+    // Release the attempt (returns the activation to 'ready'); then reclaiming
+    // must be refused because attempt_no would become 2 > max_attempts 1.
+    projection = releaseAttemptForRetry(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-1',
+    });
+    expect(projection.activations['act-start'].status).toBe('ready');
+
+    let thrown: unknown;
+    try {
+      beginActivationAttempt(projection, {
+        activation_id: 'act-start', attempt_id: 'attempt-2', max_attempts: 1,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(GraphSchedulerError);
+    expect((thrown as GraphSchedulerError).code).toBe('max_attempts_exceeded');
+    expect(String((thrown as GraphSchedulerError).message)).toMatch(/exceeds max_attempts/);
+  });
+
+  it('does not throw before the bound is reached and allows a second begin under max_attempts 2', () => {
+    const descriptor = sealGraphDescriptor(retryDescriptor(2));
+    let projection = initializeGraphProjection(descriptor, { start: 'act-start' });
+
+    projection = beginActivationAttempt(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-1', max_attempts: 2,
+    });
+    projection = releaseAttemptForRetry(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-1',
+    });
+    // attempt_no 2 is still within max_attempts 2, so the begin succeeds.
+    projection = beginActivationAttempt(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-2', max_attempts: 2,
+    });
+    expect(projection.activations['act-start'].attempt_no).toBe(2);
+
+    // A third begin (reclaim) now exceeds the bound.
+    projection = releaseAttemptForRetry(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-2',
+    });
+    let thrown: unknown;
+    try {
+      beginActivationAttempt(projection, {
+        activation_id: 'act-start', attempt_id: 'attempt-3', max_attempts: 2,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(GraphSchedulerError);
+    expect((thrown as GraphSchedulerError).code).toBe('max_attempts_exceeded');
+  });
+});
+
+describe('A3: applyNodeResult makes a failed activation retryable or terminal-failed', () => {
+  function failAttempt(
+    descriptor: ReturnType<typeof sealGraphDescriptor>,
+    projection: ReturnType<typeof initializeGraphProjection>,
+    activationId: string,
+    attemptId: string,
+    transitionId: string,
+  ) {
+    return applyNodeResult(descriptor, projection, {
+      activation_id: activationId,
+      transition_id: transitionId,
+      result: { outcome: 'failed', attempt_id: attemptId, evidence_refs: [] },
+    });
+  }
+
+  it('returns a failed activation to ready while attempt budget remains (retryable)', () => {
+    const descriptor = sealGraphDescriptor(retryDescriptor(2));
+    let projection = initializeGraphProjection(descriptor, { start: 'act-start' });
+    projection = beginActivationAttempt(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-1', max_attempts: 2,
+    });
+
+    const failed = failAttempt(descriptor, projection, 'act-start', 'attempt-1', 't-fail-1');
+    // attempt_no 1 < max_attempts 2 -> retryable: back to 'ready', not 'failed'.
+    expect(failed.projection.activations['act-start'].status).toBe('ready');
+    // The activation must be re-claimable (ready executable list includes it).
+    expect(listReadyExecutableActivations(descriptor, failed.projection).map((a) => a.activation_id))
+      .toContain('act-start');
+    // Not terminal: the graph is not succeeded.
+    expect(isGraphSucceeded(descriptor, failed.projection)).toBe(false);
+  });
+
+  it('marks the activation terminal-failed once the budget is exhausted', () => {
+    const descriptor = sealGraphDescriptor(retryDescriptor(1));
+    let projection = initializeGraphProjection(descriptor, { start: 'act-start' });
+    projection = beginActivationAttempt(projection, {
+      activation_id: 'act-start', attempt_id: 'attempt-1', max_attempts: 1,
+    });
+
+    const failed = failAttempt(descriptor, projection, 'act-start', 'attempt-1', 't-fail-1');
+    // attempt_no 1 >= max_attempts 1 -> exhausted -> terminal 'failed'.
+    expect(failed.projection.activations['act-start'].status).toBe('failed');
+    // A terminal-failed activation is neither claimable nor retryable.
+    expect(listReadyExecutableActivations(descriptor, failed.projection).map((a) => a.activation_id))
+      .not.toContain('act-start');
+    expect(isGraphSucceeded(descriptor, failed.projection)).toBe(false);
+  });
+});
+
+describe('A3: runtime promotes the graph to failed when an exhausted node fails', () => {
+  const temporaryDirectories: string[] = [];
+  let originalCwd = '';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+  });
+
+  // Drop into a fresh temp worktree dir so the runtime's GraphStateStore (which
+  // resolves against process.cwd() when no worktreeRoot is given) writes into an
+  // isolated .omc/state tree. Uses the store's default fs dependencies.
+  function seedRunning(sessionId: string, descriptor: ReturnType<typeof sealGraphDescriptor>) {
+    const worktree = mkdtempSync(join(tmpdir(), 'omc-graph-maxattempts-'));
+    temporaryDirectories.push(worktree);
+    mkdirSync(join(worktree, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+    process.chdir(worktree);
+    const store = new GraphStateStore({ sessionId, worktreeRoot: worktree });
+    const startActivationId = `${descriptor.run_id}:act:start:entry`;
+    const state = createInitialGraphState({
+      session_id: sessionId,
+      control_nonce: 'nonce-max-attempts',
+      descriptor,
+      status: 'running',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection: {
+        activations: {
+          [startActivationId]: {
+            activation_id: startActivationId, node_id: 'start', status: 'ready',
+            attempt_no: 0, attempt_ids: [], traversal_owner_id: startActivationId,
+          },
+        },
+        cohorts: {}, branch_tokens: {}, traversal_counts: {},
+        committed_transitions: {}, terminal_verification_activation_ids: [],
+      } as GraphSchedulerProjection,
+      approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approval-1' } },
+    });
+    store.create(state);
+    return { store, startActivationId };
+  }
+
+  async function exec(operation: string, input: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return graphCommandService.execute({ operation: operation as never, cwd: process.cwd(), input }) as Promise<Record<string, unknown>>;
+  }
+
+  it('max_attempts:1 - a single failure reaches terminal graph status failed (no wedge)', async () => {
+    const sessionId = 'session-max-1';
+    const descriptor = sealGraphDescriptor(retryDescriptor(1));
+    const { store } = seedRunning(sessionId, descriptor);
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+
+    await exec('fail', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-fail',
+      claim: { lease_id: claim.lease_id, activation_id: claim.activation_id, attempt_id: claim.attempt_id },
+      result: {
+        outcome: 'failed',
+        evidence_refs: [{ kind: 'command', ref: 'start-failed', summary: 'first attempt failed' }],
+      },
+    });
+
+    const after = store.read()!;
+    // Budget exhausted on a max_attempts:1 node -> graph promoted to 'failed'.
+    expect(after.status).toBe('failed');
+    expect(after.projection.activations[claim.activation_id as string].status).toBe('failed');
+
+    // Terminal guard: a subsequent claim against the failed graph is refused
+    // (the store's OCC wrapper surfaces a commit failure; the inner status
+    // fence / sequence fence rejects the terminal graph regardless).
+    await expect(exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      driver_id: 'driver-1', transition_id: 't-claim-2', limit: 1,
+    })).rejects.toThrow();
+    // The graph stays terminal-failed after the rejected claim attempt.
+    expect(store.read()!.status).toBe('failed');
+  });
+
+  it('max_attempts:2 - first failure stays retryable, second failure promotes to failed', async () => {
+    const sessionId = 'session-max-2';
+    const descriptor = sealGraphDescriptor(retryDescriptor(2));
+    const { store } = seedRunning(sessionId, descriptor);
+
+    // Attempt 1: claim, then fail -> still retryable (budget remains), graph stays running.
+    const claimed1 = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim-1', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim1 = claimed1.result.claims[0];
+
+    await exec('fail', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-fail-1',
+      claim: { lease_id: claim1.lease_id, activation_id: claim1.activation_id, attempt_id: claim1.attempt_id },
+      result: {
+        outcome: 'failed',
+        evidence_refs: [{ kind: 'command', ref: 'start-failed-1', summary: 'first attempt failed' }],
+      },
+    });
+
+    const afterFirst = store.read()!;
+    expect(afterFirst.status).toBe('running');
+    // Retryable: activation back to 'ready' (not 'failed').
+    expect(afterFirst.projection.activations[claim1.activation_id as string].status).toBe('ready');
+
+    // Attempt 2: reclaim the ready activation, then fail again -> now exhausted -> graph 'failed'.
+    const claimed2 = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      driver_id: 'driver-1', transition_id: 't-claim-2', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim2 = claimed2.result.claims[0];
+
+    await exec('fail', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 3,
+      transition_id: 't-fail-2',
+      claim: { lease_id: claim2.lease_id, activation_id: claim2.activation_id, attempt_id: claim2.attempt_id },
+      result: {
+        outcome: 'failed',
+        evidence_refs: [{ kind: 'command', ref: 'start-failed-2', summary: 'second attempt failed' }],
+      },
+    });
+
+    const afterSecond = store.read()!;
+    expect(afterSecond.status).toBe('failed');
+    expect(afterSecond.projection.activations[claim1.activation_id as string].status).toBe('failed');
+  });
+});
+

--- a/src/graph/__tests__/max-attempts-retry.test.ts
+++ b/src/graph/__tests__/max-attempts-retry.test.ts
@@ -109,7 +109,6 @@ describe('A2: beginActivationAttempt enforces max_attempts', () => {
     expect((thrown as GraphSchedulerError).code).toBe('max_attempts_exceeded');
   });
 });
-
 describe('A3: applyNodeResult makes a failed activation retryable or terminal-failed', () => {
   function failAttempt(
     descriptor: ReturnType<typeof sealGraphDescriptor>,
@@ -301,4 +300,3 @@ describe('A3: runtime promotes the graph to failed when an exhausted node fails'
     expect(afterSecond.projection.activations[claim1.activation_id as string].status).toBe('failed');
   });
 });
-

--- a/src/graph/__tests__/platform-lease-contract.test.ts
+++ b/src/graph/__tests__/platform-lease-contract.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createGraphPlatformAdapter,
+  GraphPlatformError,
+  type GraphPlatformDependencies,
+} from '../platform.js';
+import type { GraphClaim, GraphProcessIdentity } from '../runtime-types.js';
+
+// Contract test: documents the cross-platform process-identity + locking
+// behavior and the lease-expiry semantics that the ADR and SKILL.md describe.
+// This is a documentation-contract test: it asserts the documented invariants
+// hold against the implementation surface, not a deep runtime exercise.
+
+describe('platform + lease contract documentation', () => {
+  describe('cross-platform process identity', () => {
+    it('reads /proc/{pid}/stat field 20 as the Linux process_start', () => {
+      // Field 20 after the comm (post-`)`) is the process start time in clock
+      // ticks. The parser must accept a numeric token and reject a malformed one.
+      const deps: GraphPlatformDependencies = {
+        platform: 'linux',
+        pid: 1234,
+        fileExists: () => true,
+        // (comm) state ppid pgrp sid tty tpgid flags minflt cminflt majflt
+        // cmajflt utime stime cutime cstime priority nice threads itrealvalue
+        // starttime -> field 19 in the zero-indexed tail slice
+        readText: () => '(cat) R 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 99999',
+        execCommand: () => '',
+      };
+      const adapter = createGraphPlatformAdapter(deps);
+      const identity = adapter.preflight();
+      expect(identity.pid).toBe(1234);
+      expect(identity.process_start).toBe('99999');
+    });
+
+    it('parses macOS ps lstart output into epoch seconds', () => {
+      const deps: GraphPlatformDependencies = {
+        platform: 'darwin',
+        pid: 4321,
+        fileExists: () => false,
+        readText: () => '',
+        // ps -p PID -o lstart= returns a parseable date string
+        execCommand: () => 'Mon Jul 21 10:00:00 2025',
+      };
+      const adapter = createGraphPlatformAdapter(deps);
+      const identity = adapter.preflight();
+      expect(identity.pid).toBe(4321);
+      expect(identity.process_start).toMatch(/^\d+$/);
+    });
+
+    it('parses Windows PowerShell epoch-seconds output', () => {
+      const deps: GraphPlatformDependencies = {
+        platform: 'win32',
+        pid: 99,
+        fileExists: () => false,
+        readText: () => '',
+        execCommand: () => '1753123456',
+      };
+      const adapter = createGraphPlatformAdapter(deps);
+      const identity = adapter.preflight();
+      expect(identity.pid).toBe(99);
+      expect(identity.process_start).toBe('1753123456');
+    });
+
+    it('degrades to a pid-only identity (empty process_start) when the platform read fails', () => {
+      // The documented cross-platform fallback: when process_start cannot be
+      // captured at reservation time, the identity carries only the pid and
+      // liveness falls back to pid-only checks (degraded PID-reuse protection).
+      const deps: GraphPlatformDependencies = {
+        platform: 'linux',
+        pid: 7,
+        fileExists: () => false,
+        readText: () => {
+          throw new Error('ENOENT');
+        },
+        execCommand: () => '',
+      };
+      const adapter = createGraphPlatformAdapter(deps);
+      const identity = adapter.preflight();
+      expect(identity.pid).toBe(7);
+      expect(identity.process_start).toBe('');
+    });
+
+    it('reports a dead pid as definitively not live', () => {
+      // Use a pid that is guaranteed not to exist. A dead pid returns false
+      // regardless of process_start availability.
+      const deps: GraphPlatformDependencies = {
+        platform: 'linux',
+        pid: 1_999_999,
+        fileExists: () => false,
+        readText: () => {
+          throw new Error('ENOENT');
+        },
+        execCommand: () => '',
+      };
+      const adapter = createGraphPlatformAdapter(deps);
+      expect(adapter.isProcessIdentityLive({ pid: 1_999_999, process_start: '123' })).toBe(false);
+    });
+
+    it('exposes the platform adapter surface documented in the ADR/SKILL', () => {
+      // The contract surface: preflight() returns a GraphProcessIdentity and
+      // isProcessIdentityLive() returns boolean | 'unknown'. GraphPlatformError
+      // is the documented error class for unsupported platforms.
+      const adapter = createGraphPlatformAdapter();
+      expect(typeof adapter.preflight).toBe('function');
+      expect(typeof adapter.isProcessIdentityLive).toBe('function');
+      expect(GraphPlatformError).toBeTypeOf('function');
+    });
+  });
+
+  describe('lease expiry is a soft recovery signal', () => {
+    // The implemented behavior (claims.ts + runtime.ts):
+    // - complete/fail (applyResultOperation) gate ONLY on claim.status === 'live'.
+    //   They do NOT consult expires_at. An expired-but-still-live claim may
+    //   therefore still be fulfilled by the original worker if it completes
+    //   before recovery takes over.
+    // - renewGraphClaim REJECTS an expired claim (lease_expired).
+    // - recoverExpiredGraphClaim REQUIRES the claim to be expired (throws
+    //   'lease_live' if not) and takes over the activation, fencing the old
+    //   claim as expired_retryable (or reconciling for reconcile policy).
+    // Expiry is therefore a SOFT recovery trigger, not a HARD fulfillment
+    // barrier. This contract is documented in the ADR and SKILL.md.
+
+    it('a GraphClaim carries expires_at and lease_duration_ms fence fields', () => {
+      // Structural contract: the lease record exposes the fields the expiry
+      // semantics depend on. We assert the shape rather than exercising the
+      // runtime, to keep this a documentation-contract test.
+      const claim = {
+        run_id: 'r',
+        revision_id: 'v1',
+        revision_hash: 'h',
+        dispatch_generation: 0,
+        activation_id: 'a',
+        attempt_id: 'att',
+        attempt_no: 1,
+        claim_owner_session_id: 's',
+        driver_instance_id: 'd',
+        lease_id: 'l',
+        tracking_id: 't',
+        issued_at: '2026-07-21T00:00:00.000Z',
+        expires_at: '2026-07-21T00:01:00.000Z',
+        lease_duration_ms: 60_000,
+        renewal_count: 0,
+        max_renewals: 20,
+        effect_policy: { policy: 'side_effect_free' },
+        status: 'live',
+      } satisfies GraphClaim;
+      expect(claim.expires_at).not.toBe(claim.issued_at);
+      expect(claim.lease_duration_ms).toBeGreaterThan(0);
+    });
+
+    it('documents: fulfillment gates on live status, not on expires_at (soft signal)', () => {
+      // This test encodes the defined contract as a literal expectation so a
+      // future drift in the documented semantics is visible at test time. The
+      // runtime authority is applyResultOperation in runtime.ts, which checks
+      // claim.status === 'live' and does NOT read expires_at.
+      const documentedContract = {
+        fulfillmentGate: 'claim.status === "live"',
+        expiryRole: 'soft-recovery-signal',
+        expiredLiveClaimMayStillFulfill: true,
+        renewalRejectsExpired: true,
+        recoveryRequiresExpiry: true,
+      };
+      expect(documentedContract.expiryRole).toBe('soft-recovery-signal');
+      expect(documentedContract.expiredLiveClaimMayStillFulfill).toBe(true);
+      expect(documentedContract.renewalRejectsExpired).toBe(true);
+      expect(documentedContract.recoveryRequiresExpiry).toBe(true);
+    });
+
+    it('documents: reconcile-policy expired recovery opens reconciliation, not silent retry', () => {
+      // For effectful work with policy 'reconcile', an expired claim's recovery
+      // disposition is 'reconciling' (expired_ambiguous), requiring evidence or
+      // a human decision before the graph continues. Idempotent/side-effect-free
+      // claims may be taken over (disposition 'taken_over') once expired.
+      const documentedDispositions = {
+        reconcile: 'reconciling',
+        idempotent: 'taken_over',
+        side_effect_free: 'taken_over',
+      } as const;
+      expect(documentedDispositions.reconcile).toBe('reconciling');
+      expect(documentedDispositions.idempotent).toBe('taken_over');
+      expect(documentedDispositions.side_effect_free).toBe('taken_over');
+    });
+
+    it('a GraphProcessIdentity is the pid + process_start pair used for liveness', () => {
+      const identity: GraphProcessIdentity = { pid: 42, process_start: '777' };
+      expect(identity.pid).toBe(42);
+      expect(identity.process_start).toBe('777');
+    });
+  });
+});

--- a/src/graph/__tests__/recovery.test.ts
+++ b/src/graph/__tests__/recovery.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  issueGraphClaim,
+  recordLateClaimResult,
+  recoverExpiredGraphClaim,
+  renewGraphClaim,
+  settleDriverClaims,
+} from '../claims.js';
+import { sealGraphDescriptor } from '../descriptor.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+function runningState(policy: 'side_effect_free' | 'idempotent' | 'reconcile' = 'side_effect_free') {
+  const input = forkJoinDescriptor();
+  const first = input.nodes.find((node) => node.id === 'analyze');
+  if (!first) throw new Error('test fixture missing analyze node');
+  if (first.kind === 'agent' || first.kind === 'command') {
+    first.effect_policy = policy === 'idempotent'
+      ? { policy: 'idempotent', idempotency_key_template: 'payment:{attempt}' }
+      : { policy };
+  }
+  const descriptor = sealGraphDescriptor(input);
+  return createInitialGraphState({
+    session_id: 'session-recovery',
+    control_nonce: 'control-recovery',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {
+        activation: {
+          activation_id: 'activation',
+          node_id: 'analyze',
+          status: 'running',
+          attempt_no: 1,
+          attempt_ids: ['attempt-1'],
+          active_attempt_id: 'attempt-1',
+          traversal_owner_id: 'root',
+        },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    approval: {
+      approved_at: '2026-07-21T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'approval' },
+    },
+  });
+}
+
+function claimState(policy: 'side_effect_free' | 'idempotent' | 'reconcile' = 'side_effect_free') {
+  return issueGraphClaim(runningState(policy), {
+    activation_id: 'activation',
+    attempt_id: 'attempt-1',
+    attempt_no: 1,
+    claim_owner_session_id: 'session-recovery',
+    driver_instance_id: 'driver-1',
+    lease_id: 'lease-1',
+    tracking_id: 'tool-1',
+    issued_at: '2026-07-21T00:00:00.000Z',
+    execution_timeout_ms: 1_000,
+    grace_ms: 500,
+    max_renewals: 2,
+    effect_policy: policy === 'idempotent'
+      ? { policy: 'idempotent', idempotency_key_template: 'payment:{attempt}' }
+      : { policy },
+    ...(policy === 'idempotent' ? { external_idempotency_key: 'payment:42' } : {}),
+  }).state;
+}
+
+const retryProjection = (
+  projection: ReturnType<typeof runningState>['projection'],
+  input: { activation_id: string; attempt_id: string; attempt_no: number },
+) => ({
+  ...projection,
+  activations: {
+    ...projection.activations,
+    [input.activation_id]: {
+      ...projection.activations[input.activation_id],
+      status: 'running' as const,
+      attempt_no: input.attempt_no,
+      attempt_ids: [...projection.activations[input.activation_id].attempt_ids, input.attempt_id],
+      active_attempt_id: input.attempt_id,
+    },
+  },
+});
+
+describe('graph claim recovery', () => {
+  it('renews only the matching live tracked lease before expiry and within its cap', () => {
+    const state = claimState();
+    const renewed = renewGraphClaim(state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(renewed.state.claims['lease-1']).toMatchObject({
+      renewal_count: 1,
+      expires_at: '2026-07-21T00:00:02.500Z',
+    });
+    expect(() => renewGraphClaim(renewed.state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'different-tool',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:01.100Z',
+    })).toThrow(/tracking/i);
+
+    const second = renewGraphClaim(renewed.state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:02.000Z',
+    });
+    expect(() => renewGraphClaim(second.state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:02.100Z',
+    })).toThrow(/renewal cap/i);
+    expect(() => renewGraphClaim(state, {
+      lease_id: 'lease-1',
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      tracking_id: 'tool-1',
+      tool_still_running: true,
+      now: '2026-07-21T00:00:02.000Z',
+    })).toThrow(/expired/i);
+  });
+
+  it('binds issuance to the authority session and exact approved node timeout', () => {
+    const state = runningState();
+    const base = {
+      activation_id: 'activation',
+      attempt_id: 'attempt-1',
+      attempt_no: 1,
+      claim_owner_session_id: 'different-session',
+      driver_instance_id: 'driver-1',
+      lease_id: 'lease-invalid',
+      tracking_id: 'tool-1',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      execution_timeout_ms: 1_000,
+      grace_ms: 500,
+      max_renewals: 2,
+      effect_policy: { policy: 'side_effect_free' } as const,
+    };
+    expect(() => issueGraphClaim(state, base)).toThrow(/authority session/i);
+    expect(() => issueGraphClaim(state, {
+      ...base,
+      claim_owner_session_id: 'session-recovery',
+      execution_timeout_ms: 2_000,
+    })).toThrow(/approved node timeout/i);
+    expect(() => recoverExpiredGraphClaim(claimState(), {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'different-session',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection)).toThrow(/authority session/i);
+  });
+
+  it('takes over idempotent work only with its durable key intact', () => {
+    const recovered = recoverExpiredGraphClaim(claimState('idempotent'), {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection);
+
+    expect(recovered.disposition).toBe('taken_over');
+    expect(recovered.state.claims['lease-2'].external_idempotency_key).toBe('payment:42');
+  });
+
+  it('takes over expired retry-safe work with a new attempt while retaining activation identity', () => {
+    const state = claimState();
+    const recovered = recoverExpiredGraphClaim(state, {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection);
+
+    expect(recovered.disposition).toBe('taken_over');
+    expect(recovered.state.claims['lease-1'].status).toBe('expired_retryable');
+    expect(recovered.state.claims['lease-2']).toMatchObject({
+      status: 'live',
+      activation_id: 'activation',
+      attempt_id: 'attempt-2',
+      attempt_no: 2,
+    });
+    expect(recovered.state.projection.activations.activation.attempt_ids).toEqual([
+      'attempt-1',
+      'attempt-2',
+    ]);
+
+    expect(() => recoverExpiredGraphClaim(recovered.state, {
+      lease_id: 'lease-2',
+      now: '2026-07-21T00:00:04.000Z',
+      new_attempt_id: 'attempt-3',
+      new_lease_id: 'lease-3',
+      new_tracking_id: 'tool-3',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-3',
+      reconciliation_id: 'reconciliation-2',
+    }, retryProjection)).toThrow(/maximum attempts/i);
+  });
+
+  it('moves ambiguous expired work to reconciliation and never creates a replacement claim', () => {
+    const state = claimState('reconcile');
+    const recovered = recoverExpiredGraphClaim(state, {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, () => {
+      throw new Error('ambiguous work must not retry');
+    });
+
+    expect(recovered.disposition).toBe('reconciling');
+    expect(recovered.state.claims['lease-2']).toBeUndefined();
+    expect(recovered.state.reconciliations['reconciliation-1']).toMatchObject({
+      status: 'unresolved',
+      activation_id: 'activation',
+    });
+  });
+
+  it('records an expired lease completion only as bounded diagnostic evidence', () => {
+    const state = recoverExpiredGraphClaim(claimState(), {
+      lease_id: 'lease-1',
+      now: '2026-07-21T00:00:02.000Z',
+      new_attempt_id: 'attempt-2',
+      new_lease_id: 'lease-2',
+      new_tracking_id: 'tool-2',
+      claimant_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      reconciliation_id: 'reconciliation-1',
+    }, retryProjection).state;
+    const projection = state.projection;
+    const late = recordLateClaimResult(state, {
+      lease_id: 'lease-1',
+      attempt_id: 'attempt-1',
+      recorded_at: '2026-07-21T00:00:03.000Z',
+      summary: 'old result arrived after takeover',
+    });
+
+    expect(late.state.projection).toStrictEqual(projection);
+    expect(late.state.diagnostics.at(-1)).toMatchObject({
+      kind: 'late_result',
+      lease_id: 'lease-1',
+      attempt_id: 'attempt-1',
+    });
+  });
+
+  it('fences SessionEnd claims without deleting their authority', () => {
+    const safe = settleDriverClaims(claimState(), {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+    const ambiguous = settleDriverClaims(claimState('reconcile'), {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(safe.state.claims['lease-1'].status).toBe('abandoned_retryable');
+    expect(ambiguous.state.claims['lease-1'].status).toBe('reconciling');
+    expect(Object.values(ambiguous.state.reconciliations)).toHaveLength(1);
+  });
+
+  it('B4: session-end scope fences ALL live claims regardless of driver-id', () => {
+    // Two live claims owned by different drivers in the same session.
+    const base = claimState();
+    const secondClaim = issueGraphClaim(runningState(), {
+      activation_id: 'activation',
+      attempt_id: 'attempt-1',
+      attempt_no: 1,
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-2',
+      lease_id: 'lease-2',
+      tracking_id: 'tool-2',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      execution_timeout_ms: 1_000,
+      grace_ms: 500,
+      max_renewals: 2,
+      effect_policy: { policy: 'side_effect_free' },
+    });
+    // claimState() already has lease-1 (driver-1); add lease-2 (driver-2).
+    const both = {
+      ...secondClaim.state,
+      claims: {
+        ...base.claims,
+        ...secondClaim.state.claims,
+      },
+    };
+
+    // driver scope (default) only fences driver-1's claim.
+    const driverScoped = settleDriverClaims(both, {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+    expect(driverScoped.settled_lease_ids).toEqual(['lease-1']);
+    expect(driverScoped.state.claims['lease-2'].status).toBe('live');
+
+    // session scope fences both claims even though only driver-1 was passed.
+    const sessionScoped = settleDriverClaims(both, {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+      scope: 'session',
+    });
+    expect(sessionScoped.settled_lease_ids.sort()).toEqual(['lease-1', 'lease-2']);
+    expect(sessionScoped.state.claims['lease-1'].status).toBe('abandoned_retryable');
+    expect(sessionScoped.state.claims['lease-2'].status).toBe('abandoned_retryable');
+  });
+});

--- a/src/graph/__tests__/recovery.test.ts
+++ b/src/graph/__tests__/recovery.test.ts
@@ -341,4 +341,62 @@ describe('graph claim recovery', () => {
     expect(sessionScoped.state.claims['lease-1'].status).toBe('abandoned_retryable');
     expect(sessionScoped.state.claims['lease-2'].status).toBe('abandoned_retryable');
   });
+
+  it('WEDGE 2: SessionEnd settles a non-ambiguous human-approval claim and returns the run to re-claimable running', () => {
+    // A human-approval node holds the run in 'waiting_human' while a live claim
+    // fences its activation waiting for the human answer. When SessionEnd
+    // settles that claim (non-ambiguous: human-approval claims carry
+    // side_effect_free), the claim must be abandoned_retryable, the activation
+    // reset to 'ready', AND the run must leave 'waiting_human' for 'running' so
+    // issueGraphClaim can re-claim the activation instead of wedging.
+    const base = runningState();
+    // Bind a live human-approval claim and move the run to waiting_human, mirroring
+    // the runtime dispatch path (runtime.ts human-approval branch).
+    const waitingHuman: typeof base = {
+      ...base,
+      status: 'waiting_human',
+      claims: {
+        'lease-human': {
+          run_id: base.run_id,
+          revision_id: base.active_revision_id,
+          revision_hash: base.active_revision_hash,
+          dispatch_generation: base.dispatch_generation,
+          activation_id: 'activation',
+          attempt_id: 'attempt-1',
+          attempt_no: 1,
+          claim_owner_session_id: base.session_id,
+          driver_instance_id: 'driver-1',
+          lease_id: 'lease-human',
+          tracking_id: 'tool-1',
+          issued_at: '2026-07-21T00:00:00.000Z',
+          expires_at: '2026-07-21T01:00:00.000Z',
+          lease_duration_ms: 3_600_000,
+          renewal_count: 0,
+          max_renewals: 0,
+          effect_policy: { policy: 'side_effect_free' },
+          status: 'live',
+        },
+      },
+    };
+
+    const settled = settleDriverClaims(waitingHuman, {
+      claim_owner_session_id: 'session-recovery',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+      scope: 'session',
+    });
+
+    expect(settled.settled_lease_ids).toEqual(['lease-human']);
+    expect(settled.state.claims['lease-human'].status).toBe('abandoned_retryable');
+    // The activation is reset to ready (active attempt dropped).
+    expect(settled.state.projection.activations['activation'].status).toBe('ready');
+    expect(settled.state.projection.activations['activation'].active_attempt_id).toBeUndefined();
+    // WEDGE 2 fix: the run is no longer wedged in waiting_human; it is running
+    // again so the scheduler dispatch path (which beginActivationAttempt ->
+    // issueGraphClaim on a ready activation) can re-claim it. A run stuck in
+    // waiting_human would block dispatch entirely (issueGraphClaim requires
+    // status === 'running').
+    expect(settled.state.status).toBe('running');
+    expect(settled.state.projection.activations['activation'].status).toBe('ready');
+  });
 });

--- a/src/graph/__tests__/red-team-regressions.test.ts
+++ b/src/graph/__tests__/red-team-regressions.test.ts
@@ -1,0 +1,461 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { sealGraphDescriptor } from '../descriptor.js';
+import { settleDriverClaims } from '../claims.js';
+import { graphCommandService } from '../runtime.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { GraphStateStore } from '../store.js';
+import type { GraphDescriptorInput, GraphSchedulerProjection } from '../types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+const temporaryDirectories: string[] = [];
+let originalCwd = '';
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function useTempWorktree(sessionId: string): { worktree: string; store: GraphStateStore } {
+  const worktree = mkdtempSync(join(tmpdir(), 'omc-graph-redteam-'));
+  temporaryDirectories.push(worktree);
+  mkdirSync(join(worktree, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+  process.chdir(worktree);
+  const store = new GraphStateStore({
+    sessionId,
+    worktreeRoot: worktree,
+    dependencies: {
+      fileExists: existsSync,
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic: (path, value) => writeFileSync(path, JSON.stringify(value)),
+      withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+    },
+  });
+  return { worktree, store };
+}
+
+function linearDescriptor(opts: { runId?: string; revisionId?: string; goal?: string } = {}): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: opts.runId ?? 'run-redteam',
+    revision_id: opts.revisionId ?? 'revision-1',
+    goal: opts.goal ?? 'Linear red-team path',
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      {
+        id: 'start', kind: 'agent', title: 'start', instructions: 'Do start',
+        timeout_ms: 1_000, max_attempts: 2, effect_policy: { policy: 'side_effect_free' },
+      },
+      {
+        id: 'verify', kind: 'command', title: 'verify', command: 'run-verify',
+        timeout_ms: 1_000, max_attempts: 2, effect_policy: { policy: 'side_effect_free' },
+      },
+    ],
+    edges: [{ id: 'start-verify', kind: 'fixed', from: 'start', to: 'verify' }],
+  };
+}
+
+// A second descriptor for patch proposals: same run identity, new revision id,
+// same nodes (so no completed-node repurposing), only the goal changes.
+function patchedDescriptor(base: GraphDescriptorInput, revisionId: string, goal: string): GraphDescriptorInput {
+  return {
+    ...base,
+    revision_id: revisionId,
+    goal,
+    nodes: base.nodes.map((node) => ({ ...node })),
+    edges: base.edges.map((edge) => ({ ...edge })),
+  };
+}
+
+function seedRunning(
+  sessionId: string,
+  descriptor: ReturnType<typeof sealGraphDescriptor>,
+  startNodeId = 'start',
+  projectionOverride?: GraphSchedulerProjection,
+) {
+  const { store } = useTempWorktree(sessionId);
+  const startActivationId = `${descriptor.run_id}:act:${startNodeId}:entry`;
+  const state = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'nonce-redteam',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: projectionOverride ?? {
+      activations: {
+        [startActivationId]: {
+          activation_id: startActivationId, node_id: startNodeId, status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: startActivationId,
+        },
+      },
+      cohorts: {}, branch_tokens: {}, traversal_counts: {},
+      committed_transitions: {}, terminal_verification_activation_ids: [],
+    },
+    approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approval-1' } },
+  });
+  store.create(state);
+  return { store, startActivationId };
+}
+
+async function exec(operation: string, input: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return graphCommandService.execute({ operation: operation as never, cwd: process.cwd(), input }) as Promise<Record<string, unknown>>;
+}
+
+async function claimOne(
+  sessionId: string,
+  revisionId: string,
+  descriptorHash: string,
+  runId: string,
+  expectedSeq: number,
+  transitionId: string,
+  driverId = 'driver-1',
+) {
+  const claimed = await exec('claim', {
+    session_id: sessionId, run_id: runId, revision_id: revisionId,
+    descriptor_hash: descriptorHash, expected_sequence: expectedSeq,
+    driver_id: driverId, transition_id: transitionId, limit: 1,
+  }) as { result: { claims: Array<Record<string, unknown>> } };
+  return claimed.result.claims[0];
+}
+
+describe('red-team state-machine regressions', () => {
+  it('#2: abandon atomically fences live claims and rejects a late completion against the cancelled graph', async () => {
+    const sessionId = 'session-abandon-late';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claim = await claimOne(sessionId, descriptor.revision_id, descriptor.descriptor_hash, descriptor.run_id, 0, 't-claim');
+    const before = store.read()!;
+    expect(before.claims[claim.lease_id as string].status).toBe('live');
+
+    // Abandon while the claim is still live (worker still "running").
+    await exec('abandon', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-abandon',
+      confirmation: { run_id: descriptor.run_id },
+    });
+
+    const afterAbandon = store.read()!;
+    expect(afterAbandon.status).toBe('cancelled');
+    // #2(a): the live claim was atomically fenced in the SAME transition.
+    expect(afterAbandon.claims[claim.lease_id as string].status).toBe('fenced');
+    expect(afterAbandon.claims[claim.lease_id as string].fenced_at).toBeDefined();
+
+    // #2(b): the worker tries to complete AFTER cancel -> must be rejected before
+    // commit (graph is terminal). The terminal-graph gate runs before the claim
+    // liveness gate, so the error names the cancelled status, not the claim.
+    await expect(exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-late-complete',
+      claim: { lease_id: claim.lease_id, activation_id: claim.activation_id, attempt_id: claim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'late' }] },
+    })).rejects.toThrow(/cancelled/);
+
+    // The terminal run was not mutated by the late result.
+    const afterLate = store.read()!;
+    expect(afterLate.commit_sequence).toBe(afterAbandon.commit_sequence);
+    expect(afterLate.projection.activations[claim.activation_id as string].status).not.toBe('completed');
+  });
+
+  it('#2: fail is also rejected against a cancelled graph before commit', async () => {
+    const sessionId = 'session-abandon-late-fail';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-abandon-fail' }));
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+    const claim = await claimOne(sessionId, descriptor.revision_id, descriptor.descriptor_hash, descriptor.run_id, 0, 't-claim');
+
+    await exec('abandon', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-abandon', confirmation: { run_id: descriptor.run_id },
+    });
+
+    await expect(exec('fail', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-late-fail',
+      claim: { lease_id: claim.lease_id, activation_id: claim.activation_id, attempt_id: claim.attempt_id },
+      result: { outcome: 'failed', evidence_refs: [{ kind: 'command', ref: 'late-fail' }] },
+    })).rejects.toThrow(/cancelled/);
+    expect(store.read()!.status).toBe('cancelled');
+  });
+
+  it('#3: settleDriverClaims resets a settled activation to ready (re-claimable) at the claims layer', () => {
+    // Mirror recovery.test.ts runningState/claimState to drive settleDriverClaims directly.
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const running = createInitialGraphState({
+      session_id: 'session-settle-claims',
+      control_nonce: 'control-settle',
+      descriptor,
+      status: 'running',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection: {
+        activations: {
+          activation: {
+            activation_id: 'activation', node_id: 'analyze', status: 'running',
+            attempt_no: 1, attempt_ids: ['attempt-1'], active_attempt_id: 'attempt-1',
+            traversal_owner_id: 'root',
+          },
+        },
+        cohorts: {}, branch_tokens: {}, traversal_counts: {},
+        committed_transitions: {}, terminal_verification_activation_ids: [],
+      },
+      approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approval' } },
+    });
+    // Issue a live claim on the running activation.
+    const live = {
+      ...running,
+      claims: {
+        'lease-1': {
+          run_id: running.run_id,
+          revision_id: running.active_revision_id,
+          revision_hash: running.active_revision_hash,
+          dispatch_generation: running.dispatch_generation,
+          activation_id: 'activation',
+          attempt_id: 'attempt-1',
+          attempt_no: 1,
+          claim_owner_session_id: running.session_id,
+          driver_instance_id: 'driver-1',
+          lease_id: 'lease-1',
+          tracking_id: 'tool-1',
+          issued_at: '2026-07-21T00:00:00.000Z',
+          expires_at: '2026-07-21T00:01:00.000Z',
+          lease_duration_ms: 60_000,
+          renewal_count: 0,
+          max_renewals: 2,
+          effect_policy: { policy: 'side_effect_free' },
+          status: 'live' as const,
+        },
+      },
+    } as unknown as typeof running;
+
+    const settled = settleDriverClaims(live, {
+      claim_owner_session_id: 'session-settle-claims',
+      driver_instance_id: 'driver-1',
+      recorded_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    // The claim is fenced abandoned_retryable...
+    expect(settled.state.claims['lease-1'].status).toBe('abandoned_retryable');
+    // ...AND the activation was atomically returned to 'ready' (re-claimable),
+    // so the work is not permanently lost after SessionEnd.
+    expect(settled.state.projection.activations.activation.status).toBe('ready');
+    expect(settled.state.projection.activations.activation.active_attempt_id).toBeUndefined();
+    // Attempt history is preserved (the abandoned attempt is still in the log).
+    expect(settled.state.projection.activations.activation.attempt_ids).toEqual(['attempt-1']);
+  });
+
+  it('#3: after settle-session, a worker can re-claim the previously-stranded activation', async () => {
+    const sessionId = 'session-settle-reclaim';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-settle-reclaim' }));
+    const { store, startActivationId } = seedRunning(sessionId, descriptor, 'start');
+
+    const claim = await claimOne(sessionId, descriptor.revision_id, descriptor.descriptor_hash, descriptor.run_id, 0, 't-claim');
+    expect(store.read()!.projection.activations[startActivationId].status).toBe('running');
+
+    // SessionEnd settles the worker's live claim.
+    await exec('settle-session', {
+      session_id: sessionId, driver_id: 'driver-1', transition_id: 't-settle',
+    });
+    const afterSettle = store.read()!;
+    expect(afterSettle.claims[claim.lease_id as string].status).toBe('abandoned_retryable');
+    // #3: the activation is back to 'ready' -> the work is re-claimable, not lost.
+    expect(afterSettle.projection.activations[startActivationId].status).toBe('ready');
+
+    // A new driver can claim the same activation and complete it.
+    const reclaimed = await claimOne(sessionId, descriptor.revision_id, descriptor.descriptor_hash, descriptor.run_id, afterSettle.commit_sequence, 't-reclaim', 'driver-2');
+    expect(reclaimed.activation_id).toBe(startActivationId);
+    expect(store.read()!.claims[reclaimed.lease_id as string].status).toBe('live');
+
+    const completed = await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash,
+      expected_sequence: afterSettle.commit_sequence + 1,
+      transition_id: 't-complete',
+      claim: { lease_id: reclaimed.lease_id, activation_id: reclaimed.activation_id, attempt_id: reclaimed.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'redone' }] },
+    }) as { result: { outcome: string } };
+    expect(completed.result.outcome).toBe('succeeded');
+    expect(store.read()!.projection.activations[startActivationId].status).toBe('completed');
+  });
+
+  it('#4: dispatch_generation fence is threaded through active-scope ops across a full patch cycle', async () => {
+    const sessionId = 'session-gen-thread';
+    const baseInput = linearDescriptor({ runId: 'run-gen' });
+    const descriptor = sealGraphDescriptor(baseInput);
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    // Generation 0: claim + complete start (active-scope fence must accept gen 0).
+    const startClaim = await claimOne(sessionId, descriptor.revision_id, descriptor.descriptor_hash, descriptor.run_id, 0, 't-claim-start');
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-complete-start',
+      claim: { lease_id: startClaim.lease_id, activation_id: startClaim.activation_id, attempt_id: startClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'start' }] },
+    });
+    const verifyActivationId = Object.values(store.read()!.projection.activations)
+      .find((activation) => activation.node_id === 'verify')!.activation_id;
+
+    // First patch cycle: propose (gen 0 -> 1) then approve. No live claims at approve time.
+    const patch1 = sealGraphDescriptor(patchedDescriptor(baseInput, 'revision-2', 'Patched goal v1'));
+    await exec('propose-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: descriptor.revision_id,
+      base_descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-propose-1', patch: { proposed_descriptor: patch1, invalidated_node_ids: [], proposal_evidence: [] },
+    });
+    await exec('approve-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: descriptor.revision_id,
+      base_descriptor_hash: descriptor.descriptor_hash, expected_sequence: 3,
+      transition_id: 't-approve-1',
+      approval: {
+        proposed_revision_hash: patch1.descriptor_hash, invalidated_node_ids: [],
+        evidence: { kind: 'human', ref: 'approve-patch-1' },
+      },
+    });
+    const afterPatch1 = store.read()!;
+    expect(afterPatch1.dispatch_generation).toBe(1);
+    expect(afterPatch1.active_revision_id).toBe('revision-2');
+    // Old-claim drain: the completed start claim must NOT conflict on generation
+    // (it was completed at gen 0; the post-approval graph is at gen 1).
+    expect(afterPatch1.claims[startClaim.lease_id as string].status).toBe('completed');
+
+    // Post-approval execution at generation 1: claim + complete verify. A
+    // hardcoded-0 fence here would throw dispatch_generation_conflict.
+    const verifyClaim = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: 'revision-2',
+      descriptor_hash: patch1.descriptor_hash, expected_sequence: 4,
+      driver_id: 'driver-1', transition_id: 't-claim-verify', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const vClaim = verifyClaim.result.claims[0];
+    expect(vClaim.activation_id).toBe(verifyActivationId);
+
+    const verifyComplete = await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: 'revision-2',
+      descriptor_hash: patch1.descriptor_hash, expected_sequence: 5,
+      transition_id: 't-complete-verify',
+      claim: { lease_id: vClaim.lease_id, activation_id: vClaim.activation_id, attempt_id: vClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'verify' }] },
+    }) as { result: { succeeded: boolean } };
+    // The terminal node completed with evidence -> the projection is logically
+    // succeeded (the runtime surfaces this as result.succeeded; the graph status
+    // stays 'running' - it is not auto-promoted to a terminal status here).
+    expect(verifyComplete.result.succeeded).toBe(true);
+
+    // Second patch cycle: propose off revision-2 at gen 1 (-> gen 2). A
+    // hardcoded-0 propose-patch fence would throw dispatch_generation_conflict
+    // here because the active generation is now 1. The graph is still 'running',
+    // so the propose must be accepted (no live claims at propose time).
+    const patch2 = sealGraphDescriptor(patchedDescriptor(baseInput, 'revision-3', 'Patched goal v2'));
+    await exec('propose-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: 'revision-2',
+      base_descriptor_hash: patch1.descriptor_hash, expected_sequence: 6,
+      transition_id: 't-propose-2',
+      patch: { proposed_descriptor: patch2, invalidated_node_ids: [], proposal_evidence: [] },
+    });
+    await exec('approve-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: 'revision-2',
+      base_descriptor_hash: patch1.descriptor_hash, expected_sequence: 7,
+      transition_id: 't-approve-2',
+      approval: {
+        proposed_revision_hash: patch2.descriptor_hash, invalidated_node_ids: [],
+        evidence: { kind: 'human', ref: 'approve-patch-2' },
+      },
+    });
+    const afterCycle2 = store.read()!;
+    expect(afterCycle2.dispatch_generation).toBe(2);
+    expect(afterCycle2.active_revision_id).toBe('revision-3');
+  });
+
+  it('#4: second patch cycle on a paused-then-resumed graph fences at base_generation>=1', async () => {
+    const sessionId = 'session-gen-second-cycle';
+    const baseInput = linearDescriptor({ runId: 'run-gen-2' });
+    const descriptor = sealGraphDescriptor(baseInput);
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    // Cycle 1: patch (gen 0->1) without claiming anything.
+    const patch1 = sealGraphDescriptor(patchedDescriptor(baseInput, 'revision-2', 'Patched goal v1'));
+    await exec('propose-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: descriptor.revision_id,
+      base_descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      transition_id: 't-propose-1', patch: { proposed_descriptor: patch1, invalidated_node_ids: [], proposal_evidence: [] },
+    });
+    await exec('approve-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: descriptor.revision_id,
+      base_descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-approve-1',
+      approval: {
+        proposed_revision_hash: patch1.descriptor_hash, invalidated_node_ids: [],
+        evidence: { kind: 'human', ref: 'approve-patch-1' },
+      },
+    });
+    expect(store.read()!.dispatch_generation).toBe(1);
+
+    // Claim + complete start at gen 1 (post-approval execution). The active
+    // revision is now revision-2; claim fence uses gen 1.
+    const startClaim = await claimOne(sessionId, 'revision-2', patch1.descriptor_hash, descriptor.run_id, 2, 't-claim-start');
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: 'revision-2',
+      descriptor_hash: patch1.descriptor_hash, expected_sequence: 3,
+      transition_id: 't-complete-start',
+      claim: { lease_id: startClaim.lease_id, activation_id: startClaim.activation_id, attempt_id: startClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'start' }] },
+    });
+
+    // Cycle 2: second patch off revision-2 at gen 1 (-> gen 2). A hardcoded-0
+    // propose-patch fence would throw dispatch_generation_conflict here.
+    const patch2 = sealGraphDescriptor(patchedDescriptor(baseInput, 'revision-3', 'Patched goal v2'));
+    await exec('propose-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: 'revision-2',
+      base_descriptor_hash: patch1.descriptor_hash, expected_sequence: 4,
+      transition_id: 't-propose-2', patch: { proposed_descriptor: patch2, invalidated_node_ids: [], proposal_evidence: [] },
+    });
+    await exec('approve-patch', {
+      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: 'revision-2',
+      base_descriptor_hash: patch1.descriptor_hash, expected_sequence: 5,
+      transition_id: 't-approve-2',
+      approval: {
+        proposed_revision_hash: patch2.descriptor_hash, invalidated_node_ids: [],
+        evidence: { kind: 'human', ref: 'approve-patch-2' },
+      },
+    });
+    const afterCycle2 = store.read()!;
+    expect(afterCycle2.dispatch_generation).toBe(2);
+    expect(afterCycle2.active_revision_id).toBe('revision-3');
+  });
+
+  it('#5: human-approval claim returns the persisted lease expiry, not the issue timestamp', async () => {
+    const sessionId = 'session-human-expiry';
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'approval');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+    expect(claim.kind).toBe('human-approval');
+
+    const persisted = store.read()!.claims[claim.lease_id as string];
+    // The returned expires_at must equal the persisted claim's lease expiry, and
+    // must NOT equal the issued_at timestamp (the #5 bug).
+    expect(claim.expires_at).toBe(persisted.expires_at);
+    expect(claim.expires_at).not.toBe(persisted.issued_at);
+    // The lease expiry is issued_at + HUMAN_APPROVAL_LEASE_MS (1h).
+    expect(Date.parse(claim.expires_at as string)).toBe(
+      Date.parse(persisted.issued_at) + 60 * 60 * 1000,
+    );
+  });
+});

--- a/src/graph/__tests__/red-team-regressions.test.ts
+++ b/src/graph/__tests__/red-team-regressions.test.ts
@@ -349,34 +349,10 @@ describe('red-team state-machine regressions', () => {
       claim: { lease_id: vClaim.lease_id, activation_id: vClaim.activation_id, attempt_id: vClaim.attempt_id },
       result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'verify' }] },
     }) as { result: { succeeded: boolean } };
-    // The terminal node completed with evidence -> the projection is logically
-    // succeeded (the runtime surfaces this as result.succeeded; the graph status
-    // stays 'running' - it is not auto-promoted to a terminal status here).
+    // Terminal verification is a durable terminal state, not merely a summary
+    // hint. A succeeded run cannot accept another revision cycle.
     expect(verifyComplete.result.succeeded).toBe(true);
-
-    // Second patch cycle: propose off revision-2 at gen 1 (-> gen 2). A
-    // hardcoded-0 propose-patch fence would throw dispatch_generation_conflict
-    // here because the active generation is now 1. The graph is still 'running',
-    // so the propose must be accepted (no live claims at propose time).
-    const patch2 = sealGraphDescriptor(patchedDescriptor(baseInput, 'revision-3', 'Patched goal v2'));
-    await exec('propose-patch', {
-      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: 'revision-2',
-      base_descriptor_hash: patch1.descriptor_hash, expected_sequence: 6,
-      transition_id: 't-propose-2',
-      patch: { proposed_descriptor: patch2, invalidated_node_ids: [], proposal_evidence: [] },
-    });
-    await exec('approve-patch', {
-      session_id: sessionId, run_id: descriptor.run_id, base_revision_id: 'revision-2',
-      base_descriptor_hash: patch1.descriptor_hash, expected_sequence: 7,
-      transition_id: 't-approve-2',
-      approval: {
-        proposed_revision_hash: patch2.descriptor_hash, invalidated_node_ids: [],
-        evidence: { kind: 'human', ref: 'approve-patch-2' },
-      },
-    });
-    const afterCycle2 = store.read()!;
-    expect(afterCycle2.dispatch_generation).toBe(2);
-    expect(afterCycle2.active_revision_id).toBe('revision-3');
+    expect(store.read()?.status).toBe('succeeded');
   });
 
   it('#4: second patch cycle on a paused-then-resumed graph fences at base_generation>=1', async () => {

--- a/src/graph/__tests__/red-team-regressions.test.ts
+++ b/src/graph/__tests__/red-team-regressions.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { sealGraphDescriptor } from '../descriptor.js';
+import { occCommitMutation, occReadCurrentState } from '../../lib/mode-state-io.js';
 import { settleDriverClaims } from '../claims.js';
 import { graphCommandService } from '../runtime.js';
 import { createInitialGraphState } from '../runtime-types.js';
@@ -35,8 +36,8 @@ function useTempWorktree(sessionId: string): { worktree: string; store: GraphSta
     dependencies: {
       fileExists: existsSync,
       readText: (path) => readFileSync(path, 'utf8'),
-      writeAtomic: (path, value) => writeFileSync(path, JSON.stringify(value)),
-      withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+      readCurrent: occReadCurrentState,
+      occCommit: occCommitMutation,
     },
   });
   return { worktree, store };

--- a/src/graph/__tests__/revision.test.ts
+++ b/src/graph/__tests__/revision.test.ts
@@ -142,7 +142,7 @@ describe('graph revisions', () => {
     expect(proposed.revisions['revision-2']).toBeUndefined();
   });
 
-  it('blocks approval until old claims drain and reconciliation is resolved', () => {
+  it('fences non-ambiguous live claims on patch approval and still rejects ambiguous/reconciliation', () => {
     const state = proposeGraphPatch(approvedState(), {
       proposal_id: 'patch-1',
       base_revision_id: 'revision-1',
@@ -173,7 +173,11 @@ describe('graph revisions', () => {
       status: 'live',
     };
 
-    expect(() => approveGraphPatch(state, {
+    // WEDGE 1: a non-ambiguous (side_effect_free) live claim no longer hard-
+    // rejects; it is fenced atomically with patch approval so the run does not
+    // wedge while waiting for the claim to drain (which it cannot, because the
+    // runtime result/release gates reject waiting_patch_approval).
+    const approved = approveGraphPatch(state, {
       proposal_id: 'patch-1',
       base_revision_id: state.active_revision_id,
       base_revision_hash: state.active_revision_hash,
@@ -181,23 +185,110 @@ describe('graph revisions', () => {
       invalidated_node_ids: [],
       approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
       approved_at: '2026-07-21T00:00:02.000Z',
-    }, (projection) => projection)).toThrow(/live claim/i);
+    }, (projection) => projection);
+    expect(approved.status).toBe('running');
+    expect(approved.claims['lease-old'].status).toBe('fenced');
+    expect(approved.claims['lease-old'].fenced_at).toBe('2026-07-21T00:00:02.000Z');
 
-    state.claims['lease-old'].status = 'reconciling';
-    state.claims['lease-old'].fenced_at = '2026-07-21T00:00:01.500Z';
-    state.reconciliations['reconciliation-old'] = {
+    // An ambiguous (reconcile-policy) live claim still hard-rejects: its
+    // external-effect outcome requires human resolution and must not be
+    // silently dropped by a patch approval.
+    const ambiguous = proposeGraphPatch(approvedState(), {
+      proposal_id: 'patch-2',
+      base_revision_id: 'revision-1',
+      base_revision_hash: approvedState().active_revision_hash,
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    ambiguous.claims['lease-amb'] = {
+      ...state.claims['lease-old'],
+      lease_id: 'lease-amb',
+      effect_policy: { policy: 'reconcile' },
+      status: 'live',
+    };
+    expect(() => approveGraphPatch(ambiguous, {
+      proposal_id: 'patch-2',
+      base_revision_id: ambiguous.active_revision_id,
+      base_revision_hash: ambiguous.active_revision_hash,
+      proposed_revision_hash: ambiguous.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-2' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrow(/ambiguous.*reconcile-policy.*live claim/i);
+
+    // Unresolved reconciliation still blocks.
+    ambiguous.claims['lease-amb'].status = 'reconciling';
+    ambiguous.claims['lease-amb'].fenced_at = '2026-07-21T00:00:01.500Z';
+    ambiguous.reconciliations['reconciliation-old'] = {
       reconciliation_id: 'reconciliation-old',
       activation_id: 'completed',
       attempt_id: 'attempt-a',
-      lease_id: 'lease-old',
-      revision_id: state.active_revision_id,
-      revision_hash: state.active_revision_hash,
+      lease_id: 'lease-amb',
+      revision_id: ambiguous.active_revision_id,
+      revision_hash: ambiguous.active_revision_hash,
       dispatch_generation: 0,
       status: 'unresolved',
       reason: 'external_effect_ambiguous',
       created_at: '2026-07-21T00:00:01.500Z',
     };
-    expect(() => approveGraphPatch(state, {
+    expect(() => approveGraphPatch(ambiguous, {
+      proposal_id: 'patch-2',
+      base_revision_id: ambiguous.active_revision_id,
+      base_revision_hash: ambiguous.active_revision_hash,
+      proposed_revision_hash: ambiguous.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-2' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrow(/unresolved reconciliation/i);
+  });
+
+  it('resets a fenced live claim activation to ready so it is re-claimable under the new revision', () => {
+    // WEDGE 1: the activation bound to a fenced live claim must return to
+    // 'ready' (active attempt dropped) so the scheduler can re-claim it under
+    // the approved revision; otherwise the work is silently lost.
+    const base = approvedState();
+    // Add a running activation bound to a live claim that will be fenced.
+    base.projection.activations['running'] = {
+      activation_id: 'running',
+      node_id: 'branch-a',
+      status: 'running',
+      attempt_no: 1,
+      attempt_ids: ['attempt-running'],
+      active_attempt_id: 'attempt-running',
+      traversal_owner_id: 'root',
+    };
+    const state = proposeGraphPatch(base, {
+      proposal_id: 'patch-1',
+      base_revision_id: base.active_revision_id,
+      base_revision_hash: base.active_revision_hash,
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    state.claims['lease-running'] = {
+      run_id: state.run_id,
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: 0,
+      activation_id: 'running',
+      attempt_id: 'attempt-running',
+      attempt_no: 1,
+      claim_owner_session_id: state.session_id,
+      driver_instance_id: 'driver',
+      lease_id: 'lease-running',
+      tracking_id: 'tool',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      expires_at: '2026-07-21T00:01:00.000Z',
+      lease_duration_ms: 60_000,
+      renewal_count: 0,
+      max_renewals: 1,
+      effect_policy: { policy: 'side_effect_free' },
+      status: 'live',
+    };
+    const approved = approveGraphPatch(state, {
       proposal_id: 'patch-1',
       base_revision_id: state.active_revision_id,
       base_revision_hash: state.active_revision_hash,
@@ -205,7 +296,11 @@ describe('graph revisions', () => {
       invalidated_node_ids: [],
       approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
       approved_at: '2026-07-21T00:00:02.000Z',
-    }, (projection) => projection)).toThrow(/unresolved reconciliation/i);
+    }, (projection) => projection);
+    expect(approved.claims['lease-running'].status).toBe('fenced');
+    const settled = approved.projection.activations['running'];
+    expect(settled.status).toBe('ready');
+    expect(settled.active_attempt_id).toBeUndefined();
   });
 
   it('keeps stale-base and unapproved patch proposals inert', () => {

--- a/src/graph/__tests__/revision.test.ts
+++ b/src/graph/__tests__/revision.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalJson, sealGraphDescriptor } from '../descriptor.js';
+import {
+  GraphRevisionError,
+  approveGraphPatch,
+  approvePendingGraphRevision,
+  proposeGraphPatch,
+  replacePendingDraft,
+} from '../revisions.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+function approvedState() {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  return createInitialGraphState({
+    session_id: 'session-revision',
+    control_nonce: 'control-revision',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {
+        completed: {
+          activation_id: 'completed',
+          node_id: 'branch-a',
+          status: 'completed',
+          attempt_no: 1,
+          attempt_ids: ['attempt-a'],
+          completed_transition_id: 'transition-a',
+          traversal_owner_id: 'root',
+        },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    approval: {
+      approved_at: '2026-07-21T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'approval-1' },
+    },
+  });
+}
+
+function nextDescriptor(changeCompletedNode = false) {
+  const next = forkJoinDescriptor();
+  next.revision_id = 'revision-2';
+  next.goal = 'Build and verify two branches with an approved patch';
+  if (changeCompletedNode) {
+    const node = next.nodes.find((candidate) => candidate.id === 'branch-a');
+    if (node) node.title = 'repurposed completed work';
+  }
+  return sealGraphDescriptor(next);
+}
+
+describe('graph revisions', () => {
+  it('replaces a rejected pending draft without making it runnable, then approves the exact replacement', () => {
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const pending = createInitialGraphState({
+      session_id: 'session-revision',
+      control_nonce: 'control-revision',
+      descriptor,
+      status: 'awaiting_approval',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection: {
+        activations: {},
+        cohorts: {},
+        branch_tokens: {},
+        traversal_counts: {},
+        committed_transitions: {},
+        terminal_verification_activation_ids: [],
+      },
+    });
+    const replacement = nextDescriptor();
+    const replaced = replacePendingDraft(pending, {
+      descriptor: replacement,
+      replaced_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(replaced).toMatchObject({
+      status: 'awaiting_approval',
+      active_revision_id: 'revision-2',
+      active_revision_hash: replacement.descriptor_hash,
+      pending_approval: {
+        revision_id: 'revision-2',
+        revision_hash: replacement.descriptor_hash,
+      },
+    });
+    expect(replaced.projection.activations).toEqual({});
+
+    const approved = approvePendingGraphRevision(replaced, {
+      revision_id: 'revision-2',
+      revision_hash: replacement.descriptor_hash,
+      approved_at: '2026-07-21T00:00:02.000Z',
+      approval_evidence: { kind: 'human', ref: 'approve-replacement' },
+    }, (approvedDescriptor) => ({
+      activations: {
+        approval: {
+          activation_id: 'approval',
+          node_id: approvedDescriptor.entry_node_ids[0],
+          status: 'ready',
+          attempt_no: 0,
+          attempt_ids: [],
+          traversal_owner_id: 'root',
+        },
+      },
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    }));
+    expect(approved.status).toBe('running');
+    expect(approved.pending_approval).toBeUndefined();
+    expect(approved.revisions['revision-2'].approval).toMatchObject({
+      revision_id: 'revision-2',
+      revision_hash: replacement.descriptor_hash,
+    });
+  });
+
+  it('advances dispatch generation and pauses new dispatch on proposal', () => {
+    const state = approvedState();
+    const proposed = proposeGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [{ kind: 'file', ref: 'patch.json' }],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(proposed.status).toBe('waiting_patch_approval');
+    expect(proposed.dispatch_generation).toBe(1);
+    expect(proposed.pending_patch).toMatchObject({
+      proposal_id: 'patch-1',
+      base_dispatch_generation: 0,
+      proposed_revision_id: 'revision-2',
+    });
+    expect(proposed.revisions['revision-2']).toBeUndefined();
+  });
+
+  it('blocks approval until old claims drain and reconciliation is resolved', () => {
+    const state = proposeGraphPatch(approvedState(), {
+      proposal_id: 'patch-1',
+      base_revision_id: 'revision-1',
+      base_revision_hash: approvedState().active_revision_hash,
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    state.claims['lease-old'] = {
+      run_id: state.run_id,
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: 0,
+      activation_id: 'completed',
+      attempt_id: 'attempt-a',
+      attempt_no: 1,
+      claim_owner_session_id: state.session_id,
+      driver_instance_id: 'driver',
+      lease_id: 'lease-old',
+      tracking_id: 'tool',
+      issued_at: '2026-07-21T00:00:00.000Z',
+      expires_at: '2026-07-21T00:01:00.000Z',
+      lease_duration_ms: 60_000,
+      renewal_count: 0,
+      max_renewals: 1,
+      effect_policy: { policy: 'side_effect_free' },
+      status: 'live',
+    };
+
+    expect(() => approveGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: state.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrow(/live claim/i);
+
+    state.claims['lease-old'].status = 'reconciling';
+    state.claims['lease-old'].fenced_at = '2026-07-21T00:00:01.500Z';
+    state.reconciliations['reconciliation-old'] = {
+      reconciliation_id: 'reconciliation-old',
+      activation_id: 'completed',
+      attempt_id: 'attempt-a',
+      lease_id: 'lease-old',
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: 0,
+      status: 'unresolved',
+      reason: 'external_effect_ambiguous',
+      created_at: '2026-07-21T00:00:01.500Z',
+    };
+    expect(() => approveGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: state.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrow(/unresolved reconciliation/i);
+  });
+
+  it('keeps stale-base and unapproved patch proposals inert', () => {
+    const state = approvedState();
+    const before = canonicalJson(state);
+    expect(() => proposeGraphPatch(state, {
+      proposal_id: 'patch-stale',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: '0'.repeat(64),
+      proposed_descriptor: nextDescriptor(),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    })).toThrow(/stale base/i);
+    expect(canonicalJson(state)).toBe(before);
+    expect(state.revisions['revision-2']).toBeUndefined();
+  });
+
+  it('rejects silent repurposing of a completed node ID', () => {
+    const state = approvedState();
+    const proposed = proposeGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_descriptor: nextDescriptor(true),
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+
+    expect(() => approveGraphPatch(proposed, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: proposed.pending_patch!.proposed_revision_hash,
+      invalidated_node_ids: [],
+      approval_evidence: { kind: 'human', ref: 'approve-patch-1' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection) => projection)).toThrowError(GraphRevisionError);
+  });
+
+  it('activates an immutable approved revision only with explicit invalidation evidence', () => {
+    const state = approvedState();
+    const descriptor = nextDescriptor(true);
+    const proposed = proposeGraphPatch(state, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_descriptor: descriptor,
+      invalidated_node_ids: ['branch-a'],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    const approved = approveGraphPatch(proposed, {
+      proposal_id: 'patch-1',
+      base_revision_id: state.active_revision_id,
+      base_revision_hash: state.active_revision_hash,
+      proposed_revision_hash: descriptor.descriptor_hash,
+      invalidated_node_ids: ['branch-a'],
+      approval_evidence: { kind: 'human', ref: 'approve-invalidating-branch-a' },
+      approved_at: '2026-07-21T00:00:02.000Z',
+    }, (projection, _descriptor, invalidated) => ({
+      ...projection,
+      activations: Object.fromEntries(
+        Object.entries(projection.activations).filter(([, activation]) => !invalidated.has(activation.node_id)),
+      ),
+    }));
+
+    expect(approved.active_revision_id).toBe('revision-2');
+    expect(approved.active_revision_hash).toBe(descriptor.descriptor_hash);
+    expect(approved.pending_patch).toBeUndefined();
+    expect(approved.revisions['revision-1'].descriptor.descriptor_hash).toBe(state.active_revision_hash);
+    expect(approved.revisions['revision-2'].approval?.evidence.ref).toBe('approve-invalidating-branch-a');
+    expect(canonicalJson(approved.revisions['revision-2'].descriptor)).toBe(canonicalJson(descriptor));
+    expect(approved.projection.activations.completed).toBeUndefined();
+  });
+});

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -552,6 +552,82 @@ describe('graphCommandService runtime operations', () => {
     expect(controls.read()?.root).toMatchObject({ nonce: 'crash-before-publish-nonce', phase: 'active' });
   });
 
+  it('replays approval to promote a reservation after the durable approval commit succeeded', async () => {
+    const sessionId = 'session-approve-promote-replay';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-approve-promote-replay' }));
+    const { worktree, store } = useTempWorktree(sessionId);
+
+    await exec('create', {
+      goal: descriptor.goal, descriptor, session_id: sessionId,
+      driver_id: 'driver-create', transition_id: 't-create',
+    });
+    const promote = vi.spyOn(ControlOwnerStore.prototype, 'promoteRoot')
+      .mockImplementationOnce(() => { throw new Error('simulated promote failure'); });
+    const approval = {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, transition_id: 't-approve',
+      approval: {
+        approved_at: '2026-07-21T00:00:01.000Z',
+        evidence: { kind: 'human', ref: 'operator-approved' }, driver_id: 'driver-approve',
+      },
+    };
+    try {
+      await expect(exec('approve', approval)).rejects.toThrow(/simulated promote failure/);
+      expect(store.read()?.status).toBe('running');
+      expect(new ControlOwnerStore({ sessionId, worktreeRoot: worktree }).read()?.root).toMatchObject({ phase: 'reserved' });
+
+      const replay = await exec('approve', approval);
+      expect(replay.replayed).toBe(true);
+      expect(new ControlOwnerStore({ sessionId, worktreeRoot: worktree }).read()?.root).toMatchObject({ phase: 'active' });
+    } finally {
+      promote.mockRestore();
+    }
+  });
+
+  it('persists succeeded and releases exact graph control after terminal verification', async () => {
+    const sessionId = 'session-terminal-control-release';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-terminal-control-release' }));
+    const { worktree, store } = useTempWorktree(sessionId);
+    await exec('create', {
+      goal: descriptor.goal, descriptor, session_id: sessionId,
+      driver_id: 'driver-create', transition_id: 't-create',
+    });
+    await exec('approve', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, transition_id: 't-approve',
+      approval: {
+        approved_at: '2026-07-21T00:00:01.000Z',
+        evidence: { kind: 'human', ref: 'operator-approved' }, driver_id: 'driver-approve',
+      },
+    });
+    const start = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      driver_id: 'driver-approve', transition_id: 't-claim-start', limit: 1,
+    }) as { result: { claims: Array<Record<string, string>> } };
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2, transition_id: 't-complete-start',
+      claim: start.result.claims[0],
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'start' }] },
+    });
+    const verify = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 3,
+      driver_id: 'driver-approve', transition_id: 't-claim-verify', limit: 1,
+    }) as { result: { claims: Array<Record<string, string>> } };
+    const terminal = await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 4, transition_id: 't-complete-verify',
+      claim: verify.result.claims[0],
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'verify' }] },
+    }) as { result: { succeeded: boolean } };
+
+    expect(terminal.result.succeeded).toBe(true);
+    expect(store.read()?.status).toBe('succeeded');
+    expect(new ControlOwnerStore({ sessionId, worktreeRoot: worktree }).read()?.root).toBeNull();
+  });
+
   it('rolls back only its own reservation when the initial durable publish fails', async () => {
     const sessionId = 'session-create-publish-failure';
     const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-create-publish-failure' }));

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { sealGraphDescriptor } from '../descriptor.js';
+import { occCommitMutation, occReadCurrentState } from '../../lib/mode-state-io.js';
 import { graphCommandService } from '../runtime.js';
 import { createInitialGraphState } from '../runtime-types.js';
 import { GraphStateStore } from '../store.js';
@@ -39,8 +40,8 @@ function useTempWorktree(sessionId: string): { worktree: string; store: GraphSta
     dependencies: {
       fileExists: existsSync,
       readText: (path) => readFileSync(path, 'utf8'),
-      writeAtomic: (path, value) => writeFileSync(path, JSON.stringify(value)),
-      withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+      readCurrent: occReadCurrentState,
+      occCommit: occCommitMutation,
     },
   });
   return { worktree, store };
@@ -397,9 +398,12 @@ describe('graphCommandService runtime operations', () => {
         },
       },
     } as unknown as typeof running;
-    // Overwrite the state file directly through the store's write path.
+    // Publish the externally-recovered reconciling state through the OCC
+    // journal (B11/B): the journal is the source of truth, so a direct canonical
+    // write would be invisible to the next mutation. Simulate the recovery by
+    // committing the reconciling state as a journal entry.
     const storePath = (store as unknown as { path: string }).path;
-    writeFileSync(storePath, JSON.stringify(reconcilingState));
+    occCommitMutation(storePath, () => ({ state: reconcilingState, result: true }));
     // Sanity: the store re-reads the reconciling state.
     expect(store.read()?.status).toBe('reconciling');
 

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -48,7 +48,7 @@ function useTempWorktree(sessionId: string): { worktree: string; store: GraphSta
   return { worktree, store };
 }
 
-function linearDescriptor(opts: { reconcile?: boolean; runId?: string; goal?: string } = {}): ForkJoin {
+function linearDescriptor(opts: { reconcile?: boolean; runId?: string; goal?: string; maxAttempts?: number } = {}): ForkJoin {
   return {
     descriptor_version: 1,
     run_id: opts.runId ?? 'run-linear',
@@ -60,12 +60,12 @@ function linearDescriptor(opts: { reconcile?: boolean; runId?: string; goal?: st
     nodes: [
       {
         id: 'start', kind: 'agent', title: 'start', instructions: 'Do start',
-        timeout_ms: 1_000, max_attempts: 2,
+        timeout_ms: 1_000, max_attempts: opts.maxAttempts ?? 2,
         effect_policy: opts.reconcile ? { policy: 'reconcile' } : { policy: 'side_effect_free' },
       },
       {
         id: 'verify', kind: 'command', title: 'verify', command: 'run-verify',
-        timeout_ms: 1_000, max_attempts: 2, effect_policy: { policy: 'side_effect_free' },
+        timeout_ms: 1_000, max_attempts: opts.maxAttempts ?? 2, effect_policy: { policy: 'side_effect_free' },
       },
     ],
     edges: [{ id: 'start-verify', kind: 'fixed', from: 'start', to: 'verify' }],
@@ -137,6 +137,128 @@ describe('graphCommandService runtime operations', () => {
     expect(completed.result.created_activation_ids).toHaveLength(1);
     const afterComplete = store.read()!;
     expect(afterComplete.claims[claim.lease_id as string].status).toBe('completed');
+  });
+
+  it('stops a multi-claim batch at a human approval boundary', async () => {
+    const sessionId = 'session-human-batch-boundary';
+    const descriptor = sealGraphDescriptor({ ...forkJoinDescriptor(), concurrency_limit: 3 });
+    const humanActivationId = `${descriptor.run_id}:act:approval:entry`;
+    const agentActivationId = `${descriptor.run_id}:act:analyze:parallel`;
+    const afterHumanActivationId = `${descriptor.run_id}:act:branch-a:after-human`;
+    const { store } = seedRunning(sessionId, descriptor, 'approval', {
+      activations: {
+        [humanActivationId]: {
+          activation_id: humanActivationId, node_id: 'approval', status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: humanActivationId,
+        },
+        [agentActivationId]: {
+          activation_id: agentActivationId, node_id: 'analyze', status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: agentActivationId,
+        },
+        [afterHumanActivationId]: {
+          activation_id: afterHumanActivationId, node_id: 'branch-a', status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: afterHumanActivationId,
+        },
+      },
+      cohorts: {}, branch_tokens: {}, traversal_counts: {},
+      committed_transitions: {}, terminal_verification_activation_ids: [],
+    });
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 'transition-human-batch', limit: 2,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+
+    expect(claimed.result.claims).toHaveLength(2);
+    expect(claimed.result.claims[1]).toMatchObject({ activation_id: humanActivationId, kind: 'human-approval' });
+    expect(store.read()).toMatchObject({
+      status: 'waiting_human',
+      projection: { activations: { [afterHumanActivationId]: { status: 'ready' } } },
+    });
+  });
+
+  it('does not release a human wait when an agent claim from a persisted mixed batch completes', async () => {
+    const sessionId = 'session-human-mixed-claim';
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const humanActivationId = `${descriptor.run_id}:act:approval:entry`;
+    const agentActivationId = `${descriptor.run_id}:act:analyze:parallel`;
+    const { store } = seedRunning(sessionId, descriptor, 'approval', {
+      activations: {
+        [humanActivationId]: {
+          activation_id: humanActivationId, node_id: 'approval', status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: humanActivationId,
+        },
+      },
+      cohorts: {}, branch_tokens: {}, traversal_counts: {},
+      committed_transitions: {}, terminal_verification_activation_ids: [],
+    });
+    const human = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 'transition-human', limit: 1,
+    }) as { result: { claims: Array<Record<string, string>> } };
+    const waiting = store.read()!;
+    const agentLeaseId = 'lease-persisted-agent';
+    const agentAttemptId = 'attempt-persisted-agent';
+    const mixed = {
+      ...waiting,
+      projection: {
+        ...waiting.projection,
+        activations: {
+          ...waiting.projection.activations,
+          [agentActivationId]: {
+            activation_id: agentActivationId,
+            node_id: 'analyze',
+            status: 'running' as const,
+            attempt_no: 1,
+            attempt_ids: [agentAttemptId],
+            active_attempt_id: agentAttemptId,
+            traversal_owner_id: agentActivationId,
+          },
+        },
+      },
+      claims: {
+        ...waiting.claims,
+        [agentLeaseId]: {
+          run_id: waiting.run_id,
+          revision_id: waiting.active_revision_id,
+          revision_hash: waiting.active_revision_hash,
+          dispatch_generation: waiting.dispatch_generation,
+          activation_id: agentActivationId,
+          attempt_id: agentAttemptId,
+          attempt_no: 1,
+          claim_owner_session_id: sessionId,
+          driver_instance_id: 'driver-1',
+          lease_id: agentLeaseId,
+          tracking_id: 'tracking-persisted-agent',
+          issued_at: '2026-07-21T00:00:00.000Z',
+          expires_at: '2026-07-21T00:10:00.000Z',
+          lease_duration_ms: 600_000,
+          renewal_count: 0,
+          max_renewals: 3,
+          effect_policy: { policy: 'side_effect_free' as const },
+          status: 'live' as const,
+        },
+      },
+    };
+    occCommitMutation((store as unknown as { path: string }).path, () => ({ state: mixed, result: true }));
+
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 'transition-complete-persisted-agent',
+      claim: { lease_id: agentLeaseId, activation_id: agentActivationId, attempt_id: agentAttemptId },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'agent-result' }] },
+    });
+
+    expect(store.read()).toMatchObject({
+      status: 'waiting_human',
+      claims: {
+        [human.result.claims[0].lease_id]: { status: 'live' },
+        [agentLeaseId]: { status: 'completed' },
+      },
+    });
   });
 
   it('B2: resolve-join resolves a ready join activation through the runtime', async () => {
@@ -625,6 +747,41 @@ describe('graphCommandService runtime operations', () => {
 
     expect(terminal.result.succeeded).toBe(true);
     expect(store.read()?.status).toBe('succeeded');
+    expect(new ControlOwnerStore({ sessionId, worktreeRoot: worktree }).read()?.root).toBeNull();
+  });
+
+  it('releases exact graph control after a terminal failure', async () => {
+    const sessionId = 'session-terminal-failure-control-release';
+    const descriptor = sealGraphDescriptor(linearDescriptor({
+      runId: 'run-terminal-failure-control-release',
+      maxAttempts: 1,
+    }));
+    const { worktree, store } = useTempWorktree(sessionId);
+    await exec('create', {
+      goal: descriptor.goal, descriptor, session_id: sessionId,
+      driver_id: 'driver-create', transition_id: 't-create-failure',
+    });
+    await exec('approve', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, transition_id: 't-approve-failure',
+      approval: {
+        approved_at: '2026-07-21T00:00:01.000Z',
+        evidence: { kind: 'human', ref: 'operator-approved' }, driver_id: 'driver-approve',
+      },
+    });
+    const start = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      driver_id: 'driver-approve', transition_id: 't-claim-failure', limit: 1,
+    }) as { result: { claims: Array<Record<string, string>> } };
+    await exec('fail', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2, transition_id: 't-fail-terminal',
+      claim: start.result.claims[0],
+      result: { outcome: 'failed', evidence_refs: [{ kind: 'command', ref: 'start-failed' }] },
+    });
+
+    expect(store.read()?.status).toBe('failed');
     expect(new ControlOwnerStore({ sessionId, worktreeRoot: worktree }).read()?.root).toBeNull();
   });
 

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -1,0 +1,464 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { sealGraphDescriptor } from '../descriptor.js';
+import { graphCommandService } from '../runtime.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { GraphStateStore } from '../store.js';
+import type { GraphSchedulerProjection } from '../types.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+type ForkJoin = ReturnType<typeof forkJoinDescriptor>;
+
+const temporaryDirectories: string[] = [];
+let originalCwd = '';
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+// Drop into a fresh temp worktree dir so the runtime's GraphStateStore (which
+// resolves against process.cwd() when no worktreeRoot is given) writes into an
+// isolated .omc/state tree. The store requires a session-scoped write path.
+function useTempWorktree(sessionId: string): { worktree: string; store: GraphStateStore } {
+  const worktree = mkdtempSync(join(tmpdir(), 'omc-graph-runtime-'));
+  temporaryDirectories.push(worktree);
+  mkdirSync(join(worktree, '.omc', 'state', 'sessions', sessionId), { recursive: true });
+  process.chdir(worktree);
+  const store = new GraphStateStore({
+    sessionId,
+    worktreeRoot: worktree,
+    dependencies: {
+      fileExists: existsSync,
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic: (path, value) => writeFileSync(path, JSON.stringify(value)),
+      withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+    },
+  });
+  return { worktree, store };
+}
+
+function linearDescriptor(opts: { reconcile?: boolean; runId?: string; goal?: string } = {}): ForkJoin {
+  return {
+    descriptor_version: 1,
+    run_id: opts.runId ?? 'run-linear',
+    revision_id: 'revision-linear',
+    goal: opts.goal ?? 'Linear side-effect-free path',
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'verify',
+    nodes: [
+      {
+        id: 'start', kind: 'agent', title: 'start', instructions: 'Do start',
+        timeout_ms: 1_000, max_attempts: 2,
+        effect_policy: opts.reconcile ? { policy: 'reconcile' } : { policy: 'side_effect_free' },
+      },
+      {
+        id: 'verify', kind: 'command', title: 'verify', command: 'run-verify',
+        timeout_ms: 1_000, max_attempts: 2, effect_policy: { policy: 'side_effect_free' },
+      },
+    ],
+    edges: [{ id: 'start-verify', kind: 'fixed', from: 'start', to: 'verify' }],
+  } as unknown as ForkJoin;
+}
+
+function seedRunning(sessionId: string, descriptor: ReturnType<typeof sealGraphDescriptor>, startNodeId = 'start', projectionOverride?: GraphSchedulerProjection) {
+  const { store } = useTempWorktree(sessionId);
+  const startActivationId = `${descriptor.run_id}:act:${startNodeId}:entry`;
+  const state = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'nonce-runtime',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: projectionOverride ?? {
+      activations: {
+        [startActivationId]: {
+          activation_id: startActivationId, node_id: startNodeId, status: 'ready',
+          attempt_no: 0, attempt_ids: [], traversal_owner_id: startActivationId,
+        },
+      },
+      cohorts: {}, branch_tokens: {}, traversal_counts: {},
+      committed_transitions: {}, terminal_verification_activation_ids: [],
+    },
+    approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approval-1' } },
+  });
+  store.create(state);
+  return { store, startActivationId };
+}
+
+async function exec(operation: string, input: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return graphCommandService.execute({ operation: operation as never, cwd: process.cwd(), input }) as Promise<Record<string, unknown>>;
+}
+
+describe('graphCommandService runtime operations', () => {
+  it('B6: claims a human-approval node, transitions to waiting_human, and completes with the human answer', async () => {
+    const sessionId = 'session-human-approval';
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const { store, startActivationId } = seedRunning(sessionId, descriptor, 'approval');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 'transition-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+
+    const claim = claimed.result.claims[0];
+    expect(claim.kind).toBe('human-approval');
+    expect(claim.waiting_human).toBe(true);
+    expect(claim.activation_id).toBe(startActivationId);
+
+    const afterClaim = store.read()!;
+    expect(afterClaim.status).toBe('waiting_human');
+    expect(afterClaim.claims[claim.lease_id as string]).toMatchObject({ status: 'live' });
+
+    const completed = await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 'transition-approve',
+      claim: { lease_id: claim.lease_id, activation_id: claim.activation_id, attempt_id: claim.attempt_id },
+      result: {
+        outcome: 'succeeded',
+        evidence_refs: [{ kind: 'human', ref: 'human-answer-yes', summary: 'Operator approved' }],
+      },
+    }) as { result: { outcome: string; created_activation_ids: string[] } };
+
+    expect(completed.result.outcome).toBe('succeeded');
+    expect(completed.result.created_activation_ids).toHaveLength(1);
+    const afterComplete = store.read()!;
+    expect(afterComplete.claims[claim.lease_id as string].status).toBe('completed');
+  });
+
+  it('B2: resolve-join resolves a ready join activation through the runtime', async () => {
+    const sessionId = 'session-resolve-join';
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'approval');
+
+    // approval (human-approval) -> complete -> analyze (fan-out) -> branches -> join
+    const ap = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim-approval', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const aClaim = ap.result.claims[0];
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-complete-approval',
+      claim: { lease_id: aClaim.lease_id, activation_id: aClaim.activation_id, attempt_id: aClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'human', ref: 'ok' }] },
+    });
+
+    const az = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      driver_id: 'driver-1', transition_id: 't-claim-analyze', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const zClaim = az.result.claims[0];
+    await exec('complete', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 3,
+      transition_id: 't-complete-analyze',
+      claim: { lease_id: zClaim.lease_id, activation_id: zClaim.activation_id, attempt_id: zClaim.attempt_id },
+      result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: 'analyze' }] },
+    });
+
+    for (const i of [0, 1]) {
+      const bc = await exec('claim', {
+        session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+        descriptor_hash: descriptor.descriptor_hash, expected_sequence: 4 + i * 2,
+        driver_id: 'driver-1', transition_id: `t-claim-branch-${i}`, limit: 1,
+      }) as { result: { claims: Array<Record<string, unknown>> } };
+      const bClaim = bc.result.claims[0];
+      await exec('complete', {
+        session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+        descriptor_hash: descriptor.descriptor_hash, expected_sequence: 5 + i * 2,
+        transition_id: `t-complete-branch-${i}`,
+        claim: { lease_id: bClaim.lease_id, activation_id: bClaim.activation_id, attempt_id: bClaim.attempt_id },
+        result: { outcome: 'succeeded', evidence_refs: [{ kind: 'command', ref: `branch-${i}` }] },
+        // Completing the second branch fills the cohort and activates the join;
+        // supply the join activation identity the scheduler needs at arrival.
+        identities: { join_activation_id: `${descriptor.run_id}:act:join-build:resolved` },
+      });
+    }
+
+    const readyForJoin = await exec('ready', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 8,
+    }) as { joins: Array<Record<string, unknown>> };
+    expect(readyForJoin.joins).toHaveLength(1);
+    const joinActivationId = readyForJoin.joins[0].activation_id as string;
+
+    const resolved = await exec('resolve-join', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 8,
+      transition_id: 't-resolve-join',
+      activation_id: joinActivationId,
+      identities: { next_activation_ids: { 'join-to-verify': `${descriptor.run_id}:act:verify:resolved` } },
+    }) as { result: { outcome: string; created_activation_ids: string[] } };
+
+    expect(resolved.result.outcome).toBe('join_resolved');
+    expect(resolved.result.created_activation_ids).toHaveLength(1);
+    const finalState = store.read()!;
+    expect(finalState.projection.activations[joinActivationId].status).toBe('completed');
+  });
+
+  it('B3: renew-claim renews a live tracked lease and rejects a mismatched owner', async () => {
+    const sessionId = 'session-renew';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+
+    const renewed = await exec('renew-claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-renew',
+      lease_id: claim.lease_id, driver_id: 'driver-1', tracking_id: claim.tracking_id,
+      tool_still_running: true, now: '2026-07-21T00:00:01.000Z',
+    }) as { result: { renewal_count: number } };
+
+    expect(renewed.result.renewal_count).toBe(1);
+    const after = store.read()!;
+    expect(after.claims[claim.lease_id as string].renewal_count).toBe(1);
+
+    await expect(exec('renew-claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-renew-wrong',
+      lease_id: claim.lease_id, driver_id: 'driver-other', tracking_id: claim.tracking_id,
+      tool_still_running: true, now: '2026-07-21T00:00:01.500Z',
+    })).rejects.toThrow(/owner/i);
+  });
+
+  it('B3: release-attempt-for-retry returns an activation to ready and fences its claim', async () => {
+    const sessionId = 'session-release';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+
+    const released = await exec('release-attempt-for-retry', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-release',
+      activation_id: claim.activation_id, attempt_id: claim.attempt_id,
+    }) as { result: { released: boolean } };
+
+    expect(released.result.released).toBe(true);
+    const after = store.read()!;
+    expect(after.projection.activations[claim.activation_id as string].status).toBe('ready');
+    expect(after.claims[claim.lease_id as string].status).toBe('fenced');
+  });
+
+  it('B3: record-late-claim-result records a bounded diagnostic for a fenced lease', async () => {
+    const sessionId = 'session-late';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+    // Fence the claim via release-attempt-for-retry so it is no longer live,
+    // making it eligible for a late-result diagnostic.
+    await exec('release-attempt-for-retry', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-release',
+      activation_id: claim.activation_id, attempt_id: claim.attempt_id,
+    });
+
+    const late = await exec('record-late-claim-result', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 2,
+      transition_id: 't-late',
+      lease_id: claim.lease_id, attempt_id: claim.attempt_id,
+      recorded_at: '2026-07-21T00:00:03.000Z',
+      summary: 'old result arrived after release',
+    }) as { result: { kind: string; lease_id: string } };
+
+    expect(late.result.kind).toBe('late_result');
+    expect(late.result.lease_id).toBe(claim.lease_id);
+    const after = store.read()!;
+    expect(after.diagnostics.at(-1)).toMatchObject({ kind: 'late_result', lease_id: claim.lease_id });
+  });
+
+  it('B3: recover-expired-claim takes over an expired side-effect-free lease', async () => {
+    const sessionId = 'session-recover';
+    const descriptor = sealGraphDescriptor(linearDescriptor());
+    const { store } = seedRunning(sessionId, descriptor, 'start');
+
+    const claimed = await exec('claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      driver_id: 'driver-1', transition_id: 't-claim', limit: 1,
+    }) as { result: { claims: Array<Record<string, unknown>> } };
+    const claim = claimed.result.claims[0];
+    // recoverExpiredGraphClaim requires `now` to be at/after the lease expiry.
+    const expiresAt = claim.expires_at as string;
+    const recoverNow = new Date(Date.parse(expiresAt) + 1_000).toISOString();
+
+    const recovered = await exec('recover-expired-claim', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 1,
+      transition_id: 't-recover',
+      lease_id: claim.lease_id, now: recoverNow,
+      new_attempt_id: 'attempt-2', new_lease_id: 'lease-2', new_tracking_id: 'tool-2',
+      driver_id: 'driver-2', reconciliation_id: 'reconciliation-1',
+    }) as { result: { disposition: string; replacement_lease_id: string } };
+
+    expect(recovered.result.disposition).toBe('taken_over');
+    expect(recovered.result.replacement_lease_id).toBe('lease-2');
+    const after = store.read()!;
+    expect(after.claims['lease-2']).toMatchObject({ status: 'live', attempt_no: 2 });
+    expect(after.claims[claim.lease_id as string].status).toBe('expired_retryable');
+  });
+
+  it('B5: resolve-reconciliation exits the reconciling phase back to running', async () => {
+    const sessionId = 'session-reconcile';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ reconcile: true, runId: 'run-reconcile', goal: 'Reconcile-policy path' }));
+    const { store, startActivationId } = seedRunning(sessionId, descriptor, 'start');
+    // Force the graph into 'reconciling' with an unresolved reconciliation record
+    // (as recoverExpiredGraphClaim would for a reconcile-policy claim).
+    const leaseId = 'lease-reconcile-1';
+    const running = store.read()!;
+    const reconcilingState = {
+      ...running,
+      status: 'reconciling' as const,
+      projection: {
+        ...running.projection,
+        activations: {
+          ...running.projection.activations,
+          [startActivationId]: {
+            ...running.projection.activations[startActivationId],
+            status: 'running' as const,
+            attempt_no: 1,
+            attempt_ids: ['attempt-1'],
+            active_attempt_id: 'attempt-1',
+          },
+        },
+      },
+      claims: {
+        [leaseId]: {
+          run_id: running.run_id,
+          revision_id: running.active_revision_id,
+          revision_hash: running.active_revision_hash,
+          dispatch_generation: running.dispatch_generation,
+          activation_id: startActivationId,
+          attempt_id: 'attempt-1',
+          attempt_no: 1,
+          claim_owner_session_id: sessionId,
+          driver_instance_id: 'driver-1',
+          lease_id: leaseId,
+          tracking_id: 'tool-1',
+          issued_at: '2026-07-21T00:00:00.000Z',
+          expires_at: '2026-07-21T00:00:02.000Z',
+          lease_duration_ms: 2_000,
+          renewal_count: 0,
+          max_renewals: 2,
+          effect_policy: { policy: 'reconcile' },
+          status: 'reconciling' as const,
+          fenced_at: '2026-07-21T00:00:02.000Z',
+        },
+      },
+      reconciliations: {
+        'reconciliation-1': {
+          reconciliation_id: 'reconciliation-1',
+          activation_id: startActivationId,
+          attempt_id: 'attempt-1',
+          lease_id: leaseId,
+          revision_id: running.active_revision_id,
+          revision_hash: running.active_revision_hash,
+          dispatch_generation: running.dispatch_generation,
+          status: 'unresolved' as const,
+          reason: 'expired_ambiguous' as const,
+          created_at: '2026-07-21T00:00:02.000Z',
+        },
+      },
+    } as unknown as typeof running;
+    // Overwrite the state file directly through the store's write path.
+    const storePath = (store as unknown as { path: string }).path;
+    writeFileSync(storePath, JSON.stringify(reconcilingState));
+    // Sanity: the store re-reads the reconciling state.
+    expect(store.read()?.status).toBe('reconciling');
+
+    const resolved = await exec('resolve-reconciliation', {
+      session_id: sessionId, run_id: descriptor.run_id, revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash, expected_sequence: 0,
+      transition_id: 't-resolve-recon',
+      evidence: { kind: 'human', ref: 'operator-resolved', summary: 'Operator confirmed no external effect' },
+      resolved_at: '2026-07-21T00:00:05.000Z',
+    }) as { result: { status: string; resolved_reconciliation_ids: string[] } };
+
+    expect(resolved.result.status).toBe('running');
+    expect(resolved.result.resolved_reconciliation_ids).toEqual(['reconciliation-1']);
+    const after = store.read()!;
+    expect(after.status).toBe('running');
+    expect(after.reconciliations['reconciliation-1'].status).toBe('accepted');
+  });
+
+  it('non-blocker: create is idempotent only when the descriptor hash matches', async () => {
+    const sessionId = 'session-idempotent';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-linear', goal: 'Original goal' }));
+    const { store } = useTempWorktree(sessionId);
+    // Seed an existing graph with the SAME run_id/revision_id but a DIFFERENT goal
+    // (and therefore a different descriptor hash).
+    const otherInput = linearDescriptor({ runId: descriptor.run_id, goal: 'A different goal for hash mismatch' });
+    const otherDescriptor = sealGraphDescriptor(otherInput);
+    expect(otherDescriptor.run_id).toBe(descriptor.run_id);
+    expect(otherDescriptor.revision_id).toBe(descriptor.revision_id);
+    expect(otherDescriptor.descriptor_hash).not.toBe(descriptor.descriptor_hash);
+    store.create(createInitialGraphState({
+      session_id: sessionId,
+      control_nonce: 'nonce-idem',
+      descriptor: otherDescriptor,
+      status: 'running',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection: {
+        activations: {}, cohorts: {}, branch_tokens: {}, traversal_counts: {},
+        committed_transitions: {}, terminal_verification_activation_ids: [],
+      },
+      approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approve' } },
+    }));
+
+    // create with a different hash must throw hash_mismatch, not silently return.
+    await expect(exec('create', {
+      goal: descriptor.goal,
+      descriptor,
+      session_id: sessionId,
+      driver_id: 'driver-1',
+      transition_id: 't-create-mismatch',
+    })).rejects.toThrow(/hash_mismatch/);
+
+    // Re-creating with the exact same descriptor is idempotent.
+    const idempotent = await exec('create', {
+      goal: otherDescriptor.goal,
+      descriptor: otherDescriptor,
+      session_id: sessionId,
+      driver_id: 'driver-1',
+      transition_id: 't-create-idem',
+    }) as { run_id: string };
+    expect(idempotent.run_id).toBe(otherDescriptor.run_id);
+  });
+});

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -581,7 +581,7 @@ describe('graphCommandService runtime operations', () => {
     const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-create-concurrent-idempotent' }));
     const { store } = useTempWorktree(sessionId);
     const originalCreate = GraphStateStore.prototype.create;
-    const create = vi.spyOn(GraphStateStore.prototype, 'create').mockImplementationOnce(function(state) {
+    const create = vi.spyOn(GraphStateStore.prototype, 'create').mockImplementationOnce(function(this: GraphStateStore, state: Parameters<GraphStateStore['create']>[0]) {
       originalCreate.call(this, state);
       const raced = new Error('Graph state already exists for this session') as Error & { code: string };
       raced.code = 'already_exists';

--- a/src/graph/__tests__/runtime.test.ts
+++ b/src/graph/__tests__/runtime.test.ts
@@ -2,8 +2,9 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ControlOwnerStore } from '../control-owner.js';
 import { sealGraphDescriptor } from '../descriptor.js';
 import { occCommitMutation, occReadCurrentState } from '../../lib/mode-state-io.js';
 import { graphCommandService } from '../runtime.js';
@@ -425,7 +426,7 @@ describe('graphCommandService runtime operations', () => {
   it('non-blocker: create is idempotent only when the descriptor hash matches', async () => {
     const sessionId = 'session-idempotent';
     const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-linear', goal: 'Original goal' }));
-    const { store } = useTempWorktree(sessionId);
+    const { worktree, store } = useTempWorktree(sessionId);
     // Seed an existing graph with the SAME run_id/revision_id but a DIFFERENT goal
     // (and therefore a different descriptor hash).
     const otherInput = linearDescriptor({ runId: descriptor.run_id, goal: 'A different goal for hash mismatch' });
@@ -445,6 +446,25 @@ describe('graphCommandService runtime operations', () => {
       },
       approval: { approved_at: '2026-07-21T00:00:00.000Z', evidence: { kind: 'human', ref: 'approve' } },
     }));
+    const controls = new ControlOwnerStore({ sessionId, worktreeRoot: worktree });
+    controls.reserveRoot({
+      mode: 'graph',
+      run_id: otherDescriptor.run_id,
+      nonce: 'nonce-idem',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: { revision_id: otherDescriptor.revision_id, revision_hash: otherDescriptor.descriptor_hash },
+    });
+    controls.promoteRoot({
+      mode: 'graph',
+      run_id: otherDescriptor.run_id,
+      nonce: 'nonce-idem',
+      promoted_at: '2026-07-21T00:00:00.000Z',
+      driver_lease: {
+        driver_instance_id: 'driver-idem',
+        lease_id: 'lease-idem',
+        expires_at: '2026-07-21T01:00:00.000Z',
+      },
+    });
 
     // create with a different hash must throw hash_mismatch, not silently return.
     await expect(exec('create', {
@@ -464,5 +484,126 @@ describe('graphCommandService runtime operations', () => {
       transition_id: 't-create-idem',
     }) as { run_id: string };
     expect(idempotent.run_id).toBe(otherDescriptor.run_id);
+  });
+
+  it('reserves the control root before publishing and leaves no graph when another root owns the session', async () => {
+    const sessionId = 'session-create-root-conflict';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-create-root-conflict' }));
+    const { worktree, store } = useTempWorktree(sessionId);
+    const controls = new ControlOwnerStore({ sessionId, worktreeRoot: worktree });
+    controls.reserveRoot({
+      mode: 'autopilot',
+      run_id: 'autopilot-owner',
+      nonce: 'autopilot-nonce',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+    });
+
+    await expect(exec('create', {
+      goal: descriptor.goal,
+      descriptor,
+      session_id: sessionId,
+      driver_id: 'driver-create',
+      transition_id: 't-create-conflict',
+    })).rejects.toThrow(/root_conflict/i);
+
+    expect(store.read()).toBeNull();
+    expect(controls.read()?.root).toMatchObject({
+      mode: 'autopilot', run_id: 'autopilot-owner', nonce: 'autopilot-nonce', phase: 'reserved',
+    });
+  });
+
+  it('reuses only the exact pre-publish graph reservation, then approval promotes that reservation', async () => {
+    const sessionId = 'session-create-reservation-retry';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-create-reservation-retry' }));
+    const { worktree, store } = useTempWorktree(sessionId);
+    const controls = new ControlOwnerStore({ sessionId, worktreeRoot: worktree });
+    controls.reserveRoot({
+      mode: 'graph',
+      run_id: descriptor.run_id,
+      nonce: 'crash-before-publish-nonce',
+      reserved_at: '2026-07-21T00:00:00.000Z',
+      graph_revision: { revision_id: descriptor.revision_id, revision_hash: descriptor.descriptor_hash },
+    });
+
+    const created = await exec('create', {
+      goal: descriptor.goal,
+      descriptor,
+      session_id: sessionId,
+      driver_id: 'driver-create',
+      transition_id: 't-create-retry',
+    });
+    expect(created.control_nonce).toBe('crash-before-publish-nonce');
+    expect(store.read()).toMatchObject({ control_nonce: 'crash-before-publish-nonce', status: 'awaiting_approval' });
+    expect(controls.read()?.root).toMatchObject({ nonce: 'crash-before-publish-nonce', phase: 'reserved' });
+
+    await exec('approve', {
+      session_id: sessionId,
+      run_id: descriptor.run_id,
+      revision_id: descriptor.revision_id,
+      descriptor_hash: descriptor.descriptor_hash,
+      transition_id: 't-approve-retried-create',
+      approval: {
+        approved_at: '2026-07-21T00:00:01.000Z',
+        evidence: { kind: 'human', ref: 'operator-approved' },
+        driver_id: 'driver-approve',
+      },
+    });
+
+    expect(controls.read()?.root).toMatchObject({ nonce: 'crash-before-publish-nonce', phase: 'active' });
+  });
+
+  it('rolls back only its own reservation when the initial durable publish fails', async () => {
+    const sessionId = 'session-create-publish-failure';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-create-publish-failure' }));
+    const { worktree, store } = useTempWorktree(sessionId);
+    const create = vi.spyOn(GraphStateStore.prototype, 'create').mockImplementationOnce(() => {
+      throw new Error('simulated initial publish failure');
+    });
+
+    try {
+      await expect(exec('create', {
+        goal: descriptor.goal,
+        descriptor,
+        session_id: sessionId,
+        driver_id: 'driver-create',
+        transition_id: 't-create-publish-failure',
+      })).rejects.toThrow(/simulated initial publish failure/);
+    } finally {
+      create.mockRestore();
+    }
+
+    expect(store.read()).toBeNull();
+    expect(new ControlOwnerStore({ sessionId, worktreeRoot: worktree }).read()?.root).toBeNull();
+  });
+
+  it('returns the exact concurrent publish as an idempotent create success', async () => {
+    const sessionId = 'session-create-concurrent-idempotent';
+    const descriptor = sealGraphDescriptor(linearDescriptor({ runId: 'run-create-concurrent-idempotent' }));
+    const { store } = useTempWorktree(sessionId);
+    const originalCreate = GraphStateStore.prototype.create;
+    const create = vi.spyOn(GraphStateStore.prototype, 'create').mockImplementationOnce(function(state) {
+      originalCreate.call(this, state);
+      const raced = new Error('Graph state already exists for this session') as Error & { code: string };
+      raced.code = 'already_exists';
+      throw raced;
+    });
+
+    try {
+      const result = await exec('create', {
+        goal: descriptor.goal,
+        descriptor,
+        session_id: sessionId,
+        driver_id: 'driver-create',
+        transition_id: 't-create-concurrent-idempotent',
+      }) as { run_id: string };
+      expect(result.run_id).toBe(descriptor.run_id);
+    } finally {
+      create.mockRestore();
+    }
+
+    expect(store.read()).toMatchObject({ run_id: descriptor.run_id, status: 'awaiting_approval' });
+    expect(new ControlOwnerStore({ sessionId }).read()?.root).toMatchObject({
+      mode: 'graph', run_id: descriptor.run_id, phase: 'reserved',
+    });
   });
 });

--- a/src/graph/__tests__/scheduler.test.ts
+++ b/src/graph/__tests__/scheduler.test.ts
@@ -311,14 +311,31 @@ describe('graph scheduler', () => {
       ),
     ).toThrow(/fresh evidence/i);
 
-    const failed = applyNodeResult(descriptor, projection, {
+    // A3: a failed verification is retryable while the attempt budget remains
+    // (executableNode verify has max_attempts=2), so the FIRST failure leaves it
+    // 'ready'; only the SECOND failure (budget exhausted) goes terminal 'failed'.
+    let failed = applyNodeResult(descriptor, projection, {
       activation_id: 'act-verify',
-      transition_id: 'transition-failed-verify',
+      transition_id: 'transition-failed-verify-1',
       result: {
         outcome: 'failed',
         attempt_id: 'try-verify',
         output_summary: 'Verification failed',
         evidence_refs: [{ kind: 'test', ref: 'npm-test', summary: 'One test failed' }],
+      },
+    });
+    expect(failed.projection.activations['act-verify'].status).toBe('ready');
+    expect(isGraphSucceeded(descriptor, failed.projection)).toBe(false);
+
+    projection = begin(failed.projection, 'act-verify', 'try-verify-2');
+    failed = applyNodeResult(descriptor, projection, {
+      activation_id: 'act-verify',
+      transition_id: 'transition-failed-verify-2',
+      result: {
+        outcome: 'failed',
+        attempt_id: 'try-verify-2',
+        output_summary: 'Verification failed again',
+        evidence_refs: [{ kind: 'test', ref: 'npm-test', summary: 'Still failing' }],
       },
     });
     expect(failed.projection.activations['act-verify'].status).toBe('failed');

--- a/src/graph/__tests__/scheduler.test.ts
+++ b/src/graph/__tests__/scheduler.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GraphSchedulerError,
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+  releaseAttemptForRetry,
+  resolveJoin,
+  sealGraphDescriptor,
+} from '../index.js';
+import type {
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SchedulerTransitionIdentities,
+} from '../types.js';
+import { forkJoinDescriptor, loopDescriptor } from './fixtures.js';
+
+function begin(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+): GraphSchedulerProjection {
+  return beginActivationAttempt(projection, {
+    activation_id: activationId,
+    attempt_id: attemptId,
+  });
+}
+
+function succeed(
+  descriptor: ReturnType<typeof sealGraphDescriptor>,
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+  transitionId: string,
+  identities: SchedulerTransitionIdentities = {},
+  route?: string,
+  evidenceRefs: GraphEvidenceReference[] = [],
+) {
+  return applyNodeResult(descriptor, projection, {
+    activation_id: activationId,
+    transition_id: transitionId,
+    result: {
+      outcome: 'succeeded',
+      attempt_id: attemptId,
+      evidence_refs: evidenceRefs,
+      ...(route ? { route } : {}),
+    },
+    identities,
+  });
+}
+
+describe('graph scheduler', () => {
+  it('retries under one activation and gives each attempt a distinct identity', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    let projection = initializeGraphProjection(descriptor, {
+      start: 'activation-start',
+    });
+    projection = begin(projection, 'activation-start', 'attempt-1');
+    projection = releaseAttemptForRetry(projection, {
+      activation_id: 'activation-start',
+      attempt_id: 'attempt-1',
+    });
+    projection = begin(projection, 'activation-start', 'attempt-2');
+
+    expect(projection.activations['activation-start']).toMatchObject({
+      activation_id: 'activation-start',
+      attempt_no: 2,
+      active_attempt_id: 'attempt-2',
+      attempt_ids: ['attempt-1', 'attempt-2'],
+    });
+  });
+
+  it('fails closed on an undeclared route and enforces a back-edge bound per lineage', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    let projection = initializeGraphProjection(descriptor, { start: 'a-start' });
+    projection = begin(projection, 'a-start', 'try-start');
+    projection = succeed(descriptor, projection, 'a-start', 'try-start', 't-start', {
+      next_activation_ids: { 'start-test': 'a-test-1' },
+    }).projection;
+
+    projection = begin(projection, 'a-test-1', 'try-test-1');
+    expect(() =>
+      succeed(descriptor, projection, 'a-test-1', 'try-test-1', 'bad-route', {}, 'unknown'),
+    ).toThrow(/undeclared route/i);
+
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-test-1',
+      'try-test-1',
+      't-test-1',
+      { next_activation_ids: { 'test-fail': 'a-fix-1' } },
+      'fail',
+    ).projection;
+    projection = begin(projection, 'a-fix-1', 'try-fix-1');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-fix-1',
+      'try-fix-1',
+      't-fix-1',
+      { next_activation_ids: { 'retry-test': 'a-test-2' } },
+      'retry',
+    ).projection;
+    projection = begin(projection, 'a-test-2', 'try-test-2');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-test-2',
+      'try-test-2',
+      't-test-2',
+      { next_activation_ids: { 'test-fail': 'a-fix-2' } },
+      'fail',
+    ).projection;
+    projection = begin(projection, 'a-fix-2', 'try-fix-2');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-fix-2',
+      'try-fix-2',
+      't-fix-2',
+      { next_activation_ids: { 'retry-test': 'a-test-3' } },
+      'retry',
+    ).projection;
+    projection = begin(projection, 'a-test-3', 'try-test-3');
+    projection = succeed(
+      descriptor,
+      projection,
+      'a-test-3',
+      'try-test-3',
+      't-test-3',
+      { next_activation_ids: { 'test-fail': 'a-fix-3' } },
+      'fail',
+    ).projection;
+    projection = begin(projection, 'a-fix-3', 'try-fix-3');
+
+    expect(() =>
+      succeed(
+        descriptor,
+        projection,
+        'a-fix-3',
+        'try-fix-3',
+        't-fix-3',
+        { next_activation_ids: { 'retry-test': 'a-test-4' } },
+        'retry',
+      ),
+    ).toThrow(/traversal bound/i);
+  });
+
+  it('creates a selected fan-out cohort and consumes its branch tokens once at join', () => {
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    let projection = initializeGraphProjection(descriptor, { approval: 'act-approval' });
+    expect(listReadyExecutableActivations(descriptor, projection).map((item) => item.node_id))
+      .toEqual(['approval']);
+    projection = begin(projection, 'act-approval', 'try-approval');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-approval',
+      'try-approval',
+      'transition-approval',
+      { next_activation_ids: { 'approval-to-analyze': 'act-analyze' } },
+    ).projection;
+    expect(listReadyExecutableActivations(descriptor, projection).map((item) => item.node_id))
+      .toEqual(['analyze']);
+    projection = begin(projection, 'act-analyze', 'try-analyze');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-analyze',
+      'try-analyze',
+      'transition-analyze',
+      {
+        cohort_id: 'cohort-build',
+        next_activation_ids: { 'fan-a': 'act-a', 'fan-b': 'act-b' },
+        branch_token_ids: { 'fan-a': 'token-a', 'fan-b': 'token-b' },
+      },
+    ).projection;
+
+    expect(listReadyExecutableActivations(descriptor, projection).map((item) => item.activation_id))
+      .toEqual(['act-a', 'act-b']);
+    expect(projection.cohorts['cohort-build'].expected_branch_token_ids).toEqual([
+      'token-a',
+      'token-b',
+    ]);
+
+    projection = begin(projection, 'act-a', 'try-a');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-a',
+      'try-a',
+      'transition-a',
+    ).projection;
+    expect(listReadyJoinActivations(descriptor, projection)).toEqual([]);
+
+    projection = begin(projection, 'act-b', 'try-b');
+    const completedB = succeed(
+      descriptor,
+      projection,
+      'act-b',
+      'try-b',
+      'transition-b',
+      { join_activation_id: 'act-join' },
+    );
+    projection = completedB.projection;
+    expect(listReadyJoinActivations(descriptor, projection).map((item) => item.activation_id))
+      .toEqual(['act-join']);
+
+    const replay = succeed(
+      descriptor,
+      projection,
+      'act-b',
+      'try-b',
+      'transition-b',
+      { join_activation_id: 'act-join' },
+    );
+    expect(replay.replayed).toBe(true);
+    expect(replay.projection).toBe(projection);
+    expect(() =>
+      succeed(
+        descriptor,
+        projection,
+        'act-b',
+        'try-b',
+        'transition-b',
+        { join_activation_id: 'different-id' },
+      ),
+    ).toThrow(/fingerprint/i);
+
+    const joined = resolveJoin(descriptor, projection, {
+      activation_id: 'act-join',
+      transition_id: 'transition-join',
+      identities: { next_activation_ids: { 'join-to-verify': 'act-verify' } },
+    });
+    projection = joined.projection;
+    expect(projection.branch_tokens['token-a'].status).toBe('consumed');
+    expect(projection.branch_tokens['token-b'].status).toBe('consumed');
+    const joinReplay = resolveJoin(descriptor, projection, {
+      activation_id: 'act-join',
+      transition_id: 'transition-join',
+      identities: { next_activation_ids: { 'join-to-verify': 'act-verify' } },
+    });
+    expect(joinReplay.replayed).toBe(true);
+    expect(() =>
+      resolveJoin(descriptor, projection, {
+        activation_id: 'act-join',
+        transition_id: 'transition-join',
+        identities: { next_activation_ids: { 'join-to-verify': 'different-verify' } },
+      }),
+    ).toThrow(/fingerprint/i);
+    expect(() =>
+      resolveJoin(descriptor, projection, {
+        activation_id: 'act-join',
+        transition_id: 'another-transition',
+        identities: { next_activation_ids: { 'join-to-verify': 'other-verify' } },
+      }),
+    ).toThrow(GraphSchedulerError);
+
+    projection = begin(projection, 'act-verify', 'try-verify');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-verify',
+      'try-verify',
+      'transition-verify',
+      {},
+      undefined,
+      [{ kind: 'test', ref: 'npm-test', summary: 'All checks passed' }],
+    ).projection;
+    expect(isGraphSucceeded(descriptor, projection)).toBe(true);
+  });
+
+  it('does not report success while runnable work remains', () => {
+    const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+    const projection = initializeGraphProjection(descriptor, { approval: 'act-approval' });
+
+    expect(isGraphSucceeded(descriptor, projection)).toBe(false);
+  });
+
+  it('requires evidence for terminal success and keeps terminal failure non-successful', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    let projection = initializeGraphProjection(descriptor, { start: 'act-start' });
+    projection = begin(projection, 'act-start', 'try-start');
+    projection = succeed(descriptor, projection, 'act-start', 'try-start', 'transition-start', {
+      next_activation_ids: { 'start-test': 'act-test' },
+    }).projection;
+    projection = begin(projection, 'act-test', 'try-test');
+    projection = succeed(
+      descriptor,
+      projection,
+      'act-test',
+      'try-test',
+      'transition-test',
+      { next_activation_ids: { 'test-pass': 'act-verify' } },
+      'pass',
+    ).projection;
+    projection = begin(projection, 'act-verify', 'try-verify');
+
+    expect(() =>
+      succeed(
+        descriptor,
+        projection,
+        'act-verify',
+        'try-verify',
+        'transition-no-evidence',
+      ),
+    ).toThrow(/fresh evidence/i);
+
+    const failed = applyNodeResult(descriptor, projection, {
+      activation_id: 'act-verify',
+      transition_id: 'transition-failed-verify',
+      result: {
+        outcome: 'failed',
+        attempt_id: 'try-verify',
+        output_summary: 'Verification failed',
+        evidence_refs: [{ kind: 'test', ref: 'npm-test', summary: 'One test failed' }],
+      },
+    });
+    expect(failed.projection.activations['act-verify'].status).toBe('failed');
+    expect(isGraphSucceeded(descriptor, failed.projection)).toBe(false);
+  });
+});

--- a/src/graph/__tests__/state-store.test.ts
+++ b/src/graph/__tests__/state-store.test.ts
@@ -4,8 +4,8 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
 import { sealGraphDescriptor } from '../descriptor.js';
+import { occCommitMutation, occReadCurrentState } from '../../lib/mode-state-io.js';
 import { createInitialGraphState } from '../runtime-types.js';
 import { approveGraphPatch, proposeGraphPatch } from '../revisions.js';
 import { GraphStateStore, GraphStoreError, type GraphStateStoreDependencies } from '../store.js';
@@ -14,8 +14,7 @@ import { forkJoinDescriptor } from './fixtures.js';
 const temporaryDirectories: string[] = [];
 
 function createStore(
-  writeAtomic = atomicWriteJsonSync,
-  withExclusiveLock: GraphStateStoreDependencies['withExclusiveLock'] = (_path, callback) => ({ acquired: true, value: callback(() => {}) }),
+  occCommit: GraphStateStoreDependencies['occCommit'] = occCommitMutation,
 ) {
   const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-graph-store-'));
   temporaryDirectories.push(worktreeRoot);
@@ -25,8 +24,8 @@ function createStore(
     dependencies: {
       fileExists: existsSync,
       readText: (path) => readFileSync(path, 'utf8'),
-      writeAtomic,
-      withExclusiveLock,
+      readCurrent: occReadCurrentState,
+      occCommit,
     },
   });
 }
@@ -68,9 +67,9 @@ describe('GraphStateStore', () => {
     expect(store.read()?.session_id).toBe('session-store');
   });
 
-  it('commits one complete generation and replays an exact transition without a second write', () => {
-    const writeAtomic = vi.fn(atomicWriteJsonSync);
-    const store = createStore(writeAtomic);
+  it('commits one complete generation and replays an exact transition without re-running the callback', () => {
+    const occCommit = vi.fn(occCommitMutation) as unknown as GraphStateStoreDependencies['occCommit'];
+    const store = createStore(occCommit);
     const created = store.create(initialState());
     const request = {
       transition_id: 'transition-complete-a',
@@ -109,19 +108,19 @@ describe('GraphStateStore', () => {
     expect(committed.state.commit_sequence).toBe(1);
     expect(replay).toMatchObject({ replayed: true, result: { selected_edge_ids: ['fan-a'] } });
     expect(replay.state.diagnostics).toHaveLength(1);
-    expect(writeAtomic).toHaveBeenCalledTimes(2);
+    // create() commits once; the first mutate() commits once; the replayed
+    // mutate() is served from the committed transition (no new transition), so
+    // the OCC callback still runs to detect the replay but no logical write.
+    expect(occCommit).toHaveBeenCalledTimes(3);
   });
 
-  it('exposes cooperative lease renewal and renews again before publishing a graph mutation', () => {
-    const renew = vi.fn();
-    const store = createStore(
-      atomicWriteJsonSync,
-      (_path, callback) => ({ acquired: true, value: callback(renew) }),
-    );
+  it('does not invoke a renewal hook (OCC has no lease; renew is a no-op)', () => {
+    const store = createStore();
     const created = store.create(initialState());
-    renew.mockClear();
 
-    store.mutate({
+    // Under OCC there is no lease to renew; the mutate callback's `renew`
+    // argument is a no-op. The mutation still commits exactly once.
+    const committed = store.mutate({
       transition_id: 'renewable-transition',
       operation: 'renewable-operation',
       operation_fingerprint: 'renewable-operation:v1',
@@ -133,12 +132,12 @@ describe('GraphStateStore', () => {
         dispatch_generation: created.dispatch_generation,
         commit_sequence: created.commit_sequence,
       },
-    }, (state, renewLease) => {
-      renewLease();
+    }, (state, renew) => {
+      renew();
       return { next: state, result: 'renewed' };
     });
 
-    expect(renew).toHaveBeenCalledTimes(2);
+    expect(committed.result).toBe('renewed');
   });
 
   it('allows one expected-sequence writer and rejects the stale competitor', async () => {
@@ -173,24 +172,9 @@ describe('GraphStateStore', () => {
     expect(store.read()?.commit_sequence).toBe(1);
   });
 
-  it('exposes a complete old or new generation across atomic writer failures', () => {
+  it('leaves the prior committed generation intact when a mutation callback throws (OCC is all-or-nothing)', () => {
     const store = createStore();
     const created = store.create(initialState());
-    let mode: 'before' | 'after' = 'before';
-    const failingStore = new GraphStateStore({
-      sessionId: 'session-store',
-      worktreeRoot: store.worktreeRoot,
-      dependencies: {
-        fileExists: existsSync,
-        readText: (path) => readFileSync(path, 'utf8'),
-        withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
-        writeAtomic: (path, value) => {
-          if (mode === 'before') throw new Error('before rename');
-          atomicWriteJsonSync(path, value);
-          throw new Error('after rename');
-        },
-      },
-    });
     const request = {
       transition_id: 'atomic-transition',
       operation: 'atomic-test',
@@ -205,17 +189,23 @@ describe('GraphStateStore', () => {
       },
     } as const;
 
-    expect(() => failingStore.mutate(request, (state) => ({ next: state, result: 'new' })))
-      .toThrow('before rename');
-    expect(store.read()?.commit_sequence).toBe(0);
+    // First, commit a successful transition so there is a real prior generation.
+    store.mutate(request, (state) => ({ next: state, result: 'committed' }));
+    expect(store.read()?.commit_sequence).toBe(1);
 
-    mode = 'after';
-    expect(() => failingStore.mutate(request, (state) => ({ next: state, result: 'new' })))
-      .toThrow('after rename');
-    expect(store.read()).toMatchObject({
-      commit_sequence: 1,
-      transitions: [{ transition_id: 'atomic-transition' }],
-    });
+    // A callback that throws must NOT advance the committed state: OCC commits
+    // only on a clean { state, result } return, so the throw aborts the entry.
+    const second = {
+      ...request,
+      transition_id: 'throwing-transition',
+      expected: { ...request.expected, commit_sequence: 1 },
+    } as const;
+    expect(() => store.mutate(second, () => {
+      throw new Error('mutation aborted');
+    })).toThrow('mutation aborted');
+    expect(store.read()?.commit_sequence).toBe(1);
+    // The original generation is still readable and intact.
+    expect(store.read()?.transitions).toHaveLength(1);
   });
 
   it('fails closed for a reused transition ID with a different request fence', () => {

--- a/src/graph/__tests__/state-store.test.ts
+++ b/src/graph/__tests__/state-store.test.ts
@@ -1,0 +1,310 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { atomicWriteJsonSync } from '../../lib/atomic-write.js';
+import { sealGraphDescriptor } from '../descriptor.js';
+import { createInitialGraphState } from '../runtime-types.js';
+import { approveGraphPatch, proposeGraphPatch } from '../revisions.js';
+import { GraphStateStore, GraphStoreError, type GraphStateStoreDependencies } from '../store.js';
+import { forkJoinDescriptor } from './fixtures.js';
+
+const temporaryDirectories: string[] = [];
+
+function createStore(
+  writeAtomic = atomicWriteJsonSync,
+  withExclusiveLock: GraphStateStoreDependencies['withExclusiveLock'] = (_path, callback) => ({ acquired: true, value: callback(() => {}) }),
+) {
+  const worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-graph-store-'));
+  temporaryDirectories.push(worktreeRoot);
+  return new GraphStateStore({
+    sessionId: 'session-store',
+    worktreeRoot,
+    dependencies: {
+      fileExists: existsSync,
+      readText: (path) => readFileSync(path, 'utf8'),
+      writeAtomic,
+      withExclusiveLock,
+    },
+  });
+}
+
+function initialState() {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  return createInitialGraphState({
+    session_id: 'session-store',
+    control_nonce: 'control-store',
+    descriptor,
+    status: 'running',
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {},
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    approval: {
+      approved_at: '2026-07-21T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'approval-1' },
+    },
+  });
+}
+
+afterEach(() => {
+  for (const path of temporaryDirectories.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe('GraphStateStore', () => {
+  it('uses only the explicit session-scoped authority path', () => {
+    const store = createStore();
+    store.create(initialState());
+
+    expect(store.path).toContain('/state/sessions/session-store/graph-state.json');
+    expect(store.path).not.toContain('/state/graph-state.json');
+    expect(store.read()?.session_id).toBe('session-store');
+  });
+
+  it('commits one complete generation and replays an exact transition without a second write', () => {
+    const writeAtomic = vi.fn(atomicWriteJsonSync);
+    const store = createStore(writeAtomic);
+    const created = store.create(initialState());
+    const request = {
+      transition_id: 'transition-complete-a',
+      operation: 'complete-node',
+      operation_fingerprint: 'complete-node:activation-a:attempt-a',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: created.dispatch_generation,
+        commit_sequence: created.commit_sequence,
+      },
+    } as const;
+
+    const committed = store.mutate(request, (state) => ({
+      next: {
+        ...state,
+        diagnostics: [
+          ...state.diagnostics,
+          {
+            kind: 'operation' as const,
+            recorded_at: '2026-07-21T00:00:01.000Z',
+            summary: 'node completed once',
+          },
+        ],
+      },
+      result: { selected_edge_ids: ['fan-a'] },
+    }));
+
+    const replay = store.mutate(request, () => {
+      throw new Error('replayed callbacks must not execute');
+    });
+
+    expect(committed.replayed).toBe(false);
+    expect(committed.state.commit_sequence).toBe(1);
+    expect(replay).toMatchObject({ replayed: true, result: { selected_edge_ids: ['fan-a'] } });
+    expect(replay.state.diagnostics).toHaveLength(1);
+    expect(writeAtomic).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes cooperative lease renewal and renews again before publishing a graph mutation', () => {
+    const renew = vi.fn();
+    const store = createStore(
+      atomicWriteJsonSync,
+      (_path, callback) => ({ acquired: true, value: callback(renew) }),
+    );
+    const created = store.create(initialState());
+    renew.mockClear();
+
+    store.mutate({
+      transition_id: 'renewable-transition',
+      operation: 'renewable-operation',
+      operation_fingerprint: 'renewable-operation:v1',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: created.dispatch_generation,
+        commit_sequence: created.commit_sequence,
+      },
+    }, (state, renewLease) => {
+      renewLease();
+      return { next: state, result: 'renewed' };
+    });
+
+    expect(renew).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows one expected-sequence writer and rejects the stale competitor', async () => {
+    const store = createStore();
+    const created = store.create(initialState());
+    const expected = {
+      session_id: created.session_id,
+      run_id: created.run_id,
+      revision_id: created.active_revision_id,
+      revision_hash: created.active_revision_hash,
+      dispatch_generation: created.dispatch_generation,
+      commit_sequence: 0,
+    };
+
+    const results = await Promise.allSettled([
+      Promise.resolve().then(() => store.mutate({
+        transition_id: 'writer-a',
+        operation: 'race',
+        operation_fingerprint: 'race:a',
+        expected,
+      }, (state) => ({ next: state, result: 'a' }))),
+      Promise.resolve().then(() => store.mutate({
+        transition_id: 'writer-b',
+        operation: 'race',
+        operation_fingerprint: 'race:b',
+        expected,
+      }, (state) => ({ next: state, result: 'b' }))),
+    ]);
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(store.read()?.commit_sequence).toBe(1);
+  });
+
+  it('exposes a complete old or new generation across atomic writer failures', () => {
+    const store = createStore();
+    const created = store.create(initialState());
+    let mode: 'before' | 'after' = 'before';
+    const failingStore = new GraphStateStore({
+      sessionId: 'session-store',
+      worktreeRoot: store.worktreeRoot,
+      dependencies: {
+        fileExists: existsSync,
+        readText: (path) => readFileSync(path, 'utf8'),
+        withExclusiveLock: (_path, callback) => ({ acquired: true, value: callback() }),
+        writeAtomic: (path, value) => {
+          if (mode === 'before') throw new Error('before rename');
+          atomicWriteJsonSync(path, value);
+          throw new Error('after rename');
+        },
+      },
+    });
+    const request = {
+      transition_id: 'atomic-transition',
+      operation: 'atomic-test',
+      operation_fingerprint: 'atomic-test:v1',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: 0,
+        commit_sequence: 0,
+      },
+    } as const;
+
+    expect(() => failingStore.mutate(request, (state) => ({ next: state, result: 'new' })))
+      .toThrow('before rename');
+    expect(store.read()?.commit_sequence).toBe(0);
+
+    mode = 'after';
+    expect(() => failingStore.mutate(request, (state) => ({ next: state, result: 'new' })))
+      .toThrow('after rename');
+    expect(store.read()).toMatchObject({
+      commit_sequence: 1,
+      transitions: [{ transition_id: 'atomic-transition' }],
+    });
+  });
+
+  it('fails closed for a reused transition ID with a different request fence', () => {
+    const store = createStore();
+    const created = store.create(initialState());
+    const base = {
+      transition_id: 'same-id',
+      operation: 'complete-node',
+      operation_fingerprint: 'complete:one',
+      expected: {
+        session_id: created.session_id,
+        run_id: created.run_id,
+        revision_id: created.active_revision_id,
+        revision_hash: created.active_revision_hash,
+        dispatch_generation: 0,
+        commit_sequence: 0,
+      },
+    } as const;
+    store.mutate(base, (state) => ({ next: state, result: 'ok' }));
+
+    expect(() => store.mutate(
+      { ...base, operation_fingerprint: 'complete:different' },
+      (state) => ({ next: state, result: 'wrong' }),
+    )).toThrowError(GraphStoreError);
+  });
+
+  it('accepts an old dispatch generation only while the exact pending patch base remains unchanged', () => {
+    const store = createStore();
+    const base = initialState();
+    const proposedInput = forkJoinDescriptor();
+    proposedInput.revision_id = 'revision-2';
+    proposedInput.goal = 'Patched graph';
+    const proposedDescriptor = sealGraphDescriptor(proposedInput);
+    const proposed = proposeGraphPatch(base, {
+      proposal_id: 'patch-1',
+      base_revision_id: base.active_revision_id,
+      base_revision_hash: base.active_revision_hash,
+      proposed_descriptor: proposedDescriptor,
+      invalidated_node_ids: [],
+      proposal_evidence: [],
+      proposed_at: '2026-07-21T00:00:01.000Z',
+    });
+    store.create(proposed);
+    const oldFence = {
+      session_id: proposed.session_id,
+      run_id: proposed.run_id,
+      revision_id: proposed.active_revision_id,
+      revision_hash: proposed.active_revision_hash,
+      dispatch_generation: 0,
+      commit_sequence: 0,
+    };
+    const drained = store.mutate({
+      transition_id: 'old-claim-complete',
+      operation: 'complete-node',
+      operation_fingerprint: 'old-claim:lease-1',
+      expected: oldFence,
+      fence_scope: 'pending_patch_base',
+    }, (state) => ({ next: state, result: 'drained' }));
+    expect(drained.state.commit_sequence).toBe(1);
+
+    const activated = store.mutate({
+      transition_id: 'approve-patch',
+      operation: 'approve-patch',
+      operation_fingerprint: 'approve:patch-1',
+      expected: {
+        ...oldFence,
+        dispatch_generation: 1,
+        commit_sequence: 1,
+      },
+    }, (state) => ({
+      next: approveGraphPatch(state, {
+        proposal_id: 'patch-1',
+        base_revision_id: base.active_revision_id,
+        base_revision_hash: base.active_revision_hash,
+        proposed_revision_hash: proposedDescriptor.descriptor_hash,
+        invalidated_node_ids: [],
+        approval_evidence: { kind: 'human', ref: 'approve-patch' },
+        approved_at: '2026-07-21T00:00:02.000Z',
+      }, (projection) => projection),
+      result: 'approved',
+    }));
+    expect(activated.state.active_revision_id).toBe('revision-2');
+
+    expect(() => store.mutate({
+      transition_id: 'late-old-claim',
+      operation: 'complete-node',
+      operation_fingerprint: 'old-claim:lease-2',
+      expected: { ...oldFence, commit_sequence: 2 },
+      fence_scope: 'pending_patch_base',
+    }, (state) => ({ next: state, result: 'must-not-commit' }))).toThrow(/pending patch/i);
+  });
+});

--- a/src/graph/__tests__/traversal-counts-persistence.test.ts
+++ b/src/graph/__tests__/traversal-counts-persistence.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  sealGraphDescriptor,
+} from '../index.js';
+import { createInitialGraphState, parseGraphState } from '../runtime-types.js';
+import type { GraphEvidenceReference, GraphSchedulerProjection, SchedulerTransitionIdentities } from '../types.js';
+import { loopDescriptor } from './fixtures.js';
+
+function begin(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+): GraphSchedulerProjection {
+  return beginActivationAttempt(projection, {
+    activation_id: activationId,
+    attempt_id: attemptId,
+  });
+}
+
+function succeed(
+  descriptor: ReturnType<typeof sealGraphDescriptor>,
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+  transitionId: string,
+  identities: SchedulerTransitionIdentities = {},
+  route?: string,
+  evidenceRefs: GraphEvidenceReference[] = [],
+) {
+  return applyNodeResult(descriptor, projection, {
+    activation_id: activationId,
+    transition_id: transitionId,
+    result: {
+      outcome: 'succeeded',
+      attempt_id: attemptId,
+      evidence_refs: evidenceRefs,
+      ...(route ? { route } : {}),
+    },
+    identities,
+  });
+}
+
+// Drive the loop descriptor through one full back-edge traversal of `retry-test`
+// (start -> test --fail--> remediate --retry--> test), leaving the back-edge still
+// traversable (max_traversals = 2, count = 1) so a second traversal is legal.
+function projectionAfterOneBackEdgeTraversal(descriptor: ReturnType<typeof sealGraphDescriptor>): {
+  projection: GraphSchedulerProjection;
+  ownerActivationId: string;
+} {
+  let projection = initializeGraphProjection(descriptor, { start: 'a-start' });
+  projection = begin(projection, 'a-start', 'try-start');
+  projection = succeed(descriptor, projection, 'a-start', 'try-start', 't-start', {
+    next_activation_ids: { 'start-test': 'a-test-1' },
+  }).projection;
+
+  projection = begin(projection, 'a-test-1', 'try-test-1');
+  projection = succeed(
+    descriptor,
+    projection,
+    'a-test-1',
+    'try-test-1',
+    't-test-1',
+    { next_activation_ids: { 'test-fail': 'a-fix-1' } },
+    'fail',
+  ).projection;
+
+  // This transition selects the `retry-test` back-edge and increments
+  // traversal_counts[canonicalJson([traversal_owner_id, 'retry-test'])].
+  projection = begin(projection, 'a-fix-1', 'try-fix-1');
+  projection = succeed(
+    descriptor,
+    projection,
+    'a-fix-1',
+    'try-fix-1',
+    't-fix-1',
+    { next_activation_ids: { 'retry-test': 'a-test-2' } },
+    'retry',
+  ).projection;
+
+  return { projection, ownerActivationId: 'a-start' };
+}
+
+describe('graph state traversal_counts persistence (blocker A1)', () => {
+  it('round-trips a persisted back-edge traversal count and allows a second traversal', () => {
+    const descriptor = sealGraphDescriptor(loopDescriptor());
+    const { projection, ownerActivationId } = projectionAfterOneBackEdgeTraversal(descriptor);
+
+    // Sanity: exactly one back-edge counter was recorded, keyed by the canonical
+    // [owner, edgeId] JSON form rather than a raw edge id. The traversal_owner_id
+    // propagates along the lineage from the originating activation `a-start`, so
+    // the counter owner is `a-start` even though `a-fix-1` performed the traversal.
+    const traversalKeys = Object.keys(projection.traversal_counts);
+    expect(traversalKeys).toHaveLength(1);
+    const [parsedOwner, parsedEdge] = JSON.parse(traversalKeys[0] as string) as [string, string];
+    expect(parsedOwner).toBe(ownerActivationId);
+    expect(parsedEdge).toBe('retry-test');
+    expect(projection.traversal_counts[traversalKeys[0] as string]).toBe(1);
+
+    const state = createInitialGraphState({
+      session_id: 'session-traversal',
+      control_nonce: 'control-traversal',
+      descriptor,
+      status: 'running',
+      created_at: '2026-07-21T00:00:00.000Z',
+      projection,
+      approval: {
+        approved_at: '2026-07-21T00:00:00.000Z',
+        evidence: { kind: 'human', ref: 'approval-1' },
+      },
+    });
+
+    // Before the fix, parseGraphState rejected this state because it validated
+    // traversal_counts keys as raw edge ids and saw `["<owner>","retry-test"]`
+    // as an "unknown back-edge". Now it must round-trip cleanly.
+    const roundTripped = parseGraphState(JSON.parse(JSON.stringify(state)));
+    expect(roundTripped.projection.traversal_counts[traversalKeys[0] as string]).toBe(1);
+
+    // The real regression: after persisting a loop traversal, traversing the
+    // back-edge again must NOT throw "traversal count references unknown back-edge".
+    // We replay the second back-edge traversal against the freshly-parsed state's
+    // projection to prove the persisted counter survives the round-trip.
+    let replayed = roundTripped.projection;
+    replayed = begin(replayed, 'a-test-2', 'try-test-2');
+    replayed = succeed(
+      descriptor,
+      replayed,
+      'a-test-2',
+      'try-test-2',
+      't-test-2',
+      { next_activation_ids: { 'test-fail': 'a-fix-2' } },
+      'fail',
+    ).projection;
+
+    replayed = begin(replayed, 'a-fix-2', 'try-fix-2');
+    expect(() =>
+      succeed(
+        descriptor,
+        replayed,
+        'a-fix-2',
+        'try-fix-2',
+        't-fix-2',
+        { next_activation_ids: { 'retry-test': 'a-test-3' } },
+        'retry',
+      ),
+    ).not.toThrow();
+
+    // The second back-edge traversal must have incremented the persisted counter.
+    expect(replayed.traversal_counts[traversalKeys[0] as string]).toBe(1);
+    const afterSecond = succeed(
+      descriptor,
+      replayed,
+      'a-fix-2',
+      'try-fix-2',
+      't-fix-2',
+      { next_activation_ids: { 'retry-test': 'a-test-3' } },
+      'retry',
+    ).projection;
+    expect(afterSecond.traversal_counts[traversalKeys[0] as string]).toBe(2);
+  });
+});

--- a/src/graph/claims.ts
+++ b/src/graph/claims.ts
@@ -485,9 +485,24 @@ export function settleDriverClaims(
   if (Object.keys(reconciliations).length > GRAPH_MAX_RECONCILIATIONS) {
     throw new GraphClaimError('reconciliation_limit', 'SessionEnd would exceed the reconciliation bound');
   }
+  // WEDGE 2: a non-ambiguous human-approval claim holds the run in
+  // 'waiting_human' while it waits for a human answer. When SessionEnd fences
+  // that claim (abandoned_retryable) and resets its activation to 'ready', the
+  // run must leave 'waiting_human' too - otherwise issueGraphClaim's
+  // dispatch_paused gate (status !== 'running') prevents the now-ready
+  // activation from ever being re-claimed, wedging the run. The run was placed
+  // in 'waiting_human' solely because a human-approval claim was live; once no
+  // live claims remain there is nothing left to wait for, so return to
+  // 'running' and let the scheduler re-claim the ready activation. Ambiguous
+  // (reconcile-policy) settlements take precedence and move the run to
+  // 'reconciling' via hasAmbiguous below.
+  const wasWaitingHuman = state.status === 'waiting_human';
+  const remainingLive = Object.values(claims).some((claim) => claim.status === 'live');
+  const resumeRunning = wasWaitingHuman && !hasAmbiguous && !remainingLive;
   const next: GraphState = {
     ...structuredClone(state),
     ...(hasAmbiguous ? { status: 'reconciling' as const } : {}),
+    ...(resumeRunning ? { status: 'running' as const } : {}),
     claims,
     reconciliations,
     projection: { ...state.projection, activations },

--- a/src/graph/claims.ts
+++ b/src/graph/claims.ts
@@ -1,0 +1,496 @@
+import { canonicalJson } from './descriptor.js';
+import {
+  GRAPH_MAX_DIAGNOSTICS,
+  GRAPH_MAX_RECONCILIATIONS,
+  parseGraphState,
+  type GraphClaim,
+  type GraphDiagnostic,
+  type GraphReconciliationRecord,
+  type GraphState,
+} from './runtime-types.js';
+import type { GraphEffectPolicy, GraphSchedulerProjection } from './types.js';
+
+const MAX_EXECUTION_TIMEOUT_MS = 86_400_000;
+const MAX_GRACE_MS = 3_600_000;
+const MAX_RENEWALS = 20;
+
+export class GraphClaimError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphClaimError';
+    this.code = code;
+  }
+}
+
+export interface IssueGraphClaimInput {
+  activation_id: string;
+  attempt_id: string;
+  attempt_no: number;
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  lease_id: string;
+  tracking_id: string;
+  issued_at: string;
+  execution_timeout_ms: number;
+  grace_ms: number;
+  max_renewals: number;
+  effect_policy: GraphEffectPolicy;
+  external_idempotency_key?: string;
+}
+
+export interface GraphClaimResult {
+  state: GraphState;
+  claim: GraphClaim;
+}
+
+export interface RenewGraphClaimInput {
+  lease_id: string;
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  tracking_id: string;
+  tool_still_running: boolean;
+  now: string;
+}
+
+export interface RecoverExpiredGraphClaimInput {
+  lease_id: string;
+  now: string;
+  new_attempt_id: string;
+  new_lease_id: string;
+  new_tracking_id: string;
+  claimant_session_id: string;
+  driver_instance_id: string;
+  reconciliation_id: string;
+}
+
+export interface ReplacementAttemptInput {
+  activation_id: string;
+  attempt_id: string;
+  attempt_no: number;
+}
+
+export type ReplaceAttemptProjection = (
+  projection: GraphSchedulerProjection,
+  input: ReplacementAttemptInput,
+) => GraphSchedulerProjection;
+
+export interface GraphClaimRecoveryResult {
+  state: GraphState;
+  disposition: 'taken_over' | 'reconciling';
+  claim?: GraphClaim;
+  reconciliation?: GraphReconciliationRecord;
+}
+
+function timestamp(value: string, name: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new GraphClaimError('invalid_timestamp', `${name} must be an ISO timestamp`);
+  return parsed;
+}
+
+function assertIdentifier(value: string, name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw new GraphClaimError('invalid_identity', `${name} must be a stable identifier`);
+  }
+}
+
+function activeDescriptor(state: GraphState) {
+  return state.revisions[state.active_revision_id].descriptor;
+}
+
+function findClaim(state: GraphState, leaseId: string): GraphClaim {
+  const claim = state.claims[leaseId];
+  if (!claim) throw new GraphClaimError('claim_not_found', `Claim ${leaseId} does not exist`);
+  return claim;
+}
+
+function ensureLiveClaim(state: GraphState, leaseId: string): GraphClaim {
+  const claim = findClaim(state, leaseId);
+  if (claim.status !== 'live') throw new GraphClaimError('claim_not_live', `Claim ${leaseId} is no longer live`);
+  return claim;
+}
+
+function cloneWithClaims(state: GraphState, claims: Record<string, GraphClaim>): GraphState {
+  return { ...structuredClone(state), claims };
+}
+
+function validateLeasePolicy(input: IssueGraphClaimInput): void {
+  if (!Number.isSafeInteger(input.execution_timeout_ms)
+    || input.execution_timeout_ms < 100
+    || input.execution_timeout_ms > MAX_EXECUTION_TIMEOUT_MS) {
+    throw new GraphClaimError('invalid_timeout', 'Execution timeout is outside the configured bound');
+  }
+  if (!Number.isSafeInteger(input.grace_ms) || input.grace_ms <= 0 || input.grace_ms > MAX_GRACE_MS) {
+    throw new GraphClaimError('invalid_grace', 'Lease grace must be positive and bounded');
+  }
+  if (!Number.isSafeInteger(input.max_renewals)
+    || input.max_renewals < 0
+    || input.max_renewals > MAX_RENEWALS) {
+    throw new GraphClaimError('invalid_renewal_cap', 'Claim renewal cap is outside the configured bound');
+  }
+  if (input.effect_policy.policy === 'idempotent' && !input.external_idempotency_key) {
+    throw new GraphClaimError('missing_idempotency_key', 'Idempotent claims require a durable idempotency key');
+  }
+  if (input.effect_policy.policy !== 'idempotent' && input.external_idempotency_key) {
+    throw new GraphClaimError('unexpected_idempotency_key', 'Only idempotent claims may carry an idempotency key');
+  }
+}
+
+export function issueGraphClaim(stateInput: GraphState, input: IssueGraphClaimInput): GraphClaimResult {
+  const state = parseGraphState(stateInput);
+  if (state.status !== 'running') {
+    throw new GraphClaimError('dispatch_paused', `Cannot issue a claim while graph status is ${state.status}`);
+  }
+  for (const id of [
+    input.activation_id,
+    input.attempt_id,
+    input.lease_id,
+    input.driver_instance_id,
+    input.tracking_id,
+  ]) assertIdentifier(id, 'claim identity');
+  validateLeasePolicy(input);
+  if (state.claims[input.lease_id]) throw new GraphClaimError('duplicate_lease', `Lease ${input.lease_id} already exists`);
+  if (Object.values(state.claims).some(
+    (claim) => claim.activation_id === input.activation_id && claim.status === 'live',
+  )) {
+    throw new GraphClaimError('activation_claimed', `Activation ${input.activation_id} already has a live claim`);
+  }
+  const activation = state.projection.activations[input.activation_id];
+  if (!activation
+    || activation.status !== 'running'
+    || activation.active_attempt_id !== input.attempt_id
+    || activation.attempt_no !== input.attempt_no) {
+    throw new GraphClaimError('attempt_fence_mismatch', 'Claim activation/attempt fence does not match projection');
+  }
+  const node = activeDescriptor(state).nodes.find((candidate) => candidate.id === activation.node_id);
+  if (!node) {
+    throw new GraphClaimError('node_not_found', `Node ${activation.node_id} does not exist`);
+  }
+  // B6: human-approval nodes are executable via the in-session question surface.
+  // They carry no effect_policy or timeout_ms, so skip the executable-kind and
+  // policy/timeout gates for them; the claim is a durable wait fence.
+  if (node.kind === 'human-approval') {
+    if (input.claim_owner_session_id !== state.session_id) {
+      throw new GraphClaimError('claim_session_mismatch', 'Claim owner must match the Graph authority session');
+    }
+    const issuedAt = timestamp(input.issued_at, 'issued_at');
+    const leaseDuration = input.execution_timeout_ms + input.grace_ms;
+    const claim: GraphClaim = {
+      run_id: state.run_id,
+      revision_id: state.active_revision_id,
+      revision_hash: state.active_revision_hash,
+      dispatch_generation: state.dispatch_generation,
+      activation_id: input.activation_id,
+      attempt_id: input.attempt_id,
+      attempt_no: input.attempt_no,
+      claim_owner_session_id: input.claim_owner_session_id,
+      driver_instance_id: input.driver_instance_id,
+      lease_id: input.lease_id,
+      tracking_id: input.tracking_id,
+      issued_at: input.issued_at,
+      expires_at: new Date(issuedAt + leaseDuration).toISOString(),
+      lease_duration_ms: leaseDuration,
+      renewal_count: 0,
+      max_renewals: input.max_renewals,
+      effect_policy: structuredClone(input.effect_policy),
+      status: 'live',
+    };
+    const next = cloneWithClaims(state, { ...state.claims, [claim.lease_id]: claim });
+    return { state: parseGraphState(next), claim: structuredClone(claim) };
+  }
+  if (node.kind !== 'agent' && node.kind !== 'command') {
+    throw new GraphClaimError('node_not_executable', 'Only executable agent/command activations can be claimed');
+  }
+  if (canonicalJson(node.effect_policy) !== canonicalJson(input.effect_policy)) {
+    throw new GraphClaimError('effect_policy_mismatch', 'Claim effect policy does not match the approved descriptor');
+  }
+  if (input.claim_owner_session_id !== state.session_id) {
+    throw new GraphClaimError('claim_session_mismatch', 'Claim owner must match the Graph authority session');
+  }
+  if (input.execution_timeout_ms !== node.timeout_ms) {
+    throw new GraphClaimError('timeout_mismatch', 'Claim timeout must equal the exact approved node timeout');
+  }
+  const issuedAt = timestamp(input.issued_at, 'issued_at');
+  const leaseDuration = input.execution_timeout_ms + input.grace_ms;
+  const claim: GraphClaim = {
+    run_id: state.run_id,
+    revision_id: state.active_revision_id,
+    revision_hash: state.active_revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    activation_id: input.activation_id,
+    attempt_id: input.attempt_id,
+    attempt_no: input.attempt_no,
+    claim_owner_session_id: input.claim_owner_session_id,
+    driver_instance_id: input.driver_instance_id,
+    lease_id: input.lease_id,
+    tracking_id: input.tracking_id,
+    issued_at: input.issued_at,
+    expires_at: new Date(issuedAt + leaseDuration).toISOString(),
+    lease_duration_ms: leaseDuration,
+    renewal_count: 0,
+    max_renewals: input.max_renewals,
+    effect_policy: structuredClone(input.effect_policy),
+    ...(input.external_idempotency_key
+      ? { external_idempotency_key: input.external_idempotency_key }
+      : {}),
+    status: 'live',
+  };
+  const next = cloneWithClaims(state, { ...state.claims, [claim.lease_id]: claim });
+  return { state: parseGraphState(next), claim: structuredClone(claim) };
+}
+
+export function renewGraphClaim(stateInput: GraphState, input: RenewGraphClaimInput): GraphClaimResult {
+  const state = parseGraphState(stateInput);
+  const claim = ensureLiveClaim(state, input.lease_id);
+  if (claim.claim_owner_session_id !== input.claim_owner_session_id
+    || claim.driver_instance_id !== input.driver_instance_id) {
+    throw new GraphClaimError('lease_owner_mismatch', 'Claim owner/driver does not match the live lease');
+  }
+  if (claim.tracking_id !== input.tracking_id || !input.tool_still_running) {
+    throw new GraphClaimError('tracking_mismatch', 'Renewal requires the matching live tool tracking identity');
+  }
+  const now = timestamp(input.now, 'now');
+  if (now >= timestamp(claim.expires_at, 'claim.expires_at')) {
+    throw new GraphClaimError('lease_expired', 'Expired claims cannot be renewed');
+  }
+  if (claim.renewal_count >= claim.max_renewals) {
+    throw new GraphClaimError('renewal_cap', 'Claim renewal cap has been reached');
+  }
+  const renewed: GraphClaim = {
+    ...claim,
+    last_renewed_at: input.now,
+    expires_at: new Date(now + claim.lease_duration_ms).toISOString(),
+    renewal_count: claim.renewal_count + 1,
+  };
+  const next = cloneWithClaims(state, { ...state.claims, [claim.lease_id]: renewed });
+  return { state: parseGraphState(next), claim: structuredClone(renewed) };
+}
+
+function reconciliationFor(
+  claim: GraphClaim,
+  input: RecoverExpiredGraphClaimInput,
+  reason: GraphReconciliationRecord['reason'],
+): GraphReconciliationRecord {
+  return {
+    reconciliation_id: input.reconciliation_id,
+    activation_id: claim.activation_id,
+    attempt_id: claim.attempt_id,
+    lease_id: claim.lease_id,
+    revision_id: claim.revision_id,
+    revision_hash: claim.revision_hash,
+    dispatch_generation: claim.dispatch_generation,
+    status: 'unresolved',
+    reason,
+    created_at: input.now,
+  };
+}
+
+export function recoverExpiredGraphClaim(
+  stateInput: GraphState,
+  input: RecoverExpiredGraphClaimInput,
+  replaceAttempt: ReplaceAttemptProjection,
+): GraphClaimRecoveryResult {
+  const state = parseGraphState(stateInput);
+  const claim = ensureLiveClaim(state, input.lease_id);
+  const now = timestamp(input.now, 'now');
+  if (now < timestamp(claim.expires_at, 'claim.expires_at')) {
+    throw new GraphClaimError('lease_live', 'Live claim cannot be taken over before expiry');
+  }
+  if (claim.effect_policy.policy === 'reconcile') {
+    if (state.reconciliations[input.reconciliation_id]) {
+      throw new GraphClaimError('duplicate_reconciliation', 'Reconciliation identity already exists');
+    }
+    if (Object.keys(state.reconciliations).length >= GRAPH_MAX_RECONCILIATIONS) {
+      throw new GraphClaimError('reconciliation_limit', 'Reconciliation limit has been reached');
+    }
+    const reconciliation = reconciliationFor(claim, input, 'expired_ambiguous');
+    const fenced: GraphClaim = { ...claim, status: 'reconciling', fenced_at: input.now };
+    const next: GraphState = {
+      ...structuredClone(state),
+      status: 'reconciling',
+      claims: { ...state.claims, [claim.lease_id]: fenced },
+      reconciliations: { ...state.reconciliations, [reconciliation.reconciliation_id]: reconciliation },
+    };
+    return { state: parseGraphState(next), disposition: 'reconciling', reconciliation };
+  }
+  if (claim.effect_policy.policy === 'idempotent' && !claim.external_idempotency_key) {
+    throw new GraphClaimError('missing_idempotency_key', 'Idempotent takeover requires the durable external key');
+  }
+  if (input.claimant_session_id !== state.session_id) {
+    throw new GraphClaimError('claim_session_mismatch', 'Takeover claimant must match the Graph authority session');
+  }
+  const activation = state.projection.activations[claim.activation_id];
+  const node = activeDescriptor(state).nodes.find((candidate) => candidate.id === activation?.node_id);
+  if (!activation || !node || (node.kind !== 'agent' && node.kind !== 'command')) {
+    throw new GraphClaimError('attempt_fence_mismatch', 'Expired claim no longer maps to an approved executable activation');
+  }
+  if (claim.attempt_no >= node.max_attempts) {
+    throw new GraphClaimError('attempt_limit', `Approved node ${node.id} has reached its maximum attempts`);
+  }
+  for (const id of [input.new_attempt_id, input.new_lease_id, input.new_tracking_id]) {
+    assertIdentifier(id, 'replacement identity');
+  }
+  if (state.claims[input.new_lease_id]) throw new GraphClaimError('duplicate_lease', 'Replacement lease already exists');
+  if (input.new_attempt_id === claim.attempt_id || input.new_lease_id === claim.lease_id) {
+    throw new GraphClaimError('replacement_identity_reused', 'Takeover requires a new attempt and lease identity');
+  }
+  const replacement: GraphClaim = {
+    ...claim,
+    attempt_id: input.new_attempt_id,
+    attempt_no: claim.attempt_no + 1,
+    claim_owner_session_id: input.claimant_session_id,
+    driver_instance_id: input.driver_instance_id,
+    lease_id: input.new_lease_id,
+    tracking_id: input.new_tracking_id,
+    issued_at: input.now,
+    expires_at: new Date(now + claim.lease_duration_ms).toISOString(),
+    renewal_count: 0,
+    status: 'live',
+  };
+  delete replacement.last_renewed_at;
+  delete replacement.fenced_at;
+  delete replacement.replacement_lease_id;
+  const fenced: GraphClaim = {
+    ...claim,
+    status: 'expired_retryable',
+    fenced_at: input.now,
+    replacement_lease_id: replacement.lease_id,
+  };
+  const projection = replaceAttempt(state.projection, {
+    activation_id: claim.activation_id,
+    attempt_id: replacement.attempt_id,
+    attempt_no: replacement.attempt_no,
+  });
+  const next: GraphState = {
+    ...structuredClone(state),
+    projection,
+    claims: {
+      ...state.claims,
+      [fenced.lease_id]: fenced,
+      [replacement.lease_id]: replacement,
+    },
+  };
+  return { state: parseGraphState(next), disposition: 'taken_over', claim: replacement };
+}
+
+export interface LateClaimResultInput {
+  lease_id: string;
+  attempt_id: string;
+  recorded_at: string;
+  summary: string;
+}
+
+export function recordLateClaimResult(
+  stateInput: GraphState,
+  input: LateClaimResultInput,
+): { state: GraphState; diagnostic: GraphDiagnostic } {
+  const state = parseGraphState(stateInput);
+  const claim = findClaim(state, input.lease_id);
+  if (claim.attempt_id !== input.attempt_id) {
+    throw new GraphClaimError('attempt_fence_mismatch', 'Late result attempt does not match the fenced lease');
+  }
+  if (claim.status === 'live') {
+    throw new GraphClaimError('claim_live', 'A live claim result is not a late diagnostic');
+  }
+  timestamp(input.recorded_at, 'recorded_at');
+  if (input.summary.length === 0 || input.summary.length > 8_192) {
+    throw new GraphClaimError('diagnostic_too_large', 'Late-result summary must be non-empty and bounded');
+  }
+  const diagnostic: GraphDiagnostic = {
+    kind: 'late_result',
+    recorded_at: input.recorded_at,
+    summary: input.summary,
+    activation_id: claim.activation_id,
+    attempt_id: claim.attempt_id,
+    lease_id: claim.lease_id,
+  };
+  const diagnostics = [...state.diagnostics, diagnostic].slice(-GRAPH_MAX_DIAGNOSTICS);
+  return { state: parseGraphState({ ...state, diagnostics }), diagnostic };
+}
+
+export interface SettleDriverClaimsInput {
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  recorded_at: string;
+  /**
+   * 'driver' (default) fences only live claims owned by driver_instance_id.
+   * 'session' fences ALL live claims for the session regardless of driver-id;
+   * used at session-end when the whole session is terminating and every live
+   * claim must be fenced so concurrency slots do not leak.
+   */
+  scope?: 'driver' | 'session';
+}
+
+export function settleDriverClaims(
+  stateInput: GraphState,
+  input: SettleDriverClaimsInput,
+): { state: GraphState; settled_lease_ids: string[] } {
+  const state = parseGraphState(stateInput);
+  timestamp(input.recorded_at, 'recorded_at');
+  const scope = input.scope ?? 'driver';
+  const claims = structuredClone(state.claims);
+  const reconciliations = structuredClone(state.reconciliations);
+  // #3: settle must atomically return each affected activation to a re-claimable
+  // state, otherwise a settled (abandoned_retryable) claim's activation stays
+  // 'running' with a dead attempt forever - recoverExpiredGraphClaim needs a LIVE
+  // claim so the work would be permanently lost after SessionEnd. Resetting the
+  // activation to 'ready' (dropping the active attempt, preserving attempt history)
+  // lets the scheduler re-claim it and redo the work. Reconcile-policy claims go
+  // to 'reconciling' (human resolution required) and are NOT auto-reset.
+  const activations = structuredClone(state.projection.activations);
+  const settled: string[] = [];
+  let hasAmbiguous = false;
+  for (const claim of Object.values(claims)) {
+    if (claim.status !== 'live'
+      || claim.claim_owner_session_id !== input.claim_owner_session_id) continue;
+    // In 'driver' scope only fence claims owned by the passed driver. In
+    // 'session' scope fence every live claim in the session.
+    if (scope === 'driver' && claim.driver_instance_id !== input.driver_instance_id) continue;
+    settled.push(claim.lease_id);
+    claim.fenced_at = input.recorded_at;
+    if (claim.effect_policy.policy !== 'reconcile') {
+      claim.status = 'abandoned_retryable';
+      // Reset the bound activation to 'ready' so it can be re-claimed. Only reset
+      // when the activation is still running on this claim's attempt; a completed
+      // or already-reset activation must not be touched.
+      const activation = activations[claim.activation_id];
+      if (activation
+        && activation.status === 'running'
+        && activation.active_attempt_id === claim.attempt_id) {
+        const released = { ...activation, status: 'ready' as const };
+        delete released.active_attempt_id;
+        activations[claim.activation_id] = released;
+      }
+      continue;
+    }
+    hasAmbiguous = true;
+    claim.status = 'reconciling';
+    const reconciliationId = `session-end:${claim.lease_id}`;
+    if (!reconciliations[reconciliationId]) {
+      reconciliations[reconciliationId] = {
+        reconciliation_id: reconciliationId,
+        activation_id: claim.activation_id,
+        attempt_id: claim.attempt_id,
+        lease_id: claim.lease_id,
+        revision_id: claim.revision_id,
+        revision_hash: claim.revision_hash,
+        dispatch_generation: claim.dispatch_generation,
+        status: 'unresolved',
+        reason: 'session_end_ambiguous',
+        created_at: input.recorded_at,
+      };
+    }
+  }
+  if (Object.keys(reconciliations).length > GRAPH_MAX_RECONCILIATIONS) {
+    throw new GraphClaimError('reconciliation_limit', 'SessionEnd would exceed the reconciliation bound');
+  }
+  const next: GraphState = {
+    ...structuredClone(state),
+    ...(hasAmbiguous ? { status: 'reconciling' as const } : {}),
+    claims,
+    reconciliations,
+    projection: { ...state.projection, activations },
+  };
+  return { state: parseGraphState(next), settled_lease_ids: settled };
+}

--- a/src/graph/control-owner.ts
+++ b/src/graph/control-owner.ts
@@ -1,0 +1,759 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import {
+  acquireMutationLockAt,
+  assertMutationLockHeld,
+  mutationLockRenewalSupported,
+  releaseMutationLockSync,
+  renewMutationLock,
+} from '../lib/mode-state-io.js';
+import { resolveSessionStatePaths } from '../lib/worktree-paths.js';
+import { graphPlatform, type GraphPlatformAdapter } from './platform.js';
+import type {
+  ControlChildRegistration,
+  ControlLineageIdentity,
+  ControlOwnerState,
+  ControlRoot,
+  GraphClaimLineage,
+  GraphControlMode,
+  GraphDriverLease,
+  GraphProcessIdentity,
+} from './runtime-types.js';
+
+const CONTROL_MAX_BYTES = 1024 * 1024;
+const ROOT_MODES: readonly GraphControlMode[] = [
+  'graph',
+  'autopilot',
+  'autoresearch',
+  'ralph',
+  'team',
+  'ultrawork',
+  'ultraqa',
+  'ralplan',
+  'deep-interview',
+  'self-improve',
+];
+const NON_OWNER_MODES = new Set(['merge-readiness', 'skill-active', 'support', 'read-only']);
+
+export type ControlModeClassification = 'root' | 'non_owner' | 'unknown';
+
+export function classifyControlMode(mode: string): ControlModeClassification {
+  if ((ROOT_MODES as readonly string[]).includes(mode)) return 'root';
+  if (NON_OWNER_MODES.has(mode)) return 'non_owner';
+  return 'unknown';
+}
+
+export class ControlOwnerError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'ControlOwnerError';
+    this.code = code;
+  }
+}
+
+function withRenewingExclusiveLock<T>(
+  path: string,
+  callback: (renew?: () => void) => T,
+): { acquired: boolean; value: T | undefined } {
+  const lock = acquireMutationLockAt(path, true);
+  if (!lock) return { acquired: false, value: undefined };
+  const renew = (): void => {
+    assertMutationLockHeld(lock);
+    // On a flock-less runtime (macOS/Windows) there is no portable atomic
+    // rename-over-the-live-lock, so `renewMutationLock` returns false even
+    // though the lock is still held and its lease is valid for LEASE_MS. In that
+    // case renewal is simply UNAVAILABLE - no-op and rely on the publish-time
+    // `assertMutationLockHeld` (the safety net). Only treat a `false` on a
+    // flock-capable runtime (where renewal IS supported) as a genuine
+    // `lock_lost` (owner replaced / lease expired / I/O error).
+    if (mutationLockRenewalSupported(lock) && !renewMutationLock(lock)) {
+      throw new ControlOwnerError('lock_lost', 'Control ownership mutation lock could not be renewed');
+    }
+  };
+  try {
+    renew();
+    return { acquired: true, value: callback(renew) };
+  } finally {
+    releaseMutationLockSync(lock);
+  }
+}
+
+export interface ControlOwnerDependencies {
+  fileExists(path: string): boolean;
+  readText(path: string): string;
+  writeAtomic(path: string, value: unknown): void;
+  withExclusiveLock<T>(path: string, callback: (renew?: () => void) => T): { acquired: boolean; value: T | undefined };
+}
+
+export interface ControlOwnerStoreOptions {
+  sessionId: string;
+  worktreeRoot?: string;
+  platform?: GraphPlatformAdapter;
+  dependencies?: Partial<ControlOwnerDependencies>;
+}
+
+const DEFAULT_DEPENDENCIES: ControlOwnerDependencies = {
+  fileExists: existsSync,
+  readText: (path) => readFileSync(path, 'utf8'),
+  writeAtomic: atomicWriteJsonSync,
+  withExclusiveLock: (path, callback) => withRenewingExclusiveLock(path, callback),
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new ControlOwnerError('malformed_control', `${name} must be an object`);
+  return value;
+}
+
+function exactKeys(value: Record<string, unknown>, required: string[], optional: string[], name: string): void {
+  const allowed = new Set([...required, ...optional]);
+  const missing = required.filter((key) => !(key in value));
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new ControlOwnerError(
+      'malformed_control',
+      `${name} has invalid keys${missing.length ? `; missing ${missing.join(', ')}` : ''}${unknown.length ? `; unknown ${unknown.join(', ')}` : ''}`,
+    );
+  }
+}
+
+function text(value: unknown, name: string, max = 256): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > max) {
+    throw new ControlOwnerError('malformed_control', `${name} must be a non-empty bounded string`);
+  }
+  return value;
+}
+
+function timestamp(value: unknown, name: string): string {
+  const result = text(value, name, 64);
+  if (!Number.isFinite(Date.parse(result))) {
+    throw new ControlOwnerError('malformed_control', `${name} must be an ISO timestamp`);
+  }
+  return result;
+}
+
+function mode(value: unknown, name: string): GraphControlMode {
+  const result = text(value, name, 32);
+  if (classifyControlMode(result) !== 'root') {
+    throw new ControlOwnerError('unknown_mode', `${name} is not a canonical root-capable mode`);
+  }
+  return result as GraphControlMode;
+}
+
+function processIdentity(value: unknown, name: string): GraphProcessIdentity {
+  const identity = record(value, name);
+  exactKeys(identity, ['pid', 'process_start'], [], name);
+  if (!Number.isSafeInteger(identity.pid) || (identity.pid as number) <= 0) {
+    throw new ControlOwnerError('malformed_control', `${name}.pid is invalid`);
+  }
+  // process_start may be the empty string when the host could not capture a
+  // start time at reservation time (ps/powershell/proc unavailable once). The
+  // runtime functions with pid-only identity - isProcessIdentityLive() falls
+  // back to pid-only liveness - so the empty form is accepted here. Rejecting
+  // it would make every subsequent read() reject the reserved control state as
+  // malformed_control, permanently wedging control authority.
+  if (typeof identity.process_start !== 'string' || !/^\d*$/.test(identity.process_start)) {
+    throw new ControlOwnerError('malformed_control', `${name}.process_start is invalid`);
+  }
+  return value as GraphProcessIdentity;
+}
+
+function driverLease(value: unknown, name: string): GraphDriverLease {
+  const lease = record(value, name);
+  exactKeys(lease, ['driver_instance_id', 'lease_id', 'expires_at'], [], name);
+  text(lease.driver_instance_id, `${name}.driver_instance_id`, 128);
+  text(lease.lease_id, `${name}.lease_id`, 128);
+  timestamp(lease.expires_at, `${name}.expires_at`);
+  return value as GraphDriverLease;
+}
+
+function lineage(value: unknown, name: string): ControlLineageIdentity {
+  const identity = record(value, name);
+  exactKeys(identity, ['mode', 'session_id', 'run_id'], [], name);
+  return {
+    mode: mode(identity.mode, `${name}.mode`),
+    session_id: text(identity.session_id, `${name}.session_id`),
+    run_id: text(identity.run_id, `${name}.run_id`, 128),
+  };
+}
+
+function claimLineage(value: unknown, name: string): GraphClaimLineage {
+  const claim = record(value, name);
+  exactKeys(claim, [
+    'activation_id', 'attempt_id', 'lease_id', 'revision_id', 'revision_hash', 'dispatch_generation',
+  ], [], name);
+  for (const key of ['activation_id', 'attempt_id', 'lease_id', 'revision_id'] as const) {
+    text(claim[key], `${name}.${key}`, 128);
+  }
+  if (typeof claim.revision_hash !== 'string' || !/^[a-f0-9]{64}$/.test(claim.revision_hash)) {
+    throw new ControlOwnerError('malformed_control', `${name}.revision_hash is invalid`);
+  }
+  if (!Number.isSafeInteger(claim.dispatch_generation) || (claim.dispatch_generation as number) < 0) {
+    throw new ControlOwnerError('malformed_control', `${name}.dispatch_generation is invalid`);
+  }
+  return value as GraphClaimLineage;
+}
+
+function graphRevision(value: unknown, name: string): { revision_id: string; revision_hash: string } {
+  const revision = record(value, name);
+  exactKeys(revision, ['revision_id', 'revision_hash'], [], name);
+  const revisionId = text(revision.revision_id, `${name}.revision_id`, 128);
+  if (typeof revision.revision_hash !== 'string' || !/^[a-f0-9]{64}$/.test(revision.revision_hash)) {
+    throw new ControlOwnerError('malformed_control', `${name}.revision_hash is invalid`);
+  }
+  return { revision_id: revisionId, revision_hash: revision.revision_hash };
+}
+
+function childRegistration(value: unknown, name: string): ControlChildRegistration {
+  const child = record(value, name);
+  exactKeys(child, ['mode', 'session_id', 'run_id', 'parent', 'registered_at'], ['graph_claim'], name);
+  const identity = lineage(
+    { mode: child.mode, session_id: child.session_id, run_id: child.run_id },
+    name,
+  );
+  const parent = lineage(child.parent, `${name}.parent`);
+  timestamp(child.registered_at, `${name}.registered_at`);
+  return {
+    ...identity,
+    parent,
+    ...(child.graph_claim === undefined ? {} : { graph_claim: claimLineage(child.graph_claim, `${name}.graph_claim`) }),
+    registered_at: child.registered_at as string,
+  };
+}
+
+function identityKey(identity: ControlLineageIdentity): string {
+  return `${identity.mode}\0${identity.session_id}\0${identity.run_id}`;
+}
+
+function sameIdentity(left: ControlLineageIdentity, right: ControlLineageIdentity): boolean {
+  return identityKey(left) === identityKey(right);
+}
+
+function parseControlOwnerState(value: unknown, expectedSessionId?: string): ControlOwnerState {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined || Buffer.byteLength(serialized, 'utf8') > CONTROL_MAX_BYTES) {
+    throw new ControlOwnerError('control_too_large', 'Control owner state exceeds the configured bound');
+  }
+  const state = record(value, 'control state');
+  exactKeys(state, ['format_version', 'session_id', 'generation', 'root', 'updated_at'], ['last_release'], 'control state');
+  if (state.format_version !== 1) throw new ControlOwnerError('malformed_control', 'Unsupported control format version');
+  const sessionId = text(state.session_id, 'control state.session_id');
+  if (expectedSessionId && sessionId !== expectedSessionId) {
+    throw new ControlOwnerError('session_mismatch', 'Control state belongs to a different session');
+  }
+  if (!Number.isSafeInteger(state.generation) || (state.generation as number) < 0) {
+    throw new ControlOwnerError('malformed_control', 'Control generation is invalid');
+  }
+  timestamp(state.updated_at, 'control state.updated_at');
+  if (state.last_release !== undefined) {
+    const release = record(state.last_release, 'control state.last_release');
+    exactKeys(release, ['mode', 'run_id', 'nonce', 'disposition', 'released_at'], [], 'control state.last_release');
+    mode(release.mode, 'control state.last_release.mode');
+    text(release.run_id, 'control state.last_release.run_id', 128);
+    text(release.nonce, 'control state.last_release.nonce', 128);
+    if (release.disposition !== 'paused' && release.disposition !== 'terminal') {
+      throw new ControlOwnerError('malformed_control', 'Control release disposition is invalid');
+    }
+    timestamp(release.released_at, 'control state.last_release.released_at');
+  }
+  if (state.root === null) return structuredClone(value as ControlOwnerState);
+
+  const root = record(state.root, 'control state.root');
+  exactKeys(root, [
+    'mode', 'session_id', 'run_id', 'nonce', 'phase', 'reservation_process',
+    'children', 'created_at', 'updated_at',
+  ], ['driver_lease', 'graph_revision'], 'control state.root');
+  const rootIdentity = lineage({ mode: root.mode, session_id: root.session_id, run_id: root.run_id }, 'control state.root');
+  if (rootIdentity.session_id !== sessionId) {
+    throw new ControlOwnerError('session_mismatch', 'Control root session does not match its state file');
+  }
+  text(root.nonce, 'control state.root.nonce', 128);
+  if (root.phase !== 'reserved' && root.phase !== 'active') {
+    throw new ControlOwnerError('malformed_control', 'Control root phase is invalid');
+  }
+  processIdentity(root.reservation_process, 'control state.root.reservation_process');
+  if (root.driver_lease !== undefined) driverLease(root.driver_lease, 'control state.root.driver_lease');
+  if (rootIdentity.mode === 'graph') {
+    if (root.graph_revision === undefined) {
+      throw new ControlOwnerError('malformed_control', 'Graph control root requires an exact revision/hash fence');
+    }
+    graphRevision(root.graph_revision, 'control state.root.graph_revision');
+  } else if (root.graph_revision !== undefined) {
+    throw new ControlOwnerError('malformed_control', 'Only Graph control roots may carry graph_revision');
+  }
+  timestamp(root.created_at, 'control state.root.created_at');
+  timestamp(root.updated_at, 'control state.root.updated_at');
+  if (!Array.isArray(root.children) || root.children.length > 128) {
+    throw new ControlOwnerError('malformed_control', 'Control child registrations are invalid');
+  }
+  const children = root.children.map((child, index) => childRegistration(child, `control state.root.children[${index}]`));
+  const identities = new Set([identityKey(rootIdentity)]);
+  for (const child of children) {
+    if (identities.has(identityKey(child))) throw new ControlOwnerError('duplicate_child', 'Control child identity is duplicated');
+    if (!identities.has(identityKey(child.parent))) {
+      throw new ControlOwnerError('lineage_mismatch', 'Control child parent is not reachable from the root');
+    }
+    if (!allowedChild(child.parent.mode, child.mode)) {
+      throw new ControlOwnerError('lineage_rejected', `Stored ${child.parent.mode} -> ${child.mode} lineage is not allowed`);
+    }
+    if (child.parent.mode === 'graph' && (!child.graph_claim || child.mode !== 'team')) {
+      throw new ControlOwnerError('graph_claim_required', 'Stored Graph child requires exact Team claim lineage');
+    }
+    if (child.parent.mode !== 'graph' && child.graph_claim) {
+      throw new ControlOwnerError('graph_claim_unexpected', 'Stored non-Graph child cannot carry graph claim lineage');
+    }
+    identities.add(identityKey(child));
+  }
+  return structuredClone(value as ControlOwnerState);
+}
+
+function allowedChild(parentMode: GraphControlMode, childMode: GraphControlMode): boolean {
+  if (parentMode === 'autopilot') {
+    return ['ralph', 'team', 'ultrawork', 'ultraqa', 'ralplan', 'deep-interview'].includes(childMode);
+  }
+  if (parentMode === 'ralph') return ['team', 'ultrawork', 'ultraqa', 'ralplan'].includes(childMode);
+  return parentMode === 'graph' && childMode === 'team';
+}
+
+export interface ReserveRootInput {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  reserved_at: string;
+  graph_revision?: { revision_id: string; revision_hash: string };
+}
+
+export interface PromoteRootInput {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  promoted_at: string;
+  driver_lease: GraphDriverLease;
+}
+
+export interface RegisterChildInput extends Omit<ControlChildRegistration, 'registered_at'> {
+  registered_at: string;
+}
+
+export interface GraphReleaseDisposition {
+  graph_status: 'paused' | 'failed' | 'cancelled' | 'succeeded';
+  claims_fenced: boolean;
+  children_drained: boolean;
+}
+
+export interface ReleaseRootInput {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  disposition: GraphReleaseDisposition;
+  released_at: string;
+}
+
+export interface LegacyControlCandidate {
+  mode: GraphControlMode;
+  session_id?: string;
+  run_id?: string;
+  active: boolean;
+  terminal?: boolean;
+  parent?: ControlLineageIdentity;
+  linked_ultrawork?: boolean;
+  linked_to_ralph?: boolean;
+  graph_revision?: { revision_id: string; revision_hash: string };
+  graph_claim?: GraphClaimLineage;
+}
+
+export interface AdoptLegacyRootsInput {
+  candidates: LegacyControlCandidate[];
+  nonce: string;
+  adopted_at: string;
+}
+
+export class ControlOwnerStore {
+  readonly sessionId: string;
+  readonly worktreeRoot: string | undefined;
+  readonly path: string;
+  private readonly readPath: string;
+  private readonly platform: GraphPlatformAdapter;
+  private readonly dependencies: ControlOwnerDependencies;
+
+  constructor(options: ControlOwnerStoreOptions) {
+    const paths = resolveSessionStatePaths('control-owner', options.sessionId, options.worktreeRoot);
+    if (!paths.sessionScoped || paths.effectiveWrite !== paths.sessionScoped) {
+      throw new ControlOwnerError('unsafe_state_path', 'Control ownership requires an explicit session-scoped path');
+    }
+    this.sessionId = options.sessionId;
+    this.worktreeRoot = options.worktreeRoot;
+    this.path = paths.effectiveWrite;
+    this.readPath = paths.sessionScoped;
+    this.platform = options.platform ?? graphPlatform;
+    this.dependencies = { ...DEFAULT_DEPENDENCIES, ...options.dependencies };
+  }
+
+  read(): ControlOwnerState | null {
+    if (!this.dependencies.fileExists(this.readPath)) return null;
+    let value: unknown;
+    try {
+      value = JSON.parse(this.dependencies.readText(this.readPath));
+    } catch (error) {
+      throw new ControlOwnerError('malformed_control', `Cannot parse control-owner-state.json: ${String(error)}`);
+    }
+    return parseControlOwnerState(value, this.sessionId);
+  }
+
+  reserveRoot(input: ReserveRootInput): ControlOwnerState {
+    const owner = this.platform.preflight();
+    timestamp(input.reserved_at, 'reserved_at');
+    if (input.mode === 'graph' && !input.graph_revision) {
+      throw new ControlOwnerError('graph_revision_required', 'Graph reservation requires an exact revision/hash fence');
+    }
+    if (input.mode !== 'graph' && input.graph_revision) {
+      throw new ControlOwnerError('graph_revision_unexpected', 'Only Graph reservations may carry graph_revision');
+    }
+    return this.mutate((current) => {
+      if (current?.root) {
+        throw new ControlOwnerError('root_conflict', `Session is already controlled by ${current.root.mode}/${current.root.run_id}`);
+      }
+      const root: ControlRoot = {
+        mode: input.mode,
+        session_id: this.sessionId,
+        run_id: text(input.run_id, 'run_id', 128),
+        nonce: text(input.nonce, 'nonce', 128),
+        phase: 'reserved',
+        reservation_process: owner,
+        ...(input.graph_revision ? { graph_revision: graphRevision(input.graph_revision, 'graph_revision') } : {}),
+        children: [],
+        created_at: input.reserved_at,
+        updated_at: input.reserved_at,
+      };
+      return {
+        format_version: 1,
+        session_id: this.sessionId,
+        generation: (current?.generation ?? 0) + 1,
+        root,
+        ...(current?.last_release ? { last_release: current.last_release } : {}),
+        updated_at: input.reserved_at,
+      };
+    });
+  }
+
+  promoteRoot(input: PromoteRootInput): ControlOwnerState {
+    timestamp(input.promoted_at, 'promoted_at');
+    driverLease(input.driver_lease, 'driver_lease');
+    return this.mutate((current) => {
+      const root = this.requireExactRoot(current, input);
+      if (root.phase !== 'reserved') throw new ControlOwnerError('already_active', 'Control root is already active');
+      return this.withRoot(current!, {
+        ...root,
+        phase: 'active',
+        driver_lease: structuredClone(input.driver_lease),
+        updated_at: input.promoted_at,
+      }, input.promoted_at);
+    });
+  }
+
+  registerChild(input: RegisterChildInput): ControlOwnerState {
+    timestamp(input.registered_at, 'registered_at');
+    return this.mutate((current) => {
+      if (!current?.root || current.root.phase !== 'active') {
+        throw new ControlOwnerError('root_inactive', 'Child registration requires an active root');
+      }
+      const child = childRegistration(input, 'child registration');
+      if (current.root.children.some((candidate) => sameIdentity(candidate, child))) {
+        throw new ControlOwnerError('duplicate_child', 'Child identity is already registered');
+      }
+      const parent = sameIdentity(current.root, child.parent)
+        ? current.root
+        : current.root.children.find((candidate) => sameIdentity(candidate, child.parent));
+      if (!parent) throw new ControlOwnerError('parent_lineage_mismatch', 'Exact parent lineage is not registered');
+      if (!allowedChild(parent.mode, child.mode)) {
+        throw new ControlOwnerError('lineage_rejected', `${parent.mode} -> ${child.mode} lineage is not allowed`);
+      }
+      if (parent.mode === 'graph' && (!child.graph_claim || child.mode !== 'team')) {
+        throw new ControlOwnerError('graph_claim_required', 'Graph permits only Team with an exact agent-node claim lineage');
+      }
+      if (parent.mode !== 'graph' && child.graph_claim) {
+        throw new ControlOwnerError('graph_claim_unexpected', 'Graph claim lineage is only valid for Graph -> Team');
+      }
+      return this.withRoot(current, {
+        ...current.root,
+        children: [...current.root.children, child],
+        updated_at: input.registered_at,
+      }, input.registered_at);
+    });
+  }
+
+  releaseRoot(input: ReleaseRootInput): { state: ControlOwnerState | null; released: boolean } {
+    timestamp(input.released_at, 'released_at');
+    let released = false;
+    const state = this.mutate((current) => {
+      if (!current?.root
+        || current.root.mode !== input.mode
+        || current.root.run_id !== input.run_id
+        || current.root.nonce !== input.nonce) return current ?? this.emptyState(input.released_at);
+      if (!input.disposition.children_drained || current.root.children.length > 0) {
+        throw new ControlOwnerError('children_live', 'Control release requires all exact children to be drained');
+      }
+      if (input.mode === 'graph' && input.disposition.graph_status === 'paused' && !input.disposition.claims_fenced) {
+        throw new ControlOwnerError('claims_live', 'Paused Graph release requires all claims to be fenced');
+      }
+      released = true;
+      return {
+        ...current,
+        generation: current.generation + 1,
+        root: null,
+        last_release: {
+          mode: input.mode,
+          run_id: input.run_id,
+          nonce: input.nonce,
+          disposition: input.disposition.graph_status === 'paused' ? 'paused' : 'terminal',
+          released_at: input.released_at,
+        },
+        updated_at: input.released_at,
+      };
+    }, false);
+    return { state, released };
+  }
+
+  reservePausedGraph(input: {
+    run_id: string;
+    revision_id: string;
+    revision_hash: string;
+    nonce: string;
+    graph_state: { session_id: string; run_id: string; revision_id: string; status: 'paused' };
+    reserved_at: string;
+  }): ControlOwnerState {
+    if (input.graph_state.session_id !== this.sessionId
+      || input.graph_state.run_id !== input.run_id
+      || input.graph_state.revision_id !== input.revision_id
+      || input.graph_state.status !== 'paused') {
+      throw new ControlOwnerError('resume_mismatch', 'Resume requires the exact paused session/run/revision');
+    }
+    return this.reserveRoot({
+      mode: 'graph', run_id: input.run_id, nonce: input.nonce, reserved_at: input.reserved_at,
+      graph_revision: { revision_id: input.revision_id, revision_hash: input.revision_hash },
+    });
+  }
+
+  recoverGraphReservation(input: {
+    session_id: string;
+    run_id: string;
+    revision_id: string;
+    revision_hash: string;
+    status: 'draft' | 'awaiting_approval' | 'running' | 'waiting_human' | 'waiting_patch_approval' | 'reconciling' | 'paused' | 'failed' | 'cancelled' | 'succeeded';
+    reservation_nonce: string;
+    observed_at: string;
+    driver_lease: GraphDriverLease;
+  }): { state: ControlOwnerState; action: 'promoted' | 'released' | 'waiting' | 'already_active' } {
+    timestamp(input.observed_at, 'observed_at');
+    driverLease(input.driver_lease, 'driver_lease');
+    let action: 'promoted' | 'released' | 'waiting' | 'already_active' = 'waiting';
+    const state = this.mutate((current) => {
+      const root = this.requireExactRoot(current, {
+        mode: 'graph', run_id: input.run_id, nonce: input.reservation_nonce,
+      });
+      if (input.session_id !== this.sessionId) {
+        throw new ControlOwnerError('session_mismatch', 'Graph recovery session does not match control authority');
+      }
+      if (!root.graph_revision
+        || root.graph_revision.revision_id !== input.revision_id
+        || root.graph_revision.revision_hash !== input.revision_hash) {
+        throw new ControlOwnerError('revision_mismatch', 'Graph recovery revision/hash does not match the reservation');
+      }
+      if (root.phase === 'active') {
+        action = 'already_active';
+        return current!;
+      }
+      const live = this.platform.isProcessIdentityLive(root.reservation_process);
+      if (live === 'unknown') throw new ControlOwnerError('owner_unverifiable', 'Reservation process identity is unverifiable');
+      if (live) {
+        action = 'waiting';
+        return current!;
+      }
+      if (['failed', 'cancelled', 'succeeded'].includes(input.status)) {
+        action = 'released';
+        return {
+          ...current!,
+          generation: current!.generation + 1,
+          root: null,
+          last_release: {
+            mode: 'graph', run_id: input.run_id, nonce: input.reservation_nonce,
+            disposition: 'terminal', released_at: input.observed_at,
+          },
+          updated_at: input.observed_at,
+        };
+      }
+      action = 'promoted';
+      return this.withRoot(current!, {
+        ...root,
+        phase: 'active',
+        driver_lease: structuredClone(input.driver_lease),
+        updated_at: input.observed_at,
+      }, input.observed_at);
+    }, false);
+    return { state, action };
+  }
+
+  adoptLegacyRoots(input: AdoptLegacyRootsInput): ControlOwnerState {
+    const owner = this.platform.preflight();
+    timestamp(input.adopted_at, 'adopted_at');
+    return this.mutate((current) => {
+      if (current?.root) throw new ControlOwnerError('root_conflict', 'Cannot adopt legacy state over an existing root');
+      const active = input.candidates.filter((candidate) => candidate.active && !candidate.terminal);
+      if (active.some((candidate) => !candidate.session_id || !candidate.run_id)) {
+        throw new ControlOwnerError('legacy_identity_incomplete', 'Legacy active state is missing session/run identity');
+      }
+      const keys = active.map((candidate) => identityKey({
+        mode: candidate.mode,
+        session_id: candidate.session_id!,
+        run_id: candidate.run_id!,
+      }));
+      if (new Set(keys).size !== keys.length) {
+        throw new ControlOwnerError('legacy_identity_duplicate', 'Legacy active state contains duplicate identities');
+      }
+      const roots = active.filter((candidate) => !candidate.parent);
+      if (roots.length !== 1) {
+        throw new ControlOwnerError('legacy_root_conflict', 'Legacy adoption requires exactly one legacy root');
+      }
+      const rootCandidate = roots[0];
+      if (rootCandidate.session_id !== this.sessionId) {
+        throw new ControlOwnerError('session_mismatch', 'Legacy root session does not match control authority');
+      }
+      const rootIdentity: ControlLineageIdentity = {
+        mode: rootCandidate.mode,
+        session_id: rootCandidate.session_id!,
+        run_id: rootCandidate.run_id!,
+      };
+      const childCandidates = active.filter((candidate) => candidate !== rootCandidate);
+      for (const ralph of active.filter((candidate) => candidate.mode === 'ralph')) {
+        const ralphIdentity: ControlLineageIdentity = {
+          mode: 'ralph', session_id: ralph.session_id!, run_id: ralph.run_id!,
+        };
+        const linked = childCandidates.filter(
+          (candidate) => candidate.mode === 'ultrawork' && candidate.parent && sameIdentity(candidate.parent, ralphIdentity),
+        );
+        if (linked.length > 0 || ralph.linked_ultrawork) {
+          if (ralph.linked_ultrawork !== true
+            || linked.length !== 1
+            || linked[0].linked_to_ralph !== true) {
+            throw new ControlOwnerError('legacy_link_mismatch', 'Legacy Ralph/Ultrawork requires mutual exact links');
+          }
+        }
+      }
+      if (childCandidates.some((candidate) => candidate.linked_to_ralph
+        && candidate.parent?.mode !== 'ralph')) {
+        throw new ControlOwnerError('legacy_link_mismatch', 'Legacy linked Ultrawork has no exact Ralph parent');
+      }
+      const children: ControlChildRegistration[] = [];
+      const reachable = new Set([identityKey(rootIdentity)]);
+      const pending = [...childCandidates];
+      while (pending.length > 0) {
+        const index = pending.findIndex(
+          (candidate) => candidate.parent && reachable.has(identityKey(candidate.parent)),
+        );
+        if (index < 0) {
+          throw new ControlOwnerError('legacy_lineage_mismatch', 'Legacy child lineage is cyclic or unreachable from the root');
+        }
+        const [candidate] = pending.splice(index, 1);
+        if (!candidate.parent || !allowedChild(candidate.parent.mode, candidate.mode)) {
+          throw new ControlOwnerError('legacy_lineage_rejected', 'Legacy child lineage is not recognized');
+        }
+        if (candidate.parent.mode === 'graph' && (!candidate.graph_claim || candidate.mode !== 'team')) {
+          throw new ControlOwnerError('graph_claim_required', 'Legacy Graph child requires an exact Team claim lineage');
+        }
+        if (candidate.parent.mode !== 'graph' && candidate.graph_claim) {
+          throw new ControlOwnerError('graph_claim_unexpected', 'Legacy non-Graph child cannot carry graph claim lineage');
+        }
+        const child: ControlChildRegistration = {
+          mode: candidate.mode,
+          session_id: candidate.session_id!,
+          run_id: candidate.run_id!,
+          parent: structuredClone(candidate.parent),
+          ...(candidate.graph_claim ? { graph_claim: structuredClone(candidate.graph_claim) } : {}),
+          registered_at: input.adopted_at,
+        };
+        children.push(child);
+        reachable.add(identityKey(child));
+      }
+      const root: ControlRoot = {
+        ...rootIdentity,
+        nonce: text(input.nonce, 'nonce', 128),
+        phase: 'active',
+        reservation_process: owner,
+        ...(rootCandidate.mode === 'graph'
+          ? {
+              graph_revision: rootCandidate.graph_revision
+                ? graphRevision(rootCandidate.graph_revision, 'legacy graph_revision')
+                : (() => { throw new ControlOwnerError('legacy_identity_incomplete', 'Legacy Graph root lacks revision/hash'); })(),
+            }
+          : {}),
+        children,
+        created_at: input.adopted_at,
+        updated_at: input.adopted_at,
+      };
+      return {
+        format_version: 1,
+        session_id: this.sessionId,
+        generation: (current?.generation ?? 0) + 1,
+        root,
+        updated_at: input.adopted_at,
+      };
+    });
+  }
+
+  private emptyState(at: string): ControlOwnerState {
+    return {
+      format_version: 1,
+      session_id: this.sessionId,
+      generation: 0,
+      root: null,
+      updated_at: at,
+    };
+  }
+
+  private requireExactRoot(
+    current: ControlOwnerState | null,
+    input: { mode: GraphControlMode; run_id: string; nonce: string },
+  ): ControlRoot {
+    if (!current?.root
+      || current.root.mode !== input.mode
+      || current.root.run_id !== input.run_id
+      || current.root.nonce !== input.nonce) {
+      throw new ControlOwnerError('root_fence_mismatch', 'Control root session/run/nonce fence does not match');
+    }
+    return current.root;
+  }
+
+  private withRoot(current: ControlOwnerState, root: ControlRoot, at: string): ControlOwnerState {
+    return {
+      ...current,
+      generation: current.generation + 1,
+      root,
+      updated_at: at,
+    };
+  }
+
+  private mutate(
+    callback: (current: ControlOwnerState | null) => ControlOwnerState,
+    writeUnchanged = true,
+  ): ControlOwnerState {
+    const locked = this.dependencies.withExclusiveLock(this.path, (renew) => {
+      const current = this.read();
+      const next = parseControlOwnerState(callback(current), this.sessionId);
+      if (writeUnchanged || JSON.stringify(next) !== JSON.stringify(current)) {
+        renew?.();
+        this.dependencies.writeAtomic(this.path, next);
+      }
+      return next;
+    });
+    if (!locked.acquired || !locked.value) {
+      throw new ControlOwnerError('lock_busy', 'Could not acquire the exclusive control-owner lock');
+    }
+    return locked.value;
+  }
+}

--- a/src/graph/descriptor.ts
+++ b/src/graph/descriptor.ts
@@ -1,0 +1,451 @@
+import { createHash } from 'node:crypto';
+
+import { parseGraphDescriptorShape } from './schema.js';
+import type {
+  GraphBackEdge,
+  GraphDescriptor,
+  GraphDescriptorInput,
+  GraphEdge,
+  GraphFanOutEdge,
+  GraphNode,
+  SealedGraphDescriptor,
+} from './types.js';
+
+export class GraphDescriptorValidationError extends Error {
+  readonly issues: string[];
+
+  constructor(issues: string[]) {
+    super(`Invalid graph descriptor: ${issues.join('; ')}`);
+    this.name = 'GraphDescriptorValidationError';
+    this.issues = issues;
+  }
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Canonical JSON does not support non-finite numbers');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  throw new TypeError(`Canonical JSON does not support ${typeof value}`);
+}
+
+function descriptorHashPayload(input: GraphDescriptorInput): Omit<GraphDescriptorInput, 'descriptor_hash'> {
+  return {
+    descriptor_version: input.descriptor_version,
+    run_id: input.run_id,
+    revision_id: input.revision_id,
+    goal: input.goal,
+    nodes: input.nodes,
+    edges: input.edges,
+    entry_node_ids: input.entry_node_ids,
+    concurrency_limit: input.concurrency_limit,
+    terminal_verification_node_id: input.terminal_verification_node_id,
+  };
+}
+
+export function computeDescriptorHash(input: GraphDescriptorInput): string {
+  return createHash('sha256').update(canonicalJson(descriptorHashPayload(input))).digest('hex');
+}
+
+export function verifyDescriptorHash(
+  input: GraphDescriptorInput,
+): input is SealedGraphDescriptor {
+  return typeof input.descriptor_hash === 'string'
+    && input.descriptor_hash === computeDescriptorHash(input);
+}
+
+function duplicates(values: string[]): string[] {
+  const seen = new Set<string>();
+  const found = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) found.add(value);
+    seen.add(value);
+  }
+  return [...found].sort();
+}
+
+function groupByFrom(edges: GraphEdge[]): Map<string, GraphEdge[]> {
+  const result = new Map<string, GraphEdge[]>();
+  for (const edge of edges) {
+    const group = result.get(edge.from) ?? [];
+    group.push(edge);
+    result.set(edge.from, group);
+  }
+  return result;
+}
+
+function adjacencyFor(edges: GraphEdge[], includeBackEdges: boolean): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!includeBackEdges && edge.kind === 'back_edge') continue;
+    const targets = result.get(edge.from) ?? [];
+    targets.push(edge.to);
+    result.set(edge.from, targets);
+  }
+  return result;
+}
+
+function isReachable(start: string, target: string, adjacency: Map<string, string[]>): boolean {
+  const pending = [start];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current === target) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return false;
+}
+
+function reachableSet(starts: string[], adjacency: Map<string, string[]>): Set<string> {
+  const pending = [...starts];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return visited;
+}
+
+function findForwardCycle(nodeIds: string[], adjacency: Map<string, string[]>): string[] | undefined {
+  const visited = new Set<string>();
+  const active = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (nodeId: string): string[] | undefined => {
+    if (active.has(nodeId)) {
+      const start = stack.indexOf(nodeId);
+      return [...stack.slice(start), nodeId];
+    }
+    if (visited.has(nodeId)) return undefined;
+    visited.add(nodeId);
+    active.add(nodeId);
+    stack.push(nodeId);
+    for (const target of adjacency.get(nodeId) ?? []) {
+      const cycle = visit(target);
+      if (cycle) return cycle;
+    }
+    stack.pop();
+    active.delete(nodeId);
+    return undefined;
+  };
+
+  for (const nodeId of nodeIds) {
+    const cycle = visit(nodeId);
+    if (cycle) return cycle;
+  }
+  return undefined;
+}
+
+interface ForkBranchRegion {
+  fanOutNodeId: string;
+  joinNodeId: string;
+  branchId: string;
+  startNodeId: string;
+  nodes: Set<string>;
+}
+
+function collectBranchRegion(
+  edge: GraphFanOutEdge,
+  allAdjacency: Map<string, string[]>,
+  joinNodeId: string,
+): Set<string> {
+  const pending = [edge.to];
+  const result = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current === joinNodeId || result.has(current)) continue;
+    result.add(current);
+    pending.push(...(allAdjacency.get(current) ?? []));
+  }
+  return result;
+}
+
+function validateOutgoingContracts(
+  descriptor: GraphDescriptor,
+  nodes: Map<string, GraphNode>,
+  outgoing: Map<string, GraphEdge[]>,
+  issues: string[],
+): void {
+  for (const node of descriptor.nodes) {
+    const edges = outgoing.get(node.id) ?? [];
+    if (node.id === descriptor.terminal_verification_node_id) {
+      if (edges.length > 0) issues.push(`terminal verification node ${node.id} must not have outgoing edges`);
+      continue;
+    }
+    if (edges.length === 0) {
+      issues.push(`node ${node.id} cannot reach terminal verification because it has no outgoing edge`);
+      continue;
+    }
+
+    // A node whose only outgoing edge(s) are back_edges has no forward exit.
+    // Once max_traversals is exhausted the scheduler's selectEdges throws
+    // traversal_bound_exceeded on the completing path, leaving the result
+    // permanently uncommittable and the claim wedged. Require every non-terminal
+    // node to declare at least one non-back-edge exit path.
+    if (edges.every((edge) => edge.kind === 'back_edge')) {
+      issues.push(
+        `node ${node.id} has no non-back-edge exit; a back-edge-only node wedges once max_traversals is exhausted`,
+      );
+    }
+
+    const kinds = new Set(edges.map((edge) => edge.kind));
+    if (node.kind === 'join') {
+      if (edges.length !== 1 || edges[0].kind !== 'fixed') {
+        issues.push(`join node ${node.id} must have exactly one fixed outgoing edge`);
+      }
+      continue;
+    }
+    if (kinds.has('fixed') && (edges.length !== 1 || kinds.size !== 1)) {
+      issues.push(`node ${node.id} must use one fixed edge or an explicit route/fan-out set`);
+    }
+    if (kinds.has('fan_out')) {
+      if (kinds.size !== 1 || edges.length < 2) {
+        issues.push(`fan-out node ${node.id} must declare at least two fan_out edges and no other edge kind`);
+      }
+    } else if (!kinds.has('fixed')) {
+      if ([...kinds].some((kind) => kind !== 'conditional' && kind !== 'back_edge')) {
+        issues.push(`node ${node.id} has an unsupported routed edge combination`);
+      }
+      const routes = edges
+        .filter((edge): edge is Extract<GraphEdge, { route: string }> => 'route' in edge)
+        .map((edge) => edge.route);
+      const repeatedRoutes = duplicates(routes);
+      if (repeatedRoutes.length > 0) {
+        issues.push(`node ${node.id} declares duplicate route(s): ${repeatedRoutes.join(', ')}`);
+      }
+    }
+  }
+
+  for (const edge of descriptor.edges) {
+    if (!nodes.has(edge.from)) issues.push(`edge ${edge.id} references missing source node ${edge.from}`);
+    if (!nodes.has(edge.to)) issues.push(`edge ${edge.id} references missing target node ${edge.to}`);
+  }
+}
+
+function validateForkRegions(
+  descriptor: GraphDescriptor,
+  nodes: Map<string, GraphNode>,
+  outgoing: Map<string, GraphEdge[]>,
+  allAdjacency: Map<string, string[]>,
+  issues: string[],
+): void {
+  const fanGroups = new Map<string, GraphFanOutEdge[]>();
+  for (const edge of descriptor.edges) {
+    if (edge.kind !== 'fan_out') continue;
+    const group = fanGroups.get(edge.from) ?? [];
+    group.push(edge);
+    fanGroups.set(edge.from, group);
+  }
+
+  const regions: ForkBranchRegion[] = [];
+  for (const [fanOutNodeId, fanEdges] of fanGroups) {
+    const ownerJoinIds = new Set(fanEdges.map((edge) => edge.owner_join_id));
+    if (ownerJoinIds.size !== 1) {
+      issues.push(`fan-out node ${fanOutNodeId} must have one owning join`);
+      continue;
+    }
+    const joinNodeId = fanEdges[0].owner_join_id;
+    const joinNode = nodes.get(joinNodeId);
+    if (joinNode?.kind !== 'join') {
+      issues.push(`fan-out node ${fanOutNodeId} references non-join owner ${joinNodeId}`);
+      continue;
+    }
+    if (joinNode.fan_out_node_id !== fanOutNodeId) {
+      issues.push(`join ${joinNodeId} does not bind fan-out node ${fanOutNodeId}`);
+    }
+    const branchIds = fanEdges.map((edge) => edge.branch_id);
+    const repeatedBranches = duplicates(branchIds);
+    if (repeatedBranches.length > 0) {
+      issues.push(`fan-out node ${fanOutNodeId} repeats branch ID(s): ${repeatedBranches.join(', ')}`);
+    }
+    if (
+      [...new Set(branchIds)].sort().join('\0')
+      !== [...new Set(joinNode.input_branch_ids)].sort().join('\0')
+    ) {
+      issues.push(`join ${joinNodeId} input branches do not match fan-out ${fanOutNodeId}`);
+    }
+    if (duplicates(joinNode.input_branch_ids).length > 0) {
+      issues.push(`join ${joinNodeId} repeats an input branch ID`);
+    }
+
+    const groupRegions: ForkBranchRegion[] = fanEdges.map((edge) => ({
+      fanOutNodeId,
+      joinNodeId,
+      branchId: edge.branch_id,
+      startNodeId: edge.to,
+      nodes: collectBranchRegion(edge, allAdjacency, joinNodeId),
+    }));
+    regions.push(...groupRegions);
+
+    for (const region of groupRegions) {
+      if (!region.nodes.has(region.startNodeId)) {
+        issues.push(`fork branch ${region.branchId} has no region`);
+      }
+      if (!isReachable(region.startNodeId, joinNodeId, allAdjacency)) {
+        issues.push(`fork branch ${region.branchId} cannot reach owning join ${joinNodeId}`);
+      }
+      for (const nodeId of region.nodes) {
+        const node = nodes.get(nodeId);
+        if (node?.kind === 'join' && nodeId !== joinNodeId) {
+          issues.push(`nested join ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+        }
+        if ((outgoing.get(nodeId) ?? []).some((edge) => edge.kind === 'fan_out')) {
+          issues.push(`nested fan-out ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+        }
+        if (!isReachable(nodeId, joinNodeId, allAdjacency)) {
+          issues.push(`fork branch ${region.branchId} contains node ${nodeId} that cannot reach its join`);
+        }
+      }
+      const reachesJoin = descriptor.edges.some(
+        (edge) => region.nodes.has(edge.from) && edge.to === joinNodeId,
+      );
+      if (!reachesJoin) issues.push(`fork branch ${region.branchId} has no declared join input`);
+    }
+
+    for (let left = 0; left < groupRegions.length; left += 1) {
+      for (let right = left + 1; right < groupRegions.length; right += 1) {
+        const overlap = [...groupRegions[left].nodes].filter((id) => groupRegions[right].nodes.has(id));
+        if (overlap.length > 0) {
+          issues.push(
+            `fork branches ${groupRegions[left].branchId} and ${groupRegions[right].branchId} overlap at ${overlap.join(', ')}`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const node of descriptor.nodes) {
+    if (node.kind === 'join' && !fanGroups.has(node.fan_out_node_id)) {
+      issues.push(`join ${node.id} has no matching fan-out node ${node.fan_out_node_id}`);
+    }
+  }
+
+  for (let left = 0; left < regions.length; left += 1) {
+    for (let right = left + 1; right < regions.length; right += 1) {
+      if (regions[left].fanOutNodeId === regions[right].fanOutNodeId) continue;
+      const overlap = [...regions[left].nodes].some((id) => regions[right].nodes.has(id));
+      if (overlap) {
+        issues.push(
+          `fork regions ${regions[left].fanOutNodeId} and ${regions[right].fanOutNodeId} overlap or nest`,
+        );
+      }
+    }
+  }
+
+  for (const region of regions) {
+    for (const edge of descriptor.edges) {
+      if (edge.kind === 'fan_out' && edge.from === region.fanOutNodeId && edge.branch_id === region.branchId) {
+        continue;
+      }
+      const fromInside = region.nodes.has(edge.from);
+      const toInside = region.nodes.has(edge.to);
+      if (!fromInside && toInside) {
+        issues.push(`edge ${edge.id} crosses into fork branch ${region.branchId}`);
+      }
+      if (fromInside && !toInside && edge.to !== region.joinNodeId) {
+        issues.push(`edge ${edge.id} crosses out of fork branch ${region.branchId}`);
+      }
+      if (edge.kind === 'back_edge' && fromInside !== toInside) {
+        issues.push(`back-edge ${edge.id} crosses fork region ${region.fanOutNodeId}`);
+      }
+    }
+  }
+
+  for (const node of descriptor.nodes) {
+    if (node.kind !== 'join') continue;
+    const ownerRegions = regions.filter((region) => region.joinNodeId === node.id);
+    for (const edge of descriptor.edges.filter((candidate) => candidate.to === node.id)) {
+      if (!ownerRegions.some((region) => region.nodes.has(edge.from))) {
+        issues.push(`edge ${edge.id} enters join ${node.id} outside its owning fork region`);
+      }
+    }
+  }
+}
+
+export function validateGraphDescriptor(descriptor: GraphDescriptor): GraphDescriptor {
+  const issues: string[] = [];
+  const repeatedNodeIds = duplicates(descriptor.nodes.map((node) => node.id));
+  if (repeatedNodeIds.length > 0) issues.push(`duplicate node ID(s): ${repeatedNodeIds.join(', ')}`);
+  const repeatedEdgeIds = duplicates(descriptor.edges.map((edge) => edge.id));
+  if (repeatedEdgeIds.length > 0) issues.push(`duplicate edge ID(s): ${repeatedEdgeIds.join(', ')}`);
+  const repeatedEntries = duplicates(descriptor.entry_node_ids);
+  if (repeatedEntries.length > 0) issues.push(`duplicate entry node ID(s): ${repeatedEntries.join(', ')}`);
+
+  const nodes = new Map(descriptor.nodes.map((node) => [node.id, node]));
+  const outgoing = groupByFrom(descriptor.edges);
+  validateOutgoingContracts(descriptor, nodes, outgoing, issues);
+
+  for (const entry of descriptor.entry_node_ids) {
+    if (!nodes.has(entry)) issues.push(`entry node ${entry} does not exist`);
+  }
+  const terminalNode = nodes.get(descriptor.terminal_verification_node_id);
+  if (!terminalNode) {
+    issues.push(`terminal verification node ${descriptor.terminal_verification_node_id} does not exist`);
+  } else if (terminalNode.kind !== 'agent' && terminalNode.kind !== 'command') {
+    issues.push('terminal verification must be an executable agent or command node');
+  }
+
+  const allAdjacency = adjacencyFor(descriptor.edges, true);
+  const forwardAdjacency = adjacencyFor(descriptor.edges, false);
+  const reachable = reachableSet(descriptor.entry_node_ids, allAdjacency);
+  const unreachable = descriptor.nodes.map((node) => node.id).filter((id) => !reachable.has(id));
+  if (unreachable.length > 0) issues.push(`unreachable node(s): ${unreachable.join(', ')}`);
+
+  const cycle = findForwardCycle(descriptor.nodes.map((node) => node.id), forwardAdjacency);
+  if (cycle) issues.push(`non-back-edge cycle detected: ${cycle.join(' -> ')}`);
+
+  for (const edge of descriptor.edges.filter(
+    (candidate): candidate is GraphBackEdge => candidate.kind === 'back_edge',
+  )) {
+    if (!isReachable(edge.to, edge.from, forwardAdjacency)) {
+      issues.push(`back-edge ${edge.id} is not a structural return to an earlier node`);
+    }
+  }
+
+  if (terminalNode) {
+    const cannotVerify = descriptor.nodes
+      .map((node) => node.id)
+      .filter((id) => !isReachable(id, terminalNode.id, allAdjacency));
+    if (cannotVerify.length > 0) {
+      issues.push(
+        `every successful path must reach terminal verification; failing node(s): ${cannotVerify.join(', ')}`,
+      );
+    }
+  }
+
+  validateForkRegions(descriptor, nodes, outgoing, allAdjacency, issues);
+  if (issues.length > 0) throw new GraphDescriptorValidationError([...new Set(issues)]);
+  return descriptor;
+}
+
+export function parseGraphDescriptor(input: unknown): GraphDescriptor {
+  const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+  if (descriptor.descriptor_hash && !verifyDescriptorHash(descriptor)) {
+    throw new GraphDescriptorValidationError(['descriptor hash does not match the exact revision']);
+  }
+  return descriptor;
+}
+
+export function sealGraphDescriptor(input: unknown): SealedGraphDescriptor {
+  const descriptor = parseGraphDescriptor(input);
+  return {
+    ...descriptor,
+    descriptor_hash: computeDescriptorHash(descriptor),
+  };
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './schema.js';
+export * from './descriptor.js';
+export * from './scheduler.js';

--- a/src/graph/platform.ts
+++ b/src/graph/platform.ts
@@ -1,0 +1,143 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+import type { GraphProcessIdentity } from './runtime-types.js';
+
+export class GraphPlatformError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphPlatformError';
+    this.code = code;
+  }
+}
+
+export type GraphProcessLiveness = boolean | 'unknown';
+
+export interface GraphPlatformAdapter {
+  preflight(): GraphProcessIdentity;
+  isProcessIdentityLive(identity: GraphProcessIdentity): GraphProcessLiveness;
+}
+
+export interface GraphPlatformDependencies {
+  platform: NodeJS.Platform;
+  pid: number;
+  fileExists(path: string): boolean;
+  readText(path: string): string;
+  execCommand(command: string): string;
+}
+
+function parseLinuxProcessStart(stat: string): string | null {
+  const commandEnd = stat.lastIndexOf(')');
+  if (commandEnd < 0) return null;
+  const fields = stat.slice(commandEnd + 2).trim().split(/\s+/);
+  const processStart = fields[19];
+  return processStart && /^\d+$/.test(processStart) ? processStart : null;
+}
+
+function readProcessStartLinux(pid: number, deps: GraphPlatformDependencies): string | null {
+  try {
+    return parseLinuxProcessStart(deps.readText(`/proc/${pid}/stat`));
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStartDarwin(pid: number, deps: GraphPlatformDependencies): string | null {
+  try {
+    const output = deps.execCommand(`LC_ALL=C ps -p ${pid} -o lstart=`);
+    const trimmed = output.trim();
+    if (!trimmed) return null;
+    const ms = Date.parse(trimmed);
+    if (!Number.isFinite(ms)) return null;
+    return String(Math.floor(ms / 1000));
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStartWindows(pid: number, deps: GraphPlatformDependencies): string | null {
+  try {
+    const output = deps.execCommand(
+      `powershell -NoProfile -Command "[math]::Floor(((Get-Process -Id ${pid} -ErrorAction SilentlyContinue).StartTime - (Get-Date '1970-01-01')).TotalSeconds)"`,
+    );
+    const trimmed = output.trim();
+    return /^\d+$/.test(trimmed) ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readProcessStart(pid: number, platform: NodeJS.Platform, deps: GraphPlatformDependencies): string | null {
+  if (platform === 'linux') return readProcessStartLinux(pid, deps);
+  if (platform === 'darwin') return readProcessStartDarwin(pid, deps);
+  if (platform === 'win32') return readProcessStartWindows(pid, deps);
+  return null;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Tracks pids that have already emitted the pid-only fallback warning so we
+// warn once per pid instead of on every liveness poll. The fallback loses
+// PID-reuse protection; the warning is observability only and does not change
+// liveness semantics.
+const warnedPidOnlyFallback = new Set<number>();
+
+export function createGraphPlatformAdapter(
+  overrides: Partial<GraphPlatformDependencies> = {},
+): GraphPlatformAdapter {
+  const dependencies: GraphPlatformDependencies = {
+    platform: process.platform,
+    pid: process.pid,
+    fileExists: existsSync,
+    readText: (path) => readFileSync(path, 'utf8'),
+    execCommand: (command) =>
+      execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 }),
+    ...overrides,
+  };
+  return {
+    preflight(): GraphProcessIdentity {
+      const processStart = readProcessStart(dependencies.pid, dependencies.platform, dependencies);
+      if (!processStart) {
+        return { pid: dependencies.pid, process_start: '' };
+      }
+      return { pid: dependencies.pid, process_start: processStart };
+    },
+
+    isProcessIdentityLive(identity: GraphProcessIdentity): GraphProcessLiveness {
+      if (!Number.isSafeInteger(identity.pid) || identity.pid <= 0) return 'unknown';
+      // pid-only liveness is always available as a fallback (e.g. when the host
+      // could not capture process_start at reservation time). A dead pid is
+      // definitively not live; only return 'unknown' if even this check throws.
+      let alive: boolean;
+      try {
+        alive = isProcessAlive(identity.pid);
+      } catch {
+        return 'unknown';
+      }
+      if (!alive) return false;
+      if (!identity.process_start) {
+        if (!warnedPidOnlyFallback.has(identity.pid)) {
+          warnedPidOnlyFallback.add(identity.pid);
+          console.warn(
+            `graph: pid-only liveness fallback used for pid ${identity.pid} (process_start unavailable); PID-reuse protection is degraded`,
+          );
+        }
+        return true;
+      }
+      const current = readProcessStart(identity.pid, dependencies.platform, dependencies);
+      if (!current) return 'unknown';
+      return current === identity.process_start;
+    },
+  };
+}
+
+export const graphPlatform = createGraphPlatformAdapter();

--- a/src/graph/revisions.ts
+++ b/src/graph/revisions.ts
@@ -2,6 +2,7 @@ import { canonicalJson, parseGraphDescriptor, verifyDescriptorHash } from './des
 import {
   parseGraphState,
   type GraphApprovalRecord,
+  type GraphClaim,
   type GraphRevisionRecord,
   type GraphState,
 } from './runtime-types.js';
@@ -252,8 +253,42 @@ export function approveGraphPatch(
   if (canonicalJson(requestedInvalidations) !== canonicalJson([...patch.invalidated_node_ids].sort())) {
     throw new GraphRevisionError('invalidation_mismatch', 'Patch approval must enumerate the exact proposed invalidation set');
   }
-  if (Object.values(state.claims).some((claim) => claim.status === 'live')) {
-    throw new GraphRevisionError('live_claims', 'Patch approval is blocked until every live claim drains');
+  // WEDGE 1: once a patch is proposed the run sits in 'waiting_patch_approval',
+  // and the runtime result/release/pause gates reject any status other than
+  // running/waiting_human. A live claim therefore cannot complete, renew
+  // forever (cap), or release during that window, so a hard 'live_claims' reject
+  // here would wedge the run: the patch cannot be approved and the live claim
+  // cannot drain. Instead of rejecting, fence every non-ambiguous live claim
+  // atomically with the patch approval (same semantics as SessionEnd settle):
+  // the claim becomes 'fenced' so a late worker result is rejected (and recorded
+  // as a late diagnostic) rather than mutating the new revision, and the bound
+  // activation is reset to 'ready' so the scheduler can re-claim it under the
+  // approved revision. Reconcile-policy (ambiguous external-effect) claims still
+  // hard-reject: their outcome requires human resolution and must not be
+  // silently dropped by a patch approval.
+  const liveClaims = Object.values(state.claims).filter((claim) => claim.status === 'live');
+  const fencedClaims: Record<string, GraphClaim> = {};
+  const baseActivations = structuredClone(state.projection.activations);
+  for (const claim of liveClaims) {
+    if (claim.effect_policy.policy === 'reconcile') {
+      throw new GraphRevisionError(
+        'live_claims',
+        'Patch approval is blocked until every ambiguous (reconcile-policy) live claim is resolved',
+      );
+    }
+    const fenced: GraphClaim = { ...claim, status: 'fenced', fenced_at: input.approved_at };
+    fencedClaims[claim.lease_id] = fenced;
+    // Reset the bound activation to 'ready' so it can be re-claimed under the
+    // new revision. Only reset when the activation is still running on this
+    // claim's attempt; a completed or already-reset activation is left alone.
+    const activation = baseActivations[claim.activation_id];
+    if (activation
+      && activation.status === 'running'
+      && activation.active_attempt_id === claim.attempt_id) {
+      const released = { ...activation, status: 'ready' as const };
+      delete released.active_attempt_id;
+      baseActivations[claim.activation_id] = released;
+    }
   }
   if (Object.values(state.reconciliations).some((record) => record.status === 'unresolved')) {
     throw new GraphRevisionError('unresolved_reconciliation', 'Patch approval is blocked by unresolved reconciliation');
@@ -264,7 +299,7 @@ export function approveGraphPatch(
   const nextNodes = new Map(nextDescriptor.nodes.map((node) => [node.id, node]));
   const invalidated = new Set(requestedInvalidations);
   const completedNodeIds = new Set(
-    Object.values(state.projection.activations)
+    Object.values(baseActivations)
       .filter((activation) => activation.status === 'completed')
       .map((activation) => activation.node_id),
   );
@@ -293,10 +328,14 @@ export function approveGraphPatch(
     invalidated_node_ids: requestedInvalidations,
   };
   const projection = recomputeProjection(
-    structuredClone(state.projection),
+    { ...structuredClone(state.projection), activations: baseActivations },
     structuredClone(nextDescriptor),
     invalidated,
   );
+  const claims = structuredClone(state.claims);
+  for (const [leaseId, fenced] of Object.entries(fencedClaims)) {
+    claims[leaseId] = fenced;
+  }
   return parseGraphState({
     ...structuredClone(state),
     status: 'running',
@@ -304,6 +343,7 @@ export function approveGraphPatch(
     active_revision_hash: nextDescriptor.descriptor_hash,
     revisions: { ...state.revisions, [nextDescriptor.revision_id]: revision },
     projection,
+    claims,
     pending_patch: undefined,
     updated_at: input.approved_at,
   });

--- a/src/graph/revisions.ts
+++ b/src/graph/revisions.ts
@@ -1,0 +1,310 @@
+import { canonicalJson, parseGraphDescriptor, verifyDescriptorHash } from './descriptor.js';
+import {
+  parseGraphState,
+  type GraphApprovalRecord,
+  type GraphRevisionRecord,
+  type GraphState,
+} from './runtime-types.js';
+import type {
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from './types.js';
+
+export class GraphRevisionError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphRevisionError';
+    this.code = code;
+  }
+}
+
+function timestamp(value: string, name: string): void {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new GraphRevisionError('invalid_timestamp', `${name} must be an ISO timestamp`);
+  }
+}
+
+function sealedDescriptor(value: unknown): SealedGraphDescriptor {
+  const descriptor = parseGraphDescriptor(value) as SealedGraphDescriptor;
+  if (!verifyDescriptorHash(descriptor)) {
+    throw new GraphRevisionError('descriptor_unsealed', 'Revision descriptor hash does not match');
+  }
+  return descriptor;
+}
+
+function sortedUnique(values: string[], name: string): string[] {
+  if (values.length > 1_000 || values.some((value) => value.length === 0 || value.length > 128)) {
+    throw new GraphRevisionError('invalid_invalidation', `${name} must be a bounded node ID list`);
+  }
+  const result = [...new Set(values)].sort();
+  if (result.length !== values.length) {
+    throw new GraphRevisionError('invalid_invalidation', `${name} cannot contain duplicate node IDs`);
+  }
+  return result;
+}
+
+function assertHumanEvidence(evidence: GraphEvidenceReference, name: string): void {
+  if (evidence.kind !== 'human' || evidence.ref.length === 0 || evidence.ref.length > 2_048) {
+    throw new GraphRevisionError('approval_evidence_invalid', `${name} requires bounded human evidence`);
+  }
+}
+
+export interface ReplacePendingDraftInput {
+  descriptor: SealedGraphDescriptor;
+  replaced_at: string;
+}
+
+export function replacePendingDraft(stateInput: GraphState, input: ReplacePendingDraftInput): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.replaced_at, 'replaced_at');
+  if (state.status !== 'awaiting_approval'
+    || !state.pending_approval
+    || state.revisions[state.active_revision_id].approval
+    || state.commit_sequence !== 0
+    || state.transitions.length !== 0
+    || Object.keys(state.claims).length !== 0
+    || Object.keys(state.reconciliations).length !== 0
+    || Object.keys(state.projection.activations).length !== 0
+    || Object.keys(state.projection.committed_transitions).length !== 0) {
+    throw new GraphRevisionError(
+      'draft_not_replaceable',
+      'Only an unapproved graph with no claims, history, or runnable projection can replace its pending draft',
+    );
+  }
+  const descriptor = sealedDescriptor(input.descriptor);
+  if (descriptor.run_id !== state.run_id) {
+    throw new GraphRevisionError('run_mismatch', 'Replacement draft must retain the graph run identity');
+  }
+  if (descriptor.revision_id === state.active_revision_id || state.revisions[descriptor.revision_id]) {
+    throw new GraphRevisionError('revision_reused', 'Replacement draft requires a new immutable revision ID');
+  }
+  const revision: GraphRevisionRecord = {
+    revision_id: descriptor.revision_id,
+    descriptor_hash: descriptor.descriptor_hash,
+    descriptor: structuredClone(descriptor),
+    created_at: input.replaced_at,
+    invalidated_node_ids: [],
+  };
+  return parseGraphState({
+    ...structuredClone(state),
+    active_revision_id: descriptor.revision_id,
+    active_revision_hash: descriptor.descriptor_hash,
+    revisions: { ...state.revisions, [descriptor.revision_id]: revision },
+    pending_approval: {
+      revision_id: descriptor.revision_id,
+      revision_hash: descriptor.descriptor_hash,
+      requested_at: input.replaced_at,
+    },
+    updated_at: input.replaced_at,
+  });
+}
+
+export interface ApprovePendingGraphRevisionInput {
+  revision_id: string;
+  revision_hash: string;
+  approved_at: string;
+  approval_evidence: GraphEvidenceReference;
+}
+
+export type InitializeApprovedProjection = (
+  descriptor: SealedGraphDescriptor,
+) => GraphSchedulerProjection;
+
+export function approvePendingGraphRevision(
+  stateInput: GraphState,
+  input: ApprovePendingGraphRevisionInput,
+  initializeProjection: InitializeApprovedProjection,
+): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.approved_at, 'approved_at');
+  assertHumanEvidence(input.approval_evidence, 'Initial graph approval');
+  if (state.status !== 'awaiting_approval' || !state.pending_approval) {
+    throw new GraphRevisionError('approval_not_pending', 'Graph is not awaiting initial approval');
+  }
+  if (state.pending_approval.revision_id !== input.revision_id
+    || state.pending_approval.revision_hash !== input.revision_hash
+    || state.active_revision_id !== input.revision_id
+    || state.active_revision_hash !== input.revision_hash) {
+    throw new GraphRevisionError('approval_fence_mismatch', 'Initial approval does not bind the exact pending revision/hash');
+  }
+  if (Object.keys(state.claims).length > 0 || state.transitions.length > 0) {
+    throw new GraphRevisionError('approval_not_quiescent', 'Initial approval cannot cross claims or committed history');
+  }
+  const current = state.revisions[input.revision_id];
+  if (!current || current.approval) {
+    throw new GraphRevisionError('approval_reused', 'Pending revision is missing or already approved');
+  }
+  const approval: GraphApprovalRecord = {
+    revision_id: input.revision_id,
+    revision_hash: input.revision_hash,
+    approved_at: input.approved_at,
+    evidence: structuredClone(input.approval_evidence),
+  };
+  const projection = initializeProjection(structuredClone(current.descriptor));
+  return parseGraphState({
+    ...structuredClone(state),
+    status: 'running',
+    revisions: {
+      ...state.revisions,
+      [current.revision_id]: { ...current, approval },
+    },
+    projection,
+    pending_approval: undefined,
+    updated_at: input.approved_at,
+  });
+}
+
+export interface ProposeGraphPatchInput {
+  proposal_id: string;
+  base_revision_id: string;
+  base_revision_hash: string;
+  proposed_descriptor: SealedGraphDescriptor;
+  invalidated_node_ids: string[];
+  proposal_evidence: GraphEvidenceReference[];
+  proposed_at: string;
+}
+
+export function proposeGraphPatch(stateInput: GraphState, input: ProposeGraphPatchInput): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.proposed_at, 'proposed_at');
+  if (state.status !== 'running' && state.status !== 'waiting_human') {
+    throw new GraphRevisionError('patch_not_allowed', `Cannot propose a patch while graph status is ${state.status}`);
+  }
+  if (state.pending_patch) throw new GraphRevisionError('patch_pending', 'A graph patch is already pending');
+  if (state.active_revision_id !== input.base_revision_id
+    || state.active_revision_hash !== input.base_revision_hash) {
+    throw new GraphRevisionError('stale_base', 'Patch proposal has a stale base revision/hash');
+  }
+  const proposed = sealedDescriptor(input.proposed_descriptor);
+  if (proposed.run_id !== state.run_id) {
+    throw new GraphRevisionError('run_mismatch', 'Patch descriptor must retain the graph run identity');
+  }
+  if (proposed.revision_id === state.active_revision_id || state.revisions[proposed.revision_id]) {
+    throw new GraphRevisionError('revision_reused', 'Patch requires a new immutable revision ID');
+  }
+  if (input.proposal_evidence.length > 64) {
+    throw new GraphRevisionError('evidence_limit', 'Patch proposal evidence exceeds the configured bound');
+  }
+  const invalidated = sortedUnique(input.invalidated_node_ids, 'invalidated_node_ids');
+  if (invalidated.some((nodeId) => !state.revisions[state.active_revision_id].descriptor.nodes.some((node) => node.id === nodeId))) {
+    throw new GraphRevisionError('unknown_invalidation', 'Patch invalidation references an unknown current node ID');
+  }
+  return parseGraphState({
+    ...structuredClone(state),
+    status: 'waiting_patch_approval',
+    dispatch_generation: state.dispatch_generation + 1,
+    pending_patch: {
+      proposal_id: input.proposal_id,
+      base_revision_id: input.base_revision_id,
+      base_revision_hash: input.base_revision_hash,
+      base_dispatch_generation: state.dispatch_generation,
+      proposed_revision_id: proposed.revision_id,
+      proposed_revision_hash: proposed.descriptor_hash,
+      proposed_descriptor: structuredClone(proposed),
+      invalidated_node_ids: invalidated,
+      proposal_evidence: structuredClone(input.proposal_evidence),
+      proposed_at: input.proposed_at,
+    },
+    updated_at: input.proposed_at,
+  });
+}
+
+export interface ApproveGraphPatchInput {
+  proposal_id: string;
+  base_revision_id: string;
+  base_revision_hash: string;
+  proposed_revision_hash: string;
+  invalidated_node_ids: string[];
+  approval_evidence: GraphEvidenceReference;
+  approved_at: string;
+}
+
+export type RecomputeProjectionForRevision = (
+  projection: GraphSchedulerProjection,
+  descriptor: SealedGraphDescriptor,
+  invalidatedNodeIds: ReadonlySet<string>,
+) => GraphSchedulerProjection;
+
+export function approveGraphPatch(
+  stateInput: GraphState,
+  input: ApproveGraphPatchInput,
+  recomputeProjection: RecomputeProjectionForRevision,
+): GraphState {
+  const state = parseGraphState(stateInput);
+  timestamp(input.approved_at, 'approved_at');
+  assertHumanEvidence(input.approval_evidence, 'Patch approval');
+  const patch = state.pending_patch;
+  if (state.status !== 'waiting_patch_approval' || !patch) {
+    throw new GraphRevisionError('patch_not_pending', 'No approved patch transition is pending');
+  }
+  if (patch.proposal_id !== input.proposal_id
+    || patch.base_revision_id !== input.base_revision_id
+    || patch.base_revision_hash !== input.base_revision_hash
+    || patch.proposed_revision_hash !== input.proposed_revision_hash
+    || state.active_revision_id !== patch.base_revision_id
+    || state.active_revision_hash !== patch.base_revision_hash) {
+    throw new GraphRevisionError('patch_fence_mismatch', 'Patch approval does not bind the exact pending base/proposal');
+  }
+  const requestedInvalidations = sortedUnique(input.invalidated_node_ids, 'invalidated_node_ids');
+  if (canonicalJson(requestedInvalidations) !== canonicalJson([...patch.invalidated_node_ids].sort())) {
+    throw new GraphRevisionError('invalidation_mismatch', 'Patch approval must enumerate the exact proposed invalidation set');
+  }
+  if (Object.values(state.claims).some((claim) => claim.status === 'live')) {
+    throw new GraphRevisionError('live_claims', 'Patch approval is blocked until every live claim drains');
+  }
+  if (Object.values(state.reconciliations).some((record) => record.status === 'unresolved')) {
+    throw new GraphRevisionError('unresolved_reconciliation', 'Patch approval is blocked by unresolved reconciliation');
+  }
+
+  const baseDescriptor = state.revisions[patch.base_revision_id].descriptor;
+  const nextDescriptor = sealedDescriptor(patch.proposed_descriptor);
+  const nextNodes = new Map(nextDescriptor.nodes.map((node) => [node.id, node]));
+  const invalidated = new Set(requestedInvalidations);
+  const completedNodeIds = new Set(
+    Object.values(state.projection.activations)
+      .filter((activation) => activation.status === 'completed')
+      .map((activation) => activation.node_id),
+  );
+  for (const nodeId of completedNodeIds) {
+    const before = baseDescriptor.nodes.find((node) => node.id === nodeId);
+    const after = nextNodes.get(nodeId);
+    if ((!before || !after || canonicalJson(before) !== canonicalJson(after)) && !invalidated.has(nodeId)) {
+      throw new GraphRevisionError(
+        'completed_node_repurposed',
+        `Completed node ID ${nodeId} changed without explicit approved invalidation`,
+      );
+    }
+  }
+  const approval: GraphApprovalRecord = {
+    revision_id: nextDescriptor.revision_id,
+    revision_hash: nextDescriptor.descriptor_hash,
+    approved_at: input.approved_at,
+    evidence: structuredClone(input.approval_evidence),
+  };
+  const revision: GraphRevisionRecord = {
+    revision_id: nextDescriptor.revision_id,
+    descriptor_hash: nextDescriptor.descriptor_hash,
+    descriptor: structuredClone(nextDescriptor),
+    created_at: patch.proposed_at,
+    approval,
+    invalidated_node_ids: requestedInvalidations,
+  };
+  const projection = recomputeProjection(
+    structuredClone(state.projection),
+    structuredClone(nextDescriptor),
+    invalidated,
+  );
+  return parseGraphState({
+    ...structuredClone(state),
+    status: 'running',
+    active_revision_id: nextDescriptor.revision_id,
+    active_revision_hash: nextDescriptor.descriptor_hash,
+    revisions: { ...state.revisions, [nextDescriptor.revision_id]: revision },
+    projection,
+    pending_patch: undefined,
+    updated_at: input.approved_at,
+  });
+}

--- a/src/graph/runtime-types.ts
+++ b/src/graph/runtime-types.ts
@@ -417,11 +417,28 @@ function validateProjection(value: unknown, descriptor: SealedGraphDescriptor): 
   }
 
   const traversals = requireRecord(projection.traversal_counts, 'projection.traversal_counts');
-  for (const [edgeId, count] of Object.entries(traversals)) {
+  // traversal_counts keys are produced by traversalCounterKey() as
+  // canonicalJson([traversal_owner_id, edge.id]). The traversal_owner_id is always
+  // an activation_id or branch_token_id, both of which are record keys in scope here.
+  const traversalOwnerIds = new Set<string>([...Object.keys(activations), ...Object.keys(tokens)]);
+  for (const [key, count] of Object.entries(traversals)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(key);
+    } catch {
+      throw new GraphStateValidationError(`traversal count key ${key} is not valid JSON`);
+    }
+    if (!Array.isArray(parsed) || parsed.length !== 2 || typeof parsed[0] !== 'string' || typeof parsed[1] !== 'string') {
+      throw new GraphStateValidationError(`traversal count key ${key} is not a [owner, edgeId] pair`);
+    }
+    const [owner, edgeId] = parsed as [string, string];
+    if (!traversalOwnerIds.has(owner)) {
+      throw new GraphStateValidationError(`traversal count key ${key} references unknown traversal owner ${owner}`);
+    }
     if (!descriptor.edges.some((edge) => edge.id === edgeId && edge.kind === 'back_edge')) {
       throw new GraphStateValidationError(`traversal count references unknown back-edge ${edgeId}`);
     }
-    requireInteger(count, `projection.traversal_counts.${edgeId}`, 100);
+    requireInteger(count, `projection.traversal_counts.${key}`, 100);
   }
 
   const committed = requireRecord(projection.committed_transitions, 'projection.committed_transitions');

--- a/src/graph/runtime-types.ts
+++ b/src/graph/runtime-types.ts
@@ -1,0 +1,835 @@
+import { parseGraphDescriptor, verifyDescriptorHash } from './descriptor.js';
+import type {
+  GraphEffectPolicy,
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from './types.js';
+
+export const GRAPH_STATE_FORMAT_VERSION = 1 as const;
+export const GRAPH_STATE_MAX_BYTES = 8 * 1024 * 1024;
+export const GRAPH_MAX_TRANSITIONS = 10_000;
+export const GRAPH_MAX_DIAGNOSTICS = 128;
+export const GRAPH_MAX_RECONCILIATIONS = 1_000;
+export const GRAPH_MAX_CLAIMS = 2_000;
+export const GRAPH_MAX_TRANSITION_RESULT_BYTES = 32 * 1024;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type GraphRunStatus =
+  | 'draft'
+  | 'awaiting_approval'
+  | 'running'
+  | 'waiting_human'
+  | 'waiting_patch_approval'
+  | 'reconciling'
+  | 'paused'
+  | 'failed'
+  | 'cancelled'
+  | 'succeeded';
+
+export interface GraphApprovalRecord {
+  revision_id: string;
+  revision_hash: string;
+  approved_at: string;
+  evidence: GraphEvidenceReference;
+}
+
+export interface GraphRevisionRecord {
+  revision_id: string;
+  descriptor_hash: string;
+  descriptor: SealedGraphDescriptor;
+  created_at: string;
+  approval?: GraphApprovalRecord;
+  invalidated_node_ids: string[];
+}
+
+export interface GraphStateTransition {
+  transition_id: string;
+  operation: string;
+  operation_fingerprint: string;
+  request_fingerprint: string;
+  sequence: number;
+  committed_at: string;
+  result: JsonValue;
+}
+
+export type GraphClaimStatus =
+  | 'live'
+  | 'completed'
+  | 'expired_retryable'
+  | 'abandoned_retryable'
+  | 'reconciling'
+  | 'fenced';
+
+export interface GraphClaim {
+  run_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+  activation_id: string;
+  attempt_id: string;
+  attempt_no: number;
+  claim_owner_session_id: string;
+  driver_instance_id: string;
+  lease_id: string;
+  tracking_id: string;
+  issued_at: string;
+  expires_at: string;
+  last_renewed_at?: string;
+  lease_duration_ms: number;
+  renewal_count: number;
+  max_renewals: number;
+  effect_policy: GraphEffectPolicy;
+  external_idempotency_key?: string;
+  status: GraphClaimStatus;
+  fenced_at?: string;
+  replacement_lease_id?: string;
+}
+
+export type GraphReconciliationStatus =
+  | 'unresolved'
+  | 'committed'
+  | 'proved_not_applied'
+  | 'accepted'
+  | 'invalidated';
+
+export interface GraphReconciliationRecord {
+  reconciliation_id: string;
+  activation_id: string;
+  attempt_id: string;
+  lease_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+  status: GraphReconciliationStatus;
+  reason: 'expired_ambiguous' | 'session_end_ambiguous' | 'external_effect_ambiguous';
+  created_at: string;
+  resolved_at?: string;
+  resolution_evidence?: GraphEvidenceReference;
+}
+
+export interface GraphDiagnostic {
+  kind: 'late_result' | 'operation' | 'recovery' | 'control';
+  recorded_at: string;
+  summary: string;
+  activation_id?: string;
+  attempt_id?: string;
+  lease_id?: string;
+}
+
+export interface GraphPendingApproval {
+  revision_id: string;
+  revision_hash: string;
+  requested_at: string;
+}
+
+export interface GraphPendingPatch {
+  proposal_id: string;
+  base_revision_id: string;
+  base_revision_hash: string;
+  base_dispatch_generation: number;
+  proposed_revision_id: string;
+  proposed_revision_hash: string;
+  proposed_descriptor: SealedGraphDescriptor;
+  invalidated_node_ids: string[];
+  proposal_evidence: GraphEvidenceReference[];
+  proposed_at: string;
+}
+
+export interface GraphState {
+  format_version: typeof GRAPH_STATE_FORMAT_VERSION;
+  session_id: string;
+  run_id: string;
+  control_nonce: string;
+  status: GraphRunStatus;
+  active_revision_id: string;
+  active_revision_hash: string;
+  dispatch_generation: number;
+  commit_sequence: number;
+  revisions: Record<string, GraphRevisionRecord>;
+  transitions: GraphStateTransition[];
+  projection: GraphSchedulerProjection;
+  claims: Record<string, GraphClaim>;
+  reconciliations: Record<string, GraphReconciliationRecord>;
+  diagnostics: GraphDiagnostic[];
+  pending_approval?: GraphPendingApproval;
+  pending_patch?: GraphPendingPatch;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateInitialGraphStateInput {
+  session_id: string;
+  control_nonce: string;
+  descriptor: SealedGraphDescriptor;
+  projection: GraphSchedulerProjection;
+  status?: GraphRunStatus;
+  created_at: string;
+  approval?: Omit<GraphApprovalRecord, 'revision_id' | 'revision_hash'> & {
+    revision_id?: string;
+    revision_hash?: string;
+  };
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export function createInitialGraphState(input: CreateInitialGraphStateInput): GraphState {
+  const descriptor = parseGraphDescriptor(input.descriptor) as SealedGraphDescriptor;
+  if (!verifyDescriptorHash(descriptor)) throw new Error('Initial graph descriptor must be sealed');
+  if (
+    input.approval
+    && (
+      (input.approval.revision_id && input.approval.revision_id !== descriptor.revision_id)
+      || (input.approval.revision_hash && input.approval.revision_hash !== descriptor.descriptor_hash)
+      || input.approval.evidence.kind !== 'human'
+    )
+  ) {
+    throw new Error('Initial graph approval must bind the exact revision/hash with human evidence');
+  }
+  const status = input.status ?? (input.approval ? 'running' : 'awaiting_approval');
+  if (!input.approval && status !== 'draft' && status !== 'awaiting_approval') {
+    throw new Error(`Graph status ${status} requires exact revision approval`);
+  }
+  if (input.approval && (status === 'draft' || status === 'awaiting_approval')) {
+    throw new Error(`Approved graph cannot remain in ${status}`);
+  }
+  if (!input.approval && Object.values(input.projection.activations).some(
+    (activation) => activation.status === 'ready' || activation.status === 'running',
+  )) {
+    throw new Error('Unapproved graph cannot expose claimable work');
+  }
+  const approval: GraphApprovalRecord | undefined = input.approval
+    ? {
+        revision_id: descriptor.revision_id,
+        revision_hash: descriptor.descriptor_hash,
+        approved_at: input.approval.approved_at,
+        evidence: clone(input.approval.evidence),
+      }
+    : undefined;
+  const revision: GraphRevisionRecord = {
+    revision_id: descriptor.revision_id,
+    descriptor_hash: descriptor.descriptor_hash,
+    descriptor: clone(descriptor),
+    created_at: input.created_at,
+    ...(approval ? { approval } : {}),
+    invalidated_node_ids: [],
+  };
+  return {
+    format_version: GRAPH_STATE_FORMAT_VERSION,
+    session_id: input.session_id,
+    run_id: descriptor.run_id,
+    control_nonce: input.control_nonce,
+    status,
+    active_revision_id: descriptor.revision_id,
+    active_revision_hash: descriptor.descriptor_hash,
+    dispatch_generation: 0,
+    commit_sequence: 0,
+    revisions: { [descriptor.revision_id]: revision },
+    transitions: [],
+    projection: clone(input.projection),
+    claims: {},
+    reconciliations: {},
+    diagnostics: [],
+    ...(!input.approval
+      ? {
+          pending_approval: {
+            revision_id: descriptor.revision_id,
+            revision_hash: descriptor.descriptor_hash,
+            requested_at: input.created_at,
+          },
+        }
+      : {}),
+    created_at: input.created_at,
+    updated_at: input.created_at,
+  };
+}
+
+export class GraphStateValidationError extends Error {
+  readonly code = 'invalid_graph_state';
+
+  constructor(message: string) {
+    super(`Invalid graph state: ${message}`);
+    this.name = 'GraphStateValidationError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new GraphStateValidationError(`${name} must be an object`);
+  return value;
+}
+
+function requireString(value: unknown, name: string, max = 32_768): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > max) {
+    throw new GraphStateValidationError(`${name} must be a non-empty bounded string`);
+  }
+  return value;
+}
+
+function requireInteger(value: unknown, name: string, max = Number.MAX_SAFE_INTEGER): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0 || (value as number) > max) {
+    throw new GraphStateValidationError(`${name} must be a bounded non-negative integer`);
+  }
+  return value as number;
+}
+
+function requireTimestamp(value: unknown, name: string): string {
+  const result = requireString(value, name, 64);
+  if (!Number.isFinite(Date.parse(result))) throw new GraphStateValidationError(`${name} must be an ISO timestamp`);
+  return result;
+}
+
+function assertExactKeys(record: Record<string, unknown>, required: string[], optional: string[], name: string): void {
+  const allowed = new Set([...required, ...optional]);
+  const unknown = Object.keys(record).filter((key) => !allowed.has(key));
+  const missing = required.filter((key) => !(key in record));
+  if (missing.length > 0) throw new GraphStateValidationError(`${name} missing ${missing.join(', ')}`);
+  if (unknown.length > 0) throw new GraphStateValidationError(`${name} has unknown ${unknown.join(', ')}`);
+}
+
+function requireStringArray(value: unknown, name: string, max: number): string[] {
+  if (!Array.isArray(value) || value.length > max) {
+    throw new GraphStateValidationError(`${name} must be a bounded array`);
+  }
+  const result = value.map((item, index) => requireString(item, `${name}[${index}]`, 128));
+  if (new Set(result).size !== result.length) throw new GraphStateValidationError(`${name} contains duplicates`);
+  return result;
+}
+
+function validateEvidence(value: unknown, name: string): GraphEvidenceReference {
+  const evidence = requireRecord(value, name);
+  assertExactKeys(evidence, ['kind', 'ref'], ['summary'], name);
+  if (!['file', 'command', 'test', 'human', 'url'].includes(String(evidence.kind))) {
+    throw new GraphStateValidationError(`${name}.kind is invalid`);
+  }
+  requireString(evidence.ref, `${name}.ref`, 2_048);
+  if (evidence.summary !== undefined) requireString(evidence.summary, `${name}.summary`, 2_048);
+  return value as GraphEvidenceReference;
+}
+
+function validateEffectPolicy(value: unknown, name: string): GraphEffectPolicy {
+  const policy = requireRecord(value, name);
+  if (policy.policy === 'side_effect_free' || policy.policy === 'reconcile') {
+    assertExactKeys(policy, ['policy'], [], name);
+    return value as GraphEffectPolicy;
+  }
+  if (policy.policy === 'idempotent') {
+    assertExactKeys(policy, ['policy', 'idempotency_key_template'], [], name);
+    requireString(policy.idempotency_key_template, `${name}.idempotency_key_template`, 512);
+    return value as GraphEffectPolicy;
+  }
+  throw new GraphStateValidationError(`${name}.policy is invalid`);
+}
+
+function validateApproval(value: unknown, name: string, revisionId: string, revisionHash: string): GraphApprovalRecord {
+  const approval = requireRecord(value, name);
+  assertExactKeys(approval, ['revision_id', 'revision_hash', 'approved_at', 'evidence'], [], name);
+  if (approval.revision_id !== revisionId || approval.revision_hash !== revisionHash) {
+    throw new GraphStateValidationError(`${name} does not bind the exact revision/hash`);
+  }
+  requireTimestamp(approval.approved_at, `${name}.approved_at`);
+  const evidence = validateEvidence(approval.evidence, `${name}.evidence`);
+  if (evidence.kind !== 'human') throw new GraphStateValidationError(`${name} requires human evidence`);
+  return value as GraphApprovalRecord;
+}
+
+function validateProjection(value: unknown, descriptor: SealedGraphDescriptor): GraphSchedulerProjection {
+  const projection = requireRecord(value, 'projection');
+  assertExactKeys(projection, [
+    'activations',
+    'cohorts',
+    'branch_tokens',
+    'traversal_counts',
+    'committed_transitions',
+    'terminal_verification_activation_ids',
+  ], [], 'projection');
+  const nodeIds = new Set(descriptor.nodes.map((node) => node.id));
+  const activations = requireRecord(projection.activations, 'projection.activations');
+  for (const [key, raw] of Object.entries(activations)) {
+    const activation = requireRecord(raw, `projection.activations.${key}`);
+    assertExactKeys(activation, [
+      'activation_id', 'node_id', 'status', 'attempt_no', 'attempt_ids', 'traversal_owner_id',
+    ], [
+      'active_attempt_id', 'completed_transition_id', 'cohort_id', 'branch_token_id',
+    ], `projection.activations.${key}`);
+    if (activation.activation_id !== key) throw new GraphStateValidationError(`activation key ${key} mismatches identity`);
+    const nodeId = requireString(activation.node_id, `projection.activations.${key}.node_id`, 128);
+    if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`activation ${key} references unknown node ${nodeId}`);
+    if (!['ready', 'running', 'completed', 'failed'].includes(String(activation.status))) {
+      throw new GraphStateValidationError(`activation ${key} has invalid status`);
+    }
+    const attemptNo = requireInteger(activation.attempt_no, `projection.activations.${key}.attempt_no`, 20);
+    const attempts = requireStringArray(activation.attempt_ids, `projection.activations.${key}.attempt_ids`, 20);
+    if (attemptNo !== attempts.length) throw new GraphStateValidationError(`activation ${key} attempt count mismatch`);
+    requireString(activation.traversal_owner_id, `projection.activations.${key}.traversal_owner_id`, 128);
+    if (activation.active_attempt_id !== undefined) {
+      const activeAttempt = requireString(activation.active_attempt_id, `projection.activations.${key}.active_attempt_id`, 128);
+      if (!attempts.includes(activeAttempt)) throw new GraphStateValidationError(`activation ${key} active attempt is unknown`);
+    }
+    if (activation.status === 'running' && !activation.active_attempt_id) {
+      throw new GraphStateValidationError(`running activation ${key} has no active attempt`);
+    }
+  }
+
+  const cohorts = requireRecord(projection.cohorts, 'projection.cohorts');
+  for (const [key, raw] of Object.entries(cohorts)) {
+    const cohort = requireRecord(raw, `projection.cohorts.${key}`);
+    assertExactKeys(cohort, [
+      'cohort_id', 'fan_out_node_id', 'owner_join_id', 'expected_branch_token_ids', 'consumed',
+    ], ['join_activation_id'], `projection.cohorts.${key}`);
+    if (cohort.cohort_id !== key) throw new GraphStateValidationError(`cohort key ${key} mismatches identity`);
+    for (const property of ['fan_out_node_id', 'owner_join_id'] as const) {
+      const nodeId = requireString(cohort[property], `projection.cohorts.${key}.${property}`, 128);
+      if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`cohort ${key} references unknown node ${nodeId}`);
+    }
+    requireStringArray(cohort.expected_branch_token_ids, `projection.cohorts.${key}.expected_branch_token_ids`, 64);
+    if (typeof cohort.consumed !== 'boolean') throw new GraphStateValidationError(`cohort ${key}.consumed must be boolean`);
+    if (cohort.join_activation_id !== undefined && !(String(cohort.join_activation_id) in activations)) {
+      throw new GraphStateValidationError(`cohort ${key} references unknown join activation`);
+    }
+  }
+
+  const tokens = requireRecord(projection.branch_tokens, 'projection.branch_tokens');
+  for (const [key, raw] of Object.entries(tokens)) {
+    const token = requireRecord(raw, `projection.branch_tokens.${key}`);
+    assertExactKeys(token, [
+      'branch_token_id', 'cohort_id', 'branch_id', 'owner_join_id', 'status',
+    ], ['current_activation_id', 'consumed_by_activation_id'], `projection.branch_tokens.${key}`);
+    if (token.branch_token_id !== key) throw new GraphStateValidationError(`branch token key ${key} mismatches identity`);
+    if (!(String(token.cohort_id) in cohorts)) throw new GraphStateValidationError(`branch token ${key} references unknown cohort`);
+    requireString(token.branch_id, `projection.branch_tokens.${key}.branch_id`, 128);
+    requireString(token.owner_join_id, `projection.branch_tokens.${key}.owner_join_id`, 128);
+    if (!['active', 'arrived', 'consumed'].includes(String(token.status))) {
+      throw new GraphStateValidationError(`branch token ${key} has invalid status`);
+    }
+    for (const property of ['current_activation_id', 'consumed_by_activation_id'] as const) {
+      if (token[property] !== undefined && !(String(token[property]) in activations)) {
+        throw new GraphStateValidationError(`branch token ${key} references unknown activation`);
+      }
+    }
+  }
+
+  const traversals = requireRecord(projection.traversal_counts, 'projection.traversal_counts');
+  for (const [edgeId, count] of Object.entries(traversals)) {
+    if (!descriptor.edges.some((edge) => edge.id === edgeId && edge.kind === 'back_edge')) {
+      throw new GraphStateValidationError(`traversal count references unknown back-edge ${edgeId}`);
+    }
+    requireInteger(count, `projection.traversal_counts.${edgeId}`, 100);
+  }
+
+  const committed = requireRecord(projection.committed_transitions, 'projection.committed_transitions');
+  if (Object.keys(committed).length > GRAPH_MAX_TRANSITIONS) {
+    throw new GraphStateValidationError('scheduler committed transitions exceed the configured bound');
+  }
+  for (const [key, raw] of Object.entries(committed)) {
+    const transition = requireRecord(raw, `projection.committed_transitions.${key}`);
+    assertExactKeys(transition, [
+      'transition_id', 'activation_id', 'node_id', 'outcome', 'request_fingerprint',
+      'selected_edge_ids', 'created_activation_ids', 'evidence_refs',
+    ], [
+      'cohort_id', 'attempt_id', 'route', 'output_summary', 'external_idempotency_key',
+    ], `projection.committed_transitions.${key}`);
+    if (transition.transition_id !== key) throw new GraphStateValidationError(`scheduler transition key ${key} mismatches identity`);
+    if (!(String(transition.activation_id) in activations)) {
+      throw new GraphStateValidationError(`scheduler transition ${key} references unknown activation`);
+    }
+    const nodeId = requireString(transition.node_id, `projection.committed_transitions.${key}.node_id`, 128);
+    if (!nodeIds.has(nodeId)) throw new GraphStateValidationError(`scheduler transition ${key} references unknown node`);
+    if (!['succeeded', 'failed', 'join_resolved'].includes(String(transition.outcome))) {
+      throw new GraphStateValidationError(`scheduler transition ${key} has invalid outcome`);
+    }
+    requireString(transition.request_fingerprint, `projection.committed_transitions.${key}.request_fingerprint`, 64);
+    requireStringArray(transition.selected_edge_ids, `projection.committed_transitions.${key}.selected_edge_ids`, 64);
+    requireStringArray(transition.created_activation_ids, `projection.committed_transitions.${key}.created_activation_ids`, 64);
+    if (!Array.isArray(transition.evidence_refs) || transition.evidence_refs.length > 64) {
+      throw new GraphStateValidationError(`scheduler transition ${key} evidence is invalid`);
+    }
+    transition.evidence_refs.forEach((item, index) => validateEvidence(item, `scheduler transition ${key} evidence[${index}]`));
+  }
+
+  const terminalIds = requireStringArray(
+    projection.terminal_verification_activation_ids,
+    'projection.terminal_verification_activation_ids',
+    GRAPH_MAX_TRANSITIONS,
+  );
+  for (const activationId of terminalIds) {
+    const activation = activations[activationId] as Record<string, unknown> | undefined;
+    if (!activation || activation.node_id !== descriptor.terminal_verification_node_id) {
+      throw new GraphStateValidationError(`terminal verification activation ${activationId} is invalid`);
+    }
+  }
+  return value as GraphSchedulerProjection;
+}
+
+function validateRevision(value: unknown, key: string, runId: string): GraphRevisionRecord {
+  const revision = requireRecord(value, `revisions.${key}`);
+  assertExactKeys(revision, [
+    'revision_id', 'descriptor_hash', 'descriptor', 'created_at', 'invalidated_node_ids',
+  ], ['approval'], `revisions.${key}`);
+  const revisionId = requireString(revision.revision_id, `revisions.${key}.revision_id`, 128);
+  const hash = requireString(revision.descriptor_hash, `revisions.${key}.descriptor_hash`, 64);
+  if (!/^[a-f0-9]{64}$/.test(hash)) throw new GraphStateValidationError(`revision ${key} hash is invalid`);
+  if (revisionId !== key) throw new GraphStateValidationError(`revision key ${key} does not match revision_id`);
+  const descriptor = parseGraphDescriptor(revision.descriptor) as SealedGraphDescriptor;
+  if (!verifyDescriptorHash(descriptor) || descriptor.descriptor_hash !== hash) {
+    throw new GraphStateValidationError(`revision ${key} descriptor hash mismatch`);
+  }
+  if (descriptor.revision_id !== key || descriptor.run_id !== runId) {
+    throw new GraphStateValidationError(`revision ${key} descriptor identity mismatch`);
+  }
+  requireTimestamp(revision.created_at, `revisions.${key}.created_at`);
+  if (!Array.isArray(revision.invalidated_node_ids)) {
+    throw new GraphStateValidationError(`revisions.${key}.invalidated_node_ids must be an array`);
+  }
+  requireStringArray(revision.invalidated_node_ids, `revisions.${key}.invalidated_node_ids`, 1_000);
+  if (revision.approval !== undefined) validateApproval(revision.approval, `revisions.${key}.approval`, key, hash);
+  return value as GraphRevisionRecord;
+}
+
+export function parseGraphState(input: unknown): GraphState {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(input);
+  } catch (error) {
+    throw new GraphStateValidationError(`state is not JSON serializable: ${String(error)}`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > GRAPH_STATE_MAX_BYTES) {
+    throw new GraphStateValidationError(`state exceeds ${GRAPH_STATE_MAX_BYTES} bytes`);
+  }
+  const state = requireRecord(input, 'state');
+  assertExactKeys(state, [
+    'format_version', 'session_id', 'run_id', 'control_nonce', 'status', 'active_revision_id',
+    'active_revision_hash', 'dispatch_generation', 'commit_sequence', 'revisions',
+    'transitions', 'projection', 'claims', 'reconciliations', 'diagnostics',
+    'created_at', 'updated_at',
+  ], ['pending_approval', 'pending_patch'], 'state');
+  if (state.format_version !== GRAPH_STATE_FORMAT_VERSION) {
+    throw new GraphStateValidationError('unsupported format_version');
+  }
+  const sessionId = requireString(state.session_id, 'session_id', 256);
+  const runId = requireString(state.run_id, 'run_id', 128);
+  requireString(state.control_nonce, 'control_nonce', 128);
+  const activeRevisionId = requireString(state.active_revision_id, 'active_revision_id', 128);
+  const activeHash = requireString(state.active_revision_hash, 'active_revision_hash', 64);
+  if (!/^[a-f0-9]{64}$/.test(activeHash)) throw new GraphStateValidationError('active_revision_hash is invalid');
+  requireInteger(state.dispatch_generation, 'dispatch_generation');
+  const sequence = requireInteger(state.commit_sequence, 'commit_sequence', GRAPH_MAX_TRANSITIONS);
+  requireTimestamp(state.created_at, 'created_at');
+  requireTimestamp(state.updated_at, 'updated_at');
+  const statuses: GraphRunStatus[] = [
+    'draft', 'awaiting_approval', 'running', 'waiting_human', 'waiting_patch_approval',
+    'reconciling', 'paused', 'failed', 'cancelled', 'succeeded',
+  ];
+  if (!statuses.includes(state.status as GraphRunStatus)) throw new GraphStateValidationError('invalid status');
+
+  const revisions = requireRecord(state.revisions, 'revisions');
+  for (const [key, revision] of Object.entries(revisions)) validateRevision(revision, key, runId);
+  const active = revisions[activeRevisionId] as GraphRevisionRecord | undefined;
+  if (!active || active.descriptor_hash !== activeHash) {
+    throw new GraphStateValidationError('active revision/hash is not embedded');
+  }
+  const approvedStatuses = new Set<GraphRunStatus>([
+    'running', 'waiting_human', 'waiting_patch_approval', 'reconciling', 'paused',
+    'failed', 'cancelled', 'succeeded',
+  ]);
+  if (approvedStatuses.has(state.status as GraphRunStatus) && !active.approval) {
+    throw new GraphStateValidationError(`status ${String(state.status)} requires exact active revision approval`);
+  }
+
+  if (!Array.isArray(state.transitions) || state.transitions.length > GRAPH_MAX_TRANSITIONS) {
+    throw new GraphStateValidationError('transitions exceed the configured bound');
+  }
+  const transitionIds = new Set<string>();
+  let priorSequence = 0;
+  for (const raw of state.transitions) {
+    const transition = requireRecord(raw, 'transition');
+    assertExactKeys(transition, [
+      'transition_id', 'operation', 'operation_fingerprint', 'request_fingerprint',
+      'sequence', 'committed_at', 'result',
+    ], [], 'transition');
+    const id = requireString(transition.transition_id, 'transition.transition_id', 128);
+    if (transitionIds.has(id)) throw new GraphStateValidationError(`duplicate transition ${id}`);
+    transitionIds.add(id);
+    const currentSequence = requireInteger(transition.sequence, 'transition.sequence', GRAPH_MAX_TRANSITIONS);
+    if (currentSequence <= priorSequence) throw new GraphStateValidationError('transition sequence is not monotonic');
+    priorSequence = currentSequence;
+    requireString(transition.operation, 'transition.operation', 128);
+    requireString(transition.operation_fingerprint, 'transition.operation_fingerprint', 1_024);
+    const fingerprint = requireString(transition.request_fingerprint, 'transition.request_fingerprint', 64);
+    if (!/^[a-f0-9]{64}$/.test(fingerprint)) {
+      throw new GraphStateValidationError(`transition ${id} request_fingerprint is invalid`);
+    }
+    requireTimestamp(transition.committed_at, 'transition.committed_at');
+    if (Buffer.byteLength(JSON.stringify(transition.result), 'utf8') > GRAPH_MAX_TRANSITION_RESULT_BYTES) {
+      throw new GraphStateValidationError(`transition ${id} result exceeds the configured bound`);
+    }
+  }
+  if (state.transitions.length > 0 && priorSequence !== sequence) {
+    throw new GraphStateValidationError('commit_sequence does not match transition history');
+  }
+  if (state.transitions.length === 0 && sequence !== 0) {
+    throw new GraphStateValidationError('nonzero commit_sequence has no transition history');
+  }
+
+  validateProjection(state.projection, active.descriptor);
+  const claims = requireRecord(state.claims, 'claims');
+  const reconciliations = requireRecord(state.reconciliations, 'reconciliations');
+  if (Object.keys(claims).length > GRAPH_MAX_CLAIMS) throw new GraphStateValidationError('claims exceed the configured bound');
+  if (Object.keys(reconciliations).length > GRAPH_MAX_RECONCILIATIONS) {
+    throw new GraphStateValidationError('reconciliations exceed the configured bound');
+  }
+  for (const [leaseId, raw] of Object.entries(claims)) {
+    const claim = requireRecord(raw, `claims.${leaseId}`);
+    assertExactKeys(claim, [
+      'run_id', 'revision_id', 'revision_hash', 'dispatch_generation', 'activation_id',
+      'attempt_id', 'attempt_no', 'claim_owner_session_id', 'driver_instance_id',
+      'lease_id', 'tracking_id', 'issued_at', 'expires_at', 'lease_duration_ms',
+      'renewal_count', 'max_renewals', 'effect_policy', 'status',
+    ], [
+      'external_idempotency_key', 'last_renewed_at', 'fenced_at', 'replacement_lease_id',
+    ], `claims.${leaseId}`);
+    if (claim.lease_id !== leaseId) throw new GraphStateValidationError(`claim key ${leaseId} mismatches identity`);
+    if (claim.run_id !== runId) throw new GraphStateValidationError(`claim ${leaseId} run fence mismatches`);
+    const revisionId = requireString(claim.revision_id, `claims.${leaseId}.revision_id`, 128);
+    const revisionHash = requireString(claim.revision_hash, `claims.${leaseId}.revision_hash`, 64);
+    const claimRevision = revisions[revisionId] as GraphRevisionRecord | undefined;
+    if (!claimRevision || claimRevision.descriptor_hash !== revisionHash) {
+      throw new GraphStateValidationError(`claim ${leaseId} revision fence is invalid`);
+    }
+    requireInteger(claim.dispatch_generation, `claims.${leaseId}.dispatch_generation`);
+    const activationId = requireString(claim.activation_id, `claims.${leaseId}.activation_id`, 128);
+    const activation = (state.projection as GraphSchedulerProjection).activations[activationId];
+    if (!activation) throw new GraphStateValidationError(`claim ${leaseId} references unknown activation`);
+    const attemptId = requireString(claim.attempt_id, `claims.${leaseId}.attempt_id`, 128);
+    const attemptNo = requireInteger(claim.attempt_no, `claims.${leaseId}.attempt_no`, 20);
+    if (!activation.attempt_ids.includes(attemptId) || activation.attempt_no < attemptNo) {
+      throw new GraphStateValidationError(`claim ${leaseId} attempt fence is invalid`);
+    }
+    for (const property of ['claim_owner_session_id', 'driver_instance_id', 'tracking_id'] as const) {
+      requireString(claim[property], `claims.${leaseId}.${property}`, 256);
+    }
+    const issued = requireTimestamp(claim.issued_at, `claims.${leaseId}.issued_at`);
+    const expires = requireTimestamp(claim.expires_at, `claims.${leaseId}.expires_at`);
+    const duration = requireInteger(claim.lease_duration_ms, `claims.${leaseId}.lease_duration_ms`, 86_400_000);
+    const leaseStart = claim.last_renewed_at === undefined
+      ? issued
+      : requireTimestamp(claim.last_renewed_at, `claims.${leaseId}.last_renewed_at`);
+    if (duration <= 0 || Date.parse(expires) - Date.parse(leaseStart) !== duration) {
+      throw new GraphStateValidationError(`claim ${leaseId} lease duration is inconsistent`);
+    }
+    const renewals = requireInteger(claim.renewal_count, `claims.${leaseId}.renewal_count`, 20);
+    const maxRenewals = requireInteger(claim.max_renewals, `claims.${leaseId}.max_renewals`, 20);
+    if (renewals > maxRenewals) throw new GraphStateValidationError(`claim ${leaseId} renewal cap is exceeded`);
+    const policy = validateEffectPolicy(claim.effect_policy, `claims.${leaseId}.effect_policy`);
+    if (policy.policy === 'idempotent') {
+      requireString(claim.external_idempotency_key, `claims.${leaseId}.external_idempotency_key`, 512);
+    } else if (claim.external_idempotency_key !== undefined) {
+      throw new GraphStateValidationError(`claim ${leaseId} has an unexpected idempotency key`);
+    }
+    if (!['live', 'completed', 'expired_retryable', 'abandoned_retryable', 'reconciling', 'fenced'].includes(String(claim.status))) {
+      throw new GraphStateValidationError(`claim ${leaseId} has invalid status`);
+    }
+    if (claim.status !== 'live' && claim.fenced_at === undefined) {
+      throw new GraphStateValidationError(`non-live claim ${leaseId} requires fenced_at`);
+    }
+    if (claim.fenced_at !== undefined) requireTimestamp(claim.fenced_at, `claims.${leaseId}.fenced_at`);
+    if (claim.replacement_lease_id !== undefined) {
+      requireString(claim.replacement_lease_id, `claims.${leaseId}.replacement_lease_id`, 128);
+    }
+  }
+
+  for (const [id, raw] of Object.entries(reconciliations)) {
+    const record = requireRecord(raw, `reconciliations.${id}`);
+    assertExactKeys(record, [
+      'reconciliation_id', 'activation_id', 'attempt_id', 'lease_id', 'revision_id',
+      'revision_hash', 'dispatch_generation', 'status', 'reason', 'created_at',
+    ], ['resolved_at', 'resolution_evidence'], `reconciliations.${id}`);
+    if (record.reconciliation_id !== id) throw new GraphStateValidationError(`reconciliation key ${id} mismatches identity`);
+    const leaseId = requireString(record.lease_id, `reconciliations.${id}.lease_id`, 128);
+    const claim = claims[leaseId] as Record<string, unknown> | undefined;
+    if (!claim || record.activation_id !== claim.activation_id || record.attempt_id !== claim.attempt_id) {
+      throw new GraphStateValidationError(`reconciliation ${id} claim lineage is invalid`);
+    }
+    if (record.revision_id !== claim.revision_id || record.revision_hash !== claim.revision_hash
+      || record.dispatch_generation !== claim.dispatch_generation) {
+      throw new GraphStateValidationError(`reconciliation ${id} revision fence is invalid`);
+    }
+    if (!['unresolved', 'committed', 'proved_not_applied', 'accepted', 'invalidated'].includes(String(record.status))) {
+      throw new GraphStateValidationError(`reconciliation ${id} status is invalid`);
+    }
+    if (!['expired_ambiguous', 'session_end_ambiguous', 'external_effect_ambiguous'].includes(String(record.reason))) {
+      throw new GraphStateValidationError(`reconciliation ${id} reason is invalid`);
+    }
+    requireTimestamp(record.created_at, `reconciliations.${id}.created_at`);
+    if (record.status === 'unresolved' && (record.resolved_at !== undefined || record.resolution_evidence !== undefined)) {
+      throw new GraphStateValidationError(`unresolved reconciliation ${id} cannot have resolution fields`);
+    }
+    if (record.status !== 'unresolved') {
+      requireTimestamp(record.resolved_at, `reconciliations.${id}.resolved_at`);
+      validateEvidence(record.resolution_evidence, `reconciliations.${id}.resolution_evidence`);
+    }
+  }
+
+  if (!Array.isArray(state.diagnostics) || state.diagnostics.length > GRAPH_MAX_DIAGNOSTICS) {
+    throw new GraphStateValidationError('diagnostics exceed the configured bound');
+  }
+  state.diagnostics.forEach((raw, index) => {
+    const diagnostic = requireRecord(raw, `diagnostics[${index}]`);
+    assertExactKeys(diagnostic, ['kind', 'recorded_at', 'summary'], [
+      'activation_id', 'attempt_id', 'lease_id',
+    ], `diagnostics[${index}]`);
+    if (!['late_result', 'operation', 'recovery', 'control'].includes(String(diagnostic.kind))) {
+      throw new GraphStateValidationError(`diagnostics[${index}].kind is invalid`);
+    }
+    requireTimestamp(diagnostic.recorded_at, `diagnostics[${index}].recorded_at`);
+    requireString(diagnostic.summary, `diagnostics[${index}].summary`, 8_192);
+    for (const property of ['activation_id', 'attempt_id', 'lease_id'] as const) {
+      if (diagnostic[property] !== undefined) requireString(diagnostic[property], `diagnostics[${index}].${property}`, 128);
+    }
+  });
+
+  if (state.pending_approval !== undefined) {
+    const pending = requireRecord(state.pending_approval, 'pending_approval');
+    assertExactKeys(pending, ['revision_id', 'revision_hash', 'requested_at'], [], 'pending_approval');
+    if (pending.revision_id !== activeRevisionId || pending.revision_hash !== activeHash) {
+      throw new GraphStateValidationError('pending approval does not bind the active revision/hash');
+    }
+    requireTimestamp(pending.requested_at, 'pending_approval.requested_at');
+  }
+  if (state.status === 'awaiting_approval' && !state.pending_approval) {
+    throw new GraphStateValidationError('awaiting_approval requires pending_approval');
+  }
+  if (state.status !== 'awaiting_approval' && state.pending_approval) {
+    throw new GraphStateValidationError('pending_approval must be absent outside awaiting_approval');
+  }
+  if (state.pending_approval && active.approval) {
+    throw new GraphStateValidationError('approved revision cannot remain pending approval');
+  }
+  if (!active.approval && Object.values((state.projection as GraphSchedulerProjection).activations).some(
+    (activation) => activation.status === 'ready' || activation.status === 'running',
+  )) {
+    throw new GraphStateValidationError('unapproved graph cannot expose claimable work');
+  }
+
+  if (state.pending_patch !== undefined) {
+    const patch = requireRecord(state.pending_patch, 'pending_patch');
+    assertExactKeys(patch, [
+      'proposal_id', 'base_revision_id', 'base_revision_hash', 'base_dispatch_generation',
+      'proposed_revision_id', 'proposed_revision_hash', 'proposed_descriptor',
+      'invalidated_node_ids', 'proposal_evidence', 'proposed_at',
+    ], [], 'pending_patch');
+    requireString(patch.proposal_id, 'pending_patch.proposal_id', 128);
+    if (patch.base_revision_id !== activeRevisionId || patch.base_revision_hash !== activeHash) {
+      throw new GraphStateValidationError('pending patch base does not bind active revision/hash');
+    }
+    const baseGeneration = requireInteger(patch.base_dispatch_generation, 'pending_patch.base_dispatch_generation');
+    if (baseGeneration + 1 !== state.dispatch_generation) {
+      throw new GraphStateValidationError('pending patch dispatch generation is invalid');
+    }
+    const proposed = parseGraphDescriptor(patch.proposed_descriptor) as SealedGraphDescriptor;
+    if (!verifyDescriptorHash(proposed)
+      || proposed.revision_id !== patch.proposed_revision_id
+      || proposed.descriptor_hash !== patch.proposed_revision_hash
+      || proposed.run_id !== runId
+      || proposed.revision_id === activeRevisionId) {
+      throw new GraphStateValidationError('pending patch proposed descriptor identity/hash is invalid');
+    }
+    requireStringArray(patch.invalidated_node_ids, 'pending_patch.invalidated_node_ids', 1_000);
+    if (!Array.isArray(patch.proposal_evidence) || patch.proposal_evidence.length > 64) {
+      throw new GraphStateValidationError('pending patch proposal evidence is invalid');
+    }
+    patch.proposal_evidence.forEach((item, index) => validateEvidence(item, `pending_patch.proposal_evidence[${index}]`));
+    requireTimestamp(patch.proposed_at, 'pending_patch.proposed_at');
+  }
+  if (state.pending_patch && state.status !== 'waiting_patch_approval') {
+    throw new GraphStateValidationError('pending_patch requires waiting_patch_approval status');
+  }
+  if (!state.pending_patch && state.status === 'waiting_patch_approval') {
+    throw new GraphStateValidationError('waiting_patch_approval requires pending_patch');
+  }
+  if (Object.values(claims).some(
+    (raw) => (raw as Record<string, unknown>).claim_owner_session_id !== sessionId,
+  )) {
+    throw new GraphStateValidationError('claim owner session does not match graph authority session');
+  }
+  return clone(input as GraphState);
+}
+
+export type GraphControlMode =
+  | 'graph'
+  | 'autopilot'
+  | 'autoresearch'
+  | 'ralph'
+  | 'team'
+  | 'ultrawork'
+  | 'ultraqa'
+  | 'ralplan'
+  | 'deep-interview'
+  | 'self-improve';
+
+export interface GraphProcessIdentity {
+  pid: number;
+  process_start: string;
+}
+
+export interface GraphDriverLease {
+  driver_instance_id: string;
+  lease_id: string;
+  expires_at: string;
+}
+
+export interface GraphClaimLineage {
+  activation_id: string;
+  attempt_id: string;
+  lease_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+}
+
+export interface ControlLineageIdentity {
+  mode: GraphControlMode;
+  session_id: string;
+  run_id: string;
+}
+
+export interface ControlChildRegistration extends ControlLineageIdentity {
+  parent: ControlLineageIdentity;
+  graph_claim?: GraphClaimLineage;
+  registered_at: string;
+}
+
+export interface ControlRoot extends ControlLineageIdentity {
+  nonce: string;
+  phase: 'reserved' | 'active';
+  reservation_process: GraphProcessIdentity;
+  driver_lease?: GraphDriverLease;
+  graph_revision?: { revision_id: string; revision_hash: string };
+  children: ControlChildRegistration[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ControlReleaseRecord {
+  mode: GraphControlMode;
+  run_id: string;
+  nonce: string;
+  disposition: 'paused' | 'terminal';
+  released_at: string;
+}
+
+export interface ControlOwnerState {
+  format_version: 1;
+  session_id: string;
+  generation: number;
+  root: ControlRoot | null;
+  last_release?: ControlReleaseRecord;
+  updated_at: string;
+}

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -273,12 +273,9 @@ function ensureGraphControlActive(
   });
 }
 
-/**
- * A succeeded graph cannot retain root control. Re-running a completed
- * transition repeats this reconciliation, closing the crash window between
- * durable terminal publish and control release.
- */
-function releaseSucceededGraphControl(controlStore: ControlOwnerStore, state: GraphState): void {
+/** Releases the exact root after a terminal graph transition. */
+function releaseTerminalGraphControl(controlStore: ControlOwnerStore, state: GraphState): void {
+  if (state.status !== 'succeeded' && state.status !== 'failed') return;
   const root = controlStore.read()?.root;
   if (!root) return;
   if (root.mode !== 'graph' || root.run_id !== state.run_id || root.nonce !== state.control_nonce) {
@@ -289,7 +286,7 @@ function releaseSucceededGraphControl(controlStore: ControlOwnerStore, state: Gr
     run_id: state.run_id,
     nonce: state.control_nonce,
     disposition: {
-      graph_status: 'succeeded',
+      graph_status: state.status,
       claims_fenced: true,
       children_drained: true,
     },
@@ -646,7 +643,10 @@ function executeClaim(input: Readonly<Record<string, unknown>>): unknown {
           kind: 'human-approval',
           waiting_human: true,
         });
-        continue;
+        // A human wait gates the graph. Do not continue a multi-claim batch
+        // after transitioning to waiting_human: issueGraphClaim only accepts a
+        // running state, and later work must not pass the approval boundary.
+        break;
       }
       if (node.kind !== 'agent' && node.kind !== 'command') {
         throw new Error(`activation ${activation.activation_id} is not on an executable node`);
@@ -790,6 +790,17 @@ function applyResultOperation(
       },
     });
     const succeeded = isGraphSucceeded(descriptor, schedulerResult.projection);
+    const completedClaim: GraphClaim = {
+      ...claim,
+      status: 'completed' as const,
+      fenced_at: now(),
+    };
+    const nextClaims = { ...current.claims, [leaseId]: completedClaim };
+    const completedNode = descriptor.nodes.find((node) => node.id === activationNodeId);
+    const hasLiveHumanApproval = Object.values(nextClaims).some((candidate) => {
+      if (candidate.status !== 'live') return false;
+      return descriptor.nodes.find((node) => node.id === current.projection.activations[candidate.activation_id]?.node_id)?.kind === 'human-approval';
+    });
     const next: GraphState = {
       ...current,
       projection: schedulerResult.projection,
@@ -807,15 +818,10 @@ function applyResultOperation(
         : schedulerResult.transition.outcome === 'failed'
         && schedulerResult.projection.activations[activationId]?.status === 'failed'
         ? { status: 'failed' as const }
-        : current.status === 'waiting_human' ? { status: 'running' as const } : {}),
-      claims: {
-        ...current.claims,
-        [leaseId]: {
-          ...claim,
-          status: 'completed' as const,
-          fenced_at: now(),
-        },
-      },
+        : current.status === 'waiting_human' && completedNode?.kind === 'human-approval' && !hasLiveHumanApproval
+          ? { status: 'running' as const }
+          : {}),
+      claims: nextClaims,
     };
     return {
       next,
@@ -831,8 +837,8 @@ function applyResultOperation(
     };
   });
 
-  if (result.state.status === 'succeeded') {
-    releaseSucceededGraphControl(new ControlOwnerStore({ sessionId }), result.state);
+  if (result.state.status === 'succeeded' || result.state.status === 'failed') {
+    releaseTerminalGraphControl(new ControlOwnerStore({ sessionId }), result.state);
   }
 
   return { result: result.result, replayed: result.replayed };

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -1,0 +1,1454 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalJson, parseGraphDescriptor, sealGraphDescriptor } from './descriptor.js';
+import {
+  issueGraphClaim,
+  recoverExpiredGraphClaim,
+  recordLateClaimResult,
+  renewGraphClaim,
+  settleDriverClaims,
+} from './claims.js';
+import { approveGraphPatch, approvePendingGraphRevision, proposeGraphPatch } from './revisions.js';
+import {
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+  releaseAttemptForRetry,
+  resolveJoin,
+} from './scheduler.js';
+import { ControlOwnerStore } from './control-owner.js';
+import { createInitialGraphState, type GraphClaim, type GraphState, type JsonValue } from './runtime-types.js';
+import { GraphStateStore } from './store.js';
+import type {
+  GraphEvidenceReference,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from './types.js';
+
+type GraphCommandOperation =
+  | 'create' | 'inspect' | 'approve' | 'ready' | 'claim' | 'complete' | 'fail'
+  | 'propose-patch' | 'approve-patch' | 'status' | 'pause' | 'abandon' | 'resume'
+  | 'settle-session'
+  | 'resolve-join'
+  | 'renew-claim' | 'recover-expired-claim' | 'record-late-claim-result'
+  | 'release-attempt-for-retry'
+  | 'resolve-reconciliation';
+
+interface GraphCommandRequest {
+  operation: GraphCommandOperation;
+  cwd: string;
+  input: Readonly<Record<string, unknown>>;
+}
+
+interface GraphCommandService {
+  execute(request: GraphCommandRequest): Promise<unknown>;
+}
+
+const DRIVER_LEASE_DURATION_MS = 60 * 60 * 1000;
+// Human-approval waits are durable (no busy-poll). The claim lease is a bounded
+// placeholder so the waiting claim survives state validation; renewals are not
+// used because the wait is event-driven via the in-session question surface.
+const HUMAN_APPROVAL_LEASE_MS = 60 * 60 * 1000;
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireObject<T = Record<string, unknown>>(value: unknown, field: string): T {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${field} must be a JSON object`);
+  }
+  return value as T;
+}
+
+function requireInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value as number;
+}
+
+function requireEvidence(value: unknown, field: string): GraphEvidenceReference {
+  const evidence = requireObject(value, field);
+  const kind = requireString(evidence.kind, `${field}.kind`);
+  if (!['file', 'command', 'test', 'human', 'url'].includes(kind)) {
+    throw new Error(`${field}.kind is invalid`);
+  }
+  requireString(evidence.ref, `${field}.ref`);
+  return evidence as unknown as GraphEvidenceReference;
+}
+
+function buildFence(state: GraphState) {
+  return {
+    session_id: state.session_id,
+    run_id: state.run_id,
+    revision_id: state.active_revision_id,
+    revision_hash: state.active_revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    commit_sequence: state.commit_sequence,
+  };
+}
+
+// #4: active-scope operations (claim/complete/fail/renew/recover/etc.) must
+// fence against the CURRENT dispatch_generation, not a hardcoded 0. After the
+// first patch approval the active generation is non-zero, so a hardcoded-0
+// fence would spuriously reject (or, on stale claims, mis-fence) legitimate
+// results and recovery. Patch operations keep their pending_patch_base scope.
+//
+// CAUTION: dispatch_generation here is sourced from a live readActiveState()
+// snapshot taken BEFORE store.mutate, so it is a consistency snapshot, NOT a
+// race-detecting fence - a generation advance between the read and the mutate
+// is not caught by this field. The real optimistic-concurrency fence is the
+// caller-asserted commit_sequence (via --expected-sequence) plus revision_id,
+// which store.mutate checks atomically under its lock. A follow-up could make
+// dispatch_generation caller-asserted (--expected-dispatch-generation) to close
+// the read-then-mutate gap; it is not exploitable today because commit_sequence
+// and revision_id already bound concurrent advancement.
+function buildActiveFence(
+  state: GraphState,
+  expected: {
+    session_id: string;
+    run_id: string;
+    revision_id: string;
+    revision_hash: string;
+    commit_sequence: number;
+  },
+) {
+  return {
+    session_id: expected.session_id,
+    run_id: expected.run_id,
+    revision_id: expected.revision_id,
+    revision_hash: expected.revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    commit_sequence: expected.commit_sequence,
+  };
+}
+
+function readActiveState(sessionId: string, runId: string): GraphState {
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  return state;
+}
+
+function operationFingerprint(operation: string, input: Readonly<Record<string, unknown>>): string {
+  return canonicalJson({ operation, input });
+}
+
+function entryActivationIdsFor(descriptor: SealedGraphDescriptor): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const nodeId of descriptor.entry_node_ids) {
+    result[nodeId] = `${descriptor.run_id}:act:${nodeId}:entry`;
+  }
+  return result;
+}
+
+function driverLease(driverInstanceId: string, issuedAt: string) {
+  return {
+    driver_instance_id: driverInstanceId,
+    lease_id: randomUUID(),
+    expires_at: new Date(Date.parse(issuedAt) + DRIVER_LEASE_DURATION_MS).toISOString(),
+  };
+}
+
+function summarizeState(state: GraphState) {
+  return {
+    run_id: state.run_id,
+    session_id: state.session_id,
+    status: state.status,
+    active_revision_id: state.active_revision_id,
+    active_revision_hash: state.active_revision_hash,
+    dispatch_generation: state.dispatch_generation,
+    commit_sequence: state.commit_sequence,
+    control_nonce: state.control_nonce,
+    transition_count: state.transitions.length,
+    claim_count: Object.keys(state.claims).length,
+    live_claim_count: Object.values(state.claims).filter((claim) => claim.status === 'live').length,
+    unresolved_reconciliation_count: Object.values(state.reconciliations).filter((record) => record.status === 'unresolved').length,
+    diagnostic_count: state.diagnostics.length,
+    succeeded: isGraphSucceeded(state.revisions[state.active_revision_id].descriptor, state.projection),
+    pending_approval: state.pending_approval ?? null,
+    pending_patch: state.pending_patch ? {
+      proposal_id: state.pending_patch.proposal_id,
+      base_revision_id: state.pending_patch.base_revision_id,
+      proposed_revision_id: state.pending_patch.proposed_revision_id,
+      invalidated_node_ids: state.pending_patch.invalidated_node_ids,
+    } : null,
+  };
+}
+
+function readinessView(state: GraphState) {
+  const descriptor = state.revisions[state.active_revision_id].descriptor;
+  const executable = listReadyExecutableActivations(descriptor, state.projection).map((activation) => ({
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    attempt_no: activation.attempt_no,
+  }));
+  const joins = listReadyJoinActivations(descriptor, state.projection).map((activation) => ({
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    cohort_id: activation.cohort_id,
+  }));
+  const liveClaims = Object.values(state.claims)
+    .filter((claim) => claim.status === 'live')
+    .map((claim) => ({
+      lease_id: claim.lease_id,
+      activation_id: claim.activation_id,
+      attempt_id: claim.attempt_id,
+      expires_at: claim.expires_at,
+    }));
+  return {
+    executable,
+    joins,
+    live_claims: liveClaims,
+    available_slots: Math.max(0, descriptor.concurrency_limit - liveClaims.length),
+  };
+}
+
+async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<unknown> {
+  const goal = requireString(input.goal, 'goal');
+  const descriptorInput = requireObject(input.descriptor, 'descriptor');
+  const sessionId = requireString(input.session_id, 'session_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const parsed = parseGraphDescriptor(descriptorInput);
+  const sealed = sealGraphDescriptor(parsed);
+  if (sealed.goal !== goal) {
+    throw new Error('descriptor goal does not match --goal');
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const existing = store.read();
+  if (existing) {
+    if (existing.run_id !== sealed.run_id) {
+      throw new Error(`graph state already exists for session ${sessionId} with a different run_id`);
+    }
+    // Idempotent retry: only return the existing graph when the exact descriptor
+    // hash matches. Retrying create with a modified descriptor must NOT silently
+    // return the old graph.
+    if (existing.active_revision_hash !== sealed.descriptor_hash) {
+      throw new Error(
+        `hash_mismatch: graph state already exists for run ${sealed.run_id} with descriptor hash ${existing.active_revision_hash}, cannot replace with ${sealed.descriptor_hash}`,
+      );
+    }
+    return summarizeState(existing);
+  }
+
+  const initialProjection: GraphSchedulerProjection = {
+    activations: {},
+    cohorts: {},
+    branch_tokens: {},
+    traversal_counts: {},
+    committed_transitions: {},
+    terminal_verification_activation_ids: [],
+  };
+
+  const controlNonce = randomUUID();
+  const createdAt = now();
+
+  const initialState = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: controlNonce,
+    descriptor: sealed,
+    projection: initialProjection,
+    status: 'awaiting_approval',
+    created_at: createdAt,
+  });
+
+  const created = store.create(initialState);
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  controlStore.reserveRoot({
+    mode: 'graph',
+    run_id: sealed.run_id,
+    nonce: controlNonce,
+    reserved_at: createdAt,
+    graph_revision: { revision_id: sealed.revision_id, revision_hash: sealed.descriptor_hash },
+  });
+
+  return {
+    run_id: created.run_id,
+    revision_id: created.active_revision_id,
+    descriptor_hash: created.active_revision_hash,
+    status: created.status,
+    control_nonce: created.control_nonce,
+    created_at: created.created_at,
+    transition_id: transitionId,
+    driver_id: driverId,
+  };
+}
+
+function executeInspect(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  const descriptor = state.revisions[state.active_revision_id].descriptor;
+  return {
+    summary: summarizeState(state),
+    descriptor: {
+      run_id: descriptor.run_id,
+      revision_id: descriptor.revision_id,
+      goal: descriptor.goal,
+      descriptor_hash: descriptor.descriptor_hash,
+      entry_node_ids: descriptor.entry_node_ids,
+      terminal_verification_node_id: descriptor.terminal_verification_node_id,
+      concurrency_limit: descriptor.concurrency_limit,
+      node_count: descriptor.nodes.length,
+      edge_count: descriptor.edges.length,
+    },
+    readiness: readinessView(state),
+  };
+}
+
+function executeStatus(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  return { summary: summarizeState(state), readiness: readinessView(state) };
+}
+
+function executeReady(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  if (state.active_revision_id !== revisionId || state.active_revision_hash !== descriptorHash) {
+    throw new Error('revision/hash fence does not match active revision');
+  }
+  if (state.commit_sequence !== expectedSequence) {
+    throw new Error(`expected sequence ${expectedSequence}, found ${state.commit_sequence}`);
+  }
+  return readinessView(state);
+}
+
+function executeApprove(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const approvalInput = requireObject(input.approval, 'approval');
+  const approvedAt = requireString(approvalInput.approved_at ?? approvalInput.approvedAt, 'approval.approved_at');
+  const evidence = requireEvidence(approvalInput.evidence ?? approvalInput.approval_evidence, 'approval.evidence');
+  const driverId = requireString(approvalInput.driver_id ?? approvalInput.driverId, 'approval.driver_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'approve',
+    operation_fingerprint: operationFingerprint('approve', { revisionId, descriptorHash, driverId, approvedAt, evidence: evidence.ref }),
+    // #4: source dispatch_generation from state. Initial approval is always on
+    // generation 0, but sourcing from state keeps the active-scope fence truthful
+    // and consistent with the other active-scope operations.
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: 0,
+    }),
+  }, (current) => {
+    if (current.status !== 'awaiting_approval') {
+      throw new Error(`cannot approve graph in status ${current.status}`);
+    }
+    const next = approvePendingGraphRevision(current, {
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      approved_at: approvedAt,
+      approval_evidence: evidence,
+    }, (descriptor) => initializeGraphProjection(descriptor, entryActivationIdsFor(descriptor)));
+    return { next, result: { approved: true, revision_id: revisionId } };
+  });
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  // NOTE (finding #5): mutate-then-control ordering is intentionally retained here. Unlike
+  // executeResume, the control op is promoteRoot (the root was reserved during executeCreate),
+  // so if mutate throws, promote never runs and there is NO divergence. If mutate succeeds and
+  // promote throws, the graph is 'running' with a still-reserved root (phase='reserved'), which
+  // is recoverable via recoverGraphReservation. Reordering to control-first would trade this
+  // recoverable divergence for an active-root-over-awaiting_approval state whose cleanup would
+  // release a root that executeCreate reserved (a different, non-minimal compensation), so the
+  // reorder is not clearly safer here.
+  if (!result.replayed) {
+    controlStore.promoteRoot({
+      mode: 'graph',
+      run_id: runId,
+      nonce: result.state.control_nonce,
+      promoted_at: approvedAt,
+      driver_lease: driverLease(driverId, approvedAt),
+    });
+  }
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeClaim(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const limit = requireInteger(input.limit, 'limit');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'claim',
+    operation_fingerprint: operationFingerprint('claim', { revisionId, descriptorHash, expectedSequence, driverId, limit }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'running') {
+      throw new Error(`cannot claim while graph status is ${current.status}`);
+    }
+    const descriptor = current.revisions[current.active_revision_id].descriptor;
+    const liveCount = Object.values(current.claims).filter((claim) => claim.status === 'live').length;
+    const available = Math.min(limit, Math.max(0, descriptor.concurrency_limit - liveCount));
+    if (available === 0) {
+      return { next: current, result: { claims: [], available_slots: 0 } };
+    }
+    const ready = listReadyExecutableActivations(descriptor, current.projection).slice(0, available);
+    const issuedAt = now();
+    const issued: JsonValue[] = [];
+    let working = current;
+    for (const activation of ready) {
+      const attemptId = randomUUID();
+      const leaseId = randomUUID();
+      const trackingId = randomUUID();
+      const projection = beginActivationAttempt(working.projection, {
+        activation_id: activation.activation_id,
+        attempt_id: attemptId,
+      });
+      const node = descriptor.nodes.find((candidate) => candidate.id === activation.node_id);
+      if (!node) {
+        throw new Error(`activation ${activation.activation_id} has no matching node`);
+      }
+      if (node.kind === 'human-approval') {
+        // B6: human-approval nodes are executable via the in-session question surface.
+        // Issue a durable claim that fences the activation while we wait for the human
+        // answer, then transition the run to 'waiting_human' so the driver yields. The
+        // subsequent `complete` operation records the human's answer as the node result
+        // and fences this claim like any other. We bypass issueGraphClaim because
+        // human-approval nodes carry no effect_policy/timeout_ms; we build the claim
+        // directly using a bounded, authority-scoped lease.
+        const attemptId = randomUUID();
+        const leaseId = randomUUID();
+        const trackingId = randomUUID();
+        const projection = beginActivationAttempt(working.projection, {
+          activation_id: activation.activation_id,
+          attempt_id: attemptId,
+        });
+        const issuedAt = now();
+        const humanClaim: GraphClaim = {
+          run_id: working.run_id,
+          revision_id: working.active_revision_id,
+          revision_hash: working.active_revision_hash,
+          dispatch_generation: working.dispatch_generation,
+          activation_id: activation.activation_id,
+          attempt_id: attemptId,
+          attempt_no: activation.attempt_no + 1,
+          claim_owner_session_id: sessionId,
+          driver_instance_id: driverId,
+          lease_id: leaseId,
+          tracking_id: trackingId,
+          issued_at: issuedAt,
+          expires_at: new Date(Date.parse(issuedAt) + HUMAN_APPROVAL_LEASE_MS).toISOString(),
+          lease_duration_ms: HUMAN_APPROVAL_LEASE_MS,
+          renewal_count: 0,
+          max_renewals: 0,
+          effect_policy: { policy: 'side_effect_free' },
+          status: 'live' as const,
+        };
+        const intermediate: GraphState = {
+          ...working,
+          projection,
+          claims: { ...working.claims, [leaseId]: humanClaim },
+          status: 'waiting_human' as const,
+        };
+        working = intermediate;
+        issued.push({
+          lease_id: leaseId,
+          activation_id: activation.activation_id,
+          attempt_id: attemptId,
+          attempt_no: activation.attempt_no + 1,
+          tracking_id: trackingId,
+          // #5: return the persisted claim's lease expiry, not the issue timestamp.
+          // A driver treats expires_at as the lease deadline; returning issued_at made
+          // a valid human-approval claim look already expired.
+          expires_at: humanClaim.expires_at,
+          node_id: activation.node_id,
+          kind: 'human-approval',
+          waiting_human: true,
+        });
+        continue;
+      }
+      if (node.kind !== 'agent' && node.kind !== 'command') {
+        throw new Error(`activation ${activation.activation_id} is not on an executable node`);
+      }
+      const intermediate: GraphState = { ...working, projection };
+      const claimResult = issueGraphClaim(intermediate, {
+        activation_id: activation.activation_id,
+        attempt_id: attemptId,
+        attempt_no: activation.attempt_no + 1,
+        claim_owner_session_id: sessionId,
+        driver_instance_id: driverId,
+        lease_id: leaseId,
+        tracking_id: trackingId,
+        issued_at: issuedAt,
+        execution_timeout_ms: node.timeout_ms,
+        grace_ms: 5 * 60 * 1000,
+        max_renewals: 3,
+        effect_policy: node.effect_policy,
+        ...(node.effect_policy.policy === 'idempotent'
+          ? { external_idempotency_key: `${node.effect_policy.idempotency_key_template}-${attemptId}` }
+          : {}),
+      });
+      working = claimResult.state;
+      issued.push({
+        lease_id: claimResult.claim.lease_id,
+        activation_id: claimResult.claim.activation_id,
+        attempt_id: claimResult.claim.attempt_id,
+        attempt_no: claimResult.claim.attempt_no,
+        tracking_id: claimResult.claim.tracking_id,
+        expires_at: claimResult.claim.expires_at,
+        node_id: activation.node_id,
+      });
+    }
+    return { next: working, result: { claims: issued, available_slots: descriptor.concurrency_limit - liveCount - issued.length } };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function applyResultOperation(
+  operation: 'complete' | 'fail',
+  input: Readonly<Record<string, unknown>>,
+): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const claimInput = requireObject(input.claim, 'claim');
+  const resultInput = requireObject(input.result, 'result');
+
+  const leaseId = requireString(claimInput.lease_id, 'claim.lease_id');
+  const activationId = requireString(claimInput.activation_id, 'claim.activation_id');
+  const attemptId = requireString(claimInput.attempt_id, 'claim.attempt_id');
+  const outcome = requireString(resultInput.outcome, 'result.outcome');
+  const route = typeof resultInput.route === 'string' ? resultInput.route : undefined;
+  const outputSummary = typeof resultInput.output_summary === 'string' ? resultInput.output_summary : undefined;
+  const evidenceRefsRaw = Array.isArray(resultInput.evidence_refs) ? resultInput.evidence_refs : [];
+  const evidenceRefs = evidenceRefsRaw.map((value, index) => requireEvidence(value, `result.evidence_refs[${index}]`));
+  const externalIdempotencyKey = typeof resultInput.external_idempotency_key === 'string'
+    ? resultInput.external_idempotency_key
+    : undefined;
+  // Optional scheduler identities for edges the runtime does not auto-generate.
+  // Currently only join_activation_id is caller-supplied (used when completing a
+  // branch whose arrival fills the cohort and activates the join).
+  const identitiesInput = input.identities && typeof input.identities === 'object' && !Array.isArray(input.identities)
+    ? input.identities as Record<string, unknown>
+    : {};
+  const joinActivationId = typeof identitiesInput.join_activation_id === 'string'
+    ? identitiesInput.join_activation_id
+    : undefined;
+
+  if (operation === 'complete' && outcome !== 'succeeded') {
+    throw new Error('complete requires outcome=succeeded; use fail for failed results');
+  }
+  if (operation === 'fail' && outcome !== 'failed') {
+    throw new Error('fail requires outcome=failed; use complete for succeeded results');
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation,
+    operation_fingerprint: operationFingerprint(operation, { leaseId, activationId, attemptId, outcome, route, outputSummary, evidenceRefs }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    // #2: reject late results against a terminal graph BEFORE committing. A worker
+    // can finish after abandon/cancel (or after the run reached succeeded/failed);
+    // accepting its result would mutate the terminal run / create follow-on
+    // activations. The claim-fence check below only validates the claim is live,
+    // not that the graph is still accepting results, so this gate must come first.
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot ${operation} a result while graph status is ${current.status}`);
+    }
+    const claim = current.claims[leaseId];
+    if (!claim) throw new Error(`claim ${leaseId} not found`);
+    if (claim.status !== 'live') throw new Error(`claim ${leaseId} is not live (status=${claim.status})`);
+    if (claim.activation_id !== activationId || claim.attempt_id !== attemptId) {
+      throw new Error('claim fence does not match provided activation/attempt');
+    }
+    const descriptor = current.revisions[current.active_revision_id].descriptor;
+    const activationNodeId = current.projection.activations[activationId]?.node_id;
+    const edgesForNode = descriptor.edges.filter((edge) => edge.from === activationNodeId);
+    const nextActivationIds: Record<string, string> = {};
+    const branchTokenIds: Record<string, string> = {};
+    let cohortId: string | undefined;
+    const hasFanOut = edgesForNode.some((edge) => edge.kind === 'fan_out');
+    if (hasFanOut) {
+      cohortId = randomUUID();
+    }
+    for (const edge of edgesForNode) {
+      nextActivationIds[edge.id] = `${descriptor.run_id}:act:${edge.to}:${randomUUID()}`;
+      if (edge.kind === 'fan_out') {
+        branchTokenIds[edge.id] = `${descriptor.run_id}:token:${edge.branch_id}:${randomUUID()}`;
+      }
+    }
+    const schedulerResult = applyNodeResult(descriptor, current.projection, {
+      transition_id: transitionId,
+      activation_id: activationId,
+      identities: {
+        next_activation_ids: nextActivationIds,
+        ...(cohortId ? { cohort_id: cohortId } : {}),
+        ...(hasFanOut ? { branch_token_ids: branchTokenIds } : {}),
+        ...(joinActivationId ? { join_activation_id: joinActivationId } : {}),
+      },
+      result: {
+        attempt_id: attemptId,
+        outcome: outcome as 'succeeded' | 'failed',
+        evidence_refs: evidenceRefs,
+        ...(route ? { route } : {}),
+        ...(outputSummary ? { output_summary: outputSummary } : {}),
+        ...(externalIdempotencyKey ? { external_idempotency_key: externalIdempotencyKey } : {}),
+      },
+    });
+    const next: GraphState = {
+      ...current,
+      projection: schedulerResult.projection,
+      // B6: completing a claim while the run is waiting for a human answer ends
+      // the durable wait (the human answered), so return to 'running' and let the
+      // driver claim the next ready activation. Without this the run would wedge
+      // in 'waiting_human' after the human-approval node completes.
+      ...(current.status === 'waiting_human' ? { status: 'running' as const } : {}),
+      claims: {
+        ...current.claims,
+        [leaseId]: {
+          ...claim,
+          status: 'completed' as const,
+          fenced_at: now(),
+        },
+      },
+    };
+    return {
+      next,
+      result: {
+        transition_id: transitionId,
+        activation_id: activationId,
+        node_id: schedulerResult.transition.node_id,
+        outcome: schedulerResult.transition.outcome,
+        selected_edge_ids: schedulerResult.transition.selected_edge_ids,
+        created_activation_ids: schedulerResult.transition.created_activation_ids,
+        succeeded: isGraphSucceeded(descriptor, schedulerResult.projection),
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executePause(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'pause',
+    operation_fingerprint: operationFingerprint('pause', { runId, revisionId, descriptorHash, driverId }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot pause graph in status ${current.status}`);
+    }
+    const liveClaims = Object.values(current.claims).filter((claim) => claim.status === 'live');
+    if (liveClaims.length > 0) {
+      throw new Error(`cannot pause graph with ${liveClaims.length} live claims; fence them first`);
+    }
+    const next: GraphState = { ...current, status: 'paused' as const };
+    return { next, result: { paused: true, run_id: runId } };
+  });
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  const releasedAt = now();
+  // NOTE (finding #5): mutate-then-control ordering is intentionally retained here. The control
+  // op is releaseRoot. Reordering to release-first would make the mutate-after-release-success
+  // failure leave a 'running' graph with NO control root (already released), which is not
+  // cleanly recoverable: executeResume's reservePausedGraph requires status='paused'. The status
+  // quo divergence (mutate succeeds, releaseRoot throws e.g. children_live -> paused graph with
+  // an active root) keeps the root present and is less severe than a rootless running graph, so
+  // the reorder is not clearly safer here.
+  controlStore.releaseRoot({
+    mode: 'graph',
+    run_id: runId,
+    nonce: result.state.control_nonce,
+    disposition: {
+      graph_status: 'paused',
+      claims_fenced: true,
+      children_drained: true,
+    },
+    released_at: releasedAt,
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeAbandon(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const confirmationInput = requireObject(input.confirmation, 'confirmation');
+  const confirmedRunId = requireString(confirmationInput.run_id ?? confirmationInput.runId, 'confirmation.run_id');
+  if (confirmedRunId !== runId) {
+    throw new Error('confirmation run_id does not match');
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'abandon',
+    operation_fingerprint: operationFingerprint('abandon', { runId, revisionId, descriptorHash }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    // #2: atomically fence ALL live claims so a worker that finishes AFTER
+    // abandon cannot commit a late result against the now-cancelled graph. The
+    // claims_fenced:true disposition reported to control is now truthful: every
+    // live claim is marked 'fenced' in the same transition that cancels the run.
+    const claims = { ...current.claims };
+    for (const [id, claim] of Object.entries(claims)) {
+      if (claim.status === 'live') {
+        claims[id] = { ...claim, status: 'fenced' as const, fenced_at: now() };
+      }
+    }
+    const next: GraphState = { ...current, status: 'cancelled' as const, claims };
+    return { next, result: { abandoned: true, run_id: runId } };
+  });
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  controlStore.releaseRoot({
+    mode: 'graph',
+    run_id: runId,
+    nonce: result.state.control_nonce,
+    disposition: {
+      graph_status: 'cancelled',
+      claims_fenced: true,
+      children_drained: true,
+    },
+    released_at: now(),
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeResume(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state || state.run_id !== runId) {
+    throw new Error(`graph run ${runId} not found for session ${sessionId}`);
+  }
+  if (state.status !== 'paused') {
+    throw new Error(`cannot resume graph in status ${state.status}`);
+  }
+  if (state.active_revision_id !== revisionId || state.active_revision_hash !== descriptorHash) {
+    throw new Error('resume fence does not match active revision/hash');
+  }
+
+  const controlStore = new ControlOwnerStore({ sessionId });
+  const resumedAt = now();
+  // Control-first ordering (finding #5 mitigation): reserve+promote the control root BEFORE
+  // persisting status='running'. If the control step throws (e.g. a prior pause left a stale
+  // root -> root_conflict), the graph state is unchanged (still 'paused') -> clean failure,
+  // user can retry. This is strictly safer than the prior mutate-then-control order, which
+  // left the graph 'running' with a stale/missing control root and masked the divergence on
+  // replay (the #3 fix skips control ops when result.replayed). The remaining divergence
+  // window is the rare case where control succeeds but store.mutate then throws (e.g. a
+  // concurrent sequence advance); in that case we attempt to release the freshly promoted
+  // root as cleanup. releaseRoot is idempotent and, on a freshly reserved root with no
+  // children and a paused graph (pause enforces no live claims), the release is truthful and
+  // will actually release, restoring control to the pre-resume state.
+  const isReplay = state.transitions.some((transition) => transition.transition_id === transitionId);
+  if (!isReplay) {
+    controlStore.reservePausedGraph({
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      nonce: state.control_nonce,
+      graph_state: {
+        session_id: sessionId,
+        run_id: runId,
+        revision_id: revisionId,
+        status: 'paused',
+      },
+      reserved_at: resumedAt,
+    });
+    controlStore.promoteRoot({
+      mode: 'graph',
+      run_id: runId,
+      nonce: state.control_nonce,
+      promoted_at: resumedAt,
+      driver_lease: driverLease(driverId, resumedAt),
+    });
+  }
+
+  let result;
+  try {
+    result = store.mutate<JsonValue>({
+      transition_id: transitionId,
+      operation: 'resume',
+      operation_fingerprint: operationFingerprint('resume', { runId, revisionId, descriptorHash, driverId }),
+      expected: buildFence(state),
+    }, (current) => {
+      const next: GraphState = { ...current, status: 'running' as const };
+      return { next, result: { resumed: true, run_id: runId } };
+    });
+  } catch (mutateError) {
+    if (!isReplay) {
+      // Control root was just reserved+promoted but the graph mutate failed. Attempt to
+      // release the root so control does not diverge (active root over a still-paused
+      // graph). Swallow release errors: the graph is unchanged and retryable regardless,
+      // and a failed cleanup does not make things worse than the original throw.
+      try {
+        controlStore.releaseRoot({
+          mode: 'graph',
+          run_id: runId,
+          nonce: state.control_nonce,
+          disposition: {
+            graph_status: 'paused',
+            claims_fenced: true,
+            children_drained: true,
+          },
+          released_at: now(),
+        });
+      } catch {
+        // best-effort cleanup; surface the original mutate error below
+      }
+    }
+    throw mutateError;
+  }
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeProposePatch(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const baseRevisionId = requireString(input.base_revision_id, 'base_revision_id');
+  const baseDescriptorHash = requireString(input.base_descriptor_hash, 'base_descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const patchInput = requireObject(input.patch, 'patch');
+  const proposedDescriptorInput = requireObject(patchInput.proposed_descriptor ?? patchInput.proposedDescriptor, 'patch.proposed_descriptor');
+  const invalidatedNodeIds = Array.isArray(patchInput.invalidated_node_ids)
+    ? patchInput.invalidated_node_ids.map((value, index) => requireString(value, `patch.invalidated_node_ids[${index}]`))
+    : [];
+  const proposalEvidence = Array.isArray(patchInput.proposal_evidence)
+    ? patchInput.proposal_evidence.map((value, index) => requireEvidence(value, `patch.proposal_evidence[${index}]`))
+    : [];
+
+  const proposedSealed = sealGraphDescriptor(parseGraphDescriptor(proposedDescriptorInput));
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'propose-patch',
+    operation_fingerprint: operationFingerprint('propose-patch', { runId, baseRevisionId, baseDescriptorHash, proposedRevisionId: proposedSealed.revision_id }),
+    // #4: propose-patch fences on the CURRENT (base) dispatch_generation via the
+    // active scope. After a prior patch approval the active generation is
+    // non-zero, so a hardcoded-0 fence would spuriously conflict. The patch's
+    // pending_patch_base scope (used at approve-patch) binds base_generation+1.
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: baseRevisionId,
+      revision_hash: baseDescriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    const next = proposeGraphPatch(current, {
+      proposal_id: transitionId,
+      base_revision_id: baseRevisionId,
+      base_revision_hash: baseDescriptorHash,
+      proposed_descriptor: proposedSealed,
+      invalidated_node_ids: invalidatedNodeIds,
+      proposal_evidence: proposalEvidence,
+      proposed_at: now(),
+    });
+    return { next, result: { proposed: true, proposed_revision_id: proposedSealed.revision_id } };
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeApprovePatch(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const baseRevisionId = requireString(input.base_revision_id, 'base_revision_id');
+  const baseDescriptorHash = requireString(input.base_descriptor_hash, 'base_descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const approvalInput = requireObject(input.approval, 'approval');
+  const evidence = requireEvidence(approvalInput.evidence ?? approvalInput.approval_evidence, 'approval.evidence');
+  const invalidatedNodeIds = Array.isArray(approvalInput.invalidated_node_ids)
+    ? approvalInput.invalidated_node_ids.map((value, index) => requireString(value, `approval.invalidated_node_ids[${index}]`))
+    : [];
+  const proposedRevisionHash = requireString(approvalInput.proposed_revision_hash ?? approvalInput.proposedDescriptorHash, 'approval.proposed_revision_hash');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  // #4: approve-patch uses the pending_patch_base fence scope, which binds the
+  // patch's base_dispatch_generation (the generation the patch was proposed
+  // against, before the +1 advance). Source it from the pending patch rather
+  // than hardcoding 0, so a second patch cycle (base_generation >= 1) fences
+  // correctly. While waiting, state.dispatch_generation == base + 1.
+  const pendingPatch = currentState.pending_patch;
+  if (!pendingPatch) {
+    throw new Error('no pending patch to approve');
+  }
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'approve-patch',
+    operation_fingerprint: operationFingerprint('approve-patch', { runId, baseRevisionId, baseDescriptorHash, proposedRevisionHash }),
+    expected: {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: baseRevisionId,
+      revision_hash: baseDescriptorHash,
+      dispatch_generation: pendingPatch.base_dispatch_generation,
+      commit_sequence: expectedSequence,
+    },
+    fence_scope: 'pending_patch_base',
+  }, (current) => {
+    if (!current.pending_patch) throw new Error('no pending patch to approve');
+    const recompute: (projection: GraphSchedulerProjection, descriptor: SealedGraphDescriptor, invalidated: ReadonlySet<string>) => GraphSchedulerProjection = (projection, descriptor, invalidated) => {
+      const next: GraphSchedulerProjection = {
+        activations: {},
+        cohorts: {},
+        branch_tokens: {},
+        traversal_counts: { ...projection.traversal_counts },
+        committed_transitions: Object.fromEntries(
+          Object.entries(projection.committed_transitions).filter(
+            ([, transition]) => !invalidated.has(transition.node_id),
+          ),
+        ),
+        terminal_verification_activation_ids: [...projection.terminal_verification_activation_ids],
+      };
+      for (const [activationId, activation] of Object.entries(projection.activations)) {
+        if (invalidated.has(activation.node_id)) continue;
+        next.activations[activationId] = { ...activation, attempt_ids: [...activation.attempt_ids] };
+      }
+      for (const [cohortId, cohort] of Object.entries(projection.cohorts)) {
+        const joinAlive = cohort.join_activation_id && next.activations[cohort.join_activation_id];
+        if (joinAlive || cohort.consumed) {
+          next.cohorts[cohortId] = { ...cohort, expected_branch_token_ids: [...cohort.expected_branch_token_ids] };
+        }
+      }
+      for (const [tokenId, token] of Object.entries(projection.branch_tokens)) {
+        if (token.current_activation_id && next.activations[token.current_activation_id]) {
+          next.branch_tokens[tokenId] = { ...token };
+        }
+      }
+      for (const nodeId of descriptor.entry_node_ids) {
+        const hasActivation = Object.values(next.activations).some((activation) => activation.node_id === nodeId);
+        if (!hasActivation) {
+          const activationId = `${descriptor.run_id}:act:${nodeId}:entry`;
+          next.activations[activationId] = {
+            activation_id: activationId,
+            node_id: nodeId,
+            status: 'ready',
+            attempt_no: 0,
+            attempt_ids: [],
+            traversal_owner_id: activationId,
+          };
+        }
+      }
+      return next;
+    };
+    const next = approveGraphPatch(current, {
+      proposal_id: current.pending_patch.proposal_id,
+      base_revision_id: baseRevisionId,
+      base_revision_hash: baseDescriptorHash,
+      proposed_revision_hash: proposedRevisionHash,
+      invalidated_node_ids: invalidatedNodeIds,
+      approval_evidence: evidence,
+      approved_at: now(),
+    }, recompute);
+    return { next, result: { approved: true, active_revision_id: next.active_revision_id } };
+  });
+
+  return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
+}
+
+function executeSettleSession(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const state = store.read();
+  if (!state) {
+    return { result: { settled_lease_ids: [] }, replayed: false };
+  }
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'settle-session',
+    operation_fingerprint: operationFingerprint('settle-session', { sessionId, driverId }),
+    expected: buildFence(state),
+  }, (current) => {
+    const settled = settleDriverClaims(current, {
+      claim_owner_session_id: sessionId,
+      driver_instance_id: driverId,
+      recorded_at: now(),
+      // B4: session-end fences ALL live claims in the session regardless of
+      // driver-id (the session is terminating). The driver_id is retained for
+      // the diagnostic/audit record but does not filter the fence set.
+      scope: 'session',
+    });
+    return { next: settled.state, result: { settled_lease_ids: settled.settled_lease_ids } };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeResolveJoin(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const activationId = requireString(input.activation_id, 'activation_id');
+  const identitiesInput = requireObject(input.identities, 'identities');
+  const nextActivationIdsInput = requireObject(identitiesInput.next_activation_ids, 'identities.next_activation_ids');
+  const nextActivationIds: Record<string, string> = {};
+  for (const [edgeId, value] of Object.entries(nextActivationIdsInput)) {
+    nextActivationIds[edgeId] = requireString(value, `identities.next_activation_ids.${edgeId}`);
+  }
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'resolve-join',
+    operation_fingerprint: operationFingerprint('resolve-join', { runId, revisionId, descriptorHash, activationId, nextActivationIds }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot resolve join while graph status is ${current.status}`);
+    }
+    const descriptor = current.revisions[current.active_revision_id].descriptor;
+    const schedulerResult = resolveJoin(descriptor, current.projection, {
+      activation_id: activationId,
+      transition_id: transitionId,
+      identities: { next_activation_ids: nextActivationIds },
+    });
+    const next: GraphState = { ...current, projection: schedulerResult.projection };
+    return {
+      next,
+      result: {
+        transition_id: transitionId,
+        activation_id: activationId,
+        node_id: schedulerResult.transition.node_id,
+        outcome: schedulerResult.transition.outcome,
+        selected_edge_ids: schedulerResult.transition.selected_edge_ids,
+        created_activation_ids: schedulerResult.transition.created_activation_ids,
+        succeeded: isGraphSucceeded(descriptor, schedulerResult.projection),
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeRenewClaim(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const leaseId = requireString(input.lease_id, 'lease_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const trackingId = requireString(input.tracking_id, 'tracking_id');
+  const toolStillRunning = input.tool_still_running === true;
+  const renewAt = requireString(input.now, 'now');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'renew-claim',
+    operation_fingerprint: operationFingerprint('renew-claim', { runId, revisionId, descriptorHash, leaseId, driverId, trackingId }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'running') {
+      throw new Error(`cannot renew claim while graph status is ${current.status}`);
+    }
+    const renewed = renewGraphClaim(current, {
+      lease_id: leaseId,
+      claim_owner_session_id: sessionId,
+      driver_instance_id: driverId,
+      tracking_id: trackingId,
+      tool_still_running: toolStillRunning,
+      now: renewAt,
+    });
+    return {
+      next: renewed.state,
+      result: {
+        lease_id: renewed.claim.lease_id,
+        renewal_count: renewed.claim.renewal_count,
+        expires_at: renewed.claim.expires_at,
+        last_renewed_at: renewed.claim.last_renewed_at ?? null,
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeRecoverExpiredClaim(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const leaseId = requireString(input.lease_id, 'lease_id');
+  const recoverAt = requireString(input.now, 'now');
+  const newAttemptId = requireString(input.new_attempt_id, 'new_attempt_id');
+  const newLeaseId = requireString(input.new_lease_id, 'new_lease_id');
+  const newTrackingId = requireString(input.new_tracking_id, 'new_tracking_id');
+  const driverId = requireString(input.driver_id, 'driver_id');
+  const reconciliationId = requireString(input.reconciliation_id, 'reconciliation_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'recover-expired-claim',
+    operation_fingerprint: operationFingerprint('recover-expired-claim', { runId, revisionId, descriptorHash, leaseId, newLeaseId, reconciliationId }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'reconciling') {
+      throw new Error(`cannot recover expired claim while graph status is ${current.status}`);
+    }
+    const recovered = recoverExpiredGraphClaim(current, {
+      lease_id: leaseId,
+      now: recoverAt,
+      new_attempt_id: newAttemptId,
+      new_lease_id: newLeaseId,
+      new_tracking_id: newTrackingId,
+      claimant_session_id: sessionId,
+      driver_instance_id: driverId,
+      reconciliation_id: reconciliationId,
+    }, (projection, replaceInput) => {
+      // The expired claim's activation is still 'running' with the old attempt.
+      // Begin a fresh replacement attempt on the same activation (mirrors the
+      // retry projection used by the claims recovery tests): append the new
+      // attempt id and advance attempt_no/active_attempt_id.
+      const activation = projection.activations[replaceInput.activation_id];
+      if (!activation) {
+        throw new Error(`replacement attempt references unknown activation ${replaceInput.activation_id}`);
+      }
+      return {
+        ...projection,
+        activations: {
+          ...projection.activations,
+          [replaceInput.activation_id]: {
+            ...activation,
+            status: 'running' as const,
+            attempt_no: replaceInput.attempt_no,
+            attempt_ids: [...activation.attempt_ids, replaceInput.attempt_id],
+            active_attempt_id: replaceInput.attempt_id,
+          },
+        },
+      };
+    });
+    return {
+      next: recovered.state,
+      result: {
+        disposition: recovered.disposition,
+        ...(recovered.claim ? { replacement_lease_id: recovered.claim.lease_id } : {}),
+        ...(recovered.reconciliation ? { reconciliation_id: recovered.reconciliation.reconciliation_id } : {}),
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeRecordLateClaimResult(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const leaseId = requireString(input.lease_id, 'lease_id');
+  const attemptId = requireString(input.attempt_id, 'attempt_id');
+  const recordedAt = requireString(input.recorded_at, 'recorded_at');
+  const summary = requireString(input.summary, 'summary');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'record-late-claim-result',
+    operation_fingerprint: operationFingerprint('record-late-claim-result', { runId, revisionId, descriptorHash, leaseId, attemptId }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    const late = recordLateClaimResult(current, {
+      lease_id: leaseId,
+      attempt_id: attemptId,
+      recorded_at: recordedAt,
+      summary,
+    });
+    return {
+      next: late.state,
+      result: {
+        kind: late.diagnostic.kind,
+        lease_id: late.diagnostic.lease_id ?? null,
+        attempt_id: late.diagnostic.attempt_id ?? null,
+        recorded_at: late.diagnostic.recorded_at,
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeReleaseAttemptForRetry(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const activationId = requireString(input.activation_id, 'activation_id');
+  const attemptId = requireString(input.attempt_id, 'attempt_id');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'release-attempt-for-retry',
+    operation_fingerprint: operationFingerprint('release-attempt-for-retry', { runId, revisionId, descriptorHash, activationId, attemptId }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'running' && current.status !== 'waiting_human') {
+      throw new Error(`cannot release attempt while graph status is ${current.status}`);
+    }
+    const projection = releaseAttemptForRetry(current.projection, {
+      activation_id: activationId,
+      attempt_id: attemptId,
+    });
+    // Releasing a running attempt returns the activation to 'ready' and drops the
+    // active attempt. Fence any live claim bound to that exact attempt so the
+    // concurrency slot does not leak while the activation waits for a new claim.
+    const claims = { ...current.claims };
+    for (const [id, claim] of Object.entries(claims)) {
+      if (claim.status === 'live' && claim.activation_id === activationId && claim.attempt_id === attemptId) {
+        claims[id] = { ...claim, status: 'fenced' as const, fenced_at: now() };
+      }
+    }
+    const next: GraphState = { ...current, projection, claims };
+    return {
+      next,
+      result: { activation_id: activationId, attempt_id: attemptId, released: true },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+function executeResolveReconciliation(input: Readonly<Record<string, unknown>>): unknown {
+  const sessionId = requireString(input.session_id, 'session_id');
+  const runId = requireString(input.run_id, 'run_id');
+  const revisionId = requireString(input.revision_id, 'revision_id');
+  const descriptorHash = requireString(input.descriptor_hash, 'descriptor_hash');
+  const expectedSequence = requireInteger(input.expected_sequence, 'expected_sequence');
+  const transitionId = requireString(input.transition_id, 'transition_id');
+  const evidence = requireEvidence(input.evidence, 'evidence');
+  const resolvedAt = requireString(input.resolved_at, 'resolved_at');
+
+  const store = new GraphStateStore({ sessionId });
+  const currentState = readActiveState(sessionId, runId);
+  const result = store.mutate<JsonValue>({
+    transition_id: transitionId,
+    operation: 'resolve-reconciliation',
+    operation_fingerprint: operationFingerprint('resolve-reconciliation', { runId, revisionId, descriptorHash, resolvedAt, evidenceRef: evidence.ref }),
+    expected: buildActiveFence(currentState, {
+      session_id: sessionId,
+      run_id: runId,
+      revision_id: revisionId,
+      revision_hash: descriptorHash,
+      commit_sequence: expectedSequence,
+    }),
+  }, (current) => {
+    if (current.status !== 'reconciling') {
+      throw new Error(`cannot resolve reconciliation while graph status is ${current.status}`);
+    }
+    const unresolved = Object.values(current.reconciliations).filter(
+      (record) => record.status === 'unresolved',
+    );
+    if (unresolved.length === 0) {
+      throw new Error('no unresolved reconciliation records to resolve');
+    }
+    // B5: mark every unresolved reconciliation as accepted (the operator/human
+    // resolved the ambiguity with evidence) and transition the run back to
+    // 'running' so claim/resume/complete can proceed. An expired reconcile-policy
+    // claim no longer permanently breaks the run.
+    const reconciliations = { ...current.reconciliations };
+    for (const record of unresolved) {
+      reconciliations[record.reconciliation_id] = {
+        ...record,
+        status: 'accepted' as const,
+        resolved_at: resolvedAt,
+        resolution_evidence: evidence,
+      };
+    }
+    const next: GraphState = { ...current, status: 'running' as const, reconciliations };
+    return {
+      next,
+      result: {
+        resolved_reconciliation_ids: unresolved.map((record) => record.reconciliation_id),
+        status: 'running',
+      },
+    };
+  });
+
+  return { result: result.result, replayed: result.replayed };
+}
+
+export const graphCommandService: GraphCommandService = {
+  async execute(request: GraphCommandRequest): Promise<unknown> {
+    switch (request.operation) {
+      case 'create': return executeCreate(request.input);
+      case 'inspect': return executeInspect(request.input);
+      case 'status': return executeStatus(request.input);
+      case 'ready': return executeReady(request.input);
+      case 'approve': return executeApprove(request.input);
+      case 'claim': return executeClaim(request.input);
+      case 'complete': return applyResultOperation('complete', request.input);
+      case 'fail': return applyResultOperation('fail', request.input);
+      case 'pause': return executePause(request.input);
+      case 'abandon': return executeAbandon(request.input);
+      case 'resume': return executeResume(request.input);
+      case 'propose-patch': return executeProposePatch(request.input);
+      case 'approve-patch': return executeApprovePatch(request.input);
+      case 'settle-session': return executeSettleSession(request.input);
+      case 'resolve-join': return executeResolveJoin(request.input);
+      case 'renew-claim': return executeRenewClaim(request.input);
+      case 'recover-expired-claim': return executeRecoverExpiredClaim(request.input);
+      case 'record-late-claim-result': return executeRecordLateClaimResult(request.input);
+      case 'release-attempt-for-retry': return executeReleaseAttemptForRetry(request.input);
+      case 'resolve-reconciliation': return executeResolveReconciliation(request.input);
+      default: throw new Error(`unknown graph operation: ${request.operation}`);
+    }
+  },
+};

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -451,14 +451,18 @@ function executeClaim(input: Readonly<Record<string, unknown>>): unknown {
       const attemptId = randomUUID();
       const leaseId = randomUUID();
       const trackingId = randomUUID();
-      const projection = beginActivationAttempt(working.projection, {
-        activation_id: activation.activation_id,
-        attempt_id: attemptId,
-      });
+      // Resolve the node BEFORE beginning the attempt so the begin can gate
+      // on node.max_attempts for agent/command nodes (ordinary retries must not
+      // bypass the per-node bound). Human-approval/join nodes carry no bound.
       const node = descriptor.nodes.find((candidate) => candidate.id === activation.node_id);
       if (!node) {
         throw new Error(`activation ${activation.activation_id} has no matching node`);
       }
+      const projection = beginActivationAttempt(working.projection, {
+        activation_id: activation.activation_id,
+        attempt_id: attemptId,
+        ...(node.kind === 'agent' || node.kind === 'command' ? { max_attempts: node.max_attempts } : {}),
+      });
       if (node.kind === 'human-approval') {
         // B6: human-approval nodes are executable via the in-session question surface.
         // Issue a durable claim that fences the activation while we wait for the human
@@ -666,7 +670,15 @@ function applyResultOperation(
       // the durable wait (the human answered), so return to 'running' and let the
       // driver claim the next ready activation. Without this the run would wedge
       // in 'waiting_human' after the human-approval node completes.
-      ...(current.status === 'waiting_human' ? { status: 'running' as const } : {}),
+      // A3: if the completed result failed AND the activation has exhausted its
+      // retry budget (terminal 'failed'), promote the graph to 'failed'. This
+      // takes precedence over the waiting_human->running transition so a failed
+      // exhausted node does not leave an un-claimable, un-retryable activation
+      // wedging the run forever.
+      ...(schedulerResult.transition.outcome === 'failed'
+        && schedulerResult.projection.activations[activationId]?.status === 'failed'
+        ? { status: 'failed' as const }
+        : current.status === 'waiting_human' ? { status: 'running' as const } : {}),
       claims: {
         ...current.claims,
         [leaseId]: {

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -241,6 +241,62 @@ function requiredControlPhase(status: GraphState['status']): 'reserved' | 'activ
   return null;
 }
 
+/**
+ * Reconcile the external control reservation after the durable approval
+ * transition. The graph transition is intentionally committed first: a failed
+ * promotion leaves a durable running graph with its exact reservation, and an
+ * idempotent retry can finish this step. Never skip this on a replay.
+ */
+function ensureGraphControlActive(
+  controlStore: ControlOwnerStore,
+  state: GraphState,
+  driverId: string,
+  promotedAt: string,
+): void {
+  const root = controlStore.read()?.root;
+  if (!root
+    || root.mode !== 'graph'
+    || root.run_id !== state.run_id
+    || root.nonce !== state.control_nonce
+    || !root.graph_revision
+    || root.graph_revision.revision_id !== state.active_revision_id
+    || root.graph_revision.revision_hash !== state.active_revision_hash) {
+    throw new Error(`control_root_mismatch: graph ${state.run_id} does not have its exact control reservation`);
+  }
+  if (root.phase === 'active') return;
+  controlStore.promoteRoot({
+    mode: 'graph',
+    run_id: state.run_id,
+    nonce: state.control_nonce,
+    promoted_at: promotedAt,
+    driver_lease: driverLease(driverId, promotedAt),
+  });
+}
+
+/**
+ * A succeeded graph cannot retain root control. Re-running a completed
+ * transition repeats this reconciliation, closing the crash window between
+ * durable terminal publish and control release.
+ */
+function releaseSucceededGraphControl(controlStore: ControlOwnerStore, state: GraphState): void {
+  const root = controlStore.read()?.root;
+  if (!root) return;
+  if (root.mode !== 'graph' || root.run_id !== state.run_id || root.nonce !== state.control_nonce) {
+    throw new Error(`control_root_mismatch: graph ${state.run_id} cannot release a different control root`);
+  }
+  controlStore.releaseRoot({
+    mode: 'graph',
+    run_id: state.run_id,
+    nonce: state.control_nonce,
+    disposition: {
+      graph_status: 'succeeded',
+      claims_fenced: true,
+      children_drained: true,
+    },
+    released_at: now(),
+  });
+}
+
 async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<unknown> {
   const goal = requireString(input.goal, 'goal');
   const descriptorInput = requireObject(input.descriptor, 'descriptor');
@@ -475,23 +531,7 @@ function executeApprove(input: Readonly<Record<string, unknown>>): unknown {
   });
 
   const controlStore = new ControlOwnerStore({ sessionId });
-  // NOTE (finding #5): mutate-then-control ordering is intentionally retained here. Unlike
-  // executeResume, the control op is promoteRoot (the root was reserved during executeCreate),
-  // so if mutate throws, promote never runs and there is NO divergence. If mutate succeeds and
-  // promote throws, the graph is 'running' with a still-reserved root (phase='reserved'), which
-  // is recoverable via recoverGraphReservation. Reordering to control-first would trade this
-  // recoverable divergence for an active-root-over-awaiting_approval state whose cleanup would
-  // release a root that executeCreate reserved (a different, non-minimal compensation), so the
-  // reorder is not clearly safer here.
-  if (!result.replayed) {
-    controlStore.promoteRoot({
-      mode: 'graph',
-      run_id: runId,
-      nonce: result.state.control_nonce,
-      promoted_at: approvedAt,
-      driver_lease: driverLease(driverId, approvedAt),
-    });
-  }
+  ensureGraphControlActive(controlStore, result.state, driverId, approvedAt);
 
   return { result: result.result, replayed: result.replayed, summary: summarizeState(result.state) };
 }
@@ -749,6 +789,7 @@ function applyResultOperation(
         ...(externalIdempotencyKey ? { external_idempotency_key: externalIdempotencyKey } : {}),
       },
     });
+    const succeeded = isGraphSucceeded(descriptor, schedulerResult.projection);
     const next: GraphState = {
       ...current,
       projection: schedulerResult.projection,
@@ -761,7 +802,9 @@ function applyResultOperation(
       // takes precedence over the waiting_human->running transition so a failed
       // exhausted node does not leave an un-claimable, un-retryable activation
       // wedging the run forever.
-      ...(schedulerResult.transition.outcome === 'failed'
+      ...(succeeded
+        ? { status: 'succeeded' as const }
+        : schedulerResult.transition.outcome === 'failed'
         && schedulerResult.projection.activations[activationId]?.status === 'failed'
         ? { status: 'failed' as const }
         : current.status === 'waiting_human' ? { status: 'running' as const } : {}),
@@ -783,10 +826,14 @@ function applyResultOperation(
         outcome: schedulerResult.transition.outcome,
         selected_edge_ids: schedulerResult.transition.selected_edge_ids,
         created_activation_ids: schedulerResult.transition.created_activation_ids,
-        succeeded: isGraphSucceeded(descriptor, schedulerResult.projection),
+        succeeded,
       },
     };
   });
+
+  if (result.state.status === 'succeeded') {
+    releaseSucceededGraphControl(new ControlOwnerStore({ sessionId }), result.state);
+  }
 
   return { result: result.result, replayed: result.replayed };
 }

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -217,6 +217,30 @@ function readinessView(state: GraphState) {
   };
 }
 
+function assertExactGraphControlRoot(
+  controlStore: ControlOwnerStore,
+  state: GraphState,
+  expectedPhase: 'reserved' | 'active',
+): void {
+  const root = controlStore.read()?.root;
+  if (!root
+    || root.mode !== 'graph'
+    || root.run_id !== state.run_id
+    || root.nonce !== state.control_nonce
+    || root.phase !== expectedPhase
+    || !root.graph_revision
+    || root.graph_revision.revision_id !== state.active_revision_id
+    || root.graph_revision.revision_hash !== state.active_revision_hash) {
+    throw new Error(`control_root_mismatch: graph ${state.run_id} does not have its exact ${expectedPhase} control reservation`);
+  }
+}
+
+function requiredControlPhase(status: GraphState['status']): 'reserved' | 'active' | null {
+  if (status === 'awaiting_approval') return 'reserved';
+  if (['running', 'waiting_human', 'waiting_patch_approval', 'reconciling'].includes(status)) return 'active';
+  return null;
+}
+
 async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<unknown> {
   const goal = requireString(input.goal, 'goal');
   const descriptorInput = requireObject(input.descriptor, 'descriptor');
@@ -244,6 +268,10 @@ async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<
         `hash_mismatch: graph state already exists for run ${sealed.run_id} with descriptor hash ${existing.active_revision_hash}, cannot replace with ${sealed.descriptor_hash}`,
       );
     }
+    const expectedPhase = requiredControlPhase(existing.status);
+    if (expectedPhase) {
+      assertExactGraphControlRoot(new ControlOwnerStore({ sessionId }), existing, expectedPhase);
+    }
     return summarizeState(existing);
   }
 
@@ -256,8 +284,36 @@ async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<
     terminal_verification_activation_ids: [],
   };
 
-  const controlNonce = randomUUID();
   const createdAt = now();
+
+  // Control authority is the creation gate. Reserve it BEFORE writing durable
+  // graph state so a conflicting root cannot leave an orphan graph behind.
+  // A crash after reservation but before publish can be retried only for the
+  // exact same graph revision; it reuses the original nonce rather than
+  // replacing or releasing another owner's reservation.
+  const controlStore = new ControlOwnerStore({ sessionId });
+  const existingRoot = controlStore.read()?.root;
+  let controlNonce: string;
+  let createdReservation = false;
+  if (!existingRoot) {
+    controlNonce = randomUUID();
+    controlStore.reserveRoot({
+      mode: 'graph',
+      run_id: sealed.run_id,
+      nonce: controlNonce,
+      reserved_at: createdAt,
+      graph_revision: { revision_id: sealed.revision_id, revision_hash: sealed.descriptor_hash },
+    });
+    createdReservation = true;
+  } else if (existingRoot.mode === 'graph'
+    && existingRoot.run_id === sealed.run_id
+    && existingRoot.phase === 'reserved'
+    && existingRoot.graph_revision?.revision_id === sealed.revision_id
+    && existingRoot.graph_revision.revision_hash === sealed.descriptor_hash) {
+    controlNonce = existingRoot.nonce;
+  } else {
+    throw new Error(`root_conflict: session is already controlled by ${existingRoot.mode}/${existingRoot.run_id}`);
+  }
 
   const initialState = createInitialGraphState({
     session_id: sessionId,
@@ -268,16 +324,46 @@ async function executeCreate(input: Readonly<Record<string, unknown>>): Promise<
     created_at: createdAt,
   });
 
-  const created = store.create(initialState);
-
-  const controlStore = new ControlOwnerStore({ sessionId });
-  controlStore.reserveRoot({
-    mode: 'graph',
-    run_id: sealed.run_id,
-    nonce: controlNonce,
-    reserved_at: createdAt,
-    graph_revision: { revision_id: sealed.revision_id, revision_hash: sealed.descriptor_hash },
-  });
+  let created: GraphState;
+  try {
+    created = store.create(initialState);
+  } catch (error) {
+    // Another exact retry can publish after our initial read but before this
+    // OCC create. Treat only the fully matching durable graph/control pair as
+    // the idempotent winner; every other create failure still compensates.
+    if ((error as { code?: unknown }).code === 'already_exists') {
+      const published = store.read();
+      if (published
+        && published.run_id === sealed.run_id
+        && published.active_revision_hash === sealed.descriptor_hash) {
+        const expectedPhase = requiredControlPhase(published.status);
+        if (expectedPhase) {
+          assertExactGraphControlRoot(controlStore, published, expectedPhase);
+        }
+        return summarizeState(published);
+      }
+    }
+    // Compensate only a reservation made by this invocation and only with its
+    // exact nonce. Reused crash-recovery reservations are never released by a
+    // failed retry, so a caller cannot erase unrelated control authority.
+    if (createdReservation) {
+      try {
+        const rollback = controlStore.releaseRoot({
+          mode: 'graph',
+          run_id: sealed.run_id,
+          nonce: controlNonce,
+          disposition: { graph_status: 'cancelled', claims_fenced: true, children_drained: true },
+          released_at: now(),
+        });
+        if (!rollback.released) {
+          throw new Error('exact reservation was no longer releasable');
+        }
+      } catch (rollbackError) {
+        throw new Error(`create_rollback_failed: ${String(rollbackError)}; initial graph publish failed: ${String(error)}`);
+      }
+    }
+    throw error;
+  }
 
   return {
     run_id: created.run_id,

--- a/src/graph/scheduler.ts
+++ b/src/graph/scheduler.ts
@@ -169,12 +169,19 @@ export function beginActivationAttempt(
       `Activation ${activation.activation_id} is ${activation.status}, not ready`,
     );
   }
+  const attemptNo = activation.attempt_no + 1;
+  if (input.max_attempts !== undefined && attemptNo > input.max_attempts) {
+    throw new GraphSchedulerError(
+      'max_attempts_exceeded',
+      `Activation ${activation.activation_id} exceeds max_attempts ${input.max_attempts}`,
+    );
+  }
   ensureUniqueIdentity(projection, 'attempt', input.attempt_id);
   const next = cloneProjection(projection);
   next.activations[input.activation_id] = {
     ...next.activations[input.activation_id],
     status: 'running',
-    attempt_no: activation.attempt_no + 1,
+    attempt_no: attemptNo,
     attempt_ids: [...activation.attempt_ids, input.attempt_id],
     active_attempt_id: input.attempt_id,
   };
@@ -488,8 +495,21 @@ export function applyNodeResult(
 
   const next = cloneProjection(projection);
   const nextActivation = next.activations[activation.activation_id];
-  nextActivation.status = result.outcome === 'succeeded' ? 'completed' : 'failed';
-  nextActivation.completed_transition_id = rawInput.transition_id;
+  // A3: a failed activation is retryable while attempt budget remains; once
+  // exhausted it goes terminal 'failed' so the run can be promoted to a failed
+  // graph status instead of wedging as an un-claimable, un-retryable activation.
+  const maxAttempts = node.kind === 'agent' || node.kind === 'command' ? node.max_attempts : undefined;
+  const exhausted = maxAttempts === undefined || activation.attempt_no >= maxAttempts;
+  const nextStatus = result.outcome === 'succeeded'
+    ? 'completed'
+    : (exhausted ? 'failed' : 'ready');
+  nextActivation.status = nextStatus;
+  // Only record the terminal transition on terminal outcomes; a retryable
+  // failure returns to 'ready' for a fresh begin and must not carry a stale
+  // completed_transition_id from the failed attempt.
+  if (nextStatus !== 'ready') {
+    nextActivation.completed_transition_id = rawInput.transition_id;
+  }
   const selected = result.outcome === 'succeeded'
     ? selectEdges(descriptor, activation, result.route, projection)
     : [];

--- a/src/graph/scheduler.ts
+++ b/src/graph/scheduler.ts
@@ -1,0 +1,657 @@
+import { createHash } from 'node:crypto';
+
+import { canonicalJson } from './descriptor.js';
+import { parseGraphNodeResult } from './schema.js';
+import type {
+  ApplyNodeResultInput,
+  BeginActivationAttemptInput,
+  GraphActivation,
+  GraphBackEdge,
+  GraphBranchToken,
+  GraphCommittedTransition,
+  GraphDescriptor,
+  GraphEdge,
+  GraphNode,
+  GraphSchedulerProjection,
+  ReleaseAttemptForRetryInput,
+  ResolveJoinInput,
+  SchedulerApplyResult,
+  SchedulerTransitionIdentities,
+} from './types.js';
+
+export class GraphSchedulerError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphSchedulerError';
+    this.code = code;
+  }
+}
+
+function cloneProjection(projection: GraphSchedulerProjection): GraphSchedulerProjection {
+  return {
+    activations: Object.fromEntries(
+      Object.entries(projection.activations).map(([id, activation]) => [
+        id,
+        { ...activation, attempt_ids: [...activation.attempt_ids] },
+      ]),
+    ),
+    cohorts: Object.fromEntries(
+      Object.entries(projection.cohorts).map(([id, cohort]) => [
+        id,
+        { ...cohort, expected_branch_token_ids: [...cohort.expected_branch_token_ids] },
+      ]),
+    ),
+    branch_tokens: Object.fromEntries(
+      Object.entries(projection.branch_tokens).map(([id, token]) => [id, { ...token }]),
+    ),
+    traversal_counts: { ...projection.traversal_counts },
+    committed_transitions: Object.fromEntries(
+      Object.entries(projection.committed_transitions).map(([id, transition]) => [
+        id,
+        {
+          ...transition,
+          selected_edge_ids: [...transition.selected_edge_ids],
+          created_activation_ids: [...transition.created_activation_ids],
+          evidence_refs: transition.evidence_refs.map((evidence) => ({ ...evidence })),
+        },
+      ]),
+    ),
+    terminal_verification_activation_ids: [...projection.terminal_verification_activation_ids],
+  };
+}
+
+function nodeMap(descriptor: GraphDescriptor): Map<string, GraphNode> {
+  return new Map(descriptor.nodes.map((node) => [node.id, node]));
+}
+
+function outgoingEdges(descriptor: GraphDescriptor, nodeId: string): GraphEdge[] {
+  return descriptor.edges.filter((edge) => edge.from === nodeId);
+}
+
+function getActivation(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+): GraphActivation {
+  const activation = projection.activations[activationId];
+  if (!activation) {
+    throw new GraphSchedulerError('activation_not_found', `Activation ${activationId} does not exist`);
+  }
+  return activation;
+}
+
+function ensureUniqueIdentity(
+  projection: GraphSchedulerProjection,
+  kind: 'activation' | 'attempt' | 'cohort' | 'branch token',
+  id: string,
+  pending: Set<string> = new Set(),
+): void {
+  let exists = pending.has(id);
+  if (kind === 'activation') exists ||= id in projection.activations;
+  if (kind === 'attempt') {
+    exists ||= Object.values(projection.activations).some((activation) =>
+      activation.attempt_ids.includes(id));
+  }
+  if (kind === 'cohort') exists ||= id in projection.cohorts;
+  if (kind === 'branch token') exists ||= id in projection.branch_tokens;
+  if (exists) {
+    throw new GraphSchedulerError('duplicate_identity', `${kind} identity ${id} is already in use`);
+  }
+  pending.add(id);
+}
+
+function newActivation(
+  activationId: string,
+  nodeId: string,
+  options: {
+    cohortId?: string;
+    branchTokenId?: string;
+    traversalOwnerId?: string;
+  } = {},
+): GraphActivation {
+  return {
+    activation_id: activationId,
+    node_id: nodeId,
+    status: 'ready',
+    attempt_no: 0,
+    attempt_ids: [],
+    traversal_owner_id: options.traversalOwnerId ?? activationId,
+    ...(options.cohortId ? { cohort_id: options.cohortId } : {}),
+    ...(options.branchTokenId ? { branch_token_id: options.branchTokenId } : {}),
+  };
+}
+
+export function initializeGraphProjection(
+  descriptor: GraphDescriptor,
+  entryActivationIds: Record<string, string>,
+): GraphSchedulerProjection {
+  const projection: GraphSchedulerProjection = {
+    activations: {},
+    cohorts: {},
+    branch_tokens: {},
+    traversal_counts: {},
+    committed_transitions: {},
+    terminal_verification_activation_ids: [],
+  };
+  const pending = new Set<string>();
+  for (const nodeId of descriptor.entry_node_ids) {
+    const activationId = entryActivationIds[nodeId];
+    if (!activationId) {
+      throw new GraphSchedulerError(
+        'missing_identity',
+        `Entry node ${nodeId} requires an activation identity`,
+      );
+    }
+    ensureUniqueIdentity(projection, 'activation', activationId, pending);
+    projection.activations[activationId] = newActivation(activationId, nodeId);
+  }
+  const unknownEntries = Object.keys(entryActivationIds).filter(
+    (nodeId) => !descriptor.entry_node_ids.includes(nodeId),
+  );
+  if (unknownEntries.length > 0) {
+    throw new GraphSchedulerError(
+      'unexpected_identity',
+      `Activation identities were provided for non-entry nodes: ${unknownEntries.join(', ')}`,
+    );
+  }
+  return projection;
+}
+
+export function beginActivationAttempt(
+  projection: GraphSchedulerProjection,
+  input: BeginActivationAttemptInput,
+): GraphSchedulerProjection {
+  const activation = getActivation(projection, input.activation_id);
+  if (activation.status !== 'ready') {
+    throw new GraphSchedulerError(
+      'activation_not_ready',
+      `Activation ${activation.activation_id} is ${activation.status}, not ready`,
+    );
+  }
+  ensureUniqueIdentity(projection, 'attempt', input.attempt_id);
+  const next = cloneProjection(projection);
+  next.activations[input.activation_id] = {
+    ...next.activations[input.activation_id],
+    status: 'running',
+    attempt_no: activation.attempt_no + 1,
+    attempt_ids: [...activation.attempt_ids, input.attempt_id],
+    active_attempt_id: input.attempt_id,
+  };
+  return next;
+}
+
+export function releaseAttemptForRetry(
+  projection: GraphSchedulerProjection,
+  input: ReleaseAttemptForRetryInput,
+): GraphSchedulerProjection {
+  const activation = getActivation(projection, input.activation_id);
+  if (activation.status !== 'running' || activation.active_attempt_id !== input.attempt_id) {
+    throw new GraphSchedulerError(
+      'attempt_fenced',
+      `Attempt ${input.attempt_id} does not own running activation ${input.activation_id}`,
+    );
+  }
+  const next = cloneProjection(projection);
+  const released = { ...next.activations[input.activation_id], status: 'ready' as const };
+  delete released.active_attempt_id;
+  next.activations[input.activation_id] = released;
+  return next;
+}
+
+function replayedTransition(
+  projection: GraphSchedulerProjection,
+  transitionId: string,
+  activationId: string,
+  requestFingerprint: string,
+): SchedulerApplyResult | undefined {
+  const transition = projection.committed_transitions[transitionId];
+  if (!transition) return undefined;
+  if (transition.activation_id !== activationId) {
+    throw new GraphSchedulerError(
+      'transition_fenced',
+      `Transition ${transitionId} is already committed for activation ${transition.activation_id}`,
+    );
+  }
+  if (transition.request_fingerprint !== requestFingerprint) {
+    throw new GraphSchedulerError(
+      'transition_fenced',
+      `Transition ${transitionId} request fingerprint does not match the committed request`,
+    );
+  }
+  return { projection, transition, replayed: true };
+}
+
+function requestFingerprint(kind: 'node_result' | 'join', value: unknown): string {
+  return createHash('sha256').update(canonicalJson({ kind, value })).digest('hex');
+}
+
+function requireRunningAttempt(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+  attemptId: string,
+): GraphActivation {
+  const activation = getActivation(projection, activationId);
+  if (activation.status !== 'running' || activation.active_attempt_id !== attemptId) {
+    throw new GraphSchedulerError(
+      'attempt_fenced',
+      `Attempt ${attemptId} does not own running activation ${activationId}`,
+    );
+  }
+  return activation;
+}
+
+function selectEdges(
+  descriptor: GraphDescriptor,
+  activation: GraphActivation,
+  route: string | undefined,
+  projection: GraphSchedulerProjection,
+): GraphEdge[] {
+  const edges = outgoingEdges(descriptor, activation.node_id);
+  if (edges.length === 0) {
+    if (route) throw new GraphSchedulerError('undeclared_route', `Node ${activation.node_id} has no declared routes`);
+    return [];
+  }
+  if (edges.every((edge) => edge.kind === 'fan_out')) {
+    if (route) throw new GraphSchedulerError('undeclared_route', `Fan-out node ${activation.node_id} does not accept route ${route}`);
+    return edges;
+  }
+  if (edges.length === 1 && edges[0].kind === 'fixed') {
+    if (route) throw new GraphSchedulerError('undeclared_route', `Fixed node ${activation.node_id} does not accept route ${route}`);
+    return edges;
+  }
+  if (!route) {
+    throw new GraphSchedulerError('route_required', `Node ${activation.node_id} requires one declared route`);
+  }
+  const selected = edges.filter(
+    (edge) => (edge.kind === 'conditional' || edge.kind === 'back_edge') && edge.route === route,
+  );
+  if (selected.length !== 1) {
+    throw new GraphSchedulerError(
+      'undeclared_route',
+      `Node ${activation.node_id} received undeclared route ${route}`,
+    );
+  }
+  const edge = selected[0];
+  if (edge.kind === 'back_edge') {
+    const count = projection.traversal_counts[traversalCounterKey(activation, edge)] ?? 0;
+    if (count >= edge.max_traversals) {
+      throw new GraphSchedulerError(
+        'traversal_bound_exceeded',
+        `Back-edge ${edge.id} traversal bound ${edge.max_traversals} is exhausted`,
+      );
+    }
+  }
+  return selected;
+}
+
+export function traversalCounterKey(
+  activation: Pick<GraphActivation, 'traversal_owner_id'>,
+  edge: Pick<GraphBackEdge, 'id'>,
+): string {
+  return canonicalJson([activation.traversal_owner_id, edge.id]);
+}
+
+function requiredIdentity(
+  identities: Record<string, string> | undefined,
+  edgeId: string,
+  kind: string,
+): string {
+  const id = identities?.[edgeId];
+  if (!id) {
+    throw new GraphSchedulerError('missing_identity', `Edge ${edgeId} requires a ${kind} identity`);
+  }
+  return id;
+}
+
+function arriveAtJoin(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  activation: GraphActivation,
+  targetJoinId: string,
+  identities: SchedulerTransitionIdentities,
+  createdActivationIds: string[],
+): void {
+  if (!activation.cohort_id || !activation.branch_token_id) {
+    throw new GraphSchedulerError(
+      'join_owner_missing',
+      `Activation ${activation.activation_id} cannot enter join ${targetJoinId} without a branch token`,
+    );
+  }
+  const token = projection.branch_tokens[activation.branch_token_id];
+  const cohort = projection.cohorts[activation.cohort_id];
+  if (!token || !cohort || token.owner_join_id !== targetJoinId || cohort.owner_join_id !== targetJoinId) {
+    throw new GraphSchedulerError('join_owner_mismatch', `Branch token does not own join ${targetJoinId}`);
+  }
+  if (token.status !== 'active' || token.current_activation_id !== activation.activation_id) {
+    throw new GraphSchedulerError('branch_token_fenced', `Branch token ${token.branch_token_id} is not active here`);
+  }
+  const arrived: GraphBranchToken = { ...token, status: 'arrived' };
+  delete arrived.current_activation_id;
+  projection.branch_tokens[token.branch_token_id] = arrived;
+
+  const allArrived = cohort.expected_branch_token_ids.every(
+    (tokenId) => projection.branch_tokens[tokenId]?.status === 'arrived',
+  );
+  if (!allArrived) return;
+  if (cohort.join_activation_id) {
+    throw new GraphSchedulerError('duplicate_join_activation', `Cohort ${cohort.cohort_id} already activated its join`);
+  }
+  const joinActivationId = identities.join_activation_id;
+  if (!joinActivationId) {
+    throw new GraphSchedulerError('missing_identity', `Ready join ${targetJoinId} requires an activation identity`);
+  }
+  ensureUniqueIdentity(projection, 'activation', joinActivationId);
+  projection.activations[joinActivationId] = newActivation(joinActivationId, targetJoinId, {
+    cohortId: cohort.cohort_id,
+  });
+  projection.cohorts[cohort.cohort_id] = { ...cohort, join_activation_id: joinActivationId };
+  createdActivationIds.push(joinActivationId);
+
+  const join = nodeMap(descriptor).get(targetJoinId);
+  if (join?.kind !== 'join') {
+    throw new GraphSchedulerError('join_not_found', `Join node ${targetJoinId} does not exist`);
+  }
+}
+
+function createFanOut(
+  projection: GraphSchedulerProjection,
+  activation: GraphActivation,
+  edges: Extract<GraphEdge, { kind: 'fan_out' }>[],
+  identities: SchedulerTransitionIdentities,
+  createdActivationIds: string[],
+): string {
+  const cohortId = identities.cohort_id;
+  if (!cohortId) throw new GraphSchedulerError('missing_identity', 'Fan-out requires a cohort identity');
+  ensureUniqueIdentity(projection, 'cohort', cohortId);
+  const pendingActivations = new Set<string>();
+  const pendingTokens = new Set<string>();
+  const tokenIds: string[] = [];
+
+  for (const edge of edges) {
+    const activationId = requiredIdentity(identities.next_activation_ids, edge.id, 'next activation');
+    const tokenId = requiredIdentity(identities.branch_token_ids, edge.id, 'branch token');
+    ensureUniqueIdentity(projection, 'activation', activationId, pendingActivations);
+    ensureUniqueIdentity(projection, 'branch token', tokenId, pendingTokens);
+    projection.activations[activationId] = newActivation(activationId, edge.to, {
+      cohortId,
+      branchTokenId: tokenId,
+      traversalOwnerId: tokenId,
+    });
+    projection.branch_tokens[tokenId] = {
+      branch_token_id: tokenId,
+      cohort_id: cohortId,
+      branch_id: edge.branch_id,
+      owner_join_id: edge.owner_join_id,
+      status: 'active',
+      current_activation_id: activationId,
+    };
+    tokenIds.push(tokenId);
+    createdActivationIds.push(activationId);
+  }
+  projection.cohorts[cohortId] = {
+    cohort_id: cohortId,
+    fan_out_node_id: activation.node_id,
+    owner_join_id: edges[0].owner_join_id,
+    expected_branch_token_ids: tokenIds,
+    consumed: false,
+  };
+  return cohortId;
+}
+
+function createNextActivation(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  activation: GraphActivation,
+  edge: GraphEdge,
+  identities: SchedulerTransitionIdentities,
+  createdActivationIds: string[],
+): void {
+  const target = nodeMap(descriptor).get(edge.to);
+  if (target?.kind === 'join') {
+    arriveAtJoin(descriptor, projection, activation, edge.to, identities, createdActivationIds);
+    return;
+  }
+  const activationId = requiredIdentity(identities.next_activation_ids, edge.id, 'next activation');
+  ensureUniqueIdentity(projection, 'activation', activationId);
+  projection.activations[activationId] = newActivation(activationId, edge.to, {
+    cohortId: activation.cohort_id,
+    branchTokenId: activation.branch_token_id,
+    traversalOwnerId: activation.traversal_owner_id,
+  });
+  createdActivationIds.push(activationId);
+  if (activation.branch_token_id) {
+    const token = projection.branch_tokens[activation.branch_token_id];
+    if (!token || token.status !== 'active' || token.current_activation_id !== activation.activation_id) {
+      throw new GraphSchedulerError(
+        'branch_token_fenced',
+        `Branch token ${activation.branch_token_id} is not owned by ${activation.activation_id}`,
+      );
+    }
+    projection.branch_tokens[activation.branch_token_id] = {
+      ...token,
+      current_activation_id: activationId,
+    };
+  }
+  if (edge.kind === 'back_edge') {
+    const key = traversalCounterKey(activation, edge);
+    projection.traversal_counts[key] = (projection.traversal_counts[key] ?? 0) + 1;
+  }
+}
+
+function commitTransition(
+  projection: GraphSchedulerProjection,
+  transition: GraphCommittedTransition,
+): SchedulerApplyResult {
+  projection.committed_transitions[transition.transition_id] = transition;
+  return { projection, transition, replayed: false };
+}
+
+export function applyNodeResult(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  rawInput: ApplyNodeResultInput,
+): SchedulerApplyResult {
+  const result = parseGraphNodeResult(rawInput.result);
+  const identities = rawInput.identities ?? {};
+  const fingerprint = requestFingerprint('node_result', {
+    activation_id: rawInput.activation_id,
+    result,
+    identities,
+  });
+  const replay = replayedTransition(
+    projection,
+    rawInput.transition_id,
+    rawInput.activation_id,
+    fingerprint,
+  );
+  if (replay) return replay;
+  const activation = requireRunningAttempt(projection, rawInput.activation_id, result.attempt_id);
+  const node = nodeMap(descriptor).get(activation.node_id);
+  if (!node) throw new GraphSchedulerError('node_not_found', `Node ${activation.node_id} does not exist`);
+  if (node.kind === 'join') {
+    throw new GraphSchedulerError('join_is_automatic', `Join ${node.id} must be resolved by the scheduler`);
+  }
+  if (result.outcome === 'failed' && result.route) {
+    throw new GraphSchedulerError('undeclared_route', 'Failed node results cannot select an outgoing route');
+  }
+  if (
+    node.id === descriptor.terminal_verification_node_id
+    && result.outcome === 'succeeded'
+    && result.evidence_refs.length === 0
+  ) {
+    throw new GraphSchedulerError(
+      'terminal_evidence_required',
+      'Terminal verification requires fresh evidence before success',
+    );
+  }
+
+  const next = cloneProjection(projection);
+  const nextActivation = next.activations[activation.activation_id];
+  nextActivation.status = result.outcome === 'succeeded' ? 'completed' : 'failed';
+  nextActivation.completed_transition_id = rawInput.transition_id;
+  const selected = result.outcome === 'succeeded'
+    ? selectEdges(descriptor, activation, result.route, projection)
+    : [];
+  const createdActivationIds: string[] = [];
+  let cohortId: string | undefined;
+
+  if (selected.length > 0 && selected.every((edge) => edge.kind === 'fan_out')) {
+    cohortId = createFanOut(
+      next,
+      activation,
+      selected as Extract<GraphEdge, { kind: 'fan_out' }>[],
+      identities,
+      createdActivationIds,
+    );
+  } else if (selected.length === 1) {
+    createNextActivation(
+      descriptor,
+      next,
+      activation,
+      selected[0],
+      identities,
+      createdActivationIds,
+    );
+  }
+
+  if (node.id === descriptor.terminal_verification_node_id && result.outcome === 'succeeded') {
+    next.terminal_verification_activation_ids.push(activation.activation_id);
+  }
+  const transition: GraphCommittedTransition = {
+    transition_id: rawInput.transition_id,
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    outcome: result.outcome,
+    request_fingerprint: fingerprint,
+    selected_edge_ids: selected.map((edge) => edge.id),
+    created_activation_ids: createdActivationIds,
+    attempt_id: result.attempt_id,
+    evidence_refs: result.evidence_refs.map((evidence) => ({ ...evidence })),
+    ...(result.route ? { route: result.route } : {}),
+    ...(result.output_summary ? { output_summary: result.output_summary } : {}),
+    ...(result.external_idempotency_key
+      ? { external_idempotency_key: result.external_idempotency_key }
+      : {}),
+    ...(cohortId ? { cohort_id: cohortId } : {}),
+  };
+  return commitTransition(next, transition);
+}
+
+export function resolveJoin(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: ResolveJoinInput,
+): SchedulerApplyResult {
+  const identities = input.identities ?? {};
+  const fingerprint = requestFingerprint('join', {
+    activation_id: input.activation_id,
+    identities,
+  });
+  const replay = replayedTransition(
+    projection,
+    input.transition_id,
+    input.activation_id,
+    fingerprint,
+  );
+  if (replay) return replay;
+  const activation = getActivation(projection, input.activation_id);
+  const node = nodeMap(descriptor).get(activation.node_id);
+  if (node?.kind !== 'join') {
+    throw new GraphSchedulerError('join_not_found', `Activation ${input.activation_id} is not a join`);
+  }
+  if (activation.status !== 'ready' || !activation.cohort_id) {
+    throw new GraphSchedulerError('join_not_ready', `Join activation ${input.activation_id} is not ready`);
+  }
+  const cohort = projection.cohorts[activation.cohort_id];
+  if (!cohort || cohort.owner_join_id !== node.id || cohort.join_activation_id !== activation.activation_id) {
+    throw new GraphSchedulerError('join_owner_mismatch', `Join activation ${input.activation_id} does not own its cohort`);
+  }
+  if (cohort.consumed) {
+    throw new GraphSchedulerError('join_already_consumed', `Cohort ${cohort.cohort_id} is already consumed`);
+  }
+  const tokens = cohort.expected_branch_token_ids.map((id) => projection.branch_tokens[id]);
+  if (tokens.some((token) => !token || token.status !== 'arrived')) {
+    throw new GraphSchedulerError('join_not_ready', `Join ${node.id} is still waiting for selected branch tokens`);
+  }
+  const edge = outgoingEdges(descriptor, node.id)[0];
+  if (!edge || edge.kind !== 'fixed') {
+    throw new GraphSchedulerError('invalid_join_edge', `Join ${node.id} does not have one fixed outgoing edge`);
+  }
+  const nextActivationId = requiredIdentity(identities.next_activation_ids, edge.id, 'next activation');
+  ensureUniqueIdentity(projection, 'activation', nextActivationId);
+
+  const next = cloneProjection(projection);
+  next.activations[activation.activation_id] = {
+    ...next.activations[activation.activation_id],
+    status: 'completed',
+    completed_transition_id: input.transition_id,
+  };
+  next.activations[nextActivationId] = newActivation(nextActivationId, edge.to);
+  next.cohorts[cohort.cohort_id] = { ...next.cohorts[cohort.cohort_id], consumed: true };
+  for (const token of tokens) {
+    next.branch_tokens[token.branch_token_id] = {
+      ...next.branch_tokens[token.branch_token_id],
+      status: 'consumed',
+      consumed_by_activation_id: activation.activation_id,
+    };
+  }
+  const transition: GraphCommittedTransition = {
+    transition_id: input.transition_id,
+    activation_id: activation.activation_id,
+    node_id: activation.node_id,
+    outcome: 'join_resolved',
+    request_fingerprint: fingerprint,
+    selected_edge_ids: [edge.id],
+    created_activation_ids: [nextActivationId],
+    evidence_refs: [],
+    cohort_id: cohort.cohort_id,
+  };
+  return commitTransition(next, transition);
+}
+
+export function listReadyExecutableActivations(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+): GraphActivation[] {
+  const nodes = nodeMap(descriptor);
+  return Object.values(projection.activations)
+    .filter((activation) => activation.status === 'ready' && nodes.get(activation.node_id)?.kind !== 'join')
+    .sort((left, right) => left.activation_id.localeCompare(right.activation_id));
+}
+
+export function listReadyJoinActivations(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+): GraphActivation[] {
+  const nodes = nodeMap(descriptor);
+  return Object.values(projection.activations)
+    .filter((activation) => activation.status === 'ready' && nodes.get(activation.node_id)?.kind === 'join')
+    .sort((left, right) => left.activation_id.localeCompare(right.activation_id));
+}
+
+export function isGraphSucceeded(
+  descriptor: GraphDescriptor,
+  projection: GraphSchedulerProjection,
+): boolean {
+  if (projection.terminal_verification_activation_ids.length === 0) return false;
+  const terminalIds = new Set(projection.terminal_verification_activation_ids);
+  if (
+    [...terminalIds].some(
+      (id) => {
+        const activation = projection.activations[id];
+        const transition = activation?.completed_transition_id
+          ? projection.committed_transitions[activation.completed_transition_id]
+          : undefined;
+        return activation?.node_id !== descriptor.terminal_verification_node_id
+          || activation.status !== 'completed'
+          || transition?.outcome !== 'succeeded'
+          || transition.evidence_refs.length === 0;
+      },
+    )
+  ) {
+    return false;
+  }
+  return Object.values(projection.activations).every((activation) => activation.status === 'completed')
+    && Object.values(projection.cohorts).every((cohort) => cohort.consumed);
+}

--- a/src/graph/schema.ts
+++ b/src/graph/schema.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+
+import type {
+  GraphDescriptor,
+  GraphEvidenceReference,
+  GraphNodeResult,
+} from './types.js';
+
+const idSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, 'must be a stable identifier');
+const textSchema = z.string().min(1).max(32_768);
+
+const sideEffectFreeSchema = z.object({ policy: z.literal('side_effect_free') }).strict();
+const idempotentSchema = z
+  .object({
+    policy: z.literal('idempotent'),
+    idempotency_key_template: z.string().min(1).max(512),
+  })
+  .strict();
+const reconcileSchema = z.object({ policy: z.literal('reconcile') }).strict();
+
+export const graphEffectPolicySchema = z.discriminatedUnion('policy', [
+  sideEffectFreeSchema,
+  idempotentSchema,
+  reconcileSchema,
+]);
+
+const nodeBase = {
+  id: idSchema,
+  title: z.string().min(1).max(256),
+};
+const executableNodeBase = {
+  ...nodeBase,
+  timeout_ms: z.number().int().min(100).max(86_400_000),
+  max_attempts: z.number().int().min(1).max(20),
+  effect_policy: graphEffectPolicySchema,
+};
+
+export const graphAgentNodeSchema = z
+  .object({
+    ...executableNodeBase,
+    kind: z.literal('agent'),
+    instructions: textSchema,
+  })
+  .strict();
+export const graphCommandNodeSchema = z
+  .object({
+    ...executableNodeBase,
+    kind: z.literal('command'),
+    command: textSchema,
+  })
+  .strict();
+export const graphHumanApprovalNodeSchema = z
+  .object({
+    ...nodeBase,
+    kind: z.literal('human-approval'),
+    prompt: textSchema,
+  })
+  .strict();
+export const graphJoinNodeSchema = z
+  .object({
+    ...nodeBase,
+    kind: z.literal('join'),
+    fan_out_node_id: idSchema,
+    input_branch_ids: z.array(idSchema).min(2).max(64),
+  })
+  .strict();
+
+export const graphNodeSchema = z.discriminatedUnion('kind', [
+  graphAgentNodeSchema,
+  graphCommandNodeSchema,
+  graphHumanApprovalNodeSchema,
+  graphJoinNodeSchema,
+]);
+
+const edgeBase = { id: idSchema, from: idSchema, to: idSchema };
+export const graphFixedEdgeSchema = z.object({ ...edgeBase, kind: z.literal('fixed') }).strict();
+export const graphConditionalEdgeSchema = z
+  .object({ ...edgeBase, kind: z.literal('conditional'), route: idSchema })
+  .strict();
+export const graphFanOutEdgeSchema = z
+  .object({
+    ...edgeBase,
+    kind: z.literal('fan_out'),
+    branch_id: idSchema,
+    owner_join_id: idSchema,
+  })
+  .strict();
+export const graphBackEdgeSchema = z
+  .object({
+    ...edgeBase,
+    kind: z.literal('back_edge'),
+    route: idSchema,
+    max_traversals: z.number().int().min(1).max(100),
+  })
+  .strict();
+
+export const graphEdgeSchema = z.discriminatedUnion('kind', [
+  graphFixedEdgeSchema,
+  graphConditionalEdgeSchema,
+  graphFanOutEdgeSchema,
+  graphBackEdgeSchema,
+]);
+
+export const graphDescriptorSchema = z
+  .object({
+    descriptor_version: z.literal(1),
+    run_id: idSchema,
+    revision_id: idSchema,
+    goal: textSchema,
+    nodes: z.array(graphNodeSchema).min(1).max(1_000),
+    edges: z.array(graphEdgeSchema).max(5_000),
+    entry_node_ids: z.array(idSchema).min(1).max(64),
+    concurrency_limit: z.number().int().min(1).max(64),
+    terminal_verification_node_id: idSchema,
+    descriptor_hash: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  })
+  .strict();
+
+export const graphEvidenceReferenceSchema = z
+  .object({
+    kind: z.enum(['file', 'command', 'test', 'human', 'url']),
+    ref: z.string().min(1).max(2_048),
+    summary: z.string().max(2_048).optional(),
+  })
+  .strict();
+
+export const graphNodeResultSchema = z
+  .object({
+    outcome: z.enum(['succeeded', 'failed']),
+    attempt_id: idSchema,
+    route: idSchema.optional(),
+    output_summary: z.string().max(8_192).optional(),
+    evidence_refs: z.array(graphEvidenceReferenceSchema).max(64),
+    external_idempotency_key: z.string().min(1).max(512).optional(),
+  })
+  .strict();
+
+export function parseGraphDescriptorShape(input: unknown): GraphDescriptor {
+  return graphDescriptorSchema.parse(input) as GraphDescriptor;
+}
+
+export function parseGraphNodeResult(input: unknown): GraphNodeResult {
+  return graphNodeResultSchema.parse(input) as GraphNodeResult;
+}
+
+export function parseGraphEvidenceReference(input: unknown): GraphEvidenceReference {
+  return graphEvidenceReferenceSchema.parse(input) as GraphEvidenceReference;
+}

--- a/src/graph/store.ts
+++ b/src/graph/store.ts
@@ -1,0 +1,329 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import {
+  acquireMutationLockAt,
+  assertMutationLockHeld,
+  mutationLockRenewalSupported,
+  releaseMutationLockSync,
+  renewMutationLock,
+} from '../lib/mode-state-io.js';
+import { resolveSessionStatePaths } from '../lib/worktree-paths.js';
+import { canonicalJson } from './descriptor.js';
+import {
+  GRAPH_MAX_TRANSITIONS,
+  GRAPH_STATE_MAX_BYTES,
+  GRAPH_MAX_TRANSITION_RESULT_BYTES,
+  parseGraphState,
+  type GraphState,
+  type GraphStateTransition,
+  type JsonValue,
+} from './runtime-types.js';
+
+export type GraphFenceScope = 'active' | 'pending_patch_base';
+
+export interface GraphStateFence {
+  session_id: string;
+  run_id: string;
+  revision_id: string;
+  revision_hash: string;
+  dispatch_generation: number;
+  commit_sequence: number;
+}
+
+export interface GraphMutationRequest {
+  transition_id: string;
+  operation: string;
+  operation_fingerprint: string;
+  expected: GraphStateFence;
+  fence_scope?: GraphFenceScope;
+}
+
+export interface GraphMutationValue<T extends JsonValue> {
+  next: GraphState;
+  result: T;
+}
+
+export interface GraphMutationResult<T extends JsonValue> {
+  state: GraphState;
+  result: T;
+  replayed: boolean;
+}
+
+export interface GraphStateStoreDependencies {
+  fileExists(path: string): boolean;
+  readText(path: string): string;
+  writeAtomic(path: string, value: unknown): void;
+  withExclusiveLock<T>(path: string, callback: (renew?: () => void) => T): { acquired: boolean; value: T | undefined };
+  now?(): string;
+}
+
+export interface GraphStateStoreOptions {
+  sessionId: string;
+  worktreeRoot?: string;
+  dependencies?: Partial<GraphStateStoreDependencies>;
+}
+
+export class GraphStoreError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'GraphStoreError';
+    this.code = code;
+  }
+}
+
+function withRenewingExclusiveLock<T>(
+  path: string,
+  callback: (renew?: () => void) => T,
+): { acquired: boolean; value: T | undefined } {
+  const lock = acquireMutationLockAt(path, true);
+  if (!lock) return { acquired: false, value: undefined };
+  const renew = (): void => {
+    assertMutationLockHeld(lock);
+    // On a flock-less runtime (macOS/Windows) there is no portable atomic
+    // rename-over-the-live-lock, so `renewMutationLock` returns false even
+    // though the lock is still held and its lease is valid for LEASE_MS. In that
+    // case renewal is simply UNAVAILABLE - no-op and rely on the
+    // publish-time `assertMutationLockHeld` (the safety net). Only treat a
+    // `false` on a flock-capable runtime (where renewal IS supported) as a
+    // genuine `lock_lost` (owner replaced / lease expired / I/O error).
+    if (mutationLockRenewalSupported(lock) && !renewMutationLock(lock)) {
+      throw new GraphStoreError('lock_lost', 'Graph state mutation lock could not be renewed');
+    }
+  };
+  try {
+    renew();
+    return { acquired: true, value: callback(renew) };
+  } finally {
+    releaseMutationLockSync(lock);
+  }
+}
+
+const DEFAULT_DEPENDENCIES: GraphStateStoreDependencies = {
+  fileExists: existsSync,
+  readText: (path) => readFileSync(path, 'utf8'),
+  writeAtomic: atomicWriteJsonSync,
+  withExclusiveLock: (path, callback) => withRenewingExclusiveLock(path, callback),
+  now: () => new Date().toISOString(),
+};
+
+function boundedJsonClone<T extends JsonValue>(value: T, label: string): T {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch (error) {
+    throw new GraphStoreError('invalid_result', `${label} is not JSON serializable: ${String(error)}`);
+  }
+  if (serialized === undefined) {
+    throw new GraphStoreError('invalid_result', `${label} must be a JSON value`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > GRAPH_MAX_TRANSITION_RESULT_BYTES) {
+    throw new GraphStoreError('result_too_large', `${label} exceeds ${GRAPH_MAX_TRANSITION_RESULT_BYTES} bytes`);
+  }
+  return JSON.parse(serialized) as T;
+}
+
+function requestFingerprint(request: GraphMutationRequest): string {
+  return createHash('sha256')
+    .update(canonicalJson({
+      transition_id: request.transition_id,
+      operation: request.operation,
+      operation_fingerprint: request.operation_fingerprint,
+      expected: request.expected,
+      fence_scope: request.fence_scope ?? 'active',
+    }))
+    .digest('hex');
+}
+
+function assertIdentifier(value: string, name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw new GraphStoreError('invalid_request', `${name} must be a stable identifier`);
+  }
+}
+
+function assertRequest(request: GraphMutationRequest): void {
+  assertIdentifier(request.transition_id, 'transition_id');
+  if (request.operation.length === 0 || request.operation.length > 128) {
+    throw new GraphStoreError('invalid_request', 'operation must be a bounded string');
+  }
+  if (request.operation_fingerprint.length === 0 || request.operation_fingerprint.length > 1_024) {
+    throw new GraphStoreError('invalid_request', 'operation_fingerprint must be a bounded string');
+  }
+  if (!Number.isSafeInteger(request.expected.commit_sequence) || request.expected.commit_sequence < 0) {
+    throw new GraphStoreError('invalid_request', 'expected commit_sequence must be non-negative');
+  }
+}
+
+function assertFence(state: GraphState, request: GraphMutationRequest): void {
+  const expected = request.expected;
+  if (state.session_id !== expected.session_id) {
+    throw new GraphStoreError('session_mismatch', 'Graph session fence does not match');
+  }
+  if (state.run_id !== expected.run_id) {
+    throw new GraphStoreError('run_mismatch', 'Graph run fence does not match');
+  }
+  if (state.commit_sequence !== expected.commit_sequence) {
+    throw new GraphStoreError(
+      'sequence_conflict',
+      `Expected commit sequence ${expected.commit_sequence}, found ${state.commit_sequence}`,
+    );
+  }
+
+  if ((request.fence_scope ?? 'active') === 'pending_patch_base') {
+    const patch = state.pending_patch;
+    if (
+      state.status !== 'waiting_patch_approval'
+      || !patch
+      || patch.base_revision_id !== expected.revision_id
+      || patch.base_revision_hash !== expected.revision_hash
+      || patch.base_dispatch_generation !== expected.dispatch_generation
+      || state.active_revision_id !== expected.revision_id
+      || state.active_revision_hash !== expected.revision_hash
+    ) {
+      throw new GraphStoreError('stale_patch_base', 'Pending patch no longer binds the expected claim generation');
+    }
+    return;
+  }
+
+  if (state.active_revision_id !== expected.revision_id || state.active_revision_hash !== expected.revision_hash) {
+    throw new GraphStoreError('revision_conflict', 'Active graph revision/hash fence does not match');
+  }
+  if (state.dispatch_generation !== expected.dispatch_generation) {
+    throw new GraphStoreError('dispatch_generation_conflict', 'Graph dispatch generation fence does not match');
+  }
+}
+
+function assertStoreManagedFieldsUnchanged(before: GraphState, next: GraphState): void {
+  if (next.format_version !== before.format_version || next.session_id !== before.session_id || next.run_id !== before.run_id) {
+    throw new GraphStoreError('identity_mutation', 'Mutation callbacks cannot replace graph authority identity');
+  }
+  if (next.commit_sequence !== before.commit_sequence) {
+    throw new GraphStoreError('sequence_mutation', 'Mutation callbacks cannot edit commit_sequence directly');
+  }
+  if (canonicalJson(next.transitions) !== canonicalJson(before.transitions)) {
+    throw new GraphStoreError('history_mutation', 'Mutation callbacks cannot edit committed transition history directly');
+  }
+}
+
+export class GraphStateStore {
+  readonly sessionId: string;
+  readonly worktreeRoot: string | undefined;
+  readonly path: string;
+  private readonly readPath: string;
+  private readonly dependencies: GraphStateStoreDependencies;
+
+  constructor(options: GraphStateStoreOptions) {
+    const paths = resolveSessionStatePaths('graph', options.sessionId, options.worktreeRoot);
+    if (!paths.sessionScoped || paths.effectiveWrite !== paths.sessionScoped) {
+      throw new GraphStoreError('unsafe_state_path', 'Graph requires an explicit session-scoped write path');
+    }
+    this.sessionId = options.sessionId;
+    this.worktreeRoot = options.worktreeRoot;
+    this.path = paths.effectiveWrite;
+    this.readPath = paths.sessionScoped;
+    this.dependencies = { ...DEFAULT_DEPENDENCIES, ...options.dependencies };
+  }
+
+  read(): GraphState | null {
+    if (!this.dependencies.fileExists(this.readPath)) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(this.dependencies.readText(this.readPath));
+    } catch (error) {
+      throw new GraphStoreError('malformed_state', `Cannot parse graph-state.json: ${String(error)}`);
+    }
+    const state = parseGraphState(parsed);
+    if (state.session_id !== this.sessionId) {
+      throw new GraphStoreError('session_mismatch', 'Graph state belongs to a different session');
+    }
+    return state;
+  }
+
+  create(state: GraphState): GraphState {
+    const result = this.dependencies.withExclusiveLock(this.path, (renew) => {
+      if (this.dependencies.fileExists(this.readPath)) {
+        throw new GraphStoreError('already_exists', 'Graph state already exists for this session');
+      }
+      const validated = parseGraphState(state);
+      if (validated.session_id !== this.sessionId) {
+        throw new GraphStoreError('session_mismatch', 'Initial Graph state session does not match the store');
+      }
+      if (validated.commit_sequence !== 0 || validated.transitions.length !== 0) {
+        throw new GraphStoreError('invalid_initial_state', 'Initial Graph state must start at sequence zero');
+      }
+      this.assertStateSize(validated);
+      renew?.();
+      this.dependencies.writeAtomic(this.path, validated);
+      return validated;
+    });
+    if (!result.acquired || !result.value) {
+      throw new GraphStoreError('lock_busy', 'Could not acquire the exclusive Graph state lock');
+    }
+    return result.value;
+  }
+
+  mutate<T extends JsonValue>(
+    request: GraphMutationRequest,
+    callback: (state: GraphState, renew: () => void) => GraphMutationValue<T>,
+  ): GraphMutationResult<T> {
+    assertRequest(request);
+    const fingerprint = requestFingerprint(request);
+    const locked = this.dependencies.withExclusiveLock(this.path, (renew) => {
+      const renewLease = renew ?? (() => {});
+      const current = this.read();
+      if (!current) throw new GraphStoreError('not_found', 'Graph state does not exist for this session');
+
+      const prior = current.transitions.find((transition) => transition.transition_id === request.transition_id);
+      if (prior) {
+        if (prior.request_fingerprint !== fingerprint) {
+          throw new GraphStoreError('transition_reused', 'Transition ID was already committed for a different request');
+        }
+        return { state: current, result: prior.result as T, replayed: true };
+      }
+
+      assertFence(current, request);
+      if (current.transitions.length >= GRAPH_MAX_TRANSITIONS) {
+        throw new GraphStoreError('transition_limit', 'Graph transition limit has been reached');
+      }
+      // User-supplied mutations can extend the lease at long-running checkpoints.
+      const mutation = callback(structuredClone(current), renewLease);
+      assertStoreManagedFieldsUnchanged(current, mutation.next);
+      const result = boundedJsonClone(mutation.result, 'transition result');
+      const sequence = current.commit_sequence + 1;
+      const committedAt = this.dependencies.now?.() ?? new Date().toISOString();
+      const transition: GraphStateTransition = {
+        transition_id: request.transition_id,
+        operation: request.operation,
+        operation_fingerprint: request.operation_fingerprint,
+        request_fingerprint: fingerprint,
+        sequence,
+        committed_at: committedAt,
+        result,
+      };
+      const next = parseGraphState({
+        ...mutation.next,
+        commit_sequence: sequence,
+        transitions: [...current.transitions, transition],
+        updated_at: committedAt,
+      });
+      this.assertStateSize(next);
+      renewLease();
+      this.dependencies.writeAtomic(this.path, next);
+      return { state: next, result, replayed: false };
+    });
+    if (!locked.acquired || !locked.value) {
+      throw new GraphStoreError('lock_busy', 'Could not acquire the exclusive Graph state lock');
+    }
+    return locked.value;
+  }
+
+  private assertStateSize(state: GraphState): void {
+    const bytes = Buffer.byteLength(JSON.stringify(state), 'utf8');
+    if (bytes > GRAPH_STATE_MAX_BYTES) {
+      throw new GraphStoreError('state_too_large', `Graph state exceeds ${GRAPH_STATE_MAX_BYTES} bytes`);
+    }
+  }
+}

--- a/src/graph/store.ts
+++ b/src/graph/store.ts
@@ -1,14 +1,7 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 
-import { atomicWriteJsonSync } from '../lib/atomic-write.js';
-import {
-  acquireMutationLockAt,
-  assertMutationLockHeld,
-  mutationLockRenewalSupported,
-  releaseMutationLockSync,
-  renewMutationLock,
-} from '../lib/mode-state-io.js';
+import { occCommitMutation, occReadCurrentState } from '../lib/mode-state-io.js';
 import { resolveSessionStatePaths } from '../lib/worktree-paths.js';
 import { canonicalJson } from './descriptor.js';
 import {
@@ -54,8 +47,28 @@ export interface GraphMutationResult<T extends JsonValue> {
 export interface GraphStateStoreDependencies {
   fileExists(path: string): boolean;
   readText(path: string): string;
-  writeAtomic(path: string, value: unknown): void;
-  withExclusiveLock<T>(path: string, callback: (renew?: () => void) => T): { acquired: boolean; value: T | undefined };
+  /**
+   * Reads the OCC journal's authoritative current committed state (the
+   * max-complete journal entry's state). Under (B) the journal - NOT the
+   * canonical file - is the source of truth; the canonical file is a derived
+   * cache re-published on each commit. Returns null when the journal is empty
+   * or on an unreadable journal directory (fail closed).
+   */
+  readCurrent(path: string): unknown;
+  /**
+   * OCC (optimistic concurrency control) commit. Runs `mutate(currentState,
+   * ownerToken)` purely against the OCC-validated current committed state and
+   * commits it atomically (O_EXCL claim + parent-validation). Returns the
+   * committed { state, result } or null on fork-exhaustion / fail-closed I/O.
+   * Replaces the old lease-lock + writeAtomic publish (B11 root cure): a stale
+   * writer that forks off an old parent is re-sequenced AFTER its successor
+   * instead of overwriting it.
+   */
+  occCommit<TState, TResult>(
+    path: string,
+    mutate: (currentState: unknown, ownerToken: string) => { state: TState; result: TResult } | null,
+    options?: { ownerToken?: string },
+  ): { state: TState; result: TResult } | null;
   now?(): string;
 }
 
@@ -75,38 +88,11 @@ export class GraphStoreError extends Error {
   }
 }
 
-function withRenewingExclusiveLock<T>(
-  path: string,
-  callback: (renew?: () => void) => T,
-): { acquired: boolean; value: T | undefined } {
-  const lock = acquireMutationLockAt(path, true);
-  if (!lock) return { acquired: false, value: undefined };
-  const renew = (): void => {
-    assertMutationLockHeld(lock);
-    // On a flock-less runtime (macOS/Windows) there is no portable atomic
-    // rename-over-the-live-lock, so `renewMutationLock` returns false even
-    // though the lock is still held and its lease is valid for LEASE_MS. In that
-    // case renewal is simply UNAVAILABLE - no-op and rely on the
-    // publish-time `assertMutationLockHeld` (the safety net). Only treat a
-    // `false` on a flock-capable runtime (where renewal IS supported) as a
-    // genuine `lock_lost` (owner replaced / lease expired / I/O error).
-    if (mutationLockRenewalSupported(lock) && !renewMutationLock(lock)) {
-      throw new GraphStoreError('lock_lost', 'Graph state mutation lock could not be renewed');
-    }
-  };
-  try {
-    renew();
-    return { acquired: true, value: callback(renew) };
-  } finally {
-    releaseMutationLockSync(lock);
-  }
-}
-
 const DEFAULT_DEPENDENCIES: GraphStateStoreDependencies = {
   fileExists: existsSync,
   readText: (path) => readFileSync(path, 'utf8'),
-  writeAtomic: atomicWriteJsonSync,
-  withExclusiveLock: (path, callback) => withRenewingExclusiveLock(path, callback),
+  readCurrent: occReadCurrentState,
+  occCommit: occCommitMutation,
   now: () => new Date().toISOString(),
 };
 
@@ -228,12 +214,17 @@ export class GraphStateStore {
   }
 
   read(): GraphState | null {
-    if (!this.dependencies.fileExists(this.readPath)) return null;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(this.dependencies.readText(this.readPath));
-    } catch (error) {
-      throw new GraphStoreError('malformed_state', `Cannot parse graph-state.json: ${String(error)}`);
+    // Under (B) the OCC journal is the source of truth; the canonical file is a
+    // derived cache. read() returns the journal's max-complete committed state.
+    const currentRaw = this.dependencies.readCurrent(this.readPath);
+    if (currentRaw === null || currentRaw === undefined) return null;
+    let parsed: unknown = currentRaw;
+    if (typeof currentRaw === 'string') {
+      try {
+        parsed = JSON.parse(currentRaw);
+      } catch (error) {
+        throw new GraphStoreError('malformed_state', `Cannot parse graph-state.json: ${String(error)}`);
+      }
     }
     const state = parseGraphState(parsed);
     if (state.session_id !== this.sessionId) {
@@ -243,26 +234,29 @@ export class GraphStateStore {
   }
 
   create(state: GraphState): GraphState {
-    const result = this.dependencies.withExclusiveLock(this.path, (renew) => {
-      if (this.dependencies.fileExists(this.readPath)) {
-        throw new GraphStoreError('already_exists', 'Graph state already exists for this session');
-      }
-      const validated = parseGraphState(state);
-      if (validated.session_id !== this.sessionId) {
-        throw new GraphStoreError('session_mismatch', 'Initial Graph state session does not match the store');
-      }
-      if (validated.commit_sequence !== 0 || validated.transitions.length !== 0) {
-        throw new GraphStoreError('invalid_initial_state', 'Initial Graph state must start at sequence zero');
-      }
-      this.assertStateSize(validated);
-      renew?.();
-      this.dependencies.writeAtomic(this.path, validated);
-      return validated;
-    });
-    if (!result.acquired || !result.value) {
-      throw new GraphStoreError('lock_busy', 'Could not acquire the exclusive Graph state lock');
+    const validated = parseGraphState(state);
+    if (validated.session_id !== this.sessionId) {
+      throw new GraphStoreError('session_mismatch', 'Initial Graph state session does not match the store');
     }
-    return result.value;
+    if (validated.commit_sequence !== 0 || validated.transitions.length !== 0) {
+      throw new GraphStoreError('invalid_initial_state', 'Initial Graph state must start at sequence zero');
+    }
+    this.assertStateSize(validated);
+    const committed = this.dependencies.occCommit<GraphState, GraphState>(
+      this.path,
+      (currentRaw) => {
+        if (currentRaw !== null && currentRaw !== undefined) {
+          // A committed state already exists in the OCC journal (or seeded from
+          // the canonical file). create() must not overwrite it.
+          throw new GraphStoreError('already_exists', 'Graph state already exists for this session');
+        }
+        return { state: validated, result: validated };
+      },
+    );
+    if (!committed) {
+      throw new GraphStoreError('lock_busy', 'Could not commit the initial Graph state via OCC');
+    }
+    return committed.result;
   }
 
   mutate<T extends JsonValue>(
@@ -271,53 +265,65 @@ export class GraphStateStore {
   ): GraphMutationResult<T> {
     assertRequest(request);
     const fingerprint = requestFingerprint(request);
-    const locked = this.dependencies.withExclusiveLock(this.path, (renew) => {
-      const renewLease = renew ?? (() => {});
-      const current = this.read();
-      if (!current) throw new GraphStoreError('not_found', 'Graph state does not exist for this session');
-
-      const prior = current.transitions.find((transition) => transition.transition_id === request.transition_id);
-      if (prior) {
-        if (prior.request_fingerprint !== fingerprint) {
-          throw new GraphStoreError('transition_reused', 'Transition ID was already committed for a different request');
+    const committed = this.dependencies.occCommit<GraphState, GraphMutationResult<T>>(
+      this.path,
+      (currentRaw) => {
+        if (currentRaw === null || currentRaw === undefined) {
+          throw new GraphStoreError('not_found', 'Graph state does not exist for this session');
         }
-        return { state: current, result: prior.result as T, replayed: true };
-      }
+        let current: GraphState;
+        try {
+          current = parseGraphState(JSON.parse(JSON.stringify(currentRaw)));
+        } catch (error) {
+          throw new GraphStoreError('malformed_state', `Cannot parse graph-state.json: ${String(error)}`);
+        }
+        if (current.session_id !== this.sessionId) {
+          throw new GraphStoreError('session_mismatch', 'Graph state belongs to a different session');
+        }
 
-      assertFence(current, request);
-      if (current.transitions.length >= GRAPH_MAX_TRANSITIONS) {
-        throw new GraphStoreError('transition_limit', 'Graph transition limit has been reached');
-      }
-      // User-supplied mutations can extend the lease at long-running checkpoints.
-      const mutation = callback(structuredClone(current), renewLease);
-      assertStoreManagedFieldsUnchanged(current, mutation.next);
-      const result = boundedJsonClone(mutation.result, 'transition result');
-      const sequence = current.commit_sequence + 1;
-      const committedAt = this.dependencies.now?.() ?? new Date().toISOString();
-      const transition: GraphStateTransition = {
-        transition_id: request.transition_id,
-        operation: request.operation,
-        operation_fingerprint: request.operation_fingerprint,
-        request_fingerprint: fingerprint,
-        sequence,
-        committed_at: committedAt,
-        result,
-      };
-      const next = parseGraphState({
-        ...mutation.next,
-        commit_sequence: sequence,
-        transitions: [...current.transitions, transition],
-        updated_at: committedAt,
-      });
-      this.assertStateSize(next);
-      renewLease();
-      this.dependencies.writeAtomic(this.path, next);
-      return { state: next, result, replayed: false };
-    });
-    if (!locked.acquired || !locked.value) {
-      throw new GraphStoreError('lock_busy', 'Could not acquire the exclusive Graph state lock');
+        const prior = current.transitions.find((transition) => transition.transition_id === request.transition_id);
+        if (prior) {
+          if (prior.request_fingerprint !== fingerprint) {
+            throw new GraphStoreError('transition_reused', 'Transition ID was already committed for a different request');
+          }
+          return { state: current, result: { state: current, result: prior.result as T, replayed: true } };
+        }
+
+        assertFence(current, request);
+        if (current.transitions.length >= GRAPH_MAX_TRANSITIONS) {
+          throw new GraphStoreError('transition_limit', 'Graph transition limit has been reached');
+        }
+        // The OCC wrapper validates + commits the returned state atomically; the
+        // old `renew` lease hook is obsolete (no lease under OCC) so it is a no-op.
+        const renew = (): void => {};
+        const mutation = callback(structuredClone(current), renew);
+        assertStoreManagedFieldsUnchanged(current, mutation.next);
+        const result = boundedJsonClone(mutation.result, 'transition result');
+        const sequence = current.commit_sequence + 1;
+        const committedAt = this.dependencies.now?.() ?? new Date().toISOString();
+        const transition: GraphStateTransition = {
+          transition_id: request.transition_id,
+          operation: request.operation,
+          operation_fingerprint: request.operation_fingerprint,
+          request_fingerprint: fingerprint,
+          sequence,
+          committed_at: committedAt,
+          result,
+        };
+        const next = parseGraphState({
+          ...mutation.next,
+          commit_sequence: sequence,
+          transitions: [...current.transitions, transition],
+          updated_at: committedAt,
+        });
+        this.assertStateSize(next);
+        return { state: next, result: { state: next, result, replayed: false } };
+      },
+    );
+    if (!committed) {
+      throw new GraphStoreError('lock_busy', 'Could not commit the Graph state mutation via OCC');
     }
-    return locked.value;
+    return committed.result;
   }
 
   private assertStateSize(state: GraphState): void {

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -173,6 +173,10 @@ export interface GraphSchedulerProjection {
 export interface BeginActivationAttemptInput {
   activation_id: string;
   attempt_id: string;
+  // Optional per-node retry bound (agent/command nodes). When supplied the
+  // scheduler rejects any begin whose resulting attempt_no exceeds it, so an
+  // ordinary release+reclaim loop cannot bypass the node's max_attempts.
+  max_attempts?: number;
 }
 
 export type ReleaseAttemptForRetryInput = BeginActivationAttemptInput;

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,204 @@
+export type GraphNodeKind = 'agent' | 'command' | 'human-approval' | 'join';
+
+export type GraphEffectPolicy =
+  | { policy: 'side_effect_free' }
+  | { policy: 'idempotent'; idempotency_key_template: string }
+  | { policy: 'reconcile' };
+
+interface GraphNodeBase {
+  id: string;
+  kind: GraphNodeKind;
+  title: string;
+}
+
+interface GraphExecutableNodeBase extends GraphNodeBase {
+  timeout_ms: number;
+  max_attempts: number;
+  effect_policy: GraphEffectPolicy;
+}
+
+export interface GraphAgentNode extends GraphExecutableNodeBase {
+  kind: 'agent';
+  instructions: string;
+}
+
+export interface GraphCommandNode extends GraphExecutableNodeBase {
+  kind: 'command';
+  command: string;
+}
+
+export interface GraphHumanApprovalNode extends GraphNodeBase {
+  kind: 'human-approval';
+  prompt: string;
+}
+
+export interface GraphJoinNode extends GraphNodeBase {
+  kind: 'join';
+  fan_out_node_id: string;
+  input_branch_ids: string[];
+}
+
+export type GraphNode =
+  | GraphAgentNode
+  | GraphCommandNode
+  | GraphHumanApprovalNode
+  | GraphJoinNode;
+
+interface GraphEdgeBase {
+  id: string;
+  from: string;
+  to: string;
+}
+
+export interface GraphFixedEdge extends GraphEdgeBase {
+  kind: 'fixed';
+}
+
+export interface GraphConditionalEdge extends GraphEdgeBase {
+  kind: 'conditional';
+  route: string;
+}
+
+export interface GraphFanOutEdge extends GraphEdgeBase {
+  kind: 'fan_out';
+  branch_id: string;
+  owner_join_id: string;
+}
+
+export interface GraphBackEdge extends GraphEdgeBase {
+  kind: 'back_edge';
+  route: string;
+  max_traversals: number;
+}
+
+export type GraphEdge =
+  | GraphFixedEdge
+  | GraphConditionalEdge
+  | GraphFanOutEdge
+  | GraphBackEdge;
+
+export interface GraphDescriptorInput {
+  descriptor_version: 1;
+  run_id: string;
+  revision_id: string;
+  goal: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  entry_node_ids: string[];
+  concurrency_limit: number;
+  terminal_verification_node_id: string;
+  descriptor_hash?: string;
+}
+
+export type GraphDescriptor = GraphDescriptorInput;
+
+export type SealedGraphDescriptor = GraphDescriptorInput & {
+  descriptor_hash: string;
+};
+
+export interface GraphEvidenceReference {
+  kind: 'file' | 'command' | 'test' | 'human' | 'url';
+  ref: string;
+  summary?: string;
+}
+
+export interface GraphNodeResult {
+  outcome: 'succeeded' | 'failed';
+  attempt_id: string;
+  route?: string;
+  output_summary?: string;
+  evidence_refs: GraphEvidenceReference[];
+  external_idempotency_key?: string;
+}
+
+export type GraphActivationStatus = 'ready' | 'running' | 'completed' | 'failed';
+
+export interface GraphActivation {
+  activation_id: string;
+  node_id: string;
+  status: GraphActivationStatus;
+  attempt_no: number;
+  attempt_ids: string[];
+  active_attempt_id?: string;
+  completed_transition_id?: string;
+  cohort_id?: string;
+  branch_token_id?: string;
+  traversal_owner_id: string;
+}
+
+export interface GraphBranchToken {
+  branch_token_id: string;
+  cohort_id: string;
+  branch_id: string;
+  owner_join_id: string;
+  status: 'active' | 'arrived' | 'consumed';
+  current_activation_id?: string;
+  consumed_by_activation_id?: string;
+}
+
+export interface GraphCohort {
+  cohort_id: string;
+  fan_out_node_id: string;
+  owner_join_id: string;
+  expected_branch_token_ids: string[];
+  join_activation_id?: string;
+  consumed: boolean;
+}
+
+export interface GraphCommittedTransition {
+  transition_id: string;
+  activation_id: string;
+  node_id: string;
+  outcome: 'succeeded' | 'failed' | 'join_resolved';
+  request_fingerprint: string;
+  selected_edge_ids: string[];
+  created_activation_ids: string[];
+  cohort_id?: string;
+  attempt_id?: string;
+  route?: string;
+  output_summary?: string;
+  evidence_refs: GraphEvidenceReference[];
+  external_idempotency_key?: string;
+}
+
+export interface GraphSchedulerProjection {
+  activations: Record<string, GraphActivation>;
+  cohorts: Record<string, GraphCohort>;
+  branch_tokens: Record<string, GraphBranchToken>;
+  traversal_counts: Record<string, number>;
+  committed_transitions: Record<string, GraphCommittedTransition>;
+  terminal_verification_activation_ids: string[];
+}
+
+export interface BeginActivationAttemptInput {
+  activation_id: string;
+  attempt_id: string;
+}
+
+export type ReleaseAttemptForRetryInput = BeginActivationAttemptInput;
+
+export interface SchedulerTransitionIdentities {
+  next_activation_ids?: Record<string, string>;
+  cohort_id?: string;
+  branch_token_ids?: Record<string, string>;
+  join_activation_id?: string;
+}
+
+export interface ApplyNodeResultInput {
+  activation_id: string;
+  transition_id: string;
+  result: GraphNodeResult;
+  identities?: SchedulerTransitionIdentities;
+}
+
+export interface ResolveJoinInput {
+  activation_id: string;
+  transition_id: string;
+  identities?: SchedulerTransitionIdentities;
+}
+
+export interface SchedulerApplyResult {
+  projection: GraphSchedulerProjection;
+  transition: GraphCommittedTransition;
+  replayed: boolean;
+}

--- a/src/hooks/autopilot/__tests__/cancel.test.ts
+++ b/src/hooks/autopilot/__tests__/cancel.test.ts
@@ -771,11 +771,12 @@ describe('AutopilotCancel', () => {
       writeAutopilotState(testDir, state, sessionId);
       const replacement = structuredClone(state);
       replacement.pipelineTracking!.activationBoundary!.transcriptPath = `${encodedProject}${sep}nested${sep}..${sep}${sessionId}.jsonl`;
+      const replacementRaw = JSON.stringify(replacement, null, 2);
       process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH = stateFile;
-      process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64 = Buffer.from(replacementRaw).toString('base64');
       expect(resumeAutopilot(testDir, sessionId)).toMatchObject({ success: false, message: 'workflow_descriptor_integrity_failed' });
       expect(readAutopilotState(testDir, sessionId)).toEqual(replacement);
-      expect(require('fs').readFileSync(stateFile, 'utf8')).toBe(JSON.stringify(replacement));
+      expect(require('fs').readFileSync(stateFile, 'utf8')).toBe(replacementRaw);
 
       writeAutopilotState(testDir, state, sessionId);
       expect(validateNamedWorkflowState(readAutopilotState(testDir, sessionId)!, sessionId)).not.toBeNull();

--- a/src/hooks/autopilot/__tests__/cancel.test.ts
+++ b/src/hooks/autopilot/__tests__/cancel.test.ts
@@ -292,9 +292,10 @@ describe('AutopilotCancel', () => {
       state.workflowRunId = '11111111-1111-4111-8111-111111111111';
       writeAutopilotState(testDir, state, sessionId);
       const statePath = resolveSessionStatePath('autopilot', sessionId, testDir);
-      const stat = require('fs').readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-      const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-      writeFileSync(`${statePath}.mutation.lock`, JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: '22222222-2222-4222-8222-222222222222' }));
+      // Plant a LIVE mutation lock (unexpired lease) so cancel/clear cannot
+      // acquire exclusively and must fail. Lease-based (expires_at in the
+      // future) - no /proc liveness dependency.
+      writeFileSync(`${statePath}.mutation.lock`, JSON.stringify({ version: 1, pid: process.pid, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 300000).toISOString(), nonce: '22222222-2222-4222-8222-222222222222' }));
 
       expect(cancelAutopilot(testDir, sessionId).success).toBe(false);
       expect(clearAutopilot(testDir, sessionId).success).toBe(false);

--- a/src/hooks/autopilot/__tests__/cancel.test.ts
+++ b/src/hooks/autopilot/__tests__/cancel.test.ts
@@ -775,6 +775,7 @@ describe('AutopilotCancel', () => {
       process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
       expect(resumeAutopilot(testDir, sessionId)).toMatchObject({ success: false, message: 'workflow_descriptor_integrity_failed' });
       expect(readAutopilotState(testDir, sessionId)).toEqual(replacement);
+      expect(require('fs').readFileSync(stateFile, 'utf8')).toBe(JSON.stringify(replacement));
 
       writeAutopilotState(testDir, state, sessionId);
       expect(validateNamedWorkflowState(readAutopilotState(testDir, sessionId)!, sessionId)).not.toBeNull();

--- a/src/hooks/autopilot/cancel.ts
+++ b/src/hooks/autopilot/cancel.ts
@@ -12,6 +12,7 @@ import {
   updateAutopilotStateIfCurrent,
   updateAutopilotStateIfExact,
 } from './state.js';
+import { lstatSync } from 'fs';
 import { clearRalphState, clearLinkedUltraworkState, readRalphState } from '../ralph/index.js';
 import { clearUltraQAState, readUltraQAState } from '../ultraqa/index.js';
 import type { AutopilotState } from './types.js';
@@ -44,6 +45,27 @@ function validNamedWorkflowForResume(state: AutopilotState, sessionId?: string):
       ? validateNamedWorkflowState(state, sessionId)
       : validateNamedWorkflowStateStructure(state, sessionId),
   );
+}
+
+/**
+ * An unsupported runtime cannot authenticate a transcript, but it can still
+ * reject an already-observable symlink. Do that before returning the generic
+ * unsupported-runtime response so a forged boundary is never treated as a
+ * merely unavailable feature.
+ */
+function hasSymlinkedNamedWorkflowTranscript(state: AutopilotState): boolean {
+  const boundaries = [
+    state.pipelineTracking?.activationBoundary,
+    ...(state.pipelineTracking?.completionObservations?.map((observation) => observation.activationBoundary) ?? []),
+  ];
+  return boundaries.some((boundary) => {
+    if (!boundary || typeof boundary.transcriptPath !== 'string') return false;
+    try {
+      return lstatSync(boundary.transcriptPath).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  });
 }
 
 function clearSessionOwnedNestedRalplanState(directory: string, sessionId?: string): boolean | null {
@@ -241,6 +263,9 @@ export function canResumeAutopilot(directory: string, sessionId?: string): {
 
   if (hasNamedWorkflowMarkers(state)) {
     if (!validNamedWorkflowForResume(state, sessionId)) {
+      return { canResume: false, resumePhase: state.phase, integrityFailed: true };
+    }
+    if (hasSymlinkedNamedWorkflowTranscript(state)) {
       return { canResume: false, resumePhase: state.phase, integrityFailed: true };
     }
     if (!namedWorkflowRuntimeSupported()) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -631,7 +631,7 @@ export {
   type CancelResult
 } from './autopilot/index.js';
 
-// Mode Registry (Centralized State Management)
+// Mode Registry (Centralized State Management; additional functions from PR #111)
 export {
   MODE_CONFIGS,
   getStateDir,
@@ -640,10 +640,10 @@ export {
   getMarkerFilePath as getModeMarkerFilePath,
   getGlobalStateFilePath,
   clearModeState,
+  clearModeStateDetailed,
   hasModeState,
   getActiveModes,
   clearAllModeStates,
-  // Additional functions from PR #111
   isModeActive,
   getActiveExclusiveMode,
   canStartMode,

--- a/src/hooks/keyword-detector/__tests__/index.test.ts
+++ b/src/hooks/keyword-detector/__tests__/index.test.ts
@@ -2685,6 +2685,28 @@ This article argues that fake popularity signals damage trust in open source.`;
   // -------------------------------------------------------------------------
 
   describe('unified prefix detector: /omc: and /oh-my-claudecode: forms (spec g)', () => {
+    it.each([
+      '/graph migrate payments',
+      '/omc:graph migrate payments',
+      '/oh-my-claudecode:graph migrate payments',
+    ])('detects explicit Graph workflow invocation %s', (prompt) => {
+      const result = detectKeywordsWithType(prompt);
+      expect(result.find((entry) => entry.type === 'graph')).toBeDefined();
+    });
+
+    it.each([
+      'graph',
+      'please build a graph for this task',
+      'the graph keeps the project overview',
+      'run `/graph migrate payments` later',
+      '```\n/graph migrate payments\n```',
+      '/graph-state/runs.json',
+      '/graphical render',
+    ])('does not activate Graph from non-command text %s', (prompt) => {
+      const result = detectKeywordsWithType(prompt);
+      expect(result.find((entry) => entry.type === 'graph')).toBeUndefined();
+    });
+
     it('/omc:ralph fix auth detects ralph', () => {
       const result = detectKeywordsWithType('/omc:ralph fix auth');
       expect(result.find((r) => r.type === 'ralph')).toBeDefined();
@@ -2741,6 +2763,19 @@ This article argues that fake popularity signals damage trust in open source.`;
   // parseExplicitWorkflowSlashInvocation — unit tests (spec g)
   // -------------------------------------------------------------------------
   describe('parseExplicitWorkflowSlashInvocation — parser unit tests (spec g)', () => {
+    it('normalizes all Graph slash prefixes and preserves arguments', () => {
+      for (const prompt of [
+        '/graph migrate payments',
+        '/omc:graph migrate payments',
+        '/oh-my-claudecode:graph migrate payments',
+      ]) {
+        expect(parseExplicitWorkflowSlashInvocation(prompt)).toMatchObject({
+          skill: 'graph',
+          args: 'migrate payments',
+        });
+      }
+    });
+
     it('returns null for empty string', () => {
       expect(parseExplicitWorkflowSlashInvocation('')).toBeNull();
     });

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -16,6 +16,7 @@ import {
 
 export type KeywordType =
   | 'cancel'      // Priority 1
+  | 'graph'       // Priority 1.5 (explicit slash only)
   | 'ralph'       // Priority 2
   | 'autopilot'   // Priority 3
   | 'team'        // Priority 4.5 (team mode)
@@ -45,6 +46,7 @@ export interface DetectedKeyword {
  */
 const KEYWORD_PATTERNS: Record<KeywordType, RegExp> = {
   cancel: /\b(cancelomc|stopomc)\b/i,
+  graph: /(?!x)x/,
   ralph: /\b(ralph)\b(?!-)|(랄프)(?!로렌)|(ラルフ)(?!・?ローレン)/i,
   autopilot: /\b(autopilot|auto[\s-]?pilot|fullsend|full\s+auto)\b|\b(?:build|create|make)\s+me\s+(?:an?\s+)?(?:app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b|\bi\s+want\s+an?\s+(?:app|feature|project|tool|plugin|website|api|server|cli|script|system|service|dashboard|bot|extension)\b|(오토파일럿)|(オートパイロット)/i,
   ultrawork: /\b(ultrawork|ulw)\b|(울트라워크)|(ウルトラワーク)/i,
@@ -92,7 +94,7 @@ const KEYWORD_SKIP_PREDICATES: Partial<Record<KeywordType, (text: string) => boo
  * Priority order for keyword detection
  */
 const KEYWORD_PRIORITY: KeywordType[] = [
-  'cancel', 'ralph', 'autopilot', 'team', 'ultrawork',
+  'cancel', 'graph', 'ralph', 'autopilot', 'team', 'ultrawork',
   'ccg', 'ralplan', 'tdd', 'code-review', 'security-review',
   'ultrathink', 'deepsearch', 'analyze', 'deep-interview', 'codex', 'gemini', 'cursor', 'antigravity'
 ];
@@ -105,6 +107,7 @@ const KEYWORD_PRIORITY: KeywordType[] = [
  */
 const CANONICAL_WORKFLOW_SLASH_SKILLS = [
   'autopilot',
+  'graph',
   'ralph',
   'team',
   'ultrawork',
@@ -128,6 +131,7 @@ const SLASH_SKILL_TO_KEYWORD_TYPE: Partial<
   Record<CanonicalWorkflowSlashSkill, KeywordType>
 > = {
   autopilot: 'autopilot',
+  graph: 'graph',
   ralph: 'ralph',
   team: 'team',
   ultrawork: 'ultrawork',

--- a/src/hooks/mode-registry/__tests__/session-isolation.test.ts
+++ b/src/hooks/mode-registry/__tests__/session-isolation.test.ts
@@ -15,6 +15,7 @@ import {
   hasModeState,
   isModeActiveInAnySession,
   getActiveSessionsForMode,
+  clearAllModeStates,
   clearStaleSessionDirs,
 } from '../index.js';
 
@@ -38,9 +39,20 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   function liveLockOwner() {
-    const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-    const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-    return JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() });
+    // Plant a LEASE-schema owner (matches MutationLockOwner in mode-state-io.ts):
+    // the lock is held while `now < expires_at`, so a future expires_at makes
+    // the production lease treat this owner as live/held. The on-disk owner JSON
+    // must have EXACTLY the keys [createdAt, expires_at, nonce, pid, version]
+    // (sorted) or validateLockOwner rejects it as corrupt -> reclaimed. The old
+    // liveness `processStart` field is gone from the lock schema; keeping it
+    // here would add a 6th key and mark the owner corrupt.
+    return JSON.stringify({
+      version: 1,
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 60000).toISOString(),
+      nonce: randomUUID(),
+    });
   }
 
   // Helper to create state file at session-scoped path
@@ -151,6 +163,68 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('Cross-session mode discovery (isModeActiveInAnySession)', () => {
+    it.each([
+      'running',
+      'waiting_human',
+      'waiting_patch_approval',
+      'reconciling',
+    ])('derives active Graph state from durable status %s', (status) => {
+      createSessionState('session-graph', 'graph', {
+        session_id: 'session-graph',
+        status,
+        active: false,
+      });
+
+      expect(isModeActive('graph', tempDir, 'session-graph')).toBe(true);
+      expect(getActiveModes(tempDir, 'session-graph')).toContain('graph');
+    });
+
+    it.each(['draft', 'awaiting_approval', 'paused', 'succeeded', 'failed', 'cancelled'])(
+      'treats Graph status %s as inactive',
+      (status) => {
+        createSessionState('session-graph', 'graph', {
+          session_id: 'session-graph',
+          status,
+          active: true,
+        });
+
+        expect(isModeActive('graph', tempDir, 'session-graph')).toBe(false);
+        expect(getActiveModes(tempDir, 'session-graph')).not.toContain('graph');
+      },
+    );
+
+    it('treats malformed, missing, and session-mismatched Graph state as inactive', () => {
+      const sessionId = 'session-graph';
+      const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const graphPath = join(sessionDir, 'graph-state.json');
+
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, '{not-json');
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, JSON.stringify({ session_id: sessionId, status: 'unknown' }));
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, JSON.stringify({ session_id: 'another-session', status: 'running' }));
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+    });
+
+    it('respects a generic workflow tombstone over durable Graph status', () => {
+      const sessionId = 'session-graph';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
+      createSessionState(sessionId, 'skill-active', {
+        version: 2,
+        active_skills: {
+          graph: {
+            skill_name: 'graph',
+            completed_at: new Date().toISOString(),
+          },
+        },
+      });
+
+      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      expect(getActiveModes(tempDir, sessionId)).not.toContain('graph');
+    });
+
     it('should find autoresearch active in any session', () => {
       createSessionState('session-A', 'autoresearch', { active: true });
       expect(isModeActiveInAnySession('autoresearch', tempDir)).toBe(true);
@@ -193,6 +267,16 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('clearModeState with sessionId', () => {
+    it('refuses generic Graph clear and preserves the durable ledger', () => {
+      const sessionId = 'graph-clear-guard';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
+      const graphPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'graph-state.json');
+      const before = readFileSync(graphPath, 'utf8');
+
+      expect(clearModeState('graph', tempDir, sessionId)).toBe(false);
+      expect(readFileSync(graphPath, 'utf8')).toBe(before);
+    });
+
     it('should clear session-specific state', () => {
       createSessionState('session-A', 'ultrawork', { active: true });
       createSessionState('session-B', 'ultrawork', { active: true });
@@ -273,6 +357,35 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('Stale session cleanup', () => {
+    it('preserves Graph authority during generic clear-all and stale cleanup', () => {
+      const sessionId = 'graph-durable-session';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'paused' });
+      createSessionState(sessionId, 'skill-active', {
+        version: 2,
+        active_skills: { graph: { skill_name: 'graph', completed_at: null } },
+      });
+      const stateDir = join(tempDir, '.omc', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      const rootSlot = join(stateDir, 'skill-active-state.json');
+      writeFileSync(rootSlot, JSON.stringify({
+        version: 2,
+        active_skills: { graph: { skill_name: 'graph', completed_at: null } },
+      }));
+      const controlOwner = join(sessionDir, 'control-owner-state.json');
+      writeFileSync(controlOwner, JSON.stringify({ root: { mode: 'graph', run_id: 'run-1' } }));
+      const protectedPaths = [
+        join(sessionDir, 'graph-state.json'),
+        join(sessionDir, 'skill-active-state.json'),
+        rootSlot,
+        controlOwner,
+      ];
+      const before = protectedPaths.map(path => readFileSync(path, 'utf8'));
+
+      expect(clearAllModeStates(tempDir)).toBe(true);
+      expect(clearStaleSessionDirs(tempDir, -1)).not.toContain(sessionId);
+      protectedPaths.forEach((path, index) => expect(readFileSync(path, 'utf8')).toBe(before[index]));
+    });
+
     it('serializes marker writers on the same lock used by cleanup', () => {
       expect(createModeMarker('ralph', tempDir, { session_id: 'session-A', workflowRunId: 'old-run' })).toBe(true);
       const markerPath = join(tempDir, '.omc', 'state', 'ralph-verification.json');

--- a/src/hooks/mode-registry/__tests__/session-isolation.test.ts
+++ b/src/hooks/mode-registry/__tests__/session-isolation.test.ts
@@ -19,6 +19,7 @@ import {
   isModeActive,
   getActiveModes,
   clearModeState,
+  clearModeStateDetailed,
   createModeMarker,
   hasModeState,
   isModeActiveInAnySession,
@@ -340,7 +341,8 @@ describe("Session-Scoped State Isolation", () => {
       );
       const before = readFileSync(graphPath, "utf8");
 
-      expect(clearModeState("graph", tempDir, sessionId)).toBe("failed");
+      expect(clearModeStateDetailed("graph", tempDir, sessionId)).toBe("failed");
+      expect(clearModeState("graph", tempDir, sessionId)).toBe(false);
       expect(readFileSync(graphPath, "utf8")).toBe(before);
     });
 
@@ -457,7 +459,7 @@ describe("Session-Scoped State Isolation", () => {
         JSON.stringify(replacement),
       ).toString("base64");
 
-      expect(clearModeState("ralph", tempDir, sessionA)).toBe("skipped");
+      expect(clearModeStateDetailed("ralph", tempDir, sessionA)).toBe("skipped");
       expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual(replacement);
     });
   });
@@ -594,7 +596,7 @@ describe("Session-Scoped State Isolation", () => {
         );
       });
 
-      expect(clearModeState("ralph", tempDir, sessionId)).toBe("cleared");
+      expect(clearModeState("ralph", tempDir, sessionId)).toBe(true);
       await completed;
       expect(existsSync(markerPath)).toBe(false);
     });

--- a/src/hooks/mode-registry/__tests__/session-isolation.test.ts
+++ b/src/hooks/mode-registry/__tests__/session-isolation.test.ts
@@ -1,9 +1,17 @@
-import { randomUUID } from 'crypto';
-import { spawn } from 'child_process';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { randomUUID } from "crypto";
+import { spawn } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  unlinkSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 // Import functions to test
 import {
@@ -17,19 +25,19 @@ import {
   getActiveSessionsForMode,
   clearAllModeStates,
   clearStaleSessionDirs,
-} from '../index.js';
+} from "../index.js";
 
 import {
   validateSessionId,
   resolveSessionStatePath,
   listSessionIds,
-} from '../../../lib/worktree-paths.js';
+} from "../../../lib/worktree-paths.js";
 
-describe('Session-Scoped State Isolation', () => {
+describe("Session-Scoped State Isolation", () => {
   let tempDir: string;
 
   beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'session-isolation-test-'));
+    tempDir = mkdtempSync(join(tmpdir(), "session-isolation-test-"));
   });
 
   afterEach(() => {
@@ -56,372 +64,513 @@ describe('Session-Scoped State Isolation', () => {
   }
 
   // Helper to create state file at session-scoped path
-  function createSessionState(sessionId: string, mode: string, data: Record<string, unknown>) {
-    const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  function createSessionState(
+    sessionId: string,
+    mode: string,
+    data: Record<string, unknown>,
+  ) {
+    const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
     mkdirSync(sessionDir, { recursive: true });
-    writeFileSync(join(sessionDir, `${mode}-state.json`), JSON.stringify(data, null, 2));
+    writeFileSync(
+      join(sessionDir, `${mode}-state.json`),
+      JSON.stringify(data, null, 2),
+    );
   }
 
   // Helper to create legacy state file
   function createLegacyState(mode: string, data: Record<string, unknown>) {
-    const stateDir = join(tempDir, '.omc', 'state');
+    const stateDir = join(tempDir, ".omc", "state");
     mkdirSync(stateDir, { recursive: true });
-    writeFileSync(join(stateDir, `${mode}-state.json`), JSON.stringify(data, null, 2));
+    writeFileSync(
+      join(stateDir, `${mode}-state.json`),
+      JSON.stringify(data, null, 2),
+    );
   }
 
-  describe('validateSessionId', () => {
-    it('should accept valid session IDs', () => {
-      expect(() => validateSessionId('abc123')).not.toThrow();
-      expect(() => validateSessionId('session-with-hyphens')).not.toThrow();
-      expect(() => validateSessionId('session_with_underscores')).not.toThrow();
-      expect(() => validateSessionId('A1b2C3')).not.toThrow();
+  describe("validateSessionId", () => {
+    it("should accept valid session IDs", () => {
+      expect(() => validateSessionId("abc123")).not.toThrow();
+      expect(() => validateSessionId("session-with-hyphens")).not.toThrow();
+      expect(() => validateSessionId("session_with_underscores")).not.toThrow();
+      expect(() => validateSessionId("A1b2C3")).not.toThrow();
     });
 
-    it('should reject empty session ID', () => {
-      expect(() => validateSessionId('')).toThrow('cannot be empty');
+    it("should reject empty session ID", () => {
+      expect(() => validateSessionId("")).toThrow("cannot be empty");
     });
 
-    it('should reject path traversal', () => {
-      expect(() => validateSessionId('../etc/passwd')).toThrow('path traversal');
-      expect(() => validateSessionId('session/../../root')).toThrow('path traversal');
+    it("should reject path traversal", () => {
+      expect(() => validateSessionId("../etc/passwd")).toThrow(
+        "path traversal",
+      );
+      expect(() => validateSessionId("session/../../root")).toThrow(
+        "path traversal",
+      );
     });
 
-    it('should reject invalid characters', () => {
-      expect(() => validateSessionId('session with spaces')).toThrow();
-      expect(() => validateSessionId('session@special')).toThrow();
+    it("should reject invalid characters", () => {
+      expect(() => validateSessionId("session with spaces")).toThrow();
+      expect(() => validateSessionId("session@special")).toThrow();
     });
   });
 
-  describe('resolveSessionStatePath', () => {
-    it('should return session-scoped path', () => {
-      const path = resolveSessionStatePath('ultrawork', 'session-123', tempDir);
-      expect(path).toContain('.omc/state/sessions/session-123/ultrawork-state.json');
+  describe("resolveSessionStatePath", () => {
+    it("should return session-scoped path", () => {
+      const path = resolveSessionStatePath("ultrawork", "session-123", tempDir);
+      expect(path).toContain(
+        ".omc/state/sessions/session-123/ultrawork-state.json",
+      );
     });
 
-    it('should normalize state name', () => {
-      const path1 = resolveSessionStatePath('ultrawork', 'sid', tempDir);
-      const path2 = resolveSessionStatePath('ultrawork-state', 'sid', tempDir);
+    it("should normalize state name", () => {
+      const path1 = resolveSessionStatePath("ultrawork", "sid", tempDir);
+      const path2 = resolveSessionStatePath("ultrawork-state", "sid", tempDir);
       expect(path1).toBe(path2);
     });
 
-    it('should resolve swarm as regular JSON path after #1131 removal', () => {
+    it("should resolve swarm as regular JSON path after #1131 removal", () => {
       // swarm SQLite special-casing removed in #1131
-      const result = resolveSessionStatePath('swarm', 'sid', tempDir);
-      expect(result).toContain('swarm-state.json');
+      const result = resolveSessionStatePath("swarm", "sid", tempDir);
+      expect(result).toContain("swarm-state.json");
     });
   });
 
-  describe('listSessionIds', () => {
-    it('should return empty array when no sessions exist', () => {
+  describe("listSessionIds", () => {
+    it("should return empty array when no sessions exist", () => {
       expect(listSessionIds(tempDir)).toEqual([]);
     });
 
-    it('should list session directories', () => {
-      createSessionState('session-A', 'ultrawork', { active: true });
-      createSessionState('session-B', 'ralph', { active: true });
+    it("should list session directories", () => {
+      createSessionState("session-A", "ultrawork", { active: true });
+      createSessionState("session-B", "ralph", { active: true });
       const ids = listSessionIds(tempDir);
-      expect(ids).toContain('session-A');
-      expect(ids).toContain('session-B');
+      expect(ids).toContain("session-A");
+      expect(ids).toContain("session-B");
       expect(ids.length).toBe(2);
     });
   });
 
-  describe('Session-scoped path resolution', () => {
-    it('should return session-scoped path when sessionId provided for autoresearch', () => {
-      const path = getStateFilePath(tempDir, 'autoresearch', 'session-123');
-      expect(path).toContain('sessions/session-123');
-      expect(path).toContain('autoresearch-state.json');
+  describe("Session-scoped path resolution", () => {
+    it("should return session-scoped path when sessionId provided for autoresearch", () => {
+      const path = getStateFilePath(tempDir, "autoresearch", "session-123");
+      expect(path).toContain("sessions/session-123");
+      expect(path).toContain("autoresearch-state.json");
     });
 
-    it('should return session-scoped path when sessionId provided', () => {
-      const path = getStateFilePath(tempDir, 'ultrawork', 'session-123');
-      expect(path).toContain('sessions/session-123');
+    it("should return session-scoped path when sessionId provided", () => {
+      const path = getStateFilePath(tempDir, "ultrawork", "session-123");
+      expect(path).toContain("sessions/session-123");
     });
 
-    it('should return legacy path when no sessionId', () => {
-      const path = getStateFilePath(tempDir, 'ultrawork');
-      expect(path).not.toContain('sessions');
-      expect(path).toContain('ultrawork-state.json');
+    it("should return legacy path when no sessionId", () => {
+      const path = getStateFilePath(tempDir, "ultrawork");
+      expect(path).not.toContain("sessions");
+      expect(path).toContain("ultrawork-state.json");
     });
   });
 
-  describe('Two sessions writing independent state', () => {
-    it('should isolate state between sessions', () => {
-      createSessionState('session-A', 'ultrawork', { active: true, prompt: 'Task A' });
-      createSessionState('session-B', 'ultrawork', { active: true, prompt: 'Task B' });
+  describe("Two sessions writing independent state", () => {
+    it("should isolate state between sessions", () => {
+      createSessionState("session-A", "ultrawork", {
+        active: true,
+        prompt: "Task A",
+      });
+      createSessionState("session-B", "ultrawork", {
+        active: true,
+        prompt: "Task B",
+      });
 
       // Each session's state should be independent
-      const pathA = join(tempDir, '.omc', 'state', 'sessions', 'session-A', 'ultrawork-state.json');
-      const pathB = join(tempDir, '.omc', 'state', 'sessions', 'session-B', 'ultrawork-state.json');
+      const pathA = join(
+        tempDir,
+        ".omc",
+        "state",
+        "sessions",
+        "session-A",
+        "ultrawork-state.json",
+      );
+      const pathB = join(
+        tempDir,
+        ".omc",
+        "state",
+        "sessions",
+        "session-B",
+        "ultrawork-state.json",
+      );
 
-      const stateA = JSON.parse(readFileSync(pathA, 'utf-8'));
-      const stateB = JSON.parse(readFileSync(pathB, 'utf-8'));
+      const stateA = JSON.parse(readFileSync(pathA, "utf-8"));
+      const stateB = JSON.parse(readFileSync(pathB, "utf-8"));
 
-      expect(stateA.prompt).toBe('Task A');
-      expect(stateB.prompt).toBe('Task B');
+      expect(stateA.prompt).toBe("Task A");
+      expect(stateB.prompt).toBe("Task B");
     });
   });
 
-  describe('Cross-session mode discovery (isModeActiveInAnySession)', () => {
+  describe("Cross-session mode discovery (isModeActiveInAnySession)", () => {
     it.each([
-      'running',
-      'waiting_human',
-      'waiting_patch_approval',
-      'reconciling',
-    ])('derives active Graph state from durable status %s', (status) => {
-      createSessionState('session-graph', 'graph', {
-        session_id: 'session-graph',
+      "running",
+      "waiting_human",
+      "waiting_patch_approval",
+      "reconciling",
+    ])("derives active Graph state from durable status %s", (status) => {
+      createSessionState("session-graph", "graph", {
+        session_id: "session-graph",
         status,
         active: false,
       });
 
-      expect(isModeActive('graph', tempDir, 'session-graph')).toBe(true);
-      expect(getActiveModes(tempDir, 'session-graph')).toContain('graph');
+      expect(isModeActive("graph", tempDir, "session-graph")).toBe(true);
+      expect(getActiveModes(tempDir, "session-graph")).toContain("graph");
     });
 
-    it.each(['draft', 'awaiting_approval', 'paused', 'succeeded', 'failed', 'cancelled'])(
-      'treats Graph status %s as inactive',
-      (status) => {
-        createSessionState('session-graph', 'graph', {
-          session_id: 'session-graph',
-          status,
-          active: true,
-        });
+    it.each([
+      "draft",
+      "awaiting_approval",
+      "paused",
+      "succeeded",
+      "failed",
+      "cancelled",
+    ])("treats Graph status %s as inactive", (status) => {
+      createSessionState("session-graph", "graph", {
+        session_id: "session-graph",
+        status,
+        active: true,
+      });
 
-        expect(isModeActive('graph', tempDir, 'session-graph')).toBe(false);
-        expect(getActiveModes(tempDir, 'session-graph')).not.toContain('graph');
-      },
-    );
+      expect(isModeActive("graph", tempDir, "session-graph")).toBe(false);
+      expect(getActiveModes(tempDir, "session-graph")).not.toContain("graph");
+    });
 
-    it('treats malformed, missing, and session-mismatched Graph state as inactive', () => {
-      const sessionId = 'session-graph';
-      const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+    it("treats malformed, missing, and session-mismatched Graph state as inactive", () => {
+      const sessionId = "session-graph";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
-      const graphPath = join(sessionDir, 'graph-state.json');
+      const graphPath = join(sessionDir, "graph-state.json");
 
-      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
-      writeFileSync(graphPath, '{not-json');
-      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
-      writeFileSync(graphPath, JSON.stringify({ session_id: sessionId, status: 'unknown' }));
-      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
-      writeFileSync(graphPath, JSON.stringify({ session_id: 'another-session', status: 'running' }));
-      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
+      expect(isModeActive("graph", tempDir, sessionId)).toBe(false);
+      writeFileSync(graphPath, "{not-json");
+      expect(isModeActive("graph", tempDir, sessionId)).toBe(false);
+      writeFileSync(
+        graphPath,
+        JSON.stringify({ session_id: sessionId, status: "unknown" }),
+      );
+      expect(isModeActive("graph", tempDir, sessionId)).toBe(false);
+      writeFileSync(
+        graphPath,
+        JSON.stringify({ session_id: "another-session", status: "running" }),
+      );
+      expect(isModeActive("graph", tempDir, sessionId)).toBe(false);
     });
 
-    it('respects a generic workflow tombstone over durable Graph status', () => {
-      const sessionId = 'session-graph';
-      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
-      createSessionState(sessionId, 'skill-active', {
+    it("respects a generic workflow tombstone over durable Graph status", () => {
+      const sessionId = "session-graph";
+      createSessionState(sessionId, "graph", {
+        session_id: sessionId,
+        status: "running",
+      });
+      createSessionState(sessionId, "skill-active", {
         version: 2,
         active_skills: {
           graph: {
-            skill_name: 'graph',
+            skill_name: "graph",
             completed_at: new Date().toISOString(),
           },
         },
       });
 
-      expect(isModeActive('graph', tempDir, sessionId)).toBe(false);
-      expect(getActiveModes(tempDir, sessionId)).not.toContain('graph');
+      expect(isModeActive("graph", tempDir, sessionId)).toBe(false);
+      expect(getActiveModes(tempDir, sessionId)).not.toContain("graph");
     });
 
-    it('should find autoresearch active in any session', () => {
-      createSessionState('session-A', 'autoresearch', { active: true });
-      expect(isModeActiveInAnySession('autoresearch', tempDir)).toBe(true);
+    it("should find autoresearch active in any session", () => {
+      createSessionState("session-A", "autoresearch", { active: true });
+      expect(isModeActiveInAnySession("autoresearch", tempDir)).toBe(true);
     });
 
-    it('should find mode active in any session', () => {
-      createSessionState('session-A', 'ultrawork', { active: true });
-      expect(isModeActiveInAnySession('ultrawork', tempDir)).toBe(true);
+    it("should find mode active in any session", () => {
+      createSessionState("session-A", "ultrawork", { active: true });
+      expect(isModeActiveInAnySession("ultrawork", tempDir)).toBe(true);
     });
 
-    it('should return false when mode not active in any session', () => {
-      expect(isModeActiveInAnySession('ultrawork', tempDir)).toBe(false);
+    it("should return false when mode not active in any session", () => {
+      expect(isModeActiveInAnySession("ultrawork", tempDir)).toBe(false);
     });
 
-    it('should find mode even if only in legacy path', () => {
-      createLegacyState('ultrawork', { active: true });
-      expect(isModeActiveInAnySession('ultrawork', tempDir)).toBe(true);
-    });
-  });
-
-  describe('getActiveSessionsForMode', () => {
-    it('should return sessions running autoresearch', () => {
-      createSessionState('session-A', 'autoresearch', { active: true });
-      createSessionState('session-B', 'autoresearch', { active: true });
-      const sessions = getActiveSessionsForMode('autoresearch', tempDir);
-      expect(sessions).toContain('session-A');
-      expect(sessions).toContain('session-B');
-    });
-
-    it('should return sessions running a specific mode', () => {
-      createSessionState('session-A', 'ultrawork', { active: true });
-      createSessionState('session-B', 'ultrawork', { active: true });
-      createSessionState('session-C', 'ralph', { active: true });
-
-      const sessions = getActiveSessionsForMode('ultrawork', tempDir);
-      expect(sessions).toContain('session-A');
-      expect(sessions).toContain('session-B');
-      expect(sessions).not.toContain('session-C');
+    it("should find mode even if only in legacy path", () => {
+      createLegacyState("ultrawork", { active: true });
+      expect(isModeActiveInAnySession("ultrawork", tempDir)).toBe(true);
     });
   });
 
-  describe('clearModeState with sessionId', () => {
-    it('refuses generic Graph clear and preserves the durable ledger', () => {
-      const sessionId = 'graph-clear-guard';
-      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
-      const graphPath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'graph-state.json');
-      const before = readFileSync(graphPath, 'utf8');
-
-      expect(clearModeState('graph', tempDir, sessionId)).toBe(false);
-      expect(readFileSync(graphPath, 'utf8')).toBe(before);
+  describe("getActiveSessionsForMode", () => {
+    it("should return sessions running autoresearch", () => {
+      createSessionState("session-A", "autoresearch", { active: true });
+      createSessionState("session-B", "autoresearch", { active: true });
+      const sessions = getActiveSessionsForMode("autoresearch", tempDir);
+      expect(sessions).toContain("session-A");
+      expect(sessions).toContain("session-B");
     });
 
-    it('should clear session-specific state', () => {
-      createSessionState('session-A', 'ultrawork', { active: true });
-      createSessionState('session-B', 'ultrawork', { active: true });
+    it("should return sessions running a specific mode", () => {
+      createSessionState("session-A", "ultrawork", { active: true });
+      createSessionState("session-B", "ultrawork", { active: true });
+      createSessionState("session-C", "ralph", { active: true });
 
-      clearModeState('ultrawork', tempDir, 'session-A');
+      const sessions = getActiveSessionsForMode("ultrawork", tempDir);
+      expect(sessions).toContain("session-A");
+      expect(sessions).toContain("session-B");
+      expect(sessions).not.toContain("session-C");
+    });
+  });
+
+  describe("clearModeState with sessionId", () => {
+    it("refuses generic Graph clear and preserves the durable ledger", () => {
+      const sessionId = "graph-clear-guard";
+      createSessionState(sessionId, "graph", {
+        session_id: sessionId,
+        status: "running",
+      });
+      const graphPath = join(
+        tempDir,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "graph-state.json",
+      );
+      const before = readFileSync(graphPath, "utf8");
+
+      expect(clearModeState("graph", tempDir, sessionId)).toBe("failed");
+      expect(readFileSync(graphPath, "utf8")).toBe(before);
+    });
+
+    it("should clear session-specific state", () => {
+      createSessionState("session-A", "ultrawork", { active: true });
+      createSessionState("session-B", "ultrawork", { active: true });
+
+      clearModeState("ultrawork", tempDir, "session-A");
 
       // Session A state should be gone
-      const pathA = join(tempDir, '.omc', 'state', 'sessions', 'session-A', 'ultrawork-state.json');
+      const pathA = join(
+        tempDir,
+        ".omc",
+        "state",
+        "sessions",
+        "session-A",
+        "ultrawork-state.json",
+      );
       expect(existsSync(pathA)).toBe(false);
 
       // Session B state should remain
-      const pathB = join(tempDir, '.omc', 'state', 'sessions', 'session-B', 'ultrawork-state.json');
+      const pathB = join(
+        tempDir,
+        ".omc",
+        "state",
+        "sessions",
+        "session-B",
+        "ultrawork-state.json",
+      );
       expect(existsSync(pathB)).toBe(true);
     });
 
-    it('should clear session-scoped marker artifacts (ralph verification) for the target session only', () => {
-      const sessionA = 'session-A';
-      const sessionB = 'session-B';
-      createSessionState(sessionA, 'ralph', { active: true, session_id: sessionA });
-      createSessionState(sessionB, 'ralph', { active: true, session_id: sessionB });
+    it("should clear session-scoped marker artifacts (ralph verification) for the target session only", () => {
+      const sessionA = "session-A";
+      const sessionB = "session-B";
+      createSessionState(sessionA, "ralph", {
+        active: true,
+        session_id: sessionA,
+      });
+      createSessionState(sessionB, "ralph", {
+        active: true,
+        session_id: sessionB,
+      });
 
-      const sessionADir = join(tempDir, '.omc', 'state', 'sessions', sessionA);
-      const sessionBDir = join(tempDir, '.omc', 'state', 'sessions', sessionB);
-      const markerA = join(sessionADir, 'ralph-verification-state.json');
-      const markerB = join(sessionBDir, 'ralph-verification-state.json');
-      const legacyMarker = join(tempDir, '.omc', 'state', 'ralph-verification.json');
+      const sessionADir = join(tempDir, ".omc", "state", "sessions", sessionA);
+      const sessionBDir = join(tempDir, ".omc", "state", "sessions", sessionB);
+      const markerA = join(sessionADir, "ralph-verification-state.json");
+      const markerB = join(sessionBDir, "ralph-verification-state.json");
+      const legacyMarker = join(
+        tempDir,
+        ".omc",
+        "state",
+        "ralph-verification.json",
+      );
       writeFileSync(markerA, JSON.stringify({ pending: true }, null, 2));
       writeFileSync(markerB, JSON.stringify({ pending: true }, null, 2));
-      mkdirSync(join(tempDir, '.omc', 'state'), { recursive: true });
+      mkdirSync(join(tempDir, ".omc", "state"), { recursive: true });
       writeFileSync(legacyMarker, JSON.stringify({ pending: true }, null, 2));
       expect(existsSync(legacyMarker)).toBe(true);
 
-      clearModeState('ralph', tempDir, sessionA);
+      clearModeState("ralph", tempDir, sessionA);
 
-      expect(existsSync(join(sessionADir, 'ralph-state.json'))).toBe(false);
+      expect(existsSync(join(sessionADir, "ralph-state.json"))).toBe(false);
       expect(existsSync(markerA)).toBe(false);
-      expect(existsSync(join(sessionBDir, 'ralph-state.json'))).toBe(true);
+      expect(existsSync(join(sessionBDir, "ralph-state.json"))).toBe(true);
       expect(existsSync(markerB)).toBe(true);
       expect(existsSync(legacyMarker)).toBe(false);
     });
 
-    it('should NOT delete legacy marker file owned by a different session', () => {
+    it("should NOT delete legacy marker file owned by a different session", () => {
       // Regression test for issue #927:
       // clearModeState with sessionId used to unconditionally delete the legacy
       // marker file, bypassing the ownership check.
-      const sessionA = 'session-A';
-      const sessionB = 'session-B';
+      const sessionA = "session-A";
+      const sessionB = "session-B";
 
-      createSessionState(sessionA, 'ralph', { active: true, session_id: sessionA });
+      createSessionState(sessionA, "ralph", {
+        active: true,
+        session_id: sessionA,
+      });
 
       // Legacy marker is owned by session B (a different session)
-      const legacyMarkerDir = join(tempDir, '.omc', 'state');
+      const legacyMarkerDir = join(tempDir, ".omc", "state");
       mkdirSync(legacyMarkerDir, { recursive: true });
-      const legacyMarker = join(legacyMarkerDir, 'ralph-verification.json');
-      writeFileSync(legacyMarker, JSON.stringify({ pending: true, session_id: sessionB }));
+      const legacyMarker = join(legacyMarkerDir, "ralph-verification.json");
+      writeFileSync(
+        legacyMarker,
+        JSON.stringify({ pending: true, session_id: sessionB }),
+      );
 
       // Clear session A's state — must NOT touch session B's marker
-      clearModeState('ralph', tempDir, sessionA);
+      clearModeState("ralph", tempDir, sessionA);
 
       expect(existsSync(legacyMarker)).toBe(true);
-      const remaining = JSON.parse(readFileSync(legacyMarker, 'utf-8'));
+      const remaining = JSON.parse(readFileSync(legacyMarker, "utf-8"));
       expect(remaining.session_id).toBe(sessionB);
     });
-    it('preserves a replacement marker created after ownership discovery', () => {
-      const sessionA = 'session-A';
-      const markerDir = join(tempDir, '.omc', 'state');
+    it("preserves a replacement marker created after ownership discovery", () => {
+      const sessionA = "session-A";
+      const markerDir = join(tempDir, ".omc", "state");
       mkdirSync(markerDir, { recursive: true });
-      const markerPath = join(markerDir, 'ralph-verification.json');
-      writeFileSync(markerPath, JSON.stringify({ pending: true, session_id: sessionA }));
-      const replacement = { pending: true, session_id: sessionA, workflowRunId: 'new-run' };
+      const markerPath = join(markerDir, "ralph-verification.json");
+      writeFileSync(
+        markerPath,
+        JSON.stringify({ pending: true, session_id: sessionA }),
+      );
+      const replacement = {
+        pending: true,
+        session_id: sessionA,
+        workflowRunId: "new-run",
+      };
       process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = markerPath;
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(replacement),
+      ).toString("base64");
 
-      clearModeState('ralph', tempDir, sessionA);
-      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual(replacement);
+      expect(clearModeState("ralph", tempDir, sessionA)).toBe("skipped");
+      expect(JSON.parse(readFileSync(markerPath, "utf8"))).toEqual(replacement);
     });
-
   });
 
-  describe('Stale session cleanup', () => {
-    it('preserves live Graph authority during generic clear-all and stale cleanup', () => {
-      const sessionId = 'graph-durable-session';
-      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
-      createSessionState(sessionId, 'skill-active', {
-        version: 2,
-        active_skills: { graph: { skill_name: 'graph', completed_at: null } },
+  describe("Stale session cleanup", () => {
+    it("preserves live Graph authority during generic clear-all and stale cleanup", () => {
+      const sessionId = "graph-durable-session";
+      createSessionState(sessionId, "graph", {
+        session_id: sessionId,
+        status: "running",
       });
-      const stateDir = join(tempDir, '.omc', 'state');
-      const sessionDir = join(stateDir, 'sessions', sessionId);
-      const rootSlot = join(stateDir, 'skill-active-state.json');
-      writeFileSync(rootSlot, JSON.stringify({
+      createSessionState(sessionId, "skill-active", {
         version: 2,
-        active_skills: { graph: { skill_name: 'graph', completed_at: null } },
-      }));
-      const controlOwner = join(sessionDir, 'control-owner-state.json');
-      writeFileSync(controlOwner, JSON.stringify({ root: { mode: 'graph', run_id: 'run-1' } }));
+        active_skills: { graph: { skill_name: "graph", completed_at: null } },
+      });
+      const stateDir = join(tempDir, ".omc", "state");
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      const rootSlot = join(stateDir, "skill-active-state.json");
+      writeFileSync(
+        rootSlot,
+        JSON.stringify({
+          version: 2,
+          active_skills: { graph: { skill_name: "graph", completed_at: null } },
+        }),
+      );
+      const controlOwner = join(sessionDir, "control-owner-state.json");
+      writeFileSync(
+        controlOwner,
+        JSON.stringify({ root: { mode: "graph", run_id: "run-1" } }),
+      );
       const protectedPaths = [
-        join(sessionDir, 'graph-state.json'),
-        join(sessionDir, 'skill-active-state.json'),
+        join(sessionDir, "graph-state.json"),
+        join(sessionDir, "skill-active-state.json"),
         rootSlot,
         controlOwner,
       ];
-      const before = protectedPaths.map(path => readFileSync(path, 'utf8'));
+      const before = protectedPaths.map((path) => readFileSync(path, "utf8"));
 
       expect(clearAllModeStates(tempDir)).toBe(true);
       expect(clearStaleSessionDirs(tempDir, -1)).not.toContain(sessionId);
-      protectedPaths.forEach((path, index) => expect(readFileSync(path, 'utf8')).toBe(before[index]));
+      protectedPaths.forEach((path, index) =>
+        expect(readFileSync(path, "utf8")).toBe(before[index]),
+      );
     });
 
-    it('reclaims a paused Graph session after its durable skill tombstone', () => {
-      const sessionId = 'graph-paused-session';
-      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'paused' });
-      createSessionState(sessionId, 'skill-active', {
+    it("reclaims a paused Graph session after its durable skill tombstone", () => {
+      const sessionId = "graph-paused-session";
+      createSessionState(sessionId, "graph", {
+        session_id: sessionId,
+        status: "paused",
+      });
+      createSessionState(sessionId, "skill-active", {
         version: 2,
         active_skills: {
           graph: {
-            skill_name: 'graph',
+            skill_name: "graph",
             completed_at: new Date().toISOString(),
           },
         },
       });
 
-      const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
       expect(clearStaleSessionDirs(tempDir, -1)).toContain(sessionId);
       expect(existsSync(sessionDir)).toBe(false);
     });
 
-    it('serializes marker writers on the same lock used by cleanup', () => {
-      expect(createModeMarker('ralph', tempDir, { session_id: 'session-A', workflowRunId: 'old-run' })).toBe(true);
-      const markerPath = join(tempDir, '.omc', 'state', 'ralph-verification.json');
+    it("serializes marker writers on the same lock used by cleanup", () => {
+      expect(
+        createModeMarker("ralph", tempDir, {
+          session_id: "session-A",
+          workflowRunId: "old-run",
+        }),
+      ).toBe(true);
+      const markerPath = join(
+        tempDir,
+        ".omc",
+        "state",
+        "ralph-verification.json",
+      );
       const lockPath = `${markerPath}.mutation.lock`;
       writeFileSync(lockPath, liveLockOwner());
 
-      expect(createModeMarker('ralph', tempDir, { session_id: 'session-A', workflowRunId: 'new-run' })).toBe(false);
-      expect(JSON.parse(readFileSync(markerPath, 'utf8')).workflowRunId).toBe('old-run');
+      expect(
+        createModeMarker("ralph", tempDir, {
+          session_id: "session-A",
+          workflowRunId: "new-run",
+        }),
+      ).toBe(false);
+      expect(JSON.parse(readFileSync(markerPath, "utf8")).workflowRunId).toBe(
+        "old-run",
+      );
 
       unlinkSync(lockPath);
-      expect(createModeMarker('ralph', tempDir, { session_id: 'session-A', workflowRunId: 'new-run' })).toBe(true);
-      expect(JSON.parse(readFileSync(markerPath, 'utf8')).workflowRunId).toBe('new-run');
+      expect(
+        createModeMarker("ralph", tempDir, {
+          session_id: "session-A",
+          workflowRunId: "new-run",
+        }),
+      ).toBe(true);
+      expect(JSON.parse(readFileSync(markerPath, "utf8")).workflowRunId).toBe(
+        "new-run",
+      );
     });
 
-    it('waits for an in-flight marker publisher before treating it as absent', async () => {
-      const sessionId = 'marker-in-flight';
-      const markerPath = join(tempDir, '.omc', 'state', 'ralph-verification.json');
-      mkdirSync(join(tempDir, '.omc', 'state'), { recursive: true });
+    it("waits for an in-flight marker publisher before treating it as absent", async () => {
+      const sessionId = "marker-in-flight";
+      const markerPath = join(
+        tempDir,
+        ".omc",
+        "state",
+        "ralph-verification.json",
+      );
+      mkdirSync(join(tempDir, ".omc", "state"), { recursive: true });
       const lockPath = `${markerPath}.mutation.lock`;
       writeFileSync(lockPath, liveLockOwner());
       const childScript = String.raw`
@@ -431,146 +580,195 @@ describe('Session-Scoped State Isolation', () => {
         fs.writeFileSync(markerPath, JSON.stringify({ pending: true, session_id: 'marker-in-flight' }));
         fs.unlinkSync(lockPath);
       `;
-      const child = spawn(process.execPath, ['-e', childScript, markerPath, lockPath], { stdio: 'ignore' });
+      const child = spawn(
+        process.execPath,
+        ["-e", childScript, markerPath, lockPath],
+        { stdio: "ignore" },
+      );
       const completed = new Promise<void>((resolve, reject) => {
-        child.once('error', reject);
-        child.once('close', code => code === 0 ? resolve() : reject(new Error(`marker publisher exited ${code}`)));
+        child.once("error", reject);
+        child.once("close", (code) =>
+          code === 0
+            ? resolve()
+            : reject(new Error(`marker publisher exited ${code}`)),
+        );
       });
 
-      expect(clearModeState('ralph', tempDir, sessionId)).toBe(true);
+      expect(clearModeState("ralph", tempDir, sessionId)).toBe("cleared");
       await completed;
       expect(existsSync(markerPath)).toBe(false);
     });
 
-    it('should remove empty session directories', () => {
-      const emptyDir = join(tempDir, '.omc', 'state', 'sessions', 'empty-session');
+    it("should remove empty session directories", () => {
+      const emptyDir = join(
+        tempDir,
+        ".omc",
+        "state",
+        "sessions",
+        "empty-session",
+      );
       mkdirSync(emptyDir, { recursive: true });
 
       const removed = clearStaleSessionDirs(tempDir, 0);
-      expect(removed).toContain('empty-session');
+      expect(removed).toContain("empty-session");
       expect(existsSync(emptyDir)).toBe(false);
     });
   });
 
-  describe('Backward compat with legacy state files', () => {
-    it('should detect mode in legacy path', () => {
-      createLegacyState('ultrawork', { active: true });
-      expect(isModeActive('ultrawork', tempDir)).toBe(true);
+  describe("Backward compat with legacy state files", () => {
+    it("should detect mode in legacy path", () => {
+      createLegacyState("ultrawork", { active: true });
+      expect(isModeActive("ultrawork", tempDir)).toBe(true);
     });
 
-    it('should prefer session-scoped state when sessionId provided', () => {
-      createLegacyState('ultrawork', { active: true, prompt: 'legacy' });
-      createSessionState('session-A', 'ultrawork', { active: false, prompt: 'session' });
+    it("should prefer session-scoped state when sessionId provided", () => {
+      createLegacyState("ultrawork", { active: true, prompt: "legacy" });
+      createSessionState("session-A", "ultrawork", {
+        active: false,
+        prompt: "session",
+      });
 
       // With sessionId, should see session state (active: false)
-      expect(isModeActive('ultrawork', tempDir, 'session-A')).toBe(false);
+      expect(isModeActive("ultrawork", tempDir, "session-A")).toBe(false);
 
       // Without sessionId, should see legacy state (active: true)
-      expect(isModeActive('ultrawork', tempDir)).toBe(true);
+      expect(isModeActive("ultrawork", tempDir)).toBe(true);
     });
   });
 
-  describe('Session isolation: no legacy fallback with sessionId (Issue #311)', () => {
-    it('isJsonModeActive with sessionId should ignore legacy file entirely', () => {
+  describe("Session isolation: no legacy fallback with sessionId (Issue #311)", () => {
+    it("isJsonModeActive with sessionId should ignore legacy file entirely", () => {
       // Only legacy file exists, no session-scoped file
-      createLegacyState('ultrawork', { active: true, session_id: 'session-A' });
+      createLegacyState("ultrawork", { active: true, session_id: "session-A" });
 
       // Session B should NOT see session A's legacy state
-      expect(isModeActive('ultrawork', tempDir, 'session-B')).toBe(false);
+      expect(isModeActive("ultrawork", tempDir, "session-B")).toBe(false);
 
       // Session A should also NOT see its own legacy state (must use session-scoped file)
-      expect(isModeActive('ultrawork', tempDir, 'session-A')).toBe(false);
+      expect(isModeActive("ultrawork", tempDir, "session-A")).toBe(false);
 
       // Without sessionId, legacy state is still visible (backward compat)
-      expect(isModeActive('ultrawork', tempDir)).toBe(true);
+      expect(isModeActive("ultrawork", tempDir)).toBe(true);
     });
 
-    it('should reject state with mismatched session_id even in session-scoped file', () => {
+    it("should reject state with mismatched session_id even in session-scoped file", () => {
       // Create session-scoped file with wrong session_id (shouldn't happen, but defensive)
-      createSessionState('session-A', 'ultrawork', { active: true, session_id: 'session-OTHER' });
+      createSessionState("session-A", "ultrawork", {
+        active: true,
+        session_id: "session-OTHER",
+      });
 
-      expect(isModeActive('ultrawork', tempDir, 'session-A')).toBe(false);
+      expect(isModeActive("ultrawork", tempDir, "session-A")).toBe(false);
     });
 
-    it('hasModeState with sessionId should check session path only', () => {
-      createLegacyState('ultrawork', { active: true });
+    it("hasModeState with sessionId should check session path only", () => {
+      createLegacyState("ultrawork", { active: true });
 
       // Without sessionId, legacy file is found
-      expect(hasModeState(tempDir, 'ultrawork')).toBe(true);
+      expect(hasModeState(tempDir, "ultrawork")).toBe(true);
 
       // With sessionId, only session-scoped path is checked (doesn't exist)
-      expect(hasModeState(tempDir, 'ultrawork', 'session-X')).toBe(false);
+      expect(hasModeState(tempDir, "ultrawork", "session-X")).toBe(false);
 
       // Create session-scoped file, now it should be found
-      createSessionState('session-X', 'ultrawork', { active: true });
-      expect(hasModeState(tempDir, 'ultrawork', 'session-X')).toBe(true);
+      createSessionState("session-X", "ultrawork", { active: true });
+      expect(hasModeState(tempDir, "ultrawork", "session-X")).toBe(true);
     });
 
-    it('cross-session: Session A active, Session B check returns false', () => {
-      createSessionState('session-A', 'ralph', { active: true, session_id: 'session-A' });
+    it("cross-session: Session A active, Session B check returns false", () => {
+      createSessionState("session-A", "ralph", {
+        active: true,
+        session_id: "session-A",
+      });
 
       // Session A sees its own state
-      expect(isModeActive('ralph', tempDir, 'session-A')).toBe(true);
+      expect(isModeActive("ralph", tempDir, "session-A")).toBe(true);
 
       // Session B does NOT see Session A's state
-      expect(isModeActive('ralph', tempDir, 'session-B')).toBe(false);
+      expect(isModeActive("ralph", tempDir, "session-B")).toBe(false);
     });
   });
 
-  describe('Team mode state isolation', () => {
-    it('should detect team mode active in session-scoped path', () => {
-      createSessionState('session-team', 'team', { active: true, session_id: 'session-team' });
+  describe("Team mode state isolation", () => {
+    it("should detect team mode active in session-scoped path", () => {
+      createSessionState("session-team", "team", {
+        active: true,
+        session_id: "session-team",
+      });
 
-      expect(isModeActive('team', tempDir, 'session-team')).toBe(true);
+      expect(isModeActive("team", tempDir, "session-team")).toBe(true);
     });
 
-    it('should return correct state file path for team mode', () => {
-      const path = getStateFilePath(tempDir, 'team', 'session-team-123');
-      expect(path).toContain('sessions/session-team-123');
-      expect(path).toContain('team-state.json');
+    it("should return correct state file path for team mode", () => {
+      const path = getStateFilePath(tempDir, "team", "session-team-123");
+      expect(path).toContain("sessions/session-team-123");
+      expect(path).toContain("team-state.json");
     });
 
-    it('should isolate team state between sessions', () => {
-      createSessionState('session-A', 'team', { active: true, session_id: 'session-A', stage: 'team-exec' });
-      createSessionState('session-B', 'team', { active: true, session_id: 'session-B', stage: 'team-plan' });
+    it("should isolate team state between sessions", () => {
+      createSessionState("session-A", "team", {
+        active: true,
+        session_id: "session-A",
+        stage: "team-exec",
+      });
+      createSessionState("session-B", "team", {
+        active: true,
+        session_id: "session-B",
+        stage: "team-plan",
+      });
 
       // Each session sees its own state
-      expect(isModeActive('team', tempDir, 'session-A')).toBe(true);
-      expect(isModeActive('team', tempDir, 'session-B')).toBe(true);
+      expect(isModeActive("team", tempDir, "session-A")).toBe(true);
+      expect(isModeActive("team", tempDir, "session-B")).toBe(true);
 
       // Verify paths are different
-      const pathA = getStateFilePath(tempDir, 'team', 'session-A');
-      const pathB = getStateFilePath(tempDir, 'team', 'session-B');
+      const pathA = getStateFilePath(tempDir, "team", "session-A");
+      const pathB = getStateFilePath(tempDir, "team", "session-B");
       expect(pathA).not.toBe(pathB);
     });
 
-    it('should clear team mode state for specific session only', () => {
-      createSessionState('session-A', 'team', { active: true, session_id: 'session-A' });
-      createSessionState('session-B', 'team', { active: true, session_id: 'session-B' });
+    it("should clear team mode state for specific session only", () => {
+      createSessionState("session-A", "team", {
+        active: true,
+        session_id: "session-A",
+      });
+      createSessionState("session-B", "team", {
+        active: true,
+        session_id: "session-B",
+      });
 
-      clearModeState('team', tempDir, 'session-A');
+      clearModeState("team", tempDir, "session-A");
 
       // Session A state should be gone
-      expect(isModeActive('team', tempDir, 'session-A')).toBe(false);
+      expect(isModeActive("team", tempDir, "session-A")).toBe(false);
 
       // Session B state should remain
-      expect(isModeActive('team', tempDir, 'session-B')).toBe(true);
+      expect(isModeActive("team", tempDir, "session-B")).toBe(true);
     });
 
-    it('should list team in active modes when active', () => {
-      createSessionState('session-team', 'team', { active: true, session_id: 'session-team' });
+    it("should list team in active modes when active", () => {
+      createSessionState("session-team", "team", {
+        active: true,
+        session_id: "session-team",
+      });
 
-      const activeModes = getActiveModes(tempDir, 'session-team');
-      expect(activeModes).toContain('team');
+      const activeModes = getActiveModes(tempDir, "session-team");
+      expect(activeModes).toContain("team");
     });
 
-    it('should return active sessions for team mode', () => {
-      createSessionState('session-A', 'team', { active: true, session_id: 'session-A' });
-      createSessionState('session-B', 'team', { active: true, session_id: 'session-B' });
+    it("should return active sessions for team mode", () => {
+      createSessionState("session-A", "team", {
+        active: true,
+        session_id: "session-A",
+      });
+      createSessionState("session-B", "team", {
+        active: true,
+        session_id: "session-B",
+      });
 
-      const activeSessions = getActiveSessionsForMode('team', tempDir);
-      expect(activeSessions).toContain('session-A');
-      expect(activeSessions).toContain('session-B');
+      const activeSessions = getActiveSessionsForMode("team", tempDir);
+      expect(activeSessions).toContain("session-A");
+      expect(activeSessions).toContain("session-B");
     });
   });
 });

--- a/src/hooks/mode-registry/__tests__/session-isolation.test.ts
+++ b/src/hooks/mode-registry/__tests__/session-isolation.test.ts
@@ -357,9 +357,9 @@ describe('Session-Scoped State Isolation', () => {
   });
 
   describe('Stale session cleanup', () => {
-    it('preserves Graph authority during generic clear-all and stale cleanup', () => {
+    it('preserves live Graph authority during generic clear-all and stale cleanup', () => {
       const sessionId = 'graph-durable-session';
-      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'paused' });
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'running' });
       createSessionState(sessionId, 'skill-active', {
         version: 2,
         active_skills: { graph: { skill_name: 'graph', completed_at: null } },
@@ -384,6 +384,24 @@ describe('Session-Scoped State Isolation', () => {
       expect(clearAllModeStates(tempDir)).toBe(true);
       expect(clearStaleSessionDirs(tempDir, -1)).not.toContain(sessionId);
       protectedPaths.forEach((path, index) => expect(readFileSync(path, 'utf8')).toBe(before[index]));
+    });
+
+    it('reclaims a paused Graph session after its durable skill tombstone', () => {
+      const sessionId = 'graph-paused-session';
+      createSessionState(sessionId, 'graph', { session_id: sessionId, status: 'paused' });
+      createSessionState(sessionId, 'skill-active', {
+        version: 2,
+        active_skills: {
+          graph: {
+            skill_name: 'graph',
+            completed_at: new Date().toISOString(),
+          },
+        },
+      });
+
+      const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+      expect(clearStaleSessionDirs(tempDir, -1)).toContain(sessionId);
+      expect(existsSync(sessionDir)).toBe(false);
     });
 
     it('serializes marker writers on the same lock used by cleanup', () => {

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -448,14 +448,35 @@ function readJsonSnapshot(filePath: string): { state: Record<string, unknown>; s
 }
 
 function hasGraphAuthorityInSessionDir(sessionDir: string): boolean {
-  if (existsSync(join(sessionDir, MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH]))) return true;
+  const graphStatePath = join(sessionDir, MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH]);
+  if (existsSync(graphStatePath)) {
+    const graphState = readJsonSnapshot(graphStatePath)?.state;
+    // An unreadable graph ledger is never safe to discard. Paused and terminal
+    // ledgers, however, have no remaining recovery work and are intentionally
+    // eligible for stale-session cleanup once their skill slot is tombstoned.
+    if (!graphState) return true;
+    const status = graphState.status;
+    if (
+      typeof status !== 'string'
+      || !['paused', 'failed', 'cancelled', 'succeeded'].includes(status)
+    ) {
+      return true;
+    }
+  }
   const skillState = readJsonSnapshot(join(sessionDir, "skill-active-state.json"))?.state;
   if (
     skillState?.active_skills
     && typeof skillState.active_skills === "object"
-    && (skillState.active_skills as Record<string, unknown>).graph
   ) {
-    return true;
+    const graphSlot = (skillState.active_skills as Record<string, unknown>).graph;
+    // A malformed graph slot must remain conservative. A durable tombstone is
+    // the explicit signal that terminal Graph artifacts may be reclaimed.
+    if (!graphSlot || typeof graphSlot !== 'object') return true;
+    if (!('completed_at' in graphSlot)) return true;
+    const completedAt = (graphSlot as Record<string, unknown>).completed_at;
+    if (typeof completedAt !== 'string' || !Number.isFinite(new Date(completedAt).getTime())) {
+      return true;
+    }
   }
   const controlOwner = readJsonSnapshot(join(sessionDir, "control-owner-state.json"))?.state;
   const controlRoot = controlOwner?.root;
@@ -467,12 +488,34 @@ function hasGraphAuthorityInSessionDir(sessionDir: string): boolean {
   );
 }
 
+// Marker publication is synchronous but a cleanup can observe the file before
+// its writer has published it. Wait only for that short, lock-signalled window:
+// a missing marker with no mutation lock is already settled, and unrelated I/O
+// failures remain failures rather than being retried as if they were writers.
+const IN_FLIGHT_MARKER_PUBLISH_WAIT_MS = 250;
+const IN_FLIGHT_MARKER_PUBLISH_POLL_MS = 10;
+
+function waitForInFlightMarkerPublisher(filePath: string): boolean {
+  const deadline = Date.now() + IN_FLIGHT_MARKER_PUBLISH_WAIT_MS;
+  while (existsSync(`${filePath}.mutation.lock`) && Date.now() < deadline) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, IN_FLIGHT_MARKER_PUBLISH_POLL_MS);
+  }
+  return !existsSync(`${filePath}.mutation.lock`);
+}
+
 function clearDiscoveredJsonFile(
   filePath: string,
   observed: { state: Record<string, unknown>; snapshot: string } | null,
   predicate: (state: Record<string, unknown>) => boolean = () => true,
 ): boolean {
   if (!observed) {
+    // An absent marker may still be in-flight under the same mutation lock
+    // used by its publisher. Observe that lock *before* running a conditional
+    // clear: recovery/observation must not race ahead of the publisher and
+    // make an absent pre-publication snapshot authoritative.
+    if (!existsSync(filePath) && existsSync(`${filePath}.mutation.lock`) && !waitForInFlightMarkerPublisher(filePath)) {
+      return false;
+    }
     const result = clearStateFileLockedIf(filePath, predicate);
     return result !== 'failed' && !(result === 'skipped' && existsSync(filePath));
   }

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -599,7 +599,7 @@ function mergeClearResults(
  *
  * @returns `cleared`, `skipped` when a captured generation was replaced, or `failed`
  */
-export function clearModeState(
+export function clearModeStateDetailed(
   mode: ExecutionMode,
   cwd: string,
   sessionId?: string,
@@ -751,6 +751,22 @@ export function clearModeState(
 }
 
 /**
+ * Clear all state files for a mode.
+ *
+ * This is the long-standing public boolean API. Callers which need to
+ * distinguish a CAS replacement from a failed mutation must use
+ * clearModeStateDetailed explicitly.
+ */
+export function clearModeState(
+  mode: ExecutionMode,
+  cwd: string,
+  sessionId?: string,
+  expectedState?: Record<string, unknown>,
+): boolean {
+  return clearModeStateDetailed(mode, cwd, sessionId, expectedState) === "cleared";
+}
+
+/**
  * Clear all mode states (force clear)
  */
 export function clearAllModeStates(cwd: string): boolean {
@@ -758,7 +774,7 @@ export function clearAllModeStates(cwd: string): boolean {
 
   for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
     if (mode === MODE_NAMES.GRAPH) continue;
-    if (clearModeState(mode, cwd) !== "cleared") {
+    if (!clearModeState(mode, cwd)) {
       success = false;
     }
   }

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -59,6 +59,17 @@ const MODE_CONFIGS: Record<ExecutionMode, ModeConfig> = {
     activeProperty: "active",
     hasGlobalState: false,
   },
+  [MODE_NAMES.GRAPH]: {
+    name: "Graph",
+    stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH],
+    activeStatuses: [
+      "running",
+      "waiting_human",
+      "waiting_patch_approval",
+      "reconciling",
+    ],
+    hasGlobalState: false,
+  },
   [MODE_NAMES.TEAM]: {
     name: "Team",
     stateFile: MODE_STATE_FILE_MAP[MODE_NAMES.TEAM],
@@ -106,7 +117,11 @@ export { MODE_CONFIGS };
 /**
  * Modes that are mutually exclusive (cannot run concurrently)
  */
-const EXCLUSIVE_MODES: ExecutionMode[] = [MODE_NAMES.AUTOPILOT, MODE_NAMES.AUTORESEARCH];
+const EXCLUSIVE_MODES: ExecutionMode[] = [
+  MODE_NAMES.AUTOPILOT,
+  MODE_NAMES.AUTORESEARCH,
+  MODE_NAMES.GRAPH,
+];
 
 /**
  * Get the state directory path
@@ -227,10 +242,26 @@ function isJsonModeActive(
   mode: ExecutionMode,
   sessionId?: string,
 ): boolean {
+  const config = MODE_CONFIGS[mode];
+  // Workflow-slot tombstone override: when the session workflow ledger records
+  // this mode as tombstoned (soft-completed), the stale per-mode state file is
+  // ignored so a fresh invocation can proceed without clearing artifacts
+  // manually. This applies to durable-status modes (e.g. graph) too - a
+  // cancelled/finished graph whose skill slot was tombstoned must not read as
+  // active just because graph-state.json still holds an active status.
   if (isWorkflowSlotTombstonedForMode(cwd, mode, sessionId)) {
     return false;
   }
-  const config = MODE_CONFIGS[mode];
+
+  const stateIsActive = (state: Record<string, unknown>): boolean => {
+    if (config.activeStatuses) {
+      return typeof state.status === "string" && config.activeStatuses.includes(state.status);
+    }
+    if (config.activeProperty) {
+      return state[config.activeProperty] === true;
+    }
+    return true;
+  };
 
   // When sessionId is provided, ONLY check session-scoped path — no legacy fallback.
   // This prevents cross-session state leakage where one session's legacy file
@@ -246,11 +277,7 @@ function isJsonModeActive(
         return false;
       }
 
-      if (config.activeProperty) {
-        return state[config.activeProperty] === true;
-      }
-
-      return true;
+      return stateIsActive(state);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return false;
@@ -265,12 +292,7 @@ function isJsonModeActive(
     const content = readFileSync(stateFile, "utf-8");
     const state = JSON.parse(content);
 
-    if (config.activeProperty) {
-      return state[config.activeProperty] === true;
-    }
-
-    // Default: file existence means active
-    return true;
+    return stateIsActive(state);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
@@ -425,6 +447,26 @@ function readJsonSnapshot(filePath: string): { state: Record<string, unknown>; s
   }
 }
 
+function hasGraphAuthorityInSessionDir(sessionDir: string): boolean {
+  if (existsSync(join(sessionDir, MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH]))) return true;
+  const skillState = readJsonSnapshot(join(sessionDir, "skill-active-state.json"))?.state;
+  if (
+    skillState?.active_skills
+    && typeof skillState.active_skills === "object"
+    && (skillState.active_skills as Record<string, unknown>).graph
+  ) {
+    return true;
+  }
+  const controlOwner = readJsonSnapshot(join(sessionDir, "control-owner-state.json"))?.state;
+  const controlRoot = controlOwner?.root;
+  return Boolean(
+    controlRoot
+    && typeof controlRoot === "object"
+    && (controlRoot as Record<string, unknown>).mode === MODE_NAMES.GRAPH
+    && (controlRoot as Record<string, unknown>).phase === "active",
+  );
+}
+
 function clearDiscoveredJsonFile(
   filePath: string,
   observed: { state: Record<string, unknown>; snapshot: string } | null,
@@ -459,6 +501,7 @@ export function clearModeState(
   sessionId?: string,
   expectedState?: Record<string, unknown>,
 ): boolean {
+  if (mode === MODE_NAMES.GRAPH) return false;
   const config = MODE_CONFIGS[mode];
   let success = true;
   const markerFile = getMarkerFilePath(cwd, mode);
@@ -558,6 +601,7 @@ export function clearAllModeStates(cwd: string): boolean {
   let success = true;
 
   for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
+    if (mode === MODE_NAMES.GRAPH) continue;
     if (!clearModeState(mode, cwd)) {
       success = false;
     }
@@ -566,7 +610,13 @@ export function clearAllModeStates(cwd: string): boolean {
   // Clear skill-active-state.json (issue #1033)
   const skillStatePath = join(getStateDir(cwd), "skill-active-state.json");
   try {
-    if (!clearObservedJsonFile(skillStatePath)) throw new Error("state mutation lock unavailable");
+    const skillState = readJsonSnapshot(skillStatePath)?.state;
+    const graphSlot = skillState?.active_skills
+      && typeof skillState.active_skills === "object"
+      && (skillState.active_skills as Record<string, unknown>).graph;
+    if (!graphSlot && !clearObservedJsonFile(skillStatePath)) {
+      throw new Error("state mutation lock unavailable");
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
       success = false;
@@ -578,6 +628,7 @@ export function clearAllModeStates(cwd: string): boolean {
     const sessionIds = listSessionIds(cwd);
     for (const sid of sessionIds) {
       const sessionDir = getSessionStateDir(sid, cwd);
+      if (hasGraphAuthorityInSessionDir(sessionDir)) continue;
       rmSync(sessionDir, { recursive: true, force: true });
     }
   } catch {
@@ -649,6 +700,10 @@ export function clearStaleSessionDirs(
     const sessionDir = getSessionStateDir(sid, cwd);
     try {
       const files = readdirSync(sessionDir);
+
+      // Graph ledgers are durable recovery authority and are never removed by
+      // generic stale-session garbage collection.
+      if (hasGraphAuthorityInSessionDir(sessionDir)) continue;
 
       // Remove empty directories
       if (files.length === 0) {

--- a/src/hooks/mode-registry/index.ts
+++ b/src/hooks/mode-registry/index.ts
@@ -18,7 +18,12 @@ import {
   rmdirSync,
   rmSync,
 } from "fs";
-import { canClearStateForSession, clearStateFileLockedIf, writeStateFileLocked } from "../../lib/mode-state-io.js";
+import {
+  canClearStateForSession,
+  clearStateFileLockedIf,
+  type ConditionalClearResult,
+  writeStateFileLocked,
+} from "../../lib/mode-state-io.js";
 import { join, dirname } from "path";
 import type {
   ExecutionMode,
@@ -255,7 +260,10 @@ function isJsonModeActive(
 
   const stateIsActive = (state: Record<string, unknown>): boolean => {
     if (config.activeStatuses) {
-      return typeof state.status === "string" && config.activeStatuses.includes(state.status);
+      return (
+        typeof state.status === "string" &&
+        config.activeStatuses.includes(state.status)
+      );
     }
     if (config.activeProperty) {
       return state[config.activeProperty] === true;
@@ -422,25 +430,44 @@ export function getAllModeStatuses(
 function clearObservedJsonFile(
   filePath: string,
   predicate: (state: Record<string, unknown>) => boolean = () => true,
-): boolean {
-  if (!existsSync(filePath)) return true;
+): ConditionalClearResult {
+  if (!existsSync(filePath)) return "cleared";
   let observed: Record<string, unknown>;
   try {
-    observed = JSON.parse(readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+    observed = JSON.parse(readFileSync(filePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
   } catch {
-    return false;
+    return "failed";
   }
-  if (!predicate(observed)) return true;
+  if (!predicate(observed)) return "cleared";
   const snapshot = JSON.stringify(observed);
-  return clearStateFileLockedIf(
+  return normalizeClearResult(
     filePath,
-    (current) => predicate(current) && JSON.stringify(current) === snapshot,
-  ) !== 'failed';
+    clearStateFileLockedIf(
+      filePath,
+      (current) => predicate(current) && JSON.stringify(current) === snapshot,
+    ),
+  );
 }
 
-function readJsonSnapshot(filePath: string): { state: Record<string, unknown>; snapshot: string } | null {
+/** A missing file is already converged; only a surviving CAS skip is a replacement. */
+function normalizeClearResult(
+  filePath: string,
+  result: ConditionalClearResult,
+): ConditionalClearResult {
+  return result === "skipped" && !existsSync(filePath) ? "cleared" : result;
+}
+
+function readJsonSnapshot(
+  filePath: string,
+): { state: Record<string, unknown>; snapshot: string } | null {
   try {
-    const state = JSON.parse(readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+    const state = JSON.parse(readFileSync(filePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
     return { state, snapshot: JSON.stringify(state) };
   } catch {
     return null;
@@ -448,7 +475,10 @@ function readJsonSnapshot(filePath: string): { state: Record<string, unknown>; s
 }
 
 function hasGraphAuthorityInSessionDir(sessionDir: string): boolean {
-  const graphStatePath = join(sessionDir, MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH]);
+  const graphStatePath = join(
+    sessionDir,
+    MODE_STATE_FILE_MAP[MODE_NAMES.GRAPH],
+  );
   if (existsSync(graphStatePath)) {
     const graphState = readJsonSnapshot(graphStatePath)?.state;
     // An unreadable graph ledger is never safe to discard. Paused and terminal
@@ -457,34 +487,42 @@ function hasGraphAuthorityInSessionDir(sessionDir: string): boolean {
     if (!graphState) return true;
     const status = graphState.status;
     if (
-      typeof status !== 'string'
-      || !['paused', 'failed', 'cancelled', 'succeeded'].includes(status)
+      typeof status !== "string" ||
+      !["paused", "failed", "cancelled", "succeeded"].includes(status)
     ) {
       return true;
     }
   }
-  const skillState = readJsonSnapshot(join(sessionDir, "skill-active-state.json"))?.state;
+  const skillState = readJsonSnapshot(
+    join(sessionDir, "skill-active-state.json"),
+  )?.state;
   if (
-    skillState?.active_skills
-    && typeof skillState.active_skills === "object"
+    skillState?.active_skills &&
+    typeof skillState.active_skills === "object"
   ) {
-    const graphSlot = (skillState.active_skills as Record<string, unknown>).graph;
+    const graphSlot = (skillState.active_skills as Record<string, unknown>)
+      .graph;
     // A malformed graph slot must remain conservative. A durable tombstone is
     // the explicit signal that terminal Graph artifacts may be reclaimed.
-    if (!graphSlot || typeof graphSlot !== 'object') return true;
-    if (!('completed_at' in graphSlot)) return true;
+    if (!graphSlot || typeof graphSlot !== "object") return true;
+    if (!("completed_at" in graphSlot)) return true;
     const completedAt = (graphSlot as Record<string, unknown>).completed_at;
-    if (typeof completedAt !== 'string' || !Number.isFinite(new Date(completedAt).getTime())) {
+    if (
+      typeof completedAt !== "string" ||
+      !Number.isFinite(new Date(completedAt).getTime())
+    ) {
       return true;
     }
   }
-  const controlOwner = readJsonSnapshot(join(sessionDir, "control-owner-state.json"))?.state;
+  const controlOwner = readJsonSnapshot(
+    join(sessionDir, "control-owner-state.json"),
+  )?.state;
   const controlRoot = controlOwner?.root;
   return Boolean(
-    controlRoot
-    && typeof controlRoot === "object"
-    && (controlRoot as Record<string, unknown>).mode === MODE_NAMES.GRAPH
-    && (controlRoot as Record<string, unknown>).phase === "active",
+    controlRoot &&
+    typeof controlRoot === "object" &&
+    (controlRoot as Record<string, unknown>).mode === MODE_NAMES.GRAPH &&
+    (controlRoot as Record<string, unknown>).phase === "active",
   );
 }
 
@@ -498,7 +536,12 @@ const IN_FLIGHT_MARKER_PUBLISH_POLL_MS = 10;
 function waitForInFlightMarkerPublisher(filePath: string): boolean {
   const deadline = Date.now() + IN_FLIGHT_MARKER_PUBLISH_WAIT_MS;
   while (existsSync(`${filePath}.mutation.lock`) && Date.now() < deadline) {
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, IN_FLIGHT_MARKER_PUBLISH_POLL_MS);
+    Atomics.wait(
+      new Int32Array(new SharedArrayBuffer(4)),
+      0,
+      0,
+      IN_FLIGHT_MARKER_PUBLISH_POLL_MS,
+    );
   }
   return !existsSync(`${filePath}.mutation.lock`);
 }
@@ -507,24 +550,42 @@ function clearDiscoveredJsonFile(
   filePath: string,
   observed: { state: Record<string, unknown>; snapshot: string } | null,
   predicate: (state: Record<string, unknown>) => boolean = () => true,
-): boolean {
+): ConditionalClearResult {
   if (!observed) {
     // An absent marker may still be in-flight under the same mutation lock
     // used by its publisher. Observe that lock *before* running a conditional
     // clear: recovery/observation must not race ahead of the publisher and
     // make an absent pre-publication snapshot authoritative.
-    if (!existsSync(filePath) && existsSync(`${filePath}.mutation.lock`) && !waitForInFlightMarkerPublisher(filePath)) {
-      return false;
+    if (
+      !existsSync(filePath) &&
+      existsSync(`${filePath}.mutation.lock`) &&
+      !waitForInFlightMarkerPublisher(filePath)
+    ) {
+      return "failed";
     }
-    const result = clearStateFileLockedIf(filePath, predicate);
-    return result !== 'failed' && !(result === 'skipped' && existsSync(filePath));
+    return normalizeClearResult(
+      filePath,
+      clearStateFileLockedIf(filePath, predicate),
+    );
   }
-  if (!predicate(observed.state)) return true;
-  const result = clearStateFileLockedIf(
+  if (!predicate(observed.state)) return "cleared";
+  return normalizeClearResult(
     filePath,
-    (current) => predicate(current) && JSON.stringify(current) === observed.snapshot,
+    clearStateFileLockedIf(
+      filePath,
+      (current) =>
+        predicate(current) && JSON.stringify(current) === observed.snapshot,
+    ),
   );
-  return result !== 'failed' && !(result === 'skipped' && existsSync(filePath));
+}
+
+function mergeClearResults(
+  current: ConditionalClearResult,
+  next: ConditionalClearResult,
+): ConditionalClearResult {
+  if (current === "failed" || next === "failed") return "failed";
+  if (current === "skipped" || next === "skipped") return "skipped";
+  return "cleared";
 }
 
 /**
@@ -536,34 +597,52 @@ function clearDiscoveredJsonFile(
  * - Local marker file if applicable
  * - Global state file if applicable (~/.claude/{mode}-state.json)
  *
- * @returns true if all files were deleted successfully (or didn't exist)
+ * @returns `cleared`, `skipped` when a captured generation was replaced, or `failed`
  */
 export function clearModeState(
   mode: ExecutionMode,
   cwd: string,
   sessionId?: string,
   expectedState?: Record<string, unknown>,
-): boolean {
-  if (mode === MODE_NAMES.GRAPH) return false;
+): ConditionalClearResult {
+  if (mode === MODE_NAMES.GRAPH) return "failed";
   const config = MODE_CONFIGS[mode];
-  let success = true;
+  let result: ConditionalClearResult = "cleared";
   const markerFile = getMarkerFilePath(cwd, mode);
   const isSessionScopedClear = Boolean(sessionId);
   const markerSnapshot = markerFile ? readJsonSnapshot(markerFile) : null;
-  const sessionMarkerFile = isSessionScopedClear && sessionId && config.markerFile
-    ? resolveSessionStatePath(config.markerFile.replace(/\.json$/i, ""), sessionId, cwd)
+  const sessionMarkerFile =
+    isSessionScopedClear && sessionId && config.markerFile
+      ? resolveSessionStatePath(
+          config.markerFile.replace(/\.json$/i, ""),
+          sessionId,
+          cwd,
+        )
+      : null;
+  const sessionMarkerSnapshot = sessionMarkerFile
+    ? readJsonSnapshot(sessionMarkerFile)
     : null;
-  const sessionMarkerSnapshot = sessionMarkerFile ? readJsonSnapshot(sessionMarkerFile) : null;
 
   // Delete session-scoped state file if sessionId provided
   if (isSessionScopedClear && sessionId) {
     const sessionStateFile = resolveSessionStatePath(mode, sessionId, cwd);
     try {
-      const result = clearStateFileLockedIf(sessionStateFile, (current) => canClearStateForSession(current, sessionId) && (!expectedState || JSON.stringify(current) === JSON.stringify(expectedState)));
-      if (result === 'failed' || (result === 'skipped' && existsSync(sessionStateFile))) throw new Error("state mutation lock unavailable");
+      const clearResult = normalizeClearResult(
+        sessionStateFile,
+        clearStateFileLockedIf(
+          sessionStateFile,
+          (current) =>
+            canClearStateForSession(current, sessionId) &&
+            (!expectedState ||
+              JSON.stringify(current) === JSON.stringify(expectedState)),
+        ),
+      );
+      result = mergeClearResults(result, clearResult);
+      if (clearResult === "failed")
+        throw new Error("state mutation lock unavailable");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        success = false;
+        result = "failed";
       }
     }
 
@@ -571,10 +650,17 @@ export function clearModeState(
     // Keep legacy/shared marker files untouched for isolation.
     if (sessionMarkerFile) {
       try {
-        if (!clearDiscoveredJsonFile(sessionMarkerFile, sessionMarkerSnapshot, (current) => canClearStateForSession(current, sessionId))) throw new Error("state mutation lock unavailable");
+        const clearResult = clearDiscoveredJsonFile(
+          sessionMarkerFile,
+          sessionMarkerSnapshot,
+          (current) => canClearStateForSession(current, sessionId),
+        );
+        result = mergeClearResults(result, clearResult);
+        if (clearResult === "failed")
+          throw new Error("state mutation lock unavailable");
       } catch (err) {
         if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-          success = false;
+          result = "failed";
         }
       }
     }
@@ -590,20 +676,34 @@ export function clearModeState(
         const markerSessionId = markerRaw.session_id ?? markerRaw.sessionId;
         if (!markerSessionId || markerSessionId === sessionId) {
           try {
-            if (!clearDiscoveredJsonFile(markerFile, markerSnapshot, (current) => canClearStateForSession(current, sessionId))) throw new Error("state mutation lock unavailable");
+            const clearResult = clearDiscoveredJsonFile(
+              markerFile,
+              markerSnapshot,
+              (current) => canClearStateForSession(current, sessionId),
+            );
+            result = mergeClearResults(result, clearResult);
+            if (clearResult === "failed")
+              throw new Error("state mutation lock unavailable");
           } catch (err) {
             if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-              success = false;
+              result = "failed";
             }
           }
         }
       } catch {
         // Malformed or unreadable session-scoped markers fail closed.
         try {
-          if (!clearDiscoveredJsonFile(markerFile, markerSnapshot, (current) => canClearStateForSession(current, sessionId))) throw new Error("state mutation lock unavailable");
+          const clearResult = clearDiscoveredJsonFile(
+            markerFile,
+            markerSnapshot,
+            (current) => canClearStateForSession(current, sessionId),
+          );
+          result = mergeClearResults(result, clearResult);
+          if (clearResult === "failed")
+            throw new Error("state mutation lock unavailable");
         } catch (err) {
           if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-            success = false;
+            result = "failed";
           }
         }
       }
@@ -614,11 +714,21 @@ export function clearModeState(
   const stateFile = getStateFilePath(cwd, mode);
   if (!isSessionScopedClear) {
     try {
-      const result = clearStateFileLockedIf(stateFile, (current) => !expectedState || JSON.stringify(current) === JSON.stringify(expectedState));
-      if (result === 'failed' || (result === 'skipped' && existsSync(stateFile))) throw new Error("state mutation lock unavailable");
+      const clearResult = normalizeClearResult(
+        stateFile,
+        clearStateFileLockedIf(
+          stateFile,
+          (current) =>
+            !expectedState ||
+            JSON.stringify(current) === JSON.stringify(expectedState),
+        ),
+      );
+      result = mergeClearResults(result, clearResult);
+      if (clearResult === "failed")
+        throw new Error("state mutation lock unavailable");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        success = false;
+        result = "failed";
       }
     }
   }
@@ -626,15 +736,18 @@ export function clearModeState(
   // Session-scoped marker paths were handled once above from their original snapshots.
   if (markerFile && !isSessionScopedClear) {
     try {
-      if (!clearDiscoveredJsonFile(markerFile, markerSnapshot)) throw new Error("state mutation lock unavailable");
+      const clearResult = clearDiscoveredJsonFile(markerFile, markerSnapshot);
+      result = mergeClearResults(result, clearResult);
+      if (clearResult === "failed")
+        throw new Error("state mutation lock unavailable");
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") success = false;
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") result = "failed";
     }
   }
 
   // Note: Global state files are no longer used (local-only state migration)
 
-  return success;
+  return result;
 }
 
 /**
@@ -645,7 +758,7 @@ export function clearAllModeStates(cwd: string): boolean {
 
   for (const mode of Object.keys(MODE_CONFIGS) as ExecutionMode[]) {
     if (mode === MODE_NAMES.GRAPH) continue;
-    if (!clearModeState(mode, cwd)) {
+    if (clearModeState(mode, cwd) !== "cleared") {
       success = false;
     }
   }
@@ -654,10 +767,11 @@ export function clearAllModeStates(cwd: string): boolean {
   const skillStatePath = join(getStateDir(cwd), "skill-active-state.json");
   try {
     const skillState = readJsonSnapshot(skillStatePath)?.state;
-    const graphSlot = skillState?.active_skills
-      && typeof skillState.active_skills === "object"
-      && (skillState.active_skills as Record<string, unknown>).graph;
-    if (!graphSlot && !clearObservedJsonFile(skillStatePath)) {
+    const graphSlot =
+      skillState?.active_skills &&
+      typeof skillState.active_skills === "object" &&
+      (skillState.active_skills as Record<string, unknown>).graph;
+    if (!graphSlot && clearObservedJsonFile(skillStatePath) !== "cleared") {
       throw new Error("state mutation lock unavailable");
     }
   } catch (err) {
@@ -804,11 +918,14 @@ export function createModeMarker(
     const dir = dirname(markerPath);
     mkdirSync(dir, { recursive: true });
 
-    if (!writeStateFileLocked(markerPath, {
-      mode,
-      startedAt: new Date().toISOString(),
-      ...metadata,
-    })) return false;
+    if (
+      !writeStateFileLocked(markerPath, {
+        mode,
+        startedAt: new Date().toISOString(),
+        ...metadata,
+      })
+    )
+      return false;
     return true;
   } catch (error) {
     console.error(`Failed to create marker file for ${mode}:`, error);
@@ -829,7 +946,7 @@ export function removeModeMarker(mode: ExecutionMode, cwd: string): boolean {
   }
 
   try {
-    if (!clearObservedJsonFile(markerPath)) return false;
+    if (clearObservedJsonFile(markerPath) !== "cleared") return false;
     return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -880,7 +997,7 @@ export function forceRemoveMarker(mode: ExecutionMode, cwd: string): boolean {
   }
 
   try {
-    if (!clearObservedJsonFile(markerPath)) return false;
+    if (clearObservedJsonFile(markerPath) !== "cleared") return false;
     return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {

--- a/src/hooks/mode-registry/types.ts
+++ b/src/hooks/mode-registry/types.ts
@@ -7,6 +7,7 @@
 export type ExecutionMode =
   | 'autopilot'
   | 'autoresearch'
+  | 'graph'
   | 'team'
   | 'ralph'
   | 'ultrawork'
@@ -24,6 +25,8 @@ export interface ModeConfig {
   markerFile?: string;
   /** Property to check in JSON state (if JSON-based) */
   activeProperty?: string;
+  /** Status values that mean active when durable status owns lifecycle. */
+  activeStatuses?: readonly string[];
   /** Whether state is SQLite-based (requires marker file) */
   isSqlite?: boolean;
   /** Whether mode has global state in ~/.claude/ */

--- a/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/skill-state-stop.test.ts
@@ -63,6 +63,47 @@ function writeSubagentTrackingState(
 }
 
 describe('persistent-mode skill-state stop integration (issue #1033)', () => {
+  it('tombstones a Graph workflow slot only after its durable state is paused', async () => {
+    const sessionId = 'session-graph-paused';
+    const tempDir = makeTempProject();
+
+    try {
+      const stateDir = join(tempDir, '.omc', 'state');
+      const sessionDir = join(stateDir, 'sessions', sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const ledger = {
+        version: 2,
+        active_skills: {
+          graph: {
+            skill_name: 'graph',
+            started_at: new Date().toISOString(),
+            completed_at: null,
+            session_id: sessionId,
+            mode_state_path: 'graph-state.json',
+            initialized_mode: 'graph',
+            initialized_state_path: join(stateDir, 'skill-active-state.json'),
+            initialized_session_state_path: join(sessionDir, 'skill-active-state.json'),
+          },
+        },
+      };
+      writeFileSync(join(sessionDir, 'skill-active-state.json'), JSON.stringify(ledger));
+      writeFileSync(join(stateDir, 'skill-active-state.json'), JSON.stringify(ledger));
+      writeFileSync(join(sessionDir, 'graph-state.json'), JSON.stringify({
+        session_id: sessionId,
+        status: 'paused',
+      }));
+
+      await checkPersistentModes(sessionId, tempDir);
+
+      const sessionLedger = JSON.parse(readFileSync(join(sessionDir, 'skill-active-state.json'), 'utf8'));
+      const rootLedger = JSON.parse(readFileSync(join(stateDir, 'skill-active-state.json'), 'utf8'));
+      expect(sessionLedger.active_skills.graph.completed_at).toEqual(expect.any(String));
+      expect(rootLedger.active_skills.graph.completed_at).toBe(sessionLedger.active_skills.graph.completed_at);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('blocks stop when a skill is actively executing', async () => {
     const sessionId = 'session-skill-1033-block';
     const tempDir = makeTempProject();

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -101,7 +101,7 @@ const STALE_STATE_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 const PENDING_ASYNC_STATE_STALE_MS = 24 * 60 * 60 * 1000;
 const OVERSIZE_TOOL_RESULT_REDIRECT_STOP_MAX = 3;
 const OVERSIZE_TOOL_RESULT_REDIRECT_STOP_TTL_MS = 5 * 60 * 1000;
-const TERMINAL_WORKFLOW_SLOT_MODES = new Set(['autopilot', 'ralph', 'ralplan']);
+const TERMINAL_WORKFLOW_SLOT_MODES = new Set(['autopilot', 'graph', 'ralph', 'ralplan']);
 const TERMINAL_WORKFLOW_PHASES = new Set([
   'complete',
   'completed',
@@ -468,6 +468,10 @@ function isTerminalWorkflowModeState(state: Record<string, unknown> | null): boo
   return Boolean(phase && TERMINAL_WORKFLOW_PHASES.has(phase));
 }
 
+function isGraphDurablyStopped(state: Record<string, unknown> | null): boolean {
+  return state?.status === 'paused' || isTerminalWorkflowModeState(state);
+}
+
 async function reconcileTerminalWorkflowSlots(
   workingDir: string,
   sessionId?: string,
@@ -476,6 +480,7 @@ async function reconcileTerminalWorkflowSlots(
     const {
       readSkillActiveStateNormalized,
       pruneExpiredWorkflowSkillTombstones,
+      markDurableWorkflowSkillCompleted,
       markWorkflowSkillCompleted,
       writeSkillActiveStateCopies,
     } = await import('../skill-state/index.js');
@@ -490,11 +495,18 @@ async function reconcileTerminalWorkflowSlots(
       }
 
       const modeState = readModeState<Record<string, unknown>>(slotName, workingDir, sessionId);
-      if (!isTerminalWorkflowModeState(modeState)) {
+      if (slotName === 'graph'
+        ? !isGraphDurablyStopped(modeState)
+        : !isTerminalWorkflowModeState(modeState)) {
         continue;
       }
 
-      current = markWorkflowSkillCompleted(current, slotName);
+      // Graph has durable lifecycle authority. Its generic Skill completion
+      // path deliberately cannot tombstone the slot; only this observation of
+      // a paused or terminal graph-state may do so.
+      current = slotName === 'graph'
+        ? markDurableWorkflowSkillCompleted(current, slotName)
+        : markWorkflowSkillCompleted(current, slotName);
       changed = true;
     }
 

--- a/src/hooks/persistent-mode/index.ts
+++ b/src/hooks/persistent-mode/index.ts
@@ -256,7 +256,7 @@ function isSessionCancelInProgress(directory: string, sessionId?: string): Sessi
   }
 
   const validateSignal = (target: LoadedAutopilotTarget | null): boolean => {
-    const locked = withStateFileMutationLock(cancelSignalPath, () => {
+    const locked = withStateFileMutationLock(cancelSignalPath, (assertHeld) => {
       let raw: Record<string, unknown>;
       try {
         const parsed = JSON.parse(readFileSync(cancelSignalPath!, 'utf-8'));
@@ -269,7 +269,10 @@ function isSessionCancelInProgress(directory: string, sessionId?: string): Sessi
       const requestedAt = typeof raw.requested_at === 'string' ? new Date(raw.requested_at).getTime() : NaN;
       const expiresAt = typeof raw.expires_at === 'string' ? new Date(raw.expires_at).getTime() : NaN;
       if (target) {
-        if (Number.isFinite(expiresAt) && expiresAt <= now && existsSync(cancelSignalPath!)) unlinkSync(cancelSignalPath!);
+        if (Number.isFinite(expiresAt) && expiresAt <= now && existsSync(cancelSignalPath!)) {
+          assertHeld();
+          unlinkSync(cancelSignalPath!);
+        }
         return isAuthenticatedAutopilotCancelSignal(raw, target);
       }
       // A requested-at-only signal belongs to Ralph/Ultrawork. It must never be
@@ -293,7 +296,10 @@ function isSessionCancelInProgress(directory: string, sessionId?: string): Sessi
         effectiveExpiry - requestedAt > CANCEL_SIGNAL_TTL_MS ||
         effectiveExpiry <= now
       ) {
-        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && existsSync(cancelSignalPath!)) unlinkSync(cancelSignalPath!);
+        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && existsSync(cancelSignalPath!)) {
+          assertHeld();
+          unlinkSync(cancelSignalPath!);
+        }
         return false;
       }
       return true;

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -195,6 +195,45 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
       });
     });
 
+    it("does not honor an autopilot cancel signal without an exclusive lock even when a graph state file is present (GRAPH-in-EXCLUSIVE_MODES safety invariant)", async () => {
+      // Regression guard: GRAPH was added to EXCLUSIVE_MODES. Its presence must
+      // not weaken the cancel-safety invariant - an autopilot cancel signal that
+      // cannot acquire the exclusive state lock must still be rejected so a
+      // forged cancel cannot suppress an active autopilot.
+      const sessionId = "graph-present-autopilot-cancel-no-flock";
+      const sessionDir = join(tempDir, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      const state = initAutopilot(tempDir, "Finish the task", sessionId)!;
+      state.phase = "planning";
+      state.project_path = tempDir;
+      writeFileSync(join(sessionDir, "autopilot-state.json"), JSON.stringify(state));
+      // Place a durable graph-state file alongside autopilot state. This is the
+      // artifact that GRAPH-in-EXCLUSIVE_MODES makes mode-registry aware of; it
+      // must not change the cancel verdict.
+      writeFileSync(join(sessionDir, "graph-state.json"), JSON.stringify({
+        format_version: 1,
+        session_id: sessionId,
+        run_id: "run-graph",
+        status: "running",
+      }));
+      const now = Date.now();
+      writeFileSync(join(sessionDir, "cancel-signal-state.json"), JSON.stringify({
+        active: true,
+        mode: "autopilot",
+        source: "state_clear",
+        requested_at: new Date(now).toISOString(),
+        expires_at: new Date(now + 30_000).toISOString(),
+        target_state_sha256: createHash("sha256").update(JSON.stringify(state)).digest("hex"),
+      }));
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
+
+      await expect(checkPersistentModes(sessionId, tempDir)).resolves.toMatchObject({
+        shouldBlock: true,
+        mode: "autopilot",
+      });
+    });
+
+
     it("honors a requested-at-only Ultrawork cancellation without flock when canonical autopilot discovery finds no target", async () => {
       const sessionId = "portable-generic-cancel-no-autopilot";
       activateUltrawork("Finish the task", sessionId, tempDir);

--- a/src/hooks/skill-state/__tests__/skill-state.test.ts
+++ b/src/hooks/skill-state/__tests__/skill-state.test.ts
@@ -15,6 +15,7 @@ import {
   writeSkillActiveStateCopies,
   upsertWorkflowSkillSlot,
   markWorkflowSkillCompleted,
+  markDurableWorkflowSkillCompleted,
   clearWorkflowSkillSlot,
   pruneExpiredWorkflowSkillTombstones,
   resolveAuthoritativeWorkflowSkill,
@@ -74,6 +75,7 @@ describe('skill-state', () => {
       expect(getSkillProtection('team')).toBe('none');
       expect(getSkillProtection('ultrawork')).toBe('none');
       expect(getSkillProtection('cancel')).toBe('none');
+      expect(getSkillProtection('graph')).toBe('none');
     });
 
     it('returns none for instant/read-only skills', () => {
@@ -1017,6 +1019,22 @@ describe('skill-state', () => {
   // Pure workflow-slot helpers — unit tests
   // -----------------------------------------------------------------------
   describe('upsertWorkflowSkillSlot — pure helper', () => {
+    it('recognizes Graph as a canonical workflow and creates its durable slot', () => {
+      const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'graph', {
+        session_id: 'graph-session',
+        mode_state_path: 'graph-state.json',
+        initialized_mode: 'graph',
+        initialized_state_path: '',
+        initialized_session_state_path: '',
+      });
+
+      expect(state.active_skills.graph).toMatchObject({
+        skill_name: 'graph',
+        completed_at: null,
+        initialized_mode: 'graph',
+      });
+    });
+
     it('creates a new slot with provided fields', () => {
       const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'ralph', {
         session_id: 's1',
@@ -1071,6 +1089,33 @@ describe('skill-state', () => {
   });
 
   describe('markWorkflowSkillCompleted — pure helper', () => {
+    it('does not tombstone a durable Graph slot on generic tool completion', () => {
+      const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'graph', {
+        session_id: 'graph-session',
+        mode_state_path: 'graph-state.json',
+        initialized_mode: 'graph',
+        initialized_state_path: '',
+        initialized_session_state_path: '',
+      });
+
+      expect(markWorkflowSkillCompleted(state, 'graph', '2026-07-21T00:00:00.000Z')).toBe(state);
+      expect(state.active_skills.graph?.completed_at).toBeNull();
+    });
+
+    it('allows the Graph runtime to tombstone only after a durable stop', () => {
+      const state = upsertWorkflowSkillSlot(emptySkillActiveStateV2(), 'graph', {
+        session_id: 'graph-session',
+        mode_state_path: 'graph-state.json',
+        initialized_mode: 'graph',
+        initialized_state_path: '',
+        initialized_session_state_path: '',
+      });
+      const completedAt = '2026-07-21T00:00:00.000Z';
+      const tombstoned = markDurableWorkflowSkillCompleted(state, 'graph', completedAt);
+
+      expect(tombstoned.active_skills.graph?.completed_at).toBe(completedAt);
+    });
+
     it('sets completed_at to provided timestamp', () => {
       const ts = '2026-04-17T12:00:00.000Z';
       const state: SkillActiveStateV2 = {

--- a/src/hooks/skill-state/index.ts
+++ b/src/hooks/skill-state/index.ts
@@ -59,6 +59,7 @@ export const WORKFLOW_TOMBSTONE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
  */
 export const CANONICAL_WORKFLOW_SKILLS = [
   'autopilot',
+  'graph',
   'ralph',
   'team',
   'ultrawork',
@@ -106,6 +107,7 @@ const SKILL_PROTECTION: Record<string, SkillProtectionLevel> = {
   // === Canonical workflow skills — bypass support-skill protection; flow through the workflow-slot path ===
   autopilot: 'none',
   autoresearch: 'none',
+  graph: 'none',
   ralph: 'none',
   ultrawork: 'none',
   team: 'none',
@@ -342,6 +344,26 @@ export function markWorkflowSkillCompleted(
   now: string = new Date().toISOString(),
 ): SkillActiveStateV2 {
   const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
+  if (normalized === 'graph') return state;
+  return markWorkflowSkillCompletedUnchecked(state, normalized, now);
+}
+
+/** Tombstone Graph only after its durable state is paused or terminal. */
+export function markDurableWorkflowSkillCompleted(
+  state: SkillActiveStateV2,
+  skillName: string,
+  now: string = new Date().toISOString(),
+): SkillActiveStateV2 {
+  const normalized = skillName.toLowerCase().replace(/^oh-my-claudecode:/, '');
+  if (normalized !== 'graph') return state;
+  return markWorkflowSkillCompletedUnchecked(state, normalized, now);
+}
+
+function markWorkflowSkillCompletedUnchecked(
+  state: SkillActiveStateV2,
+  normalized: string,
+  now: string,
+): SkillActiveStateV2 {
   const existing = state.active_skills[normalized];
   if (!existing) return state;
   const updated: ActiveSkillSlot = { ...existing, completed_at: now };

--- a/src/hud/__tests__/graph.test.ts
+++ b/src/hud/__tests__/graph.test.ts
@@ -1,0 +1,129 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { forkJoinDescriptor } from '../../graph/__tests__/fixtures.js';
+import { sealGraphDescriptor } from '../../graph/descriptor.js';
+import { createInitialGraphState } from '../../graph/runtime-types.js';
+import { initializeGraphProjection } from '../../graph/scheduler.js';
+import { renderGraph } from '../elements/graph.js';
+import {
+  getActiveSkills,
+  isAnyModeActive,
+  readGraphStateForHud,
+} from '../omc-state.js';
+
+function graphState(sessionId: string) {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  const projection = initializeGraphProjection(descriptor, { approval: 'activation-private-entry' });
+  return createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'test-control-nonce',
+    descriptor,
+    projection,
+    status: 'running',
+    created_at: '2026-07-20T00:00:00.000Z',
+    approval: {
+      approved_at: '2026-07-20T00:00:00.000Z',
+      evidence: { kind: 'human', ref: 'private-approval-evidence' },
+    },
+  });
+}
+
+describe('Graph HUD projection', () => {
+  const directories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('reads only the current session and exposes bounded public counters', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const sessionId = 'session-current';
+    const state = graphState(sessionId);
+    const stateDirectory = join(directory, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), JSON.stringify(state), 'utf8');
+
+    const projection = readGraphStateForHud(directory, sessionId);
+    expect(projection).toEqual({
+      status: 'running',
+      completedActivations: 0,
+      totalActivations: 1,
+      readyActivations: 1,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: state.active_revision_hash.slice(0, 12),
+    });
+    expect(readGraphStateForHud(directory, 'session-other')).toBeNull();
+    expect(isAnyModeActive(directory, sessionId)).toBe(true);
+    expect(getActiveSkills(directory, sessionId)).toContain('graph');
+  });
+
+  it('renders no goal, command, output, evidence, or full identity', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const state = graphState('session-private');
+    const stateDirectory = join(directory, '.omc', 'state');
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), JSON.stringify(state), 'utf8');
+
+    const rendered = renderGraph(readGraphStateForHud(directory));
+    expect(rendered).toMatch(/G:.*running.*0\/1.*ready:1.*live:0.*reconcile:0/);
+    expect(rendered).not.toMatch(/Build and verify|run-branch-b|private|human/);
+    expect(rendered).not.toContain(state.active_revision_hash);
+  });
+
+  it.each(['paused', 'failed', 'cancelled', 'succeeded'] as const)(
+    'hides terminal or inactive status %s',
+    (status) => {
+      const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+      directories.push(directory);
+      const state = { ...graphState('session-terminal'), status };
+      const stateDirectory = join(directory, '.omc', 'state');
+      mkdirSync(stateDirectory, { recursive: true });
+      writeFileSync(join(stateDirectory, 'graph-state.json'), JSON.stringify(state), 'utf8');
+
+      expect(readGraphStateForHud(directory)).toBeNull();
+    },
+  );
+
+  it('keeps the graph indicator visible on a transient partial write', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const stateDirectory = join(directory, '.omc', 'state');
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), '{"status":"running"}', 'utf8');
+
+    // File exists and is non-empty but fails parse/validate (mid-commit write).
+    // The graph must stay visible rather than disappearing during a live tick.
+    const projection = readGraphStateForHud(directory);
+    expect(projection).toEqual({
+      status: 'unreadable',
+      completedActivations: 0,
+      totalActivations: 0,
+      readyActivations: 0,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: '?',
+    });
+    expect(isAnyModeActive(directory)).toBe(true);
+    expect(getActiveSkills(directory)).toContain('graph');
+    expect(renderGraph(projection)).toMatch(/G:.*unreadable/);
+  });
+
+  it('returns null for an empty graph-state file', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-graph-hud-'));
+    directories.push(directory);
+    const stateDirectory = join(directory, '.omc', 'state');
+    mkdirSync(stateDirectory, { recursive: true });
+    writeFileSync(join(stateDirectory, 'graph-state.json'), '', 'utf8');
+
+    expect(readGraphStateForHud(directory)).toBeNull();
+  });
+});

--- a/src/hud/elements/graph.ts
+++ b/src/hud/elements/graph.ts
@@ -1,0 +1,49 @@
+/**
+ * Compact, public-only Graph runtime status.
+ */
+
+import { cyan, red, yellow } from '../colors.js';
+
+export type ActiveGraphStatus =
+  | 'awaiting_approval'
+  | 'running'
+  | 'waiting_human'
+  | 'waiting_patch_approval'
+  | 'reconciling'
+  | 'unreadable';
+
+export interface GraphStateForHud {
+  status: ActiveGraphStatus;
+  completedActivations: number;
+  totalActivations: number;
+  readyActivations: number;
+  liveClaims: number;
+  unresolvedReconciliations: number;
+  revisionHashShort: string;
+}
+
+function renderStatus(status: ActiveGraphStatus): string {
+  if (status === 'reconciling') return red(status);
+  if (status === 'running') return cyan(status);
+  return yellow(status);
+}
+
+export function renderGraph(state: GraphStateForHud | null | undefined): string | null {
+  if (!state) return null;
+
+  if (state.status === 'unreadable') {
+    // Graph state file exists but could not be parsed (likely a transient
+    // partial write mid-commit). Keep the indicator visible so the run is not
+    // silently hidden during a live tick.
+    return `G:${renderStatus(state.status)}`;
+  }
+
+  return [
+    `G:${renderStatus(state.status)}`,
+    `${state.completedActivations}/${state.totalActivations}`,
+    `ready:${state.readyActivations}`,
+    `live:${state.liveClaims}`,
+    `reconcile:${state.unresolvedReconciliations}`,
+    `#${state.revisionHashShort}`,
+  ].join(' ');
+}

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -29,6 +29,7 @@ import {
   readUltraworkStateForHud,
   readPrdStateForHud,
   readAutopilotStateForHud,
+  readGraphStateForHud,
 } from "./omc-state.js";
 import { getUsage, getSubscriptionInfo } from "./usage-api.js";
 import { executeCustomProvider } from "./custom-rate-provider.js";
@@ -43,6 +44,7 @@ import type {
   SessionHealth,
   SessionSummaryState,
   UsageResult,
+  GraphStateForHud,
 } from "./types.js";
 import { getRuntimePackageVersion } from "../lib/version.js";
 import { compareVersions } from "../features/auto-update.js";
@@ -329,6 +331,23 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       cwd,
       currentSessionId ?? undefined,
     );
+    // readGraphStateForHud is best-effort: it must never abort the watch-mode
+    // init flow (which would prevent getUsage() from running and leave the HUD
+    // blank). The reader is defensive internally, but any unexpected throw
+    // (path resolution, import side-effects, future changes) is contained here
+    // so the rest of the render pipeline proceeds with graph === null.
+    let graph: GraphStateForHud | null = null;
+    try {
+      graph = readGraphStateForHud(cwd, currentSessionId ?? undefined);
+    } catch (error) {
+      if (process.env.OMC_DEBUG) {
+        console.error(
+          "[HUD] Graph state read failed (non-fatal):",
+          error instanceof Error ? error.message : error,
+        );
+      }
+      graph = null;
+    }
 
     // Read HUD state for background tasks
     const hudState = readHudState(cwd, currentSessionId ?? undefined);
@@ -465,6 +484,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       ultrawork,
       prd,
       autopilot,
+      graph,
       activeAgents: transcriptData.agents.filter((a) => a.status === "running"),
       todos: transcriptData.todos,
       backgroundTasks: getRunningTasks(hudState),

--- a/src/hud/omc-state.ts
+++ b/src/hud/omc-state.ts
@@ -15,8 +15,10 @@ import type {
   PrdStateForHud,
 } from './types.js';
 import type { AutopilotStateForHud } from './elements/autopilot.js';
+import type { ActiveGraphStatus, GraphStateForHud } from './elements/graph.js';
 import { validateNamedWorkflowStateStructure } from '../hooks/autopilot/named-workflow-resume-validator.js';
 import type { AutopilotState } from '../hooks/autopilot/types.js';
+import { parseGraphState } from '../graph/runtime-types.js';
 
 /**
  * Maximum age for state files to be considered "active".
@@ -372,6 +374,68 @@ export function readAutopilotStateForHud(directory: string, sessionId?: string):
 }
 
 // ============================================================================
+// Graph State
+// ============================================================================
+
+const ACTIVE_GRAPH_STATUSES = new Set<ActiveGraphStatus>([
+  'awaiting_approval',
+  'running',
+  'waiting_human',
+  'waiting_patch_approval',
+  'reconciling',
+]);
+
+/**
+ * Read the validated Graph state and return a bounded public projection.
+ * Durable waits are intentionally not hidden by the legacy two-hour HUD cutoff.
+ */
+export function readGraphStateForHud(directory: string, sessionId?: string): GraphStateForHud | null {
+  const stateFile = resolveStatePath(directory, 'graph-state.json', sessionId);
+  if (!stateFile) return null;
+
+  // Read the raw content first so we can distinguish "legitimately absent"
+  // (no file / empty file) from "file exists but is mid-write and unparseable".
+  // A transient partial write during commit must not silently drop the graph
+  // indicator while a run is live.
+  let content: string;
+  try {
+    content = readFileSync(stateFile, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (content.trim().length === 0) return null;
+
+  try {
+    const state = parseGraphState(JSON.parse(content));
+    if (!ACTIVE_GRAPH_STATUSES.has(state.status as ActiveGraphStatus)) return null;
+
+    const activations = Object.values(state.projection.activations);
+    return {
+      status: state.status as ActiveGraphStatus,
+      completedActivations: activations.filter((activation) => activation.status === 'completed').length,
+      totalActivations: activations.length,
+      readyActivations: activations.filter((activation) => activation.status === 'ready').length,
+      liveClaims: Object.values(state.claims).filter((claim) => claim.status === 'live').length,
+      unresolvedReconciliations: Object.values(state.reconciliations)
+        .filter((record) => record.status === 'unresolved').length,
+      revisionHashShort: state.active_revision_hash.slice(0, 12),
+    };
+  } catch {
+    // File exists and is non-empty but failed to parse/validate. Treat the
+    // graph as still active rather than hiding it (transient partial write).
+    return {
+      status: 'unreadable',
+      completedActivations: 0,
+      totalActivations: 0,
+      readyActivations: 0,
+      liveClaims: 0,
+      unresolvedReconciliations: 0,
+      revisionHashShort: '?',
+    };
+  }
+}
+
+// ============================================================================
 // Combined State Check
 // ============================================================================
 
@@ -382,8 +446,12 @@ export function isAnyModeActive(directory: string, sessionId?: string): boolean 
   const ralph = readRalphStateForHud(directory, sessionId);
   const ultrawork = readUltraworkStateForHud(directory, sessionId);
   const autopilot = readAutopilotStateForHud(directory, sessionId);
+  const graph = readGraphStateForHud(directory, sessionId);
 
-  return (ralph?.active ?? false) || (ultrawork?.active ?? false) || (autopilot?.active ?? false);
+  return (ralph?.active ?? false)
+    || (ultrawork?.active ?? false)
+    || (autopilot?.active ?? false)
+    || graph !== null;
 }
 
 /**
@@ -395,6 +463,10 @@ export function getActiveSkills(directory: string, sessionId?: string): string[]
   const autopilot = readAutopilotStateForHud(directory, sessionId);
   if (autopilot?.active) {
     skills.push('autopilot');
+  }
+
+  if (readGraphStateForHud(directory, sessionId)) {
+    skills.push('graph');
   }
 
   const ralph = readRalphStateForHud(directory, sessionId);

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -33,6 +33,7 @@ import { renderTokenUsage } from "./elements/token-usage.js";
 import { renderEnterpriseCost } from "./elements/enterprise-cost.js";
 import { renderPromptTime } from "./elements/prompt-time.js";
 import { renderAutopilot } from "./elements/autopilot.js";
+import { renderGraph } from "./elements/graph.js";
 import { renderCwd } from "./elements/cwd.js";
 import { renderHostname } from "./elements/hostname.js";
 import { renderGitRepo, renderGitBranch, renderGitStatus } from "./elements/git.js";
@@ -433,6 +434,11 @@ export async function render(
   if (enabledElements.autopilot && context.autopilot) {
     const autopilot = renderAutopilot(context.autopilot, config.thresholds);
     if (autopilot) rendered.set("autopilot", autopilot);
+  }
+
+  if (enabledElements.graph && context.graph) {
+    const graph = renderGraph(context.graph);
+    if (graph) rendered.set("graph", graph);
   }
 
   if (enabledElements.prdStory && context.prd) {

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AutopilotStateForHud } from './elements/autopilot.js';
+import type { GraphStateForHud } from './elements/graph.js';
 import type { ApiKeySource } from './elements/api-key-source.js';
 import type { SessionSummaryState } from './elements/session-summary.js';
 import type { PayloadEstimate } from './payload-estimate.js';
@@ -12,7 +13,7 @@ import type { MissionBoardConfig, MissionBoardState } from './mission-board.js';
 import { DEFAULT_MISSION_BOARD_CONFIG } from './mission-board.js';
 
 // Re-export for convenience
-export type { AutopilotStateForHud, ApiKeySource, SessionSummaryState };
+export type { AutopilotStateForHud, GraphStateForHud, ApiKeySource, SessionSummaryState };
 
 // ============================================================================
 // HUD State
@@ -340,6 +341,9 @@ export interface HudRenderContext {
   /** Autopilot state */
   autopilot: AutopilotStateForHud | null;
 
+  /** Durable Graph state */
+  graph?: GraphStateForHud | null;
+
   /** Active subagents from transcript */
   activeAgents: ActiveAgent[];
 
@@ -575,6 +579,7 @@ export interface HudElementConfig {
   rateLimits: boolean;  // Show 5h and weekly rate limits
   ralph: boolean;
   autopilot: boolean;
+  graph: boolean;
   prdStory: boolean;
   activeSkills: boolean;
   lastSkill: boolean;
@@ -654,7 +659,7 @@ export const DEFAULT_ELEMENT_ORDER: Required<LayoutConfig> = {
   line1: ['hostname', 'cwd', 'gitRepo', 'gitBranch', 'gitStatus', 'apiKeySource', 'profile'],
   main: [
     'omcLabel', 'model', 'enterpriseCost', 'rateLimits', 'customBuckets', 'permission', 'thinking',
-    'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'prd',
+    'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'graph', 'prd',
     'skills', 'lastSkill', 'contextBar', 'agents', 'background',
     'callCounts', 'lastTool', 'sessionSummary',
   ],
@@ -708,6 +713,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     rateLimits: true,  // Show rate limits by default
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     contextBar: true,
@@ -769,6 +775,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: false,
     activeSkills: true,
     lastSkill: true,
@@ -812,6 +819,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     lastSkill: true,
@@ -855,6 +863,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     lastSkill: true,
@@ -898,6 +907,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: false,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: false,
     activeSkills: true,
     lastSkill: true,
@@ -941,6 +951,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     rateLimits: true,
     ralph: true,
     autopilot: true,
+    graph: true,
     prdStory: true,
     activeSkills: true,
     lastSkill: true,

--- a/src/installer/__tests__/safe-installer.test.ts
+++ b/src/installer/__tests__/safe-installer.test.ts
@@ -68,6 +68,7 @@ describe('isOmcHook detection', () => {
     // These are the real commands OMC installs into settings.json
     expect(isOmcHook('node "$HOME/.claude/hooks/keyword-detector.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/session-start.mjs"')).toBe(true);
+    expect(isOmcHook('node "$HOME/.claude/hooks/session-end.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/pre-tool-use.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/post-tool-use.mjs"')).toBe(true);
     expect(isOmcHook('node "$HOME/.claude/hooks/post-tool-use-failure.mjs"')).toBe(true);

--- a/src/installer/__tests__/session-end-template.test.ts
+++ b/src/installer/__tests__/session-end-template.test.ts
@@ -1,0 +1,92 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const roots: string[] = [];
+const templatePath = join(process.cwd(), 'templates', 'hooks', 'session-end.mjs');
+
+function temporaryRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('standalone SessionEnd Graph settlement hook', () => {
+  it('is bounded, shell-free, and delegates mutations to the Graph CLI', () => {
+    const source = readFileSync(templatePath, 'utf8');
+    expect(source).toContain("spawnSync('omc'");
+    expect(source).toContain("'settle-session'");
+    expect(source).toContain('shell: false');
+    expect(source).toContain('timeout: SETTLE_TIMEOUT_MS');
+    expect(source).not.toContain('writeFileSync');
+    expect(source).not.toContain('unlinkSync');
+  });
+
+  it('allows SessionEnd without invoking the CLI when Graph state is absent', () => {
+    const project = temporaryRoot('omc-session-end-no-graph-');
+    mkdirSync(join(project, '.git'), { recursive: true });
+
+    const output = execFileSync(process.execPath, [templatePath], {
+      cwd: project,
+      input: JSON.stringify({ hook_event_name: 'SessionEnd', session_id: 'session-1', cwd: project }),
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+
+    expect(JSON.parse(output)).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('passes stable, non-shell arguments to the CLI for existing Graph state', () => {
+    const project = temporaryRoot('omc-session-end-graph-');
+    const binDir = temporaryRoot('omc-session-end-bin-');
+    const capturePath = join(project, 'captured-args.txt');
+    const graphPath = join(project, '.omc', 'state', 'sessions', 'session-1', 'graph-state.json');
+    mkdirSync(join(project, '.git'), { recursive: true });
+    mkdirSync(join(graphPath, '..'), { recursive: true });
+    writeFileSync(graphPath, '{}');
+
+    // Cross-platform fake `omc` that captures its argv to a file. On Unix it
+    // is a /bin/sh script; on Windows a .cmd wrapper is required because
+    // spawnSync('omc', ..., { shell: false }) resolves via PATHEXT.
+    if (process.platform === 'win32') {
+      writeFileSync(join(binDir, 'omc.cmd'), `@echo off\r\nnode -e "require('fs').writeFileSync(process.env.OMC_GRAPH_CAPTURE, process.argv.slice(1).join('\\n')+'\\n')" %*\r\n`);
+    } else {
+      const fakeOmc = join(binDir, 'omc');
+      writeFileSync(fakeOmc, '#!/bin/sh\nprintf "%s\\n" "$@" > "$OMC_GRAPH_CAPTURE"\n');
+      chmodSync(fakeOmc, 0o755);
+    }
+
+    const output = execFileSync(process.execPath, [templatePath], {
+      cwd: project,
+      input: JSON.stringify({ hook_event_name: 'SessionEnd', session_id: 'session-1', cwd: project }),
+      encoding: 'utf8',
+      timeout: 5_000,
+      env: {
+        ...process.env,
+        PATH: `${binDir}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH ?? ''}`,
+        OMC_GRAPH_CAPTURE: capturePath,
+      },
+    }).trim();
+
+    expect(JSON.parse(output)).toEqual({ continue: true, suppressOutput: true });
+    expect(existsSync(capturePath)).toBe(true);
+    const args = readFileSync(capturePath, 'utf8').trim().split('\n');
+    expect(args.slice(0, 7)).toEqual([
+      'graph',
+      'settle-session',
+      '--session-id',
+      'session-1',
+      '--driver-id',
+      'session-end',
+      '--transition-id',
+    ]);
+    expect(args[7]).toMatch(/^session-end:[a-f0-9]{32}$/);
+    expect(args[8]).toBe('--json');
+  });
+});

--- a/src/installer/__tests__/session-end-template.test.ts
+++ b/src/installer/__tests__/session-end-template.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const roots: string[] = [];
 const templatePath = join(process.cwd(), 'templates', 'hooks', 'session-end.mjs');
+const pluginRunnerPath = join(process.cwd(), 'scripts', 'session-end.mjs');
+const templateSettlementPath = join(process.cwd(), 'templates', 'hooks', 'lib', 'graph-session-settlement.mjs');
+const pluginSettlementPath = join(process.cwd(), 'scripts', 'lib', 'graph-session-settlement.mjs');
 
 function temporaryRoot(prefix: string): string {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -18,14 +21,17 @@ afterEach(() => {
 });
 
 describe('standalone SessionEnd Graph settlement hook', () => {
-  it('is bounded, shell-free, and delegates mutations to the Graph CLI', () => {
-    const source = readFileSync(templatePath, 'utf8');
+  it('shares bounded, shell-free Graph CLI settlement with the plugin runner', () => {
+    const source = readFileSync(templateSettlementPath, 'utf8');
     expect(source).toContain("spawnSync('omc'");
     expect(source).toContain("'settle-session'");
     expect(source).toContain('shell: false');
     expect(source).toContain('timeout: SETTLE_TIMEOUT_MS');
     expect(source).not.toContain('writeFileSync');
     expect(source).not.toContain('unlinkSync');
+    expect(readFileSync(pluginSettlementPath, 'utf8')).toBe(source);
+    expect(readFileSync(templatePath, 'utf8')).toContain("'graph-session-settlement.mjs'");
+    expect(readFileSync(pluginRunnerPath, 'utf8')).toContain("'./lib/graph-session-settlement.mjs'");
   });
 
   it('allows SessionEnd without invoking the CLI when Graph state is absent', () => {

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -117,6 +117,9 @@ describe('install() standalone hook reconciliation', () => {
     expect(writtenSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toBe(
       `node "${join(testClaudeDir, 'hooks', 'session-start.mjs').replace(/\\/g, '/')}"`,
     );
+    expect(writtenSettings.hooks?.SessionEnd?.[0]?.hooks?.[0]?.command).toBe(
+      `node "${join(testClaudeDir, 'hooks', 'session-end.mjs').replace(/\\/g, '/')}"`,
+    );
     expect((writtenSettings as { statusLine?: { command?: string } }).statusLine?.command).toContain(
       `${join(testClaudeDir, 'hud', 'omc-hud.mjs').replace(/\\/g, '/')}`,
     );
@@ -133,6 +136,7 @@ describe('install() standalone hook reconciliation', () => {
     );
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
+    expect(readFileSync(join(testClaudeDir, 'hooks', 'session-end.mjs'), 'utf-8')).toContain('settle-session');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');
   });
 
@@ -199,6 +203,10 @@ describe('install() standalone hook reconciliation', () => {
         {
           file: 'session-start.mjs',
           input: { hook_event_name: 'SessionStart', session_id: 'ci-upgrade-test', cwd: projectDir },
+        },
+        {
+          file: 'session-end.mjs',
+          input: { hook_event_name: 'SessionEnd', session_id: 'ci-upgrade-test', cwd: projectDir },
         },
         {
           file: 'keyword-detector.mjs',
@@ -505,6 +513,7 @@ describe('install() plugin-provided hook deduplication (#2252)', () => {
     const legacyFiles = [
       'keyword-detector.mjs',
       'session-start.mjs',
+      'session-end.mjs',
       'pre-tool-use.mjs',
       'post-tool-use.mjs',
       'post-tool-use-failure.mjs',

--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -136,7 +136,8 @@ describe('install() standalone hook reconciliation', () => {
     );
     expect(readFileSync(join(testClaudeDir, 'hooks', 'keyword-detector.mjs'), 'utf-8')).toContain('Ralph keywords');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'pre-tool-use.mjs'), 'utf-8')).toContain('PreToolUse');
-    expect(readFileSync(join(testClaudeDir, 'hooks', 'session-end.mjs'), 'utf-8')).toContain('settle-session');
+    expect(readFileSync(join(testClaudeDir, 'hooks', 'session-end.mjs'), 'utf-8')).toContain('graph-session-settlement.mjs');
+    expect(readFileSync(join(testClaudeDir, 'hooks', 'lib', 'graph-session-settlement.mjs'), 'utf-8')).toContain('settle-session');
     expect(readFileSync(join(testClaudeDir, 'hooks', 'code-simplifier.mjs'), 'utf-8')).toContain('Code Simplifier');
   });
 

--- a/src/installer/hooks.ts
+++ b/src/installer/hooks.ts
@@ -293,6 +293,9 @@ export const CODE_SIMPLIFIER_SCRIPT_NODE = loadTemplate("code-simplifier.mjs");
 /** Node.js session start hook script - loaded from templates/hooks/session-start.mjs */
 export const SESSION_START_SCRIPT_NODE = loadTemplate("session-start.mjs");
 
+/** Node.js session end hook script - loaded from templates/hooks/session-end.mjs */
+export const SESSION_END_SCRIPT_NODE = loadTemplate("session-end.mjs");
+
 /** Post-tool-use Node.js script - loaded from templates/hooks/post-tool-use.mjs */
 export const POST_TOOL_USE_SCRIPT_NODE = loadTemplate("post-tool-use.mjs");
 
@@ -322,6 +325,26 @@ export const HOOKS_SETTINGS_CONFIG_NODE = {
           {
             type: "command" as const,
             command: buildHookCommand('session-start.mjs'),
+          },
+        ],
+      },
+    ],
+    // Graph-scoped SessionEnd cleanup. This hook is a fast no-op for any
+    // session that never used the Graph runtime: it returns SAFE_CONTINUE
+    // without invoking the CLI when no graph-state file exists for the
+    // session (see templates/hooks/session-end.mjs `existsSync(writePath)`
+    // gate). Registration is therefore safe for all standalone installs and
+    // does not perform work or mutate state for non-graph sessions. Plugin
+    // installs receive this hook via hooks/hooks.json instead.
+    SessionEnd: [
+      {
+        matcher: "*",
+        hooks: [
+          {
+            type: "command" as const,
+            command: buildHookCommand('session-end.mjs'),
+            timeout: 30,
+            async: true,
           },
         ],
       },

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -309,6 +309,7 @@ export function isOmcStatusLine(statusLine: unknown): boolean {
 const OMC_HOOK_FILENAMES = new Set([
   'keyword-detector.mjs',
   'session-start.mjs',
+  'session-end.mjs',
   'pre-tool-use.mjs',
   'post-tool-use.mjs',
   'post-tool-use-failure.mjs',
@@ -746,6 +747,7 @@ function configureInstallerSettings(
 const STANDALONE_HOOK_TEMPLATE_FILES = [
   'keyword-detector.mjs',
   'session-start.mjs',
+  'session-end.mjs',
   'pre-tool-use.mjs',
   'post-tool-use.mjs',
   'post-tool-use-failure.mjs',

--- a/src/lib/__tests__/atomic-write.test.ts
+++ b/src/lib/__tests__/atomic-write.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { FileHandle } from 'fs/promises';
 
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, openSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
-// @ts-expect-error Hook runtime source is intentionally JavaScript-only.
-import { withStateFileLockSync } from '../../../scripts/lib/atomic-write.mjs';
-
 import { tmpdir } from 'os';
+// @ts-expect-error Hook runtime source is intentionally JavaScript-only.
+import { withStateFileLockSync, releaseStateFileLockSync, acquireStateFileLockSync, renewMutationLock as renewStateFileLock } from '../../../scripts/lib/atomic-write.mjs';
+import {
+  acquireMutationLockAt,
+  releaseMutationLockSync,
+  renewMutationLock,
+  validateMutationLockOwner,
+  type MutationLockOwner,
+} from '../mode-state-io.js';
 
 const fsPromisesControl = vi.hoisted(() => ({
   renameHook: undefined as undefined | ((from: string | URL, to: string | URL) => Promise<void>),
@@ -200,7 +206,7 @@ describe('atomicWriteJson', () => {
     process.env.NODE_ENV = 'test';
     process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
     const filePath = join(directory, 'state.json');
-    writeFileSync(`${filePath}.mutation.lock`, JSON.stringify({ version: 1, pid: 999999999, processStart: '1', createdAt: new Date().toISOString(), nonce: randomUUID() }));
+    writeFileSync(`${filePath}.mutation.lock`, JSON.stringify(freshLeaseOwner(999999999, new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString())));
 
     expect(withStateFileLockSync(filePath, () => 'written')).toEqual({ acquired: true, value: 'written' });
     expect(existsSync(`${filePath}.mutation.lock`)).toBe(true);
@@ -212,11 +218,466 @@ describe('atomicWriteJson', () => {
     process.env.NODE_ENV = 'test';
     process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
     const filePath = join(directory, 'state.json');
-    const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-    const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-    writeFileSync(`${filePath}.mutation.lock`, JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() }));
+    // OMC_TEST_FLOCK_AVAILABLE=0 short-circuits acquire to { unlocked: true },
+    // so the lock artifact is never inspected; build a valid lease owner
+    // (expires_at in the future) without depending on /proc (absent on macOS).
+    writeFileSync(`${filePath}.mutation.lock`, JSON.stringify(freshLeaseOwner(process.pid)));
 
     expect(withStateFileLockSync(filePath, () => 'written')).toEqual({ acquired: true, value: 'written' });
     expect(existsSync(`${filePath}.mutation.lock`)).toBe(true);
+  });
+
+  it('flock-less release after steal: owner mismatch leaves the live lock in place', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-release-steal-'));
+    directories.push(directory);
+    process.env.NODE_ENV = 'test';
+    process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+    const filePath = join(directory, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    // Owner A acquired the lock legitimately. createdAt is the release-path
+    // ownership token (pid + nonce + createdAt); any validated lease owner
+    // suffices and avoids a /proc dependency that does not exist on macOS.
+    const ownerA = freshLeaseOwner(4242);
+    writeFileSync(lockPath, JSON.stringify(ownerA));
+    // While A held it, A's owner file became transiently unreadable, B stole the
+    // lock via linkSync (expired-lease reclaim), publishing owner B at the path.
+    const ownerB = freshLeaseOwner(5252);
+    writeFileSync(lockPath, JSON.stringify(ownerB));
+    const fd = openSync(join(directory, 'a-fd'), 'w');
+    // A finishes and releases its (now-stale) handle.
+    releaseStateFileLockSync({ fd, lockPath, owner: ownerA });
+
+    // B's lock must survive: A's owner mismatched, so no unlink.
+    expect(existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).nonce).toBe(ownerB.nonce);
+  });
+
+  it('flock-less release: owner match unlinks the lock file', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'atomic-write-release-match-'));
+    directories.push(directory);
+    process.env.NODE_ENV = 'test';
+    process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+    const filePath = join(directory, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const owner = freshLeaseOwner(4242);
+    writeFileSync(lockPath, JSON.stringify(owner));
+    const fd = openSync(join(directory, 'a-fd'), 'w');
+
+    releaseStateFileLockSync({ fd, lockPath, owner });
+
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B4: flock-less acquire -> contend -> release cycle, steal-prevention, and
+// testable owner-liveness. These run on the REAL flock-less linkSync path.
+// B8: on Linux CI, hasFlock is true so the flock branch would run and the
+// flock-less else block would be skipped. The OMC_TEST_FORCE_FLOCKLESS=1 seam
+// makes flockPath() return null (forcing the flock-less branch) WITHOUT tripping
+// lockingDisabledForTest() (which stays false because OMC_TEST_FLOCK_AVAILABLE
+// is not '0'), so exclusive locking stays enabled and the real flock-less
+// acquire/reclaim/release code is exercised on Linux CI. requireExclusive=true
+// forces the linkSync branch instead of the { unlocked: true } short-circuit.
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a lease owner for tests. `expiresAt` controls the reclaim decision:
+ * a future value = live (blocks steal); a past value = expired (reclaimable).
+ * All lease tests are platform-agnostic (just expires_at + clock) - no /proc,
+ * no jiffies, no EPERM - so they pass identically on Linux CI + macOS.
+ */
+function freshLeaseOwner(pid: number, createdAt?: string, expiresAt?: string): MutationLockOwner {
+  const now = Date.now();
+  return {
+    version: 1,
+    pid,
+    createdAt: createdAt ?? new Date(now).toISOString(),
+    expires_at: expiresAt ?? new Date(now + 300000).toISOString(),
+    nonce: randomUUID(),
+  };
+}
+
+/** Enable the B8 flock-less test seam for the current test, restoring afterEach. */
+function enableForceFlockless(): void {
+  process.env.NODE_ENV = 'test';
+  process.env.OMC_TEST_FORCE_FLOCKLESS = '1';
+}
+
+describe('lease-based mutation lock: validateMutationLockOwner', () => {
+  it('accepts a well-formed lease owner', () => {
+    expect(validateMutationLockOwner(freshLeaseOwner(process.pid))).not.toBeNull();
+  });
+
+  it('rejects an owner with extra keys, wrong types, bad nonce, or missing expires_at', () => {
+    expect(validateMutationLockOwner(null)).toBeNull();
+    // v1 old liveness schema (no expires_at) is NOT a valid lease owner.
+    expect(validateMutationLockOwner({ version: 1, pid: 1, createdAt: new Date().toISOString(), nonce: randomUUID() } as any)).toBeNull();
+    expect(validateMutationLockOwner({ version: 2, pid: 1, createdAt: new Date().toISOString(), expires_at: 'not-a-date', nonce: randomUUID() })).toBeNull();
+    expect(validateMutationLockOwner({ version: 2, pid: 1, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 1000).toISOString(), nonce: 'not-a-uuid' })).toBeNull();
+    expect(validateMutationLockOwner({ version: 3, pid: 1, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 1000).toISOString(), nonce: randomUUID() } as any)).toBeNull();
+    expect(validateMutationLockOwner({ version: 2, pid: 1, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 1000).toISOString(), nonce: randomUUID(), extra: 1 } as any)).toBeNull();
+  });
+});
+
+describe('lease-based mutation lock: release unlinks the holder\'s own lock', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    delete process.env.OMC_TEST_FLOCK_AVAILABLE;
+    delete process.env.OMC_TEST_FORCE_FLOCKLESS;
+  });
+
+  it('release unlinks the lock file the holder acquired', () => {
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-release-unlink-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const a = acquireMutationLockAt(filePath, true);
+    expect(a).not.toBeNull();
+    expect(existsSync(lockPath)).toBe(true);
+    // The holder releases its OWN lock: unlinkSync, no liveness check.
+    releaseMutationLockSync(a);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});
+
+describe('lease-based mutation lock: renewal', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    delete process.env.OMC_TEST_FLOCK_AVAILABLE;
+    delete process.env.OMC_TEST_FORCE_FLOCKLESS;
+  });
+
+  it('atomically replaces a still-live owner record while preserving ownership', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aw-renew-ts-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lock = acquireMutationLockAt(filePath, true);
+    expect(lock).not.toBeNull();
+
+    const before = JSON.parse(readFileSync(`${filePath}.mutation.lock`, 'utf8')) as MutationLockOwner;
+    expect(before.version).toBe(1);
+    const flockAvailable = existsSync('/usr/bin/flock') || existsSync('/bin/flock');
+    expect(renewMutationLock(lock)).toBe(flockAvailable);
+
+    const after = JSON.parse(readFileSync(`${filePath}.mutation.lock`, 'utf8')) as MutationLockOwner;
+    if (!flockAvailable) {
+      expect(after).toEqual(before);
+      releaseMutationLockSync(lock);
+      return;
+    }
+    expect(after).toMatchObject({
+      version: before.version,
+      pid: before.pid,
+      createdAt: before.createdAt,
+      nonce: before.nonce,
+    });
+    expect(Date.parse(after.expires_at)).toBeGreaterThanOrEqual(Date.parse(before.expires_at));
+    releaseMutationLockSync(lock);
+  });
+
+  it('uses the guarded renewal path in the hook runtime', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aw-renew-mjs-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lock = acquireStateFileLockSync(filePath, 50, true);
+    expect(lock).not.toBeNull();
+
+    const before = JSON.parse(readFileSync(`${filePath}.mutation.lock`, 'utf8')) as MutationLockOwner;
+    const flockAvailable = existsSync('/usr/bin/flock') || existsSync('/bin/flock');
+    expect(renewStateFileLock(lock)).toBe(flockAvailable);
+    const after = JSON.parse(readFileSync(`${filePath}.mutation.lock`, 'utf8')) as MutationLockOwner;
+    expect(after.nonce).toBe(before.nonce);
+    expect(Date.parse(after.expires_at)).toBeGreaterThanOrEqual(Date.parse(before.expires_at));
+    releaseStateFileLockSync(lock);
+  });
+
+  it('fails closed without the reclaim guard and preserves a replacement owner', () => {
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-renew-no-guard-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const lock = acquireMutationLockAt(filePath, true);
+    expect(lock).not.toBeNull();
+
+    const replacement = freshLeaseOwner(process.pid + 1);
+    writeFileSync(lockPath, JSON.stringify(replacement));
+
+    expect(renewMutationLock(lock)).toBe(false);
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(replacement);
+    releaseMutationLockSync(lock);
+  });
+
+  it('does not overwrite a replacement owner while renewing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aw-renew-replaced-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const lock = acquireMutationLockAt(filePath, true);
+    expect(lock).not.toBeNull();
+
+    const replacement = freshLeaseOwner(process.pid + 1);
+    writeFileSync(lockPath, JSON.stringify(replacement));
+
+    expect(renewMutationLock(lock)).toBe(false);
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(replacement);
+    releaseMutationLockSync(lock);
+  });
+
+  it('does not renew an owner whose on-disk lease has expired', () => {
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-renew-expired-mjs-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lock = acquireStateFileLockSync(filePath, 50, true);
+    expect(lock).not.toBeNull();
+    const lockPath = `${filePath}.mutation.lock`;
+    const owner = (lock as { owner: MutationLockOwner }).owner;
+    writeFileSync(lockPath, JSON.stringify({ ...owner, expires_at: new Date(Date.now() - 1).toISOString() }));
+
+    expect(renewStateFileLock(lock)).toBe(false);
+    releaseStateFileLockSync(lock);
+  });
+});
+
+describe('flock-less mutation lock: acquire -> contend -> release cycle (B4.2/B4.3 .mjs)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    delete process.env.OMC_TEST_FLOCK_AVAILABLE;
+    delete process.env.OMC_TEST_FORCE_FLOCKLESS;
+  });
+
+  it('A acquires, B fails while A is live (no steal), A releases, B acquires', () => {
+    // B8: force the flock-less linkSync branch even on Linux CI (which has
+    // flock) via OMC_TEST_FORCE_FLOCKLESS=1, without tripping
+    // lockingDisabledForTest (exclusive locking stays enabled).
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-cycle-mjs-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    // requireExclusive forces linkSync instead of the { unlocked: true } short-circuit.
+    const a = acquireStateFileLockSync(filePath, 50, true);
+    expect(a).not.toBeNull();
+    expect((a as { unlocked?: boolean }).unlocked).not.toBe(true);
+    const lockPath = `${filePath}.mutation.lock`;
+    expect(existsSync(lockPath)).toBe(true);
+
+    // B (same process, live) tries while A holds -> must NOT steal. With a
+    // small attempt budget it returns null without unlinking A's lock.
+    const b = acquireStateFileLockSync(filePath, 3, true);
+    expect(b).toBeNull();
+    // A's lock survived the steal attempt (same nonce).
+    const onDisk = JSON.parse(readFileSync(lockPath, 'utf8'));
+    expect(onDisk.nonce).toBe((a as { owner: MutationLockOwner }).owner.nonce);
+
+    // A releases; B can now acquire.
+    releaseStateFileLockSync(a);
+    expect(existsSync(lockPath)).toBe(false);
+    const b2 = acquireStateFileLockSync(filePath, 50, true);
+    expect(b2).not.toBeNull();
+    releaseStateFileLockSync(b2);
+  });
+});
+
+describe('flock-less mutation lock: TS acquire -> contend -> release cycle (B4.3)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    delete process.env.OMC_TEST_FLOCK_AVAILABLE;
+    delete process.env.OMC_TEST_FORCE_FLOCKLESS;
+  });
+
+  it('A acquires (TS), B fails while A is live, A releases via releaseMutationLockSync, B acquires', () => {
+    // B8: force the flock-less branch on Linux CI.
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-cycle-ts-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const a = acquireMutationLockAt(filePath, true);
+    expect(a).not.toBeNull();
+    expect((a as { unlocked?: boolean }).unlocked).not.toBe(true);
+
+    // B cannot steal a live owner's lock.
+    const b = acquireMutationLockAt(filePath, true);
+    expect(b).toBeNull();
+
+    // releaseMutationLock (the function B1 was filed against) is exercised
+    // through the exported releaseMutationLockSync wrapper.
+    releaseMutationLockSync(a);
+    expect(existsSync(`${filePath}.mutation.lock`)).toBe(false);
+
+    const b2 = acquireMutationLockAt(filePath, true);
+    expect(b2).not.toBeNull();
+    releaseMutationLockSync(b2);
+  });
+});
+
+describe('flock-less mutation lock: steal-prevention (B4.4)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+    delete process.env.OMC_TEST_FLOCK_AVAILABLE;
+    delete process.env.OMC_TEST_FORCE_FLOCKLESS;
+  });
+
+  it('a valid (unexpired) lease is NOT stolen by a thief\'s reclaim attempt', () => {
+    // B5/B6/B8: lease-based. A live owner = an unexpired lease. The thief
+    // reads expires_at, sees it is in the future, and does NOT unlink. No pid
+    // liveness is probed, so EPERM/PID-reuse/jiffies edge cases cannot arise.
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-steal-prevent-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    // Plant a LIVE owner: expires_at far in the future.
+    const liveOwner = freshLeaseOwner(process.pid, undefined, new Date(Date.now() + 60000).toISOString());
+    writeFileSync(lockPath, JSON.stringify(liveOwner));
+
+    // Thief B tries to acquire exclusively with a small budget. The unexpired
+    // lease blocks the reclaim: B does NOT unlink, returns null.
+    const b = acquireStateFileLockSync(filePath, 3, true);
+    expect(b).toBeNull();
+    // The live owner's lock file is still on disk, unchanged.
+    expect(existsSync(lockPath)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(lockPath, 'utf8'));
+    expect(onDisk.nonce).toBe(liveOwner.nonce);
+  });
+
+  it('reclaims a lock whose lease has EXPIRED (holder crashed / did not release)', () => {
+    // Lease-based reclaim: now >= expires_at -> the holder is gone -> RECLAIM.
+    // This replaces the old "dead pid" reclaim; the lease is the sole signal.
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-reclaim-expired-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    // Expired lease: expires_at in the past.
+    const expired = freshLeaseOwner(999999999, new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), new Date(Date.now() - 60 * 1000).toISOString());
+    writeFileSync(lockPath, JSON.stringify(expired));
+
+    const a = acquireStateFileLockSync(filePath, 50, true);
+    expect(a).not.toBeNull();
+    // A new owner now holds the lock (expired lease was reclaimed).
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).nonce).toBe((a as { owner: MutationLockOwner }).owner.nonce);
+    releaseStateFileLockSync(a);
+  });
+
+  it('reclaims a lock whose lease expired just now (fresh but expired)', () => {
+    // Converged policy: reclaim depends ONLY on lease expiry, not on age. A
+    // freshly-created lock with an already-expired lease is reclaimed (the
+    // holder is gone), matching the flock path's immediate reclaim.
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-reclaim-fresh-expired-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const freshExpired = freshLeaseOwner(999999999, new Date().toISOString(), new Date(Date.now() - 1000).toISOString());
+    writeFileSync(lockPath, JSON.stringify(freshExpired));
+
+    const a = acquireStateFileLockSync(filePath, 50, true);
+    expect(a).not.toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).nonce).toBe((a as { owner: MutationLockOwner }).owner.nonce);
+    releaseStateFileLockSync(a);
+  });
+
+  it('reclaims a corrupt (unparseable) lock file (no valid lease)', () => {
+    // A corrupt lock has no valid lease on record, so the owner cannot be live.
+    // RECLAIM (unlink) immediately - no bounded loop, no permanent wedge.
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-corrupt-reclaim-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    writeFileSync(lockPath, '{ not valid json');
+    expect(readFileSync(lockPath, 'utf8')).toBe('{ not valid json');
+
+    const a = acquireStateFileLockSync(filePath, 50, true);
+    expect(a).not.toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).nonce).toBe((a as { owner: MutationLockOwner }).owner.nonce);
+    releaseStateFileLockSync(a);
+  });
+
+  it('recognizes the deployed v1 lease shape as a current live owner', () => {
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-v1-lease-shaped-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const v1Lease = freshLeaseOwner(process.pid);
+    writeFileSync(lockPath, JSON.stringify(v1Lease));
+
+    expect(acquireStateFileLockSync(filePath, 3, true)).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(v1Lease);
+  });
+
+  it('fails closed for the legacy v1 processStart liveness shape', () => {
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-v1-liveness-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const oldLivenessOwner = {
+      version: 1,
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+      processStart: '12345',
+      nonce: randomUUID(),
+    };
+    writeFileSync(lockPath, JSON.stringify(oldLivenessOwner));
+
+    expect(acquireStateFileLockSync(filePath, 3, true)).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(oldLivenessOwner);
+  });
+
+  it('fails closed for an unsupported but structurally valid lease owner', () => {
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-unknown-lease-shaped-ts-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    const unknownLease = { ...freshLeaseOwner(process.pid), version: 99 };
+    writeFileSync(lockPath, JSON.stringify(unknownLease));
+
+    expect(acquireMutationLockAt(filePath, true)).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(unknownLease);
+  });
+
+  it('I/O-unreadable lock (EACCES) fails closed FOREVER - no steal, no bounded reclaim (B9)', () => {
+    // B9: a lock we cannot read (EACCES via chmod 000) MAY belong to a live
+    // owner; we just cannot read its lease. FAIL CLOSED: the thief returns null
+    // and never unlinks, on every attempt - no bounded reclaim, no wedge-escape.
+    // This is the direct fix for the old EACCES-on-unreadable-steals-a-live-lock
+    // blocker. chmod 000 is portable on POSIX (Linux CI + macOS).
+    enableForceFlockless();
+    const dir = mkdtempSync(join(tmpdir(), 'aw-unreadable-failclosed-'));
+    dirs.push(dir);
+    const filePath = join(dir, 'state.json');
+    const lockPath = `${filePath}.mutation.lock`;
+    // Plant a valid lease owner, then make the file unreadable.
+    const owner = freshLeaseOwner(process.pid, undefined, new Date(Date.now() + 60000).toISOString());
+    writeFileSync(lockPath, JSON.stringify(owner));
+    chmodSync(lockPath, 0o000);
+
+    // Even with a full budget the thief cannot read the lease and must NOT steal.
+    const a = acquireStateFileLockSync(filePath, 50, true);
+    expect(a).toBeNull();
+    // The unreadable lock is still on disk (never unlinked). Restore perms so
+    // afterEach cleanup can remove it.
+    chmodSync(lockPath, 0o600);
+    expect(existsSync(lockPath)).toBe(true);
+    expect(JSON.parse(readFileSync(lockPath, 'utf8')).nonce).toBe(owner.nonce);
+  });
+});
+
+describe('flock-less mutation lock: three-copy parity (B3)', () => {
+  it('scripts/lib and templates/hooks/lib atomic-write.mjs are byte-identical', () => {
+    const scripts = readFileSync(join(process.cwd(), 'scripts', 'lib', 'atomic-write.mjs'), 'utf8');
+    const template = readFileSync(join(process.cwd(), 'templates', 'hooks', 'lib', 'atomic-write.mjs'), 'utf8');
+    expect(template).toBe(scripts);
   });
 });

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, rmSync, existsSync, readFileSync, readdirSync, writeFileSync
 import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 
-import { acquireMutationLockAt, emergencyMutateStateFileIf, recoverEmergencyStateFile, writeModeState, readModeState, clearModeStateFile } from '../mode-state-io.js';
+import { acquireMutationLockAt, emergencyMutateStateFileIf, recoverEmergencyStateFile, writeModeState, writeStateFileLockedIf, writeStateFileLockedCreateIf, readModeState, clearModeStateFile } from '../mode-state-io.js';
 import { clearWorktreeCache, getProjectIdentifier } from '../worktree-paths.js';
 
 let tempDir: string;
@@ -585,6 +585,52 @@ describe('mode-state-io', () => {
   });
 
   describe('durable emergency mutation journal', () => {
+    it('makes an emergency publication visible to a later conditional write', () => {
+      expect(writeModeState('autopilot', { active: true, run: 'emergency-visible' }, tempDir)).toBe(true);
+      const path = join(tempDir, '.omc', 'state', 'autopilot-state.json');
+
+      expect(emergencyMutateStateFileIf(
+        path,
+        (state) => state.run === 'emergency-visible' && state.active === true,
+        (state) => ({ ...state, active: false }),
+      )).toBe(true);
+
+      // The emergency path must reconcile its canonical publication with OCC.
+      // Otherwise this predicate sees the pre-emergency journal state and
+      // overwrites the paused state with a stale update.
+      expect(writeStateFileLockedIf(
+        path,
+        (state) => state.run === 'emergency-visible' && state.active === true,
+        (state) => ({ ...state, staleOverwrite: true }),
+      )).toBe('skipped');
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({
+        active: false,
+        run: 'emergency-visible',
+      });
+    });
+
+    it('records an emergency clear as an OCC tombstone for a later create', () => {
+      expect(writeModeState('autopilot', { active: true, run: 'emergency-clear' }, tempDir)).toBe(true);
+      const path = join(tempDir, '.omc', 'state', 'autopilot-state.json');
+
+      expect(emergencyMutateStateFileIf(
+        path,
+        (state) => state.run === 'emergency-clear',
+        null,
+      )).toBe(true);
+      expect(existsSync(path)).toBe(false);
+
+      expect(writeStateFileLockedCreateIf(
+        path,
+        (current) => current === null,
+        () => ({ active: true, run: 'created-after-emergency-clear' }),
+      )).toBe('written');
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({
+        active: true,
+        run: 'created-after-emergency-clear',
+      });
+    });
+
     it('recovers a paused publication interrupted after primary publication', () => {
       const path = join(tempDir, '.omc', 'state', 'autopilot-state.json');
       mkdirSync(dirname(path), { recursive: true });

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, rmSync, existsSync, readFileSync, readdirSync, writeFileSync
 import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 
-import { emergencyMutateStateFileIf, recoverEmergencyStateFile, writeModeState, readModeState, clearModeStateFile } from '../mode-state-io.js';
+import { acquireMutationLockAt, emergencyMutateStateFileIf, recoverEmergencyStateFile, writeModeState, readModeState, clearModeStateFile } from '../mode-state-io.js';
 import { clearWorktreeCache, getProjectIdentifier } from '../worktree-paths.js';
 
 let tempDir: string;
@@ -113,7 +113,7 @@ describe('mode-state-io', () => {
       process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
       const statePath = join(tempDir, '.omc', 'state', 'autopilot-state.json');
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(`${statePath}.mutation.lock`, JSON.stringify({ version: 1, pid: 999999999, processStart: '1', createdAt: new Date().toISOString(), nonce: randomUUID() }));
+      writeFileSync(`${statePath}.mutation.lock`, JSON.stringify({ version: 1, pid: 999999999, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 300000).toISOString(), nonce: randomUUID() }));
 
       expect(writeModeState('autopilot', { active: true }, tempDir)).toBe(true);
       expect(existsSync(`${statePath}.mutation.lock`)).toBe(true);
@@ -124,14 +124,32 @@ describe('mode-state-io', () => {
       process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
       const statePath = join(tempDir, '.omc', 'state', 'autopilot-state.json');
       mkdirSync(dirname(statePath), { recursive: true });
-      const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-      const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-      const owner = { version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() };
+      // OMC_TEST_FLOCK_AVAILABLE=0 short-circuits acquire to { unlocked: true },
+      // so the lock artifact is never inspected; plant a valid lease-schema
+      // owner (expires_at in the future). No /proc dependency (absent on macOS).
+      const owner = { version: 1, pid: process.pid, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 300000).toISOString(), nonce: randomUUID() };
       writeFileSync(`${statePath}.mutation.lock`, JSON.stringify(owner));
 
       expect(writeModeState('autopilot', { active: true }, tempDir)).toBe(true);
       expect(existsSync(`${statePath}.mutation.lock`)).toBe(true);
       expect(existsSync(statePath)).toBe(true);
+    });
+
+    it('fails closed for an old liveness lock instead of reclaiming it', () => {
+      const statePath = join(tempDir, '.omc', 'state', 'autopilot-state.json');
+      mkdirSync(dirname(statePath), { recursive: true });
+      const legacyOwner = {
+        version: 1,
+        pid: process.pid,
+        processStart: '1',
+        createdAt: new Date().toISOString(),
+        nonce: randomUUID(),
+      };
+      const lockPath = `${statePath}.mutation.lock`;
+      writeFileSync(lockPath, JSON.stringify(legacyOwner));
+
+      expect(acquireMutationLockAt(statePath, true)).toBeNull();
+      expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(legacyOwner);
     });
 
     it('should include sessionId in _meta when sessionId is provided', () => {
@@ -331,8 +349,8 @@ describe('mode-state-io', () => {
       writeFileSync(lockPath, JSON.stringify({
         version: 1,
         pid: 999999999,
-        processStart: '1',
         createdAt: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 300000).toISOString(),
         nonce: randomUUID(),
       }));
 
@@ -365,9 +383,10 @@ describe('mode-state-io', () => {
       writeFileSync(statePath, JSON.stringify(state));
       writeFileSync(legacyPath, JSON.stringify(state));
       writeFileSync(artifactPath, JSON.stringify({ count: 2 }));
-      const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-      const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-      writeFileSync(`${statePath}.mutation.lock`, JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() }));
+      // Plant a LIVE mutation lock: an unexpired lease blocks the exclusive
+      // acquire so clearModeStateFile fails (snapshots preserved). Lease-based
+      // (expires_at in the future) - no /proc liveness dependency.
+      writeFileSync(`${statePath}.mutation.lock`, JSON.stringify({ version: 1, pid: process.pid, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 300000).toISOString(), nonce: randomUUID() }));
       const snapshots = [statePath, legacyPath, artifactPath].map((path) => readFileSync(path));
 
       expect(clearModeStateFile('autopilot', tempDir, sessionId, state)).toBe(false);
@@ -378,10 +397,10 @@ describe('mode-state-io', () => {
       const sessionId = 'in-flight-activation';
       const statePath = join(tempDir, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
       mkdirSync(dirname(statePath), { recursive: true });
-      const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-      const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
+      // Plant a LIVE mutation lock (unexpired lease) held by the publisher child.
+      // clearModeStateFile waits; the child unlinks the lock after publishing.
       const lockPath = `${statePath}.mutation.lock`;
-      writeFileSync(lockPath, JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() }));
+      writeFileSync(lockPath, JSON.stringify({ version: 1, pid: process.pid, createdAt: new Date().toISOString(), expires_at: new Date(Date.now() + 300000).toISOString(), nonce: randomUUID() }));
       const childScript = String.raw`
         const fs = require('fs');
         const [statePath, lockPath] = process.argv.slice(1);

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -646,6 +646,27 @@ describe('mode-state-io', () => {
       expect(existsSync(`${path}.emergency-journal.json`)).toBe(false);
     });
 
+    it('retains the authenticated journal when publication crashes before its OCC fence', () => {
+      const path = join(tempDir, '.omc', 'state', 'autopilot-state.json');
+      expect(writeModeState('autopilot', { active: true, run: 'fence-retry' }, tempDir)).toBe(true);
+
+      process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'before-occ-fence';
+      expect(emergencyMutateStateFileIf(
+        path,
+        (state) => state.run === 'fence-retry',
+        (state) => ({ ...state, active: false }),
+      )).toBe(false);
+      delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
+
+      // The canonical payload is visible, but its durable retry parent must
+      // remain until recovery has sequenced it into the OCC journal.
+      expect(JSON.parse(readFileSync(path, 'utf8'))).toMatchObject({ active: false, run: 'fence-retry' });
+      expect(existsSync(`${path}.emergency-journal.json`)).toBe(true);
+      expect(recoverEmergencyStateFile(path)).toBe(true);
+      expect(existsSync(`${path}.emergency-journal.json`)).toBe(false);
+      expect(writeStateFileLockedIf(path, (state) => state.active === true, (state) => ({ ...state, stale: true }))).toBe('skipped');
+    });
+
     it('preserves a foreign transaction under the recovery claim while default recovery still converges', () => {
       const path = join(tempDir, '.omc', 'state', 'shared-home-autopilot-state.json');
       mkdirSync(dirname(path), { recursive: true });

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -639,6 +639,9 @@ describe('mode-state-io', () => {
       expect(emergencyMutateStateFileIf(path, (state) => state.run === 'one', (state) => ({ ...state, active: false }))).toBe(false);
       delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
       expect(recoverEmergencyStateFile(path)).toBe(true);
+      // Reconciliation sequences this already-published generation without
+      // routing its compact bytes through atomicWriteJsonSync.
+      expect(readFileSync(path, 'utf8')).toBe(JSON.stringify({ active: false, run: 'one' }));
       expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ active: false, run: 'one' });
       expect(existsSync(`${path}.emergency-journal.json`)).toBe(false);
     });

--- a/src/lib/__tests__/mode-state-io.test.ts
+++ b/src/lib/__tests__/mode-state-io.test.ts
@@ -22,6 +22,10 @@ describe('mode-state-io', () => {
     delete process.env.OMC_STATE_DIR;
     delete process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH;
     delete process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64;
+    delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH;
+    delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64;
+    delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH;
+    delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64;
     delete process.env.OMC_TEST_FLOCK_AVAILABLE;
     delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
     delete process.env.OMC_TEST_EMERGENCY_REPLACEMENT_PATH;
@@ -585,6 +589,38 @@ describe('mode-state-io', () => {
   });
 
   describe('durable emergency mutation journal', () => {
+    it('skips a conditional write that races a malformed canonical replacement', () => {
+      const path = join(tempDir, '.omc', 'state', 'conditional-write-raced-replacement.json');
+      const original = JSON.stringify({ active: true, run: 'original' });
+      const replacement = '{"active":false';
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, original);
+      process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH = path;
+      process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64 = Buffer.from(replacement).toString('base64');
+
+      expect(writeStateFileLockedIf(
+        path,
+        (state) => state.active === true,
+        (state) => ({ ...state, changed: true }),
+      )).toBe('skipped');
+      expect(readFileSync(path, 'utf8')).toBe(replacement);
+    });
+
+    it('skips a conditional create that races a malformed canonical replacement', () => {
+      const path = join(tempDir, '.omc', 'state', 'conditional-create-raced-replacement.json');
+      const replacement = '{"active":true';
+      mkdirSync(dirname(path), { recursive: true });
+      process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH = path;
+      process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64 = Buffer.from(replacement).toString('base64');
+
+      expect(writeStateFileLockedCreateIf(
+        path,
+        (current) => current === null,
+        () => ({ active: true, run: 'created' }),
+      )).toBe('skipped');
+      expect(readFileSync(path, 'utf8')).toBe(replacement);
+    });
+
     it('makes an emergency publication visible to a later conditional write', () => {
       expect(writeModeState('autopilot', { active: true, run: 'emergency-visible' }, tempDir)).toBe(true);
       const path = join(tempDir, '.omc', 'state', 'autopilot-state.json');

--- a/src/lib/mode-names.ts
+++ b/src/lib/mode-names.ts
@@ -10,6 +10,7 @@
 export const MODE_NAMES = {
   AUTOPILOT: 'autopilot',
   AUTORESEARCH: 'autoresearch',
+  GRAPH: 'graph',
   TEAM: 'team',
   RALPH: 'ralph',
   ULTRAWORK: 'ultrawork',
@@ -40,6 +41,7 @@ export type ModeName = typeof MODE_NAMES[keyof typeof MODE_NAMES];
 export const ALL_MODE_NAMES: readonly ModeName[] = [
   MODE_NAMES.AUTOPILOT,
   MODE_NAMES.AUTORESEARCH,
+  MODE_NAMES.GRAPH,
   MODE_NAMES.TEAM,
   MODE_NAMES.RALPH,
   MODE_NAMES.ULTRAWORK,
@@ -57,6 +59,7 @@ export const ALL_MODE_NAMES: readonly ModeName[] = [
 export const MODE_STATE_FILE_MAP: Readonly<Record<ModeName, string>> = {
   [MODE_NAMES.AUTOPILOT]: 'autopilot-state.json',
   [MODE_NAMES.AUTORESEARCH]: 'autoresearch-state.json',
+  [MODE_NAMES.GRAPH]: 'graph-state.json',
   [MODE_NAMES.TEAM]: 'team-state.json',
   [MODE_NAMES.RALPH]: 'ralph-state.json',
   [MODE_NAMES.ULTRAWORK]: 'ultrawork-state.json',

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -1035,6 +1035,17 @@ export function occReconcileCanonicalState(filePath: string, assertHeld?: () => 
   return true;
 }
 
+/** Reconcile a recovered emergency publication while sharing normal write/clear exclusion. */
+function reconcileRecoveredEmergencyStateFile(filePath: string): boolean {
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return false;
+  try {
+    return occReconcileCanonicalState(filePath, () => assertMutationLockHeld(lock));
+  } finally {
+    releaseMutationLock(lock);
+  }
+}
+
 /** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */
 export function occCleanupOwner(filePath: string, ownerToken: string): void {
   const dir = occJournalDir(filePath);
@@ -1676,7 +1687,8 @@ export function recoverEmergencyStateFile(filePath: string, options?: EmergencyR
     if (!recoveryGenerationsAuthorized(filePath, current, authorizeState)) return true;
     if (!reconcileEmergencyPublicationTemps(filePath, authorizeState)) return false;
     if (!current || current.quarantinePath !== `${filePath}.emergency-quarantine.${current.transactionId}` || isEmergencyOwnerLive(current.owner)) return false;
-    return recoverDeadEmergencyStateFile(filePath, authorizeState);
+    return recoverDeadEmergencyStateFile(filePath, authorizeState) &&
+      reconcileRecoveredEmergencyStateFile(filePath);
   } finally {
     releaseRecoveryClaim(claimPath, claim);
   }

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -341,7 +341,12 @@ function acquireLockAt(path: string, requireExclusive = false): MutationLock | n
 }
 
 function acquireMutationLock(filePath: string): MutationLock | null {
-  return acquireLockAt(`${filePath}.mutation.lock`);
+  // State mutation is never best-effort: public write/clear paths must honor
+  // the same lock even on flock-less hosts. `unlocked` is only for legacy
+  // observational callers that explicitly request non-exclusive access. The
+  // explicit no-lock test seam preserves its historical unlocked simulation;
+  // real macOS/Windows hosts take the linkSync O_EXCL branch below.
+  return acquireLockAt(`${filePath}.mutation.lock`, !lockingDisabledForTest());
 }
 
 function sameLockOwner(left: MutationLockOwner, right: MutationLockOwner): boolean {
@@ -704,6 +709,7 @@ type OccReadCurrentResult = {
   state: unknown;
   empty: boolean;
   ioError: boolean;
+  reservedSeq: number;
 };
 
 function occJournalDir(filePath: string): string {
@@ -722,7 +728,13 @@ function occAbortedPath(dir: string, seq: number, token: string): string {
   return join(dir, `${seq}.${token}.aborted`);
 }
 
+/** A sequence-level O_EXCL reservation: one sequence has exactly one writer. */
+function occClaimPath(dir: string, seq: number): string {
+  return join(dir, `${seq}.claim`);
+}
+
 const OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+const OCC_CLAIM_NAME_RE = /^(\d+)\.claim$/;
 
 /**
  * Scans the OCC journal directory and returns the current committed state: the
@@ -740,12 +752,19 @@ function occReadCurrent(filePath: string): OccReadCurrentResult {
     names = readdirSync(dir);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false };
-    return { seq: -1, state: null, empty: false, ioError: true };
+    if (code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false, reservedSeq: -1 };
+    return { seq: -1, state: null, empty: false, ioError: true, reservedSeq: -1 };
   }
-  const completeSeqs = new Set<number>();
+  const completeBySeq = new Map<number, string | null>();
   const entryBySeq = new Map<number, string>();
+  let reservedSeq = -1;
   for (const name of names) {
+    const claim = OCC_CLAIM_NAME_RE.exec(name);
+    if (claim) {
+      const seq = Number(claim[1]);
+      if (Number.isInteger(seq) && seq >= 0) reservedSeq = Math.max(reservedSeq, seq);
+      continue;
+    }
     const match = OCC_ENTRY_NAME_RE.exec(name);
     if (!match) continue;
     const seq = Number(match[1]);
@@ -753,54 +772,69 @@ function occReadCurrent(filePath: string): OccReadCurrentResult {
     const token = match[2];
     const kind = match[3];
     if (kind === 'complete') {
-      completeSeqs.add(seq);
+      const existing = completeBySeq.get(seq);
+      completeBySeq.set(seq, existing === undefined ? token : existing === token ? token : null);
     } else if (kind === 'json') {
-      if (!entryBySeq.has(seq)) entryBySeq.set(seq, token);
+      const existing = entryBySeq.get(seq);
+      if (existing === undefined) entryBySeq.set(seq, token);
+      else if (existing !== token) return { seq: -1, state: null, empty: false, ioError: true, reservedSeq };
     }
   }
-  if (completeSeqs.size === 0) return { seq: -1, state: null, empty: true, ioError: false };
+  if (completeBySeq.size === 0) return { seq: -1, state: null, empty: true, ioError: false, reservedSeq };
   let maxSeq = -1;
-  for (const seq of completeSeqs) if (seq > maxSeq) maxSeq = seq;
+  for (const seq of completeBySeq.keys()) if (seq > maxSeq) maxSeq = seq;
+  const completeToken = completeBySeq.get(maxSeq);
   const token = entryBySeq.get(maxSeq);
-  if (!token) {
+  if (!token || !completeToken || completeToken !== token) {
     // A complete marker exists without its entry json: the entry was pruned or
     // never written. Treat the journal as unreadable at this fence and fail
     // closed rather than guessing a parent.
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   let raw: string;
   try {
     raw = readFileSync(occEntryPath(dir, maxSeq, token), 'utf8');
   } catch {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   let entry: unknown;
   try {
     entry = JSON.parse(raw);
   } catch {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   const record = entry as Record<string, unknown> | null;
   if (!record || typeof record !== 'object' || record.seq !== maxSeq || record.owner_token !== token || !('state' in record)) {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
-  return { seq: maxSeq, state: record.state, empty: false, ioError: false };
+  return { seq: maxSeq, state: record.state, empty: false, ioError: false, reservedSeq };
 }
 
-/** Seed state for the first commit when the journal is empty: the canonical file, if any. */
-function occSeedState(filePath: string): unknown {
+type OccCanonicalSnapshot = { state: unknown; fingerprint: string; ioError: boolean };
+
+/**
+ * The canonical file is an integrity fence as well as a compatibility cache.
+ * Non-OCC paths still exist in deployed installs, so an OCC retry must see a
+ * valid canonical replacement instead of committing against a stale journal.
+ */
+function occReadCanonicalSnapshot(filePath: string): OccCanonicalSnapshot {
   try {
-    const raw = readFileSync(filePath, 'utf8');
-    return JSON.parse(raw);
+    const state = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    return { state, fingerprint: JSON.stringify(state), ioError: false };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') return null;
-    throw error;
+    if (code === 'ENOENT') return { state: null, fingerprint: 'absent', ioError: false };
+    return { state: null, fingerprint: '', ioError: true };
   }
+}
+
+function occStateFingerprint(state: unknown): string {
+  return state === null ? 'absent' : JSON.stringify(state);
 }
 
 /** Removes only the caller's OWN incomplete entry + any markers for (seq, token). */
 function occCleanupOwn(dir: string, seq: number, token: string): void {
+  try { unlinkSync(occClaimPath(dir, seq)); } catch { /* absent */ }
   try { unlinkSync(occEntryPath(dir, seq, token)); } catch { /* absent */ }
   try { unlinkSync(occCompletePath(dir, seq, token)); } catch { /* absent */ }
   try { unlinkSync(occAbortedPath(dir, seq, token)); } catch { /* absent */ }
@@ -812,7 +846,7 @@ function occPruneOld(dir: string, currentSeq: number): void {
   try { names = readdirSync(dir); } catch { return; }
   const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
   for (const name of names) {
-    const match = OCC_ENTRY_NAME_RE.exec(name);
+    const match = OCC_ENTRY_NAME_RE.exec(name) ?? OCC_CLAIM_NAME_RE.exec(name);
     if (!match) continue;
     const seq = Number(match[1]);
     if (Number.isInteger(seq) && seq < cutoff) {
@@ -825,6 +859,8 @@ export type OccMutate<TState, TResult> = (currentState: unknown, ownerToken: str
 
 export interface OccCommitOptions {
   ownerToken?: string;
+  /** Called at the commit/publish boundary by public mutation-lock holders. */
+  assertHeld?: () => void;
 }
 
 /**
@@ -842,46 +878,58 @@ export function occCommitMutation<TState, TResult>(
   options?: OccCommitOptions,
 ): { state: TState; result: TResult } | null {
   const dir = occJournalDir(filePath);
-  mkdirSync(dir, { recursive: true });
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch {
+    return null;
+  }
   const ownerToken = options?.ownerToken ?? randomUUID();
   let parentSeq = -1;
   let parentState: unknown = null;
   for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
     const current = occReadCurrent(filePath);
     if (current.ioError) return null; // fail closed: cannot fence without reading
+    const canonical = occReadCanonicalSnapshot(filePath);
+    if (canonical.ioError) return null;
     if (current.empty) {
       parentSeq = -1;
-      parentState = occSeedState(filePath);
+      parentState = canonical.state;
     } else {
       parentSeq = current.seq;
-      parentState = current.state;
+      parentState = occStateFingerprint(current.state) === canonical.fingerprint ? current.state : canonical.state;
     }
     let produced: { state: TState; result: TResult } | null;
     produced = mutate(parentState, ownerToken);
     if (produced === null || produced === undefined) return null; // cancelled, no commit
     const next = produced.state;
-    const seq = parentSeq + 1;
+    const seq = Math.max(parentSeq, current.reservedSeq) + 1;
     const entryPath = occEntryPath(dir, seq, ownerToken);
     let fd: number | undefined;
-    let claimed = false;
     try {
+      // Claim the sequence itself, not a token-qualified child. Otherwise two
+      // writers can both create `<seq>.<token>.json` and lose one mutation.
+      fd = openSync(occClaimPath(dir, seq), 'wx', 0o600);
+      writeAllSync(fd, ownerToken, 'occ sequence claim');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
       fd = openSync(entryPath, 'wx', 0o600);
       const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
       writeAllSync(fd, JSON.stringify(entry), 'occ journal entry');
       fsyncSync(fd);
       closeSync(fd);
       fd = undefined;
-      claimed = true;
     } catch (error) {
       if (fd !== undefined) { try { closeSync(fd); } catch { /* best-effort descriptor cleanup */ } }
       const code = (error as NodeJS.ErrnoException).code;
       if (code === 'EEXIST') {
-        // Another writer already claimed this seq. Re-read and retry with seq+1.
+        // Another writer owns this exact sequence. Re-read its reservation and
+        // claim a later sequence rather than sharing a token-qualified child.
         continue;
       }
+      occCleanupOwn(dir, seq, ownerToken);
       return null;
     }
-    void claimed;
     // Test seam (B11 probe): when a pause hook is registered for this filePath,
     // invoke it AFTER the entry is claimed but BEFORE the fence revalidation.
     // This deterministically forces the stale-holder-publishes-after-reclaim
@@ -904,6 +952,24 @@ export function occCommitMutation<TState, TResult>(
       // mark the fork as aborted so it is distinguishable from a live claim
       try { closeSync(openSync(occAbortedPath(dir, seq, ownerToken), 'wx', 0o600)); } catch { /* already marked */ }
       continue; // re-run mutate on the successor's state
+    }
+    try {
+      options?.assertHeld?.();
+    } catch {
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    // This is deliberately adjacent to marker publication. A canonical-only
+    // replacement observed after the mutation was calculated invalidates this
+    // attempt so conditional writers cannot overwrite it from stale state.
+    const canonicalFence = occReadCanonicalSnapshot(filePath);
+    if (canonicalFence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (canonicalFence.fingerprint !== canonical.fingerprint) {
+      occCleanupOwn(dir, seq, ownerToken);
+      continue;
     }
     // COMMIT: create the .complete marker via O_EXCL.
     let markerFd: number | undefined;
@@ -945,6 +1011,30 @@ export function occReadCurrentState(filePath: string): unknown {
   return current.state;
 }
 
+/**
+ * Record a completed non-OCC publication while the caller holds the same
+ * mutation lock used by public writes and clears. Emergency transactions use
+ * this after their crash-safe canonical publish so later OCC reads cannot see
+ * a stale journal generation. An absent canonical file is an explicit
+ * tombstone; it is restored to absent after the journal commit.
+ */
+export function occReconcileCanonicalState(filePath: string, assertHeld?: () => void): boolean {
+  const snapshot = occReadCanonicalSnapshot(filePath);
+  if (snapshot.ioError) return false;
+  const committed = occCommitMutation<unknown, boolean>(
+    filePath,
+    () => ({ state: snapshot.state, result: true }),
+    { assertHeld },
+  );
+  if (committed === null) return false;
+  if (snapshot.state === null) {
+    try { unlinkSync(filePath); } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+    }
+  }
+  return true;
+}
+
 /** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */
 export function occCleanupOwner(filePath: string, ownerToken: string): void {
   const dir = occJournalDir(filePath);
@@ -976,8 +1066,18 @@ export function writeStateFileLocked(filePath: string, state: Record<string, unk
   // sequence, so a stale holder whose lease expired mid-mutation is
   // re-sequenced AFTER any successor instead of overwriting it. The mutation is
   // pure (returns `state` regardless of current); the OCC wrapper commits.
-  const committed = occCommitMutation<Record<string, unknown>, boolean>(filePath, () => ({ state, result: true }));
-  return committed !== null;
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return false;
+  try {
+    const committed = occCommitMutation<Record<string, unknown>, boolean>(
+      filePath,
+      () => ({ state, result: true }),
+      { assertHeld: () => assertMutationLockHeld(lock) },
+    );
+    return committed !== null;
+  } finally {
+    releaseMutationLock(lock);
+  }
 }
 
 export function clearStateFileLocked(filePath: string): boolean {
@@ -1070,15 +1170,24 @@ export function writeStateFileLockedIf(
   // validated current committed state on each retry, so a stale writer that
   // forked off an old parent re-runs against the successor's state. A
   // predicate that no longer holds returns null (skip) without committing.
-  const committed = occCommitMutation<Record<string, unknown> | null, ConditionalWriteResult>(filePath, (currentRaw) => {
-    if (currentRaw === null || currentRaw === undefined) return null;
-    if (typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
-    const current = currentRaw as Record<string, unknown>;
-    if (!predicate(current)) return { state: current, result: 'skipped' as ConditionalWriteResult };
-    return { state: transform(current), result: 'written' as ConditionalWriteResult };
-  });
-  if (committed === null) return 'skipped';
-  return committed.result;
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return 'failed';
+  try {
+    let skipped = false;
+    const committed = occCommitMutation<Record<string, unknown>, ConditionalWriteResult>(filePath, (currentRaw) => {
+      if (currentRaw === null || currentRaw === undefined || typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
+      const current = currentRaw as Record<string, unknown>;
+      if (!predicate(current)) {
+        skipped = true;
+        return null;
+      }
+      return { state: transform(current), result: 'written' as ConditionalWriteResult };
+    }, { assertHeld: () => assertMutationLockHeld(lock) });
+    if (committed === null) return skipped ? 'skipped' : 'failed';
+    return committed.result;
+  } finally {
+    releaseMutationLock(lock);
+  }
 }
 
 export function writeStateFileLockedCreateIf(
@@ -1099,17 +1208,27 @@ export function writeStateFileLockedCreateIf(
   // OCC commit (B11 root cure): the create-if mutation runs against the OCC-
   // validated current (null when absent). The predicate gates whether a state
   // is produced at all; a falsy predicate returns null (skip, no commit).
-  const committed = occCommitMutation<Record<string, unknown>, ConditionalWriteResult>(filePath, (currentRaw) => {
-    let current: Record<string, unknown> | null = null;
-    if (currentRaw !== null && currentRaw !== undefined) {
-      if (typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
-      current = currentRaw as Record<string, unknown>;
-    }
-    if (!predicate(current)) return { state: current ?? {}, result: 'skipped' as ConditionalWriteResult };
-    return { state: transform(current), result: 'written' as ConditionalWriteResult };
-  });
-  if (committed === null) return 'skipped';
-  return committed.result;
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return 'failed';
+  try {
+    let skipped = false;
+    const committed = occCommitMutation<Record<string, unknown>, ConditionalWriteResult>(filePath, (currentRaw) => {
+      let current: Record<string, unknown> | null = null;
+      if (currentRaw !== null && currentRaw !== undefined) {
+        if (typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
+        current = currentRaw as Record<string, unknown>;
+      }
+      if (!predicate(current)) {
+        skipped = true;
+        return null;
+      }
+      return { state: transform(current), result: 'written' as ConditionalWriteResult };
+    }, { assertHeld: () => assertMutationLockHeld(lock) });
+    if (committed === null) return skipped ? 'skipped' : 'failed';
+    return committed.result;
+  } finally {
+    releaseMutationLock(lock);
+  }
 }
 
 /**
@@ -1680,35 +1799,10 @@ export function emergencyMutateStateFileIf(
   transform: ((current: Record<string, unknown>) => Record<string, unknown>) | null,
   recoveryOptions?: EmergencyRecoveryOptions,
 ): boolean {
-  // TODO(B11/OCC composition): under (B) the OCC journal is the source of truth
-  // and the canonical file is a derived cache. This emergency mutation's final
-  // publish writes the CANONICAL file directly (linkSync for publish intent,
-  // unlink at capture for clear intent) without committing an OCC journal entry,
-  // so a subsequent writeStateFileLocked*/clearStateFileLocked* call (which reads
-  // current from the journal) would NOT observe it - the same class of visibility
-  // gap that required routing recoverExpiredGraphClaim and the runtime.test.ts
-  // setup through OCC/the store.
-  //
-  // Routing the emergency publish through occCommitMutation was ATTEMPTED and
-  // STOPPED as genuinely risky: the emergency mutation is NOT a pure function of
-  // the OCC current - it is a function of the emergency journal's captured +
-  // digested canonical generation (originalDigest/intendedDigest fence its
-  // single-write crash-safety). OCC's pure-callback model would, on a fork,
-  // re-run the callback against a DIFFERENT current than the emergency captured,
-  // so committing the emergency's intended `next` as a constant after a successor
-  // could clobber the successor's value with an older intended state. A correct
-  // composition would need the OCC mutate callback to re-derive the emergency
-  // intent against the OCC-validated current (re-running predicate + transform +
-  // digest), which materially changes the emergency crash-recovery invariants and
-  // cannot be verified safe on macOS (the emergency crash-injection tests live
-  // in the flock-gated workflow-profile suite). The graph path + write family +
-  // clear family (tombstones) + deterministic B11 probes are all (B)-correct and
-  // green; only this emergency-publish visibility gap remains. Callers that mix
-  // emergencyMutateStateFileIf with writeStateFileLocked*/clearStateFileLocked*
-  // on the same filePath may not see the emergency mutation through the journal;
-  // the emergency journal itself remains crash-safe and the canonical file is
-  // still updated.
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return false;
+  const lock = acquireMutationLock(filePath);
+  if (!lock) return false;
+  try {
   const owner = emergencyOwner();
   if (!owner) return false;
   const transactionId = randomUUID();
@@ -1765,10 +1859,14 @@ export function emergencyMutateStateFileIf(
       if (!writeEmergencyJournal(journalPath, journal)) return false;
     }
     if (emergencyCrashAt('before-cleanup')) { abandonEmergencyJournalForTest(journalPath, journal); return false; }
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    return removeOwnedEmergencyArtifacts(journalPath, journal, true) &&
+      occReconcileCanonicalState(filePath, () => assertMutationLockHeld(lock));
   } catch {
     if (journal) abandonEmergencyJournal(journalPath, journal);
     return false;
+  }
+  } finally {
+    releaseMutationLock(lock);
   }
 }
 

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -1249,11 +1249,23 @@ export function clearStateFileLockedIf(
     let skipped = false;
     let canonicalReplaced = false;
     const committed = occCommitMutation<null, ConditionalClearResult>(filePath, (currentRaw) => {
-      if (currentRaw === null || typeof currentRaw !== 'object' || Array.isArray(currentRaw)) {
+      // The clear is an exact-deletion capability over the discovered canonical
+      // bytes. The OCC journal head may be a tombstone (null) while the canonical
+      // cache still carries bytes written by a non-OCC (legacy) writer - e.g. a
+      // malformed named marker written by an older install. In that case evaluate
+      // the predicate against the canonical state (the CAS fence guarantees it
+      // matches observedCanonical here) so the clear proceeds instead of being
+      // silently skipped, which would strand the marker and fail the caller.
+      let current = currentRaw;
+      if (current === null || current === undefined || typeof current !== 'object' || Array.isArray(current)) {
+        const canonical = occReadCanonicalSnapshot(filePath);
+        current = canonical.ioError ? null : canonical.state;
+      }
+      if (current === null || typeof current !== 'object' || Array.isArray(current)) {
         skipped = true;
         return null;
       }
-      if (!predicate(currentRaw as Record<string, unknown>)) {
+      if (!predicate(current as Record<string, unknown>)) {
         skipped = true;
         return null;
       }
@@ -1894,8 +1906,15 @@ function recoverDeadEmergencyStateFile(
       if (intent === 'publish' && digest(payloadPath) !== intendedDigest) return false;
       if (!owned()) return false;
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
+        // A replacement appeared DURING capture, before the original was durably
+        // quarantined and unlinked. The emergency no longer applies to this
+        // generation: abort so the caller surfaces the recovery failure, while
+        // cleaning up the partial transaction so no ownerless artifact remains.
+        // This mirrors the live emergencyMutateStateFileIf capture-failure path
+        // and the .mjs recovery: the replacement wins and is never sequenced.
         if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) {
-          return finish(true);
+          removeOwnedEmergencyArtifacts(journalPath, journal, true);
+          return false;
         }
         return false;
       }

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -19,7 +19,7 @@ import {
   ensureOmcDir,
   listSessionIds,
 } from './worktree-paths.js';
-import { atomicWriteJsonSync } from './atomic-write.js';
+import { atomicWriteFileSync, atomicWriteJsonSync } from './atomic-write.js';
 
 /**
  * On-disk lock schema version.
@@ -871,8 +871,12 @@ export interface OccCommitOptions {
   assertHeld?: () => void;
   /** Journal this generation without serializing it back over canonical bytes. */
   suppressCanonicalRepublish?: boolean;
-  /** Internal recursion guard for canonical-to-journal reconciliation. */
-  skipCanonicalReconciliation?: boolean;
+  /** Internal authenticated external-publication bridge; never infer from cache. */
+  authenticatedExternalParent?: unknown;
+  /** Optional cache-byte CAS fence for conditional publication operations. */
+  expectedCanonicalContentFingerprint?: string;
+  /** Called when the optional canonical CAS fence detects a replacement. */
+  onCanonicalCompareFailed?: () => void;
 }
 
 /**
@@ -903,27 +907,27 @@ export function occCommitMutation<TState, TResult>(
     if (current.ioError) return null; // fail closed: cannot fence without reading
     const canonical = occReadCanonicalSnapshot(filePath);
     if (canonical.ioError) return null;
+    if (options?.expectedCanonicalContentFingerprint !== undefined &&
+      canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      return null;
+    }
     if (current.empty) {
       parentSeq = -1;
-      parentState = canonical.state;
+      // An authenticated external transaction has already captured this
+      // source generation before publishing its compatibility bytes. Its
+      // parent is therefore not inferred from those post-publication bytes.
+      parentState = options && Object.prototype.hasOwnProperty.call(options, 'authenticatedExternalParent')
+        ? options.authenticatedExternalParent
+        : canonical.state;
     } else {
       parentSeq = current.seq;
-      if (!options?.skipCanonicalReconciliation && occStateFingerprint(current.state) !== canonical.stateFingerprint) {
-        // Canonical is the compatibility authority for pre-OCC and emergency
-        // publishers. Sequence it before evaluating a conditional mutation so
-        // a later skip cannot leave journal readers on the old generation.
-        const reconciled = occCommitMutation<unknown, boolean>(
-          filePath,
-          () => ({ state: canonical.state, result: true }),
-          {
-            assertHeld: options?.assertHeld,
-            suppressCanonicalRepublish: true,
-            skipCanonicalReconciliation: true,
-          },
-        );
-        if (reconciled === null) return null;
-        continue;
-      }
+      // Once a journal head exists it is the sole state authority. The
+      // canonical file is a compatibility cache and may be delayed, stale, or
+      // replaced by an older installed writer. Never turn those bytes into a
+      // journal generation implicitly: that is precisely how a stale cache
+      // could roll a committed head backwards. Authenticated external writers
+      // use occCommitAuthenticatedExternalState below with a parent fence.
       parentState = current.state;
     }
     const produced = mutate(parentState, ownerToken);
@@ -994,6 +998,12 @@ export function occCommitMutation<TState, TResult>(
       occCleanupOwn(dir, seq, ownerToken);
       return null;
     }
+    if (options?.expectedCanonicalContentFingerprint !== undefined &&
+      canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
     if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
       occCleanupOwn(dir, seq, ownerToken);
       continue;
@@ -1021,8 +1031,8 @@ export function occCommitMutation<TState, TResult>(
       try {
         atomicWriteJsonSync(filePath, next);
       } catch {
-        // The journal commit remains durable. A later writer will reconcile
-        // the compatibility file before it evaluates its own mutation.
+        // The journal commit remains durable. A later writer will re-publish
+        // the authoritative head; cache bytes are never journal input.
       }
     }
     return produced;
@@ -1040,31 +1050,82 @@ export function occReadCurrentState(filePath: string): unknown {
 }
 
 /**
- * Record a completed non-OCC publication while the caller holds the same
- * mutation lock used by public writes and clears. Emergency transactions use
- * this after their crash-safe canonical publish so later OCC reads cannot see
- * a stale journal generation. An absent canonical file is an explicit
- * tombstone; it is restored to absent after the journal commit.
+ * Sequence a non-OCC publication only when it proves the journal parent from
+ * which it was computed. This is the bridge for crash-safe emergency writers:
+ * their transaction authenticates the source bytes, then this fence prevents a
+ * completed newer OCC generation from being overwritten by the publication.
+ *
+ * Arbitrary canonical-only writes deliberately have no access to this API and
+ * therefore remain compatibility-cache changes, never journal authority.
  */
-export function occReconcileCanonicalState(filePath: string, assertHeld?: () => void): boolean {
+export function occCommitAuthenticatedExternalState(
+  filePath: string,
+  expectedParentState: unknown,
+  publishedState: unknown,
+  assertHeld?: () => void,
+): boolean {
   const committed = occCommitMutation<unknown, boolean>(
     filePath,
-    // occCommitMutation first sequences any observed canonical mismatch; this
-    // callback then receives that fenced generation on every retry. Do not
-    // capture a pre-retry snapshot here or a concurrent replacement could be
-    // reintroduced into the journal.
-    (currentState) => ({ state: currentState, result: true }),
-    { assertHeld, suppressCanonicalRepublish: true },
+    (currentState) => {
+      if (occStateFingerprint(currentState) !== occStateFingerprint(expectedParentState)) return null;
+      return { state: publishedState, result: true };
+    },
+    { assertHeld, suppressCanonicalRepublish: true, authenticatedExternalParent: expectedParentState },
   );
-  return committed !== null;
+  if (committed !== null) return true;
+  // A crash can happen after the durable OCC marker but before the emergency
+  // transaction removes its recovery artifacts. Treat an already-sequenced
+  // intended state as idempotent success so recovery can safely finish cleanup
+  // without trying to re-parent a completed transaction.
+  const current = occReadCurrent(filePath);
+  return !current.ioError && !current.empty &&
+    occStateFingerprint(current.state) === occStateFingerprint(publishedState);
 }
 
-/** Reconcile a recovered emergency publication while sharing normal write/clear exclusion. */
-function reconcileRecoveredEmergencyStateFile(filePath: string): boolean {
+/** Re-publish the authoritative head without ever deriving a new one from cache bytes. */
+function occRestoreCanonicalFromJournal(filePath: string, assertHeld?: () => void): boolean {
+  const current = occReadCurrent(filePath);
+  if (current.ioError || current.empty) return !current.ioError;
+  try {
+    assertHeld?.();
+    if (current.state === null) {
+      try { unlinkSync(filePath); } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+      }
+    } else {
+      atomicWriteJsonSync(filePath, current.state);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finish a recovered emergency publication through the same parent fence used
+ * by the live writer. Older journals have no authenticated parsed parent; in
+ * that case the only safe action is restoring the existing journal authority.
+ */
+function commitRecoveredEmergencyPublication(filePath: string, journal: EmergencyMutationJournal): boolean {
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
   try {
-    return occReconcileCanonicalState(filePath, () => assertMutationLockHeld(lock));
+    const assertHeld = () => assertMutationLockHeld(lock);
+    if (!journal.parentState || !journal.intent) return occRestoreCanonicalFromJournal(filePath, assertHeld);
+    let publishedState: unknown = null;
+    if (journal.intent === 'publish') {
+      let raw: string;
+      try { raw = readFileSync(filePath, 'utf8'); publishedState = JSON.parse(raw); } catch { return false; }
+      // Recovery may have deliberately discarded this transaction because an
+      // unrelated canonical replacement won the exact-byte publication race.
+      // That replacement is not authenticated to become a journal head.
+      if (stateDigest(raw) !== journal.intendedDigest) return true;
+    } else if (existsSync(filePath)) {
+      // A clear that did not leave the primary absent likewise lost its
+      // publication race; preserve the winner without sequencing it.
+      return true;
+    }
+    return occCommitAuthenticatedExternalState(filePath, journal.parentState, publishedState, assertHeld);
   } finally {
     releaseMutationLock(lock);
   }
@@ -1157,6 +1218,12 @@ export function clearStateFileLockedIf(
   recoveryOptions?: EmergencyRecoveryOptions,
 ): ConditionalClearResult {
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return 'failed';
+  // Conditional clear has a second fence besides the journal predicate: a
+  // canonical replacement between observation and publish belongs to another
+  // publication attempt and must be preserved. The bytes are only a CAS
+  // generation token here, never input to journal state selection.
+  const observedCanonical = occReadCanonicalSnapshot(filePath);
+  if (observedCanonical.ioError) return 'failed';
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64) {
     try {
       const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64, 'base64').toString('utf8')) as Record<string, unknown>;
@@ -1170,6 +1237,7 @@ export function clearStateFileLockedIf(
   if (!lock) return 'failed';
   try {
     let skipped = false;
+    let canonicalReplaced = false;
     const committed = occCommitMutation<null, ConditionalClearResult>(filePath, (currentRaw) => {
       if (currentRaw === null || typeof currentRaw !== 'object' || Array.isArray(currentRaw)) {
         skipped = true;
@@ -1180,8 +1248,13 @@ export function clearStateFileLockedIf(
         return null;
       }
       return { state: null, result: 'cleared' };
-    }, { assertHeld: () => assertMutationLockHeld(lock), suppressCanonicalRepublish: true });
-    if (committed === null) return skipped ? 'skipped' : 'failed';
+    }, {
+      assertHeld: () => assertMutationLockHeld(lock),
+      suppressCanonicalRepublish: true,
+      expectedCanonicalContentFingerprint: observedCanonical.contentFingerprint,
+      onCanonicalCompareFailed: () => { canonicalReplaced = true; },
+    });
+    if (committed === null) return skipped || canonicalReplaced ? 'skipped' : 'failed';
     assertMutationLockHeld(lock);
     unlinkSync(filePath);
     return committed.result;
@@ -1202,8 +1275,11 @@ export function writeStateFileLockedIf(
   if (!recoverEmergencyStateFile(filePath)) return 'failed';
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64) {
     try {
-      const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64, 'base64').toString('utf8')) as Record<string, unknown>;
-      atomicWriteJsonSync(filePath, replacement);
+      // The seam models an external replacement that races this conditional
+      // write. Preserve the supplied bytes exactly: parsing and reserializing
+      // would hide byte-level replacement regressions behind JSON formatting.
+      const replacementRaw = Buffer.from(process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64, 'base64').toString('utf8');
+      atomicWriteFileSync(filePath, replacementRaw);
     } finally {
       delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH;
       delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64;
@@ -1308,6 +1384,8 @@ type EmergencyMutationJournal = {
   owner: EmergencyJournalOwner;
   sessionOwner?: string;
   originalDigest?: string;
+  /** Parsed source authenticated before the canonical publication. */
+  parentState?: Record<string, unknown>;
   intendedDigest?: string;
   intent?: 'clear' | 'publish';
   quarantinePath: string;
@@ -1502,6 +1580,7 @@ function readEmergencyJournal(path: string): EmergencyMutationJournal | null {
       typeof journal.owner.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(journal.owner.nonce) ||
       (journal.sessionOwner !== undefined && typeof journal.sessionOwner !== 'string') ||
       (journal.originalDigest !== undefined && (typeof journal.originalDigest !== 'string' || !/^[0-9a-f]{64}$/i.test(journal.originalDigest))) ||
+      (journal.parentState !== undefined && (journal.parentState === null || typeof journal.parentState !== 'object' || Array.isArray(journal.parentState))) ||
       (journal.intendedDigest !== undefined && (typeof journal.intendedDigest !== 'string' || !/^[0-9a-f]{64}$/i.test(journal.intendedDigest))) ||
       (journal.intent !== undefined && journal.intent !== 'clear' && journal.intent !== 'publish') ||
       typeof journal.quarantinePath !== 'string' ||
@@ -1722,15 +1801,20 @@ export function recoverEmergencyStateFile(filePath: string, options?: EmergencyR
     if (!recoveryGenerationsAuthorized(filePath, current, authorizeState)) return true;
     if (!reconcileEmergencyPublicationTemps(filePath, authorizeState)) return false;
     if (!current || current.quarantinePath !== `${filePath}.emergency-quarantine.${current.transactionId}` || isEmergencyOwnerLive(current.owner)) return false;
-    return recoverDeadEmergencyStateFile(filePath, authorizeState) &&
-      reconcileRecoveredEmergencyStateFile(filePath);
+    if (!recoverDeadEmergencyStateFile(filePath, authorizeState, true)) return false;
+    if (!commitRecoveredEmergencyPublication(filePath, current)) return false;
+    return removeOwnedEmergencyArtifacts(journalPath, current, true);
   } finally {
     releaseRecoveryClaim(claimPath, claim);
   }
 }
 
 /** Recover a previously interrupted emergency mutation while holding the recovery claim. */
-function recoverDeadEmergencyStateFile(filePath: string, authorizeState?: EmergencyStateAuthorization): boolean {
+function recoverDeadEmergencyStateFile(
+  filePath: string,
+  authorizeState?: EmergencyStateAuthorization,
+  preserveCompletedJournal = false,
+): boolean {
   const journalPath = emergencyJournalPath(filePath);
   if (!existsSync(journalPath)) return true;
   const journal = readEmergencyJournal(journalPath);
@@ -1757,7 +1841,7 @@ function recoverDeadEmergencyStateFile(filePath: string, authorizeState?: Emerge
       return originalStillPrimary && removeOwnedEmergencyArtifacts(journalPath, journal, false);
     }
     journal.phase = 'prepared';
-    return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState);
+    return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState, preserveCompletedJournal);
   }
   const originalDigest = journal.originalDigest!;
   const intent = journal.intent!;
@@ -1767,7 +1851,9 @@ function recoverDeadEmergencyStateFile(filePath: string, authorizeState?: Emerge
   const finalize = (): boolean => removeOwnedEmergencyArtifacts(journalPath, journal, hasQuarantine);
 
   if (hasPrimary && hasQuarantine) {
-    if (intent === 'publish' && digest(filePath) === intendedDigest && digest(journal.quarantinePath) === originalDigest) return finalize();
+    if (intent === 'publish' && digest(filePath) === intendedDigest && digest(journal.quarantinePath) === originalDigest) {
+      return preserveCompletedJournal || finalize();
+    }
     // The primary is an unrelated replacement. It wins; discard only this transaction.
     return removeOwnedEmergencyArtifacts(journalPath, journal, true);
   }
@@ -1782,22 +1868,23 @@ function recoverDeadEmergencyStateFile(filePath: string, authorizeState?: Emerge
         return false;
       }
       journal.phase = 'quarantined';
-      return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState);
+      return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState, preserveCompletedJournal);
     }
     return false;
   }
   if (!hasQuarantine) {
-    return intent === 'clear' && journal.phase === 'published' && removeOwnedEmergencyArtifacts(journalPath, journal, false);
+    return intent === 'clear' && journal.phase === 'published' &&
+      (preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, false));
   }
   if (digest(journal.quarantinePath) !== originalDigest || !owned()) return false;
   try {
-    if (intent === 'clear') return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    if (intent === 'clear') return preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, true);
     const payload = readFileSync(payloadPath, 'utf8');
     if (stateDigest(payload) !== intendedDigest || !owned()) return false;
     linkSync(payloadPath, filePath); // exclusive: never overwrite a replacement
     journal.phase = 'published';
     if (!writeEmergencyJournal(journalPath, journal)) return false;
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    return preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, true);
   } catch { return false; }
 }
 
@@ -1814,7 +1901,7 @@ function abandonEmergencyJournal(journalPath: string, journal: EmergencyMutation
 
 /** Test crashes must relinquish ownership; a real crashed process is not live. */
 function abandonEmergencyJournalForTest(journalPath: string, journal: EmergencyMutationJournal): void {
-  if (!emergencyCrashAt('after-payload') && !emergencyCrashAt('before-rename') && !emergencyCrashAt('after-rename') && !emergencyCrashAt('after-publication') && !emergencyCrashAt('before-cleanup')) return;
+  if (!emergencyCrashAt('after-payload') && !emergencyCrashAt('before-rename') && !emergencyCrashAt('after-rename') && !emergencyCrashAt('after-publication') && !emergencyCrashAt('before-occ-fence') && !emergencyCrashAt('before-cleanup')) return;
   abandonEmergencyJournal(journalPath, journal);
 }
 
@@ -1869,6 +1956,7 @@ export function emergencyMutateStateFileIf(
     Object.assign(journal, {
       ...(getStateSessionOwner(current) ? { sessionOwner: getStateSessionOwner(current) } : {}),
       originalDigest: stateDigest(originalRaw),
+      parentState: current,
       ...(transformedRaw === undefined ? { intent: 'clear' as const } : { intent: 'publish' as const, intendedDigest: stateDigest(transformedRaw) }),
     });
     if (!owns() || !writeEmergencyJournal(journalPath, journal)) return false;
@@ -1906,8 +1994,17 @@ export function emergencyMutateStateFileIf(
       if (!writeEmergencyJournal(journalPath, journal)) return false;
     }
     if (emergencyCrashAt('before-cleanup')) { abandonEmergencyJournalForTest(journalPath, journal); return false; }
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true) &&
-      occReconcileCanonicalState(filePath, () => assertMutationLockHeld(lock));
+    // Keep the authenticated recovery journal and quarantined source until the
+    // OCC parent fence is durable. Otherwise a failed final fence would strand
+    // a canonical publication with no durable retry parent.
+    if (emergencyCrashAt('before-occ-fence')) { abandonEmergencyJournalForTest(journalPath, journal); return false; }
+    if (!occCommitAuthenticatedExternalState(
+        filePath,
+        current,
+        transformedRaw === undefined ? null : JSON.parse(transformedRaw),
+        () => assertMutationLockHeld(lock),
+      )) return false;
+    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
   } catch {
     if (journal) abandonEmergencyJournal(journalPath, journal);
     return false;

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -6,7 +6,7 @@
  * and file permissions so that individual mode modules don't duplicate this logic.
  */
 
-import { closeSync, existsSync, fstatSync, fsyncSync, linkSync, mkdirSync, openSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync, writeSync } from 'fs';
+import { closeSync, existsSync, fstatSync, fsyncSync, linkSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync, writeSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { createHash, randomUUID } from 'crypto';
 import { spawnSync } from 'child_process';
@@ -21,45 +21,178 @@ import {
 } from './worktree-paths.js';
 import { atomicWriteJsonSync } from './atomic-write.js';
 
-type MutationLockOwner = { version: 1; pid: number; processStart: string; createdAt: string; nonce: string };
-type MutationLock = { fd: number; path: string; owner: MutationLockOwner } | { unlocked: true };
-function flockPath(): string | null { return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null; }
+/**
+ * On-disk lock schema version.
+ *
+ * - v1 lease = the deployed lease contract: `{ version: 1, pid, createdAt,
+ *   expires_at, nonce }`. Keep emitting this version so older deployed readers
+ *   do not classify a current lock as corrupt and reclaim it.
+ * - v1 liveness = the older, distinct shape `{ version: 1, pid, processStart,
+ *   createdAt, nonce }` (no `expires_at`). Its owner may still be alive, so we
+ *   NEVER reclaim it and fail closed. See B12.
+ * - Unknown lease versions are structurally valid records under an unsupported
+ *   contract and likewise fail closed rather than being treated as corrupt.
+ *
+ * The lease's `expires_at` is the sole reclaim key for the v1 lease shape.
+ *   `expires_at` is the sole reclaim key (no liveness probe). Reclaimed only when
+ *   `now >= expires_at` or the JSON is corrupt. See B11/B12.
+ */
+const LOCK_SCHEMA_VERSION = 1;
+const LOCK_OLD_SCHEMA_VERSION = 1;
+/** Pre-upgrade (v1) liveness-schema key set: has `processStart`, no `expires_at`. */
+const LOCK_OLD_OWNER_KEYS = ['createdAt', 'nonce', 'pid', 'processStart', 'version'] as const;
+export type MutationLockOwner = { version: 1; pid: number; createdAt: string; expires_at: string; nonce: string };
+export type MutationLock = { fd: number; path: string; owner: MutationLockOwner } | { unlocked: true };
+/**
+ * Lease duration (ms) for a mutation lock. Generous enough that a single
+ * acquire->mutate->release cycle (graph mutation or autopilot state write)
+ * almost always completes within the lease. As a SAFETY NET against a holder
+ * whose critical section overruns the lease (B11: the lease would otherwise
+ * expire mid-mutation and admit a second writer), the holder re-validates its
+ * OWN lease immediately before publishing (see assertMutationLockHeld) and
+ * aborts with `lease_expired_during_mutation` if it has expired. Long-held
+ * locks (e.g. a slow graph mutation) SHOULD additionally call renewMutationLock
+ * periodically to extend `expires_at` while still working, so the lease does
+ * not expire under them. If the holder crashes or fails to release, a later
+ * acquirer reclaims once `now >= expires_at`.
+ */
+const LOCK_LEASE_MS = 300000; // 5 minutes
+
+/** Returns the current wall-clock ms; `expires_at` is compared against this. */
+function leaseNow(): number {
+  return Date.now();
+}
+
+function flockPath(): string | null {
+  // B8 test seam: OMC_TEST_FORCE_FLOCKLESS=1 (NODE_ENV=test only) forces the
+  // flock-less linkSync branch on a host that actually has flock (Linux CI),
+  // so the flock-less acquire/reclaim/release code is exercised there. Unlike
+  // OMC_TEST_FLOCK_AVAILABLE=0 it does NOT trip lockingDisabledForTest(), so
+  // exclusive locking stays enabled and the real flock-less path runs.
+  if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FORCE_FLOCKLESS === '1') return null;
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null;
+}
+/**
+ * True only when the test harness explicitly simulates a runtime with NO
+ * locking primitives whatsoever (OMC_TEST_FLOCK_AVAILABLE=0). Distinct from a
+ * real flock-less runtime (Windows/macOS): there, linkSync-based O_EXCL locking
+ * is still a valid mutual-exclusion mechanism and may be used. Under the test
+ * simulation, exclusive locks must remain unavailable (return null) so callers
+ * fail closed - the same contract the dev branch established.
+ */
+function lockingDisabledForTest(): boolean {
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0';
+}
+// Lease-based mutation lock reclaim script (runs under an exclusive `flock` guard
+// on `${path}.reclaim.guard` so the reclaim read+unlink is atomic w.r.t. other
+// reclaimers). The script reads the on-disk owner and decides:
+//   exit 0 -> lock was reclaimable (expired lease OR corrupt) and has been
+//             unlinked; the caller should retry linkSync to acquire.
+//   exit 2 -> lock has a VALID, UNEXPIRED v1 lease (live owner); do NOT reclaim.
+//   exit 3 -> the lock could not be read with a non-ENOENT I/O error
+//             (EACCES/EMFILE/EIO/ENOMEM): the owner MAY be alive and we just
+//             cannot read its lease. FAIL CLOSED (no steal). Operator attention.
+//   exit 4 -> owner replaced between read and unlink (TOCTOU); caller retries.
+//   exit 5 -> the on-disk owner is a v1 (old-liveness contract) record
+//             (has processStart, no expires_at). The old owner MAY be alive; we
+//             do NOT reclaim it and do NOT unlink. FAIL CLOSED (B12). The caller
+//             fails closed (wait / return null). Operator attention.
+//   exit 6 -> the on-disk owner is a structurally valid lease record under an
+//             unsupported schema version. It MAY be held under a newer contract;
+//             fail closed rather than reclaiming it.
+// For `release` the script unlinks only if the on-disk owner exactly matches the
+// expected owner (pid + nonce + createdAt); a mismatched owner (or a v1 owner,
+// or a corrupt owner) is left in place.
 const LOCK_REMOVAL_SCRIPT = String.raw`
 const fs = require('fs');
-const [operation, lockPath, expectedRaw] = process.argv.slice(1);
-const keys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
+const [operation, lockPath, expectedRaw, renewalPath] = process.argv.slice(1);
+const leaseKeys = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'];
+const oldKeys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
 function readOwner() {
+  let raw;
   try {
-    const value = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    raw = fs.readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return 'absent';
+    return 'io_error';
+  }
+  try {
+    const value = JSON.parse(raw);
     const actual = Object.keys(value).sort();
-    if (actual.length !== keys.length || !actual.every((key, index) => key === keys[index]) || value.version !== 1 || !Number.isSafeInteger(value.pid) || value.pid <= 0 || typeof value.processStart !== 'string' || !/^\d+$/.test(value.processStart) || typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt)) || typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return null;
-    return value;
-  } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); return null; }
+    // v1 lease schema (the deployed current contract): expires_at, no processStart.
+    const leaseShaped = actual.length === leaseKeys.length && actual.every((key, index) => key === leaseKeys[index]) && Number.isSafeInteger(value.version) && value.version > 0 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.expires_at === 'string' && Number.isFinite(Date.parse(value.expires_at)) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce);
+    if (leaseShaped && value.version === 1) return value;
+    // v1 old-liveness schema (pre-upgrade contract): version 1, processStart, no
+    // expires_at. NOT corrupt - it is a live lock held under the old contract. The
+    // old owner may be alive; FAIL CLOSED (B12): never unlink, never reclaim.
+    if (actual.length === oldKeys.length && actual.every((key, index) => key === oldKeys[index]) && value.version === 1 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.processStart === 'string' && /^\d+$/.test(value.processStart) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce)) return 'old_version';
+    if (leaseShaped) return 'unknown_version';
+    // B12: a structurally-valid versioned object under a shape we don't recognise
+    // (e.g. a future lease with extra/renamed fields) MAY be a live owner. FAIL
+    // CLOSED (unknown_version -> exit 6): never unlink, never reclaim. Reserve
+    // 'corrupt' for genuinely unparseable / non-versioned garbage.
+    if (value && typeof value === 'object' && !Array.isArray(value) && Number.isSafeInteger(value.version) && value.version > 0) return 'unknown_version';
+    return 'corrupt';
+  } catch (error) { return 'corrupt'; }
 }
-const owner = readOwner();
-if (!owner) process.exit(3);
 if (operation === 'release') {
   let expected;
   try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
-  if (owner.pid !== expected.pid || owner.processStart !== expected.processStart || owner.nonce !== expected.nonce) process.exit(4);
-  try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(0);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5); // not ours; leave the old-contract lock in place
+  if (current === 'unknown_version') process.exit(6); // not ours; leave the unsupported-contract lock in place
+  if (current === 'corrupt') process.exit(3);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); }
 }
-if (process.platform !== 'linux') process.exit(3);
-let currentStart;
-try {
-  const stat = fs.readFileSync('/proc/' + owner.pid + '/stat', 'utf8');
-  const end = stat.lastIndexOf(')');
-  const fields = end >= 0 ? stat.slice(end + 2).trim().split(/\s+/) : [];
-  currentStart = fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
-} catch (error) { currentStart = error && error.code === 'ENOENT' ? 'absent' : null; }
-if (currentStart === null) process.exit(3);
-if (currentStart !== 'absent' && currentStart === owner.processStart) process.exit(2);
-try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+if (operation === 'renew') {
+  let expected;
+  try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(4);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5);
+  if (current === 'unknown_version') process.exit(6);
+  if (current === 'corrupt') process.exit(4);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  if (Date.now() >= Date.parse(current.expires_at)) process.exit(2);
+  try { fs.renameSync(renewalPath, lockPath); process.exit(0); } catch { process.exit(3); }
+}
+const current = readOwner();
+if (current === 'absent') process.exit(0);
+if (current === 'io_error') process.exit(3);
+if (current === 'old_version') process.exit(5); // old-contract owner may be live; FAIL CLOSED (B12)
+if (current === 'unknown_version') process.exit(6); // unknown-contract owner may be live; FAIL CLOSED
+if (current === 'corrupt') { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+if (Date.now() >= Date.parse(current.expires_at)) { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+process.exit(2);
 `;
+
+// ---------------------------------------------------------------------------
+// Emergency-journal process identity (NOT used by the mutation lock).
+//
+// The mutation lock is LEASE-based (see freshLockOwner/readLockOwner below) and
+// does NOT probe process liveness. This processStartIdentity helper is retained
+// exclusively for the EMERGENCY JOURNAL subsystem (recoverEmergencyStateFile /
+// emergencyMutateStateFileIf and their recovery-claim script), which still
+// authenticates a crashed transaction's owner by process-start identity. It is
+// intentionally kept separate from the lease lock so the mutation-lock blockers
+// (B5/B6/B7/B8/B9/B10) cannot recur via the emergency path's liveness probe.
+// ---------------------------------------------------------------------------
+let cachedSelfProcessStart: string | undefined;
+
+function selfProcessStart(): string {
+  if (cachedSelfProcessStart === undefined) {
+    cachedSelfProcessStart = String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1000)));
+  }
+  return cachedSelfProcessStart;
+}
 
 function processStartIdentity(pid: number): string | 'absent' | null {
   if (!Number.isSafeInteger(pid) || pid <= 0) return null;
-  if (process.platform !== 'linux') return pid === process.pid ? String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1000))) : null;
+  if (process.platform !== 'linux') return pid === process.pid ? selfProcessStart() : null;
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_EMERGENCY_PROCESS_START_UNKNOWN_PID === String(pid)) return null;
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
@@ -70,6 +203,24 @@ function processStartIdentity(pid: number): string | 'absent' | null {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === 'ENOENT' ? 'absent' : null;
   }
+}
+
+/**
+ * Computes the owner record written to a freshly acquired lock file. The lease
+ * expires_at = now + LOCK_LEASE_MS; it is the ONLY reclaim key (no process
+ * liveness is probed). pid + nonce + createdAt stay for debug/ownership identity
+ * (release verifies them to avoid unlinking a lock a live owner lawfully
+ * reclaimed and re-acquired).
+ */
+function freshLockOwner(): MutationLockOwner {
+  const now = leaseNow();
+  return {
+    version: LOCK_SCHEMA_VERSION,
+    pid: process.pid,
+    createdAt: new Date(now).toISOString(),
+    expires_at: new Date(now + LOCK_LEASE_MS).toISOString(),
+    nonce: randomUUID(),
+  };
 }
 
 function writeAllSync(fd: number, content: string, label: string): void {
@@ -88,26 +239,37 @@ function writeAllSync(fd: number, content: string, label: string): void {
 }
 
 
-function guardedLockRemoval(path: string, operation: 'reclaim' | 'release', owner?: MutationLockOwner): 'retry' | 'live' | 'replaced' | 'unverifiable' {
+function guardedLockRemoval(path: string, operation: 'reclaim' | 'release', owner?: MutationLockOwner): 'retry' | 'live' | 'replaced' | 'unverifiable' | 'old_version' | 'unknown_version' {
   const flock = flockPath();
   if (!flock) return 'unverifiable';
   const result = spawnSync(flock, ['-x', `${path}.reclaim.guard`, process.execPath, '-e', LOCK_REMOVAL_SCRIPT, operation, path, owner ? JSON.stringify(owner) : ''], { stdio: 'ignore', timeout: 2000 });
   if (result.status === 0) return 'retry';
   if (result.status === 2) return 'live';
   if (result.status === 4) return 'replaced';
+  if (result.status === 5) return 'old_version';
+  if (result.status === 6) return 'unknown_version';
   return 'unverifiable';
+}
+
+/** Compares and replaces a lease while holding the reclaimer's guard. */
+function guardedLockRenewal(path: string, owner: MutationLockOwner, renewalPath: string): boolean {
+  const flock = flockPath();
+  if (!flock) return false;
+  const result = spawnSync(flock, ['-x', `${path}.reclaim.guard`, process.execPath, '-e', LOCK_REMOVAL_SCRIPT, 'renew', path, JSON.stringify(owner), renewalPath], { stdio: 'ignore', timeout: 2000 });
+  return result.status === 0;
 }
 
 function acquireLockAt(path: string, requireExclusive = false): MutationLock | null {
   mkdirSync(dirname(path), { recursive: true });
-  if (!flockPath()) return requireExclusive ? null : { unlocked: true };
-  const processStart = processStartIdentity(process.pid);
-  if (!processStart || processStart === 'absent') {
-    console.error(`[omc-lock] state_mutation_lock_owner_unverifiable: ${path}`);
-    return null;
-  }
+  const hasFlock = !!flockPath();
+  // Under the explicit test no-locking simulation, exclusive locks are
+  // unavailable (fail closed), matching the dev contract. On real flock-less
+  // runtimes (Windows/macOS) we still fall through to linkSync-based locking.
+  if (lockingDisabledForTest()) return requireExclusive ? null : { unlocked: true };
+  if (!hasFlock && !requireExclusive) return { unlocked: true };
+  // No process-liveness probe: the lease (expires_at) is the sole reclaim key.
   for (let attempt = 0; attempt < 50; attempt += 1) {
-    const owner: MutationLockOwner = { version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() };
+    const owner = freshLockOwner();
     const tempPath = `${path}.${process.pid}.${owner.nonce}.tmp`;
     let fd: number | undefined;
     try {
@@ -121,12 +283,58 @@ function acquireLockAt(path: string, requireExclusive = false): MutationLock | n
       if (fd !== undefined) { try { closeSync(fd); } catch { /* best-effort descriptor cleanup */ } }
       try { unlinkSync(tempPath); } catch { /* best-effort unpublished temp cleanup */ }
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') return null;
-      const disposition = guardedLockRemoval(path, 'reclaim');
-      if (disposition === 'unverifiable') {
-        console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path}`);
-        return null;
+      // A lock already exists. Decide reclaim by LEASE, not process liveness.
+      // Both the flock and flock-less paths use the SAME policy (B7/B10
+      // convergence): reclaim only when the lease is expired or the owner JSON
+      // is corrupt; a valid unexpired lease blocks (fail closed); an I/O-
+      // unreadable lock fails closed forever (B9: the owner MAY be alive).
+      if (hasFlock) {
+        const disposition = guardedLockRemoval(path, 'reclaim');
+        if (disposition === 'unverifiable') {
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path}`);
+          return null;
+        }
+        if (disposition === 'old_version' || disposition === 'unknown_version') {
+          // v1 old-liveness contract owner on disk: the pre-upgrade owner MAY be
+          // alive. FAIL CLOSED (B12): never reclaim, never steal. Surface it so an
+          // operator can intervene; bail rather than spin forever.
+          console.error(`[omc-lock] state_mutation_lock_${disposition}: ${path}`);
+          return null;
+        }
+        if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        // 'retry' (reclaimed) or 'replaced' (TOCTOU): loop and re-attempt linkSync.
+      } else {
+        const current = readLockOwner(path);
+        if (current === 'absent') {
+          // Lock vanished between EEXIST and read (race): retry linkSync.
+        } else if (current === null) {
+          // I/O read failure (EACCES/EMFILE/EIO/ENOMEM) on a possibly-live
+          // lock. The owner MAY be alive; we just cannot read its lease. FAIL
+          // CLOSED (B9): no steal, no bounded reclaim, no wedge-escape. Log so
+          // the event is observable for operator attention.
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${path}`);
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        } else if (current === 'old_version' || current === 'unknown_version' || current === 'unrecognised') {
+          // v1 old-liveness contract owner (processStart, no expires_at), an
+          // exact-lease-shape owner under an unsupported version, OR a
+          // structurally-valid versioned owner under a shape we don't recognise:
+          // the owner MAY be alive under a contract we don't know. FAIL CLOSED
+          // (B12): do NOT unlink, do NOT steal. Surface it; bail rather than spin.
+          console.error(`[omc-lock] state_mutation_lock_${current}: ${path}`);
+          return null;
+        } else if (current === 'corrupt') {
+          // Readable but unparseable/invalid owner JSON: no valid lease is on
+          // record, so the owner cannot be live. RECLAIM (unlink) and retry.
+          try { unlinkSync(path); } catch { /* race; retry linkSync */ }
+        } else if (leaseNow() >= Date.parse(current.expires_at)) {
+          // Valid owner whose lease has EXPIRED: the holder crashed or failed
+          // to release. RECLAIM (unlink) and retry.
+          try { unlinkSync(path); } catch { /* race; retry linkSync */ }
+        } else {
+          // Valid owner with an unexpired lease: LIVE. Do NOT steal; wait.
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        }
       }
-      if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
   }
   return null;
@@ -136,22 +344,308 @@ function acquireMutationLock(filePath: string): MutationLock | null {
   return acquireLockAt(`${filePath}.mutation.lock`);
 }
 
+function sameLockOwner(left: MutationLockOwner, right: MutationLockOwner): boolean {
+  return left.pid === right.pid && left.nonce === right.nonce && left.createdAt === right.createdAt;
+}
+
+const LOCK_OWNER_KEYS = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'] as const;
+
+/**
+ * True when `value` matches the pre-upgrade v1 LIVENESS-schema owner shape
+ * (`processStart` present, no `expires_at`, version 1). Such a record is a lock
+ * held under the OLD contract; the owner may still be alive. It is NOT corrupt
+ * and must NEVER be reclaimed (B12). Distinct from a corrupt/malformed record.
+ */
+function isOldLivenessOwner(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const actual = Object.keys(record).sort();
+  if (actual.length !== LOCK_OLD_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OLD_OWNER_KEYS[index])) return false;
+  if (record.version !== LOCK_OLD_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(record.pid) || (record.pid as number) <= 0) return false;
+  if (typeof record.createdAt !== 'string' || !Number.isFinite(Date.parse(record.createdAt))) return false;
+  if (typeof record.processStart !== 'string' || !/^\d+$/.test(record.processStart)) return false;
+  if (typeof record.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(record.nonce)) return false;
+  return true;
+}
+
+/**
+ * Validates a parsed object as a lease-based (v1) MutationLockOwner using the
+ * SAME checks the flock path's LOCK_REMOVAL_SCRIPT enforces: exact key set,
+ * version===1, positive integer pid, parseable createdAt, parseable
+ * expires_at (the lease reclaim key), and a 36-char UUID nonce. pid is kept
+ * for debug/ownership identity and is NOT probed for liveness. Returns the
+ * owner or null. A v1 old-liveness record is NOT null here; use
+ * isOldLivenessOwner to detect it. This is the single owner validator (B4).
+ */
+function validateLockOwner(value: unknown): MutationLockOwner | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const actual = Object.keys(record).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return null;
+  if (record.version !== LOCK_SCHEMA_VERSION) return null;
+  if (!Number.isSafeInteger(record.pid) || (record.pid as number) <= 0) return null;
+  if (typeof record.createdAt !== 'string' || !Number.isFinite(Date.parse(record.createdAt))) return null;
+  if (typeof record.expires_at !== 'string' || !Number.isFinite(Date.parse(record.expires_at))) return null;
+  if (typeof record.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(record.nonce)) return null;
+  return record as unknown as MutationLockOwner;
+}
+
+function isUnknownLeaseOwner(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const actual = Object.keys(record).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return false;
+  if (!Number.isSafeInteger(record.version) || (record.version as number) <= 0 || record.version === LOCK_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(record.pid) || (record.pid as number) <= 0) return false;
+  if (typeof record.createdAt !== 'string' || !Number.isFinite(Date.parse(record.createdAt))) return false;
+  if (typeof record.expires_at !== 'string' || !Number.isFinite(Date.parse(record.expires_at))) return false;
+  return typeof record.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(record.nonce);
+}
+
+/**
+ * True when `value` is a structurally-valid-but-UNRECOGNISED versioned owner: a
+ * JSON object that carries a positive-integer `version` field but does NOT
+ * match any schema this build knows (v1 lease, v1 old-liveness, or the exact
+ * 5-key unknown-lease shape handled by `isUnknownLeaseOwner`). Such a record
+ * may be a live lock held under a future contract whose shape we don't
+ * recognise (B12: e.g. a #3553-era or v2 lease with extra/renamed fields). It
+ * is NOT corrupt (the bytes are valid) and must NEVER be reclaimed: reclaiming
+ * it would destroy a live owner's lock. Callers FAIL CLOSED on it. Reserve
+ * `'corrupt'` for genuinely unparseable bytes / non-versioned garbage.
+ */
+function isUnrecognisedVersionedOwner(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(record.version) || (record.version as number) <= 0) return false;
+  // Anything versioned we didn't recognise above is an unknown contract. This
+  // intentionally includes records with extra/missing fields relative to the
+  // known key sets, so a future-schema live owner is never stolen as 'corrupt'.
+  return true;
+}
+
+/**
+ * Reads and validates the on-disk lease owner. Returns:
+ *  - the validated v1 lease owner on success,
+ *  - 'absent' when the lock file does not exist (ENOENT),
+ *  - 'corrupt' when the file is readable but genuinely unparseable/invalid
+ *    (broken JSON, non-object, or a non-versioned record with no `version`):
+ *    no valid lease is on record and the owner cannot be live, so reclaim.
+ *  - 'old_version' when the file is a readable v1 old-liveness-schema record
+ *    (processStart, no expires_at): a lock held under the OLD contract whose
+ *    owner may be alive. Callers FAIL CLOSED on it (B12): never reclaim.
+ *  - 'unknown_version' when the file is the exact v1-lease key set under a
+ *    different positive version (unsupported contract). FAIL CLOSED (B12).
+ *  - 'unrecognised' when the file is a structurally-valid versioned JSON object
+ *    under a shape this build does not recognise (e.g. a future lease with
+ *    extra/renamed fields). The owner MAY be live; FAIL CLOSED (B12): never
+ *    reclaim, never unlink. Distinct from 'corrupt' (genuinely bad bytes).
+ *  - null when the read itself failed with a non-ENOENT I/O error
+ *    (EACCES/EMFILE/EIO/ENOMEM) - the owner MAY be alive; callers fail closed.
+ * The 6-way result lets the caller fail closed on an unreadable lock (B9), an
+ * old-contract lock (B12), or an unrecognised-but-valid lock (B12); reclaim
+ * only a genuinely corrupt lock; and block on a valid unexpired lease.
+ */
+function readLockOwner(path: string): MutationLockOwner | 'absent' | 'corrupt' | 'old_version' | 'unknown_version' | 'unrecognised' | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return 'absent';
+    return null; // I/O failure (EACCES/EMFILE/EIO/...) - may be a live lock we cannot read
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 'corrupt'; // readable but unparseable JSON - no valid lease
+  }
+  if (isOldLivenessOwner(parsed)) return 'old_version';
+  if (isUnknownLeaseOwner(parsed)) return 'unknown_version';
+  const owner = validateLockOwner(parsed);
+  if (owner !== null) return owner;
+  // B12: a versioned object we don't recognise may be a live owner under a
+  // future contract. Fail closed (never unlink) instead of stealing it as
+  // 'corrupt'. Only non-versioned / non-object garbage stays 'corrupt'.
+  if (isUnrecognisedVersionedOwner(parsed)) return 'unrecognised';
+  return 'corrupt';
+}
+
 function releaseMutationLock(lock: MutationLock | null): void {
   if (!lock || 'unlocked' in lock) return;
   try { closeSync(lock.fd); } catch { /* lock metadata ownership still guards release */ }
-  guardedLockRemoval(lock.path, 'release', lock.owner);
+  if (flockPath()) {
+    // Flock path: the guarded removal script unlinks only if the on-disk owner
+    // exactly matches ours (pid + nonce + createdAt); a mismatched owner is a
+    // live owner that lawfully reclaimed after our lease expired, so we leave
+    // it in place (the script exits 4 and we log).
+    const disposition = guardedLockRemoval(lock.path, 'release', lock.owner);
+    if (disposition === 'replaced' || disposition === 'old_version') {
+      console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.path}`);
+    }
+    return;
+  }
+  // flock-less runtime (macOS/Windows) or the explicit test simulation: the
+  // holder releases its OWN lock. Re-validate immediately before unlink to close
+  // the TOCTOU window between readLockOwner and unlinkSync: if the on-disk owner
+  // no longer matches (our lease expired and a later acquirer reclaimed it, or a
+  // concurrent release raced), leave the live owner's lock in place and log.
+  const current = readLockOwner(lock.path);
+  if (current === 'absent') return; // already released
+  if (current === null) return; // unreadable - do not unlink what we cannot verify
+  if (current === 'old_version' || current === 'unknown_version' || current === 'unrecognised') {
+    // The on-disk lock is now a record under a contract we don't recognise
+    // (v1 old-liveness, an unsupported lease version, or an unrecognised
+    // versioned shape - e.g. a pre-upgrade owner or a future-schema owner that
+    // reclaimed after our lease expired). It is NOT ours; leave it in place
+    // (B12) - never unlink an owner whose schema we cannot verify.
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.path}`);
+    return;
+  }
+  if (current !== 'corrupt' && sameLockOwner(current, lock.owner)) {
+    try { unlinkSync(lock.path); } catch { /* race or already removed */ }
+  } else {
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.path}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test surface (B4): export the lease-owner validator and a thin acquire/
+// release pair so the flock-less lock cycle can be exercised end-to-end in
+// tests without going through the full state-file write path. Owner liveness
+// is now lease-based (expires_at), so no processStart/jiffies seam is needed.
+// ---------------------------------------------------------------------------
+
+export function validateMutationLockOwner(value: unknown): MutationLockOwner | null {
+  return validateLockOwner(value);
+}
+
+/** Acquire a mutation lock at an explicit path (test surface). */
+export function acquireMutationLockAt(filePath: string, requireExclusive = false): MutationLock | null {
+  return acquireLockAt(`${filePath}.mutation.lock`, requireExclusive);
+}
+
+/** Release a mutation lock previously acquired via acquireMutationLockAt. */
+export function releaseMutationLockSync(lock: MutationLock | null): void {
+  releaseMutationLock(lock);
+}
+
+/**
+ * Re-validates that the holder's OWN lease is still live (B11). Re-reads the
+ * on-disk owner at `lock.path` and confirms (a) it is still our lock
+ * (`sameLockOwner`: pid + nonce + createdAt) and (b) `now < expires_at`. If the
+ * lease has expired while we were still in the critical section, a second writer
+ * may already have reclaimed and re-acquired the lock; publishing now would
+ * silently overwrite that writer's work. To make that violation DETECTABLE
+ * rather than silent, this throws `lease_expired_during_mutation` and logs the
+ * two-writer overlap. Call this immediately BEFORE publishing under a lock whose
+ * critical section may approach LEASE_MS; withStateFileMutationLock does so
+ * automatically before invoking the callback.
+ *
+ * Note: this is the holder checking ITS OWN lease, not someone else's. A holder
+ * that overruns its lease is the bug; this is the safety net that catches it.
+ */
+export function assertMutationLockHeld(lock: MutationLock | null): void {
+  if (!lock || 'unlocked' in lock) return;
+  const current = readLockOwner(lock.path);
+  if (current === 'absent' || current === 'old_version' || current === 'unknown_version' || current === 'unrecognised' || current === 'corrupt' || current === null) {
+    // Our lock is gone / unreadable / replaced by an owner under a contract we
+    // don't recognise (old-liveness, unsupported lease version, or an
+    // unrecognised versioned shape): a later writer may have reclaimed after our
+    // lease expired. Treat as an overlap.
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.path}`);
+    throw new Error(`lease_expired_during_mutation: holder's lock is no longer live at ${lock.path}`);
+  }
+  if (!sameLockOwner(current, lock.owner)) {
+    // A later writer reclaimed our expired lease and re-acquired: overlap.
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.path}`);
+    throw new Error(`lease_expired_during_mutation: on-disk owner replaced at ${lock.path}`);
+  }
+  if (leaseNow() >= Date.parse(current.expires_at)) {
+    // Our lease has expired while we are still in the critical section. A second
+    // writer can reclaim at any moment. Abort the publish and surface the
+    // two-writer overlap so it is observable, not silent.
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.path}`);
+    throw new Error(`lease_expired_during_mutation: holder's lease expired before publish at ${lock.path}`);
+  }
+}
+
+/**
+ * Extends the holder's lease by re-writing `expires_at = now + LEASE_MS` while
+ * still holding the lock (B11). For long critical sections (e.g. a slow graph
+ * mutation that may approach or exceed LEASE_MS), callers should renew
+ * periodically so the lease does not expire under them and admit a second
+ * writer. Renewal re-validates that the on-disk owner is still ours (otherwise a
+ * later writer has already reclaimed our expired lease and we must NOT publish);
+ * on owner mismatch or I/O failure it returns false and the caller should abort.
+ * Returns true on a successful renewal. No-op (returns true) for unlocked locks.
+ */
+export function renewMutationLock(lock: MutationLock | null): boolean {
+  if (!lock || 'unlocked' in lock) return true;
+  // A read followed by rename is not a path-level CAS. Without the shared
+  // reclaimer guard there is no portable safe replacement, so fail closed.
+  if (!flockPath()) return false;
+  const current = readLockOwner(lock.path);
+  if (current === 'absent' || current === 'old_version' || current === 'unknown_version' || current === 'unrecognised' || current === 'corrupt' || current === null) return false;
+  if (!sameLockOwner(current, lock.owner)) return false; // someone else owns it now
+  if (leaseNow() >= Date.parse(current.expires_at)) return false;
+  const renewedExpiresAt = new Date(leaseNow() + LOCK_LEASE_MS).toISOString();
+  const tempPath = `${lock.path}.${process.pid}.${lock.owner.nonce}.renew.tmp`;
+  let fd: number | undefined;
+  try {
+    const renewed: MutationLockOwner = { ...lock.owner, expires_at: renewedExpiresAt };
+    fd = openSync(tempPath, 'wx', 0o600);
+    writeAllSync(fd, JSON.stringify(renewed), 'lock renewal publication');
+    fsyncSync(fd);
+    // Repeat identity and expiry validation under the same guard reclaimers
+    // use, then replace atomically. This cannot overwrite a later owner.
+    if (!guardedLockRenewal(lock.path, lock.owner, tempPath)) return false;
+    lock.owner = renewed;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) { try { closeSync(fd); } catch { /* best-effort descriptor cleanup */ } }
+    try { unlinkSync(tempPath); } catch { /* best-effort unpublished temp cleanup */ }
+  }
+}
+
+/**
+ * Reports whether `renewMutationLock` can actually extend the lease for `lock`
+ * on the current runtime (B11). On a flock-capable runtime it returns true; on
+ * a flock-less runtime (macOS/Windows) it returns false, because a portable
+ * atomic rename-over-the-live-lock is unavailable without the shared reclaimer
+ * guard, so `renewMutationLock` returns false there regardless of whether the
+ * lock is still held. Unlocked locks are trivially "supported" (renewal is a
+ * no-op that returns true).
+ *
+ * Callers that gate on renewal failure should use this to distinguish
+ * "renewal unsupported on this runtime" (the lock is NOT lost - it is still
+ * held via the O_EXCL linkSync and its lease is still valid for LEASE_MS; the
+ * holder should NO-OP, relying on `assertMutationLockHeld` before publish as the
+ * safety net) from "renewal attempted on a supported runtime and failed" (the
+ * lock WAS lost - owner replaced / lease expired / I/O error - and the caller
+ * must abort). Treating the unsupported case as `lock_lost` would break every
+ * mutation on macOS/Windows.
+ */
+export function mutationLockRenewalSupported(lock: MutationLock | null): boolean {
+  if (!lock || 'unlocked' in lock) return true;
+  return !!flockPath();
 }
 
 /** Executes a read or mutation against a state file under its mutation lock. */
 export function withStateFileMutationLock<T>(
   filePath: string,
-  callback: () => T,
+  callback: (assertHeld: () => void) => T,
   requireExclusive = false,
 ): { acquired: boolean; value: T | undefined } {
   const lock = acquireLockAt(`${filePath}.mutation.lock`, requireExclusive);
   if (!lock) return { acquired: false, value: undefined };
   try {
-    return { acquired: true, value: callback() };
+    // Callers with a publication inside the callback invoke this immediately
+    // before it. Zero-argument callbacks remain source-compatible.
+    return { acquired: true, value: callback(() => assertMutationLockHeld(lock)) };
   } finally {
     releaseMutationLock(lock);
   }
@@ -162,6 +656,7 @@ export function writeStateFileLocked(filePath: string, state: Record<string, unk
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
   try {
+    assertMutationLockHeld(lock); // B11: abort publish if our lease expired mid-mutation
     atomicWriteJsonSync(filePath, state);
     return true;
   } catch {
@@ -176,6 +671,7 @@ export function clearStateFileLocked(filePath: string): boolean {
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
   try {
+    assertMutationLockHeld(lock); // B11: abort mutation if our lease expired mid-mutation
     if (existsSync(filePath)) unlinkSync(filePath);
     return true;
   } catch {
@@ -219,6 +715,7 @@ export function clearStateFileLockedIf(
       return 'failed';
     }
     if (!predicate(current)) return 'skipped';
+    assertMutationLockHeld(lock); // B11: abort mutation if our lease expired mid-mutation
     unlinkSync(filePath);
     return 'cleared';
   } catch {
@@ -257,6 +754,7 @@ export function writeStateFileLockedIf(
       return 'failed';
     }
     if (!predicate(current)) return 'skipped';
+    assertMutationLockHeld(lock); // B11: abort publish if our lease expired mid-mutation
     atomicWriteJsonSync(filePath, transform(current));
     return 'written';
   } catch {
@@ -290,6 +788,7 @@ export function writeStateFileLockedCreateIf(
       catch { return 'failed'; }
     }
     if (!predicate(current)) return 'skipped';
+    assertMutationLockHeld(lock); // B11: abort publish if our lease expired mid-mutation
     atomicWriteJsonSync(filePath, transform(current));
     return 'written';
   } catch {
@@ -307,6 +806,23 @@ export function writeStateFileLockedCreateIf(
 type EmergencyJournalOwner = {
   pid: number;
   processStart: string;
+  nonce: string;
+};
+
+/**
+ * Owner record for an emergency recovery claim. This is the EMERGENCY subsystem
+ * (crash-recovery of an interrupted exact mutation), NOT the mutation lock: it
+ * authenticates the claimant by process-start identity (processStart) so a dead
+ * or recycled pid's stale claim can be reclaimed. It is intentionally kept
+ * separate from the lease-based MutationLockOwner so the mutation-lock liveness
+ * blockers cannot recur here. The on-disk schema is validated by
+ * RECOVERY_CLAIM_SCRIPT (processStart required).
+ */
+type RecoveryClaimOwner = {
+  version: 1;
+  pid: number;
+  processStart: string;
+  createdAt: string;
   nonce: string;
 };
 
@@ -454,7 +970,7 @@ try {
 } catch { try { if (fd !== undefined) fs.closeSync(fd); } catch {} try { fs.unlinkSync(claimPath); } catch {} process.exit(3); }
 `;
 
-function guardedRecoveryClaim(path: string, operation: 'acquire' | 'release', owner: MutationLockOwner): 'claimed' | 'live' | 'replaced' | 'unverifiable' {
+function guardedRecoveryClaim(path: string, operation: 'acquire' | 'release', owner: RecoveryClaimOwner): 'claimed' | 'live' | 'replaced' | 'unverifiable' {
   const flock = flockPath();
   if (!flock) return 'unverifiable';
   const result = spawnSync(flock, ['-x', `${path}.recovery.guard`, process.execPath, '-e', RECOVERY_CLAIM_SCRIPT, operation, path, JSON.stringify(owner)], { stdio: 'ignore', timeout: 2000 });
@@ -464,26 +980,26 @@ function guardedRecoveryClaim(path: string, operation: 'acquire' | 'release', ow
   return 'unverifiable';
 }
 
-function acquireRecoveryClaim(path: string): MutationLockOwner | null {
+function acquireRecoveryClaim(path: string): RecoveryClaimOwner | null {
   const processStart = processStartIdentity(process.pid);
   if (!processStart || processStart === 'absent') return null;
-  const owner: MutationLockOwner = { version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() };
+  const owner: RecoveryClaimOwner = { version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() };
   if (!flockPath()) return publishEmergencyFileExclusive(path, JSON.stringify(owner)) ? owner : null;
   return guardedRecoveryClaim(path, 'acquire', owner) === 'claimed' ? owner : null;
 }
 
-function readRecoveryClaim(path: string): MutationLockOwner | null {
+function readRecoveryClaim(path: string): RecoveryClaimOwner | null {
   try {
-    const owner = JSON.parse(readFileSync(path, 'utf8')) as MutationLockOwner;
+    const owner = JSON.parse(readFileSync(path, 'utf8')) as RecoveryClaimOwner;
     return owner.version === 1 && Number.isSafeInteger(owner.pid) && owner.pid > 0 && typeof owner.processStart === 'string' && typeof owner.createdAt === 'string' && typeof owner.nonce === 'string' ? owner : null;
   } catch { return null; }
 }
 
-function sameRecoveryClaim(left: MutationLockOwner, right: MutationLockOwner): boolean {
+function sameRecoveryClaim(left: RecoveryClaimOwner, right: RecoveryClaimOwner): boolean {
   return left.pid === right.pid && left.processStart === right.processStart && left.nonce === right.nonce;
 }
 
-function releaseRecoveryClaim(path: string, owner: MutationLockOwner): void {
+function releaseRecoveryClaim(path: string, owner: RecoveryClaimOwner): void {
   if (!flockPath()) {
     try {
       const current = readRecoveryClaim(path);
@@ -623,7 +1139,7 @@ function recoveryGenerationsAuthorized(
 
 /** Shared-home recovery claims contain no project identity, so pre-existing
  * claim publications are never attributable to the caller and must survive. */
-function hasUnattributableRecoveryClaimArtifact(filePath: string, recoveryClaim?: MutationLockOwner): boolean {
+function hasUnattributableRecoveryClaimArtifact(filePath: string, recoveryClaim?: RecoveryClaimOwner): boolean {
   const directory = dirname(filePath);
   const base = filePath.slice(directory.length + 1).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const tempPattern = new RegExp(`^${base}\\.emergency-recovery\\.claim\\.\\d+\\.\\d+\\.[0-9a-f-]{36}\\.tmp$`, 'i');
@@ -642,7 +1158,7 @@ function hasUnattributableRecoveryClaimArtifact(filePath: string, recoveryClaim?
 function sharedRecoveryArtifactsAuthorized(
   filePath: string,
   authorizeState: EmergencyStateAuthorization | undefined,
-  recoveryClaim?: MutationLockOwner,
+  recoveryClaim?: RecoveryClaimOwner,
 ): boolean {
   if (!authorizeState) return true;
   if (hasUnattributableRecoveryClaimArtifact(filePath, recoveryClaim)) return false;

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -651,22 +651,344 @@ export function withStateFileMutationLock<T>(
   }
 }
 
-export function writeStateFileLocked(filePath: string, state: Record<string, unknown>): boolean {
-  if (!recoverEmergencyStateFile(filePath)) return false;
-  const lock = acquireMutationLock(filePath);
-  if (!lock) return false;
+// ===========================================================================
+// OCC (optimistic concurrency control) journal - root cure for B11.
+//
+// The lease lock above cannot atomically (check-ownership + write) an EXISTING
+// state file on a flock-less runtime (macOS/Windows): renewMutationLock returns
+// false there and assertMutationLockHeld is a read-then-write TOCTOU, so a
+// stale holder whose lease expired mid-mutation can overwrite a successor's
+// publish (B11), and a stale releaser can unlink a successor's lock (release
+// race). No combination of rename/link/unlink atomically fences an EXISTING
+// file on flock-less. OCC fixes it using ONLY O_EXCL (portable, no flock, no
+// liveness probe, testable on mac): every mutation sequences a NEW journal
+// entry under an O_EXCL name and validates its parent against the current
+// committed sequence; a stale writer that forks off an old parent is DETECTED
+// and re-sequenced AFTER its successor instead of overwriting it. There is no
+// shared lock to unlink - cleanup only ever touches the writer's OWN entries.
+//
+// Journal layout per state file `filePath`:
+//   dir:        filePath.journal/
+//   entry:      <seq>.<owner_token>.json        = { seq, parent_seq, owner_token, state }
+//   commit:     <seq>.<owner_token>.complete    (O_EXCL file = committed)
+//   aborted:    <seq>.<owner_token>.aborted     (marker for a detected dead fork)
+// "current" = the entry with the MAX seq bearing a .complete marker. Readers
+// scan the directory for the max complete seq (small N; entries with seq <
+// current - K are pruned, K=8) and read that entry's state. The canonical
+// `filePath` is re-published (atomicWriteJsonSync) right after each commit so
+// existing readers that do not understand the journal keep working.
+//
+// The JS mirror lives in scripts/lib/atomic-write.mjs (byte-identical to
+// templates/hooks/lib/atomic-write.mjs); this TS copy mirrors it semantically.
+// ===========================================================================
+
+/** Prune window: keep entries whose seq >= currentSeq - OCC_JOURNAL_PRUNE_BEHIND. */
+const OCC_JOURNAL_PRUNE_BEHIND = 8;
+/** Bounded O_EXCL claim retries per commit attempt (defends against live contention). */
+const OCC_JOURNAL_MAX_RETRIES = 50;
+
+/**
+ * Test seam for the deterministic B11 probe (stale-holder-publishes-after-reclaim).
+ * When `pauseAfterClaim` is set, `occCommitMutation` invokes its `fn` AFTER
+ * claiming an entry and BEFORE the fence revalidation, letting a test
+ * deschedule writer A, commit writer B fully, then resume A so A must detect
+ * its fork. Unused in production (the hook object stays empty).
+ */
+export interface OccTestHooks {
+  pauseAfterClaim?: { filePath: string; fn: (seq: number, ownerToken: string, parentSeq: number) => void };
+}
+export const OCC_TEST_HOOKS: OccTestHooks = {};
+
+type OccReadCurrentResult = {
+  seq: number;
+  state: unknown;
+  empty: boolean;
+  ioError: boolean;
+};
+
+function occJournalDir(filePath: string): string {
+  return `${filePath}.journal`;
+}
+
+function occEntryPath(dir: string, seq: number, token: string): string {
+  return join(dir, `${seq}.${token}.json`);
+}
+
+function occCompletePath(dir: string, seq: number, token: string): string {
+  return join(dir, `${seq}.${token}.complete`);
+}
+
+function occAbortedPath(dir: string, seq: number, token: string): string {
+  return join(dir, `${seq}.${token}.aborted`);
+}
+
+const OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+
+/**
+ * Scans the OCC journal directory and returns the current committed state: the
+ * entry with the maximum `seq` that bears a `.complete` marker. Returns
+ * { seq: -1, state: null, empty: true } when no committed entry exists yet (the
+ * journal is empty). Returns ioError=true ONLY when the journal directory is
+ * present but unreadable with a non-ENOENT I/O error - in that case the caller
+ * FAILS CLOSED (operator attention): an OCC commit cannot proceed safely
+ * without being able to read the committed sequence fence.
+ */
+function occReadCurrent(filePath: string): OccReadCurrentResult {
+  const dir = occJournalDir(filePath);
+  let names: string[];
   try {
-    assertMutationLockHeld(lock); // B11: abort publish if our lease expired mid-mutation
-    atomicWriteJsonSync(filePath, state);
-    return true;
+    names = readdirSync(dir);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false };
+    return { seq: -1, state: null, empty: false, ioError: true };
+  }
+  const completeSeqs = new Set<number>();
+  const entryBySeq = new Map<number, string>();
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (!Number.isInteger(seq) || seq < 0) continue;
+    const token = match[2];
+    const kind = match[3];
+    if (kind === 'complete') {
+      completeSeqs.add(seq);
+    } else if (kind === 'json') {
+      if (!entryBySeq.has(seq)) entryBySeq.set(seq, token);
+    }
+  }
+  if (completeSeqs.size === 0) return { seq: -1, state: null, empty: true, ioError: false };
+  let maxSeq = -1;
+  for (const seq of completeSeqs) if (seq > maxSeq) maxSeq = seq;
+  const token = entryBySeq.get(maxSeq);
+  if (!token) {
+    // A complete marker exists without its entry json: the entry was pruned or
+    // never written. Treat the journal as unreadable at this fence and fail
+    // closed rather than guessing a parent.
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(occEntryPath(dir, maxSeq, token), 'utf8');
   } catch {
-    return false;
-  } finally {
-    releaseMutationLock(lock);
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  let entry: unknown;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  const record = entry as Record<string, unknown> | null;
+  if (!record || typeof record !== 'object' || record.seq !== maxSeq || record.owner_token !== token || !('state' in record)) {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  return { seq: maxSeq, state: record.state, empty: false, ioError: false };
+}
+
+/** Seed state for the first commit when the journal is empty: the canonical file, if any. */
+function occSeedState(filePath: string): unknown {
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return null;
+    throw error;
   }
 }
 
+/** Removes only the caller's OWN incomplete entry + any markers for (seq, token). */
+function occCleanupOwn(dir: string, seq: number, token: string): void {
+  try { unlinkSync(occEntryPath(dir, seq, token)); } catch { /* absent */ }
+  try { unlinkSync(occCompletePath(dir, seq, token)); } catch { /* absent */ }
+  try { unlinkSync(occAbortedPath(dir, seq, token)); } catch { /* absent */ }
+}
+
+/** Prunes committed entries older than currentSeq - K (keeps the history tail bounded). */
+function occPruneOld(dir: string, currentSeq: number): void {
+  let names: string[];
+  try { names = readdirSync(dir); } catch { return; }
+  const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (Number.isInteger(seq) && seq < cutoff) {
+      try { unlinkSync(join(dir, name)); } catch { /* race; ignore */ }
+    }
+  }
+}
+
+export type OccMutate<TState, TResult> = (currentState: unknown, ownerToken: string) => { state: TState; result: TResult } | null;
+
+export interface OccCommitOptions {
+  ownerToken?: string;
+}
+
+/**
+ * OCC commit protocol (replaces writeAtomic-under-lock for concurrency fencing).
+ *
+ * `mutate(currentState)` is PURE: it returns { state, result } (or `null` to
+ * cancel without committing). The wrapper handles claim, parent-validation,
+ * commit, re-publication, and retry. Returns the committed result, or `null`
+ * if every retry forked (extremely live contention) or on a journal-directory
+ * I/O error (fail closed) or a thrown/cancelled mutation.
+ */
+export function occCommitMutation<TState, TResult>(
+  filePath: string,
+  mutate: OccMutate<TState, TResult>,
+  options?: OccCommitOptions,
+): { state: TState; result: TResult } | null {
+  const dir = occJournalDir(filePath);
+  mkdirSync(dir, { recursive: true });
+  const ownerToken = options?.ownerToken ?? randomUUID();
+  let parentSeq = -1;
+  let parentState: unknown = null;
+  for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
+    const current = occReadCurrent(filePath);
+    if (current.ioError) return null; // fail closed: cannot fence without reading
+    if (current.empty) {
+      parentSeq = -1;
+      parentState = occSeedState(filePath);
+    } else {
+      parentSeq = current.seq;
+      parentState = current.state;
+    }
+    let produced: { state: TState; result: TResult } | null;
+    produced = mutate(parentState, ownerToken);
+    if (produced === null || produced === undefined) return null; // cancelled, no commit
+    const next = produced.state;
+    const seq = parentSeq + 1;
+    const entryPath = occEntryPath(dir, seq, ownerToken);
+    let fd: number | undefined;
+    let claimed = false;
+    try {
+      fd = openSync(entryPath, 'wx', 0o600);
+      const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
+      writeAllSync(fd, JSON.stringify(entry), 'occ journal entry');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
+      claimed = true;
+    } catch (error) {
+      if (fd !== undefined) { try { closeSync(fd); } catch { /* best-effort descriptor cleanup */ } }
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'EEXIST') {
+        // Another writer already claimed this seq. Re-read and retry with seq+1.
+        continue;
+      }
+      return null;
+    }
+    void claimed;
+    // Test seam (B11 probe): when a pause hook is registered for this filePath,
+    // invoke it AFTER the entry is claimed but BEFORE the fence revalidation.
+    // This deterministically forces the stale-holder-publishes-after-reclaim
+    // interleaving: A claims, yields here, B commits fully, A resumes and must
+    // detect the fork. No-op in production (no hook registered).
+    if (OCC_TEST_HOOKS.pauseAfterClaim && OCC_TEST_HOOKS.pauseAfterClaim.filePath === filePath) {
+      try { OCC_TEST_HOOKS.pauseAfterClaim.fn(seq, ownerToken, parentSeq); } catch { /* test seam; ignore */ }
+    }
+    // RE-VALIDATE (the fence): re-scan the current committed max. If a successor
+    // committed in the window (current.seq > parentSeq), this entry is a DEAD
+    // FORK off a stale parent: mark it aborted, re-run the mutation on the
+    // successor's state, and re-sequence AFTER it. It NEVER overwrites.
+    const fence = occReadCurrent(filePath);
+    if (fence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (!fence.empty && fence.seq > parentSeq) {
+      try { unlinkSync(occEntryPath(dir, seq, ownerToken)); } catch { /* absent */ }
+      // mark the fork as aborted so it is distinguishable from a live claim
+      try { closeSync(openSync(occAbortedPath(dir, seq, ownerToken), 'wx', 0o600)); } catch { /* already marked */ }
+      continue; // re-run mutate on the successor's state
+    }
+    // COMMIT: create the .complete marker via O_EXCL.
+    let markerFd: number | undefined;
+    try {
+      markerFd = openSync(occCompletePath(dir, seq, ownerToken), 'wx', 0o600);
+      fsyncSync(markerFd);
+      closeSync(markerFd);
+    } catch (error) {
+      if (markerFd !== undefined) { try { closeSync(markerFd); } catch { /* best-effort descriptor cleanup */ } }
+      occCleanupOwn(dir, seq, ownerToken);
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'EEXIST') continue; // marker already exists for this (seq, token); retry
+      return null;
+    }
+    // Re-validate this seq is still the max complete (else a successor committed
+    // between our fence read and our marker; we still committed a valid child of
+    // `parentSeq`, which is fine - the successor simply sequences ahead). If our
+    // entry is now NOT the max, it remains a valid committed ancestor: leave it.
+    occPruneOld(dir, seq);
+    // Re-publish the canonical file so legacy readers see the latest state.
+    try {
+      atomicWriteJsonSync(filePath, next);
+    } catch {
+      // The journal IS the source of truth; a failed canonical re-publish is
+      // non-fatal (the committed entry already advances current). Return success.
+    }
+    return produced;
+  }
+  return null; // exhausted retries under extreme live contention
+}
+
+/** Reads the current committed state via the OCC journal (test + reader surface). */
+export function occReadCurrentState(filePath: string): unknown {
+  const current = occReadCurrent(filePath);
+  if (current.ioError) return null;
+  if (current.empty) {
+    try { return JSON.parse(readFileSync(filePath, 'utf8')); } catch { return null; }
+  }
+  return current.state;
+}
+
+/** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */
+export function occCleanupOwner(filePath: string, ownerToken: string): void {
+  const dir = occJournalDir(filePath);
+  let names: string[];
+  try { names = readdirSync(dir); } catch { return; }
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    if (match[2] !== ownerToken) continue; // never touch another writer's entries
+    const seq = Number(match[1]);
+    void seq;
+    const kind = match[3];
+    // Only remove entries that lack a .complete marker (incomplete forks).
+    if (kind === 'json' || kind === 'aborted') {
+      const hasComplete = names.some((other) => {
+        const om = OCC_ENTRY_NAME_RE.exec(other);
+        return om && om[1] === match[1] && om[2] === ownerToken && om[3] === 'complete';
+      });
+      if (!hasComplete) {
+        try { unlinkSync(join(dir, name)); } catch { /* race */ }
+      }
+    }
+  }
+}
+
+export function writeStateFileLocked(filePath: string, state: Record<string, unknown>): boolean {
+  if (!recoverEmergencyStateFile(filePath)) return false;
+  // OCC commit (B11 root cure): the publish is fenced by an O_EXCL journal
+  // sequence, so a stale holder whose lease expired mid-mutation is
+  // re-sequenced AFTER any successor instead of overwriting it. The mutation is
+  // pure (returns `state` regardless of current); the OCC wrapper commits.
+  const committed = occCommitMutation<Record<string, unknown>, boolean>(filePath, () => ({ state, result: true }));
+  return committed !== null;
+}
+
 export function clearStateFileLocked(filePath: string): boolean {
+  // NOTE: clear stays on the lease lock (NOT the OCC tombstone path). The OCC
+  // tombstone migration was reverted: it broke ~242 tests because the tombstone
+  // commit did not reliably unlink the canonical file for clear / runtime-
+  // artifact paths (clearModeState leaves marker files present). The maintainer's
+  // B11 "release" is satisfied by the lock-release path + occCleanupOwner (no
+  // shared lock file under OCC for writes) + release probe #2; the state-clear
+  // on the lease lock is fail-closed: assertMutationLockHeld aborts on overlap,
+  // and under (B) the canonical is a derived cache so a stale clear is harmless.
   if (!recoverEmergencyStateFile(filePath)) return false;
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
@@ -694,6 +1016,8 @@ export function clearStateFileLockedIf(
   predicate: (current: Record<string, unknown>) => boolean,
   recoveryOptions?: EmergencyRecoveryOptions,
 ): ConditionalClearResult {
+  // NOTE: conditional clear stays on the lease lock (see clearStateFileLocked
+  // above). The OCC tombstone migration was reverted for breaking clears.
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return 'failed';
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64) {
     try {
@@ -742,26 +1066,19 @@ export function writeStateFileLockedIf(
       delete process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64;
     }
   }
-  if (!existsSync(filePath)) return 'skipped';
-  const lock = acquireMutationLock(filePath);
-  if (!lock) return 'failed';
-  try {
-    if (!existsSync(filePath)) return 'skipped';
-    let current: Record<string, unknown>;
-    try {
-      current = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
-    } catch {
-      return 'failed';
-    }
-    if (!predicate(current)) return 'skipped';
-    assertMutationLockHeld(lock); // B11: abort publish if our lease expired mid-mutation
-    atomicWriteJsonSync(filePath, transform(current));
-    return 'written';
-  } catch {
-    return 'failed';
-  } finally {
-    releaseMutationLock(lock);
-  }
+  // OCC commit (B11 root cure): predicate + transform run against the OCC-
+  // validated current committed state on each retry, so a stale writer that
+  // forked off an old parent re-runs against the successor's state. A
+  // predicate that no longer holds returns null (skip) without committing.
+  const committed = occCommitMutation<Record<string, unknown> | null, ConditionalWriteResult>(filePath, (currentRaw) => {
+    if (currentRaw === null || currentRaw === undefined) return null;
+    if (typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
+    const current = currentRaw as Record<string, unknown>;
+    if (!predicate(current)) return { state: current, result: 'skipped' as ConditionalWriteResult };
+    return { state: transform(current), result: 'written' as ConditionalWriteResult };
+  });
+  if (committed === null) return 'skipped';
+  return committed.result;
 }
 
 export function writeStateFileLockedCreateIf(
@@ -770,32 +1087,29 @@ export function writeStateFileLockedCreateIf(
   transform: (current: Record<string, unknown> | null) => Record<string, unknown>,
 ): ConditionalWriteResult {
   if (!recoverEmergencyStateFile(filePath)) return 'failed';
-  const lock = acquireMutationLock(filePath);
-  if (!lock) return 'failed';
-  try {
-    if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64) {
-      try {
-        const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64, 'base64').toString('utf8')) as Record<string, unknown>;
-        atomicWriteJsonSync(filePath, replacement);
-      } finally {
-        delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH;
-        delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64;
-      }
+  if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64) {
+    try {
+      const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64, 'base64').toString('utf8')) as Record<string, unknown>;
+      atomicWriteJsonSync(filePath, replacement);
+    } finally {
+      delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH;
+      delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64;
     }
-    let current: Record<string, unknown> | null = null;
-    if (existsSync(filePath)) {
-      try { current = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>; }
-      catch { return 'failed'; }
-    }
-    if (!predicate(current)) return 'skipped';
-    assertMutationLockHeld(lock); // B11: abort publish if our lease expired mid-mutation
-    atomicWriteJsonSync(filePath, transform(current));
-    return 'written';
-  } catch {
-    return 'failed';
-  } finally {
-    releaseMutationLock(lock);
   }
+  // OCC commit (B11 root cure): the create-if mutation runs against the OCC-
+  // validated current (null when absent). The predicate gates whether a state
+  // is produced at all; a falsy predicate returns null (skip, no commit).
+  const committed = occCommitMutation<Record<string, unknown>, ConditionalWriteResult>(filePath, (currentRaw) => {
+    let current: Record<string, unknown> | null = null;
+    if (currentRaw !== null && currentRaw !== undefined) {
+      if (typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
+      current = currentRaw as Record<string, unknown>;
+    }
+    if (!predicate(current)) return { state: current ?? {}, result: 'skipped' as ConditionalWriteResult };
+    return { state: transform(current), result: 'written' as ConditionalWriteResult };
+  });
+  if (committed === null) return 'skipped';
+  return committed.result;
 }
 
 /**
@@ -1366,6 +1680,34 @@ export function emergencyMutateStateFileIf(
   transform: ((current: Record<string, unknown>) => Record<string, unknown>) | null,
   recoveryOptions?: EmergencyRecoveryOptions,
 ): boolean {
+  // TODO(B11/OCC composition): under (B) the OCC journal is the source of truth
+  // and the canonical file is a derived cache. This emergency mutation's final
+  // publish writes the CANONICAL file directly (linkSync for publish intent,
+  // unlink at capture for clear intent) without committing an OCC journal entry,
+  // so a subsequent writeStateFileLocked*/clearStateFileLocked* call (which reads
+  // current from the journal) would NOT observe it - the same class of visibility
+  // gap that required routing recoverExpiredGraphClaim and the runtime.test.ts
+  // setup through OCC/the store.
+  //
+  // Routing the emergency publish through occCommitMutation was ATTEMPTED and
+  // STOPPED as genuinely risky: the emergency mutation is NOT a pure function of
+  // the OCC current - it is a function of the emergency journal's captured +
+  // digested canonical generation (originalDigest/intendedDigest fence its
+  // single-write crash-safety). OCC's pure-callback model would, on a fork,
+  // re-run the callback against a DIFFERENT current than the emergency captured,
+  // so committing the emergency's intended `next` as a constant after a successor
+  // could clobber the successor's value with an older intended state. A correct
+  // composition would need the OCC mutate callback to re-derive the emergency
+  // intent against the OCC-validated current (re-running predicate + transform +
+  // digest), which materially changes the emergency crash-recovery invariants and
+  // cannot be verified safe on macOS (the emergency crash-injection tests live
+  // in the flock-gated workflow-profile suite). The graph path + write family +
+  // clear family (tombstones) + deterministic B11 probes are all (B)-correct and
+  // green; only this emergency-publish visibility gap remains. Callers that mix
+  // emergencyMutateStateFileIf with writeStateFileLocked*/clearStateFileLocked*
+  // on the same filePath may not see the emergency mutation through the journal;
+  // the emergency journal itself remains crash-safe and the canonical file is
+  // still updated.
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return false;
   const owner = emergencyOwner();
   if (!owner) return false;

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -1303,6 +1303,9 @@ function sameEmergencyOwner(left: EmergencyJournalOwner, right: EmergencyJournal
 
 /** Unknown process identity is treated as live: stealing a claim is never safe. */
 function isEmergencyOwnerLive(owner: EmergencyJournalOwner): boolean {
+  // Deterministic crash injection relinquishes ownership with this sentinel.
+  // It is test-only; real unknown process identities remain fail-closed.
+  if (process.env.NODE_ENV === 'test' && owner.pid === 999999999 && owner.processStart === 'abandoned') return false;
   const current = processStartIdentity(owner.pid);
   return current === null || (current !== 'absent' && current === owner.processStart);
 }

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -836,6 +836,17 @@ function occReadCanonicalSnapshot(filePath: string): OccCanonicalSnapshot {
   }
 }
 
+/** Reads only the canonical generation token, without requiring valid JSON. */
+function occReadCanonicalContentFingerprint(filePath: string): { contentFingerprint: string; ioError: boolean } {
+  try {
+    return { contentFingerprint: stateDigest(readFileSync(filePath, 'utf8')), ioError: false };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { contentFingerprint: 'absent', ioError: false };
+    return { contentFingerprint: '', ioError: true };
+  }
+}
+
 function occStateFingerprint(state: unknown): string {
   return state === null ? 'absent' : JSON.stringify(state);
 }
@@ -904,14 +915,13 @@ export function occCommitMutation<TState, TResult>(
   let parentState: unknown = null;
   for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
     const current = occReadCurrent(filePath);
-    if (current.ioError) return null; // fail closed: cannot fence without reading
     const canonical = occReadCanonicalSnapshot(filePath);
-    if (canonical.ioError) return null;
     if (options?.expectedCanonicalContentFingerprint !== undefined &&
       canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
       options.onCanonicalCompareFailed?.();
       return null;
     }
+    if (current.ioError || canonical.ioError) return null; // fail closed: cannot fence without reading
     if (current.empty) {
       parentSeq = -1;
       // An authenticated external transaction has already captured this
@@ -994,13 +1004,13 @@ export function occCommitMutation<TState, TResult>(
     // replacement observed after the mutation was calculated invalidates this
     // attempt so conditional writers cannot overwrite it from stale state.
     const canonicalFence = occReadCanonicalSnapshot(filePath);
-    if (canonicalFence.ioError) {
-      occCleanupOwn(dir, seq, ownerToken);
-      return null;
-    }
     if (options?.expectedCanonicalContentFingerprint !== undefined &&
       canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
       options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return null;
+    }
+    if (canonicalFence.ioError) {
       occCleanupOwn(dir, seq, ownerToken);
       return null;
     }
@@ -1273,6 +1283,8 @@ export function writeStateFileLockedIf(
   transform: (current: Record<string, unknown>) => Record<string, unknown>,
 ): ConditionalWriteResult {
   if (!recoverEmergencyStateFile(filePath)) return 'failed';
+  const observedCanonical = occReadCanonicalContentFingerprint(filePath);
+  if (observedCanonical.ioError) return 'failed';
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_WRITE_REPLACEMENT_BASE64) {
     try {
       // The seam models an external replacement that races this conditional
@@ -1293,6 +1305,7 @@ export function writeStateFileLockedIf(
   if (!lock) return 'failed';
   try {
     let skipped = false;
+    let canonicalReplaced = false;
     const committed = occCommitMutation<Record<string, unknown>, ConditionalWriteResult>(filePath, (currentRaw) => {
       if (currentRaw === null || currentRaw === undefined || typeof currentRaw !== 'object' || Array.isArray(currentRaw)) return null;
       const current = currentRaw as Record<string, unknown>;
@@ -1301,8 +1314,12 @@ export function writeStateFileLockedIf(
         return null;
       }
       return { state: transform(current), result: 'written' as ConditionalWriteResult };
-    }, { assertHeld: () => assertMutationLockHeld(lock) });
-    if (committed === null) return skipped ? 'skipped' : 'failed';
+    }, {
+      assertHeld: () => assertMutationLockHeld(lock),
+      expectedCanonicalContentFingerprint: observedCanonical.contentFingerprint,
+      onCanonicalCompareFailed: () => { canonicalReplaced = true; },
+    });
+    if (committed === null) return skipped || canonicalReplaced ? 'skipped' : 'failed';
     return committed.result;
   } finally {
     releaseMutationLock(lock);
@@ -1315,10 +1332,12 @@ export function writeStateFileLockedCreateIf(
   transform: (current: Record<string, unknown> | null) => Record<string, unknown>,
 ): ConditionalWriteResult {
   if (!recoverEmergencyStateFile(filePath)) return 'failed';
+  const observedCanonical = occReadCanonicalContentFingerprint(filePath);
+  if (observedCanonical.ioError) return 'failed';
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64) {
     try {
-      const replacement = JSON.parse(Buffer.from(process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64, 'base64').toString('utf8')) as Record<string, unknown>;
-      atomicWriteJsonSync(filePath, replacement);
+      const replacementRaw = Buffer.from(process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64, 'base64').toString('utf8');
+      atomicWriteFileSync(filePath, replacementRaw);
     } finally {
       delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH;
       delete process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64;
@@ -1331,6 +1350,7 @@ export function writeStateFileLockedCreateIf(
   if (!lock) return 'failed';
   try {
     let skipped = false;
+    let canonicalReplaced = false;
     const committed = occCommitMutation<Record<string, unknown>, ConditionalWriteResult>(filePath, (currentRaw) => {
       let current: Record<string, unknown> | null = null;
       if (currentRaw !== null && currentRaw !== undefined) {
@@ -1342,8 +1362,12 @@ export function writeStateFileLockedCreateIf(
         return null;
       }
       return { state: transform(current), result: 'written' as ConditionalWriteResult };
-    }, { assertHeld: () => assertMutationLockHeld(lock) });
-    if (committed === null) return skipped ? 'skipped' : 'failed';
+    }, {
+      assertHeld: () => assertMutationLockHeld(lock),
+      expectedCanonicalContentFingerprint: observedCanonical.contentFingerprint,
+      onCanonicalCompareFailed: () => { canonicalReplaced = true; },
+    });
+    if (committed === null) return skipped || canonicalReplaced ? 'skipped' : 'failed';
     return committed.result;
   } finally {
     releaseMutationLock(lock);
@@ -1802,7 +1826,10 @@ export function recoverEmergencyStateFile(filePath: string, options?: EmergencyR
     if (!reconcileEmergencyPublicationTemps(filePath, authorizeState)) return false;
     if (!current || current.quarantinePath !== `${filePath}.emergency-quarantine.${current.transactionId}` || isEmergencyOwnerLive(current.owner)) return false;
     if (!recoverDeadEmergencyStateFile(filePath, authorizeState, true)) return false;
-    if (!commitRecoveredEmergencyPublication(filePath, current)) return false;
+    // Legacy journals have no authenticated OCC parent. Their recovery has
+    // already either published the durable payload or safely discarded it;
+    // do not route a safe discard through publication reconciliation.
+    if (current.parentState && !commitRecoveredEmergencyPublication(filePath, current)) return false;
     return removeOwnedEmergencyArtifacts(journalPath, current, true);
   } finally {
     releaseRecoveryClaim(claimPath, claim);
@@ -1823,6 +1850,11 @@ function recoverDeadEmergencyStateFile(
   if (!recoveryGenerationsAuthorized(filePath, journal, authorizeState)) return true;
   const owned = () => journalIsOwned(journalPath, journal.transactionId, journal.owner);
   if (!owned()) return false;
+  // Top-level recovery owns cleanup after it has either sequenced the recovered
+  // publication or deliberately preserved a replacement. Keeping cleanup in
+  // one place prevents a safe discard from being reported as a later failure.
+  const finish = (removeQuarantine: boolean): boolean =>
+    preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, removeQuarantine);
   const payloadPath = `${journal.quarantinePath}.payload`;
   const digest = (path: string): string | null => {
     try { return stateDigest(readFileSync(path, 'utf8')); } catch { return null; }
@@ -1831,14 +1863,14 @@ function recoverDeadEmergencyStateFile(
     const complete = typeof journal.originalDigest === 'string' && (journal.intent === 'clear' || (journal.intent === 'publish' && typeof journal.intendedDigest === 'string'));
     if (!complete) {
       if (existsSync(journal.quarantinePath) || existsSync(payloadPath)) return false;
-      return removeOwnedEmergencyArtifacts(journalPath, journal, false);
+      return finish(false);
     }
     const originalStillPrimary = !existsSync(journal.quarantinePath) && digest(filePath) === journal.originalDigest;
     if (journal.intent === 'publish' && digest(payloadPath) !== journal.intendedDigest) {
-      return originalStillPrimary && removeOwnedEmergencyArtifacts(journalPath, journal, false);
+      return originalStillPrimary && finish(false);
     }
     if (journal.intent === 'clear' && existsSync(payloadPath)) {
-      return originalStillPrimary && removeOwnedEmergencyArtifacts(journalPath, journal, false);
+      return originalStillPrimary && finish(false);
     }
     journal.phase = 'prepared';
     return writeEmergencyJournal(journalPath, journal) && recoverDeadEmergencyStateFile(filePath, authorizeState, preserveCompletedJournal);
@@ -1848,14 +1880,14 @@ function recoverDeadEmergencyStateFile(
   const intendedDigest = journal.intendedDigest;
   const hasPrimary = existsSync(filePath);
   const hasQuarantine = existsSync(journal.quarantinePath);
-  const finalize = (): boolean => removeOwnedEmergencyArtifacts(journalPath, journal, hasQuarantine);
+  const finalize = (): boolean => finish(hasQuarantine);
 
   if (hasPrimary && hasQuarantine) {
     if (intent === 'publish' && digest(filePath) === intendedDigest && digest(journal.quarantinePath) === originalDigest) {
-      return preserveCompletedJournal || finalize();
+      return finalize();
     }
     // The primary is an unrelated replacement. It wins; discard only this transaction.
-    return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    return finish(true);
   }
   if (hasPrimary) {
     if (!hasQuarantine && journal.phase === 'prepared' && digest(filePath) === originalDigest) {
@@ -1863,7 +1895,7 @@ function recoverDeadEmergencyStateFile(
       if (!owned()) return false;
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
         if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) {
-          removeOwnedEmergencyArtifacts(journalPath, journal, true);
+          return finish(true);
         }
         return false;
       }
@@ -1874,17 +1906,17 @@ function recoverDeadEmergencyStateFile(
   }
   if (!hasQuarantine) {
     return intent === 'clear' && journal.phase === 'published' &&
-      (preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, false));
+      finish(false);
   }
   if (digest(journal.quarantinePath) !== originalDigest || !owned()) return false;
   try {
-    if (intent === 'clear') return preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    if (intent === 'clear') return finish(true);
     const payload = readFileSync(payloadPath, 'utf8');
     if (stateDigest(payload) !== intendedDigest || !owned()) return false;
     linkSync(payloadPath, filePath); // exclusive: never overwrite a replacement
     journal.phase = 'published';
     if (!writeEmergencyJournal(journalPath, journal)) return false;
-    return preserveCompletedJournal || removeOwnedEmergencyArtifacts(journalPath, journal, true);
+    return finish(true);
   } catch { return false; }
 }
 

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -810,7 +810,14 @@ function occReadCurrent(filePath: string): OccReadCurrentResult {
   return { seq: maxSeq, state: record.state, empty: false, ioError: false, reservedSeq };
 }
 
-type OccCanonicalSnapshot = { state: unknown; fingerprint: string; ioError: boolean };
+type OccCanonicalSnapshot = {
+  state: unknown;
+  /** Exact primary bytes, used to fence replacement without normalizing them. */
+  contentFingerprint: string;
+  /** Parsed-state identity, used to decide whether a journal reconciliation is needed. */
+  stateFingerprint: string;
+  ioError: boolean;
+};
 
 /**
  * The canonical file is an integrity fence as well as a compatibility cache.
@@ -819,12 +826,13 @@ type OccCanonicalSnapshot = { state: unknown; fingerprint: string; ioError: bool
  */
 function occReadCanonicalSnapshot(filePath: string): OccCanonicalSnapshot {
   try {
-    const state = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
-    return { state, fingerprint: JSON.stringify(state), ioError: false };
+    const raw = readFileSync(filePath, 'utf8');
+    const state = JSON.parse(raw) as unknown;
+    return { state, contentFingerprint: stateDigest(raw), stateFingerprint: JSON.stringify(state), ioError: false };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT') return { state: null, fingerprint: 'absent', ioError: false };
-    return { state: null, fingerprint: '', ioError: true };
+    if (code === 'ENOENT') return { state: null, contentFingerprint: 'absent', stateFingerprint: 'absent', ioError: false };
+    return { state: null, contentFingerprint: '', stateFingerprint: '', ioError: true };
   }
 }
 
@@ -861,6 +869,10 @@ export interface OccCommitOptions {
   ownerToken?: string;
   /** Called at the commit/publish boundary by public mutation-lock holders. */
   assertHeld?: () => void;
+  /** Journal this generation without serializing it back over canonical bytes. */
+  suppressCanonicalRepublish?: boolean;
+  /** Internal recursion guard for canonical-to-journal reconciliation. */
+  skipCanonicalReconciliation?: boolean;
 }
 
 /**
@@ -896,7 +908,23 @@ export function occCommitMutation<TState, TResult>(
       parentState = canonical.state;
     } else {
       parentSeq = current.seq;
-      parentState = occStateFingerprint(current.state) === canonical.fingerprint ? current.state : canonical.state;
+      if (!options?.skipCanonicalReconciliation && occStateFingerprint(current.state) !== canonical.stateFingerprint) {
+        // Canonical is the compatibility authority for pre-OCC and emergency
+        // publishers. Sequence it before evaluating a conditional mutation so
+        // a later skip cannot leave journal readers on the old generation.
+        const reconciled = occCommitMutation<unknown, boolean>(
+          filePath,
+          () => ({ state: canonical.state, result: true }),
+          {
+            assertHeld: options?.assertHeld,
+            suppressCanonicalRepublish: true,
+            skipCanonicalReconciliation: true,
+          },
+        );
+        if (reconciled === null) return null;
+        continue;
+      }
+      parentState = current.state;
     }
     let produced: { state: TState; result: TResult } | null;
     produced = mutate(parentState, ownerToken);
@@ -967,7 +995,7 @@ export function occCommitMutation<TState, TResult>(
       occCleanupOwn(dir, seq, ownerToken);
       return null;
     }
-    if (canonicalFence.fingerprint !== canonical.fingerprint) {
+    if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
       occCleanupOwn(dir, seq, ownerToken);
       continue;
     }
@@ -990,11 +1018,13 @@ export function occCommitMutation<TState, TResult>(
     // entry is now NOT the max, it remains a valid committed ancestor: leave it.
     occPruneOld(dir, seq);
     // Re-publish the canonical file so legacy readers see the latest state.
-    try {
-      atomicWriteJsonSync(filePath, next);
-    } catch {
-      // The journal IS the source of truth; a failed canonical re-publish is
-      // non-fatal (the committed entry already advances current). Return success.
+    if (!options?.suppressCanonicalRepublish) {
+      try {
+        atomicWriteJsonSync(filePath, next);
+      } catch {
+        // The journal commit remains durable. A later writer will reconcile
+        // the compatibility file before it evaluates its own mutation.
+      }
     }
     return produced;
   }
@@ -1005,10 +1035,9 @@ export function occCommitMutation<TState, TResult>(
 export function occReadCurrentState(filePath: string): unknown {
   const current = occReadCurrent(filePath);
   if (current.ioError) return null;
-  if (current.empty) {
-    try { return JSON.parse(readFileSync(filePath, 'utf8')); } catch { return null; }
-  }
-  return current.state;
+  if (!current.empty) return current.state;
+  const canonical = occReadCanonicalSnapshot(filePath);
+  return canonical.ioError ? null : canonical.state;
 }
 
 /**
@@ -1019,20 +1048,16 @@ export function occReadCurrentState(filePath: string): unknown {
  * tombstone; it is restored to absent after the journal commit.
  */
 export function occReconcileCanonicalState(filePath: string, assertHeld?: () => void): boolean {
-  const snapshot = occReadCanonicalSnapshot(filePath);
-  if (snapshot.ioError) return false;
   const committed = occCommitMutation<unknown, boolean>(
     filePath,
-    () => ({ state: snapshot.state, result: true }),
-    { assertHeld },
+    // occCommitMutation first sequences any observed canonical mismatch; this
+    // callback then receives that fenced generation on every retry. Do not
+    // capture a pre-retry snapshot here or a concurrent replacement could be
+    // reintroduced into the journal.
+    (currentState) => ({ state: currentState, result: true }),
+    { assertHeld, suppressCanonicalRepublish: true },
   );
-  if (committed === null) return false;
-  if (snapshot.state === null) {
-    try { unlinkSync(filePath); } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
-    }
-  }
-  return true;
+  return committed !== null;
 }
 
 /** Reconcile a recovered emergency publication while sharing normal write/clear exclusion. */
@@ -1092,19 +1117,24 @@ export function writeStateFileLocked(filePath: string, state: Record<string, unk
 }
 
 export function clearStateFileLocked(filePath: string): boolean {
-  // NOTE: clear stays on the lease lock (NOT the OCC tombstone path). The OCC
-  // tombstone migration was reverted: it broke ~242 tests because the tombstone
-  // commit did not reliably unlink the canonical file for clear / runtime-
-  // artifact paths (clearModeState leaves marker files present). The maintainer's
-  // B11 "release" is satisfied by the lock-release path + occCleanupOwner (no
-  // shared lock file under OCC for writes) + release probe #2; the state-clear
-  // on the lease lock is fail-closed: assertMutationLockHeld aborts on overlap,
-  // and under (B) the canonical is a derived cache so a stale clear is harmless.
   if (!recoverEmergencyStateFile(filePath)) return false;
   const lock = acquireMutationLock(filePath);
   if (!lock) return false;
   try {
-    assertMutationLockHeld(lock); // B11: abort mutation if our lease expired mid-mutation
+    // Runtime artifact cleanup also routes through this primitive for small
+    // non-JSON marker files. They have no OCC state to tombstone.
+    if (!filePath.endsWith('.json')) {
+      assertMutationLockHeld(lock);
+      if (existsSync(filePath)) unlinkSync(filePath);
+      return true;
+    }
+    const committed = occCommitMutation<null, boolean>(
+      filePath,
+      () => ({ state: null, result: true }),
+      { assertHeld: () => assertMutationLockHeld(lock), suppressCanonicalRepublish: true },
+    );
+    if (committed === null) return false;
+    assertMutationLockHeld(lock);
     if (existsSync(filePath)) unlinkSync(filePath);
     return true;
   } catch {
@@ -1127,8 +1157,6 @@ export function clearStateFileLockedIf(
   predicate: (current: Record<string, unknown>) => boolean,
   recoveryOptions?: EmergencyRecoveryOptions,
 ): ConditionalClearResult {
-  // NOTE: conditional clear stays on the lease lock (see clearStateFileLocked
-  // above). The OCC tombstone migration was reverted for breaking clears.
   if (!recoverEmergencyStateFile(filePath, recoveryOptions)) return 'failed';
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH === filePath && process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64) {
     try {
@@ -1142,17 +1170,22 @@ export function clearStateFileLockedIf(
   const lock = acquireMutationLock(filePath);
   if (!lock) return 'failed';
   try {
-    if (!existsSync(filePath)) return 'skipped';
-    let current: Record<string, unknown>;
-    try {
-      current = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
-    } catch {
-      return 'failed';
-    }
-    if (!predicate(current)) return 'skipped';
-    assertMutationLockHeld(lock); // B11: abort mutation if our lease expired mid-mutation
+    let skipped = false;
+    const committed = occCommitMutation<null, ConditionalClearResult>(filePath, (currentRaw) => {
+      if (currentRaw === null || typeof currentRaw !== 'object' || Array.isArray(currentRaw)) {
+        skipped = true;
+        return null;
+      }
+      if (!predicate(currentRaw as Record<string, unknown>)) {
+        skipped = true;
+        return null;
+      }
+      return { state: null, result: 'cleared' };
+    }, { assertHeld: () => assertMutationLockHeld(lock), suppressCanonicalRepublish: true });
+    if (committed === null) return skipped ? 'skipped' : 'failed';
+    assertMutationLockHeld(lock);
     unlinkSync(filePath);
-    return 'cleared';
+    return committed.result;
   } catch {
     return 'failed';
   } finally {

--- a/src/lib/mode-state-io.ts
+++ b/src/lib/mode-state-io.ts
@@ -6,7 +6,7 @@
  * and file permissions so that individual mode modules don't duplicate this logic.
  */
 
-import { closeSync, existsSync, fstatSync, fsyncSync, linkSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync, writeSync } from 'fs';
+import { closeSync, existsSync, fstatSync, fsyncSync, linkSync, mkdirSync, openSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync, writeSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { createHash, randomUUID } from 'crypto';
 import { spawnSync } from 'child_process';
@@ -926,8 +926,7 @@ export function occCommitMutation<TState, TResult>(
       }
       parentState = current.state;
     }
-    let produced: { state: TState; result: TResult } | null;
-    produced = mutate(parentState, ownerToken);
+    const produced = mutate(parentState, ownerToken);
     if (produced === null || produced === undefined) return null; // cancelled, no commit
     const next = produced.state;
     const seq = Math.max(parentSeq, current.reservedSeq) + 1;

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -2400,6 +2400,53 @@ describe('state-tools', () => {
       }
     });
 
+    it('clear all removes unrelated skill-active slots without crossing session boundaries', async () => {
+      const sessionId = 'graph-clear-mixed-slots';
+      const siblingSessionId = 'graph-clear-mixed-slots-sibling';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      const mixedSlots = {
+        version: 2,
+        active_skills: {
+          graph: { skill_name: 'graph', session_id: sessionId, completed_at: null },
+          ralph: { skill_name: 'ralph', session_id: sessionId, completed_at: null },
+        },
+      };
+      writeFileSync(paths.rootSlot, JSON.stringify(mixedSlots));
+      writeFileSync(paths.sessionSlot, JSON.stringify(mixedSlots));
+
+      const siblingDir = join(TEST_DIR, '.omc', 'state', 'sessions', siblingSessionId);
+      mkdirSync(siblingDir, { recursive: true });
+      const siblingSlot = join(siblingDir, 'skill-active-state.json');
+      const siblingSlots = {
+        version: 2,
+        active_skills: {
+          graph: { skill_name: 'graph', session_id: siblingSessionId, completed_at: null },
+          team: { skill_name: 'team', session_id: siblingSessionId, completed_at: null },
+        },
+      };
+      writeFileSync(siblingSlot, JSON.stringify(siblingSlots));
+
+      const result = await stateClearTool.handler({
+        mode: 'all',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const clearAll = JSON.parse(result.content[0].text);
+
+      expect(clearAll).toMatchObject({
+        type: 'clear_all',
+        cleared_modes: expect.arrayContaining(['skill-active']),
+        preserved_graph_workflow_slot: true,
+      });
+      for (const path of [paths.rootSlot, paths.sessionSlot]) {
+        expect(JSON.parse(readFileSync(path, 'utf8')).active_skills).toEqual({
+          graph: { skill_name: 'graph', session_id: sessionId, completed_at: null },
+        });
+      }
+      expect(JSON.parse(readFileSync(siblingSlot, 'utf8'))).toEqual(siblingSlots);
+    });
+
     it('clear all preserves Graph slot and control ownership when the primary ledger is missing', async () => {
       const sessionId = 'graph-clear-all-missing-ledger';
       const paths = writeGuardedGraphArtifacts(sessionId);

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -1,25 +1,39 @@
-import { createHash, randomUUID } from 'crypto';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, unlinkSync, writeFileSync, existsSync, lstatSync } from 'fs';
-import { tmpdir } from 'os';
-import { basename, dirname, join } from 'path';
+import { createHash, randomUUID } from "crypto";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+  existsSync,
+  lstatSync,
+} from "fs";
+import { tmpdir } from "os";
+import { basename, dirname, join } from "path";
 import {
   stateReadTool,
   stateWriteTool,
   stateClearTool,
   stateListActiveTool,
   stateGetStatusTool,
-} from '../state-tools.js';
-import { emergencyMutateStateFileIf } from '../../lib/mode-state-io.js';
-import { sealGraphDescriptor } from '../../graph/descriptor.js';
-import { createInitialGraphState, type GraphRunStatus } from '../../graph/runtime-types.js';
-import { forkJoinDescriptor } from '../../graph/__tests__/fixtures.js';
+} from "../state-tools.js";
+import { emergencyMutateStateFileIf } from "../../lib/mode-state-io.js";
+import { sealGraphDescriptor } from "../../graph/descriptor.js";
+import {
+  createInitialGraphState,
+  type GraphRunStatus,
+} from "../../graph/runtime-types.js";
+import { forkJoinDescriptor } from "../../graph/__tests__/fixtures.js";
 
-const TEST_DIR = '/tmp/state-tools-test';
+const TEST_DIR = "/tmp/state-tools-test";
 
 // Mock validateWorkingDirectory to allow test directory
-vi.mock('../../lib/worktree-paths.js', async () => {
-  const actual = await vi.importActual('../../lib/worktree-paths.js');
+vi.mock("../../lib/worktree-paths.js", async () => {
+  const actual = await vi.importActual("../../lib/worktree-paths.js");
   return {
     ...actual,
     validateWorkingDirectory: vi.fn((workingDirectory?: string) => {
@@ -46,8 +60,15 @@ function liveLockOwner() {
 }
 
 function portableWorkflowState(sessionId: string): Record<string, unknown> {
-  const transcriptRoot = '/tmp/state-tools-transcripts';
-  const fileIdentity = { device: 0, inode: 0, size: 0, mtimeNs: '0', ctimeNs: '0', contentSha256: '0'.repeat(64) };
+  const transcriptRoot = "/tmp/state-tools-transcripts";
+  const fileIdentity = {
+    device: 0,
+    inode: 0,
+    size: 0,
+    mtimeNs: "0",
+    ctimeNs: "0",
+    contentSha256: "0".repeat(64),
+  };
   const activationBoundary = {
     transcriptPath: `${transcriptRoot}/${sessionId}.jsonl`,
     transcriptRoot,
@@ -56,67 +77,120 @@ function portableWorkflowState(sessionId: string): Record<string, unknown> {
     byteOffset: 0,
     fileIdentity,
   };
-  const startedAt = '2026-01-01T00:00:00.000Z';
-  const stages = ['ralplan', 'execution'];
+  const startedAt = "2026-01-01T00:00:00.000Z";
+  const stages = ["ralplan", "execution"];
   return {
     active: true,
     session_id: sessionId,
-    prompt: 'private prompt',
-    phase: 'ralplan',
-    workflowRunId: '11111111-1111-4111-8111-111111111111',
+    prompt: "private prompt",
+    phase: "ralplan",
+    workflowRunId: "11111111-1111-4111-8111-111111111111",
     workflow: {
       descriptorVersion: 1,
-      workflowName: 'release-train',
+      workflowName: "release-train",
       profileVersion: 1,
       stages,
-      profileHash: createHash('sha256').update('{"descriptorVersion":1,"profileVersion":1,"stages":["ralplan","execution"],"workflowName":"release-train"}').digest('hex'),
+      profileHash: createHash("sha256")
+        .update(
+          '{"descriptorVersion":1,"profileVersion":1,"stages":["ralplan","execution"],"workflowName":"release-train"}',
+        )
+        .digest("hex"),
     },
     pipelineTracking: {
-      stages: [{ id: 'ralplan', status: 'active', iterations: 0, startedAt }, { id: 'execution', status: 'pending', iterations: 0 }],
+      stages: [
+        { id: "ralplan", status: "active", iterations: 0, startedAt },
+        { id: "execution", status: "pending", iterations: 0 },
+      ],
       currentStageIndex: 0,
       trackingRevision: 0,
       activationBoundary,
       completionObservations: [],
     },
   };
-
 }
-function completedPortableWorkflowState(sessionId: string): Record<string, unknown> {
+function completedPortableWorkflowState(
+  sessionId: string,
+): Record<string, unknown> {
   const state = portableWorkflowState(sessionId);
   const tracking = state.pipelineTracking as Record<string, unknown>;
-  const initialBoundary = structuredClone(tracking.activationBoundary as Record<string, unknown>);
-  const initialIdentity = structuredClone(initialBoundary.fileIdentity as Record<string, unknown>);
-  const completedAt = '2026-01-01T00:01:00.000Z';
-  const stages = ['ralplan', 'execution'];
-  tracking.stages = stages.map((id) => ({ id, status: 'complete', iterations: 0, startedAt: '2026-01-01T00:00:00.000Z', completedAt }));
+  const initialBoundary = structuredClone(
+    tracking.activationBoundary as Record<string, unknown>,
+  );
+  const initialIdentity = structuredClone(
+    initialBoundary.fileIdentity as Record<string, unknown>,
+  );
+  const completedAt = "2026-01-01T00:01:00.000Z";
+  const stages = ["ralplan", "execution"];
+  tracking.stages = stages.map((id) => ({
+    id,
+    status: "complete",
+    iterations: 0,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt,
+  }));
   tracking.currentStageIndex = stages.length;
   tracking.trackingRevision = stages.length;
-  const firstStable = { ...initialIdentity, size: 1, contentSha256: '1'.repeat(64) };
-  const secondBoundary = { ...initialBoundary, byteOffset: 1, fileIdentity: firstStable };
-  const secondStable = { ...firstStable, size: 2, contentSha256: '2'.repeat(64) };
+  const firstStable = {
+    ...initialIdentity,
+    size: 1,
+    contentSha256: "1".repeat(64),
+  };
+  const secondBoundary = {
+    ...initialBoundary,
+    byteOffset: 1,
+    fileIdentity: firstStable,
+  };
+  const secondStable = {
+    ...firstStable,
+    size: 2,
+    contentSha256: "2".repeat(64),
+  };
   tracking.completionObservations = [
     {
-      stageId: 'ralplan', sessionId, signalId: 'PIPELINE_RALPLAN_COMPLETE', lineNumber: 0, byteOffset: 0,
-      recordContentSha256: '1'.repeat(64), stableFile: firstStable, activationBoundary: initialBoundary, observedAt: completedAt,
+      stageId: "ralplan",
+      sessionId,
+      signalId: "PIPELINE_RALPLAN_COMPLETE",
+      lineNumber: 0,
+      byteOffset: 0,
+      recordContentSha256: "1".repeat(64),
+      stableFile: firstStable,
+      activationBoundary: initialBoundary,
+      observedAt: completedAt,
     },
     {
-      stageId: 'execution', sessionId, signalId: 'PIPELINE_EXECUTION_COMPLETE', lineNumber: 1, byteOffset: 1,
-      recordContentSha256: '2'.repeat(64), stableFile: secondStable, activationBoundary: secondBoundary, observedAt: completedAt,
+      stageId: "execution",
+      sessionId,
+      signalId: "PIPELINE_EXECUTION_COMPLETE",
+      lineNumber: 1,
+      byteOffset: 1,
+      recordContentSha256: "2".repeat(64),
+      stableFile: secondStable,
+      activationBoundary: secondBoundary,
+      observedAt: completedAt,
     },
   ];
-  tracking.activationBoundary = { ...initialBoundary, byteOffset: 2, fileIdentity: secondStable };
-  return { ...state, active: false, phase: 'complete', status: 'private-terminal-status' };
+  tracking.activationBoundary = {
+    ...initialBoundary,
+    byteOffset: 2,
+    fileIdentity: secondStable,
+  };
+  return {
+    ...state,
+    active: false,
+    phase: "complete",
+    status: "private-terminal-status",
+  };
 }
 
-function graphState(sessionId: string, status: GraphRunStatus = 'running') {
+function graphState(sessionId: string, status: GraphRunStatus = "running") {
   const descriptor = sealGraphDescriptor(forkJoinDescriptor());
-  const approved = !['draft', 'awaiting_approval'].includes(status);
+  const approved = !["draft", "awaiting_approval"].includes(status);
   const state = createInitialGraphState({
     session_id: sessionId,
-    control_nonce: 'test-control-nonce',
+    control_nonce: "test-control-nonce",
     descriptor,
     status,
-    created_at: '2026-07-21T00:00:00.000Z',
+    created_at: "2026-07-21T00:00:00.000Z",
     projection: {
       activations: {},
       cohorts: {},
@@ -128,58 +202,74 @@ function graphState(sessionId: string, status: GraphRunStatus = 'running') {
     ...(approved
       ? {
           approval: {
-            approved_at: '2026-07-21T00:00:00.000Z',
-            evidence: { kind: 'human' as const, ref: 'private-human-evidence' },
+            approved_at: "2026-07-21T00:00:00.000Z",
+            evidence: { kind: "human" as const, ref: "private-human-evidence" },
           },
         }
       : {}),
   });
   state.diagnostics.push({
-    kind: 'operation',
-    recorded_at: '2026-07-21T00:00:01.000Z',
-    summary: 'private diagnostic detail',
+    kind: "operation",
+    recorded_at: "2026-07-21T00:00:01.000Z",
+    summary: "private diagnostic detail",
   });
   return state;
 }
 
 function fileSha256(path: string): string {
-  return createHash('sha256').update(readFileSync(path)).digest('hex');
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function writeGuardedGraphArtifacts(sessionId: string, status: GraphRunStatus | 'malformed' = 'running') {
-  const stateRoot = join(TEST_DIR, '.omc', 'state');
-  const sessionDir = join(stateRoot, 'sessions', sessionId);
+function writeGuardedGraphArtifacts(
+  sessionId: string,
+  status: GraphRunStatus | "malformed" = "running",
+) {
+  const stateRoot = join(TEST_DIR, ".omc", "state");
+  const sessionDir = join(stateRoot, "sessions", sessionId);
   mkdirSync(sessionDir, { recursive: true });
   const paths = {
-    graph: join(sessionDir, 'graph-state.json'),
-    rootSlot: join(stateRoot, 'skill-active-state.json'),
-    sessionSlot: join(sessionDir, 'skill-active-state.json'),
-    controlOwner: join(sessionDir, 'control-owner-state.json'),
+    graph: join(sessionDir, "graph-state.json"),
+    rootSlot: join(stateRoot, "skill-active-state.json"),
+    sessionSlot: join(sessionDir, "skill-active-state.json"),
+    controlOwner: join(sessionDir, "control-owner-state.json"),
   };
-  writeFileSync(paths.graph, status === 'malformed' ? '{not-json' : JSON.stringify(graphState(sessionId, status)));
+  writeFileSync(
+    paths.graph,
+    status === "malformed"
+      ? "{not-json"
+      : JSON.stringify(graphState(sessionId, status)),
+  );
   const slot = JSON.stringify({
     version: 2,
     active_skills: {
       graph: {
-        skill_name: 'graph',
+        skill_name: "graph",
         session_id: sessionId,
         completed_at: null,
-        private_slot_detail: 'must remain unchanged',
+        private_slot_detail: "must remain unchanged",
       },
     },
   });
   writeFileSync(paths.rootSlot, slot);
   writeFileSync(paths.sessionSlot, slot);
-  writeFileSync(paths.controlOwner, JSON.stringify({
-    version: 1,
-    root: { mode: 'graph', session_id: sessionId, run_id: 'run-1', nonce: 'private-nonce' },
-  }));
+  writeFileSync(
+    paths.controlOwner,
+    JSON.stringify({
+      version: 1,
+      root: {
+        mode: "graph",
+        session_id: sessionId,
+        run_id: "run-1",
+        nonce: "private-nonce",
+      },
+    }),
+  );
   return paths;
 }
 
-describe('state-tools', () => {
+describe("state-tools", () => {
   beforeEach(() => {
-    mkdirSync(join(TEST_DIR, '.omc', 'state'), { recursive: true });
+    mkdirSync(join(TEST_DIR, ".omc", "state"), { recursive: true });
   });
 
   afterEach(() => {
@@ -194,156 +284,251 @@ describe('state-tools', () => {
     delete process.env.OMC_TEST_EMERGENCY_REPLACEMENT_BASE64;
   });
 
-  describe('state_read', () => {
-    it('should return state when file exists at session-scoped path', async () => {
-      const sessionId = 'session-read-test';
-      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+  describe("state_read", () => {
+    it("should return state when file exists at session-scoped path", async () => {
+      const sessionId = "session-read-test";
+      const sessionDir = join(TEST_DIR, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
       writeFileSync(
-        join(sessionDir, 'ralph-state.json'),
-        JSON.stringify({ active: true, iteration: 3 })
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({ active: true, iteration: 3 }),
       );
 
       const result = await stateReadTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('active');
-      expect(result.content[0].text).toContain('iteration');
+      expect(result.content[0].text).toContain("active");
+      expect(result.content[0].text).toContain("iteration");
     });
 
-    it('should indicate when no state exists', async () => {
+    it("should indicate when no state exists", async () => {
       const result = await stateReadTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('No state found');
+      expect(result.content[0].text).toContain("No state found");
     });
-    it('redacts every malformed named marker without exposing private state', async () => {
-      const sessionId = 'named-read-redaction';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("redacts every malformed named marker without exposing private state", async () => {
+      const sessionId = "named-read-redaction";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
 
-      for (const marker of [{ workflow: false }, { workflowRunId: '' }, { pipelineTracking: null }]) {
-        writeFileSync(statePath, JSON.stringify({
-          active: true,
+      for (const marker of [
+        { workflow: false },
+        { workflowRunId: "" },
+        { pipelineTracking: null },
+      ]) {
+        writeFileSync(
+          statePath,
+          JSON.stringify({
+            active: true,
+            session_id: sessionId,
+            prompt: "private prompt",
+            transcript: "private transcript",
+            evidence: ["private evidence"],
+            workflowRunId: "private-run-id",
+            ...marker,
+          }),
+        );
+        const result = await stateReadTool.handler({
+          mode: "autopilot",
           session_id: sessionId,
-          prompt: 'private prompt',
-          transcript: 'private transcript',
-          evidence: ['private evidence'],
-          workflowRunId: 'private-run-id',
-          ...marker,
-        }));
-        const result = await stateReadTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-        const publicState = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
+          workingDirectory: TEST_DIR,
+        });
+        const publicState = JSON.parse(
+          result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1],
+        );
         expect(publicState).toEqual({
-          name: 'invalid',
+          name: "invalid",
           version: 1,
-          shortHash: 'invalid',
+          shortHash: "invalid",
           stages: [],
           currentStage: null,
-          status: 'workflow_descriptor_integrity_failed',
-          progress: '0/0',
+          status: "workflow_descriptor_integrity_failed",
+          progress: "0/0",
         });
-        expect(result.content[0].text).not.toMatch(/private prompt|private transcript|private evidence|private-run-id/);
+        expect(result.content[0].text).not.toMatch(
+          /private prompt|private transcript|private evidence|private-run-id/,
+        );
       }
     });
 
-    it('projects a structurally valid portable named workflow without transcript authentication', async () => {
-      const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("projects a structurally valid portable named workflow without transcript authentication", async () => {
+      const sessionId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify(portableWorkflowState(sessionId)));
+      writeFileSync(
+        statePath,
+        JSON.stringify(portableWorkflowState(sessionId)),
+      );
 
-      const result = await stateReadTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      const publicState = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
-      expect(publicState).toMatchObject({
-        name: 'release-train',
-        currentStage: 'ralplan',
-        progress: '1/2',
+      const result = await stateReadTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
       });
-      expect(result.content[0].text).not.toContain('private prompt');
+      const publicState = JSON.parse(
+        result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1],
+      );
+      expect(publicState).toMatchObject({
+        name: "release-train",
+        currentStage: "ralplan",
+        progress: "1/2",
+      });
+      expect(result.content[0].text).not.toContain("private prompt");
     });
-    it('uses the public run capability to pause the exact named workflow', async () => {
-      const sessionId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("uses the public run capability to pause the exact named workflow", async () => {
+      const sessionId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify(portableWorkflowState(sessionId)));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+      writeFileSync(
+        statePath,
+        JSON.stringify(portableWorkflowState(sessionId)),
+      );
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
 
-      const readResult = await stateReadTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      const publicState = JSON.parse(readResult.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
-      expect(publicState.workflowRunId).toBe('11111111-1111-4111-8111-111111111111');
+      const readResult = await stateReadTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const publicState = JSON.parse(
+        readResult.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1],
+      );
+      expect(publicState.workflowRunId).toBe(
+        "11111111-1111-4111-8111-111111111111",
+      );
 
       const pauseResult = await stateWriteTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         active: false,
         state: { workflowRunId: publicState.workflowRunId },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
       expect(pauseResult.isError).not.toBe(true);
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toMatchObject({
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toMatchObject({
         active: false,
         workflowRunId: publicState.workflowRunId,
       });
     });
-    it('derives public status from validated current-stage topology rather than private record status', async () => {
-      const sessionId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("derives public status from validated current-stage topology rather than private record status", async () => {
+      const sessionId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({ ...portableWorkflowState(sessionId), status: 'private-status' }));
+      writeFileSync(
+        statePath,
+        JSON.stringify({
+          ...portableWorkflowState(sessionId),
+          status: "private-status",
+        }),
+      );
 
-      const result = await stateReadTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      const publicState = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
-      expect(publicState.status).toBe('active');
-      expect(result.content[0].text).not.toContain('private-status');
+      const result = await stateReadTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const publicState = JSON.parse(
+        result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1],
+      );
+      expect(publicState.status).toBe("active");
+      expect(result.content[0].text).not.toContain("private-status");
     });
 
-    it('projects terminal named workflows with clamped progress and terminal topology status', async () => {
-      const sessionId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("projects terminal named workflows with clamped progress and terminal topology status", async () => {
+      const sessionId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify(completedPortableWorkflowState(sessionId)));
+      writeFileSync(
+        statePath,
+        JSON.stringify(completedPortableWorkflowState(sessionId)),
+      );
 
-      const result = await stateReadTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      const publicState = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
-      expect(publicState).toMatchObject({ currentStage: null, status: 'complete', progress: '2/2' });
-      expect(result.content[0].text).not.toContain('private-terminal-status');
+      const result = await stateReadTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const publicState = JSON.parse(
+        result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1],
+      );
+      expect(publicState).toMatchObject({
+        currentStage: null,
+        status: "complete",
+        progress: "2/2",
+      });
+      expect(result.content[0].text).not.toContain("private-terminal-status");
     });
   });
 
-  describe('state_write', () => {
-    it('should write state to legacy path when no session_id provided', async () => {
+  describe("state_write", () => {
+    it("should write state to legacy path when no session_id provided", async () => {
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         state: { active: true, iteration: 1 },
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Successfully wrote');
-      const legacyPath = join(TEST_DIR, '.omc', 'state', 'ralph-state.json');
+      expect(result.content[0].text).toContain("Successfully wrote");
+      const legacyPath = join(TEST_DIR, ".omc", "state", "ralph-state.json");
       expect(existsSync(legacyPath)).toBe(true);
     });
 
-    it('should add _meta field to written state', async () => {
+    it("should add _meta field to written state", async () => {
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
-        state: { someField: 'value' },
+        mode: "ralph",
+        state: { someField: "value" },
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Successfully wrote');
-      expect(result.content[0].text).toContain('_meta');
+      expect(result.content[0].text).toContain("Successfully wrote");
+      expect(result.content[0].text).toContain("_meta");
     });
 
-    it('should include session ID in _meta when provided', async () => {
-      const sessionId = 'session-meta-test';
+    it("should include session ID in _meta when provided", async () => {
+      const sessionId = "session-meta-test";
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         state: { active: true },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -351,38 +536,58 @@ describe('state-tools', () => {
 
       expect(result.content[0].text).toContain(`"sessionId": "${sessionId}"`);
     });
-    it('creates a missing generic autopilot pause state', async () => {
-      const sessionId = 'missing-generic-pause';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("creates a missing generic autopilot pause state", async () => {
+      const sessionId = "missing-generic-pause";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
 
       const result = await stateWriteTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         active: false,
-        state: { prompt: 'legacy pause request' },
+        state: { prompt: "legacy pause request" },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       expect(result.isError).toBeUndefined();
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toMatchObject({
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toMatchObject({
         active: false,
-        prompt: 'legacy pause request',
+        prompt: "legacy pause request",
       });
     });
 
-    it('merges a generic legacy autopilot pause without discarding tracking', async () => {
-      const sessionId = 'legacy-pause-preserves-state';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("merges a generic legacy autopilot pause without discarding tracking", async () => {
+      const sessionId = "legacy-pause-preserves-state";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({
-        active: true,
-        session_id: sessionId,
-        prompt: 'preserved legacy task',
-        pipeline: { currentStageIndex: 0, stages: [{ id: 'ralplan', status: 'active' }] },
-      }));
+      writeFileSync(
+        statePath,
+        JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          prompt: "preserved legacy task",
+          pipeline: {
+            currentStageIndex: 0,
+            stages: [{ id: "ralplan", status: "active" }],
+          },
+        }),
+      );
 
       const result = await stateWriteTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         active: false,
         iteration: 4,
         session_id: sessionId,
@@ -390,167 +595,345 @@ describe('state-tools', () => {
       });
 
       expect(result.isError).toBeUndefined();
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toMatchObject({
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toMatchObject({
         active: false,
         iteration: 4,
-        prompt: 'preserved legacy task',
-        pipeline: { currentStageIndex: 0, stages: [{ id: 'ralplan', status: 'active' }] },
+        prompt: "preserved legacy task",
+        pipeline: {
+          currentStageIndex: 0,
+          stages: [{ id: "ralplan", status: "active" }],
+        },
       });
     });
-    it('does not let a lock-held Stop be overwritten by state_write cancellation', async () => {
-      const sessionId = 'stop-cancel-race';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("does not let a lock-held Stop be overwritten by state_write cancellation", async () => {
+      const sessionId = "stop-cancel-race";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({ active: true, trackingRevision: 0 }));
+      writeFileSync(
+        statePath,
+        JSON.stringify({ active: true, trackingRevision: 0 }),
+      );
       const before = readFileSync(statePath);
       const lockPath = `${statePath}.mutation.lock`;
       writeFileSync(lockPath, liveLockOwner());
 
-      const blocked = await stateWriteTool.handler({ mode: 'autopilot', active: false, session_id: sessionId, workingDirectory: TEST_DIR });
+      const blocked = await stateWriteTool.handler({
+        mode: "autopilot",
+        active: false,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(blocked.isError).toBe(true);
       expect(readFileSync(statePath)).toEqual(before);
 
       unlinkSync(lockPath);
-      const retried = await stateWriteTool.handler({ mode: 'autopilot', active: false, session_id: sessionId, workingDirectory: TEST_DIR });
+      const retried = await stateWriteTool.handler({
+        mode: "autopilot",
+        active: false,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(retried.isError).not.toBe(true);
-      expect(JSON.parse(readFileSync(statePath, 'utf8')).active).toBe(false);
+      expect(JSON.parse(readFileSync(statePath, "utf8")).active).toBe(false);
     });
 
-    it('does not clear activation state while its mutation lock is held', async () => {
-      const sessionId = 'activation-cleanup-race';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      await stateWriteTool.handler({ mode: 'autopilot', active: true, session_id: sessionId, workingDirectory: TEST_DIR });
+    it("does not clear activation state while its mutation lock is held", async () => {
+      const sessionId = "activation-cleanup-race";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
+      await stateWriteTool.handler({
+        mode: "autopilot",
+        active: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       const lockPath = `${statePath}.mutation.lock`;
       writeFileSync(lockPath, liveLockOwner());
 
-      const blocked = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
+      const blocked = await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(blocked.content[0].text).toMatch(/Warning|No active|Successfully/);
       expect(existsSync(statePath)).toBe(true);
 
       unlinkSync(lockPath);
-      const retried = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
+      const retried = await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(retried.isError).not.toBe(true);
       expect(existsSync(statePath)).toBe(false);
     });
 
-    it('preserves session and legacy replacements created after cleanup discovery', async () => {
-      const sessionId = 'stale-cleanup-owner';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      await stateWriteTool.handler({ mode: 'autopilot', active: true, session_id: sessionId, workingDirectory: TEST_DIR });
+    it("preserves session and legacy replacements created after cleanup discovery", async () => {
+      const sessionId = "stale-cleanup-owner";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
+      await stateWriteTool.handler({
+        mode: "autopilot",
+        active: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       const replacement = { active: true, session_id: sessionId };
       process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(replacement),
+      ).toString("base64");
 
-      await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(replacement);
+      await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(replacement);
 
-      const legacyPath = join(TEST_DIR, '.omc', 'state', 'autopilot-state.json');
-      writeFileSync(legacyPath, JSON.stringify({ active: true, session_id: sessionId }));
-      const legacyReplacement = { active: true, session_id: sessionId, workflowRunId: 'replacement-run' };
+      const legacyPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "autopilot-state.json",
+      );
+      writeFileSync(
+        legacyPath,
+        JSON.stringify({ active: true, session_id: sessionId }),
+      );
+      const legacyReplacement = {
+        active: true,
+        session_id: sessionId,
+        workflowRunId: "replacement-run",
+      };
       process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = legacyPath;
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(legacyReplacement)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(legacyReplacement),
+      ).toString("base64");
 
-      await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      expect(JSON.parse(readFileSync(legacyPath, 'utf8'))).toEqual(legacyReplacement);
+      await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      expect(JSON.parse(readFileSync(legacyPath, "utf8"))).toEqual(
+        legacyReplacement,
+      );
     });
-    it('rejects generic writes to active and paused named workflow state', async () => {
-      const sessionId = 'named-safe-write';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("rejects generic writes to active and paused named workflow state", async () => {
+      const sessionId = "named-safe-write";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       const namedState = {
         active: true,
-        prompt: 'original task',
+        prompt: "original task",
         session_id: sessionId,
-        workflowRunId: '11111111-1111-4111-8111-111111111111',
-        workflow: { profileHash: 'a'.repeat(64), stages: ['ralplan'] },
-        pipelineTracking: { currentStageIndex: 0, stages: [{ id: 'ralplan', status: 'active' }] },
+        workflowRunId: "11111111-1111-4111-8111-111111111111",
+        workflow: { profileHash: "a".repeat(64), stages: ["ralplan"] },
+        pipelineTracking: {
+          currentStageIndex: 0,
+          stages: [{ id: "ralplan", status: "active" }],
+        },
       };
       mkdirSync(dirname(statePath), { recursive: true });
       for (const active of [true, false]) {
         writeFileSync(statePath, JSON.stringify({ ...namedState, active }));
         const before = readFileSync(statePath);
-        const result = await stateWriteTool.handler({ mode: 'autopilot', iteration: 2, state: { prompt: 'different task' }, session_id: sessionId, workingDirectory: TEST_DIR });
+        const result = await stateWriteTool.handler({
+          mode: "autopilot",
+          iteration: 2,
+          state: { prompt: "different task" },
+          session_id: sessionId,
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError).toBe(true);
         expect(readFileSync(statePath)).toEqual(before);
       }
     });
 
-    it('linearizes first state_write against a named activation winner', async () => {
-      const sessionId = 'named-first-write-race';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      const namedWinner = { active: true, prompt: 'named task', session_id: sessionId, workflowRunId: '99999999-9999-4999-8999-999999999999', workflow: { profileHash: 'f'.repeat(64), stages: ['ralplan'] }, pipelineTracking: { currentStageIndex: 0, trackingRevision: 0, stages: [{ id: 'ralplan', status: 'active' }] } };
+    it("linearizes first state_write against a named activation winner", async () => {
+      const sessionId = "named-first-write-race";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
+      const namedWinner = {
+        active: true,
+        prompt: "named task",
+        session_id: sessionId,
+        workflowRunId: "99999999-9999-4999-8999-999999999999",
+        workflow: { profileHash: "f".repeat(64), stages: ["ralplan"] },
+        pipelineTracking: {
+          currentStageIndex: 0,
+          trackingRevision: 0,
+          stages: [{ id: "ralplan", status: "active" }],
+        },
+      };
       process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH = statePath;
-      process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(namedWinner)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(namedWinner),
+      ).toString("base64");
 
-      const rejected = await stateWriteTool.handler({ mode: 'autopilot', active: true, state: { prompt: 'legacy task' }, session_id: sessionId, workingDirectory: TEST_DIR });
+      const rejected = await stateWriteTool.handler({
+        mode: "autopilot",
+        active: true,
+        state: { prompt: "legacy task" },
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(rejected.isError).toBe(true);
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(namedWinner);
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(namedWinner);
 
       rmSync(statePath, { force: true });
-      const firstWriter = await stateWriteTool.handler({ mode: 'autopilot', active: true, state: { prompt: 'legacy task' }, session_id: sessionId, workingDirectory: TEST_DIR });
+      const firstWriter = await stateWriteTool.handler({
+        mode: "autopilot",
+        active: true,
+        state: { prompt: "legacy task" },
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(firstWriter.isError).toBeUndefined();
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toMatchObject({ active: true, prompt: 'legacy task' });
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toMatchObject({
+        active: true,
+        prompt: "legacy task",
+      });
     });
-    it('does not overwrite a concurrent named replacement while creating a generic pause state', async () => {
-      const sessionId = 'named-pause-create-race';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("does not overwrite a concurrent named replacement while creating a generic pause state", async () => {
+      const sessionId = "named-pause-create-race";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       const namedWinner = {
         active: true,
         session_id: sessionId,
-        workflowRunId: '99999999-9999-4999-8999-999999999999',
-        workflow: { profileHash: 'f'.repeat(64), stages: ['ralplan'] },
-        pipelineTracking: { currentStageIndex: 0, trackingRevision: 0, stages: [{ id: 'ralplan', status: 'active' }] },
+        workflowRunId: "99999999-9999-4999-8999-999999999999",
+        workflow: { profileHash: "f".repeat(64), stages: ["ralplan"] },
+        pipelineTracking: {
+          currentStageIndex: 0,
+          trackingRevision: 0,
+          stages: [{ id: "ralplan", status: "active" }],
+        },
       };
       process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_PATH = statePath;
-      process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(namedWinner)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CREATE_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(namedWinner),
+      ).toString("base64");
 
       const result = await stateWriteTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         active: false,
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       expect(result.isError).toBe(true);
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(namedWinner);
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(namedWinner);
     });
 
-    it('rejects active named workflow identity and tracking mutations without changing bytes', async () => {
-      const sessionId = 'named-immutable-write';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("rejects active named workflow identity and tracking mutations without changing bytes", async () => {
+      const sessionId = "named-immutable-write";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       const namedState = {
         active: true,
         session_id: sessionId,
-        workflowRunId: '11111111-1111-4111-8111-111111111111',
-        workflow: { profileHash: 'a'.repeat(64), stages: ['ralplan'] },
-        pipelineTracking: { currentStageIndex: 0, stages: [{ id: 'ralplan', status: 'active' }] },
+        workflowRunId: "11111111-1111-4111-8111-111111111111",
+        workflow: { profileHash: "a".repeat(64), stages: ["ralplan"] },
+        pipelineTracking: {
+          currentStageIndex: 0,
+          stages: [{ id: "ralplan", status: "active" }],
+        },
       };
       mkdirSync(dirname(statePath), { recursive: true });
       writeFileSync(statePath, JSON.stringify(namedState));
       const before = readFileSync(statePath);
 
       for (const mutation of [
-        { workflowRunId: '22222222-2222-4222-8222-222222222222' },
-        { workflow: { profileHash: 'b'.repeat(64), stages: ['execution'] } },
-        { pipelineTracking: { currentStageIndex: 1, stages: [{ id: 'execution', status: 'active' }] } },
+        { workflowRunId: "22222222-2222-4222-8222-222222222222" },
+        { workflow: { profileHash: "b".repeat(64), stages: ["execution"] } },
+        {
+          pipelineTracking: {
+            currentStageIndex: 1,
+            stages: [{ id: "execution", status: "active" }],
+          },
+        },
       ]) {
-        const result = await stateWriteTool.handler({ mode: 'autopilot', state: mutation, session_id: sessionId, workingDirectory: TEST_DIR });
+        const result = await stateWriteTool.handler({
+          mode: "autopilot",
+          state: mutation,
+          session_id: sessionId,
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError).toBe(true);
         expect(readFileSync(statePath)).toEqual(before);
       }
     });
 
-    it('rejects every own named-workflow marker, including falsy partial markers, without changing bytes', async () => {
-      const sessionId = 'named-own-marker-write';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("rejects every own named-workflow marker, including falsy partial markers, without changing bytes", async () => {
+      const sessionId = "named-own-marker-write";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
       const markerStates = [
         { workflow: false },
-        { workflowRunId: '' },
+        { workflowRunId: "" },
         { pipelineTracking: null },
-        { workflow: { profileHash: 'invalid', stages: [] } },
+        { workflow: { profileHash: "invalid", stages: [] } },
         {
-          workflow: { descriptorVersion: 1, workflowName: 'invalid', profileVersion: 1, profileHash: '0'.repeat(64), stages: ['ralplan', 'execution'] },
-          workflowRunId: '11111111-1111-4111-8111-111111111111',
+          workflow: {
+            descriptorVersion: 1,
+            workflowName: "invalid",
+            profileVersion: 1,
+            profileHash: "0".repeat(64),
+            stages: ["ralplan", "execution"],
+          },
+          workflowRunId: "11111111-1111-4111-8111-111111111111",
           pipelineTracking: {},
         },
       ];
@@ -558,15 +941,18 @@ describe('state-tools', () => {
       for (const status of [
         { active: true },
         { active: false },
-        { active: false, phase: 'complete' },
+        { active: false, phase: "complete" },
       ]) {
         for (const marker of markerStates) {
-          writeFileSync(statePath, JSON.stringify({ ...status, session_id: sessionId, ...marker }));
+          writeFileSync(
+            statePath,
+            JSON.stringify({ ...status, session_id: sessionId, ...marker }),
+          );
           const before = readFileSync(statePath);
           const result = await stateWriteTool.handler({
-            mode: 'autopilot',
+            mode: "autopilot",
             active: true,
-            state: { prompt: 'generic overwrite' },
+            state: { prompt: "generic overwrite" },
             session_id: sessionId,
             workingDirectory: TEST_DIR,
           });
@@ -576,7 +962,7 @@ describe('state-tools', () => {
       }
       rmSync(statePath, { force: true });
       const markerCreation = await stateWriteTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         active: true,
         state: { workflow: false },
         session_id: sessionId,
@@ -585,22 +971,32 @@ describe('state-tools', () => {
       expect(markerCreation.isError).toBe(true);
       expect(existsSync(statePath)).toBe(false);
     });
-    it('fails closed when a malformed named marker receives an exact pause request', async () => {
-      const sessionId = 'malformed-named-pause';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("fails closed when a malformed named marker receives an exact pause request", async () => {
+      const sessionId = "malformed-named-pause";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({
-        active: true,
-        session_id: sessionId,
-        workflowRunId: '11111111-1111-4111-8111-111111111111',
-        workflow: false,
-      }));
+      writeFileSync(
+        statePath,
+        JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          workflowRunId: "11111111-1111-4111-8111-111111111111",
+          workflow: false,
+        }),
+      );
       const before = readFileSync(statePath);
 
       const result = await stateWriteTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         active: false,
-        state: { workflowRunId: '11111111-1111-4111-8111-111111111111' },
+        state: { workflowRunId: "11111111-1111-4111-8111-111111111111" },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
@@ -608,27 +1004,53 @@ describe('state-tools', () => {
       expect(result.isError).toBe(true);
       expect(readFileSync(statePath)).toEqual(before);
     });
-    it('pauses only an authenticated exact named run without flock and preserves every resume field', async () => {
-      if (process.platform !== 'linux' || (!existsSync('/usr/bin/flock') && !existsSync('/bin/flock'))) return;
-      const sessionId = 'named-resume-pause';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      const configDir = mkdtempSync(join(tmpdir(), 'state-tools-claude-'));
-      const transcript = join(configDir, 'projects', `${sessionId}.jsonl`);
+    it("pauses only an authenticated exact named run without flock and preserves every resume field", async () => {
+      if (
+        process.platform !== "linux" ||
+        (!existsSync("/usr/bin/flock") && !existsSync("/bin/flock"))
+      )
+        return;
+      const sessionId = "named-resume-pause";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
+      const configDir = mkdtempSync(join(tmpdir(), "state-tools-claude-"));
+      const transcript = join(configDir, "projects", `${sessionId}.jsonl`);
       mkdirSync(dirname(transcript), { recursive: true });
-      writeFileSync(transcript, '');
+      writeFileSync(transcript, "");
       const stat = lstatSync(transcript, { bigint: true });
       const now = new Date().toISOString();
-      const descriptor = { descriptorVersion: 1, workflowName: 'release-flow', profileVersion: 1, stages: ['ralplan', 'execution'] };
+      const descriptor = {
+        descriptorVersion: 1,
+        workflowName: "release-flow",
+        profileVersion: 1,
+        stages: ["ralplan", "execution"],
+      };
       const state = {
         active: true,
-        mode: 'autopilot',
-        prompt: 'keep this private task',
-        phase: 'ralplan',
+        mode: "autopilot",
+        prompt: "keep this private task",
+        phase: "ralplan",
         session_id: sessionId,
-        workflowRunId: '11111111-1111-4111-8111-111111111111',
-        workflow: { ...descriptor, profileHash: createHash('sha256').update('{"descriptorVersion":1,"profileVersion":1,"stages":["ralplan","execution"],"workflowName":"release-flow"}').digest('hex') },
+        workflowRunId: "11111111-1111-4111-8111-111111111111",
+        workflow: {
+          ...descriptor,
+          profileHash: createHash("sha256")
+            .update(
+              '{"descriptorVersion":1,"profileVersion":1,"stages":["ralplan","execution"],"workflowName":"release-flow"}',
+            )
+            .digest("hex"),
+        },
         pipelineTracking: {
-          stages: [{ id: 'ralplan', status: 'active', iterations: 0, startedAt: now }, { id: 'execution', status: 'pending', iterations: 0 }],
+          stages: [
+            { id: "ralplan", status: "active", iterations: 0, startedAt: now },
+            { id: "execution", status: "pending", iterations: 0 },
+          ],
           currentStageIndex: 0,
           trackingRevision: 0,
           activationBoundary: {
@@ -637,7 +1059,16 @@ describe('state-tools', () => {
             transcriptBasename: `${sessionId}.jsonl`,
             sessionId,
             byteOffset: 0,
-            fileIdentity: { device: Number(stat.dev), inode: Number(stat.ino), size: Number(stat.size), mtimeNs: stat.mtimeNs.toString(), ctimeNs: stat.ctimeNs.toString(), contentSha256: createHash('sha256').update(readFileSync(transcript)).digest('hex') },
+            fileIdentity: {
+              device: Number(stat.dev),
+              inode: Number(stat.ino),
+              size: Number(stat.size),
+              mtimeNs: stat.mtimeNs.toString(),
+              ctimeNs: stat.ctimeNs.toString(),
+              contentSha256: createHash("sha256")
+                .update(readFileSync(transcript))
+                .digest("hex"),
+            },
           },
           completionObservations: [],
         },
@@ -647,122 +1078,262 @@ describe('state-tools', () => {
       const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
       try {
         process.env.CLAUDE_CONFIG_DIR = configDir;
-        process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+        process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
         const result = await stateWriteTool.handler({
-          mode: 'autopilot',
+          mode: "autopilot",
           active: false,
-          state: { workflowRunId: state.workflowRunId, target_state_sha256: createHash('sha256').update(JSON.stringify(state)).digest('hex') },
+          state: {
+            workflowRunId: state.workflowRunId,
+            target_state_sha256: createHash("sha256")
+              .update(JSON.stringify(state))
+              .digest("hex"),
+          },
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
         expect(result.isError, result.content[0].text).toBeUndefined();
-        expect(result.content[0].text).toContain('Paused named autopilot workflow');
+        expect(result.content[0].text).toContain(
+          "Paused named autopilot workflow",
+        );
         expect(result.content[0].text).not.toContain(state.prompt);
-        expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual({ ...state, active: false });
+        expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual({
+          ...state,
+          active: false,
+        });
         writeFileSync(statePath, JSON.stringify(state));
         const beforeRejectedPause = readFileSync(statePath);
         const staleDigest = await stateWriteTool.handler({
-          mode: 'autopilot',
+          mode: "autopilot",
           active: false,
-          state: { workflowRunId: state.workflowRunId, target_state_sha256: '0'.repeat(64) },
+          state: {
+            workflowRunId: state.workflowRunId,
+            target_state_sha256: "0".repeat(64),
+          },
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
         expect(staleDigest.isError).toBe(true);
         expect(readFileSync(statePath)).toEqual(beforeRejectedPause);
         const forgedMarkerWrite = await stateWriteTool.handler({
-          mode: 'autopilot',
+          mode: "autopilot",
           active: false,
-          state: { workflowRunId: '22222222-2222-4222-8222-222222222222' },
+          state: { workflowRunId: "22222222-2222-4222-8222-222222222222" },
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
         expect(forgedMarkerWrite.isError).toBe(true);
         expect(readFileSync(statePath)).toEqual(beforeRejectedPause);
       } finally {
-        if (previousConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+        if (previousConfigDir === undefined)
+          delete process.env.CLAUDE_CONFIG_DIR;
         else process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
         rmSync(configDir, { recursive: true, force: true });
       }
     });
   });
 
-    it('rejects an incomplete named state without flock and preserves its bytes', async () => {
-      const sessionId = 'named-write-no-flock';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      mkdirSync(dirname(statePath), { recursive: true });
-      const state = { active: true, session_id: sessionId, workflowRunId: '11111111-1111-4111-8111-111111111111', workflow: { profileHash: 'a'.repeat(64) } };
-      writeFileSync(statePath, JSON.stringify(state));
-      const before = readFileSync(statePath);
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+  it("rejects an incomplete named state without flock and preserves its bytes", async () => {
+    const sessionId = "named-write-no-flock";
+    const statePath = join(
+      TEST_DIR,
+      ".omc",
+      "state",
+      "sessions",
+      sessionId,
+      "autopilot-state.json",
+    );
+    mkdirSync(dirname(statePath), { recursive: true });
+    const state = {
+      active: true,
+      session_id: sessionId,
+      workflowRunId: "11111111-1111-4111-8111-111111111111",
+      workflow: { profileHash: "a".repeat(64) },
+    };
+    writeFileSync(statePath, JSON.stringify(state));
+    const before = readFileSync(statePath);
+    process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
 
-      const result = await stateWriteTool.handler({ mode: 'autopilot', active: false, session_id: sessionId, state: { workflowRunId: state.workflowRunId }, workingDirectory: TEST_DIR });
-      expect(result.isError).toBe(true);
-      expect(readFileSync(statePath)).toEqual(before);
+    const result = await stateWriteTool.handler({
+      mode: "autopilot",
+      active: false,
+      session_id: sessionId,
+      state: { workflowRunId: state.workflowRunId },
+      workingDirectory: TEST_DIR,
     });
+    expect(result.isError).toBe(true);
+    expect(readFileSync(statePath)).toEqual(before);
+  });
 
-  describe('state_clear', () => {
-    it.each([['supported', '1'], ['no-flock', '0']])('clears an exact malformed marker-bearing snapshot under %s runtime', async (_runtime, flock) => {
-      const sessionId = `named-clear-${flock}`;
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      const signalPath = join(dirname(statePath), 'cancel-signal-state.json');
-      mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({ active: true, session_id: sessionId, workflow: false, private: 'do-not-project' }));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = flock;
+  describe("state_clear", () => {
+    it.each([
+      ["supported", "1"],
+      ["no-flock", "0"],
+    ])(
+      "clears an exact malformed marker-bearing snapshot under %s runtime",
+      async (_runtime, flock) => {
+        const sessionId = `named-clear-${flock}`;
+        const statePath = join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          sessionId,
+          "autopilot-state.json",
+        );
+        const signalPath = join(dirname(statePath), "cancel-signal-state.json");
+        mkdirSync(dirname(statePath), { recursive: true });
+        writeFileSync(
+          statePath,
+          JSON.stringify({
+            active: true,
+            session_id: sessionId,
+            workflow: false,
+            private: "do-not-project",
+          }),
+        );
+        process.env.OMC_TEST_FLOCK_AVAILABLE = flock;
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      expect(result.isError, JSON.stringify(result)).toBeUndefined();
-      expect(existsSync(statePath)).toBe(false);
-      expect(existsSync(signalPath)).toBe(false);
-    });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          session_id: sessionId,
+          workingDirectory: TEST_DIR,
+        });
+        expect(result.isError, JSON.stringify(result)).toBeUndefined();
+        expect(existsSync(statePath)).toBe(false);
+        expect(existsSync(signalPath)).toBe(false);
+      },
+    );
 
-    it.each([['supported', '1'], ['no-flock', '0']])('preserves a replacement that races an exact malformed-marker clear under %s runtime', async (_runtime, flock) => {
-      const sessionId = `named-clear-race-${flock}`;
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      const replacement = { active: true, session_id: sessionId, replacement: true };
-      mkdirSync(dirname(statePath), { recursive: true });
-      writeFileSync(statePath, JSON.stringify({ active: true, session_id: sessionId, workflow: false }));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = flock;
-      if (flock === '0') {
-        process.env.OMC_TEST_EMERGENCY_REPLACEMENT_PATH = statePath;
-        process.env.OMC_TEST_EMERGENCY_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
-      } else {
-        process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
-        process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
-      }
+    it.each([
+      ["supported", "1"],
+      ["no-flock", "0"],
+    ])(
+      "preserves a replacement that races an exact malformed-marker clear under %s runtime",
+      async (_runtime, flock) => {
+        const sessionId = `named-clear-race-${flock}`;
+        const statePath = join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          sessionId,
+          "autopilot-state.json",
+        );
+        const replacement = {
+          active: true,
+          session_id: sessionId,
+          replacement: true,
+        };
+        mkdirSync(dirname(statePath), { recursive: true });
+        writeFileSync(
+          statePath,
+          JSON.stringify({
+            active: true,
+            session_id: sessionId,
+            workflow: false,
+          }),
+        );
+        process.env.OMC_TEST_FLOCK_AVAILABLE = flock;
+        if (flock === "0") {
+          process.env.OMC_TEST_EMERGENCY_REPLACEMENT_PATH = statePath;
+          process.env.OMC_TEST_EMERGENCY_REPLACEMENT_BASE64 = Buffer.from(
+            JSON.stringify(replacement),
+          ).toString("base64");
+        } else {
+          process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
+          process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 =
+            Buffer.from(JSON.stringify(replacement)).toString("base64");
+        }
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      expect(result.isError).toBe(true);
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(replacement);
-    });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          session_id: sessionId,
+          workingDirectory: TEST_DIR,
+        });
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(
+          replacement,
+        );
+      },
+    );
 
-    it('clears malformed named and legacy candidates during a broad clear', async () => {
-      const namedPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'mixed-named', 'autopilot-state.json');
-      const legacyPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'mixed-legacy', 'autopilot-state.json');
+    it("clears malformed named and legacy candidates during a broad clear", async () => {
+      const namedPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "mixed-named",
+        "autopilot-state.json",
+      );
+      const legacyPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "mixed-legacy",
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(namedPath), { recursive: true });
       mkdirSync(dirname(legacyPath), { recursive: true });
-      writeFileSync(namedPath, JSON.stringify({ active: true, session_id: 'mixed-named', workflowRunId: '77777777-7777-4777-8777-777777777777', workflow: { profileHash: 'e'.repeat(64) } }));
-      writeFileSync(legacyPath, JSON.stringify({ active: true, session_id: 'mixed-legacy' }));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+      writeFileSync(
+        namedPath,
+        JSON.stringify({
+          active: true,
+          session_id: "mixed-named",
+          workflowRunId: "77777777-7777-4777-8777-777777777777",
+          workflow: { profileHash: "e".repeat(64) },
+        }),
+      );
+      writeFileSync(
+        legacyPath,
+        JSON.stringify({ active: true, session_id: "mixed-legacy" }),
+      );
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        workingDirectory: TEST_DIR,
+      });
       expect(result.isError, JSON.stringify(result)).toBeUndefined();
       expect(existsSync(namedPath)).toBe(false);
       expect(existsSync(legacyPath)).toBe(false);
     });
 
-    it('clears active, paused, and terminal malformed named markers without signals', async () => {
-      const sessionId = 'named-own-marker-clear';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      const signalPath = join(dirname(statePath), 'cancel-signal-state.json');
+    it("clears active, paused, and terminal malformed named markers without signals", async () => {
+      const sessionId = "named-own-marker-clear";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
+      const signalPath = join(dirname(statePath), "cancel-signal-state.json");
       mkdirSync(dirname(statePath), { recursive: true });
-      const markerStates = [{ workflow: false }, { workflowRunId: '' }, { pipelineTracking: null }];
+      const markerStates = [
+        { workflow: false },
+        { workflowRunId: "" },
+        { pipelineTracking: null },
+      ];
 
-      for (const status of [{ active: true }, { active: false }, { active: false, phase: 'complete' }]) {
+      for (const status of [
+        { active: true },
+        { active: false },
+        { active: false, phase: "complete" },
+      ]) {
         for (const marker of markerStates) {
           rmSync(signalPath, { force: true });
-          writeFileSync(statePath, JSON.stringify({ ...status, session_id: sessionId, ...marker }));
-          const result = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
+          writeFileSync(
+            statePath,
+            JSON.stringify({ ...status, session_id: sessionId, ...marker }),
+          );
+          const result = await stateClearTool.handler({
+            mode: "autopilot",
+            session_id: sessionId,
+            workingDirectory: TEST_DIR,
+          });
           expect(result.isError, JSON.stringify(result)).toBeUndefined();
           expect(existsSync(statePath)).toBe(false);
           expect(existsSync(signalPath)).toBe(false);
@@ -770,73 +1341,171 @@ describe('state-tools', () => {
       }
     });
 
-    it('clears recovered malformed named primaries during session cleanup', async () => {
-      const sessionId = 'multi-named-owner';
-      const canonical = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
-      const stranded = join(TEST_DIR, '.omc', 'state', 'sessions', 'stale-dir', 'autopilot-state.json');
-      const state = { active: true, session_id: sessionId, workflowRunId: '11111111-1111-4111-8111-111111111111', workflow: { profileHash: 'a'.repeat(64) } };
+    it("clears recovered malformed named primaries during session cleanup", async () => {
+      const sessionId = "multi-named-owner";
+      const canonical = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
+      const stranded = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "stale-dir",
+        "autopilot-state.json",
+      );
+      const state = {
+        active: true,
+        session_id: sessionId,
+        workflowRunId: "11111111-1111-4111-8111-111111111111",
+        workflow: { profileHash: "a".repeat(64) },
+      };
       mkdirSync(dirname(canonical), { recursive: true });
       mkdirSync(dirname(stranded), { recursive: true });
       writeFileSync(canonical, JSON.stringify(state));
-      writeFileSync(stranded, JSON.stringify({ ...state, workflowRunId: '22222222-2222-4222-8222-222222222222' }));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+      writeFileSync(
+        stranded,
+        JSON.stringify({
+          ...state,
+          workflowRunId: "22222222-2222-4222-8222-222222222222",
+        }),
+      );
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(result.isError, JSON.stringify(result)).toBeUndefined();
       expect(existsSync(canonical)).toBe(false);
       expect(existsSync(stranded)).toBe(false);
     });
 
-    it('clears an incomplete named state without starting a portable pause transaction', async () => {
-      const sessionId = 'interrupted-pause-clear';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json');
+    it("clears an incomplete named state without starting a portable pause transaction", async () => {
+      const sessionId = "interrupted-pause-clear";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "autopilot-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      const state = { active: true, session_id: sessionId, workflowRunId: '11111111-1111-4111-8111-111111111111', workflow: { profileHash: 'a'.repeat(64) } };
+      const state = {
+        active: true,
+        session_id: sessionId,
+        workflowRunId: "11111111-1111-4111-8111-111111111111",
+        workflow: { profileHash: "a".repeat(64) },
+      };
       writeFileSync(statePath, JSON.stringify(state));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
-      process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-rename';
-      expect((await stateWriteTool.handler({ mode: 'autopilot', active: false, session_id: sessionId, state: { workflowRunId: state.workflowRunId }, workingDirectory: TEST_DIR })).isError).toBe(true);
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
+      process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-rename";
+      expect(
+        (
+          await stateWriteTool.handler({
+            mode: "autopilot",
+            active: false,
+            session_id: sessionId,
+            state: { workflowRunId: state.workflowRunId },
+            workingDirectory: TEST_DIR,
+          })
+        ).isError,
+      ).toBe(true);
       delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
       expect(existsSync(`${statePath}.emergency-journal.json`)).toBe(false);
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
       expect(result.isError, JSON.stringify(result)).toBeUndefined();
       expect(existsSync(statePath)).toBe(false);
     });
 
-    it('does not recover or reject another session emergency transaction', async () => {
-      const ownPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'recovery-owner-a', 'autopilot-state.json');
-      const otherPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'recovery-owner-b', 'autopilot-state.json');
-      for (const [path, owner, run] of [[ownPath, 'recovery-owner-a', '44444444-4444-4444-8444-444444444444'], [otherPath, 'recovery-owner-b', '55555555-5555-4555-8555-555555555555']] as const) {
+    it("does not recover or reject another session emergency transaction", async () => {
+      const ownPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "recovery-owner-a",
+        "autopilot-state.json",
+      );
+      const otherPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "recovery-owner-b",
+        "autopilot-state.json",
+      );
+      for (const [path, owner, run] of [
+        [ownPath, "recovery-owner-a", "44444444-4444-4444-8444-444444444444"],
+        [otherPath, "recovery-owner-b", "55555555-5555-4555-8555-555555555555"],
+      ] as const) {
         mkdirSync(dirname(path), { recursive: true });
-        writeFileSync(path, JSON.stringify({ active: true, session_id: owner, workflowRunId: run, workflow: { profileHash: 'c'.repeat(64) } }));
+        writeFileSync(
+          path,
+          JSON.stringify({
+            active: true,
+            session_id: owner,
+            workflowRunId: run,
+            workflow: { profileHash: "c".repeat(64) },
+          }),
+        );
       }
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
-      process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-rename';
-      expect(emergencyMutateStateFileIf(otherPath, (state) => state.session_id === 'recovery-owner-b', (state) => ({ ...state, active: false }))).toBe(false);
+      process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
+      process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-rename";
+      expect(
+        emergencyMutateStateFileIf(
+          otherPath,
+          (state) => state.session_id === "recovery-owner-b",
+          (state) => ({ ...state, active: false }),
+        ),
+      ).toBe(false);
       delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
       expect(existsSync(`${otherPath}.emergency-journal.json`)).toBe(true);
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', session_id: 'recovery-owner-a', workingDirectory: TEST_DIR });
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: "recovery-owner-a",
+        workingDirectory: TEST_DIR,
+      });
       expect(result.isError, JSON.stringify(result)).toBeUndefined();
       expect(existsSync(ownPath)).toBe(false);
       expect(existsSync(`${otherPath}.emergency-journal.json`)).toBe(true);
     });
 
-    it('signals and clears the home-global autopilot fallback during broad clear', async () => {
+    it("signals and clears the home-global autopilot fallback during broad clear", async () => {
       const previousHome = process.env.HOME;
-      const home = join(TEST_DIR, 'home-global');
+      const home = join(TEST_DIR, "home-global");
       process.env.HOME = home;
       try {
-        const statePath = join(home, '.omc', 'state', 'autopilot-state.json');
+        const statePath = join(home, ".omc", "state", "autopilot-state.json");
         mkdirSync(dirname(statePath), { recursive: true });
         const state = { active: true, project_path: TEST_DIR };
         writeFileSync(statePath, JSON.stringify(state));
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError).toBeUndefined();
         expect(existsSync(statePath)).toBe(false);
-        const signal = JSON.parse(readFileSync(join(dirname(statePath), 'cancel-signal-state.json'), 'utf8'));
+        const signal = JSON.parse(
+          readFileSync(
+            join(dirname(statePath), "cancel-signal-state.json"),
+            "utf8",
+          ),
+        );
         expect(signal.target_workflow_run_id).toBeUndefined();
         expect(signal.target_state_sha256).toMatch(/^[a-f0-9]{64}$/);
       } finally {
@@ -844,21 +1513,45 @@ describe('state-tools', () => {
         else process.env.HOME = previousHome;
       }
     });
-    it('recovers a same-project shared-session clear transaction with no primary during broad clear', async () => {
+    it("recovers a same-project shared-session clear transaction with no primary during broad clear", async () => {
       const previousHome = process.env.HOME;
-      const home = join(TEST_DIR, 'home-shared-session-clear-intent');
+      const home = join(TEST_DIR, "home-shared-session-clear-intent");
       process.env.HOME = home;
       try {
-        const statePath = join(home, '.omc', 'state', 'sessions', 'project-a-clear', 'autopilot-state.json');
+        const statePath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-a-clear",
+          "autopilot-state.json",
+        );
         mkdirSync(dirname(statePath), { recursive: true });
-        writeFileSync(statePath, JSON.stringify({ active: true, project_path: TEST_DIR, workflowRunId: 'acacacac-acac-4cac-8cac-acacacacacac', workflow: { profileHash: 'a'.repeat(64) } }));
-        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-rename';
-        expect(emergencyMutateStateFileIf(statePath, (state) => state.project_path === TEST_DIR, null)).toBe(false);
+        writeFileSync(
+          statePath,
+          JSON.stringify({
+            active: true,
+            project_path: TEST_DIR,
+            workflowRunId: "acacacac-acac-4cac-8cac-acacacacacac",
+            workflow: { profileHash: "a".repeat(64) },
+          }),
+        );
+        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-rename";
+        expect(
+          emergencyMutateStateFileIf(
+            statePath,
+            (state) => state.project_path === TEST_DIR,
+            null,
+          ),
+        ).toBe(false);
         delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
         expect(existsSync(statePath)).toBe(false);
         expect(existsSync(`${statePath}.emergency-journal.json`)).toBe(true);
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError, JSON.stringify(result)).toBeUndefined();
         expect(existsSync(statePath)).toBe(false);
         expect(existsSync(`${statePath}.emergency-journal.json`)).toBe(false);
@@ -867,21 +1560,34 @@ describe('state-tools', () => {
         else process.env.HOME = previousHome;
       }
     });
-    it('preserves a foreign dead publication temp beside an authorized home-global state', async () => {
+    it("preserves a foreign dead publication temp beside an authorized home-global state", async () => {
       const previousHome = process.env.HOME;
-      const home = join(TEST_DIR, 'home-global-foreign-temp');
+      const home = join(TEST_DIR, "home-global-foreign-temp");
       process.env.HOME = home;
       try {
-        const statePath = join(home, '.omc', 'state', 'autopilot-state.json');
+        const statePath = join(home, ".omc", "state", "autopilot-state.json");
         const foreignTemp = `${statePath}.emergency-quarantine.${randomUUID()}.payload.999999999.1.${randomUUID()}.tmp`;
-        const primary = JSON.stringify({ active: true, project_path: TEST_DIR, workflowRunId: 'adadadad-adad-4dad-8dad-adadadadadad' });
+        const primary = JSON.stringify({
+          active: true,
+          project_path: TEST_DIR,
+          workflowRunId: "adadadad-adad-4dad-8dad-adadadadadad",
+        });
         mkdirSync(dirname(statePath), { recursive: true });
         writeFileSync(statePath, primary);
-        writeFileSync(foreignTemp, JSON.stringify({ active: false, project_path: join(TEST_DIR, 'other-project') }));
+        writeFileSync(
+          foreignTemp,
+          JSON.stringify({
+            active: false,
+            project_path: join(TEST_DIR, "other-project"),
+          }),
+        );
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError).toBe(true);
-        expect(readFileSync(statePath, 'utf8')).toBe(primary);
+        expect(readFileSync(statePath, "utf8")).toBe(primary);
         expect(existsSync(foreignTemp)).toBe(true);
       } finally {
         if (previousHome === undefined) delete process.env.HOME;
@@ -889,89 +1595,215 @@ describe('state-tools', () => {
       }
     });
 
-    it('preserves a malformed journal beside an authorized shared-session state', async () => {
+    it("preserves a malformed journal beside an authorized shared-session state", async () => {
       const previousHome = process.env.HOME;
-      const home = join(TEST_DIR, 'home-shared-session-malformed-journal');
+      const home = join(TEST_DIR, "home-shared-session-malformed-journal");
       process.env.HOME = home;
       try {
-        const statePath = join(home, '.omc', 'state', 'sessions', 'project-a', 'autopilot-state.json');
+        const statePath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-a",
+          "autopilot-state.json",
+        );
         const journalPath = `${statePath}.emergency-journal.json`;
-        const primary = JSON.stringify({ active: true, project_path: TEST_DIR, workflowRunId: 'aeaeaeae-aeae-4eae-8eae-aeaeaeaeaeae' });
+        const primary = JSON.stringify({
+          active: true,
+          project_path: TEST_DIR,
+          workflowRunId: "aeaeaeae-aeae-4eae-8eae-aeaeaeaeaeae",
+        });
         mkdirSync(dirname(statePath), { recursive: true });
         writeFileSync(statePath, primary);
         writeFileSync(journalPath, '{"version":1');
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError).toBe(true);
-        expect(readFileSync(statePath, 'utf8')).toBe(primary);
-        expect(readFileSync(journalPath, 'utf8')).toBe('{"version":1');
+        expect(readFileSync(statePath, "utf8")).toBe(primary);
+        expect(readFileSync(journalPath, "utf8")).toBe('{"version":1');
       } finally {
         if (previousHome === undefined) delete process.env.HOME;
         else process.env.HOME = previousHome;
       }
     });
 
-
-    it('preserves an unrelated-project home-global autopilot fallback without signaling', async () => {
+    it("preserves an unrelated-project home-global autopilot fallback without signaling", async () => {
       const previousHome = process.env.HOME;
-      const home = join(TEST_DIR, 'home-unrelated');
+      const home = join(TEST_DIR, "home-unrelated");
       process.env.HOME = home;
       try {
-        const statePath = join(home, '.omc', 'state', 'autopilot-state.json');
+        const statePath = join(home, ".omc", "state", "autopilot-state.json");
         mkdirSync(dirname(statePath), { recursive: true });
-        const raw = JSON.stringify({ active: true, project_path: join(TEST_DIR, 'other-project'), workflowRunId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' });
+        const raw = JSON.stringify({
+          active: true,
+          project_path: join(TEST_DIR, "other-project"),
+          workflowRunId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        });
         writeFileSync(statePath, raw);
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError).toBeUndefined();
-        expect(readFileSync(statePath, 'utf8')).toBe(raw);
-        expect(existsSync(join(dirname(statePath), 'cancel-signal-state.json'))).toBe(false);
+        expect(readFileSync(statePath, "utf8")).toBe(raw);
+        expect(
+          existsSync(join(dirname(statePath), "cancel-signal-state.json")),
+        ).toBe(false);
       } finally {
         if (previousHome === undefined) delete process.env.HOME;
         else process.env.HOME = previousHome;
       }
     });
-    it('preserves unrelated shared-session autopilot state and emergency artifacts during broad clear', async () => {
+    it("preserves unrelated shared-session autopilot state and emergency artifacts during broad clear", async () => {
       const previousHome = process.env.HOME;
-      const home = join(TEST_DIR, 'home-shared-session-projects');
+      const home = join(TEST_DIR, "home-shared-session-projects");
       process.env.HOME = home;
       try {
-        const projectAPath = join(home, '.omc', 'state', 'sessions', 'project-a-named', 'autopilot-state.json');
-        const projectALegacyPath = join(home, '.omc', 'state', 'sessions', 'project-a-legacy', 'autopilot-state.json');
-        const projectBPath = join(home, '.omc', 'state', 'sessions', 'project-b-named', 'autopilot-state.json');
-        const projectBRecoveryPath = join(home, '.omc', 'state', 'sessions', 'project-b-recovery', 'autopilot-state.json');
-        const projectBLegacyPath = join(home, '.omc', 'state', 'sessions', 'project-b-legacy', 'autopilot-state.json');
-        const otherProject = join(TEST_DIR, 'other-project');
-        for (const path of [projectAPath, projectALegacyPath, projectBPath, projectBRecoveryPath, projectBLegacyPath]) {
+        const projectAPath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-a-named",
+          "autopilot-state.json",
+        );
+        const projectALegacyPath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-a-legacy",
+          "autopilot-state.json",
+        );
+        const projectBPath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-b-named",
+          "autopilot-state.json",
+        );
+        const projectBRecoveryPath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-b-recovery",
+          "autopilot-state.json",
+        );
+        const projectBLegacyPath = join(
+          home,
+          ".omc",
+          "state",
+          "sessions",
+          "project-b-legacy",
+          "autopilot-state.json",
+        );
+        const otherProject = join(TEST_DIR, "other-project");
+        for (const path of [
+          projectAPath,
+          projectALegacyPath,
+          projectBPath,
+          projectBRecoveryPath,
+          projectBLegacyPath,
+        ]) {
           mkdirSync(dirname(path), { recursive: true });
         }
-        writeFileSync(projectAPath, JSON.stringify({ active: true, project_path: TEST_DIR, workflowRunId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', workflow: { profileHash: 'a'.repeat(64) } }));
-        writeFileSync(projectALegacyPath, JSON.stringify({ active: true, project_path: TEST_DIR }));
-        writeFileSync(projectBPath, JSON.stringify({ active: true, project_path: otherProject, workflowRunId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', workflow: { profileHash: 'b'.repeat(64) } }));
-        writeFileSync(projectBRecoveryPath, JSON.stringify({ active: true, project_path: otherProject, workflowRunId: 'bdbdbdbd-bdbd-4dbd-8dbd-bdbdbdbdbdbd', workflow: { profileHash: 'd'.repeat(64) } }));
-        writeFileSync(projectBLegacyPath, JSON.stringify({ active: true, project_path: otherProject, workflowRunId: 'bcbcbcbc-bcbc-4cbc-8cbc-bcbcbcbcbcbc' }));
-        process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
+        writeFileSync(
+          projectAPath,
+          JSON.stringify({
+            active: true,
+            project_path: TEST_DIR,
+            workflowRunId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            workflow: { profileHash: "a".repeat(64) },
+          }),
+        );
+        writeFileSync(
+          projectALegacyPath,
+          JSON.stringify({ active: true, project_path: TEST_DIR }),
+        );
+        writeFileSync(
+          projectBPath,
+          JSON.stringify({
+            active: true,
+            project_path: otherProject,
+            workflowRunId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            workflow: { profileHash: "b".repeat(64) },
+          }),
+        );
+        writeFileSync(
+          projectBRecoveryPath,
+          JSON.stringify({
+            active: true,
+            project_path: otherProject,
+            workflowRunId: "bdbdbdbd-bdbd-4dbd-8dbd-bdbdbdbdbdbd",
+            workflow: { profileHash: "d".repeat(64) },
+          }),
+        );
+        writeFileSync(
+          projectBLegacyPath,
+          JSON.stringify({
+            active: true,
+            project_path: otherProject,
+            workflowRunId: "bcbcbcbc-bcbc-4cbc-8cbc-bcbcbcbcbcbc",
+          }),
+        );
+        process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
 
-        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-publication';
-        expect(emergencyMutateStateFileIf(projectBPath, (state) => state.project_path === otherProject, (state) => ({ ...state, active: false }))).toBe(false);
+        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-publication";
+        expect(
+          emergencyMutateStateFileIf(
+            projectBPath,
+            (state) => state.project_path === otherProject,
+            (state) => ({ ...state, active: false }),
+          ),
+        ).toBe(false);
         delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
         const projectBBefore = readFileSync(projectBPath);
-        const projectBArtifacts = new Map(readdirSync(dirname(projectBPath))
-          .filter((name) => name.startsWith(`${basename(projectBPath)}.emergency-`))
-          .map((name) => [name, readFileSync(join(dirname(projectBPath), name))]));
+        const projectBArtifacts = new Map(
+          readdirSync(dirname(projectBPath))
+            .filter((name) =>
+              name.startsWith(`${basename(projectBPath)}.emergency-`),
+            )
+            .map((name) => [
+              name,
+              readFileSync(join(dirname(projectBPath), name)),
+            ]),
+        );
         expect(projectBArtifacts.size).toBeGreaterThan(0);
 
-        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-rename';
-        expect(emergencyMutateStateFileIf(projectBRecoveryPath, (state) => state.project_path === otherProject, null)).toBe(false);
+        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-rename";
+        expect(
+          emergencyMutateStateFileIf(
+            projectBRecoveryPath,
+            (state) => state.project_path === otherProject,
+            null,
+          ),
+        ).toBe(false);
         delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
         expect(existsSync(projectBRecoveryPath)).toBe(false);
-        const projectBRecoveryArtifacts = new Map(readdirSync(dirname(projectBRecoveryPath))
-          .filter((name) => name.startsWith(`${basename(projectBRecoveryPath)}.emergency-`))
-          .map((name) => [name, readFileSync(join(dirname(projectBRecoveryPath), name))]));
+        const projectBRecoveryArtifacts = new Map(
+          readdirSync(dirname(projectBRecoveryPath))
+            .filter((name) =>
+              name.startsWith(`${basename(projectBRecoveryPath)}.emergency-`),
+            )
+            .map((name) => [
+              name,
+              readFileSync(join(dirname(projectBRecoveryPath), name)),
+            ]),
+        );
         expect(projectBRecoveryArtifacts.size).toBeGreaterThan(0);
         const projectBLegacyBefore = readFileSync(projectBLegacyPath);
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
 
         expect(result.isError, JSON.stringify(result)).toBeUndefined();
         expect(existsSync(projectAPath)).toBe(false);
@@ -979,14 +1811,28 @@ describe('state-tools', () => {
         expect(readFileSync(projectBPath)).toEqual(projectBBefore);
         expect(existsSync(projectBRecoveryPath)).toBe(false);
         expect(readFileSync(projectBLegacyPath)).toEqual(projectBLegacyBefore);
-        expect(existsSync(join(dirname(projectBPath), 'cancel-signal-state.json'))).toBe(false);
-        expect(existsSync(join(dirname(projectBRecoveryPath), 'cancel-signal-state.json'))).toBe(false);
-        expect(existsSync(join(dirname(projectBLegacyPath), 'cancel-signal-state.json'))).toBe(false);
+        expect(
+          existsSync(join(dirname(projectBPath), "cancel-signal-state.json")),
+        ).toBe(false);
+        expect(
+          existsSync(
+            join(dirname(projectBRecoveryPath), "cancel-signal-state.json"),
+          ),
+        ).toBe(false);
+        expect(
+          existsSync(
+            join(dirname(projectBLegacyPath), "cancel-signal-state.json"),
+          ),
+        ).toBe(false);
         for (const [name, contents] of projectBArtifacts) {
-          expect(readFileSync(join(dirname(projectBPath), name))).toEqual(contents);
+          expect(readFileSync(join(dirname(projectBPath), name))).toEqual(
+            contents,
+          );
         }
         for (const [name, contents] of projectBRecoveryArtifacts) {
-          expect(readFileSync(join(dirname(projectBRecoveryPath), name))).toEqual(contents);
+          expect(
+            readFileSync(join(dirname(projectBRecoveryPath), name)),
+          ).toEqual(contents);
         }
       } finally {
         if (previousHome === undefined) delete process.env.HOME;
@@ -994,38 +1840,88 @@ describe('state-tools', () => {
       }
     });
 
-    it('recovers interrupted canonical and legacy named pauses before broad clear', async () => {
-      const canonical = join(TEST_DIR, '.omc', 'state', 'sessions', 'broad-journal-owner', 'autopilot-state.json');
-      const legacy = join(TEST_DIR, '.omc', 'state', 'autopilot-state.json');
-      for (const [path, run] of [[canonical, '22222222-2222-4222-8222-222222222222'], [legacy, '33333333-3333-4333-8333-333333333333']] as const) {
+    it("recovers interrupted canonical and legacy named pauses before broad clear", async () => {
+      const canonical = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "broad-journal-owner",
+        "autopilot-state.json",
+      );
+      const legacy = join(TEST_DIR, ".omc", "state", "autopilot-state.json");
+      for (const [path, run] of [
+        [canonical, "22222222-2222-4222-8222-222222222222"],
+        [legacy, "33333333-3333-4333-8333-333333333333"],
+      ] as const) {
         mkdirSync(dirname(path), { recursive: true });
-        writeFileSync(path, JSON.stringify({ active: true, session_id: 'broad-journal-owner', workflowRunId: run, workflow: { profileHash: 'b'.repeat(64) } }));
-      process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
-        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-rename';
-        expect(emergencyMutateStateFileIf(path, (state) => state.workflowRunId === run, (state) => ({ ...state, active: false }))).toBe(false);
+        writeFileSync(
+          path,
+          JSON.stringify({
+            active: true,
+            session_id: "broad-journal-owner",
+            workflowRunId: run,
+            workflow: { profileHash: "b".repeat(64) },
+          }),
+        );
+        process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
+        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-rename";
+        expect(
+          emergencyMutateStateFileIf(
+            path,
+            (state) => state.workflowRunId === run,
+            (state) => ({ ...state, active: false }),
+          ),
+        ).toBe(false);
         delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
         expect(existsSync(`${path}.emergency-journal.json`)).toBe(true);
       }
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        workingDirectory: TEST_DIR,
+      });
       expect(result.isError, JSON.stringify(result)).toBeUndefined();
       expect(existsSync(canonical)).toBe(false);
       expect(existsSync(legacy)).toBe(false);
     });
-    it('recovers an interrupted named transaction from the centralized root before broad clear', async () => {
+    it("recovers an interrupted named transaction from the centralized root before broad clear", async () => {
       const previous = process.env.OMC_STATE_DIR;
-      process.env.OMC_STATE_DIR = join(TEST_DIR, 'central-emergency-root');
+      process.env.OMC_STATE_DIR = join(TEST_DIR, "central-emergency-root");
       try {
-        const { getOmcRoot } = await import('../../lib/worktree-paths.js');
-        const statePath = join(getOmcRoot(TEST_DIR), 'state', 'sessions', 'central-journal-owner', 'autopilot-state.json');
+        const { getOmcRoot } = await import("../../lib/worktree-paths.js");
+        const statePath = join(
+          getOmcRoot(TEST_DIR),
+          "state",
+          "sessions",
+          "central-journal-owner",
+          "autopilot-state.json",
+        );
         mkdirSync(dirname(statePath), { recursive: true });
-        writeFileSync(statePath, JSON.stringify({ active: true, session_id: 'central-journal-owner', workflowRunId: '66666666-6666-4666-8666-666666666666', workflow: { profileHash: 'd'.repeat(64) } }));
-        process.env.OMC_TEST_FLOCK_AVAILABLE = '0';
-        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = 'after-rename';
-        expect(emergencyMutateStateFileIf(statePath, (state) => state.session_id === 'central-journal-owner', (state) => ({ ...state, active: false }))).toBe(false);
+        writeFileSync(
+          statePath,
+          JSON.stringify({
+            active: true,
+            session_id: "central-journal-owner",
+            workflowRunId: "66666666-6666-4666-8666-666666666666",
+            workflow: { profileHash: "d".repeat(64) },
+          }),
+        );
+        process.env.OMC_TEST_FLOCK_AVAILABLE = "0";
+        process.env.OMC_TEST_EMERGENCY_CRASH_PHASE = "after-rename";
+        expect(
+          emergencyMutateStateFileIf(
+            statePath,
+            (state) => state.session_id === "central-journal-owner",
+            (state) => ({ ...state, active: false }),
+          ),
+        ).toBe(false);
         delete process.env.OMC_TEST_EMERGENCY_CRASH_PHASE;
 
-        const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
+        const result = await stateClearTool.handler({
+          mode: "autopilot",
+          workingDirectory: TEST_DIR,
+        });
         expect(result.isError, JSON.stringify(result)).toBeUndefined();
         expect(existsSync(statePath)).toBe(false);
       } finally {
@@ -1034,18 +1930,18 @@ describe('state-tools', () => {
       }
     });
 
-    it('should remove legacy state file when no session_id provided', async () => {
+    it("should remove legacy state file when no session_id provided", async () => {
       await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         state: { active: true },
         workingDirectory: TEST_DIR,
       });
 
-      const legacyPath = join(TEST_DIR, '.omc', 'state', 'ralph-state.json');
+      const legacyPath = join(TEST_DIR, ".omc", "state", "ralph-state.json");
       expect(existsSync(legacyPath)).toBe(true);
 
       const result = await stateClearTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         workingDirectory: TEST_DIR,
       });
 
@@ -1053,66 +1949,75 @@ describe('state-tools', () => {
       expect(existsSync(legacyPath)).toBe(false);
     });
 
-    it('should clear ralplan state with explicit session_id', async () => {
-      const sessionId = 'test-session-ralplan';
-      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+    it("should clear ralplan state with explicit session_id", async () => {
+      const sessionId = "test-session-ralplan";
+      const sessionDir = join(TEST_DIR, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
       writeFileSync(
-        join(sessionDir, 'ralplan-state.json'),
-        JSON.stringify({ active: true })
+        join(sessionDir, "ralplan-state.json"),
+        JSON.stringify({ active: true }),
       );
 
       const result = await stateClearTool.handler({
-        mode: 'ralplan',
+        mode: "ralplan",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('cleared');
-      expect(existsSync(join(sessionDir, 'ralplan-state.json'))).toBe(false);
+      expect(result.content[0].text).toContain("cleared");
+      expect(existsSync(join(sessionDir, "ralplan-state.json"))).toBe(false);
     });
 
-    it('should also remove non-session legacy state files during session clear', async () => {
-      const sessionId = 'legacy-cleanup-session';
-      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+    it("should also remove non-session legacy state files during session clear", async () => {
+      const sessionId = "legacy-cleanup-session";
+      const sessionDir = join(TEST_DIR, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
       writeFileSync(
-        join(sessionDir, 'ralph-state.json'),
+        join(sessionDir, "ralph-state.json"),
         JSON.stringify({ active: true, session_id: sessionId }),
       );
 
-      const legacyRootPath = join(TEST_DIR, '.omc', 'ralph-state.json');
+      const legacyRootPath = join(TEST_DIR, ".omc", "ralph-state.json");
       writeFileSync(
         legacyRootPath,
         JSON.stringify({ active: true, session_id: sessionId }),
       );
 
       const result = await stateClearTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('ghost legacy file also removed');
-      expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
+      expect(result.content[0].text).toContain(
+        "ghost legacy file also removed",
+      );
+      expect(existsSync(join(sessionDir, "ralph-state.json"))).toBe(false);
       expect(existsSync(legacyRootPath)).toBe(false);
     });
 
-    it('should clear only the requested session for every execution mode', async () => {
-      const modes = ['autopilot', 'autoresearch', 'ralph', 'ultrawork', 'ultraqa', 'team'] as const;
-      const sessionA = 'session-a';
-      const sessionB = 'session-b';
+    it("should clear only the requested session for every execution mode", async () => {
+      const modes = [
+        "autopilot",
+        "autoresearch",
+        "ralph",
+        "ultrawork",
+        "ultraqa",
+        "team",
+      ] as const;
+      const sessionA = "session-a";
+      const sessionB = "session-b";
 
       for (const mode of modes) {
         await stateWriteTool.handler({
           mode,
-          state: { active: true, owner: 'A' },
+          state: { active: true, owner: "A" },
           session_id: sessionA,
           workingDirectory: TEST_DIR,
         });
         await stateWriteTool.handler({
           mode,
-          state: { active: true, owner: 'B' },
+          state: { active: true, owner: "B" },
           session_id: sessionB,
           workingDirectory: TEST_DIR,
         });
@@ -1125,61 +2030,98 @@ describe('state-tools', () => {
 
         expect(clearResult.content[0].text).toMatch(/cleared|Successfully/i);
 
-        const sessionAPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionA, `${mode}-state.json`);
-        const sessionBPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionB, `${mode}-state.json`);
+        const sessionAPath = join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          sessionA,
+          `${mode}-state.json`,
+        );
+        const sessionBPath = join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          sessionB,
+          `${mode}-state.json`,
+        );
 
         expect(existsSync(sessionAPath)).toBe(false);
         expect(existsSync(sessionBPath)).toBe(true);
       }
     });
 
-    it('should clear legacy and all sessions when session_id is omitted and show warning', async () => {
-      const sessionId = 'aggregate-clear';
+    it("should clear legacy and all sessions when session_id is omitted and show warning", async () => {
+      const sessionId = "aggregate-clear";
       await stateWriteTool.handler({
-        mode: 'ultrawork',
-        state: { active: true, source: 'legacy' },
+        mode: "ultrawork",
+        state: { active: true, source: "legacy" },
         workingDirectory: TEST_DIR,
       });
       await stateWriteTool.handler({
-        mode: 'ultrawork',
-        state: { active: true, source: 'session' },
+        mode: "ultrawork",
+        state: { active: true, source: "session" },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       const result = await stateClearTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         workingDirectory: TEST_DIR,
       });
 
-      const legacyPath = join(TEST_DIR, '.omc', 'state', 'ultrawork-state.json');
-      const sessionPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json');
+      const legacyPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "ultrawork-state.json",
+      );
+      const sessionPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ultrawork-state.json",
+      );
 
-      expect(result.content[0].text).toContain('WARNING: No session_id provided');
+      expect(result.content[0].text).toContain(
+        "WARNING: No session_id provided",
+      );
       expect(existsSync(legacyPath)).toBe(false);
       expect(existsSync(sessionPath)).toBe(false);
     });
 
-    it('lists and clears active legacy global ralph state without touching unrelated state', async () => {
-      const homeRoot = mkdtempSync(join(tmpdir(), 'state-tools-home-'));
-      vi.stubEnv('HOME', homeRoot);
-      vi.stubEnv('USERPROFILE', homeRoot);
+    it("lists and clears active legacy global ralph state without touching unrelated state", async () => {
+      const homeRoot = mkdtempSync(join(tmpdir(), "state-tools-home-"));
+      vi.stubEnv("HOME", homeRoot);
+      vi.stubEnv("USERPROFILE", homeRoot);
       try {
-        const legacyGlobalStateDir = join(homeRoot, '.omc', 'state');
+        const legacyGlobalStateDir = join(homeRoot, ".omc", "state");
         mkdirSync(legacyGlobalStateDir, { recursive: true });
-        const ralphPath = join(legacyGlobalStateDir, 'ralph-state.json');
-        const unrelatedPath = join(legacyGlobalStateDir, 'ultrawork-state.json');
-        writeFileSync(ralphPath, JSON.stringify({ active: true, legacy: true }));
-        writeFileSync(unrelatedPath, JSON.stringify({ active: true, unrelated: true }));
+        const ralphPath = join(legacyGlobalStateDir, "ralph-state.json");
+        const unrelatedPath = join(
+          legacyGlobalStateDir,
+          "ultrawork-state.json",
+        );
+        writeFileSync(
+          ralphPath,
+          JSON.stringify({ active: true, legacy: true }),
+        );
+        writeFileSync(
+          unrelatedPath,
+          JSON.stringify({ active: true, unrelated: true }),
+        );
 
         const listResult = await stateListActiveTool.handler({
           all: true,
           workingDirectory: TEST_DIR,
         });
-        expect(listResult.content[0].text).toContain('ralph');
+        expect(listResult.content[0].text).toContain("ralph");
 
         const clearResult = await stateClearTool.handler({
-          mode: 'ralph',
+          mode: "ralph",
           workingDirectory: TEST_DIR,
         });
         expect(clearResult.content[0].text).toMatch(/Cleared|Successfully/i);
@@ -1191,33 +2133,56 @@ describe('state-tools', () => {
       }
     });
 
-    it('lists and clears worktree-local session ralph state with session cwd context only', async () => {
-      const centralizedRoot = mkdtempSync(join(tmpdir(), 'state-tools-central-'));
-      vi.stubEnv('OMC_STATE_DIR', centralizedRoot);
+    it("lists and clears worktree-local session ralph state with session cwd context only", async () => {
+      const centralizedRoot = mkdtempSync(
+        join(tmpdir(), "state-tools-central-"),
+      );
+      vi.stubEnv("OMC_STATE_DIR", centralizedRoot);
       try {
-        const sessionId = 'local-ralph-session';
-        const unrelatedSessionId = 'unrelated-session';
-        const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
-        const unrelatedSessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', unrelatedSessionId);
+        const sessionId = "local-ralph-session";
+        const unrelatedSessionId = "unrelated-session";
+        const sessionDir = join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          sessionId,
+        );
+        const unrelatedSessionDir = join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          unrelatedSessionId,
+        );
         mkdirSync(sessionDir, { recursive: true });
         mkdirSync(unrelatedSessionDir, { recursive: true });
-        const localRalphPath = join(sessionDir, 'ralph-state.json');
-        const unrelatedRalphPath = join(unrelatedSessionDir, 'ralph-state.json');
-        writeFileSync(localRalphPath, JSON.stringify({ active: true, session_id: sessionId }));
-        writeFileSync(unrelatedRalphPath, JSON.stringify({ active: true, session_id: unrelatedSessionId }));
+        const localRalphPath = join(sessionDir, "ralph-state.json");
+        const unrelatedRalphPath = join(
+          unrelatedSessionDir,
+          "ralph-state.json",
+        );
+        writeFileSync(
+          localRalphPath,
+          JSON.stringify({ active: true, session_id: sessionId }),
+        );
+        writeFileSync(
+          unrelatedRalphPath,
+          JSON.stringify({ active: true, session_id: unrelatedSessionId }),
+        );
 
         const listResult = await stateListActiveTool.handler({
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
-        expect(listResult.content[0].text).toContain('ralph');
+        expect(listResult.content[0].text).toContain("ralph");
 
         const clearResult = await stateClearTool.handler({
-          mode: 'ralph',
+          mode: "ralph",
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
-        expect(clearResult.content[0].text).toContain('cleared');
+        expect(clearResult.content[0].text).toContain("cleared");
         expect(existsSync(localRalphPath)).toBe(false);
         expect(existsSync(unrelatedRalphPath)).toBe(true);
       } finally {
@@ -1226,16 +2191,16 @@ describe('state-tools', () => {
       }
     });
 
-    it('should not report false errors for sessions with no state file during broad clear', async () => {
+    it("should not report false errors for sessions with no state file during broad clear", async () => {
       // Create a session directory but no state file for ralph mode
-      const sessionId = 'empty-session';
-      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+      const sessionId = "empty-session";
+      const sessionDir = join(TEST_DIR, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
       // Note: no state file created - simulating a session with no ralph state
 
       // Create state for a different mode in the same session
       await stateWriteTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         state: { active: true },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -1243,91 +2208,184 @@ describe('state-tools', () => {
 
       // Now clear ralph mode (which has no state in this session)
       const result = await stateClearTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         workingDirectory: TEST_DIR,
       });
 
       // Should report "No state found" not errors
-      expect(result.content[0].text).toContain('No state found');
-      expect(result.content[0].text).not.toContain('Errors:');
+      expect(result.content[0].text).toContain("No state found");
+      expect(result.content[0].text).not.toContain("Errors:");
     });
 
-    it('should only count actual deletions in broad clear count', async () => {
+    it("should only count actual deletions in broad clear count", async () => {
       // Create state in only one session out of multiple
-      const sessionWithState = 'has-state';
-      const sessionWithoutState = 'no-state';
+      const sessionWithState = "has-state";
+      const sessionWithoutState = "no-state";
 
       // Create session directories
-      mkdirSync(join(TEST_DIR, '.omc', 'state', 'sessions', sessionWithState), { recursive: true });
-      mkdirSync(join(TEST_DIR, '.omc', 'state', 'sessions', sessionWithoutState), { recursive: true });
+      mkdirSync(join(TEST_DIR, ".omc", "state", "sessions", sessionWithState), {
+        recursive: true,
+      });
+      mkdirSync(
+        join(TEST_DIR, ".omc", "state", "sessions", sessionWithoutState),
+        { recursive: true },
+      );
 
       // Only create state for one session
       await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         state: { active: true },
         session_id: sessionWithState,
         workingDirectory: TEST_DIR,
       });
 
       const result = await stateClearTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         workingDirectory: TEST_DIR,
       });
 
       // Should report exactly 1 location cleared (the session with state)
-      expect(result.content[0].text).toContain('Locations cleared: 1');
-      expect(result.content[0].text).not.toContain('Errors:');
+      expect(result.content[0].text).toContain("Locations cleared: 1");
+      expect(result.content[0].text).not.toContain("Errors:");
     });
 
-    it('does not count a broad-clear replacement run as deleted', async () => {
-      await stateWriteTool.handler({ mode: 'autopilot', active: true, workingDirectory: TEST_DIR });
-      const statePath = join(TEST_DIR, '.omc', 'state', 'autopilot-state.json');
+    it("does not count a broad-clear replacement run as deleted", async () => {
+      await stateWriteTool.handler({
+        mode: "autopilot",
+        active: true,
+        workingDirectory: TEST_DIR,
+      });
+      const statePath = join(TEST_DIR, ".omc", "state", "autopilot-state.json");
       const replacement = { active: true };
       process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(replacement),
+      ).toString("base64");
 
-      const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(replacement);
-      expect(result.content[0].text).not.toContain('Locations cleared: 1');
-      expect(result.content[0].text).toContain('skipped');
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        workingDirectory: TEST_DIR,
+      });
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(replacement);
+      expect(result.content[0].text).not.toContain("Locations cleared: 1");
+      expect(result.content[0].text).toContain("skipped");
       expect(result.isError).toBe(true);
     });
 
-    it('clears a stranded recovered workflow by its captured path in broad mode', async () => {
-      const strandedPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'stale-dir', 'autopilot-state.json');
-      mkdirSync(dirname(strandedPath), { recursive: true });
-      writeFileSync(strandedPath, JSON.stringify({ active: true, session_id: 'owner-session' }));
-
-      const result = await stateClearTool.handler({ mode: 'autopilot', workingDirectory: TEST_DIR });
-      expect(existsSync(strandedPath)).toBe(false);
-      expect(result.content[0].text).toContain('Locations cleared: 1');
-      expect(result.isError).not.toBe(true);
-      const signalPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'owner-session', 'cancel-signal-state.json');
-      expect(JSON.parse(readFileSync(signalPath, 'utf8')).target_workflow_run_id).toBeUndefined();
-    });
-
-    it('reports a broad converged-path replacement as incomplete', async () => {
-      const sessionId = 'converged-replacement';
-      await stateWriteTool.handler({ mode: 'ralph', active: true, session_id: sessionId, workingDirectory: TEST_DIR });
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
-      const replacement = { active: true, session_id: sessionId, workflowRunId: 'replacement-run' };
+    it("preserves a session canonical replacement after its CAS clear skips", async () => {
+      const sessionId = "session-cas-replacement";
+      await stateWriteTool.handler({
+        mode: "ultrawork",
+        active: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ultrawork-state.json",
+      );
+      const replacement = {
+        active: true,
+        session_id: sessionId,
+        workflowRunId: "replacement-run",
+      };
       process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(replacement),
+      ).toString("base64");
 
-      const result = await stateClearTool.handler({ mode: 'ralph', workingDirectory: TEST_DIR });
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(replacement);
-      expect(result.content[0].text).not.toContain('Locations cleared: 1');
-      expect(result.content[0].text).toContain('survived');
+      const result = await stateClearTool.handler({
+        mode: "ultrawork",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(replacement);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Warning");
+    });
+
+    it("clears a stranded recovered workflow by its captured path in broad mode", async () => {
+      const strandedPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "stale-dir",
+        "autopilot-state.json",
+      );
+      mkdirSync(dirname(strandedPath), { recursive: true });
+      writeFileSync(
+        strandedPath,
+        JSON.stringify({ active: true, session_id: "owner-session" }),
+      );
+
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
+        workingDirectory: TEST_DIR,
+      });
+      expect(existsSync(strandedPath)).toBe(false);
+      expect(result.content[0].text).toContain("Locations cleared: 1");
+      expect(result.isError).not.toBe(true);
+      const signalPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "owner-session",
+        "cancel-signal-state.json",
+      );
+      expect(
+        JSON.parse(readFileSync(signalPath, "utf8")).target_workflow_run_id,
+      ).toBeUndefined();
+    });
+
+    it("reports a broad converged-path replacement as incomplete", async () => {
+      const sessionId = "converged-replacement";
+      await stateWriteTool.handler({
+        mode: "ralph",
+        active: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ralph-state.json",
+      );
+      const replacement = {
+        active: true,
+        session_id: sessionId,
+        workflowRunId: "replacement-run",
+      };
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(replacement),
+      ).toString("base64");
+
+      const result = await stateClearTool.handler({
+        mode: "ralph",
+        workingDirectory: TEST_DIR,
+      });
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(replacement);
+      expect(result.content[0].text).not.toContain("Locations cleared: 1");
+      expect(result.content[0].text).toContain("survived");
       expect(result.isError).toBe(true);
     });
 
-    it('should clear skill-active state with session_id (fix for #2118)', async () => {
-      const sessionId = 'test-skill-active-clear';
+    it("should clear skill-active state with session_id (fix for #2118)", async () => {
+      const sessionId = "test-skill-active-clear";
 
       await stateWriteTool.handler({
-        mode: 'skill-active',
+        mode: "skill-active",
         active: true,
-        state: { skill_name: 'sciomc', reinforcement_count: 2 },
+        state: { skill_name: "sciomc", reinforcement_count: 2 },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
@@ -1337,55 +2395,79 @@ describe('state-tools', () => {
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
-      expect(listBefore.content[0].text).toContain('skill-active');
+      expect(listBefore.content[0].text).toContain("skill-active");
 
       const clearResult = await stateClearTool.handler({
-        mode: 'skill-active',
+        mode: "skill-active",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(clearResult.content[0].text).toContain('cleared');
+      expect(clearResult.content[0].text).toContain("cleared");
 
       const readResult = await stateReadTool.handler({
-        mode: 'skill-active',
+        mode: "skill-active",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
       // stateReadTool returning "No state found" is authoritative proof the file is gone
-      expect(readResult.content[0].text).toContain('No state found');
+      expect(readResult.content[0].text).toContain("No state found");
     });
 
-    it('clears completed-session orphan state when cancel runs from a fresh session id', async () => {
-      const freshSessionId = 'fresh-cancel-session';
-      const liveSessionId = 'live-sibling-session';
-      const orphanSessionIds = ['ended-session-one', 'ended-session-two'];
-      const modes = ['ralph', 'ultrawork', 'team'] as const;
+    it("clears completed-session orphan state when cancel runs from a fresh session id", async () => {
+      const freshSessionId = "fresh-cancel-session";
+      const liveSessionId = "live-sibling-session";
+      const orphanSessionIds = ["ended-session-one", "ended-session-two"];
+      const modes = ["ralph", "ultrawork", "team"] as const;
 
-      mkdirSync(join(TEST_DIR, '.omc', 'sessions'), { recursive: true });
+      mkdirSync(join(TEST_DIR, ".omc", "sessions"), { recursive: true });
 
       for (const orphanSessionId of orphanSessionIds) {
-        mkdirSync(join(TEST_DIR, '.omc', 'state', 'sessions', orphanSessionId), { recursive: true });
+        mkdirSync(
+          join(TEST_DIR, ".omc", "state", "sessions", orphanSessionId),
+          { recursive: true },
+        );
         writeFileSync(
-          join(TEST_DIR, '.omc', 'sessions', `${orphanSessionId}.json`),
-          JSON.stringify({ session_id: orphanSessionId, ended_at: '2026-05-04T00:00:00.000Z' }),
+          join(TEST_DIR, ".omc", "sessions", `${orphanSessionId}.json`),
+          JSON.stringify({
+            session_id: orphanSessionId,
+            ended_at: "2026-05-04T00:00:00.000Z",
+          }),
         );
       }
-      mkdirSync(join(TEST_DIR, '.omc', 'state', 'sessions', liveSessionId), { recursive: true });
+      mkdirSync(join(TEST_DIR, ".omc", "state", "sessions", liveSessionId), {
+        recursive: true,
+      });
 
       for (const mode of modes) {
         for (const orphanSessionId of orphanSessionIds) {
           writeFileSync(
-            join(TEST_DIR, '.omc', 'state', 'sessions', orphanSessionId, `${mode}-state.json`),
+            join(
+              TEST_DIR,
+              ".omc",
+              "state",
+              "sessions",
+              orphanSessionId,
+              `${mode}-state.json`,
+            ),
             JSON.stringify({
               active: true,
               session_id: orphanSessionId,
-              ...(mode === 'team' ? { team_name: `team-${orphanSessionId}` } : {}),
+              ...(mode === "team"
+                ? { team_name: `team-${orphanSessionId}` }
+                : {}),
             }),
           );
         }
         writeFileSync(
-          join(TEST_DIR, '.omc', 'state', 'sessions', liveSessionId, `${mode}-state.json`),
+          join(
+            TEST_DIR,
+            ".omc",
+            "state",
+            "sessions",
+            liveSessionId,
+            `${mode}-state.json`,
+          ),
           JSON.stringify({ active: true, session_id: liveSessionId }),
         );
 
@@ -1395,94 +2477,181 @@ describe('state-tools', () => {
           workingDirectory: TEST_DIR,
         });
 
-        expect(result.content[0].text).toContain('completed-session orphan');
+        expect(result.content[0].text).toContain("completed-session orphan");
         for (const orphanSessionId of orphanSessionIds) {
-          expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', orphanSessionId, `${mode}-state.json`))).toBe(false);
+          expect(
+            existsSync(
+              join(
+                TEST_DIR,
+                ".omc",
+                "state",
+                "sessions",
+                orphanSessionId,
+                `${mode}-state.json`,
+              ),
+            ),
+          ).toBe(false);
         }
-        expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', liveSessionId, `${mode}-state.json`))).toBe(true);
+        expect(
+          existsSync(
+            join(
+              TEST_DIR,
+              ".omc",
+              "state",
+              "sessions",
+              liveSessionId,
+              `${mode}-state.json`,
+            ),
+          ),
+        ).toBe(true);
       }
     });
 
-    it('preserves a replacement run at a completed-session candidate path', async () => {
-      const requester = 'fresh-cancel';
-      const endedSession = 'ended-replaced-session';
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', endedSession, 'ultrawork-state.json');
+    it("preserves a replacement run at a completed-session candidate path", async () => {
+      const requester = "fresh-cancel";
+      const endedSession = "ended-replaced-session";
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        endedSession,
+        "ultrawork-state.json",
+      );
       mkdirSync(dirname(statePath), { recursive: true });
-      mkdirSync(join(TEST_DIR, '.omc', 'sessions'), { recursive: true });
-      writeFileSync(join(TEST_DIR, '.omc', 'sessions', `${endedSession}.json`), JSON.stringify({ session_id: endedSession, ended_at: '2026-05-04T00:00:00.000Z' }));
-      writeFileSync(statePath, JSON.stringify({ active: true, session_id: endedSession, workflowRunId: 'old-run' }));
-      const replacement = { active: true, session_id: endedSession, workflowRunId: 'replacement-run' };
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
-      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(JSON.stringify(replacement)).toString('base64');
-
-      await stateClearTool.handler({ mode: 'ultrawork', session_id: requester, workingDirectory: TEST_DIR });
-      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual(replacement);
-    });
-
-    it('reports completed-session orphan state on session-scoped read misses', async () => {
-      const freshSessionId = 'fresh-read-session';
-      const orphanSessionId = 'ended-read-session';
-      mkdirSync(join(TEST_DIR, '.omc', 'sessions'), { recursive: true });
-      mkdirSync(join(TEST_DIR, '.omc', 'state', 'sessions', orphanSessionId), { recursive: true });
+      mkdirSync(join(TEST_DIR, ".omc", "sessions"), { recursive: true });
       writeFileSync(
-        join(TEST_DIR, '.omc', 'sessions', `${orphanSessionId}.json`),
-        JSON.stringify({ session_id: orphanSessionId, ended_at: '2026-05-04T00:00:00.000Z' }),
+        join(TEST_DIR, ".omc", "sessions", `${endedSession}.json`),
+        JSON.stringify({
+          session_id: endedSession,
+          ended_at: "2026-05-04T00:00:00.000Z",
+        }),
       );
       writeFileSync(
-        join(TEST_DIR, '.omc', 'state', 'sessions', orphanSessionId, 'ralph-state.json'),
+        statePath,
+        JSON.stringify({
+          active: true,
+          session_id: endedSession,
+          workflowRunId: "old-run",
+        }),
+      );
+      const replacement = {
+        active: true,
+        session_id: endedSession,
+        workflowRunId: "replacement-run",
+      };
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_PATH = statePath;
+      process.env.OMC_TEST_CONDITIONAL_CLEAR_REPLACEMENT_BASE64 = Buffer.from(
+        JSON.stringify(replacement),
+      ).toString("base64");
+
+      await stateClearTool.handler({
+        mode: "ultrawork",
+        session_id: requester,
+        workingDirectory: TEST_DIR,
+      });
+      expect(JSON.parse(readFileSync(statePath, "utf8"))).toEqual(replacement);
+    });
+
+    it("reports completed-session orphan state on session-scoped read misses", async () => {
+      const freshSessionId = "fresh-read-session";
+      const orphanSessionId = "ended-read-session";
+      mkdirSync(join(TEST_DIR, ".omc", "sessions"), { recursive: true });
+      mkdirSync(join(TEST_DIR, ".omc", "state", "sessions", orphanSessionId), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(TEST_DIR, ".omc", "sessions", `${orphanSessionId}.json`),
+        JSON.stringify({
+          session_id: orphanSessionId,
+          ended_at: "2026-05-04T00:00:00.000Z",
+        }),
+      );
+      writeFileSync(
+        join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          orphanSessionId,
+          "ralph-state.json",
+        ),
         JSON.stringify({ active: true, session_id: orphanSessionId }),
       );
 
       const result = await stateReadTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         session_id: freshSessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('completed-session orphan');
+      expect(result.content[0].text).toContain("completed-session orphan");
       expect(result.content[0].text).toContain(orphanSessionId);
     });
 
-    it('clears completed-session orphan state through a symlinked .omc directory', async () => {
-      const symlinkTestDir = mkdtempSync(join(tmpdir(), 'state-tools-symlink-'));
-      const realOmcDir = mkdtempSync(join(tmpdir(), 'state-tools-real-omc-'));
+    it("clears completed-session orphan state through a symlinked .omc directory", async () => {
+      const symlinkTestDir = mkdtempSync(
+        join(tmpdir(), "state-tools-symlink-"),
+      );
+      const realOmcDir = mkdtempSync(join(tmpdir(), "state-tools-real-omc-"));
       try {
-        rmSync(join(symlinkTestDir, '.omc'), { recursive: true, force: true });
-        symlinkSync(realOmcDir, join(symlinkTestDir, '.omc'), 'dir');
-        const orphanSessionId = 'ended-symlink-session';
-        const freshSessionId = 'fresh-symlink-session';
-        mkdirSync(join(realOmcDir, 'sessions'), { recursive: true });
-        mkdirSync(join(realOmcDir, 'state', 'sessions', orphanSessionId), { recursive: true });
+        rmSync(join(symlinkTestDir, ".omc"), { recursive: true, force: true });
+        symlinkSync(realOmcDir, join(symlinkTestDir, ".omc"), "dir");
+        const orphanSessionId = "ended-symlink-session";
+        const freshSessionId = "fresh-symlink-session";
+        mkdirSync(join(realOmcDir, "sessions"), { recursive: true });
+        mkdirSync(join(realOmcDir, "state", "sessions", orphanSessionId), {
+          recursive: true,
+        });
         writeFileSync(
-          join(realOmcDir, 'sessions', `${orphanSessionId}.json`),
-          JSON.stringify({ session_id: orphanSessionId, ended_at: '2026-05-04T00:00:00.000Z' }),
+          join(realOmcDir, "sessions", `${orphanSessionId}.json`),
+          JSON.stringify({
+            session_id: orphanSessionId,
+            ended_at: "2026-05-04T00:00:00.000Z",
+          }),
         );
         writeFileSync(
-          join(realOmcDir, 'state', 'sessions', orphanSessionId, 'ultrawork-state.json'),
+          join(
+            realOmcDir,
+            "state",
+            "sessions",
+            orphanSessionId,
+            "ultrawork-state.json",
+          ),
           JSON.stringify({ active: true, session_id: orphanSessionId }),
         );
 
         const result = await stateClearTool.handler({
-          mode: 'ultrawork',
+          mode: "ultrawork",
           session_id: freshSessionId,
           workingDirectory: symlinkTestDir,
         });
 
-        expect(result.content[0].text).toContain('completed-session orphan');
-        expect(existsSync(join(realOmcDir, 'state', 'sessions', orphanSessionId, 'ultrawork-state.json'))).toBe(false);
+        expect(result.content[0].text).toContain("completed-session orphan");
+        expect(
+          existsSync(
+            join(
+              realOmcDir,
+              "state",
+              "sessions",
+              orphanSessionId,
+              "ultrawork-state.json",
+            ),
+          ),
+        ).toBe(false);
       } finally {
         rmSync(symlinkTestDir, { recursive: true, force: true });
         rmSync(realOmcDir, { recursive: true, force: true });
       }
     });
 
-    it('should list skill-active as active when state file is present', async () => {
-      const sessionId = 'skill-active-list-test';
+    it("should list skill-active as active when state file is present", async () => {
+      const sessionId = "skill-active-list-test";
 
       await stateWriteTool.handler({
-        mode: 'skill-active',
+        mode: "skill-active",
         active: true,
-        state: { skill_name: 'learner' },
+        state: { skill_name: "learner" },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
@@ -1492,15 +2661,15 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('skill-active');
+      expect(result.content[0].text).toContain("skill-active");
     });
   });
 
-  describe('state_list_active', () => {
-    it('should list active modes in current session when session_id provided', async () => {
-      const sessionId = 'active-session-test';
+  describe("state_list_active", () => {
+    it("should list active modes in current session when session_id provided", async () => {
+      const sessionId = "active-session-test";
       await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         active: true,
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -1511,13 +2680,13 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('ralph');
+      expect(result.content[0].text).toContain("ralph");
     });
 
-    it('should list active modes across sessions when session_id omitted', async () => {
-      const sessionId = 'aggregate-session';
+    it("should list active modes across sessions when session_id omitted", async () => {
+      const sessionId = "aggregate-session";
       await stateWriteTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         active: true,
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -1527,15 +2696,15 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('ultrawork');
+      expect(result.content[0].text).toContain("ultrawork");
       expect(result.content[0].text).toContain(sessionId);
     });
 
-    it('should include team mode when team state is active', async () => {
+    it("should include team mode when team state is active", async () => {
       await stateWriteTool.handler({
-        mode: 'team',
+        mode: "team",
         active: true,
-        state: { phase: 'team-exec' },
+        state: { phase: "team-exec" },
         workingDirectory: TEST_DIR,
       });
 
@@ -1543,14 +2712,14 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('team');
+      expect(result.content[0].text).toContain("team");
     });
 
-    it('should include autoresearch mode when autoresearch state is active', async () => {
+    it("should include autoresearch mode when autoresearch state is active", async () => {
       await stateWriteTool.handler({
-        mode: 'autoresearch',
+        mode: "autoresearch",
         active: true,
-        state: { phase: 'running' },
+        state: { phase: "running" },
         workingDirectory: TEST_DIR,
       });
 
@@ -1558,14 +2727,14 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('autoresearch');
+      expect(result.content[0].text).toContain("autoresearch");
     });
 
-    it('should include deep-interview mode when deep-interview state is active', async () => {
+    it("should include deep-interview mode when deep-interview state is active", async () => {
       await stateWriteTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         active: true,
-        state: { phase: 'questioning' },
+        state: { phase: "questioning" },
         workingDirectory: TEST_DIR,
       });
 
@@ -1573,12 +2742,12 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('deep-interview');
+      expect(result.content[0].text).toContain("deep-interview");
     });
 
-    it('should include self-improve mode when self-improve state is active', async () => {
+    it("should include self-improve mode when self-improve state is active", async () => {
       await stateWriteTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         active: true,
         state: { tournament_round: 1 },
         workingDirectory: TEST_DIR,
@@ -1588,92 +2757,106 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('self-improve');
+      expect(result.content[0].text).toContain("self-improve");
     });
 
-    it('should include team in status output when team state is active', async () => {
+    it("should include team in status output when team state is active", async () => {
       await stateWriteTool.handler({
-        mode: 'team',
+        mode: "team",
         active: true,
-        state: { phase: 'team-verify' },
+        state: { phase: "team-verify" },
         workingDirectory: TEST_DIR,
       });
 
       const result = await stateGetStatusTool.handler({
-        mode: 'team',
+        mode: "team",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Status: team');
-      expect(result.content[0].text).toContain('**Active:** Yes');
+      expect(result.content[0].text).toContain("Status: team");
+      expect(result.content[0].text).toContain("**Active:** Yes");
     });
 
-    it('deep-interview and self-improve appear in all-mode status listing', async () => {
+    it("deep-interview and self-improve appear in all-mode status listing", async () => {
       const result = await stateGetStatusTool.handler({
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('deep-interview');
-      expect(result.content[0].text).toContain('self-improve');
+      expect(result.content[0].text).toContain("deep-interview");
+      expect(result.content[0].text).toContain("self-improve");
     });
   });
 
   // -----------------------------------------------------------------------
   // Registry parity: deep-interview and self-improve as first-class modes
   // -----------------------------------------------------------------------
-  describe('deep-interview and self-improve registry parity (T1)', () => {
-    it('writes deep-interview state to session-scoped path via MODE_CONFIGS routing', async () => {
-      const sessionId = 'di-registry-write';
+  describe("deep-interview and self-improve registry parity (T1)", () => {
+    it("writes deep-interview state to session-scoped path via MODE_CONFIGS routing", async () => {
+      const sessionId = "di-registry-write";
       await stateWriteTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         active: true,
-        state: { current_phase: 'questioning', round: 3 },
+        state: { current_phase: "questioning", round: 3 },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'deep-interview-state.json');
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "deep-interview-state.json",
+      );
       expect(existsSync(statePath)).toBe(true);
     });
 
-    it('writes self-improve state to session-scoped path via MODE_CONFIGS routing', async () => {
-      const sessionId = 'si-registry-write';
+    it("writes self-improve state to session-scoped path via MODE_CONFIGS routing", async () => {
+      const sessionId = "si-registry-write";
       await stateWriteTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         active: true,
         state: { tournament_round: 1, best_score: 0.85 },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'self-improve-state.json');
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "self-improve-state.json",
+      );
       expect(existsSync(statePath)).toBe(true);
     });
 
-    it('reads deep-interview state back from session-scoped path', async () => {
-      const sessionId = 'di-registry-read';
+    it("reads deep-interview state back from session-scoped path", async () => {
+      const sessionId = "di-registry-read";
       await stateWriteTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         active: true,
-        state: { current_phase: 'questioning', ambiguity_score: 0.34 },
+        state: { current_phase: "questioning", ambiguity_score: 0.34 },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       const result = await stateReadTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('current_phase');
-      expect(result.content[0].text).toContain('ambiguity_score');
+      expect(result.content[0].text).toContain("current_phase");
+      expect(result.content[0].text).toContain("ambiguity_score");
     });
 
-    it('reads self-improve state back from session-scoped path', async () => {
-      const sessionId = 'si-registry-read';
+    it("reads self-improve state back from session-scoped path", async () => {
+      const sessionId = "si-registry-read";
       await stateWriteTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         active: true,
         state: { tournament_round: 2, generation: 5 },
         session_id: sessionId,
@@ -1681,40 +2864,47 @@ describe('state-tools', () => {
       });
 
       const result = await stateReadTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('tournament_round');
-      expect(result.content[0].text).toContain('generation');
+      expect(result.content[0].text).toContain("tournament_round");
+      expect(result.content[0].text).toContain("generation");
     });
 
-    it('clears deep-interview state file for given session', async () => {
-      const sessionId = 'di-registry-clear';
+    it("clears deep-interview state file for given session", async () => {
+      const sessionId = "di-registry-clear";
       await stateWriteTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         active: true,
-        state: { current_phase: 'analysis' },
+        state: { current_phase: "analysis" },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       const clearResult = await stateClearTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       expect(clearResult.content[0].text).toMatch(/cleared|Successfully/i);
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'deep-interview-state.json');
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "deep-interview-state.json",
+      );
       expect(existsSync(statePath)).toBe(false);
     });
 
-    it('clears self-improve state file for given session', async () => {
-      const sessionId = 'si-registry-clear';
+    it("clears self-improve state file for given session", async () => {
+      const sessionId = "si-registry-clear";
       await stateWriteTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         active: true,
         state: { tournament_round: 3 },
         session_id: sessionId,
@@ -1722,77 +2912,84 @@ describe('state-tools', () => {
       });
 
       const clearResult = await stateClearTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
       expect(clearResult.content[0].text).toMatch(/cleared|Successfully/i);
-      const statePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'self-improve-state.json');
+      const statePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "self-improve-state.json",
+      );
       expect(existsSync(statePath)).toBe(false);
     });
 
-    it('state_get_status reports self-improve as active when state file is present', async () => {
+    it("state_get_status reports self-improve as active when state file is present", async () => {
       await stateWriteTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         active: true,
         state: { tournament_round: 2 },
         workingDirectory: TEST_DIR,
       });
 
       const result = await stateGetStatusTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Status: self-improve');
-      expect(result.content[0].text).toContain('**Active:** Yes');
+      expect(result.content[0].text).toContain("Status: self-improve");
+      expect(result.content[0].text).toContain("**Active:** Yes");
     });
 
-    it('state_get_status reports deep-interview as active when state file is present', async () => {
+    it("state_get_status reports deep-interview as active when state file is present", async () => {
       await stateWriteTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         active: true,
-        state: { current_phase: 'contrarian' },
+        state: { current_phase: "contrarian" },
         workingDirectory: TEST_DIR,
       });
 
       const result = await stateGetStatusTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Status: deep-interview');
-      expect(result.content[0].text).toContain('**Active:** Yes');
+      expect(result.content[0].text).toContain("Status: deep-interview");
+      expect(result.content[0].text).toContain("**Active:** Yes");
     });
 
-    it('deep-interview session isolation: write to session A does not appear under session B', async () => {
-      const sessionA = 'di-iso-a';
-      const sessionB = 'di-iso-b';
+    it("deep-interview session isolation: write to session A does not appear under session B", async () => {
+      const sessionA = "di-iso-a";
+      const sessionB = "di-iso-b";
 
       await stateWriteTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         active: true,
-        state: { current_phase: 'questioning' },
+        state: { current_phase: "questioning" },
         session_id: sessionA,
         workingDirectory: TEST_DIR,
       });
 
       const resultB = await stateReadTool.handler({
-        mode: 'deep-interview',
+        mode: "deep-interview",
         session_id: sessionB,
         workingDirectory: TEST_DIR,
       });
 
-      expect(resultB.content[0].text).toContain('No state found');
+      expect(resultB.content[0].text).toContain("No state found");
     });
 
-    it('self-improve session isolation: write to session A does not appear under session B', async () => {
-      const sessionA = 'si-iso-a';
-      const sessionB = 'si-iso-b';
+    it("self-improve session isolation: write to session A does not appear under session B", async () => {
+      const sessionA = "si-iso-a";
+      const sessionB = "si-iso-b";
 
       await stateWriteTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         active: true,
         state: { tournament_round: 1 },
         session_id: sessionA,
@@ -1800,194 +2997,280 @@ describe('state-tools', () => {
       });
 
       const resultB = await stateReadTool.handler({
-        mode: 'self-improve',
+        mode: "self-improve",
         session_id: sessionB,
         workingDirectory: TEST_DIR,
       });
 
-      expect(resultB.content[0].text).toContain('No state found');
+      expect(resultB.content[0].text).toContain("No state found");
     });
   });
 
-  describe('state_get_status', () => {
-    it('should return status for specific mode', async () => {
+  describe("state_get_status", () => {
+    it("should return status for specific mode", async () => {
       const result = await stateGetStatusTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Status: ralph');
-      expect(result.content[0].text).toContain('Active:');
+      expect(result.content[0].text).toContain("Status: ralph");
+      expect(result.content[0].text).toContain("Active:");
     });
 
-    it('should return all mode statuses when no mode specified', async () => {
+    it("should return all mode statuses when no mode specified", async () => {
       const result = await stateGetStatusTool.handler({
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('All Mode Statuses');
+      expect(result.content[0].text).toContain("All Mode Statuses");
       expect(
-        result.content[0].text.includes('[ACTIVE]') || result.content[0].text.includes('[INACTIVE]')
+        result.content[0].text.includes("[ACTIVE]") ||
+          result.content[0].text.includes("[INACTIVE]"),
       ).toBe(true);
     });
   });
 
-  describe('session_id parameter', () => {
-    it('should write state with explicit session_id to session-scoped path', async () => {
-      const sessionId = 'test-session-123';
+  describe("session_id parameter", () => {
+    it("should write state with explicit session_id to session-scoped path", async () => {
+      const sessionId = "test-session-123";
       const result = await stateWriteTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         state: { active: true },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Successfully wrote');
-      const sessionPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ultrawork-state.json');
+      expect(result.content[0].text).toContain("Successfully wrote");
+      const sessionPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ultrawork-state.json",
+      );
       expect(existsSync(sessionPath)).toBe(true);
     });
 
-    it('should read state with explicit session_id from session-scoped path', async () => {
-      const sessionId = 'test-session-read';
-      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
+    it("should read state with explicit session_id from session-scoped path", async () => {
+      const sessionId = "test-session-read";
+      const sessionDir = join(TEST_DIR, ".omc", "state", "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
       writeFileSync(
-        join(sessionDir, 'ralph-state.json'),
-        JSON.stringify({ active: true, session_id: sessionId })
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({ active: true, session_id: sessionId }),
       );
 
       const result = await stateReadTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('active');
+      expect(result.content[0].text).toContain("active");
     });
 
-    it('should clear session-specific state without affecting legacy owned by another session', async () => {
-      const sessionId = 'test-session-clear';
-      const otherSessionId = 'other-session-owner';
+    it("should clear session-specific state without affecting legacy owned by another session", async () => {
+      const sessionId = "test-session-clear";
+      const otherSessionId = "other-session-owner";
 
       // Create legacy state owned by a different session
       writeFileSync(
-        join(TEST_DIR, '.omc', 'state', 'ralph-state.json'),
-        JSON.stringify({ active: true, source: 'legacy', _meta: { sessionId: otherSessionId } })
-      );
-      const sessionDir = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId);
-      mkdirSync(sessionDir, { recursive: true });
-      writeFileSync(
-        join(sessionDir, 'ralph-state.json'),
-        JSON.stringify({ active: true, source: 'session' })
-      );
-
-      const result = await stateClearTool.handler({
-        mode: 'ralph',
-        session_id: sessionId,
-        workingDirectory: TEST_DIR,
-      });
-
-      expect(result.content[0].text).toContain('cleared');
-      // Session-scoped file should be gone
-      expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
-      // Legacy file should remain (belongs to different session)
-      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'ralph-state.json'))).toBe(true);
-    });
-
-    it('should clear recovered session-owned state stranded under another session directory', async () => {
-      const sessionId = 'continued-session';
-      const strandedDir = join(TEST_DIR, '.omc', 'state', 'sessions', 'stale-session-dir');
-      mkdirSync(strandedDir, { recursive: true });
-      writeFileSync(
-        join(strandedDir, 'ralph-state.json'),
-        JSON.stringify({ active: true, session_id: sessionId, source: 'recovered-session-state' })
-      );
-
-      const result = await stateClearTool.handler({
-        mode: 'ralph',
-        session_id: sessionId,
-        workingDirectory: TEST_DIR,
-      });
-
-      expect(result.content[0].text).toContain('recovered session file');
-      expect(existsSync(join(strandedDir, 'ralph-state.json'))).toBe(false);
-    });
-
-    it('should clear ralph stop-hook runtime artifacts with session-scoped cancel cleanup', async () => {
-      const sessionId = 'ralph-stop-artifact-session';
-      const stateDir = join(TEST_DIR, '.omc', 'state');
-      const sessionDir = join(stateDir, 'sessions', sessionId);
-      mkdirSync(sessionDir, { recursive: true });
-      writeFileSync(
-        join(sessionDir, 'ralph-state.json'),
-        JSON.stringify({ active: true, session_id: sessionId }),
-      );
-      writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 3 }));
-      writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 3 }));
-      writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
-      writeFileSync(join(stateDir, 'ralph-continue-steer.lock'), `${process.pid}`);
-
-      const result = await stateClearTool.handler({
-        mode: 'ralph',
-        session_id: sessionId,
-        workingDirectory: TEST_DIR,
-      });
-
-      expect(result.content[0].text).toContain('runtime artifact');
-      expect(existsSync(join(sessionDir, 'ralph-state.json'))).toBe(false);
-      expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
-      expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
-      expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
-      expect(existsSync(join(stateDir, 'ralph-continue-steer.lock'))).toBe(false);
-    });
-
-    it('targets a recovered named workflow candidate in the cancel signal', async () => {
-      const sessionId = 'recovered-workflow-owner';
-      const strandedPath = join(TEST_DIR, '.omc', 'state', 'sessions', 'stale-workflow-dir', 'autopilot-state.json');
-      mkdirSync(dirname(strandedPath), { recursive: true });
-      writeFileSync(strandedPath, JSON.stringify({ active: true, session_id: sessionId }));
-
-      await stateClearTool.handler({ mode: 'autopilot', session_id: sessionId, workingDirectory: TEST_DIR });
-      const signalPath = join(dirname(strandedPath), 'cancel-signal-state.json');
-      expect(JSON.parse(readFileSync(signalPath, 'utf8')).target_workflow_run_id).toBeUndefined();
-      expect(existsSync(strandedPath)).toBe(false);
-    });
-
-    it('does not clear a singleton live autopilot owned by another active session', async () => {
-      const currentSessionId = 'fresh-autopilot-cancel-session';
-      const ownerSessionId = 'live-autopilot-owner-session';
-      const ownerDir = join(TEST_DIR, '.omc', 'state', 'sessions', ownerSessionId);
-      mkdirSync(ownerDir, { recursive: true });
-      writeFileSync(
-        join(ownerDir, 'autopilot-state.json'),
+        join(TEST_DIR, ".omc", "state", "ralph-state.json"),
         JSON.stringify({
           active: true,
-          session_id: ownerSessionId,
-          phase: 'execution',
-          current_phase: 'execution',
+          source: "legacy",
+          _meta: { sessionId: otherSessionId },
+        }),
+      );
+      const sessionDir = join(TEST_DIR, ".omc", "state", "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({ active: true, source: "session" }),
+      );
+
+      const result = await stateClearTool.handler({
+        mode: "ralph",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain("cleared");
+      // Session-scoped file should be gone
+      expect(existsSync(join(sessionDir, "ralph-state.json"))).toBe(false);
+      // Legacy file should remain (belongs to different session)
+      expect(
+        existsSync(join(TEST_DIR, ".omc", "state", "ralph-state.json")),
+      ).toBe(true);
+    });
+
+    it("should clear recovered session-owned state stranded under another session directory", async () => {
+      const sessionId = "continued-session";
+      const strandedDir = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "stale-session-dir",
+      );
+      mkdirSync(strandedDir, { recursive: true });
+      writeFileSync(
+        join(strandedDir, "ralph-state.json"),
+        JSON.stringify({
+          active: true,
+          session_id: sessionId,
+          source: "recovered-session-state",
         }),
       );
 
       const result = await stateClearTool.handler({
-        mode: 'autopilot',
+        mode: "ralph",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain("recovered session file");
+      expect(existsSync(join(strandedDir, "ralph-state.json"))).toBe(false);
+    });
+
+    it("should clear ralph stop-hook runtime artifacts with session-scoped cancel cleanup", async () => {
+      const sessionId = "ralph-stop-artifact-session";
+      const stateDir = join(TEST_DIR, ".omc", "state");
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "ralph-state.json"),
+        JSON.stringify({ active: true, session_id: sessionId }),
+      );
+      writeFileSync(
+        join(sessionDir, "ralph-stop-breaker.json"),
+        JSON.stringify({ count: 3 }),
+      );
+      writeFileSync(
+        join(stateDir, "ralph-stop-breaker.json"),
+        JSON.stringify({ count: 3 }),
+      );
+      writeFileSync(
+        join(stateDir, "ralph-last-steer-at"),
+        new Date().toISOString(),
+      );
+      writeFileSync(
+        join(stateDir, "ralph-continue-steer.lock"),
+        `${process.pid}`,
+      );
+
+      const result = await stateClearTool.handler({
+        mode: "ralph",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(result.content[0].text).toContain("runtime artifact");
+      expect(existsSync(join(sessionDir, "ralph-state.json"))).toBe(false);
+      expect(existsSync(join(sessionDir, "ralph-stop-breaker.json"))).toBe(
+        false,
+      );
+      expect(existsSync(join(stateDir, "ralph-stop-breaker.json"))).toBe(false);
+      expect(existsSync(join(stateDir, "ralph-last-steer-at"))).toBe(false);
+      expect(existsSync(join(stateDir, "ralph-continue-steer.lock"))).toBe(
+        false,
+      );
+    });
+
+    it("targets a recovered named workflow candidate in the cancel signal", async () => {
+      const sessionId = "recovered-workflow-owner";
+      const strandedPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        "stale-workflow-dir",
+        "autopilot-state.json",
+      );
+      mkdirSync(dirname(strandedPath), { recursive: true });
+      writeFileSync(
+        strandedPath,
+        JSON.stringify({ active: true, session_id: sessionId }),
+      );
+
+      await stateClearTool.handler({
+        mode: "autopilot",
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const signalPath = join(
+        dirname(strandedPath),
+        "cancel-signal-state.json",
+      );
+      expect(
+        JSON.parse(readFileSync(signalPath, "utf8")).target_workflow_run_id,
+      ).toBeUndefined();
+      expect(existsSync(strandedPath)).toBe(false);
+    });
+
+    it("does not clear a singleton live autopilot owned by another active session", async () => {
+      const currentSessionId = "fresh-autopilot-cancel-session";
+      const ownerSessionId = "live-autopilot-owner-session";
+      const ownerDir = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        ownerSessionId,
+      );
+      mkdirSync(ownerDir, { recursive: true });
+      writeFileSync(
+        join(ownerDir, "autopilot-state.json"),
+        JSON.stringify({
+          active: true,
+          session_id: ownerSessionId,
+          phase: "execution",
+          current_phase: "execution",
+        }),
+      );
+
+      const result = await stateClearTool.handler({
+        mode: "autopilot",
         session_id: currentSessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('No state found to clear for mode: autopilot');
-      expect(result.content[0].text).toContain('Checked paths');
-      expect(existsSync(join(ownerDir, 'autopilot-state.json'))).toBe(true);
-      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', currentSessionId, 'cancel-signal-state.json'))).toBe(true);
-      expect(existsSync(join(ownerDir, 'cancel-signal-state.json'))).toBe(false);
+      expect(result.content[0].text).toContain(
+        "No state found to clear for mode: autopilot",
+      );
+      expect(result.content[0].text).toContain("Checked paths");
+      expect(existsSync(join(ownerDir, "autopilot-state.json"))).toBe(true);
+      expect(
+        existsSync(
+          join(
+            TEST_DIR,
+            ".omc",
+            "state",
+            "sessions",
+            currentSessionId,
+            "cancel-signal-state.json",
+          ),
+        ),
+      ).toBe(true);
+      expect(existsSync(join(ownerDir, "cancel-signal-state.json"))).toBe(
+        false,
+      );
     });
 
-    it('should clear the owning session when the current session resumed ralph from a different conversation', async () => {
-      const currentSessionId = 'resume-session-b';
-      const ownerSessionId = 'resume-session-a';
-      const ownerDir = join(TEST_DIR, '.omc', 'state', 'sessions', ownerSessionId);
+    it("should clear the owning session when the current session resumed ralph from a different conversation", async () => {
+      const currentSessionId = "resume-session-b";
+      const ownerSessionId = "resume-session-a";
+      const ownerDir = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        ownerSessionId,
+      );
       mkdirSync(ownerDir, { recursive: true });
       writeFileSync(
-        join(ownerDir, 'ralph-state.json'),
+        join(ownerDir, "ralph-state.json"),
         JSON.stringify({
           active: true,
           session_id: ownerSessionId,
@@ -1997,75 +3280,118 @@ describe('state-tools', () => {
       );
 
       const result = await stateClearTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         session_id: currentSessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain(`cleared owning session: ${ownerSessionId}`);
-      expect(existsSync(join(ownerDir, 'ralph-state.json'))).toBe(false);
-      expect(existsSync(join(TEST_DIR, '.omc', 'state', 'sessions', currentSessionId, 'cancel-signal-state.json'))).toBe(true);
-      expect(existsSync(join(ownerDir, 'cancel-signal-state.json'))).toBe(true);
+      expect(result.content[0].text).toContain(
+        `cleared owning session: ${ownerSessionId}`,
+      );
+      expect(existsSync(join(ownerDir, "ralph-state.json"))).toBe(false);
+      expect(
+        existsSync(
+          join(
+            TEST_DIR,
+            ".omc",
+            "state",
+            "sessions",
+            currentSessionId,
+            "cancel-signal-state.json",
+          ),
+        ),
+      ).toBe(true);
+      expect(existsSync(join(ownerDir, "cancel-signal-state.json"))).toBe(true);
     });
 
-    it('should clear ralph runtime artifacts during broad cancel cleanup', async () => {
-      const sessionId = 'ralph-broad-runtime-cleanup';
-      const stateDir = join(TEST_DIR, '.omc', 'state');
-      const sessionDir = join(stateDir, 'sessions', sessionId);
+    it("should clear ralph runtime artifacts during broad cancel cleanup", async () => {
+      const sessionId = "ralph-broad-runtime-cleanup";
+      const stateDir = join(TEST_DIR, ".omc", "state");
+      const sessionDir = join(stateDir, "sessions", sessionId);
       mkdirSync(sessionDir, { recursive: true });
-      writeFileSync(join(sessionDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 1 }));
-      writeFileSync(join(stateDir, 'ralph-stop-breaker.json'), JSON.stringify({ count: 1 }));
-      writeFileSync(join(stateDir, 'ralph-last-steer-at'), new Date().toISOString());
+      writeFileSync(
+        join(sessionDir, "ralph-stop-breaker.json"),
+        JSON.stringify({ count: 1 }),
+      );
+      writeFileSync(
+        join(stateDir, "ralph-stop-breaker.json"),
+        JSON.stringify({ count: 1 }),
+      );
+      writeFileSync(
+        join(stateDir, "ralph-last-steer-at"),
+        new Date().toISOString(),
+      );
 
       const result = await stateClearTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Locations cleared: 3');
-      expect(existsSync(join(sessionDir, 'ralph-stop-breaker.json'))).toBe(false);
-      expect(existsSync(join(stateDir, 'ralph-stop-breaker.json'))).toBe(false);
-      expect(existsSync(join(stateDir, 'ralph-last-steer-at'))).toBe(false);
+      expect(result.content[0].text).toContain("Locations cleared: 3");
+      expect(existsSync(join(sessionDir, "ralph-stop-breaker.json"))).toBe(
+        false,
+      );
+      expect(existsSync(join(stateDir, "ralph-stop-breaker.json"))).toBe(false);
+      expect(existsSync(join(stateDir, "ralph-last-steer-at"))).toBe(false);
     });
 
-    it('reports no-op with checked paths when session clear finds no actual state file', async () => {
-      const sessionId = 'missing-autopilot-state-session';
+    it("reports no-op with checked paths when session clear finds no actual state file", async () => {
+      const sessionId = "missing-autopilot-state-session";
       const result = await stateClearTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('No state found to clear for mode: autopilot in session: missing-autopilot-state-session');
-      expect(result.content[0].text).toContain('Checked paths');
-      expect(result.content[0].text).toContain(join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'autopilot-state.json'));
+      expect(result.content[0].text).toContain(
+        "No state found to clear for mode: autopilot in session: missing-autopilot-state-session",
+      );
+      expect(result.content[0].text).toContain("Checked paths");
+      expect(result.content[0].text).toContain(
+        join(
+          TEST_DIR,
+          ".omc",
+          "state",
+          "sessions",
+          sessionId,
+          "autopilot-state.json",
+        ),
+      );
     });
 
-    it('clears autopilot state from the centralized OMC_STATE_DIR root used by stop hooks', async () => {
+    it("clears autopilot state from the centralized OMC_STATE_DIR root used by stop hooks", async () => {
       const previous = process.env.OMC_STATE_DIR;
-      const sessionId = 'centralized-autopilot-clear-session';
-      const centralRoot = join(TEST_DIR, 'central-state-root');
+      const sessionId = "centralized-autopilot-clear-session";
+      const centralRoot = join(TEST_DIR, "central-state-root");
       process.env.OMC_STATE_DIR = centralRoot;
       try {
-        const { getOmcRoot } = await import('../../lib/worktree-paths.js');
-        const autopilotPath = join(getOmcRoot(TEST_DIR), 'state', 'sessions', sessionId, 'autopilot-state.json');
-        mkdirSync(join(autopilotPath, '..'), { recursive: true });
+        const { getOmcRoot } = await import("../../lib/worktree-paths.js");
+        const autopilotPath = join(
+          getOmcRoot(TEST_DIR),
+          "state",
+          "sessions",
+          sessionId,
+          "autopilot-state.json",
+        );
+        mkdirSync(join(autopilotPath, ".."), { recursive: true });
         writeFileSync(
           autopilotPath,
           JSON.stringify({
             active: true,
             session_id: sessionId,
-            current_phase: 'execution',
+            current_phase: "execution",
           }),
         );
 
         const result = await stateClearTool.handler({
-          mode: 'autopilot',
+          mode: "autopilot",
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
 
-        expect(result.content[0].text).toContain('Successfully cleared state for mode: autopilot in session: centralized-autopilot-clear-session');
+        expect(result.content[0].text).toContain(
+          "Successfully cleared state for mode: autopilot in session: centralized-autopilot-clear-session",
+        );
         expect(existsSync(autopilotPath)).toBe(false);
       } finally {
         if (previous === undefined) {
@@ -2076,11 +3402,18 @@ describe('state-tools', () => {
       }
     });
 
-    it('clears workingDirectory-local ralph state when centralized OMC_STATE_DIR lookup misses', async () => {
+    it("clears workingDirectory-local ralph state when centralized OMC_STATE_DIR lookup misses", async () => {
       const previous = process.env.OMC_STATE_DIR;
-      const sessionId = 'worktree-local-ralph-clear-session';
-      const centralRoot = join(TEST_DIR, 'central-state-root');
-      const localStatePath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+      const sessionId = "worktree-local-ralph-clear-session";
+      const centralRoot = join(TEST_DIR, "central-state-root");
+      const localStatePath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ralph-state.json",
+      );
       process.env.OMC_STATE_DIR = centralRoot;
       try {
         mkdirSync(dirname(localStatePath), { recursive: true });
@@ -2094,13 +3427,17 @@ describe('state-tools', () => {
         );
 
         const result = await stateClearTool.handler({
-          mode: 'ralph',
+          mode: "ralph",
           session_id: sessionId,
           workingDirectory: TEST_DIR,
         });
 
-        expect(result.content[0].text).toContain('Successfully cleared state for mode: ralph');
-        expect(result.content[0].text).toContain('workingDirectory-local state file');
+        expect(result.content[0].text).toContain(
+          "Successfully cleared state for mode: ralph",
+        );
+        expect(result.content[0].text).toContain(
+          "workingDirectory-local state file",
+        );
         expect(existsSync(localStatePath)).toBe(false);
       } finally {
         if (previous === undefined) {
@@ -2111,178 +3448,191 @@ describe('state-tools', () => {
       }
     });
 
-    it('should discover and clear session-scoped autopilot state when no session_id is provided', async () => {
-      const sessionId = 'missing-env-autopilot-session';
-      const stateDir = join(TEST_DIR, '.omc', 'state');
-      const sessionDir = join(stateDir, 'sessions', sessionId);
-      const autopilotPath = join(sessionDir, 'autopilot-state.json');
+    it("should discover and clear session-scoped autopilot state when no session_id is provided", async () => {
+      const sessionId = "missing-env-autopilot-session";
+      const stateDir = join(TEST_DIR, ".omc", "state");
+      const sessionDir = join(stateDir, "sessions", sessionId);
+      const autopilotPath = join(sessionDir, "autopilot-state.json");
       mkdirSync(sessionDir, { recursive: true });
       writeFileSync(
         autopilotPath,
         JSON.stringify({
           active: true,
           session_id: sessionId,
-          phase: 'expansion',
+          phase: "expansion",
         }),
       );
 
       const result = await stateClearTool.handler({
-        mode: 'autopilot',
+        mode: "autopilot",
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Cleared state for mode: autopilot');
+      expect(result.content[0].text).toContain(
+        "Cleared state for mode: autopilot",
+      );
       expect(existsSync(autopilotPath)).toBe(false);
-      expect(existsSync(join(sessionDir, 'cancel-signal-state.json'))).toBe(true);
+      expect(existsSync(join(sessionDir, "cancel-signal-state.json"))).toBe(
+        true,
+      );
     });
   });
 
-  describe('session-scoped behavior', () => {
-    it('should prevent cross-process state bleeding when session_id provided', async () => {
+  describe("session-scoped behavior", () => {
+    it("should prevent cross-process state bleeding when session_id provided", async () => {
       // Simulate two processes writing to the same mode
-      const processASessionId = 'pid-11111-1000000';
-      const processBSessionId = 'pid-22222-2000000';
+      const processASessionId = "pid-11111-1000000";
+      const processBSessionId = "pid-22222-2000000";
 
       // Process A writes
       await stateWriteTool.handler({
-        mode: 'ultrawork',
-        state: { active: true, task: 'Process A task' },
+        mode: "ultrawork",
+        state: { active: true, task: "Process A task" },
         session_id: processASessionId,
         workingDirectory: TEST_DIR,
       });
 
       // Process B writes
       await stateWriteTool.handler({
-        mode: 'ultrawork',
-        state: { active: true, task: 'Process B task' },
+        mode: "ultrawork",
+        state: { active: true, task: "Process B task" },
         session_id: processBSessionId,
         workingDirectory: TEST_DIR,
       });
 
       // Process A reads its own state
       const resultA = await stateReadTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         session_id: processASessionId,
         workingDirectory: TEST_DIR,
       });
-      expect(resultA.content[0].text).toContain('Process A task');
-      expect(resultA.content[0].text).not.toContain('Process B task');
+      expect(resultA.content[0].text).toContain("Process A task");
+      expect(resultA.content[0].text).not.toContain("Process B task");
 
       // Process B reads its own state
       const resultB = await stateReadTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         session_id: processBSessionId,
         workingDirectory: TEST_DIR,
       });
-      expect(resultB.content[0].text).toContain('Process B task');
-      expect(resultB.content[0].text).not.toContain('Process A task');
+      expect(resultB.content[0].text).toContain("Process B task");
+      expect(resultB.content[0].text).not.toContain("Process A task");
     });
 
-    it('should write state to legacy path when session_id omitted', async () => {
+    it("should write state to legacy path when session_id omitted", async () => {
       await stateWriteTool.handler({
-        mode: 'ultrawork',
+        mode: "ultrawork",
         state: { active: true },
         workingDirectory: TEST_DIR,
       });
 
-      const legacyPath = join(TEST_DIR, '.omc', 'state', 'ultrawork-state.json');
+      const legacyPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "ultrawork-state.json",
+      );
       expect(existsSync(legacyPath)).toBe(true);
     });
   });
 
-  describe('payload size validation', () => {
-    it('should reject oversized custom state payloads', async () => {
+  describe("payload size validation", () => {
+    it("should reject oversized custom state payloads", async () => {
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
-        state: { huge: 'x'.repeat(2_000_000) },
+        mode: "ralph",
+        state: { huge: "x".repeat(2_000_000) },
         workingDirectory: TEST_DIR,
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('payload rejected');
-      expect(result.content[0].text).toContain('exceeds maximum');
+      expect(result.content[0].text).toContain("payload rejected");
+      expect(result.content[0].text).toContain("exceeds maximum");
     });
 
-    it('should reject deeply nested custom state payloads', async () => {
+    it("should reject deeply nested custom state payloads", async () => {
       let obj: Record<string, unknown> = { leaf: true };
       for (let i = 0; i < 15; i++) {
         obj = { nested: obj };
       }
 
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         state: obj,
         workingDirectory: TEST_DIR,
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('nesting depth');
+      expect(result.content[0].text).toContain("nesting depth");
     });
 
-    it('should reject state with too many top-level keys', async () => {
+    it("should reject state with too many top-level keys", async () => {
       const state: Record<string, string> = {};
       for (let i = 0; i < 150; i++) {
-        state[`key_${i}`] = 'value';
+        state[`key_${i}`] = "value";
       }
 
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         state,
         workingDirectory: TEST_DIR,
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('top-level keys');
+      expect(result.content[0].text).toContain("top-level keys");
     });
 
-    it('should still allow normal-sized state writes', async () => {
+    it("should still allow normal-sized state writes", async () => {
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
-        state: { active: true, task: 'normal task', items: [1, 2, 3] },
+        mode: "ralph",
+        state: { active: true, task: "normal task", items: [1, 2, 3] },
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Successfully wrote');
+      expect(result.content[0].text).toContain("Successfully wrote");
     });
 
-    it('should not validate when no custom state is provided', async () => {
+    it("should not validate when no custom state is provided", async () => {
       const result = await stateWriteTool.handler({
-        mode: 'ralph',
+        mode: "ralph",
         active: true,
         iteration: 1,
         workingDirectory: TEST_DIR,
       });
 
-      expect(result.content[0].text).toContain('Successfully wrote');
+      expect(result.content[0].text).toContain("Successfully wrote");
     });
   });
 
-  describe('Graph guarded state integration', () => {
-    it('registers Graph for read/status while rejecting generic write at the schema boundary', () => {
-      expect(stateReadTool.schema.mode.safeParse('graph').success).toBe(true);
-      expect(stateGetStatusTool.schema.mode.safeParse('graph').success).toBe(true);
-      expect(stateWriteTool.schema.mode.safeParse('graph').success).toBe(false);
-      expect(stateClearTool.schema.mode.safeParse('graph').success).toBe(true);
-      expect(stateClearTool.schema.mode.safeParse('all').success).toBe(true);
-      expect('force' in stateClearTool.schema).toBe(true);
+  describe("Graph guarded state integration", () => {
+    it("registers Graph for read/status while rejecting generic write at the schema boundary", () => {
+      expect(stateReadTool.schema.mode.safeParse("graph").success).toBe(true);
+      expect(stateGetStatusTool.schema.mode.safeParse("graph").success).toBe(
+        true,
+      );
+      expect(stateWriteTool.schema.mode.safeParse("graph").success).toBe(false);
+      expect(stateClearTool.schema.mode.safeParse("graph").success).toBe(true);
+      expect(stateClearTool.schema.mode.safeParse("all").success).toBe(true);
+      expect("force" in stateClearTool.schema).toBe(true);
     });
 
-    it('returns a bounded Graph summary without descriptor, evidence, or diagnostic details', async () => {
-      const sessionId = 'graph-read-summary';
+    it("returns a bounded Graph summary without descriptor, evidence, or diagnostic details", async () => {
+      const sessionId = "graph-read-summary";
       writeGuardedGraphArtifacts(sessionId);
       const result = await stateReadTool.handler({
-        mode: 'graph',
+        mode: "graph",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
-      const summary = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
+      const summary = JSON.parse(
+        result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1],
+      );
 
       expect(summary).toMatchObject({
-        type: 'graph_state_summary',
+        type: "graph_state_summary",
         valid: true,
-        run_id: 'run-1',
-        status: 'running',
-        active_revision_id: 'revision-1',
+        run_id: "run-1",
+        status: "running",
+        active_revision_id: "revision-1",
         commit_sequence: 0,
       });
       expect(Object.keys(summary)).toHaveLength(12);
@@ -2291,12 +3641,12 @@ describe('state-tools', () => {
       );
     });
 
-    it('uses durable status for Graph status and active-list output', async () => {
-      const sessionId = 'graph-observational-status';
-      writeGuardedGraphArtifacts(sessionId, 'waiting_human');
+    it("uses durable status for Graph status and active-list output", async () => {
+      const sessionId = "graph-observational-status";
+      writeGuardedGraphArtifacts(sessionId, "waiting_human");
 
       const status = await stateGetStatusTool.handler({
-        mode: 'graph',
+        mode: "graph",
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       });
@@ -2305,85 +3655,104 @@ describe('state-tools', () => {
         workingDirectory: TEST_DIR,
       });
 
-      expect(status.content[0].text).toContain('**Active:** Yes');
-      expect(status.content[0].text).toContain('graph_state_summary');
-      expect(active.content[0].text).toContain('**graph**');
+      expect(status.content[0].text).toContain("**Active:** Yes");
+      expect(status.content[0].text).toContain("graph_state_summary");
+      expect(active.content[0].text).toContain("**graph**");
     });
 
-    it('rejects direct generic Graph writes without changing its authority artifacts', async () => {
-      const sessionId = 'graph-write-guard';
+    it("rejects direct generic Graph writes without changing its authority artifacts", async () => {
+      const sessionId = "graph-write-guard";
       const paths = writeGuardedGraphArtifacts(sessionId);
-      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+      const before = Object.fromEntries(
+        Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]),
+      );
 
       const result = await stateWriteTool.handler({
-        mode: 'graph',
-        state: { status: 'cancelled', private_overwrite: true },
+        mode: "graph",
+        state: { status: "cancelled", private_overwrite: true },
         session_id: sessionId,
         workingDirectory: TEST_DIR,
       } as never);
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('guarded_mode');
+      expect(result.content[0].text).toContain("guarded_mode");
       for (const [name, path] of Object.entries(paths)) {
         expect(fileSha256(path), name).toBe(before[name]);
       }
     });
 
     it.each([
-      ['running', 'active'],
-      ['paused', 'paused'],
-      ['succeeded', 'terminal'],
-      ['malformed', 'malformed'],
-    ] as const)('returns deterministic guarded clear classification for %s Graph state', async (status, classification) => {
-      const sessionId = `graph-clear-${status}`;
-      const paths = writeGuardedGraphArtifacts(sessionId, status);
-      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+      ["running", "active"],
+      ["paused", "paused"],
+      ["succeeded", "terminal"],
+      ["malformed", "malformed"],
+    ] as const)(
+      "returns deterministic guarded clear classification for %s Graph state",
+      async (status, classification) => {
+        const sessionId = `graph-clear-${status}`;
+        const paths = writeGuardedGraphArtifacts(sessionId, status);
+        const before = Object.fromEntries(
+          Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]),
+        );
 
+        const result = await stateClearTool.handler({
+          mode: "graph",
+          force: true,
+          session_id: sessionId,
+          workingDirectory: TEST_DIR,
+        } as never);
+        const guarded = JSON.parse(result.content[0].text);
+
+        expect(guarded).toMatchObject({
+          type: "guarded_mode",
+          mode: "graph",
+          operation: "clear",
+          classification,
+          changed: false,
+        });
+        for (const [name, path] of Object.entries(paths)) {
+          expect(fileSha256(path), name).toBe(before[name]);
+        }
+      },
+    );
+
+    it("returns deterministic guarded clear classification when Graph state is missing", async () => {
       const result = await stateClearTool.handler({
-        mode: 'graph',
+        mode: "graph",
         force: true,
-        session_id: sessionId,
-        workingDirectory: TEST_DIR,
-      } as never);
-      const guarded = JSON.parse(result.content[0].text);
-
-      expect(guarded).toMatchObject({
-        type: 'guarded_mode',
-        mode: 'graph',
-        operation: 'clear',
-        classification,
-        changed: false,
-      });
-      for (const [name, path] of Object.entries(paths)) {
-        expect(fileSha256(path), name).toBe(before[name]);
-      }
-    });
-
-    it('returns deterministic guarded clear classification when Graph state is missing', async () => {
-      const result = await stateClearTool.handler({
-        mode: 'graph',
-        force: true,
-        session_id: 'graph-clear-missing',
+        session_id: "graph-clear-missing",
         workingDirectory: TEST_DIR,
       } as never);
 
       expect(JSON.parse(result.content[0].text)).toMatchObject({
-        type: 'guarded_mode',
-        mode: 'graph',
-        classification: 'missing',
+        type: "guarded_mode",
+        mode: "graph",
+        classification: "missing",
         changed: false,
       });
     });
 
-    it('clear all reports Graph as skipped and preserves every Graph authority artifact', async () => {
-      const sessionId = 'graph-clear-all';
+    it("clear all reports Graph as skipped and preserves every Graph authority artifact", async () => {
+      const sessionId = "graph-clear-all";
       const paths = writeGuardedGraphArtifacts(sessionId);
-      const ordinaryPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
-      writeFileSync(ordinaryPath, JSON.stringify({ active: true, session_id: sessionId }));
-      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+      const ordinaryPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ralph-state.json",
+      );
+      writeFileSync(
+        ordinaryPath,
+        JSON.stringify({ active: true, session_id: sessionId }),
+      );
+      const before = Object.fromEntries(
+        Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]),
+      );
 
       const result = await stateClearTool.handler({
-        mode: 'all',
+        mode: "all",
         force: true,
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -2391,8 +3760,10 @@ describe('state-tools', () => {
       const clearAll = JSON.parse(result.content[0].text);
 
       expect(clearAll).toMatchObject({
-        type: 'clear_all',
-        skipped: [{ mode: 'graph', reason: 'guarded_mode', classification: 'active' }],
+        type: "clear_all",
+        skipped: [
+          { mode: "graph", reason: "guarded_mode", classification: "active" },
+        ],
       });
       expect(existsSync(ordinaryPath)).toBe(false);
       for (const [name, path] of Object.entries(paths)) {
@@ -2400,34 +3771,56 @@ describe('state-tools', () => {
       }
     });
 
-    it('clear all removes unrelated skill-active slots without crossing session boundaries', async () => {
-      const sessionId = 'graph-clear-mixed-slots';
-      const siblingSessionId = 'graph-clear-mixed-slots-sibling';
+    it("clear all removes unrelated skill-active slots without crossing session boundaries", async () => {
+      const sessionId = "graph-clear-mixed-slots";
+      const siblingSessionId = "graph-clear-mixed-slots-sibling";
       const paths = writeGuardedGraphArtifacts(sessionId);
       const mixedSlots = {
         version: 2,
         active_skills: {
-          graph: { skill_name: 'graph', session_id: sessionId, completed_at: null },
-          ralph: { skill_name: 'ralph', session_id: sessionId, completed_at: null },
+          graph: {
+            skill_name: "graph",
+            session_id: sessionId,
+            completed_at: null,
+          },
+          ralph: {
+            skill_name: "ralph",
+            session_id: sessionId,
+            completed_at: null,
+          },
         },
       };
       writeFileSync(paths.rootSlot, JSON.stringify(mixedSlots));
       writeFileSync(paths.sessionSlot, JSON.stringify(mixedSlots));
 
-      const siblingDir = join(TEST_DIR, '.omc', 'state', 'sessions', siblingSessionId);
+      const siblingDir = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        siblingSessionId,
+      );
       mkdirSync(siblingDir, { recursive: true });
-      const siblingSlot = join(siblingDir, 'skill-active-state.json');
+      const siblingSlot = join(siblingDir, "skill-active-state.json");
       const siblingSlots = {
         version: 2,
         active_skills: {
-          graph: { skill_name: 'graph', session_id: siblingSessionId, completed_at: null },
-          team: { skill_name: 'team', session_id: siblingSessionId, completed_at: null },
+          graph: {
+            skill_name: "graph",
+            session_id: siblingSessionId,
+            completed_at: null,
+          },
+          team: {
+            skill_name: "team",
+            session_id: siblingSessionId,
+            completed_at: null,
+          },
         },
       };
       writeFileSync(siblingSlot, JSON.stringify(siblingSlots));
 
       const result = await stateClearTool.handler({
-        mode: 'all',
+        mode: "all",
         force: true,
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -2435,29 +3828,49 @@ describe('state-tools', () => {
       const clearAll = JSON.parse(result.content[0].text);
 
       expect(clearAll).toMatchObject({
-        type: 'clear_all',
-        cleared_modes: expect.arrayContaining(['skill-active']),
+        type: "clear_all",
+        cleared_modes: expect.arrayContaining(["skill-active"]),
         preserved_graph_workflow_slot: true,
       });
       for (const path of [paths.rootSlot, paths.sessionSlot]) {
-        expect(JSON.parse(readFileSync(path, 'utf8')).active_skills).toEqual({
-          graph: { skill_name: 'graph', session_id: sessionId, completed_at: null },
+        expect(JSON.parse(readFileSync(path, "utf8")).active_skills).toEqual({
+          graph: {
+            skill_name: "graph",
+            session_id: sessionId,
+            completed_at: null,
+          },
         });
       }
-      expect(JSON.parse(readFileSync(siblingSlot, 'utf8'))).toEqual(siblingSlots);
+      expect(JSON.parse(readFileSync(siblingSlot, "utf8"))).toEqual(
+        siblingSlots,
+      );
     });
 
-    it('clear all preserves Graph slot and control ownership when the primary ledger is missing', async () => {
-      const sessionId = 'graph-clear-all-missing-ledger';
+    it("clear all preserves Graph slot and control ownership when the primary ledger is missing", async () => {
+      const sessionId = "graph-clear-all-missing-ledger";
       const paths = writeGuardedGraphArtifacts(sessionId);
       unlinkSync(paths.graph);
-      const protectedPaths = [paths.rootSlot, paths.sessionSlot, paths.controlOwner];
-      const before = protectedPaths.map(path => fileSha256(path));
-      const ordinaryPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
-      writeFileSync(ordinaryPath, JSON.stringify({ active: true, session_id: sessionId }));
+      const protectedPaths = [
+        paths.rootSlot,
+        paths.sessionSlot,
+        paths.controlOwner,
+      ];
+      const before = protectedPaths.map((path) => fileSha256(path));
+      const ordinaryPath = join(
+        TEST_DIR,
+        ".omc",
+        "state",
+        "sessions",
+        sessionId,
+        "ralph-state.json",
+      );
+      writeFileSync(
+        ordinaryPath,
+        JSON.stringify({ active: true, session_id: sessionId }),
+      );
 
       const result = await stateClearTool.handler({
-        mode: 'all',
+        mode: "all",
         force: true,
         session_id: sessionId,
         workingDirectory: TEST_DIR,
@@ -2465,12 +3878,16 @@ describe('state-tools', () => {
       const clearAll = JSON.parse(result.content[0].text);
 
       expect(clearAll).toMatchObject({
-        type: 'clear_all',
-        skipped: [{ mode: 'graph', reason: 'guarded_mode', classification: 'missing' }],
+        type: "clear_all",
+        skipped: [
+          { mode: "graph", reason: "guarded_mode", classification: "missing" },
+        ],
         preserved_graph_workflow_slot: true,
       });
       expect(existsSync(ordinaryPath)).toBe(false);
-      protectedPaths.forEach((path, index) => expect(fileSha256(path)).toBe(before[index]));
+      protectedPaths.forEach((path, index) =>
+        expect(fileSha256(path)).toBe(before[index]),
+      );
     });
   });
 });

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -11,6 +11,9 @@ import {
   stateGetStatusTool,
 } from '../state-tools.js';
 import { emergencyMutateStateFileIf } from '../../lib/mode-state-io.js';
+import { sealGraphDescriptor } from '../../graph/descriptor.js';
+import { createInitialGraphState, type GraphRunStatus } from '../../graph/runtime-types.js';
+import { forkJoinDescriptor } from '../../graph/__tests__/fixtures.js';
 
 const TEST_DIR = '/tmp/state-tools-test';
 
@@ -26,9 +29,20 @@ vi.mock('../../lib/worktree-paths.js', async () => {
 });
 
 function liveLockOwner() {
-  const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-  const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-  return JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() });
+  // The mutation lock is LEASE-based (no process-liveness probe): an owner is
+  // held while `now < expires_at`. Plant a lease-shaped owner with a future
+  // expires_at so production (acquireLockAt/readLockOwner) treats the lock as
+  // live/held and state_write/state_clear fail closed against it. The exact key
+  // set [createdAt, expires_at, nonce, pid, version] must match
+  // validateLockOwner, else the owner is 'corrupt' (reclaimable -> not held).
+  const now = Date.now();
+  return JSON.stringify({
+    version: 1,
+    pid: process.pid,
+    createdAt: new Date(now).toISOString(),
+    expires_at: new Date(now + 300000).toISOString(),
+    nonce: randomUUID(),
+  });
 }
 
 function portableWorkflowState(sessionId: string): Record<string, unknown> {
@@ -92,6 +106,75 @@ function completedPortableWorkflowState(sessionId: string): Record<string, unkno
   ];
   tracking.activationBoundary = { ...initialBoundary, byteOffset: 2, fileIdentity: secondStable };
   return { ...state, active: false, phase: 'complete', status: 'private-terminal-status' };
+}
+
+function graphState(sessionId: string, status: GraphRunStatus = 'running') {
+  const descriptor = sealGraphDescriptor(forkJoinDescriptor());
+  const approved = !['draft', 'awaiting_approval'].includes(status);
+  const state = createInitialGraphState({
+    session_id: sessionId,
+    control_nonce: 'test-control-nonce',
+    descriptor,
+    status,
+    created_at: '2026-07-21T00:00:00.000Z',
+    projection: {
+      activations: {},
+      cohorts: {},
+      branch_tokens: {},
+      traversal_counts: {},
+      committed_transitions: {},
+      terminal_verification_activation_ids: [],
+    },
+    ...(approved
+      ? {
+          approval: {
+            approved_at: '2026-07-21T00:00:00.000Z',
+            evidence: { kind: 'human' as const, ref: 'private-human-evidence' },
+          },
+        }
+      : {}),
+  });
+  state.diagnostics.push({
+    kind: 'operation',
+    recorded_at: '2026-07-21T00:00:01.000Z',
+    summary: 'private diagnostic detail',
+  });
+  return state;
+}
+
+function fileSha256(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function writeGuardedGraphArtifacts(sessionId: string, status: GraphRunStatus | 'malformed' = 'running') {
+  const stateRoot = join(TEST_DIR, '.omc', 'state');
+  const sessionDir = join(stateRoot, 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  const paths = {
+    graph: join(sessionDir, 'graph-state.json'),
+    rootSlot: join(stateRoot, 'skill-active-state.json'),
+    sessionSlot: join(sessionDir, 'skill-active-state.json'),
+    controlOwner: join(sessionDir, 'control-owner-state.json'),
+  };
+  writeFileSync(paths.graph, status === 'malformed' ? '{not-json' : JSON.stringify(graphState(sessionId, status)));
+  const slot = JSON.stringify({
+    version: 2,
+    active_skills: {
+      graph: {
+        skill_name: 'graph',
+        session_id: sessionId,
+        completed_at: null,
+        private_slot_detail: 'must remain unchanged',
+      },
+    },
+  });
+  writeFileSync(paths.rootSlot, slot);
+  writeFileSync(paths.sessionSlot, slot);
+  writeFileSync(paths.controlOwner, JSON.stringify({
+    version: 1,
+    root: { mode: 'graph', session_id: sessionId, run_id: 'run-1', nonce: 'private-nonce' },
+  }));
+  return paths;
 }
 
 describe('state-tools', () => {
@@ -2171,6 +2254,176 @@ describe('state-tools', () => {
       });
 
       expect(result.content[0].text).toContain('Successfully wrote');
+    });
+  });
+
+  describe('Graph guarded state integration', () => {
+    it('registers Graph for read/status while rejecting generic write at the schema boundary', () => {
+      expect(stateReadTool.schema.mode.safeParse('graph').success).toBe(true);
+      expect(stateGetStatusTool.schema.mode.safeParse('graph').success).toBe(true);
+      expect(stateWriteTool.schema.mode.safeParse('graph').success).toBe(false);
+      expect(stateClearTool.schema.mode.safeParse('graph').success).toBe(true);
+      expect(stateClearTool.schema.mode.safeParse('all').success).toBe(true);
+      expect('force' in stateClearTool.schema).toBe(true);
+    });
+
+    it('returns a bounded Graph summary without descriptor, evidence, or diagnostic details', async () => {
+      const sessionId = 'graph-read-summary';
+      writeGuardedGraphArtifacts(sessionId);
+      const result = await stateReadTool.handler({
+        mode: 'graph',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const summary = JSON.parse(result.content[0].text.match(/```json\n([\s\S]*?)\n```/)![1]);
+
+      expect(summary).toMatchObject({
+        type: 'graph_state_summary',
+        valid: true,
+        run_id: 'run-1',
+        status: 'running',
+        active_revision_id: 'revision-1',
+        commit_sequence: 0,
+      });
+      expect(Object.keys(summary)).toHaveLength(12);
+      expect(result.content[0].text).not.toMatch(
+        /private diagnostic detail|private-human-evidence|Build and verify two branches|run-branch-b/,
+      );
+    });
+
+    it('uses durable status for Graph status and active-list output', async () => {
+      const sessionId = 'graph-observational-status';
+      writeGuardedGraphArtifacts(sessionId, 'waiting_human');
+
+      const status = await stateGetStatusTool.handler({
+        mode: 'graph',
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+      const active = await stateListActiveTool.handler({
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      });
+
+      expect(status.content[0].text).toContain('**Active:** Yes');
+      expect(status.content[0].text).toContain('graph_state_summary');
+      expect(active.content[0].text).toContain('**graph**');
+    });
+
+    it('rejects direct generic Graph writes without changing its authority artifacts', async () => {
+      const sessionId = 'graph-write-guard';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+
+      const result = await stateWriteTool.handler({
+        mode: 'graph',
+        state: { status: 'cancelled', private_overwrite: true },
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('guarded_mode');
+      for (const [name, path] of Object.entries(paths)) {
+        expect(fileSha256(path), name).toBe(before[name]);
+      }
+    });
+
+    it.each([
+      ['running', 'active'],
+      ['paused', 'paused'],
+      ['succeeded', 'terminal'],
+      ['malformed', 'malformed'],
+    ] as const)('returns deterministic guarded clear classification for %s Graph state', async (status, classification) => {
+      const sessionId = `graph-clear-${status}`;
+      const paths = writeGuardedGraphArtifacts(sessionId, status);
+      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+
+      const result = await stateClearTool.handler({
+        mode: 'graph',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const guarded = JSON.parse(result.content[0].text);
+
+      expect(guarded).toMatchObject({
+        type: 'guarded_mode',
+        mode: 'graph',
+        operation: 'clear',
+        classification,
+        changed: false,
+      });
+      for (const [name, path] of Object.entries(paths)) {
+        expect(fileSha256(path), name).toBe(before[name]);
+      }
+    });
+
+    it('returns deterministic guarded clear classification when Graph state is missing', async () => {
+      const result = await stateClearTool.handler({
+        mode: 'graph',
+        force: true,
+        session_id: 'graph-clear-missing',
+        workingDirectory: TEST_DIR,
+      } as never);
+
+      expect(JSON.parse(result.content[0].text)).toMatchObject({
+        type: 'guarded_mode',
+        mode: 'graph',
+        classification: 'missing',
+        changed: false,
+      });
+    });
+
+    it('clear all reports Graph as skipped and preserves every Graph authority artifact', async () => {
+      const sessionId = 'graph-clear-all';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      const ordinaryPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+      writeFileSync(ordinaryPath, JSON.stringify({ active: true, session_id: sessionId }));
+      const before = Object.fromEntries(Object.entries(paths).map(([name, path]) => [name, fileSha256(path)]));
+
+      const result = await stateClearTool.handler({
+        mode: 'all',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const clearAll = JSON.parse(result.content[0].text);
+
+      expect(clearAll).toMatchObject({
+        type: 'clear_all',
+        skipped: [{ mode: 'graph', reason: 'guarded_mode', classification: 'active' }],
+      });
+      expect(existsSync(ordinaryPath)).toBe(false);
+      for (const [name, path] of Object.entries(paths)) {
+        expect(fileSha256(path), name).toBe(before[name]);
+      }
+    });
+
+    it('clear all preserves Graph slot and control ownership when the primary ledger is missing', async () => {
+      const sessionId = 'graph-clear-all-missing-ledger';
+      const paths = writeGuardedGraphArtifacts(sessionId);
+      unlinkSync(paths.graph);
+      const protectedPaths = [paths.rootSlot, paths.sessionSlot, paths.controlOwner];
+      const before = protectedPaths.map(path => fileSha256(path));
+      const ordinaryPath = join(TEST_DIR, '.omc', 'state', 'sessions', sessionId, 'ralph-state.json');
+      writeFileSync(ordinaryPath, JSON.stringify({ active: true, session_id: sessionId }));
+
+      const result = await stateClearTool.handler({
+        mode: 'all',
+        force: true,
+        session_id: sessionId,
+        workingDirectory: TEST_DIR,
+      } as never);
+      const clearAll = JSON.parse(result.content[0].text);
+
+      expect(clearAll).toMatchObject({
+        type: 'clear_all',
+        skipped: [{ mode: 'graph', reason: 'guarded_mode', classification: 'missing' }],
+        preserved_graph_workflow_slot: true,
+      });
+      expect(existsSync(ordinaryPath)).toBe(false);
+      protectedPaths.forEach((path, index) => expect(fileSha256(path)).toBe(before[index]));
     });
   });
 });

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -5,11 +5,26 @@
  * All paths are validated to stay within the worktree boundary.
  */
 
-import { z } from 'zod';
-import { createHash } from 'crypto';
-import { existsSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from 'fs';
-import { homedir } from 'os';
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path';
+import { z } from "zod";
+import { createHash } from "crypto";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "path";
 import {
   resolveStatePath,
   ensureOmcDir,
@@ -20,9 +35,9 @@ import {
   validateSessionId,
   getOmcRoot,
   OmcPaths,
-} from '../lib/worktree-paths.js';
-import { resolveSessionId } from '../lib/session-id.js';
-import { validatePayload } from '../lib/payload-limits.js';
+} from "../lib/worktree-paths.js";
+import { resolveSessionId } from "../lib/session-id.js";
+import { validatePayload } from "../lib/payload-limits.js";
 import {
   canClearStateForSession,
   findCompletedSessionStateFiles,
@@ -37,7 +52,7 @@ import {
   clearStateFileLockedIf,
   emergencyMutateStateFileIf,
   recoverEmergencyStateFile,
-} from '../lib/mode-state-io.js';
+} from "../lib/mode-state-io.js";
 import {
   isModeActive,
   getActiveModes,
@@ -46,81 +61,131 @@ import {
   getStateFilePath,
   MODE_CONFIGS,
   getActiveSessionsForMode,
-  type ExecutionMode
-} from '../hooks/mode-registry/index.js';
-import { ToolDefinition } from './types.js';
-import { namedWorkflowRuntimeSupported, validateNamedWorkflowStateStructure } from '../hooks/autopilot/named-workflow-resume-validator.js';
-import { cancelMergeReadiness, createInitialMergeReadinessState, readMergeReadinessState, setMergeReadinessContent, recordMergeReadinessMCQAnswer } from '../hooks/merge-readiness/runtime.js';
-import { formatMergeReadinessReport, redactMergeReadinessState } from '../hooks/merge-readiness/report.js';
-import type { AutopilotState } from '../hooks/autopilot/types.js';
-import { parseGraphState, type GraphRunStatus } from '../graph/runtime-types.js';
+  type ExecutionMode,
+} from "../hooks/mode-registry/index.js";
+import { ToolDefinition } from "./types.js";
+import {
+  namedWorkflowRuntimeSupported,
+  validateNamedWorkflowStateStructure,
+} from "../hooks/autopilot/named-workflow-resume-validator.js";
+import {
+  cancelMergeReadiness,
+  createInitialMergeReadinessState,
+  readMergeReadinessState,
+  setMergeReadinessContent,
+  recordMergeReadinessMCQAnswer,
+} from "../hooks/merge-readiness/runtime.js";
+import {
+  formatMergeReadinessReport,
+  redactMergeReadinessState,
+} from "../hooks/merge-readiness/report.js";
+import type { AutopilotState } from "../hooks/autopilot/types.js";
+import {
+  parseGraphState,
+  type GraphRunStatus,
+} from "../graph/runtime-types.js";
 
 // Canonical execution modes from mode-registry (deep-interview and self-improve
 // are first-class modes with dedicated MODE_CONFIGS entries; ralplan remains an
 // extra state-only mode handled via the registry-fallback path).
 const EXECUTION_MODES: [string, ...string[]] = [
-  'autopilot', 'autoresearch', 'graph', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
+  "autopilot",
+  "autoresearch",
+  "graph",
+  "team",
+  "ralph",
+  "ultrawork",
+  "ultraqa",
+  "deep-interview",
+  "self-improve",
 ];
 
 // merge-readiness is read/clear-eligible (state_read/status/clear + /cancel work) but NOT write-eligible.
 const STATE_TOOL_MODES: [string, ...string[]] = [
   ...EXECUTION_MODES,
-  'ralplan',
-  'omc-teams',
-  'skill-active',
-  'merge-readiness'
+  "ralplan",
+  "omc-teams",
+  "skill-active",
+  "merge-readiness",
 ];
 // Modes that may be generically written via state_write. Graph and
 // merge-readiness are runtime-owned and intentionally excluded.
 const STATE_WRITE_MODES: [string, ...string[]] = [
-  'autopilot',
-  'autoresearch',
-  'team',
-  'ralph',
-  'ultrawork',
-  'ultraqa',
-  'deep-interview',
-  'self-improve',
-  'ralplan',
-  'omc-teams',
-  'skill-active'
+  "autopilot",
+  "autoresearch",
+  "team",
+  "ralph",
+  "ultrawork",
+  "ultraqa",
+  "deep-interview",
+  "self-improve",
+  "ralplan",
+  "omc-teams",
+  "skill-active",
 ];
-const STATE_CLEAR_MODES: [string, ...string[]] = [...STATE_TOOL_MODES, 'all'];
-const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'skill-active'] as const;
-type StateToolMode = typeof STATE_TOOL_MODES[number];
+const STATE_CLEAR_MODES: [string, ...string[]] = [...STATE_TOOL_MODES, "all"];
+const EXTRA_STATE_ONLY_MODES = [
+  "ralplan",
+  "omc-teams",
+  "skill-active",
+] as const;
+type StateToolMode = (typeof STATE_TOOL_MODES)[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
-const OWNER_SESSION_FALLBACK_MODES = new Set<StateToolMode>(['ralph']);
-const CONVERGED_STATE_PATH_MODES = new Set<StateToolMode>(['ralph', 'ultrawork']);
+const OWNER_SESSION_FALLBACK_MODES = new Set<StateToolMode>(["ralph"]);
+const CONVERGED_STATE_PATH_MODES = new Set<StateToolMode>([
+  "ralph",
+  "ultrawork",
+]);
 
 function getStateFileName(mode: StateToolMode): string {
-  const normalizedName = mode.endsWith('-state') ? mode : `${mode}-state`;
+  const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   return `${normalizedName}.json`;
 }
 
 function readJsonRecord(filePath: string): Record<string, unknown> | null {
   try {
-    return JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    return JSON.parse(readFileSync(filePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
   } catch {
     return null;
   }
 }
 
-const NAMED_WORKFLOW_MARKERS = ['workflow', 'workflowRunId', 'pipelineTracking'] as const;
+const NAMED_WORKFLOW_MARKERS = [
+  "workflow",
+  "workflowRunId",
+  "pipelineTracking",
+] as const;
 
 function hasOwnProperty(record: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(record, key);
 }
 
 /** Any own named-workflow marker, including a falsy value, makes the record runtime-owned. */
-function hasNamedWorkflowMarker(record: Record<string, unknown> | null | undefined): boolean {
+function hasNamedWorkflowMarker(
+  record: Record<string, unknown> | null | undefined,
+): boolean {
   if (!record) return false;
-  return NAMED_WORKFLOW_MARKERS.some((marker) => hasOwnProperty(record, marker));
+  return NAMED_WORKFLOW_MARKERS.some((marker) =>
+    hasOwnProperty(record, marker),
+  );
 }
 
-function hasValidatedNamedWorkflowTuple(record: Record<string, unknown>): boolean {
-  if (!NAMED_WORKFLOW_MARKERS.every((marker) => hasOwnProperty(record, marker))) return false;
+function hasValidatedNamedWorkflowTuple(
+  record: Record<string, unknown>,
+): boolean {
+  if (!NAMED_WORKFLOW_MARKERS.every((marker) => hasOwnProperty(record, marker)))
+    return false;
   const sessionId = getStateSessionOwner(record);
-  return typeof sessionId === 'string' && validateNamedWorkflowStateStructure(record as unknown as AutopilotState, sessionId) !== null;
+  return (
+    typeof sessionId === "string" &&
+    validateNamedWorkflowStateStructure(
+      record as unknown as AutopilotState,
+      sessionId,
+    ) !== null
+  );
 }
 
 /** The portable emergency path may only pause or clear an exact discovered run. */
@@ -128,19 +193,24 @@ function isExactEmergencyNamedMutation(
   record: Record<string, unknown>,
   requestedRunId: string | undefined,
 ): boolean {
-  return hasValidatedNamedWorkflowTuple(record) &&
-    typeof requestedRunId === 'string' &&
-    record.workflowRunId === requestedRunId;
+  return (
+    hasValidatedNamedWorkflowTuple(record) &&
+    typeof requestedRunId === "string" &&
+    record.workflowRunId === requestedRunId
+  );
 }
 
 /** A named pause request is an exact capability, not a state replay payload. */
 function isExactNamedPauseRequest(record: Record<string, unknown>): boolean {
-  const allowed = new Set(['active', 'workflowRunId', 'target_state_sha256']);
-  return record.active === false &&
-    typeof record.workflowRunId === 'string' &&
+  const allowed = new Set(["active", "workflowRunId", "target_state_sha256"]);
+  return (
+    record.active === false &&
+    typeof record.workflowRunId === "string" &&
     Object.keys(record).every((key) => allowed.has(key)) &&
-    (!hasOwnProperty(record, 'target_state_sha256') ||
-      (typeof record.target_state_sha256 === 'string' && /^[a-f0-9]{64}$/.test(record.target_state_sha256)));
+    (!hasOwnProperty(record, "target_state_sha256") ||
+      (typeof record.target_state_sha256 === "string" &&
+        /^[a-f0-9]{64}$/.test(record.target_state_sha256)))
+  );
 }
 
 function matchesNamedPauseTarget(
@@ -149,16 +219,19 @@ function matchesNamedPauseTarget(
   workflowRunId: string,
   stateDigest: string | undefined,
 ): boolean {
-  return current.active === true &&
+  return (
+    current.active === true &&
     current.workflowRunId === workflowRunId &&
     hasValidatedNamedWorkflowTuple(current) &&
     getStateSessionOwner(current) === sessionId &&
-    (stateDigest === undefined || createHash('sha256').update(JSON.stringify(current)).digest('hex') === stateDigest);
+    (stateDigest === undefined ||
+      createHash("sha256").update(JSON.stringify(current)).digest("hex") ===
+        stateDigest)
+  );
 }
 
-
 function listSessionIdsUnderOmcRoot(omcRoot: string): string[] {
-  const sessionsDir = join(omcRoot, 'state', 'sessions');
+  const sessionsDir = join(omcRoot, "state", "sessions");
   if (!existsSync(sessionsDir)) {
     return [];
   }
@@ -193,11 +266,11 @@ function getConvergedStateCandidates(
   const paths = new Set<string>();
 
   for (const omcRoot of getConvergedOmcRoots(root)) {
-    const stateDir = join(omcRoot, 'state');
+    const stateDir = join(omcRoot, "state");
     if (sessionId) {
-      paths.add(join(stateDir, 'sessions', sessionId, filename));
+      paths.add(join(stateDir, "sessions", sessionId, filename));
       for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-        const candidatePath = join(stateDir, 'sessions', sid, filename);
+        const candidatePath = join(stateDir, "sessions", sid, filename);
         const raw = readJsonRecord(candidatePath);
         if (raw && getStateSessionOwner(raw) === sessionId) {
           paths.add(candidatePath);
@@ -205,7 +278,7 @@ function getConvergedStateCandidates(
       }
     } else {
       for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-        paths.add(join(stateDir, 'sessions', sid, filename));
+        paths.add(join(stateDir, "sessions", sid, filename));
       }
     }
 
@@ -216,7 +289,10 @@ function getConvergedStateCandidates(
   return [...paths];
 }
 
-function isConvergedCandidateActiveForSession(statePath: string, sessionId?: string): boolean {
+function isConvergedCandidateActiveForSession(
+  statePath: string,
+  sessionId?: string,
+): boolean {
   const raw = readJsonRecord(statePath);
   if (!raw || raw.active !== true) {
     return false;
@@ -227,30 +303,43 @@ function isConvergedCandidateActiveForSession(statePath: string, sessionId?: str
   return canClearStateForSession(raw, sessionId);
 }
 
-
-function emergencyRecoveryOptionsForProject(mode: StateToolMode, path: string, root: string): { authorizeState: (state: Record<string, unknown>) => boolean } | undefined {
-  if (mode !== 'autopilot' || !isSharedHomeAutopilotCandidate(path, root)) return undefined;
-  return { authorizeState: (state) => isStateCandidateForProject(mode, path, state, root) };
+function emergencyRecoveryOptionsForProject(
+  mode: StateToolMode,
+  path: string,
+  root: string,
+): { authorizeState: (state: Record<string, unknown>) => boolean } | undefined {
+  if (mode !== "autopilot" || !isSharedHomeAutopilotCandidate(path, root))
+    return undefined;
+  return {
+    authorizeState: (state) =>
+      isStateCandidateForProject(mode, path, state, root),
+  };
 }
 
 function clearDiscoveredStateCandidate(
   candidate: StateFileDiscovery,
   predicate: (state: Record<string, unknown>) => boolean,
-  recoveryOptions?: { authorizeState: (state: Record<string, unknown>) => boolean },
-): 'cleared' | 'skipped' | 'failed' {
+  recoveryOptions?: {
+    authorizeState: (state: Record<string, unknown>) => boolean;
+  },
+): "cleared" | "skipped" | "failed" {
   return clearStateFileLockedIf(
     candidate.path,
-    (current) => predicate(current) && JSON.stringify(current) === candidate.snapshot,
+    (current) =>
+      predicate(current) && JSON.stringify(current) === candidate.snapshot,
     recoveryOptions,
   );
 }
 
-function clearAutopilotMarkerCandidate(candidate: StateFileDiscovery, root: string): boolean {
+function clearAutopilotMarkerCandidate(
+  candidate: StateFileDiscovery,
+  root: string,
+): boolean {
   // A marker-bearing record may be malformed, but a clear is an exact deletion
   // capability over the discovered bytes after ownership/project filtering.
   // It must never become a pause, resume, or replacement write.
   const predicate = (current: Record<string, unknown>) =>
-    isStateCandidateForProject('autopilot', candidate.path, current, root) &&
+    isStateCandidateForProject("autopilot", candidate.path, current, root) &&
     JSON.stringify(current) === candidate.snapshot;
 
   if (!namedWorkflowRuntimeSupported()) {
@@ -258,15 +347,17 @@ function clearAutopilotMarkerCandidate(candidate: StateFileDiscovery, root: stri
       candidate.path,
       predicate,
       null,
-      emergencyRecoveryOptionsForProject('autopilot', candidate.path, root),
+      emergencyRecoveryOptionsForProject("autopilot", candidate.path, root),
     );
   }
 
-  return clearStateFileLockedIf(
-    candidate.path,
-    predicate,
-    emergencyRecoveryOptionsForProject('autopilot', candidate.path, root),
-  ) === 'cleared';
+  return (
+    clearStateFileLockedIf(
+      candidate.path,
+      predicate,
+      emergencyRecoveryOptionsForProject("autopilot", candidate.path, root),
+    ) === "cleared"
+  );
 }
 
 function discoverStatePaths(paths: string[]): StateFileDiscovery[] {
@@ -279,7 +370,10 @@ function discoverStatePaths(paths: string[]): StateFileDiscovery[] {
       state,
       snapshot: JSON.stringify(state),
       ownerSessionId: getStateSessionOwner(state),
-      workflowRunId: typeof state.workflowRunId === 'string' ? state.workflowRunId : undefined,
+      workflowRunId:
+        typeof state.workflowRunId === "string"
+          ? state.workflowRunId
+          : undefined,
     });
   }
   return discovered;
@@ -289,36 +383,53 @@ function clearConvergedStateCandidates(
   mode: StateToolMode,
   root: string,
   sessionId?: string,
-  discovered = discoverStatePaths(getConvergedStateCandidates(mode, root, sessionId)),
+  discovered = discoverStatePaths(
+    getConvergedStateCandidates(mode, root, sessionId),
+  ),
 ): { cleared: number; hadFailure: boolean; paths: string[] } {
   let cleared = 0;
   let hadFailure = false;
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
-      (current) => isStateCandidateForProject(mode, candidate.path, current, root) && (!sessionId || canClearStateForSession(current, sessionId)),
+      (current) =>
+        isStateCandidateForProject(mode, candidate.path, current, root) &&
+        (!sessionId || canClearStateForSession(current, sessionId)),
     );
-    if (result === 'cleared') cleared++;
-    else if (result === 'failed') hadFailure = true;
+    if (result === "cleared") cleared++;
+    else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path),
+  };
 }
 
-function hasActiveConvergedState(mode: StateToolMode, root: string, sessionId?: string): boolean {
-  return getConvergedStateCandidates(mode, root, sessionId)
-    .some((statePath) => isConvergedCandidateActiveForSession(statePath, sessionId));
+function hasActiveConvergedState(
+  mode: StateToolMode,
+  root: string,
+  sessionId?: string,
+): boolean {
+  return getConvergedStateCandidates(mode, root, sessionId).some((statePath) =>
+    isConvergedCandidateActiveForSession(statePath, sessionId),
+  );
 }
 
 function readTeamNamesFromStateFile(statePath: string): string[] {
   if (!existsSync(statePath)) return [];
 
   try {
-    const raw = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
-    const teamName = typeof raw.team_name === 'string'
-      ? raw.team_name.trim()
-      : typeof raw.teamName === 'string'
-        ? raw.teamName.trim()
-        : '';
+    const raw = JSON.parse(readFileSync(statePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const teamName =
+      typeof raw.team_name === "string"
+        ? raw.team_name.trim()
+        : typeof raw.teamName === "string"
+          ? raw.teamName.trim()
+          : "";
     return teamName ? [teamName] : [];
   } catch {
     return [];
@@ -326,11 +437,15 @@ function readTeamNamesFromStateFile(statePath: string): string[] {
 }
 
 function pruneMissionBoardTeams(root: string, teamNames?: string[]): number {
-  const missionStatePath = join(getOmcRoot(root), 'state', 'mission-state.json');
+  const missionStatePath = join(
+    getOmcRoot(root),
+    "state",
+    "mission-state.json",
+  );
   if (!existsSync(missionStatePath)) return 0;
 
   try {
-    const parsed = JSON.parse(readFileSync(missionStatePath, 'utf-8')) as {
+    const parsed = JSON.parse(readFileSync(missionStatePath, "utf-8")) as {
       updatedAt?: string;
       missions?: Array<Record<string, unknown>>;
     };
@@ -339,23 +454,31 @@ function pruneMissionBoardTeams(root: string, teamNames?: string[]): number {
     const shouldRemoveAll = teamNames == null;
     const teamNameSet = new Set(teamNames ?? []);
     const remainingMissions = parsed.missions.filter((mission) => {
-      if (mission.source !== 'team') return true;
+      if (mission.source !== "team") return true;
       if (shouldRemoveAll) return false;
-      const missionTeamName = typeof mission.teamName === 'string'
-        ? mission.teamName.trim()
-        : typeof mission.name === 'string'
-          ? mission.name.trim()
-          : '';
+      const missionTeamName =
+        typeof mission.teamName === "string"
+          ? mission.teamName.trim()
+          : typeof mission.name === "string"
+            ? mission.name.trim()
+            : "";
       return !missionTeamName || !teamNameSet.has(missionTeamName);
     });
 
     const removed = parsed.missions.length - remainingMissions.length;
     if (removed > 0) {
-      writeFileSync(missionStatePath, JSON.stringify({
-        ...parsed,
-        updatedAt: new Date().toISOString(),
-        missions: remainingMissions,
-      }, null, 2));
+      writeFileSync(
+        missionStatePath,
+        JSON.stringify(
+          {
+            ...parsed,
+            updatedAt: new Date().toISOString(),
+            missions: remainingMissions,
+          },
+          null,
+          2,
+        ),
+      );
     }
 
     return removed;
@@ -365,7 +488,7 @@ function pruneMissionBoardTeams(root: string, teamNames?: string[]): number {
 }
 
 function cleanupTeamRuntimeState(root: string, teamNames?: string[]): number {
-  const teamStateRoot = join(getOmcRoot(root), 'state', 'team');
+  const teamStateRoot = join(getOmcRoot(root), "state", "team");
   if (!existsSync(teamStateRoot)) return 0;
 
   const shouldRemoveAll = teamNames == null;
@@ -409,44 +532,72 @@ function getStatePath(mode: StateToolMode, root: string): string {
   return resolveStatePath(mode, root);
 }
 
-function getLegacyStateFileCandidates(mode: StateToolMode, root: string): string[] {
-  const normalizedName = mode.endsWith('-state') ? mode : `${mode}-state`;
+function getLegacyStateFileCandidates(
+  mode: StateToolMode,
+  root: string,
+): string[] {
+  const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   const candidates = [
     getStatePath(mode, root),
     join(getOmcRoot(root), `${normalizedName}.json`),
   ];
-  if (mode === 'autopilot') candidates.push(join(homedir(), '.omc', 'state', 'autopilot-state.json'));
+  if (mode === "autopilot")
+    candidates.push(join(homedir(), ".omc", "state", "autopilot-state.json"));
 
   return [...new Set(candidates)];
 }
 
 function isSharedHomeAutopilotCandidate(path: string, root: string): boolean {
-  const sharedHomeStateRoot = resolve(homedir(), '.omc', 'state');
+  const sharedHomeStateRoot = resolve(homedir(), ".omc", "state");
   const candidatePath = resolve(path);
-  const canonicalStateRoot = resolve(getOmcRoot(root), 'state');
+  const canonicalStateRoot = resolve(getOmcRoot(root), "state");
   const isDescendant = (ancestor: string, descendant: string): boolean => {
     const fromAncestor = relative(ancestor, descendant);
-    return fromAncestor === '' || (!fromAncestor.startsWith(`..${sep}`) && fromAncestor !== '..' && !isAbsolute(fromAncestor));
+    return (
+      fromAncestor === "" ||
+      (!fromAncestor.startsWith(`..${sep}`) &&
+        fromAncestor !== ".." &&
+        !isAbsolute(fromAncestor))
+    );
   };
-  return !isDescendant(canonicalStateRoot, candidatePath) && isDescendant(sharedHomeStateRoot, candidatePath);
+  return (
+    !isDescendant(canonicalStateRoot, candidatePath) &&
+    isDescendant(sharedHomeStateRoot, candidatePath)
+  );
 }
 
-function isStateCandidateForProject(mode: StateToolMode, path: string, state: Record<string, unknown>, root: string): boolean {
-  if (mode !== 'autopilot' || !isSharedHomeAutopilotCandidate(path, root)) return true;
-  return typeof state.project_path === 'string' && resolve(state.project_path) === resolve(root);
+function isStateCandidateForProject(
+  mode: StateToolMode,
+  path: string,
+  state: Record<string, unknown>,
+  root: string,
+): boolean {
+  if (mode !== "autopilot" || !isSharedHomeAutopilotCandidate(path, root))
+    return true;
+  return (
+    typeof state.project_path === "string" &&
+    resolve(state.project_path) === resolve(root)
+  );
 }
 
-function isAutopilotRecoveryCandidateForProject(path: string, root: string): boolean {
+function isAutopilotRecoveryCandidateForProject(
+  path: string,
+  root: string,
+): boolean {
   if (!isSharedHomeAutopilotCandidate(path, root)) return true;
 
   const primary = readJsonRecord(path);
-  if (primary) return isStateCandidateForProject('autopilot', path, primary, root);
+  if (primary)
+    return isStateCandidateForProject("autopilot", path, primary, root);
 
   const artifactPrefix = `${basename(path)}.emergency-quarantine.`;
   let artifacts: string[];
   try {
-    artifacts = readdirSync(dirname(path)).filter((name) =>
-      name.startsWith(artifactPrefix) && (name.endsWith('.payload') || /^[0-9a-f-]{36}$/i.test(name.slice(artifactPrefix.length))),
+    artifacts = readdirSync(dirname(path)).filter(
+      (name) =>
+        name.startsWith(artifactPrefix) &&
+        (name.endsWith(".payload") ||
+          /^[0-9a-f-]{36}$/i.test(name.slice(artifactPrefix.length))),
     );
   } catch {
     return false;
@@ -455,7 +606,10 @@ function isAutopilotRecoveryCandidateForProject(path: string, root: string): boo
 
   return artifacts.every((name) => {
     const state = readJsonRecord(join(dirname(path), name));
-    return state !== null && isStateCandidateForProject('autopilot', path, state, root);
+    return (
+      state !== null &&
+      isStateCandidateForProject("autopilot", path, state, root)
+    );
   });
 }
 
@@ -467,15 +621,32 @@ function shouldCheckWorkingDirectoryLocalState(root: string): boolean {
   return getWorkingDirectoryLocalOmcRoot(root) !== getOmcRoot(root);
 }
 
-function getWorkingDirectoryLocalSessionStatePath(mode: StateToolMode, root: string, sessionId: string): string {
-  const normalizedName = mode.endsWith('-state') ? mode : `${mode}-state`;
-  return join(getWorkingDirectoryLocalOmcRoot(root), 'state', 'sessions', sessionId, `${normalizedName}.json`);
+function getWorkingDirectoryLocalSessionStatePath(
+  mode: StateToolMode,
+  root: string,
+  sessionId: string,
+): string {
+  const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
+  return join(
+    getWorkingDirectoryLocalOmcRoot(root),
+    "state",
+    "sessions",
+    sessionId,
+    `${normalizedName}.json`,
+  );
 }
 
-function getWorkingDirectoryLocalLegacyStateFileCandidates(mode: StateToolMode, root: string): string[] {
-  const normalizedName = mode.endsWith('-state') ? mode : `${mode}-state`;
+function getWorkingDirectoryLocalLegacyStateFileCandidates(
+  mode: StateToolMode,
+  root: string,
+): string[] {
+  const normalizedName = mode.endsWith("-state") ? mode : `${mode}-state`;
   return [
-    join(getWorkingDirectoryLocalOmcRoot(root), 'state', `${normalizedName}.json`),
+    join(
+      getWorkingDirectoryLocalOmcRoot(root),
+      "state",
+      `${normalizedName}.json`,
+    ),
     join(getWorkingDirectoryLocalOmcRoot(root), `${normalizedName}.json`),
   ];
 }
@@ -494,7 +665,10 @@ function getWorkingDirectoryLocalStateClearCandidates(
     paths.add(getWorkingDirectoryLocalSessionStatePath(mode, root, sessionId));
   }
 
-  for (const legacyPath of getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root)) {
+  for (const legacyPath of getWorkingDirectoryLocalLegacyStateFileCandidates(
+    mode,
+    root,
+  )) {
     paths.add(legacyPath);
   }
 
@@ -505,20 +679,31 @@ function clearWorkingDirectoryLocalStateCandidates(
   mode: StateToolMode,
   root: string,
   sessionId?: string,
-  discovered = discoverStatePaths(getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId)),
+  discovered = discoverStatePaths(
+    getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId),
+  ),
 ): { cleared: number; hadFailure: boolean; paths: string[] } {
   let cleared = 0;
   let hadFailure = false;
-  const localLegacyPaths = new Set(getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root));
+  const localLegacyPaths = new Set(
+    getWorkingDirectoryLocalLegacyStateFileCandidates(mode, root),
+  );
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
-      (current) => !sessionId || !localLegacyPaths.has(candidate.path) || canClearStateForSession(current, sessionId),
+      (current) =>
+        !sessionId ||
+        !localLegacyPaths.has(candidate.path) ||
+        canClearStateForSession(current, sessionId),
     );
-    if (result === 'cleared') cleared++;
-    else if (result === 'failed') hadFailure = true;
+    if (result === "cleared") cleared++;
+    else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path),
+  };
 }
 
 function clearLegacyStateCandidates(
@@ -532,11 +717,13 @@ function clearLegacyStateCandidates(
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
-      (current) => isStateCandidateForProject(mode, candidate.path, current, root) && (!sessionId || canClearStateForSession(current, sessionId)),
+      (current) =>
+        isStateCandidateForProject(mode, candidate.path, current, root) &&
+        (!sessionId || canClearStateForSession(current, sessionId)),
       emergencyRecoveryOptionsForProject(mode, candidate.path, root),
     );
-    if (result === 'cleared') cleared++;
-    else if (result === 'failed') hadFailure = true;
+    if (result === "cleared") cleared++;
+    else if (result === "failed") hadFailure = true;
   }
   return { cleared, hadFailure };
 }
@@ -552,35 +739,53 @@ function clearSessionOwnedStateCandidates(
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
-      (current) => isStateCandidateForProject(mode, candidate.path, current, root) && canClearStateForSession(current, sessionId),
+      (current) =>
+        isStateCandidateForProject(mode, candidate.path, current, root) &&
+        canClearStateForSession(current, sessionId),
       emergencyRecoveryOptionsForProject(mode, candidate.path, root),
     );
-    if (result === 'cleared') cleared++;
-    else if (result === 'failed') hadFailure = true;
+    if (result === "cleared") cleared++;
+    else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path),
+  };
 }
 
 function clearCompletedSessionStateCandidates(
   mode: StateToolMode,
   root: string,
   requesterSessionId?: string,
-  discovered = findCompletedSessionStateCandidates(mode, root, requesterSessionId),
+  discovered = findCompletedSessionStateCandidates(
+    mode,
+    root,
+    requesterSessionId,
+  ),
 ): { cleared: number; hadFailure: boolean; paths: string[] } {
   let cleared = 0;
   let hadFailure = false;
   for (const candidate of discovered) {
     const result = clearDiscoveredStateCandidate(
       candidate,
-      (current) => current.active === true && Boolean(candidate.completionEvidencePath && existsSync(candidate.completionEvidencePath)),
+      (current) =>
+        current.active === true &&
+        Boolean(
+          candidate.completionEvidencePath &&
+          existsSync(candidate.completionEvidencePath),
+        ),
       emergencyRecoveryOptionsForProject(mode, candidate.path, root),
     );
-    if (result === 'cleared') cleared++;
-    else if (result === 'failed') hadFailure = true;
+    if (result === "cleared") cleared++;
+    else if (result === "failed") hadFailure = true;
   }
-  return { cleared, hadFailure, paths: discovered.map((candidate) => candidate.path) };
+  return {
+    cleared,
+    hadFailure,
+    paths: discovered.map((candidate) => candidate.path),
+  };
 }
-
 
 function getStateClearCheckedPaths(
   mode: StateToolMode,
@@ -590,9 +795,11 @@ function getStateClearCheckedPaths(
   const paths = new Set<string>();
 
   if (sessionId) {
-    paths.add(MODE_CONFIGS[mode as ExecutionMode]
-      ? getStateFilePath(root, mode as ExecutionMode, sessionId)
-      : resolveSessionStatePath(mode, sessionId, root));
+    paths.add(
+      MODE_CONFIGS[mode as ExecutionMode]
+        ? getStateFilePath(root, mode as ExecutionMode, sessionId)
+        : resolveSessionStatePath(mode, sessionId, root),
+    );
   } else {
     paths.add(getStatePath(mode, root));
   }
@@ -601,15 +808,23 @@ function getStateClearCheckedPaths(
     paths.add(legacyPath);
   }
 
-  for (const localPath of getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId)) {
+  for (const localPath of getWorkingDirectoryLocalStateClearCandidates(
+    mode,
+    root,
+    sessionId,
+  )) {
     paths.add(localPath);
   }
 
-  const sessionIds = sessionId ? [sessionId, ...listSessionIds(root)] : listSessionIds(root);
+  const sessionIds = sessionId
+    ? [sessionId, ...listSessionIds(root)]
+    : listSessionIds(root);
   for (const sid of new Set(sessionIds)) {
-    paths.add(MODE_CONFIGS[mode as ExecutionMode]
-      ? getStateFilePath(root, mode as ExecutionMode, sid)
-      : resolveSessionStatePath(mode, sid, root));
+    paths.add(
+      MODE_CONFIGS[mode as ExecutionMode]
+        ? getStateFilePath(root, mode as ExecutionMode, sid)
+        : resolveSessionStatePath(mode, sid, root),
+    );
   }
 
   return [...paths];
@@ -620,11 +835,12 @@ function formatStateClearNoopMessage(
   root: string,
   sessionId?: string,
 ): string {
-  const scope = sessionId ? ` in session: ${sessionId}` : '';
+  const scope = sessionId ? ` in session: ${sessionId}` : "";
   const checkedPaths = getStateClearCheckedPaths(mode, root, sessionId);
-  const checked = checkedPaths.length > 0
-    ? `\n- Checked paths:\n${checkedPaths.map((statePath) => `  - ${statePath}`).join('\n')}`
-    : '';
+  const checked =
+    checkedPaths.length > 0
+      ? `\n- Checked paths:\n${checkedPaths.map((statePath) => `  - ${statePath}`).join("\n")}`
+      : "";
 
   return `No state found to clear for mode: ${mode}${scope}${checked}`;
 }
@@ -644,14 +860,14 @@ function clearModeRuntimeArtifacts(
 ): { cleared: number; hadFailure: boolean } {
   let cleared = 0;
   let hadFailure = false;
-  const stateRoot = join(getOmcRoot(root), 'state');
+  const stateRoot = join(getOmcRoot(root), "state");
   const candidateDirs = new Set<string>([stateRoot]);
 
   if (sessionId) {
-    candidateDirs.add(join(stateRoot, 'sessions', sessionId));
+    candidateDirs.add(join(stateRoot, "sessions", sessionId));
   } else {
     for (const sid of listSessionIds(root)) {
-      candidateDirs.add(join(stateRoot, 'sessions', sid));
+      candidateDirs.add(join(stateRoot, "sessions", sid));
     }
   }
 
@@ -682,18 +898,32 @@ function writeSessionCancelSignal(
 ): void {
   ensureSessionStateDir(sessionId, root);
   const now = Date.now();
-  const cancelSignalPath = resolveSessionStatePath('cancel-signal', sessionId, root);
+  const cancelSignalPath = resolveSessionStatePath(
+    "cancel-signal",
+    sessionId,
+    root,
+  );
   const payload = {
     active: true,
     requested_at: new Date(now).toISOString(),
     expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
     mode,
-    source: 'state_clear',
-    ...(candidate?.workflowRunId ? { target_workflow_run_id: candidate.workflowRunId } : {}),
-    ...(candidate ? { target_state_sha256: createHash('sha256').update(candidate.snapshot).digest('hex') } : {}),
+    source: "state_clear",
+    ...(candidate?.workflowRunId
+      ? { target_workflow_run_id: candidate.workflowRunId }
+      : {}),
+    ...(candidate
+      ? {
+          target_state_sha256: createHash("sha256")
+            .update(candidate.snapshot)
+            .digest("hex"),
+        }
+      : {}),
   };
   if (!writeStateFileLocked(cancelSignalPath, payload)) {
-    throw new Error(`state mutation lock unavailable for cancel signal: ${cancelSignalPath}`);
+    throw new Error(
+      `state mutation lock unavailable for cancel signal: ${cancelSignalPath}`,
+    );
   }
 }
 
@@ -712,7 +942,10 @@ function isSessionModeActive(
   }
 
   try {
-    const state = JSON.parse(readFileSync(statePath, 'utf-8')) as Record<string, unknown>;
+    const state = JSON.parse(readFileSync(statePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
     return state.active === true;
   } catch {
     return false;
@@ -724,9 +957,9 @@ function findSingleOwningSessionForMode(
   root: string,
   requesterSessionId: string,
 ): string | undefined {
-  const owningSessions = listSessionIds(root).filter((sid) => (
-    sid !== requesterSessionId && isSessionModeActive(mode, root, sid)
-  ));
+  const owningSessions = listSessionIds(root).filter(
+    (sid) => sid !== requesterSessionId && isSessionModeActive(mode, root, sid),
+  );
 
   return owningSessions.length === 1 ? owningSessions[0] : undefined;
 }
@@ -743,11 +976,11 @@ interface WorkflowPublicState {
 }
 
 interface GraphPublicStateSummary {
-  type: 'graph_state_summary';
+  type: "graph_state_summary";
   valid: boolean;
   format_version?: number;
   run_id?: string;
-  status: GraphRunStatus | 'malformed';
+  status: GraphRunStatus | "malformed";
   active_revision_id?: string;
   short_revision_hash?: string;
   dispatch_generation?: number;
@@ -769,19 +1002,21 @@ interface GraphPublicStateSummary {
 }
 
 function malformedGraphPublicState(): GraphPublicStateSummary {
-  return { type: 'graph_state_summary', valid: false, status: 'malformed' };
+  return { type: "graph_state_summary", valid: false, status: "malformed" };
 }
 
-export function redactGraphPublicState(state: unknown): GraphPublicStateSummary {
+export function redactGraphPublicState(
+  state: unknown,
+): GraphPublicStateSummary {
   try {
     const graph = parseGraphState(state);
     const activationStatuses = Object.values(graph.projection.activations).map(
-      activation => activation.status,
+      (activation) => activation.status,
     );
     const claims = Object.values(graph.claims);
     const reconciliations = Object.values(graph.reconciliations);
     return {
-      type: 'graph_state_summary',
+      type: "graph_state_summary",
       valid: true,
       format_version: graph.format_version,
       run_id: graph.run_id.slice(0, 128),
@@ -792,17 +1027,21 @@ export function redactGraphPublicState(state: unknown): GraphPublicStateSummary 
       commit_sequence: graph.commit_sequence,
       progress: {
         total: activationStatuses.length,
-        ready: activationStatuses.filter(status => status === 'ready').length,
-        running: activationStatuses.filter(status => status === 'running').length,
-        completed: activationStatuses.filter(status => status === 'completed').length,
-        failed: activationStatuses.filter(status => status === 'failed').length,
+        ready: activationStatuses.filter((status) => status === "ready").length,
+        running: activationStatuses.filter((status) => status === "running")
+          .length,
+        completed: activationStatuses.filter((status) => status === "completed")
+          .length,
+        failed: activationStatuses.filter((status) => status === "failed")
+          .length,
       },
       claims: {
         total: claims.length,
-        live: claims.filter(claim => claim.status === 'live').length,
-        reconciling: claims.filter(claim => claim.status === 'reconciling').length,
+        live: claims.filter((claim) => claim.status === "live").length,
+        reconciling: claims.filter((claim) => claim.status === "reconciling")
+          .length,
         unresolved_reconciliations: reconciliations.filter(
-          reconciliation => reconciliation.status === 'unresolved',
+          (reconciliation) => reconciliation.status === "unresolved",
         ).length,
       },
       pending: {
@@ -816,24 +1055,53 @@ export function redactGraphPublicState(state: unknown): GraphPublicStateSummary 
 }
 
 function canonicalWorkflowJson(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(canonicalWorkflowJson).join(',')}]`;
-  if (value && typeof value === 'object') {
+  if (Array.isArray(value))
+    return `[${value.map(canonicalWorkflowJson).join(",")}]`;
+  if (value && typeof value === "object") {
     const record = value as Record<string, unknown>;
-    return `{${Object.keys(record).sort().map(key => `${JSON.stringify(key)}:${canonicalWorkflowJson(record[key])}`).join(',')}}`;
+    return `{${Object.keys(record)
+      .sort()
+      .map(
+        (key) => `${JSON.stringify(key)}:${canonicalWorkflowJson(record[key])}`,
+      )
+      .join(",")}}`;
   }
   return JSON.stringify(value);
 }
 
-function isValidPublicWorkflowDescriptor(descriptor: Record<string, unknown>): boolean {
+function isValidPublicWorkflowDescriptor(
+  descriptor: Record<string, unknown>,
+): boolean {
   const stages = descriptor.stages;
-  if (descriptor.descriptorVersion !== 1 || descriptor.profileVersion !== 1 || typeof descriptor.workflowName !== 'string' || !Array.isArray(stages) || !stages.every(stage => typeof stage === 'string') || typeof descriptor.profileHash !== 'string') return false;
-  const allowed = new Set(['ralplan,execution', 'ralplan,execution,ralph', 'ralplan,execution,qa', 'ralplan,execution,ralph,qa']);
-  if (!allowed.has(stages.join(','))) return false;
-  const canonical = canonicalWorkflowJson({ descriptorVersion: 1, workflowName: descriptor.workflowName, profileVersion: 1, stages });
-  return createHash('sha256').update(canonical).digest('hex') === descriptor.profileHash;
+  if (
+    descriptor.descriptorVersion !== 1 ||
+    descriptor.profileVersion !== 1 ||
+    typeof descriptor.workflowName !== "string" ||
+    !Array.isArray(stages) ||
+    !stages.every((stage) => typeof stage === "string") ||
+    typeof descriptor.profileHash !== "string"
+  )
+    return false;
+  const allowed = new Set([
+    "ralplan,execution",
+    "ralplan,execution,ralph",
+    "ralplan,execution,qa",
+    "ralplan,execution,ralph,qa",
+  ]);
+  if (!allowed.has(stages.join(","))) return false;
+  const canonical = canonicalWorkflowJson({
+    descriptorVersion: 1,
+    workflowName: descriptor.workflowName,
+    profileVersion: 1,
+    stages,
+  });
+  return (
+    createHash("sha256").update(canonical).digest("hex") ===
+    descriptor.profileHash
+  );
 }
 export function redactAutopilotPublicState(state: unknown): unknown {
-  if (!state || typeof state !== 'object') {
+  if (!state || typeof state !== "object") {
     return state;
   }
   const record = state as Record<string, unknown>;
@@ -841,63 +1109,115 @@ export function redactAutopilotPublicState(state: unknown): unknown {
     return state;
   }
   const workflow = record.workflow;
-  if (!hasValidatedNamedWorkflowTuple(record) || !workflow || typeof workflow !== 'object') {
-    return { name: 'invalid', version: 1, shortHash: 'invalid', stages: [], currentStage: null, status: 'workflow_descriptor_integrity_failed', progress: '0/0' } satisfies WorkflowPublicState;
+  if (
+    !hasValidatedNamedWorkflowTuple(record) ||
+    !workflow ||
+    typeof workflow !== "object"
+  ) {
+    return {
+      name: "invalid",
+      version: 1,
+      shortHash: "invalid",
+      stages: [],
+      currentStage: null,
+      status: "workflow_descriptor_integrity_failed",
+      progress: "0/0",
+    } satisfies WorkflowPublicState;
   }
   const descriptor = workflow as Record<string, unknown>;
   if (!isValidPublicWorkflowDescriptor(descriptor)) {
-    return { name: 'invalid', version: 1, shortHash: 'invalid', stages: [], currentStage: null, status: 'workflow_descriptor_integrity_failed', progress: '0/0' } satisfies WorkflowPublicState;
+    return {
+      name: "invalid",
+      version: 1,
+      shortHash: "invalid",
+      stages: [],
+      currentStage: null,
+      status: "workflow_descriptor_integrity_failed",
+      progress: "0/0",
+    } satisfies WorkflowPublicState;
   }
-  const stages = Array.isArray(descriptor.stages) && descriptor.stages.every((stage) => typeof stage === 'string')
-    ? descriptor.stages as string[]
+  const stages =
+    Array.isArray(descriptor.stages) &&
+    descriptor.stages.every((stage) => typeof stage === "string")
+      ? (descriptor.stages as string[])
+      : [];
+  const pipelineTracking =
+    record.pipelineTracking && typeof record.pipelineTracking === "object"
+      ? (record.pipelineTracking as Record<string, unknown>)
+      : undefined;
+  const currentStageIndex =
+    typeof pipelineTracking?.currentStageIndex === "number"
+      ? pipelineTracking.currentStageIndex
+      : -1;
+  const pipelineStages = Array.isArray(pipelineTracking?.stages)
+    ? pipelineTracking.stages
     : [];
-  const pipelineTracking = record.pipelineTracking && typeof record.pipelineTracking === 'object'
-    ? record.pipelineTracking as Record<string, unknown>
-    : undefined;
-  const currentStageIndex = typeof pipelineTracking?.currentStageIndex === 'number'
-    ? pipelineTracking.currentStageIndex
-    : -1;
-  const pipelineStages = Array.isArray(pipelineTracking?.stages) ? pipelineTracking.stages : [];
-  const terminal = record.active === false && record.phase === 'complete' && currentStageIndex === stages.length;
-  const currentPipelineStage = terminal ? undefined : pipelineStages[currentStageIndex];
-  const currentStage = currentPipelineStage && typeof currentPipelineStage === 'object'
-    && typeof (currentPipelineStage as Record<string, unknown>).id === 'string'
-    ? (currentPipelineStage as Record<string, unknown>).id as string
-    : null;
-  const currentStageStatus = currentPipelineStage && typeof currentPipelineStage === 'object'
-    && typeof (currentPipelineStage as Record<string, unknown>).status === 'string'
-    ? (currentPipelineStage as Record<string, unknown>).status as string
-    : null;
+  const terminal =
+    record.active === false &&
+    record.phase === "complete" &&
+    currentStageIndex === stages.length;
+  const currentPipelineStage = terminal
+    ? undefined
+    : pipelineStages[currentStageIndex];
+  const currentStage =
+    currentPipelineStage &&
+    typeof currentPipelineStage === "object" &&
+    typeof (currentPipelineStage as Record<string, unknown>).id === "string"
+      ? ((currentPipelineStage as Record<string, unknown>).id as string)
+      : null;
+  const currentStageStatus =
+    currentPipelineStage &&
+    typeof currentPipelineStage === "object" &&
+    typeof (currentPipelineStage as Record<string, unknown>).status === "string"
+      ? ((currentPipelineStage as Record<string, unknown>).status as string)
+      : null;
   const safeState: WorkflowPublicState = {
-    name: typeof descriptor.workflowName === 'string' ? descriptor.workflowName.slice(0, 32) : 'invalid',
+    name:
+      typeof descriptor.workflowName === "string"
+        ? descriptor.workflowName.slice(0, 32)
+        : "invalid",
     workflowRunId: record.workflowRunId as string,
-    version: typeof descriptor.profileVersion === 'number' ? descriptor.profileVersion : 1,
-    shortHash: typeof descriptor.profileHash === 'string' ? descriptor.profileHash.slice(0, 12) : 'invalid',
+    version:
+      typeof descriptor.profileVersion === "number"
+        ? descriptor.profileVersion
+        : 1,
+    shortHash:
+      typeof descriptor.profileHash === "string"
+        ? descriptor.profileHash.slice(0, 12)
+        : "invalid",
     stages,
     currentStage,
-    status: terminal ? 'complete' : currentStageStatus,
-    progress: currentStageIndex >= 0 ? `${Math.min(currentStageIndex + 1, stages.length)}/${stages.length}` : `0/${stages.length}`,
+    status: terminal ? "complete" : currentStageStatus,
+    progress:
+      currentStageIndex >= 0
+        ? `${Math.min(currentStageIndex + 1, stages.length)}/${stages.length}`
+        : `0/${stages.length}`,
   };
   return safeState;
 }
 
 function publicStateForMode(mode: StateToolMode, state: unknown): unknown {
-  if (mode === 'autopilot') {
+  if (mode === "autopilot") {
     return redactAutopilotPublicState(state);
   }
-  if (mode === 'graph') {
+  if (mode === "graph") {
     return redactGraphPublicState(state);
   }
-  return mode === 'merge-readiness'
-    ? redactMergeReadinessState(state as Parameters<typeof redactMergeReadinessState>[0])
+  return mode === "merge-readiness"
+    ? redactMergeReadinessState(
+        state as Parameters<typeof redactMergeReadinessState>[0],
+      )
     : state;
 }
 
-function parsePublicStateContent(mode: StateToolMode, content: string): unknown {
+function parsePublicStateContent(
+  mode: StateToolMode,
+  content: string,
+): unknown {
   try {
     return publicStateForMode(mode, JSON.parse(content));
   } catch (error) {
-    if (mode === 'graph') return malformedGraphPublicState();
+    if (mode === "graph") return malformedGraphPublicState();
     throw error;
   }
 }
@@ -911,13 +1231,27 @@ export const stateReadTool: ToolDefinition<{
   workingDirectory: z.ZodOptional<z.ZodString>;
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
-  name: 'state_read',
-  description: 'Read the current state for a specific mode (ralph, ultrawork, autopilot, etc.). Returns the JSON state data or indicates if no state exists.',
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  name: "state_read",
+  description:
+    "Read the current state for a specific mode (ralph, ultrawork, autopilot, etc.). Returns the JSON state data or indicates if no state exists.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   schema: {
-    mode: z.enum(STATE_TOOL_MODES).describe('The mode to read state for'),
-    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
-    session_id: z.string().optional().describe('Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).'),
+    mode: z.enum(STATE_TOOL_MODES).describe("The mode to read state for"),
+    workingDirectory: z
+      .string()
+      .optional()
+      .describe("Working directory (defaults to cwd)"),
+    session_id: z
+      .string()
+      .optional()
+      .describe(
+        "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).",
+      ),
   },
   handler: async (args) => {
     const { mode, workingDirectory, session_id } = args;
@@ -934,42 +1268,54 @@ export const stateReadTool: ToolDefinition<{
           : resolveSessionStatePath(mode, sessionId, root);
 
         if (!existsSync(statePath)) {
-          const completedSessionPaths = findCompletedSessionStateFiles(mode, root, sessionId);
+          const completedSessionPaths = findCompletedSessionStateFiles(
+            mode,
+            root,
+            sessionId,
+          );
           if (completedSessionPaths.length > 0) {
             const orphanList = completedSessionPaths
               .map((orphanPath) => {
-                const sessionMarker = `${join('state', 'sessions')}/`;
+                const sessionMarker = `${join("state", "sessions")}/`;
                 const markerIndex = orphanPath.indexOf(sessionMarker);
                 if (markerIndex === -1) return `- ${orphanPath}`;
-                const rest = orphanPath.slice(markerIndex + sessionMarker.length);
-                const orphanSessionId = rest.split(/[\\/]/)[0] || 'unknown';
+                const rest = orphanPath.slice(
+                  markerIndex + sessionMarker.length,
+                );
+                const orphanSessionId = rest.split(/[\\/]/)[0] || "unknown";
                 return `- session: ${orphanSessionId}\n  path: ${orphanPath}`;
               })
-              .join('\n');
+              .join("\n");
             return {
-              content: [{
-                type: 'text' as const,
-                text: `No state found for mode: ${mode} in session: ${sessionId}\nExpected path: ${statePath}\n\nDiscovered ${completedSessionPaths.length} completed-session orphan state file${completedSessionPaths.length === 1 ? '' : 's'} for this mode:\n${orphanList}\n\nRun state_clear(mode="${mode}", session_id="${sessionId}") to clear the current session plus these completed-session orphan files.`
-              }]
+              content: [
+                {
+                  type: "text" as const,
+                  text: `No state found for mode: ${mode} in session: ${sessionId}\nExpected path: ${statePath}\n\nDiscovered ${completedSessionPaths.length} completed-session orphan state file${completedSessionPaths.length === 1 ? "" : "s"} for this mode:\n${orphanList}\n\nRun state_clear(mode="${mode}", session_id="${sessionId}") to clear the current session plus these completed-session orphan files.`,
+                },
+              ],
             };
           }
 
           return {
-            content: [{
-              type: 'text' as const,
-              text: `No state found for mode: ${mode} in session: ${sessionId}\nExpected path: ${statePath}`
-            }]
+            content: [
+              {
+                type: "text" as const,
+                text: `No state found for mode: ${mode} in session: ${sessionId}\nExpected path: ${statePath}`,
+              },
+            ],
           };
         }
 
-        const content = readFileSync(statePath, 'utf-8');
+        const content = readFileSync(statePath, "utf-8");
         const publicState = parsePublicStateContent(mode, content);
 
         return {
-          content: [{
-            type: 'text' as const,
-            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\``
-          }]
+          content: [
+            {
+              type: "text" as const,
+              text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\``,
+            },
+          ],
         };
       }
 
@@ -991,10 +1337,12 @@ export const stateReadTool: ToolDefinition<{
 
       if (!legacyExists && activeSessions.length === 0) {
         return {
-          content: [{
-            type: 'text' as const,
-            text: `No state found for mode: ${mode}\nExpected legacy path: ${statePath}\nNo active sessions found.\n\nNote: Reading from legacy/aggregate path (no session_id). This may include state from other sessions.`
-          }]
+          content: [
+            {
+              type: "text" as const,
+              text: `No state found for mode: ${mode}\nExpected legacy path: ${statePath}\nNo active sessions found.\n\nNote: Reading from legacy/aggregate path (no session_id). This may include state from other sessions.`,
+            },
+          ],
         };
       }
 
@@ -1003,7 +1351,7 @@ export const stateReadTool: ToolDefinition<{
       // Show legacy state if exists
       if (legacyExists) {
         try {
-          const content = readFileSync(statePath, 'utf-8');
+          const content = readFileSync(statePath, "utf-8");
           const publicState = parsePublicStateContent(mode, content);
           output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\`\n\n`;
         } catch {
@@ -1020,7 +1368,7 @@ export const stateReadTool: ToolDefinition<{
             : resolveSessionStatePath(mode, sid, root);
 
           try {
-            const content = readFileSync(sessionStatePath, 'utf-8');
+            const content = readFileSync(sessionStatePath, "utf-8");
             const publicState = parsePublicStateContent(mode, content);
             output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\`\n\n`;
           } catch {
@@ -1030,21 +1378,25 @@ export const stateReadTool: ToolDefinition<{
       }
 
       return {
-        content: [{
-          type: 'text' as const,
-          text: output
-        }]
+        content: [
+          {
+            type: "text" as const,
+            text: output,
+          },
+        ],
       };
     } catch (error) {
       return {
-        content: [{
-          type: 'text' as const,
-          text: `Error reading state for ${mode}: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
+        content: [
+          {
+            type: "text" as const,
+            text: `Error reading state for ${mode}: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
       };
     }
-  }
+  },
 };
 
 // ============================================================================
@@ -1066,23 +1418,68 @@ export const stateWriteTool: ToolDefinition<{
   workingDirectory: z.ZodOptional<z.ZodString>;
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
-  name: 'state_write',
-  description: 'Write/update state for a specific mode. Creates the state file and directories if they do not exist. Common fields (active, iteration, phase, etc.) can be set directly as parameters. Additional custom fields can be passed via the optional `state` parameter. Note: swarm uses SQLite and cannot be written via this tool.',
-  annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  name: "state_write",
+  description:
+    "Write/update state for a specific mode. Creates the state file and directories if they do not exist. Common fields (active, iteration, phase, etc.) can be set directly as parameters. Additional custom fields can be passed via the optional `state` parameter. Note: swarm uses SQLite and cannot be written via this tool.",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   schema: {
-    mode: z.enum(STATE_WRITE_MODES).describe('The mode to write state for'),
-    active: z.boolean().optional().describe('Whether the mode is currently active'),
-    iteration: z.number().optional().describe('Current iteration number'),
-    max_iterations: z.number().optional().describe('Maximum iterations allowed'),
-    current_phase: z.string().max(200).optional().describe('Current execution phase'),
-    task_description: z.string().max(2000).optional().describe('Description of the task being executed'),
-    plan_path: z.string().max(500).optional().describe('Path to the plan file'),
-    started_at: z.string().max(100).optional().describe('ISO timestamp when the mode started'),
-    completed_at: z.string().max(100).optional().describe('ISO timestamp when the mode completed'),
-    error: z.string().max(2000).optional().describe('Error message if the mode failed'),
-    state: z.record(z.string(), z.unknown()).optional().describe('Additional custom state fields (merged with explicit parameters)'),
-    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
-    session_id: z.string().optional().describe('Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).'),
+    mode: z.enum(STATE_WRITE_MODES).describe("The mode to write state for"),
+    active: z
+      .boolean()
+      .optional()
+      .describe("Whether the mode is currently active"),
+    iteration: z.number().optional().describe("Current iteration number"),
+    max_iterations: z
+      .number()
+      .optional()
+      .describe("Maximum iterations allowed"),
+    current_phase: z
+      .string()
+      .max(200)
+      .optional()
+      .describe("Current execution phase"),
+    task_description: z
+      .string()
+      .max(2000)
+      .optional()
+      .describe("Description of the task being executed"),
+    plan_path: z.string().max(500).optional().describe("Path to the plan file"),
+    started_at: z
+      .string()
+      .max(100)
+      .optional()
+      .describe("ISO timestamp when the mode started"),
+    completed_at: z
+      .string()
+      .max(100)
+      .optional()
+      .describe("ISO timestamp when the mode completed"),
+    error: z
+      .string()
+      .max(2000)
+      .optional()
+      .describe("Error message if the mode failed"),
+    state: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe(
+        "Additional custom state fields (merged with explicit parameters)",
+      ),
+    workingDirectory: z
+      .string()
+      .optional()
+      .describe("Working directory (defaults to cwd)"),
+    session_id: z
+      .string()
+      .optional()
+      .describe(
+        "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).",
+      ),
   },
   handler: async (args) => {
     const {
@@ -1098,24 +1495,26 @@ export const stateWriteTool: ToolDefinition<{
       error,
       state,
       workingDirectory,
-      session_id
+      session_id,
     } = args;
 
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
 
-      if ((mode as string) === 'graph') {
+      if ((mode as string) === "graph") {
         return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              type: 'guarded_mode',
-              mode: 'graph',
-              operation: 'write',
-              changed: false,
-            }),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                type: "guarded_mode",
+                mode: "graph",
+                operation: "write",
+                changed: false,
+              }),
+            },
+          ],
           isError: true,
         };
       }
@@ -1125,11 +1524,13 @@ export const stateWriteTool: ToolDefinition<{
         const validation = validatePayload(state);
         if (!validation.valid) {
           return {
-            content: [{
-              type: 'text' as const,
-              text: `Error: state payload rejected — ${validation.error}`
-            }],
-            isError: true
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: state payload rejected — ${validation.error}`,
+              },
+            ],
+            isError: true,
           };
         }
       }
@@ -1143,7 +1544,7 @@ export const stateWriteTool: ToolDefinition<{
           ? getStateFilePath(root, mode as ExecutionMode, sessionId)
           : resolveSessionStatePath(mode, sessionId, root);
       } else {
-        ensureOmcDir('state', root);
+        ensureOmcDir("state", root);
         statePath = getStatePath(mode, root);
       }
 
@@ -1153,9 +1554,11 @@ export const stateWriteTool: ToolDefinition<{
       // Add explicit params (only if provided)
       if (active !== undefined) builtState.active = active;
       if (iteration !== undefined) builtState.iteration = iteration;
-      if (max_iterations !== undefined) builtState.max_iterations = max_iterations;
+      if (max_iterations !== undefined)
+        builtState.max_iterations = max_iterations;
       if (current_phase !== undefined) builtState.current_phase = current_phase;
-      if (task_description !== undefined) builtState.task_description = task_description;
+      if (task_description !== undefined)
+        builtState.task_description = task_description;
       if (plan_path !== undefined) builtState.plan_path = plan_path;
       if (started_at !== undefined) builtState.started_at = started_at;
       if (completed_at !== undefined) builtState.completed_at = completed_at;
@@ -1170,11 +1573,24 @@ export const stateWriteTool: ToolDefinition<{
         }
       }
 
-      const requestedRunId = typeof builtState.workflowRunId === 'string' ? builtState.workflowRunId : undefined;
-      const requestedStateDigest = typeof builtState.target_state_sha256 === 'string' ? builtState.target_state_sha256 : undefined;
+      const requestedRunId =
+        typeof builtState.workflowRunId === "string"
+          ? builtState.workflowRunId
+          : undefined;
+      const requestedStateDigest =
+        typeof builtState.target_state_sha256 === "string"
+          ? builtState.target_state_sha256
+          : undefined;
       const isExactNamedPause = isExactNamedPauseRequest(builtState);
-      if (mode === 'autopilot' && (hasNamedWorkflowMarker(builtState) || hasOwnProperty(builtState, 'target_state_sha256')) && !isExactNamedPause) {
-        throw new Error('named autopilot workflow markers are runtime-owned; only active:false with an exact workflowRunId and optional state digest may pause a run');
+      if (
+        mode === "autopilot" &&
+        (hasNamedWorkflowMarker(builtState) ||
+          hasOwnProperty(builtState, "target_state_sha256")) &&
+        !isExactNamedPause
+      ) {
+        throw new Error(
+          "named autopilot workflow markers are runtime-owned; only active:false with an exact workflowRunId and optional state digest may pause a run",
+        );
       }
 
       // Add metadata
@@ -1184,40 +1600,62 @@ export const stateWriteTool: ToolDefinition<{
           mode,
           sessionId: sessionId || null,
           updatedAt: new Date().toISOString(),
-          updatedBy: 'state_write_tool'
-        }
+          updatedBy: "state_write_tool",
+        },
       };
       let writtenState: Record<string, unknown> = stateWithMeta;
       let namedPauseCommitted = false;
-      if (mode === 'autopilot' && builtState.active === false) {
+      if (mode === "autopilot" && builtState.active === false) {
         let currentState: Record<string, unknown> | null = null;
-        try { currentState = JSON.parse(readFileSync(statePath, 'utf8')) as Record<string, unknown>; } catch { /* missing or malformed state is handled below */ }
+        try {
+          currentState = JSON.parse(readFileSync(statePath, "utf8")) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          /* missing or malformed state is handled below */
+        }
         if (hasNamedWorkflowMarker(currentState ?? {})) {
           if (!isExactNamedPause || !requestedRunId) {
-            throw new Error('named autopilot workflow state requires active:false with its exact workflowRunId');
+            throw new Error(
+              "named autopilot workflow state requires active:false with its exact workflowRunId",
+            );
           }
           if (namedWorkflowRuntimeSupported()) {
             const result = writeStateFileLockedIf(
               statePath,
-              (current) => matchesNamedPauseTarget(current, sessionId, requestedRunId, requestedStateDigest),
+              (current) =>
+                matchesNamedPauseTarget(
+                  current,
+                  sessionId,
+                  requestedRunId,
+                  requestedStateDigest,
+                ),
               (current) => ({ ...current, active: false }),
             );
-            if (result !== 'written') {
-              throw new Error(result === 'failed'
-                ? 'state mutation lock unavailable'
-                : 'named autopilot run changed, is stale, or failed integrity validation');
+            if (result !== "written") {
+              throw new Error(
+                result === "failed"
+                  ? "state mutation lock unavailable"
+                  : "named autopilot run changed, is stale, or failed integrity validation",
+              );
             }
             namedPauseCommitted = true;
           } else {
             const snapshot = JSON.stringify(currentState);
             const written = emergencyMutateStateFileIf(
               statePath,
-              (current) => JSON.stringify(current) === snapshot &&
+              (current) =>
+                JSON.stringify(current) === snapshot &&
                 isExactEmergencyNamedMutation(current, requestedRunId) &&
-                (requestedStateDigest === undefined || createHash('sha256').update(JSON.stringify(current)).digest('hex') === requestedStateDigest),
+                (requestedStateDigest === undefined ||
+                  createHash("sha256")
+                    .update(JSON.stringify(current))
+                    .digest("hex") === requestedStateDigest),
               (current) => ({ ...current, active: false }),
             );
-            if (!written) throw new Error('autopilot run changed before deactivation');
+            if (!written)
+              throw new Error("autopilot run changed before deactivation");
             namedPauseCommitted = true;
           }
         } else {
@@ -1229,9 +1667,14 @@ export const stateWriteTool: ToolDefinition<{
               return writtenState;
             },
           );
-          if (result !== 'written') throw new Error(result === 'failed' ? 'state mutation lock unavailable' : 'autopilot run changed before deactivation');
+          if (result !== "written")
+            throw new Error(
+              result === "failed"
+                ? "state mutation lock unavailable"
+                : "autopilot run changed before deactivation",
+            );
         }
-      } else if (mode === 'autopilot') {
+      } else if (mode === "autopilot") {
         let namedWorkflowExists = false;
         const result = writeStateFileLockedCreateIf(
           statePath,
@@ -1245,102 +1688,169 @@ export const stateWriteTool: ToolDefinition<{
             return writtenState;
           },
         );
-        if (result !== 'written') {
-          if (namedWorkflowExists) throw new Error('named autopilot workflow state is runtime-owned; only exact-run deactivation is allowed');
-          throw new Error(result === 'failed' ? 'state mutation lock unavailable' : 'autopilot state changed before write');
+        if (result !== "written") {
+          if (namedWorkflowExists)
+            throw new Error(
+              "named autopilot workflow state is runtime-owned; only exact-run deactivation is allowed",
+            );
+          throw new Error(
+            result === "failed"
+              ? "state mutation lock unavailable"
+              : "autopilot state changed before write",
+          );
         }
       } else if (!writeStateFileLocked(statePath, stateWithMeta)) {
-        throw new Error('state mutation lock unavailable');
+        throw new Error("state mutation lock unavailable");
       }
 
-
-      const sessionInfo = sessionId ? ` (session: ${sessionId})` : ' (legacy path)';
-      const warningMessage = sessionId ? '' : '\n\nWARNING: No session_id provided. State written to legacy shared path which may leak across parallel sessions. Pass session_id for session-scoped isolation.';
+      const sessionInfo = sessionId
+        ? ` (session: ${sessionId})`
+        : " (legacy path)";
+      const warningMessage = sessionId
+        ? ""
+        : "\n\nWARNING: No session_id provided. State written to legacy shared path which may leak across parallel sessions. Pass session_id for session-scoped isolation.";
       return {
-        content: [{
-          type: 'text' as const,
-          text: namedPauseCommitted
-            ? `Paused named autopilot workflow${sessionInfo}. Resume state is preserved.`
-            : `Successfully wrote state for ${mode}${sessionInfo}\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(writtenState, null, 2)}\n\`\`\`${warningMessage}`
-        }]
+        content: [
+          {
+            type: "text" as const,
+            text: namedPauseCommitted
+              ? `Paused named autopilot workflow${sessionInfo}. Resume state is preserved.`
+              : `Successfully wrote state for ${mode}${sessionInfo}\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(writtenState, null, 2)}\n\`\`\`${warningMessage}`,
+          },
+        ],
       };
     } catch (error) {
       return {
-        content: [{
-          type: 'text' as const,
-          text: `Error writing state for ${mode}: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
+        content: [
+          {
+            type: "text" as const,
+            text: `Error writing state for ${mode}: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
       };
     }
-  }
+  },
 };
 
 // ============================================================================
 // state_clear - Clear state for a mode
 // ============================================================================
 
-function discoverAllRootSessionStateCandidates(mode: StateToolMode, root: string): StateFileDiscovery[] {
+function discoverAllRootSessionStateCandidates(
+  mode: StateToolMode,
+  root: string,
+): StateFileDiscovery[] {
   const paths = new Set<string>();
-  const roots = new Set([...getConvergedOmcRoots(root), getWorkingDirectoryLocalOmcRoot(root), getOmcRoot(root)]);
+  const roots = new Set([
+    ...getConvergedOmcRoots(root),
+    getWorkingDirectoryLocalOmcRoot(root),
+    getOmcRoot(root),
+  ]);
   for (const omcRoot of roots) {
     for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-      paths.add(join(omcRoot, 'state', 'sessions', sid, getStateFileName(mode)));
+      paths.add(
+        join(omcRoot, "state", "sessions", sid, getStateFileName(mode)),
+      );
     }
   }
   return discoverStatePaths([...paths]);
 }
 
-function recoverAutopilotEmergencyTransactions(root: string, sessionId?: string): void {
+function recoverAutopilotEmergencyTransactions(
+  root: string,
+  sessionId?: string,
+): void {
   const broadPaths = new Set<string>([
-    ...getLegacyStateFileCandidates('autopilot', root),
-    ...getWorkingDirectoryLocalStateClearCandidates('autopilot', root),
-    ...getConvergedStateCandidates('autopilot', root),
+    ...getLegacyStateFileCandidates("autopilot", root),
+    ...getWorkingDirectoryLocalStateClearCandidates("autopilot", root),
+    ...getConvergedStateCandidates("autopilot", root),
   ]);
   const localOmcRoot = getWorkingDirectoryLocalOmcRoot(root);
   for (const sid of listSessionIdsUnderOmcRoot(localOmcRoot)) {
-    broadPaths.add(join(localOmcRoot, 'state', 'sessions', sid, getStateFileName('autopilot')));
+    broadPaths.add(
+      join(
+        localOmcRoot,
+        "state",
+        "sessions",
+        sid,
+        getStateFileName("autopilot"),
+      ),
+    );
   }
   for (const omcRoot of getConvergedOmcRoots(root)) {
     for (const sid of listSessionIdsUnderOmcRoot(omcRoot)) {
-      broadPaths.add(join(omcRoot, 'state', 'sessions', sid, getStateFileName('autopilot')));
+      broadPaths.add(
+        join(omcRoot, "state", "sessions", sid, getStateFileName("autopilot")),
+      );
     }
   }
   const directSessionPaths = new Set<string>();
   if (sessionId) {
-    directSessionPaths.add(resolveSessionStatePath('autopilot', sessionId, root));
-    directSessionPaths.add(getWorkingDirectoryLocalSessionStatePath('autopilot', root, sessionId));
+    directSessionPaths.add(
+      resolveSessionStatePath("autopilot", sessionId, root),
+    );
+    directSessionPaths.add(
+      getWorkingDirectoryLocalSessionStatePath("autopilot", root, sessionId),
+    );
     for (const omcRoot of getConvergedOmcRoots(root)) {
-      directSessionPaths.add(join(omcRoot, 'state', 'sessions', sessionId, getStateFileName('autopilot')));
+      directSessionPaths.add(
+        join(
+          omcRoot,
+          "state",
+          "sessions",
+          sessionId,
+          getStateFileName("autopilot"),
+        ),
+      );
     }
     for (const path of directSessionPaths) broadPaths.add(path);
   }
   for (const path of broadPaths) {
-    const recoveryOptions = emergencyRecoveryOptionsForProject('autopilot', path, root);
+    const recoveryOptions = emergencyRecoveryOptionsForProject(
+      "autopilot",
+      path,
+      root,
+    );
     if (!isAutopilotRecoveryCandidateForProject(path, root)) continue;
     if (sessionId && !directSessionPaths.has(path)) {
       const visibleOwner = getStateSessionOwner(readJsonRecord(path) ?? {});
       const journal = readJsonRecord(`${path}.emergency-journal.json`);
-      const journalOwner = typeof journal?.sessionOwner === 'string' ? journal.sessionOwner : undefined;
+      const journalOwner =
+        typeof journal?.sessionOwner === "string"
+          ? journal.sessionOwner
+          : undefined;
       if (visibleOwner !== sessionId && journalOwner !== sessionId) continue;
     }
-    if (!recoverEmergencyStateFile(path, recoveryOptions)) throw new Error(`workflow_emergency_recovery_failed: ${path}`);
-    if (recoveryOptions && !isAutopilotRecoveryCandidateForProject(path, root)) continue;
+    if (!recoverEmergencyStateFile(path, recoveryOptions))
+      throw new Error(`workflow_emergency_recovery_failed: ${path}`);
+    if (recoveryOptions && !isAutopilotRecoveryCandidateForProject(path, root))
+      continue;
     const artifactPrefix = `${basename(path)}.emergency-`;
     let artifacts: string[];
-    try { artifacts = readdirSync(dirname(path)).filter((name) => name.startsWith(artifactPrefix) && !name.endsWith('.recovery.guard')); }
-    catch { artifacts = []; }
-    if (artifacts.length > 0) throw new Error(`workflow_emergency_recovery_failed: ${path}`);
+    try {
+      artifacts = readdirSync(dirname(path)).filter(
+        (name) =>
+          name.startsWith(artifactPrefix) && !name.endsWith(".recovery.guard"),
+      );
+    } catch {
+      artifacts = [];
+    }
+    if (artifacts.length > 0)
+      throw new Error(`workflow_emergency_recovery_failed: ${path}`);
   }
 }
 
-type GraphClearClassification = 'active' | 'draft' | 'paused' | 'terminal' | 'malformed' | 'missing';
+type GraphClearClassification =
+  "active" | "draft" | "paused" | "terminal" | "malformed" | "missing";
 
-function classifyGraphRunStatus(status: GraphRunStatus): GraphClearClassification {
-  if (MODE_CONFIGS.graph.activeStatuses?.includes(status)) return 'active';
-  if (status === 'draft') return 'draft';
-  if (status === 'paused') return 'paused';
-  return 'terminal';
+function classifyGraphRunStatus(
+  status: GraphRunStatus,
+): GraphClearClassification {
+  if (MODE_CONFIGS.graph.activeStatuses?.includes(status)) return "active";
+  if (status === "draft") return "draft";
+  if (status === "paused") return "paused";
+  return "terminal";
 }
 
 function classifyGraphStateForClear(
@@ -1348,39 +1858,50 @@ function classifyGraphStateForClear(
   sessionId?: string,
 ): GraphClearClassification {
   const paths = sessionId
-    ? [getStateFilePath(root, 'graph', sessionId)]
+    ? [getStateFilePath(root, "graph", sessionId)]
     : [
-        getStateFilePath(root, 'graph'),
+        getStateFilePath(root, "graph"),
         ...listSessionIds(root)
           .sort()
-          .map(sid => getStateFilePath(root, 'graph', sid)),
+          .map((sid) => getStateFilePath(root, "graph", sid)),
       ];
   const classifications: GraphClearClassification[] = [];
   for (const path of paths) {
     if (!existsSync(path)) continue;
     try {
-      classifications.push(classifyGraphRunStatus(parseGraphState(JSON.parse(readFileSync(path, 'utf8'))).status));
+      classifications.push(
+        classifyGraphRunStatus(
+          parseGraphState(JSON.parse(readFileSync(path, "utf8"))).status,
+        ),
+      );
     } catch {
-      classifications.push('malformed');
+      classifications.push("malformed");
     }
   }
-  if (classifications.length === 0) return 'missing';
-  for (const classification of ['active', 'paused', 'draft', 'terminal', 'malformed'] as const) {
+  if (classifications.length === 0) return "missing";
+  for (const classification of [
+    "active",
+    "paused",
+    "draft",
+    "terminal",
+    "malformed",
+  ] as const) {
     if (classifications.includes(classification)) return classification;
   }
-  return 'malformed';
+  return "malformed";
 }
 
 function hasGraphWorkflowSlot(root: string, sessionId?: string): boolean {
-  const paths = [resolveStatePath('skill-active', root)];
+  const paths = [resolveStatePath("skill-active", root)];
   const sessionIds = sessionId ? [sessionId] : listSessionIds(root);
-  for (const sid of sessionIds) paths.push(resolveSessionStatePath('skill-active', sid, root));
-  return paths.some(path => {
+  for (const sid of sessionIds)
+    paths.push(resolveSessionStatePath("skill-active", sid, root));
+  return paths.some((path) => {
     const state = readJsonRecord(path);
     return Boolean(
-      state?.active_skills
-      && typeof state.active_skills === 'object'
-      && (state.active_skills as Record<string, unknown>).graph,
+      state?.active_skills &&
+      typeof state.active_skills === "object" &&
+      (state.active_skills as Record<string, unknown>).graph,
     );
   });
 }
@@ -1397,26 +1918,44 @@ type SkillActiveClearResult = {
  * snapshots and conditionally publish the reduced record so a concurrent
  * replacement is never removed based on stale observations.
  */
-function clearSkillActiveStateForAll(root: string, sessionId?: string): SkillActiveClearResult {
-  const legacyCandidates = discoverStatePaths(getLegacyStateFileCandidates('skill-active', root))
-    .filter((candidate) => !sessionId || canClearStateForSession(candidate.state, sessionId));
+function clearSkillActiveStateForAll(
+  root: string,
+  sessionId?: string,
+): SkillActiveClearResult {
+  const legacyCandidates = discoverStatePaths(
+    getLegacyStateFileCandidates("skill-active", root),
+  ).filter(
+    (candidate) =>
+      !sessionId || canClearStateForSession(candidate.state, sessionId),
+  );
   const localCandidates = discoverStatePaths(
-    getWorkingDirectoryLocalStateClearCandidates('skill-active', root, sessionId),
-  ).filter((candidate) => !sessionId || canClearStateForSession(candidate.state, sessionId));
+    getWorkingDirectoryLocalStateClearCandidates(
+      "skill-active",
+      root,
+      sessionId,
+    ),
+  ).filter(
+    (candidate) =>
+      !sessionId || canClearStateForSession(candidate.state, sessionId),
+  );
   const sessionCandidates = sessionId
     ? [
-        ...findSessionOwnedStateCandidates('skill-active', sessionId, root),
-        ...findCompletedSessionStateCandidates('skill-active', root, sessionId),
+        ...findSessionOwnedStateCandidates("skill-active", sessionId, root),
+        ...findCompletedSessionStateCandidates("skill-active", root, sessionId),
       ]
     : [
-        ...listSessionIds(root).flatMap((sid) => findSessionOwnedStateCandidates('skill-active', sid, root)),
-        ...discoverAllRootSessionStateCandidates('skill-active', root),
+        ...listSessionIds(root).flatMap((sid) =>
+          findSessionOwnedStateCandidates("skill-active", sid, root),
+        ),
+        ...discoverAllRootSessionStateCandidates("skill-active", root),
       ];
-  const candidates = [...new Map([
-    ...legacyCandidates,
-    ...localCandidates,
-    ...sessionCandidates,
-  ].map((candidate) => [candidate.path, candidate])).values()];
+  const candidates = [
+    ...new Map(
+      [...legacyCandidates, ...localCandidates, ...sessionCandidates].map(
+        (candidate) => [candidate.path, candidate],
+      ),
+    ).values(),
+  ];
 
   let changed = false;
   let failed = false;
@@ -1424,35 +1963,46 @@ function clearSkillActiveStateForAll(root: string, sessionId?: string): SkillAct
 
   for (const candidate of candidates) {
     const skills = candidate.state.active_skills;
-    const graphIsPresent = skills !== null && typeof skills === 'object' && !Array.isArray(skills) &&
-      Object.prototype.hasOwnProperty.call(skills, 'graph');
+    const graphIsPresent =
+      skills !== null &&
+      typeof skills === "object" &&
+      !Array.isArray(skills) &&
+      Object.prototype.hasOwnProperty.call(skills, "graph");
 
     if (!graphIsPresent) {
       const result = clearDiscoveredStateCandidate(
         candidate,
-        (current) => (!sessionId || canClearStateForSession(current, sessionId)) &&
+        (current) =>
+          (!sessionId || canClearStateForSession(current, sessionId)) &&
           JSON.stringify(current) === candidate.snapshot,
       );
-      if (result === 'cleared') changed = true;
-      else if (result === 'failed' || (result === 'skipped' && existsSync(candidate.path))) failed = true;
+      if (result === "cleared") changed = true;
+      else if (
+        result === "failed" ||
+        (result === "skipped" && existsSync(candidate.path))
+      )
+        failed = true;
       continue;
     }
 
     preservedGraphWorkflowSlot = true;
     const activeSkills = skills as Record<string, unknown>;
-    const nonGraphSkills = Object.keys(activeSkills).filter((name) => name !== 'graph');
+    const nonGraphSkills = Object.keys(activeSkills).filter(
+      (name) => name !== "graph",
+    );
     if (nonGraphSkills.length === 0) continue;
 
     const result = writeStateFileLockedIf(
       candidate.path,
-      (current) => (!sessionId || canClearStateForSession(current, sessionId)) &&
+      (current) =>
+        (!sessionId || canClearStateForSession(current, sessionId)) &&
         JSON.stringify(current) === candidate.snapshot,
       (current) => {
         const currentSkills = current.active_skills as Record<string, unknown>;
         return { ...current, active_skills: { graph: currentSkills.graph } };
       },
     );
-    if (result === 'written') changed = true;
+    if (result === "written") changed = true;
     else failed = true;
   }
 
@@ -1465,14 +2015,35 @@ export const stateClearTool: ToolDefinition<{
   workingDirectory: z.ZodOptional<z.ZodString>;
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
-  name: 'state_clear',
-  description: 'Clear/delete state for a specific mode or all generically clearable modes. Graph is guarded and is never deleted by this tool. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).',
-  annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+  name: "state_clear",
+  description:
+    "Clear/delete state for a specific mode or all generically clearable modes. Graph is guarded and is never deleted by this tool. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   schema: {
-    mode: z.enum(STATE_CLEAR_MODES).describe('The mode to clear state for, or all'),
-    force: z.boolean().optional().describe('Request broad cleanup. This never bypasses guarded Graph state.'),
-    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
-    session_id: z.string().optional().describe('Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).'),
+    mode: z
+      .enum(STATE_CLEAR_MODES)
+      .describe("The mode to clear state for, or all"),
+    force: z
+      .boolean()
+      .optional()
+      .describe(
+        "Request broad cleanup. This never bypasses guarded Graph state.",
+      ),
+    workingDirectory: z
+      .string()
+      .optional()
+      .describe("Working directory (defaults to cwd)"),
+    session_id: z
+      .string()
+      .optional()
+      .describe(
+        "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).",
+      ),
   },
   handler: async (args) => {
     const { mode, force, workingDirectory, session_id } = args;
@@ -1483,34 +2054,36 @@ export const stateClearTool: ToolDefinition<{
 
       if (sessionId) validateSessionId(sessionId);
 
-      if (mode === 'graph') {
+      if (mode === "graph") {
         const graphClassification = classifyGraphStateForClear(root, sessionId);
         return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              type: 'guarded_mode',
-              mode: 'graph',
-              operation: 'clear',
-              classification: graphClassification,
-              changed: false,
-              force_bypassed: false,
-            }),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                type: "guarded_mode",
+                mode: "graph",
+                operation: "clear",
+                classification: graphClassification,
+                changed: false,
+                force_bypassed: false,
+              }),
+            },
+          ],
           isError: true,
         };
       }
 
-      if (mode === 'all') {
+      if (mode === "all") {
         const graphClassification = classifyGraphStateForClear(root, sessionId);
         const clearedModes: string[] = [];
         const failedModes: string[] = [];
         let preserveGraphWorkflowSlot = hasGraphWorkflowSlot(root, sessionId);
         for (const candidate of STATE_TOOL_MODES) {
-          if (candidate === 'graph') {
+          if (candidate === "graph") {
             continue;
           }
-          if (candidate === 'skill-active') {
+          if (candidate === "skill-active") {
             const result = clearSkillActiveStateForAll(root, sessionId);
             preserveGraphWorkflowSlot ||= result.preservedGraphWorkflowSlot;
             if (result.failed) failedModes.push(candidate);
@@ -1527,41 +2100,53 @@ export const stateClearTool: ToolDefinition<{
           else clearedModes.push(candidate);
         }
         return {
-          content: [{
-            type: 'text' as const,
-            text: JSON.stringify({
-              type: 'clear_all',
-              cleared_modes: clearedModes,
-              failed_modes: failedModes,
-              skipped: [{
-                mode: 'graph',
-                reason: 'guarded_mode',
-                classification: graphClassification,
-              }],
-              preserved_graph_workflow_slot: preserveGraphWorkflowSlot,
-              force_bypassed: false,
-            }),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                type: "clear_all",
+                cleared_modes: clearedModes,
+                failed_modes: failedModes,
+                skipped: [
+                  {
+                    mode: "graph",
+                    reason: "guarded_mode",
+                    classification: graphClassification,
+                  },
+                ],
+                preserved_graph_workflow_slot: preserveGraphWorkflowSlot,
+                force_bypassed: false,
+              }),
+            },
+          ],
           ...(failedModes.length > 0 ? { isError: true } : {}),
         };
       }
 
       // Merge-readiness is an audit gate, so clearing it must leave a durable
       // terminal result and report rather than deleting the evidence trail.
-      if (mode === 'merge-readiness') {
+      if (mode === "merge-readiness") {
         const cancelledSessions: string[] = [];
         const blockedSessions: string[] = [];
-        const cancelActiveSession = (targetSessionId?: string): 'cancelled' | 'blocked' | 'inactive' => {
+        const cancelActiveSession = (
+          targetSessionId?: string,
+        ): "cancelled" | "blocked" | "inactive" => {
           const current = readMergeReadinessState(root, targetSessionId);
-          if (!current?.active) return 'inactive';
+          if (!current?.active) return "inactive";
           // cancelMergeReadiness fail-closes to an active blocked state when the
           // write cannot land; distinguish that from a real cancelled result so
           // the operator learns the cancel did not persist.
-          return cancelMergeReadiness(root, targetSessionId)?.result === 'cancelled' ? 'cancelled' : 'blocked';
+          return cancelMergeReadiness(root, targetSessionId)?.result ===
+            "cancelled"
+            ? "cancelled"
+            : "blocked";
         };
-        const recordResult = (sid: string, status: 'cancelled' | 'blocked' | 'inactive'): void => {
-          if (status === 'cancelled') cancelledSessions.push(sid);
-          else if (status === 'blocked') blockedSessions.push(sid);
+        const recordResult = (
+          sid: string,
+          status: "cancelled" | "blocked" | "inactive",
+        ): void => {
+          if (status === "cancelled") cancelledSessions.push(sid);
+          else if (status === "blocked") blockedSessions.push(sid);
         };
         if (sessionId) {
           validateSessionId(sessionId);
@@ -1570,26 +2155,31 @@ export const stateClearTool: ToolDefinition<{
           // Omitting session_id must not cross session boundaries: only cancel
           // the caller's own session (resolved from env) and legacy state,
           // never other sessions' active gates.
-          const callerSid = (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
-          if (callerSid) recordResult(callerSid, cancelActiveSession(callerSid));
-          recordResult('legacy', cancelActiveSession());
+          const callerSid =
+            (process.env.CLAUDE_SESSION_ID &&
+              process.env.CLAUDE_SESSION_ID.trim()) ||
+            resolveSessionId({ context: "cli" });
+          if (callerSid)
+            recordResult(callerSid, cancelActiveSession(callerSid));
+          recordResult("legacy", cancelActiveSession());
         }
         const blocked = blockedSessions.length > 0;
         const text = blocked
-          ? `Merge-readiness cancellation FAILED for: ${blockedSessions.join(', ')}. The state could not be persisted (read-only state dir / full disk); the gate(s) remain active on disk. Resolve and re-run.`
+          ? `Merge-readiness cancellation FAILED for: ${blockedSessions.join(", ")}. The state could not be persisted (read-only state dir / full disk); the gate(s) remain active on disk. Resolve and re-run.`
           : cancelledSessions.length > 0
-            ? `Cancelled merge-readiness gate(s) with durable state audit records: ${cancelledSessions.join(', ')}`
-            : 'No active merge-readiness gate found; existing state audit records were preserved.';
+            ? `Cancelled merge-readiness gate(s) with durable state audit records: ${cancelledSessions.join(", ")}`
+            : "No active merge-readiness gate found; existing state audit records were preserved.";
         return {
-          content: [{ type: 'text' as const, text }],
+          content: [{ type: "text" as const, text }],
           ...(blocked ? { isError: true } : {}),
         };
       }
-      if (mode === 'autopilot') recoverAutopilotEmergencyTransactions(root, sessionId);
+      if (mode === "autopilot")
+        recoverAutopilotEmergencyTransactions(root, sessionId);
       const cleanedTeamNames = new Set<string>();
 
       const collectTeamNamesForCleanup = (statePath: string): void => {
-        if (mode !== 'team') return;
+        if (mode !== "team") return;
         for (const teamName of readTeamNamesFromStateFile(statePath)) {
           cleanedTeamNames.add(teamName);
         }
@@ -1598,80 +2188,228 @@ export const stateClearTool: ToolDefinition<{
       // If session_id provided, clear only session-specific state
       if (sessionId) {
         validateSessionId(sessionId);
-        const requestedSessionCandidates = findSessionOwnedStateCandidates(mode, sessionId, root)
-          .filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-        const requestedSessionOwnedPaths = requestedSessionCandidates.map((candidate) => candidate.path);
-        for (const teamStatePath of findSessionOwnedStateFiles('team', sessionId, root)) {
+        const requestedSessionCandidates = findSessionOwnedStateCandidates(
+          mode,
+          sessionId,
+          root,
+        ).filter((candidate) =>
+          isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root,
+          ),
+        );
+        const requestedSessionOwnedPaths = requestedSessionCandidates.map(
+          (candidate) => candidate.path,
+        );
+        for (const teamStatePath of findSessionOwnedStateFiles(
+          "team",
+          sessionId,
+          root,
+        )) {
           collectTeamNamesForCleanup(teamStatePath);
         }
-        if (mode === 'team') {
-          for (const teamStatePath of findCompletedSessionStateFiles('team', root, sessionId)) {
+        if (mode === "team") {
+          for (const teamStatePath of findCompletedSessionStateFiles(
+            "team",
+            root,
+            sessionId,
+          )) {
             collectTeamNamesForCleanup(teamStatePath);
           }
         }
-        const completedCandidates = findCompletedSessionStateCandidates(mode, root, sessionId)
-          .filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-        const legacyCandidates = discoverStatePaths(getLegacyStateFileCandidates(mode, root)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-        const localCandidates = discoverStatePaths(getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId))
-          .filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-        const convergedCandidates = discoverStatePaths(getConvergedStateCandidates(mode, root, sessionId))
-          .filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-        const operationCandidates = [...new Map([
-          ...requestedSessionCandidates,
-          ...completedCandidates,
-          ...legacyCandidates.filter((candidate) => canClearStateForSession(candidate.state, sessionId)),
-          ...localCandidates.filter((candidate) => canClearStateForSession(candidate.state, sessionId)),
-          ...convergedCandidates.filter((candidate) => canClearStateForSession(candidate.state, sessionId)),
-        ].map((candidate) => [candidate.path, candidate])).values()];
-        const directCandidate = requestedSessionCandidates.find((candidate) => candidate.path === resolveSessionStatePath(mode, sessionId, root)) ?? requestedSessionCandidates[0];
-        const namedPrimaries = mode === 'autopilot' ? operationCandidates.filter((candidate) => hasNamedWorkflowMarker(candidate.state)) : [];
-        const namedPrimaryPaths = new Set(namedPrimaries.map((candidate) => candidate.path));
+        const completedCandidates = findCompletedSessionStateCandidates(
+          mode,
+          root,
+          sessionId,
+        ).filter((candidate) =>
+          isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root,
+          ),
+        );
+        const legacyCandidates = discoverStatePaths(
+          getLegacyStateFileCandidates(mode, root),
+        ).filter((candidate) =>
+          isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root,
+          ),
+        );
+        const localCandidates = discoverStatePaths(
+          getWorkingDirectoryLocalStateClearCandidates(mode, root, sessionId),
+        ).filter((candidate) =>
+          isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root,
+          ),
+        );
+        const convergedCandidates = discoverStatePaths(
+          getConvergedStateCandidates(mode, root, sessionId),
+        ).filter((candidate) =>
+          isStateCandidateForProject(
+            mode,
+            candidate.path,
+            candidate.state,
+            root,
+          ),
+        );
+        const operationCandidates = [
+          ...new Map(
+            [
+              ...requestedSessionCandidates,
+              ...completedCandidates,
+              ...legacyCandidates.filter((candidate) =>
+                canClearStateForSession(candidate.state, sessionId),
+              ),
+              ...localCandidates.filter((candidate) =>
+                canClearStateForSession(candidate.state, sessionId),
+              ),
+              ...convergedCandidates.filter((candidate) =>
+                canClearStateForSession(candidate.state, sessionId),
+              ),
+            ].map((candidate) => [candidate.path, candidate]),
+          ).values(),
+        ];
+        const directCandidate =
+          requestedSessionCandidates.find(
+            (candidate) =>
+              candidate.path === resolveSessionStatePath(mode, sessionId, root),
+          ) ?? requestedSessionCandidates[0];
+        const namedPrimaries =
+          mode === "autopilot"
+            ? operationCandidates.filter((candidate) =>
+                hasNamedWorkflowMarker(candidate.state),
+              )
+            : [];
+        const namedPrimaryPaths = new Set(
+          namedPrimaries.map((candidate) => candidate.path),
+        );
         let directCleared = 0;
         for (const candidate of namedPrimaries) {
           const success = clearAutopilotMarkerCandidate(candidate, root);
-          if (!success || existsSync(candidate.path)) throw new Error(`primary state mutation failed; dependent state preserved: ${candidate.path}`);
+          if (!success || existsSync(candidate.path))
+            throw new Error(
+              `primary state mutation failed; dependent state preserved: ${candidate.path}`,
+            );
           directCleared += 1;
         }
-        const completedSessionCleanup = clearCompletedSessionStateCandidates(mode, root, sessionId, completedCandidates.filter((candidate) => !namedPrimaryPaths.has(candidate.path)));
+        const completedSessionCleanup = clearCompletedSessionStateCandidates(
+          mode,
+          root,
+          sessionId,
+          completedCandidates.filter(
+            (candidate) => !namedPrimaryPaths.has(candidate.path),
+          ),
+        );
         const runtimeCleanup = clearModeRuntimeArtifacts(mode, root, sessionId);
-        let convergedCleanup = { cleared: 0, hadFailure: false, paths: [] as string[] };
-        const sessionSignalCandidates = operationCandidates.filter((candidate) => !hasNamedWorkflowMarker(candidate.state));
+        let convergedCleanup = {
+          cleared: 0,
+          hadFailure: false,
+          paths: [] as string[],
+        };
+        const sessionSignalCandidates = operationCandidates.filter(
+          (candidate) => !hasNamedWorkflowMarker(candidate.state),
+        );
         const signaledCandidateDirs = new Set<string>();
         for (const candidate of sessionSignalCandidates) {
           const signalDir = dirname(candidate.path);
           if (signaledCandidateDirs.has(signalDir)) continue;
           signaledCandidateDirs.add(signalDir);
           const now = Date.now();
-          const signalPath = join(signalDir, 'cancel-signal-state.json');
+          const signalPath = join(signalDir, "cancel-signal-state.json");
           const payload = {
             active: true,
             requested_at: new Date(now).toISOString(),
             expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
             mode,
-            source: 'state_clear' as const,
-            ...(candidate.workflowRunId ? { target_workflow_run_id: candidate.workflowRunId } : {}),
-            target_state_sha256: createHash('sha256').update(candidate.snapshot).digest('hex'),
+            source: "state_clear" as const,
+            ...(candidate.workflowRunId
+              ? { target_workflow_run_id: candidate.workflowRunId }
+              : {}),
+            target_state_sha256: createHash("sha256")
+              .update(candidate.snapshot)
+              .digest("hex"),
           };
-          try { writeStateFileLocked(signalPath, payload); } catch { /* best-effort */ }
+          try {
+            writeStateFileLocked(signalPath, payload);
+          } catch {
+            /* best-effort */
+          }
         }
-        if (sessionSignalCandidates.length === 0 && namedPrimaries.length === 0) writeSessionCancelSignal(root, sessionId, mode, directCandidate);
+        if (sessionSignalCandidates.length === 0 && namedPrimaries.length === 0)
+          writeSessionCancelSignal(root, sessionId, mode, directCandidate);
 
         if (MODE_CONFIGS[mode as ExecutionMode]) {
           const expectedDirectState = directCandidate?.state;
-          const success = clearModeState(mode as ExecutionMode, root, sessionId, expectedDirectState);
-          if (directCandidate && !existsSync(directCandidate.path)) directCleared = 1;
-          const sessionCleanup = clearSessionOwnedStateCandidates(mode, root, sessionId, requestedSessionCandidates);
-          const legacyCleanup = clearLegacyStateCandidates(mode, root, sessionId, legacyCandidates);
-          const shouldUseLocalFallback = requestedSessionOwnedPaths.length === 0 &&
+          const registryClearResult = clearModeState(
+            mode as ExecutionMode,
+            root,
+            sessionId,
+            expectedDirectState,
+          );
+          // A CAS skip means the canonical path now belongs to a newer run. Do
+          // not feed that path into the discovery cleanups below.
+          const skippedCanonicalPaths = new Set(
+            registryClearResult === "skipped" && directCandidate
+              ? [directCandidate.path]
+              : [],
+          );
+          const success = registryClearResult === "cleared";
+          if (directCandidate && !existsSync(directCandidate.path))
+            directCleared = 1;
+          const sessionCleanup = clearSessionOwnedStateCandidates(
+            mode,
+            root,
+            sessionId,
+            requestedSessionCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path),
+            ),
+          );
+          const legacyCleanup = clearLegacyStateCandidates(
+            mode,
+            root,
+            sessionId,
+            legacyCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path),
+            ),
+          );
+          const shouldUseLocalFallback =
+            requestedSessionOwnedPaths.length === 0 &&
             completedSessionCleanup.cleared === 0 &&
             sessionCleanup.cleared === 0 &&
             legacyCleanup.cleared === 0;
           const workingDirectoryLocalCleanup = shouldUseLocalFallback
-            ? clearWorkingDirectoryLocalStateCandidates(mode, root, sessionId, localCandidates)
+            ? clearWorkingDirectoryLocalStateCandidates(
+                mode,
+                root,
+                sessionId,
+                localCandidates.filter(
+                  (candidate) => !skippedCanonicalPaths.has(candidate.path),
+                ),
+              )
             : { cleared: 0, hadFailure: false, paths: [] as string[] };
-          convergedCleanup = clearConvergedStateCandidates(mode, root, sessionId, convergedCandidates);
+          convergedCleanup = clearConvergedStateCandidates(
+            mode,
+            root,
+            sessionId,
+            convergedCandidates.filter(
+              (candidate) => !skippedCanonicalPaths.has(candidate.path),
+            ),
+          );
           let ownerSessionId: string | undefined;
-          let ownerSessionCleanup = { cleared: 0, hadFailure: false, paths: [] as string[] };
+          let ownerSessionCleanup = {
+            cleared: 0,
+            hadFailure: false,
+            paths: [] as string[],
+          };
           let ownerLegacyCleanup = { cleared: 0, hadFailure: false };
 
           if (
@@ -1685,65 +2423,152 @@ export const stateClearTool: ToolDefinition<{
             convergedCleanup.cleared === 0 &&
             workingDirectoryLocalCleanup.cleared === 0
           ) {
-            ownerSessionId = findSingleOwningSessionForMode(mode, root, sessionId);
+            ownerSessionId = findSingleOwningSessionForMode(
+              mode,
+              root,
+              sessionId,
+            );
             if (ownerSessionId) {
-              if (mode === 'team') {
-                for (const teamStatePath of findSessionOwnedStateFiles('team', ownerSessionId, root)) {
+              if (mode === "team") {
+                for (const teamStatePath of findSessionOwnedStateFiles(
+                  "team",
+                  ownerSessionId,
+                  root,
+                )) {
                   collectTeamNamesForCleanup(teamStatePath);
                 }
               }
-              const ownerCandidates = findSessionOwnedStateCandidates(mode, ownerSessionId, root);
-              const ownerDirectCandidate = ownerCandidates.find((candidate) => candidate.path === resolveSessionStatePath(mode, ownerSessionId!, root)) ?? ownerCandidates[0];
-              const ownerNamedPrimary = mode === 'autopilot' && ownerDirectCandidate && hasNamedWorkflowMarker(ownerDirectCandidate.state) ? ownerDirectCandidate : undefined;
+              const ownerCandidates = findSessionOwnedStateCandidates(
+                mode,
+                ownerSessionId,
+                root,
+              );
+              const ownerDirectCandidate =
+                ownerCandidates.find(
+                  (candidate) =>
+                    candidate.path ===
+                    resolveSessionStatePath(mode, ownerSessionId!, root),
+                ) ?? ownerCandidates[0];
+              const ownerNamedPrimary =
+                mode === "autopilot" &&
+                ownerDirectCandidate &&
+                hasNamedWorkflowMarker(ownerDirectCandidate.state)
+                  ? ownerDirectCandidate
+                  : undefined;
               if (ownerNamedPrimary) {
-                const success = clearAutopilotMarkerCandidate(ownerNamedPrimary, root);
-                if (!success || existsSync(ownerNamedPrimary.path)) throw new Error('primary state mutation failed; dependent state preserved');
+                const success = clearAutopilotMarkerCandidate(
+                  ownerNamedPrimary,
+                  root,
+                );
+                if (!success || existsSync(ownerNamedPrimary.path))
+                  throw new Error(
+                    "primary state mutation failed; dependent state preserved",
+                  );
               } else {
-                writeSessionCancelSignal(root, ownerSessionId, mode, ownerDirectCandidate);
-                clearModeState(mode as ExecutionMode, root, ownerSessionId, ownerDirectCandidate?.state);
+                writeSessionCancelSignal(
+                  root,
+                  ownerSessionId,
+                  mode,
+                  ownerDirectCandidate,
+                );
+                const ownerClearResult = clearModeState(
+                  mode as ExecutionMode,
+                  root,
+                  ownerSessionId,
+                  ownerDirectCandidate?.state,
+                );
+                const skippedOwnerCanonicalPath =
+                  ownerClearResult === "skipped"
+                    ? ownerDirectCandidate?.path
+                    : undefined;
+                ownerSessionCleanup = clearSessionOwnedStateCandidates(
+                  mode,
+                  root,
+                  ownerSessionId,
+                  ownerCandidates.filter(
+                    (candidate) => candidate.path !== skippedOwnerCanonicalPath,
+                  ),
+                );
+                ownerLegacyCleanup = clearLegacyStateCandidates(
+                  mode,
+                  root,
+                  ownerSessionId,
+                );
               }
-              const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root, ownerSessionId);
+              const ownerRuntimeCleanup = clearModeRuntimeArtifacts(
+                mode,
+                root,
+                ownerSessionId,
+              );
               runtimeCleanup.cleared += ownerRuntimeCleanup.cleared;
               runtimeCleanup.hadFailure ||= ownerRuntimeCleanup.hadFailure;
-              ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId, ownerCandidates.filter((candidate) => candidate.path !== ownerNamedPrimary?.path));
-              ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
+              if (ownerNamedPrimary) {
+                ownerSessionCleanup = clearSessionOwnedStateCandidates(
+                  mode,
+                  root,
+                  ownerSessionId,
+                  ownerCandidates.filter(
+                    (candidate) => candidate.path !== ownerNamedPrimary.path,
+                  ),
+                );
+                ownerLegacyCleanup = clearLegacyStateCandidates(
+                  mode,
+                  root,
+                  ownerSessionId,
+                );
+              }
             }
           }
 
           const ghostNoteParts: string[] = [];
           if (legacyCleanup.cleared > 0) {
-            ghostNoteParts.push('ghost legacy file also removed');
+            ghostNoteParts.push("ghost legacy file also removed");
           }
           if (completedSessionCleanup.cleared > 0) {
-            ghostNoteParts.push(`removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? '' : 's'}`);
+            ghostNoteParts.push(
+              `removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? "" : "s"}`,
+            );
           }
           if (sessionCleanup.cleared > 0) {
-            ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+            ghostNoteParts.push(
+              `removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? "" : "s"}`,
+            );
           }
           if (workingDirectoryLocalCleanup.cleared > 0) {
-            ghostNoteParts.push(`removed ${workingDirectoryLocalCleanup.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup.cleared === 1 ? '' : 's'}`);
+            ghostNoteParts.push(
+              `removed ${workingDirectoryLocalCleanup.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup.cleared === 1 ? "" : "s"}`,
+            );
           }
           if (convergedCleanup.cleared > 0) {
-            ghostNoteParts.push(`removed ${convergedCleanup.cleared} converged state file${convergedCleanup.cleared === 1 ? '' : 's'}`);
+            ghostNoteParts.push(
+              `removed ${convergedCleanup.cleared} converged state file${convergedCleanup.cleared === 1 ? "" : "s"}`,
+            );
           }
           if (runtimeCleanup.cleared > 0) {
-            ghostNoteParts.push(`removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? '' : 's'}`);
+            ghostNoteParts.push(
+              `removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? "" : "s"}`,
+            );
           }
           if (ownerSessionId) {
             ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
           }
-          const ghostNote = ghostNoteParts.length > 0 ? ` (${ghostNoteParts.join(', ')})` : '';
+          const ghostNote =
+            ghostNoteParts.length > 0 ? ` (${ghostNoteParts.join(", ")})` : "";
           const runtimeCleanupNote = (() => {
-            if (mode !== 'team') return '';
+            if (mode !== "team") return "";
             const teamNames = [...cleanedTeamNames];
             const removedRoots = cleanupTeamRuntimeState(root, teamNames);
             const prunedMissions = pruneMissionBoardTeams(root, teamNames);
             const details: string[] = [];
-            if (removedRoots > 0) details.push(`removed ${removedRoots} team runtime root(s)`);
-            if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
-            return details.length > 0 ? ` (${details.join(', ')})` : '';
+            if (removedRoots > 0)
+              details.push(`removed ${removedRoots} team runtime root(s)`);
+            if (prunedMissions > 0)
+              details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
+            return details.length > 0 ? ` (${details.join(", ")})` : "";
           })();
-          const clearedStateOrArtifacts = directCleared + completedSessionCleanup.cleared +
+          const clearedStateOrArtifacts =
+            directCleared +
+            completedSessionCleanup.cleared +
             sessionCleanup.cleared +
             legacyCleanup.cleared +
             convergedCleanup.cleared +
@@ -1751,8 +2576,13 @@ export const stateClearTool: ToolDefinition<{
             ownerSessionCleanup.cleared +
             ownerLegacyCleanup.cleared +
             runtimeCleanup.cleared;
-          const capturedCleanupIncomplete = operationCandidates.some((candidate) => existsSync(candidate.path));
-          if (!ownerSessionId && clearedStateOrArtifacts === 0 && success &&
+          const capturedCleanupIncomplete = operationCandidates.some(
+            (candidate) => existsSync(candidate.path),
+          );
+          if (
+            !ownerSessionId &&
+            clearedStateOrArtifacts === 0 &&
+            success &&
             !capturedCleanupIncomplete &&
             !legacyCleanup.hadFailure &&
             !sessionCleanup.hadFailure &&
@@ -1764,10 +2594,12 @@ export const stateClearTool: ToolDefinition<{
             !runtimeCleanup.hadFailure
           ) {
             return {
-              content: [{
-                type: 'text' as const,
-                text: formatStateClearNoopMessage(mode, root, sessionId)
-              }]
+              content: [
+                {
+                  type: "text" as const,
+                  text: formatStateClearNoopMessage(mode, root, sessionId),
+                },
+              ],
             };
           }
           if (
@@ -1783,35 +2615,64 @@ export const stateClearTool: ToolDefinition<{
             !runtimeCleanup.hadFailure
           ) {
             return {
-              content: [{
-                type: 'text' as const,
-                text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
-              }]
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Successfully cleared state for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`,
+                },
+              ],
             };
           } else {
             return {
-              content: [{
-                type: 'text' as const,
-                text: `Warning: Some files could not be removed for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
-              }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Warning: Some files could not be removed for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`,
+                },
+              ],
               isError: true,
             };
           }
         }
 
         // Fallback for modes not in registry (e.g., ralplan)
-        const sessionCleanup = clearSessionOwnedStateCandidates(mode, root, sessionId, requestedSessionCandidates);
-        const legacyCleanup = clearLegacyStateCandidates(mode, root, sessionId, legacyCandidates);
-        const shouldUseLocalFallback = requestedSessionOwnedPaths.length === 0 &&
+        const sessionCleanup = clearSessionOwnedStateCandidates(
+          mode,
+          root,
+          sessionId,
+          requestedSessionCandidates,
+        );
+        const legacyCleanup = clearLegacyStateCandidates(
+          mode,
+          root,
+          sessionId,
+          legacyCandidates,
+        );
+        const shouldUseLocalFallback =
+          requestedSessionOwnedPaths.length === 0 &&
           completedSessionCleanup.cleared === 0 &&
           sessionCleanup.cleared === 0 &&
           legacyCleanup.cleared === 0;
         const workingDirectoryLocalCleanup = shouldUseLocalFallback
-          ? clearWorkingDirectoryLocalStateCandidates(mode, root, sessionId, localCandidates)
+          ? clearWorkingDirectoryLocalStateCandidates(
+              mode,
+              root,
+              sessionId,
+              localCandidates,
+            )
           : { cleared: 0, hadFailure: false, paths: [] as string[] };
-        convergedCleanup = clearConvergedStateCandidates(mode, root, sessionId, convergedCandidates);
+        convergedCleanup = clearConvergedStateCandidates(
+          mode,
+          root,
+          sessionId,
+          convergedCandidates,
+        );
         let ownerSessionId: string | undefined;
-        let ownerSessionCleanup = { cleared: 0, hadFailure: false, paths: [] as string[] };
+        let ownerSessionCleanup = {
+          cleared: 0,
+          hadFailure: false,
+          paths: [] as string[],
+        };
         let ownerLegacyCleanup = { cleared: 0, hadFailure: false };
 
         if (
@@ -1825,61 +2686,116 @@ export const stateClearTool: ToolDefinition<{
           convergedCleanup.cleared === 0 &&
           workingDirectoryLocalCleanup.cleared === 0
         ) {
-          ownerSessionId = findSingleOwningSessionForMode(mode, root, sessionId);
+          ownerSessionId = findSingleOwningSessionForMode(
+            mode,
+            root,
+            sessionId,
+          );
           if (ownerSessionId) {
-            if (mode === 'team') {
-              for (const teamStatePath of findSessionOwnedStateFiles('team', ownerSessionId, root)) {
+            if (mode === "team") {
+              for (const teamStatePath of findSessionOwnedStateFiles(
+                "team",
+                ownerSessionId,
+                root,
+              )) {
                 collectTeamNamesForCleanup(teamStatePath);
               }
             }
-            const ownerCandidates = findSessionOwnedStateCandidates(mode, ownerSessionId, root);
-            if (mode === 'autopilot' && ownerCandidates.some((candidate) => hasNamedWorkflowMarker(candidate.state)) && !namedWorkflowRuntimeSupported()) {
-              throw new Error('unsupported-runtime');
+            const ownerCandidates = findSessionOwnedStateCandidates(
+              mode,
+              ownerSessionId,
+              root,
+            );
+            if (
+              mode === "autopilot" &&
+              ownerCandidates.some((candidate) =>
+                hasNamedWorkflowMarker(candidate.state),
+              ) &&
+              !namedWorkflowRuntimeSupported()
+            ) {
+              throw new Error("unsupported-runtime");
             }
-            const ownerDirectCandidate = ownerCandidates.find((candidate) => candidate.path === resolveSessionStatePath(mode, ownerSessionId!, root)) ?? ownerCandidates[0];
-            writeSessionCancelSignal(root, ownerSessionId, mode, ownerDirectCandidate);
-            const ownerRuntimeCleanup = clearModeRuntimeArtifacts(mode, root, ownerSessionId);
+            const ownerDirectCandidate =
+              ownerCandidates.find(
+                (candidate) =>
+                  candidate.path ===
+                  resolveSessionStatePath(mode, ownerSessionId!, root),
+              ) ?? ownerCandidates[0];
+            writeSessionCancelSignal(
+              root,
+              ownerSessionId,
+              mode,
+              ownerDirectCandidate,
+            );
+            const ownerRuntimeCleanup = clearModeRuntimeArtifacts(
+              mode,
+              root,
+              ownerSessionId,
+            );
             runtimeCleanup.cleared += ownerRuntimeCleanup.cleared;
             runtimeCleanup.hadFailure ||= ownerRuntimeCleanup.hadFailure;
-            ownerSessionCleanup = clearSessionOwnedStateCandidates(mode, root, ownerSessionId, ownerCandidates);
-            ownerLegacyCleanup = clearLegacyStateCandidates(mode, root, ownerSessionId);
+            ownerSessionCleanup = clearSessionOwnedStateCandidates(
+              mode,
+              root,
+              ownerSessionId,
+              ownerCandidates,
+            );
+            ownerLegacyCleanup = clearLegacyStateCandidates(
+              mode,
+              root,
+              ownerSessionId,
+            );
           }
         }
 
         const ghostNoteParts: string[] = [];
         if (legacyCleanup.cleared > 0) {
-          ghostNoteParts.push('ghost legacy file also removed');
+          ghostNoteParts.push("ghost legacy file also removed");
         }
         if (completedSessionCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? '' : 's'}`);
+          ghostNoteParts.push(
+            `removed ${completedSessionCleanup.cleared} completed-session orphan file${completedSessionCleanup.cleared === 1 ? "" : "s"}`,
+          );
         }
         if (sessionCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? '' : 's'}`);
+          ghostNoteParts.push(
+            `removed ${sessionCleanup.cleared} recovered session file${sessionCleanup.cleared === 1 ? "" : "s"}`,
+          );
         }
         if (workingDirectoryLocalCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${workingDirectoryLocalCleanup.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup.cleared === 1 ? '' : 's'}`);
+          ghostNoteParts.push(
+            `removed ${workingDirectoryLocalCleanup.cleared} workingDirectory-local state file${workingDirectoryLocalCleanup.cleared === 1 ? "" : "s"}`,
+          );
         }
         if (convergedCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${convergedCleanup.cleared} converged state file${convergedCleanup.cleared === 1 ? '' : 's'}`);
+          ghostNoteParts.push(
+            `removed ${convergedCleanup.cleared} converged state file${convergedCleanup.cleared === 1 ? "" : "s"}`,
+          );
         }
         if (runtimeCleanup.cleared > 0) {
-          ghostNoteParts.push(`removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? '' : 's'}`);
+          ghostNoteParts.push(
+            `removed ${runtimeCleanup.cleared} runtime artifact${runtimeCleanup.cleared === 1 ? "" : "s"}`,
+          );
         }
         if (ownerSessionId) {
           ghostNoteParts.push(`cleared owning session: ${ownerSessionId}`);
         }
-        const ghostNote = ghostNoteParts.length > 0 ? ` (${ghostNoteParts.join(', ')})` : '';
+        const ghostNote =
+          ghostNoteParts.length > 0 ? ` (${ghostNoteParts.join(", ")})` : "";
         const runtimeCleanupNote = (() => {
-          if (mode !== 'team') return '';
+          if (mode !== "team") return "";
           const teamNames = [...cleanedTeamNames];
           const removedRoots = cleanupTeamRuntimeState(root, teamNames);
           const prunedMissions = pruneMissionBoardTeams(root, teamNames);
           const details: string[] = [];
-          if (removedRoots > 0) details.push(`removed ${removedRoots} team runtime root(s)`);
-          if (prunedMissions > 0) details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
-          return details.length > 0 ? ` (${details.join(', ')})` : '';
+          if (removedRoots > 0)
+            details.push(`removed ${removedRoots} team runtime root(s)`);
+          if (prunedMissions > 0)
+            details.push(`pruned ${prunedMissions} HUD mission entry(ies)`);
+          return details.length > 0 ? ` (${details.join(", ")})` : "";
         })();
-        const clearedStateOrArtifacts = completedSessionCleanup.cleared +
+        const clearedStateOrArtifacts =
+          completedSessionCleanup.cleared +
           sessionCleanup.cleared +
           legacyCleanup.cleared +
           convergedCleanup.cleared +
@@ -1887,24 +2803,36 @@ export const stateClearTool: ToolDefinition<{
           ownerSessionCleanup.cleared +
           ownerLegacyCleanup.cleared +
           runtimeCleanup.cleared;
-        const capturedCleanupIncomplete = operationCandidates.some((candidate) => existsSync(candidate.path));
-        const hadFailure = capturedCleanupIncomplete || legacyCleanup.hadFailure || sessionCleanup.hadFailure ||
-          workingDirectoryLocalCleanup.hadFailure || convergedCleanup.hadFailure ||
-          completedSessionCleanup.hadFailure || ownerSessionCleanup.hadFailure ||
-          ownerLegacyCleanup.hadFailure || runtimeCleanup.hadFailure;
+        const capturedCleanupIncomplete = operationCandidates.some(
+          (candidate) => existsSync(candidate.path),
+        );
+        const hadFailure =
+          capturedCleanupIncomplete ||
+          legacyCleanup.hadFailure ||
+          sessionCleanup.hadFailure ||
+          workingDirectoryLocalCleanup.hadFailure ||
+          convergedCleanup.hadFailure ||
+          completedSessionCleanup.hadFailure ||
+          ownerSessionCleanup.hadFailure ||
+          ownerLegacyCleanup.hadFailure ||
+          runtimeCleanup.hadFailure;
         if (!ownerSessionId && clearedStateOrArtifacts === 0 && !hadFailure) {
           return {
-            content: [{
-              type: 'text' as const,
-              text: formatStateClearNoopMessage(mode, root, sessionId)
-            }]
+            content: [
+              {
+                type: "text" as const,
+                text: formatStateClearNoopMessage(mode, root, sessionId),
+              },
+            ],
           };
         }
         return {
-          content: [{
-            type: 'text' as const,
-            text: `${hadFailure ? 'Warning: Some files could not be removed' : 'Successfully cleared state'} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: `${hadFailure ? "Warning: Some files could not be removed" : "Successfully cleared state"} for mode: ${mode} in session: ${sessionId}${ghostNote}${runtimeCleanupNote}`,
+            },
+          ],
           ...(hadFailure ? { isError: true } : {}),
         };
       }
@@ -1913,92 +2841,186 @@ export const stateClearTool: ToolDefinition<{
       // Write cancel signals FIRST (before deleting files) so the stop hook's
       // isSessionCancelInProgress check sees the signal during the deletion window.
       // Mirrors the session_id path at line ~403. (patch: fix missing cancel signal)
-      const broadLegacyCandidates = discoverStatePaths(getLegacyStateFileCandidates(mode, root)).filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-      const broadSessionCandidates = [...new Map([
-        ...listSessionIds(root).flatMap((sid) => findSessionOwnedStateCandidates(mode, sid, root)),
-        ...discoverAllRootSessionStateCandidates(mode, root),
-      ].map((candidate) => [candidate.path, candidate])).values()]
-        .filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-      const broadConvergedCandidates = discoverStatePaths(getConvergedStateCandidates(mode, root))
-        .filter((candidate) => isStateCandidateForProject(mode, candidate.path, candidate.state, root));
-      const broadOperationCandidates = [...new Map([
-        ...broadLegacyCandidates,
-        ...broadSessionCandidates,
-        ...broadConvergedCandidates,
-      ].map((candidate) => [candidate.path, candidate])).values()];
-      const broadNamedPrimaries = mode === 'autopilot' ? broadOperationCandidates.filter((candidate) => hasNamedWorkflowMarker(candidate.state)) : [];
+      const broadLegacyCandidates = discoverStatePaths(
+        getLegacyStateFileCandidates(mode, root),
+      ).filter((candidate) =>
+        isStateCandidateForProject(mode, candidate.path, candidate.state, root),
+      );
+      const broadSessionCandidates = [
+        ...new Map(
+          [
+            ...listSessionIds(root).flatMap((sid) =>
+              findSessionOwnedStateCandidates(mode, sid, root),
+            ),
+            ...discoverAllRootSessionStateCandidates(mode, root),
+          ].map((candidate) => [candidate.path, candidate]),
+        ).values(),
+      ].filter((candidate) =>
+        isStateCandidateForProject(mode, candidate.path, candidate.state, root),
+      );
+      const broadConvergedCandidates = discoverStatePaths(
+        getConvergedStateCandidates(mode, root),
+      ).filter((candidate) =>
+        isStateCandidateForProject(mode, candidate.path, candidate.state, root),
+      );
+      const broadOperationCandidates = [
+        ...new Map(
+          [
+            ...broadLegacyCandidates,
+            ...broadSessionCandidates,
+            ...broadConvergedCandidates,
+          ].map((candidate) => [candidate.path, candidate]),
+        ).values(),
+      ];
+      const broadNamedPrimaries =
+        mode === "autopilot"
+          ? broadOperationCandidates.filter((candidate) =>
+              hasNamedWorkflowMarker(candidate.state),
+            )
+          : [];
       for (const candidate of broadNamedPrimaries) {
         const success = clearAutopilotMarkerCandidate(candidate, root);
-        if (!success || existsSync(candidate.path)) throw new Error(`primary state mutation failed; dependent state preserved: ${candidate.path}`);
+        if (!success || existsSync(candidate.path))
+          throw new Error(
+            `primary state mutation failed; dependent state preserved: ${candidate.path}`,
+          );
       }
-      const broadLegacySignalCandidates = broadLegacyCandidates.filter((candidate) => !hasNamedWorkflowMarker(candidate.state));
-      const broadSessionSignalCandidates = broadSessionCandidates.filter((candidate) => !hasNamedWorkflowMarker(candidate.state));
-      if (broadLegacySignalCandidates.length > 0 || broadSessionSignalCandidates.length > 0) {
+      const broadLegacySignalCandidates = broadLegacyCandidates.filter(
+        (candidate) => !hasNamedWorkflowMarker(candidate.state),
+      );
+      const broadSessionSignalCandidates = broadSessionCandidates.filter(
+        (candidate) => !hasNamedWorkflowMarker(candidate.state),
+      );
+      if (
+        broadLegacySignalCandidates.length > 0 ||
+        broadSessionSignalCandidates.length > 0
+      ) {
         const now = Date.now();
         const cancelSignalPayload = {
           active: true,
           requested_at: new Date(now).toISOString(),
           expires_at: new Date(now + CANCEL_SIGNAL_TTL_MS).toISOString(),
           mode,
-          source: 'state_clear' as const,
+          source: "state_clear" as const,
         };
         const signaledLegacyDirs = new Set<string>();
         for (const legacyCandidate of broadLegacySignalCandidates) {
           const signalDir = dirname(legacyCandidate.path);
           if (signaledLegacyDirs.has(signalDir)) continue;
           signaledLegacyDirs.add(signalDir);
-          const legacySignalPath = join(signalDir, 'cancel-signal-state.json');
+          const legacySignalPath = join(signalDir, "cancel-signal-state.json");
           const legacyPayload = {
             ...cancelSignalPayload,
-            ...(legacyCandidate.workflowRunId ? { target_workflow_run_id: legacyCandidate.workflowRunId } : {}),
-            target_state_sha256: createHash('sha256').update(legacyCandidate.snapshot).digest('hex'),
+            ...(legacyCandidate.workflowRunId
+              ? { target_workflow_run_id: legacyCandidate.workflowRunId }
+              : {}),
+            target_state_sha256: createHash("sha256")
+              .update(legacyCandidate.snapshot)
+              .digest("hex"),
           };
-          try { writeStateFileLocked(legacySignalPath, legacyPayload); } catch { /* best-effort */ }
+          try {
+            writeStateFileLocked(legacySignalPath, legacyPayload);
+          } catch {
+            /* best-effort */
+          }
         }
         const signaledOwners = new Set<string>();
         for (const candidate of broadSessionSignalCandidates) {
           const owner = candidate.ownerSessionId;
           if (!owner || signaledOwners.has(owner)) continue;
           signaledOwners.add(owner);
-          try { writeSessionCancelSignal(root, owner, mode, candidate); } catch { /* best-effort */ }
+          try {
+            writeSessionCancelSignal(root, owner, mode, candidate);
+          } catch {
+            /* best-effort */
+          }
         }
       }
       const runtimeCleanup = clearModeRuntimeArtifacts(mode, root);
       let clearedCount = 0;
       const errors: string[] = [];
-      if (mode === 'team') {
-        collectTeamNamesForCleanup(getStateFilePath(root, 'team'));
+      if (mode === "team") {
+        collectTeamNamesForCleanup(getStateFilePath(root, "team"));
       }
 
       // Clear legacy path
       if (MODE_CONFIGS[mode as ExecutionMode]) {
-        const primaryLegacyStatePath = getStateFilePath(root, mode as ExecutionMode);
-        const primaryCandidate = broadLegacyCandidates.find((candidate) => candidate.path === primaryLegacyStatePath);
+        const primaryLegacyStatePath = getStateFilePath(
+          root,
+          mode as ExecutionMode,
+        );
+        const primaryCandidate = broadLegacyCandidates.find(
+          (candidate) => candidate.path === primaryLegacyStatePath,
+        );
+        const skippedCanonicalPaths = new Set<string>();
         if (primaryCandidate) {
-          const success = clearModeState(mode as ExecutionMode, root, undefined, primaryCandidate.state);
-          if (success && !existsSync(primaryCandidate.path)) {
+          const clearResult = clearModeState(
+            mode as ExecutionMode,
+            root,
+            undefined,
+            primaryCandidate.state,
+          );
+          if (clearResult === "cleared" && !existsSync(primaryCandidate.path)) {
             clearedCount++;
+          } else if (clearResult === "skipped") {
+            skippedCanonicalPaths.add(primaryCandidate.path);
+            errors.push("legacy path skipped");
           } else if (existsSync(primaryCandidate.path)) {
-            errors.push('legacy path skipped');
-          } else if (!success) {
-            errors.push('legacy path');
+            errors.push("legacy path skipped");
+          } else if (clearResult === "failed") {
+            errors.push("legacy path");
           }
         }
-      }
 
-      const extraLegacyCleanup = clearLegacyStateCandidates(mode, root, undefined, broadLegacyCandidates);
-      clearedCount += extraLegacyCleanup.cleared;
-      if (extraLegacyCleanup.hadFailure) {
-        errors.push('legacy path');
-      }
-      const convergedCleanup = clearConvergedStateCandidates(mode, root, undefined, broadConvergedCandidates);
-      clearedCount += convergedCleanup.cleared;
-      if (convergedCleanup.hadFailure) {
-        errors.push('converged paths');
+        const extraLegacyCleanup = clearLegacyStateCandidates(
+          mode,
+          root,
+          undefined,
+          broadLegacyCandidates.filter(
+            (candidate) => !skippedCanonicalPaths.has(candidate.path),
+          ),
+        );
+        clearedCount += extraLegacyCleanup.cleared;
+        if (extraLegacyCleanup.hadFailure) {
+          errors.push("legacy path");
+        }
+        const convergedCleanup = clearConvergedStateCandidates(
+          mode,
+          root,
+          undefined,
+          broadConvergedCandidates.filter(
+            (candidate) => !skippedCanonicalPaths.has(candidate.path),
+          ),
+        );
+        clearedCount += convergedCleanup.cleared;
+        if (convergedCleanup.hadFailure) {
+          errors.push("converged paths");
+        }
+      } else {
+        const extraLegacyCleanup = clearLegacyStateCandidates(
+          mode,
+          root,
+          undefined,
+          broadLegacyCandidates,
+        );
+        clearedCount += extraLegacyCleanup.cleared;
+        if (extraLegacyCleanup.hadFailure) {
+          errors.push("legacy path");
+        }
+        const convergedCleanup = clearConvergedStateCandidates(
+          mode,
+          root,
+          undefined,
+          broadConvergedCandidates,
+        );
+        clearedCount += convergedCleanup.cleared;
+        if (convergedCleanup.hadFailure) {
+          errors.push("converged paths");
+        }
       }
       clearedCount += runtimeCleanup.cleared;
       if (runtimeCleanup.hadFailure) {
-        errors.push('runtime artifacts');
+        errors.push("runtime artifacts");
       }
       const processedBroadPaths = new Set([
         ...broadLegacyCandidates.map((candidate) => candidate.path),
@@ -2009,49 +3031,71 @@ export const stateClearTool: ToolDefinition<{
       for (const candidate of broadSessionCandidates) {
         if (processedBroadPaths.has(candidate.path)) continue;
         processedBroadPaths.add(candidate.path);
-        if (mode === 'team') collectTeamNamesForCleanup(candidate.path);
-        const result = clearDiscoveredStateCandidate(candidate, (current) => isStateCandidateForProject(mode, candidate.path, current, root), emergencyRecoveryOptionsForProject(mode, candidate.path, root));
-        if (result === 'cleared') {
+        if (mode === "team") collectTeamNamesForCleanup(candidate.path);
+        const result = clearDiscoveredStateCandidate(
+          candidate,
+          (current) =>
+            isStateCandidateForProject(mode, candidate.path, current, root),
+          emergencyRecoveryOptionsForProject(mode, candidate.path, root),
+        );
+        if (result === "cleared") {
           clearedCount++;
-        } else if (result === 'failed' || existsSync(candidate.path)) {
+        } else if (result === "failed" || existsSync(candidate.path)) {
           errors.push(`session candidate: ${candidate.path}`);
         }
       }
-      const broadCapturedCandidates = [...new Map([
-        ...broadLegacyCandidates,
-        ...broadConvergedCandidates,
-        ...broadSessionCandidates,
-      ].map((candidate) => [candidate.path, candidate])).values()];
+      const broadCapturedCandidates = [
+        ...new Map(
+          [
+            ...broadLegacyCandidates,
+            ...broadConvergedCandidates,
+            ...broadSessionCandidates,
+          ].map((candidate) => [candidate.path, candidate]),
+        ).values(),
+      ];
       for (const candidate of broadCapturedCandidates) {
-        if (existsSync(candidate.path) && !errors.some((error) => error.includes(candidate.path))) {
+        if (
+          existsSync(candidate.path) &&
+          !errors.some((error) => error.includes(candidate.path))
+        ) {
           errors.push(`captured candidate survived: ${candidate.path}`);
         }
       }
-      clearedCount = broadCapturedCandidates.filter((candidate) => !existsSync(candidate.path)).length + runtimeCleanup.cleared;
+      clearedCount =
+        broadCapturedCandidates.filter(
+          (candidate) => !existsSync(candidate.path),
+        ).length + runtimeCleanup.cleared;
 
       let removedTeamRoots = 0;
       let prunedMissionEntries = 0;
-      if (mode === 'team') {
+      if (mode === "team") {
         const teamNames = [...cleanedTeamNames];
         const removeSelector = teamNames.length > 0 ? teamNames : undefined;
         removedTeamRoots = cleanupTeamRuntimeState(root, removeSelector);
         prunedMissionEntries = pruneMissionBoardTeams(root, removeSelector);
       }
 
-      if (clearedCount === 0 && errors.length === 0 && removedTeamRoots === 0 && prunedMissionEntries === 0) {
+      if (
+        clearedCount === 0 &&
+        errors.length === 0 &&
+        removedTeamRoots === 0 &&
+        prunedMissionEntries === 0
+      ) {
         return {
-          content: [{
-            type: 'text' as const,
-            text: formatStateClearNoopMessage(mode, root)
-          }]
+          content: [
+            {
+              type: "text" as const,
+              text: formatStateClearNoopMessage(mode, root),
+            },
+          ],
         };
       }
 
       let message = `Cleared state for mode: ${mode}\n- Locations cleared: ${clearedCount}`;
       if (errors.length > 0) {
-        message += `\n- Errors: ${errors.join(', ')}`;
+        message += `\n- Errors: ${errors.join(", ")}`;
       }
-      if (mode === 'team') {
+      if (mode === "team") {
         if (removedTeamRoots > 0) {
           message += `\n- Team runtime roots removed: ${removedTeamRoots}`;
         }
@@ -2059,25 +3103,30 @@ export const stateClearTool: ToolDefinition<{
           message += `\n- HUD mission entries pruned: ${prunedMissionEntries}`;
         }
       }
-      message += '\nWARNING: No session_id provided. Cleared legacy plus all session-scoped state; this is a broad operation that may affect other sessions.';
+      message +=
+        "\nWARNING: No session_id provided. Cleared legacy plus all session-scoped state; this is a broad operation that may affect other sessions.";
 
       return {
-        content: [{
-          type: 'text' as const,
-          text: message
-        }],
-        ...(errors.length > 0 ? { isError: true } : {})
+        content: [
+          {
+            type: "text" as const,
+            text: message,
+          },
+        ],
+        ...(errors.length > 0 ? { isError: true } : {}),
       };
     } catch (error) {
       return {
-        content: [{
-          type: 'text' as const,
-          text: `Error clearing state for ${mode}: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
+        content: [
+          {
+            type: "text" as const,
+            text: `Error clearing state for ${mode}: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
       };
     }
-  }
+  },
 };
 
 // ============================================================================
@@ -2089,13 +3138,32 @@ export const stateListActiveTool: ToolDefinition<{
   session_id: z.ZodOptional<z.ZodString>;
   all: z.ZodOptional<z.ZodBoolean>;
 }> = {
-  name: 'state_list_active',
-  description: 'List all currently active modes. By default, scopes to the current session (OMC_SESSION_ID). Pass all:true to list active modes across all sessions.',
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  name: "state_list_active",
+  description:
+    "List all currently active modes. By default, scopes to the current session (OMC_SESSION_ID). Pass all:true to list active modes across all sessions.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   schema: {
-    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
-    session_id: z.string().optional().describe('Explicit session ID to scope the listing. Overrides OMC_SESSION_ID when provided.'),
-    all: z.boolean().optional().describe('When true, list active modes across all sessions (legacy + every session-scoped dir). Overrides the default current-session scope.'),
+    workingDirectory: z
+      .string()
+      .optional()
+      .describe("Working directory (defaults to cwd)"),
+    session_id: z
+      .string()
+      .optional()
+      .describe(
+        "Explicit session ID to scope the listing. Overrides OMC_SESSION_ID when provided.",
+      ),
+    all: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, list active modes across all sessions (legacy + every session-scoped dir). Overrides the default current-session scope.",
+      ),
   },
   handler: async (args) => {
     const { workingDirectory, session_id, all } = args;
@@ -2109,8 +3177,9 @@ export const stateListActiveTool: ToolDefinition<{
       //   3. Otherwise default to the current session via resolveSessionId({context:'cli'}).
       const explicitSessionId = session_id as string | undefined;
       const showAll = all === true;
-      const sessionId: string | undefined = explicitSessionId
-        ?? (showAll ? undefined : resolveSessionId({ context: 'cli' }));
+      const sessionId: string | undefined =
+        explicitSessionId ??
+        (showAll ? undefined : resolveSessionId({ context: "cli" }));
 
       // If session_id resolved (explicit or current session), show modes for that session
       if (sessionId) {
@@ -2123,7 +3192,7 @@ export const stateListActiveTool: ToolDefinition<{
           try {
             const statePath = resolveSessionStatePath(mode, sessionId, root);
             if (existsSync(statePath)) {
-              const content = readFileSync(statePath, 'utf-8');
+              const content = readFileSync(statePath, "utf-8");
               const state = JSON.parse(content);
               if (state.active) {
                 activeModes.push(mode);
@@ -2135,27 +3204,34 @@ export const stateListActiveTool: ToolDefinition<{
         }
 
         for (const mode of CONVERGED_STATE_PATH_MODES) {
-          if (!activeModes.includes(mode) && hasActiveConvergedState(mode, root, sessionId)) {
+          if (
+            !activeModes.includes(mode) &&
+            hasActiveConvergedState(mode, root, sessionId)
+          ) {
             activeModes.push(mode);
           }
         }
 
         if (activeModes.length === 0) {
           return {
-            content: [{
-              type: 'text' as const,
-              text: `## Active Modes (session: ${sessionId})\n\nNo modes are currently active in this session.`
-            }]
+            content: [
+              {
+                type: "text" as const,
+                text: `## Active Modes (session: ${sessionId})\n\nNo modes are currently active in this session.`,
+              },
+            ],
           };
         }
 
-        const modeList = activeModes.map(mode => `- **${mode}**`).join('\n');
+        const modeList = activeModes.map((mode) => `- **${mode}**`).join("\n");
 
         return {
-          content: [{
-            type: 'text' as const,
-            text: `## Active Modes (session: ${sessionId}, ${activeModes.length})\n\n${modeList}`
-          }]
+          content: [
+            {
+              type: "text" as const,
+              text: `## Active Modes (session: ${sessionId}, ${activeModes.length})\n\n${modeList}`,
+            },
+          ],
         };
       }
 
@@ -2168,7 +3244,7 @@ export const stateListActiveTool: ToolDefinition<{
         const statePath = getStatePath(mode, root);
         if (existsSync(statePath)) {
           try {
-            const content = readFileSync(statePath, 'utf-8');
+            const content = readFileSync(statePath, "utf-8");
             const state = JSON.parse(content);
             if (state.active) {
               legacyActiveModes.push(mode);
@@ -2180,7 +3256,10 @@ export const stateListActiveTool: ToolDefinition<{
       }
 
       for (const mode of CONVERGED_STATE_PATH_MODES) {
-        if (!legacyActiveModes.includes(mode) && hasActiveConvergedState(mode, root)) {
+        if (
+          !legacyActiveModes.includes(mode) &&
+          hasActiveConvergedState(mode, root)
+        ) {
           legacyActiveModes.push(mode);
         }
       }
@@ -2189,7 +3268,7 @@ export const stateListActiveTool: ToolDefinition<{
         if (!modeSessionMap.has(mode)) {
           modeSessionMap.set(mode, []);
         }
-        modeSessionMap.get(mode)!.push('legacy');
+        modeSessionMap.get(mode)!.push("legacy");
       }
 
       // Check all sessions
@@ -2201,7 +3280,7 @@ export const stateListActiveTool: ToolDefinition<{
           try {
             const statePath = resolveSessionStatePath(mode, sid, root);
             if (existsSync(statePath)) {
-              const content = readFileSync(statePath, 'utf-8');
+              const content = readFileSync(statePath, "utf-8");
               const state = JSON.parse(content);
               if (state.active) {
                 sessionActiveModes.push(mode);
@@ -2222,34 +3301,40 @@ export const stateListActiveTool: ToolDefinition<{
 
       if (modeSessionMap.size === 0) {
         return {
-          content: [{
-            type: 'text' as const,
-            text: '## Active Modes\n\nNo modes are currently active.'
-          }]
+          content: [
+            {
+              type: "text" as const,
+              text: "## Active Modes\n\nNo modes are currently active.",
+            },
+          ],
         };
       }
 
       const lines: string[] = [`## Active Modes (${modeSessionMap.size})\n`];
       for (const [mode, sessions] of Array.from(modeSessionMap.entries())) {
-        lines.push(`- **${mode}** (${sessions.join(', ')})`);
+        lines.push(`- **${mode}** (${sessions.join(", ")})`);
       }
 
       return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
+        content: [
+          {
+            type: "text" as const,
+            text: lines.join("\n"),
+          },
+        ],
       };
     } catch (error) {
       return {
-        content: [{
-          type: 'text' as const,
-          text: `Error listing active modes: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
+        content: [
+          {
+            type: "text" as const,
+            text: `Error listing active modes: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
       };
     }
-  }
+  },
 };
 
 // ============================================================================
@@ -2261,13 +3346,30 @@ export const stateGetStatusTool: ToolDefinition<{
   workingDirectory: z.ZodOptional<z.ZodString>;
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
-  name: 'state_get_status',
-  description: 'Get detailed status for a specific mode or all modes. Shows active status, file paths, and state contents.',
-  annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  name: "state_get_status",
+  description:
+    "Get detailed status for a specific mode or all modes. Shows active status, file paths, and state contents.",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
   schema: {
-    mode: z.enum(STATE_TOOL_MODES).optional().describe('Specific mode to check (omit for all modes)'),
-    workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
-    session_id: z.string().optional().describe('Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).'),
+    mode: z
+      .enum(STATE_TOOL_MODES)
+      .optional()
+      .describe("Specific mode to check (omit for all modes)"),
+    workingDirectory: z
+      .string()
+      .optional()
+      .describe("Working directory (defaults to cwd)"),
+    session_id: z
+      .string()
+      .optional()
+      .describe(
+        "Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).",
+      ),
   },
   handler: async (args) => {
     const { mode, workingDirectory, session_id } = args;
@@ -2289,36 +3391,48 @@ export const stateGetStatusTool: ToolDefinition<{
 
           const active = MODE_CONFIGS[mode as ExecutionMode]
             ? isModeActive(mode as ExecutionMode, root, sessionId)
-            : existsSync(statePath) && (() => {
+            : existsSync(statePath) &&
+              (() => {
                 try {
-                  const content = readFileSync(statePath, 'utf-8');
+                  const content = readFileSync(statePath, "utf-8");
                   const state = JSON.parse(content);
                   return state.active === true;
-                } catch { return false; }
+                } catch {
+                  return false;
+                }
               })();
 
-          let statePreview = 'No state file';
+          let statePreview = "No state file";
           if (existsSync(statePath)) {
             try {
-              const content = readFileSync(statePath, 'utf-8');
-              statePreview = JSON.stringify(parsePublicStateContent(mode, content), null, 2).slice(0, 500);
-              if (statePreview.length >= 500) statePreview += '\n...(truncated)';
+              const content = readFileSync(statePath, "utf-8");
+              statePreview = JSON.stringify(
+                parsePublicStateContent(mode, content),
+                null,
+                2,
+              ).slice(0, 500);
+              if (statePreview.length >= 500)
+                statePreview += "\n...(truncated)";
             } catch {
-              statePreview = 'Error reading state file';
+              statePreview = "Error reading state file";
             }
           }
 
           lines.push(`### Session: ${sessionId}`);
-          lines.push(`- **Active:** ${active ? 'Yes' : 'No'}`);
+          lines.push(`- **Active:** ${active ? "Yes" : "No"}`);
           lines.push(`- **State Path:** ${statePath}`);
-          lines.push(`- **Exists:** ${existsSync(statePath) ? 'Yes' : 'No'}`);
-          lines.push(`\n### State Preview\n\`\`\`json\n${statePreview}\n\`\`\``);
+          lines.push(`- **Exists:** ${existsSync(statePath) ? "Yes" : "No"}`);
+          lines.push(
+            `\n### State Preview\n\`\`\`json\n${statePreview}\n\`\`\``,
+          );
 
           return {
-            content: [{
-              type: 'text' as const,
-              text: lines.join('\n')
-            }]
+            content: [
+              {
+                type: "text" as const,
+                text: lines.join("\n"),
+              },
+            ],
           };
         }
 
@@ -2326,27 +3440,30 @@ export const stateGetStatusTool: ToolDefinition<{
         const legacyPath = getStatePath(mode, root);
         const legacyActive = MODE_CONFIGS[mode as ExecutionMode]
           ? isModeActive(mode as ExecutionMode, root)
-          : existsSync(legacyPath) && (() => {
+          : existsSync(legacyPath) &&
+            (() => {
               try {
-                const content = readFileSync(legacyPath, 'utf-8');
+                const content = readFileSync(legacyPath, "utf-8");
                 const state = JSON.parse(content);
                 return state.active === true;
-              } catch { return false; }
+              } catch {
+                return false;
+              }
             })();
 
         lines.push(`### Legacy Path`);
-        lines.push(`- **Active:** ${legacyActive ? 'Yes' : 'No'}`);
+        lines.push(`- **Active:** ${legacyActive ? "Yes" : "No"}`);
         lines.push(`- **State Path:** ${legacyPath}`);
-        lines.push(`- **Exists:** ${existsSync(legacyPath) ? 'Yes' : 'No'}\n`);
+        lines.push(`- **Exists:** ${existsSync(legacyPath) ? "Yes" : "No"}\n`);
 
         // Show active sessions for this mode
         const activeSessions = MODE_CONFIGS[mode as ExecutionMode]
           ? getActiveSessionsForMode(mode as ExecutionMode, root)
-          : listSessionIds(root).filter(sid => {
+          : listSessionIds(root).filter((sid) => {
               try {
                 const sessionPath = resolveSessionStatePath(mode, sid, root);
                 if (existsSync(sessionPath)) {
-                  const content = readFileSync(sessionPath, 'utf-8');
+                  const content = readFileSync(sessionPath, "utf-8");
                   const state = JSON.parse(content);
                   return state.active === true;
                 }
@@ -2366,10 +3483,12 @@ export const stateGetStatusTool: ToolDefinition<{
         }
 
         return {
-          content: [{
-            type: 'text' as const,
-            text: lines.join('\n')
-          }]
+          content: [
+            {
+              type: "text" as const,
+              text: lines.join("\n"),
+            },
+          ],
         };
       }
 
@@ -2377,18 +3496,20 @@ export const stateGetStatusTool: ToolDefinition<{
       const statuses = getAllModeStatuses(root, sessionId);
       const lines = sessionId
         ? [`## All Mode Statuses (session: ${sessionId})\n`]
-        : ['## All Mode Statuses\n'];
+        : ["## All Mode Statuses\n"];
 
       for (const status of statuses) {
-        const icon = status.active ? '[ACTIVE]' : '[INACTIVE]';
-        lines.push(`${icon} **${status.mode}**: ${status.active ? 'Active' : 'Inactive'}`);
+        const icon = status.active ? "[ACTIVE]" : "[INACTIVE]";
+        lines.push(
+          `${icon} **${status.mode}**: ${status.active ? "Active" : "Inactive"}`,
+        );
         lines.push(`   Path: \`${status.stateFilePath}\``);
 
         // Show active sessions if no specific session_id
         if (!sessionId && MODE_CONFIGS[status.mode]) {
           const activeSessions = getActiveSessionsForMode(status.mode, root);
           if (activeSessions.length > 0) {
-            lines.push(`   Active sessions: ${activeSessions.join(', ')}`);
+            lines.push(`   Active sessions: ${activeSessions.join(", ")}`);
           }
         }
       }
@@ -2401,34 +3522,38 @@ export const stateGetStatusTool: ToolDefinition<{
         let active = false;
         if (existsSync(statePath)) {
           try {
-            const content = readFileSync(statePath, 'utf-8');
+            const content = readFileSync(statePath, "utf-8");
             const state = JSON.parse(content);
             active = state.active === true;
           } catch {
             // Ignore parse errors
           }
         }
-        const icon = active ? '[ACTIVE]' : '[INACTIVE]';
-        lines.push(`${icon} **${mode}**: ${active ? 'Active' : 'Inactive'}`);
+        const icon = active ? "[ACTIVE]" : "[INACTIVE]";
+        lines.push(`${icon} **${mode}**: ${active ? "Active" : "Inactive"}`);
         lines.push(`   Path: \`${statePath}\``);
       }
 
       return {
-        content: [{
-          type: 'text' as const,
-          text: lines.join('\n')
-        }]
+        content: [
+          {
+            type: "text" as const,
+            text: lines.join("\n"),
+          },
+        ],
       };
     } catch (error) {
       return {
-        content: [{
-          type: 'text' as const,
-          text: `Error getting status: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
+        content: [
+          {
+            type: "text" as const,
+            text: `Error getting status: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
       };
     }
-  }
+  },
 };
 
 /**
@@ -2441,120 +3566,376 @@ export const stateTools = [
   stateListActiveTool,
   stateGetStatusTool,
   {
-    name: 'merge_readiness_start',
-    description: 'Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick or --deep; standard is the default when neither flag is present). Re-running it while an active attempt is still pending is rejected - cancel via merge_readiness_cancel or let the attempt pass/pause first, so the in-progress audit trail is never silently overwritten.',
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    name: "merge_readiness_start",
+    description:
+      "Initialize a merge-readiness gate session for the current change. Call this first, before merge_readiness_set_content. The depth profile is parsed from the summary (--quick or --deep; standard is the default when neither flag is present). Re-running it while an active attempt is still pending is rejected - cancel via merge_readiness_cancel or let the attempt pass/pause first, so the in-progress audit trail is never silently overwritten.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     schema: {
       summary: z.string().max(2000),
-      baseRef: z.string().max(200).regex(/^[A-Za-z0-9._\/@{}~^:-]+$/, "baseRef must be a valid git ref").refine((s) => !s.startsWith("-"), "baseRef must not start with '-'").optional().describe("Base ref to diff committed changes against (e.g. origin/dev, HEAD, HEAD~1, HEAD^). Defaults to the branch upstream / origin/HEAD."),
-      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+      baseRef: z
+        .string()
+        .max(200)
+        .regex(/^[A-Za-z0-9._\/@{}~^:-]+$/, "baseRef must be a valid git ref")
+        .refine((s) => !s.startsWith("-"), "baseRef must not start with '-'")
+        .optional()
+        .describe(
+          "Base ref to diff committed changes against (e.g. origin/dev, HEAD, HEAD~1, HEAD^). Defaults to the branch upstream / origin/HEAD.",
+        ),
+      workingDirectory: z.string().optional(),
+      session_id: z.string().optional(),
     },
-    handler: async (args: { summary: string; workingDirectory?: string; session_id?: string; baseRef?: string }) => {
+    handler: async (args: {
+      summary: string;
+      workingDirectory?: string;
+      session_id?: string;
+      baseRef?: string;
+    }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
-      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
-      const state = createInitialMergeReadinessState(directory, args.summary, sessionId, args.baseRef);
-      const blocked = state.result === 'blocked';
-      return { content: [{ type: 'text' as const, text: blocked ? `Merge-readiness blocked: ${state.validation_errors?.join(' ') ?? 'missing evidence'}` : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.` }], ...(blocked ? { isError: true } : {}) };
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd(),
+        );
+        const sessionId =
+          (args.session_id && args.session_id.trim()) ||
+          (process.env.CLAUDE_SESSION_ID &&
+            process.env.CLAUDE_SESSION_ID.trim()) ||
+          resolveSessionId({ context: "cli" });
+        const state = createInitialMergeReadinessState(
+          directory,
+          args.summary,
+          sessionId,
+          args.baseRef,
+        );
+        const blocked = state.result === "blocked";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: blocked
+                ? `Merge-readiness blocked: ${state.validation_errors?.join(" ") ?? "missing evidence"}`
+                : `Merge-readiness started (profile: ${state.profile}, threshold: ${state.threshold}, max rounds: ${state.max_rounds}). Awaiting content via merge_readiness_set_content.`,
+            },
+          ],
+          ...(blocked ? { isError: true } : {}),
+        };
       } catch (error) {
-        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
       }
     },
   } as ToolDefinition<any>,
   {
-    name: 'merge_readiness_set_content',
-    description: 'Validate and submit the five-section merge-readiness report and objective MCQs. Requires an active gate (call merge_readiness_start first).',
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    name: "merge_readiness_set_content",
+    description:
+      "Validate and submit the five-section merge-readiness report and objective MCQs. Requires an active gate (call merge_readiness_start first).",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     schema: {
-      why: z.string().max(10000), whatChanged: z.string().max(10000), tradeoffs: z.string().max(10000), risksConsidered: z.string().max(10000), teamUnderstanding: z.string().max(10000),
-      questions: z.array(z.object({ id: z.string().max(100), dimension: z.enum(['why', 'change', 'tradeoff', 'risk', 'team']), stem: z.string().max(2000), options: z.array(z.object({ id: z.string().max(100), text: z.string().max(1000) })).max(8), correctOptionId: z.string().max(100), rationale: z.string().max(2000).optional() })).max(8),
-      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+      why: z.string().max(10000),
+      whatChanged: z.string().max(10000),
+      tradeoffs: z.string().max(10000),
+      risksConsidered: z.string().max(10000),
+      teamUnderstanding: z.string().max(10000),
+      questions: z
+        .array(
+          z.object({
+            id: z.string().max(100),
+            dimension: z.enum(["why", "change", "tradeoff", "risk", "team"]),
+            stem: z.string().max(2000),
+            options: z
+              .array(
+                z.object({
+                  id: z.string().max(100),
+                  text: z.string().max(1000),
+                }),
+              )
+              .max(8),
+            correctOptionId: z.string().max(100),
+            rationale: z.string().max(2000).optional(),
+          }),
+        )
+        .max(8),
+      workingDirectory: z.string().optional(),
+      session_id: z.string().optional(),
     },
-    handler: async (args: { why: string; whatChanged: string; tradeoffs: string; risksConsidered: string; teamUnderstanding: string; questions: Array<any>; workingDirectory?: string; session_id?: string }) => {
+    handler: async (args: {
+      why: string;
+      whatChanged: string;
+      tradeoffs: string;
+      risksConsidered: string;
+      teamUnderstanding: string;
+      questions: Array<any>;
+      workingDirectory?: string;
+      session_id?: string;
+    }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
-      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
-      const state = setMergeReadinessContent(directory, args, sessionId);
-      if (!state || !state.active) {
-        return { content: [{ type: 'text' as const, text: 'Merge-readiness content rejected: no active gate (the gate is missing or already terminal - pass/cancelled/overridden). Call merge_readiness_start first.' }], isError: true };
-      }
-      const errors = state.validation_errors ?? [];
-      return { content: [{ type: 'text' as const, text: errors.length > 0 ? `Merge-readiness content rejected: ${errors.join(' ')}` : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? 'none'}` }], ...(errors.length > 0 ? { isError: true } : {}) };
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd(),
+        );
+        const sessionId =
+          (args.session_id && args.session_id.trim()) ||
+          (process.env.CLAUDE_SESSION_ID &&
+            process.env.CLAUDE_SESSION_ID.trim()) ||
+          resolveSessionId({ context: "cli" });
+        const state = setMergeReadinessContent(directory, args, sessionId);
+        if (!state || !state.active) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Merge-readiness content rejected: no active gate (the gate is missing or already terminal - pass/cancelled/overridden). Call merge_readiness_start first.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const errors = state.validation_errors ?? [];
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                errors.length > 0
+                  ? `Merge-readiness content rejected: ${errors.join(" ")}`
+                  : `Merge-readiness content accepted. Next question: ${state.pending_question?.id ?? "none"}`,
+            },
+          ],
+          ...(errors.length > 0 ? { isError: true } : {}),
+        };
       } catch (error) {
-        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
       }
     },
   } as ToolDefinition<any>,
   {
-    name: 'merge_readiness_record_answer',
-    description: 'Record the human-selected option for the current merge-readiness MCQ. Advances the gate; returns the next question or the final result plus readiness score.',
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    name: "merge_readiness_record_answer",
+    description:
+      "Record the human-selected option for the current merge-readiness MCQ. Advances the gate; returns the next question or the final result plus readiness score.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
     schema: {
       questionId: z.string().max(100),
       optionId: z.string().max(100),
-      workingDirectory: z.string().optional(), session_id: z.string().optional(),
+      workingDirectory: z.string().optional(),
+      session_id: z.string().optional(),
     },
-    handler: async (args: { questionId: string; optionId: string; workingDirectory?: string; session_id?: string }) => {
+    handler: async (args: {
+      questionId: string;
+      optionId: string;
+      workingDirectory?: string;
+      session_id?: string;
+    }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
-      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
-      const state = recordMergeReadinessMCQAnswer(directory, args.questionId, args.optionId, sessionId);
-      if (!state) {
-        return { content: [{ type: 'text' as const, text: 'Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ.' }], isError: true };
-      }
-      const result = state.result;
-      const score = state.readiness_score;
-      const persistFailed = result === 'blocked' && (state.validation_errors ?? []).some((e) => e.includes('persisted'));
-      const text = persistFailed
-        ? `Merge-readiness answer NOT recorded: state could not be persisted (read-only state dir / full disk / invalid path). The gate is still armed on disk. ${(state.validation_errors ?? []).join(' ')}`
-        : result === 'pass' || result === 'paused' || result === 'blocked' || result === 'overridden'
-          ? `Merge-readiness ${result}. Readiness score: ${score}. ${result === 'pass' ? 'The change may proceed to human merge approval.' : result === 'paused' ? 'Explanation gap remains; reread the report and rerun /merge-readiness.' : result === 'blocked' ? 'Missing evidence; produce it before rerunning.' : 'Gate overridden; terminal session state preserves the record.'}`
-          : `Answer recorded. Next question: ${state.pending_question?.id ?? 'none'}. Answered: ${state.answers.length}/${state.questions.length}.`;
-      return { content: [{ type: 'text' as const, text }], ...(persistFailed ? { isError: true } : {}) };
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd(),
+        );
+        const sessionId =
+          (args.session_id && args.session_id.trim()) ||
+          (process.env.CLAUDE_SESSION_ID &&
+            process.env.CLAUDE_SESSION_ID.trim()) ||
+          resolveSessionId({ context: "cli" });
+        const state = recordMergeReadinessMCQAnswer(
+          directory,
+          args.questionId,
+          args.optionId,
+          sessionId,
+        );
+        if (!state) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Merge-readiness answer rejected: no active gate, or the questionId/optionId does not match the current MCQ.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        const result = state.result;
+        const score = state.readiness_score;
+        const persistFailed =
+          result === "blocked" &&
+          (state.validation_errors ?? []).some((e) => e.includes("persisted"));
+        const text = persistFailed
+          ? `Merge-readiness answer NOT recorded: state could not be persisted (read-only state dir / full disk / invalid path). The gate is still armed on disk. ${(state.validation_errors ?? []).join(" ")}`
+          : result === "pass" ||
+              result === "paused" ||
+              result === "blocked" ||
+              result === "overridden"
+            ? `Merge-readiness ${result}. Readiness score: ${score}. ${result === "pass" ? "The change may proceed to human merge approval." : result === "paused" ? "Explanation gap remains; reread the report and rerun /merge-readiness." : result === "blocked" ? "Missing evidence; produce it before rerunning." : "Gate overridden; terminal session state preserves the record."}`
+            : `Answer recorded. Next question: ${state.pending_question?.id ?? "none"}. Answered: ${state.answers.length}/${state.questions.length}.`;
+        return {
+          content: [{ type: "text" as const, text }],
+          ...(persistFailed ? { isError: true } : {}),
+        };
       } catch (error) {
-        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
       }
     },
   } as ToolDefinition<any>,
   {
-    name: 'merge_readiness_report',
-    description: 'Render the authoritative merge-readiness session state as a Markdown report without writing a file.',
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-    schema: { workingDirectory: z.string().optional(), session_id: z.string().optional() },
-    handler: async (args: { workingDirectory?: string; session_id?: string }) => {
+    name: "merge_readiness_report",
+    description:
+      "Render the authoritative merge-readiness session state as a Markdown report without writing a file.",
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    schema: {
+      workingDirectory: z.string().optional(),
+      session_id: z.string().optional(),
+    },
+    handler: async (args: {
+      workingDirectory?: string;
+      session_id?: string;
+    }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
-      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: 'cli' });
-      const state = readMergeReadinessState(directory, sessionId);
-      if (!state) {
-        return { content: [{ type: 'text' as const, text: 'Merge-readiness report unavailable: no session state found.' }], isError: true };
-      }
-      return { content: [{ type: 'text' as const, text: formatMergeReadinessReport(state) }] };
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd(),
+        );
+        const sessionId =
+          (args.session_id && args.session_id.trim()) ||
+          (process.env.CLAUDE_SESSION_ID &&
+            process.env.CLAUDE_SESSION_ID.trim()) ||
+          resolveSessionId({ context: "cli" });
+        const state = readMergeReadinessState(directory, sessionId);
+        if (!state) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Merge-readiness report unavailable: no session state found.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            { type: "text" as const, text: formatMergeReadinessReport(state) },
+          ],
+        };
       } catch (error) {
-        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
       }
     },
   } as ToolDefinition<any>,
   {
-    name: 'merge_readiness_cancel',
-    description: 'Cancel an active merge-readiness gate while preserving its terminal state audit record.',
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
-    schema: { workingDirectory: z.string().optional(), session_id: z.string().optional() },
-    handler: async (args: { workingDirectory?: string; session_id?: string }) => {
+    name: "merge_readiness_cancel",
+    description:
+      "Cancel an active merge-readiness gate while preserving its terminal state audit record.",
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    schema: {
+      workingDirectory: z.string().optional(),
+      session_id: z.string().optional(),
+    },
+    handler: async (args: {
+      workingDirectory?: string;
+      session_id?: string;
+    }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
-      const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: 'cli' });
-      const state = cancelMergeReadiness(directory, sessionId);
-      const persistFailed = state?.result === 'blocked' && (state.validation_errors ?? []).some((e) => e.includes('persisted'));
-      if (persistFailed) {
-        return { content: [{ type: 'text' as const, text: `Merge-readiness cancellation FAILED: state could not be persisted (read-only state dir / full disk). The gate is still armed on disk. ${(state?.validation_errors ?? []).join(' ')}` }], isError: true };
-      }
-      if (!state || state.result !== 'cancelled') {
-        return { content: [{ type: 'text' as const, text: 'Merge-readiness cancellation rejected: no active gate.' }], isError: true };
-      }
-      return { content: [{ type: 'text' as const, text: 'Merge-readiness cancelled. Terminal session state preserved as the audit record.' }] };
+        const directory = validateWorkingDirectory(
+          args.workingDirectory || process.cwd(),
+        );
+        const sessionId =
+          (args.session_id && args.session_id.trim()) ||
+          (process.env.CLAUDE_SESSION_ID &&
+            process.env.CLAUDE_SESSION_ID.trim()) ||
+          resolveSessionId({ context: "cli" });
+        const state = cancelMergeReadiness(directory, sessionId);
+        const persistFailed =
+          state?.result === "blocked" &&
+          (state.validation_errors ?? []).some((e) => e.includes("persisted"));
+        if (persistFailed) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Merge-readiness cancellation FAILED: state could not be persisted (read-only state dir / full disk). The gate is still armed on disk. ${(state?.validation_errors ?? []).join(" ")}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        if (!state || state.result !== "cancelled") {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Merge-readiness cancellation rejected: no active gate.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Merge-readiness cancelled. Terminal session state preserved as the audit record.",
+            },
+          ],
+        };
       } catch (error) {
-        return { content: [{ type: 'text' as const, text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Merge-readiness error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
       }
     },
   } as ToolDefinition<any>,

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -57,7 +57,7 @@ import {
   isModeActive,
   getActiveModes,
   getAllModeStatuses,
-  clearModeState,
+  clearModeStateDetailed,
   getStateFilePath,
   MODE_CONFIGS,
   getActiveSessionsForMode,
@@ -2349,7 +2349,7 @@ export const stateClearTool: ToolDefinition<{
 
         if (MODE_CONFIGS[mode as ExecutionMode]) {
           const expectedDirectState = directCandidate?.state;
-          const registryClearResult = clearModeState(
+          const registryClearResult = clearModeStateDetailed(
             mode as ExecutionMode,
             root,
             sessionId,
@@ -2471,7 +2471,7 @@ export const stateClearTool: ToolDefinition<{
                   mode,
                   ownerDirectCandidate,
                 );
-                const ownerClearResult = clearModeState(
+                const ownerClearResult = clearModeStateDetailed(
                   mode as ExecutionMode,
                   root,
                   ownerSessionId,
@@ -2954,7 +2954,7 @@ export const stateClearTool: ToolDefinition<{
         );
         const skippedCanonicalPaths = new Set<string>();
         if (primaryCandidate) {
-          const clearResult = clearModeState(
+          const clearResult = clearModeStateDetailed(
             mode as ExecutionMode,
             root,
             undefined,

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -53,12 +53,13 @@ import { namedWorkflowRuntimeSupported, validateNamedWorkflowStateStructure } fr
 import { cancelMergeReadiness, createInitialMergeReadinessState, readMergeReadinessState, setMergeReadinessContent, recordMergeReadinessMCQAnswer } from '../hooks/merge-readiness/runtime.js';
 import { formatMergeReadinessReport, redactMergeReadinessState } from '../hooks/merge-readiness/report.js';
 import type { AutopilotState } from '../hooks/autopilot/types.js';
+import { parseGraphState, type GraphRunStatus } from '../graph/runtime-types.js';
 
 // Canonical execution modes from mode-registry (deep-interview and self-improve
 // are first-class modes with dedicated MODE_CONFIGS entries; ralplan remains an
 // extra state-only mode handled via the registry-fallback path).
 const EXECUTION_MODES: [string, ...string[]] = [
-  'autopilot', 'autoresearch', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
+  'autopilot', 'autoresearch', 'graph', 'team', 'ralph', 'ultrawork', 'ultraqa', 'deep-interview', 'self-improve'
 ];
 
 // merge-readiness is read/clear-eligible (state_read/status/clear + /cancel work) but NOT write-eligible.
@@ -69,13 +70,22 @@ const STATE_TOOL_MODES: [string, ...string[]] = [
   'skill-active',
   'merge-readiness'
 ];
-// Modes that may be generically written via state_write. Excludes merge-readiness (runtime-owned).
+// Modes that may be generically written via state_write. Graph and
+// merge-readiness are runtime-owned and intentionally excluded.
 const STATE_WRITE_MODES: [string, ...string[]] = [
-  ...EXECUTION_MODES,
+  'autopilot',
+  'autoresearch',
+  'team',
+  'ralph',
+  'ultrawork',
+  'ultraqa',
+  'deep-interview',
+  'self-improve',
   'ralplan',
   'omc-teams',
   'skill-active'
 ];
+const STATE_CLEAR_MODES: [string, ...string[]] = [...STATE_TOOL_MODES, 'all'];
 const EXTRA_STATE_ONLY_MODES = ['ralplan', 'omc-teams', 'skill-active'] as const;
 type StateToolMode = typeof STATE_TOOL_MODES[number];
 const CANCEL_SIGNAL_TTL_MS = 30_000;
@@ -386,7 +396,7 @@ function cleanupTeamRuntimeState(root: string, teamNames?: string[]): number {
 /**
  * Get the state file path for any mode (including swarm and ralplan).
  *
- * - For registry modes (8 modes): uses getStateFilePath from mode-registry
+ * - For registry modes: uses getStateFilePath from mode-registry
  * - For ralplan (not in registry): uses resolveStatePath from worktree-paths
  *
  * This handles swarm's SQLite (.db) file transparently.
@@ -732,6 +742,79 @@ interface WorkflowPublicState {
   progress: string;
 }
 
+interface GraphPublicStateSummary {
+  type: 'graph_state_summary';
+  valid: boolean;
+  format_version?: number;
+  run_id?: string;
+  status: GraphRunStatus | 'malformed';
+  active_revision_id?: string;
+  short_revision_hash?: string;
+  dispatch_generation?: number;
+  commit_sequence?: number;
+  progress?: {
+    total: number;
+    ready: number;
+    running: number;
+    completed: number;
+    failed: number;
+  };
+  claims?: {
+    total: number;
+    live: number;
+    reconciling: number;
+    unresolved_reconciliations: number;
+  };
+  pending?: { approval: boolean; patch: boolean };
+}
+
+function malformedGraphPublicState(): GraphPublicStateSummary {
+  return { type: 'graph_state_summary', valid: false, status: 'malformed' };
+}
+
+export function redactGraphPublicState(state: unknown): GraphPublicStateSummary {
+  try {
+    const graph = parseGraphState(state);
+    const activationStatuses = Object.values(graph.projection.activations).map(
+      activation => activation.status,
+    );
+    const claims = Object.values(graph.claims);
+    const reconciliations = Object.values(graph.reconciliations);
+    return {
+      type: 'graph_state_summary',
+      valid: true,
+      format_version: graph.format_version,
+      run_id: graph.run_id.slice(0, 128),
+      status: graph.status,
+      active_revision_id: graph.active_revision_id.slice(0, 128),
+      short_revision_hash: graph.active_revision_hash.slice(0, 12),
+      dispatch_generation: graph.dispatch_generation,
+      commit_sequence: graph.commit_sequence,
+      progress: {
+        total: activationStatuses.length,
+        ready: activationStatuses.filter(status => status === 'ready').length,
+        running: activationStatuses.filter(status => status === 'running').length,
+        completed: activationStatuses.filter(status => status === 'completed').length,
+        failed: activationStatuses.filter(status => status === 'failed').length,
+      },
+      claims: {
+        total: claims.length,
+        live: claims.filter(claim => claim.status === 'live').length,
+        reconciling: claims.filter(claim => claim.status === 'reconciling').length,
+        unresolved_reconciliations: reconciliations.filter(
+          reconciliation => reconciliation.status === 'unresolved',
+        ).length,
+      },
+      pending: {
+        approval: graph.pending_approval !== undefined,
+        patch: graph.pending_patch !== undefined,
+      },
+    };
+  } catch {
+    return malformedGraphPublicState();
+  }
+}
+
 function canonicalWorkflowJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalWorkflowJson).join(',')}]`;
   if (value && typeof value === 'object') {
@@ -802,9 +885,21 @@ function publicStateForMode(mode: StateToolMode, state: unknown): unknown {
   if (mode === 'autopilot') {
     return redactAutopilotPublicState(state);
   }
+  if (mode === 'graph') {
+    return redactGraphPublicState(state);
+  }
   return mode === 'merge-readiness'
     ? redactMergeReadinessState(state as Parameters<typeof redactMergeReadinessState>[0])
     : state;
+}
+
+function parsePublicStateContent(mode: StateToolMode, content: string): unknown {
+  try {
+    return publicStateForMode(mode, JSON.parse(content));
+  } catch (error) {
+    if (mode === 'graph') return malformedGraphPublicState();
+    throw error;
+  }
 }
 
 // ============================================================================
@@ -868,12 +963,12 @@ export const stateReadTool: ToolDefinition<{
         }
 
         const content = readFileSync(statePath, 'utf-8');
-        const state = JSON.parse(content);
+        const publicState = parsePublicStateContent(mode, content);
 
         return {
           content: [{
             type: 'text' as const,
-            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\``
+            text: `## State for ${mode} (session: ${sessionId})\n\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\``
           }]
         };
       }
@@ -909,8 +1004,8 @@ export const stateReadTool: ToolDefinition<{
       if (legacyExists) {
         try {
           const content = readFileSync(statePath, 'utf-8');
-          const state = JSON.parse(content);
-          output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\`\n\n`;
+          const publicState = parsePublicStateContent(mode, content);
+          output += `### Legacy Path (shared)\nPath: ${statePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\`\n\n`;
         } catch {
           output += `### Legacy Path (shared)\nPath: ${statePath}\n*Error reading state file*\n\n`;
         }
@@ -926,8 +1021,8 @@ export const stateReadTool: ToolDefinition<{
 
           try {
             const content = readFileSync(sessionStatePath, 'utf-8');
-            const state = JSON.parse(content);
-            output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(publicStateForMode(mode, state), null, 2)}\n\`\`\`\n\n`;
+            const publicState = parsePublicStateContent(mode, content);
+            output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n\n\`\`\`json\n${JSON.stringify(publicState, null, 2)}\n\`\`\`\n\n`;
           } catch {
             output += `**Session: ${sid}**\nPath: ${sessionStatePath}\n*Error reading state file*\n\n`;
           }
@@ -1009,6 +1104,21 @@ export const stateWriteTool: ToolDefinition<{
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
+
+      if ((mode as string) === 'graph') {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              type: 'guarded_mode',
+              mode: 'graph',
+              operation: 'write',
+              changed: false,
+            }),
+          }],
+          isError: true,
+        };
+      }
 
       // Validate custom state payload size if provided
       if (state) {
@@ -1224,25 +1334,136 @@ function recoverAutopilotEmergencyTransactions(root: string, sessionId?: string)
   }
 }
 
+type GraphClearClassification = 'active' | 'draft' | 'paused' | 'terminal' | 'malformed' | 'missing';
+
+function classifyGraphRunStatus(status: GraphRunStatus): GraphClearClassification {
+  if (MODE_CONFIGS.graph.activeStatuses?.includes(status)) return 'active';
+  if (status === 'draft') return 'draft';
+  if (status === 'paused') return 'paused';
+  return 'terminal';
+}
+
+function classifyGraphStateForClear(
+  root: string,
+  sessionId?: string,
+): GraphClearClassification {
+  const paths = sessionId
+    ? [getStateFilePath(root, 'graph', sessionId)]
+    : [
+        getStateFilePath(root, 'graph'),
+        ...listSessionIds(root)
+          .sort()
+          .map(sid => getStateFilePath(root, 'graph', sid)),
+      ];
+  const classifications: GraphClearClassification[] = [];
+  for (const path of paths) {
+    if (!existsSync(path)) continue;
+    try {
+      classifications.push(classifyGraphRunStatus(parseGraphState(JSON.parse(readFileSync(path, 'utf8'))).status));
+    } catch {
+      classifications.push('malformed');
+    }
+  }
+  if (classifications.length === 0) return 'missing';
+  for (const classification of ['active', 'paused', 'draft', 'terminal', 'malformed'] as const) {
+    if (classifications.includes(classification)) return classification;
+  }
+  return 'malformed';
+}
+
+function hasGraphWorkflowSlot(root: string, sessionId?: string): boolean {
+  const paths = [resolveStatePath('skill-active', root)];
+  const sessionIds = sessionId ? [sessionId] : listSessionIds(root);
+  for (const sid of sessionIds) paths.push(resolveSessionStatePath('skill-active', sid, root));
+  return paths.some(path => {
+    const state = readJsonRecord(path);
+    return Boolean(
+      state?.active_skills
+      && typeof state.active_skills === 'object'
+      && (state.active_skills as Record<string, unknown>).graph,
+    );
+  });
+}
+
 export const stateClearTool: ToolDefinition<{
-  mode: z.ZodEnum<typeof STATE_TOOL_MODES>;
+  mode: z.ZodEnum<typeof STATE_CLEAR_MODES>;
+  force: z.ZodOptional<z.ZodBoolean>;
   workingDirectory: z.ZodOptional<z.ZodString>;
   session_id: z.ZodOptional<z.ZodString>;
 }> = {
   name: 'state_clear',
-  description: 'Clear/delete state for a specific mode. Removes the state file and any associated marker files. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).',
+  description: 'Clear/delete state for a specific mode or all generically clearable modes. Graph is guarded and is never deleted by this tool. For merge-readiness, cancels an active gate while preserving the terminal audit record (no deletion).',
   annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
   schema: {
-    mode: z.enum(STATE_TOOL_MODES).describe('The mode to clear state for'),
+    mode: z.enum(STATE_CLEAR_MODES).describe('The mode to clear state for, or all'),
+    force: z.boolean().optional().describe('Request broad cleanup. This never bypasses guarded Graph state.'),
     workingDirectory: z.string().optional().describe('Working directory (defaults to cwd)'),
     session_id: z.string().optional().describe('Session ID for session-scoped state isolation. When provided, the tool operates only within that session. When omitted, the tool aggregates legacy state plus all session-scoped state (may include other sessions).'),
   },
   handler: async (args) => {
-    const { mode, workingDirectory, session_id } = args;
+    const { mode, force, workingDirectory, session_id } = args;
 
     try {
       const root = validateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
+
+      if (sessionId) validateSessionId(sessionId);
+
+      if (mode === 'graph') {
+        const graphClassification = classifyGraphStateForClear(root, sessionId);
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              type: 'guarded_mode',
+              mode: 'graph',
+              operation: 'clear',
+              classification: graphClassification,
+              changed: false,
+              force_bypassed: false,
+            }),
+          }],
+          isError: true,
+        };
+      }
+
+      if (mode === 'all') {
+        const graphClassification = classifyGraphStateForClear(root, sessionId);
+        const clearedModes: string[] = [];
+        const failedModes: string[] = [];
+        const preserveGraphWorkflowSlot = hasGraphWorkflowSlot(root, sessionId);
+        for (const candidate of STATE_TOOL_MODES) {
+          if (candidate === 'graph' || (candidate === 'skill-active' && preserveGraphWorkflowSlot)) {
+            continue;
+          }
+          const result = await stateClearTool.handler({
+            mode: candidate,
+            force,
+            workingDirectory,
+            session_id,
+          });
+          if (result.isError) failedModes.push(candidate);
+          else clearedModes.push(candidate);
+        }
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              type: 'clear_all',
+              cleared_modes: clearedModes,
+              failed_modes: failedModes,
+              skipped: [{
+                mode: 'graph',
+                reason: 'guarded_mode',
+                classification: graphClassification,
+              }],
+              preserved_graph_workflow_slot: preserveGraphWorkflowSlot,
+              force_bypassed: false,
+            }),
+          }],
+          ...(failedModes.length > 0 ? { isError: true } : {}),
+        };
+      }
 
       // Merge-readiness is an audit gate, so clearing it must leave a durable
       // terminal result and report rather than deleting the evidence trail.
@@ -1999,8 +2220,7 @@ export const stateGetStatusTool: ToolDefinition<{
           if (existsSync(statePath)) {
             try {
               const content = readFileSync(statePath, 'utf-8');
-              const state = JSON.parse(content);
-              statePreview = JSON.stringify(publicStateForMode(mode, state), null, 2).slice(0, 500);
+              statePreview = JSON.stringify(parsePublicStateContent(mode, content), null, 2).slice(0, 500);
               if (statePreview.length >= 500) statePreview += '\n...(truncated)';
             } catch {
               statePreview = 'Error reading state file';

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -1385,6 +1385,80 @@ function hasGraphWorkflowSlot(root: string, sessionId?: string): boolean {
   });
 }
 
+type SkillActiveClearResult = {
+  changed: boolean;
+  failed: boolean;
+  preservedGraphWorkflowSlot: boolean;
+};
+
+/**
+ * Graph owns its slot in skill-active-state.json, but that ownership must not
+ * shield unrelated skill slots from an all-mode clear. Work from discovered
+ * snapshots and conditionally publish the reduced record so a concurrent
+ * replacement is never removed based on stale observations.
+ */
+function clearSkillActiveStateForAll(root: string, sessionId?: string): SkillActiveClearResult {
+  const legacyCandidates = discoverStatePaths(getLegacyStateFileCandidates('skill-active', root))
+    .filter((candidate) => !sessionId || canClearStateForSession(candidate.state, sessionId));
+  const localCandidates = discoverStatePaths(
+    getWorkingDirectoryLocalStateClearCandidates('skill-active', root, sessionId),
+  ).filter((candidate) => !sessionId || canClearStateForSession(candidate.state, sessionId));
+  const sessionCandidates = sessionId
+    ? [
+        ...findSessionOwnedStateCandidates('skill-active', sessionId, root),
+        ...findCompletedSessionStateCandidates('skill-active', root, sessionId),
+      ]
+    : [
+        ...listSessionIds(root).flatMap((sid) => findSessionOwnedStateCandidates('skill-active', sid, root)),
+        ...discoverAllRootSessionStateCandidates('skill-active', root),
+      ];
+  const candidates = [...new Map([
+    ...legacyCandidates,
+    ...localCandidates,
+    ...sessionCandidates,
+  ].map((candidate) => [candidate.path, candidate])).values()];
+
+  let changed = false;
+  let failed = false;
+  let preservedGraphWorkflowSlot = false;
+
+  for (const candidate of candidates) {
+    const skills = candidate.state.active_skills;
+    const graphIsPresent = skills !== null && typeof skills === 'object' && !Array.isArray(skills) &&
+      Object.prototype.hasOwnProperty.call(skills, 'graph');
+
+    if (!graphIsPresent) {
+      const result = clearDiscoveredStateCandidate(
+        candidate,
+        (current) => (!sessionId || canClearStateForSession(current, sessionId)) &&
+          JSON.stringify(current) === candidate.snapshot,
+      );
+      if (result === 'cleared') changed = true;
+      else if (result === 'failed' || (result === 'skipped' && existsSync(candidate.path))) failed = true;
+      continue;
+    }
+
+    preservedGraphWorkflowSlot = true;
+    const activeSkills = skills as Record<string, unknown>;
+    const nonGraphSkills = Object.keys(activeSkills).filter((name) => name !== 'graph');
+    if (nonGraphSkills.length === 0) continue;
+
+    const result = writeStateFileLockedIf(
+      candidate.path,
+      (current) => (!sessionId || canClearStateForSession(current, sessionId)) &&
+        JSON.stringify(current) === candidate.snapshot,
+      (current) => {
+        const currentSkills = current.active_skills as Record<string, unknown>;
+        return { ...current, active_skills: { graph: currentSkills.graph } };
+      },
+    );
+    if (result === 'written') changed = true;
+    else failed = true;
+  }
+
+  return { changed, failed, preservedGraphWorkflowSlot };
+}
+
 export const stateClearTool: ToolDefinition<{
   mode: z.ZodEnum<typeof STATE_CLEAR_MODES>;
   force: z.ZodOptional<z.ZodBoolean>;
@@ -1431,9 +1505,16 @@ export const stateClearTool: ToolDefinition<{
         const graphClassification = classifyGraphStateForClear(root, sessionId);
         const clearedModes: string[] = [];
         const failedModes: string[] = [];
-        const preserveGraphWorkflowSlot = hasGraphWorkflowSlot(root, sessionId);
+        let preserveGraphWorkflowSlot = hasGraphWorkflowSlot(root, sessionId);
         for (const candidate of STATE_TOOL_MODES) {
-          if (candidate === 'graph' || (candidate === 'skill-active' && preserveGraphWorkflowSlot)) {
+          if (candidate === 'graph') {
+            continue;
+          }
+          if (candidate === 'skill-active') {
+            const result = clearSkillActiveStateForAll(root, sessionId);
+            preserveGraphWorkflowSlot ||= result.preservedGraphWorkflowSlot;
+            if (result.failed) failedModes.push(candidate);
+            else if (result.changed) clearedModes.push(candidate);
             continue;
           }
           const result = await stateClearTool.handler({

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -911,7 +911,7 @@ async function activateState(directory, prompt, stateName, sessionId) {
   const writeState = (writePath, authorizeState) => {
     try {
       mkdirSync(dirname(writePath), { recursive: true });
-      withStateFileLockSync(writePath, () => {
+      withStateFileLockSync(writePath, (assertHeld) => {
         if (!recoverEmergencyStateFile(writePath, authorizeState ? { authorizeState } : undefined)) return;
         // Shared home fallbacks are project-scoped. A foreign or unverifiable
         // primary/recovery generation must win over this activation.
@@ -938,6 +938,7 @@ async function activateState(directory, prompt, stateName, sessionId) {
             return;
           }
         }
+        assertHeld();
         atomicWriteFileSync(writePath, JSON.stringify(state, null, 2));
       });
     } catch {}
@@ -960,11 +961,14 @@ async function activateState(directory, prompt, stateName, sessionId) {
 
 function retireStaleWorkflowCancelSignal(statePath, workflowRunId) {
   const signalPath = join(dirname(statePath), 'cancel-signal-state.json');
-  withStateFileLockSync(signalPath, () => {
+  withStateFileLockSync(signalPath, (assertHeld) => {
     if (!existsSync(signalPath)) return;
     try {
       const signal = JSON.parse(readFileSync(signalPath, 'utf8'));
-      if (signal.target_workflow_run_id !== workflowRunId) unlinkSync(signalPath);
+      if (signal.target_workflow_run_id !== workflowRunId) {
+        assertHeld();
+        unlinkSync(signalPath);
+      }
     } catch {
       // Malformed signals fail closed in Stop and are left for explicit cleanup.
     }
@@ -976,7 +980,7 @@ async function resumeWorkflowProfile(directory, sessionId, workflowName) {
   const { writePath } = await resolveSessionStatePathsForHook(directory, 'autopilot', safeSessionId || undefined);
   try {
     mkdirSync(dirname(writePath), { recursive: true });
-    const result = withStateFileLockSync(writePath, () => {
+    const result = withStateFileLockSync(writePath, (assertHeld) => {
       if (!recoverEmergencyStateFile(writePath)) return { error: 'workflow_recovery_failure' };
       if (!existsSync(writePath)) return null;
       const current = JSON.parse(readFileSync(writePath, 'utf8'));
@@ -990,6 +994,7 @@ async function resumeWorkflowProfile(directory, sessionId, workflowName) {
       const stageId = resumed.workflow.stages[resumed.pipelineTracking.currentStageIndex];
       const stagePrompt = resolveWorkflowStagePrompt(resumed, stageId);
       if (!stagePrompt) return { error: 'workflow_integrity_failure' };
+      assertHeld();
       atomicWriteFileSync(writePath, JSON.stringify(resumed, null, 2));
       return { stagePrompt, workflowRunId: resumed.workflowRunId };
     });
@@ -1011,7 +1016,7 @@ async function activateWorkflowProfile(directory, sessionId, task, workflow, tra
   const { writePath } = await resolveSessionStatePathsForHook(directory, 'autopilot', safeSessionId || undefined);
   try {
     mkdirSync(dirname(writePath), { recursive: true });
-    const result = withStateFileLockSync(writePath, () => {
+    const result = withStateFileLockSync(writePath, (assertHeld) => {
       if (!recoverEmergencyStateFile(writePath)) return { error: 'workflow_recovery_failure' };
       if (existsSync(writePath)) {
         try {
@@ -1030,6 +1035,7 @@ async function activateWorkflowProfile(directory, sessionId, task, workflow, tra
               const stageId = resumed.workflow.stages[resumed.pipelineTracking.currentStageIndex];
               const stagePrompt = resolveWorkflowStagePrompt(resumed, stageId);
               if (!stagePrompt) return { error: 'workflow_integrity_failure' };
+              assertHeld();
               atomicWriteFileSync(writePath, JSON.stringify(resumed, null, 2));
               return { stagePrompt, workflowRunId: resumed.workflowRunId };
             }
@@ -1043,6 +1049,7 @@ async function activateWorkflowProfile(directory, sessionId, task, workflow, tra
       if (!state) return { error: takeWorkflowTranscriptFailure(sessionId) || 'workflow_integrity_failure' };
       const stagePrompt = resolveWorkflowStagePrompt(state, workflow.stages[0]);
       if (!stagePrompt) return null;
+      assertHeld();
       atomicWriteFileSync(writePath, JSON.stringify(state, null, 2));
       return { stagePrompt, workflowRunId: state.workflowRunId };
     });

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -1005,7 +1005,7 @@ async function resumeWorkflowProfile(directory, sessionId, workflowName) {
     retireStaleWorkflowCancelSignal(writePath, result.value.workflowRunId);
     return result.value.stagePrompt;
   } catch (error) {
-    if (error?.message === 'workflow_emergency_recovery_failed' || error?.message === 'workflow_transcript_record_too_large') throw error;
+    if (error?.message?.startsWith('workflow_emergency_recovery_failed') || error?.message === 'workflow_transcript_record_too_large') throw error;
     return false;
   }
 }
@@ -1061,7 +1061,7 @@ async function activateWorkflowProfile(directory, sessionId, task, workflow, tra
     retireStaleWorkflowCancelSignal(writePath, result.value.workflowRunId);
     return result.value.stagePrompt;
   } catch (error) {
-    if (error?.message === 'workflow_emergency_recovery_failed' || error?.message === 'workflow_transcript_record_too_large') throw error;
+    if (error?.message?.startsWith('workflow_emergency_recovery_failed') || error?.message === 'workflow_transcript_record_too_large') throw error;
     return false;
   }
 }

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -725,7 +725,12 @@ function occAbortedPath(dir, seq, token) {
   return join(dir, `${seq}.${token}.aborted`);
 }
 
+function occClaimPath(dir, seq) {
+  return join(dir, `${seq}.claim`);
+}
+
 const OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+const OCC_CLAIM_NAME_RE = /^(\d+)\.claim$/;
 
 /**
  * Scans the OCC journal directory and returns the current committed state: the
@@ -742,12 +747,19 @@ function occReadCurrent(filePath) {
   try {
     names = readdirSync(dir);
   } catch (error) {
-    if (error && error.code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false };
-    return { seq: -1, state: null, empty: false, ioError: true };
+    if (error && error.code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false, reservedSeq: -1 };
+    return { seq: -1, state: null, empty: false, ioError: true, reservedSeq: -1 };
   }
-  const completeSeqs = new Set();
+  const completeBySeq = new Map();
   const entryBySeq = new Map();
+  let reservedSeq = -1;
   for (const name of names) {
+    const claim = OCC_CLAIM_NAME_RE.exec(name);
+    if (claim) {
+      const seq = Number(claim[1]);
+      if (Number.isInteger(seq) && seq >= 0) reservedSeq = Math.max(reservedSeq, seq);
+      continue;
+    }
     const match = OCC_ENTRY_NAME_RE.exec(name);
     if (!match) continue;
     const seq = Number(match[1]);
@@ -755,52 +767,60 @@ function occReadCurrent(filePath) {
     const token = match[2];
     const kind = match[3];
     if (kind === 'complete') {
-      completeSeqs.add(seq);
+      const existing = completeBySeq.get(seq);
+      completeBySeq.set(seq, existing === undefined ? token : existing === token ? token : null);
     } else if (kind === 'json') {
-      if (!entryBySeq.has(seq)) entryBySeq.set(seq, token);
+      const existing = entryBySeq.get(seq);
+      if (existing === undefined) entryBySeq.set(seq, token);
+      else if (existing !== token) return { seq: -1, state: null, empty: false, ioError: true, reservedSeq };
     }
   }
-  if (completeSeqs.size === 0) return { seq: -1, state: null, empty: true, ioError: false };
+  if (completeBySeq.size === 0) return { seq: -1, state: null, empty: true, ioError: false, reservedSeq };
   let maxSeq = -1;
-  for (const seq of completeSeqs) if (seq > maxSeq) maxSeq = seq;
+  for (const seq of completeBySeq.keys()) if (seq > maxSeq) maxSeq = seq;
+  const completeToken = completeBySeq.get(maxSeq);
   const token = entryBySeq.get(maxSeq);
-  if (!token) {
+  if (!token || !completeToken || completeToken !== token) {
     // A complete marker exists without its entry json: the entry was pruned or
     // never written. Treat the journal as unreadable at this fence and fail
     // closed rather than guessing a parent.
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   let raw;
   try {
     raw = readFileSync(occEntryPath(dir, maxSeq, token), 'utf8');
   } catch {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   let entry;
   try {
     entry = JSON.parse(raw);
   } catch {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
   if (!entry || typeof entry !== 'object' || entry.seq !== maxSeq || entry.owner_token !== token || !('state' in entry)) {
-    return { seq: maxSeq, state: null, empty: false, ioError: true };
+    return { seq: maxSeq, state: null, empty: false, ioError: true, reservedSeq };
   }
-  return { seq: maxSeq, state: entry.state, empty: false, ioError: false };
+  return { seq: maxSeq, state: entry.state, empty: false, ioError: false, reservedSeq };
 }
 
-/** Seed state for the first commit when the journal is empty: the canonical file, if any. */
-function occSeedState(filePath) {
+function occReadCanonicalSnapshot(filePath) {
   try {
-    const raw = readFileSync(filePath, 'utf8');
-    return JSON.parse(raw);
+    const state = JSON.parse(readFileSync(filePath, 'utf8'));
+    return { state, fingerprint: JSON.stringify(state), ioError: false };
   } catch (error) {
-    if (error && error.code === 'ENOENT') return null;
-    throw error;
+    if (error && error.code === 'ENOENT') return { state: null, fingerprint: 'absent', ioError: false };
+    return { state: null, fingerprint: '', ioError: true };
   }
+}
+
+function occStateFingerprint(state) {
+  return state === null ? 'absent' : JSON.stringify(state);
 }
 
 /** Removes only the caller's OWN incomplete entry + any markers for (seq, token). */
 function occCleanupOwn(dir, seq, token) {
+  try { unlinkSync(occClaimPath(dir, seq)); } catch { /* absent */ }
   try { unlinkSync(occEntryPath(dir, seq, token)); } catch { /* absent */ }
   try { unlinkSync(occCompletePath(dir, seq, token)); } catch { /* absent */ }
   try { unlinkSync(occAbortedPath(dir, seq, token)); } catch { /* absent */ }
@@ -812,7 +832,7 @@ function occPruneOld(dir, currentSeq) {
   try { names = readdirSync(dir); } catch { return; }
   const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
   for (const name of names) {
-    const match = OCC_ENTRY_NAME_RE.exec(name);
+    const match = OCC_ENTRY_NAME_RE.exec(name) || OCC_CLAIM_NAME_RE.exec(name);
     if (!match) continue;
     const seq = Number(match[1]);
     if (Number.isInteger(seq) && seq < cutoff) {
@@ -835,7 +855,7 @@ function occPruneOld(dir, currentSeq) {
  */
 export function occCommitMutation(filePath, mutate, options = {}) {
   const dir = occJournalDir(filePath);
-  ensureDirSync(dir);
+  try { ensureDirSync(dir); } catch { return false; }
   const ownerToken = options.ownerToken || randomUUID();
   let parentSeq = -1;
   let parentState = null;
@@ -843,35 +863,41 @@ export function occCommitMutation(filePath, mutate, options = {}) {
   for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
     const current = occReadCurrent(filePath);
     if (current.ioError) return false; // fail closed: cannot fence without reading
+    const canonical = occReadCanonicalSnapshot(filePath);
+    if (canonical.ioError) return false;
     if (current.empty) {
       parentSeq = -1;
-      parentState = occSeedState(filePath);
+      parentState = canonical.state;
     } else {
       parentSeq = current.seq;
-      parentState = current.state;
+      parentState = occStateFingerprint(current.state) === canonical.fingerprint ? current.state : canonical.state;
     }
     let produced;
     produced = mutate(parentState, ownerToken);
     if (produced === null || produced === undefined) return false; // cancelled, no commit
     next = produced;
-    const seq = parentSeq + 1;
+    const seq = Math.max(parentSeq, current.reservedSeq) + 1;
     const entryPath = occEntryPath(dir, seq, ownerToken);
     let fd;
-    let claimed = false;
     try {
+      fd = openSync(occClaimPath(dir, seq), 'wx', 0o600);
+      writeAllSync(fd, ownerToken, 'occ sequence claim');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
       fd = openSync(entryPath, 'wx', 0o600);
       const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
       writeAllSync(fd, JSON.stringify(entry), 'occ journal entry');
       fsyncSync(fd);
       closeSync(fd);
       fd = undefined;
-      claimed = true;
     } catch (error) {
       if (fd !== undefined) { try { closeSync(fd); } catch {} }
       if (error && error.code === 'EEXIST') {
         // Another writer already claimed this seq. Re-read and retry with seq+1.
         continue;
       }
+      occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
     // Test seam (B11 probe): when a pause hook is registered for this filePath,
@@ -896,6 +922,19 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       // mark the fork as aborted so it is distinguishable from a live claim
       try { openSync(occAbortedPath(dir, seq, ownerToken), 'wx', 0o600); } catch { /* already marked */ }
       continue; // re-run mutate on the successor's state
+    }
+    try { options.assertHeld?.(); } catch {
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    const canonicalFence = occReadCanonicalSnapshot(filePath);
+    if (canonicalFence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    if (canonicalFence.fingerprint !== canonical.fingerprint) {
+      occCleanupOwn(dir, seq, ownerToken);
+      continue;
     }
     // COMMIT: create the .complete marker via O_EXCL.
     let markerFd;

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -806,11 +806,12 @@ function occReadCurrent(filePath) {
 
 function occReadCanonicalSnapshot(filePath) {
   try {
-    const state = JSON.parse(readFileSync(filePath, 'utf8'));
-    return { state, fingerprint: JSON.stringify(state), ioError: false };
+    const raw = readFileSync(filePath, 'utf8');
+    const state = JSON.parse(raw);
+    return { state, contentFingerprint: stateDigest(raw), stateFingerprint: JSON.stringify(state), ioError: false };
   } catch (error) {
-    if (error && error.code === 'ENOENT') return { state: null, fingerprint: 'absent', ioError: false };
-    return { state: null, fingerprint: '', ioError: true };
+    if (error && error.code === 'ENOENT') return { state: null, contentFingerprint: 'absent', stateFingerprint: 'absent', ioError: false };
+    return { state: null, contentFingerprint: '', stateFingerprint: '', ioError: true };
   }
 }
 
@@ -870,7 +871,16 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       parentState = canonical.state;
     } else {
       parentSeq = current.seq;
-      parentState = occStateFingerprint(current.state) === canonical.fingerprint ? current.state : canonical.state;
+      if (!options.skipCanonicalReconciliation && occStateFingerprint(current.state) !== canonical.stateFingerprint) {
+        const reconciled = occCommitMutation(
+          filePath,
+          () => ({ state: canonical.state, result: true }),
+          { assertHeld: options.assertHeld, suppressCanonicalRepublish: true, skipCanonicalReconciliation: true },
+        );
+        if (!reconciled) return false;
+        continue;
+      }
+      parentState = current.state;
     }
     let produced;
     produced = mutate(parentState, ownerToken);
@@ -932,7 +942,7 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
-    if (canonicalFence.fingerprint !== canonical.fingerprint) {
+    if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
       occCleanupOwn(dir, seq, ownerToken);
       continue;
     }
@@ -956,11 +966,13 @@ export function occCommitMutation(filePath, mutate, options = {}) {
     // entry is now NOT the max, it remains a valid committed ancestor: leave it.
     occPruneOld(dir, seq);
     // Re-publish the canonical file so legacy readers see the latest state.
-    try {
-      atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
-    } catch {
-      // The journal IS the source of truth; a failed canonical re-publish is
-      // non-fatal (the committed entry already advances current). Return true.
+    if (!options.suppressCanonicalRepublish) {
+      try {
+        atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
+      } catch {
+        // The journal commit remains durable. A later writer reconciles the
+        // compatibility file before evaluating its mutation.
+      }
     }
     return true;
   }
@@ -971,10 +983,9 @@ export function occCommitMutation(filePath, mutate, options = {}) {
 export function occReadCurrentState(filePath) {
   const current = occReadCurrent(filePath);
   if (current.ioError) return null;
-  if (current.empty) {
-    try { return JSON.parse(readFileSync(filePath, 'utf8')); } catch { return null; }
-  }
-  return current.state;
+  if (!current.empty) return current.state;
+  const canonical = occReadCanonicalSnapshot(filePath);
+  return canonical.ioError ? null : canonical.state;
 }
 
 /** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -866,20 +866,24 @@ export function occCommitMutation(filePath, mutate, options = {}) {
     if (current.ioError) return false; // fail closed: cannot fence without reading
     const canonical = occReadCanonicalSnapshot(filePath);
     if (canonical.ioError) return false;
+    if (options.expectedCanonicalContentFingerprint !== undefined &&
+      canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      return false;
+    }
     if (current.empty) {
       parentSeq = -1;
-      parentState = canonical.state;
+      // An authenticated external publisher supplies the source it captured
+      // before cache publication. Never infer that parent from post-publish
+      // canonical bytes.
+      parentState = Object.prototype.hasOwnProperty.call(options, 'authenticatedExternalParent')
+        ? options.authenticatedExternalParent
+        : canonical.state;
     } else {
       parentSeq = current.seq;
-      if (!options.skipCanonicalReconciliation && occStateFingerprint(current.state) !== canonical.stateFingerprint) {
-        const reconciled = occCommitMutation(
-          filePath,
-          () => ({ state: canonical.state, result: true }),
-          { assertHeld: options.assertHeld, suppressCanonicalRepublish: true, skipCanonicalReconciliation: true },
-        );
-        if (!reconciled) return false;
-        continue;
-      }
+      // A committed journal head is authoritative. `filePath` is only a
+      // compatibility cache and may be stale or written by an older install;
+      // it must never be silently promoted into a new journal generation.
       parentState = current.state;
     }
     let produced;
@@ -942,6 +946,12 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
+    if (options.expectedCanonicalContentFingerprint !== undefined &&
+      canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
+      options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
     if (canonicalFence.contentFingerprint !== canonical.contentFingerprint) {
       occCleanupOwn(dir, seq, ownerToken);
       continue;
@@ -970,8 +980,8 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       try {
         atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
       } catch {
-        // The journal commit remains durable. A later writer reconciles the
-        // compatibility file before evaluating its mutation.
+        // The journal commit remains durable. A later writer re-publishes its
+        // authoritative head; cache bytes are never journal input.
       }
     }
     return true;

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -667,6 +667,301 @@ export function withStateFileLockSync(filePath, callback, requireExclusive = fal
   }
 }
 
+// ===========================================================================
+// OCC (optimistic concurrency control) journal - root cure for B11.
+//
+// The lease lock above cannot atomically (check-ownership + write) an EXISTING
+// state file on a flock-less runtime (macOS/Windows): renewMutationLock returns
+// false there and assertMutationLockHeld is a read-then-write TOCTOU, so a
+// stale holder whose lease expired mid-mutation can overwrite a successor's
+// publish (B11), and a stale releaser can unlink a successor's lock (release
+// race). No combination of rename/link/unlink atomically fences an EXISTING file
+// on flock-less. OCC fixes it using ONLY O_EXCL (portable, no flock, no
+// liveness probe, testable on mac): every mutation sequences a NEW journal
+// entry under an O_EXCL name and validates its parent against the current
+// committed sequence; a stale writer that forks off an old parent is DETECTED
+// and re-sequenced AFTER its successor instead of overwriting it. There is no
+// shared lock to unlink - cleanup only ever touches the writer's OWN entries.
+//
+// Journal layout per state file `filePath`:
+//   dir:        filePath.journal/
+//   entry:      <seq>.<owner_token>.json        = { seq, parent_seq, owner_token, state }
+//   commit:     <seq>.<owner_token>.complete    (O_EXCL file = committed)
+//   aborted:    <seq>.<owner_token>.aborted     (marker for a detected dead fork)
+// "current" = the entry with the MAX seq bearing a .complete marker. Readers
+// scan the directory for the max complete seq (small N; entries with seq <
+// current - K are pruned, K=8) and read that entry's state. The canonical
+// `filePath` is re-published (atomicWriteFileSync) right after each commit so
+// existing readers that do not understand the journal keep working.
+// ===========================================================================
+
+/** Prune window: keep entries whose seq >= currentSeq - OCC_JOURNAL_PRUNE_BEHIND. */
+const OCC_JOURNAL_PRUNE_BEHIND = 8;
+/** Bounded O_EXCL claim retries per commit attempt (defends against live contention). */
+const OCC_JOURNAL_MAX_RETRIES = 50;
+
+/**
+ * Test seam for the deterministic B11 probe (stale-holder-publishes-after-reclaim).
+ * When `pauseAfterClaim` is set, `occCommitMutation` invokes its `fn` AFTER
+ * claiming an entry and BEFORE the fence revalidation, letting a test
+ * deschedule writer A, commit writer B fully, then resume A so A must detect
+ * its fork. Unused in production (the hook object stays empty).
+ */
+export const OCC_TEST_HOOKS = { pauseAfterClaim: null };
+
+function occJournalDir(filePath) {
+  return `${filePath}.journal`;
+}
+
+function occEntryPath(dir, seq, token) {
+  return join(dir, `${seq}.${token}.json`);
+}
+
+function occCompletePath(dir, seq, token) {
+  return join(dir, `${seq}.${token}.complete`);
+}
+
+function occAbortedPath(dir, seq, token) {
+  return join(dir, `${seq}.${token}.aborted`);
+}
+
+const OCC_ENTRY_NAME_RE = /^(\d+)\.([0-9a-f-]{36})\.(json|complete|aborted)$/i;
+
+/**
+ * Scans the OCC journal directory and returns the current committed state: the
+ * entry with the maximum `seq` that bears a `.complete` marker. Returns
+ * { seq: -1, state: null, empty: true } when no committed entry exists yet (the
+ * journal is empty). Returns null (current=null, ioError=true) ONLY when the
+ * journal directory is present but unreadable with a non-ENOENT I/O error - in
+ * that case the caller FAILS CLOSED (operator attention): an OCC commit cannot
+ * proceed safely without being able to read the committed sequence fence.
+ */
+function occReadCurrent(filePath) {
+  const dir = occJournalDir(filePath);
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return { seq: -1, state: null, empty: true, ioError: false };
+    return { seq: -1, state: null, empty: false, ioError: true };
+  }
+  const completeSeqs = new Set();
+  const entryBySeq = new Map();
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (!Number.isInteger(seq) || seq < 0) continue;
+    const token = match[2];
+    const kind = match[3];
+    if (kind === 'complete') {
+      completeSeqs.add(seq);
+    } else if (kind === 'json') {
+      if (!entryBySeq.has(seq)) entryBySeq.set(seq, token);
+    }
+  }
+  if (completeSeqs.size === 0) return { seq: -1, state: null, empty: true, ioError: false };
+  let maxSeq = -1;
+  for (const seq of completeSeqs) if (seq > maxSeq) maxSeq = seq;
+  const token = entryBySeq.get(maxSeq);
+  if (!token) {
+    // A complete marker exists without its entry json: the entry was pruned or
+    // never written. Treat the journal as unreadable at this fence and fail
+    // closed rather than guessing a parent.
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  let raw;
+  try {
+    raw = readFileSync(occEntryPath(dir, maxSeq, token), 'utf8');
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  let entry;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  if (!entry || typeof entry !== 'object' || entry.seq !== maxSeq || entry.owner_token !== token || !('state' in entry)) {
+    return { seq: maxSeq, state: null, empty: false, ioError: true };
+  }
+  return { seq: maxSeq, state: entry.state, empty: false, ioError: false };
+}
+
+/** Seed state for the first commit when the journal is empty: the canonical file, if any. */
+function occSeedState(filePath) {
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+/** Removes only the caller's OWN incomplete entry + any markers for (seq, token). */
+function occCleanupOwn(dir, seq, token) {
+  try { unlinkSync(occEntryPath(dir, seq, token)); } catch { /* absent */ }
+  try { unlinkSync(occCompletePath(dir, seq, token)); } catch { /* absent */ }
+  try { unlinkSync(occAbortedPath(dir, seq, token)); } catch { /* absent */ }
+}
+
+/** Prunes committed entries older than currentSeq - K (keeps the history tail bounded). */
+function occPruneOld(dir, currentSeq) {
+  let names;
+  try { names = readdirSync(dir); } catch { return; }
+  const cutoff = currentSeq - OCC_JOURNAL_PRUNE_BEHIND;
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    const seq = Number(match[1]);
+    if (Number.isInteger(seq) && seq < cutoff) {
+      try { unlinkSync(join(dir, name)); } catch { /* race; ignore */ }
+    }
+  }
+}
+
+/**
+ * OCC commit protocol (replaces writeAtomic-under-lock for concurrency fencing).
+ *
+ * `mutate(currentState)` is PURE: it returns the next state (or `null` /
+ * `undefined` to cancel without committing). The wrapper handles claim,
+ * parent-validation, commit, re-publication, and retry. Returns:
+ *   - true on a committed mutation (current advanced),
+ *   - false if every retry forked (extremely live contention) or on a journal-
+ *     directory I/O error (fail closed) or a thrown mutation.
+ *
+ * The graph store passes `{next, result}` callbacks; this wrapper is generic.
+ */
+export function occCommitMutation(filePath, mutate, options = {}) {
+  const dir = occJournalDir(filePath);
+  ensureDirSync(dir);
+  const ownerToken = options.ownerToken || randomUUID();
+  let parentSeq = -1;
+  let parentState = null;
+  let next = null;
+  for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
+    const current = occReadCurrent(filePath);
+    if (current.ioError) return false; // fail closed: cannot fence without reading
+    if (current.empty) {
+      parentSeq = -1;
+      parentState = occSeedState(filePath);
+    } else {
+      parentSeq = current.seq;
+      parentState = current.state;
+    }
+    let produced;
+    produced = mutate(parentState, ownerToken);
+    if (produced === null || produced === undefined) return false; // cancelled, no commit
+    next = produced;
+    const seq = parentSeq + 1;
+    const entryPath = occEntryPath(dir, seq, ownerToken);
+    let fd;
+    let claimed = false;
+    try {
+      fd = openSync(entryPath, 'wx', 0o600);
+      const entry = { seq, parent_seq: parentSeq, owner_token: ownerToken, state: next };
+      writeAllSync(fd, JSON.stringify(entry), 'occ journal entry');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = undefined;
+      claimed = true;
+    } catch (error) {
+      if (fd !== undefined) { try { closeSync(fd); } catch {} }
+      if (error && error.code === 'EEXIST') {
+        // Another writer already claimed this seq. Re-read and retry with seq+1.
+        continue;
+      }
+      return false;
+    }
+    // Test seam (B11 probe): when a pause hook is registered for this filePath,
+    // invoke it AFTER the entry is claimed but BEFORE the fence revalidation.
+    // This deterministically forces the stale-holder-publishes-after-reclaim
+    // interleaving: A claims, yields here, B commits fully, A resumes and must
+    // detect the fork. No-op in production (no hook registered).
+    if (OCC_TEST_HOOKS.pauseAfterClaim && OCC_TEST_HOOKS.pauseAfterClaim.filePath === filePath) {
+      try { OCC_TEST_HOOKS.pauseAfterClaim.fn(seq, ownerToken, parentSeq); } catch { /* test seam; ignore */ }
+    }
+    // RE-VALIDATE (the fence): re-scan the current committed max. If a successor
+    // committed in the window (current.seq > parentSeq), this entry is a DEAD
+    // FORK off a stale parent: mark it aborted, re-run the mutation on the
+    // successor's state, and re-sequence AFTER it. It NEVER overwrites.
+    const fence = occReadCurrent(filePath);
+    if (fence.ioError) {
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    if (!fence.empty && fence.seq > parentSeq) {
+      try { unlinkSync(occEntryPath(dir, seq, ownerToken)); } catch { /* absent */ }
+      // mark the fork as aborted so it is distinguishable from a live claim
+      try { openSync(occAbortedPath(dir, seq, ownerToken), 'wx', 0o600); } catch { /* already marked */ }
+      continue; // re-run mutate on the successor's state
+    }
+    // COMMIT: create the .complete marker via O_EXCL.
+    let markerFd;
+    try {
+      markerFd = openSync(occCompletePath(dir, seq, ownerToken), 'wx', 0o600);
+      fsyncSync(markerFd);
+      closeSync(markerFd);
+    } catch (error) {
+      // A .complete marker already exists for this (seq, token): impossible for
+      // a fresh token; treat as a fork and retry.
+      if (markerFd !== undefined) { try { closeSync(markerFd); } catch {} }
+      occCleanupOwn(dir, seq, ownerToken);
+      if (error && error.code === 'EEXIST') continue;
+      return false;
+    }
+    // Re-validate this seq is still the max complete (else a successor committed
+    // between our fence read and our marker; we still committed a valid child of
+    // `parentSeq`, which is fine - the successor simply sequences ahead). If our
+    // entry is now NOT the max, it remains a valid committed ancestor: leave it.
+    occPruneOld(dir, seq);
+    // Re-publish the canonical file so legacy readers see the latest state.
+    try {
+      atomicWriteFileSync(filePath, JSON.stringify(next, null, 2));
+    } catch {
+      // The journal IS the source of truth; a failed canonical re-publish is
+      // non-fatal (the committed entry already advances current). Return true.
+    }
+    return true;
+  }
+  return false; // exhausted retries under extreme live contention
+}
+
+/** Reads the current committed state via the OCC journal (test + reader surface). */
+export function occReadCurrentState(filePath) {
+  const current = occReadCurrent(filePath);
+  if (current.ioError) return null;
+  if (current.empty) {
+    try { return JSON.parse(readFileSync(filePath, 'utf8')); } catch { return null; }
+  }
+  return current.state;
+}
+
+/** Cleans up only this owner token's stale INCOMPLETE entries (release race cure). */
+export function occCleanupOwner(filePath, ownerToken) {
+  const dir = occJournalDir(filePath);
+  let names;
+  try { names = readdirSync(dir); } catch { return; }
+  for (const name of names) {
+    const match = OCC_ENTRY_NAME_RE.exec(name);
+    if (!match) continue;
+    if (match[2] !== ownerToken) continue; // never touch another writer's entries
+    const seq = Number(match[1]);
+    const kind = match[3];
+    // Only remove entries that lack a .complete marker (incomplete forks).
+    if (kind === 'json' || kind === 'aborted') {
+      const hasComplete = names.some((other) => {
+        const om = OCC_ENTRY_NAME_RE.exec(other);
+        return om && om[1] === match[1] && om[2] === ownerToken && om[3] === 'complete';
+      });
+      if (!hasComplete) {
+        try { unlinkSync(join(dir, name)); } catch { /* race */ }
+      }
+    }
+  }
+}
+
 /** Recover an interrupted exact emergency state mutation without touching replacements. */
 function stateDigest(raw) {
   return createHash('sha256').update(raw).digest('hex');

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -863,14 +863,13 @@ export function occCommitMutation(filePath, mutate, options = {}) {
   let next = null;
   for (let attempt = 0; attempt < OCC_JOURNAL_MAX_RETRIES; attempt += 1) {
     const current = occReadCurrent(filePath);
-    if (current.ioError) return false; // fail closed: cannot fence without reading
     const canonical = occReadCanonicalSnapshot(filePath);
-    if (canonical.ioError) return false;
     if (options.expectedCanonicalContentFingerprint !== undefined &&
       canonical.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
       options.onCanonicalCompareFailed?.();
       return false;
     }
+    if (current.ioError || canonical.ioError) return false; // fail closed: cannot fence without reading
     if (current.empty) {
       parentSeq = -1;
       // An authenticated external publisher supplies the source it captured
@@ -942,13 +941,13 @@ export function occCommitMutation(filePath, mutate, options = {}) {
       return false;
     }
     const canonicalFence = occReadCanonicalSnapshot(filePath);
-    if (canonicalFence.ioError) {
-      occCleanupOwn(dir, seq, ownerToken);
-      return false;
-    }
     if (options.expectedCanonicalContentFingerprint !== undefined &&
       canonicalFence.contentFingerprint !== options.expectedCanonicalContentFingerprint) {
       options.onCanonicalCompareFailed?.();
+      occCleanupOwn(dir, seq, ownerToken);
+      return false;
+    }
+    if (canonicalFence.ioError) {
       occCleanupOwn(dir, seq, ownerToken);
       return false;
     }
@@ -1421,7 +1420,7 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
       if (intent === 'publish' && digest(payloadPath) !== intendedDigest) return false;
       if (!owned()) return false;
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
-        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) removeOwnedEmergencyArtifacts(journalPath, journal, true);
+        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) return removeOwnedEmergencyArtifacts(journalPath, journal, true);
         return false;
       }
       journal.phase = 'quarantined';

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -1035,8 +1035,11 @@ function sameEmergencyOwner(left, right) {
   return left.pid === right.pid && left.processStart === right.processStart && left.nonce === right.nonce;
 }
 
-/** Unknown process identity is treated as live; only an exact start identity proves ownership. */
+/** Unknown process identity is treated as live: stealing a claim is never safe. */
 function isEmergencyOwnerLive(owner) {
+  // Deterministic crash injection relinquishes ownership with this sentinel.
+  // It is test-only; real unknown process identities remain fail-closed.
+  if (process.env.NODE_ENV === 'test' && owner.pid === 999999999 && owner.processStart === 'abandoned') return false;
   const currentStart = processStartIdentity(owner.pid);
   return currentStart !== 'absent' && (currentStart === null || currentStart === owner.processStart);
 }
@@ -1420,7 +1423,17 @@ function recoverDeadEmergencyStateFile(filePath, authorizeState) {
       if (intent === 'publish' && digest(payloadPath) !== intendedDigest) return false;
       if (!owned()) return false;
       if (!captureAndUnlinkPrimary(filePath, journal.quarantinePath, originalDigest)) {
-        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) return removeOwnedEmergencyArtifacts(journalPath, journal, true);
+        // A replacement appeared DURING capture, before the original was durably
+        // quarantined and unlinked. The emergency no longer applies to this
+        // generation: abort so the caller surfaces the recovery failure, while
+        // cleaning up the partial transaction so no ownerless artifact remains.
+        // This mirrors the live emergencyMutateStateFileIf capture-failure path.
+        // A quarantine that capture created before detecting the replacement is
+        // removed; the replacement wins and is never sequenced through OCC.
+        if (owned() && existsSync(filePath) && existsSync(journal.quarantinePath) && digest(filePath) !== originalDigest) {
+          removeOwnedEmergencyArtifacts(journalPath, journal, true);
+          return false;
+        }
         return false;
       }
       journal.phase = 'quarantined';

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -105,45 +105,166 @@ export function atomicWriteFileSync(filePath, content) {
   }
 }
 
+// Keep emitting the deployed v1 lease wire format. Older readers classify a
+// different version as corrupt and can otherwise reclaim a live current lock.
 const LOCK_SCHEMA_VERSION = 1;
-function flockPath() { return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null; }
+const LOCK_OLD_SCHEMA_VERSION = 1;
+/** Pre-upgrade (v1) liveness-schema key set: has `processStart`, no `expires_at`. */
+const LOCK_OLD_OWNER_KEYS = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
+/**
+ * Lease duration (ms) for a mutation lock. Generous enough that a single
+ * acquire->mutate->release cycle (graph mutation or autopilot state write)
+ * almost always completes within the lease. As a SAFETY NET against a holder
+ * whose critical section overruns the lease (B11: the lease would otherwise
+ * expire mid-mutation and admit a second writer), the holder re-validates its
+ * OWN lease immediately before publishing (see assertMutationLockHeld) and
+ * aborts with `lease_expired_during_mutation` if it has expired. Long-held
+ * locks (e.g. a slow graph mutation) SHOULD additionally call renewMutationLock
+ * periodically to extend `expires_at` while still working, so the lease does
+ * not expire under them. If the holder crashes or fails to release, a later
+ * acquirer reclaims once `now >= expires_at`.
+ */
+const LOCK_LEASE_MS = 300000; // 5 minutes
+
+/**
+ * Returns the current wall-clock ms. Centralised so tests can mock time by
+ * planting `expires_at` values; production reads `Date.now()`.
+ */
+function leaseNow() {
+  return Date.now();
+}
+
+function flockPath() {
+  // B8 test seam: OMC_TEST_FORCE_FLOCKLESS=1 (NODE_ENV=test only) forces the
+  // flock-less linkSync branch on a host that actually has flock (Linux CI),
+  // so the flock-less acquire/reclaim/release code is exercised there. Unlike
+  // OMC_TEST_FLOCK_AVAILABLE=0 it does NOT trip lockingDisabledForTest(), so
+  // exclusive locking stays enabled and the real flock-less path runs.
+  if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FORCE_FLOCKLESS === '1') return null;
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0' ? null : existsSync('/usr/bin/flock') ? '/usr/bin/flock' : existsSync('/bin/flock') ? '/bin/flock' : null;
+}
+/**
+ * True only when the test harness explicitly simulates a runtime with NO
+ * locking primitives whatsoever (OMC_TEST_FLOCK_AVAILABLE=0). Distinct from a
+ * real flock-less runtime (Windows/macOS): there, linkSync-based O_EXCL locking
+ * is still a valid mutual-exclusion mechanism and may be used. Under the test
+ * simulation, exclusive locks must remain unavailable (return null) so callers
+ * fail closed - the same contract the dev branch established. Mirrors
+ * lockingDisabledForTest() in src/lib/mode-state-io.ts.
+ */
+function lockingDisabledForTest() {
+  return process.env.NODE_ENV === 'test' && process.env.OMC_TEST_FLOCK_AVAILABLE === '0';
+}
+// Lease-based mutation lock reclaim script (runs under an exclusive `flock` guard
+// on `${lockPath}.reclaim.guard` so the reclaim read+unlink is atomic w.r.t.
+// other reclaimers). The script reads the on-disk owner and decides:
+//   exit 0 -> lock was reclaimable (expired lease OR corrupt) and has been
+//             unlinked; the caller should retry linkSync to acquire.
+//   exit 2 -> lock has a VALID, UNEXPIRED v1 lease (live owner); do NOT reclaim.
+//   exit 3 -> the lock could not be read with a non-ENOENT I/O error
+//             (EACCES/EMFILE/EIO/ENOMEM): the owner MAY be alive and we just
+//             cannot read its lease. FAIL CLOSED (no steal). Operator attention.
+//   exit 4 -> owner replaced between read and unlink (TOCTOU); caller retries.
+//   exit 5 -> the on-disk owner is a v1 (old-liveness contract) record
+//             (has processStart, no expires_at). The old owner MAY be alive; we
+//             do NOT reclaim it and do NOT unlink. FAIL CLOSED (B12). The caller
+//             fails closed (wait / return null). Operator attention.
+//   exit 6 -> lock is a structurally valid lease record with an unsupported
+//             version. It may be live under another contract; fail closed.
+// For `release` the script unlinks only if the on-disk owner exactly matches the
+// expected owner (pid + nonce + createdAt); a mismatched owner (or a v1 owner,
+// or a corrupt owner) is left in place.
 const LOCK_REMOVAL_SCRIPT = String.raw`
 const fs = require('fs');
-const [operation, lockPath, expectedRaw] = process.argv.slice(1);
-const keys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
+const [operation, lockPath, expectedRaw, renewalPath] = process.argv.slice(1);
+const leaseKeys = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'];
+const oldKeys = ['createdAt', 'nonce', 'pid', 'processStart', 'version'];
 function readOwner() {
+  let raw;
   try {
-    const value = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    raw = fs.readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return 'absent';
+    return 'io_error';
+  }
+  try {
+    const value = JSON.parse(raw);
     const actual = Object.keys(value).sort();
-    if (actual.length !== keys.length || !actual.every((key, index) => key === keys[index]) || value.version !== 1 || !Number.isSafeInteger(value.pid) || value.pid <= 0 || typeof value.processStart !== 'string' || !/^\d+$/.test(value.processStart) || typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt)) || typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return null;
-    return value;
-  } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); return null; }
+    // v1 lease schema (the deployed current contract): expires_at, no processStart.
+    const leaseShaped = actual.length === leaseKeys.length && actual.every((key, index) => key === leaseKeys[index]) && Number.isSafeInteger(value.version) && value.version > 0 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.expires_at === 'string' && Number.isFinite(Date.parse(value.expires_at)) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce);
+    if (leaseShaped && value.version === 1) return value;
+    // v1 old-liveness schema (pre-upgrade contract): version 1, processStart, no
+    // expires_at. NOT corrupt - it is a live lock held under the old contract. The
+    // old owner may be alive; FAIL CLOSED (B12): never unlink, never reclaim.
+    if (actual.length === oldKeys.length && actual.every((key, index) => key === oldKeys[index]) && value.version === 1 && Number.isSafeInteger(value.pid) && value.pid > 0 && typeof value.createdAt === 'string' && Number.isFinite(Date.parse(value.createdAt)) && typeof value.processStart === 'string' && /^\d+$/.test(value.processStart) && typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce)) return 'old_version';
+    if (leaseShaped) return 'unknown_version';
+    // B12: a structurally-valid versioned object under a shape we don't recognise
+    // (e.g. a future lease with extra/renamed fields) MAY be a live owner. FAIL
+    // CLOSED (unknown_version -> exit 6): never unlink, never reclaim. Reserve
+    // 'corrupt' for genuinely unparseable / non-versioned garbage.
+    if (value && typeof value === 'object' && !Array.isArray(value) && Number.isSafeInteger(value.version) && value.version > 0) return 'unknown_version';
+    return 'corrupt';
+  } catch (error) { return 'corrupt'; }
 }
-const owner = readOwner();
-if (!owner) process.exit(3);
 if (operation === 'release') {
   let expected;
   try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
-  if (owner.pid !== expected.pid || owner.processStart !== expected.processStart || owner.nonce !== expected.nonce) process.exit(4);
-  try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(0);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5); // not ours; leave the old-contract lock in place
+  if (current === 'unknown_version') process.exit(6); // not ours; leave the unsupported-contract lock in place
+  if (current === 'corrupt') process.exit(3);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); }
 }
-if (process.platform !== 'linux') process.exit(3);
-let currentStart;
-try {
-  const stat = fs.readFileSync('/proc/' + owner.pid + '/stat', 'utf8');
-  const end = stat.lastIndexOf(')');
-  const fields = end >= 0 ? stat.slice(end + 2).trim().split(/\s+/) : [];
-  currentStart = fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
-} catch (error) { currentStart = error && error.code === 'ENOENT' ? 'absent' : null; }
-if (currentStart === null) process.exit(3);
-if (currentStart !== 'absent' && currentStart === owner.processStart) process.exit(2);
-try { fs.unlinkSync(lockPath); process.exit(0); } catch { process.exit(3); }
+if (operation === 'renew') {
+  let expected;
+  try { expected = JSON.parse(expectedRaw); } catch { process.exit(3); }
+  const current = readOwner();
+  if (current === 'absent') process.exit(4);
+  if (current === 'io_error') process.exit(3);
+  if (current === 'old_version') process.exit(5);
+  if (current === 'unknown_version') process.exit(6);
+  if (current === 'corrupt') process.exit(4);
+  if (current.pid !== expected.pid || current.nonce !== expected.nonce || current.createdAt !== expected.createdAt) process.exit(4);
+  if (Date.now() >= Date.parse(current.expires_at)) process.exit(2);
+  try { fs.renameSync(renewalPath, lockPath); process.exit(0); } catch { process.exit(3); }
+}
+const current = readOwner();
+if (current === 'absent') process.exit(0);
+if (current === 'io_error') process.exit(3);
+if (current === 'old_version') process.exit(5); // old-contract owner may be live; FAIL CLOSED (B12)
+if (current === 'unknown_version') process.exit(6); // unknown-contract owner may be live; FAIL CLOSED
+if (current === 'corrupt') { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+if (Date.now() >= Date.parse(current.expires_at)) { try { fs.unlinkSync(lockPath); process.exit(0); } catch (error) { if (error && error.code === 'ENOENT') process.exit(0); process.exit(4); } }
+process.exit(2);
 `;
+
+// ---------------------------------------------------------------------------
+// Emergency-journal process identity (NOT used by the mutation lock).
+//
+// The mutation lock is LEASE-based (see freshLockOwner/readLockOwner above) and
+// does NOT probe process liveness. This processStartIdentity helper is retained
+// exclusively for the EMERGENCY JOURNAL subsystem (recoverEmergencyStateFile /
+// emergencyMutateStateFileIf and their recovery-claim script), which still
+// authenticates a crashed transaction's owner by process-start identity. It is
+// intentionally kept separate from the lease lock so the mutation-lock blockers
+// (B5/B6/B7/B8/B9/B10) cannot recur via the emergency path's liveness probe.
+// ---------------------------------------------------------------------------
+let cachedSelfProcessStart;
+
+function selfProcessStart() {
+  if (cachedSelfProcessStart === undefined) {
+    cachedSelfProcessStart = String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1000)));
+  }
+  return cachedSelfProcessStart;
+}
 
 function processStartIdentity(pid) {
   if (process.env.NODE_ENV === 'test' && process.env.OMC_TEST_EMERGENCY_PROCESS_START_UNKNOWN_PID === String(pid)) return null;
   if (!Number.isSafeInteger(pid) || pid <= 0) return null;
-  if (process.platform !== 'linux') return pid === process.pid ? String(Math.max(1, Math.floor(Date.now() - process.uptime() * 1000))) : null;
+  if (process.platform !== 'linux') return pid === process.pid ? selfProcessStart() : null;
   try {
     const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
     const end = stat.lastIndexOf(')');
@@ -152,6 +273,25 @@ function processStartIdentity(pid) {
     return fields[19] && /^\d+$/.test(fields[19]) ? fields[19] : null;
   } catch (error) { return error?.code === 'ENOENT' ? 'absent' : null; }
 }
+
+/**
+ * Computes the owner record written to a freshly acquired lock file. The lease
+ * expires_at = now + LOCK_LEASE_MS; it is the ONLY reclaim key (no process
+ * liveness is probed). pid + nonce + createdAt stay for debug/ownership identity
+ * (release verifies them to avoid unlinking a lock a live owner lawfully
+ * reclaimed and re-acquired).
+ */
+function freshLockOwner() {
+  const now = leaseNow();
+  return {
+    version: LOCK_SCHEMA_VERSION,
+    pid: process.pid,
+    createdAt: new Date(now).toISOString(),
+    expires_at: new Date(now + LOCK_LEASE_MS).toISOString(),
+    nonce: randomUUID(),
+  };
+}
+
 function guardedLockRemoval(lockPath, operation, owner) {
   const flock = flockPath();
   if (!flock) return 'unverifiable';
@@ -159,19 +299,30 @@ function guardedLockRemoval(lockPath, operation, owner) {
   if (result.status === 0) return 'retry';
   if (result.status === 2) return 'live';
   if (result.status === 4) return 'replaced';
+  if (result.status === 5) return 'old_version';
+  if (result.status === 6) return 'unknown_version';
   return 'unverifiable';
+}
+
+/** Compares and replaces a lease while holding the reclaimer's guard. */
+function guardedLockRenewal(lockPath, owner, renewalPath) {
+  const flock = flockPath();
+  if (!flock) return false;
+  const result = spawnSync(flock, ['-x', `${lockPath}.reclaim.guard`, process.execPath, '-e', LOCK_REMOVAL_SCRIPT, 'renew', lockPath, JSON.stringify(owner), renewalPath], { stdio: 'ignore', timeout: 2000 });
+  return result.status === 0;
 }
 
 function acquireLockAt(lockPath, attempts = 50, requireExclusive = false) {
   ensureDirSync(dirname(lockPath));
-  if (!flockPath()) return requireExclusive ? null : { unlocked: true };
-  const processStart = processStartIdentity(process.pid);
-  if (!processStart || processStart === 'absent') {
-    console.error(`[omc-lock] state_mutation_lock_owner_unverifiable: ${lockPath}`);
-    return null;
-  }
+  const hasFlock = !!flockPath();
+  // Under the explicit test no-locking simulation, exclusive locks are
+  // unavailable (fail closed), matching the dev contract. On real flock-less
+  // runtimes (Windows/macOS) we still fall through to linkSync-based locking.
+  if (lockingDisabledForTest()) return requireExclusive ? null : { unlocked: true };
+  if (!hasFlock && !requireExclusive) return { unlocked: true };
+  // No process-liveness probe: the lease (expires_at) is the sole reclaim key.
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const owner = { version: LOCK_SCHEMA_VERSION, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() };
+    const owner = freshLockOwner();
     const tempPath = `${lockPath}.${process.pid}.${owner.nonce}.tmp`;
     let fd;
     try {
@@ -185,12 +336,60 @@ function acquireLockAt(lockPath, attempts = 50, requireExclusive = false) {
       if (fd !== undefined) { try { closeSync(fd); } catch {} }
       try { unlinkSync(tempPath); } catch {}
       if (error?.code !== 'EEXIST') return null;
-      const disposition = guardedLockRemoval(lockPath, 'reclaim');
-      if (disposition === 'unverifiable') {
-        console.error(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
-        return null;
+      // A lock already exists. Decide reclaim by LEASE, not process liveness.
+      // Both the flock and flock-less paths use the SAME policy (B7/B10
+      // convergence): reclaim only when the lease is expired or the owner JSON
+      // is corrupt; a valid unexpired lease blocks (fail closed); an I/O-
+      // unreadable lock fails closed forever (B9: the owner MAY be alive).
+      if (hasFlock) {
+        const disposition = guardedLockRemoval(lockPath, 'reclaim');
+        if (disposition === 'unverifiable') {
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
+          return null;
+        }
+        if (disposition === 'old_version' || disposition === 'unknown_version' || disposition === 'unrecognised') {
+          // v1 old-liveness contract owner, an unsupported-lease-version owner,
+          // OR a structurally-valid versioned owner under a shape we don't
+          // recognise: the owner MAY be alive under a contract we don't know.
+          // FAIL CLOSED (B12): never reclaim, never steal. Surface it so an
+          // operator can intervene; bail rather than spin forever.
+          console.error(`[omc-lock] state_mutation_lock_${disposition}: ${lockPath}`);
+          return null;
+        }
+        if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        // 'retry' (reclaimed) or 'replaced' (TOCTOU): loop and re-attempt linkSync.
+      } else {
+        const current = readLockOwner(lockPath);
+        if (current === 'absent') {
+          // Lock vanished between EEXIST and read (race): retry linkSync.
+        } else if (current === null) {
+          // I/O read failure (EACCES/EMFILE/EIO/ENOMEM) on a possibly-live
+          // lock. The owner MAY be alive; we just cannot read its lease. FAIL
+          // CLOSED (B9): no steal, no bounded reclaim, no wedge-escape. Log so
+          // the event is observable for operator attention.
+          console.error(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        } else if (current === 'old_version' || current === 'unknown_version' || current === 'unrecognised') {
+          // v1 old-liveness contract owner (processStart, no expires_at), an
+          // exact-lease-shape owner under an unsupported version, OR a
+          // structurally-valid versioned owner under a shape we don't recognise:
+          // the owner MAY be alive under a contract we don't know. FAIL CLOSED
+          // (B12): do NOT unlink, do NOT steal. Surface it; bail rather than spin.
+          console.error(`[omc-lock] state_mutation_lock_${current}: ${lockPath}`);
+          return null;
+        } else if (current === 'corrupt') {
+          // Readable but unparseable/invalid owner JSON: no valid lease is on
+          // record, so the owner cannot be live. RECLAIM (unlink) and retry.
+          try { unlinkSync(lockPath); } catch { /* race; retry linkSync */ }
+        } else if (leaseNow() >= Date.parse(current.expires_at)) {
+          // Valid owner whose lease has EXPIRED: the holder crashed or failed
+          // to release. RECLAIM (unlink) and retry.
+          try { unlinkSync(lockPath); } catch { /* race; retry linkSync */ }
+        } else {
+          // Valid owner with an unexpired lease: LIVE. Do NOT steal; wait.
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        }
       }
-      if (disposition === 'live') Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
     }
   }
   return null;
@@ -200,17 +399,269 @@ export function acquireStateFileLockSync(filePath, attempts = 50, requireExclusi
   return acquireLockAt(`${filePath}.mutation.lock`, attempts, requireExclusive);
 }
 
+function sameLockOwner(left, right) {
+  return left.pid === right.pid && left.nonce === right.nonce && left.createdAt === right.createdAt;
+}
+
+const LOCK_OWNER_KEYS = ['createdAt', 'expires_at', 'nonce', 'pid', 'version'];
+
+/**
+ * True when `value` matches the pre-upgrade v1 LIVENESS-schema owner shape
+ * (`processStart` present, no `expires_at`, version 1). Such a record is a lock
+ * held under the OLD contract; the owner may still be alive. It is NOT corrupt
+ * and must NEVER be reclaimed (B12). Distinct from a corrupt/malformed record.
+ */
+function isOldLivenessOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  if (actual.length !== LOCK_OLD_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OLD_OWNER_KEYS[index])) return false;
+  if (value.version !== LOCK_OLD_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) return false;
+  if (typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt))) return false;
+  if (typeof value.processStart !== 'string' || !/^\d+$/.test(value.processStart)) return false;
+  if (typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return false;
+  return true;
+}
+
+/**
+ * Validates a parsed object as a lease-based (v1) lock owner using the SAME checks
+ * the flock path's LOCK_REMOVAL_SCRIPT enforces: exact key set, version===1,
+ * positive integer pid, parseable createdAt, parseable expires_at (the lease
+ * reclaim key), and a 36-char UUID nonce. pid is kept for debug/ownership
+ * identity and is NOT probed for liveness. Returns the owner or null. A v1
+ * old-liveness record is NOT null here; use isOldLivenessOwner to detect it.
+ * Single owner validator (B4: folded the two divergent validators into one).
+ */
+function validateLockOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const actual = Object.keys(value).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return null;
+  if (value.version !== LOCK_SCHEMA_VERSION) return null;
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) return null;
+  if (typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt))) return null;
+  if (typeof value.expires_at !== 'string' || !Number.isFinite(Date.parse(value.expires_at))) return null;
+  if (typeof value.nonce !== 'string' || !/^[0-9a-f-]{36}$/i.test(value.nonce)) return null;
+  return value;
+}
+
+function isUnknownLeaseOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  if (actual.length !== LOCK_OWNER_KEYS.length || !actual.every((key, index) => key === LOCK_OWNER_KEYS[index])) return false;
+  if (!Number.isSafeInteger(value.version) || value.version <= 0 || value.version === LOCK_SCHEMA_VERSION) return false;
+  if (!Number.isSafeInteger(value.pid) || value.pid <= 0) return false;
+  if (typeof value.createdAt !== 'string' || !Number.isFinite(Date.parse(value.createdAt))) return false;
+  if (typeof value.expires_at !== 'string' || !Number.isFinite(Date.parse(value.expires_at))) return false;
+  return typeof value.nonce === 'string' && /^[0-9a-f-]{36}$/i.test(value.nonce);
+}
+
+/**
+ * True when `value` is a structurally-valid-but-UNRECOGNISED versioned owner: a
+ * JSON object that carries a positive-integer `version` field but does NOT
+ * match any schema this build knows (v1 lease, v1 old-liveness, or the exact
+ * 5-key unknown-lease shape handled by `isUnknownLeaseOwner`). Such a record
+ * may be a live lock held under a future contract whose shape we don't
+ * recognise (B12: e.g. a #3553-era or v2 lease with extra/renamed fields). It
+ * is NOT corrupt (the bytes are valid) and must NEVER be reclaimed: reclaiming
+ * it would destroy a live owner's lock. Callers FAIL CLOSED on it. Reserve
+ * `'corrupt'` for genuinely unparseable bytes / non-versioned garbage.
+ */
+function isUnrecognisedVersionedOwner(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  if (!Number.isSafeInteger(value.version) || value.version <= 0) return false;
+  // Anything versioned we didn't recognise above is an unknown contract. This
+  // intentionally includes records with extra/missing fields relative to the
+  // known key sets, so a future-schema live owner is never stolen as 'corrupt'.
+  return true;
+}
+
+/**
+ * Reads and validates the on-disk lease owner. Returns:
+ *  - the validated v1 lease owner on success,
+ *  - 'absent' when the lock file does not exist (ENOENT),
+ *  - 'corrupt' when the file is readable but genuinely unparseable/invalid
+ *    (broken JSON, non-object, or a non-versioned record with no `version`):
+ *    no valid lease is on record and the owner cannot be live, so reclaim.
+ *  - 'old_version' when the file is a readable v1 old-liveness-schema record
+ *    (processStart, no expires_at): a lock held under the OLD contract whose
+ *    owner may be alive. Callers FAIL CLOSED on it (B12): never reclaim.
+ *  - 'unknown_version' when the file is the exact v1-lease key set under a
+ *    different positive version (unsupported contract). FAIL CLOSED (B12).
+ *  - 'unrecognised' when the file is a structurally-valid versioned JSON object
+ *    under a shape this build does not recognise (e.g. a future lease with
+ *    extra/renamed fields). The owner MAY be live; FAIL CLOSED (B12): never
+ *    reclaim, never unlink. Distinct from 'corrupt' (genuinely bad bytes).
+ *  - null when the read itself failed with a non-ENOENT I/O error
+ *    (EACCES/EMFILE/EIO/ENOMEM) - the owner MAY be alive; callers fail closed.
+ * The 6-way result lets the caller fail closed on an unreadable lock (B9), an
+ * old-contract lock (B12), or an unrecognised-but-valid lock (B12); reclaim
+ * only a genuinely corrupt lock; and block on a valid unexpired lease.
+ */
+function readLockOwner(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') return 'absent';
+    return null; // I/O failure - may be a live lock we cannot read
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return 'corrupt'; // readable but unparseable JSON - no valid lease
+  }
+  if (isOldLivenessOwner(parsed)) return 'old_version';
+  if (isUnknownLeaseOwner(parsed)) return 'unknown_version';
+  const owner = validateLockOwner(parsed);
+  if (owner !== null) return owner;
+  // B12: a versioned object we don't recognise may be a live owner under a
+  // future contract. Fail closed (never unlink) instead of stealing it as
+  // 'corrupt'. Only non-versioned / non-object garbage stays 'corrupt'.
+  if (isUnrecognisedVersionedOwner(parsed)) return 'unrecognised';
+  return 'corrupt';
+}
+
 export function releaseStateFileLockSync(lock) {
   if (!lock || lock.unlocked) return;
   try { closeSync(lock.fd); } catch {}
-  guardedLockRemoval(lock.lockPath, 'release', lock.owner);
+  if (flockPath()) {
+    // Flock path: the guarded removal script unlinks only if the on-disk owner
+    // exactly matches ours (pid + nonce + createdAt); a mismatched owner is a
+    // live owner that lawfully reclaimed after our lease expired, so we leave
+    // it in place (the script exits 4 and we log).
+    const disposition = guardedLockRemoval(lock.lockPath, 'release', lock.owner);
+    if (disposition === 'replaced' || disposition === 'old_version') {
+      console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.lockPath}`);
+    }
+    return;
+  }
+  // flock-less runtime (macOS/Windows) or the explicit test simulation: the
+  // holder releases its OWN lock. Re-validate immediately before unlink to close
+  // the TOCTOU window between readLockOwner and unlinkSync: if the on-disk owner
+  // no longer matches (our lease expired and a later acquirer reclaimed it, or a
+  // concurrent release raced), leave the live owner's lock in place and log.
+  const current = readLockOwner(lock.lockPath);
+  if (current === 'absent') return; // already released
+  if (current === null) return; // unreadable - do not unlink what we cannot verify
+  if (current === 'old_version' || current === 'unknown_version' || current === 'unrecognised') {
+    // The on-disk lock is now a record under a contract we don't recognise
+    // (v1 old-liveness, an unsupported lease version, or an unrecognised
+    // versioned shape - e.g. a pre-upgrade owner or a future-schema owner that
+    // reclaimed after our lease expired). It is NOT ours; leave it in place
+    // (B12) - never unlink an owner whose schema we cannot verify.
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.lockPath}`);
+    return;
+  }
+  if (current !== 'corrupt' && sameLockOwner(current, lock.owner)) {
+    try { unlinkSync(lock.lockPath); } catch { /* race or already removed */ }
+  } else {
+    console.error(`[omc-lock] state_mutation_lock_release_owner_mismatch: ${lock.lockPath}`);
+  }
+}
+
+/**
+ * Re-validates that the holder's OWN lease is still live (B11). Re-reads the
+ * on-disk owner at `lock.lockPath` and confirms (a) it is still our lock
+ * (`sameLockOwner`: pid + nonce + createdAt) and (b) `now < expires_at`. If the
+ * lease has expired while we were still in the critical section, a second writer
+ * may already have reclaimed and re-acquired the lock; publishing now would
+ * silently overwrite that writer's work. To make that violation DETECTABLE
+ * rather than silent, this throws `lease_expired_during_mutation` and logs the
+ * two-writer overlap. Call this immediately BEFORE publishing under a lock whose
+ * critical section may approach LEASE_MS; withStateFileLockSync does so
+ * automatically before invoking the callback.
+ *
+ * Note: this is the holder checking ITS OWN lease, not someone else's. A holder
+ * that overruns its lease is the bug; this is the safety net that catches it.
+ */
+export function assertMutationLockHeld(lock) {
+  if (!lock || lock.unlocked) return;
+  const current = readLockOwner(lock.lockPath);
+  if (current === 'absent' || current === 'old_version' || current === 'unknown_version' || current === 'unrecognised' || current === 'corrupt' || current === null) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.lockPath}`);
+    throw new Error(`lease_expired_during_mutation: holder's lock is no longer live at ${lock.lockPath}`);
+  }
+  if (!sameLockOwner(current, lock.owner)) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.lockPath}`);
+    throw new Error(`lease_expired_during_mutation: on-disk owner replaced at ${lock.lockPath}`);
+  }
+  if (leaseNow() >= Date.parse(current.expires_at)) {
+    console.error(`[omc-lock] state_mutation_lock_lease_expired_during_mutation: ${lock.lockPath}`);
+    throw new Error(`lease_expired_during_mutation: holder's lease expired before publish at ${lock.lockPath}`);
+  }
+}
+
+/**
+ * Extends the holder's lease by re-writing `expires_at = now + LEASE_MS` while
+ * still holding the lock (B11). For long critical sections (e.g. a slow graph
+ * mutation that may approach or exceed LEASE_MS), callers should renew
+ * periodically so the lease does not expire under them and admit a second
+ * writer. Renewal re-validates that the on-disk owner is still ours (otherwise a
+ * later writer has already reclaimed our expired lease and we must NOT publish);
+ * on owner mismatch or I/O failure it returns false and the caller should abort.
+ * Returns true on a successful renewal. No-op (returns true) for unlocked locks.
+ */
+export function renewMutationLock(lock) {
+  if (!lock || lock.unlocked) return true;
+  // A read followed by rename is not a path-level CAS. Without the shared
+  // reclaimer guard there is no portable safe replacement, so fail closed.
+  if (!flockPath()) return false;
+  const current = readLockOwner(lock.lockPath);
+  if (current === 'absent' || current === 'old_version' || current === 'unknown_version' || current === 'unrecognised' || current === 'corrupt' || current === null) return false;
+  if (!sameLockOwner(current, lock.owner)) return false; // someone else owns it now
+  if (leaseNow() >= Date.parse(current.expires_at)) return false;
+  const renewedExpiresAt = new Date(leaseNow() + LOCK_LEASE_MS).toISOString();
+  const tempPath = `${lock.lockPath}.${process.pid}.${lock.owner.nonce}.renew.tmp`;
+  let fd;
+  try {
+    const renewed = { ...lock.owner, expires_at: renewedExpiresAt };
+    fd = openSync(tempPath, 'wx', 0o600);
+    writeAllSync(fd, JSON.stringify(renewed), 'lock renewal publication');
+    fsyncSync(fd);
+    // Repeat identity and expiry validation under the same guard reclaimers
+    // use, then replace atomically. This cannot overwrite a later owner.
+    if (!guardedLockRenewal(lock.lockPath, lock.owner, tempPath)) return false;
+    lock.owner = renewed;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) { try { closeSync(fd); } catch {} }
+    try { unlinkSync(tempPath); } catch {}
+  }
+}
+
+/**
+ * Reports whether `renewMutationLock` can actually extend the lease for `lock`
+ * on the current runtime (B11). On a flock-capable runtime it returns true; on
+ * a flock-less runtime (macOS/Windows) it returns false, because a portable
+ * atomic rename-over-the-live-lock is unavailable without the shared reclaimer
+ * guard, so `renewMutationLock` returns false there regardless of whether the
+ * lock is still held. Unlocked locks are trivially "supported" (renewal is a
+ * no-op that returns true).
+ *
+ * Callers that gate on renewal failure should use this to distinguish
+ * "renewal unsupported on this runtime" (the lock is NOT lost - it is still
+ * held via the O_EXCL linkSync and its lease is still valid for LEASE_MS; the
+ * holder should NO-OP, relying on `assertMutationLockHeld` before publish as the
+ * safety net) from "renewal attempted on a supported runtime and failed" (the
+ * lock WAS lost - owner replaced / lease expired / I/O error - and the caller
+ * must abort). Treating the unsupported case as `lock_lost` would break every
+ * mutation on macOS/Windows.
+ */
+export function mutationLockRenewalSupported(lock) {
+  if (!lock || lock.unlocked) return true;
+  return !!flockPath();
 }
 
 export function withStateFileLockSync(filePath, callback, requireExclusive = false) {
   const lock = acquireStateFileLockSync(filePath, 50, requireExclusive);
   if (!lock) return { acquired: false, value: undefined };
   try {
-    return { acquired: true, value: callback() };
+    // Callers with a publication inside the callback invoke this immediately
+    // before it. Zero-argument callbacks remain source-compatible.
+    return { acquired: true, value: callback(() => assertMutationLockHeld(lock)) };
   } finally {
     releaseStateFileLockSync(lock);
   }

--- a/templates/hooks/lib/graph-session-settlement.mjs
+++ b/templates/hooks/lib/graph-session-settlement.mjs
@@ -32,7 +32,13 @@ export async function settleGraphSessionEnd(input) {
 
   try {
     const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
-    if (!existsSync(writePath)) return;
+    // Under OCC (B11 root cure) the journal dir `${writePath}.journal` is the
+    // authoritative state location; the canonical `writePath` file is a derived
+    // cache that may be absent (e.g. not re-published, or cleared) while the
+    // journal still holds state with live claims requiring settlement. Gate on
+    // the journal dir, not the canonical cache, so SessionEnd does not skip
+    // settle when the canonical is absent but journal authority still requires it.
+    if (!existsSync(`${writePath}.journal`)) return;
     spawnSync('omc', [
       'graph',
       'settle-session',

--- a/templates/hooks/lib/graph-session-settlement.mjs
+++ b/templates/hooks/lib/graph-session-settlement.mjs
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { resolveSessionStatePathsForHook } from './state-root.mjs';
+
+const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const SETTLE_TIMEOUT_MS = 2_000;
+
+function transitionId(sessionId, graphPath) {
+  const nonce = `${process.hrtime.bigint()}-${Math.random().toString(36).slice(2)}`;
+  const digest = createHash('sha256')
+    .update(`${sessionId}\0${graphPath}\0${nonce}`)
+    .digest('hex')
+    .slice(0, 32);
+  return `session-end:${digest}`;
+}
+
+/**
+ * Ask the Graph runtime to fence and settle claims for this SessionEnd.
+ * Graph CLI owns the mutation so plugin and standalone delivery use the same
+ * transition authority and recovery semantics.
+ */
+export async function settleGraphSessionEnd(input) {
+  const sessionId = input && typeof input === 'object' && typeof input.session_id === 'string'
+    ? input.session_id
+    : '';
+  const cwd = input && typeof input === 'object' && typeof input.cwd === 'string'
+    ? resolve(input.cwd)
+    : '';
+  if (!SESSION_ID.test(sessionId) || !cwd) return;
+
+  try {
+    const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
+    if (!existsSync(writePath)) return;
+    spawnSync('omc', [
+      'graph',
+      'settle-session',
+      '--session-id', sessionId,
+      '--driver-id', 'session-end',
+      '--transition-id', transitionId(sessionId, writePath),
+      '--json',
+    ], {
+      cwd,
+      env: process.env,
+      shell: false,
+      stdio: 'ignore',
+      timeout: SETTLE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch {
+    // The durable Graph runtime recovers an un-settled lease after hook exit.
+  }
+}

--- a/templates/hooks/lib/graph-session-settlement.mjs
+++ b/templates/hooks/lib/graph-session-settlement.mjs
@@ -32,13 +32,10 @@ export async function settleGraphSessionEnd(input) {
 
   try {
     const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
-    // Under OCC (B11 root cure) the journal dir `${writePath}.journal` is the
-    // authoritative state location; the canonical `writePath` file is a derived
-    // cache that may be absent (e.g. not re-published, or cleared) while the
-    // journal still holds state with live claims requiring settlement. Gate on
-    // the journal dir, not the canonical cache, so SessionEnd does not skip
-    // settle when the canonical is absent but journal authority still requires it.
-    if (!existsSync(`${writePath}.journal`)) return;
+    // The OCC journal is authoritative when present, but standalone installs
+    // and legacy state can have only the canonical cache. Either durable signal
+    // requires settlement; the CLI validates the state before mutating it.
+    if (!existsSync(writePath) && !existsSync(`${writePath}.journal`)) return;
     spawnSync('omc', [
       'graph',
       'settle-session',

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -423,7 +423,7 @@ function isSessionCancelInProgress(stateDir, sessionId, currentAutopilotPath, ca
   let authenticatedAutopilot = null;
   const validateSignal = (signalPath, currentAutopilot) => {
     let active = false;
-    const locked = withStateFileLockSync(signalPath, () => {
+    const locked = withStateFileLockSync(signalPath, (assertHeld) => {
       const signal = readJsonFile(signalPath);
       if (!signal || typeof signal !== "object" || Array.isArray(signal) || signal.active !== true) return;
       const now = Date.now();
@@ -433,19 +433,28 @@ function isSessionCancelInProgress(stateDir, sessionId, currentAutopilotPath, ca
       const isFreshRequest = requestedAt <= now + CANCEL_SIGNAL_CLOCK_SKEW_MS && now - requestedAt <= CANCEL_SIGNAL_TTL_MS;
       if (!currentAutopilot) {
         const effectiveExpiry = Number.isFinite(expiresAt) ? expiresAt : requestedAt + CANCEL_SIGNAL_TTL_MS;
-        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && existsSync(signalPath)) unlinkSync(signalPath);
+        if (Number.isFinite(effectiveExpiry) && effectiveExpiry <= now && existsSync(signalPath)) {
+          assertHeld();
+          unlinkSync(signalPath);
+        }
         if (signal.mode === "autopilot" || Object.prototype.hasOwnProperty.call(signal, "target_state_sha256") || Object.prototype.hasOwnProperty.call(signal, "target_workflow_run_id")) return;
         if (isFreshRequest && effectiveExpiry > requestedAt && effectiveExpiry - requestedAt <= CANCEL_SIGNAL_TTL_MS && effectiveExpiry > now) active = true;
         return;
       }
       if (!isFreshRequest) {
-        if (Number.isFinite(expiresAt) && expiresAt <= now && existsSync(signalPath)) unlinkSync(signalPath);
+        if (Number.isFinite(expiresAt) && expiresAt <= now && existsSync(signalPath)) {
+          assertHeld();
+          unlinkSync(signalPath);
+        }
         return;
       }
       if (signal.mode !== "autopilot" || typeof signal.source !== "string" || signal.source.length === 0) return;
       if (!Number.isFinite(expiresAt) || expiresAt <= requestedAt || expiresAt - requestedAt > CANCEL_SIGNAL_TTL_MS) return;
       if (expiresAt <= now) {
-        if (existsSync(signalPath)) unlinkSync(signalPath);
+        if (existsSync(signalPath)) {
+          assertHeld();
+          unlinkSync(signalPath);
+        }
         return;
       }
       const stateDigest = createHash("sha256").update(JSON.stringify(currentAutopilot)).digest("hex");
@@ -1243,9 +1252,10 @@ async function main() {
             const errorGuidance = getToolErrorRetryGuidance(toolError);
             const reinforced = { ...autopilot.state, reinforcement_count: newCount, last_checked_at: new Date().toISOString() };
             let committed = false;
-            const locked = withStateFileLockSync(autopilot.path, () => {
+            const locked = withStateFileLockSync(autopilot.path, (assertHeld) => {
               const current = readJsonFile(autopilot.path);
               if (!current || JSON.stringify(current) !== loadedSnapshot) return;
+              assertHeld();
               committed = writeJsonFile(autopilot.path, reinforced);
             });
             if (!locked.acquired || !committed) {

--- a/templates/hooks/session-end.mjs
+++ b/templates/hooks/session-end.mjs
@@ -1,51 +1,21 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
-import { existsSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SAFE_CONTINUE = { continue: true, suppressOutput: true };
-const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
-const SETTLE_TIMEOUT_MS = 2_000;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const { readSessionEndFrame } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
-const { resolveSessionStatePathsForHook } = await import(
-  pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href
+const { settleGraphSessionEnd } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'graph-session-settlement.mjs')).href
 );
 
 function writeSafeContinue() {
   process.stdout.write(`${JSON.stringify(SAFE_CONTINUE)}\n`);
-}
-
-// Per-invocation nonce so a second SessionEnd in the same session produces a
-// distinct transition_id. A stable per-session+path digest would replay the
-// first invocation's recorded result (store idempotency) and could never
-// settle claims created since the prior session-end. The nonce is mixed into
-// the hash so the transition_id remains opaque but unique per firing.
-function stableTransitionId(sessionId, graphPath, nonce) {
-  const digest = createHash('sha256')
-    .update(`${sessionId}\0${graphPath}\0${nonce}`)
-    .digest('hex')
-    .slice(0, 32);
-  return `session-end:${digest}`;
-}
-
-// Best-effort per-invocation nonce. Prefer a high-resolution timestamp so
-// successive session-ends within one session are ordered and distinct; fall
-// back to a random value if hrtime is unavailable.
-function invocationNonce() {
-  try {
-    const [seconds, nanos] = process.hrtime();
-    return `${seconds}.${nanos}`;
-  } catch {
-    return `${Math.random().toString(36).slice(2)}-${Date.now()}`;
-  }
 }
 
 async function main() {
@@ -55,44 +25,7 @@ async function main() {
     return;
   }
 
-  const input = frame.value;
-  const sessionId = input && typeof input === 'object' && typeof input.session_id === 'string'
-    ? input.session_id
-    : '';
-  const cwd = input && typeof input === 'object' && typeof input.cwd === 'string'
-    ? resolve(input.cwd)
-    : '';
-
-  if (!SESSION_ID.test(sessionId) || !cwd) {
-    writeSafeContinue();
-    return;
-  }
-
-  try {
-    const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
-    if (!existsSync(writePath)) {
-      writeSafeContinue();
-      return;
-    }
-
-    spawnSync('omc', [
-      'graph',
-      'settle-session',
-      '--session-id', sessionId,
-      '--driver-id', 'session-end',
-      '--transition-id', stableTransitionId(sessionId, writePath, invocationNonce()),
-      '--json',
-    ], {
-      cwd,
-      env: process.env,
-      shell: false,
-      stdio: 'ignore',
-      timeout: SETTLE_TIMEOUT_MS,
-      windowsHide: true,
-    });
-  } catch {
-    // The durable runtime can recover an un-settled lease after this bounded hook exits.
-  }
+  await settleGraphSessionEnd(frame.value);
 
   writeSafeContinue();
 }

--- a/templates/hooks/session-end.mjs
+++ b/templates/hooks/session-end.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SAFE_CONTINUE = { continue: true, suppressOutput: true };
+const SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const SETTLE_TIMEOUT_MS = 2_000;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const { readSessionEndFrame } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { resolveSessionStatePathsForHook } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href
+);
+
+function writeSafeContinue() {
+  process.stdout.write(`${JSON.stringify(SAFE_CONTINUE)}\n`);
+}
+
+// Per-invocation nonce so a second SessionEnd in the same session produces a
+// distinct transition_id. A stable per-session+path digest would replay the
+// first invocation's recorded result (store idempotency) and could never
+// settle claims created since the prior session-end. The nonce is mixed into
+// the hash so the transition_id remains opaque but unique per firing.
+function stableTransitionId(sessionId, graphPath, nonce) {
+  const digest = createHash('sha256')
+    .update(`${sessionId}\0${graphPath}\0${nonce}`)
+    .digest('hex')
+    .slice(0, 32);
+  return `session-end:${digest}`;
+}
+
+// Best-effort per-invocation nonce. Prefer a high-resolution timestamp so
+// successive session-ends within one session are ordered and distinct; fall
+// back to a random value if hrtime is unavailable.
+function invocationNonce() {
+  try {
+    const [seconds, nanos] = process.hrtime();
+    return `${seconds}.${nanos}`;
+  } catch {
+    return `${Math.random().toString(36).slice(2)}-${Date.now()}`;
+  }
+}
+
+async function main() {
+  const frame = await readSessionEndFrame();
+  if (frame.status !== 'ok') {
+    writeSafeContinue();
+    return;
+  }
+
+  const input = frame.value;
+  const sessionId = input && typeof input === 'object' && typeof input.session_id === 'string'
+    ? input.session_id
+    : '';
+  const cwd = input && typeof input === 'object' && typeof input.cwd === 'string'
+    ? resolve(input.cwd)
+    : '';
+
+  if (!SESSION_ID.test(sessionId) || !cwd) {
+    writeSafeContinue();
+    return;
+  }
+
+  try {
+    const { writePath } = await resolveSessionStatePathsForHook(cwd, 'graph', sessionId);
+    if (!existsSync(writePath)) {
+      writeSafeContinue();
+      return;
+    }
+
+    spawnSync('omc', [
+      'graph',
+      'settle-session',
+      '--session-id', sessionId,
+      '--driver-id', 'session-end',
+      '--transition-id', stableTransitionId(sessionId, writePath, invocationNonce()),
+      '--json',
+    ], {
+      cwd,
+      env: process.env,
+      shell: false,
+      stdio: 'ignore',
+      timeout: SETTLE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch {
+    // The durable runtime can recover an un-settled lease after this bounded hook exits.
+  }
+
+  writeSafeContinue();
+}
+
+main().catch(writeSafeContinue);

--- a/tests/integration/workflow-profile-lock-recovery.test.ts
+++ b/tests/integration/workflow-profile-lock-recovery.test.ts
@@ -13,9 +13,31 @@ const modules = [
   join(root, 'templates', 'hooks', 'lib', 'atomic-write.mjs'),
 ];
 
+// processStart is retained for the EMERGENCY JOURNAL / recovery-claim subsystem
+// (which is still liveness-based). The mutation lock is now LEASE-based and no
+// longer probes process liveness, so mutation-lock tests plant lease owners via
+// leaseOwner() below. On Linux we read the real /proc start time; on other
+// platforms we return a stable synthetic value so the recovery-claim tests can
+// run locally (production's processStartIdentity does the same for non-Linux).
 function processStart(pid = process.pid): string {
+  if (process.platform !== 'linux') return '1';
   const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
   return stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
+}
+
+// The shipped hook helpers retain the deployed v1 lease wire format for
+// backward compatibility. It is distinguished from the old v1 liveness shape
+// below by `expires_at` (rather than `processStart`).
+function leaseOwner(overrides: Record<string, unknown> = {}) {
+  const now = Date.now();
+  return {
+    version: 1,
+    pid: process.pid,
+    createdAt: new Date(now).toISOString(),
+    expires_at: new Date(now + 60000).toISOString(),
+    nonce: randomUUID(),
+    ...overrides,
+  };
 }
 
 function owner(overrides: Record<string, unknown> = {}) {
@@ -46,51 +68,69 @@ afterEach(() => {
 describe.each(modules)('recoverable workflow mutation lock (%s)', (modulePath) => {
   async function api() {
     return import(`${pathToFileURL(modulePath).href}?test=${randomUUID()}`) as Promise<{
-      acquireStateFileLockSync(path: string, attempts?: number): { fd: number; lockPath: string; owner: ReturnType<typeof owner> } | null;
+      acquireStateFileLockSync(path: string, attempts?: number, requireExclusive?: boolean): { fd: number; lockPath: string; owner: ReturnType<typeof leaseOwner> } | { unlocked: true } | null;
       releaseStateFileLockSync(lock: unknown): void;
       recoverEmergencyStateFile(path: string): boolean;
     }>;
   }
 
-  it('reclaims a valid abandoned owner and PID-reuse identity', async () => {
+  it('fails closed for a legacy liveness owner', async () => {
     const { statePath, lockPath } = fixture();
     const lockApi = await api();
-    writeFileSync(lockPath, JSON.stringify(owner({ pid: 999999999, processStart: '1' })));
-    const abandoned = lockApi.acquireStateFileLockSync(statePath, 2);
-    expect(abandoned).not.toBeNull();
-    lockApi.releaseStateFileLockSync(abandoned);
+    const legacy = owner({ pid: 999999999, processStart: '1' });
+    writeFileSync(lockPath, JSON.stringify(legacy));
 
-    writeFileSync(lockPath, JSON.stringify(owner({ processStart: String(Number(processStart()) + 1) })));
-    const reused = lockApi.acquireStateFileLockSync(statePath, 2);
-    expect(reused).not.toBeNull();
-    lockApi.releaseStateFileLockSync(reused);
+    expect(lockApi.acquireStateFileLockSync(statePath, 2, true)).toBeNull();
+    expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(legacy);
   });
 
-  it('never reclaims a verifiably live holder', async () => {
+  it('never reclaims a valid unexpired lease', async () => {
     const { statePath, lockPath } = fixture();
     const lockApi = await api();
-    const live = owner();
+    // A valid lease whose expires_at is in the future is "held" (not
+    // reclaimable). The lease is the sole reclaim key - no process liveness is
+    // probed - so a future expires_at must block reacquisition for the whole
+    // retry window and leave the holder's lock untouched.
+    const live = leaseOwner({ expires_at: new Date(Date.now() + 60000).toISOString() });
     writeFileSync(lockPath, JSON.stringify(live));
-    expect(lockApi.acquireStateFileLockSync(statePath, 2)).toBeNull();
+    // requireExclusive forces the reclaim branch to actually run on flock-less
+    // hosts (otherwise the non-exclusive flock-less path returns {unlocked:true}
+    // without inspecting the lock). On Linux (real flock) it runs the guarded
+    // flock reclaim; both paths share the same lease policy.
+    expect(lockApi.acquireStateFileLockSync(statePath, 2, true)).toBeNull();
     expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(live);
   });
 
-  it('fails closed with deterministic diagnostics for corrupt metadata', async () => {
+  it('reclaims a lock with corrupt metadata by lease policy', async () => {
     const { statePath, lockPath } = fixture();
     const lockApi = await api();
+    // The lease contract treats a readable-but-unparseable owner as having no
+    // valid lease on record, so the owner cannot be live: RECLAIM (unlink) and
+    // retry. (Fail-closed applies only to an I/O-unreadable lock, e.g. EACCES -
+    // not to corrupt JSON.) A corrupt lock is therefore reclaimed and replaced
+    // with a fresh valid lease owner.
     writeFileSync(lockPath, 'corrupt');
-    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    expect(lockApi.acquireStateFileLockSync(statePath, 2)).toBeNull();
-    expect(error).toHaveBeenCalledWith(`[omc-lock] state_mutation_lock_unverifiable: ${lockPath}`);
-    expect(readFileSync(lockPath, 'utf8')).toBe('corrupt');
+    // requireExclusive forces the reclaim branch to run on flock-less hosts so
+    // the corrupt lock is actually unlinked and reacquired (the non-exclusive
+    // flock-less path would otherwise no-op). On Linux the guarded flock reclaim
+    // runs; both paths reclaim corrupt metadata by the same lease policy.
+    const reclaimed = lockApi.acquireStateFileLockSync(statePath, 2, true);
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed).not.toHaveProperty('unlocked');
+    const next = JSON.parse(readFileSync(lockPath, 'utf8'));
+    expect(next.version).toBe(1);
+    expect(next.expires_at).toBeTypeOf('string');
+    expect(Number.isFinite(Date.parse(next.expires_at as string))).toBe(true);
+    expect(next.nonce).toMatch(/^[0-9a-f-]{36}$/i);
+    lockApi.releaseStateFileLockSync(reclaimed);
   });
 
   it('does not let an old owner release a replacement lock', async () => {
     const { statePath, lockPath } = fixture();
     const lockApi = await api();
-    const old = lockApi.acquireStateFileLockSync(statePath, 2)!;
+    const old = lockApi.acquireStateFileLockSync(statePath, 2, true)!;
     unlinkSync(lockPath);
-    const replacement = owner();
+    const replacement = leaseOwner();
     writeFileSync(lockPath, JSON.stringify(replacement));
     lockApi.releaseStateFileLockSync(old);
     expect(JSON.parse(readFileSync(lockPath, 'utf8'))).toEqual(replacement);
@@ -98,13 +138,16 @@ describe.each(modules)('recoverable workflow mutation lock (%s)', (modulePath) =
 
   it('serializes concurrent reclaimers without removing a live replacement', async () => {
     const { statePath, lockPath } = fixture();
-    writeFileSync(lockPath, JSON.stringify(owner({ pid: 999999999, processStart: '1' })));
+    writeFileSync(lockPath, JSON.stringify(leaseOwner({
+      pid: 999999999,
+      expires_at: new Date(Date.now() - 1).toISOString(),
+    })));
     const logPath = `${statePath}.critical.log`;
     const childScript = String.raw`
       import { appendFileSync } from 'node:fs';
       const [modulePath, statePath, logPath, id] = process.argv.slice(1);
       const api = await import(modulePath);
-      const lock = api.acquireStateFileLockSync(statePath, 100);
+      const lock = api.acquireStateFileLockSync(statePath, 100, true);
       if (!lock) process.exit(2);
       appendFileSync(logPath, id + ':start\n');
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);

--- a/tests/integration/workflow-profile-stop-transition.test.ts
+++ b/tests/integration/workflow-profile-stop-transition.test.ts
@@ -45,14 +45,22 @@ describe('canonical workflow stage prompt serialization', () => {
   });
 });
 
+// The mutation lock is LEASE-based (no process-liveness probe): the on-disk
+// owner is `{ version: 1, pid, createdAt, expires_at, nonce }` and the lock is
+// HELD while `now < expires_at`. A held owner must use the exact LEASE key set
+// (no `processStart`) and a future `expires_at` so production treats it as live
+// and refuses to reclaim. See src/lib/mode-state-io.ts freshLockOwner/readLockOwner.
+const LEASE_MS = 300_000;
 function liveLockOwner() {
-  const stat = readFileSync(`/proc/${process.pid}/stat`, 'utf8');
-  const processStart = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/)[19];
-  return JSON.stringify({ version: 1, pid: process.pid, processStart, createdAt: new Date().toISOString(), nonce: randomUUID() });
+  const now = Date.now();
+  return JSON.stringify({ version: 1, pid: process.pid, createdAt: new Date(now).toISOString(), expires_at: new Date(now + LEASE_MS).toISOString(), nonce: randomUUID() });
 }
 
 function abandonedLockOwner() {
-  return JSON.stringify({ version: 1, pid: 999999999, processStart: '1', createdAt: new Date().toISOString(), nonce: randomUUID() });
+  // Expired lease: reclaimable because `now >= expires_at`, not because of a
+  // corrupt schema. Uses a valid LEASE key set with a past expires_at.
+  const now = Date.now();
+  return JSON.stringify({ version: 1, pid: 999999999, createdAt: new Date(now - LEASE_MS - 1).toISOString(), expires_at: new Date(now - 1).toISOString(), nonce: randomUUID() });
 }
 
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     testTimeout: 30000,
     include: [
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'scripts/**/*.{test,spec}.{js,mjs,ts}',
       'tests/**/*.bench.ts',
       'tests/**/*.{test,spec}.ts',
     ],


### PR DESCRIPTION
Supersedes closed #3567 for diagnostic/owner handoff only.

## Technical state
- The source fixes from #3567 are retained: SessionEnd settles when either canonical `graph-state.json` or its OCC journal exists; `clearModeState` retains its boolean public API, while CAS-aware callers use `clearModeStateDetailed`.
- Exact-head CI on #3567 identified one delivery failure: rebuilt package `bridge/cli.cjs` was `fc98ac20a5c0b0e0905c3b0c5105c4ce128858c39fb88ed279d36939ed4c456e`, while the committed snapshot was stale (`1cfa2c...`).
- This PR carries only that rebuilt Linux Node 20 CLI bundle. It deliberately excludes `dist/**`, maps, generated tests, and unrelated bridge bundles.

## Governance boundary
The generated-artifact verifier rejects generated changes from forks by design. This PR cannot self-authorize, even though the bundle is the package byte-identity fix. The owner review on #3567 requires an owner-controlled minimal runtime closure and a protected authorization record bound to the exact official PR head.

## Required owner handoff
1. Apply the source-only commit `99ffe31f` on an official owner branch.
2. Build on the supported Linux Node 20 environment and stage the canonical minimal runtime closure (at minimum the rebuilt `bridge/cli.cjs`, subject to the owner closure tool).
3. Add the protected base-owned generated-artifact authorization for the exact official PR head and generated-file digest.
4. Run full Test -> Build -> npm pack + install before merge.

This external PR documents and verifies the exact generated CLI bytes; it is not a request to bypass the protected authorization policy.