### PR TITLE
fix(psm): stop zsh-tied names from defeating the worktree deletion guard

### DIFF
--- a/skills/project-session-manager/lib/providers/azure-devops.sh
+++ b/skills/project-session-manager/lib/providers/azure-devops.sh
@@ -30,9 +30,11 @@ provider_azure_pr_merged() {
     local repo="$2"
     command -v az >/dev/null 2>&1 || return 1
     command -v jq >/dev/null 2>&1 || return 1
-    local status
-    status=$(az repos pr show --id "$pr_number" --output json 2>/dev/null | jq -r '.status // empty')
-    [[ "$status" == "completed" ]]
+    # Not `status`: zsh makes it read-only (it is $?), so `local status` aborts
+    # the function outright when this lib is sourced into a zsh shell.
+    local pr_status
+    pr_status=$(az repos pr show --id "$pr_number" --output json 2>/dev/null | jq -r '.status // empty')
+    [[ "$pr_status" == "completed" ]]
 }
 
 provider_azure_issue_closed() {

--- a/skills/project-session-manager/lib/worktree.sh
+++ b/skills/project-session-manager/lib/worktree.sh
@@ -5,22 +5,29 @@
 # Returns 0 if valid, 1 if invalid
 # Usage: validate_worktree_path <path>
 validate_worktree_path() {
-    local path="$1"
+    # NOT named `path`: zsh ties $path to the $PATH array, so `local path=...`
+    # replaces PATH with the candidate directory for the rest of the function.
+    # jq then falls off PATH, psm_get_worktree_root returns empty, `cd ''` is a
+    # zsh no-op, and abs_root silently becomes the caller's cwd — so this guard
+    # ends up comparing against the wrong root in both directions.
+    local wt_path="$1"
     local worktree_root
     worktree_root=$(psm_get_worktree_root 2>/dev/null) || return 1
+    # An empty root would make the containment check below meaningless.
+    [[ -n "$worktree_root" ]] || return 1
 
     # Path must exist and be a directory
-    if [[ ! -d "$path" ]]; then
+    if [[ ! -d "$wt_path" ]]; then
         return 1
     fi
 
     # Resolve to absolute paths for comparison
     local abs_path abs_root
-    abs_path=$(cd "$path" 2>/dev/null && pwd) || return 1
+    abs_path=$(cd "$wt_path" 2>/dev/null && pwd) || return 1
     abs_root=$(cd "$worktree_root" 2>/dev/null && pwd) || return 1
 
     # Check path is under root and doesn't contain ..
-    if [[ "$abs_path" != "$abs_root"/* ]] || [[ "$path" == *".."* ]]; then
+    if [[ "$abs_path" != "$abs_root"/* ]] || [[ "$wt_path" == *".."* ]]; then
         echo "error|Invalid worktree path: not under PSM root" >&2
         return 1
     fi

--- a/skills/project-session-manager/psm.sh
+++ b/skills/project-session-manager/psm.sh
@@ -61,24 +61,28 @@ psm_validate_worktree_result() {
         [[ "$remainder" == *"|"* ]] || break
         remainder="${remainder#*|}"
     done
-    local status="${fields[0]}"
+    # Not named `status`/`path`: zsh ties both to shell state ($? and the $PATH
+    # array), so declaring them local corrupts that state for the rest of the
+    # function. Harmless while this file only ever runs under its bash shebang,
+    # renamed so it stays correct if it is ever sourced.
+    local record_status="${fields[0]}"
     local count="${#fields[@]}"
-    local path="${fields[1]:-}"
+    local record_path="${fields[1]:-}"
     local branch="${fields[2]:-}"
-    case "$status" in
+    case "$record_status" in
         created|exists)
             # Required fields must be present and not whitespace-only, or the caller
             # could launch tmux in an empty/unusable working directory.
             case "$schema" in
                 pr)
-                    if [[ "$count" -ne 2 ]] || [[ "$path" =~ ^[[:space:]]*$ ]]; then
-                        log_error "Malformed worktree result: invalid $status record"
+                    if [[ "$count" -ne 2 ]] || [[ "$record_path" =~ ^[[:space:]]*$ ]]; then
+                        log_error "Malformed worktree result: invalid $record_status record"
                         return 1
                     fi
                     ;;
                 branched)
-                    if [[ "$count" -ne 3 ]] || [[ "$path" =~ ^[[:space:]]*$ ]] || [[ "$branch" =~ ^[[:space:]]*$ ]]; then
-                        log_error "Malformed worktree result: invalid $status record"
+                    if [[ "$count" -ne 3 ]] || [[ "$record_path" =~ ^[[:space:]]*$ ]] || [[ "$branch" =~ ^[[:space:]]*$ ]]; then
+                        log_error "Malformed worktree result: invalid $record_status record"
                         return 1
                     fi
                     ;;

--- a/skills/self-improve/scripts/validate.sh
+++ b/skills/self-improve/scripts/validate.sh
@@ -304,24 +304,25 @@ check_result_schema() {
     fi
     ok "Result contains all required fields."
 
-    # Validate status enum
-    local status
-    status=$(jq -r '.status' "${result_file}" 2>/dev/null)
-    case "${status}" in
+    # Validate status enum. Not named `status`: zsh makes it read-only (it is $?),
+    # so `local status` aborts the function outright under zsh.
+    local result_status
+    result_status=$(jq -r '.status' "${result_file}" 2>/dev/null)
+    case "${result_status}" in
         success|regression|error|timeout) ;;
         *)
-            err "Invalid status '${status}'. Must be one of: success, regression, error, timeout"
+            err "Invalid status '${result_status}'. Must be one of: success, regression, error, timeout"
             exit 1
             ;;
     esac
-    ok "Status '${status}' is valid."
+    ok "Status '${result_status}' is valid."
 
     # Check failure_analysis on non-success status
-    if [[ "${status}" != "success" ]]; then
+    if [[ "${result_status}" != "success" ]]; then
         local fa_type
         fa_type=$(jq -r '.failure_analysis | type' "${result_file}" 2>/dev/null)
         if [[ "${fa_type}" != "object" ]]; then
-            err "failure_analysis must be a non-null object when status is '${status}' (got ${fa_type})"
+            err "failure_analysis must be a non-null object when status is '${result_status}' (got ${fa_type})"
             exit 1
         fi
 

--- a/tests/lint/shell-zsh-tied-locals.test.ts
+++ b/tests/lint/shell-zsh-tied-locals.test.ts
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+
+/**
+ * zsh ties these parameters to shell state — `path`/`cdpath`/`fpath`/`manpath`/
+ * `module_path` are the array views of the corresponding colon-lists, `status` is
+ * `$?`, `argv` is the positional parameters, and `options`/`prompt` are shell
+ * settings. Declaring one `local` inside a function therefore does not create a
+ * private variable, it overwrites that shell state for the rest of the call.
+ *
+ * `local path="$1"` is the dangerous one: it replaces PATH with a single
+ * directory, so every external command in the function silently disappears. That
+ * is how validate_worktree_path came to compare a deletion candidate against the
+ * caller's cwd instead of the PSM worktree root — accepting paths it exists to
+ * reject. These files carry a bash shebang, but they are libraries meant to be
+ * sourced, and a skill agent's shell is frequently zsh.
+ */
+const ZSH_TIED_NAMES = [
+  'path',
+  'cdpath',
+  'fpath',
+  'manpath',
+  'module_path',
+  'argv',
+  'status',
+  'options',
+  'prompt',
+] as const;
+
+const DECLARATION = new RegExp(String.raw`^\s*(?:local|typeset|declare)\s+(?:-\w+\s+)*(${ZSH_TIED_NAMES.join('|')})\b`);
+
+function toForwardSlash(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function shellFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'node_modules' || entry.name === '.git' ? [] : shellFiles(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.sh') ? [entryPath] : [];
+  });
+}
+
+describe('shell libraries', () => {
+  it('never declare zsh-tied parameters as locals', () => {
+    const offenders = shellFiles(join(REPO_ROOT, 'skills')).flatMap((filePath) =>
+      readFileSync(filePath, 'utf8')
+        .split('\n')
+        .flatMap((line, index) => {
+          const match = DECLARATION.exec(line);
+          return match ? [`${toForwardSlash(relative(REPO_ROOT, filePath))}:${index + 1} declares \`${match[1]}\``] : [];
+        }),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`validate_worktree_path()` in `skills/project-session-manager/lib/worktree.sh` opens with:

```bash
local path="$1"
```

zsh ties `$path` to the `$PATH` array, so that line **replaces PATH** with the candidate directory for the rest of the function. The cascade:

1. `jq` is no longer on PATH → `psm_get_worktree_root` returns empty. Its `|| return 1` never fires, because `echo ""` still exits 0.
2. `cd ''` is a no-op in zsh → `abs_root` becomes the **caller's cwd** instead of `~/.psm/worktrees`.
3. The containment check compares the deletion candidate against the wrong root.

The files carry a bash shebang, but these are libraries meant to be sourced, and a skill agent's shell is frequently zsh (Claude Code on macOS).

## Impact

Wrong in both directions. Reproduced under zsh with cwd set to the source repo, against unmodified `dev`:

```
validate_worktree_path <repo>/apps            -> ACCEPTED   # not under PSM root
validate_worktree_path ~/.psm/worktrees/x/ok  -> refused    # is under PSM root
```

The **false accept** is the dangerous one: this is the last check before `git worktree remove --force` and the `rm -rf "$worktree_path"` fallback in `psm_remove_worktree`. The false refusal is merely confusing — it reports *"Invalid worktree path: not under PSM root"* for a path plainly under the PSM root, which reads like a `projects.json` problem and invites reaching for a raw `git worktree remove --force` instead, bypassing the dirt guard entirely.

Found while cleaning up two merged-PR worktrees, where `psm_remove_worktree` refused both.

## Fix

- Rename to `wt_path`, plus an explicit `[[ -n "$worktree_root" ]] || return 1` so a future empty root can't make the containment check vacuous.
- Same class elsewhere: **`local status`** is a hard error in zsh (`read-only variable: status` — it's `$?`), aborting the function outright when sourced:
  - `lib/providers/azure-devops.sh` — `provider_azure_pr_merged` would abort and return non-zero, so **every Azure PR reads as unmerged** and `psm cleanup` never cleans an Azure session.
  - `skills/self-improve/scripts/validate.sh` — same declaration.
- `psm.sh`'s `psm_validate_worktree_result` used `local status` / `local path`; renamed defensively. It runs under its bash shebang today, so this is not a live bug — its accept/reject behaviour was diffed against the original across valid, whitespace-only, unknown-status, empty and too-many-field records to confirm no change.
- New `tests/lint/shell-zsh-tied-locals.test.ts` keeps zsh-tied parameter names (`path`, `cdpath`, `fpath`, `manpath`, `module_path`, `argv`, `status`, `options`, `prompt`) out of `local`/`typeset`/`declare` in `skills/**/*.sh`. It flags the original `worktree.sh:8` and passes on the fix.

## Verification

- Fixed guard accepts a real PSM worktree and refuses a path under cwd-but-outside-root, under **both** zsh and bash.
- `npm run lint` — clean.
- `npx vitest run tests/lint` — 5 files, 50 tests passing (includes the new guard).
- `bash -n` and `zsh -n` clean on every changed shell file.
- Behaviour of the renamed `psm_validate_worktree_result` diffed byte-for-byte against the pre-rename original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
