### PR TITLE
fix(claude-md): remove over-verification guidance for Claude 5 models

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -14,8 +14,9 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 </operating_principles>
 
 <delegation_rules>
-Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
-Work directly for: trivial ops, small clarifications, single commands.
+Delegate for large, genuinely independent tracks of work: multi-file changes, refactors, wide investigations, planning, research.
+Work directly for: trivial ops, small clarifications, single commands, and anything finishable in a handful of tool calls.
+Do not delegate a subagent to verify or double-check your own work. If one subagent can do the job, use one rather than several.
 Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
 </delegation_rules>
 
@@ -52,16 +53,11 @@ Stages: `team-plan` → `team-prd` → `team-exec` → `team-verify` → `team-f
 Fix loop bounded by max attempts. `team ralph` links both modes.
 </team_pipeline>
 
-<verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
-If verification fails, keep iterating.
-</verification>
-
 <execution_protocols>
 Broad requests: explore first, then plan. 2+ independent tasks in parallel. `run_in_background` for builds/tests.
 Keep authoring and review as separate passes: writer pass creates or revises content, reviewer/verifier pass evaluates it later in a separate lane.
 Never self-approve in the same active context; use `code-reviewer` or `verifier` for the approval pass.
-Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+Before concluding: zero pending tasks, tests passing.
 </execution_protocols>
 
 <commit_protocol>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,9 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 </operating_principles>
 
 <delegation_rules>
-Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
-Work directly for: trivial ops, small clarifications, single commands.
+Delegate for large, genuinely independent tracks of work: multi-file changes, refactors, wide investigations, planning, research.
+Work directly for: trivial ops, small clarifications, single commands, and anything finishable in a handful of tool calls.
+Do not delegate a subagent to verify or double-check your own work. If one subagent can do the job, use one rather than several.
 Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
 </delegation_rules>
 
@@ -53,16 +54,11 @@ Stages: `team-plan` → `team-prd` → `team-exec` → `team-verify` → `team-f
 Fix loop bounded by max attempts. `team ralph` links both modes.
 </team_pipeline>
 
-<verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
-If verification fails, keep iterating.
-</verification>
-
 <execution_protocols>
 Broad requests: explore first, then plan. 2+ independent tasks in parallel. `run_in_background` for builds/tests.
 Keep authoring and review as separate passes: writer pass creates or revises content, reviewer/verifier pass evaluates it later in a separate lane.
 Never self-approve in the same active context; use `code-reviewer` or `verifier` for the approval pass.
-Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+Before concluding: zero pending tasks, tests passing.
 Local OMC fork: edits to `src/**/*.ts` require `npm run build` before they show up in the running Claude Code plugin (it loads `dist/`, not `src/`). After editing TS, surface a one-line reminder per editing round — see `skills/local-build-reminder/SKILL.md`. `.mjs`/`.cjs`/`.md` files load from disk; no build needed.
 </execution_protocols>
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -14,8 +14,9 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 </operating_principles>
 
 <delegation_rules>
-Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
-Work directly for: trivial ops, small clarifications, single commands.
+Delegate for large, genuinely independent tracks of work: multi-file changes, refactors, wide investigations, planning, research.
+Work directly for: trivial ops, small clarifications, single commands, and anything finishable in a handful of tool calls.
+Do not delegate a subagent to verify or double-check your own work. If one subagent can do the job, use one rather than several.
 Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usage → `document-specialist` (repo docs first; Context Hub / `chub` when available, graceful web fallback otherwise).
 </delegation_rules>
 
@@ -32,11 +33,6 @@ Team orchestration is explicit via `/team`.
 Detailed agent catalog, tools, team pipeline, commit protocol, and full skills registry live in the native `omc-reference` skill when skills are available, including reference for `explore`, `planner`, `architect`, `executor`, `designer`, and `writer`; this file remains sufficient without skill support.
 </skills>
 
-<verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
-If verification fails, keep iterating.
-</verification>
-
 <failure_mode_guards>
 User input: when clarification, preference, or approval is required and AskUserQuestion is available, use AskUserQuestion instead of ending with a prose question; ask one focused question with 2-4 options. Use prose only when AskUserQuestion is unavailable or a free-form value is required.
 Session/worktree continuity: before editing after resume/compaction or inside a linked worktree, re-check `git status --short --branch`, current cwd, and relevant `.omc/state/` or `.omc/handoffs/` artifacts so work does not continue on the wrong branch or stale context.
@@ -47,7 +43,7 @@ No fake completion: TODO-style placeholder notes, `test.skip`/`.only`, stub test
 Broad requests: explore first, then plan. 2+ independent tasks in parallel. `run_in_background` for builds/tests.
 Keep authoring and review as separate passes: writer pass creates or revises content, reviewer/verifier pass evaluates it later in a separate lane.
 Never self-approve in the same active context; use `code-reviewer` or `verifier` for the approval pass.
-Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+Before concluding: zero pending tasks, tests passing.
 </execution_protocols>
 
 <hooks_and_context>


### PR DESCRIPTION
Anthropic's [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) names explicit verification instructions as a pattern to **remove** for Claude 5 generation models:

> Claude Opus 5 verifies its own work without being told to. If your prompt contains explicit verification instructions ("include a final verification step for any non-trivial task," "use a subagent to verify"), remove them: instructions like these cause over-verification on Claude Opus 5, and removing them reduces wasted tokens with no loss in quality. The same applies to legacy harness scaffolding that adds separate verification steps.

The same guide notes Opus 5 delegates to subagents *more* readily than prior models, and recommends capping delegation rather than encouraging it:

> Delegate to a subagent only for large tasks that are genuinely independent and parallelizable [...] Do not delegate work you can finish yourself in a handful of tool calls, and do not use subagents to verify or double-check your own work.

For context on the wider shift, Anthropic's [context engineering post](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) reports removing over 80% of Claude Code's own system prompt for these models with no measurable loss on coding evals.

The coordinator template currently ships all three of the patterns above, so OMC users on Opus 5 and Fable 5 pay a token and latency cost that works against the model's trained behaviour.

## Changes

Three edits to the shipped template, applied consistently to `docs/CLAUDE.md` (canonical), `CLAUDE.md`, and `.github/CLAUDE.md`:

**1. Remove the `<verification>` block.** This is the guide's named example, including the verifier sizing line.

```diff
-<verification>
-Verify before claiming completion. Size appropriately: small→haiku, standard→sonnet, large/security→opus.
-If verification fails, keep iterating.
-</verification>
```

**2. Scope `<delegation_rules>` to large independent work**, and state that subagents must not verify the model's own output.

```diff
-Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
-Work directly for: trivial ops, small clarifications, single commands.
+Delegate for large, genuinely independent tracks of work: multi-file changes, refactors, wide investigations, planning, research.
+Work directly for: trivial ops, small clarifications, single commands, and anything finishable in a handful of tool calls.
+Do not delegate a subagent to verify or double-check your own work. If one subagent can do the job, use one rather than several.
```

**3. Drop `verifier evidence collected`** from the concluding checklist, for the same reason.

```diff
-Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+Before concluding: zero pending tasks, tests passing.
```

**`bridge/claude-md-coordinator.cjs` is deliberately not committed.** `docs/CLAUDE.md` is digest pinned by that artifact, so my first push included the regenerated file. That was wrong: it tripped `Authorize generated artifacts from base trust root`, which an external contributor cannot satisfy, and it was never necessary. `release.yml` runs `npm run build`, which includes `build:claude-md-coordinator`, so the artifact is regenerated from `docs/CLAUDE.md` on the way out.

Verified locally with `scripts/ci/check-no-committed-build-artifacts.mjs` against this PR's base and head: exit 1 with the artifact committed (`OWNER_CONFIRMATION_REQUIRED`), exit 0 without it. This PR is now three markdown files and nothing else.

## Deliberately not changed

**`<model_routing>` stays as is.** It looks like a candidate, since effort levels are now the primary cost control on Opus 5. But the Agent tool still accepts a `model` parameter, so haiku/sonnet/opus routing for subagents remains correct and is core to what OMC does. Removing it would also break the `should include model routing` assertion in `src/__tests__/installer.test.ts`. Out of scope here.

**`AGENTS.md` carries the same guidance** at lines 14, 50, and 290, but it is repo internal and does not ship to users, so I left it alone. Happy to follow up if you want it aligned.

**`Never self-approve in the same active context`** in `<execution_protocols>` is kept. It reads like verification scaffolding but it is a separation of duties rule, which is a different thing from asking the model to re-check itself.

## Testing

- `src/__tests__/installer.test.ts` 45/45 pass, including the `delegation_rules` and `model_routing` assertions.
- `src/installer/__tests__/claude-md-merge.test.ts` and `src/__tests__/setup-claude-md-script.test.ts` pass.
- `node scripts/plugin-shipping-surface.mjs verify` exits 0. Confirmed the check is real by tampering with `docs/CLAUDE.md` and watching it exit 1.
- `src/__tests__/plugin-shipping-surface.test.ts` has 7 failures on this machine, but they reproduce identically on the base commit with no changes applied, so they are environmental (`better-sqlite3` will not compile against Node 26, so deps were installed with `--ignore-scripts`). Not introduced by this PR.

Net effect on the template: 13 insertions, 25 deletions.
