### PR TITLE
ci: refresh authorization for PR #3602 rebased head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1518,8 +1518,8 @@
     {
       "pullNumber": 3602,
       "targetRef": "dev",
-      "mergeBaseSha": "23349fc99645175b34b283b1a3cc2e6f840ecdaf",
-      "headSha": "25631c08eb0f02607a307842f456f19099936478",
+      "mergeBaseSha": "124833654805b6b885f4ac7f9c87fdf285f08d00",
+      "headSha": "d17c59e3ecb374087065f4df88adc1deb26f59eb",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Base-owned generated-artifact authorization refresh for PR #3602 after its rebase onto dev `124833654805b6b885f4ac7f9c87fdf285f08d00`. Exact product head: `d17c59e3ecb374087065f4df88adc1deb26f59eb`; generated closure and manifest entry are updated only for this exact pair.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*