### PR TITLE
ci: authorize latest head for PR #3602

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1518,8 +1518,8 @@
     {
       "pullNumber": 3602,
       "targetRef": "dev",
-      "mergeBaseSha": "652948ed0132961d5d6cf1d5a58a5bb72bcd6c2c",
-      "headSha": "fcd73d701707c6e4ab976b072d0ebb67901f356c",
+      "mergeBaseSha": "5cc4b4393d6c2287c7baf6abededbba1f689b200",
+      "headSha": "9dbde753415c17d5f6ef288dcfbd349924e978e6",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Base-owned authorization for latest exact PR #3602 head `9dbde753415c17d5f6ef288dcfbd349924e978e6` against dev base `5cc4b4393d6c2287c7baf6abededbba1f689b200`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*