### PR TITLE
ci: restore exact-head authorization for PR #3539

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1252,8 +1252,8 @@
     {
       "pullNumber": 3539,
       "targetRef": "dev",
-      "mergeBaseSha": "6808b8671d2aad2566b4e01ca47b7c9fb90b059b",
-      "headSha": "44ee6a74c9cf9d2a927f024189d1c636cc33aefd",
+      "mergeBaseSha": "77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3",
+      "headSha": "e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-05T00:00:00.000Z",
       "generatedDelta": {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -255,8 +255,8 @@ describe('generated-artifact base trust root workflow', () => {
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({
       targetRef: 'dev',
-      headSha: '44ee6a74c9cf9d2a927f024189d1c636cc33aefd',
-      mergeBaseSha: '6808b8671d2aad2566b4e01ca47b7c9fb90b059b',
+      headSha: 'e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd',
+      mergeBaseSha: '77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3',
     });
   });
 


### PR DESCRIPTION
## Summary
- restore the base-owned authorization to PR #3539 exact head `e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd`
- restore its canonical compare merge base `77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3`
- retain the previously reviewed five-file generated closure unchanged

The temporary GitHub-generated merge head was REST-verified but GraphQL attributed its signer to `web-flow`, not the protected owner, so it cannot satisfy the existing owner-signature contract.

## Verification
- `npm test -- --run src/__tests__/generated-artifact-authorization.test.ts` (19 passed)
- JSON parse and `git diff --check` passed