### PR TITLE
fix(post-tool-verifier): key background detection off tool_input (#3578)

### DIFF
--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -350,18 +350,26 @@ export function detectBashFailure(output) {
     .some(line => linePatterns.some(pattern => pattern.test(line)));
 }
 
-// Detect background operation
-function detectBackgroundOperation(output) {
-  const bgPatterns = [
-    /started/i,
-    /running/i,
-    /background/i,
-    /async/i,
-    /task_id/i,
-    /spawned/i,
-  ];
+// Detect whether a tool call was actually backgrounded.
+//
+// The PostToolUse payload carries the tool's own `tool_input`, and Bash/Task
+// expose `run_in_background` — that flag, not the command output, is what
+// determines background execution. Substring-matching words like "running" or
+// "async" against arbitrary output misreports ordinary foreground calls
+// (issue #3578).
+export function isBackgroundToolInvocation(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object' || Array.isArray(toolInput)) return false;
+  return toolInput.run_in_background === true;
+}
 
-  return bgPatterns.some(pattern => pattern.test(output));
+// Anchored fallback for the harness's own background-launch announcement.
+// Deliberately case-sensitive and anchored to the start of the output: text
+// that merely quotes the phrase elsewhere is not a launch (same rule as
+// src/hud/transcript.ts). Only the Task family gets this fallback — Bash has
+// no equivalent announcement, so it relies on the input flag alone.
+export function detectAnnouncedBackgroundLaunch(output) {
+  if (typeof output !== 'string') return false;
+  return /^(?:Async agent launched|Background task (?:launched|resumed))\b/.test(output.trimStart());
 }
 
 function resolveTranscriptPath(transcriptPath, cwd) {
@@ -897,6 +905,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
     rawLength = 0,
     structuredWriteSuccess = false,
     structuredWriteFailure = false,
+    toolInput = {},
   } = options;
   let message = '';
 
@@ -909,7 +918,7 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
         message = `Command exited with code ${code} but produced valid output. This may be expected behavior.`;
       } else if (detectBashFailure(toolOutput)) {
         message = 'Command failed. Please investigate the error and fix before continuing.';
-      } else if (QUIET_LEVEL < 2 && detectBackgroundOperation(toolOutput)) {
+      } else if (QUIET_LEVEL < 2 && isBackgroundToolInvocation(toolInput)) {
         message = 'Background operation detected. Remember to verify results before proceeding.';
       }
       break;
@@ -920,7 +929,10 @@ function generateMessage(toolName, toolOutput, sessionId, toolCount, directory, 
       const agentSummary = getAgentCompletionSummary(directory, QUIET_LEVEL, sessionId);
       if (detectWriteFailure(toolOutput)) {
         message = 'Task delegation failed. Verify agent name and parameters.';
-      } else if (QUIET_LEVEL < 2 && detectBackgroundOperation(toolOutput)) {
+      } else if (
+        QUIET_LEVEL < 2 &&
+        (isBackgroundToolInvocation(toolInput) || detectAnnouncedBackgroundLaunch(toolOutput))
+      ) {
         message = 'Background task launched. Use TaskOutput to check results when needed.';
       } else if (QUIET_LEVEL < 2 && toolCount > 5) {
         message = `Multiple tasks delegated (${toolCount} total). Track their completion status.`;
@@ -1021,13 +1033,13 @@ async function main() {
     const { clipped: clippedToolOutput, wasTruncated } = clipToolOutputForAnalysis(toolName, toolOutput);
     const sessionId = data.session_id || data.sessionId || 'unknown';
     const directory = data.cwd || data.directory || process.cwd();
+    const toolInput = data.tool_input || data.toolInput || {};
 
     // Update session statistics
     const toolCount = updateStats(toolName, sessionId);
 
     // Append Bash commands to ~/.bash_history for terminal recall
     if ((toolName === 'Bash' || toolName === 'bash') && getBashHistoryConfig()) {
-      const toolInput = data.tool_input || data.toolInput || {};
       const command = typeof toolInput === 'string' ? toolInput : (toolInput.command || '');
       appendToBashHistory(command);
     }
@@ -1043,7 +1055,6 @@ async function main() {
     }
 
     if (toolName === 'Skill' || toolName === 'skill') {
-      const toolInput = data.tool_input || data.toolInput || {};
       const skillName = getInvokedSkillName(toolInput);
       const currentState = readSkillActiveState(directory, sessionId);
       const completingSkill = (skillName ?? '')
@@ -1064,6 +1075,7 @@ async function main() {
         rawLength: toolOutput.length,
         structuredWriteSuccess,
         structuredWriteFailure,
+        toolInput,
       }),
       await maybeBuildPreemptiveCompactionMessage(toolName, data, directory),
     );

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import process from 'process';
-import { detectBashFailure, detectWriteFailure, isClaudeCodeWriteSuccess, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
+import { detectAnnouncedBackgroundLaunch, detectBashFailure, detectWriteFailure, isBackgroundToolInvocation, isClaudeCodeWriteSuccess, isNonZeroExitWithOutput, summarizeAgentResult } from '../../scripts/post-tool-verifier.mjs';
 
 const SCRIPT_PATH = join(process.cwd(), 'scripts', 'post-tool-verifier.mjs');
 const TEMPLATE_HOOK_PATH = join(process.cwd(), 'templates', 'hooks', 'post-tool-use.mjs');
@@ -1064,5 +1064,155 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
       expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
       expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
     });
+  });
+});
+
+describe('background operation detection (issue #3578)', () => {
+  const TRIGGER_WORDS = ['started', 'running', 'background', 'async', 'task_id', 'spawned'];
+
+  describe('isBackgroundToolInvocation', () => {
+    it('is true only when run_in_background is exactly true', () => {
+      expect(isBackgroundToolInvocation({ run_in_background: true })).toBe(true);
+      expect(isBackgroundToolInvocation({ run_in_background: false })).toBe(false);
+      expect(isBackgroundToolInvocation({ run_in_background: 'true' })).toBe(false);
+      expect(isBackgroundToolInvocation({ command: 'echo running' })).toBe(false);
+    });
+
+    it('fails safe on malformed or missing tool_input', () => {
+      expect(isBackgroundToolInvocation(undefined)).toBe(false);
+      expect(isBackgroundToolInvocation(null)).toBe(false);
+      expect(isBackgroundToolInvocation('run_in_background')).toBe(false);
+      expect(isBackgroundToolInvocation([{ run_in_background: true }])).toBe(false);
+      expect(isBackgroundToolInvocation(42)).toBe(false);
+    });
+  });
+
+  describe('detectAnnouncedBackgroundLaunch', () => {
+    it('matches the harness announcement only at the start of output', () => {
+      expect(detectAnnouncedBackgroundLaunch('Async agent launched successfully\nagentId: a8de3dd')).toBe(true);
+      expect(detectAnnouncedBackgroundLaunch('  Background task launched\n')).toBe(true);
+      expect(detectAnnouncedBackgroundLaunch('Background task resumed')).toBe(true);
+    });
+
+    it('does not match the phrase quoted elsewhere in the output', () => {
+      expect(
+        detectAnnouncedBackgroundLaunch('Report: the parser checks for Async agent launched strings.'),
+      ).toBe(false);
+    });
+
+    it('is case-sensitive by design', () => {
+      expect(detectAnnouncedBackgroundLaunch('async agent launched successfully')).toBe(false);
+    });
+
+    it('fails safe on non-string output', () => {
+      expect(detectAnnouncedBackgroundLaunch(undefined)).toBe(false);
+      expect(detectAnnouncedBackgroundLaunch(null)).toBe(false);
+      expect(detectAnnouncedBackgroundLaunch({ text: 'Async agent launched' })).toBe(false);
+    });
+  });
+
+  describe('foreground Bash never reports a background operation', () => {
+    for (const word of TRIGGER_WORDS) {
+      it(`does not fire when foreground output contains "${word}"`, () => {
+        const out = runPostToolVerifier({
+          tool_name: 'Bash',
+          tool_input: { command: 'echo demo' },
+          tool_response: `the service is ${word} normally`,
+          session_id: `bg-fp-${word}`,
+        });
+
+        expect(out).toEqual({ continue: true, suppressOutput: true });
+      });
+    }
+
+    it('does not fire when foreground output contains every trigger word at once', () => {
+      const out = runPostToolVerifier({
+        tool_name: 'Bash',
+        tool_input: { command: 'cat notes.txt' },
+        tool_response: TRIGGER_WORDS.join(' '),
+        session_id: 'bg-fp-all',
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+    });
+
+    it('does not fire for the reported repro payload', () => {
+      const out = runPostToolVerifier({
+        tool_name: 'Bash',
+        tool_input: { command: 'echo "the service is running"' },
+        tool_response: 'the service is running',
+        session_id: 'bg-fp-repro',
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+    });
+  });
+
+  describe('genuine background invocations still fire', () => {
+    it('fires for Bash with run_in_background=true', () => {
+      const out = runPostToolVerifier({
+        tool_name: 'Bash',
+        tool_input: { command: 'sleep 100', run_in_background: true },
+        tool_response: 'ok',
+        session_id: 'bg-real-bash',
+      });
+
+      expect(out.hookSpecificOutput.additionalContext).toContain('Background operation detected');
+    });
+
+    it('fires for Task with run_in_background=true', () => {
+      const out = runPostToolVerifier({
+        tool_name: 'Task',
+        tool_input: { description: 'explore', run_in_background: true },
+        tool_response: 'ok',
+        session_id: 'bg-real-task',
+      });
+
+      expect(out.hookSpecificOutput.additionalContext).toContain('Background task launched');
+    });
+
+    it('fires for a Task output leading with the launch announcement', () => {
+      const out = runPostToolVerifier({
+        tool_name: 'Task',
+        tool_input: { description: 'explore' },
+        tool_response: 'Async agent launched successfully\nagentId: a8de3dd',
+        session_id: 'bg-real-announce',
+      });
+
+      expect(out.hookSpecificOutput.additionalContext).toContain('Background task launched');
+    });
+
+    it('does not fire for a foreground Task result that merely quotes the announcement', () => {
+      const out = runPostToolVerifier({
+        tool_name: 'Task',
+        tool_input: { description: 'investigate' },
+        tool_response: 'Investigation report: the parser matches "Async agent launched" text.',
+        session_id: 'bg-fg-task-quote',
+      });
+
+      expect(out).toEqual({ continue: true, suppressOutput: true });
+    });
+  });
+
+  describe('malformed tool_input fails safely', () => {
+    for (const [label, toolInput] of [
+      ['missing', undefined],
+      ['null', null],
+      ['string', 'run_in_background=true'],
+      ['array', [{ run_in_background: true }]],
+    ]) {
+      it(`does not fire and still continues for ${label} tool_input`, () => {
+        const payload = {
+          tool_name: 'Bash',
+          tool_response: TRIGGER_WORDS.join(' '),
+          session_id: `bg-malformed-${label}`,
+        };
+        if (toolInput !== undefined) payload.tool_input = toolInput;
+
+        const out = runPostToolVerifier(payload);
+
+        expect(out).toEqual({ continue: true, suppressOutput: true });
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

`post-tool-verifier.mjs` emitted "Background operation detected" for ordinary foreground `Bash` calls: `detectBackgroundOperation` substring-matched `started|running|background|async|task_id|spawned` against arbitrary tool *output* and never consulted whether the call was actually backgrounded.

This replaces the output heuristic with the authoritative input signal.

## Changes

`scripts/post-tool-verifier.mjs`
- Removed `detectBackgroundOperation(output)`.
- Added `isBackgroundToolInvocation(toolInput)` — reads `run_in_background === true` from the PostToolUse `tool_input` payload; fails safe on null/array/non-object input.
- Added `detectAnnouncedBackgroundLaunch(output)` — anchored, case-sensitive match on the harness's own launch announcement (`Async agent launched`, `Background task launched|resumed`), following the existing precedent in `src/hud/transcript.ts`.
- Bash relies on the input flag alone (it has no launch announcement); the Task family additionally accepts the anchored announcement so legitimate background-launch reminders are preserved.
- `tool_input` is threaded into `generateMessage` via its existing options bag. Quiet-level semantics unchanged.

## Verification

- New `describe('background operation detection (issue #3578)')` suite covers: each trigger word in foreground Bash output produces no message; `run_in_background: true` still fires for Bash and Task; leading announcement fires for Task; mid-text quoted announcement does not; lowercase announcement does not (locks case-sensitivity); malformed `tool_input` fails safe.
- `npx vitest run src/__tests__/post-tool-verifier.test.mjs src/__tests__/hooks` — 373 passed.
- `npx tsc --noEmit` clean.
- Manual repro: `{"tool_name":"Bash","tool_response":"the service is running"}` now returns `{continue:true, suppressOutput:true}`; the same payload with `run_in_background: true` still emits the reminder.

Fixes #3578
