### PR TITLE
ci: authorize corrected head for PR #3538

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1215,24 +1215,24 @@
       "pullNumber": 3538,
       "targetRef": "dev",
       "mergeBaseSha": "3219495628cbf7680632f37e261351929508f295",
-      "headSha": "91244ff23963efe072cdadf6ae64adf2bd6815fd",
+      "headSha": "24e4e2f0e92dc4c4f61636d32fc411614fae3728",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {
-        "count": 4,
-        "sha256": "6a95230f5f872775de42c2eed9a007d930afc79aed1260aa2666b285c4346f27"
+        "count": 5,
+        "sha256": "05928b05a6f218fed553ecbb17ad276d4019ba70ac97b2581c39b104b38a4fd8"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
-          "sha": "a14ed7b45cddee0f32c5f59b0267785cccf6d302",
+          "sha": "3e31b5e9815150c2d2e5e9cd3d803692243aa197",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "de7fa172728e6ba135f7cf5bf84a61ec45e9f1c0",
+          "sha": "40089f6f49e697fe5ad1b759207855c6528e3d1c",
           "previousFilename": null
         },
         {
@@ -1244,7 +1244,13 @@
         {
           "status": "modified",
           "filename": "dist/installer/claude-md-transaction.js",
-          "sha": "6792903e324a83d1f68485b288757f2f2e61829b",
+          "sha": "8a3c29bd6cc3ee42a705c046418ebbf38234b9cb",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.js",
+          "sha": "b56860d8f1d518b4963c5196fb8f1aa4c3740776",
           "previousFilename": null
         }
       ]

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -252,11 +252,11 @@ describe('generated-artifact base trust root workflow', () => {
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',
-      headSha: '91244ff23963efe072cdadf6ae64adf2bd6815fd',
+      headSha: '24e4e2f0e92dc4c4f61636d32fc411614fae3728',
       mergeBaseSha: '3219495628cbf7680632f37e261351929508f295',
       generatedDelta: {
-        count: 4,
-        sha256: '6a95230f5f872775de42c2eed9a007d930afc79aed1260aa2666b285c4346f27',
+        count: 5,
+        sha256: '05928b05a6f218fed553ecbb17ad276d4019ba70ac97b2581c39b104b38a4fd8',
       },
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3539)).toMatchObject({


### PR DESCRIPTION
## Summary

Refresh the base-owned generated-artifact authorization for PR #3538 after exact-head adversarial review found and repaired three transaction-boundary defects.

## Exact authorization identity

- target PR: #3538
- target ref: `dev`
- exact corrected head: `24e4e2f0e92dc4c4f61636d32fc411614fae3728`
- exact merge base: `3219495628cbf7680632f37e261351929508f295`
- generated record count: 5
- canonical delta SHA-256: `05928b05a6f218fed553ecbb17ad276d4019ba70ac97b2581c39b104b38a4fd8`
- expiry: `2026-08-12T00:00:00.000Z`

Authorized closure:

- `bridge/claude-md-coordinator.cjs` — `3e31b5e9815150c2d2e5e9cd3d803692243aa197`
- `bridge/cli.cjs` — `40089f6f49e697fe5ad1b759207855c6528e3d1c`
- `dist/installer/claude-md-transaction.d.ts` — `91f44678af2a904d691d7bd61fdad5eae478a923`
- `dist/installer/claude-md-transaction.js` — `8a3c29bd6cc3ee42a705c046418ebbf38234b9cb`
- `dist/installer/index.js` — `b56860d8f1d518b4963c5196fb8f1aa4c3740776`

The closure was derived from the live fully enumerated PR file API and recomputed with `canonicalizeGeneratedFiles` / `calculateGeneratedDelta` from the base-owned verifier. The membership guard pins the exact head, merge base, count, and digest.

## Corrected product boundary

The new head preserves contained-symlink authority and additionally:

- revalidates the captured alias after the final forward mutation before reporting success;
- fails closed when a transaction-created rollback path is swapped to a dangling symlink;
- preserves public `Updated CLAUDE.md` status for an existing file reached through a symlinked config root using transaction operation metadata.

## Authorization verification

- `validateAuthorizationManifest(...)` — passed
- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts` — 19/19 passed
- `git diff --check` — passed

This PR changes only the base-owned manifest and its membership guard. It does not alter PR #3538 product code, generated artifacts, the candidate containment classifier, or the verifier.

Signed-off-by: Yeachan-Heo <hurrc04@gmail.com>
