### PR TITLE
fix(launch): stop omc re-login from isolated profile auth drift

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -105526,32 +105526,56 @@ function credentialExpiry(parsed) {
   return typeof expiresAt === "number" && Number.isFinite(expiresAt) ? expiresAt : null;
 }
 function resolveCredentialWritePath(path25) {
-  try {
-    if (!(0, import_fs118.lstatSync)(path25).isSymbolicLink()) return path25;
-    const target = (0, import_fs118.readlinkSync)(path25);
-    return (0, import_path138.isAbsolute)(target) ? target : (0, import_path138.join)((0, import_path138.dirname)(path25), target);
-  } catch {
-    return path25;
+  let current = path25;
+  for (let depth = 0; depth < 16; depth += 1) {
+    try {
+      if (!(0, import_fs118.lstatSync)(current).isSymbolicLink()) return current;
+      const target = (0, import_fs118.readlinkSync)(current);
+      current = (0, import_path138.isAbsolute)(target) ? target : (0, import_path138.join)((0, import_path138.dirname)(current), target);
+    } catch {
+      return current;
+    }
   }
+  return current;
 }
-function accountIdentity(value) {
-  if (!isJsonObject(value)) return null;
+function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
+  const sourceAccount = isJsonObject(sourceClaudeJson?.oauthAccount) ? sourceClaudeJson.oauthAccount : null;
+  const runtimeAccount = isJsonObject(runtimeClaudeJson?.oauthAccount) ? runtimeClaudeJson.oauthAccount : null;
+  if (!sourceAccount || !runtimeAccount) return false;
+  let compared = false;
   for (const key of ["accountUuid", "emailAddress", "email"]) {
-    const candidate = value[key];
-    if (typeof candidate === "string" && candidate.trim().length > 0) return candidate.trim();
+    const sourceValue = sourceAccount[key];
+    const runtimeValue = runtimeAccount[key];
+    const sourceId = typeof sourceValue === "string" ? sourceValue.trim() : "";
+    const runtimeId = typeof runtimeValue === "string" ? runtimeValue.trim() : "";
+    if (!sourceId || !runtimeId) continue;
+    compared = true;
+    if (sourceId !== runtimeId) return false;
   }
-  return null;
+  return compared;
 }
-function accountIdentitiesDiffer(sourceClaudeJson, runtimeClaudeJson) {
-  const sourceIdentity = accountIdentity(sourceClaudeJson?.oauthAccount);
-  const runtimeIdentity = accountIdentity(runtimeClaudeJson?.oauthAccount);
-  return sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity;
-}
-function onboardingVersionNumber(value) {
-  if (typeof value === "number") return Number.isFinite(value) ? value : null;
-  if (typeof value !== "string" || value.trim().length === 0) return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
+function compareOnboardingVersion(left, right) {
+  const toParts = (value) => {
+    if (typeof value === "number") return Number.isFinite(value) ? [value] : null;
+    if (typeof value !== "string" || value.trim().length === 0) return null;
+    const parts = value.trim().split(/[.+-]/).map((part) => {
+      if (part.length === 0 || !/^\d+$/.test(part)) return Number.NaN;
+      return Number(part);
+    });
+    if (parts.some((part) => !Number.isFinite(part))) return null;
+    return parts;
+  };
+  const leftParts = toParts(left);
+  const rightParts = toParts(right);
+  if (!leftParts || !rightParts) return null;
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const a = leftParts[index] ?? 0;
+    const b = rightParts[index] ?? 0;
+    if (a > b) return 1;
+    if (a < b) return -1;
+  }
+  return 0;
 }
 function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceClaudeJson = readJsonObject4((0, import_path138.join)((0, import_path138.dirname)(baseConfigDir), ".claude.json"))) {
   if (!sourceClaudeJson) return;
@@ -105564,9 +105588,8 @@ function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceCl
   const sourceVersion = sourceClaudeJson.lastOnboardingVersion;
   if (typeof sourceVersion === "string" || typeof sourceVersion === "number") {
     const runtimeHasVersion = hasOwn(runtimeClaudeJson, "lastOnboardingVersion");
-    const runtimeVersion = onboardingVersionNumber(runtimeClaudeJson.lastOnboardingVersion);
-    const sourceVersionNumber = onboardingVersionNumber(sourceVersion);
-    if (!runtimeHasVersion || sourceVersionNumber !== null && (runtimeVersion === null || sourceVersionNumber > runtimeVersion)) {
+    const compared = compareOnboardingVersion(sourceVersion, runtimeClaudeJson.lastOnboardingVersion);
+    if (!runtimeHasVersion || compared !== null && compared > 0) {
       runtimeClaudeJson.lastOnboardingVersion = sourceVersion;
       changed = true;
     }
@@ -105581,13 +105604,9 @@ function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceCl
     } else if (!hasOwn(runtimeClaudeJson, "oauthAccount")) {
       runtimeClaudeJson.oauthAccount = sourceAccount;
       changed = true;
-    } else {
-      const sourceIdentity = accountIdentity(sourceAccount);
-      const runtimeIdentity = accountIdentity(runtimeClaudeJson.oauthAccount);
-      if (sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity) {
-        runtimeClaudeJson.oauthAccount = sourceAccount;
-        changed = true;
-      }
+    } else if (!accountsProvenSame(sourceClaudeJson, runtimeClaudeJson)) {
+      runtimeClaudeJson.oauthAccount = sourceAccount;
+      changed = true;
     }
   }
   if (isJsonObject(sourceClaudeJson.mcpServers)) {
@@ -105647,7 +105666,7 @@ function reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sour
   }
   const baseExpiresAt = credentialExpiry(baseInspection.parsed);
   if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt) return;
