### PR TITLE
ci: authorize signed merge head for PR #3539

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1252,8 +1252,8 @@
     {
       "pullNumber": 3539,
       "targetRef": "dev",
-      "mergeBaseSha": "77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3",
-      "headSha": "e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd",
+      "mergeBaseSha": "6808b8671d2aad2566b4e01ca47b7c9fb90b059b",
+      "headSha": "44ee6a74c9cf9d2a927f024189d1c636cc33aefd",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-05T00:00:00.000Z",
       "generatedDelta": {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -255,8 +255,8 @@ describe('generated-artifact base trust root workflow', () => {
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({
       targetRef: 'dev',
-      headSha: 'e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd',
-      mergeBaseSha: '77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3',
+      headSha: '44ee6a74c9cf9d2a927f024189d1c636cc33aefd',
+      mergeBaseSha: '6808b8671d2aad2566b4e01ca47b7c9fb90b059b',
     });
   });
 


### PR DESCRIPTION
## Summary
- authorize the GitHub-signed merge head `44ee6a74c9cf9d2a927f024189d1c636cc33aefd` for installer PR #3539
- bind the authorization to merge base `6808b8671d2aad2566b4e01ca47b7c9fb90b059b`
- retain the previously reviewed five-file generated closure

## Verification
- `npm test -- --run src/__tests__/generated-artifact-authorization.test.ts` (19 passed)
- JSON parse and `git diff --check` passed
- GitHub REST reports the authorized head signature as `valid`