### PR TITLE
ci: authorize repaired closure for PR #3539

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1252,31 +1252,43 @@
     {
       "pullNumber": 3539,
       "targetRef": "dev",
-      "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
-      "headSha": "2396c60c67722f576efb8f61183c48f6883cc178",
+      "mergeBaseSha": "77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3",
+      "headSha": "e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-05T00:00:00.000Z",
       "generatedDelta": {
-        "count": 3,
-        "sha256": "a419dd54588869a4ea889854f4e753ad7c2f1d736038bda25234273c44c2e211"
+        "count": 5,
+        "sha256": "cd6c0d30b94098bc262d2613a0de56dbbe128fc73d4043fd1f67884c3cf56e3c"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "69f86054a5a2b1f1671df0bdf2f1a426dadcc7d3",
+          "sha": "a77e6fb3df22eff36bb7956380c85deaa5c5e4e7",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/historical-agent-ownership.d.ts",
+          "sha": "3902ec42a77d6fa6ebf1366a188c14af9e451a21",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/historical-agent-ownership.js",
+          "sha": "73dbb7342a1affb00a3d1f435fd178aae4816822",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/index.d.ts",
-          "sha": "f5ffa2b1b1dee166e565aba9a7536a95f638ddf3",
+          "sha": "5fe1619f84ef538126c56080dd63a068052204c2",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/index.js",
-          "sha": "736b2b41a336c94ab7886452a6c09b2fd7fcb033",
+          "sha": "92295b0f7b76f41253f0572da186a2ce618112c7",
           "previousFilename": null
         }
       ]

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -255,8 +255,8 @@ describe('generated-artifact base trust root workflow', () => {
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({
       targetRef: 'dev',
-      headSha: '2396c60c67722f576efb8f61183c48f6883cc178',
-      mergeBaseSha: '10078ece166ad36332390ecbaab2d5e247852bbc',
+      headSha: 'e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd',
+      mergeBaseSha: '77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3',
     });
   });
 


### PR DESCRIPTION
## Purpose

Refreshes the base-owned generated-artifact authorization for PR #3539 after its package-parity repair advanced the head to `e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd`.

## Exact authorization

- target: `dev`
- merge base: `77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3`
- generated records: 5
- canonical delta SHA-256: `cd6c0d30b94098bc262d2613a0de56dbbe128fc73d4043fd1f67884c3cf56e3c`
- files: `bridge/cli.cjs`, `dist/installer/historical-agent-ownership.d.ts`, `dist/installer/historical-agent-ownership.js`, `dist/installer/index.d.ts`, `dist/installer/index.js`

The closure was derived from GitHub's live PR files API and independently recalculated with the protected verifier's `calculateGeneratedDelta` implementation. Records #3537, #3538, and #3541 and the verifier/workflow policy are unchanged.

## Verification

- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts src/__tests__/no-committed-build-artifacts.test.ts` — 24 passed
- `npx eslint src/__tests__/generated-artifact-authorization.test.ts` — passed
- `validateAuthorizationManifest()` and `calculateGeneratedDelta()` — exact record accepted
