### PR TITLE
feat(hud): reasoning-effort display + fix stale model after /model (closes #1675)

### DIFF
--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -68,7 +68,8 @@ cat > "$INPUT_TMP" 2>/dev/null || :
 
 extract_json_string() {
   key=$1
-  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$INPUT_TMP" 2>/dev/null | head -1
+  file=${2:-$INPUT_TMP}
+  sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$file" 2>/dev/null | head -1
 }
 
 SESSION_KEY=$(extract_json_string session_id)
@@ -106,6 +107,28 @@ if [ -s "$INPUT_TMP" ]; then
   mv "$INPUT_TMP" "$INPUT_FILE" 2>/dev/null || cp "$INPUT_TMP" "$INPUT_FILE" 2>/dev/null || :
 fi
 rm -f "$INPUT_TMP" 2>/dev/null || :
+
+# Detect a model/effort switch (e.g. `/model`) so the hot path below can
+# force a synchronous refresh instead of serving stale cached text. Claude
+# Code does not reliably re-poll the statusLine right after a bare /model
+# selection, so without this the wrong model can stay on screen until some
+# unrelated interaction happens to trigger another statusLine call.
+MARKER_FILE="$CACHE_DIR/model-effort.$SESSION_KEY.txt"
+NEW_MARKER=""
+MODEL_CHANGED=0
+if [ -s "$INPUT_FILE" ]; then
+  NEW_MODEL_ID=$(extract_json_string id "$INPUT_FILE")
+  if [ -n "$NEW_MODEL_ID" ]; then
+    NEW_EFFORT_LEVEL=$(extract_json_string level "$INPUT_FILE")
+    NEW_MARKER="${NEW_MODEL_ID}|${NEW_EFFORT_LEVEL}"
+    if [ -f "$MARKER_FILE" ]; then
+      PREV_MARKER=$(cat "$MARKER_FILE" 2>/dev/null)
+      if [ "$NEW_MARKER" != "$PREV_MARKER" ]; then
+        MODEL_CHANGED=1
+      fi
+    fi
+  fi
+fi
 
 try_acquire_lock() {
   if mkdir "$LOCK_DIR" 2>/dev/null; then
@@ -145,6 +168,9 @@ refresh_cache() {
   # Keep the last good line if rendering fails or returns empty output.
   if [ -s "$NODE_STDOUT_TMP" ]; then
     mv "$NODE_STDOUT_TMP" "$OUTPUT_FILE" 2>/dev/null || cp "$NODE_STDOUT_TMP" "$OUTPUT_FILE" 2>/dev/null || :
+    if [ -n "$NEW_MARKER" ]; then
+      printf '%s' "$NEW_MARKER" > "$MARKER_FILE" 2>/dev/null || :
+    fi
   fi
 
   rm -f "$NODE_STDOUT_TMP" "$NODE_STDERR_TMP" 2>/dev/null || :
@@ -152,8 +178,9 @@ refresh_cache() {
   trap - EXIT HUP INT TERM
 }
 
-# Hot path: return immediately from the last successful render for this session.
-if [ -s "$OUTPUT_FILE" ]; then
+# Hot path: return immediately from the last successful render for this
+# session, unless the model/effort just changed (see MODEL_CHANGED above).
+if [ -s "$OUTPUT_FILE" ] && [ "$MODEL_CHANGED" != "1" ]; then
   cat "$OUTPUT_FILE" 2>/dev/null || printf '[OMC] Starting...\n'
   # Refresh in background for the next frame.
   if try_acquire_lock; then
@@ -166,15 +193,23 @@ if [ -s "$OUTPUT_FILE" ]; then
   exit 0
 fi
 
-# First render for this session: do a synchronous refresh so the user
-# sees the real HUD from the first frame. Claude Code v2.1.x does not
-# re-poll the statusLine until user interaction, so an async background
-# refresh leaves the pane stuck on "[OMC] Starting..." until they type.
+# First render for this session, or a just-detected model/effort switch: do
+# a synchronous refresh so the user sees the correct HUD on this frame.
+# Claude Code v2.1.x does not re-poll the statusLine until user interaction,
+# so an async background refresh could leave a stale/placeholder line on
+# screen until some unrelated interaction happens to trigger another call.
 if [ -s "$INPUT_FILE" ] && try_acquire_lock; then
   refresh_cache
   if [ -s "$OUTPUT_FILE" ]; then
     cat "$OUTPUT_FILE" 2>/dev/null && exit 0
   fi
+fi
+
+# Couldn't refresh synchronously (e.g. a background refresh already holds
+# the lock) — fall back to the last good render rather than a blank
+# placeholder; the next call will pick up the fresh content.
+if [ -s "$OUTPUT_FILE" ]; then
+  cat "$OUTPUT_FILE" 2>/dev/null && exit 0
 fi
 
 printf '[OMC] Starting...\n'

--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -72,6 +72,19 @@ extract_json_string() {
   sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" "$file" 2>/dev/null | head -1
 }
 
+# Like extract_json_string, but scoped to a specific flat parent object
+# (e.g. "id" within "model":{...}) instead of the first bare match anywhere
+# in the payload. Both `model` and `effort` are flat, single-level objects
+# in the real statusline schema, so matching up to the first `}` is safe.
+extract_nested_json_string() {
+  parent=$1
+  key=$2
+  file=${3:-$INPUT_TMP}
+  object=$(sed -n "s/.*\"$parent\"[[:space:]]*:[[:space:]]*{\([^}]*\)}.*/\1/p" "$file" 2>/dev/null | head -1)
+  [ -n "$object" ] || return 0
+  printf '%s' "$object" | sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+}
+
 SESSION_KEY=$(extract_json_string session_id)
 if [ -z "$SESSION_KEY" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
   SESSION_KEY=$CLAUDE_SESSION_ID
@@ -117,9 +130,9 @@ MARKER_FILE="$CACHE_DIR/model-effort.$SESSION_KEY.txt"
 NEW_MARKER=""
 MODEL_CHANGED=0
 if [ -s "$INPUT_FILE" ]; then
-  NEW_MODEL_ID=$(extract_json_string id "$INPUT_FILE")
+  NEW_MODEL_ID=$(extract_nested_json_string model id "$INPUT_FILE")
   if [ -n "$NEW_MODEL_ID" ]; then
-    NEW_EFFORT_LEVEL=$(extract_json_string level "$INPUT_FILE")
+    NEW_EFFORT_LEVEL=$(extract_nested_json_string effort level "$INPUT_FILE")
     NEW_MARKER="${NEW_MODEL_ID}|${NEW_EFFORT_LEVEL}"
     if [ -f "$MARKER_FILE" ]; then
       PREV_MARKER=$(cat "$MARKER_FILE" 2>/dev/null)
@@ -168,9 +181,16 @@ refresh_cache() {
   # Keep the last good line if rendering fails or returns empty output.
   if [ -s "$NODE_STDOUT_TMP" ]; then
     mv "$NODE_STDOUT_TMP" "$OUTPUT_FILE" 2>/dev/null || cp "$NODE_STDOUT_TMP" "$OUTPUT_FILE" 2>/dev/null || :
-    if [ -n "$NEW_MARKER" ]; then
-      printf '%s' "$NEW_MARKER" > "$MARKER_FILE" 2>/dev/null || :
-    fi
+  fi
+
+  # Record that we've reacted to this model/effort regardless of whether the
+  # render itself succeeded. The marker means "already forced a synchronous
+  # refresh for this selection", not "successfully rendered it" — otherwise a
+  # renderer that keeps failing would never advance the marker, and every
+  # single frame would retry a blocking foreground Node spawn forever instead
+  # of falling back to the cheap hot path like it did before this selection.
+  if [ -n "$NEW_MARKER" ]; then
+    printf '%s' "$NEW_MARKER" > "$MARKER_FILE" 2>/dev/null || :
   fi
 
   rm -f "$NODE_STDOUT_TMP" "$NODE_STDERR_TMP" 2>/dev/null || :

--- a/src/__tests__/hud/model.test.ts
+++ b/src/__tests__/hud/model.test.ts
@@ -92,18 +92,16 @@ describe('model element', () => {
       expect(result).toContain('Model: Sonnet 5 (high)');
     });
 
-    it('omits the effort suffix when effort level is null', () => {
-      const result = renderModel('claude-sonnet-5', 'versioned', undefined, null);
-      expect(result).not.toBeNull();
-      expect(result).toContain('Model: Sonnet 5');
-      expect(result).not.toContain('(');
-    });
-
-    it('omits the effort suffix when effort level is omitted', () => {
-      const result = renderModel('claude-sonnet-5', 'versioned');
-      expect(result).not.toBeNull();
-      expect(result).toContain('Model: Sonnet 5');
-      expect(result).not.toContain('(');
+    it('omits the effort suffix when effort level is null or omitted', () => {
+      // Compare against the omitted-argument call instead of asserting
+      // "no parenthesis in the output" — that assertion would be brittle
+      // against unrelated model IDs that legitimately render parenthesized
+      // detail (e.g. a future "Opus 4.8 (1M context)" format).
+      const withNullEffort = renderModel('claude-sonnet-5', 'versioned', undefined, null);
+      const withOmittedEffort = renderModel('claude-sonnet-5', 'versioned');
+      expect(withNullEffort).not.toBeNull();
+      expect(withNullEffort).toBe(withOmittedEffort);
+      expect(withNullEffort).toContain('Model: Sonnet 5');
     });
   });
 });

--- a/src/__tests__/hud/model.test.ts
+++ b/src/__tests__/hud/model.test.ts
@@ -85,5 +85,25 @@ describe('model element', () => {
     it('returns null for null input', () => {
       expect(renderModel(null)).toBeNull();
     });
+
+    it('appends the reasoning-effort level when provided', () => {
+      const result = renderModel('claude-sonnet-5', 'versioned', undefined, 'high');
+      expect(result).not.toBeNull();
+      expect(result).toContain('Model: Sonnet 5 (high)');
+    });
+
+    it('omits the effort suffix when effort level is null', () => {
+      const result = renderModel('claude-sonnet-5', 'versioned', undefined, null);
+      expect(result).not.toBeNull();
+      expect(result).toContain('Model: Sonnet 5');
+      expect(result).not.toContain('(');
+    });
+
+    it('omits the effort suffix when effort level is omitted', () => {
+      const result = renderModel('claude-sonnet-5', 'versioned');
+      expect(result).not.toBeNull();
+      expect(result).toContain('Model: Sonnet 5');
+      expect(result).not.toContain('(');
+    });
   });
 });

--- a/src/__tests__/hud/render.test.ts
+++ b/src/__tests__/hud/render.test.ts
@@ -836,10 +836,15 @@ describe('optional HUD line defaults', () => {
 });
 
 describe('HUD model display', () => {
-  const createModelContext = (modelName: string | null, modelId: string | null = null): HudRenderContext => ({
+  const createModelContext = (
+    modelName: string | null,
+    modelId: string | null = null,
+    effortLevel: string | null = null,
+  ): HudRenderContext => ({
     contextPercent: 0,
     modelName,
     modelId,
+    effortLevel,
     ralph: null,
     ultrawork: null,
     prd: null,
@@ -939,5 +944,24 @@ describe('HUD model display', () => {
 
     expect(output).toBe('\u001b[1m[OMC#4.14.0]\u001b[0m');
     expect(output).not.toContain('Unknown');
+  });
+
+  it('renders the reasoning-effort level end-to-end through the effortLevel context field', async () => {
+    const output = await render(
+      createModelContext('Claude Sonnet 4.5', null, 'high'),
+      modelConfig,
+    );
+
+    expect(output).toContain('Model: Sonnet 4.5 (high)');
+  });
+
+  it('omits the effort level when the effortLevel element is disabled in config', async () => {
+    const output = await render(
+      createModelContext('Claude Sonnet 4.5', null, 'high'),
+      { ...modelConfig, elements: { ...modelConfig.elements, effortLevel: false } },
+    );
+
+    expect(output).toContain('Model: Sonnet 4.5');
+    expect(output).not.toContain('(high)');
   });
 });

--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -7,6 +7,7 @@ import { execSync } from 'child_process';
 import type { StatuslineStdin } from '../../hud/types.js';
 import {
   getContextPercent,
+  getEffortLevel,
   getModelId,
   getModelName,
   getRateLimitsFromStdin,
@@ -292,6 +293,21 @@ describe('HUD stdin model display', () => {
 
     expect(getModelName(stdin)).toBeNull();
     expect(getModelId(stdin)).toBeNull();
+  });
+});
+
+describe('HUD stdin effort level', () => {
+  it('reads the effort level from stdin', () => {
+    const stdin = makeStdin({ effort: { level: 'high' } });
+    expect(getEffortLevel(stdin)).toBe('high');
+  });
+
+  it('returns null when stdin omits the effort block', () => {
+    expect(getEffortLevel(makeStdin({ effort: undefined }))).toBeNull();
+  });
+
+  it('returns null for a blank effort level instead of guessing', () => {
+    expect(getEffortLevel(makeStdin({ effort: { level: '   ' } }))).toBeNull();
   });
 });
 

--- a/src/hud/elements/model.ts
+++ b/src/hud/elements/model.ts
@@ -77,8 +77,10 @@ export function renderModel(
   modelId: string | null | undefined,
   format: ModelFormat = 'versioned',
   labels: Pick<HudLabels, 'model'> = DEFAULT_HUD_LABELS,
+  effortLevel: string | null = null,
 ): string | null {
   const name = formatModelName(modelId, format);
   if (!name) return null;
-  return cyan(`${labels.model}: ${name}`);
+  const effortSuffix = effortLevel ? ` (${effortLevel})` : '';
+  return cyan(`${labels.model}: ${name}${effortSuffix}`);
 }

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -13,6 +13,7 @@ import {
   getContextPercent,
   getModelId,
   getModelName,
+  getEffortLevel,
   getRateLimitsFromStdin,
   stabilizeContextPercent,
 } from "./stdin.js";
@@ -461,6 +462,7 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
       contextDisplayScope: currentSessionId ?? cwd,
       modelName: getModelName(stdin),
       modelId: getModelId(stdin),
+      effortLevel: getEffortLevel(stdin),
       ralph,
       ultrawork,
       prd,

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -288,11 +288,12 @@ export async function render(
     ? context.modelId ?? context.modelName
     : context.modelName;
   if (enabledElements.model && modelSource) {
+    const showEffortLevel = enabledElements.effortLevel ?? true;
     const modelElement = renderModel(
       modelSource,
       enabledElements.modelFormat,
       hudLabels,
-      context.effortLevel ?? null,
+      showEffortLevel ? context.effortLevel ?? null : null,
     );
     if (modelElement) rendered.set("model", modelElement);
   }

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -292,6 +292,7 @@ export async function render(
       modelSource,
       enabledElements.modelFormat,
       hudLabels,
+      context.effortLevel ?? null,
     );
     if (modelElement) rendered.set("model", modelElement);
   }

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -405,3 +405,13 @@ export function getModelName(stdin: StatuslineStdin): string | null {
   const displayName = stdin.model?.display_name?.trim();
   return displayName || getModelId(stdin);
 }
+
+/**
+ * Get the current reasoning-effort level from stdin (e.g. 'low', 'medium',
+ * 'high', 'xhigh', 'max'). Returns null when Claude Code does not provide
+ * effort metadata.
+ */
+export function getEffortLevel(stdin: StatuslineStdin): string | null {
+  const level = stdin.effort?.level?.trim();
+  return level || null;
+}

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -57,6 +57,11 @@ export interface StatuslineStdin {
     display_name?: string;
   };
 
+  /** Reasoning-effort metadata from Claude Code statusline stdin */
+  effort?: {
+    level?: string;
+  };
+
   /** Context window metrics from Claude Code statusline stdin */
   context_window?: {
     context_window_size?: number;
@@ -346,6 +351,9 @@ export interface HudRenderContext {
 
   /** Raw model id from Claude Code statusline stdin; used when full model format is requested */
   modelId?: string | null;
+
+  /** Reasoning-effort level from Claude Code statusline stdin; null when unavailable */
+  effortLevel?: string | null;
 
   /** Ralph loop state */
   ralph: RalphStateForHud | null;

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -597,6 +597,7 @@ export interface HudElementConfig {
   gitInfoPosition: 'above' | 'below';  // Position of git info relative to main HUD line
   model: boolean;            // Show current model name
   modelFormat: ModelFormat;   // Model name verbosity level
+  effortLevel?: boolean;      // Show reasoning-effort level next to the model name (default: true)
   omcLabel: boolean;
   updateNotification?: boolean; // Show available-update prompt text in the OMC label
   rateLimits: boolean;  // Show 5h and weekly rate limits
@@ -730,6 +731,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     gitInfoPosition: 'above',  // Git info above main HUD line (backward compatible)
     model: true,              // Show only when Claude Code statusline stdin provides a model
     modelFormat: 'versioned', // Preserve model version by default
+    effortLevel: true,        // Show reasoning-effort level next to the model name
     omcLabel: true,
     updateNotification: true, // Preserve existing update prompt behavior by default
     rateLimits: true,  // Show rate limits by default
@@ -791,6 +793,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     gitInfoPosition: 'above',
     model: true,
     modelFormat: 'versioned',
+    effortLevel: false,  // Keep the model line short in the minimal preset
     omcLabel: true,
     updateNotification: true,
     rateLimits: true,
@@ -834,6 +837,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     gitInfoPosition: 'above',
     model: true,
     modelFormat: 'versioned',
+    effortLevel: true,
     omcLabel: true,
     updateNotification: true,
     rateLimits: true,
@@ -877,6 +881,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     gitInfoPosition: 'above',
     model: true,
     modelFormat: 'versioned',
+    effortLevel: true,
     omcLabel: true,
     updateNotification: true,
     rateLimits: true,
@@ -920,6 +925,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     gitInfoPosition: 'above',
     model: true,
     modelFormat: 'versioned',
+    effortLevel: true,
     omcLabel: true,
     updateNotification: true,
     rateLimits: false,
@@ -963,6 +969,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     gitInfoPosition: 'above',
     model: true,
     modelFormat: 'versioned',
+    effortLevel: true,
     omcLabel: true,
     updateNotification: true,
     rateLimits: true,

--- a/src/installer/__tests__/hud-cache-wrapper.test.ts
+++ b/src/installer/__tests__/hud-cache-wrapper.test.ts
@@ -291,4 +291,104 @@ describe('HUD cached statusLine launcher', () => {
     }
   });
 
+  it('forces a synchronous refresh when the model changed since the last recorded marker', () => {
+    // Without this, a bare `/model` switch would keep showing the stale
+    // cached model line until some unrelated interaction happened to
+    // trigger another statusLine call (see hud-cache-wrapper.sh comments).
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'OLD MODEL LINE\n');
+      writeFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'claude-old|');
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nprintf "NEW MODEL LINE\\n"\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('NEW MODEL LINE\n');
+      expect(readFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'utf8')).toBe('NEW MODEL LINE\n');
+      expect(readFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'utf8')).toBe('claude|');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not force a synchronous refresh when the model/effort marker is unchanged', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'CACHED HUD LINE\n');
+      writeFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'claude|');
+      mkdirSync(join(staged.cacheDir, 'render.session-123.lock'));
+
+      const nodeMarker = join(staged.dir, 'node-invoked');
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), `#!/bin/sh\ntouch ${JSON.stringify(nodeMarker)}\nexit 0\n`, 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('CACHED HUD LINE\n');
+      expect(existsSync(nodeMarker)).toBe(false);
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the last good render when the model changed but a refresh is already in flight', () => {
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'OLD MODEL LINE\n');
+      writeFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'claude-old|');
+      mkdirSync(join(staged.cacheDir, 'render.session-123.lock'));
+
+      const nodeMarker = join(staged.dir, 'node-invoked');
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), `#!/bin/sh\ntouch ${JSON.stringify(nodeMarker)}\nexit 0\n`, 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('OLD MODEL LINE\n');
+      expect(existsSync(nodeMarker)).toBe(false);
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/installer/__tests__/hud-cache-wrapper.test.ts
+++ b/src/installer/__tests__/hud-cache-wrapper.test.ts
@@ -327,16 +327,22 @@ describe('HUD cached statusLine launcher', () => {
   });
 
   it('does not force a synchronous refresh when the model/effort marker is unchanged', () => {
+    // Deliberately does NOT pre-hold the render lock: with a held lock, the
+    // hot path and the (incorrectly) forced-sync path both degrade to "cat
+    // the stale render and exit", making them indistinguishable. Instead,
+    // the fake `node` sleeps well past the process timeout. If MODEL_CHANGED
+    // were wrongly true here, the wrapper would block on a foreground
+    // `refresh_cache` waiting on that sleep and get killed by the timeout —
+    // so a clean, on-time exit with the cached content proves the refresh
+    // ran only in the background, i.e. the ordinary hot path was taken.
     const staged = stageWrapper();
     try {
       writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'CACHED HUD LINE\n');
       writeFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'claude|');
-      mkdirSync(join(staged.cacheDir, 'render.session-123.lock'));
 
-      const nodeMarker = join(staged.dir, 'node-invoked');
       const fakeBin = join(staged.dir, 'bin');
       mkdirSync(fakeBin, { recursive: true });
-      writeFileSync(join(fakeBin, 'node'), `#!/bin/sh\ntouch ${JSON.stringify(nodeMarker)}\nexit 0\n`, 'utf8');
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nsleep 2\nprintf "SHOULD NOT BE SEEN SYNCHRONOUSLY\\n"\n', 'utf8');
       chmodSync(join(fakeBin, 'node'), 0o755);
 
       const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
@@ -348,18 +354,25 @@ describe('HUD cached statusLine launcher', () => {
           CLAUDE_CONFIG_DIR: staged.dir,
           OMC_HUD_CACHE_DIR: staged.cacheDir,
         },
-        timeout: 1000,
+        timeout: 800,
       });
 
       expect(result.status).toBe(0);
       expect(result.stdout).toBe('CACHED HUD LINE\n');
