### PR TITLE
ci: authorize final reconciled head for PR #3588

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1348,8 +1348,8 @@
     {
       "pullNumber": 3588,
       "targetRef": "dev",
-      "mergeBaseSha": "37ecdd664c45bf948f5b52c1c3b2ca69057df2fd",
-      "headSha": "da4647c33a90c3c8b6ab29b5cf7c20f1ac1d289c",
+      "mergeBaseSha": "b4061797a5535c54965fe5858f213332ebf32c63",
+      "headSha": "acea5fba944a6ada6daf848a3e07ca234cc9d8c8",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-14T00:00:00.000Z",
       "generatedDelta": {

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -323,8 +323,8 @@ describe('generated-artifact base trust root workflow', () => {
     const expected3588Authorization = {
       pullNumber: 3588,
       targetRef: 'dev',
-      mergeBaseSha: '37ecdd664c45bf948f5b52c1c3b2ca69057df2fd',
-      headSha: 'da4647c33a90c3c8b6ab29b5cf7c20f1ac1d289c',
+      mergeBaseSha: 'b4061797a5535c54965fe5858f213332ebf32c63',
+      headSha: 'acea5fba944a6ada6daf848a3e07ca234cc9d8c8',
       owner: 'Yeachan-Heo',
       expiresAt: '2026-08-14T00:00:00.000Z',
       generatedDelta: {


### PR DESCRIPTION
Final successor base-owned authorization for PR #3588 after the requested post-#3615 reconciliation.

- exact base/merge-base: `b4061797a5535c54965fe5858f213332ebf32c63`;
- exact #3588 head: `acea5fba944a6ada6daf848a3e07ca234cc9d8c8`;
- generated closure remains 41 files;
- generated delta remains `34bfeded0fbadc7bd4acaad2ca35a7b12fdcfe5c4a0b529eff3d15c198384b02`;
- strict manifest/fixture comparison semantics unchanged.

This supersedes merged authorization PRs #3614 and #3615 solely because their merge commits advanced the protected base and the candidate was explicitly reconciled afterward. After this authorization lands, PR #3588 must not be rewritten merely because `dev` advances by this authorization commit; its compare merge-base remains the authorized `b4061797a...`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*