### PR TITLE
ci: authorize post-merge head for PR #3588

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1348,8 +1348,8 @@
     {
       "pullNumber": 3588,
       "targetRef": "dev",
-      "mergeBaseSha": "46f26683032c4689fed0b6045cd1f156cefeae7a",
-      "headSha": "82f9eac566bb845449755737d2adb535c25f1222",
+      "mergeBaseSha": "37ecdd664c45bf948f5b52c1c3b2ca69057df2fd",
+      "headSha": "da4647c33a90c3c8b6ab29b5cf7c20f1ac1d289c",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-14T00:00:00.000Z",
       "generatedDelta": {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -323,8 +323,8 @@ describe('generated-artifact base trust root workflow', () => {
     const expected3588Authorization = {
       pullNumber: 3588,
       targetRef: 'dev',
-      mergeBaseSha: '46f26683032c4689fed0b6045cd1f156cefeae7a',
-      headSha: '82f9eac566bb845449755737d2adb535c25f1222',
+      mergeBaseSha: '37ecdd664c45bf948f5b52c1c3b2ca69057df2fd',
+      headSha: 'da4647c33a90c3c8b6ab29b5cf7c20f1ac1d289c',
       owner: 'Yeachan-Heo',
       expiresAt: '2026-08-14T00:00:00.000Z',
       generatedDelta: {


### PR DESCRIPTION
Successor base-owned authorization for PR #3588 after merged authorization PR #3614 advanced `dev`.

- supersedes merged #3614 authorization identity only;
- exact base: `37ecdd664c45bf948f5b52c1c3b2ca69057df2fd`;
- exact PR #3588 head: `da4647c33a90c3c8b6ab29b5cf7c20f1ac1d289c`;
- generated closure remains unchanged: 41 files;
- generated delta SHA-256 remains `34bfeded0fbadc7bd4acaad2ca35a7b12fdcfe5c4a0b529eff3d15c198384b02`.

Only the exact base/head identity in the protected manifest and canonical hard-coded fixture changes. Strict comparison semantics are unchanged.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*