### PR TITLE
fix(ast-tools): surface unavailable languages

### DIFF
--- a/src/__tests__/tools/ast-tools-runtime.test.ts
+++ b/src/__tests__/tools/ast-tools-runtime.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const { parseMock } = vi.hoisted(() => ({
+  parseMock: vi.fn(() => ({
+    root: () => ({
+      findAll: () => [],
+    }),
+  })),
+}));
+
+vi.mock("module", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("module")>();
+  return {
+    ...actual,
+    createRequire: () => {
+      throw new Error("force dynamic import fallback");
+    },
+  };
+});
+
+vi.mock("@ast-grep/napi", () => ({
+  Lang: {
+    TypeScript: "TypeScript",
+  },
+  parse: parseMock,
+}));
+
+import {
+  astGrepReplaceTool,
+  astGrepSearchTool,
+} from "../../tools/ast-tools.js";
+
+describe("ast tool runtime language validation", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    parseMock.mockClear();
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  function createSourceFile(extension: string, content: string): string {
+    const directory = mkdtempSync(join(tmpdir(), "omc-ast-runtime-"));
+    temporaryDirectories.push(directory);
+    writeFileSync(join(directory, `sample${extension}`), content, "utf-8");
+    return directory;
+  }
+
+  it("does not report an unavailable search language as no matches", async () => {
+    const path = createSourceFile(".py", "import pandas as pd\n");
+
+    const result = await astGrepSearchTool.handler({
+      pattern: "import pandas as pd",
+      language: "python",
+      path,
+    });
+
+    expect(result.content[0]?.text).toContain(
+      "Error in AST search: Unsupported language: python",
+    );
+    expect(result.content[0]?.text).not.toContain("No matches found");
+    expect(parseMock).not.toHaveBeenCalled();
+  });
+
+  it("does not report an unavailable replace language as no matches", async () => {
+    const path = createSourceFile(".py", "print('before')\n");
+
+    const result = await astGrepReplaceTool.handler({
+      pattern: "print($ARG)",
+      replacement: "logger.info($ARG)",
+      language: "python",
+      path,
+    });
+
+    expect(result.content[0]?.text).toContain(
+      "Error in AST replace: Unsupported language: python",
+    );
+    expect(result.content[0]?.text).not.toContain("No matches found");
+    expect(parseMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps supported languages on the normal per-file path", async () => {
+    const path = createSourceFile(".ts", "const value = 1;\n");
+
+    const result = await astGrepSearchTool.handler({
+      pattern: "const $NAME = $VALUE",
+      language: "typescript",
+      path,
+    });
+
+    expect(result.content[0]?.text).toContain("No matches found");
+    expect(result.content[0]?.text).not.toContain("Unsupported language");
+    expect(parseMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/tools/ast-tools-runtime.test.ts
+++ b/src/__tests__/tools/ast-tools-runtime.test.ts
@@ -1,14 +1,11 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-const { parseMock } = vi.hoisted(() => ({
-  parseMock: vi.fn(() => ({
-    root: () => ({
-      findAll: () => [],
-    }),
-  })),
+const { parseMock, runtimeLoadMock } = vi.hoisted(() => ({
+  parseMock: vi.fn(),
+  runtimeLoadMock: vi.fn(),
 }));
 
 vi.mock("module", async (importOriginal) => {
@@ -21,26 +18,49 @@ vi.mock("module", async (importOriginal) => {
   };
 });
 
-vi.mock("@ast-grep/napi", () => ({
-  Lang: {
-    TypeScript: "TypeScript",
-  },
-  parse: parseMock,
-}));
+vi.mock("@ast-grep/napi", () => runtimeLoadMock());
 
-import {
-  astGrepReplaceTool,
-  astGrepSearchTool,
-} from "../../tools/ast-tools.js";
+function createRuntime(languages: Record<string, string>) {
+  return {
+    Lang: languages,
+    parse: parseMock,
+  };
+}
+
+async function loadAstTools() {
+  return import("../../tools/ast-tools.js");
+}
+
+function expectRecoveryGuidance(text: string | undefined): void {
+  expect(text).toContain("npm install -g @ast-grep/napi@0.31");
+  expect(text).toContain("restart Claude Code (or the MCP server)");
+}
 
 describe("ast tool runtime language validation", () => {
   const temporaryDirectories: string[] = [];
 
+  beforeEach(() => {
+    vi.resetModules();
+    parseMock.mockReset();
+    parseMock.mockImplementation(() => ({
+      root: () => ({
+        findAll: () => [],
+      }),
+    }));
+    runtimeLoadMock.mockReset();
+    runtimeLoadMock.mockReturnValue(
+      createRuntime({
+        TypeScript: "TypeScript",
+        Python: "Python",
+      }),
+    );
+  });
+
   afterEach(() => {
-    parseMock.mockClear();
     for (const directory of temporaryDirectories.splice(0)) {
       rmSync(directory, { recursive: true, force: true });
     }
+    vi.resetModules();
   });
 
   function createSourceFile(extension: string, content: string): string {
@@ -50,23 +70,97 @@ describe("ast tool runtime language validation", () => {
     return directory;
   }
 
-  it("does not report an unavailable search language as no matches", async () => {
+  it("reports missing-module recovery guidance and caches the failed load", async () => {
+    runtimeLoadMock.mockImplementation(() => {
+      throw new Error("simulated missing package");
+    });
+    const { astGrepSearchTool } = await loadAstTools();
+    const path = createSourceFile(".ts", "const value = 1;\n");
+
+    const firstResult = await astGrepSearchTool.handler({
+      pattern: "const $NAME = $VALUE",
+      language: "typescript",
+      path,
+    });
+
+    expect(firstResult.content[0]?.text).toContain(
+      "@ast-grep/napi is not available",
+    );
+    expectRecoveryGuidance(firstResult.content[0]?.text);
+
+    runtimeLoadMock.mockReturnValue(
+      createRuntime({ TypeScript: "TypeScript" }),
+    );
+    const cachedResult = await astGrepSearchTool.handler({
+      pattern: "const $NAME = $VALUE",
+      language: "typescript",
+      path,
+    });
+
+    expect(cachedResult.content[0]?.text).toBe(firstResult.content[0]?.text);
+    expect(runtimeLoadMock).toHaveBeenCalledOnce();
+    expect(parseMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the same missing-module recovery guidance for replace", async () => {
+    runtimeLoadMock.mockImplementation(() => {
+      throw new Error("simulated missing package");
+    });
+    const { astGrepReplaceTool } = await loadAstTools();
+    const path = createSourceFile(".ts", "const value = 1;\n");
+
+    const result = await astGrepReplaceTool.handler({
+      pattern: "const $NAME = $VALUE",
+      replacement: "let $NAME = $VALUE",
+      language: "typescript",
+      path,
+    });
+
+    expect(result.content[0]?.text).toContain(
+      "@ast-grep/napi is not available",
+    );
+    expectRecoveryGuidance(result.content[0]?.text);
+    expect(parseMock).not.toHaveBeenCalled();
+  });
+
+  it("reports unsupported search language recovery and caches the loaded runtime", async () => {
+    runtimeLoadMock.mockReturnValue(
+      createRuntime({ TypeScript: "TypeScript" }),
+    );
+    const { astGrepSearchTool } = await loadAstTools();
     const path = createSourceFile(".py", "import pandas as pd\n");
 
-    const result = await astGrepSearchTool.handler({
+    const firstResult = await astGrepSearchTool.handler({
       pattern: "import pandas as pd",
       language: "python",
       path,
     });
 
-    expect(result.content[0]?.text).toContain(
+    expect(firstResult.content[0]?.text).toContain(
       "Error in AST search: Unsupported language: python",
     );
-    expect(result.content[0]?.text).not.toContain("No matches found");
+    expect(firstResult.content[0]?.text).not.toContain("No matches found");
+    expectRecoveryGuidance(firstResult.content[0]?.text);
+
+    runtimeLoadMock.mockReturnValue(
+      createRuntime({ TypeScript: "TypeScript", Python: "Python" }),
+    );
+    const cachedResult = await astGrepSearchTool.handler({
+      pattern: "import pandas as pd",
+      language: "python",
+      path,
+    });
+
+    expect(cachedResult.content[0]?.text).toBe(firstResult.content[0]?.text);
+    expect(runtimeLoadMock).toHaveBeenCalledOnce();
     expect(parseMock).not.toHaveBeenCalled();
   });
 
-  it("does not report an unavailable replace language as no matches", async () => {
+  it("reports unsupported replace language recovery instead of no matches", async () => {
+    runtimeLoadMock.mockReturnValue(
+      createRuntime({ TypeScript: "TypeScript" }),
+    );
+    const { astGrepReplaceTool } = await loadAstTools();
     const path = createSourceFile(".py", "print('before')\n");
 
     const result = await astGrepReplaceTool.handler({
@@ -80,14 +174,32 @@ describe("ast tool runtime language validation", () => {
       "Error in AST replace: Unsupported language: python",
     );
     expect(result.content[0]?.text).not.toContain("No matches found");
+    expectRecoveryGuidance(result.content[0]?.text);
     expect(parseMock).not.toHaveBeenCalled();
   });
 
-  it("keeps supported languages on the normal per-file path", async () => {
+  it("preserves genuine search no-match behavior for a supported language", async () => {
+    const { astGrepSearchTool } = await loadAstTools();
     const path = createSourceFile(".ts", "const value = 1;\n");
 
     const result = await astGrepSearchTool.handler({
       pattern: "const $NAME = $VALUE",
+      language: "typescript",
+      path,
+    });
+
+    expect(result.content[0]?.text).toContain("No matches found");
+    expect(result.content[0]?.text).not.toContain("Unsupported language");
+    expect(parseMock).toHaveBeenCalledOnce();
+  });
+
+  it("preserves genuine replace no-match behavior for a supported language", async () => {
+    const { astGrepReplaceTool } = await loadAstTools();
+    const path = createSourceFile(".ts", "const value = 1;\n");
+
+    const result = await astGrepReplaceTool.handler({
+      pattern: "console.log($VALUE)",
+      replacement: "logger.info($VALUE)",
       language: "typescript",
       path,
     });

--- a/src/tools/ast-tools.ts
+++ b/src/tools/ast-tools.ts
@@ -26,6 +26,9 @@ let sgModule: typeof import("@ast-grep/napi") | null = null;
 let sgLoadFailed = false;
 let sgLoadError = "";
 const AST_GREP_INSTALL_COMMAND = "npm install -g @ast-grep/napi@0.31";
+const AST_GREP_RECOVERY_GUIDANCE =
+  `Install the supported runtime with: ${AST_GREP_INSTALL_COMMAND}\n` +
+  "Then restart Claude Code (or the MCP server) so @ast-grep/napi is reloaded.";
 
 async function getSgModule(): Promise<typeof import("@ast-grep/napi") | null> {
   if (sgLoadFailed) {
@@ -115,7 +118,9 @@ function toLangEnum(
 
   const lang = langMap[language];
   if (!lang) {
-    throw new Error(`Unsupported language: ${language}`);
+    throw new Error(
+      `Unsupported language: ${language}. The loaded @ast-grep/napi runtime does not provide this language.\n${AST_GREP_RECOVERY_GUIDANCE}`,
+    );
   }
   return lang;
 }
@@ -351,7 +356,7 @@ Note: Patterns must be valid AST nodes for the language.`,
           content: [
             {
               type: "text" as const,
-              text: `@ast-grep/napi is not available. Install it with: ${AST_GREP_INSTALL_COMMAND}\nError: ${sgLoadError}`,
+              text: `@ast-grep/napi is not available.\n${AST_GREP_RECOVERY_GUIDANCE}\nError: ${sgLoadError}`,
             },
           ],
         };
@@ -488,7 +493,7 @@ IMPORTANT: dryRun=true (default) only previews changes. Set dryRun=false to appl
           content: [
             {
               type: "text" as const,
-              text: `@ast-grep/napi is not available. Install it with: ${AST_GREP_INSTALL_COMMAND}\nError: ${sgLoadError}`,
+              text: `@ast-grep/napi is not available.\n${AST_GREP_RECOVERY_GUIDANCE}\nError: ${sgLoadError}`,
             },
           ],
         };

--- a/src/tools/ast-tools.ts
+++ b/src/tools/ast-tools.ts
@@ -24,7 +24,8 @@ import { isToolPathRestricted } from "../lib/security-config.js";
 // via NODE_PATH set in the bundle's startup banner.
 let sgModule: typeof import("@ast-grep/napi") | null = null;
 let sgLoadFailed = false;
-let sgLoadError = '';
+let sgLoadError = "";
+const AST_GREP_INSTALL_COMMAND = "npm install -g @ast-grep/napi@0.31";
 
 async function getSgModule(): Promise<typeof import("@ast-grep/napi") | null> {
   if (sgLoadFailed) {
@@ -33,7 +34,9 @@ async function getSgModule(): Promise<typeof import("@ast-grep/napi") | null> {
   if (!sgModule) {
     try {
       // Use createRequire for CJS-style resolution (respects NODE_PATH)
-      const require = createRequire(import.meta.url || __filename || process.cwd() + '/');
+      const require = createRequire(
+        import.meta.url || __filename || process.cwd() + "/",
+      );
       sgModule = require("@ast-grep/napi") as typeof import("@ast-grep/napi");
     } catch {
       // Fallback to dynamic import for pure ESM environments
@@ -242,7 +245,9 @@ function getFilesForLanguage(
   try {
     stat = statSync(resolvedPath);
   } catch (err) {
-    throw new Error(`Cannot access path "${resolvedPath}": ${(err as Error).message}`);
+    throw new Error(
+      `Cannot access path "${resolvedPath}": ${(err as Error).message}`,
+    );
   }
 
   if (stat.isFile()) {
@@ -346,7 +351,7 @@ Note: Patterns must be valid AST nodes for the language.`,
           content: [
             {
               type: "text" as const,
-              text: `@ast-grep/napi is not available. Install it with: npm install -g @ast-grep/napi\nError: ${sgLoadError}`,
+              text: `@ast-grep/napi is not available. Install it with: ${AST_GREP_INSTALL_COMMAND}\nError: ${sgLoadError}`,
             },
           ],
         };
@@ -363,6 +368,7 @@ Note: Patterns must be valid AST nodes for the language.`,
           ],
         };
       }
+      const lang = toLangEnum(sg, language);
 
       const results: string[] = [];
       let totalMatches = 0;
@@ -372,7 +378,7 @@ Note: Patterns must be valid AST nodes for the language.`,
 
         try {
           const content = readFileSync(filePath, "utf-8");
-          const root = sg.parse(toLangEnum(sg, language), content).root();
+          const root = sg.parse(lang, content).root();
           const matches = root.findAll(pattern);
 
           for (const match of matches) {
@@ -482,7 +488,7 @@ IMPORTANT: dryRun=true (default) only previews changes. Set dryRun=false to appl
           content: [
             {
               type: "text" as const,
-              text: `@ast-grep/napi is not available. Install it with: npm install -g @ast-grep/napi\nError: ${sgLoadError}`,
+              text: `@ast-grep/napi is not available. Install it with: ${AST_GREP_INSTALL_COMMAND}\nError: ${sgLoadError}`,
             },
           ],
         };
@@ -499,6 +505,7 @@ IMPORTANT: dryRun=true (default) only previews changes. Set dryRun=false to appl
           ],
         };
       }
+      const lang = toLangEnum(sg, language);
 
       const changes: {
         file: string;
@@ -511,7 +518,7 @@ IMPORTANT: dryRun=true (default) only previews changes. Set dryRun=false to appl
       for (const filePath of files) {
         try {
           const content = readFileSync(filePath, "utf-8");
-          const root = sg.parse(toLangEnum(sg, language), content).root();
+          const root = sg.parse(lang, content).root();
           const matches = root.findAll(pattern);
 
           if (matches.length === 0) continue;
@@ -549,7 +556,7 @@ IMPORTANT: dryRun=true (default) only previews changes. Set dryRun=false to appl
                 if (captured) {
                   // Escape $ in captured text to prevent JS replacement patterns
                   // ($&, $', $`, $$) from being interpreted by replaceAll
-                  const safeText = captured.text().replace(/\$/g, '$$$$');
+                  const safeText = captured.text().replace(/\$/g, "$$$$");
                   finalReplacement = finalReplacement.replaceAll(
                     metaVar,
                     safeText,


### PR DESCRIPTION
## Summary

- validate the selected ast-grep language once before entering the per-file parse/read swallow boundary in both `ast_grep_search` and `ast_grep_replace`
- preserve the existing actionable AST error response when the loaded runtime lacks an advertised language, preventing a clean `No matches found` false negative
- keep supported-language parsing and genuine no-match behavior unchanged
- update the global install hint to the supported `@ast-grep/napi@0.31` line; the current bundle already adds `npm root -g` to `NODE_PATH`, so no machine-specific install path is needed
- add focused search, replace, and supported-language regression coverage

## Package and loader verification

- repository lock: `@ast-grep/napi` 0.31.1 exposes every language currently mapped by OMC
- current package: 0.45.0 retains TypeScript but has no Python enum without dynamic language registration
- semver: `^0.31.0` accepts 0.31.x and rejects 0.32.0, 0.34.1, and 0.45.0
- generated MCP startup prepends `npm root -g` to `NODE_PATH` and calls `Module._initPaths()`, so the reporter's proposed `~/.claude` path is not required by current dev
- shipping policy accepts the source-only change with zero generated artifact changes

## Verification

- `npm test -- --run src/__tests__/tools/ast-tools-runtime.test.ts src/__tests__/tools/ast-tools.test.ts src/__tests__/ast-tools-path-restriction.test.ts` — 19 passed
- `npx tsc --noEmit` — passed
- `npx eslint src/tools/ast-tools.ts src/__tests__/tools/ast-tools-runtime.test.ts` — passed
- `npm run build` — passed; generated outputs were not committed
- `node scripts/ci/check-multirepo-paths.mjs` — passed
- `npm run plugin:shipping:check-pr -- --base d26aa138c3ef4bcb69d56e795a347ca4013af862` — passed, zero generated artifact changes
- full `npm test -- --run` — 11,895 passed, 16 skipped, 3 failed outside the AST subsystem; two failures passed on isolated rerun, while `post-tool-verifier.test.mjs` remains sensitive to the active session's accumulated background-task count
- native hardened Ultragoal review — strong contract, clean-pass eligible, zero findings, executor QA evidence valid

Closes #3627

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*