-      expect(existsSync(nodeMarker)).toBe(false);
     } finally {
       rmSync(staged.dir, { recursive: true, force: true });
     }
   });
 
-  it('falls back to the last good render when the model changed but a refresh is already in flight', () => {
+  it('never regresses to a blank placeholder when the model changed but a refresh is already in flight', () => {
+    // With the render lock held, a forced synchronous refresh cannot
+    // acquire it and must fall back to the last good render — the same
+    // externally-observable outcome as the ordinary hot path taking that
+    // branch, since neither can spawn `node` while the lock is held. This
+    // test cannot distinguish which internal branch produced the output;
+    // it locks in the invariant that matters to the user: a model/effort
+    // change under lock contention must never show the blank "[OMC]
+    // Starting..." placeholder over an existing stale render.
     const staged = stageWrapper();
     try {
       writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'OLD MODEL LINE\n');
@@ -387,6 +400,100 @@ describe('HUD cached statusLine launcher', () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toBe('OLD MODEL LINE\n');
       expect(existsSync(nodeMarker)).toBe(false);
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('advances the marker even when the render fails, so repeated renderer failures do not force a synchronous refresh forever', () => {
+    // Regression test for a bug where the marker write was nested inside
+    // the "render succeeded" guard: a renderer that kept failing (no
+    // stdout) would never advance the marker, so MODEL_CHANGED stayed
+    // true forever and every single frame blocked on a synchronous,
+    // foreground `node` spawn instead of falling back to the cheap hot
+    // path once the marker had been recorded.
+    const staged = stageWrapper();
+    try {
+      writeFileSync(join(staged.cacheDir, 'statusline.session-123.txt'), 'OLD MODEL LINE\n');
+      writeFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'claude-old|');
+
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      // Always fails (no stdout) and sleeps 2s, so a second *synchronous*
+      // spawn on call 2 would be caught by that call's 800ms timeout.
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nsleep 2\nexit 1\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const env = {
+        ...process.env,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        CLAUDE_CONFIG_DIR: staged.dir,
+        OMC_HUD_CACHE_DIR: staged.cacheDir,
+      };
+
+      // Call 1: model changed, forces a synchronous refresh; the renderer
+      // fails (no stdout) but the marker must still advance.
+      const first = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env,
+        timeout: 3000,
+      });
+      expect(first.status).toBe(0);
+      expect(first.stdout).toBe('OLD MODEL LINE\n');
+      expect(readFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'utf8')).toBe('claude|');
+
+      // Call 2: marker now matches, so this must take the cheap hot path
+      // and return well before the fake node's 2s sleep would allow.
+      const second = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: stdinPayload,
+        encoding: 'utf8',
+        env,
+        timeout: 800,
+      });
+      expect(second.status).toBe(0);
+      expect(second.stdout).toBe('OLD MODEL LINE\n');
+    } finally {
+      rmSync(staged.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('scopes model id extraction to the model object, ignoring an unrelated bare "id" key elsewhere in the payload', () => {
+    // Regression test for the unscoped `extract_json_string id`, whose
+    // greedy sed pattern matched the LAST bare "id" key anywhere in the
+    // payload. With a decoy "id" after "model" in the JSON, that returned
+    // the decoy value instead of the real model id.
+    const staged = stageWrapper();
+    try {
+      const fakeBin = join(staged.dir, 'bin');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nprintf "RENDERED\\n"\n', 'utf8');
+      chmodSync(join(fakeBin, 'node'), 0o755);
+
+      const decoyPayload = JSON.stringify({
+        session_id: 'session-123',
+        cwd: '/tmp',
+        transcript_path: '/tmp/session.jsonl',
+        model: { id: 'claude-real' },
+        agent: { id: 'DECOY-ID' },
+      });
+
+      const result = spawnSync('sh', [staged.wrapperPath, staged.hudPath], {
+        input: decoyPayload,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:/usr/bin:/bin`,
+          CLAUDE_CONFIG_DIR: staged.dir,
+          OMC_HUD_CACHE_DIR: staged.cacheDir,
+          OMC_HUD_SYNC_REFRESH: '1',
+        },
+        timeout: 1000,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe('RENDERED\n');
+      expect(readFileSync(join(staged.cacheDir, 'model-effort.session-123.txt'), 'utf8')).toBe('claude-real|');
     } finally {
       rmSync(staged.dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Adds a reasoning-effort level next to the Model element, e.g. `Model: Sonnet 5 (high)`. Claude Code's statusLine stdin already includes `effort.level` — the HUD just never read it. Closes #1675. Configurable via a new `effortLevel` element toggle (default `true`; `false` in the `minimal` preset to keep that line short), matching the existing `showCallCounts`-style optional-boolean convention.
- Fixes a related bug: `hud-cache-wrapper.sh`'s hot path always serves the stale cached line and refreshes in the background "for the next frame." Since Claude Code doesn't reliably re-poll the statusLine right after a bare `/model` switch (per the wrapper's own existing comment), that next frame may never come — the wrong model stays on screen until an unrelated interaction happens. The wrapper now tracks the last-rendered model/effort in a small per-session marker file and forces a synchronous refresh when it changes, falling back to the stale render (never a blank placeholder) if a background refresh is already in flight.

## Review process

This branch went through two rounds of adversarial review by a fresh-context agent with no prior knowledge of the implementation, per the contributor's usual practice. Round 1 found:
- **HIGH**: the model/effort marker was only written on render success, so a renderer that kept failing would force a blocking, synchronous `node` spawn on every single frame forever. Fixed by advancing the marker regardless of render success — reproduced the exact failure scenario before and after the fix.
- **MEDIUM**: the effort suffix had no config toggle, unlike every other HUD element. Added `effortLevel?: boolean` to `HudElementConfig`.
- **MEDIUM x2**: two new tests were vacuous under mutation testing (a pre-held render lock made the old and new code paths produce identical output). Rewrote one with a timing discriminator (sleeping fake renderer + tight process timeout) and re-scoped the other's claim to the invariant it actually protects.
- **LOW**: the shell wrapper's `id`/`level` extraction used an unscoped, greedy sed match that could pick up an unrelated bare `"id"` key elsewhere in the payload. Scoped extraction to within the `model`/`effort` objects specifically.

Round 2 confirmed all of the above fixed and held up under manual mutation testing (reverting each fix independently reproduces the original failure in its corresponding test).

I manually applied this patch to my own local plugin install and used it for a live session before opening this PR — the effort suffix renders correctly and the model line updates immediately after `/model` without needing another interaction first.

## Test plan

- `npm run test:run`: full suite passes except 2 pre-existing failures in `watch-mode-init.test.ts` unrelated to this change (reproduced identically on a clean `upstream/dev` checkout via `git stash`).
- Targeted suite (`src/hud`, `src/__tests__/hud`, `src/installer/__tests__/hud-cache-wrapper.test.ts`, `src/__tests__/hud-cache-wrapper.test.ts`): 133 tests, all passing.
- Every new/rewritten test verified to fail (RED) against its corresponding pre-fix code via manual mutation, then pass (GREEN) against the fix.
- `npm run lint`: 0 errors (pre-existing unrelated warnings only).
- `npx tsc --noEmit`: clean.
- `npm run build`: succeeds; verified the compiled output renders `Model: Sonnet 5 (high)` against a real captured statusline payload.
- `npm run format` was **not** run — a clean `upstream/dev` checkout already fails `prettier --check` on ~1148 files (pre-existing repo-wide drift, confirmed in a throwaway worktree), so running it would have produced an unrelated 1148-file diff. The 8 files this PR touches were already non-conformant before these changes too; this PR is formatting-neutral.