### PR TITLE
fix(ask): bound every provider spawn so a hung CLI cannot block omc ask

### DIFF
--- a/scripts/run-provider-advisor.js
+++ b/scripts/run-provider-advisor.js
@@ -15,29 +15,53 @@ const PROVIDER_BINARIES = {
 };
 const SHOULD_USE_WINDOWS_SHELL = process.platform === 'win32';
 
+// `spawnSync` blocks until the child exits, so an advisor CLI that wedges (waiting
+// on a hidden prompt, a stalled network call, a broken auth refresh) makes `omc ask`
+// — and every `/ask` / `/ccg` flow built on it — wait forever with no diagnostic.
+// Every provider therefore gets a wall-clock bound, not just antigravity.
+//
+// The kill MUST be SIGKILL: since spawnSync does not return until the child exits,
+// a catchable SIGTERM would let a signal-trapping CLI hang past the timeout anyway.
+const TIMEOUT_KILL_SIGNAL = 'SIGKILL';
+
+// 8 minutes: comfortably above a slow-but-real agent answer, and below the 10-minute
+// Bash tool ceiling in Claude Code, so a wedged provider is reported by omc itself
+// instead of being truncated by the harness with no explanation.
+const ASK_TIMEOUT_DEFAULT_MS = 480000;
+
 // Antigravity (`agy`) headless print mode has a known upstream non-TTY bug
 // (google-antigravity/antigravity-cli#76) that, beyond the empty-exit-0 case,
 // can hang indefinitely — and agy's own `--print-timeout` flag is non-functional.
-// Bound the subprocess ourselves so a hang fails cleanly instead of blocking the
-// whole `omc ask` / `/ccg` flow forever. Generous so it never trips a real answer.
-// The kill MUST be SIGKILL: spawnSync does not return until the child exits, so a
-// catchable SIGTERM would let a signal-trapping agy hang past the timeout.
+// It keeps its own (tighter, separately tunable) budget and its own #76 diagnostics.
 const ANTIGRAVITY_TIMEOUT_DEFAULT_MS = 300000;
