### PR TITLE
test(launch): complete PR #3572 credential conflict coverage

### DIFF
--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -1438,6 +1438,41 @@ describe('prepareOmcLaunchConfigDir / launchCommand OMC companion loading', () =
     expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
   });
 
+  it('blocks credential promotion when credential email identities conflict despite matching metadata', () => {
+    const configDir = join(tempRoot!, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'CLAUDE-omc.md'), '<!-- OMC:START -->\n# OMC\n<!-- OMC:END -->\n');
+    writeFileSync(join(tempRoot!, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    const credentialsPath = join(configDir, '.credentials.json');
+    writeFileSync(credentialsPath, JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'base-token',
+        expiresAt: 100,
+        emailAddress: 'base@example.com',
+      },
+    }));
+
+    const runtimeDir = prepareOmcLaunchConfigDir(configDir);
+    writeFileSync(join(runtimeDir, '.claude.json'), JSON.stringify({
+      oauthAccount: { accountUuid: 'same-account' },
+    }));
+    rmSync(join(runtimeDir, '.credentials.json'), { force: true });
+    writeFileSync(join(runtimeDir, '.credentials.json'), JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'runtime-token',
+        expiresAt: 999,
+        emailAddress: 'runtime@example.com',
+      },
+    }));
+
+    prepareOmcLaunchConfigDir(configDir);
+    const baseCredentials = JSON.parse(readFileSync(credentialsPath, 'utf-8')) as Record<string, unknown>;
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).accessToken).toBe('base-token');
+    expect((baseCredentials.claudeAiOauth as Record<string, unknown>).expiresAt).toBe(100);
+  });
+
   it('blocks credential promotion when either account identity is missing', () => {
     const configDir = join(tempRoot!, '.claude');
     mkdirSync(configDir, { recursive: true });


### PR DESCRIPTION
Adds the remaining explicit credential-email conflict regression case to the already repaired PR #3572 head. The source behavior and generated closure are unchanged; focused launch suite passes 165 tests. This narrow owner PR also yields a GitHub-verified exact merge head for the base-owned generated-artifact authorization contract.