### PR TITLE
fix(installer): install hooks when settings.json has none

### DIFF
--- a/src/__tests__/installer-hooks-merge.test.ts
+++ b/src/__tests__/installer-hooks-merge.test.ts
@@ -62,6 +62,9 @@ function mergeEventHooks(
     } else {
       logMessages.push(`Updated ${eventType} hook (--force)`);
     }
+  } else if (existingGroups.length === 0) {
+    merged = newOmcGroups;
+    logMessages.push(`Installed ${eventType} hook`);
   } else {
     if (hasNonOmcHook) {
       logMessages.push(`Warning: ${eventType} hook has non-OMC hook. Skipping. Use --force-hooks to override.`);
@@ -317,6 +320,15 @@ describe('Hook merge during omc update', () => {
 
       // The webhook group has no command-type hooks → nonOmcGroups is empty
       expect(conflicts).toHaveLength(0);
+    });
+
+    it('installs hooks when none exist yet and no force flag is set', () => {
+      const existing: HookGroup[] = [];
+      const newOmc = [omcGroup(NEW_OMC_CMD)];
+      const { merged, conflicts, logMessages } = mergeEventHooks(existing, newOmc, {});
+      expect(merged).toEqual(newOmc);
+      expect(conflicts).toHaveLength(0);
+      expect(logMessages[0]).not.toMatch(/already configured/);
     });
   });
 });

--- a/src/__tests__/installer-mcp-config.test.ts
+++ b/src/__tests__/installer-mcp-config.test.ts
@@ -40,6 +40,20 @@ async function loadInstallerWithEnv(claudeConfigDir: string, homeDir: string, co
   return import('../installer/index.js');
 }
 