-const ANTIGRAVITY_TIMEOUT_KILL_SIGNAL = 'SIGKILL';
-const ANTIGRAVITY_TIMEOUT_MS = (() => {
-  const raw = process.env.OMC_ANTIGRAVITY_TIMEOUT_MS;
+
+const TIMEOUT_CLAMP_MAX_MS = 3600000;
+
+/**
+ * Read a timeout override from the environment.
+ * Requires a finite, integer, >=1000ms value and clamps to <=1h; anything else warns
+ * and falls back to the default so a bad override can't disable or distort the bound.
+ */
+function resolveTimeoutMs(envVar, defaultMs, logPrefix) {
+  const raw = process.env[envVar];
   if (raw === undefined || raw === '') {
-    return ANTIGRAVITY_TIMEOUT_DEFAULT_MS;
+    return defaultMs;
   }
   const parsed = Number(raw);
-  // Require a finite, integer, >=1000ms value; clamp to <=1h. Otherwise warn and
-  // fall back to the default so a bad override can't disable or distort the bound.
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1000) {
-    console.error(`[ask-antigravity] Ignoring invalid OMC_ANTIGRAVITY_TIMEOUT_MS="${raw}" (need an integer >= 1000); using ${ANTIGRAVITY_TIMEOUT_DEFAULT_MS}ms.`);
-    return ANTIGRAVITY_TIMEOUT_DEFAULT_MS;
+    console.error(`[${logPrefix}] Ignoring invalid ${envVar}="${raw}" (need an integer >= 1000); using ${defaultMs}ms.`);
+    return defaultMs;
   }
-  return Math.min(parsed, 3600000);
-})();
+  return Math.min(parsed, TIMEOUT_CLAMP_MAX_MS);
+}
+
+/** Wall-clock budget for a provider subprocess. */
+function resolveProviderTimeoutMs(provider) {
+  if (provider === 'antigravity') {
+    return resolveTimeoutMs('OMC_ANTIGRAVITY_TIMEOUT_MS', ANTIGRAVITY_TIMEOUT_DEFAULT_MS, 'ask-antigravity');
+  }
+  return resolveTimeoutMs('OMC_ASK_TIMEOUT_MS', ASK_TIMEOUT_DEFAULT_MS, `ask-${provider}`);
+}
 
 /**
  * Build CLI args for a given provider.
@@ -319,15 +343,17 @@ async function main() {
 
   const pipePromptViaStdin = shouldPipePromptViaStdin(provider, prompt);
   const providerArgs = buildProviderArgs(provider, prompt, { pipePromptViaStdin });
+  const timeoutMs = resolveProviderTimeoutMs(provider);
   const run = spawnSync(binary, providerArgs, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
     env: buildProviderEnv(provider),
     shell: SHOULD_USE_WINDOWS_SHELL,
-    // Bound antigravity so an upstream non-TTY hang (#76) fails cleanly instead of
-    // blocking forever; agy's own --print-timeout does not work. SIGKILL (not a
-    // catchable SIGTERM) guarantees spawnSync returns even if agy traps signals.
-    ...(provider === 'antigravity' ? { timeout: ANTIGRAVITY_TIMEOUT_MS, killSignal: ANTIGRAVITY_TIMEOUT_KILL_SIGNAL } : {}),
+    // Bound every provider so a wedged CLI fails cleanly instead of blocking forever.
+    // SIGKILL (not a catchable SIGTERM) guarantees spawnSync returns even if the
+    // provider traps signals.
+    timeout: timeoutMs,
+    killSignal: TIMEOUT_KILL_SIGNAL,
     ...(pipePromptViaStdin ? { input: prompt } : { stdio: ['ignore', 'pipe', 'pipe'] }),
   });
 
@@ -336,17 +362,26 @@ async function main() {
   const rawOutput = [stdout, stderr].filter(Boolean).join(stdout && stderr ? '\n\n' : '');
   let exitCode = typeof run.status === 'number' ? run.status : 1;
 
-  // Antigravity (#76): the headless non-TTY bug surfaces two ways — a clean
-  // zero-exit with NO output (output dropped on flush), or an indefinite hang.
-  // The timeout above turns a hang into a killed/non-zero run; here we also turn
-  // a zero-exit empty result into a failure, so the advisor never records
-  // "(no output)" and reports success. (Empirically agy 1.0.10 returns output
-  // under pipe capture; this surfaces the regression/refusal cases instead of
-  // masking them.) No silent success, no infinite wait — see #76 for why neither
-  // a PTY wrapper nor agy's --print-timeout is a usable workaround.
-  if (provider === 'antigravity' && (run.error?.code === 'ETIMEDOUT' || run.signal === ANTIGRAVITY_TIMEOUT_KILL_SIGNAL)) {
-    console.error(`[ask-antigravity] agy timed out after ${ANTIGRAVITY_TIMEOUT_MS}ms with no completed response (see antigravity-cli#76).`);
-    console.error('[ask-antigravity] agy headless print mode can hang on non-TTY; verify interactively with: agy -p "<prompt>"');
+  // A hang is now a killed, non-zero run for every provider: the bound above turns
+  // "waits forever with no diagnostic" into a named failure that says which CLI
+  // stalled and how to raise its budget.
+  //
+  // Antigravity (#76) additionally fails a second way — a clean zero-exit with NO
+  // output (dropped on flush) — so that case is also turned into a failure, and the
+  // advisor never records "(no output)" while reporting success. (Empirically agy
+  // 1.0.10 returns output under pipe capture; this surfaces the regression/refusal
+  // cases instead of masking them.) See #76 for why neither a PTY wrapper nor agy's
+  // own --print-timeout is a usable workaround.
+  const timedOut = run.error?.code === 'ETIMEDOUT' || run.signal === TIMEOUT_KILL_SIGNAL;
+
+  if (timedOut) {
+    console.error(`[ask-${provider}] ${binary} timed out after ${timeoutMs}ms with no completed response; the process was killed.`);
+    if (provider === 'antigravity') {
+      console.error('[ask-antigravity] agy headless print mode can hang on non-TTY (see antigravity-cli#76); verify interactively with: agy -p "<prompt>"');
+      console.error('[ask-antigravity] Raise the budget with OMC_ANTIGRAVITY_TIMEOUT_MS=<ms> if the prompt legitimately needs longer.');
+    } else {
+      console.error(`[ask-${provider}] Verify the CLI runs headlessly on its own, then raise the budget with OMC_ASK_TIMEOUT_MS=<ms> if the prompt legitimately needs longer.`);
+    }
     exitCode = exitCode === 0 ? 1 : exitCode;
   } else if (provider === 'antigravity' && exitCode === 0 && rawOutput.trim() === '') {
     console.error('[ask-antigravity] agy exited 0 but produced no output under pipe capture.');

--- a/src/cli/__tests__/ask.test.ts
+++ b/src/cli/__tests__/ask.test.ts
@@ -1090,6 +1090,111 @@ describe('run-provider-advisor script contract', () => {
     }
   });
 
+  it('bounds every provider spawn with a hard-kill timeout so a hung CLI cannot block omc ask forever', () => {
+    // spawnSync blocks until the child exits, so an unbounded provider turns a wedged
+    // CLI into an indefinite `omc ask` / `/ccg` hang. Antigravity used to be the only
+    // provider with a bound; every provider needs one.
+    const providers: Array<[provider: string, binary: string]> = [
+      ['codex', 'codex'],
+      ['claude', 'claude'],
+      ['gemini', 'gemini'],
+      ['grok', 'grok'],
+      ['cursor', 'cursor-agent'],
+    ];
+
+    for (const [provider, binary] of providers) {
+      const wd = mkdtempSync(join(tmpdir(), `omc-ask-${provider}-killcfg-`));
+      try {
+        const capturePath = join(wd, 'spawn-sync-calls.json');
+        const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+        const result = runAdvisorScriptWithPrelude(
+          preludePath,
+          [provider, '--prompt', 'reply please'],
+          wd,
+          { SPAWN_CAPTURE_PATH: capturePath },
+        );
+        expect(result.status).toBe(0);
+
+        const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+          command: string; args: string[]; options: { timeout: number | null; killSignal: string | null };
+        }>;
+        const providerRun = calls.find((c) => c.command === binary && !c.args.includes('--version'));
+        expect(providerRun).toBeDefined();
+        // SIGKILL, not a catchable SIGTERM: a signal-trapping CLI would otherwise
+        // outlive the timeout and keep spawnSync blocked.
+        expect(providerRun!.options.killSignal).toBe('SIGKILL');
+        // 8 minutes — under Claude Code's 10-minute Bash ceiling, so omc reports the
+        // stall itself instead of being truncated by the harness.
+        expect(providerRun!.options.timeout).toBe(480000);
+      } finally {
+        rmSync(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('reports a non-antigravity provider timeout as a failure naming the CLI and the override', () => {
+    const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-timeout-'));
+    try {
+      const capturePath = join(wd, 'spawn-sync-calls.json');
+      const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+      const result = runAdvisorScriptWithPrelude(
+        preludePath,
+        ['codex', '--prompt', 'reply please'],
+        wd,
+        { SPAWN_CAPTURE_PATH: capturePath, SPAWN_CAPTURE_MODE: 'timeout' },
+      );
+
+      // A killed run must fail loudly rather than record success or hang.
+      expect(result.status).toBe(1);
+      const stderr = `${result.stderr ?? ''}`;
+      expect(stderr).toContain('timed out');
+      expect(stderr).toContain('codex');
+      expect(stderr).toContain('OMC_ASK_TIMEOUT_MS');
+      // The antigravity-specific #76 guidance must not leak into other providers.
+      expect(stderr).not.toContain('antigravity-cli#76');
+    } finally {
+      rmSync(wd, { recursive: true, force: true });
+    }
+  });
+
+  it('honors a valid OMC_ASK_TIMEOUT_MS override and ignores an invalid one', () => {
+    const cases: Array<[override: string, expectedTimeout: number, expectWarning: boolean]> = [
+      ['60000', 60000, false],
+      ['-5', 480000, true],
+    ];
+
+    for (const [override, expectedTimeout, expectWarning] of cases) {
+      const wd = mkdtempSync(join(tmpdir(), 'omc-ask-codex-timeout-override-'));
+      try {
+        const capturePath = join(wd, 'spawn-sync-calls.json');
+        const preludePath = writeSpawnSyncCapturePreludeNative(wd);
+        const result = runAdvisorScriptWithPrelude(
+          preludePath,
+          ['codex', '--prompt', 'reply please'],
+          wd,
+          { SPAWN_CAPTURE_PATH: capturePath, OMC_ASK_TIMEOUT_MS: override },
+        );
+        expect(result.status).toBe(0);
+
+        const stderr = `${result.stderr ?? ''}`;
+        if (expectWarning) {
+          // A bad override must not silently disable or distort the bound.
+          expect(stderr).toContain('Ignoring invalid OMC_ASK_TIMEOUT_MS');
+        } else {
+          expect(stderr).not.toContain('Ignoring invalid OMC_ASK_TIMEOUT_MS');
+        }
+
+        const calls = JSON.parse(readFileSync(capturePath, 'utf8')) as Array<{
+          command: string; args: string[]; options: { timeout: number | null };
+        }>;
+        const providerRun = calls.find((c) => c.command === 'codex' && !c.args.includes('--version'));
+        expect(providerRun!.options.timeout).toBe(expectedTimeout);
+      } finally {
+        rmSync(wd, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('pipes multiline claude prompts over stdin so the prompt is never a raw argv value (#3221)', () => {
     const wd = mkdtempSync(join(tmpdir(), 'omc-ask-claude-multiline-stdin-'));
     const multilinePrompt = 'line one\nline two\nline three';


### PR DESCRIPTION
## Problem

`scripts/run-provider-advisor.js` runs the provider CLI with `spawnSync`, which blocks until the child exits. Only antigravity was given a `timeout`:

```js
...(provider === 'antigravity' ? { timeout: ANTIGRAVITY_TIMEOUT_MS, killSignal: 'SIGKILL' } : {}),
```

So `codex`, `claude`, `gemini`, `grok`, and `cursor` ran **unbounded**. If one of those CLIs wedges — a hidden prompt, a stalled network call, a broken auth refresh — `omc ask` waits forever, and so does everything built on it (`/ask`, `/ccg`).

Inside a Claude Code session the symptom is especially misleading: the wait isn't reported by omc at all, it surfaces ~10 minutes later as the Bash tool's own cutoff, with no indication of which provider stalled or why.

Reproduced on 4.15.6 and 4.15.8 (current `dev`) — not fixed by upgrading.

**Repro:** put a fake `codex` on `PATH` that answers `--version` then `sleep 900`, and run `omc ask codex "..."`. It never returns.

## Fix

Generalize the antigravity-only defense to every provider.

- **Every spawn gets a wall-clock `timeout` and `killSignal: 'SIGKILL'`.** The kill has to be terminal: because `spawnSync` doesn't return until the child exits, a catchable `SIGTERM` would let a signal-trapping CLI outlive the bound and keep blocking — the same reasoning already documented for antigravity.
- **Default 480000ms (8 minutes)** — comfortably above a slow-but-real agent answer, and deliberately *below* Claude Code's 10-minute Bash ceiling, so omc reports the stall itself instead of being silently truncated by the harness.
- **`OMC_ASK_TIMEOUT_MS` override**, reusing the existing validation (finite integer, `>= 1000`, clamped to 1h, warn-and-default on garbage) — extracted into a shared `resolveTimeoutMs` helper rather than duplicated.
- **A timeout now exits non-zero for every provider**, naming which CLI stalled and how to raise its budget.
- **Antigravity is unchanged in behavior**: it keeps its tighter 300s budget, its `OMC_ANTIGRAVITY_TIMEOUT_MS` override, and its `antigravity-cli#76`-specific guidance (including the empty-exit-0 case). The #76 message no longer leaks into other providers' output.

## Verification

- `npx vitest run src/cli/__tests__/ask.test.ts` → **45 passed** (42 before + 3 added).
- **The 3 new tests fail on unpatched `dev`** and pass with the fix — confirmed by reverting only the script and re-running, so they're real regression guards rather than tests written to match the new code.
- End-to-end with a fake `sleep 900` provider: patched exits `1` at the bound with `[ask-codex] codex timed out after 5000ms ...`; unpatched was still hanging when killed externally at 25s.
- `npm run lint` → 0 errors. `npx tsc --noEmit` → clean.
- No `dist/` or `bridge/` changes (per CONTRIBUTING §"Generated `dist/` and `bridge/` changes are held") — the diff is two files.

<details>
<summary>Full-suite numbers, and the one delta I want to be upfront about</summary>

`npm run test:run` on my machine (macOS, Node 25) is not green on clean `dev` either — a lot of the team/tmux/session/atomic-write tests are environment-sensitive here:

| | Test files | Tests |
|---|---|---|
| `upstream/dev`, unpatched | 25 failed / 620 passed | 300 failed / 11604 passed (11919) |
| this branch | 26 failed / 619 passed | 301 failed / 11606 passed (11922) |

The `+3` total is my added tests, all passing. Diffing the two failure lists, the single extra failing **file** is `src/hooks/session-end/__tests__/session-end-timeout.test.ts`, on a wall-clock assertion (`expected 670 to be less than or equal to 500`). It's load-sensitive flake, not a regression: it passes **3/3 in isolation on this branch**, and it doesn't import the advisor script — `src/cli/__tests__/ask.test.ts` is the only test file in the repo that references `run-provider-advisor`, and it passes.

CI is of course the authority here; flagging it so the number isn't a surprise.

</details>

## Tests added

In `src/cli/__tests__/ask.test.ts`, mirroring the existing antigravity coverage:

1. every provider (`codex`, `claude`, `gemini`, `grok`, `cursor`) is spawned with `timeout: 480000` and `killSignal: 'SIGKILL'`;
2. a non-antigravity timeout fails with a message naming the CLI and `OMC_ASK_TIMEOUT_MS`, and *without* the antigravity `#76` text;
3. a valid `OMC_ASK_TIMEOUT_MS` is honored and an invalid one warns and falls back to the default.

## Two things worth your judgement

**1. The 8-minute default is a behavior change for previously-unbounded providers.** A run that legitimately took longer than 8 minutes used to complete and now fails. I think that's the right trade — an unbounded blocking call is worse than a tunable one, and `OMC_ASK_TIMEOUT_MS` is the escape hatch — but it is a real change, not a pure bug fix, so please sanity-check the number against how long you expect a `/ccg` codex leg to run. Raising the default is a one-line change if you'd rather be more conservative.

**2. `run.signal === 'SIGKILL'` is treated as a timeout.** That means a provider killed by something *else* (OOM killer, a user's `kill -9`) is reported as "timed out after Nms". I kept this deliberately, because it's exactly the existing antigravity check generalized — but this PR does widen its blast radius from one provider to all six. Tightening it to `run.error?.code === 'ETIMEDOUT'` alone would be more precise; I left it alone to avoid changing detection semantics in the same PR. Happy to change it either way.

Behavior I verified is *unchanged* for antigravity: default still `300000`, `OMC_ANTIGRAVITY_TIMEOUT_MS` still works, and it is deliberately **not** affected by `OMC_ASK_TIMEOUT_MS` (the two knobs stay independent).

## Known limitation (pre-existing, not addressed here)

`spawnSync`'s `timeout` kills only the direct child, so a provider that spawns its own children can still orphan them. The async path solved this in d26aa138 (`fix(hud): terminate timed-out provider process groups`) by detaching and signalling the process group, but `spawnSync` has no equivalent option — doing the same here would mean restructuring the advisor to async spawn. Flagging it as a possible follow-up; this PR fixes the unbounded-wait bug without that restructure.

---

Base branch is `dev` per CONTRIBUTING §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
