### PR TITLE
fix(hud): bound timed-out provider renders

### DIFF
--- a/src/hud/__tests__/custom-rate-provider.test.ts
+++ b/src/hud/__tests__/custom-rate-provider.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnWithTimeout } from '../custom-rate-provider.js';
+
+describe('custom rate provider child lifecycle', () => {
+  it('terminates a timed-out command process group without retaining pipe handles', async () => {
+    if (process.platform === 'win32') return;
+
+    const directory = mkdtempSync(join(tmpdir(), 'omc-hud-provider-'));
+    const pidFile = join(directory, 'pid');
+    try {
+      await expect(
+        spawnWithTimeout(`echo $$ > ${JSON.stringify(pidFile)}; while :; do :; done`, 50),
+      ).rejects.toThrow('timed out');
+
+      const pid = Number(readFileSync(pidFile, 'utf8').trim());
+      expect(pid).toBeGreaterThan(0);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }, 2_000);
+
+  it('returns normal command output before the timeout', async () => {
+    await expect(spawnWithTimeout('printf normal-output', 500)).resolves.toBe('normal-output');
+  });
+
+});

--- a/src/hud/custom-rate-provider.ts
+++ b/src/hud/custom-rate-provider.ts
@@ -81,13 +81,29 @@ function isCacheValid(cache: CustomProviderCache): boolean {
  * Sends SIGTERM when the timeout fires, then SIGKILL after 200 ms if still
  * alive. The returned promise rejects on non-zero exit or timeout.
  */
-function spawnWithTimeout(cmd: string | string[], timeoutMs: number): Promise<string> {
+export function spawnWithTimeout(cmd: string | string[], timeoutMs: number): Promise<string> {
   return new Promise((resolve, reject) => {
     const [executable, ...args] = Array.isArray(cmd)
       ? cmd
       : (['sh', '-c', cmd] as string[]);
 
-    const child = spawn(executable, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(executable, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
+
+    const killTree = (signal: NodeJS.Signals): void => {
+      if (child.pid === undefined) return;
+      try {
+        if (process.platform === 'win32') {
+          child.kill(signal);
+        } else {
+          process.kill(-child.pid, signal);
+        }
+      } catch {
+        // The process group may already have exited.
+      }
+    };
 
     let stdout = '';
     child.stdout.on('data', (chunk: Buffer) => {
@@ -95,21 +111,19 @@ function spawnWithTimeout(cmd: string | string[], timeoutMs: number): Promise<st
     });
 
     let timedOut = false;
+    let escalationTimer: ReturnType<typeof setTimeout> | undefined;
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGTERM');
-      setTimeout(() => {
-        try {
-          child.kill('SIGKILL');
-        } catch {
-          // already exited
-        }
-      }, 200);
+      killTree('SIGTERM');
+      child.stdout.destroy();
+      child.stderr.destroy();
+      escalationTimer = setTimeout(() => killTree('SIGKILL'), 200);
       reject(new Error(`Custom rate limit command timed out after ${timeoutMs}ms`));
     }, timeoutMs);
 
     child.on('close', (code) => {
       clearTimeout(timer);
+      if (!timedOut && escalationTimer) clearTimeout(escalationTimer);
       if (!timedOut) {
         if (code === 0) {
           resolve(stdout);


### PR DESCRIPTION
Closes #3621

## Summary
- terminate timed-out custom HUD rate-limit provider process groups instead of only the shell child
- destroy retained stdout/stderr pipes and retain escalation until the timed-out process group is bounded
- add a regression proving a hanging provider is bounded and normal output remains valid
- keep the PR source-only: generated `dist` deltas are intentionally not shipped because the base-owned generated-artifact authorization gate rejects unauthorized generated changes; build/package closure was verified locally and CI

## Verification
- `npm run test:run -- src/hud/__tests__/custom-rate-provider.test.ts src/installer/__tests__/hud-cache-wrapper.test.ts src/__tests__/hud-cache-wrapper.test.ts src/__tests__/hud-wrapper-template-sync.test.ts`
- `npm run build`
- targeted ESLint and TypeScript check
- `npm run plugin:shipping:verify`
- `npm pack --dry-run --ignore-scripts`
- all required CI checks pass at the exact head

The fix avoids forced `process.exit`, daemon/scheduler changes, and unrelated generated artifacts.