### PR TITLE
fix(release): widen bounded npm registry propagation retry (#3635)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,9 @@ jobs:
           if npm publish "$FINAL_TARBALL" --ignore-scripts --access public --provenance 2>&1 | tee npm-publish.log; then
             VERIFICATION_PREFIX="$RUNNER_TEMP/npm-provenance-verification"
             AUDIT_JSON="$VERIFICATION_PREFIX/audit-signatures.json"
-            MAX_PROPAGATION_ATTEMPTS=6
+            MAX_PROPAGATION_ATTEMPTS=12
             ATTEMPT=1
+            BACKOFF_SECONDS=10
             while [ "$ATTEMPT" -le "$MAX_PROPAGATION_ATTEMPTS" ]; do
               rm -rf "$VERIFICATION_PREFIX"
               if npm install --ignore-scripts --no-audit --no-fund --prefix "$VERIFICATION_PREFIX" "oh-my-claude-sisyphus@$VERSION" && npm audit signatures --json --include-attestations --prefix "$VERIFICATION_PREFIX" > "$AUDIT_JSON" && test -s "$AUDIT_JSON"; then
@@ -175,15 +176,20 @@ jobs:
                 exit 1
               fi
               ATTEMPT=$((ATTEMPT + 1))
-              sleep 10
+              sleep "$BACKOFF_SECONDS"
+              BACKOFF_SECONDS=$((BACKOFF_SECONDS * 2))
+              if [ "$BACKOFF_SECONDS" -gt 60 ]; then
+                BACKOFF_SECONDS=60
+              fi
             done
             node scripts/release-boundary.mjs verify-registry --package oh-my-claude-sisyphus --version "$VERSION" --tag "$GITHUB_REF_NAME" --sha "$GITHUB_SHA" --evidence "$EVIDENCE_JSON" --tarball "$FINAL_TARBALL" --provenance required --audit "$AUDIT_JSON"
           else
             node scripts/release-boundary.mjs assert-sigstore-fallback --publish-log npm-publish.log
             node scripts/release-boundary.mjs assert-evidence --tarball "$FINAL_TARBALL" --evidence "$EVIDENCE_JSON"
             npm publish "$FINAL_TARBALL" --ignore-scripts --access public
-            MAX_FALLBACK_PROPAGATION_ATTEMPTS=6
+            MAX_FALLBACK_PROPAGATION_ATTEMPTS=12
             FALLBACK_ATTEMPT=1
+            FALLBACK_BACKOFF_SECONDS=10
             while [ "$FALLBACK_ATTEMPT" -le "$MAX_FALLBACK_PROPAGATION_ATTEMPTS" ]; do
               if node scripts/release-boundary.mjs verify-registry --package oh-my-claude-sisyphus --version "$VERSION" --tag "$GITHUB_REF_NAME" --sha "$GITHUB_SHA" --evidence "$EVIDENCE_JSON" --tarball "$FINAL_TARBALL" --provenance sigstore-fallback --publish-log npm-publish.log; then
                 break
@@ -193,7 +199,11 @@ jobs:
                 exit 1
               fi
               FALLBACK_ATTEMPT=$((FALLBACK_ATTEMPT + 1))
-              sleep 10
+              sleep "$FALLBACK_BACKOFF_SECONDS"
+              FALLBACK_BACKOFF_SECONDS=$((FALLBACK_BACKOFF_SECONDS * 2))
+              if [ "$FALLBACK_BACKOFF_SECONDS" -gt 60 ]; then
+                FALLBACK_BACKOFF_SECONDS=60
+              fi
             done
           fi
         env:

--- a/src/__tests__/release-generation.test.ts
+++ b/src/__tests__/release-generation.test.ts
@@ -408,7 +408,7 @@ describe('release generation', () => {
     expect(evidenceAssertion).toBeLessThan(fallbackPublish);
     expect(fallbackPublish).toBeLessThan(fallbackVerification);
 
-    const fallbackPropagationLimit = workflow.indexOf('MAX_FALLBACK_PROPAGATION_ATTEMPTS=6');
+    const fallbackPropagationLimit = workflow.indexOf('MAX_FALLBACK_PROPAGATION_ATTEMPTS=12');
     const fallbackPropagationLoop = workflow.indexOf(
       'while [ "$FALLBACK_ATTEMPT" -le "$MAX_FALLBACK_PROPAGATION_ATTEMPTS" ]; do',
     );
@@ -428,6 +428,12 @@ describe('release generation', () => {
     expect(fallbackVerification).toBeLessThan(fallbackPropagationExhaustion);
     expect(fallbackPropagationExhaustion).toBeLessThan(fallbackPropagationFailure);
     expect(fallbackPropagationFailure).toBeLessThan(fallbackPropagationExit);
+    expect(workflow).toContain('FALLBACK_BACKOFF_SECONDS=10');
+    expect(workflow).toContain('sleep "$FALLBACK_BACKOFF_SECONDS"');
+    expect(workflow).toContain('FALLBACK_BACKOFF_SECONDS=$((FALLBACK_BACKOFF_SECONDS * 2))');
+    expect(workflow).toContain(
+      'if [ "$FALLBACK_BACKOFF_SECONDS" -gt 60 ]; then\n                FALLBACK_BACKOFF_SECONDS=60\n              fi',
+    );
     expect(workflow).toContain(
       'workflow_dispatch:\n    inputs:\n      tag:\n        description: Exact annotated release tag to recover\n        required: true\n        type: string\n      sha:\n        description: Exact 40-character hexadecimal commit SHA to recover\n        required: true\n        type: string',
     );
@@ -445,7 +451,7 @@ describe('release generation', () => {
 
     expect(recoveryJob).not.toContain('npm publish');
 
-    expect(releaseJob).toContain('MAX_PROPAGATION_ATTEMPTS=6');
+    expect(releaseJob).toContain('MAX_PROPAGATION_ATTEMPTS=12');
     expect(releaseJob).toContain(
       'while [ "$ATTEMPT" -le "$MAX_PROPAGATION_ATTEMPTS" ]; do',
     );
@@ -458,8 +464,20 @@ describe('release generation', () => {
       'npm registry propagation did not complete after $MAX_PROPAGATION_ATTEMPTS attempts',
     );
     expect(releaseJob).toContain('ATTEMPT=$((ATTEMPT + 1))');
+    expect(releaseJob).toContain('BACKOFF_SECONDS=10');
+    expect(releaseJob).toContain('sleep "$BACKOFF_SECONDS"');
+    expect(releaseJob).toContain('BACKOFF_SECONDS=$((BACKOFF_SECONDS * 2))');
+    expect(releaseJob).toContain(
+      'if [ "$BACKOFF_SECONDS" -gt 60 ]; then\n                BACKOFF_SECONDS=60\n              fi',
+    );
+    const propagationLimits = [...workflow.matchAll(/MAX(?:_FALLBACK)?_PROPAGATION_ATTEMPTS=(\d+)/g)].map(
+      (match) => match[1],
+    );
+    expect(propagationLimits).toEqual(['12', '12']);
+    const backoffCaps = [...workflow.matchAll(/BACKOFF_SECONDS" -gt (\d+)/g)].map((match) => match[1]);
+    expect(backoffCaps).toEqual(['60', '60']);
 
-    const propagationLimit = releaseJob.indexOf('MAX_PROPAGATION_ATTEMPTS=6');
+    const propagationLimit = releaseJob.indexOf('MAX_PROPAGATION_ATTEMPTS=12');
     const propagationLoop = releaseJob.indexOf(
       'while [ "$ATTEMPT" -le "$MAX_PROPAGATION_ATTEMPTS" ]; do',
     );
@@ -478,6 +496,10 @@ describe('release generation', () => {
       'npm registry propagation did not complete after $MAX_PROPAGATION_ATTEMPTS attempts',
     );
     const propagationExit = releaseJob.indexOf('exit 1', propagationExhaustion);
+    const backoffInit = releaseJob.indexOf('BACKOFF_SECONDS=10');
+    const backoffSleep = releaseJob.indexOf('sleep "$BACKOFF_SECONDS"');
+    const backoffDouble = releaseJob.indexOf('BACKOFF_SECONDS=$((BACKOFF_SECONDS * 2))');
+    const backoffCap = releaseJob.indexOf('if [ "$BACKOFF_SECONDS" -gt 60 ]');
 
     const requiredRegistryVerifications = [
       ...releaseJob.matchAll(
@@ -497,6 +519,11 @@ describe('release generation', () => {
     expect(propagationExhaustion).toBeLessThan(propagationFailure);
     expect(propagationFailure).toBeLessThan(propagationExit);
     expect(propagationExit).toBeLessThan(requiredRegistryVerification);
+    expect(propagationLimit).toBeLessThan(backoffInit);
+    expect(backoffInit).toBeLessThan(propagationLoop);
+    expect(propagationExit).toBeLessThan(backoffSleep);
+    expect(backoffSleep).toBeLessThan(backoffDouble);
+    expect(backoffDouble).toBeLessThan(backoffCap);
 
     expect(recoveryJob).toContain(
       'RECOVERY_TAG: v4.15.4\n      RECOVERY_SHA: cb6932311ac956687e3c66bb6a48d52a8df14d56\n      RECOVERY_INPUT_TAG: ${{ inputs.tag }}\n      RECOVERY_INPUT_SHA: ${{ inputs.sha }}',


### PR DESCRIPTION
## Summary

Fixes #3635. The `Release` workflow's `Publish exact archive and verify registry` step
post-publish propagation loop was 6 attempts × 10s sleep (~60s window) in **both** the
primary provenance path and the sigstore-fallback path. `npm publish` succeeds, but the
subsequent exact-version `npm install` + `npm audit signatures` verification races npm's
registry/CDN propagation and fails with transient `ETARGET` — reddening v4.15.6, v4.15.7,
and v4.15.8 while the artifact was actually live.

## Change

Narrow change confined to `.github/workflows/release.yml`:

- **Primary path** (`--provenance`): `MAX_PROPAGATION_ATTEMPTS` 6 → 12 with capped
  exponential backoff (10s start, doubling, 60s cap). Worst-case bounded propagation
  window ~550s vs ~60s before.
- **Fallback path** (`sigstore-fallback`): identical bounded contract —
  `MAX_FALLBACK_PROPAGATION_ATTEMPTS` 6 → 12, same capped backoff.
- Fail-closed behavior is preserved unchanged:
  - publish still ships the **exact staged archive** (`$FINAL_TARBALL`);
  - `verify-registry` still enforces the exact version/tag/SHA + provenance-bound
    evidence (`--provenance required` with the audit report in the primary path,
    `sigstore-fallback` with the publish log in the fallback path);
  - terminal `ETARGET` or any integrity/attestation mismatch still fails the job —
    the loop only extends the *propagation wait*, it never masks a verification
    failure as success (exhaustion still `exit 1`).

## Tests

- `npx vitest run src/__tests__/release-generation.test.ts` → 7/7 pass.
  Regression assertions updated for the new bounded contract on **both** paths:
  12/12 attempt limits, 60/60 backoff caps, and retry-loop ordering
  (limit < backoff init < loop; exhaustion < sleep < double < cap;
  verify-registry still terminal after exhaustion).
- `release.yml` parses as YAML (jobs: `release`, `recover`).
- Extracted publish step passes `bash -n`.
- Shell simulation of the exact loop contract: exhaustion → 12 attempts + `exit 1`;
  success on attempt 3 → sleeps `10 20`; success on attempt 1 → no sleep.

## Adversarial review handoff

This PR was authored in a recovery lane without reviewer-subagent fan-out (per the
recovery session constraint). It still needs an **independent adversarial review** by a
reviewer not involved in authoring — specifically to re-check that no change weakens the
fail-closed `verify-registry` boundary and that the widened window is acceptable CI cost
for the release job.
