### PR TITLE
ci: authorize post-merge dev refresh for PR #3602

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1518,8 +1518,8 @@
     {
       "pullNumber": 3602,
       "targetRef": "dev",
-      "mergeBaseSha": "6ab9452caf26e12385434f5436acd56884c6c817",
-      "headSha": "0a64a66cb299240a3de88dd4f4ccb03bd8dbdbef",
+      "mergeBaseSha": "652948ed0132961d5d6cf1d5a58a5bb72bcd6c2c",
+      "headSha": "fcd73d701707c6e4ab976b072d0ebb67901f356c",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Base-owned authorization for PR #3602 exact head `fcd73d701707c6e4ab976b072d0ebb67901f356c` after refreshing onto dev `652948ed0132961d5d6cf1d5a58a5bb72bcd6c2c`. Generated closure remains exactly five files with the existing canonical digest.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*