### PR TITLE
ci: authorize final head for PR #3602

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1518,8 +1518,8 @@
     {
       "pullNumber": 3602,
       "targetRef": "dev",
-      "mergeBaseSha": "124833654805b6b885f4ac7f9c87fdf285f08d00",
-      "headSha": "d17c59e3ecb374087065f4df88adc1deb26f59eb",
+      "mergeBaseSha": "6ab9452caf26e12385434f5436acd56884c6c817",
+      "headSha": "0a64a66cb299240a3de88dd4f4ccb03bd8dbdbef",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Base-owned generated-artifact authorization for the final exact PR #3602 head `0a64a66cb299240a3de88dd4f4ccb03bd8dbdbef` against dev base `6ab9452caf26e12385434f5436acd56884c6c817`. Manifest entry and generated closure are exact-head bound; no product source changes.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*