### PR TITLE
fix: sandbox provider advisor commands

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -129,11 +129,15 @@ function shouldPipePromptViaStdin(provider, prompt) {
       return false;
     }
 
-    return prompt.includes('\n') || prompt.length > 500 || /^\s*-/.test(prompt);
+    return SHOULD_USE_WINDOWS_SHELL
+      || prompt.includes('\n')
+      || prompt.length > 500
+      || /^\s*-/.test(prompt);
   }
 
   // grok (ACP stdin), cursor-agent (interactive stdin), and any other provider
-  // never pipe the prompt.
+  // never pipe the prompt. Providers that require argv prompts are blocked on
+  // Windows below so untrusted prompt text never crosses cmd.exe.
   return false;
 }
 
@@ -214,6 +218,12 @@ function guardProviderPlatform(provider) {
   if (provider === 'grok') {
     console.error('[ask-grok] Blocked: no verified Grok read-only/plan mode is available.');
     console.error('[ask-grok] Use a provider with an enforced plan/read-only mode for advisory work.');
+    process.exit(1);
+  }
+  if (provider === 'cursor' && SHOULD_USE_WINDOWS_SHELL) {
+    console.error('[ask-cursor] Cursor Agent advisor mode is not supported on Windows yet:');
+    console.error('[ask-cursor]   cursor-agent requires the prompt as an argv value, which is unsafe through cmd.exe.');
+    console.error('[ask-cursor] Run `omc ask cursor` on macOS/Linux, or use Claude, Codex, or Gemini on Windows.');
     process.exit(1);
   }
   if (provider === 'antigravity' && SHOULD_USE_WINDOWS_SHELL) {
@@ -390,6 +400,10 @@ async function main() {
     console.error('[ask-antigravity] agy exited 0 but produced no output under pipe capture.');
     console.error('[ask-antigravity] Treating as failure (see google-antigravity/antigravity-cli#76).');
     console.error('[ask-antigravity] Re-run, or verify interactively with: agy -p "<prompt>"');
+    exitCode = 1;
+  } else if (provider !== 'antigravity' && exitCode === 0 && rawOutput.trim() === '') {
+    console.error(`[ask-${provider}] ${binary} exited 0 but produced no output.`);
+    console.error(`[ask-${provider}] Treating the empty advisor response as a failure.`);
     exitCode = 1;
   } else if (provider !== 'antigravity' && (run.error?.code === 'ETIMEDOUT' || run.signal === 'SIGKILL')) {
     console.error(`[ask-${provider}] provider timed out after ${PROVIDER_RUN_TIMEOUT_MS}ms with no completed response.`);

--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -14,6 +14,20 @@ const PROVIDER_BINARIES = {
   cursor: 'cursor-agent',
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
+const PROVIDER_VERSION_TIMEOUT_MS = 10000;
+const PROVIDER_RUN_TIMEOUT_DEFAULT_MS = 600000;
+const PROVIDER_RUN_TIMEOUT_MS = (() => {
+  const raw = process.env.OMC_PROVIDER_TIMEOUT_MS;
+  if (raw === undefined || raw === '') {
+    return PROVIDER_RUN_TIMEOUT_DEFAULT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1000) {
+    console.error(`[ask] Ignoring invalid OMC_PROVIDER_TIMEOUT_MS="${raw}" (need an integer >= 1000); using ${PROVIDER_RUN_TIMEOUT_DEFAULT_MS}ms.`);
+    return PROVIDER_RUN_TIMEOUT_DEFAULT_MS;
+  }
+  return Math.min(parsed, 3600000);
+})();
 
 // Antigravity (`agy`) headless print mode has a known upstream non-TTY bug
 // (google-antigravity/antigravity-cli#76) that, beyond the empty-exit-0 case,
@@ -41,22 +55,32 @@ const ANTIGRAVITY_TIMEOUT_MS = (() => {
 
 /**
  * Build CLI args for a given provider.
- * - claude: `claude -p <prompt>` (or `claude -p` reading the prompt from stdin)
- * - codex: `codex exec --dangerously-bypass-approvals-and-sandbox <prompt>`
- * - gemini: `gemini -p <prompt> --yolo`
- * - antigravity: `agy --dangerously-skip-permissions -p <prompt>` (Antigravity CLI;
+ * - claude: `claude -p <prompt> --permission-mode plan`
+ * - codex: `codex exec --skip-git-repo-check --sandbox read-only <prompt>`
+ * - gemini: `gemini -p <prompt> --approval-mode plan`
+ * - antigravity: `agy --mode plan --sandbox -p <prompt>` (Antigravity CLI;
  *   `-p` takes the prompt as its value and cannot read it from stdin, so the
- *   prompt is always passed as an arg with approval flags first, like grok)
- * - grok: `grok -p <prompt> --always-approve` (headless mode takes the prompt
+ *   prompt is always passed as an arg with safety flags first, like grok)
+ * - grok: `grok -p <prompt>` (headless mode takes the prompt
  *   as an arg; grok's stdin is reserved for ACP JSON-RPC, never the prompt)
- * - cursor: `cursor-agent --print --force --trust --sandbox disabled <prompt>`
+ * - cursor: `cursor-agent --print --mode plan --trust --sandbox enabled <prompt>`
  */
 function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}) {
   if (provider === 'codex') {
-    return ['exec', '--dangerously-bypass-approvals-and-sandbox', pipePromptViaStdin ? '-' : prompt];
+    return [
+      'exec',
+      '--skip-git-repo-check',
+      '--sandbox',
+      'read-only',
+      '--color',
+      'never',
+      pipePromptViaStdin ? '-' : prompt,
+    ];
   }
   if (provider === 'gemini') {
-    return pipePromptViaStdin ? ['--yolo'] : ['-p', prompt, '--yolo'];
+    return pipePromptViaStdin
+      ? ['--approval-mode', 'plan']
+      : ['-p', prompt, '--approval-mode', 'plan'];
   }
   if (provider === 'antigravity') {
     // Antigravity (`agy`): `-p`/`--print` takes the prompt as its VALUE (next
@@ -64,20 +88,22 @@ function buildProviderArgs(provider, prompt, { pipePromptViaStdin = false } = {}
     // (`agy -p` with no value errors "flag needs an argument"). So always pass
     // the prompt as the `-p` value with approval flags first, like grok.
     // Verified on agy 1.0.10.
-    return ['--dangerously-skip-permissions', '-p', prompt];
+    return ['--mode', 'plan', '--sandbox', '-p', prompt];
   }
   if (provider === 'grok') {
     // Grok's headless mode always takes the prompt as a `-p` arg; its stdin is
     // for ACP JSON-RPC, not the prompt, so it never uses the stdin pipe path.
-    return ['-p', prompt, '--always-approve'];
+    return ['-p', prompt];
   }
   if (provider === 'cursor') {
     // Cursor Agent's print mode takes the prompt as a positional arg. Keep stdin
     // closed so it cannot interpret advisor prompt bytes as interactive input.
-    return ['--print', '--force', '--trust', '--sandbox', 'disabled', prompt];
+    return ['--print', '--mode', 'plan', '--trust', '--sandbox', 'enabled', prompt];
   }
   // claude: `claude -p` reads the prompt from stdin when no prompt arg is given.
-  return pipePromptViaStdin ? ['-p'] : ['-p', prompt];
+  return pipePromptViaStdin
+    ? ['-p', '--permission-mode', 'plan']
+    : ['-p', prompt, '--permission-mode', 'plan'];
 }
 
 function shouldPipePromptViaStdin(provider, prompt) {
@@ -185,6 +211,11 @@ function buildProviderEnv(provider, env = process.env) {
 // as argv through cmd.exe (spawn `shell: true`) is not reliably quoted. Rather
 // than emit silently-broken output, guard Windows with a clear, actionable error.
 function guardProviderPlatform(provider) {
+  if (provider === 'grok') {
+    console.error('[ask-grok] Blocked: no verified Grok read-only/plan mode is available.');
+    console.error('[ask-grok] Use a provider with an enforced plan/read-only mode for advisory work.');
+    process.exit(1);
+  }
   if (provider === 'antigravity' && SHOULD_USE_WINDOWS_SHELL) {
     console.error('[ask-antigravity] Antigravity CLI (agy) headless mode is not supported on Windows yet:');
     console.error('[ask-antigravity]   agy --print takes the prompt as an argv value (it cannot read stdin),');
@@ -200,7 +231,15 @@ function ensureBinary(provider, binary) {
     encoding: 'utf8',
     env: buildProviderEnv(provider),
     shell: SHOULD_USE_WINDOWS_SHELL,
+    timeout: PROVIDER_VERSION_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
+
+  if (probe.error?.code === 'ETIMEDOUT' || probe.signal === 'SIGKILL') {
+    console.error(`[ask-${provider}] ${binary} --version timed out after ${PROVIDER_VERSION_TIMEOUT_MS}ms.`);
+    console.error(`[ask-${provider}] Repair or reinstall the CLI before invoking a provider.`);
+    process.exit(1);
+  }
 
   const isMissingOnWindowsShell = SHOULD_USE_WINDOWS_SHELL
     && probe.status !== 0
@@ -324,10 +363,9 @@ async function main() {
     maxBuffer: 10 * 1024 * 1024,
     env: buildProviderEnv(provider),
     shell: SHOULD_USE_WINDOWS_SHELL,
-    // Bound antigravity so an upstream non-TTY hang (#76) fails cleanly instead of
-    // blocking forever; agy's own --print-timeout does not work. SIGKILL (not a
-    // catchable SIGTERM) guarantees spawnSync returns even if agy traps signals.
-    ...(provider === 'antigravity' ? { timeout: ANTIGRAVITY_TIMEOUT_MS, killSignal: ANTIGRAVITY_TIMEOUT_KILL_SIGNAL } : {}),
+    // Bound every provider. A broken CLI must not block `omc ask` indefinitely.
+    timeout: provider === 'antigravity' ? ANTIGRAVITY_TIMEOUT_MS : PROVIDER_RUN_TIMEOUT_MS,
+    killSignal: provider === 'antigravity' ? ANTIGRAVITY_TIMEOUT_KILL_SIGNAL : 'SIGKILL',
     ...(pipePromptViaStdin ? { input: prompt } : { stdio: ['ignore', 'pipe', 'pipe'] }),
   });
 
@@ -352,6 +390,9 @@ async function main() {
     console.error('[ask-antigravity] agy exited 0 but produced no output under pipe capture.');
     console.error('[ask-antigravity] Treating as failure (see google-antigravity/antigravity-cli#76).');
     console.error('[ask-antigravity] Re-run, or verify interactively with: agy -p "<prompt>"');
+    exitCode = 1;
+  } else if (provider !== 'antigravity' && (run.error?.code === 'ETIMEDOUT' || run.signal === 'SIGKILL')) {
+    console.error(`[ask-${provider}] provider timed out after ${PROVIDER_RUN_TIMEOUT_MS}ms with no completed response.`);
     exitCode = 1;
   }
 

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -231,6 +231,12 @@ function writeSpawnSyncCapturePreludeNative(dir: string): string {
       "      input: options.input ?? null,",
       "      timeout: options.timeout ?? null,",
       "      killSignal: options.killSignal ?? null,",
+      '      env: {',
+      "        CLAUDECODE: options.env?.CLAUDECODE ?? null,",
+      "        CLAUDE_SESSION_ID: options.env?.CLAUDE_SESSION_ID ?? null,",
+      "        CLAUDECODE_SESSION_ID: options.env?.CLAUDECODE_SESSION_ID ?? null,",
+      "        CLAUDE_CODE_ENTRYPOINT: options.env?.CLAUDE_CODE_ENTRYPOINT ?? null,",
+      '      },',
       '    },',
       '  });',
       "  const isVersionProbe = Array.isArray(args) && args[0] === '--version';",
@@ -587,7 +593,9 @@ describe('run-provider-advisor script contract', () => {
     const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-advisor-env-`));
     try {
       const capturePath = join(wd, 'spawn-sync-calls.json');
-      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const preludePath = provider === 'cursor'
+        ? writeSpawnSyncCapturePreludeNative(wd)
+        : writeSpawnSyncCapturePrelude(wd);
       const result = runAdvisorScriptWithPrelude(
         preludePath,
         args,
@@ -659,7 +667,7 @@ describe('run-provider-advisor script contract', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omc-ask-cursor-args-'));
     try {
       const capturePath = join(wd, 'spawn-sync-calls.json');
-      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
       // cursor-agent print mode takes the prompt as a positional arg; stdin is
       // interactive input and must stay closed even for multiline prompts.
       const result = runAdvisorScriptWithPrelude(
@@ -700,6 +708,30 @@ describe('run-provider-advisor script contract', () => {
       expect(calls[0].options.killSignal).toBe('SIGKILL');
       expect(launch!.options.timeout).toBe(600000);
       expect(launch!.options.killSignal).toBe('SIGKILL');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('guards cursor on Windows so prompt argv never crosses cmd.exe', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-cursor-win32-guard-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['cursor', '--prompt', 'review this & whoami'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('not supported on Windows');
+      if (existsSync(capturePath)) {
+        const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{ command: string }>;
+        expect(calls.some((c) => c.command === 'cursor-agent')).toBe(false);
+      }
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }
@@ -766,6 +798,32 @@ describe('run-provider-advisor script contract', () => {
       rmSync(wd, { recursive: true, force: true });
     }
   });
+
+  it.each(['claude', 'codex', 'gemini', 'cursor'] as const)(
+    'treats an empty-output %s run as a failure',
+    (provider) => {
+      const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-empty-`));
+      try {
+        const capturePath = join(wd, 'spawn-sync-calls.json');
+        const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+        const result = runAdvisorScriptWithPrelude(
+          preludePath,
+          [provider, '--prompt', 'reply please'],
+          wd,
+          {
+            SPAWN_CAPTURE_PATH: capturePath,
+            SPAWN_CAPTURE_MODE: 'empty-output',
+          },
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('exited 0 but produced no output');
+      } finally {
+        rmSync(wd, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('sanitizes Rust env vars for codex so artifacts do not capture Rust stderr logs', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-rust-env-'));
@@ -889,6 +947,38 @@ describe('run-provider-advisor script contract', () => {
         command: 'gemini',
         args: ['--approval-mode', 'plan'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'ship safely 你好' },
+      });
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('pipes Windows claude prompts over stdin so cmd.exe never parses prompt metacharacters', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-claude-win32-stdin-'));
+    const prompt = 'review this & whoami';
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePrelude(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['claude', '--prompt', prompt],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        command: string;
+        args: string[];
+        options: { shell: boolean; input: string | null };
+      }>;
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toMatchObject({
+        command: 'claude',
+        args: ['-p', '--permission-mode', 'plan'],
+        options: { shell: true, input: prompt },
       });
     } finally {
       rmSync(wd, { recursive: true, force: true });

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -155,6 +155,8 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
       "      encoding: options.encoding ?? null,",
       "      stdio: options.stdio ?? null,",
       "      input: options.input ?? null,",
+      "      timeout: options.timeout ?? null,",
+      "      killSignal: options.killSignal ?? null,",
       '      env: {',
       "        CLAUDECODE: options.env?.CLAUDECODE ?? null,",
       "        CLAUDE_SESSION_ID: options.env?.CLAUDE_SESSION_ID ?? null,",
@@ -172,6 +174,9 @@ function writeSpawnSyncCapturePrelude(dir: string): string {
       "    return { status: 1, stdout: '', stderr: \"'\" + command + \"' is not recognized\", pid: 0, output: [], signal: null };",
       '  }',
       "  const isVersionProbe = Array.isArray(args) && args[0] === '--version';",
+      "  if (mode === 'version-timeout' && isVersionProbe) {",
+      "    return { status: null, signal: 'SIGKILL', error: { code: 'ETIMEDOUT' }, stdout: '', stderr: '', pid: 0, output: [] };",
+      '  }',
       "  if (mode === 'empty-output' && !isVersionProbe) {",
       "    return { status: 0, stdout: '', stderr: '', pid: 0, output: [], signal: null };",
       '  }',
@@ -229,6 +234,9 @@ function writeSpawnSyncCapturePreludeNative(dir: string): string {
       '    },',
       '  });',
       "  const isVersionProbe = Array.isArray(args) && args[0] === '--version';",
+      "  if (mode === 'version-timeout' && isVersionProbe) {",
+      "    return { status: null, signal: 'SIGKILL', error: { code: 'ETIMEDOUT' }, stdout: '', stderr: '', pid: 0, output: [] };",
+      '  }',
       "  if (mode === 'empty-output' && !isVersionProbe) {",
       "    return { status: 0, stdout: '', stderr: '', pid: 0, output: [], signal: null };",
       '  }',
@@ -574,7 +582,6 @@ describe('run-provider-advisor script contract', () => {
     // antigravity is intentionally omitted here: this matrix runs under the win32
     // capture prelude, and antigravity is guarded (exits early) on Windows. Its
     // env-stripping on supported platforms is covered by the non-Windows tests.
-    ['grok', ['grok', '--prompt', 'nested grok prompt']],
     ['cursor', ['cursor', '--prompt', 'nested cursor prompt']],
   ] as const)('strips Claude session env vars for %s advisor spawns', (provider, args) => {
     const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-advisor-env-`));
@@ -624,13 +631,11 @@ describe('run-provider-advisor script contract', () => {
     }
   });
 
-  it('launches grok as `grok -p <prompt> --always-approve` and never pipes stdin', () => {
+  it('fails closed for grok because no verified read-only mode is available', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omc-ask-grok-args-'));
     try {
       const capturePath = join(wd, 'spawn-sync-calls.json');
       const preludePath = writeSpawnSyncCapturePrelude(wd);
-      // A multiline prompt is piped over stdin for codex/gemini; grok reserves stdin
-      // for ACP JSON-RPC, so it must take the prompt as a `-p` arg instead.
       const result = runAdvisorScriptWithPrelude(
         preludePath,
         ['grok', '--prompt', 'review this\nand that'],
@@ -639,27 +644,18 @@ describe('run-provider-advisor script contract', () => {
       );
 
       expect(result.error).toBeUndefined();
-      expect(result.status).toBe(0);
-
-      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
-        command: string;
-        args: string[];
-        options: { input: string | null };
-      }>;
-
-      // version probe + launch, both via the `grok` binary
-      expect(calls).toHaveLength(2);
-      const launch = calls.find((c) => !c.args.includes('--version'));
-      expect(launch).toBeDefined();
-      expect(launch!.command).toBe('grok');
-      expect(launch!.args).toEqual(['-p', 'review this\nand that', '--always-approve']);
-      expect(launch!.options.input ?? null).toBeNull();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('no verified Grok read-only/plan mode');
+      if (existsSync(capturePath)) {
+        const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{ command: string }>;
+        expect(calls.some((c) => c.command === 'grok')).toBe(false);
+      }
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }
   });
 
-  it('launches cursor as `cursor-agent --print --force --trust --sandbox disabled <prompt>` and never pipes stdin', () => {
+  it('launches cursor in plan mode with sandbox enabled and never pipes stdin', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omc-ask-cursor-args-'));
     try {
       const capturePath = join(wd, 'spawn-sync-calls.json');
@@ -679,7 +675,11 @@ describe('run-provider-advisor script contract', () => {
       const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
         command: string;
         args: string[];
-        options: { input: string | null };
+        options: {
+          input: string | null;
+          timeout: number | null;
+          killSignal: string | null;
+        };
       }>;
 
       expect(calls).toHaveLength(2);
@@ -688,13 +688,80 @@ describe('run-provider-advisor script contract', () => {
       expect(launch!.command).toBe('cursor-agent');
       expect(launch!.args).toEqual([
         '--print',
-        '--force',
+        '--mode',
+        'plan',
         '--trust',
         '--sandbox',
-        'disabled',
+        'enabled',
         'review this\nand that',
       ]);
       expect(launch!.options.input ?? null).toBeNull();
+      expect(calls[0].options.timeout).toBe(10000);
+      expect(calls[0].options.killSignal).toBe('SIGKILL');
+      expect(launch!.options.timeout).toBe(600000);
+      expect(launch!.options.killSignal).toBe('SIGKILL');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('fails a provider version probe after the fixed safety timeout', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-version-timeout-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['claude', '--prompt', 'review this'],
+        wd,
+        {
+          SPAWN_CAPTURE_PATH: capturePath,
+          SPAWN_CAPTURE_MODE: 'version-timeout',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('claude --version timed out after 10000ms');
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        args: string[];
+        options: { timeout: number | null; killSignal: string | null };
+      }>;
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args).toEqual(['--version']);
+      expect(calls[0].options).toMatchObject({ timeout: 10000, killSignal: 'SIGKILL' });
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('honors the bounded provider timeout override and reports a timed-out run', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-provider-timeout-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['claude', '--prompt', 'review this'],
+        wd,
+        {
+          SPAWN_CAPTURE_PATH: capturePath,
+          SPAWN_CAPTURE_MODE: 'timeout',
+          OMC_PROVIDER_TIMEOUT_MS: '1200',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('provider timed out after 1200ms');
+
+      const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+        args: string[];
+        options: { timeout: number | null; killSignal: string | null };
+      }>;
+      expect(calls).toHaveLength(2);
+      expect(calls[1].options).toMatchObject({ timeout: 1200, killSignal: 'SIGKILL' });
     } finally {
       rmSync(wd, { recursive: true, force: true });
     }
@@ -757,7 +824,7 @@ describe('run-provider-advisor script contract', () => {
       });
       expect(calls[1]).toMatchObject({
         command: 'codex',
-        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
+        args: ['exec', '--skip-git-repo-check', '--sandbox', 'read-only', '--color', 'never', '-'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'windows cmd support 你好' },
       });
     } finally {
@@ -820,7 +887,7 @@ describe('run-provider-advisor script contract', () => {
       });
       expect(calls[1]).toMatchObject({
         command: 'gemini',
-        args: ['--yolo'],
+        args: ['--approval-mode', 'plan'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: 'ship safely 你好' },
       });
     } finally {
@@ -853,7 +920,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'codex',
-        args: ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'],
+        args: ['exec', '--skip-git-repo-check', '--sandbox', 'read-only', '--color', 'never', '-'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: multilinePrompt },
       });
     } finally {
@@ -886,7 +953,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'gemini',
-        args: ['--yolo'],
+        args: ['--approval-mode', 'plan'],
         options: { shell: true, encoding: 'utf8', stdio: null, input: longPrompt },
       });
     } finally {
@@ -920,7 +987,7 @@ describe('run-provider-advisor script contract', () => {
       // Even multiline prompts go via argv (safe: spawned without a shell); never stdin.
       expect(calls[1]).toMatchObject({
         command: 'agy',
-        args: ['--dangerously-skip-permissions', '-p', multilinePrompt],
+        args: ['--mode', 'plan', '--sandbox', '-p', multilinePrompt],
         options: { input: null },
       });
       expect(calls[1].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
@@ -954,7 +1021,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'agy',
-        args: ['--dangerously-skip-permissions', '-p', longPrompt],
+        args: ['--mode', 'plan', '--sandbox', '-p', longPrompt],
         options: { input: null },
       });
       expect(calls[1].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
@@ -963,7 +1030,7 @@ describe('run-provider-advisor script contract', () => {
     }
   });
 
-  it('launches antigravity as `agy --dangerously-skip-permissions -p <prompt>` for short prompts', () => {
+  it('launches antigravity in plan mode with sandboxing for short prompts', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omc-ask-antigravity-short-argv-'));
     const shortPrompt = 'review this change';
     try {
@@ -988,7 +1055,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'agy',
-        args: ['--dangerously-skip-permissions', '-p', shortPrompt],
+        args: ['--mode', 'plan', '--sandbox', '-p', shortPrompt],
         options: { input: null },
       });
       expect(calls[1].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
@@ -1115,7 +1182,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'claude',
-        args: ['-p'],
+        args: ['-p', '--permission-mode', 'plan'],
         options: { stdio: null, input: multilinePrompt },
       });
     } finally {
@@ -1148,7 +1215,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'claude',
-        args: ['-p'],
+        args: ['-p', '--permission-mode', 'plan'],
         options: { input: frontmatterPrompt },
       });
     } finally {
@@ -1181,7 +1248,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'claude',
-        args: ['-p'],
+        args: ['-p', '--permission-mode', 'plan'],
         options: { input: dashPrompt },
       });
     } finally {
@@ -1214,7 +1281,7 @@ describe('run-provider-advisor script contract', () => {
       expect(calls).toHaveLength(2);
       expect(calls[1]).toMatchObject({
         command: 'claude',
-        args: ['-p', shortPrompt],
+        args: ['-p', shortPrompt, '--permission-mode', 'plan'],
         options: { input: null },
       });
       expect(calls[1].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);


### PR DESCRIPTION
## What changed

- Replace provider-advisor bypass flags with enforced plan/read-only modes for Claude, Codex, Gemini, Antigravity, and Cursor.
- Fail closed for Grok until its CLI exposes a verified read-only or plan mode.
- Keep untrusted Windows prompt text out of `cmd.exe`: Claude uses stdin and
  Cursor fails closed until a safe non-shell launch path is available.
- Reject exit-0 provider runs that produce no advisor output.
- Bound provider version probes to 10 seconds and provider runs to 10 minutes by default.
- Add `OMC_PROVIDER_TIMEOUT_MS` for bounded run-time overrides.
- Expand advisor contract tests for safe arguments, timeout behavior, and fail-closed routing.

## Why

`omc ask` is advisory, but its provider launcher currently disables approval and sandbox controls. A provider response can therefore mutate the checkout even though the caller requested analysis only. Provider binaries can also hang indefinitely outside the existing Antigravity-specific guard.

## Impact

Advisor calls remain non-interactive and artifact-producing, but now run under each provider's available plan/read-only controls. Grok returns a clear error instead of launching with write-capable approval behavior.

## Validation

- `vitest --run src/cli/__tests__/ask.test.ts`: 49 passed
- `tsc --noEmit`: passed
- ESLint on `src/cli/__tests__/ask.test.ts`: passed
- `node --check scripts/run-provider-advisor.js`: passed
- SHA-keyed local gate passed for `1e3e5319e06bd19dda3fc40a87c0112cec8ed300`
