### PR TITLE
feat(lsp): fall back to basedpyright when ty is not installed

### DIFF
--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
-import { LSP_SERVERS, getPythonServer, getServerForFile, getServerForLanguage, getTypeScriptServerForWorkspace } from '../tools/lsp/servers.js';
+import { LSP_SERVERS, getPythonServer, getServerForFile, getServerForLanguage, getTypeScriptServerForWorkspace, resolveServerForContext } from '../tools/lsp/servers.js';
 
 function createTypeScriptProject(options: { version: string; tsserver?: boolean; getExePath?: boolean; tscBin?: boolean }): string {
   const root = mkdtempSync(join(tmpdir(), 'omc-lsp-ts-'));
@@ -268,5 +268,23 @@ describe('Python server selection', () => {
   it('keeps ty as the registry default entry', () => {
     expect(LSP_SERVERS.python.command).toBe('ty');
     expect(LSP_SERVERS.python.args).toEqual(['server']);
+  });
+
+  it('probes inside the dev container, not the host, when a context is present', () => {
+    const context = { containerId: 'abc123', hostWorkspaceRoot: '/host/project', containerWorkspaceRoot: '/workspaces/project' };
+
+    // host has only basedpyright, container has only ty
+    const hostPickedBasedpyright = getPythonServer((command) => command === 'basedpyright-langserver');
+    expect(resolveServerForContext(hostPickedBasedpyright, context, (_ctx, command) => command === 'ty').command).toBe('ty');
+
+    // host has only ty, container has only basedpyright
+    const hostPickedTy = getPythonServer((command) => command === 'ty');
+    expect(resolveServerForContext(hostPickedTy, context, (_ctx, command) => command === 'basedpyright-langserver').command).toBe('basedpyright-langserver');
+  });
+
+  it('leaves non-python servers and host contexts untouched', () => {
+    const context = { containerId: 'abc123', hostWorkspaceRoot: '/host/project', containerWorkspaceRoot: '/workspaces/project' };
+    expect(resolveServerForContext(LSP_SERVERS.rust, null)).toBe(LSP_SERVERS.rust);
+    expect(resolveServerForContext(LSP_SERVERS.rust, context, () => false)).toBe(LSP_SERVERS.rust);
   });
 });

--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
-import { LSP_SERVERS, getServerForFile, getServerForLanguage, getTypeScriptServerForWorkspace } from '../tools/lsp/servers.js';
+import { LSP_SERVERS, getPythonServer, getServerForFile, getServerForLanguage, getTypeScriptServerForWorkspace } from '../tools/lsp/servers.js';
 
 function createTypeScriptProject(options: { version: string; tsserver?: boolean; getExePath?: boolean; tscBin?: boolean }): string {
   const root = mkdtempSync(join(tmpdir(), 'omc-lsp-ts-'));
@@ -64,7 +64,6 @@ describe('LSP Server Configurations', () => {
 describe('getServerForFile', () => {
   const cases: [string, string][] = [
     ['app.ts', 'TypeScript Language Server'],
-    ['app.py', 'Python Language Server (ty)'],
     ['main.rs', 'Rust Analyzer'],
     ['main.go', 'gopls'],
     ['main.c', 'clangd'],
@@ -180,7 +179,6 @@ describe('getServerForLanguage', () => {
   const cases: [string, string][] = [
     ['typescript', 'TypeScript Language Server'],
     ['javascript', 'TypeScript Language Server'],
-    ['python', 'Python Language Server (ty)'],
     ['rust', 'Rust Analyzer'],
     ['go', 'gopls'],
     ['golang', 'gopls'],
@@ -243,7 +241,31 @@ describe('OmniSharp command casing', () => {
 });
 
 describe('Python server selection', () => {
-  it('should invoke ty via its LSP subcommand', () => {
+  it('prefers ty when it is installed', () => {
+    const server = getPythonServer(() => true);
+    expect(server.command).toBe('ty');
+    expect(server.args).toEqual(['server']);
+  });
+
+  it('falls back to basedpyright when ty is missing', () => {
+    const server = getPythonServer((command) => command === 'basedpyright-langserver');
+    expect(server.command).toBe('basedpyright-langserver');
+    expect(server.args).toEqual(['--stdio']);
+  });
+
+  it('reports ty with a hint naming both options when neither is installed', () => {
+    const server = getPythonServer(() => false);
+    expect(server.command).toBe('ty');
+    expect(server.installHint).toContain('basedpyright');
+  });
+
+  it('routes .py files and the python language through the resolver', () => {
+    const resolved = getPythonServer();
+    expect(getServerForFile('app.py')).toEqual(resolved);
+    expect(getServerForLanguage('python')).toEqual(resolved);
+  });
+
+  it('keeps ty as the registry default entry', () => {
     expect(LSP_SERVERS.python.command).toBe('ty');
     expect(LSP_SERVERS.python.args).toEqual(['server']);
   });

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -16,7 +16,7 @@ import {
 } from './devcontainer.js';
 import type { DevContainerContext } from './devcontainer.js';
 import type { LspServerConfig } from './servers.js';
-import { getServerForFile, commandExists } from './servers.js';
+import { getServerForFile, commandExists, resolveServerForContext } from './servers.js';
 
 /** Default timeout (ms) for LSP requests. Override with OMC_LSP_TIMEOUT_MS env var. */
 export const DEFAULT_LSP_REQUEST_TIMEOUT_MS: number = (() => {
@@ -917,11 +917,12 @@ export class LspClientManager {
     }
 
     const devContainerContext = resolveDevContainerContext(workspaceRoot);
-    const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
+    const resolvedConfig = resolveServerForContext(serverConfig, devContainerContext);
+    const key = `${workspaceRoot}:${resolvedConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
 
     let client = this.clients.get(key);
     if (!client) {
-      client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
+      client = new LspClient(workspaceRoot, resolvedConfig, devContainerContext);
       try {
         await client.connect();
         this.clients.set(key, client);
@@ -948,11 +949,12 @@ export class LspClientManager {
     }
 
     const devContainerContext = resolveDevContainerContext(workspaceRoot);
-    const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
+    const resolvedConfig = resolveServerForContext(serverConfig, devContainerContext);
+    const key = `${workspaceRoot}:${resolvedConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
 
     let client = this.clients.get(key);
     if (!client) {
-      client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
+      client = new LspClient(workspaceRoot, resolvedConfig, devContainerContext);
       try {
         await client.connect();
         this.clients.set(key, client);

--- a/src/tools/lsp/devcontainer.ts
+++ b/src/tools/lsp/devcontainer.ts
@@ -141,6 +141,15 @@ export function containerUriToHostUri(uri: string, context: DevContainerContext 
   return pathToFileURL(containerPathToHostPath(fileURLToPath(uri), context)).href;
 }
 
+/**
+ * Check whether a command exists inside the container the LSP server will
+ * be launched in (via `docker exec`), as opposed to the host PATH.
+ */
+export function commandExistsInContainer(context: DevContainerContext, command: string): boolean {
+  const result = runDocker(['exec', context.containerId, 'sh', '-c', `command -v ${command}`]);
+  return result?.status === 0;
+}
+
 function resolveDevContainerConfigPath(workspaceRoot: string): string | undefined {
   let dir = workspaceRoot;
 

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -8,6 +8,8 @@
 import { spawnSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { dirname, extname, isAbsolute, join, parse, resolve } from 'path';
+import { commandExistsInContainer } from './devcontainer.js';
+import type { DevContainerContext } from './devcontainer.js';
 
 export interface LspServerConfig {
   name: string;
@@ -131,6 +133,26 @@ export function getPythonServer(isInstalled: (command: string) => boolean = comm
     return BASEDPYRIGHT_SERVER;
   }
   return TY_SERVER;
+}
+
+/**
+ * Re-resolve a server config for the context it will actually execute in.
+ * Python selection probes PATH, and when the server launches inside a dev
+ * container (docker exec) the probe must run there — the host and container
+ * may have different servers installed.
+ */
+export function resolveServerForContext(
+  config: LspServerConfig,
+  context: DevContainerContext | null,
+  probeContainer: (context: DevContainerContext, command: string) => boolean = commandExistsInContainer
+): LspServerConfig {
+  if (!context) {
+    return config;
+  }
+  if (config.command !== TY_SERVER.command && config.command !== BASEDPYRIGHT_SERVER.command) {
+    return config;
+  }
+  return getPythonServer((command) => probeContainer(context, command));
 }
 
 /**

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -101,18 +101,44 @@ export function getTypeScriptServerForWorkspace(workspaceRoot: string): LspServe
   };
 }
 
+const PYTHON_EXTENSIONS = ['.py', '.pyw'];
+
+const TY_SERVER: LspServerConfig = {
+  name: 'Python Language Server (ty)',
+  command: 'ty',
+  args: ['server'],
+  extensions: PYTHON_EXTENSIONS,
+  installHint: 'Install ty from https://github.com/astral-sh/ty (or basedpyright: uv tool install basedpyright)'
+};
+
+const BASEDPYRIGHT_SERVER: LspServerConfig = {
+  name: 'Python Language Server (basedpyright)',
+  command: 'basedpyright-langserver',
+  args: ['--stdio'],
+  extensions: PYTHON_EXTENSIONS,
+  installHint: 'uv tool install basedpyright'
+};
+
+/**
+ * Pick the Python language server: ty when installed, otherwise basedpyright
+ * when installed, otherwise ty (whose install hint names both options).
+ */
+export function getPythonServer(isInstalled: (command: string) => boolean = commandExists): LspServerConfig {
+  if (isInstalled(TY_SERVER.command)) {
+    return TY_SERVER;
+  }
+  if (isInstalled(BASEDPYRIGHT_SERVER.command)) {
+    return BASEDPYRIGHT_SERVER;
+  }
+  return TY_SERVER;
+}
+
 /**
  * Known LSP servers and their configurations
  */
 export const LSP_SERVERS: Record<string, LspServerConfig> = {
   typescript: TYPESCRIPT_CLASSIC_SERVER,
-  python: {
-    name: 'Python Language Server (ty)',
-    command: 'ty',
-    args: ['server'],
-    extensions: ['.py', '.pyw'],
-    installHint: 'Install ty from https://github.com/astral-sh/ty'
-  },
+  python: TY_SERVER,
   rust: {
     name: 'Rust Analyzer',
     command: 'rust-analyzer',
@@ -264,6 +290,10 @@ export function getServerForFile(filePath: string, workspaceRoot?: string): LspS
     return getTypeScriptServerForWorkspace(workspaceRoot);
   }
 
+  if (PYTHON_EXTENSIONS.includes(ext)) {
+    return getPythonServer();
+  }
+
   for (const [_, config] of Object.entries(LSP_SERVERS)) {
     if (config.extensions.includes(ext)) {
       return config;
@@ -277,10 +307,13 @@ export function getServerForFile(filePath: string, workspaceRoot?: string): LspS
  * Get all available servers (installed and not installed)
  */
 export function getAllServers(): Array<LspServerConfig & { installed: boolean }> {
-  return Object.values(LSP_SERVERS).map(config => ({
-    ...config,
-    installed: commandExists(config.command)
-  }));
+  return Object.entries(LSP_SERVERS).map(([key, config]) => {
+    const resolved = key === 'python' ? getPythonServer() : config;
+    return {
+      ...resolved,
+      installed: commandExists(resolved.command)
+    };
+  });
 }
 
 /**
@@ -337,6 +370,9 @@ export function getServerForLanguage(language: string): LspServerConfig | null {
   };
 
   const serverKey = langMap[language.toLowerCase()];
+  if (serverKey === 'python') {
+    return getPythonServer();
+  }
   if (serverKey && LSP_SERVERS[serverKey]) {
     return LSP_SERVERS[serverKey];
   }


### PR DESCRIPTION
## What this does

The Python entry in the LSP registry is hardcoded to `ty`. If someone has basedpyright installed instead, the `lsp_*` tools report "no language server available" even though a perfectly good Python server is sitting on their PATH.

This PR keeps `ty` as the preferred server and adds `basedpyright-langserver --stdio` as a fallback when `ty` isn't installed — the same pattern the registry already uses for TypeScript (classic server vs typescript-go, resolved by what's actually available).

## Why basedpyright is worth supporting

- **It's the most widely deployed Python language server family.** basedpyright is a maintained superset of pyright, which is what powers Python in VS Code — so its answers match what most people's editors already say.
- **It reads `pyrightconfig.json`.** Many Python repos already carry one (venv wiring, type-checking strictness). ty ignores that file; basedpyright picks it up, so the bridge inherits the project's existing configuration with zero extra setup.
- **It installs standalone.** `uv tool install basedpyright` or `pipx install basedpyright` — a self-contained binary, no npm required.
- **ty stays the default.** ty is a great choice and this doesn't change it. But it's still 0.0.x, and some users can't or don't want to run a second Python checker alongside the one their project already standardizes on. The fallback covers them without costing ty users anything.

## Behavior

- `ty` on PATH → exactly as today.
- `ty` missing, `basedpyright-langserver` on PATH → the bridge uses basedpyright.
- Neither → same "not installed" outcome as today; the install hint now mentions both options.
- The `lsp_servers` listing reflects whichever server resolved.

## Tested

- `npx vitest run src/__tests__/lsp-servers.test.ts` — 104 passed; `src/tools/diagnostics/__tests__/lsp-aggregator.test.ts` — 4 passed; `tsc --noEmit` and `eslint` clean on the changed files.
- hover / definition / references / rename all verified working through `basedpyright-langserver --stdio` (basedpyright 1.39.5, macOS).
- Unit tests cover the resolver via an injectable `isInstalled` predicate: ty present, ty absent + basedpyright present, neither.

Closes #3624.