### PR TITLE
test(team): assert final provider-start proof

### DIFF
--- a/src/team/__tests__/worker-launch-ack.test.ts
+++ b/src/team/__tests__/worker-launch-ack.test.ts
@@ -252,6 +252,13 @@ describe('worker launch acknowledgement', () => {
     const bootstrap = runWorkerLaunchBootstrap(spec);
     await awaitWorkerLaunchAcknowledgement(launchAttempt, { timeoutMs: 2_000, pollIntervalMs: 5 });
     await bootstrap;
+    const started = JSON.parse(await readFile(launchAttempt.startedPath, 'utf8'));
+    expect(started).toMatchObject({
+      kind: 'worker_launch_provider_started',
+      attempt_id: launchAttempt.attempt_id,
+      pane_id: '%22',
+      provider: 'codex',
+    });
 
     await expect(loadCurrentWorkerLaunchAttempt({
       cwd,


### PR DESCRIPTION
Adds one final regression assertion that the provider bootstrap publishes the identity-bound durable `provider-started.json` marker before current-attempt recovery can reconcile it.

Focused worker-launch acknowledgement suite: 11/11 passed.

This bounded helper also creates the GitHub-signed exact merge head required for PR #3588's generated-artifact authorization.