### PR TITLE
ci: authorize signed final head for PR #3588

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1349,7 +1349,7 @@
       "pullNumber": 3588,
       "targetRef": "dev",
       "mergeBaseSha": "3219495628cbf7680632f37e261351929508f295",
-      "headSha": "47ce9d9aa2065bc555f88809ff04b739cced005c",
+      "headSha": "a3aac1084fea6182f0e85d1b596204a0adb213d2",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -275,7 +275,7 @@ describe('generated-artifact base trust root workflow', () => {
     });
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3588)).toMatchObject({
       targetRef: 'dev',
-      headSha: '47ce9d9aa2065bc555f88809ff04b739cced005c',
+      headSha: 'a3aac1084fea6182f0e85d1b596204a0adb213d2',
       mergeBaseSha: '3219495628cbf7680632f37e261351929508f295',
       generatedDelta: {
         count: 20,


### PR DESCRIPTION
## Summary

- bind PR #3588 authorization to GitHub-verified exact head `a3aac1084fea6182f0e85d1b596204a0adb213d2`
- retain unique merge base `3219495628cbf7680632f37e261351929508f295`
- retain the independently re-derived generated closure: count `20`, sha256 `fd7b7719f50caaeaa0a18caf9bb15d2bff6e654344565bc7226d73da4cd493e1`
- update the lockstep manifest test only

## Trust boundary

No verifier, workflow, candidate classifier, CI policy, generated artifact, or release file is changed. PR #3594 was correct for head `47ce9d9`, but GitHub REST rejected that head signature as `unknown_key`; helper PR #3595 established the GitHub-verified merge head now authorized here.

## Verification

- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts src/__tests__/no-committed-build-artifacts.test.ts` (24 passed)
- live generated closure re-derived from PR #3588 files: count 20 / sha256 `fd7b7719...`
- exact head GitHub verification reason: `valid`