+// Maps each hook event to the OMC script(s) it must reference after a
+// first-install hook merge (mergeHookGroups). Shared by the mcp-config-owned
+// settings.json test below and the dedicated first-install regression test,
+// so both assert the same contract without pinning exact command strings,
+// which vary by platform.
+const EXPECTED_HOOK_SCRIPTS: Record<string, string[]> = {
+  UserPromptSubmit: ['keyword-detector.mjs'],
+  SessionStart: ['session-start.mjs'],
+  PreToolUse: ['pre-tool-use.mjs'],
+  PostToolUse: ['post-tool-use.mjs'],
+  PostToolUseFailure: ['post-tool-use-failure.mjs'],
+  Stop: ['persistent-mode.mjs', 'code-simplifier.mjs'],
+};
+
 describe('installer MCP config ownership (issue #1802)', () => {
   let tempRoot: string;
   let homeDir: string;
@@ -103,22 +117,33 @@ describe('installer MCP config ownership (issue #1802)', () => {
     expect(existsSync(codexConfigPath)).toBe(true);
 
     const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
-    expect(settings).toEqual({
+    const { hooks, ...settingsWithoutHooks } = settings as {
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      [key: string]: unknown;
+    };
+    expect(settingsWithoutHooks).toEqual({
       theme: 'dark',
       statusLine: {
         type: 'command',
         command: 'node hud.mjs',
       },
-      hooks: {
-        PostToolUse: [],
-        PostToolUseFailure: [],
-        PreToolUse: [],
-        SessionStart: [],
-        Stop: [],
-        UserPromptSubmit: [],
-      },
     });
     expect(settings).not.toHaveProperty('mcpServers');
+
+    // This test's subject is MCP config ownership, not hooks, so we only assert
+    // that the installer's first-install hook merge (mergeHookGroups) populated
+    // every event with its OMC hook script rather than pinning exact command
+    // strings, which vary by platform (see installer-hooks-merge.test.ts and the
+    // dedicated first-install regression test below for the full hooks contract).
+    for (const [eventType, scripts] of Object.entries(EXPECTED_HOOK_SCRIPTS)) {
+      const groups = hooks?.[eventType];
+      expect(groups, `${eventType} should have hook groups`).toBeDefined();
+      expect(groups!.length, `${eventType} should not be empty`).toBeGreaterThan(0);
+      const commands = groups!.flatMap(g => g.hooks.map(h => h.command));
+      for (const script of scripts) {
+        expect(commands.some(cmd => cmd.includes(script)), `${eventType} should reference ${script}`).toBe(true);
+      }
+    }
 
     const claudeRootConfig = JSON.parse(readFileSync(claudeRootConfigPath, 'utf-8')) as Record<string, unknown>;
     expect(claudeRootConfig).toEqual({
@@ -143,5 +168,72 @@ describe('installer MCP config ownership (issue #1802)', () => {
     expect(codexConfig).toContain('# BEGIN OMC MANAGED MCP REGISTRY');
     expect(codexConfig).toContain('[mcp_servers.gitnexus]');
     expect(codexConfig).toContain('command = "gitnexus"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// This exercises the real installer's mergeHookGroups() first-install branch
+// (src/installer/index.ts), not the local mirror in installer-hooks-merge.test.ts.
+// That mirror test only proves its own copy of the merge logic is correct; it
+// would keep passing even if the production fix were reverted. This test would
+// not: it runs the actual `install()` entry point against a fresh, empty
+// CLAUDE_CONFIG_DIR with no force flags and reads back the real settings.json.
+// ---------------------------------------------------------------------------
+describe('installer hook merge — first install writes non-empty hook groups', () => {
+  let tempRoot: string;
+  let homeDir: string;
+  let claudeConfigDir: string;
+  let codexHome: string;
+  let omcHome: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'omc-installer-hooks-first-install-'));
+    homeDir = join(tempRoot, 'home');
+    claudeConfigDir = join(homeDir, '.claude');
+    codexHome = join(tempRoot, '.codex');
+    omcHome = join(tempRoot, '.omc');
+
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(claudeConfigDir, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(omcHome, { recursive: true });
+
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(tempRoot, { recursive: true, force: true });
+    vi.resetModules();
+  });
+
+  it('populates every event with its OMC hook script on a fresh install with no force flags', async () => {
+    const settingsPath = join(claudeConfigDir, 'settings.json');
+
+    // No settings.json is written beforehand: this is a first-time install
+    // into a config dir that has never had OMC hooks configured.
+    const installer = await loadInstallerWithEnv(claudeConfigDir, homeDir, codexHome, omcHome);
+    const result = installer.install({
+      skipClaudeCheck: true,
+      skipHud: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(existsSync(settingsPath)).toBe(true);
+
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    for (const [eventType, scripts] of Object.entries(EXPECTED_HOOK_SCRIPTS)) {
+      const groups = settings.hooks?.[eventType];
+      expect(groups, `${eventType} should have hook groups`).toBeDefined();
+      expect(groups!.length, `${eventType} should not be an empty array`).toBeGreaterThan(0);
+      const commands = groups!.flatMap(g => g.hooks.map(h => h.command));
+      for (const script of scripts) {
+        expect(commands.some(cmd => cmd.includes(script)), `${eventType} should reference ${script}`).toBe(true);
+      }
+    }
   });
 });

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -909,6 +909,15 @@ function mergeHookGroups(
     return [...nonOmcGroups, ...newOmcGroups];
   }
 
+  // Nothing is registered for this event yet, so this is a first-time install
+  // rather than an "already configured" state. Without this branch the empty
+  // array that was passed in is returned unchanged, which writes an empty hook
+  // list into settings.json while the log claims the event was already set up.
+  if (existingGroups.length === 0) {
+    log(`  Installed ${eventType} hook`);
+    return newOmcGroups;
+  }
+
   if (hasNonOmcHook) {
     log(`  Warning: ${eventType} hook has non-OMC hook. Skipping. Use --force-hooks to override.`);
     result.hookConflicts.push({ eventType, existingCommand: nonOmcCommand });


### PR DESCRIPTION
## What's wrong

`mergeHookGroups()` treats "no hooks are registered for this event" and "hooks are
already registered" as the same case.

On a first-time `omc setup` without `--force` / `--force-hooks`:

```
const currentGroups = existingHooks[eventType] ?? [];   // -> []
  -> nonOmcGroups = []  ->  hasNonOmcHook = false
  -> not forceHooks, not force
  -> falls through to the final else
  -> log("  <event> hook already configured, skipping")
  -> return existingGroups                              // -> [] returned unchanged
```

`settings.json` then receives an empty array for every hook event, the installer
prints `already configured, skipping` for each one, and the summary reports
`Hooks: configured`. No hook fires, and nothing indicates a problem.

## Reproduce

Point `CLAUDE_CONFIG_DIR` at an empty directory and run `omc setup`. Resulting
`settings.json`:

```json
"hooks": {
  "UserPromptSubmit": [], "SessionStart": [], "PreToolUse": [],
  "PostToolUse": [], "PostToolUseFailure": [], "Stop": []
}
```

Reproduced on 4.14.7 and on 4.15.7 (current npm latest), on Windows, in three
variants: an existing `settings.json` with no `hooks` key, no `settings.json` at
all, and a real user config directory. Re-running with `--force-hooks` writes the
hooks correctly, which is how I first noticed.

## Why this has gone unnoticed

The marketplace/plugin install — the path the README recommends for most users —
never reaches this code. The merge block is gated behind
`shouldConfigureSettingsHooks`, which is false whenever the plugin provides
`hooks/hooks.json` and is enabled; hooks come from the plugin system instead.
(In the plugin context I exercised, `omc setup` skipped the `settings.json`
write entirely and never created the file.)

The bug is confined to the standalone npm path — `npm i -g` followed by
`omc setup` with no OMC plugin enabled. Those users are also likely to recover
silently the first time they run `omc update`, which takes the `force: true`
branch.

## The fix

An explicit first-install branch. The `forceHooks` and `force` branches are
untouched, so the only behaviour that changes is the case that was returning an
empty list.

## Test

The existing edge case covered the empty-array input only with `force: true`,
which takes a different branch — that is how this slipped past the suite. Added
the no-flag case, and applied the same branch to that file's local mirror of the
merge logic so it keeps matching the installer.

`npx vitest run src/__tests__/installer-hooks-merge.test.ts` passes 29/29,
`npx tsc --noEmit` is clean, and `npm run lint` reports 0 errors (the 17 warnings
are pre-existing and in unrelated files). No `dist/` or `bridge/` artifacts are
included.
