### PR TITLE
fix(installer): clean up settings.json duplicates of the plugin's own hook commands

### DIFF
--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -494,6 +494,68 @@ describe('install() plugin-provided hook deduplication (#2252)', () => {
     expect(writtenSettings.hooks).toBeUndefined();
   });
 
+  it('removes verbatim plugin-hook-command duplicates from settings.json while preserving unrelated hooks in the same mixed group (#3638)', async () => {
+    // This models the real-world pollution shape from #3638: settings.json
+    // ends up with an exact copy of the plugin's own modern
+    // `$CLAUDE_PLUGIN_ROOT/scripts/...` hook commands, mixed into the SAME
+    // hook-group array as unrelated, non-OMC user commands. Neither
+    // `isStandaloneOmcHookCommand` (expects a `.claude/hooks/` path) nor
+    // group-level `.every()` filtering can catch this shape.
+    fakePluginRoot = mkdtempSync(join(tmpdir(), 'omc-fake-plugin-'));
+    writeCompletePluginPayload(fakePluginRoot);
+
+    const sessionStartCommands = [
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs',
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/project-memory-session.mjs',
+      'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/wiki-session-start.mjs',
+    ];
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { matcher: '*', hooks: sessionStartCommands.map(command => ({ type: 'command', command })) },
+        ],
+      },
+    }));
+
+    const pluginsDir = join(testClaudeDir, 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, 'installed_plugins.json'), JSON.stringify({
+      'oh-my-claudecode': [{ installPath: fakePluginRoot }],
+    }));
+
+    const unrelatedCommands = [
+      'orca orchestration check --peek --timeout-ms 2000',
+      'python3 /Users/x/.claude/scripts/nfd_guard.py session',
+    ];
+
+    // Single settings.json write (mirrors real user settings): plugin already
+    // enabled AND settings.json already polluted with the 3 duplicate
+    // commands sharing one mixed group with the 2 unrelated commands.
+    mkdirSync(testClaudeDir, { recursive: true });
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        SessionStart: [
+          {
+            matcher: '*',
+            hooks: [...sessionStartCommands, ...unrelatedCommands].map(command => ({ type: 'command', command })),
+          },
+        ],
+      },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+
+    const writtenSettings = JSON.parse(
+      readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8'),
+    ) as { hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+
+    expect(result.success).toBe(true);
+    const remainingCommands = writtenSettings.hooks?.SessionStart?.[0]?.hooks?.map(h => h.command) ?? [];
+    expect(remainingCommands).toEqual(unrelatedCommands);
+  });
+
   it('prunes legacy standalone OMC hook files when plugin handles hooks', async () => {
     setupPluginWithHooks();
 

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -442,12 +442,54 @@ function isShippedStandaloneHookPayload(targetPath: string, filename: string, lo
 }
 
 /**
+ * Read every command string from the currently-installed OMC plugin's own
+ * `hooks/hooks.json` manifest(s). Used to recognize settings.json entries that
+ * are verbatim duplicates of the plugin's modern `$CLAUDE_PLUGIN_ROOT/scripts/...`
+ * hook commands — a distinct pollution shape from the older standalone
+ * `.claude/hooks/*.mjs` files that `OMC_HOOK_FILENAMES`/`isStandaloneOmcHookCommand`
+ * were built to detect (see #3638).
+ *
+ * Best-effort: unreadable/missing manifests are silently skipped.
+ */
+function getPluginHookCommands(): Set<string> {
+  const commands = new Set<string>();
+  for (const pluginRoot of getInstalledOmcPluginRoots()) {
+    const hooksJsonPath = join(pluginRoot, 'hooks', 'hooks.json');
+    if (!existsSync(hooksJsonPath)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(hooksJsonPath, 'utf-8')) as {
+        hooks?: Record<string, Array<{ hooks?: Array<{ type?: string; command?: string }> }>>;
+      };
+      for (const groups of Object.values(parsed.hooks ?? {})) {
+        for (const group of groups) {
+          for (const hook of group.hooks ?? []) {
+            if (hook.type === 'command' && typeof hook.command === 'string') {
+              commands.add(hook.command);
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore unreadable manifests; recognition should remain best-effort.
+    }
+  }
+  return commands;
+}
+
+/**
  * Detect whether a hook command belongs to oh-my-claudecode.
  *
  * Recognition strategy (any match is sufficient):
  * 1. Command path contains "omc" as a path/word segment (e.g. `omc-hook.mjs`, `/omc/`)
  * 2. Command path contains "oh-my-claudecode"
  * 3. Command references a known OMC hook filename inside .claude/hooks/
+ *
+ * Deliberately does NOT compare against the installed plugin's own
+ * `hooks/hooks.json` (see `getPluginHookCommands()` below, used separately by
+ * `configureInstallerSettings()`) — this function is called from many
+ * contexts, including tests, that don't isolate `CLAUDE_CONFIG_DIR`/
+ * `CLAUDE_PLUGIN_ROOT`, and reading real plugin state here would make it
+ * silently environment-dependent.
  *
  * @param command - The hook command string
  * @returns true if the command belongs to OMC
@@ -667,19 +709,57 @@ function configureInstallerSettings(
 
   {
     const existingHooks = { ...((settings.hooks || {}) as Record<string, unknown>) };
+
+    const enabledOmcPlugin = context.runningAsPlugin || isOmcPluginEnabledInSettings(settings);
+    const pluginHandlesHooks = context.pluginProvidesHookFiles && enabledOmcPlugin;
+    // Only trust "matches the plugin's own current manifest" as a removal signal
+    // once we've confirmed the plugin is actually installed and handling hooks —
+    // otherwise there's no live hooks.json to compare against.
+    const pluginHookCommands = pluginHandlesHooks ? getPluginHookCommands() : new Set<string>();
+
     let legacyRemoved = 0;
+    let staleDuplicatesRemoved = 0;
 
     for (const [eventType, groups] of Object.entries(existingHooks)) {
       const groupList = groups as HookGroup[];
-      const filtered = groupList.filter(group => {
-        const isLegacy = group.hooks.every(h =>
+      const filtered: HookGroup[] = [];
+
+      for (const group of groupList) {
+        const isFullyLegacyGroup = group.hooks.every(h =>
           h.type === 'command'
           && typeof h.command === 'string'
           && isStandaloneOmcHookCommand(h.command)
         );
-        if (isLegacy) legacyRemoved++;
-        return !isLegacy;
-      });
+        if (isFullyLegacyGroup) {
+          legacyRemoved++;
+          continue;
+        }
+
+        // A group can be a MIX of OMC-owned and unrelated user hooks (e.g. a
+        // single "*" SessionStart group containing both a duplicated plugin
+        // command and a user's own hook). Filter per-entry rather than
+        // requiring the whole group to be uniformly OMC-owned before touching
+        // it, so unrelated hooks in the same group survive (#3638).
+        if (pluginHandlesHooks && pluginHookCommands.size > 0) {
+          const keptHooks = group.hooks.filter(h => {
+            const isStaleDuplicate = h.type === 'command'
+              && typeof h.command === 'string'
+              && pluginHookCommands.has(h.command);
+            if (isStaleDuplicate) staleDuplicatesRemoved++;
+            return !isStaleDuplicate;
+          });
+          if (keptHooks.length === 0) {
+            continue;
+          }
+          if (keptHooks.length !== group.hooks.length) {
+            filtered.push({ ...group, hooks: keptHooks });
+            continue;
+          }
+        }
+
+        filtered.push(group);
+      }
+
       if (filtered.length === 0) {
         delete existingHooks[eventType];
       } else {
@@ -690,9 +770,10 @@ function configureInstallerSettings(
     if (legacyRemoved > 0) {
       context.log(`  Cleaned up ${legacyRemoved} legacy hook entries from settings.json`);
     }
+    if (staleDuplicatesRemoved > 0) {
+      context.log(`  Cleaned up ${staleDuplicatesRemoved} stale plugin-duplicate hook entries from settings.json`);
+    }
 
-    const enabledOmcPlugin = context.runningAsPlugin || isOmcPluginEnabledInSettings(settings);
-    const pluginHandlesHooks = context.pluginProvidesHookFiles && enabledOmcPlugin;
     if (pluginHandlesHooks) {
       const activeStandaloneOmcHookFilenames = collectActiveStandaloneOmcHookFilenames(existingHooks);
       pruneLegacyStandaloneHookScripts(context.log, activeStandaloneOmcHookFilenames);


### PR DESCRIPTION
Fixes #3638.

## Corrected root cause (see [comment on the issue](https://github.com/Yeachan-Heo/oh-my-claudecode/issues/3638#issuecomment-5218047667) for the full trace)

`#2421`/`#2430` fixed duplication from the older standalone-hook-file era (`~/.claude/hooks/*.mjs`, absolute paths). This PR fixes a different, still-current shape: `settings.json` polluted with a **verbatim copy of the plugin's own modern hook command string**, e.g.

```
node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs
```

`isOmcHook()`/`isStandaloneOmcHookCommand()` never recognize this shape — it contains no `omc`/`oh-my-claudecode` substring, and the path segment is `scripts/`, not `hooks/`, so the `hooks/`-path rule doesn't even look at the filename. This is independent of which filenames are in `OMC_HOOK_FILENAMES`.

There's a second, related gap: the existing legacy-cleanup pass filters whole hook **groups** (`group.hooks.every(...)`). Real-world `settings.json` can have a single mixed group (e.g. one `SessionStart` `"*"` matcher) containing both duplicate plugin commands and a user's own unrelated hooks — group-level filtering can't touch that group even with correct per-command detection.

## What changed

- `getPluginHookCommands()` (new, private): reads the currently-installed OMC plugin's own `hooks/hooks.json` (via the existing `getInstalledOmcPluginRoots()`) and returns the flat set of its command strings.
- `configureInstallerSettings()`'s legacy-cleanup pass now also filters **per hook entry** (not just per group) when `pluginHandlesHooks` is true: any `settings.json` command that exactly matches one of the plugin's own current `hooks/hooks.json` commands is dropped, while the rest of the group (and unrelated non-OMC commands sharing that group) survive.
- Deliberately did **not** fold this into the shared, exported `isOmcHook()`. That function is called from several places/tests (e.g. `doctor-conflicts.ts`) that don't isolate `CLAUDE_CONFIG_DIR`/`CLAUDE_PLUGIN_ROOT`; giving it a new filesystem read made it silently pick up this machine's real installed plugin during an unrelated test and broke it locally. `getPluginHookCommands()` is scoped to only the one call site inside `configureInstallerSettings()`, which already has proper env isolation (verified against the existing `standalone-hook-reconcile.test.ts` harness).

## Not in scope

- `omc doctor conflicts` will still classify this pollution shape as "⚠ Other" rather than OMC-owned (same underlying gap, different call site — `checkHookConflicts()`/`isOmcHook()`). Left out of this PR for the isolation reason above; happy to follow up separately if that's wanted.

## Testing

- New test in `standalone-hook-reconcile.test.ts` (`removes verbatim plugin-hook-command duplicates from settings.json while preserving unrelated hooks in the same mixed group (#3638)`) models the exact real-world shape: 3 duplicate plugin commands + 2 unrelated user commands in one mixed `SessionStart` group.
- `npx tsc --noEmit` clean.
- Full `src/installer/__tests__/` + `src/__tests__/doctor-conflicts.test.ts` run locally (48 + 78 tests): all pass except one pre-existing `doctor-conflicts.test.ts` failure that reproduces identically on a clean `dev` checkout with these changes stashed (unrelated to this PR — looks environment-specific to this machine).
- Did **not** get a clean local run of the *entire* `npm test` suite — on this macOS dev machine it has ~300 pre-existing failures unrelated to this change (e.g. `/proc/<pid>/stat` reads, which don't exist on macOS, plus some apparent cross-file state leakage when the full suite runs in one process — a test that passes in isolation fails when run alongside hundreds of others). Scoped verification above is what I can vouch for locally; deferring to CI for the full-suite signal.
