### PR TITLE
chore(release): v4.15.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.15.7",
+      "version": "4.15.8",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.15.7"
+  "version": "4.15.8"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.15.7",
+  "version": "4.15.8",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,29 +1,54 @@
-# oh-my-claudecode v4.15.7: Bug Fixes
+# oh-my-claudecode v4.15.8: add Kimi usage
 
 ## Release Notes
 
-Release with **4 bug fixes**, **1 other change** across **5 merged PRs**.
+Release with **1 new feature**, **11 bug fixes**, **17 other changes** across **30 merged PRs**.
 
 ### Highlights
 
-- **fix(psm): fail closed on malformed worktree results** (#3531)
-- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
-- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
+- **feat(hud): add Kimi usage monitoring** (#3610)
+
+### New Features
+
+- **feat(hud): add Kimi usage monitoring** (#3610)
 
 ### Bug Fixes
 
-- **fix(psm): fail closed on malformed worktree results** (#3531)
-- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
-- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
-- **fix(windows): separate prompt host and worker timeouts** (#3525)
+- **fix(ultragoal): restore fail-closed recovery when /goal guard blocks tools** (#3632)
+- **fix(ast-tools): surface unavailable languages** (#3628)
+- **fix(team): make worker startup acknowledgement durable** (#3588)
+- **fix(doctor): make team-routing provider probes Windows-safe** (#3602)
+- **fix(installer): accept TOML literal strings in Codex MCP registry parser** (#3603)
+- **fix(installer): install hooks when settings.json has none** (#3599)
+- **fix(installer): allow contained symlink config roots** (#3538)
+- **fix(launch): stop omc re-login from isolated profile auth drift** (#3572)
+- **fix(installer): preserve custom agent definitions** (#3539)
+- **fix(hud): parse per-model weekly quotas from limits[] weekly_scoped entries** (#3577)
+- **fix(post-tool-verifier): key background detection off tool_input** (#3579)
 
 ### Other Changes
 
-- **ci: add main generated-artifact authorization trust root** (#3540)
+- **ci: authorize final reconciled head for PR #3588** (#3616)
+- **ci: authorize post-merge head for PR #3588** (#3615)
+- **ci: authorize reconciled head for PR #3588** (#3614)
+- **ci: authorize terminal head for PR #3603** (#3604)
+- **ci: authorize terminal generated head for PR #3588** (#3598)
+- **ci: authorize signed final head for PR #3588** (#3596)
+- **ci: authorize final generated head for PR #3588** (#3594)
+- **ci: authorize corrected head for PR #3538** (#3593)
+- **ci: authorize signed generated head for PR #3588** (#3592)
+- **ci: authorize exact generated head for PR #3588** (#3590)
+- **ci: authorize rebased head for PR #3538** (#3589)
+- **ci: authorize exact generated closure for PR #3572** (#3587)
+- **ci: authorize rebased head for PR #3539** (#3585)
+- **ci: restore exact-head authorization for PR #3539** (#3583)
+- **ci: authorize signed merge head for PR #3539** (#3582)
+- **ci: authorize repaired closure for PR #3539** (#3581)
+- **ci: authorize exact generated closure for PR #3539 (dev)** (#3580)
 
 ### Stats
 
-- **5 PRs merged** | **0 new features** | **4 bug fixes** | **0 security/hardening improvements** | **1 other change**
+- **30 PRs merged** | **1 new feature** | **11 bug fixes** | **0 security/hardening improvements** | **17 other changes**
 
 ### Install / Update
 
@@ -32,7 +57,7 @@ The npm CLI and the Claude Code marketplace/plugin are separate install tracks, 
 **CLI / runtime:**
 
 ```bash
-npm install -g oh-my-claude-sisyphus@4.15.7
+npm install -g oh-my-claude-sisyphus@4.15.8
 ```
 
 **Claude Code plugin:**
@@ -41,10 +66,10 @@ npm install -g oh-my-claude-sisyphus@4.15.7
 /plugin marketplace update omc
 ```
 
-**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.6...v4.15.7
+**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.7...v4.15.8
 
 ## Contributors
 
 Thank you to all contributors who made this release possible!
 
-@Yeachan-Heo
+@ltspace @Yeachan-Heo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,51 @@
-# oh-my-claudecode v4.15.7: Bug Fixes
+# oh-my-claudecode v4.15.8: add Kimi usage
 
 ## Release Notes
 
-Release with **4 bug fixes**, **1 other change** across **5 merged PRs**.
+Release with **1 new feature**, **11 bug fixes**, **17 other changes** across **30 merged PRs**.
 
 ### Highlights
 
-- **fix(psm): fail closed on malformed worktree results** (#3531)
-- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
-- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
+- **feat(hud): add Kimi usage monitoring** (#3610)
+
+### New Features
+
+- **feat(hud): add Kimi usage monitoring** (#3610)
 
 ### Bug Fixes
 
-- **fix(psm): fail closed on malformed worktree results** (#3531)
-- **fix(psm): use jira-cli --raw instead of non-existent --output json** (#3529)
-- **fix(psm): use tmux-safe session names so sessions stay manageable** (#3530)
-- **fix(windows): separate prompt host and worker timeouts** (#3525)
+- **fix(ultragoal): restore fail-closed recovery when /goal guard blocks tools** (#3632)
+- **fix(ast-tools): surface unavailable languages** (#3628)
+- **fix(team): make worker startup acknowledgement durable** (#3588)
+- **fix(doctor): make team-routing provider probes Windows-safe** (#3602)
+- **fix(installer): accept TOML literal strings in Codex MCP registry parser** (#3603)
+- **fix(installer): install hooks when settings.json has none** (#3599)
+- **fix(installer): allow contained symlink config roots** (#3538)
+- **fix(launch): stop omc re-login from isolated profile auth drift** (#3572)
+- **fix(installer): preserve custom agent definitions** (#3539)
+- **fix(hud): parse per-model weekly quotas from limits[] weekly_scoped entries** (#3577)
+- **fix(post-tool-verifier): key background detection off tool_input** (#3579)
 
 ### Other Changes
 
-- **ci: add main generated-artifact authorization trust root** (#3540)
+- **ci: authorize final reconciled head for PR #3588** (#3616)
+- **ci: authorize post-merge head for PR #3588** (#3615)
+- **ci: authorize reconciled head for PR #3588** (#3614)
+- **ci: authorize terminal head for PR #3603** (#3604)
+- **ci: authorize terminal generated head for PR #3588** (#3598)
+- **ci: authorize signed final head for PR #3588** (#3596)
+- **ci: authorize final generated head for PR #3588** (#3594)
+- **ci: authorize corrected head for PR #3538** (#3593)
+- **ci: authorize signed generated head for PR #3588** (#3592)
+- **ci: authorize exact generated head for PR #3588** (#3590)
+- **ci: authorize rebased head for PR #3538** (#3589)
+- **ci: authorize exact generated closure for PR #3572** (#3587)
+- **ci: authorize rebased head for PR #3539** (#3585)
+- **ci: restore exact-head authorization for PR #3539** (#3583)
+- **ci: authorize signed merge head for PR #3539** (#3582)
+- **ci: authorize repaired closure for PR #3539** (#3581)
+- **ci: authorize exact generated closure for PR #3539 (dev)** (#3580)
 
 ### Stats
 
-- **5 PRs merged** | **0 new features** | **4 bug fixes** | **0 security/hardening improvements** | **1 other change**
+- **30 PRs merged** | **1 new feature** | **11 bug fixes** | **0 security/hardening improvements** | **17 other changes**

--- a/README.md
+++ b/README.md
@@ -644,20 +644,20 @@ MIT
 Top personal non-fork, non-archived repos from all-time OMC contributors (100+ GitHub stars).
 
 - [@Yeachan-Heo](https://github.com/Yeachan-Heo) — [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) (⭐ 38k)
-- [@junhoyeo](https://github.com/junhoyeo) — [tokscale](https://github.com/junhoyeo/tokscale) (⭐ 4.5k)
-- [@psmux](https://github.com/psmux) — [psmux](https://github.com/psmux/psmux) (⭐ 3k)
-- [@MeroZemory](https://github.com/MeroZemory) — [ida-multi-mcp](https://github.com/MeroZemory/ida-multi-mcp) (⭐ 346)
+- [@junhoyeo](https://github.com/junhoyeo) — [tokscale](https://github.com/junhoyeo/tokscale) (⭐ 4.8k)
+- [@psmux](https://github.com/psmux) — [psmux](https://github.com/psmux/psmux) (⭐ 3.2k)
+- [@MeroZemory](https://github.com/MeroZemory) — [ida-multi-mcp](https://github.com/MeroZemory/ida-multi-mcp) (⭐ 375)
+- [@devswha](https://github.com/devswha) — [patina](https://github.com/devswha/patina) (⭐ 312)
 - [@BowTiedSwan](https://github.com/BowTiedSwan) — [buildflow](https://github.com/BowTiedSwan/buildflow) (⭐ 295)
 - [@J-Pster](https://github.com/J-Pster) — [Psters_AI_Workflow](https://github.com/J-Pster/Psters_AI_Workflow) (⭐ 291)
 - [@alohays](https://github.com/alohays) — [awesome-visual-representation-learning-with-transformers](https://github.com/alohays/awesome-visual-representation-learning-with-transformers) (⭐ 271)
-- [@devswha](https://github.com/devswha) — [patina](https://github.com/devswha/patina) (⭐ 267)
 - [@jcwleo](https://github.com/jcwleo) — [random-network-distillation-pytorch](https://github.com/jcwleo/random-network-distillation-pytorch) (⭐ 263)
-- [@HaD0Yun](https://github.com/HaD0Yun) — [Doyunha-Gopeak](https://github.com/HaD0Yun/Doyunha-Gopeak) (⭐ 235)
-- [@shaun0927](https://github.com/shaun0927) — [openchrome](https://github.com/shaun0927/openchrome) (⭐ 224)
+- [@HaD0Yun](https://github.com/HaD0Yun) — [Doyunha-Gopeak](https://github.com/HaD0Yun/Doyunha-Gopeak) (⭐ 238)
+- [@shaun0927](https://github.com/shaun0927) — [openchrome](https://github.com/shaun0927/openchrome) (⭐ 231)
 - [@emgeee](https://github.com/emgeee) — [mean-tutorial](https://github.com/emgeee/mean-tutorial) (⭐ 200)
-- [@anduinnn](https://github.com/anduinnn) — [HiFiNi-Auto-CheckIn](https://github.com/anduinnn/HiFiNi-Auto-CheckIn) (⭐ 170)
+- [@anduinnn](https://github.com/anduinnn) — [HiFiNi-Auto-CheckIn](https://github.com/anduinnn/HiFiNi-Auto-CheckIn) (⭐ 171)
+- [@changeroa](https://github.com/changeroa) — [StyleGallery](https://github.com/changeroa/StyleGallery) (⭐ 154)
 - [@Znuff](https://github.com/Znuff) — [consolas-powerline](https://github.com/Znuff/consolas-powerline) (⭐ 145)
-- [@changeroa](https://github.com/changeroa) — [StyleGallery](https://github.com/changeroa/StyleGallery) (⭐ 138)
 
 <!-- OMC:FEATURED-CONTRIBUTORS:END -->
 

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -875,8 +875,8 @@ function executeClaudeMdTransaction(request) {
 
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
-var COMPILED_ENGINE_VERSION = true ? "4.15.7" : "";
-var COMPILED_SOURCE_SHA256 = true ? "b48e214289eabf8e720ab7565c563f9b1c40b0f69e506718e9ddd8c6caf23049" : "";
+var COMPILED_ENGINE_VERSION = true ? "4.15.8" : "";
+var COMPILED_SOURCE_SHA256 = true ? "4cbb3ffaf4dd4769ce7c1c5163d3c1167d215f767868a00ea58aed1dde5cab2b" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.15.7 -->
+<!-- OMC:VERSION:4.15.8 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.7",
+  "version": "4.15.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.15.7",
+      "version": "4.15.8",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.7",
+  "version": "4.15.8",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
# oh-my-claudecode v4.15.8: add Kimi usage

## Release Notes

Release with **1 new feature**, **11 bug fixes**, **17 other changes** across **30 merged PRs**.

### Highlights

- **feat(hud): add Kimi usage monitoring** (#3610)

### New Features

- **feat(hud): add Kimi usage monitoring** (#3610)

### Bug Fixes

- **fix(ultragoal): restore fail-closed recovery when /goal guard blocks tools** (#3632)
- **fix(ast-tools): surface unavailable languages** (#3628)
- **fix(team): make worker startup acknowledgement durable** (#3588)
- **fix(doctor): make team-routing provider probes Windows-safe** (#3602)
- **fix(installer): accept TOML literal strings in Codex MCP registry parser** (#3603)
- **fix(installer): install hooks when settings.json has none** (#3599)
- **fix(installer): allow contained symlink config roots** (#3538)
- **fix(launch): stop omc re-login from isolated profile auth drift** (#3572)
- **fix(installer): preserve custom agent definitions** (#3539)
- **fix(hud): parse per-model weekly quotas from limits[] weekly_scoped entries** (#3577)
- **fix(post-tool-verifier): key background detection off tool_input** (#3579)

### Other Changes

- **ci: authorize final reconciled head for PR #3588** (#3616)
- **ci: authorize post-merge head for PR #3588** (#3615)
- **ci: authorize reconciled head for PR #3588** (#3614)
- **ci: authorize terminal head for PR #3603** (#3604)
- **ci: authorize terminal generated head for PR #3588** (#3598)
- **ci: authorize signed final head for PR #3588** (#3596)
- **ci: authorize final generated head for PR #3588** (#3594)
- **ci: authorize corrected head for PR #3538** (#3593)
- **ci: authorize signed generated head for PR #3588** (#3592)
- **ci: authorize exact generated head for PR #3588** (#3590)
- **ci: authorize rebased head for PR #3538** (#3589)
- **ci: authorize exact generated closure for PR #3572** (#3587)
- **ci: authorize rebased head for PR #3539** (#3585)
- **ci: restore exact-head authorization for PR #3539** (#3583)
- **ci: authorize signed merge head for PR #3539** (#3582)
- **ci: authorize repaired closure for PR #3539** (#3581)
- **ci: authorize exact generated closure for PR #3539 (dev)** (#3580)

### Stats

- **30 PRs merged** | **1 new feature** | **11 bug fixes** | **0 security/hardening improvements** | **17 other changes**

### Install / Update

The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.

**CLI / runtime:**

```bash
npm install -g oh-my-claude-sisyphus@4.15.8
```

**Claude Code plugin:**

```text
/plugin marketplace update omc
```

**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.7...v4.15.8

## Contributors

Thank you to all contributors who made this release possible!

@ltspace @Yeachan-Heo
