### PR TITLE
feat(keyword-detector): recognize Vietnamese activation imperatives

### DIFF
--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -613,7 +613,10 @@ function hasActivationIntentNearKeyword(context, keyword) {
   const patterns = [
     new RegExp(`\\b(?:use|run|start|enable|activate|invoke|trigger|launch)\\b[^\\n]{0,28}\\b${escaped}\\b`, 'i'),
     new RegExp(`\\b(?:fix|debug|investigate|resolve|handle|patch|address)\\b[^\\n]{0,28}\\b(?:issue|bug|problem|error)\\b[^\\n]{0,12}\\b(?:with|in)\\s+\\b${escaped}\\b`, 'i'),
-
+    // Vietnamese imperatives: "chạy ralph", "dùng/sử dụng ralph", "bật/mở/gọi ralph",
+    // "khởi động/kích hoạt ralph", "vào chế độ ralph". Verb-before-keyword within a
+    // short window so a mid-sentence mention ("vòng lặp ralph") does not match.
+    new RegExp(`(?:chạy|dùng|sử\\s*dụng|bật|mở|khởi\\s*động|kích\\s*hoạt|gọi|vào)[^\\n]{0,12}\\b${escaped}\\b`, 'i'),
   ];
 
   return patterns.some((pattern) => pattern.test(context));

--- a/src/__tests__/keyword-detector-script.test.ts
+++ b/src/__tests__/keyword-detector-script.test.ts
@@ -629,8 +629,10 @@ diff --git a/a b/b
       { prompt: '/ralph fix parser', mode: 'ralph' },
       { prompt: 'run ralph on this issue', mode: 'ralph' },
       { prompt: '랄프 켜', mode: 'ralph' },
+      { prompt: 'chạy ralph đi', mode: 'ralph' },
       { prompt: 'start ultrawork on this issue', mode: 'ultrawork' },
       { prompt: '울트라워크 돌려', mode: 'ultrawork' },
+      { prompt: 'bật ultrawork lên', mode: 'ultrawork' },
     ] as const;
 
     for (const { prompt, mode } of cases) {

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -507,7 +507,10 @@ function hasActivationIntentNearKeyword(context: string, keyword: string): boole
   const patterns = [
     new RegExp(`\\b(?:use|run|start|enable|activate|invoke|trigger|launch)\\b[^\\n]{0,28}\\b${escaped}\\b`, 'i'),
     new RegExp(`\\b(?:fix|debug|investigate|resolve|handle|patch|address)\\b[^\\n]{0,28}\\b(?:issue|bug|problem|error)\\b[^\\n]{0,12}\\b(?:with|in)\\s+\\b${escaped}\\b`, 'i'),
-
+    // Vietnamese imperatives: "chạy ralph", "dùng/sử dụng ralph", "bật/mở/gọi ralph",
+    // "khởi động/kích hoạt ralph", "vào chế độ ralph". Verb-before-keyword within a
+    // short window so a mid-sentence mention ("vòng lặp ralph") does not match.
+    new RegExp(`(?:chạy|dùng|sử\\s*dụng|bật|mở|khởi\\s*động|kích\\s*hoạt|gọi|vào)[^\\n]{0,12}\\b${escaped}\\b`, 'i'),
   ];
 
   return patterns.some((pattern) => pattern.test(context));

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -539,7 +539,10 @@ function hasActivationIntentNearKeyword(context, keyword) {
   const patterns = [
     new RegExp(`\\b(?:use|run|start|enable|activate|invoke|trigger|launch)\\b[^\\n]{0,28}\\b${escaped}\\b`, 'i'),
     new RegExp(`\\b(?:fix|debug|investigate|resolve|handle|patch|address)\\b[^\\n]{0,28}\\b(?:issue|bug|problem|error)\\b[^\\n]{0,12}\\b(?:with|in)\\s+\\b${escaped}\\b`, 'i'),
-
+    // Vietnamese imperatives: "chạy ralph", "dùng/sử dụng ralph", "bật/mở/gọi ralph",
+    // "khởi động/kích hoạt ralph", "vào chế độ ralph". Verb-before-keyword within a
+    // short window so a mid-sentence mention ("vòng lặp ralph") does not match.
+    new RegExp(`(?:chạy|dùng|sử\\s*dụng|bật|mở|khởi\\s*động|kích\\s*hoạt|gọi|vào)[^\\n]{0,12}\\b${escaped}\\b`, 'i'),
   ];
 
   return patterns.some((pattern) => pattern.test(context));


### PR DESCRIPTION
## Summary

`hasActivationIntentNearKeyword()` in the keyword detector already recognizes English verb-before-keyword activation phrasing ("use ralph", "run autopilot"), and other parts of this file (`INFORMATIONAL_INTENT_PATTERNS`, the ralph/ultrawork imperative-verb patterns) already cover Korean, Japanese, Chinese, and Thai. Vietnamese had no equivalent anywhere in the file, so a prompt like "chạy ralph đi" (run ralph) or "bật ultrawork lên" (turn on ultrawork) was not recognized as an explicit activation.

This adds one verb-before-keyword pattern for common Vietnamese activation verbs (chạy/dùng/sử dụng/bật/mở/khởi động/kích hoạt/gọi/vào — run/use/enable/open/start/activate/invoke/enter), matching the shape of the existing English pattern: the verb must appear within a short window before the keyword, so a mid-sentence mention like "vòng lặp ralph" ("the ralph loop") does not false-positive.

- `src/hooks/keyword-detector/index.ts` — canonical TS source
- `scripts/keyword-detector.mjs` — deployed hook script (this is what `runKeywordDetector` in the test suite actually spawns)
- `templates/hooks/keyword-detector.mjs` — install template copy
- `src/__tests__/keyword-detector-script.test.ts` — two new cases added to the existing issue #3162 imperative-prompt regression test (`chạy ralph đi`, `bật ultrawork lên`)

I did not attempt full parity with the Korean/Japanese/Thai coverage elsewhere in the file (mode-name aliases, informational-intent phrasing, repeated-failure complaint detection, etc.) — that's a much larger surface and I don't have native-speaker judgment to validate idiomatic phrasing there. This PR is scoped to the one generic activation-intent function, which is the gap I actually hit in daily use.

## Test plan

- [x] `npx vitest run src/__tests__/keyword-detector-script.test.ts` — 101/101 pass (includes the 2 new cases)
- [x] `npx vitest run src/__tests__/keyword-detector-echo-guard.test.ts` — 12/12 pass
- [x] `npx eslint src/hooks/keyword-detector/index.ts src/__tests__/keyword-detector-script.test.ts` — clean (matches `npm run lint`'s `src`-only scope; `templates/` and `scripts/` aren't linted by the project script either way)
- [x] `npx tsc --noEmit` — clean
