### PR TITLE
feat(lsp): add bounded basedpyright selection

### DIFF
--- a/src/__tests__/lsp-servers-python-catalog.test.ts
+++ b/src/__tests__/lsp-servers-python-catalog.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const inheritedPythonLsp = process.env.OMC_PYTHON_LSP;
+
+async function renderServerStatus(installedCommand?: string): Promise<string> {
+  vi.resetModules();
+  vi.doMock('child_process', () => ({
+    spawnSync: vi.fn((_command: string, args: string[]) => ({
+      status: args[0] === installedCommand ? 0 : 1
+    }))
+  }));
+
+  const { lspServersTool } = await import('../tools/lsp-tools.js');
+  const rendered = await lspServersTool.handler({});
+  return rendered.content[0].text;
+}
+
+beforeEach(() => {
+  delete process.env.OMC_PYTHON_LSP;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.doUnmock('child_process');
+  vi.resetModules();
+});
+
+afterAll(() => {
+  if (inheritedPythonLsp === undefined) {
+    delete process.env.OMC_PYTHON_LSP;
+  } else {
+    process.env.OMC_PYTHON_LSP = inheritedPythonLsp;
+  }
+});
+
+describe('Python LSP catalog selection', () => {
+  it('renders only the selected missing basedpyright server and install hint', async () => {
+    vi.stubEnv('OMC_PYTHON_LSP', 'basedpyright');
+
+    const text = await renderServerStatus();
+
+    expect(text).toContain('### Not Installed:');
+    expect(text).toContain('- Python Language Server (basedpyright) (basedpyright-langserver)');
+    expect(text).toContain('Extensions: .py, .pyw');
+    expect(text).toContain('Install: uv tool install basedpyright');
+    expect(text).not.toContain('Python Language Server (ty)');
+  });
+
+  it('renders only the default installed ty server', async () => {
+    delete process.env.OMC_PYTHON_LSP;
+
+    const text = await renderServerStatus('ty');
+
+    expect(text).toContain('### Installed:');
+    expect(text).toContain('- Python Language Server (ty) (ty)');
+    expect(text).not.toContain('Python Language Server (basedpyright)');
+    expect(text).not.toContain('Install: uv tool install basedpyright');
+  });
+
+  it('renders only the default missing ty server and install hint', async () => {
+    const text = await renderServerStatus();
+
+    expect(text).toContain('### Not Installed:');
+    expect(text).toContain('- Python Language Server (ty) (ty)');
+    expect(text).toContain('Install: Install ty from https://github.com/astral-sh/ty');
+    expect(text).not.toContain('Python Language Server (basedpyright)');
+    expect(text).not.toContain('Install: uv tool install basedpyright');
+  });
+});

