### PR TITLE
ci: authorize signed generated head for PR #3588

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1343,7 +1343,7 @@
       "pullNumber": 3588,
       "targetRef": "dev",
       "mergeBaseSha": "3219495628cbf7680632f37e261351929508f295",
-      "headSha": "9c625e13e53af260c75589618f2ed040c1f9eb48",
+      "headSha": "3797429ede04ee4ca71e02f0821382eab7c3ddf8",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -275,7 +275,7 @@ describe('generated-artifact base trust root workflow', () => {
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3588)).toMatchObject({
       targetRef: 'dev',
-      headSha: '9c625e13e53af260c75589618f2ed040c1f9eb48',
+      headSha: '3797429ede04ee4ca71e02f0821382eab7c3ddf8',
       mergeBaseSha: '3219495628cbf7680632f37e261351929508f295',
       generatedDelta: {
         count: 16,


### PR DESCRIPTION
Updates PR #3588's base-owned authorization from the unsigned implementation head to the GitHub-verified merge head `3797429ede04ee4ca71e02f0821382eab7c3ddf8`.

The generated closure is unchanged:
- merge base: `3219495628cbf7680632f37e261351929508f295`
- generated files: 16
- closure digest: `14aab96247a7aae58f4b1daaeb0364cfdaf17c7d4f548be64dc411f83a46e691`

Focused authorization suite: 19/19 passed.