-  if (accountIdentitiesDiffer(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
+  if (!accountsProvenSame(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
   const mergedBaseCredentials = { ...baseInspection.parsed };
   if (hasOwn(baseInspection.parsed, "claudeAiOauth") || runtimeCandidate.nested) {
     const existingNested = isJsonObject(baseInspection.parsed.claudeAiOauth) ? baseInspection.parsed.claudeAiOauth : {};

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -105375,6 +105375,8 @@ var import_child_process40 = require("child_process");
 var import_fs118 = require("fs");
 var import_os22 = require("os");
 var import_path138 = require("path");
+init_atomic_write();
+init_file_lock();
 init_mcp_registry();
 init_config_dir();
 init_tmux_utils();
@@ -105427,6 +105429,9 @@ function ensureMirroredPath(sourcePath, targetPath, options = {}) {
 function isJsonObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
 function readJsonObject4(path25) {
   try {
     const parsed = JSON.parse((0, import_fs118.readFileSync)(path25, "utf-8"));
@@ -105435,15 +105440,247 @@ function readJsonObject4(path25) {
     return null;
   }
 }
-function refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath) {
-  const sourceClaudeJsonPath = (0, import_path138.join)((0, import_path138.dirname)(baseConfigDir), ".claude.json");
-  const sourceClaudeJson = readJsonObject4(sourceClaudeJsonPath);
-  if (!sourceClaudeJson || !isJsonObject(sourceClaudeJson.mcpServers)) {
+var OAUTH_CREDENTIAL_FIELDS = [
+  "accessToken",
+  "refreshToken",
+  "expiresAt",
+  "scopes",
+  "subscriptionType",
+  "rateLimitTier",
+  "organizationUuid",
+  "accountUuid",
+  "emailAddress",
+  "email",
+  "hasExtraUsageEnabled"
+];
+function extractOAuthCandidate(parsed) {
+  const inspect = (record2, nested) => {
+    const accessToken = record2.accessToken;
+    const expiresAt = record2.expiresAt;
+    if (typeof accessToken !== "string" || accessToken.trim().length === 0) return null;
+    if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return null;
+    const fields = {};
+    for (const key of OAUTH_CREDENTIAL_FIELDS) {
+      if (hasOwn(record2, key)) fields[key] = record2[key];
+    }
+    return { nested, expiresAt, fields };
+  };
+  if (isJsonObject(parsed.claudeAiOauth)) {
+    const nestedCandidate = inspect(parsed.claudeAiOauth, true);
+    if (nestedCandidate) return nestedCandidate;
+  }
+  return inspect(parsed, false);
+}
+function hasLinkableCredentials(inspection) {
+  if (inspection.candidate) return true;
+  if (!inspection.parsed) return false;
+  const source = isJsonObject(inspection.parsed.claudeAiOauth) ? inspection.parsed.claudeAiOauth : inspection.parsed;
+  return typeof source.accessToken === "string" && source.accessToken.trim().length > 0;
+}
+function inspectCredentialFile(path25) {
+  let stat2;
+  try {
+    stat2 = (0, import_fs118.lstatSync)(path25);
+  } catch (error2) {
+    const code = error2 && typeof error2 === "object" && "code" in error2 ? error2.code : void 0;
+    if (code !== "ENOENT" && code !== "ENOTDIR") {
+      return { exists: true, regularFile: false, readable: false, valid: false, parsed: null, candidate: null };
+    }
+    return { exists: false, regularFile: false, readable: false, valid: false, parsed: null, candidate: null };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse((0, import_fs118.readFileSync)(path25, "utf-8"));
+  } catch {
+    return {
+      exists: true,
+      regularFile: stat2.isFile(),
+      readable: false,
+      valid: false,
+      parsed: null,
+      candidate: null
+    };
+  }
+  if (!isJsonObject(parsed)) {
+    return {
+      exists: true,
+      regularFile: stat2.isFile(),
+      readable: true,
+      valid: false,
+      parsed: null,
+      candidate: null
+    };
+  }
+  return {
+    exists: true,
+    regularFile: stat2.isFile(),
+    readable: true,
+    valid: true,
+    parsed,
+    candidate: extractOAuthCandidate(parsed)
+  };
+}
+function credentialExpiry(parsed) {
+  const source = isJsonObject(parsed.claudeAiOauth) ? parsed.claudeAiOauth : parsed;
+  const expiresAt = source.expiresAt;
+  return typeof expiresAt === "number" && Number.isFinite(expiresAt) ? expiresAt : null;
+}
+function resolveCredentialWritePath(path25) {
+  try {
+    if (!(0, import_fs118.lstatSync)(path25).isSymbolicLink()) return path25;
+    const target = (0, import_fs118.readlinkSync)(path25);
+    return (0, import_path138.isAbsolute)(target) ? target : (0, import_path138.join)((0, import_path138.dirname)(path25), target);
+  } catch {
+    return path25;
+  }
+}
+function accountIdentity(value) {
+  if (!isJsonObject(value)) return null;
+  for (const key of ["accountUuid", "emailAddress", "email"]) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) return candidate.trim();
+  }
+  return null;
+}
+function accountIdentitiesDiffer(sourceClaudeJson, runtimeClaudeJson) {
+  const sourceIdentity = accountIdentity(sourceClaudeJson?.oauthAccount);
+  const runtimeIdentity = accountIdentity(runtimeClaudeJson?.oauthAccount);
+  return sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity;
+}
+function onboardingVersionNumber(value) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceClaudeJson = readJsonObject4((0, import_path138.join)((0, import_path138.dirname)(baseConfigDir), ".claude.json"))) {
+  if (!sourceClaudeJson) return;
+  const runtimeClaudeJson = readJsonObject4(runtimeClaudeJsonPath) ?? {};
+  let changed = false;
+  if (sourceClaudeJson.hasCompletedOnboarding === true && runtimeClaudeJson.hasCompletedOnboarding !== true) {
+    runtimeClaudeJson.hasCompletedOnboarding = true;
+    changed = true;
+  }
+  const sourceVersion = sourceClaudeJson.lastOnboardingVersion;
+  if (typeof sourceVersion === "string" || typeof sourceVersion === "number") {
+    const runtimeHasVersion = hasOwn(runtimeClaudeJson, "lastOnboardingVersion");
+    const runtimeVersion = onboardingVersionNumber(runtimeClaudeJson.lastOnboardingVersion);
+    const sourceVersionNumber = onboardingVersionNumber(sourceVersion);
+    if (!runtimeHasVersion || sourceVersionNumber !== null && (runtimeVersion === null || sourceVersionNumber > runtimeVersion)) {
+      runtimeClaudeJson.lastOnboardingVersion = sourceVersion;
+      changed = true;
+    }
+  }
+  if (hasOwn(sourceClaudeJson, "oauthAccount")) {
+    const sourceAccount = sourceClaudeJson.oauthAccount;
+    if (sourceAccount === null || sourceAccount === void 0) {
+      if (hasOwn(runtimeClaudeJson, "oauthAccount")) {
+        delete runtimeClaudeJson.oauthAccount;
+        changed = true;
+      }
+    } else if (!hasOwn(runtimeClaudeJson, "oauthAccount")) {
+      runtimeClaudeJson.oauthAccount = sourceAccount;
+      changed = true;
+    } else {
+      const sourceIdentity = accountIdentity(sourceAccount);
+      const runtimeIdentity = accountIdentity(runtimeClaudeJson.oauthAccount);
+      if (sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity) {
+        runtimeClaudeJson.oauthAccount = sourceAccount;
+        changed = true;
+      }
+    }
+  }
+  if (isJsonObject(sourceClaudeJson.mcpServers)) {
+    runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
+    changed = true;
+  }
+  if (changed) {
+    (0, import_fs118.writeFileSync)(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+  }
+}
+function ensureMirroredCredentials(sourcePath, targetPath, hasEligibleSourceCredentials) {
+  if (!(0, import_fs118.existsSync)(sourcePath)) return;
+  const removeExistingTarget = () => {
+    try {
+      (0, import_fs118.lstatSync)(targetPath);
+      (0, import_fs118.rmSync)(targetPath, { recursive: true, force: true });
+    } catch {
+    }
+  };
+  removeExistingTarget();
+  try {
+    (0, import_fs118.symlinkSync)(sourcePath, targetPath, "file");
+    return;
+  } catch {
+    removeExistingTarget();
+  }
+  try {
+    (0, import_fs118.linkSync)(sourcePath, targetPath);
+    return;
+  } catch {
+    removeExistingTarget();
+    if (hasEligibleSourceCredentials) {
+      throw new Error("Unable to mirror Claude credentials without copying credential content");
+    }
+  }
+}
+function pathExists(path25) {
+  try {
+    (0, import_fs118.lstatSync)(path25);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sourceClaudeJson, preservedRuntimeClaudeJson) {
+  const runtimeInspection = inspectCredentialFile(runtimeCredentialsPath);
+  const runtimeCandidate = runtimeInspection.candidate;
+  if (!runtimeCandidate) return;
+  const baseCredentialsPath = (0, import_path138.join)(baseConfigDir, ".credentials.json");
+  const baseInspection = inspectCredentialFile(baseCredentialsPath);
+  if (!baseInspection.exists) return;
+  if (!baseInspection.readable || !baseInspection.valid || !baseInspection.parsed) {
+    if (runtimeInspection.regularFile) {
+      throw new Error("Unable to read or parse base Claude credentials");
+    }
     return;
   }
-  const runtimeClaudeJson = readJsonObject4(runtimeClaudeJsonPath) ?? {};
-  runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
-  (0, import_fs118.writeFileSync)(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+  const baseExpiresAt = credentialExpiry(baseInspection.parsed);
+  if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt) return;
+  if (accountIdentitiesDiffer(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
+  const mergedBaseCredentials = { ...baseInspection.parsed };
+  if (hasOwn(baseInspection.parsed, "claudeAiOauth") || runtimeCandidate.nested) {
+    const existingNested = isJsonObject(baseInspection.parsed.claudeAiOauth) ? baseInspection.parsed.claudeAiOauth : {};
+    mergedBaseCredentials.claudeAiOauth = { ...existingNested, ...runtimeCandidate.fields };
+  } else {
+    Object.assign(mergedBaseCredentials, runtimeCandidate.fields);
+  }
+  atomicWriteJsonSync(resolveCredentialWritePath(baseCredentialsPath), mergedBaseCredentials);
+}
+function swapRuntimeConfigDir(runtimeConfigDir, nextConfigDir) {
+  const previousConfigDir = `${runtimeConfigDir}.prev`;
+  let movedPrevious = false;
+  try {
+    (0, import_fs118.rmSync)(previousConfigDir, { recursive: true, force: true });
+    if (pathExists(runtimeConfigDir)) {
+      (0, import_fs118.renameSync)(runtimeConfigDir, previousConfigDir);
+      movedPrevious = true;
+    }
+    (0, import_fs118.renameSync)(nextConfigDir, runtimeConfigDir);
+  } catch (error2) {
+    try {
+      if (movedPrevious && !pathExists(runtimeConfigDir) && pathExists(previousConfigDir)) {
+        (0, import_fs118.renameSync)(previousConfigDir, runtimeConfigDir);
+      }
+    } catch {
+    }
+    (0, import_fs118.rmSync)(nextConfigDir, { recursive: true, force: true });
+    throw error2;
+  }
+  try {
+    (0, import_fs118.rmSync)(previousConfigDir, { recursive: true, force: true });
+  } catch {
+  }
 }
 function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
   const companionPath = (0, import_path138.join)(baseConfigDir, "CLAUDE-omc.md");
@@ -105451,55 +105688,81 @@ function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
     return baseConfigDir;
   }
   const runtimeConfigDir = (0, import_path138.join)(baseConfigDir, OMC_RUNTIME_DIRNAME);
+  const nextConfigDir = `${runtimeConfigDir}.next`;
   const runtimeClaudeJsonPath = (0, import_path138.join)(runtimeConfigDir, ".claude.json");
-  const preservedClaudeJson = (0, import_fs118.existsSync)(runtimeClaudeJsonPath) ? (0, import_fs118.readFileSync)(runtimeClaudeJsonPath) : null;
-  (0, import_fs118.rmSync)(runtimeConfigDir, { recursive: true, force: true });
-  (0, import_fs118.mkdirSync)(runtimeConfigDir, { recursive: true });
-  if (preservedClaudeJson) {
-    (0, import_fs118.writeFileSync)(runtimeClaudeJsonPath, preservedClaudeJson);
-  }
-  refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath);
-  (0, import_fs118.copyFileSync)(companionPath, (0, import_path138.join)(runtimeConfigDir, "CLAUDE.md"));
-  for (const entry of [
-    "agents",
-    "commands",
-    "hooks",
-    "hud",
-    "plugins",
-    "projects",
-    "rules",
-    "skills",
-    "themes",
-    OMC_CONFIG_FILE_REL,
-    ".omc-version.json",
-    ".omc-silent-update.json",
-    "keybindings.json",
-    "settings.json",
-    "settings.local.json",
-    ".credentials.json"
-  ]) {
-    ensureMirroredPath(
-      (0, import_path138.join)(baseConfigDir, entry),
-      (0, import_path138.join)(runtimeConfigDir, (0, import_path138.basename)(entry)),
-      { allowCopyFallback: entry !== ".credentials.json" }
+  const runtimeCredentialsPath = (0, import_path138.join)(runtimeConfigDir, ".credentials.json");
+  const sourceClaudeJsonPath = (0, import_path138.join)((0, import_path138.dirname)(baseConfigDir), ".claude.json");
+  const lifecycleLockPath = lockPathFor((0, import_path138.join)(baseConfigDir, ".omc-launch.prepare.lock"));
+  return withFileLockSync(lifecycleLockPath, () => {
+    const preservedClaudeJson = pathExists(runtimeClaudeJsonPath) ? (0, import_fs118.readFileSync)(runtimeClaudeJsonPath) : null;
+    const preservedRuntimeClaudeJson = readJsonObject4(runtimeClaudeJsonPath);
+    const sourceClaudeJson = readJsonObject4(sourceClaudeJsonPath);
+    reconcileRuntimeCredentials(
+      baseConfigDir,
+      runtimeCredentialsPath,
+      sourceClaudeJson,
+      preservedRuntimeClaudeJson
     );
-  }
-  const runtimeSettingsPath = (0, import_path138.join)(runtimeConfigDir, "settings.json");
-  if ((0, import_fs118.existsSync)(runtimeSettingsPath)) {
+    (0, import_fs118.rmSync)(nextConfigDir, { recursive: true, force: true });
     try {
-      const rawSettings = JSON.parse((0, import_fs118.readFileSync)(runtimeSettingsPath, "utf-8"));
-      const repaired = stripRetiredTeamMcpServers(rawSettings);
-      if (repaired.changed) {
-        (0, import_fs118.writeFileSync)(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+      (0, import_fs118.mkdirSync)(nextConfigDir, { recursive: true });
+      const nextClaudeJsonPath = (0, import_path138.join)(nextConfigDir, ".claude.json");
+      if (preservedClaudeJson) {
+        (0, import_fs118.writeFileSync)(nextClaudeJsonPath, preservedClaudeJson);
       }
-    } catch {
+      refreshRuntimeClaudeJson(baseConfigDir, nextClaudeJsonPath, sourceClaudeJson);
+      (0, import_fs118.copyFileSync)(companionPath, (0, import_path138.join)(nextConfigDir, "CLAUDE.md"));
+      for (const entry of [
+        "agents",
+        "commands",
+        "hooks",
+        "hud",
+        "plugins",
+        "projects",
+        "rules",
+        "skills",
+        "themes",
+        OMC_CONFIG_FILE_REL,
+        ".omc-version.json",
+        ".omc-silent-update.json",
+        "keybindings.json",
+        "settings.json",
+        "settings.local.json"
+      ]) {
+        ensureMirroredPath(
+          (0, import_path138.join)(baseConfigDir, entry),
+          (0, import_path138.join)(nextConfigDir, (0, import_path138.basename)(entry))
+        );
+      }
+      const baseCredentialsPath = (0, import_path138.join)(baseConfigDir, ".credentials.json");
+      const baseCredentialInspection = inspectCredentialFile(baseCredentialsPath);
+      ensureMirroredCredentials(
+        baseCredentialsPath,
+        (0, import_path138.join)(nextConfigDir, ".credentials.json"),
+        hasLinkableCredentials(baseCredentialInspection)
+      );
+      const runtimeSettingsPath = (0, import_path138.join)(nextConfigDir, "settings.json");
+      if ((0, import_fs118.existsSync)(runtimeSettingsPath)) {
+        try {
+          const rawSettings = JSON.parse((0, import_fs118.readFileSync)(runtimeSettingsPath, "utf-8"));
+          const repaired = stripRetiredTeamMcpServers(rawSettings);
+          if (repaired.changed) {
+            (0, import_fs118.writeFileSync)(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+          }
+        } catch {
+        }
+      }
+      (0, import_fs118.writeFileSync)(
+        (0, import_path138.join)(nextConfigDir, ".omc-launch-profile.json"),
+        JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2)
+      );
+    } catch (error2) {
+      (0, import_fs118.rmSync)(nextConfigDir, { recursive: true, force: true });
+      throw error2;
     }
-  }
-  (0, import_fs118.writeFileSync)(
-    (0, import_path138.join)(runtimeConfigDir, ".omc-launch-profile.json"),
-    JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2)
-  );
-  return runtimeConfigDir;
+    swapRuntimeConfigDir(runtimeConfigDir, nextConfigDir);
+    return runtimeConfigDir;
+  }, { timeoutMs: 5e3, retryDelayMs: 50 });
 }
 function isDefaultClaudeConfigDirPath2(configDir) {
   return configDir === (0, import_path138.join)((0, import_os22.homedir)(), ".claude");

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -7221,7 +7221,7 @@ async function removeFileIfExists(filePath) {
   }
 }
 function sleep2(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 var import_child_process9, fs5, fsPromises2, path5, import_url6, import_child_process10, import_util6, execFileAsync3, BRIDGE_SPAWN_TIMEOUT_MS, DEFAULT_GRACE_PERIOD_MS, SIGTERM_GRACE_MS, ownedBridgeSessionIds, USE_TCP_FALLBACK;
 var init_bridge_manager = __esm({
@@ -13254,7 +13254,7 @@ function withFileLockSync(lockPath2, fn, opts) {
   }
 }
 function sleep3(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 async function acquireFileLock(lockPath2, opts) {
   const staleLockMs = opts?.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
@@ -26911,24 +26911,24 @@ async function runSessionEndAction(context, _execute) {
     let settled = false;
     let exitCode = null;
     let settleChild = () => void 0;
-    const childExit = new Promise((resolve32) => {
+    const childExit = new Promise((resolve33) => {
       settleChild = (code2) => {
         if (settled) return;
         settled = true;
         exitCode = code2;
-        resolve32(code2);
+        resolve33(code2);
       };
       child.once("exit", settleChild);
       child.once("error", () => settleChild(null));
     });
     let deadlineTermination;
     let resolveTermination;
-    const terminationFinished = new Promise((resolve32) => {
-      resolveTermination = resolve32;
+    const terminationFinished = new Promise((resolve33) => {
+      resolveTermination = resolve33;
     });
     const terminate = async () => {
-      const postKillWait = new Promise((resolve32) => {
-        const timer = setTimeout(resolve32, Math.max(1, context.deadlineAt + POST_KILL_SETTLE_MS - Date.now()));
+      const postKillWait = new Promise((resolve33) => {
+        const timer = setTimeout(resolve33, Math.max(1, context.deadlineAt + POST_KILL_SETTLE_MS - Date.now()));
         timer.unref();
       });
       await Promise.race([Promise.resolve(killProcessTree(child.pid, "SIGKILL")).catch(() => false), postKillWait]);
@@ -26988,7 +26988,7 @@ async function runActionRunnerEntrypoint() {
       } catch {
       }
       if (armed) break;
-      await new Promise((resolve32) => setTimeout(resolve32, 10));
+      await new Promise((resolve33) => setTimeout(resolve33, 10));
     }
     if (Date.now() >= input.deadlineAt) throw new Error("runner-arm-deadline");
     const deadlineTimer = setTimeout(() => {
@@ -28640,7 +28640,7 @@ async function sendTelegram(config2, payload) {
       text: payload.message,
       parse_mode: config2.parseMode || "Markdown"
     });
-    const result = await new Promise((resolve32) => {
+    const result = await new Promise((resolve33) => {
       const req = (0, import_https.request)(
         telegramRequestOptions(Buffer.byteLength(body), config2.botToken),
         (res) => {
@@ -28656,9 +28656,9 @@ async function sendTelegram(config2, payload) {
                 }
               } catch {
               }
-              resolve32({ platform: "telegram", success: true, messageId });
+              resolve33({ platform: "telegram", success: true, messageId });
             } else {
-              resolve32({
+              resolve33({
                 platform: "telegram",
                 success: false,
                 error: `HTTP ${res.statusCode}`
@@ -28668,11 +28668,11 @@ async function sendTelegram(config2, payload) {
         }
       );
       req.on("error", (e) => {
-        resolve32({ platform: "telegram", success: false, error: e.message });
+        resolve33({ platform: "telegram", success: false, error: e.message });
       });
       req.on("timeout", () => {
         req.destroy();
-        resolve32({
+        resolve33({
           platform: "telegram",
           success: false,
           error: "Request timeout"
@@ -28919,9 +28919,9 @@ async function dispatchNotifications(config2, event, payload, platformMessages) 
           }
         )
       ),
-      new Promise((resolve32) => {
+      new Promise((resolve33) => {
         timer = setTimeout(
-          () => resolve32([
+          () => resolve33([
             {
               platform: "unknown",
               success: false,
@@ -31826,10 +31826,10 @@ async function runWithinDeadline(deadlineAt, run) {
   const controller = new AbortController();
   let timer;
   try {
-    return await Promise.race([run(controller.signal), new Promise((resolve32) => {
+    return await Promise.race([run(controller.signal), new Promise((resolve33) => {
       timer = setTimeout(() => {
         controller.abort();
-        resolve32(void 0);
+        resolve33(void 0);
       }, remaining);
     })]);
   } finally {
@@ -32554,7 +32554,7 @@ async function withProcessIdentityFileLock(lockPath2, fn, timeoutMs = 1e4) {
           continue;
         }
         if (Date.now() >= deadline) throw new Error("process_identity_lock_timeout");
-        await new Promise((resolve32) => setTimeout(resolve32, 25));
+        await new Promise((resolve33) => setTimeout(resolve33, 25));
         continue;
       }
       try {
@@ -32575,7 +32575,7 @@ async function withProcessIdentityFileLock(lockPath2, fn, timeoutMs = 1e4) {
           }
         }
         if (Date.now() >= deadline) throw new Error("process_identity_lock_timeout");
-        await new Promise((resolve32) => setTimeout(resolve32, 25));
+        await new Promise((resolve33) => setTimeout(resolve33, 25));
       }
     }
     return await fn();
@@ -33849,7 +33849,7 @@ async function withMailboxLock(teamName, workerName2, cwd2, fn) {
   while (Date.now() < deadline) {
     const result = await withLock2(lockDir, fn);
     if (result.ok) return result.value;
-    await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+    await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     delayMs = Math.min(delayMs * 2, 200);
   }
   throw new Error(`Failed to acquire mailbox lock for ${workerName2} after ${timeoutMs}ms`);
@@ -33989,7 +33989,7 @@ async function teamCreateTask(teamName, task, cwd2) {
       return taskLock.value;
     });
     if (result.ok) return result.value;
-    await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+    await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     delayMs = Math.min(delayMs * 2, 200);
   }
   throw new Error(`Failed to acquire task creation lock for team ${teamName} after ${timeoutMs}ms`);
@@ -34029,7 +34029,7 @@ async function teamUpdateTask(teamName, taskId, updates, cwd2) {
       return merged;
     });
     if (result.ok) return result.value;
-    await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+    await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     delayMs = Math.min(delayMs * 2, 200);
   }
   throw new Error(`Failed to acquire task update lock for task ${taskId} in team ${teamName} after ${timeoutMs}ms`);
@@ -36870,7 +36870,7 @@ async function withDispatchLock(teamName, cwd2, fn) {
         );
       }
       const jitter = 0.5 + Math.random() * 0.5;
-      await new Promise((resolve32) => setTimeout(resolve32, Math.floor(pollMs * jitter)));
+      await new Promise((resolve33) => setTimeout(resolve33, Math.floor(pollMs * jitter)));
       pollMs = Math.min(pollMs * 2, DISPATCH_LOCK_MAX_POLL_MS);
     }
   }
@@ -39811,8 +39811,8 @@ ${dirtyFiles.map((f) => `- \`${f}\``).join("\n")}`;
               return false;
             }
           })(),
-          new Promise((resolve32) => {
-            const t = setTimeout(() => resolve32(false), remaining);
+          new Promise((resolve33) => {
+            const t = setTimeout(() => resolve33(false), remaining);
             if (typeof t.unref === "function") t.unref();
           })
         ]);
@@ -40644,7 +40644,7 @@ async function bootstrapPersistentOwner(input, priorEpoch) {
     const fenceOk = owner ? checkOwnerFence(input.cwd, input.teamName, { epoch: owner.epoch, nonce: owner.nonce }).ok : false;
     if (isExpectedRecoveryOwnerSuccessor(owner, expectedEpoch, child.pid, childProcessStartedAt, fenceOk, bootstrapNonce) && configBound?.epoch === expectedEpoch && configBound.nonce === bootstrapNonce && configBound.pid === child.pid && configBound.process_started_at === childProcessStartedAt && active?.request_id === input.requestId && active?.recovery_id === reservation.recovery_id && active?.worker_name === input.workerName && active?.owner_epoch === expectedEpoch && active?.owner_nonce === bootstrapNonce) return true;
     if (owner && (owner.epoch > expectedEpoch || owner.epoch === expectedEpoch && owner.pid !== child.pid)) return false;
-    await new Promise((resolve32) => setTimeout(resolve32, 25));
+    await new Promise((resolve33) => setTimeout(resolve33, 25));
   }
   return false;
 }
@@ -40741,7 +40741,7 @@ function createRecoveryOwnerClient(dispatch, timing = {}) {
           teamName: normalized.teamName,
           workerName: normalized.workerName
         })) return outcome.result;
-        await new Promise((resolve32) => setTimeout(resolve32, timing.pollIntervalMs ?? 250));
+        await new Promise((resolve33) => setTimeout(resolve33, timing.pollIntervalMs ?? 250));
       }
       return timeoutResult(normalized, canonical.recovery_id);
     }
@@ -40883,7 +40883,7 @@ async function waitForRecoveryGateRecord(path25, expected, timeoutMs, pollInterv
       if (value.recovery_id === expected.recovery_id && value.worker_name === expected.worker_name && value.replacement_generation === expected.replacement_generation && value.pane_attempt_id === expected.pane_attempt_id) return true;
     } catch {
     }
-    await new Promise((resolve32) => setTimeout(resolve32, pollIntervalMs));
+    await new Promise((resolve33) => setTimeout(resolve33, pollIntervalMs));
   }
   return false;
 }
@@ -41353,7 +41353,7 @@ async function waitForWorkerStartupEvidence(teamName, workerName2, taskId, cwd2,
       return true;
     }
     if (attempt < attempts) {
-      await new Promise((resolve32) => setTimeout(resolve32, delayMs));
+      await new Promise((resolve33) => setTimeout(resolve33, delayMs));
     }
   }
   return false;
@@ -41837,14 +41837,14 @@ async function readOrCreateRecoveryAttempt(input, recoveryId, replacementGenerat
   }
 }
 function waitForBootstrapRecoveryEvidence(delayMs, signal) {
-  return new Promise((resolve32, reject) => {
+  return new Promise((resolve33, reject) => {
     if (signal?.aborted) {
       reject(signal.reason ?? new Error("bootstrap_recovery_evidence_aborted"));
       return;
     }
     const timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);
-      resolve32();
+      resolve33();
     }, delayMs);
     const onAbort = () => {
       clearTimeout(timer);
@@ -43937,7 +43937,7 @@ async function readJsonSafe5(filePath) {
         return null;
       }
     }
-    await new Promise((resolve32) => setTimeout(resolve32, 25));
+    await new Promise((resolve33) => setTimeout(resolve33, 25));
   }
   return null;
 }
@@ -44055,7 +44055,7 @@ async function nextPendingTaskIndex(runtime) {
     let task = await readTask(root2, taskId);
     if (!task) {
       for (let attempt = 1; attempt < transientReadRetryAttempts; attempt++) {
-        await new Promise((resolve32) => setTimeout(resolve32, transientReadRetryDelayMs));
+        await new Promise((resolve33) => setTimeout(resolve33, transientReadRetryDelayMs));
         task = await readTask(root2, taskId);
         if (task) break;
       }
@@ -44943,7 +44943,7 @@ async function pollTelegram(config2, state, rateLimiter) {
   try {
     const offset = state.telegramLastUpdateId ? state.telegramLastUpdateId + 1 : 0;
     const path25 = `/bot${config2.telegramBotToken}/getUpdates?offset=${offset}&timeout=0`;
-    const updates = await new Promise((resolve32, reject) => {
+    const updates = await new Promise((resolve33, reject) => {
       const req = (0, import_https2.request)(
         {
           hostname: "api.telegram.org",
@@ -44960,7 +44960,7 @@ async function pollTelegram(config2, state, rateLimiter) {
             try {
               const body = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
               if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-                resolve32(body.result || []);
+                resolve33(body.result || []);
               } else {
                 reject(new Error(`HTTP ${res.statusCode}`));
               }
@@ -45024,7 +45024,7 @@ async function pollTelegram(config2, state, rateLimiter) {
             text: "Injected into Claude Code session.",
             reply_to_message_id: msg.message_id
           });
-          await new Promise((resolve32) => {
+          await new Promise((resolve33) => {
             const replyReq = (0, import_https2.request)(
               {
                 hostname: "api.telegram.org",
@@ -45039,13 +45039,13 @@ async function pollTelegram(config2, state, rateLimiter) {
               },
               (res) => {
                 res.resume();
-                resolve32();
+                resolve33();
               }
             );
-            replyReq.on("error", () => resolve32());
+            replyReq.on("error", () => resolve33());
             replyReq.on("timeout", () => {
               replyReq.destroy();
-              resolve32();
+              resolve33();
             });
             replyReq.write(replyBody);
             replyReq.end();
@@ -45184,13 +45184,13 @@ async function pollLoop() {
         }
       }
       writeDaemonState(state);
-      await new Promise((resolve32) => setTimeout(resolve32, config2.pollIntervalMs));
+      await new Promise((resolve33) => setTimeout(resolve33, config2.pollIntervalMs));
     } catch (error2) {
       state.errors++;
       state.lastError = redactTokens(error2 instanceof Error ? error2.message : String(error2));
       log(`Poll error: ${state.lastError}`);
       writeDaemonState(state);
-      await new Promise((resolve32) => setTimeout(resolve32, config2.pollIntervalMs * 2));
+      await new Promise((resolve33) => setTimeout(resolve33, config2.pollIntervalMs * 2));
     }
   }
   log("Poll loop ended");
@@ -53692,7 +53692,7 @@ function validateCredentials(creds) {
   return !isCredentialExpired(creds);
 }
 function refreshAccessToken(refreshToken) {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const clientId = process.env.CLAUDE_CODE_OAUTH_CLIENT_ID || DEFAULT_OAUTH_CLIENT_ID;
     const body = new URLSearchParams({
       grant_type: "refresh_token",
@@ -53720,7 +53720,7 @@ function refreshAccessToken(refreshToken) {
             try {
               const parsed = JSON.parse(data);
               if (parsed.access_token) {
-                resolve32({
+                resolve33({
                   accessToken: parsed.access_token,
                   refreshToken: parsed.refresh_token || refreshToken,
                   expiresAt: parsed.expires_in ? Date.now() + parsed.expires_in * 1e3 : parsed.expires_at
@@ -53733,20 +53733,20 @@ function refreshAccessToken(refreshToken) {
           if (process.env.OMC_DEBUG) {
             console.error(`[usage-api] Token refresh failed: HTTP ${res.statusCode}`);
           }
-          resolve32(null);
+          resolve33(null);
         });
       }
     );
-    req.on("error", () => resolve32(null));
+    req.on("error", () => resolve33(null));
     req.on("timeout", () => {
       req.destroy();
-      resolve32(null);
+      resolve33(null);
     });
     req.end(body);
   });
 }
 function fetchUsageFromApi(accessToken) {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const req = import_https3.default.request(
       {
         hostname: "api.anthropic.com",
@@ -53767,41 +53767,41 @@ function fetchUsageFromApi(accessToken) {
         res.on("end", () => {
           if (res.statusCode === 200) {
             try {
-              resolve32({ data: JSON.parse(data) });
+              resolve33({ data: JSON.parse(data) });
             } catch {
-              resolve32({ data: null });
+              resolve33({ data: null });
             }
           } else if (res.statusCode === 429) {
             if (process.env.OMC_DEBUG) {
               console.error(`[usage-api] Anthropic API returned 429 (rate limited)`);
             }
-            resolve32({ data: null, rateLimited: true });
+            resolve33({ data: null, rateLimited: true });
           } else {
-            resolve32({ data: null });
+            resolve33({ data: null });
           }
         });
       }
     );
-    req.on("error", () => resolve32({ data: null }));
+    req.on("error", () => resolve33({ data: null }));
     req.on("timeout", () => {
       req.destroy();
-      resolve32({ data: null });
+      resolve33({ data: null });
     });
     req.end();
   });
 }
 function fetchUsageFromZai() {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const baseUrl = process.env.ANTHROPIC_BASE_URL;
     const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
     if (!baseUrl || !authToken) {
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     const validation = validateAnthropicBaseUrl(baseUrl);
     if (!validation.allowed) {
       console.error(`[SSRF Guard] Blocking usage API call: ${validation.reason}`);
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     try {
@@ -53829,29 +53829,29 @@ function fetchUsageFromZai() {
           res.on("end", () => {
             if (res.statusCode === 200) {
               try {
-                resolve32({ data: JSON.parse(data) });
+                resolve33({ data: JSON.parse(data) });
               } catch {
-                resolve32({ data: null });
+                resolve33({ data: null });
               }
             } else if (res.statusCode === 429) {
               if (process.env.OMC_DEBUG) {
                 console.error(`[usage-api] z.ai API returned 429 (rate limited)`);
               }
-              resolve32({ data: null, rateLimited: true });
+              resolve33({ data: null, rateLimited: true });
             } else {
-              resolve32({ data: null });
+              resolve33({ data: null });
             }
           });
         }
       );
-      req.on("error", () => resolve32({ data: null }));
+      req.on("error", () => resolve33({ data: null }));
       req.on("timeout", () => {
         req.destroy();
-        resolve32({ data: null });
+        resolve33({ data: null });
       });
       req.end();
     } catch {
-      resolve32({ data: null });
+      resolve33({ data: null });
     }
   });
 }
@@ -54121,16 +54121,16 @@ function parseZaiResponse(response) {
   return result;
 }
 function fetchUsageFromMinimax(apiKey) {
-  return new Promise((resolve32) => {
+  return new Promise((resolve33) => {
     const baseUrl = process.env.ANTHROPIC_BASE_URL;
     if (!baseUrl) {
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     const validation = validateAnthropicBaseUrl(baseUrl);
     if (!validation.allowed) {
       console.error(`[SSRF Guard] Blocking usage API call: ${validation.reason}`);
-      resolve32({ data: null });
+      resolve33({ data: null });
       return;
     }
     try {
@@ -54157,29 +54157,29 @@ function fetchUsageFromMinimax(apiKey) {
           res.on("end", () => {
             if (res.statusCode === 200) {
               try {
-                resolve32({ data: JSON.parse(data) });
+                resolve33({ data: JSON.parse(data) });
               } catch {
-                resolve32({ data: null });
+                resolve33({ data: null });
               }
             } else if (res.statusCode === 429) {
               if (process.env.OMC_DEBUG) {
                 console.error(`[usage-api] MiniMax API returned 429 (rate limited)`);
               }
-              resolve32({ data: null, rateLimited: true });
+              resolve33({ data: null, rateLimited: true });
             } else {
-              resolve32({ data: null });
+              resolve33({ data: null });
             }
           });
         }
       );
-      req.on("error", () => resolve32({ data: null }));
+      req.on("error", () => resolve33({ data: null }));
       req.on("timeout", () => {
         req.destroy();
-        resolve32({ data: null });
+        resolve33({ data: null });
       });
       req.end();
     } catch {
-      resolve32({ data: null });
+      resolve33({ data: null });
     }
   });
 }
@@ -55301,7 +55301,7 @@ function isCacheValid2(cache) {
   return Date.now() - cache.timestamp < CACHE_TTL_MS2;
 }
 function spawnWithTimeout(cmd, timeoutMs) {
-  return new Promise((resolve32, reject) => {
+  return new Promise((resolve33, reject) => {
     const [executable, ...args] = Array.isArray(cmd) ? cmd : ["sh", "-c", cmd];
     const child = (0, import_child_process43.spawn)(executable, args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
@@ -55324,7 +55324,7 @@ function spawnWithTimeout(cmd, timeoutMs) {
       clearTimeout(timer);
       if (!timedOut) {
         if (code === 0) {
-          resolve32(stdout);
+          resolve33(stdout);
         } else {
           reject(new Error(`Command exited with code ${code}`));
         }
@@ -61518,7 +61518,7 @@ var require_compile = __commonJS2((exports2) => {
     const schOrFunc = root2.refs[ref];
     if (schOrFunc)
       return schOrFunc;
-    let _sch = resolve32.call(this, root2, ref);
+    let _sch = resolve33.call(this, root2, ref);
     if (_sch === void 0) {
       const schema = (_a = root2.localRefs) === null || _a === void 0 ? void 0 : _a[ref];
       const { schemaId } = this.opts;
@@ -61545,7 +61545,7 @@ var require_compile = __commonJS2((exports2) => {
   function sameSchemaEnv(s1, s2) {
     return s1.schema === s2.schema && s1.root === s2.root && s1.baseId === s2.baseId;
   }
-  function resolve32(root2, ref) {
+  function resolve33(root2, ref) {
     let sch;
     while (typeof (sch = this.refs[ref]) == "string")
       ref = sch;
@@ -62043,7 +62043,7 @@ var require_fast_uri = __commonJS2((exports2, module2) => {
     }
     return uri;
   }
-  function resolve32(baseURI, relativeURI, options) {
+  function resolve33(baseURI, relativeURI, options) {
     const schemelessOptions = Object.assign({ scheme: "null" }, options);
     const resolved = resolveComponents(parse62(baseURI, schemelessOptions), parse62(relativeURI, schemelessOptions), schemelessOptions, true);
     return serialize(resolved, { ...schemelessOptions, skipEscape: true });
@@ -62276,7 +62276,7 @@ var require_fast_uri = __commonJS2((exports2, module2) => {
   var fastUri = {
     SCHEMES,
     normalize: normalize13,
-    resolve: resolve32,
+    resolve: resolve33,
     resolveComponents,
     equal,
     serialize,
@@ -76643,7 +76643,7 @@ var Protocol = class {
           return;
         }
         const pollInterval = (_c = (_a = task2.pollInterval) !== null && _a !== void 0 ? _a : (_b = this._options) === null || _b === void 0 ? void 0 : _b.defaultTaskPollInterval) !== null && _c !== void 0 ? _c : 1e3;
-        await new Promise((resolve32) => setTimeout(resolve32, pollInterval));
+        await new Promise((resolve33) => setTimeout(resolve33, pollInterval));
         (_d = options === null || options === void 0 ? void 0 : options.signal) === null || _d === void 0 || _d.throwIfAborted();
       }
     } catch (error2) {
@@ -76655,7 +76655,7 @@ var Protocol = class {
   }
   request(request, resultSchema, options) {
     const { relatedRequestId, resumptionToken, onresumptiontoken, task, relatedTask } = options !== null && options !== void 0 ? options : {};
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       var _a, _b, _c, _d, _e, _f, _g;
       const earlyReject = (error2) => {
         reject(error2);
@@ -76736,7 +76736,7 @@ var Protocol = class {
           if (!parseResult.success) {
             reject(parseResult.error);
           } else {
-            resolve32(parseResult.data);
+            resolve33(parseResult.data);
           }
         } catch (error2) {
           reject(error2);
@@ -76933,12 +76933,12 @@ var Protocol = class {
       }
     } catch (_d) {
     }
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       if (signal.aborted) {
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
         return;
       }
-      const timeoutId = setTimeout(resolve32, interval);
+      const timeoutId = setTimeout(resolve33, interval);
       signal.addEventListener("abort", () => {
         clearTimeout(timeoutId);
         reject(new McpError(ErrorCode.InvalidRequest, "Request cancelled"));
@@ -77737,7 +77737,7 @@ var McpServer = class {
     let task = createTaskResult.task;
     const pollInterval = (_a = task.pollInterval) !== null && _a !== void 0 ? _a : 5e3;
     while (task.status !== "completed" && task.status !== "failed" && task.status !== "cancelled") {
-      await new Promise((resolve32) => setTimeout(resolve32, pollInterval));
+      await new Promise((resolve33) => setTimeout(resolve33, pollInterval));
       const updatedTask = await extra.taskStore.getTask(taskId);
       if (!updatedTask) {
         throw new McpError(ErrorCode.InternalError, `Task ${taskId} not found during polling`);
@@ -82877,7 +82877,7 @@ var LspClient = class _LspClient {
 Install with: ${this.serverConfig.installHint}`
       );
     }
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       const command = this.devContainerContext ? "docker" : this.serverConfig.command;
       const args = this.devContainerContext ? ["exec", "-i", "-w", this.devContainerContext.containerWorkspaceRoot, this.devContainerContext.containerId, this.serverConfig.command, ...this.serverConfig.args] : this.serverConfig.args;
       this.process = (0, import_child_process4.spawn)(command, args, {
@@ -82904,7 +82904,7 @@ Install with: ${this.serverConfig.installHint}`
       });
       this.initialize().then(() => {
         this.initialized = true;
-        resolve32();
+        resolve33();
       }).catch(reject);
     });
   }
@@ -83070,13 +83070,13 @@ ${content}`);
     const message2 = `Content-Length: ${Buffer.byteLength(content)}\r
 \r
 ${content}`;
-    return new Promise((resolve32, reject) => {
+    return new Promise((resolve33, reject) => {
       const timeoutHandle = setTimeout(() => {
         this.pendingRequests.delete(id);
         reject(new Error(`LSP request '${method}' timed out after ${effectiveTimeout}ms`));
       }, effectiveTimeout);
       this.pendingRequests.set(id, {
-        resolve: resolve32,
+        resolve: resolve33,
         reject,
         timeout: timeoutHandle
       });
@@ -83152,7 +83152,7 @@ ${content}`;
       }
     });
     this.openDocuments.add(hostUri);
-    await new Promise((resolve32) => setTimeout(resolve32, 100));
+    await new Promise((resolve33) => setTimeout(resolve33, 100));
   }
   /**
    * Close a document
@@ -83313,13 +83313,13 @@ ${content}`;
     if (this.diagnostics.has(uri)) {
       return Promise.resolve();
     }
-    return new Promise((resolve32) => {
+    return new Promise((resolve33) => {
       let resolved = false;
       const timer = setTimeout(() => {
         if (!resolved) {
           resolved = true;
           this.diagnosticWaiters.delete(uri);
-          resolve32();
+          resolve33();
         }
       }, timeoutMs);
       const existing = this.diagnosticWaiters.get(uri) || [];
@@ -83327,7 +83327,7 @@ ${content}`;
         if (!resolved) {
           resolved = true;
           clearTimeout(timer);
-          resolve32();
+          resolve33();
         }
       });
       this.diagnosticWaiters.set(uri, existing);
@@ -85257,7 +85257,7 @@ var SessionLock = class {
   }
 };
 function sleep(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 
 // src/tools/python-repl/socket-client.ts
@@ -85287,7 +85287,7 @@ var JsonRpcError = class extends Error {
   }
 };
 async function sendSocketRequest(socketPath, method, params, timeout = 6e4) {
-  return new Promise((resolve32, reject) => {
+  return new Promise((resolve33, reject) => {
     const id = (0, import_crypto5.randomUUID)();
     const request = {
       jsonrpc: "2.0",
@@ -85377,7 +85377,7 @@ async function sendSocketRequest(socketPath, method, params, timeout = 6e4) {
           }
           if (!settled) {
             settled = true;
-            resolve32(response.result);
+            resolve33(response.result);
           }
         } catch (e) {
           if (!settled) {
@@ -89369,7 +89369,7 @@ function mergeArrays(fieldName, base, incoming) {
       return mergeScalarArray(base, incoming);
   }
 }
-function mergeByKey(base, incoming, keyFn, resolve32) {
+function mergeByKey(base, incoming, keyFn, resolve33) {
   const seen = /* @__PURE__ */ new Map();
   for (const item of base) {
     seen.set(keyFn(item), item);
@@ -89378,7 +89378,7 @@ function mergeByKey(base, incoming, keyFn, resolve32) {
     const key = keyFn(item);
     const existing = seen.get(key);
     if (existing) {
-      seen.set(key, resolve32(existing, item));
+      seen.set(key, resolve33(existing, item));
     } else {
       seen.set(key, item);
     }
@@ -100623,7 +100623,7 @@ async function pollLoop2(config2) {
       log2(`Poll error: ${state.lastError}`, config2);
       writeDaemonState2(state, config2);
     }
-    await new Promise((resolve32) => setTimeout(resolve32, config2.pollIntervalMs));
+    await new Promise((resolve33) => setTimeout(resolve33, config2.pollIntervalMs));
   }
 }
 function startDaemon(config2) {
@@ -103812,7 +103812,7 @@ async function ralphthonCommand(args) {
   console.log(source_default.gray("Orchestrator running. Press Ctrl+C to stop."));
 }
 function sleep5(ms) {
-  return new Promise((resolve32) => setTimeout(resolve32, ms));
+  return new Promise((resolve33) => setTimeout(resolve33, ms));
 }
 
 // src/cli/commands/ultragoal.ts
@@ -105526,33 +105526,58 @@ function credentialExpiry(parsed) {
   return typeof expiresAt === "number" && Number.isFinite(expiresAt) ? expiresAt : null;
 }
 function resolveCredentialWritePath(path25) {
-  let current = path25;
-  for (let depth = 0; depth < 16; depth += 1) {
-    try {
-      if (!(0, import_fs118.lstatSync)(current).isSymbolicLink()) return current;
-      const target = (0, import_fs118.readlinkSync)(current);
-      current = (0, import_path138.isAbsolute)(target) ? target : (0, import_path138.join)((0, import_path138.dirname)(current), target);
-    } catch {
-      return current;
+  let current = (0, import_path138.resolve)(path25);
+  const visited = /* @__PURE__ */ new Set();
+  while (true) {
+    if (visited.has(current)) {
+      throw new Error("Claude credential symlink chain contains a cycle");
     }
+    visited.add(current);
+    let stat2;
+    try {
+      stat2 = (0, import_fs118.lstatSync)(current);
+    } catch (error2) {
+      const code = error2 && typeof error2 === "object" && "code" in error2 ? error2.code : void 0;
+      if (code === "ENOENT" || code === "ENOTDIR") return current;
+      throw error2;
+    }
+    if (!stat2.isSymbolicLink()) return current;
+    const target = (0, import_fs118.readlinkSync)(current);
+    current = (0, import_path138.isAbsolute)(target) ? (0, import_path138.resolve)(target) : (0, import_path138.resolve)((0, import_path138.dirname)(current), target);
   }
-  return current;
 }
 function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
   const sourceAccount = isJsonObject(sourceClaudeJson?.oauthAccount) ? sourceClaudeJson.oauthAccount : null;
   const runtimeAccount = isJsonObject(runtimeClaudeJson?.oauthAccount) ? runtimeClaudeJson.oauthAccount : null;
   if (!sourceAccount || !runtimeAccount) return false;
+  const sourceUuid = typeof sourceAccount.accountUuid === "string" ? sourceAccount.accountUuid.trim() : "";
+  const runtimeUuid = typeof runtimeAccount.accountUuid === "string" ? runtimeAccount.accountUuid.trim() : "";
+  if (sourceUuid && runtimeUuid) return sourceUuid === runtimeUuid;
   let compared = false;
-  for (const key of ["accountUuid", "emailAddress", "email"]) {
+  for (const key of ["emailAddress", "email"]) {
     const sourceValue = sourceAccount[key];
     const runtimeValue = runtimeAccount[key];
-    const sourceId = typeof sourceValue === "string" ? sourceValue.trim() : "";
-    const runtimeId = typeof runtimeValue === "string" ? runtimeValue.trim() : "";
-    if (!sourceId || !runtimeId) continue;
+    const sourceEmail = typeof sourceValue === "string" ? sourceValue.trim() : "";
+    const runtimeEmail = typeof runtimeValue === "string" ? runtimeValue.trim() : "";
+    if (!sourceEmail || !runtimeEmail) continue;
     compared = true;
-    if (sourceId !== runtimeId) return false;
+    if (sourceEmail.toLowerCase() !== runtimeEmail.toLowerCase()) return false;
   }
   return compared;
+}
+function credentialIdentitiesConflict(baseCandidate, runtimeCandidate) {
+  if (!baseCandidate) return false;
+  for (const key of ["accountUuid", "emailAddress", "email"]) {
+    const baseValue = baseCandidate.fields[key];
+    const runtimeValue = runtimeCandidate.fields[key];
+    const baseIdentity = typeof baseValue === "string" ? baseValue.trim() : "";
+    const runtimeIdentity = typeof runtimeValue === "string" ? runtimeValue.trim() : "";
+    if (!baseIdentity || !runtimeIdentity) continue;
+    const normalizedBase = key === "accountUuid" ? baseIdentity : baseIdentity.toLowerCase();
+    const normalizedRuntime = key === "accountUuid" ? runtimeIdentity : runtimeIdentity.toLowerCase();
+    if (normalizedBase !== normalizedRuntime) return true;
+  }
+  return false;
 }
 function compareOnboardingVersion(left, right) {
   const toParts = (value) => {
@@ -105667,6 +105692,7 @@ function reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sour
   const baseExpiresAt = credentialExpiry(baseInspection.parsed);
   if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt) return;
   if (!accountsProvenSame(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
+  if (credentialIdentitiesConflict(baseInspection.candidate, runtimeCandidate)) return;
   const mergedBaseCredentials = { ...baseInspection.parsed };
   if (hasOwn(baseInspection.parsed, "claudeAiOauth") || runtimeCandidate.nested) {
     const existingNested = isJsonObject(baseInspection.parsed.claudeAiOauth) ? baseInspection.parsed.claudeAiOauth : {};
@@ -106611,15 +106637,15 @@ async function runHudWatchLoop(options) {
     if (shouldStop) {
       break;
     }
-    await new Promise((resolve32) => {
+    await new Promise((resolve33) => {
       const timer = setTimeout(() => {
         wakeSleep = null;
-        resolve32();
+        resolve33();
       }, options.intervalMs);
       wakeSleep = () => {
         clearTimeout(timer);
         wakeSleep = null;
-        resolve32();
+        resolve33();
       };
       timer.unref?.();
     });

--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -105567,15 +105567,19 @@ function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
 }
 function credentialIdentitiesConflict(baseCandidate, runtimeCandidate) {
   if (!baseCandidate) return false;
-  for (const key of ["accountUuid", "emailAddress", "email"]) {
+  const baseUuid = typeof baseCandidate.fields.accountUuid === "string" ? baseCandidate.fields.accountUuid.trim() : "";
+  const runtimeUuid = typeof runtimeCandidate.fields.accountUuid === "string" ? runtimeCandidate.fields.accountUuid.trim() : "";
+  if (baseUuid || runtimeUuid) {
+    return !baseUuid || !runtimeUuid || baseUuid !== runtimeUuid;
+  }
+  for (const key of ["emailAddress", "email"]) {
     const baseValue = baseCandidate.fields[key];
     const runtimeValue = runtimeCandidate.fields[key];
-    const baseIdentity = typeof baseValue === "string" ? baseValue.trim() : "";
-    const runtimeIdentity = typeof runtimeValue === "string" ? runtimeValue.trim() : "";
-    if (!baseIdentity || !runtimeIdentity) continue;
-    const normalizedBase = key === "accountUuid" ? baseIdentity : baseIdentity.toLowerCase();
-    const normalizedRuntime = key === "accountUuid" ? runtimeIdentity : runtimeIdentity.toLowerCase();
-    if (normalizedBase !== normalizedRuntime) return true;
+    const baseEmail = typeof baseValue === "string" ? baseValue.trim() : "";
+    const runtimeEmail = typeof runtimeValue === "string" ? runtimeValue.trim() : "";
+    if (!baseEmail && !runtimeEmail) continue;
+    if (!baseEmail || !runtimeEmail) return true;
+    if (baseEmail.toLowerCase() !== runtimeEmail.toLowerCase()) return true;
   }
   return false;
 }

--- a/dist/cli/launch.js
+++ b/dist/cli/launch.js
@@ -228,16 +228,25 @@ function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
 function credentialIdentitiesConflict(baseCandidate, runtimeCandidate) {
     if (!baseCandidate)
         return false;
-    for (const key of ['accountUuid', 'emailAddress', 'email']) {
+    const baseUuid = typeof baseCandidate.fields.accountUuid === 'string'
+        ? baseCandidate.fields.accountUuid.trim()
+        : '';
+    const runtimeUuid = typeof runtimeCandidate.fields.accountUuid === 'string'
+        ? runtimeCandidate.fields.accountUuid.trim()
+        : '';
+    if (baseUuid || runtimeUuid) {
+        return !baseUuid || !runtimeUuid || baseUuid !== runtimeUuid;
+    }
+    for (const key of ['emailAddress', 'email']) {
         const baseValue = baseCandidate.fields[key];
         const runtimeValue = runtimeCandidate.fields[key];
-        const baseIdentity = typeof baseValue === 'string' ? baseValue.trim() : '';
-        const runtimeIdentity = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
-        if (!baseIdentity || !runtimeIdentity)
+        const baseEmail = typeof baseValue === 'string' ? baseValue.trim() : '';
+        const runtimeEmail = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+        if (!baseEmail && !runtimeEmail)
             continue;
-        const normalizedBase = key === 'accountUuid' ? baseIdentity : baseIdentity.toLowerCase();
-        const normalizedRuntime = key === 'accountUuid' ? runtimeIdentity : runtimeIdentity.toLowerCase();
-        if (normalizedBase !== normalizedRuntime)
+        if (!baseEmail || !runtimeEmail)
+            return true;
+        if (baseEmail.toLowerCase() !== runtimeEmail.toLowerCase())
             return true;
     }
     return false;

--- a/dist/cli/launch.js
+++ b/dist/cli/launch.js
@@ -5,7 +5,7 @@
 import { execFileSync } from 'child_process';
 import { cpSync, copyFileSync, existsSync, lstatSync, linkSync, mkdirSync, readFileSync, readlinkSync, renameSync, rmSync, symlinkSync, writeFileSync, } from 'fs';
 import { homedir } from 'os';
-import { basename, dirname, isAbsolute, join } from 'path';
+import { basename, dirname, isAbsolute, join, resolve } from 'path';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import { lockPathFor, withFileLockSync } from '../lib/file-lock.js';
 import { resolvePluginDirArg } from '../lib/plugin-dir.js';
@@ -176,19 +176,30 @@ function credentialExpiry(parsed) {
     return typeof expiresAt === 'number' && Number.isFinite(expiresAt) ? expiresAt : null;
 }
 function resolveCredentialWritePath(path) {
-    let current = path;
-    for (let depth = 0; depth < 16; depth += 1) {
+    let current = resolve(path);
+    const visited = new Set();
+    while (true) {
+        if (visited.has(current)) {
+            throw new Error('Claude credential symlink chain contains a cycle');
+        }
+        visited.add(current);
+        let stat;
         try {
-            if (!lstatSync(current).isSymbolicLink())
+            stat = lstatSync(current);
+        }
+        catch (error) {
+            const code = error && typeof error === 'object' && 'code' in error
+                ? error.code
+                : undefined;
+            if (code === 'ENOENT' || code === 'ENOTDIR')
                 return current;
-            const target = readlinkSync(current);
-            current = isAbsolute(target) ? target : join(dirname(current), target);
+            throw error;
         }
-        catch {
+        if (!stat.isSymbolicLink())
             return current;
-        }
+        const target = readlinkSync(current);
+        current = isAbsolute(target) ? resolve(target) : resolve(dirname(current), target);
     }
-    return current;
 }
 /** True only when source and runtime can be proven to be the same account. */
 function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
@@ -196,19 +207,40 @@ function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
     const runtimeAccount = isJsonObject(runtimeClaudeJson?.oauthAccount) ? runtimeClaudeJson.oauthAccount : null;
     if (!sourceAccount || !runtimeAccount)
         return false;
+    const sourceUuid = typeof sourceAccount.accountUuid === 'string' ? sourceAccount.accountUuid.trim() : '';
+    const runtimeUuid = typeof runtimeAccount.accountUuid === 'string' ? runtimeAccount.accountUuid.trim() : '';
+    if (sourceUuid && runtimeUuid)
+        return sourceUuid === runtimeUuid;
     let compared = false;
-    for (const key of ['accountUuid', 'emailAddress', 'email']) {
+    for (const key of ['emailAddress', 'email']) {
         const sourceValue = sourceAccount[key];
         const runtimeValue = runtimeAccount[key];
-        const sourceId = typeof sourceValue === 'string' ? sourceValue.trim() : '';
-        const runtimeId = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
-        if (!sourceId || !runtimeId)
+        const sourceEmail = typeof sourceValue === 'string' ? sourceValue.trim() : '';
+        const runtimeEmail = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+        if (!sourceEmail || !runtimeEmail)
             continue;
         compared = true;
-        if (sourceId !== runtimeId)
+        if (sourceEmail.toLowerCase() !== runtimeEmail.toLowerCase())
             return false;
     }
     return compared;
+}
+function credentialIdentitiesConflict(baseCandidate, runtimeCandidate) {
+    if (!baseCandidate)
+        return false;
+    for (const key of ['accountUuid', 'emailAddress', 'email']) {
+        const baseValue = baseCandidate.fields[key];
+        const runtimeValue = runtimeCandidate.fields[key];
+        const baseIdentity = typeof baseValue === 'string' ? baseValue.trim() : '';
+        const runtimeIdentity = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+        if (!baseIdentity || !runtimeIdentity)
+            continue;
+        const normalizedBase = key === 'accountUuid' ? baseIdentity : baseIdentity.toLowerCase();
+        const normalizedRuntime = key === 'accountUuid' ? runtimeIdentity : runtimeIdentity.toLowerCase();
+        if (normalizedBase !== normalizedRuntime)
+            return true;
+    }
+    return false;
 }
 function compareOnboardingVersion(left, right) {
     const toParts = (value) => {
@@ -344,6 +376,9 @@ function reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sour
         return;
     // Fail closed unless both sides prove the same account identity.
     if (!accountsProvenSame(sourceClaudeJson, preservedRuntimeClaudeJson))
+        return;
+    // Credential fields may veto promotion but cannot establish account identity.
+    if (credentialIdentitiesConflict(baseInspection.candidate, runtimeCandidate))
         return;
     const mergedBaseCredentials = { ...baseInspection.parsed };
     if (hasOwn(baseInspection.parsed, 'claudeAiOauth') || runtimeCandidate.nested) {

--- a/dist/cli/launch.js
+++ b/dist/cli/launch.js
@@ -176,38 +176,69 @@ function credentialExpiry(parsed) {
     return typeof expiresAt === 'number' && Number.isFinite(expiresAt) ? expiresAt : null;
 }
 function resolveCredentialWritePath(path) {
-    try {
-        if (!lstatSync(path).isSymbolicLink())
-            return path;
-        const target = readlinkSync(path);
-        return isAbsolute(target) ? target : join(dirname(path), target);
+    let current = path;
+    for (let depth = 0; depth < 16; depth += 1) {
+        try {
+            if (!lstatSync(current).isSymbolicLink())
+                return current;
+            const target = readlinkSync(current);
+            current = isAbsolute(target) ? target : join(dirname(current), target);
+        }
+        catch {
+            return current;
+        }
     }
-    catch {
-        return path;
-    }
+    return current;
 }
-function accountIdentity(value) {
-    if (!isJsonObject(value))
-        return null;
+/** True only when source and runtime can be proven to be the same account. */
+function accountsProvenSame(sourceClaudeJson, runtimeClaudeJson) {
+    const sourceAccount = isJsonObject(sourceClaudeJson?.oauthAccount) ? sourceClaudeJson.oauthAccount : null;
+    const runtimeAccount = isJsonObject(runtimeClaudeJson?.oauthAccount) ? runtimeClaudeJson.oauthAccount : null;
+    if (!sourceAccount || !runtimeAccount)
+        return false;
+    let compared = false;
     for (const key of ['accountUuid', 'emailAddress', 'email']) {
-        const candidate = value[key];
-        if (typeof candidate === 'string' && candidate.trim().length > 0)
-            return candidate.trim();
+        const sourceValue = sourceAccount[key];
+        const runtimeValue = runtimeAccount[key];
+        const sourceId = typeof sourceValue === 'string' ? sourceValue.trim() : '';
+        const runtimeId = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+        if (!sourceId || !runtimeId)
+            continue;
+        compared = true;
+        if (sourceId !== runtimeId)
+            return false;
     }
-    return null;
+    return compared;
 }
-function accountIdentitiesDiffer(sourceClaudeJson, runtimeClaudeJson) {
-    const sourceIdentity = accountIdentity(sourceClaudeJson?.oauthAccount);
-    const runtimeIdentity = accountIdentity(runtimeClaudeJson?.oauthAccount);
-    return sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity;
-}
-function onboardingVersionNumber(value) {
-    if (typeof value === 'number')
-        return Number.isFinite(value) ? value : null;
-    if (typeof value !== 'string' || value.trim().length === 0)
+function compareOnboardingVersion(left, right) {
+    const toParts = (value) => {
+        if (typeof value === 'number')
+            return Number.isFinite(value) ? [value] : null;
+        if (typeof value !== 'string' || value.trim().length === 0)
+            return null;
+        const parts = value.trim().split(/[.+-]/).map((part) => {
+            if (part.length === 0 || !/^\d+$/.test(part))
+                return Number.NaN;
+            return Number(part);
+        });
+        if (parts.some((part) => !Number.isFinite(part)))
+            return null;
+        return parts;
+    };
+    const leftParts = toParts(left);
+    const rightParts = toParts(right);
+    if (!leftParts || !rightParts)
         return null;
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
+    const length = Math.max(leftParts.length, rightParts.length);
+    for (let index = 0; index < length; index += 1) {
+        const a = leftParts[index] ?? 0;
+        const b = rightParts[index] ?? 0;
+        if (a > b)
+            return 1;
+        if (a < b)
+            return -1;
+    }
+    return 0;
 }
 function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceClaudeJson = readJsonObject(join(dirname(baseConfigDir), '.claude.json'))) {
     if (!sourceClaudeJson)
@@ -221,9 +252,8 @@ function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceCl
     const sourceVersion = sourceClaudeJson.lastOnboardingVersion;
     if (typeof sourceVersion === 'string' || typeof sourceVersion === 'number') {
         const runtimeHasVersion = hasOwn(runtimeClaudeJson, 'lastOnboardingVersion');
-        const runtimeVersion = onboardingVersionNumber(runtimeClaudeJson.lastOnboardingVersion);
-        const sourceVersionNumber = onboardingVersionNumber(sourceVersion);
-        if (!runtimeHasVersion || (sourceVersionNumber !== null && (runtimeVersion === null || sourceVersionNumber > runtimeVersion))) {
+        const compared = compareOnboardingVersion(sourceVersion, runtimeClaudeJson.lastOnboardingVersion);
+        if (!runtimeHasVersion || (compared !== null && compared > 0)) {
             runtimeClaudeJson.lastOnboardingVersion = sourceVersion;
             changed = true;
         }
@@ -240,13 +270,10 @@ function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceCl
             runtimeClaudeJson.oauthAccount = sourceAccount;
             changed = true;
         }
-        else {
-            const sourceIdentity = accountIdentity(sourceAccount);
-            const runtimeIdentity = accountIdentity(runtimeClaudeJson.oauthAccount);
-            if (sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity) {
-                runtimeClaudeJson.oauthAccount = sourceAccount;
-                changed = true;
-            }
+        else if (!accountsProvenSame(sourceClaudeJson, runtimeClaudeJson)) {
+            // Prefer source account metadata when identities cannot be proven equal.
+            runtimeClaudeJson.oauthAccount = sourceAccount;
+            changed = true;
         }
     }
     if (isJsonObject(sourceClaudeJson.mcpServers)) {
@@ -315,7 +342,8 @@ function reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sour
     const baseExpiresAt = credentialExpiry(baseInspection.parsed);
     if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt)
         return;
-    if (accountIdentitiesDiffer(sourceClaudeJson, preservedRuntimeClaudeJson))
+    // Fail closed unless both sides prove the same account identity.
+    if (!accountsProvenSame(sourceClaudeJson, preservedRuntimeClaudeJson))
         return;
     const mergedBaseCredentials = { ...baseInspection.parsed };
     if (hasOwn(baseInspection.parsed, 'claudeAiOauth') || runtimeCandidate.nested) {

--- a/dist/cli/launch.js
+++ b/dist/cli/launch.js
@@ -3,9 +3,11 @@
  * Launches Claude Code with tmux session management
  */
 import { execFileSync } from 'child_process';
-import { cpSync, copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync, } from 'fs';
+import { cpSync, copyFileSync, existsSync, lstatSync, linkSync, mkdirSync, readFileSync, readlinkSync, renameSync, rmSync, symlinkSync, writeFileSync, } from 'fs';
 import { homedir } from 'os';
-import { basename, dirname, join } from 'path';
+import { basename, dirname, isAbsolute, join } from 'path';
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import { lockPathFor, withFileLockSync } from '../lib/file-lock.js';
 import { resolvePluginDirArg } from '../lib/plugin-dir.js';
 import { stripRetiredTeamMcpServers } from '../installer/mcp-registry.js';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
@@ -64,6 +66,9 @@ function ensureMirroredPath(sourcePath, targetPath, options = {}) {
 function isJsonObject(value) {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
+function hasOwn(value, key) {
+    return Object.prototype.hasOwnProperty.call(value, key);
+}
 function readJsonObject(path) {
     try {
         const parsed = JSON.parse(readFileSync(path, 'utf-8'));
@@ -73,15 +78,286 @@ function readJsonObject(path) {
         return null;
     }
 }
-function refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath) {
-    const sourceClaudeJsonPath = join(dirname(baseConfigDir), '.claude.json');
-    const sourceClaudeJson = readJsonObject(sourceClaudeJsonPath);
-    if (!sourceClaudeJson || !isJsonObject(sourceClaudeJson.mcpServers)) {
+const OAUTH_CREDENTIAL_FIELDS = [
+    'accessToken',
+    'refreshToken',
+    'expiresAt',
+    'scopes',
+    'subscriptionType',
+    'rateLimitTier',
+    'organizationUuid',
+    'accountUuid',
+    'emailAddress',
+    'email',
+    'hasExtraUsageEnabled',
+];
+function extractOAuthCandidate(parsed) {
+    const inspect = (record, nested) => {
+        const accessToken = record.accessToken;
+        const expiresAt = record.expiresAt;
+        if (typeof accessToken !== 'string' || accessToken.trim().length === 0)
+            return null;
+        if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt))
+            return null;
+        const fields = {};
+        for (const key of OAUTH_CREDENTIAL_FIELDS) {
+            if (hasOwn(record, key))
+                fields[key] = record[key];
+        }
+        return { nested, expiresAt, fields };
+    };
+    if (isJsonObject(parsed.claudeAiOauth)) {
+        const nestedCandidate = inspect(parsed.claudeAiOauth, true);
+        if (nestedCandidate)
+            return nestedCandidate;
+    }
+    return inspect(parsed, false);
+}
+function hasLinkableCredentials(inspection) {
+    if (inspection.candidate)
+        return true;
+    if (!inspection.parsed)
+        return false;
+    const source = isJsonObject(inspection.parsed.claudeAiOauth)
+        ? inspection.parsed.claudeAiOauth
+        : inspection.parsed;
+    return typeof source.accessToken === 'string' && source.accessToken.trim().length > 0;
+}
+function inspectCredentialFile(path) {
+    let stat;
+    try {
+        stat = lstatSync(path);
+    }
+    catch (error) {
+        const code = error && typeof error === 'object' && 'code' in error
+            ? error.code
+            : undefined;
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+            return { exists: true, regularFile: false, readable: false, valid: false, parsed: null, candidate: null };
+        }
+        return { exists: false, regularFile: false, readable: false, valid: false, parsed: null, candidate: null };
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    }
+    catch {
+        return {
+            exists: true,
+            regularFile: stat.isFile(),
+            readable: false,
+            valid: false,
+            parsed: null,
+            candidate: null,
+        };
+    }
+    if (!isJsonObject(parsed)) {
+        return {
+            exists: true,
+            regularFile: stat.isFile(),
+            readable: true,
+            valid: false,
+            parsed: null,
+            candidate: null,
+        };
+    }
+    return {
+        exists: true,
+        regularFile: stat.isFile(),
+        readable: true,
+        valid: true,
+        parsed,
+        candidate: extractOAuthCandidate(parsed),
+    };
+}
+function credentialExpiry(parsed) {
+    const source = isJsonObject(parsed.claudeAiOauth) ? parsed.claudeAiOauth : parsed;
+    const expiresAt = source.expiresAt;
+    return typeof expiresAt === 'number' && Number.isFinite(expiresAt) ? expiresAt : null;
+}
+function resolveCredentialWritePath(path) {
+    try {
+        if (!lstatSync(path).isSymbolicLink())
+            return path;
+        const target = readlinkSync(path);
+        return isAbsolute(target) ? target : join(dirname(path), target);
+    }
+    catch {
+        return path;
+    }
+}
+function accountIdentity(value) {
+    if (!isJsonObject(value))
+        return null;
+    for (const key of ['accountUuid', 'emailAddress', 'email']) {
+        const candidate = value[key];
+        if (typeof candidate === 'string' && candidate.trim().length > 0)
+            return candidate.trim();
+    }
+    return null;
+}
+function accountIdentitiesDiffer(sourceClaudeJson, runtimeClaudeJson) {
+    const sourceIdentity = accountIdentity(sourceClaudeJson?.oauthAccount);
+    const runtimeIdentity = accountIdentity(runtimeClaudeJson?.oauthAccount);
+    return sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity;
+}
+function onboardingVersionNumber(value) {
+    if (typeof value === 'number')
+        return Number.isFinite(value) ? value : null;
+    if (typeof value !== 'string' || value.trim().length === 0)
+        return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+function refreshRuntimeClaudeJson(baseConfigDir, runtimeClaudeJsonPath, sourceClaudeJson = readJsonObject(join(dirname(baseConfigDir), '.claude.json'))) {
+    if (!sourceClaudeJson)
+        return;
+    const runtimeClaudeJson = readJsonObject(runtimeClaudeJsonPath) ?? {};
+    let changed = false;
+    if (sourceClaudeJson.hasCompletedOnboarding === true && runtimeClaudeJson.hasCompletedOnboarding !== true) {
+        runtimeClaudeJson.hasCompletedOnboarding = true;
+        changed = true;
+    }
+    const sourceVersion = sourceClaudeJson.lastOnboardingVersion;
+    if (typeof sourceVersion === 'string' || typeof sourceVersion === 'number') {
+        const runtimeHasVersion = hasOwn(runtimeClaudeJson, 'lastOnboardingVersion');
+        const runtimeVersion = onboardingVersionNumber(runtimeClaudeJson.lastOnboardingVersion);
+        const sourceVersionNumber = onboardingVersionNumber(sourceVersion);
+        if (!runtimeHasVersion || (sourceVersionNumber !== null && (runtimeVersion === null || sourceVersionNumber > runtimeVersion))) {
+            runtimeClaudeJson.lastOnboardingVersion = sourceVersion;
+            changed = true;
+        }
+    }
+    if (hasOwn(sourceClaudeJson, 'oauthAccount')) {
+        const sourceAccount = sourceClaudeJson.oauthAccount;
+        if (sourceAccount === null || sourceAccount === undefined) {
+            if (hasOwn(runtimeClaudeJson, 'oauthAccount')) {
+                delete runtimeClaudeJson.oauthAccount;
+                changed = true;
+            }
+        }
+        else if (!hasOwn(runtimeClaudeJson, 'oauthAccount')) {
+            runtimeClaudeJson.oauthAccount = sourceAccount;
+            changed = true;
+        }
+        else {
+            const sourceIdentity = accountIdentity(sourceAccount);
+            const runtimeIdentity = accountIdentity(runtimeClaudeJson.oauthAccount);
+            if (sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity) {
+                runtimeClaudeJson.oauthAccount = sourceAccount;
+                changed = true;
+            }
+        }
+    }
+    if (isJsonObject(sourceClaudeJson.mcpServers)) {
+        runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
+        changed = true;
+    }
+    if (changed) {
+        writeFileSync(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+    }
+}
+function ensureMirroredCredentials(sourcePath, targetPath, hasEligibleSourceCredentials) {
+    if (!existsSync(sourcePath))
+        return;
+    const removeExistingTarget = () => {
+        try {
+            lstatSync(targetPath);
+            rmSync(targetPath, { recursive: true, force: true });
+        }
+        catch {
+            // A missing target is expected in a fresh staged directory.
+        }
+    };
+    removeExistingTarget();
+    try {
+        symlinkSync(sourcePath, targetPath, 'file');
         return;
     }
-    const runtimeClaudeJson = readJsonObject(runtimeClaudeJsonPath) ?? {};
-    runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
-    writeFileSync(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+    catch {
+        removeExistingTarget();
+    }
+    try {
+        linkSync(sourcePath, targetPath);
+        return;
+    }
+    catch {
+        removeExistingTarget();
+        if (hasEligibleSourceCredentials) {
+            throw new Error('Unable to mirror Claude credentials without copying credential content');
+        }
+    }
+}
+function pathExists(path) {
+    try {
+        lstatSync(path);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+function reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sourceClaudeJson, preservedRuntimeClaudeJson) {
+    const runtimeInspection = inspectCredentialFile(runtimeCredentialsPath);
+    const runtimeCandidate = runtimeInspection.candidate;
+    if (!runtimeCandidate)
+        return;
+    const baseCredentialsPath = join(baseConfigDir, '.credentials.json');
+    const baseInspection = inspectCredentialFile(baseCredentialsPath);
+    if (!baseInspection.exists)
+        return;
+    if (!baseInspection.readable || !baseInspection.valid || !baseInspection.parsed) {
+        if (runtimeInspection.regularFile) {
+            throw new Error('Unable to read or parse base Claude credentials');
+        }
+        return;
+    }
+    const baseExpiresAt = credentialExpiry(baseInspection.parsed);
+    if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt)
+        return;
+    if (accountIdentitiesDiffer(sourceClaudeJson, preservedRuntimeClaudeJson))
+        return;
+    const mergedBaseCredentials = { ...baseInspection.parsed };
+    if (hasOwn(baseInspection.parsed, 'claudeAiOauth') || runtimeCandidate.nested) {
+        const existingNested = isJsonObject(baseInspection.parsed.claudeAiOauth)
+            ? baseInspection.parsed.claudeAiOauth
+            : {};
+        mergedBaseCredentials.claudeAiOauth = { ...existingNested, ...runtimeCandidate.fields };
+    }
+    else {
+        Object.assign(mergedBaseCredentials, runtimeCandidate.fields);
+    }
+    atomicWriteJsonSync(resolveCredentialWritePath(baseCredentialsPath), mergedBaseCredentials);
+}
+function swapRuntimeConfigDir(runtimeConfigDir, nextConfigDir) {
+    const previousConfigDir = `${runtimeConfigDir}.prev`;
+    let movedPrevious = false;
+    try {
+        rmSync(previousConfigDir, { recursive: true, force: true });
+        if (pathExists(runtimeConfigDir)) {
+            renameSync(runtimeConfigDir, previousConfigDir);
+            movedPrevious = true;
+        }
+        renameSync(nextConfigDir, runtimeConfigDir);
+    }
+    catch (error) {
+        try {
+            if (movedPrevious && !pathExists(runtimeConfigDir) && pathExists(previousConfigDir)) {
+                renameSync(previousConfigDir, runtimeConfigDir);
+            }
+        }
+        catch {
+            // Keep the original swap error; the previous directory remains available for recovery.
+        }
+        rmSync(nextConfigDir, { recursive: true, force: true });
+        throw error;
+    }
+    try {
+        rmSync(previousConfigDir, { recursive: true, force: true });
+    }
+    catch {
+        // Best effort cleanup; the new runtime directory is already active.
+    }
 }
 export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) {
     const companionPath = join(baseConfigDir, 'CLAUDE-omc.md');
@@ -89,53 +365,72 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()) 
         return baseConfigDir;
     }
     const runtimeConfigDir = join(baseConfigDir, OMC_RUNTIME_DIRNAME);
+    const nextConfigDir = `${runtimeConfigDir}.next`;
     const runtimeClaudeJsonPath = join(runtimeConfigDir, '.claude.json');
-    const preservedClaudeJson = existsSync(runtimeClaudeJsonPath)
-        ? readFileSync(runtimeClaudeJsonPath)
-        : null;
-    rmSync(runtimeConfigDir, { recursive: true, force: true });
-    mkdirSync(runtimeConfigDir, { recursive: true });
-    if (preservedClaudeJson) {
-        writeFileSync(runtimeClaudeJsonPath, preservedClaudeJson);
-    }
-    refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath);
-    copyFileSync(companionPath, join(runtimeConfigDir, 'CLAUDE.md'));
-    for (const entry of [
-        'agents',
-        'commands',
-        'hooks',
-        'hud',
-        'plugins',
-        'projects',
-        'rules',
-        'skills',
-        'themes',
-        OMC_CONFIG_FILE_REL,
-        '.omc-version.json',
-        '.omc-silent-update.json',
-        'keybindings.json',
-        'settings.json',
-        'settings.local.json',
-        '.credentials.json',
-    ]) {
-        ensureMirroredPath(join(baseConfigDir, entry), join(runtimeConfigDir, basename(entry)), { allowCopyFallback: entry !== '.credentials.json' });
-    }
-    const runtimeSettingsPath = join(runtimeConfigDir, 'settings.json');
-    if (existsSync(runtimeSettingsPath)) {
+    const runtimeCredentialsPath = join(runtimeConfigDir, '.credentials.json');
+    const sourceClaudeJsonPath = join(dirname(baseConfigDir), '.claude.json');
+    const lifecycleLockPath = lockPathFor(join(baseConfigDir, '.omc-launch.prepare.lock'));
+    return withFileLockSync(lifecycleLockPath, () => {
+        const preservedClaudeJson = pathExists(runtimeClaudeJsonPath)
+            ? readFileSync(runtimeClaudeJsonPath)
+            : null;
+        const preservedRuntimeClaudeJson = readJsonObject(runtimeClaudeJsonPath);
+        const sourceClaudeJson = readJsonObject(sourceClaudeJsonPath);
+        reconcileRuntimeCredentials(baseConfigDir, runtimeCredentialsPath, sourceClaudeJson, preservedRuntimeClaudeJson);
+        rmSync(nextConfigDir, { recursive: true, force: true });
         try {
-            const rawSettings = JSON.parse(readFileSync(runtimeSettingsPath, 'utf-8'));
-            const repaired = stripRetiredTeamMcpServers(rawSettings);
-            if (repaired.changed) {
-                writeFileSync(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+            mkdirSync(nextConfigDir, { recursive: true });
+            const nextClaudeJsonPath = join(nextConfigDir, '.claude.json');
+            if (preservedClaudeJson) {
+                writeFileSync(nextClaudeJsonPath, preservedClaudeJson);
             }
+            refreshRuntimeClaudeJson(baseConfigDir, nextClaudeJsonPath, sourceClaudeJson);
+            copyFileSync(companionPath, join(nextConfigDir, 'CLAUDE.md'));
+            for (const entry of [
+                'agents',
+                'commands',
+                'hooks',
+                'hud',
+                'plugins',
+                'projects',
+                'rules',
+                'skills',
+                'themes',
+                OMC_CONFIG_FILE_REL,
+                '.omc-version.json',
+                '.omc-silent-update.json',
+                'keybindings.json',
+                'settings.json',
+                'settings.local.json',
+            ]) {
+                ensureMirroredPath(join(baseConfigDir, entry), join(nextConfigDir, basename(entry)));
+            }
+            const baseCredentialsPath = join(baseConfigDir, '.credentials.json');
+            const baseCredentialInspection = inspectCredentialFile(baseCredentialsPath);
+            ensureMirroredCredentials(baseCredentialsPath, join(nextConfigDir, '.credentials.json'), hasLinkableCredentials(baseCredentialInspection));
+            const runtimeSettingsPath = join(nextConfigDir, 'settings.json');
+            if (existsSync(runtimeSettingsPath)) {
+                try {
+                    const rawSettings = JSON.parse(readFileSync(runtimeSettingsPath, 'utf-8'));
+                    const repaired = stripRetiredTeamMcpServers(rawSettings);
+                    if (repaired.changed) {
+                        writeFileSync(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+                    }
+                }
+                catch {
+                    // Best-effort compatibility repair; launch must continue even if a legacy
+                    // settings file cannot be parsed or rewritten.
+                }
+            }
+            writeFileSync(join(nextConfigDir, '.omc-launch-profile.json'), JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2));
         }
-        catch {
-            // Best-effort compatibility repair; launch must continue even if a legacy
-            // settings file cannot be parsed or rewritten.
+        catch (error) {
+            rmSync(nextConfigDir, { recursive: true, force: true });
+            throw error;
         }
-    }
-    writeFileSync(join(runtimeConfigDir, '.omc-launch-profile.json'), JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2));
-    return runtimeConfigDir;
+        swapRuntimeConfigDir(runtimeConfigDir, nextConfigDir);
+        return runtimeConfigDir;
+    }, { timeoutMs: 5000, retryDelayMs: 50 });
 }
 function isDefaultClaudeConfigDirPath(configDir) {
     return configDir === join(homedir(), '.claude');

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -1286,10 +1286,47 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
   });
 
+  it('blocks credential promotion when either account identity is missing', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'source-account' } }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({ claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 } }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    // Runtime has no oauthAccount after a forced rewrite
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({ session: 'no-account-meta' }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 999 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
+  });
+
+  it('inherits lastOnboardingVersion using semver-aware comparison', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({ lastOnboardingVersion: '2.10.0' }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({ lastOnboardingVersion: '2.9.0' }));
+    const rebuilt = prepareOmcLaunchConfigDir(configDir);
+    const runtimeClaudeJson = JSON.parse(readFileSync(join(rebuilt, '.claude.json'), 'utf-8')) as Record<string, unknown>;
+    expect(runtimeClaudeJson.lastOnboardingVersion).toBe('2.10.0');
+  });
+
+
   it('updates a symlink target during credential promotion without replacing the symlink', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'same-account' } }));
     const targetCredentialsPath = join(tempRoot!, 'credentials-target.json');
     const credentialsPath = join(configDir, '.credentials.json');
     writeFileSync(targetCredentialsPath, JSON.stringify({
@@ -1299,6 +1336,7 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     symlinkSync(targetCredentialsPath, credentialsPath);
 
     const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'same-account' } }));
     rmSync(join(runtimeDir, '.credentials.json'), { force: true });
     writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
       claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -1068,6 +1068,53 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     }
   });
 
+  it.skipIf(process.platform === 'win32')('falls back to a hard link when credential symlink creation fails and remains reconcilable', async () => {
+    vi.resetModules();
+    const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    vi.doMock('fs', () => ({
+      ...actualFs,
+      symlinkSync: vi.fn(() => {
+        throw new Error('symlink unavailable');
+      }),
+    }));
+
+    try {
+      const { prepareOmcLaunchConfigDir: prepareWithFailedSymlink } = await import('../launch.js');
+      const configDir = join(tempRoot!, '.claude');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+      writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+        oauthAccount: { accountUuid: 'same-account' },
+      }));
+      const credentialsPath = join(configDir, '.credentials.json');
+      writeFileSync(credentialsPath, JSON.stringify({
+        claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 },
+      }));
+
+      const runtimeDir = prepareWithFailedSymlink(configDir);
+      const runtimeCredentialsPath = join(runtimeDir, '.credentials.json');
+      expect(lstatSync(runtimeCredentialsPath).isSymbolicLink()).toBe(false);
+      expect(statSync(runtimeCredentialsPath).ino).toBe(statSync(credentialsPath).ino);
+
+      rmSync(runtimeCredentialsPath, { force: true });
+      writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+        oauthAccount: { accountUuid: 'same-account' },
+      }));
+      writeFileSync(runtimeCredentialsPath, JSON.stringify({
+        claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },
+      }));
+
+      const rebuiltRuntimeDir = prepareWithFailedSymlink(configDir);
+      const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+      expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
+      expect(lstatSync(join(rebuiltRuntimeDir, '.credentials.json')).isSymbolicLink()).toBe(false);
+      expect(statSync(join(rebuiltRuntimeDir, '.credentials.json')).ino).toBe(statSync(credentialsPath).ino);
+    } finally {
+      vi.doUnmock('fs');
+      vi.resetModules();
+    }
+  });
+
   it('preserves runtime .claude.json across runtime config dir rebuilds', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });
@@ -1229,6 +1276,84 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect(readlinkSync(runtimeCredentialsPath)).toBe(credentialsPath);
   });
 
+  it('promotes a fresher credential when UUID matches despite stale email metadata', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account', emailAddress: 'Current@Example.com' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account', emailAddress: 'stale@example.COM' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
+  });
+
+  it('promotes a fresher credential when a shared email identity matches case-insensitively', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'User@Example.com' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'user@example.COM' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
+  });
+
+  it('blocks credential promotion when account emails appear only in different fields', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'same@example.com' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { email: 'same@example.com' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+  });
+
   it('does not promote a high-expiry runtime credential without an access token', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });
@@ -1278,6 +1403,33 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     rmSync(join(runtimeDir, '.credentials.json'), { force: true });
     writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
       claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 999 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
+  });
+
+  it('blocks credential promotion when credential account identities conflict despite matching metadata', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100, accountUuid: 'base-account' },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 999, accountUuid: 'runtime-account' },
     }));
 
     prepareOmcLaunchConfigDir(configDir);
@@ -1348,6 +1500,48 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     const targetCredentials = JSON.parse(readFileSync(targetCredentialsPath, 'utf-8')) as Record<string, unknown>;
     expect((targetCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
     expect(targetCredentials.unrelated).toBe('preserve-me');
+  });
+
+  it.skipIf(process.platform === 'win32')('resolves a credential symlink chain beyond the former depth cap without replacing links', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    const finalCredentialsPath = join(tempRoot!, 'credentials-final.json');
+    const chainPaths = Array.from(
+      { length: 20 },
+      (_, index) => join(tempRoot!, `credentials-link-${index}.json`),
+    );
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(finalCredentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 },
+    }));
+    for (let index = chainPaths.length - 1; index >= 0; index -= 1) {
+      symlinkSync(chainPaths[index + 1] ?? finalCredentialsPath, chainPaths[index]);
+    }
+    symlinkSync(chainPaths[0], credentialsPath);
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    expect(lstatSync(credentialsPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(credentialsPath)).toBe(chainPaths[0]);
+    for (let index = 0; index < chainPaths.length; index += 1) {
+      expect(lstatSync(chainPaths[index]).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(chainPaths[index])).toBe(chainPaths[index + 1] ?? finalCredentialsPath);
+    }
+    expect(lstatSync(finalCredentialsPath).isSymbolicLink()).toBe(false);
+    const finalCredentials = JSON.parse(readFileSync(finalCredentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((finalCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
   });
 
   it('preserves runtime .claude.json when source .claude.json is absent, invalid, or has no mcpServers', () => {

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -1045,6 +1045,9 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
       symlinkSync: vi.fn(() => {
         throw new Error('symlink unavailable');
       }),
+      linkSync: vi.fn(() => {
+        throw new Error('hardlink unavailable');
+      }),
     }));
 
     try {
@@ -1053,13 +1056,12 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
       mkdirSync(configDir, { recursive: true });
       const credentialsPath = join(configDir, '.credentials.json');
       writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
-      writeFileSync(credentialsPath, '{"accessToken":"test-only-token"}');
+      writeFileSync(credentialsPath, JSON.stringify({ accessToken: 'test-only-token', expiresAt: 1000 }));
 
-      const runtimeDir = prepareWithFailedSymlink(configDir);
-      const runtimeCredentialsPath = join(runtimeDir, '.credentials.json');
-
-      expect(existsSync(runtimeCredentialsPath)).toBe(false);
-      expect(copyFileSyncSpy).not.toHaveBeenCalledWith(credentialsPath, runtimeCredentialsPath);
+      expect(() => prepareWithFailedSymlink(configDir)).toThrow(
+        /Unable to mirror Claude credentials without copying credential content/,
+      );
+      expect(copyFileSyncSpy).not.toHaveBeenCalledWith(credentialsPath, expect.stringContaining('.credentials.json'));
     } finally {
       vi.doUnmock('fs');
       vi.resetModules();
@@ -1138,6 +1140,176 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
         playwright: { command: 'npx', args: ['@playwright/mcp'] },
       },
     });
+  });
+
+  it('seeds onboarding completion and version from source .claude.json', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      hasCompletedOnboarding: true,
+      lastOnboardingVersion: '2.1',
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    const runtimeClaudeJson = JSON.parse(readFileSync(join(runtimeDir, '.claude.json'), 'utf-8')) as Record<string, unknown>;
+
+    expect(runtimeClaudeJson.hasCompletedOnboarding).toBe(true);
+    expect(runtimeClaudeJson.lastOnboardingVersion).toBe('2.1');
+  });
+
+  it('inherits onboarding without mcpServers while preserving runtime session and projects', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({ hasCompletedOnboarding: true }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      session: 'keep-session',
+      projects: { '/repo': { history: ['keep-project'] } },
+    }));
+
+    const rebuiltRuntimeDir = prepareOmcLaunchConfigDir(configDir);
+    const runtimeClaudeJson = JSON.parse(readFileSync(join(rebuiltRuntimeDir, '.claude.json'), 'utf-8')) as Record<string, unknown>;
+
+    expect(runtimeClaudeJson.hasCompletedOnboarding).toBe(true);
+    expect(runtimeClaudeJson.session).toBe('keep-session');
+    expect(runtimeClaudeJson.projects).toEqual({ '/repo': { history: ['keep-project'] } });
+    expect(runtimeClaudeJson.mcpServers).toBeUndefined();
+  });
+
+  it('replaces mismatched oauthAccount and deletes it when source removes the account', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    const sourceClaudeJsonPath = join(tempRoot!, '.claude.json');
+    writeFileSync(sourceClaudeJsonPath, JSON.stringify({ oauthAccount: { accountUuid: 'source-account' } }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      session: 'keep-session',
+      oauthAccount: { accountUuid: 'runtime-account' },
+    }));
+
+    let runtimeClaudeJson = JSON.parse(readFileSync(join(prepareOmcLaunchConfigDir(configDir), '.claude.json'), 'utf-8')) as Record<string, unknown>;
+    expect(runtimeClaudeJson.oauthAccount).toEqual({ accountUuid: 'source-account' });
+    expect(runtimeClaudeJson.session).toBe('keep-session');
+    writeFileSync(sourceClaudeJsonPath, JSON.stringify({ oauthAccount: null }));
+    runtimeClaudeJson = JSON.parse(readFileSync(join(prepareOmcLaunchConfigDir(configDir), '.claude.json'), 'utf-8')) as Record<string, unknown>;
+    expect(runtimeClaudeJson.oauthAccount).toBeUndefined();
+    expect(runtimeClaudeJson.session).toBe('keep-session');
+  });
+
+  it('promotes a fresher nested runtime credential and preserves unrelated base keys', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'same-account' } }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100, refreshToken: 'base-refresh' },
+      unrelated: 'preserve-me',
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'same-account' } }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200, refreshToken: 'runtime-refresh' },
+    }));
+
+    const rebuiltRuntimeDir = prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    const runtimeCredentialsPath = join(rebuiltRuntimeDir, '.credentials.json');
+
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
+    expect(baseCredentials.unrelated).toBe('preserve-me');
+    expect(lstatSync(runtimeCredentialsPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(runtimeCredentialsPath)).toBe(credentialsPath);
+  });
+
+  it('does not promote a high-expiry runtime credential without an access token', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({ claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 } }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { refreshToken: 'runtime-refresh', expiresAt: 999 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
+  });
+
+  it('does not resurrect a runtime credential when the base credential file is missing', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    const runtimeCredentialsPath = join(runtimeDir, '.credentials.json');
+    writeFileSync(runtimeCredentialsPath, JSON.stringify({
+      accessToken: 'runtime-token',
+      expiresAt: 999,
+    }));
+
+    const rebuiltRuntimeDir = prepareOmcLaunchConfigDir(configDir);
+    expect(existsSync(join(configDir, '.credentials.json'))).toBe(false);
+    expect(existsSync(join(rebuiltRuntimeDir, '.credentials.json'))).toBe(false);
+  });
+
+  it('blocks credential promotion when source and runtime account identities differ', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'source-account' } }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({ claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 } }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({ oauthAccount: { accountUuid: 'different-account' } }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 999 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
+  });
+
+  it('updates a symlink target during credential promotion without replacing the symlink', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    const targetCredentialsPath = join(tempRoot!, 'credentials-target.json');
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(targetCredentialsPath, JSON.stringify({
+      claudeAiOauth: { accessToken: 'base-token', expiresAt: 100 },
+      unrelated: 'preserve-me',
+    }));
+    symlinkSync(targetCredentialsPath, credentialsPath);
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 200 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    expect(lstatSync(credentialsPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(credentialsPath)).toBe(targetCredentialsPath);
+    const targetCredentials = JSON.parse(readFileSync(targetCredentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((targetCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
+    expect(targetCredentials.unrelated).toBe('preserve-me');
   });
 
   it('preserves runtime .claude.json when source .claude.json is absent, invalid, or has no mcpServers', () => {

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -1438,6 +1438,41 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
   });
 
+  it('blocks credential promotion when credential email identities conflict despite matching metadata', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'base-token',
+        expiresAt: 100,
+        emailAddress: 'base@example.com',
+      },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'runtime-token',
+        expiresAt: 999,
+        emailAddress: 'runtime@example.com',
+      },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
+  });
+
   it('blocks credential promotion when either account identity is missing', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -1473,6 +1473,74 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
   });
 
+  it('blocks credential promotion when only the base credential has a stable identity', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'stale-account' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'base-token',
+        refreshToken: 'base-refresh',
+        expiresAt: 100,
+        accountUuid: 'current-account',
+      },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'stale-account' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: { accessToken: 'runtime-token', expiresAt: 999 },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).refreshToken).toBe('base-refresh');
+  });
+
+  it('promotes a fresher credential when credential UUID matches despite stale email', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'base-token',
+        expiresAt: 100,
+        accountUuid: 'same-account',
+        emailAddress: 'current@example.com',
+      },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'runtime-token',
+        expiresAt: 999,
+        accountUuid: 'same-account',
+        emailAddress: 'stale@example.com',
+      },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('runtime-token');
+  });
+
   it('blocks credential promotion when either account identity is missing', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -19,7 +19,7 @@ import {
   writeFileSync,
 } from 'fs';
 import { homedir } from 'os';
-import { basename, dirname, isAbsolute, join } from 'path';
+import { basename, dirname, isAbsolute, join, resolve } from 'path';
 import { atomicWriteJsonSync } from '../lib/atomic-write.js';
 import { lockPathFor, withFileLockSync } from '../lib/file-lock.js';
 import { resolvePluginDirArg } from '../lib/plugin-dir.js';
@@ -229,17 +229,30 @@ function credentialExpiry(parsed: Record<string, unknown>): number | null {
 }
 
 function resolveCredentialWritePath(path: string): string {
-  let current = path;
-  for (let depth = 0; depth < 16; depth += 1) {
-    try {
-      if (!lstatSync(current).isSymbolicLink()) return current;
-      const target = readlinkSync(current);
-      current = isAbsolute(target) ? target : join(dirname(current), target);
-    } catch {
-      return current;
+  let current = resolve(path);
+  const visited = new Set<string>();
+
+  while (true) {
+    if (visited.has(current)) {
+      throw new Error('Claude credential symlink chain contains a cycle');
     }
+    visited.add(current);
+
+    let stat: ReturnType<typeof lstatSync>;
+    try {
+      stat = lstatSync(current);
+    } catch (error) {
+      const code = error && typeof error === 'object' && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+      if (code === 'ENOENT' || code === 'ENOTDIR') return current;
+      throw error;
+    }
+
+    if (!stat.isSymbolicLink()) return current;
+    const target = readlinkSync(current);
+    current = isAbsolute(target) ? resolve(target) : resolve(dirname(current), target);
   }
-  return current;
 }
 
 /** True only when source and runtime can be proven to be the same account. */
@@ -251,17 +264,42 @@ function accountsProvenSame(
   const runtimeAccount = isJsonObject(runtimeClaudeJson?.oauthAccount) ? runtimeClaudeJson.oauthAccount : null;
   if (!sourceAccount || !runtimeAccount) return false;
 
+  const sourceUuid = typeof sourceAccount.accountUuid === 'string' ? sourceAccount.accountUuid.trim() : '';
+  const runtimeUuid = typeof runtimeAccount.accountUuid === 'string' ? runtimeAccount.accountUuid.trim() : '';
+  if (sourceUuid && runtimeUuid) return sourceUuid === runtimeUuid;
+
   let compared = false;
-  for (const key of ['accountUuid', 'emailAddress', 'email'] as const) {
+  for (const key of ['emailAddress', 'email'] as const) {
     const sourceValue = sourceAccount[key];
     const runtimeValue = runtimeAccount[key];
-    const sourceId = typeof sourceValue === 'string' ? sourceValue.trim() : '';
-    const runtimeId = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
-    if (!sourceId || !runtimeId) continue;
+    const sourceEmail = typeof sourceValue === 'string' ? sourceValue.trim() : '';
+    const runtimeEmail = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+    if (!sourceEmail || !runtimeEmail) continue;
     compared = true;
-    if (sourceId !== runtimeId) return false;
+    if (sourceEmail.toLowerCase() !== runtimeEmail.toLowerCase()) return false;
   }
   return compared;
+}
+
+function credentialIdentitiesConflict(
+  baseCandidate: OAuthCredentialCandidate | null,
+  runtimeCandidate: OAuthCredentialCandidate,
+): boolean {
+  if (!baseCandidate) return false;
+
+  for (const key of ['accountUuid', 'emailAddress', 'email'] as const) {
+    const baseValue = baseCandidate.fields[key];
+    const runtimeValue = runtimeCandidate.fields[key];
+    const baseIdentity = typeof baseValue === 'string' ? baseValue.trim() : '';
+    const runtimeIdentity = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+    if (!baseIdentity || !runtimeIdentity) continue;
+
+    const normalizedBase = key === 'accountUuid' ? baseIdentity : baseIdentity.toLowerCase();
+    const normalizedRuntime = key === 'accountUuid' ? runtimeIdentity : runtimeIdentity.toLowerCase();
+    if (normalizedBase !== normalizedRuntime) return true;
+  }
+
+  return false;
 }
 
 function compareOnboardingVersion(left: unknown, right: unknown): number | null {
@@ -411,6 +449,8 @@ function reconcileRuntimeCredentials(
   if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt) return;
   // Fail closed unless both sides prove the same account identity.
   if (!accountsProvenSame(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
+  // Credential fields may veto promotion but cannot establish account identity.
+  if (credentialIdentitiesConflict(baseInspection.candidate, runtimeCandidate)) return;
 
   const mergedBaseCredentials = { ...baseInspection.parsed };
   if (hasOwn(baseInspection.parsed, 'claudeAiOauth') || runtimeCandidate.nested) {

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -9,14 +9,19 @@ import {
   copyFileSync,
   existsSync,
   lstatSync,
+  linkSync,
   mkdirSync,
   readFileSync,
+  readlinkSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
 } from 'fs';
 import { homedir } from 'os';
-import { basename, dirname, join } from 'path';
+import { basename, dirname, isAbsolute, join } from 'path';
+import { atomicWriteJsonSync } from '../lib/atomic-write.js';
+import { lockPathFor, withFileLockSync } from '../lib/file-lock.js';
 import { resolvePluginDirArg } from '../lib/plugin-dir.js';
 import { stripRetiredTeamMcpServers } from '../installer/mcp-registry.js';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
@@ -96,6 +101,10 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
 function readJsonObject(path: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
@@ -105,16 +114,321 @@ function readJsonObject(path: string): Record<string, unknown> | null {
   }
 }
 
-function refreshRuntimeClaudeJsonMcpServers(baseConfigDir: string, runtimeClaudeJsonPath: string): void {
-  const sourceClaudeJsonPath = join(dirname(baseConfigDir), '.claude.json');
-  const sourceClaudeJson = readJsonObject(sourceClaudeJsonPath);
-  if (!sourceClaudeJson || !isJsonObject(sourceClaudeJson.mcpServers)) {
+interface OAuthCredentialCandidate {
+  nested: boolean;
+  expiresAt: number;
+  fields: Record<string, unknown>;
+}
+
+interface CredentialFileInspection {
+  exists: boolean;
+  regularFile: boolean;
+  readable: boolean;
+  valid: boolean;
+  parsed: Record<string, unknown> | null;
+  candidate: OAuthCredentialCandidate | null;
+}
+
+const OAUTH_CREDENTIAL_FIELDS = [
+  'accessToken',
+  'refreshToken',
+  'expiresAt',
+  'scopes',
+  'subscriptionType',
+  'rateLimitTier',
+  'organizationUuid',
+  'accountUuid',
+  'emailAddress',
+  'email',
+  'hasExtraUsageEnabled',
+] as const;
+
+function extractOAuthCandidate(parsed: Record<string, unknown>): OAuthCredentialCandidate | null {
+  const inspect = (record: Record<string, unknown>, nested: boolean): OAuthCredentialCandidate | null => {
+    const accessToken = record.accessToken;
+    const expiresAt = record.expiresAt;
+    if (typeof accessToken !== 'string' || accessToken.trim().length === 0) return null;
+    if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) return null;
+
+    const fields: Record<string, unknown> = {};
+    for (const key of OAUTH_CREDENTIAL_FIELDS) {
+      if (hasOwn(record, key)) fields[key] = record[key];
+    }
+    return { nested, expiresAt, fields };
+  };
+
+  if (isJsonObject(parsed.claudeAiOauth)) {
+    const nestedCandidate = inspect(parsed.claudeAiOauth, true);
+    if (nestedCandidate) return nestedCandidate;
+  }
+  return inspect(parsed, false);
+}
+
+function hasLinkableCredentials(inspection: CredentialFileInspection): boolean {
+  if (inspection.candidate) return true;
+  if (!inspection.parsed) return false;
+  const source = isJsonObject(inspection.parsed.claudeAiOauth)
+    ? inspection.parsed.claudeAiOauth
+    : inspection.parsed;
+  return typeof source.accessToken === 'string' && source.accessToken.trim().length > 0;
+}
+
+function inspectCredentialFile(path: string): CredentialFileInspection {
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      return { exists: true, regularFile: false, readable: false, valid: false, parsed: null, candidate: null };
+    }
+    return { exists: false, regularFile: false, readable: false, valid: false, parsed: null, candidate: null };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+  } catch {
+    return {
+      exists: true,
+      regularFile: stat.isFile(),
+      readable: false,
+      valid: false,
+      parsed: null,
+      candidate: null,
+    };
+  }
+
+  if (!isJsonObject(parsed)) {
+    return {
+      exists: true,
+      regularFile: stat.isFile(),
+      readable: true,
+      valid: false,
+      parsed: null,
+      candidate: null,
+    };
+  }
+
+  return {
+    exists: true,
+    regularFile: stat.isFile(),
+    readable: true,
+    valid: true,
+    parsed,
+    candidate: extractOAuthCandidate(parsed),
+  };
+}
+
+function credentialExpiry(parsed: Record<string, unknown>): number | null {
+  const source = isJsonObject(parsed.claudeAiOauth) ? parsed.claudeAiOauth : parsed;
+  const expiresAt = source.expiresAt;
+  return typeof expiresAt === 'number' && Number.isFinite(expiresAt) ? expiresAt : null;
+}
+
+function resolveCredentialWritePath(path: string): string {
+  try {
+    if (!lstatSync(path).isSymbolicLink()) return path;
+    const target = readlinkSync(path);
+    return isAbsolute(target) ? target : join(dirname(path), target);
+  } catch {
+    return path;
+  }
+}
+
+function accountIdentity(value: unknown): string | null {
+  if (!isJsonObject(value)) return null;
+  for (const key of ['accountUuid', 'emailAddress', 'email']) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate.trim();
+  }
+  return null;
+}
+
+function accountIdentitiesDiffer(
+  sourceClaudeJson: Record<string, unknown> | null,
+  runtimeClaudeJson: Record<string, unknown> | null,
+): boolean {
+  const sourceIdentity = accountIdentity(sourceClaudeJson?.oauthAccount);
+  const runtimeIdentity = accountIdentity(runtimeClaudeJson?.oauthAccount);
+  return sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity;
+}
+
+function onboardingVersionNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function refreshRuntimeClaudeJson(
+  baseConfigDir: string,
+  runtimeClaudeJsonPath: string,
+  sourceClaudeJson = readJsonObject(join(dirname(baseConfigDir), '.claude.json')),
+): void {
+  if (!sourceClaudeJson) return;
+
+  const runtimeClaudeJson = readJsonObject(runtimeClaudeJsonPath) ?? {};
+  let changed = false;
+
+  if (sourceClaudeJson.hasCompletedOnboarding === true && runtimeClaudeJson.hasCompletedOnboarding !== true) {
+    runtimeClaudeJson.hasCompletedOnboarding = true;
+    changed = true;
+  }
+
+  const sourceVersion = sourceClaudeJson.lastOnboardingVersion;
+  if (typeof sourceVersion === 'string' || typeof sourceVersion === 'number') {
+    const runtimeHasVersion = hasOwn(runtimeClaudeJson, 'lastOnboardingVersion');
+    const runtimeVersion = onboardingVersionNumber(runtimeClaudeJson.lastOnboardingVersion);
+    const sourceVersionNumber = onboardingVersionNumber(sourceVersion);
+    if (!runtimeHasVersion || (sourceVersionNumber !== null && (runtimeVersion === null || sourceVersionNumber > runtimeVersion))) {
+      runtimeClaudeJson.lastOnboardingVersion = sourceVersion;
+      changed = true;
+    }
+  }
+
+  if (hasOwn(sourceClaudeJson, 'oauthAccount')) {
+    const sourceAccount = sourceClaudeJson.oauthAccount;
+    if (sourceAccount === null || sourceAccount === undefined) {
+      if (hasOwn(runtimeClaudeJson, 'oauthAccount')) {
+        delete runtimeClaudeJson.oauthAccount;
+        changed = true;
+      }
+    } else if (!hasOwn(runtimeClaudeJson, 'oauthAccount')) {
+      runtimeClaudeJson.oauthAccount = sourceAccount;
+      changed = true;
+    } else {
+      const sourceIdentity = accountIdentity(sourceAccount);
+      const runtimeIdentity = accountIdentity(runtimeClaudeJson.oauthAccount);
+      if (sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity) {
+        runtimeClaudeJson.oauthAccount = sourceAccount;
+        changed = true;
+      }
+    }
+  }
+
+
+  if (isJsonObject(sourceClaudeJson.mcpServers)) {
+    runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
+    changed = true;
+  }
+
+  if (changed) {
+    writeFileSync(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+  }
+}
+
+function ensureMirroredCredentials(
+  sourcePath: string,
+  targetPath: string,
+  hasEligibleSourceCredentials: boolean,
+): void {
+  if (!existsSync(sourcePath)) return;
+
+  const removeExistingTarget = (): void => {
+    try {
+      lstatSync(targetPath);
+      rmSync(targetPath, { recursive: true, force: true });
+    } catch {
+      // A missing target is expected in a fresh staged directory.
+    }
+  };
+
+  removeExistingTarget();
+  try {
+    symlinkSync(sourcePath, targetPath, 'file');
+    return;
+  } catch {
+    removeExistingTarget();
+  }
+
+  try {
+    linkSync(sourcePath, targetPath);
+    return;
+  } catch {
+    removeExistingTarget();
+    if (hasEligibleSourceCredentials) {
+      throw new Error('Unable to mirror Claude credentials without copying credential content');
+    }
+  }
+}
+
+function pathExists(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reconcileRuntimeCredentials(
+  baseConfigDir: string,
+  runtimeCredentialsPath: string,
+  sourceClaudeJson: Record<string, unknown> | null,
+  preservedRuntimeClaudeJson: Record<string, unknown> | null,
+): void {
+  const runtimeInspection = inspectCredentialFile(runtimeCredentialsPath);
+  const runtimeCandidate = runtimeInspection.candidate;
+  if (!runtimeCandidate) return;
+
+  const baseCredentialsPath = join(baseConfigDir, '.credentials.json');
+  const baseInspection = inspectCredentialFile(baseCredentialsPath);
+  if (!baseInspection.exists) return;
+
+  if (!baseInspection.readable || !baseInspection.valid || !baseInspection.parsed) {
+    if (runtimeInspection.regularFile) {
+      throw new Error('Unable to read or parse base Claude credentials');
+    }
     return;
   }
 
-  const runtimeClaudeJson = readJsonObject(runtimeClaudeJsonPath) ?? {};
-  runtimeClaudeJson.mcpServers = sourceClaudeJson.mcpServers;
-  writeFileSync(runtimeClaudeJsonPath, JSON.stringify(runtimeClaudeJson, null, 2));
+  const baseExpiresAt = credentialExpiry(baseInspection.parsed);
+  if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt) return;
+  if (accountIdentitiesDiffer(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
+
+  const mergedBaseCredentials = { ...baseInspection.parsed };
+  if (hasOwn(baseInspection.parsed, 'claudeAiOauth') || runtimeCandidate.nested) {
+    const existingNested = isJsonObject(baseInspection.parsed.claudeAiOauth)
+      ? baseInspection.parsed.claudeAiOauth
+      : {};
+    mergedBaseCredentials.claudeAiOauth = { ...existingNested, ...runtimeCandidate.fields };
+  } else {
+    Object.assign(mergedBaseCredentials, runtimeCandidate.fields);
+  }
+
+  atomicWriteJsonSync(resolveCredentialWritePath(baseCredentialsPath), mergedBaseCredentials);
+}
+
+function swapRuntimeConfigDir(runtimeConfigDir: string, nextConfigDir: string): void {
+  const previousConfigDir = `${runtimeConfigDir}.prev`;
+  let movedPrevious = false;
+  try {
+    rmSync(previousConfigDir, { recursive: true, force: true });
+    if (pathExists(runtimeConfigDir)) {
+      renameSync(runtimeConfigDir, previousConfigDir);
+      movedPrevious = true;
+    }
+    renameSync(nextConfigDir, runtimeConfigDir);
+  } catch (error) {
+    try {
+      if (movedPrevious && !pathExists(runtimeConfigDir) && pathExists(previousConfigDir)) {
+        renameSync(previousConfigDir, runtimeConfigDir);
+      }
+    } catch {
+      // Keep the original swap error; the previous directory remains available for recovery.
+    }
+    rmSync(nextConfigDir, { recursive: true, force: true });
+    throw error;
+  }
+
+  try {
+    rmSync(previousConfigDir, { recursive: true, force: true });
+  } catch {
+    // Best effort cleanup; the new runtime directory is already active.
+  }
 }
 
 export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()): string {
@@ -124,64 +438,93 @@ export function prepareOmcLaunchConfigDir(baseConfigDir = getClaudeConfigDir()):
   }
 
   const runtimeConfigDir = join(baseConfigDir, OMC_RUNTIME_DIRNAME);
+  const nextConfigDir = `${runtimeConfigDir}.next`;
   const runtimeClaudeJsonPath = join(runtimeConfigDir, '.claude.json');
-  const preservedClaudeJson = existsSync(runtimeClaudeJsonPath)
-    ? readFileSync(runtimeClaudeJsonPath)
-    : null;
+  const runtimeCredentialsPath = join(runtimeConfigDir, '.credentials.json');
+  const sourceClaudeJsonPath = join(dirname(baseConfigDir), '.claude.json');
+  const lifecycleLockPath = lockPathFor(join(baseConfigDir, '.omc-launch.prepare.lock'));
 
-  rmSync(runtimeConfigDir, { recursive: true, force: true });
-  mkdirSync(runtimeConfigDir, { recursive: true });
-  if (preservedClaudeJson) {
-    writeFileSync(runtimeClaudeJsonPath, preservedClaudeJson);
-  }
-  refreshRuntimeClaudeJsonMcpServers(baseConfigDir, runtimeClaudeJsonPath);
-  copyFileSync(companionPath, join(runtimeConfigDir, 'CLAUDE.md'));
+  return withFileLockSync(lifecycleLockPath, () => {
+    const preservedClaudeJson = pathExists(runtimeClaudeJsonPath)
+      ? readFileSync(runtimeClaudeJsonPath)
+      : null;
+    const preservedRuntimeClaudeJson = readJsonObject(runtimeClaudeJsonPath);
+    const sourceClaudeJson = readJsonObject(sourceClaudeJsonPath);
 
-  for (const entry of [
-    'agents',
-    'commands',
-    'hooks',
-    'hud',
-    'plugins',
-    'projects',
-    'rules',
-    'skills',
-    'themes',
-    OMC_CONFIG_FILE_REL,
-    '.omc-version.json',
-    '.omc-silent-update.json',
-    'keybindings.json',
-    'settings.json',
-    'settings.local.json',
-    '.credentials.json',
-  ]) {
-    ensureMirroredPath(
-      join(baseConfigDir, entry),
-      join(runtimeConfigDir, basename(entry)),
-      { allowCopyFallback: entry !== '.credentials.json' },
+    reconcileRuntimeCredentials(
+      baseConfigDir,
+      runtimeCredentialsPath,
+      sourceClaudeJson,
+      preservedRuntimeClaudeJson,
     );
-  }
 
-  const runtimeSettingsPath = join(runtimeConfigDir, 'settings.json');
-  if (existsSync(runtimeSettingsPath)) {
+    rmSync(nextConfigDir, { recursive: true, force: true });
     try {
-      const rawSettings = JSON.parse(readFileSync(runtimeSettingsPath, 'utf-8')) as Record<string, unknown>;
-      const repaired = stripRetiredTeamMcpServers(rawSettings);
-      if (repaired.changed) {
-        writeFileSync(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+      mkdirSync(nextConfigDir, { recursive: true });
+      const nextClaudeJsonPath = join(nextConfigDir, '.claude.json');
+      if (preservedClaudeJson) {
+        writeFileSync(nextClaudeJsonPath, preservedClaudeJson);
       }
-    } catch {
-      // Best-effort compatibility repair; launch must continue even if a legacy
-      // settings file cannot be parsed or rewritten.
+      refreshRuntimeClaudeJson(baseConfigDir, nextClaudeJsonPath, sourceClaudeJson);
+      copyFileSync(companionPath, join(nextConfigDir, 'CLAUDE.md'));
+
+      for (const entry of [
+        'agents',
+        'commands',
+        'hooks',
+        'hud',
+        'plugins',
+        'projects',
+        'rules',
+        'skills',
+        'themes',
+        OMC_CONFIG_FILE_REL,
+        '.omc-version.json',
+        '.omc-silent-update.json',
+        'keybindings.json',
+        'settings.json',
+        'settings.local.json',
+      ]) {
+        ensureMirroredPath(
+          join(baseConfigDir, entry),
+          join(nextConfigDir, basename(entry)),
+        );
+      }
+
+      const baseCredentialsPath = join(baseConfigDir, '.credentials.json');
+      const baseCredentialInspection = inspectCredentialFile(baseCredentialsPath);
+      ensureMirroredCredentials(
+        baseCredentialsPath,
+        join(nextConfigDir, '.credentials.json'),
+        hasLinkableCredentials(baseCredentialInspection),
+      );
+
+      const runtimeSettingsPath = join(nextConfigDir, 'settings.json');
+      if (existsSync(runtimeSettingsPath)) {
+        try {
+          const rawSettings = JSON.parse(readFileSync(runtimeSettingsPath, 'utf-8')) as Record<string, unknown>;
+          const repaired = stripRetiredTeamMcpServers(rawSettings);
+          if (repaired.changed) {
+            writeFileSync(runtimeSettingsPath, JSON.stringify(repaired.settings, null, 2));
+          }
+        } catch {
+          // Best-effort compatibility repair; launch must continue even if a legacy
+          // settings file cannot be parsed or rewritten.
+        }
+      }
+
+      writeFileSync(
+        join(nextConfigDir, '.omc-launch-profile.json'),
+        JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2),
+      );
+    } catch (error) {
+      rmSync(nextConfigDir, { recursive: true, force: true });
+      throw error;
     }
-  }
 
-  writeFileSync(
-    join(runtimeConfigDir, '.omc-launch-profile.json'),
-    JSON.stringify({ sourceConfigDir: baseConfigDir, sourceClaudeMd: companionPath }, null, 2),
-  );
-
-  return runtimeConfigDir;
+    swapRuntimeConfigDir(runtimeConfigDir, nextConfigDir);
+    return runtimeConfigDir;
+  }, { timeoutMs: 5000, retryDelayMs: 50 });
 }
 
 function isDefaultClaudeConfigDirPath(configDir: string): boolean {

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -229,38 +229,64 @@ function credentialExpiry(parsed: Record<string, unknown>): number | null {
 }
 
 function resolveCredentialWritePath(path: string): string {
-  try {
-    if (!lstatSync(path).isSymbolicLink()) return path;
-    const target = readlinkSync(path);
-    return isAbsolute(target) ? target : join(dirname(path), target);
-  } catch {
-    return path;
+  let current = path;
+  for (let depth = 0; depth < 16; depth += 1) {
+    try {
+      if (!lstatSync(current).isSymbolicLink()) return current;
+      const target = readlinkSync(current);
+      current = isAbsolute(target) ? target : join(dirname(current), target);
+    } catch {
+      return current;
+    }
   }
+  return current;
 }
 
-function accountIdentity(value: unknown): string | null {
-  if (!isJsonObject(value)) return null;
-  for (const key of ['accountUuid', 'emailAddress', 'email']) {
-    const candidate = value[key];
-    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate.trim();
-  }
-  return null;
-}
-
-function accountIdentitiesDiffer(
+/** True only when source and runtime can be proven to be the same account. */
+function accountsProvenSame(
   sourceClaudeJson: Record<string, unknown> | null,
   runtimeClaudeJson: Record<string, unknown> | null,
 ): boolean {
-  const sourceIdentity = accountIdentity(sourceClaudeJson?.oauthAccount);
-  const runtimeIdentity = accountIdentity(runtimeClaudeJson?.oauthAccount);
-  return sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity;
+  const sourceAccount = isJsonObject(sourceClaudeJson?.oauthAccount) ? sourceClaudeJson.oauthAccount : null;
+  const runtimeAccount = isJsonObject(runtimeClaudeJson?.oauthAccount) ? runtimeClaudeJson.oauthAccount : null;
+  if (!sourceAccount || !runtimeAccount) return false;
+
+  let compared = false;
+  for (const key of ['accountUuid', 'emailAddress', 'email'] as const) {
+    const sourceValue = sourceAccount[key];
+    const runtimeValue = runtimeAccount[key];
+    const sourceId = typeof sourceValue === 'string' ? sourceValue.trim() : '';
+    const runtimeId = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+    if (!sourceId || !runtimeId) continue;
+    compared = true;
+    if (sourceId !== runtimeId) return false;
+  }
+  return compared;
 }
 
-function onboardingVersionNumber(value: unknown): number | null {
-  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
-  if (typeof value !== 'string' || value.trim().length === 0) return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
+function compareOnboardingVersion(left: unknown, right: unknown): number | null {
+  const toParts = (value: unknown): number[] | null => {
+    if (typeof value === 'number') return Number.isFinite(value) ? [value] : null;
+    if (typeof value !== 'string' || value.trim().length === 0) return null;
+    const parts = value.trim().split(/[.+-]/).map((part) => {
+      if (part.length === 0 || !/^\d+$/.test(part)) return Number.NaN;
+      return Number(part);
+    });
+    if (parts.some((part) => !Number.isFinite(part))) return null;
+    return parts;
+  };
+
+  const leftParts = toParts(left);
+  const rightParts = toParts(right);
+  if (!leftParts || !rightParts) return null;
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const a = leftParts[index] ?? 0;
+    const b = rightParts[index] ?? 0;
+    if (a > b) return 1;
+    if (a < b) return -1;
+  }
+  return 0;
 }
 
 function refreshRuntimeClaudeJson(
@@ -281,9 +307,8 @@ function refreshRuntimeClaudeJson(
   const sourceVersion = sourceClaudeJson.lastOnboardingVersion;
   if (typeof sourceVersion === 'string' || typeof sourceVersion === 'number') {
     const runtimeHasVersion = hasOwn(runtimeClaudeJson, 'lastOnboardingVersion');
-    const runtimeVersion = onboardingVersionNumber(runtimeClaudeJson.lastOnboardingVersion);
-    const sourceVersionNumber = onboardingVersionNumber(sourceVersion);
-    if (!runtimeHasVersion || (sourceVersionNumber !== null && (runtimeVersion === null || sourceVersionNumber > runtimeVersion))) {
+    const compared = compareOnboardingVersion(sourceVersion, runtimeClaudeJson.lastOnboardingVersion);
+    if (!runtimeHasVersion || (compared !== null && compared > 0)) {
       runtimeClaudeJson.lastOnboardingVersion = sourceVersion;
       changed = true;
     }
@@ -299,13 +324,10 @@ function refreshRuntimeClaudeJson(
     } else if (!hasOwn(runtimeClaudeJson, 'oauthAccount')) {
       runtimeClaudeJson.oauthAccount = sourceAccount;
       changed = true;
-    } else {
-      const sourceIdentity = accountIdentity(sourceAccount);
-      const runtimeIdentity = accountIdentity(runtimeClaudeJson.oauthAccount);
-      if (sourceIdentity !== null && runtimeIdentity !== null && sourceIdentity !== runtimeIdentity) {
-        runtimeClaudeJson.oauthAccount = sourceAccount;
-        changed = true;
-      }
+    } else if (!accountsProvenSame(sourceClaudeJson, runtimeClaudeJson)) {
+      // Prefer source account metadata when identities cannot be proven equal.
+      runtimeClaudeJson.oauthAccount = sourceAccount;
+      changed = true;
     }
   }
 
@@ -387,7 +409,8 @@ function reconcileRuntimeCredentials(
 
   const baseExpiresAt = credentialExpiry(baseInspection.parsed);
   if (baseExpiresAt === null || runtimeCandidate.expiresAt <= baseExpiresAt) return;
-  if (accountIdentitiesDiffer(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
+  // Fail closed unless both sides prove the same account identity.
+  if (!accountsProvenSame(sourceClaudeJson, preservedRuntimeClaudeJson)) return;
 
   const mergedBaseCredentials = { ...baseInspection.parsed };
   if (hasOwn(baseInspection.parsed, 'claudeAiOauth') || runtimeCandidate.nested) {

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -287,16 +287,24 @@ function credentialIdentitiesConflict(
 ): boolean {
   if (!baseCandidate) return false;
 
-  for (const key of ['accountUuid', 'emailAddress', 'email'] as const) {
+  const baseUuid = typeof baseCandidate.fields.accountUuid === 'string'
+    ? baseCandidate.fields.accountUuid.trim()
+    : '';
+  const runtimeUuid = typeof runtimeCandidate.fields.accountUuid === 'string'
+    ? runtimeCandidate.fields.accountUuid.trim()
+    : '';
+  if (baseUuid || runtimeUuid) {
+    return !baseUuid || !runtimeUuid || baseUuid !== runtimeUuid;
+  }
+
+  for (const key of ['emailAddress', 'email'] as const) {
     const baseValue = baseCandidate.fields[key];
     const runtimeValue = runtimeCandidate.fields[key];
-    const baseIdentity = typeof baseValue === 'string' ? baseValue.trim() : '';
-    const runtimeIdentity = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
-    if (!baseIdentity || !runtimeIdentity) continue;
-
-    const normalizedBase = key === 'accountUuid' ? baseIdentity : baseIdentity.toLowerCase();
-    const normalizedRuntime = key === 'accountUuid' ? runtimeIdentity : runtimeIdentity.toLowerCase();
-    if (normalizedBase !== normalizedRuntime) return true;
+    const baseEmail = typeof baseValue === 'string' ? baseValue.trim() : '';
+    const runtimeEmail = typeof runtimeValue === 'string' ? runtimeValue.trim() : '';
+    if (!baseEmail && !runtimeEmail) continue;
+    if (!baseEmail || !runtimeEmail) return true;
+    if (baseEmail.toLowerCase() !== runtimeEmail.toLowerCase()) return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary
Fixes #3571: `omc launch` isolated `.omc-launch` profile forced re-login / onboarding every session.

### Root causes (verified)
1. Runtime `.claude.json` only refreshed `mcpServers`; onboarding/account fields never inherited from source `~/.claude.json`.
2. `.credentials.json` was symlink-only; Claude atomic token refresh replaces the symlink with a regular file; next launch wiped the fresher runtime token and re-linked a stale base (split-brain).

### Fix
- Selective inheritance of `hasCompletedOnboarding`, `lastOnboardingVersion`, and `oauthAccount` (plus existing `mcpServers`) while preserving profile-local session/projects metadata.
- Lifecycle-locked next-launch credential reconcile: promote fresher eligible OAuth credentials into base (resolved symlink target safe), never copy secrets into divergent files.
- Staged rebuild via `.omc-launch.next` + swap; re-link credentials with symlink then hardlink; fail closed when link fails and base has linkable credentials.
- Residual: mid-session mutual logout while Claude renames a live credentials path remains out of scope (next-launch recovery is the product guarantee). **No opt-out flag.**

### Verification
- `npx vitest run src/cli/__tests__/launch.test.ts` → **156 passed**
- `npx tsc -p tsconfig.json --noEmit` → clean
- `npm run build:cli` + `plugin:shipping:stage` + `plugin:shipping:verify`
- `npm run plugin:shipping:check-pr -- --base 4f33ecff0897362d0458bd3b73eae785591fb00b` → verified (1 generated artifact: `bridge/cli.cjs`)

### Non-goals
#3570, #3538/#3539, broad auth redesign, merge.

Closes #3571