### PR TITLE
feat(wiki): skip auto-capturing session-log page for zero-human-message sessions

### DIFF
--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -913,7 +913,11 @@ export async function processSessionEnd(input: SessionEndInput): Promise<HookOut
 /** Wiki producer has no foreground lock or write; it only seals a durable capture/no-op intent. */
 export async function processWikiSessionEnd(input: SessionEndInput): Promise<HookOutput> {
   const directory = resolveToWorktreeRoot(input.cwd);
-  const intent = buildWikiSessionEndCaptureIntent({ cwd: directory, session_id: input.session_id });
+  const intent = buildWikiSessionEndCaptureIntent({
+    cwd: directory,
+    session_id: input.session_id,
+    transcript_path: input.transcript_path,
+  });
   sealWikiManifest(directory, input.session_id, intent ? { ...intent } : undefined);
   spawnSessionEndWorker({ directory, sessionId: input.session_id });
   return { continue: true };

--- a/src/hooks/wiki/__tests__/session-hooks.test.ts
+++ b/src/hooks/wiki/__tests__/session-hooks.test.ts
@@ -8,7 +8,7 @@ import fsp from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { ensureWikiDir } from '../storage.js';
-import { onSessionEnd, onSessionStart } from '../session-hooks.js';
+import { onSessionEnd, onSessionStart, buildWikiSessionEndCaptureIntent } from '../session-hooks.js';
 import { getWikiDir, readPage } from '../storage.js';
 
 describe('Wiki Session Hooks', () => {
@@ -47,6 +47,83 @@ describe('Wiki Session Hooks', () => {
     const wikiEntries = fs.readdirSync(wikiDir);
     expect(wikiEntries.filter(entry => entry.startsWith('session-log-'))).toHaveLength(0);
     expect(fs.existsSync(path.join(wikiDir, 'log.md'))).toBe(false);
+  });
+});
+
+describe('buildWikiSessionEndCaptureIntent — skip empty sessions (#3639)', () => {
+  let tempDir: string;
+  let configDir: string;
+  let originalClaudeConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-session-end-capture-'));
+    configDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'wiki-session-end-capture-config-'));
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    ensureWikiDir(tempDir);
+  });
+
+  afterEach(async () => {
+    if (originalClaudeConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    }
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    await fsp.rm(configDir, { recursive: true, force: true });
+  });
+
+  function writeTranscript(lines: unknown[]): string {
+    const transcriptPath = path.join(tempDir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptPath, lines.map(line => JSON.stringify(line)).join('\n') + '\n');
+    return transcriptPath;
+  }
+
+  it('returns null (skips capture) when the transcript has zero human messages', () => {
+    const transcriptPath = writeTranscript([
+      { type: 'user', isMeta: true, message: { role: 'user', content: '<system-reminder>...</system-reminder>' } },
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } },
+      { type: 'user', message: { role: 'user', content: [{ type: 'tool_result', content: 'ok' }] } },
+    ]);
+
+    const intent = buildWikiSessionEndCaptureIntent({
+      cwd: tempDir,
+      session_id: 'session-empty',
+      transcript_path: transcriptPath,
+    });
+
+    expect(intent).toBeNull();
+  });
+
+  it('returns a capture intent when the transcript has at least one real human message', () => {
+    const transcriptPath = writeTranscript([
+      { type: 'user', message: { role: 'user', content: 'please fix the bug' } },
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'sure' }] } },
+    ]);
+
+    const intent = buildWikiSessionEndCaptureIntent({
+      cwd: tempDir,
+      session_id: 'session-active',
+      transcript_path: transcriptPath,
+    });
+
+    expect(intent).not.toBeNull();
+    expect(intent?.sessionId).toBe('session-active');
+  });
+
+  it('fails open (still captures) when transcript_path is missing or unreadable', () => {
+    const intentNoPath = buildWikiSessionEndCaptureIntent({
+      cwd: tempDir,
+      session_id: 'session-no-path',
+    });
+    expect(intentNoPath).not.toBeNull();
+
+    const intentBadPath = buildWikiSessionEndCaptureIntent({
+      cwd: tempDir,
+      session_id: 'session-bad-path',
+      transcript_path: path.join(tempDir, 'does-not-exist.jsonl'),
+    });
+    expect(intentBadPath).not.toBeNull();
   });
 });
 

