### PR TITLE
fix(installer): prune duplicate plugin hooks

### DIFF
--- a/src/installer/__tests__/standalone-hook-reconcile.test.ts
+++ b/src/installer/__tests__/standalone-hook-reconcile.test.ts
@@ -706,4 +706,264 @@ describe('install() plugin-provided hook deduplication (#2252)', () => {
     // OMC hook should NOT be re-added
     expect(commands).not.toContain('node "$HOME/.claude/hooks/keyword-detector.mjs"');
   });
+
+  it('removes exact same-event plugin duplicates while preserving mixed user hooks and cross-event entries (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: {
+        SessionStart: [{
+          matcher: '*',
+          hooks: [{ type: 'command', command: pluginCommand }],
+        }],
+      },
+    }, null, 2));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        SessionStart: [{
+          matcher: '*',
+          timeout: 42,
+          hooks: [
+            { type: 'command', command: pluginCommand },
+            { type: 'command', command: 'node /user/session-start.mjs', userField: 'preserve-me' },
+          ],
+        }],
+        Stop: [{
+          matcher: '*',
+          hooks: [{ type: 'command', command: pluginCommand }],
+        }],
+      },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+    const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+      hooks?: Record<string, Array<Record<string, unknown> & { hooks: Array<Record<string, unknown>> }>>;
+    };
+
+    expect(result.success).toBe(true);
+    expect(writtenSettings.hooks?.SessionStart).toEqual([{
+      matcher: '*',
+      timeout: 42,
+      hooks: [{ type: 'command', command: 'node /user/session-start.mjs', userField: 'preserve-me' }],
+    }]);
+    expect(writtenSettings.hooks?.Stop?.[0]?.hooks).toEqual([
+      { type: 'command', command: pluginCommand },
+    ]);
+    const firstWrittenSettings = readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8');
+    const secondResult = install({ force: true, skipClaudeCheck: true });
+    expect(secondResult.success).toBe(true);
+    expect(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')).toBe(firstWrittenSettings);
+  });
+
+  it('reaches a fixed point when a plugin duplicate shares a group with a standalone OMC hook (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        SessionStart: [{ hooks: [
+          { type: 'command', command: pluginCommand },
+          { type: 'command', command: 'node "$HOME/.claude/hooks/session-start.mjs"' },
+        ] }],
+      },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    const firstResult = install({ force: true, skipClaudeCheck: true });
+    const firstWrittenSettings = readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8');
+    const firstSettings = JSON.parse(firstWrittenSettings) as { hooks?: Record<string, unknown> };
+    const secondResult = install({ force: true, skipClaudeCheck: true });
+
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(true);
+    expect(firstSettings.hooks).toBeUndefined();
+    expect(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')).toBe(firstWrittenSettings);
+  });
+  it('drops empty hook containers and reports exact removals in verbose mode (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }, null, 2));
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const { install } = await loadInstaller();
+      const result = install({ force: true, skipClaudeCheck: true, verbose: true });
+      const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+        hooks?: Record<string, unknown>;
+      };
+
+      expect(result.success).toBe(true);
+      expect(writtenSettings.hooks).toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        '  Removed 1 stale plugin duplicate hook entry from settings.json (events: SessionStart)',
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('fails closed with a root-aware diagnostic when the plugin registry is ambiguous (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }));
+    writeFileSync(join(testClaudeDir, 'plugins', 'installed_plugins.json'), JSON.stringify({
+      'oh-my-claudecode': [{ installPath: fakePluginRoot }],
+      'oh-my-claudecode-lookalike': [],
+    }));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }, null, 2));
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const { install } = await loadInstaller();
+      const result = install({ force: true, skipClaudeCheck: true, verbose: true });
+      const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+        hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      };
+
+      expect(result.success).toBe(true);
+      expect(writtenSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toBe(pluginCommand);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(
+        `Skipped plugin duplicate-hook cleanup: plugin root resolution is plugin (cleanupAllowed=false, roots=${fakePluginRoot})`,
+      ));
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('cleans duplicates when all installed plugin manifests agree (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    const manifest = JSON.stringify({
+      hooks: {
+        SessionStart: [{ hooks: [
+          { type: 'command', command: pluginCommand },
+          { type: 'webhook', url: 'https://example.invalid/hook' },
+        ] }],
+      },
+    });
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), manifest);
+    const secondPluginRoot = join(testClaudeDir, 'second-identical-plugin-root');
+    writeCompletePluginPayload(secondPluginRoot);
+    writeFileSync(join(secondPluginRoot, 'hooks', 'hooks.json'), manifest);
+    writeFileSync(join(testClaudeDir, 'plugins', 'installed_plugins.json'), JSON.stringify({
+      'oh-my-claudecode': [
+        { installPath: fakePluginRoot },
+        { installPath: secondPluginRoot },
+      ],
+    }));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: { SessionStart: [{ matcher: 'custom', hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+    const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+      hooks?: Record<string, unknown>;
+    };
+
+    expect(result.success).toBe(true);
+    expect(writtenSettings.hooks).toBeUndefined();
+  });
+
+  it('applies the cleanup through real update reconciliation (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }, null, 2));
+
+    vi.resetModules();
+    const { reconcileUpdateRuntime } = await import('../../features/auto-update.js');
+    const result = reconcileUpdateRuntime({ verbose: false, skipGracePeriod: true });
+    const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+      hooks?: Record<string, unknown>;
+    };
+
+    expect(result.success).toBe(true);
+    expect(writtenSettings.hooks).toBeUndefined();
+  });
+
+  it('preserves plugin-shaped settings hooks when the authoritative manifest is corrupt (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), '{');
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }],
+      },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+    const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(result.success).toBe(true);
+    expect(writtenSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toBe(pluginCommand);
+  });
+
+  it('preserves duplicates when installed plugin manifests disagree (#3638)', async () => {
+    setupPluginWithHooks();
+
+    const pluginCommand = 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/session-start.mjs';
+    writeFileSync(join(fakePluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }] },
+    }));
+    const secondPluginRoot = join(testClaudeDir, 'second-plugin-root');
+    writeCompletePluginPayload(secondPluginRoot);
+    writeFileSync(join(secondPluginRoot, 'hooks', 'hooks.json'), JSON.stringify({
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'node different-plugin-hook.mjs' }] }] },
+    }));
+    writeFileSync(join(testClaudeDir, 'plugins', 'installed_plugins.json'), JSON.stringify({
+      'oh-my-claudecode': [
+        { installPath: fakePluginRoot },
+        { installPath: secondPluginRoot },
+      ],
+    }));
+    writeFileSync(join(testClaudeDir, 'settings.json'), JSON.stringify({
+      enabledPlugins: { 'oh-my-claudecode': true },
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: pluginCommand }] }],
+      },
+    }, null, 2));
+
+    const { install } = await loadInstaller();
+    const result = install({ force: true, skipClaudeCheck: true });
+    const writtenSettings = JSON.parse(readFileSync(join(testClaudeDir, 'settings.json'), 'utf-8')) as {
+      hooks?: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+    };
+
+    expect(result.success).toBe(true);
+    expect(writtenSettings.hooks?.SessionStart?.[0]?.hooks?.[0]?.command).toBe(pluginCommand);
+  });
 });

