### PR TITLE
ci: authorize rebased head for PR #3538

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1214,25 +1214,25 @@
     {
       "pullNumber": 3538,
       "targetRef": "dev",
-      "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
-      "headSha": "e798c12426f1f11701dede43a0f35c183651627e",
+      "mergeBaseSha": "3219495628cbf7680632f37e261351929508f295",
+      "headSha": "91244ff23963efe072cdadf6ae64adf2bd6815fd",
       "owner": "Yeachan-Heo",
-      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {
         "count": 4,
-        "sha256": "aaf1c49f22f4ce08b9299432e54f708e61e37434d3af48055bf195ff0b2005e6"
+        "sha256": "6a95230f5f872775de42c2eed9a007d930afc79aed1260aa2666b285c4346f27"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
-          "sha": "ccab9e12230cb98627c610d015216451d9c6da7c",
+          "sha": "a14ed7b45cddee0f32c5f59b0267785cccf6d302",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "102f7f2ec960a74079450bfb771fa566392f2840",
+          "sha": "de7fa172728e6ba135f7cf5bf84a61ec45e9f1c0",
           "previousFilename": null
         },
         {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -251,8 +251,12 @@ describe('generated-artifact base trust root workflow', () => {
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',
-      headSha: 'e798c12426f1f11701dede43a0f35c183651627e',
-      mergeBaseSha: '10078ece166ad36332390ecbaab2d5e247852bbc',
+      headSha: '91244ff23963efe072cdadf6ae64adf2bd6815fd',
+      mergeBaseSha: '3219495628cbf7680632f37e261351929508f295',
+      generatedDelta: {
+        count: 4,
+        sha256: '6a95230f5f872775de42c2eed9a007d930afc79aed1260aa2666b285c4346f27',
+      },
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({
       targetRef: 'dev',


### PR DESCRIPTION
## Summary

Refresh the base-owned generated-artifact authorization for PR #3538 after its required rebase onto current `dev`.

## Exact authorization identity

- target PR: #3538
- target ref: `dev`
- exact head: `91244ff23963efe072cdadf6ae64adf2bd6815fd`
- exact merge base: `3219495628cbf7680632f37e261351929508f295`
- generated record count: 4
- canonical delta SHA-256: `6a95230f5f872775de42c2eed9a007d930afc79aed1260aa2666b285c4346f27`
- expiry: `2026-08-12T00:00:00.000Z`

Authorized closure:

- `bridge/claude-md-coordinator.cjs` — `a14ed7b45cddee0f32c5f59b0267785cccf6d302`
- `bridge/cli.cjs` — `de7fa172728e6ba135f7cf5bf84a61ec45e9f1c0`
- `dist/installer/claude-md-transaction.d.ts` — `91f44678af2a904d691d7bd61fdad5eae478a923`
- `dist/installer/claude-md-transaction.js` — `6792903e324a83d1f68485b288757f2f2e61829b`

The closure was independently derived from the live, fully enumerated PR file API and recomputed with `canonicalizeGeneratedFiles` / `calculateGeneratedDelta` from the base-owned verifier. The inventory regression now pins the exact head, merge base, count, and digest.

## Verification

- `validateAuthorizationManifest(...)` — passed
- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts` — 19/19 passed
- `git diff --check` — passed

This PR changes only the base-owned authorization manifest and its membership guard. It does not modify PR #3538 product code, generated artifacts, the containment classifier, or the verifier.

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>