--- a/src/__tests__/lsp-servers.test.ts
+++ b/src/__tests__/lsp-servers.test.ts
@@ -1,8 +1,8 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { describe, expect, it } from 'vitest';
-import { LSP_SERVERS, getServerForFile, getServerForLanguage, getTypeScriptServerForWorkspace } from '../tools/lsp/servers.js';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LSP_SERVERS, getAllServers, getServerForFile, getServerForLanguage, getTypeScriptServerForWorkspace, resolvePythonServer } from '../tools/lsp/servers.js';
 
 function createTypeScriptProject(options: { version: string; tsserver?: boolean; getExePath?: boolean; tscBin?: boolean }): string {
   const root = mkdtempSync(join(tmpdir(), 'omc-lsp-ts-'));
@@ -26,6 +26,24 @@ function createTypeScriptProject(options: { version: string; tsserver?: boolean;
 
   return root;
 }
+
+const inheritedPythonLsp = process.env.OMC_PYTHON_LSP;
+
+beforeEach(() => {
+  delete process.env.OMC_PYTHON_LSP;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterAll(() => {
+  if (inheritedPythonLsp === undefined) {
+    delete process.env.OMC_PYTHON_LSP;
+  } else {
+    process.env.OMC_PYTHON_LSP = inheritedPythonLsp;
+  }
+});
 
 describe('LSP Server Configurations', () => {
   const serverKeys = Object.keys(LSP_SERVERS);
@@ -243,8 +261,55 @@ describe('OmniSharp command casing', () => {
 });
 
 describe('Python server selection', () => {
-  it('should invoke ty via its LSP subcommand', () => {
+  it('uses ty by default', () => {
+    expect(process.env.OMC_PYTHON_LSP).toBeUndefined();
+    expect(resolvePythonServer()).toBe(LSP_SERVERS.python);
+    expect(getServerForFile('app.py')).toBe(LSP_SERVERS.python);
+    expect(getServerForFile('app.pyw')).toBe(LSP_SERVERS.python);
+    expect(getServerForLanguage('python')).toBe(LSP_SERVERS.python);
     expect(LSP_SERVERS.python.command).toBe('ty');
     expect(LSP_SERVERS.python.args).toEqual(['server']);
+  });
+
+  it.each(['', '   ', 'ty', 'TY', 'BasedPyright', 'pyright', 'basedpyright ', 'jedi'])(
+    'uses ty for unsupported selector value %j',
+    value => {
+      vi.stubEnv('OMC_PYTHON_LSP', value);
+
+      expect(resolvePythonServer()).toBe(LSP_SERVERS.python);
+      expect(getServerForFile('app.py')).toBe(getServerForLanguage('python'));
+      expect(getServerForFile('app.pyw')).toBe(LSP_SERVERS.python);
+    }
+  );
+
+  it('uses basedpyright only for the exact selector value', () => {
+    vi.stubEnv('OMC_PYTHON_LSP', 'basedpyright');
+
+    const server = resolvePythonServer();
+    expect(server).toMatchObject({
+      name: 'Python Language Server (basedpyright)',
+      command: 'basedpyright-langserver',
+      args: ['--stdio'],
+      extensions: ['.py', '.pyw'],
+      installHint: 'uv tool install basedpyright'
+    });
+    expect(getServerForFile('app.py')).toBe(server);
+    expect(getServerForFile('app.pyw')).toBe(server);
+    expect(getServerForLanguage('python')).toBe(server);
+  });
+
+  it('does not affect non-Python server selection', () => {
+    vi.stubEnv('OMC_PYTHON_LSP', 'basedpyright');
+
+    expect(getServerForFile('main.rs')).toBe(LSP_SERVERS.rust);
+    expect(getServerForLanguage('go')).toBe(LSP_SERVERS.go);
+  });
+
+  it('lists only the selected Python server', () => {
+    vi.stubEnv('OMC_PYTHON_LSP', 'basedpyright');
+
+    const pythonServers = getAllServers().filter(server => server.extensions.includes('.py'));
+    expect(pythonServers).toHaveLength(1);
+    expect(pythonServers[0].command).toBe('basedpyright-langserver');
   });
 });

--- a/src/tools/diagnostics/__tests__/lsp-aggregator.test.ts
+++ b/src/tools/diagnostics/__tests__/lsp-aggregator.test.ts
@@ -47,6 +47,30 @@ describe('runLspAggregatedDiagnostics', () => {
     }
   });
 
+  it('surfaces the selected basedpyright install hint without ty fallback', async () => {
+    mockGetServerForFile.mockReturnValue({
+      command: 'basedpyright-langserver',
+      installHint: 'uv tool install basedpyright'
+    });
+    mockRunWithClientLease.mockRejectedValue(
+      new Error("Language server 'basedpyright-langserver' not found.\nInstall with: uv tool install basedpyright")
+    );
+
+    const tmp = mkdtempSync(join(tmpdir(), 'lsp-agg-test-'));
+    try {
+      writeFileSync(join(tmp, 'a.py'), '');
+
+      const result = await runLspAggregatedDiagnostics(tmp, ['.py']);
+
+      expect(result.installHints).toEqual(['uv tool install basedpyright']);
+      expect(result.skippedFiles[0].reason).toBe('missing language server: basedpyright-langserver');
+      expect(result.skippedFiles[0].reason).not.toBe('missing language server: ty');
+      expect(result.success).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
   it('pre-check skips files with no registered language server', async () => {
     mockGetServerForFile
       .mockReturnValueOnce(null)

--- a/src/tools/lsp/AGENTS.md
+++ b/src/tools/lsp/AGENTS.md
@@ -120,7 +120,7 @@ This table documents catalog/discovery support. Runtime semantic quality still d
 | Language | Server | Command | Extensions |
 |----------|--------|---------|------------|
 | TypeScript/JS | typescript-language-server | `typescript-language-server` | .ts, .tsx, .js, .jsx |
-| Python | ty | `ty server` | .py, .pyw |
+| Python | ty (default), basedpyright (opt-in via `OMC_PYTHON_LSP=basedpyright`) | `ty server` / `basedpyright-langserver --stdio` | .py, .pyw |
 | Rust | rust-analyzer | `rust-analyzer` | .rs |
 | Go | gopls | `gopls` | .go |
 | C/C++ | clangd | `clangd` | .c, .h, .cpp, .cc, .hpp |

--- a/src/tools/lsp/__tests__/client-python-boundary.test.ts
+++ b/src/tools/lsp/__tests__/client-python-boundary.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../servers.js', async importOriginal => {
+  const original = await importOriginal<typeof import('../servers.js')>();
+  return {
+    ...original,
+    commandExists: vi.fn(() => false)
+  };
+});
+
+import { LspClient } from '../client.js';
+import { getServerForFile } from '../servers.js';
+
+const inheritedPythonLsp = process.env.OMC_PYTHON_LSP;
+
+beforeEach(() => {
+  delete process.env.OMC_PYTHON_LSP;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+afterAll(() => {
+  if (inheritedPythonLsp === undefined) {
+    delete process.env.OMC_PYTHON_LSP;
+  } else {
+    process.env.OMC_PYTHON_LSP = inheritedPythonLsp;
+  }
+});
+
+describe('selected Python LSP connection boundary', () => {
+  it('reports a missing basedpyright server without falling back to ty', async () => {
+    vi.stubEnv('OMC_PYTHON_LSP', 'basedpyright');
+    const config = getServerForFile('app.py');
+
+    expect(config).toMatchObject({
+      command: 'basedpyright-langserver',
+      args: ['--stdio'],
+      installHint: 'uv tool install basedpyright'
+    });
+
+    const client = new LspClient(process.cwd(), config!);
+    const error = await client.connect().then(
+      () => null,
+      reason => reason as Error
+    );
+
+    expect(error?.message).toBe(
+      "Language server 'basedpyright-langserver' not found.\nInstall with: uv tool install basedpyright"
+    );
+    expect(error?.message).not.toContain("Language server 'ty'");
+  });
+});

--- a/src/tools/lsp/__tests__/client-python-switch.test.ts
+++ b/src/tools/lsp/__tests__/client-python-switch.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LspClient, LspClientManager } from '../client.js';
+
+const inheritedPythonLsp = process.env.OMC_PYTHON_LSP;
+
+beforeEach(() => {
+  delete process.env.OMC_PYTHON_LSP;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+afterAll(() => {
+  if (inheritedPythonLsp === undefined) {
+    delete process.env.OMC_PYTHON_LSP;
+  } else {
+    process.env.OMC_PYTHON_LSP = inheritedPythonLsp;
+  }
+});
+
+describe('Python LSP client selection cache', () => {
+  it('uses separate command-keyed clients and reuses ty after switching back', async () => {
+    vi.spyOn(LspClient.prototype, 'connect').mockResolvedValue();
+    vi.spyOn(LspClient.prototype, 'disconnect').mockResolvedValue();
+    const manager = new LspClientManager();
+
+    try {
+      delete process.env.OMC_PYTHON_LSP;
+      const tyClient = await manager.getClientForFile('app.py');
+      expect(manager.clientCount).toBe(1);
+
+      vi.stubEnv('OMC_PYTHON_LSP', 'basedpyright');
+      const basedpyrightClient = await manager.getClientForFile('app.py');
+      expect(manager.clientCount).toBe(2);
+      expect(basedpyrightClient).not.toBe(tyClient);
+
+      vi.stubEnv('OMC_PYTHON_LSP', 'ty');
+      const reusedTyClient = await manager.getClientForFile('app.py');
+      expect(manager.clientCount).toBe(2);
+      expect(reusedTyClient).toBe(tyClient);
+    } finally {
+      await manager.disconnectAll();
+    }
+  });
+});

--- a/src/tools/lsp/index.ts
+++ b/src/tools/lsp/index.ts
@@ -20,6 +20,7 @@ export {
   getServerForFile,
   getServerForLanguage,
   getAllServers,
+  resolvePythonServer,
   commandExists
 } from './servers.js';
 export type { LspServerConfig } from './servers.js';

--- a/src/tools/lsp/servers.ts
+++ b/src/tools/lsp/servers.ts
@@ -242,6 +242,21 @@ export const LSP_SERVERS: Record<string, LspServerConfig> = {
   }
 };
 
+const BASEDPYRIGHT_SERVER: LspServerConfig = {
+  name: 'Python Language Server (basedpyright)',
+  command: 'basedpyright-langserver',
+  args: ['--stdio'],
+  extensions: ['.py', '.pyw'],
+  installHint: 'uv tool install basedpyright'
+};
+
+/** Resolve the supported Python language server. Only exact basedpyright opts in. */
+export function resolvePythonServer(): LspServerConfig {
+  return process.env.OMC_PYTHON_LSP === 'basedpyright'
+    ? BASEDPYRIGHT_SERVER
+    : LSP_SERVERS.python;
+}
+
 /**
  * Check if a command exists in PATH
  */
@@ -264,9 +279,9 @@ export function getServerForFile(filePath: string, workspaceRoot?: string): LspS
     return getTypeScriptServerForWorkspace(workspaceRoot);
   }
 
-  for (const [_, config] of Object.entries(LSP_SERVERS)) {
+  for (const [key, config] of Object.entries(LSP_SERVERS)) {
     if (config.extensions.includes(ext)) {
-      return config;
+      return key === 'python' ? resolvePythonServer() : config;
     }
   }
 
@@ -277,10 +292,13 @@ export function getServerForFile(filePath: string, workspaceRoot?: string): LspS
  * Get all available servers (installed and not installed)
  */
 export function getAllServers(): Array<LspServerConfig & { installed: boolean }> {
-  return Object.values(LSP_SERVERS).map(config => ({
-    ...config,
-    installed: commandExists(config.command)
-  }));
+  return Object.values(LSP_SERVERS).map(config => {
+    const selectedConfig = config === LSP_SERVERS.python ? resolvePythonServer() : config;
+    return {
+      ...selectedConfig,
+      installed: commandExists(selectedConfig.command)
+    };
+  });
 }
 
 /**
@@ -338,7 +356,7 @@ export function getServerForLanguage(language: string): LspServerConfig | null {
 
   const serverKey = langMap[language.toLowerCase()];
   if (serverKey && LSP_SERVERS[serverKey]) {
-    return LSP_SERVERS[serverKey];
+    return serverKey === 'python' ? resolvePythonServer() : LSP_SERVERS[serverKey];
   }
 
   return null;


### PR DESCRIPTION
## Summary
- keep `ty server` as the deterministic default Python LSP
- support exact `OMC_PYTHON_LSP=basedpyright` as a bounded registered alternative using `basedpyright-langserver --stdio`
- keep file, language, catalog/status, client cache, and diagnostics behavior aligned with the selected backend
- add focused regression tests for invalid selectors, ambient env isolation, selected status/install hints, client switching, and missing-server diagnostics

## Verification
- focused Python LSP suite — 123 passed
- same suite with `OMC_PYTHON_LSP=basedpyright` — 123 passed
- LSP/diagnostics regression suite — 170 passed
- changed-file ESLint — passed
- `npx tsc --noEmit` — passed
- `npm run build` — passed

Closes #3624