### PR TITLE
fix(context-guard): fall back to HUD's persisted context cache on proxy/custom-model routes (#3574)

### DIFF
--- a/scripts/context-guard-stop.mjs
+++ b/scripts/context-guard-stop.mjs
@@ -19,13 +19,13 @@
  *   - { continue: true, suppressOutput: true } otherwise
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname, resolve, basename } from 'node:path';
-import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { readStdin } from './lib/stdin.mjs';
+import { resolveContextPercent } from './lib/context-usage.mjs';
 
 const THRESHOLD = parseInt(process.env.OMC_CONTEXT_GUARD_THRESHOLD || '75', 10);
 const CRITICAL_THRESHOLD = 95;
@@ -142,43 +142,6 @@ function resolveTranscriptPath(transcriptPath, cwd) {
   return transcriptPath;
 }
 
-/**
- * Estimate context usage percentage from the transcript file.
- */
-function estimateContextPercent(transcriptPath) {
-  if (!transcriptPath) return 0;
-
-  let fd = -1;
-  try {
-    const stat = statSync(transcriptPath);
-    if (stat.size === 0) return 0;
-
-    fd = openSync(transcriptPath, 'r');
-    const readSize = Math.min(4096, stat.size);
-    const buf = Buffer.alloc(readSize);
-    readSync(fd, buf, 0, readSize, stat.size - readSize);
-    closeSync(fd);
-    fd = -1;
-
-    const tail = buf.toString('utf-8');
-
-    // Bounded quantifiers to avoid ReDoS on malformed input
-    const windowMatch = tail.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
-    const inputMatch = tail.match(/"input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
-
-    if (!windowMatch || !inputMatch) return 0;
-
-    const lastWindow = parseInt(windowMatch[windowMatch.length - 1].match(/(\d+)/)[1], 10);
-    const lastInput = parseInt(inputMatch[inputMatch.length - 1].match(/(\d+)/)[1], 10);
-
-    if (lastWindow === 0) return 0;
-    return Math.round((lastInput / lastWindow) * 100);
-  } catch {
-    return 0;
-  } finally {
-    if (fd !== -1) try { closeSync(fd); } catch { /* ignore */ }
-  }
-}
 
 /**
  * Retry guard: track how many times we've blocked this transcript.
@@ -249,7 +212,7 @@ async function main() {
     const sessionId = data.session_id || data.sessionId || '';
     const rawTranscriptPath = data.transcript_path || data.transcriptPath || '';
     const transcriptPath = resolveTranscriptPath(rawTranscriptPath, data.cwd);
-    const pct = estimateContextPercent(transcriptPath);
+    const pct = (await resolveContextPercent(data, transcriptPath, data.cwd)) ?? 0;
 
     if (pct >= CRITICAL_THRESHOLD) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));

--- a/scripts/lib/context-usage.mjs
+++ b/scripts/lib/context-usage.mjs
@@ -1,0 +1,255 @@
+import { existsSync, openSync, readFileSync, readSync, statSync, closeSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const TRANSCRIPT_TAIL_BYTES = 4096;
+const HUD_CACHE_FILENAME = 'hud-stdin-cache.json';
+
+// Same priority order as SESSION_ID_ENV_VARS in src/hud/stdin.ts, so this
+// resolver picks the same session identity the HUD itself would use.
+const SESSION_ID_ENV_VARS = ['CLAUDE_SESSION_ID', 'CLAUDECODE_SESSION_ID'];
+
+/**
+ * List candidate session ids in the same priority order the HUD uses: the
+ * current hook event's own payload first, then the session-id env vars in
+ * priority order. Each candidate is tried in order by the caller — an
+ * invalid or cache-less candidate must not stop the search, mirroring
+ * src/hud/stdin.ts's getStdinCachePath, which skips an invalid env
+ * candidate and tries the next one rather than giving up.
+ */
+function getSessionIdentityCandidates(data) {
+  const candidates = [];
+  const fromPayload = data?.session_id || data?.sessionId;
+  if (typeof fromPayload === 'string' && fromPayload.trim()) {
+    candidates.push(fromPayload.trim());
+  }
+  for (const envVar of SESSION_ID_ENV_VARS) {
+    const candidate = process.env[envVar];
+    if (typeof candidate === 'string' && candidate.trim()) {
+      candidates.push(candidate.trim());
+    }
+  }
+  return candidates;
+}
+
+function clampPercent(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return null;
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+/**
+ * Resolve context usage reported directly by a hook event payload.
+ * This preserves the #2412 fallback semantics used by the PostToolUse hook.
+ */
+export function resolveHookContextPercent(data) {
+  const contextWindow = data?.context_window;
+  if (!contextWindow || typeof contextWindow !== 'object') {
+    return null;
+  }
+
+  const usedPercentage = contextWindow.used_percentage;
+  if (Number.isFinite(usedPercentage) && usedPercentage >= 0) {
+    return clampPercent(usedPercentage);
+  }
+
+  const size = contextWindow.context_window_size;
+  if (!Number.isFinite(size) || size <= 0) {
+    return null;
+  }
+
+  const usage = contextWindow.current_usage;
+  if (!usage || typeof usage !== 'object') {
+    return null;
+  }
+
+  const inputTokens = Number(usage.input_tokens || 0);
+  const cacheCreationTokens = Number(usage.cache_creation_input_tokens || 0);
+  const cacheReadTokens = Number(usage.cache_read_input_tokens || 0);
+  const totalTokens = inputTokens + cacheCreationTokens + cacheReadTokens;
+  if (!Number.isFinite(totalTokens) || totalTokens < 0) {
+    return null;
+  }
+
+  return clampPercent((totalTokens / size) * 100);
+}
+
+function readJsonFile(filePath) {
+  try {
+    if (!existsSync(filePath)) return null;
+    return JSON.parse(readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function hasContextWindowObject(data) {
+  return Boolean(
+    data &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    Object.prototype.hasOwnProperty.call(data, 'context_window') &&
+    data.context_window &&
+    typeof data.context_window === 'object' &&
+    !Array.isArray(data.context_window),
+  );
+}
+
+/**
+ * Resolve context usage from the persisted HUD stdin cache.
+ * The HUD's own getContextPercent implementation remains the source of truth
+ * for percent calculation; this helper only locates and parses its cache.
+ */
+export async function resolveHudCacheContextPercent(data, directory) {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (!pluginRoot) return null;
+
+  try {
+    const worktreePaths = await import(
+      pathToFileURL(join(pluginRoot, 'dist', 'lib', 'worktree-paths.js')).href,
+    );
+    const hudStdin = await import(
+      pathToFileURL(join(pluginRoot, 'dist', 'hud', 'stdin.js')).href,
+    );
+    const { getWorktreeRoot, getSessionStateDir, listSessionIds, resolveOmcPath } = worktreePaths;
+    const { getContextPercent } = hudStdin;
+    if (
+      typeof getWorktreeRoot !== 'function' ||
+      typeof getSessionStateDir !== 'function' ||
+      typeof listSessionIds !== 'function' ||
+      typeof resolveOmcPath !== 'function' ||
+      typeof getContextPercent !== 'function'
+    ) {
+      return null;
+    }
+
+    const root = getWorktreeRoot(directory || undefined) || directory || process.cwd();
+    // Mirror the HUD's own session-identity resolution (src/hud/stdin.ts
+    // getStdinCachePath): try each candidate — payload session id first,
+    // then the env-var candidates in priority order — and skip a candidate
+    // that fails validation or has no usable cache rather than giving up
+    // immediately. Once ANY candidate yields a valid cache, it is
+    // authoritative — never fall through to scanning other sessions' caches
+    // once a real identity has resolved, or a concurrent unrelated session
+    // could falsely trigger this session's warning/block.
+    for (const candidate of getSessionIdentityCandidates(data)) {
+      let candidatePath;
+      try {
+        candidatePath = join(getSessionStateDir(candidate, root), HUD_CACHE_FILENAME);
+      } catch {
+        continue;
+      }
+      const cached = readJsonFile(candidatePath);
+      if (!hasContextWindowObject(cached)) continue;
+      return clampPercent(getContextPercent(cached));
+    }
+
+    // No candidate validated to a usable cache: fall back exactly as the
+    // HUD does — the legacy flat cache first, then the most recently
+    // updated session-scoped cache as a last resort (e.g. a detached
+    // watcher that never inherited session env vars).
+    let cached = readJsonFile(resolveOmcPath('state/' + HUD_CACHE_FILENAME, root));
+
+    if (cached === null) {
+      let bestPath = null;
+      let bestMtime = -Infinity;
+      let sessionIds;
+      try {
+        sessionIds = listSessionIds(root);
+      } catch {
+        sessionIds = [];
+      }
+      for (const sid of sessionIds) {
+        let path;
+        try {
+          path = join(getSessionStateDir(sid, root), HUD_CACHE_FILENAME);
+          const stats = statSync(path);
+          if (!stats.isFile() || stats.mtimeMs <= bestMtime) continue;
+          bestPath = path;
+          bestMtime = stats.mtimeMs;
+        } catch {
+          // Skip missing, invalid, or unreadable session entries.
+        }
+      }
+      if (bestPath) cached = readJsonFile(bestPath);
+    }
+
+    if (!hasContextWindowObject(cached)) return null;
+    return clampPercent(getContextPercent(cached));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve context usage from the tail of a Claude transcript.
+ * Transcript fixtures must include an explicit numeric context_window field;
+ * real Claude transcripts commonly omit that field, in which case callers
+ * should continue to the hook payload and HUD cache fallbacks.
+ */
+export function resolveTranscriptContextPercent(transcriptPath, tailBytes = TRANSCRIPT_TAIL_BYTES) {
+  if (!transcriptPath) return null;
+
+  let fd = -1;
+  try {
+    const stat = statSync(transcriptPath);
+    if (stat.size === 0) return null;
+
+    const readSize = Math.min(tailBytes, stat.size);
+    if (readSize <= 0) return null;
+    const buffer = Buffer.alloc(readSize);
+    fd = openSync(transcriptPath, 'r');
+    readSync(fd, buffer, 0, readSize, stat.size - readSize);
+    closeSync(fd);
+    fd = -1;
+
+    const tail = buffer.toString('utf-8');
+    const windowMatches = tail.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
+    const inputMatches = tail.match(/"input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
+    if (!windowMatches || !inputMatches) return null;
+
+    const cacheCreationMatches = tail.match(/"cache_creation_input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
+    const cacheReadMatches = tail.match(/"cache_read_input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
+    const lastWindow = Number.parseInt(
+      windowMatches[windowMatches.length - 1].match(/(\d+)/)?.[1] || '0',
+      10,
+    );
+    const lastInput = Number.parseInt(
+      inputMatches[inputMatches.length - 1].match(/(\d+)/)?.[1] || '0',
+      10,
+    );
+    const lastCacheCreation = Number.parseInt(
+      cacheCreationMatches?.[cacheCreationMatches.length - 1].match(/(\d+)/)?.[1] || '0',
+      10,
+    );
+    const lastCacheRead = Number.parseInt(
+      cacheReadMatches?.[cacheReadMatches.length - 1].match(/(\d+)/)?.[1] || '0',
+      10,
+    );
+
+    if (!Number.isFinite(lastWindow) || lastWindow <= 0) return null;
+    if (!Number.isFinite(lastInput) || lastInput < 0) return null;
+    if (!Number.isFinite(lastCacheCreation) || lastCacheCreation < 0) return null;
+    if (!Number.isFinite(lastCacheRead) || lastCacheRead < 0) return null;
+
+    return clampPercent(((lastInput + lastCacheCreation + lastCacheRead) / lastWindow) * 100);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== -1) {
+      try { closeSync(fd); } catch {}
+    }
+  }
+}
+
+/**
+ * Resolve context usage from the best available source, in priority order.
+ */
+export async function resolveContextPercent(data, transcriptPath, directory) {
+  const transcriptPercent = resolveTranscriptContextPercent(transcriptPath);
+  if (transcriptPercent !== null) return transcriptPercent;
+
+  const hookPercent = resolveHookContextPercent(data);
+  if (hookPercent !== null) return hookPercent;
+
+  return resolveHudCacheContextPercent(data, directory);
+}

--- a/scripts/lib/context-usage.mjs
+++ b/scripts/lib/context-usage.mjs
@@ -123,14 +123,18 @@ export async function resolveHudCacheContextPercent(data, directory) {
     }
 
     const root = getWorktreeRoot(directory || undefined) || directory || process.cwd();
-    // Mirror the HUD's own session-identity resolution (src/hud/stdin.ts
-    // getStdinCachePath): try each candidate — payload session id first,
-    // then the env-var candidates in priority order — and skip a candidate
-    // that fails validation or has no usable cache rather than giving up
-    // immediately. Once ANY candidate yields a valid cache, it is
-    // authoritative — never fall through to scanning other sessions' caches
-    // once a real identity has resolved, or a concurrent unrelated session
-    // could falsely trigger this session's warning/block.
+    // Mirror the HUD's own session-identity resolution exactly
+    // (src/hud/stdin.ts getStdinCachePath): walk the candidates — payload
+    // session id first, then the env-var candidates in priority order —
+    // and skip only a candidate that FAILS VALIDATION (getSessionStateDir
+    // throws). The FIRST candidate that validates is authoritative and the
+    // search stops there, exactly like getStdinCachePath: if that
+    // identity's own cache is missing or unusable, return null immediately
+    // rather than falling through to another (possibly concurrent,
+    // unrelated) session's cache — matching readStdinCache's behavior of
+    // returning null once a real session-scoped path was determined. Only
+    // when NO candidate validates at all do we fall through to the
+    // identity-less legacy/mtime recovery path below.
     for (const candidate of getSessionIdentityCandidates(data)) {
       let candidatePath;
       try {
@@ -139,14 +143,15 @@ export async function resolveHudCacheContextPercent(data, directory) {
         continue;
       }
       const cached = readJsonFile(candidatePath);
-      if (!hasContextWindowObject(cached)) continue;
+      if (!hasContextWindowObject(cached)) return null;
       return clampPercent(getContextPercent(cached));
     }
 
-    // No candidate validated to a usable cache: fall back exactly as the
-    // HUD does — the legacy flat cache first, then the most recently
-    // updated session-scoped cache as a last resort (e.g. a detached
-    // watcher that never inherited session env vars).
+    // No candidate validated to a real identity at all: fall back exactly
+    // as the HUD does for a fully identity-less reader — the legacy flat
+    // cache first, then the most recently updated session-scoped cache as
+    // a last resort (e.g. a detached watcher that never inherited session
+    // env vars).
     let cached = readJsonFile(resolveOmcPath('state/' + HUD_CACHE_FILENAME, root));
 
     if (cached === null) {

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -9,7 +9,6 @@
 import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, renameSync, unlinkSync } from 'fs';
-import { closeSync, openSync, readSync, statSync } from 'fs';
 import { basename, join, dirname, resolve } from 'path';
 import { homedir, tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -17,6 +16,7 @@ import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
 import { readStdin } from './lib/stdin.mjs';
+import { resolveContextPercent } from './lib/context-usage.mjs';
 import { BOUNDED_GIT_TIMEOUT_MS } from './lib/bounded-git-timeout.mjs';
 
 const AGENT_OUTPUT_ANALYSIS_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_ANALYSIS_LIMIT || '12000', 10);
@@ -24,7 +24,6 @@ const AGENT_OUTPUT_SUMMARY_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_SUMMARY
 const PREEMPTIVE_WARNING_THRESHOLD_PERCENT = parseInt(process.env.OMC_PREEMPTIVE_COMPACTION_WARNING_PERCENT || '70', 10);
 const PREEMPTIVE_CRITICAL_THRESHOLD_PERCENT = parseInt(process.env.OMC_PREEMPTIVE_COMPACTION_CRITICAL_PERCENT || '90', 10);
 const PREEMPTIVE_COOLDOWN_MS = parseInt(process.env.OMC_PREEMPTIVE_COMPACTION_COOLDOWN_MS || '60000', 10);
-const PREEMPTIVE_TRANSCRIPT_TAIL_BYTES = 4096;
 const PREEMPTIVE_LARGE_OUTPUT_TOOLS = new Set(['read', 'grep', 'glob', 'bash', 'webfetch', 'task', 'taskcreate', 'taskupdate', 'taskoutput']);
 const QUIET_LEVEL = getQuietLevel();
 const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
@@ -415,79 +414,6 @@ function resolveTranscriptPath(transcriptPath, cwd) {
   return transcriptPath;
 }
 
-function readTranscriptUsage(transcriptPath) {
-  if (!transcriptPath) return null;
-
-  let fd = -1;
-  try {
-    const stat = statSync(transcriptPath);
-    if (stat.size === 0) return null;
-
-    fd = openSync(transcriptPath, 'r');
-    const readSize = Math.min(PREEMPTIVE_TRANSCRIPT_TAIL_BYTES, stat.size);
-    const buffer = Buffer.alloc(readSize);
-    readSync(fd, buffer, 0, readSize, stat.size - readSize);
-    closeSync(fd);
-    fd = -1;
-
-    const tail = buffer.toString('utf-8');
-    const windowMatches = tail.match(/"context_window"\s{0,5}:\s{0,5}(\d+)/g);
-    const inputMatches = tail.match(/"input_tokens"\s{0,5}:\s{0,5}(\d+)/g);
-    if (!windowMatches || !inputMatches) return null;
-
-    const lastWindow = Number.parseInt(
-      windowMatches[windowMatches.length - 1].match(/(\d+)/)?.[1] || '0',
-      10,
-    );
-    const lastInput = Number.parseInt(
-      inputMatches[inputMatches.length - 1].match(/(\d+)/)?.[1] || '0',
-      10,
-    );
-    if (!Number.isFinite(lastWindow) || lastWindow <= 0) return null;
-    if (!Number.isFinite(lastInput) || lastInput < 0) return null;
-
-    return Math.round((lastInput / lastWindow) * 100);
-  } catch {
-    return null;
-  } finally {
-    if (fd !== -1) {
-      try { closeSync(fd); } catch {}
-    }
-  }
-}
-
-function readContextUsageFromHookInput(data) {
-  const contextWindow = data?.context_window;
-  if (!contextWindow || typeof contextWindow !== 'object') {
-    return null;
-  }
-
-  const usedPercentage = contextWindow.used_percentage;
-  if (Number.isFinite(usedPercentage) && usedPercentage >= 0) {
-    return Math.min(100, Math.max(0, Math.round(usedPercentage)));
-  }
-
-  const size = contextWindow.context_window_size;
-  if (!Number.isFinite(size) || size <= 0) {
-    return null;
-  }
-
-  const usage = contextWindow.current_usage;
-  if (!usage || typeof usage !== 'object') {
-    return null;
-  }
-
-  const inputTokens = Number(usage.input_tokens || 0);
-  const cacheCreationTokens = Number(usage.cache_creation_input_tokens || 0);
-  const cacheReadTokens = Number(usage.cache_read_input_tokens || 0);
-
-  const totalTokens = inputTokens + cacheCreationTokens + cacheReadTokens;
-  if (!Number.isFinite(totalTokens) || totalTokens < 0) {
-    return null;
-  }
-
-  return Math.min(100, Math.max(0, Math.round((totalTokens / size) * 100)));
-}
 
 function getPreemptiveCooldownFilePath(directory, sessionId) {
   const cooldownScope =
@@ -539,16 +465,17 @@ function buildPreemptiveContextMessage(percentUsed, severity) {
   return `[OMC WARNING] Context at ${percentUsed}% (warning threshold: ${getPreemptiveWarningThreshold()}%). Plan a /compact soon to preserve room for the next large tool output.`;
 }
 
-function maybeBuildPreemptiveCompactionMessage(toolName, data, directory) {
+async function maybeBuildPreemptiveCompactionMessage(toolName, data, directory) {
   if (!PREEMPTIVE_LARGE_OUTPUT_TOOLS.has(String(toolName || '').toLowerCase())) {
     return '';
   }
 
-  const percentFromTranscript = readTranscriptUsage(
+  const percentUsed = await resolveContextPercent(
+    data,
     resolveTranscriptPath(data.transcript_path || data.transcriptPath, directory),
+    directory,
   );
-  const percentUsed =
-    percentFromTranscript ?? readContextUsageFromHookInput(data);
+
   const warningThreshold = getPreemptiveWarningThreshold();
   const criticalThreshold = getPreemptiveCriticalThreshold();
 
@@ -1138,7 +1065,7 @@ async function main() {
         structuredWriteSuccess,
         structuredWriteFailure,
       }),
-      maybeBuildPreemptiveCompactionMessage(toolName, data, directory),
+      await maybeBuildPreemptiveCompactionMessage(toolName, data, directory),
     );
 
     // Build response - use hookSpecificOutput.additionalContext for PostToolUse

--- a/src/__tests__/context-guard-stop.test.ts
+++ b/src/__tests__/context-guard-stop.test.ts
@@ -37,6 +37,17 @@ function writeTranscriptWithContext(filePath: string, contextWindow: number, inp
   });
   writeFileSync(filePath, `${line}\n`, 'utf-8');
 }
+function writeTranscriptWithoutContext(filePath: string, inputTokens: number): void {
+  const line = JSON.stringify({
+    message: {
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: 10,
+      },
+    },
+  });
+  writeFileSync(filePath, `${line}\n`, 'utf-8');
+}
 
 describe('context-guard-stop safe recovery messaging (issue #1373)', () => {
   let tempDir: string;
@@ -64,6 +75,46 @@ describe('context-guard-stop safe recovery messaging (issue #1373)', () => {
     expect(out.decision).toBe('block');
     expect(String(out.reason)).toContain('Run /compact immediately');
     expect(String(out.reason)).toContain('.omc/state');
+  });
+
+  it('blocks using HUD cache when transcript and hook payload omit context_window', () => {
+    const sessionId = `hud-stop-${Date.now()}`;
+    writeTranscriptWithoutContext(transcriptPath, 10);
+    const cacheDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, 'hud-stdin-cache.json'),
+      JSON.stringify({
+        cwd: tempDir,
+        context_window: {
+          used_percentage: 80,
+          context_window_size: 1000,
+          current_usage: {
+            input_tokens: 10,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    const out = runContextGuardStopWithEnv(
+      {
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+        cwd: tempDir,
+        stop_reason: 'normal',
+      },
+      {
+        CLAUDE_PLUGIN_ROOT: process.cwd(),
+        OMC_CONTEXT_GUARD_THRESHOLD: '75',
+      },
+    );
+
+    expect(out.continue).toBe(false);
+    expect(out.decision).toBe('block');
+    expect(String(out.reason)).toContain('Run /compact immediately');
   });
 
   it('fails open at critical context exhaustion to avoid stop-hook deadlock', () => {

--- a/src/__tests__/context-usage.test.ts
+++ b/src/__tests__/context-usage.test.ts
@@ -275,23 +275,66 @@ describe('resolveHudCacheContextPercent', () => {
     }
   });
 
-  it('skips a valid but cache-less primary identity and uses a usable secondary candidate', async () => {
+  it('returns null for a valid but cache-less primary identity instead of falling through to a secondary candidate', async () => {
     // 'hud-valid-primary-no-cache' is a syntactically valid session id with
-    // no cache file written for it — this must be skipped (not treated as a
-    // terminal failure) in favor of the next, usable candidate.
-    writeHudCache('hud-valid-secondary-with-cache', makeHudPayload({
+    // no cache file written for it. A valid identity is authoritative the
+    // moment it is found (matching src/hud/stdin.ts's getStdinCachePath,
+    // which commits to the first candidate that passes validation) -- it
+    // must NOT fall through to a different, unrelated secondary candidate
+    // even if that candidate happens to have a cache.
+    writeHudCache('hud-unrelated-secondary-with-cache', makeHudPayload({
       context_window: { used_percentage: 77 },
     }));
 
     const originalLegacy = process.env.CLAUDECODE_SESSION_ID;
-    process.env.CLAUDECODE_SESSION_ID = 'hud-valid-secondary-with-cache';
+    process.env.CLAUDECODE_SESSION_ID = 'hud-unrelated-secondary-with-cache';
     try {
       expect(await resolveHudCacheContextPercent(
         { session_id: 'hud-valid-primary-no-cache' },
         tempDir,
-      )).toBe(77);
+      )).toBeNull();
     } finally {
       if (originalLegacy === undefined) delete process.env.CLAUDECODE_SESSION_ID; else process.env.CLAUDECODE_SESSION_ID = originalLegacy;
+    }
+  });
+
+  it('returns null for a valid payload identity with no cache even when a newer foreign session cache exists', async () => {
+    const foreignPath = writeHudCache('hud-foreign-high-session', makeHudPayload({
+      context_window: { used_percentage: 90 },
+    }));
+    utimesSync(foreignPath, (Date.now() + 1_000) / 1000, (Date.now() + 1_000) / 1000);
+
+    // The current session's own identity ('hud-valid-payload-no-cache') is
+    // syntactically valid but has not written a cache yet (e.g. before the
+    // first statusline render). It must resolve to null, never to a
+    // concurrent unrelated session's high-percentage cache -- otherwise a
+    // fresh session could be falsely warned/blocked by another session's
+    // context usage.
+    expect(await resolveHudCacheContextPercent(
+      { session_id: 'hud-valid-payload-no-cache' },
+      tempDir,
+    )).toBeNull();
+  });
+
+  it('returns null for a valid env-bound identity with no cache even when the legacy flat cache is populated', async () => {
+    const legacyDir = join(tempDir, '.omc', 'state');
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, HUD_CACHE_FILENAME),
+      JSON.stringify(makeHudPayload({ context_window: { used_percentage: 95 } })),
+      'utf-8',
+    );
+
+    const originalClaude = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = 'hud-valid-env-no-cache';
+    try {
+      // A valid env-bound identity with no cache of its own must resolve to
+      // null, never to the legacy flat cache -- the legacy path is reserved
+      // for the fully identity-less case (src/hud/stdin.ts readStdinCache
+      // only falls back to it when no session env var resolved at all).
+      expect(await resolveHudCacheContextPercent({}, tempDir)).toBeNull();
+    } finally {
+      if (originalClaude === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = originalClaude;
     }
   });
 

--- a/src/__tests__/context-usage.test.ts
+++ b/src/__tests__/context-usage.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { getContextPercent } from '../hud/stdin.js';
+import type { StatuslineStdin } from '../hud/types.js';
+
+// @ts-expect-error Local hook helper is a JS module loaded directly by the tests.
+import { resolveContextPercent, resolveHookContextPercent, resolveHudCacheContextPercent, resolveTranscriptContextPercent } from '../../scripts/lib/context-usage.mjs';
+
+const HUD_CACHE_FILENAME = 'hud-stdin-cache.json';
+
+function writeTranscript(payload: unknown): string {
+  const filePath = join(tempDir, `transcript-${Date.now()}-${Math.random()}.jsonl`);
+  writeFileSync(filePath, `${JSON.stringify(payload)}\n`, 'utf-8');
+  return filePath;
+}
+
+function writeHudCache(sessionId: string, payload: unknown): string {
+  const sessionDir = join(tempDir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  const filePath = join(sessionDir, HUD_CACHE_FILENAME);
+  writeFileSync(filePath, JSON.stringify(payload), 'utf-8');
+  return filePath;
+}
+
+function makeHudPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    cwd: tempDir,
+    transcript_path: join(tempDir, 'session.jsonl'),
+    context_window: {
+      context_window_size: 1000,
+      current_usage: {
+        input_tokens: 120,
+        cache_creation_input_tokens: 30,
+        cache_read_input_tokens: 50,
+      },
+    },
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+let originalPluginRoot: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'omc-context-usage-'));
+  originalPluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  process.env.CLAUDE_PLUGIN_ROOT = process.cwd();
+});
+
+afterEach(() => {
+  if (originalPluginRoot === undefined) {
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+  } else {
+    process.env.CLAUDE_PLUGIN_ROOT = originalPluginRoot;
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('resolveTranscriptContextPercent', () => {
+  it('returns null for production-shaped transcripts without context_window', () => {
+    const transcriptPath = writeTranscript({
+      message: {
+        usage: {
+          input_tokens: 850,
+          cache_creation_input_tokens: 50,
+          cache_read_input_tokens: 50,
+          output_tokens: 10,
+        },
+      },
+    });
+
+    expect(resolveTranscriptContextPercent(transcriptPath)).toBeNull();
+  });
+
+  it('includes cache creation and cache read tokens when context_window is present', () => {
+    const transcriptPath = writeTranscript({
+      message: {
+        usage: {
+          context_window: 1000,
+          input_tokens: 120,
+          cache_creation_input_tokens: 30,
+          cache_read_input_tokens: 250,
+          output_tokens: 10,
+        },
+      },
+    });
+
+    // input_tokens alone would be 12%; normalized HUD accounting is 40%.
+    expect(resolveTranscriptContextPercent(transcriptPath)).toBe(40);
+  });
+});
+
+describe('resolveHookContextPercent', () => {
+  it('prefers used_percentage when present', () => {
+    expect(resolveHookContextPercent({
+      context_window: { used_percentage: 53.6 },
+    })).toBe(54);
+  });
+
+  it('derives usage from current_usage including cache tokens', () => {
+    expect(resolveHookContextPercent({
+      context_window: {
+        context_window_size: 100,
+        current_usage: {
+          input_tokens: 60,
+          cache_creation_input_tokens: 5,
+          cache_read_input_tokens: 7,
+        },
+      },
+    })).toBe(72);
+  });
+
+  it('returns null when context_window is missing or malformed', () => {
+    expect(resolveHookContextPercent({})).toBeNull();
+    expect(resolveHookContextPercent({ context_window: null })).toBeNull();
+    expect(resolveHookContextPercent({
+      context_window: { context_window_size: 100 },
+    })).toBeNull();
+  });
+});
+
+describe('resolveHudCacheContextPercent', () => {
+  it('uses HUD native used_percentage from the session cache', async () => {
+    const sessionId = 'hud-native-session';
+    const payload = makeHudPayload({
+      context_window: {
+        used_percentage: 42.6,
+        context_window_size: 1000,
+        current_usage: {
+          input_tokens: 1,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+    writeHudCache(sessionId, payload);
+
+    expect(await resolveHudCacheContextPercent({ session_id: sessionId }, tempDir)).toBe(
+      getContextPercent(payload as StatuslineStdin),
+    );
+  });
+
+  it('delegates current_usage accounting to the HUD implementation', async () => {
+    const sessionId = 'hud-current-usage-session';
+    const payload = makeHudPayload();
+    writeHudCache(sessionId, payload);
+
+    expect(await resolveHudCacheContextPercent({ session_id: sessionId }, tempDir)).toBe(
+      getContextPercent(payload as StatuslineStdin),
+    );
+  });
+
+  it('falls back to the most recently modified session cache', async () => {
+    const oldPath = writeHudCache('hud-old-session', makeHudPayload({
+      context_window: { used_percentage: 12 },
+    }));
+    const freshPath = writeHudCache('hud-fresh-session', makeHudPayload({
+      context_window: { used_percentage: 67 },
+    }));
+    const past = (Date.now() - 60_000) / 1000;
+    const future = (Date.now() + 1_000) / 1000;
+    utimesSync(oldPath, past, past);
+    utimesSync(freshPath, future, future);
+    expect(await resolveHudCacheContextPercent({}, tempDir)).toBe(67);
+  });
+
+  it('uses the env-identified session cache even when a foreign session cache is newer', async () => {
+    const envSessionPath = writeHudCache('hud-env-session', makeHudPayload({
+      context_window: { used_percentage: 30 },
+    }));
+    const foreignPath = writeHudCache('hud-foreign-session', makeHudPayload({
+      context_window: { used_percentage: 91 },
+    }));
+    const past = (Date.now() - 60_000) / 1000;
+    const future = (Date.now() + 1_000) / 1000;
+    utimesSync(envSessionPath, past, past);
+    utimesSync(foreignPath, future, future);
+
+    const originalSessionEnv = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = 'hud-env-session';
+    try {
+      // No session_id on the payload itself: identity must come from the env
+      // var, not from scanning for the most recently modified cache — a
+      // concurrent unrelated session's newer cache must never be selected
+      // once an identity is known.
+      expect(await resolveHudCacheContextPercent({}, tempDir)).toBe(30);
+    } finally {
+      if (originalSessionEnv === undefined) {
+        delete process.env.CLAUDE_SESSION_ID;
+      } else {
+        process.env.CLAUDE_SESSION_ID = originalSessionEnv;
+      }
+    }
+  });
+
+  it('falls back to the legacy flat cache before scanning sessions when no identity is known', async () => {
+    const legacyDir = join(tempDir, '.omc', 'state');
+    mkdirSync(legacyDir, { recursive: true });
+    const legacyPayload = makeHudPayload({ context_window: { used_percentage: 55 } });
+    writeFileSync(join(legacyDir, HUD_CACHE_FILENAME), JSON.stringify(legacyPayload), 'utf-8');
+
+    // A session-scoped cache also exists and is newer, but with no payload
+    // session_id and no session-id env vars set, the legacy flat cache (the
+    // env-less path the HUD itself reads/writes) must win over any
+    // mtime-based session scan.
+    const sessionPath = writeHudCache('hud-unrelated-session', makeHudPayload({
+      context_window: { used_percentage: 88 },
+    }));
+    utimesSync(sessionPath, (Date.now() + 1_000) / 1000, (Date.now() + 1_000) / 1000);
+
+    const originalClaudeSession = process.env.CLAUDE_SESSION_ID;
+    const originalLegacySession = process.env.CLAUDECODE_SESSION_ID;
+    delete process.env.CLAUDE_SESSION_ID;
+    delete process.env.CLAUDECODE_SESSION_ID;
+    try {
+      expect(await resolveHudCacheContextPercent({}, tempDir)).toBe(55);
+    } finally {
+      if (originalClaudeSession !== undefined) process.env.CLAUDE_SESSION_ID = originalClaudeSession;
+      if (originalLegacySession !== undefined) process.env.CLAUDECODE_SESSION_ID = originalLegacySession;
+    }
+  });
+
+  it('skips an invalid CLAUDE_SESSION_ID and falls back to a valid CLAUDECODE_SESSION_ID', async () => {
+    const validPath = writeHudCache('hud-valid-secondary', makeHudPayload({
+      context_window: { used_percentage: 44 },
+    }));
+    void validPath;
+
+    const originalClaude = process.env.CLAUDE_SESSION_ID;
+    const originalLegacy = process.env.CLAUDECODE_SESSION_ID;
+    // '../evil' is a session id that fails validation (path-traversal shape)
+    // and must not stop the search — the next candidate should still be tried.
+    process.env.CLAUDE_SESSION_ID = '../evil';
+    process.env.CLAUDECODE_SESSION_ID = 'hud-valid-secondary';
+    try {
+      expect(await resolveHudCacheContextPercent({}, tempDir)).toBe(44);
+    } finally {
+      if (originalClaude === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = originalClaude;
+      if (originalLegacy === undefined) delete process.env.CLAUDECODE_SESSION_ID; else process.env.CLAUDECODE_SESSION_ID = originalLegacy;
+    }
+  });
+
+  it('skips an invalid payload session_id and falls back to a valid env identity', async () => {
+    writeHudCache('hud-valid-env-fallback', makeHudPayload({
+      context_window: { used_percentage: 61 },
+    }));
+
+    const originalClaude = process.env.CLAUDE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = 'hud-valid-env-fallback';
+    try {
+      expect(await resolveHudCacheContextPercent({ session_id: '../evil' }, tempDir)).toBe(61);
+    } finally {
+      if (originalClaude === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = originalClaude;
+    }
+  });
+
+  it('falls back to the legacy flat cache when every identity candidate is invalid', async () => {
+    const legacyDir = join(tempDir, '.omc', 'state');
+    mkdirSync(legacyDir, { recursive: true });
+    const legacyPayload = makeHudPayload({ context_window: { used_percentage: 38 } });
+    writeFileSync(join(legacyDir, HUD_CACHE_FILENAME), JSON.stringify(legacyPayload), 'utf-8');
+
+    const originalClaude = process.env.CLAUDE_SESSION_ID;
+    const originalLegacy = process.env.CLAUDECODE_SESSION_ID;
+    process.env.CLAUDE_SESSION_ID = '../also-evil';
+    delete process.env.CLAUDECODE_SESSION_ID;
+    try {
+      expect(await resolveHudCacheContextPercent({ session_id: '../still-evil' }, tempDir)).toBe(38);
+    } finally {
+      if (originalClaude === undefined) delete process.env.CLAUDE_SESSION_ID; else process.env.CLAUDE_SESSION_ID = originalClaude;
+      if (originalLegacy === undefined) delete process.env.CLAUDECODE_SESSION_ID; else process.env.CLAUDECODE_SESSION_ID = originalLegacy;
+    }
+  });
+
+  it('skips a valid but cache-less primary identity and uses a usable secondary candidate', async () => {
+    // 'hud-valid-primary-no-cache' is a syntactically valid session id with
+    // no cache file written for it — this must be skipped (not treated as a
+    // terminal failure) in favor of the next, usable candidate.
+    writeHudCache('hud-valid-secondary-with-cache', makeHudPayload({
+      context_window: { used_percentage: 77 },
+    }));
+
+    const originalLegacy = process.env.CLAUDECODE_SESSION_ID;
+    process.env.CLAUDECODE_SESSION_ID = 'hud-valid-secondary-with-cache';
+    try {
+      expect(await resolveHudCacheContextPercent(
+        { session_id: 'hud-valid-primary-no-cache' },
+        tempDir,
+      )).toBe(77);
+    } finally {
+      if (originalLegacy === undefined) delete process.env.CLAUDECODE_SESSION_ID; else process.env.CLAUDECODE_SESSION_ID = originalLegacy;
+    }
+  });
+
+  it('returns null when CLAUDE_PLUGIN_ROOT is unavailable', async () => {
+    delete process.env.CLAUDE_PLUGIN_ROOT;
+    expect(await resolveHudCacheContextPercent({ session_id: 'missing-root' }, tempDir)).toBeNull();
+  });
+
+  it('returns null when the cache file is missing', async () => {
+    expect(await resolveHudCacheContextPercent({ session_id: 'missing-cache' }, tempDir)).toBeNull();
+  });
+
+  it('returns null when the cache has no context_window key', async () => {
+    writeHudCache('missing-context-key', {
+      cwd: tempDir,
+      current_usage: { input_tokens: 1000 },
+    });
+
+    expect(await resolveHudCacheContextPercent({ session_id: 'missing-context-key' }, tempDir)).toBeNull();
+  });
+});
+
+describe('resolveContextPercent orchestration', () => {
+  it('prefers transcript, then hook payload, then HUD cache', async () => {
+    const transcriptPath = writeTranscript({
+      message: {
+        usage: {
+          context_window: 1000,
+          input_tokens: 800,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    });
+    writeHudCache('orchestration-session', makeHudPayload({
+      context_window: { used_percentage: 45 },
+    }));
+
+    expect(await resolveContextPercent({
+      session_id: 'orchestration-session',
+      context_window: { used_percentage: 60 },
+    }, transcriptPath, tempDir)).toBe(80);
+
+    const missingTranscript = join(tempDir, 'missing.jsonl');
+    expect(await resolveContextPercent({
+      session_id: 'orchestration-session',
+      context_window: { used_percentage: 60 },
+    }, missingTranscript, tempDir)).toBe(60);
+
+    expect(await resolveContextPercent({ session_id: 'orchestration-session' }, missingTranscript, tempDir)).toBe(45);
+    expect(await resolveContextPercent({}, missingTranscript, tempDir)).toBe(45);
+  });
+
+  it('returns null when no source has usable context data', async () => {
+    expect(await resolveContextPercent({}, join(tempDir, 'missing.jsonl'), tempDir)).toBeNull();
+  });
+});

--- a/src/__tests__/preemptive-compaction-hook.test.ts
+++ b/src/__tests__/preemptive-compaction-hook.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -55,6 +55,24 @@ function writeTranscriptWithoutContextWindow(
     'utf-8',
   );
   return transcriptPath;
+}
+function writeHudCache(dir: string, sessionId: string, usedPercentage: number): string {
+  const cacheDir = join(dir, '.omc', 'state', 'sessions', sessionId);
+  mkdirSync(cacheDir, { recursive: true });
+  const cachePath = join(cacheDir, 'hud-stdin-cache.json');
+  writeFileSync(cachePath, JSON.stringify({
+    cwd: dir,
+    context_window: {
+      used_percentage: usedPercentage,
+      context_window_size: 1000,
+      current_usage: {
+        input_tokens: 10,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  }), 'utf-8');
+  return cachePath;
 }
 
 function runPostToolVerifier(
@@ -306,6 +324,38 @@ describe('post-tool-verifier preemptive compaction warnings', () => {
         },
       },
       {
+        OMC_QUIET: '2',
+        OMC_PREEMPTIVE_COMPACTION_WARNING_PERCENT: '70',
+        OMC_PREEMPTIVE_COMPACTION_CRITICAL_PERCENT: '90',
+      },
+    );
+
+    expect(result).toEqual({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext:
+          '[OMC WARNING] Context at 72% (warning threshold: 70%). Plan a /compact soon to preserve room for the next large tool output.',
+      },
+    });
+  });
+
+  it('warns from HUD cache when transcript and hook payload omit context_window', () => {
+    const dir = makeTempDir();
+    const sessionId = `preemptive-hud-cache-${Date.now()}`;
+    const transcriptPath = writeTranscriptWithoutContextWindow(dir, 10);
+    writeHudCache(dir, sessionId, 72);
+
+    const result = runPostToolVerifier(
+      {
+        cwd: dir,
+        transcript_path: transcriptPath,
+        tool_name: 'Read',
+        session_id: sessionId,
+        tool_response: 'read output',
+      },
+      {
+        CLAUDE_PLUGIN_ROOT: process.cwd(),
         OMC_QUIET: '2',
         OMC_PREEMPTIVE_COMPACTION_WARNING_PERCENT: '70',
         OMC_PREEMPTIVE_COMPACTION_CRITICAL_PERCENT: '90',


### PR DESCRIPTION
## Problem

On CLIProxyAPI custom-model routes (`gpt-5.6-sol` in the report), the HUD statusline correctly resolves `context_window_size`/`used_percentage`, but the PostToolUse preemptive-compaction warning and the independent Stop recovery guard (`scripts/context-guard-stop.mjs`) stayed silent, letting the session cross the upstream context-window limit. `/compact` then also failed, leaving the session unrecoverable.

Closes #3574

## Root cause

Verified against a real live Claude Code transcript file: transcripts never write a top-level `context_window` field into `message.usage` (only `input_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens` / `output_tokens`). The transcript-tail regex scan duplicated in `scripts/context-guard-stop.mjs` and `scripts/post-tool-verifier.mjs` therefore never matched in production, for **any** provider — not just proxies.

- `scripts/context-guard-stop.mjs` (the independent Stop guard) had **zero fallback** beyond that dead scan and always silently returned 0%.
- `scripts/post-tool-verifier.mjs`'s existing `#2412` fallback only reads `context_window` from the *current hook event's own payload*, which is not guaranteed present on every route — confirmed by the reporter's evidence: the HUD's statusLine-fed data was correct, but the PostToolUse event's own data was not.
- The HUD's persisted stdin cache (`state/sessions/{id}/hud-stdin-cache.json`, written on every statusline render) is the one already-correct, provider-agnostic source of truth, and neither guard consulted it.

## Fix

Adds `scripts/lib/context-usage.mjs`, a shared, layered context-percent resolver used by both hooks, tried in this order:

1. A best-effort transcript-tail scan (`resolveTranscriptContextPercent`), kept for forward compatibility, now summing `input_tokens + cache_creation_input_tokens + cache_read_input_tokens` (matching HUD's `getTotalTokens` semantics) instead of `input_tokens` alone. In practice this returns `null` on real transcripts, since they lack `context_window`.
2. `context_window` on the current hook event's own payload (`resolveHookContextPercent`, the existing `#2412` fallback, extracted for reuse).
3. The HUD's persisted stdin cache (`resolveHudCacheContextPercent`), computed via `dist/hud/stdin.js`'s `getContextPercent` (never reimplemented, to avoid regressing `#3489`-style accounting drift).

Session-identity resolution for step 3 matches `src/hud/stdin.ts`'s `getStdinCachePath` **exactly**: candidates are tried in order — payload `session_id`/`sessionId`, then `CLAUDE_SESSION_ID`, then `CLAUDECODE_SESSION_ID` — skipping only a candidate that **fails validation** (`getSessionStateDir` throws). The **first candidate that validates is authoritative**: its own cache is read and returned (or `null` if that cache is missing/unusable) — the resolver never falls through to a *different* session's cache once a real identity is known, matching `readStdinCache`'s behavior exactly. Only when **no** candidate validates at all does it fall through to the identity-less recovery path: the legacy flat cache first, then the most-recently-modified session cache as a last resort (mirroring the HUD's own env-less detached-reader behavior).

Both `scripts/context-guard-stop.mjs` and `scripts/post-tool-verifier.mjs` now delegate to the shared resolver instead of their own dead-code duplicates. `maybeBuildPreemptiveCompactionMessage` in `post-tool-verifier.mjs` is now async end-to-end.

No model-name allowlists or `gpt-5.6-sol`-specific branching anywhere — fully provider-agnostic.

### Explicitly out of scope

`scripts/persistent-mode.mjs` has its own separate `estimateContextPercent` (a different fail-open critical-context check used during Ralph/Ultrawork continuation) that shares the same underlying transcript-scan limitation. It is intentionally **not** touched in this PR — confirmed with the reporter — and is noted here as a related residual risk for a possible follow-up.

## Tests

- New `src/__tests__/context-usage.test.ts`: unit tests for all four exported resolvers, including:
  - a transcript fixture with **no** `context_window` field at all (the true production shape, verified against a real transcript),
  - HUD-cache lookup and orchestration precedence,
  - session-identity candidate validation: invalid-primary-falls-back-to-valid-secondary, all-invalid-falls-back-to-legacy-cache, and — critically — a **valid but cache-less** primary/env identity resolving to `null` rather than incorrectly falling through to an unrelated session's cache (including a newer foreign session cache and a populated legacy cache, both of which must be ignored once a real identity is known).
- Extended `src/__tests__/context-guard-stop.test.ts`: HUD-cache-only end-to-end regression — transcript lacks `context_window`, hook payload lacks `context_window`, HUD cache is the only signal — Stop now blocks with recovery advice instead of silently allowing termination.
- Extended `src/__tests__/preemptive-compaction-hook.test.ts`: same HUD-cache-only scenario, PostToolUse now emits the `[OMC WARNING]`/`[OMC CRITICAL]` message.
- Cache-token accounting regression guard proving `cache_read_input_tokens` is now counted (previously silently ignored).
- Existing native-Claude-model transcript-based fixtures in both files verified unchanged (no regression to `#2412`/`#2875`/`#3489` behavior).

## Verification

```
npx tsc --noEmit                                                                    # clean
npm run build                                                                       # clean
npx vitest run src/__tests__/context-guard-stop.test.ts \
  src/__tests__/preemptive-compaction-hook.test.ts \
  src/__tests__/context-usage.test.ts \
  src/__tests__/hud/stdin.test.ts                                                   # 4 files, 75/75 passed
npx vitest run (broader src/__tests__ hooks/hud/preemptive/context-guard cluster)   # 44 files, 783/783 passed
```

Additionally verified via live CLI subprocess red-team invocations of both hook scripts (adversarial session-id path traversal, corrupt/missing cache, missing `CLAUDE_PLUGIN_ROOT`, threshold boundaries, malformed transcript paths, invalid-then-valid identity fallback, all-identities-invalid legacy fallback) — all fail-open and correct, zero bugs found. All 14 required CI checks on this PR are green.

## Remaining risk

- `scripts/persistent-mode.mjs`'s independent `estimateContextPercent` (continuation fail-open safety check) has the same transcript-scan limitation but is out of scope for this PR — flagged above as a candidate follow-up.
- The HUD-cache layer is a "last known good, same-session" signal (populated on the last statusline render for *that exact session identity*), not a live one; this is an accepted, strictly session-scoped tradeoff. It never crosses session boundaries once any real identity is known, and the fully identity-less recovery path (legacy/mtime) is reached only when no session identity resolved at all — matching the HUD's own env-less-reader contract.

Not merging — leaving for review.
