### PR TITLE
ci: authorize terminal head for PR #3603

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1514,6 +1514,32 @@
           "previousFilename": null
         }
       ]
+    },
+    {
+      "pullNumber": "3603",
+      "targetRef": "dev",
+      "mergeBaseSha": "0686239b0b6fa4e1b7d923d1b8b2aa3e7431dc15",
+      "headSha": "9d6ca59c6c1eb985d61e228a0616160823fe1d35",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-12T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 2,
+        "sha256": "a13673c490cd40b85b45c4ca20c0bef862861129abc6b75039c07ebd1addff50"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "c3802ae1f08c27add10b3f8454bbb3642c64fddc",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/mcp-registry.js",
+          "sha": "99d3c36dbb897f4a4d2ed23abb8964c68af33e9b",
+          "previousFilename": null
+        }
+      ]
     }
   ]
 }

--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1516,7 +1516,7 @@
       ]
     },
     {
-      "pullNumber": "3603",
+      "pullNumber": 3603,
       "targetRef": "dev",
       "mergeBaseSha": "0686239b0b6fa4e1b7d923d1b8b2aa3e7431dc15",
       "headSha": "9d6ca59c6c1eb985d61e228a0616160823fe1d35",
@@ -1524,7 +1524,7 @@
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {
         "count": 2,
-        "sha256": "a13673c490cd40b85b45c4ca20c0bef862861129abc6b75039c07ebd1addff50"
+        "sha256": "38ae1ee72c7070ab43d8fa24d91bde42a5ea3592d1ec1b4c79ee5da715b8f22e"
       },
       "generatedFiles": [
         {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -278,6 +278,7 @@ describe('generated-artifact base trust root workflow', () => {
       [3541, 'dev'],
       [3572, 'dev'],
       [3588, 'dev'],
+      [3603, 'dev'],
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',


### PR DESCRIPTION
Authorize generated runtime closures at exact head `9d6ca59c6c1eb985d61e228a0616160823fe1d35` for PR #3603.

**Generated artifacts (2):**
- `bridge/cli.cjs` (sha `c3802ae1`) — regenerated from updated `src/installer/mcp-registry.ts`
- `dist/installer/mcp-registry.js` (sha `99d3c36d`) — tsc output from updated source

**Merge base:** `0686239b0b6fa4e1b7d923d1b8b2aa3e7431dc15` (`origin/dev`)

Substantive CI at the authorized head is green: Test, Lint & Type Check, Windows path suite, Multi-repo AST-grep (both platforms), Size Check, Version Consistency, omc update + session-start hook.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*