### PR TITLE
ci: authorize exact generated closure for PR #3539 (dev)

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1253,18 +1253,18 @@
       "pullNumber": 3539,
       "targetRef": "dev",
       "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
-      "headSha": "a82db66c18d88759cdd3455f65fd4ae9ae95dbc9",
+      "headSha": "2396c60c67722f576efb8f61183c48f6883cc178",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-05T00:00:00.000Z",
       "generatedDelta": {
         "count": 3,
-        "sha256": "b90fbed9042db47d77c35c2adcf4425446d725dd28b67991ad3d700a94e9e45d"
+        "sha256": "a419dd54588869a4ea889854f4e753ad7c2f1d736038bda25234273c44c2e211"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "78e4dd26cef8a0ac1908e822e5e1ce5e2e8be7af",
+          "sha": "69f86054a5a2b1f1671df0bdf2f1a426dadcc7d3",
           "previousFilename": null
         },
         {
@@ -1276,7 +1276,7 @@
         {
           "status": "modified",
           "filename": "dist/installer/index.js",
-          "sha": "75b271300996bf04e421f5ebd227b7def846a1bd",
+          "sha": "736b2b41a336c94ab7886452a6c09b2fd7fcb033",
           "previousFilename": null
         }
       ]

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -253,6 +253,11 @@ describe('generated-artifact base trust root workflow', () => {
       headSha: 'e798c12426f1f11701dede43a0f35c183651627e',
       mergeBaseSha: '10078ece166ad36332390ecbaab2d5e247852bbc',
     });
+    expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({
+      targetRef: 'dev',
+      headSha: '2396c60c67722f576efb8f61183c48f6883cc178',
+      mergeBaseSha: '10078ece166ad36332390ecbaab2d5e247852bbc',
+    });
   });
 
   it('is immune to candidate workflow and checker replacement because the trusted workflow checks out only base bytes', () => {


### PR DESCRIPTION
## Purpose

Re-authorizes the **exact generated closure** for PR #3539. Its head advanced to `2396c60c6` while the base-owned record still pinned the superseded head `a82db66c1`, so the verifier failed at the head-identity assertion (`scripts/verify-generated-artifact-authorization.mjs:504`).

This is the sole mutation-owner transaction for #3539's authorization. Records #3537/#3538/#3541 are untouched.

## Why the record moved instead of the head

An earlier plan for #3539 was to force-reset its branch back to `a82db66c1` to match the stale record. That is no longer correct: `2396c60c6` is a substantive fix (`getInstalledOmcPluginRoots()` did not recognize the documented `oh-my-claudecode@oh-my-claudecode` local-marketplace id, so setup fell back to copying legacy agents into `~/.claude/agents` — recreating the exact duplication #3539 exists to prevent). Resetting would discard merge-worthy work, so the record moves to the head.

## Authorization record

| Field | Value |
|---|---|
| `pullNumber` | 3539 |
| `targetRef` | `dev` |
| `mergeBaseSha` | `10078ece166ad36332390ecbaab2d5e247852bbc` (unchanged) |
| `headSha` | `a82db66c1…` → `2396c60c67722f576efb8f61183c48f6883cc178` |
| `owner` | `Yeachan-Heo` |
| `expiresAt` | `2026-08-05T00:00:00.000Z` (unchanged) |
| generated delta | count **3**, sha256 `b90fbed9…` → `a419dd54588869a4ea889854f4e753ad7c2f1d736038bda25234273c44c2e211` |

Generated files at the exact head:

| Status | Path | Blob |
|---|---|---|
| modified | `bridge/cli.cjs` | `69f86054a5a2b1f1671df0bdf2f1a426dadcc7d3` |
| modified | `dist/installer/index.d.ts` | `f5ffa2b1b1dee166e565aba9a7536a95f638ddf3` |
| modified | `dist/installer/index.js` | `736b2b41a336c94ab7886452a6c09b2fd7fcb033` |

## Merge base

`dev` has advanced to `913b8f1d`, but `GET /compare` reports the merge base for #3539 as still `10078ece166ad36332390ecbaab2d5e247852bbc`, so `mergeBaseSha` is correct as-is and #3539 does **not** need a rebase.

## Determinism / trust

- `count`/`sha256` and the per-file blob SHAs were computed with the repository canonical `calculateGeneratedDelta` / `canonicalizeGeneratedFiles` imported from the **base-owned** verifier on `dev`, applied to the live pull-files API — not a reimplementation.
- Blob SHAs independently cross-checked against `git rev-parse 2396c60c6:<path>`.
- Full manifest passes canonical `validateAuthorizationManifest`.
- The trust model is not weakened: no verifier, workflow, or candidate-side classifier bytes are modified.

## Verification

- `src/__tests__/generated-artifact-authorization.test.ts` — 19/19 passing.
- `npx tsc --noEmit` — passed.
- Only authorization-transaction files changed (manifest + its guard test), matching the #3542 precedent.

The guard test previously pinned only #3538's exact head; this adds the equivalent pin for #3539 so a future silent head drift fails locally instead of only in CI.

## Note

This unblocks the authorization check only. The head commit signature on #3539 (and #3538) is `verified=false / unknown_key`, which `assertOwnerCommitSignature` refuses independently. That remains an owner action and is not addressed here.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*