### PR TITLE
ci: authorize rebased head for PR #3539

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1252,19 +1252,19 @@
     {
       "pullNumber": 3539,
       "targetRef": "dev",
-      "mergeBaseSha": "77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3",
-      "headSha": "e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd",
+      "mergeBaseSha": "275226395a5e0772edbf8f791cdd74ea3ec082d7",
+      "headSha": "719087055945fd2a55024c02587e1f7f3e35ee26",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-05T00:00:00.000Z",
       "generatedDelta": {
         "count": 5,
-        "sha256": "cd6c0d30b94098bc262d2613a0de56dbbe128fc73d4043fd1f67884c3cf56e3c"
+        "sha256": "8f0880ac7ccd3c6c0e69bbe3d23d83c60adec2e4252c08e1798fe3463affe95e"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "a77e6fb3df22eff36bb7956380c85deaa5c5e4e7",
+          "sha": "ed9c39822d59be737929e6e311e161fefaa899bb",
           "previousFilename": null
         },
         {
@@ -1288,7 +1288,7 @@
         {
           "status": "modified",
           "filename": "dist/installer/index.js",
-          "sha": "92295b0f7b76f41253f0572da186a2ce618112c7",
+          "sha": "0ab9af1df1ba67d5c7c7cb611d73b0b0b296a1a7",
           "previousFilename": null
         }
       ]

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -255,8 +255,8 @@ describe('generated-artifact base trust root workflow', () => {
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({
       targetRef: 'dev',
-      headSha: 'e2cf59b01a6b2d3c8be0605d0cdd59c75df161dd',
-      mergeBaseSha: '77b83cdeb0c2e385bdbe71b2ab6c194b2a533cf3',
+      headSha: '719087055945fd2a55024c02587e1f7f3e35ee26',
+      mergeBaseSha: '275226395a5e0772edbf8f791cdd74ea3ec082d7',
     });
   });
 


### PR DESCRIPTION
## Summary
- authorize PR #3539 exact final repaired head `719087055945fd2a55024c02587e1f7f3e35ee26`
- bind the record to exact compare merge base `275226395a5e0772edbf8f791cdd74ea3ec082d7`
- retain the five-file generated installer closure, with the bridge and installer blobs/digest recomputed from the live fully paginated PR file list after the substantive REQUEST_CHANGES repairs

## Live generated closure
- count: 5
- canonical SHA-256: `8f0880ac7ccd3c6c0e69bbe3d23d83c60adec2e4252c08e1798fe3463affe95e`
- `bridge/cli.cjs`: `ed9c39822d59be737929e6e311e161fefaa899bb`
- `dist/installer/historical-agent-ownership.d.ts`: `3902ec42a77d6fa6ebf1366a188c14af9e451a21`
- `dist/installer/historical-agent-ownership.js`: `73dbb7342a1affb00a3d1f435fd178aae4816822`
- `dist/installer/index.d.ts`: `5fe1619f84ef538126c56080dd63a068052204c2`
- `dist/installer/index.js`: `0ab9af1df1ba67d5c7c7cb611d73b0b0b296a1a7`

## Verification
- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts` — 19 passed
- live PR-file canonicalization/count/digest — passed
- manifest JSON parse — passed
- `git diff --check` — passed