--- a/src/installer/index.ts
+++ b/src/installer/index.ts
@@ -590,6 +590,68 @@ export function isProjectScopedPlugin(): boolean {
 type HookEntry = { type: string; command: string };
 type HookGroup = { hooks: HookEntry[] };
 
+type SettingsHookEntry = { type?: unknown; command?: unknown; [key: string]: unknown };
+type SettingsHookGroup = { hooks?: unknown; [key: string]: unknown };
+type PluginHookManifestSnapshot = {
+  valid: boolean;
+  commandsByEvent: Map<string, Set<string>>;
+  diagnostics: string[];
+};
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function filterSettingsPluginDuplicateHooks(
+  hooks: Record<string, unknown>,
+  commandsByEvent: Map<string, Set<string>>,
+): { hooks: Record<string, unknown>; removed: number; removedByEvent: Map<string, number> } {
+  const filteredHooks: Record<string, unknown> = Object.create(null);
+  const removedByEvent = new Map<string, number>();
+  let removed = 0;
+
+  for (const [eventType, groups] of Object.entries(hooks)) {
+    if (!Array.isArray(groups)) {
+      filteredHooks[eventType] = groups;
+      continue;
+    }
+
+    const eventCommands = commandsByEvent.get(eventType);
+    const filteredGroups: unknown[] = [];
+    for (const group of groups) {
+      if (!isObjectRecord(group) || !Array.isArray((group as SettingsHookGroup).hooks)) {
+        filteredGroups.push(group);
+        continue;
+      }
+
+      const groupHooks = (group as SettingsHookGroup).hooks as unknown[];
+      const survivingHooks = groupHooks.filter(entry => {
+        if (!eventCommands || !isObjectRecord(entry)) return true;
+        const hook = entry as SettingsHookEntry;
+        const isDuplicate = hook.type === 'command'
+          && typeof hook.command === 'string'
+          && eventCommands.has(hook.command);
+        if (isDuplicate) {
+          removed++;
+          removedByEvent.set(eventType, (removedByEvent.get(eventType) ?? 0) + 1);
+        }
+        return !isDuplicate;
+      });
+
+      if (survivingHooks.length === 0) continue;
+      filteredGroups.push(survivingHooks.length === groupHooks.length
+        ? group
+        : { ...group, hooks: survivingHooks });
+    }
+
+    if (filteredGroups.length > 0) {
+      filteredHooks[eventType] = filteredGroups;
+    }
+  }
+
+  return { hooks: filteredHooks, removed, removedByEvent };
+}
+
 function pruneLegacyStandaloneHookScripts(log: (msg: string) => void, activeStandaloneOmcHookFilenames = new Set<string>()): void {
   if (!existsSync(HOOKS_DIR)) {
     return;
@@ -666,9 +728,28 @@ function configureInstallerSettings(
   let settings = { ...baseSettings };
 
   {
-    const existingHooks = { ...((settings.hooks || {}) as Record<string, unknown>) };
-    let legacyRemoved = 0;
+    let existingHooks = { ...((settings.hooks || {}) as Record<string, unknown>) };
+    const enabledOmcPlugin = context.runningAsPlugin || isOmcPluginEnabledInSettings(settings);
+    const pluginHandlesHooks = context.pluginProvidesHookFiles && enabledOmcPlugin;
 
+    if (pluginHandlesHooks) {
+      const snapshot = collectPluginHookManifestSnapshot();
+      if (snapshot.valid) {
+        const filtered = filterSettingsPluginDuplicateHooks(existingHooks, snapshot.commandsByEvent);
+        existingHooks = filtered.hooks;
+        if (filtered.removed > 0) {
+          context.log(
+            `  Removed ${filtered.removed} stale plugin duplicate hook entr${filtered.removed === 1 ? 'y' : 'ies'} from settings.json (events: ${[...filtered.removedByEvent.keys()].sort().join(', ')})`,
+          );
+        }
+      } else {
+        for (const diagnostic of snapshot.diagnostics) {
+          context.log(`  Skipped plugin duplicate-hook cleanup: ${diagnostic}`);
+        }
+      }
+    }
+
+    let legacyRemoved = 0;
     for (const [eventType, groups] of Object.entries(existingHooks)) {
       const groupList = groups as HookGroup[];
       const filtered = groupList.filter(group => {
@@ -691,8 +772,6 @@ function configureInstallerSettings(
       context.log(`  Cleaned up ${legacyRemoved} legacy hook entries from settings.json`);
     }
 
-    const enabledOmcPlugin = context.runningAsPlugin || isOmcPluginEnabledInSettings(settings);
-    const pluginHandlesHooks = context.pluginProvidesHookFiles && enabledOmcPlugin;
     if (pluginHandlesHooks) {
       const activeStandaloneOmcHookFilenames = collectActiveStandaloneOmcHookFilenames(existingHooks);
       pruneLegacyStandaloneHookScripts(context.log, activeStandaloneOmcHookFilenames);
@@ -1464,6 +1543,111 @@ export function validatePluginCachePayload(root: string): { valid: boolean; erro
 
 function hasCompletePluginPayload(root: string): boolean {
   return validatePluginSyncPayload(root).length === 0;
+}
+
+function collectPluginHookManifestSnapshot(): PluginHookManifestSnapshot {
+  const resolution = resolveInstalledOmcPluginRoots();
+  if (resolution.mode !== 'plugin' || !resolution.cleanupAllowed) {
+    return {
+      valid: false,
+      commandsByEvent: new Map(),
+      diagnostics: [`plugin root resolution is ${resolution.mode} (cleanupAllowed=${resolution.cleanupAllowed}, roots=${resolution.mode === 'plugin' ? resolution.roots.join(',') : 'none'})`],
+    };
+  }
+
+  const snapshots: Array<Map<string, Set<string>>> = [];
+  for (const root of resolution.roots) {
+    if (!hasCompletePluginPayload(root)) {
+      return {
+        valid: false,
+        commandsByEvent: new Map(),
+        diagnostics: [`${root}: incomplete plugin payload`],
+      };
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(join(root, 'hooks', 'hooks.json'), 'utf-8'));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        valid: false,
+        commandsByEvent: new Map(),
+        diagnostics: [`${root}: invalid hooks/hooks.json: ${message}`],
+      };
+    }
+
+    if (!isObjectRecord(raw) || !isObjectRecord(raw.hooks)) {
+      return {
+        valid: false,
+        commandsByEvent: new Map(),
+        diagnostics: [`${root}: hooks/hooks.json must contain a hooks object`],
+      };
+    }
+
+    const commandsByEvent = new Map<string, Set<string>>();
+    for (const [eventType, groups] of Object.entries(raw.hooks)) {
+      if (!Array.isArray(groups)) {
+        return {
+          valid: false,
+          commandsByEvent: new Map(),
+          diagnostics: [`${root}: hooks.${eventType} must be an array`],
+        };
+      }
+
+      const commands = new Set<string>();
+      for (const group of groups) {
+        if (!isObjectRecord(group) || !Array.isArray(group.hooks)) {
+          return {
+            valid: false,
+            commandsByEvent: new Map(),
+            diagnostics: [`${root}: hooks.${eventType} contains an invalid hook group`],
+          };
+        }
+
+        for (const entry of group.hooks) {
+          if (!isObjectRecord(entry)) {
+            return {
+              valid: false,
+              commandsByEvent: new Map(),
+              diagnostics: [`${root}: hooks.${eventType} contains an invalid hook entry`],
+            };
+          }
+          if (entry.type !== 'command') continue;
+          if (typeof entry.command !== 'string') {
+            return {
+              valid: false,
+              commandsByEvent: new Map(),
+              diagnostics: [`${root}: hooks.${eventType} contains a command hook without a string command`],
+            };
+          }
+          commands.add(entry.command);
+        }
+      }
+      if (commands.size > 0) commandsByEvent.set(eventType, commands);
+    }
+    snapshots.push(commandsByEvent);
+  }
+
+  const normalizeSnapshot = (snapshot: Map<string, Set<string>>) => JSON.stringify(
+    [...snapshot.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([eventType, commands]) => [eventType, [...commands].sort()]),
+  );
+  const expected = snapshots[0];
+  if (!expected) {
+    return { valid: false, commandsByEvent: new Map(), diagnostics: ['no plugin roots resolved'] };
+  }
+  const expectedNormalized = normalizeSnapshot(expected);
+  if (snapshots.some(snapshot => normalizeSnapshot(snapshot) !== expectedNormalized)) {
+    return {
+      valid: false,
+      commandsByEvent: new Map(),
+      diagnostics: [`installed plugin hook manifests disagree: ${resolution.roots.join(', ')}`],
+    };
+  }
+
+  return { valid: true, commandsByEvent: expected, diagnostics: [] };
 }
 
 function countPluginSyncPayloadEntries(root: string): number {


### PR DESCRIPTION
## Summary
- remove only exact plugin-manifest hook commands duplicated in `settings.json` under the same event
- fail closed when plugin roots or hook manifests are ambiguous, incomplete, corrupt, or divergent
- preserve unrelated commands and group metadata inside mixed hook groups
- keep cleanup fixed-point with the existing legacy standalone OMC hook pass

## Tests
- `npx vitest run src/installer/__tests__/standalone-hook-reconcile.test.ts` (26 passed)
- `npx tsc --noEmit`
- `npx eslint src/installer/index.ts src/installer/__tests__/standalone-hook-reconcile.test.ts`
- `npm run build`
- `npm run test:run` (11903 passed; unrelated existing failures remain in `post-tool-verifier.test.mjs` and `session-end-process-exit.test.ts`)

Closes #3638