--- a/src/hooks/wiki/session-hooks.ts
+++ b/src/hooks/wiki/session-hooks.ts
@@ -104,15 +104,80 @@ function loadWikiConfig(root: string): WikiConfig {
 }
 
 /**
+ * A transcript record body carries a real human turn when it's a `type: 'user'`
+ * (or `message.role === 'user'`) record that isn't a meta-injected marker,
+ * compact summary, sidechain (subagent) entry, or a tool_result-only wrapper.
+ * Mirrors the classification already used by `userRecordHasToolResult` in
+ * `persistent-mode/index.ts` and by the (external) session-report analyzer.
+ */
+function isRealHumanTranscriptRecord(parsed: {
+  type?: unknown;
+  isMeta?: unknown;
+  isCompactSummary?: unknown;
+  isSidechain?: unknown;
+  message?: { role?: unknown; content?: unknown };
+}): boolean {
+  const role = parsed?.message?.role;
+  const isUserRole = parsed?.type === 'user' || role === 'user';
+  if (!isUserRole || parsed.isMeta || parsed.isCompactSummary || parsed.isSidechain) {
+    return false;
+  }
+
+  const content = parsed.message?.content;
+  if (typeof content === 'string') {
+    return content.trim().length > 0;
+  }
+  if (Array.isArray(content)) {
+    return content.some((block) => {
+      const type = (block as { type?: unknown } | null)?.type;
+      return type !== 'tool_result' && type !== 'tool_use';
+    });
+  }
+  return false;
+}
+
+/**
+ * Does this session's transcript contain at least one real human message?
+ * Used to skip auto-capturing a session-log page for no-op sessions (e.g. a
+ * bare smoke-test invocation) that would otherwise leave an empty,
+ * never-promoted stub behind forever (#3639).
+ *
+ * Fails OPEN: any read/parse error, or a missing/unreadable transcript,
+ * returns `true` (assume real activity) so a transient filesystem issue never
+ * silently suppresses a legitimate capture.
+ */
+function hasHumanMessageInTranscript(transcriptPath: string): boolean {
+  try {
+    if (!existsSync(transcriptPath)) return true;
+    const raw = readFileSync(transcriptPath, 'utf-8');
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: Parameters<typeof isRealHumanTranscriptRecord>[0];
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (isRealHumanTranscriptRecord(parsed)) return true;
+    }
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Build a JSON-safe SessionEnd capture intent without taking the wiki lock or
  * mutating the filesystem. The manifest worker durably owns and commits it.
  */
 export function buildWikiSessionEndCaptureIntent(
-  data: { cwd?: string; session_id?: string },
+  data: { cwd?: string; session_id?: string; transcript_path?: string },
 ): WikiSessionEndCaptureIntent | null {
   try {
     const root = data.cwd || process.cwd();
     if (!loadWikiConfig(root).autoCapture || !existsSync(getWikiDir(root))) return null;
+    if (data.transcript_path && !hasHumanMessageInTranscript(data.transcript_path)) return null;
 
     const sessionId = data.session_id || `session-${Date.now()}`;
     const capturedAt = new Date().toISOString();


### PR DESCRIPTION
Fixes #3639.

## Scope note

Deliberately narrower than #2264 (`feat(wiki): session-log pages accumulate without bound — need auto-expiry`), which was closed as out-of-scope product/retention policy. This PR adds **no** TTL, expiry, or cleanup-of-existing-pages behavior — it only changes whether a page gets *created* in the first place for a session that had no real content.

## Problem

The real SessionEnd capture path is `scripts/wiki-session-end.mjs` → `processWikiSessionEnd()` → `buildWikiSessionEndCaptureIntent()` → (worker) → `commitWikiSessionEndCaptureIntent()`. (`onSessionEnd` in the same file is dead code for this flow today — it's an unconditional no-op, kept only for one now-vacuous test; not touched by this PR.)

`buildWikiSessionEndCaptureIntent()` unconditionally captures a page for every session, including ones with **zero human messages** (a bare `claude -p "hi"` smoke test, an immediately-closed session, etc). Every such page is the identical content-free template — just a session ID and a "review and promote via `wiki_ingest`" reminder — and since promotion essentially never happens for these, they accumulate forever. (Found 203 of them, spanning ~3 weeks, 100% orphaned per `wiki_lint`, in one real project.)

## What changed

- New local helper `hasHumanMessageInTranscript()` in `session-hooks.ts`: scans the session's JSONL transcript for at least one record that's a real human turn (`type`/`role` `user`, not `isMeta`/`isCompactSummary`/`isSidechain`, and not tool-result-only content) — short-circuits on the first match. **Fails open**: any read/parse error, or the transcript simply not being provided, returns `true` (still captures) so a transient FS issue can never silently suppress a legitimate capture.
- Threaded `transcript_path` (already present on `SessionEndInput`, just not passed through before) from `processWikiSessionEnd()` into `buildWikiSessionEndCaptureIntent()`.
- Guard: when `transcript_path` is present and has no human message, `buildWikiSessionEndCaptureIntent()` returns `null` — the exact same no-op path already used and tested for `autoCapture: false` (`sealWikiManifest` marks the action `completed` with nothing to commit; no manifest/worker changes needed).

## Testing

- New `describe('buildWikiSessionEndCaptureIntent — skip empty sessions (#3639)')` block in `session-hooks.test.ts`: zero-human-message transcript → `null`; ≥1 human message → non-null intent; missing/unreadable transcript path → still captures (fail-open).
- `npx tsc --noEmit` clean.
- Full local run of `src/hooks/wiki/` + `src/hooks/session-end/` (23 files, 198 tests): all pass.
- Did not get a clean local run of the entire `npm test` suite on this machine — same pre-existing, apparently macOS/environment-specific noise noted in #3640 (unrelated files/areas, e.g. `/proc/<pid>/stat` reads that don't exist on macOS). Deferring to CI for the full-suite signal; the scoped runs above cover everything this PR touches.
