### PR TITLE
fix(cli): dispatch subcommands when --plugin-dir comes first

### DIFF
--- a/src/cli/__tests__/root-plugin-dir-routing.test.ts
+++ b/src/cli/__tests__/root-plugin-dir-routing.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Real commander-pipeline tests for a root-level `--plugin-dir <path>` placed
+ * *before* the subcommand, which is the ordering CONTRIBUTING and the READMEs
+ * document:
+ *
+ *   omc --plugin-dir "$PWD" setup --plugin-dir-mode
+ *
+ * The installer and the launch path are both mocked, so nothing touches the
+ * filesystem and no Claude process is spawned.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resolve } from 'path';
+import { OMC_PLUGIN_ROOT_ENV } from '../../lib/env-vars.js';
+
+// Tell src/cli/index.ts not to auto-parse process.argv on import.
+process.env.OMC_CLI_SKIP_PARSE = '1';
+
+const installMock = vi.fn(() => ({
+  success: true,
+  message: 'ok',
+  installedAgents: [],
+  installedCommands: [],
+  installedSkills: [],
+  hooksConfigured: true,
+  hookConflicts: [],
+  errors: [],
+}));
+
+vi.mock('../../installer/index.js', async () => {
+  const actual = await vi.importActual<typeof import('../../installer/index.js')>(
+    '../../installer/index.js'
+  );
+  return {
+    ...actual,
+    install: installMock,
+    isInstalled: () => true,
+    getInstallInfo: () => ({ installed: true, version: 'test' }),
+  };
+});
+
+vi.mock('../../features/auto-update.js', async () => {
+  const actual = await vi.importActual<typeof import('../../features/auto-update.js')>(
+    '../../features/auto-update.js'
+  );
+  return {
+    ...actual,
+    getInstalledVersion: () => ({ version: 'test', installPath: '/tmp' }),
+  };
+});
+
+// Bare `omc ...` falls through to launchCommand; keep it from spawning Claude.
+const launchMock = vi.fn(async () => {});
+vi.mock('../launch.js', async () => {
+  const actual = await vi.importActual<typeof import('../launch.js')>('../launch.js');
+  return { ...actual, launchCommand: launchMock };
+});
+
+const PLUGIN_DIR = '/tmp/omc-root-plugin-dir-routing';
+const ORIG_OMC_PLUGIN_ROOT = process.env[OMC_PLUGIN_ROOT_ENV];
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  installMock.mockClear();
+  launchMock.mockClear();
+  delete process.env[OMC_PLUGIN_ROOT_ENV];
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  if (ORIG_OMC_PLUGIN_ROOT === undefined) {
+    delete process.env[OMC_PLUGIN_ROOT_ENV];
+  } else {
+    process.env[OMC_PLUGIN_ROOT_ENV] = ORIG_OMC_PLUGIN_ROOT;
+  }
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+async function run(argv: string[]): Promise<void> {
+  // Fresh commander program per case: commander keeps option values on the
+  // Command instance and does not reset them between parseAsync calls.
+  vi.resetModules();
+  const { buildProgram } = await import('../index.js');
+  await buildProgram().parseAsync(argv, { from: 'user' });
+}
+
+function lastInstallOptions(): Record<string, unknown> {
+  expect(installMock).toHaveBeenCalled();
+  const calls = installMock.mock.calls;
+  return (calls[calls.length - 1] as unknown as [Record<string, unknown>])[0];
+}
+
+describe('root --plugin-dir before a subcommand', () => {
+  it('dispatches to setup instead of falling through to a Claude launch', async () => {
+    await run(['--plugin-dir', PLUGIN_DIR, 'setup']);
+
+    expect(launchMock).not.toHaveBeenCalled();
+    expect(installMock).toHaveBeenCalled();
+  });
+
+  it('exports the plugin root so setup auto-detects plugin-dir mode', async () => {
+    await run(['--plugin-dir', PLUGIN_DIR, 'setup']);
+
+    expect(process.env[OMC_PLUGIN_ROOT_ENV]).toBe(PLUGIN_DIR);
+    expect(lastInstallOptions().pluginDirMode).toBe(true);
+  });
+
+  it('runs the documented command', async () => {
+    await run(['--plugin-dir', PLUGIN_DIR, 'setup', '--plugin-dir-mode']);
+
+    expect(launchMock).not.toHaveBeenCalled();
+    expect(lastInstallOptions().pluginDirMode).toBe(true);
+  });
+
+  it('resolves a relative path before exporting it', async () => {
+    await run(['--plugin-dir', './rel-plugin-dir', 'setup']);
+
+    expect(process.env[OMC_PLUGIN_ROOT_ENV]).toBe(resolve('./rel-plugin-dir'));
+  });
+
+  it('still reaches launch when there is no subcommand', async () => {
+    await run(['--plugin-dir', PLUGIN_DIR]);
+
+    expect(launchMock).toHaveBeenCalled();
+    expect(installMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves a plain setup alone', async () => {
+    await run(['setup']);
+
+    expect(process.env[OMC_PLUGIN_ROOT_ENV]).toBeUndefined();
+    expect(lastInstallOptions().pluginDirMode).toBe(false);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -121,7 +121,16 @@ program
   .name('omc')
   .description('Multi-agent orchestration system for Claude Agent SDK')
   .version(version)
+  // Declared so commander knows it takes a value. Without that, `omc
+  // --plugin-dir <path> setup` leaves <path> sitting in the subcommand slot,
+  // and the unrecognized operand falls through to defaultAction (a Claude
+  // launch) instead of dispatching to setup. The preAction hook runs for
+  // subcommands too, so the root flag reaches them as OMC_PLUGIN_ROOT.
+  .option('--plugin-dir <path>', 'Override OMC plugin root directory (sets OMC_PLUGIN_ROOT)')
   .allowUnknownOption()
+  .hook('preAction', (thisCommand) => {
+    applyPluginDirOption(thisCommand.opts().pluginDir as string | undefined);
+  })
   .action(defaultAction);
 
 /**


### PR DESCRIPTION
## Problem

The local-checkout setup documented in CONTRIBUTING §4 (Flow A, "recommended — lowest friction"), the READMEs, `docs/GETTING-STARTED.md`, `docs/LOCAL_PLUGIN_INSTALL.md` and `docs/REFERENCE.md` never runs setup:

```
$ omc --plugin-dir "$PWD" setup --plugin-dir-mode
[omc] Error: Already inside a Claude Code session. Nested launches are not supported.
```

That message is the launch path's nested-session guard. Outside a session it gets past the guard and launches Claude Code with `setup --plugin-dir-mode` as its arguments (or stops at `claude CLI not found` where `claude` isn't installed). Setup is never invoked either way, so `~/.claude` keeps pointing at the old plugin root.

Putting the subcommand first works, so only the documented ordering is affected:

```
$ omc setup --plugin-dir-mode
Oh-My-ClaudeCode Setup
```

## Root cause

The root program calls `allowUnknownOption()` but never declares `--plugin-dir`. Commander therefore doesn't know the flag takes a value, so the path lands in the subcommand slot, matches no subcommand, and the invocation falls through to `defaultAction` — which forwards everything to `launchCommand`.

## Fix

Declare `--plugin-dir <path>` on the root program and apply it from a `preAction` hook, mirroring what `doctor` already does. Commander then consumes the value, `setup` gets the operand slot, and the hook exports `OMC_PLUGIN_ROOT` before the subcommand action runs — the signal `setup` already auto-detects for plugin-dir mode.

Bare `omc --plugin-dir <path>` still reaches launch: `defaultAction` forwards raw argv and `launchCommand` parses the flag out of it as before.

## Tests

Adds `src/cli/__tests__/root-plugin-dir-routing.test.ts`, driving the real commander program via `buildProgram()` with the installer and launch mocked. 4 of its 6 cases fail on unpatched `dev`; the 2 that pass in both guard that bare `omc --plugin-dir <path>` still launches and that plain `omc setup` is untouched.

`npm run lint` — 0 errors. On `npm run test:run` the set of failing files matches `upstream/dev` (macOS carries ~277 pre-existing failures from Linux-only `/proc` and tmux assumptions, plus a few load-sensitive ones that move between runs); the delta is +6 passing tests.
