### PR TITLE
feat(graph): land pure Graph Core contract

### DIFF
--- a/docs/adr/03570-graph-core-contract.md
+++ b/docs/adr/03570-graph-core-contract.md
@@ -1,0 +1,88 @@
+# ADR 03570: Graph Core Contract (Descriptor + Pure Scheduler)
+
+- **Status:** Accepted for v1 — this landing
+- **Issue:** #3570 (non-closing `Refs #3570`; issue remains open for the broader disposition sequence)
+- **Decision scope:** A standalone pure `src/graph/` module: deeply readonly descriptor contract, strict bounded Zod schemas, local canonical compact JSON with SHA-256 sealing, and a deterministic pure scheduler. No runtime, persistence, OCC, CLI, HUD, installer, hooks, templates, or generated `dist`/`bridge` surfaces.
+
+## Decision
+
+Land Graph Core v1 as a nine-file source-only slice — descriptor foundation plus a pure scheduler — derived for current `dev` (oracle `99ffe31` used only for behavioral cross-checks, never as import authority). The module owns:
+
+- **Descriptor contract:** deeply readonly TypeScript types, strict `.strict()` Zod content schemas, defensive `structuredClone` + `deepFreeze` ownership, structure-before-hash validation, and lowercase SHA-256 over a local canonical compact JSON. Canonicalization recursively sorts keys, preserves array order, accepts only JSON primitives, arrays, and plain objects, and rejects `undefined`, non-finite numbers, unsupported values, non-plain objects, and cycles.
+- **Hash contract:** `descriptor_hash` is a 64-hex lowercase SHA-256 over exactly the nine contract fields (`descriptor_version`, `run_id`, `revision_id`, `goal`, `nodes`, `edges`, `entry_node_ids`, `concurrency_limit`, `terminal_verification_node_id`); `descriptor_hash` and all mutable/runtime fields are excluded. Structure is validated before any hash comparison.
+- **Node/edge semantics:** agent/command executable nodes with descriptor-derived budgets; human-approval nodes with exactly one fixed outgoing edge; joins with exactly one fixed outgoing edge; fixed edges are exclusive; conditional/back-edge routes are declared; fan-out requires ≥2 fan_out edges with a single owning join; back edges are bounded structural returns; non-back-edge forward cycles are rejected; fork/join regions are non-overlapping, non-nesting, and forbid region-crossing edges; entry nodes may not be joins or interior fork-branch nodes.
+- **Pure scheduler contract:** every entrypoint consumes a `SealedGraphDescriptor`; the projection is bound to `descriptor_hash`/`run_id`/`revision_id`; all mutations and the four descriptor-dependent reads throw `descriptor_mismatch` on hash drift; ready lists are ordered by a locale-independent code-unit comparator; identities live in one global namespace per projection with context-aware key validation; the three record-bearing mutations (`applyNodeResult`, `applyHumanApproval`, `resolveJoin`) are replay-fenced with versioned fingerprints (`fingerprint_version: 1`) bound to `descriptor_hash`; `beginActivationAttempt`/`releaseAttemptForRetry` are plain projection transforms that commit no transition records; retry budgets are descriptor-derived and unbypassable; final-budget release terminal-fails (never an unstartable ready activation); human approval is a dedicated pure transition whose `approved`/`denied` records carry `output_summary` (never `summary`) and no `attempt_id`; terminal success requires evidence.
+
+### Ownership flow (stage-04)
+
+| API                          | Input class                  | Returns                      | Behavior                                                                                                                                                                                                                                                          |
+| ---------------------------- | ---------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parseGraphDescriptor`       | Hashless/draft shape         | `GraphDescriptor` (unsealed) | Strict schema parse → full `validateGraphDescriptor` → defensive `structuredClone` + `deepFreeze`. Input carrying a `descriptor_hash` throws a directed error (`parseSealedGraphDescriptor`).                                                                     |
+| `sealGraphDescriptor`        | Hashless/draft shape         | `SealedGraphDescriptor`      | Strict parse → validate → compute hash → clone + freeze with `descriptor_hash`. Input carrying a `descriptor_hash` throws a directed error. Sole draft → scheduler producer.                                                                                      |
+| `parseSealedGraphDescriptor` | Persisted hash-bearing shape | `SealedGraphDescriptor`      | Requires `descriptor_hash` (`/^[a-f0-9]{64}$/`; missing/malformed → `GraphDescriptorValidationError`); strict parse → validate → recompute hash and compare → mismatch rejects (never silently recomputes) → clone + freeze. Sole persisted → scheduler producer. |
+| `verifyDescriptorHash`       | Any                          | `boolean`                    | Non-branding, never throws; structure-before-hash predicate; `false` on any structural failure or mismatch; does not clone/freeze/mutate its input.                                                                                                               |
+
+Scheduler-accepted type is `SealedGraphDescriptor`; its producers are exactly `sealGraphDescriptor` (draft) and `parseSealedGraphDescriptor` (persisted). No assertion is needed anywhere: the type system makes it impossible to pass an unsealed value to a scheduler entrypoint.
+
+### Approval transition records (stage-04)
+
+`GraphCommittedTransition` is a discriminated union on `outcome`. Approval nodes never begin attempts, so `approved`/`denied` records omit `attempt_id` entirely; `attempt_id` appears only on `succeeded`/`failed` records. The summary field is unified to `output_summary` across `GraphApprovalDecision`, `graphApprovalDecisionSchema`, and the transition record (`summary` is removed from the public contract). Both approval outcomes require at least one evidence reference. `join_resolved` records carry a required `cohort_id` and no `attempt_id`.
+
+### Closed error boundary
+
+`GraphSchedulerErrorCode` is a closed union. Every scheduler throw uses exactly one code. Zod parse failures inside scheduler entrypoints are wrapped into `GraphSchedulerError('invalid_input', …)`; `ZodError` never escapes a scheduler entrypoint. Exported schema parsers keep throwing `ZodError` by documented validation-utility contract.
+
+## Drivers
+
+1. **Boundary purity** — no I/O, time reads, random allocation, process inspection, or mutation outside returned values (including on thrown paths).
+2. **Re-derive, never port** — `99ffe31` is an oracle for invariants/regressions only; the contract is authored from the spec and this plan, verified by the anti-port matrix.
+3. **Contract first, runnable never** — descriptor + pure scheduler semantics only; no runnable workflow is promised.
+4. **Ownership and verifiability by construction** — readonly types, clone + freeze, structure-before-hash, descriptor-bound APIs, closed errors, unbypassable invariants.
+5. **Evidence-backed governance** — every claim maps to a command; terminal PR verdict is APPROVE or BLOCK, derived fail-closed from final evidence.
+
+## Alternatives
+
+- **Port a minimal runtime vertical slice (store/claims/command service):** rejected — the locked Round-1 decision lands the pure contract first; the reference runtime depends on OCC APIs, mode-state I/O, session paths, and claims/revisions/store absent from current `dev`.
+- **Import `canonicalizeJson` from `src/hooks/autopilot/pipeline.ts`:** rejected — ESM import would pull the stateful autopilot module graph into the pure module; current `dev` already treats the 20-line helper as copyable (private copies exist elsewhere).
+- **Extract a shared `src/utils/canonical-json.ts` and refactor `pipeline.ts`:** rejected for this PR — modifies a shipped #3487 surface and widens the diff; a follow-up PR can own it.
+- **Land one of the live #3570 disposition paths (bridge-only generated closure, six-file tip, full 91-file stack):** rejected — bridge-only requires owner-authorized regeneration of a generated surface; the six-file tip is insufficient for the descriptor + scheduler contract; the full stack violates the first-landing boundary.
+
+## Why chosen
+
+The pure core is the narrowest boundary that is both meaningful and mechanically verifiable: it resolves descriptor ownership, hashing, topology, attempt, route, join, approval, replay, and error contracts before any later runtime persists them, and it can be reviewed, typechecked, tested, and diff-audited independently on current `dev`.
+
+## Consequences
+
+- This PR does not create a runnable Graph workflow.
+- Later runtime work must consume the sealed descriptor and scheduler contracts rather than redefine them.
+- Runtime persistence, claims/revisions, OCC, control ownership, platform/recovery, CLI/skill/HUD/installer/hooks/templates, concurrency enforcement, and generated `dist`/`bridge` closure remain explicit later landings.
+- `src/index.ts` is untouched; the module is exported only through `src/graph/index.ts`.
+
+### Graph Core boundary
+
+Nine files: `src/graph/types.ts`, `src/graph/schema.ts`, `src/graph/descriptor.ts`, `src/graph/scheduler.ts`, `src/graph/index.ts`, `src/graph/__tests__/fixtures.ts`, `src/graph/__tests__/descriptor.test.ts`, `src/graph/__tests__/scheduler.test.ts`, and this ADR. No other source path changes.
+
+### Anti-port matrix (summary)
+
+Adopted as invariants (re-derived from contract, cross-checked against the oracle): back-edge-only node rejection; per-lineage traversal bounds; route fencing (fail-closed `undeclared_route`); join consumed exactly once with branch-token arrival/consumption; terminal evidence required; A3 retryable-until-exhausted then terminal-failed; fingerprint-based replay. Not adopted, with replacement: caller-supplied `max_attempts` → descriptor-derived budget; per-kind identity uniqueness → single global identity namespace; `localeCompare` ordering → code-unit comparator; shallow top-level seal spread → deep clone + deep freeze; hash check without structure → structure-before-hash; open `code: string` errors → closed union; human-approval as executable → dedicated `applyHumanApproval`; begin/release without transition IDs → replay-fenced record-bearing mutations only; unbound projection → descriptor-bound projection + `descriptor_mismatch`; unversioned fingerprints → `fingerprint_version: 1` + `descriptor_hash` binding; undefined-filtering canonical JSON → strict current-dev semantics (throws); entries may include joins/branch interiors → eligible-entry rule; stage-03 `parseGraphDescriptor → GraphDescriptor` as a claimed sealed producer → disjoint producers (stage-04); stage-03 approval records requiring `attempt_id` + `summary` → no `attempt_id`, unified `output_summary`, discriminated union (stage-04).
+
+### `concurrency_limit` semantics
+
+`concurrency_limit` is sealed and validated by Graph Core (1–64 integer). Its enforcement is explicitly owned by the deferred claims/runtime layer; Graph Core performs no concurrency enforcement.
+
+### Purity and imports
+
+Module imports are limited to `node:crypto`, `zod`, and local modules. The scheduler clones its projection structurally before any mutation and never mutates its inputs, including on thrown paths. `traversalCounterKey(activation, edge)` is a pure key helper over `canonicalJson([activation.traversal_owner_id, edge.id])`.
+
+## Governance
+
+Execution proceeds only after explicit approval; this PR targets `dev` from a freshly fetched, pinned `origin/dev`, references #3570 without closing it, and records exact command statuses. The terminal PR verdict is evidence-driven `APPROVE` or `BLOCK` (never pre-assumed), ending with the exact footer:
+
+```text
+—
+*[repo owner's gaebal-gajae (clawdbot) 🦞]*
+```
+
+## Follow-ups and explicit deferrals
+
+Runtime persistence/state store; claims/leases/revisions; OCC journal/commit; control ownership; platform; settle-session; patch cycles; runtime graph-status promotion; `concurrency_limit` enforcement (claims/runtime layer); human-approval runtime UX/leases; CLI/skill/HUD/installer/plugin-manifest/hook/state-tool/template exposure; `dist`/`bridge` regeneration; full-runtime ADR; shared canonical-json util; `docs/REFERENCE.md`/`FEATURES.md` integration. Intended next order: runtime state/revision/claim contracts → OCC journal + state store → platform/control ownership → runtime operations/recovery → CLI/skill/HUD/installer → bounded generated delivery closure.

--- a/src/graph/__tests__/descriptor.test.ts
+++ b/src/graph/__tests__/descriptor.test.ts
@@ -1,0 +1,1083 @@
+/**
+ * Contract-authored descriptor tests (D1-D25) for Graph Core.
+ *
+ * Authored from the ralplan stage-04 revision (`pending-approval.md`); oracle
+ * `99ffe31` used only for behavioral cross-checks. D13 note: the stage-04
+ * ownership flow makes `parseGraphDescriptor` reject hash-bearing input; the
+ * seal round-trip is proven via `verifyDescriptorHash` + `parseSealedGraphDescriptor`.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  GraphDescriptorValidationError,
+  canonicalJson,
+  computeDescriptorHash,
+  isGraphDescriptor,
+  parseGraphDescriptor,
+  parseSealedGraphDescriptor,
+  sealGraphDescriptor,
+  verifyDescriptorHash,
+} from "../descriptor.js";
+import {
+  graphApprovalDecisionSchema,
+  graphEvidenceReferenceSchema,
+  graphNodeResultSchema,
+} from "../schema.js";
+import type {
+  GraphDescriptorInput,
+  GraphEdge,
+  GraphJoinNode,
+} from "../types.js";
+import {
+  approvalDescriptor,
+  executableNode,
+  forkJoinDescriptor,
+  loopDescriptor,
+} from "./fixtures.js";
+
+/** Minimal linear descriptor: start --fixed--> terminal. */
+function chainDescriptor(
+  startId: string,
+  edgeId: string,
+  terminalId: string,
+): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-chain",
+    revision_id: "rev-chain",
+    goal: "chain",
+    nodes: [
+      executableNode(startId, "command"),
+      executableNode(terminalId, "command"),
+    ],
+    edges: [{ id: edgeId, kind: "fixed", from: startId, to: terminalId }],
+    entry_node_ids: [startId],
+    concurrency_limit: 1,
+    terminal_verification_node_id: terminalId,
+  };
+}
+
+/** Replace the single join node of a descriptor (assumes exactly one join). */
+function replaceJoin(
+  descriptor: GraphDescriptorInput,
+  mutate: (join: GraphJoinNode) => GraphJoinNode,
+): GraphDescriptorInput {
+  return {
+    ...descriptor,
+    nodes: descriptor.nodes.map((node) =>
+      node.kind === "join" ? mutate(node) : node,
+    ),
+  };
+}
+
+describe("D1 - unknown fields at any depth rejected (.strict())", () => {
+  it("rejects an unknown top-level descriptor field", () => {
+    expect(() =>
+      parseGraphDescriptor({ ...forkJoinDescriptor(), extra: true }),
+    ).toThrow(/Unrecognized key/);
+  });
+  it("rejects an unknown node field", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...forkJoinDescriptor(),
+        nodes: [{ ...forkJoinDescriptor().nodes[0], extra: true }],
+      }),
+    ).toThrow(/Unrecognized key/);
+  });
+  it("rejects an unknown edge field", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...forkJoinDescriptor(),
+        edges: [{ ...forkJoinDescriptor().edges[0], extra: true }],
+      }),
+    ).toThrow(/Unrecognized key/);
+  });
+  it("rejects an unknown node-result field", () => {
+    expect(() =>
+      graphNodeResultSchema.parse({
+        outcome: "succeeded",
+        attempt_id: "a1",
+        evidence_refs: [],
+        extra: true,
+      }),
+    ).toThrow(/Unrecognized key/);
+  });
+  it("rejects an unknown approval-decision field", () => {
+    expect(() =>
+      graphApprovalDecisionSchema.parse({
+        decision: "approved",
+        evidence_refs: [],
+        extra: true,
+      }),
+    ).toThrow(/Unrecognized key/);
+  });
+  it("rejects an unknown evidence-reference field", () => {
+    expect(() =>
+      graphEvidenceReferenceSchema.parse({
+        kind: "file",
+        ref: "r1",
+        extra: true,
+      }),
+    ).toThrow(/Unrecognized key/);
+  });
+});
+
+describe("D2 - invalid stable IDs rejected; valid charset accepted", () => {
+  it.each([
+    ["", "empty id"],
+    ["bad!", "bang"],
+    ["bad id", "whitespace"],
+    ["a".repeat(129), ">128 chars"],
+  ])("rejects %s (%s)", (badId) => {
+    expect(() =>
+      parseGraphDescriptor(chainDescriptor(badId, "e1", "b")),
+    ).toThrow();
+  });
+  it("accepts ids using the full stable charset", () => {
+    expect(() =>
+      parseGraphDescriptor(chainDescriptor("a.b_c:d-1", "e.2", "z9")),
+    ).not.toThrow();
+  });
+});
+
+describe("D3 - duplicate node IDs rejected", () => {
+  it("rejects a repeated node id", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-dup",
+      revision_id: "rev-dup",
+      goal: "dup",
+      nodes: [
+        executableNode("a", "command"),
+        executableNode("a", "command"),
+        executableNode("b", "command"),
+      ],
+      edges: [{ id: "e1", kind: "fixed", from: "a", to: "b" }],
+      entry_node_ids: ["a"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "b",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /duplicate node ID\(s\): a/,
+    );
+  });
+});
+
+describe("D4 - duplicate edge IDs rejected", () => {
+  it("rejects a repeated edge id", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-dup-edge",
+      revision_id: "rev-dup-edge",
+      goal: "dup edge",
+      nodes: [executableNode("a", "command"), executableNode("b", "command")],
+      edges: [
+        { id: "e1", kind: "fixed", from: "a", to: "b" },
+        { id: "e1", kind: "fixed", from: "a", to: "b" },
+      ],
+      entry_node_ids: ["a"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "b",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /duplicate edge ID\(s\): e1/,
+    );
+  });
+});
+
+describe("D5 - duplicate entry IDs rejected", () => {
+  it("rejects a repeated entry node id", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...chainDescriptor("a", "e1", "b"),
+        entry_node_ids: ["a", "a"],
+      }),
+    ).toThrow(/duplicate entry node ID\(s\): a/);
+  });
+});
+
+describe("D6 - dangling from/to references rejected", () => {
+  it.each([
+    [
+      "missing source",
+      "missing",
+      "b",
+      /references missing source node missing/,
+    ],
+    ["missing target", "a", "nope", /references missing target node nope/],
+  ] as const)("rejects an edge with a %s", (_name, from, to, pattern) => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...chainDescriptor("a", "e1", "b"),
+        edges: [{ id: "e1", kind: "fixed", from, to }],
+      }),
+    ).toThrow(pattern);
+  });
+});
+
+describe("D7 - terminal verification rules", () => {
+  it("rejects a missing terminal verification node", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...forkJoinDescriptor(),
+        terminal_verification_node_id: "nope",
+      }),
+    ).toThrow(/terminal verification node nope does not exist/);
+  });
+  it("rejects a non-executable terminal kind (join)", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...forkJoinDescriptor(),
+        terminal_verification_node_id: "join",
+      }),
+    ).toThrow(
+      /terminal verification must be an executable agent or command node/,
+    );
+  });
+  it("rejects a terminal node with outgoing edges", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...forkJoinDescriptor(),
+        terminal_verification_node_id: "b1",
+      }),
+    ).toThrow(/terminal verification node b1 must not have outgoing edges/);
+  });
+});
+
+describe("D8 - reachability: unreachable and terminal-unreachable nodes rejected", () => {
+  it("rejects a node unreachable from any entry", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        nodes: [...d.nodes, executableNode("orphan", "command")],
+        edges: [
+          ...d.edges,
+          { id: "e-orphan-term", kind: "fixed", from: "orphan", to: "term" },
+        ],
+      }),
+    ).toThrow(/unreachable node\(s\): orphan/);
+  });
+  it("rejects a reachable node that cannot reach terminal verification", () => {
+    const d = loopDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        nodes: [...d.nodes, executableNode("sink", "command")],
+        edges: [
+          ...d.edges,
+          {
+            id: "e-work-sink",
+            kind: "conditional",
+            from: "work",
+            to: "sink",
+            route: "sink",
+          },
+        ],
+      }),
+    ).toThrow(/cannot reach terminal verification/);
+  });
+});
+
+describe("D9 - cycles: non-back-edge forward cycle rejected; bounded back-edge return accepted", () => {
+  it("rejects a forward cycle built from fixed edges", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-cycle",
+      revision_id: "rev-cycle",
+      goal: "cycle",
+      nodes: [
+        executableNode("a", "command"),
+        executableNode("b", "command"),
+        executableNode("term", "command"),
+      ],
+      edges: [
+        { id: "e-a-b", kind: "fixed", from: "a", to: "b" },
+        { id: "e-b-a", kind: "fixed", from: "b", to: "a" },
+      ],
+      entry_node_ids: ["a"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "term",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /non-back-edge cycle detected/,
+    );
+  });
+  it("accepts a bounded back-edge return (loop descriptor)", () => {
+    expect(() => parseGraphDescriptor(loopDescriptor())).not.toThrow();
+  });
+});
+
+describe("D10 - back-edge-only node rejected (wedging regression)", () => {
+  it("rejects a node whose only outgoing edge is a back edge", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-wedge",
+      revision_id: "rev-wedge",
+      goal: "wedge",
+      nodes: [
+        executableNode("start", "command"),
+        executableNode("work", "command"),
+        executableNode("term", "command"),
+      ],
+      edges: [
+        { id: "e-start-work", kind: "fixed", from: "start", to: "work" },
+        {
+          id: "e-work-retry",
+          kind: "back_edge",
+          from: "work",
+          to: "work",
+          route: "retry",
+          max_traversals: 3,
+        },
+      ],
+      entry_node_ids: ["start"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "term",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(/no non-back-edge exit/);
+  });
+});
+
+describe("D11 - fork/join region rules", () => {
+  it("rejects a nested join inside a fork branch", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-nested",
+      revision_id: "rev-nested",
+      goal: "nested join",
+      nodes: [
+        executableNode("fan", "agent"),
+        executableNode("b1", "agent"),
+        executableNode("b2", "command"),
+        {
+          id: "join",
+          kind: "join",
+          title: "Join",
+          fan_out_node_id: "fan",
+          input_branch_ids: ["br1", "br2"],
+        },
+        {
+          id: "nested",
+          kind: "join",
+          title: "Nested",
+          fan_out_node_id: "fan",
+          input_branch_ids: ["br1", "br2"],
+        },
+        executableNode("term", "command"),
+      ],
+      edges: [
+        {
+          id: "e-fan-b1",
+          kind: "fan_out",
+          from: "fan",
+          to: "b1",
+          branch_id: "br1",
+          owner_join_id: "join",
+        },
+        {
+          id: "e-fan-b2",
+          kind: "fan_out",
+          from: "fan",
+          to: "b2",
+          branch_id: "br2",
+          owner_join_id: "join",
+        },
+        { id: "e-b1-nested", kind: "fixed", from: "b1", to: "nested" },
+        { id: "e-nested-join", kind: "fixed", from: "nested", to: "join" },
+        { id: "e-b2-join", kind: "fixed", from: "b2", to: "join" },
+        { id: "e-join-term", kind: "fixed", from: "join", to: "term" },
+      ],
+      entry_node_ids: ["fan"],
+      concurrency_limit: 2,
+      terminal_verification_node_id: "term",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /nested join nested is not allowed inside fork region fan/,
+    );
+  });
+  it("rejects overlapping branch regions", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-overlap",
+      revision_id: "rev-overlap",
+      goal: "overlap",
+      nodes: [
+        executableNode("fan", "agent"),
+        executableNode("shared", "command"),
+        {
+          id: "join",
+          kind: "join",
+          title: "Join",
+          fan_out_node_id: "fan",
+          input_branch_ids: ["br1", "br2"],
+        },
+        executableNode("term", "command"),
+      ],
+      edges: [
+        {
+          id: "e-fan-shared-1",
+          kind: "fan_out",
+          from: "fan",
+          to: "shared",
+          branch_id: "br1",
+          owner_join_id: "join",
+        },
+        {
+          id: "e-fan-shared-2",
+          kind: "fan_out",
+          from: "fan",
+          to: "shared",
+          branch_id: "br2",
+          owner_join_id: "join",
+        },
+        { id: "e-shared-join", kind: "fixed", from: "shared", to: "join" },
+        { id: "e-join-term", kind: "fixed", from: "join", to: "term" },
+      ],
+      entry_node_ids: ["fan"],
+      concurrency_limit: 2,
+      terminal_verification_node_id: "term",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(/overlap at shared/);
+  });
+  it("rejects region-crossing edges", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: [
+          ...d.edges,
+          { id: "e-fan-b1-extra", kind: "fixed", from: "fan", to: "b1" },
+        ],
+      }),
+    ).toThrow(/crosses into fork branch br1/);
+  });
+  it("rejects a branch that cannot reach its owning join", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: d.edges.filter((edge) => edge.id !== "e-b1-join"),
+      }),
+    ).toThrow(/fork branch br1 cannot reach owning join join/);
+  });
+  it("rejects a join without a matching fan-out node", () => {
+    expect(() =>
+      parseGraphDescriptor(
+        replaceJoin(forkJoinDescriptor(), (join) => ({
+          ...join,
+          fan_out_node_id: "nope",
+        })),
+      ),
+    ).toThrow(/join join has no matching fan-out node nope/);
+  });
+  it("rejects mismatched input_branch_ids", () => {
+    expect(() =>
+      parseGraphDescriptor(
+        replaceJoin(forkJoinDescriptor(), (join) => ({
+          ...join,
+          input_branch_ids: ["br1", "brX"],
+        })),
+      ),
+    ).toThrow(/join join input branches do not match fan-out fan/);
+  });
+  it("rejects duplicate branch IDs", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: d.edges.map((edge) =>
+          edge.kind === "fan_out" ? { ...edge, branch_id: "br1" } : edge,
+        ),
+      }),
+    ).toThrow(/fan-out node fan repeats branch ID\(s\): br1/);
+  });
+});
+
+describe("D12 - entry-node eligibility", () => {
+  it("rejects a join node as an entry", () => {
+    expect(() =>
+      parseGraphDescriptor({
+        ...forkJoinDescriptor(),
+        entry_node_ids: ["join"],
+      }),
+    ).toThrow(/entry node join must not be a join node/);
+  });
+  it("rejects an interior fork-branch node as an entry", () => {
+    expect(() =>
+      parseGraphDescriptor({ ...forkJoinDescriptor(), entry_node_ids: ["b1"] }),
+    ).toThrow(/entry node b1 must not be inside a fork branch region/);
+  });
+});
+
+describe("D13 - seal round-trip", () => {
+  it("produces a 64-hex hash, verifies, and round-trips through parseSealedGraphDescriptor", () => {
+    const input = forkJoinDescriptor();
+    const sealed = sealGraphDescriptor(input);
+    expect(sealed.descriptor_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(verifyDescriptorHash(sealed)).toBe(true);
+    expect(computeDescriptorHash(sealed)).toBe(sealed.descriptor_hash);
+    expect(sealGraphDescriptor(input).descriptor_hash).toBe(
+      sealed.descriptor_hash,
+    );
+    expect(parseGraphDescriptor(input)).toEqual(input);
+    expect(
+      parseSealedGraphDescriptor(JSON.parse(JSON.stringify(sealed))),
+    ).toEqual(sealed);
+  });
+});
+
+describe("D14 - canonicalJson", () => {
+  it("produces compact, recursively key-sorted output with arrays in order", () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+    expect(canonicalJson({ a: [1, 2] })).toBe('{"a":[1,2]}');
+    expect(canonicalJson([2, 1])).toBe("[2,1]");
+    expect(canonicalJson({ outer: { z: [1], a: "x" } })).toBe(
+      '{"outer":{"a":"x","z":[1]}}',
+    );
+    expect(
+      canonicalJson(Object.assign(Object.create(null), { b: 1, a: 2 })),
+    ).toBe('{"a":2,"b":1}');
+  });
+  it("throws on undefined values and non-finite numbers", () => {
+    expect(() => canonicalJson({ a: undefined })).toThrow(TypeError);
+    expect(() => canonicalJson({ a: NaN })).toThrow(TypeError);
+    expect(() => canonicalJson({ a: Infinity })).toThrow(TypeError);
+  });
+  it("rejects non-plain objects, unsupported primitives, and cycles", () => {
+    class Custom {}
+    const cyclicObj: Record<string, unknown> = {};
+    cyclicObj.self = cyclicObj;
+    const cyclicArr: unknown[] = [];
+    cyclicArr.push(cyclicArr);
+    const bad: unknown[] = [
+      new Date(),
+      new Map(),
+      new Set(),
+      /re/,
+      new Custom(),
+      Symbol("s"),
+      (): void => {},
+      1n,
+      undefined,
+      NaN,
+      Infinity,
+      cyclicObj,
+      cyclicArr,
+    ];
+    for (const value of bad)
+      expect(() => canonicalJson(value)).toThrow(TypeError);
+    expect(() => canonicalJson({ nested: { deep: [cyclicObj] } })).toThrow(
+      TypeError,
+    );
+  });
+});
+
+describe("D15 - hash payload excludes descriptor_hash and runtime fields; tracks content", () => {
+  it("ignores descriptor_hash and decorated runtime fields", () => {
+    const base = forkJoinDescriptor();
+    const hash = computeDescriptorHash(base);
+    const decorated = {
+      ...base,
+      descriptor_hash: "a".repeat(64),
+      activations: {},
+      committed_transitions: {},
+    } as GraphDescriptorInput;
+    expect(computeDescriptorHash(decorated)).toBe(hash);
+  });
+  it("changes when goal, nodes, or edges change", () => {
+    const base = forkJoinDescriptor();
+    const hash = computeDescriptorHash(base);
+    expect(computeDescriptorHash({ ...base, goal: "different goal" })).not.toBe(
+      hash,
+    );
+    const changedNodes: GraphDescriptorInput = {
+      ...base,
+      nodes: base.nodes.map((node, index) =>
+        index === 0 ? { ...node, title: `Renamed ${node.id}` } : node,
+      ),
+    };
+    expect(computeDescriptorHash(changedNodes)).not.toBe(hash);
+    const changedEdges: GraphDescriptorInput = {
+      ...base,
+      edges: base.edges.map((edge, index) =>
+        index === 0 ? { ...edge, id: `${edge.id}-renamed` } : edge,
+      ),
+    };
+    expect(computeDescriptorHash(changedEdges)).not.toBe(hash);
+  });
+});
+
+describe("D16 - structure-before-hash and deep ownership", () => {
+  it("returns false for structurally invalid but hash-matching input", () => {
+    const valid = forkJoinDescriptor();
+    const duplicated = { ...valid, nodes: [valid.nodes[0], valid.nodes[0]] };
+    expect(
+      verifyDescriptorHash({
+        ...duplicated,
+        descriptor_hash: computeDescriptorHash(duplicated),
+      }),
+    ).toBe(false);
+  });
+  it("returns false for valid structure with a wrong hash", () => {
+    const sealed = sealGraphDescriptor(forkJoinDescriptor());
+    expect(
+      verifyDescriptorHash({ ...sealed, descriptor_hash: "f".repeat(64) }),
+    ).toBe(false);
+  });
+  it("returns false for non-objects and never throws", () => {
+    expect(verifyDescriptorHash(null)).toBe(false);
+    expect(verifyDescriptorHash(42)).toBe(false);
+    expect(verifyDescriptorHash("text")).toBe(false);
+    expect(() => verifyDescriptorHash({ descriptor_hash: "x" })).not.toThrow();
+    expect(() => verifyDescriptorHash(Symbol("s"))).not.toThrow();
+  });
+  it("deep-freezes parse/seal outputs; writes to frozen nodes throw", () => {
+    const sealed = sealGraphDescriptor(forkJoinDescriptor());
+    expect(Object.isFrozen(sealed)).toBe(true);
+    expect(Object.isFrozen(sealed.nodes)).toBe(true);
+    expect(Object.isFrozen(sealed.nodes[0])).toBe(true);
+    expect(Object.isFrozen(sealed.edges)).toBe(true);
+    expect(Object.isFrozen(sealed.edges[0])).toBe(true);
+    expect(Object.isFrozen(sealed.entry_node_ids)).toBe(true);
+    expect(() => {
+      (sealed.nodes[0] as unknown as { title: string }).title = "mutated";
+    }).toThrow(TypeError);
+  });
+});
+
+describe("D17 - fixed-edge exclusivity", () => {
+  it("rejects a node mixing a fixed edge with a conditional edge", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-fixed-excl",
+      revision_id: "rev-fixed-excl",
+      goal: "fixed exclusivity",
+      nodes: [
+        executableNode("a", "command"),
+        executableNode("mid", "command"),
+        executableNode("t1", "command"),
+        executableNode("t2", "command"),
+      ],
+      edges: [
+        { id: "e-a-mid", kind: "fixed", from: "a", to: "mid" },
+        { id: "e-mid-t1", kind: "fixed", from: "mid", to: "t1" },
+        {
+          id: "e-mid-t2",
+          kind: "conditional",
+          from: "mid",
+          to: "t2",
+          route: "x",
+        },
+      ],
+      entry_node_ids: ["a"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "t1",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /node mid must use one fixed edge or an explicit route\/fan-out set/,
+    );
+  });
+});
+
+describe("D18 - fan-out cardinality", () => {
+  it("rejects a single fan_out edge", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-fan1",
+      revision_id: "rev-fan1",
+      goal: "single fan-out",
+      nodes: [
+        executableNode("fan", "agent"),
+        executableNode("b1", "command"),
+        {
+          id: "join",
+          kind: "join",
+          title: "Join",
+          fan_out_node_id: "fan",
+          input_branch_ids: ["br1", "br2"],
+        },
+        executableNode("term", "command"),
+      ],
+      edges: [
+        {
+          id: "e-fan-b1",
+          kind: "fan_out",
+          from: "fan",
+          to: "b1",
+          branch_id: "br1",
+          owner_join_id: "join",
+        },
+        { id: "e-b1-join", kind: "fixed", from: "b1", to: "join" },
+        { id: "e-join-term", kind: "fixed", from: "join", to: "term" },
+      ],
+      entry_node_ids: ["fan"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "term",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /fan-out node fan must declare at least two fan_out edges and no other edge kind/,
+    );
+  });
+  it("rejects fan_out edges mixed with other edge kinds", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: [
+          ...d.edges,
+          { id: "e-fan-term", kind: "fixed", from: "fan", to: "term" },
+        ],
+      }),
+    ).toThrow(
+      /fan-out node fan must declare at least two fan_out edges and no other edge kind/,
+    );
+  });
+});
+
+describe("D19 - join outgoing shape", () => {
+  it("rejects a join with no outgoing edges", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: d.edges.filter((edge) => edge.id !== "e-join-term"),
+      }),
+    ).toThrow(/join node join must have exactly one fixed outgoing edge/);
+  });
+  it("rejects a join with a non-fixed outgoing edge", () => {
+    const d = forkJoinDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: d.edges.map((edge) =>
+          edge.id === "e-join-term"
+            ? {
+                id: "e-join-term",
+                kind: "conditional",
+                from: "join",
+                to: "term",
+                route: "x",
+              }
+            : edge,
+        ),
+      }),
+    ).toThrow(/join node join must have exactly one fixed outgoing edge/);
+  });
+});
+
+describe("D20 - duplicate conditional routes", () => {
+  it("rejects duplicate routes on a node", () => {
+    const input: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-routes",
+      revision_id: "rev-routes",
+      goal: "routes",
+      nodes: [
+        executableNode("s", "command"),
+        executableNode("w", "command"),
+        executableNode("t1", "command"),
+        executableNode("t2", "command"),
+      ],
+      edges: [
+        { id: "e-s-w", kind: "fixed", from: "s", to: "w" },
+        {
+          id: "e-w-t1",
+          kind: "conditional",
+          from: "w",
+          to: "t1",
+          route: "dup",
+        },
+        {
+          id: "e-w-t2",
+          kind: "conditional",
+          from: "w",
+          to: "t2",
+          route: "dup",
+        },
+      ],
+      entry_node_ids: ["s"],
+      concurrency_limit: 1,
+      terminal_verification_node_id: "t1",
+    };
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /declares duplicate route\(s\): dup/,
+    );
+  });
+});
+
+describe("D21 - back edges must be structural returns", () => {
+  it("rejects a back edge that is not a structural return to an earlier node", () => {
+    const d = loopDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: d.edges.map((edge) =>
+          edge.kind === "back_edge" && edge.id === "e-work-retry"
+            ? { ...edge, to: "term" }
+            : edge,
+        ),
+      }),
+    ).toThrow(
+      /back-edge e-work-retry is not a structural return to an earlier node/,
+    );
+  });
+});
+
+describe("D22 - human-approval single-fixed-edge rule", () => {
+  const badEdges: { name: string; edge: GraphEdge }[] = [
+    {
+      name: "conditional",
+      edge: {
+        id: "e-approval-term",
+        kind: "conditional",
+        from: "approval",
+        to: "term",
+        route: "approve",
+      },
+    },
+    {
+      name: "fan_out",
+      edge: {
+        id: "e-approval-term",
+        kind: "fan_out",
+        from: "approval",
+        to: "term",
+        branch_id: "br1",
+        owner_join_id: "join",
+      },
+    },
+    {
+      name: "back_edge",
+      edge: {
+        id: "e-approval-term",
+        kind: "back_edge",
+        from: "approval",
+        to: "term",
+        route: "retry",
+        max_traversals: 3,
+      },
+    },
+  ];
+  it.each(badEdges)(
+    "rejects a human-approval node with a $name outgoing edge",
+    ({ edge }) => {
+      const d = approvalDescriptor();
+      expect(() =>
+        parseGraphDescriptor({
+          ...d,
+          edges: d.edges.map((e) => (e.id === "e-approval-term" ? edge : e)),
+        }),
+      ).toThrow(
+        /human-approval node approval must have exactly one fixed outgoing edge/,
+      );
+    },
+  );
+  it("rejects a human-approval node with zero outgoing edges", () => {
+    const d = approvalDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: d.edges.filter((edge) => edge.id !== "e-approval-term"),
+      }),
+    ).toThrow(
+      /human-approval node approval must have exactly one fixed outgoing edge/,
+    );
+  });
+  it("rejects a human-approval node with two fixed outgoing edges", () => {
+    const d = approvalDescriptor();
+    expect(() =>
+      parseGraphDescriptor({
+        ...d,
+        edges: [
+          ...d.edges,
+          {
+            id: "e-approval-entry",
+            kind: "fixed",
+            from: "approval",
+            to: "entry",
+          },
+        ],
+      }),
+    ).toThrow(
+      /human-approval node approval must have exactly one fixed outgoing edge/,
+    );
+  });
+  it("accepts a human-approval node with exactly one fixed outgoing edge", () => {
+    expect(() => parseGraphDescriptor(approvalDescriptor())).not.toThrow();
+  });
+});
+
+describe("D23 - verifyDescriptorHash non-branding predicate and ownership producers", () => {
+  it("returns true only for structure-valid, hash-matching input", () => {
+    const sealed = sealGraphDescriptor(forkJoinDescriptor());
+    expect(verifyDescriptorHash(sealed)).toBe(true);
+    expect(
+      verifyDescriptorHash({ ...sealed, descriptor_hash: "f".repeat(64) }),
+    ).toBe(false);
+    const valid = forkJoinDescriptor();
+    const duplicated = { ...valid, nodes: [valid.nodes[0], valid.nodes[0]] };
+    expect(
+      verifyDescriptorHash({
+        ...duplicated,
+        descriptor_hash: computeDescriptorHash(duplicated),
+      }),
+    ).toBe(false);
+    expect(verifyDescriptorHash(null)).toBe(false);
+    expect(verifyDescriptorHash({})).toBe(false);
+  });
+  it("never throws", () => {
+    expect(() => verifyDescriptorHash({ descriptor_hash: 42 })).not.toThrow();
+    expect(() => verifyDescriptorHash({ descriptor_hash: "x" })).not.toThrow();
+    expect(() => verifyDescriptorHash(Symbol("s"))).not.toThrow();
+  });
+  it("never freezes or mutates the caller input", () => {
+    const caller = { ...sealGraphDescriptor(forkJoinDescriptor()) };
+    expect(Object.isFrozen(caller)).toBe(false);
+    const snapshot = JSON.stringify(caller);
+    expect(verifyDescriptorHash(caller)).toBe(true);
+    expect(Object.isFrozen(caller)).toBe(false);
+    expect(JSON.stringify(caller)).toBe(snapshot);
+  });
+  it("isGraphDescriptor is a non-throwing structural check", () => {
+    expect(isGraphDescriptor(forkJoinDescriptor())).toBe(true);
+    expect(isGraphDescriptor({ ...forkJoinDescriptor(), extra: true })).toBe(
+      false,
+    );
+    expect(isGraphDescriptor(null)).toBe(false);
+  });
+  it("parseGraphDescriptor and sealGraphDescriptor outputs are frozen at every level", () => {
+    for (const descriptor of [
+      parseGraphDescriptor(forkJoinDescriptor()),
+      sealGraphDescriptor(forkJoinDescriptor()),
+    ]) {
+      expect(Object.isFrozen(descriptor)).toBe(true);
+      expect(Object.isFrozen(descriptor.nodes)).toBe(true);
+      expect(Object.isFrozen(descriptor.nodes[0])).toBe(true);
+      expect(Object.isFrozen(descriptor.edges)).toBe(true);
+      expect(Object.isFrozen(descriptor.edges[0])).toBe(true);
+      expect(Object.isFrozen(descriptor.entry_node_ids)).toBe(true);
+    }
+  });
+});
+
+describe("D24 - parseSealedGraphDescriptor persisted sealed input matrix", () => {
+  const persisted = (): ReturnType<typeof JSON.parse> =>
+    JSON.parse(JSON.stringify(sealGraphDescriptor(forkJoinDescriptor())));
+  it("(a) accepts a valid persisted sealed descriptor and deep-freezes it", () => {
+    const input = persisted();
+    const parsed = parseSealedGraphDescriptor(input);
+    expect(parsed.descriptor_hash).toBe(input.descriptor_hash);
+    expect(parsed).toEqual(input);
+    expect(Object.isFrozen(parsed)).toBe(true);
+    expect(Object.isFrozen(parsed.nodes)).toBe(true);
+    expect(Object.isFrozen(parsed.nodes[0])).toBe(true);
+    expect(Object.isFrozen(parsed.edges)).toBe(true);
+    expect(Object.isFrozen(parsed.edges[0])).toBe(true);
+  });
+  it("(b) rejects a supplied hash mismatch", () => {
+    const input = persisted();
+    expect(() =>
+      parseSealedGraphDescriptor({ ...input, descriptor_hash: "f".repeat(64) }),
+    ).toThrow(GraphDescriptorValidationError);
+    expect(() =>
+      parseSealedGraphDescriptor({ ...input, descriptor_hash: "f".repeat(64) }),
+    ).toThrow(/does not match the exact revision/);
+  });
+  it("(c) rejects a missing descriptor_hash", () => {
+    const input = persisted();
+    const { descriptor_hash: _omitted, ...rest } = input;
+    expect(() => parseSealedGraphDescriptor(rest)).toThrow(
+      GraphDescriptorValidationError,
+    );
+    expect(() => parseSealedGraphDescriptor(rest)).toThrow(
+      /must carry a `descriptor_hash`/,
+    );
+  });
+  it("(d) rejects a malformed descriptor_hash format", () => {
+    const input = persisted();
+    expect(() =>
+      parseSealedGraphDescriptor({ ...input, descriptor_hash: "not-a-hash" }),
+    ).toThrow(GraphDescriptorValidationError);
+    expect(() =>
+      parseSealedGraphDescriptor({ ...input, descriptor_hash: "A".repeat(64) }),
+    ).toThrow(/64 lowercase hexadecimal characters/);
+  });
+  it("(e) rejects structurally invalid but hash-matching input (structure-before-hash)", () => {
+    const input = persisted();
+    const duplicated = { ...input, nodes: [input.nodes[0], input.nodes[0]] };
+    expect(() =>
+      parseSealedGraphDescriptor({
+        ...duplicated,
+        descriptor_hash: computeDescriptorHash(duplicated),
+      }),
+    ).toThrow();
+  });
+  it("(f) draft producers reject input carrying a descriptor_hash with a directed error", () => {
+    const input = persisted();
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      GraphDescriptorValidationError,
+    );
+    expect(() => parseGraphDescriptor(input)).toThrow(
+      /parseSealedGraphDescriptor/,
+    );
+    expect(() => sealGraphDescriptor(input)).toThrow(
+      GraphDescriptorValidationError,
+    );
+    expect(() => sealGraphDescriptor(input)).toThrow(
+      /parseSealedGraphDescriptor/,
+    );
+  });
+  it("(g) verifyDescriptorHash is true only for valid hash-matching input and never freezes the caller", () => {
+    const input = persisted();
+    expect(verifyDescriptorHash(input)).toBe(true);
+    expect(
+      verifyDescriptorHash({ ...input, descriptor_hash: "f".repeat(64) }),
+    ).toBe(false);
+    const caller = { ...input };
+    expect(Object.isFrozen(caller)).toBe(false);
+    verifyDescriptorHash(caller);
+    expect(Object.isFrozen(caller)).toBe(false);
+  });
+});
+
+describe("D25 - prototype-named stable IDs are safe", () => {
+  const protoInput = (): GraphDescriptorInput => ({
+    descriptor_version: 1,
+    run_id: "run-proto",
+    revision_id: "rev-proto",
+    goal: "proto ids",
+    nodes: [
+      { ...executableNode("constructor", "command"), title: "Ctor" },
+      { ...executableNode("prototype", "command"), title: "Proto" },
+      { ...executableNode("hasOwnProperty", "command"), title: "Own" },
+    ],
+    edges: [
+      { id: "e1", kind: "fixed", from: "constructor", to: "prototype" },
+      { id: "e2", kind: "fixed", from: "prototype", to: "hasOwnProperty" },
+    ],
+    entry_node_ids: ["constructor"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "hasOwnProperty",
+  });
+  it("parses, seals, verifies, and persisted-round-trips prototype-named ids", () => {
+    expect(() => parseGraphDescriptor(protoInput())).not.toThrow();
+    const sealed = sealGraphDescriptor(protoInput());
+    expect(verifyDescriptorHash(sealed)).toBe(true);
+    expect(computeDescriptorHash(sealed)).toBe(sealed.descriptor_hash);
+    expect(
+      parseSealedGraphDescriptor(JSON.parse(JSON.stringify(sealed)))
+        .descriptor_hash,
+    ).toBe(sealed.descriptor_hash);
+    expect(isGraphDescriptor(protoInput())).toBe(true);
+  });
+  it("rejects duplicate prototype-named node ids via own-key duplicates detection", () => {
+    const input = protoInput();
+    expect(() =>
+      parseGraphDescriptor({
+        ...input,
+        nodes: [...input.nodes, executableNode("constructor", "command")],
+      }),
+    ).toThrow(/duplicate node ID\(s\): constructor/);
+  });
+});

--- a/src/graph/__tests__/fixtures.ts
+++ b/src/graph/__tests__/fixtures.ts
@@ -1,0 +1,194 @@
+/**
+ * Contract-authored Graph Core test fixtures.
+ *
+ * Authored from spec `deep-interview-issue-3570-graph-core.md` and the ralplan
+ * stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only for
+ * behavioral cross-checks in the scratch harness; no reference fixture
+ * structure copied.
+ */
+
+import type {
+  GraphAgentNode,
+  GraphCommandNode,
+  GraphDescriptorInput,
+} from "../types.js";
+
+/** Minimal valid executable (agent/command) node. */
+export function executableNode(
+  id: string,
+  kind: "agent" | "command",
+): GraphAgentNode | GraphCommandNode {
+  const title = `Node ${id}`;
+  if (kind === "agent") {
+    return {
+      id,
+      kind,
+      title,
+      timeout_ms: 60_000,
+      max_attempts: 3,
+      effect_policy: { policy: "side_effect_free" },
+      instructions: `Instructions for ${id}`,
+    };
+  }
+  return {
+    id,
+    kind,
+    title,
+    timeout_ms: 60_000,
+    max_attempts: 3,
+    effect_policy: { policy: "side_effect_free" },
+    command: `echo ${id}`,
+  };
+}
+
+/** Fan-out → two branches → join → terminal verification. */
+export function forkJoinDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-fork-join",
+    revision_id: "rev-fork-join",
+    goal: "Verify fork/join orchestration",
+    nodes: [
+      {
+        ...executableNode("fan", "agent"),
+        title: "Fan out",
+      },
+      {
+        ...executableNode("b1", "agent"),
+        title: "Branch one",
+      },
+      {
+        ...executableNode("b2", "command"),
+        title: "Branch two",
+      },
+      {
+        id: "join",
+        kind: "join",
+        title: "Join",
+        fan_out_node_id: "fan",
+        input_branch_ids: ["br1", "br2"],
+      },
+      {
+        ...executableNode("term", "command"),
+        title: "Terminal",
+      },
+    ],
+    edges: [
+      {
+        id: "e-fan-b1",
+        kind: "fan_out",
+        from: "fan",
+        to: "b1",
+        branch_id: "br1",
+        owner_join_id: "join",
+      },
+      {
+        id: "e-fan-b2",
+        kind: "fan_out",
+        from: "fan",
+        to: "b2",
+        branch_id: "br2",
+        owner_join_id: "join",
+      },
+      { id: "e-b1-join", kind: "fixed", from: "b1", to: "join" },
+      { id: "e-b2-join", kind: "fixed", from: "b2", to: "join" },
+      { id: "e-join-term", kind: "fixed", from: "join", to: "term" },
+    ],
+    entry_node_ids: ["fan"],
+    concurrency_limit: 2,
+    terminal_verification_node_id: "term",
+  };
+}
+
+/**
+ * Bounded retry loop: `work` retries itself via a back edge while a forward
+ * `give-up` exit keeps the loop node from being back-edge-only.
+ */
+export function loopDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-loop",
+    revision_id: "rev-loop",
+    goal: "Verify bounded retry loop",
+    nodes: [
+      {
+        ...executableNode("start", "agent"),
+        title: "Start",
+      },
+      {
+        ...executableNode("work", "command"),
+        title: "Work",
+      },
+      {
+        ...executableNode("give_up", "command"),
+        title: "Give up",
+      },
+      {
+        ...executableNode("term", "command"),
+        title: "Terminal",
+      },
+    ],
+    edges: [
+      { id: "e-start-work", kind: "fixed", from: "start", to: "work" },
+      {
+        id: "e-work-retry",
+        kind: "back_edge",
+        from: "work",
+        to: "work",
+        route: "retry",
+        max_traversals: 3,
+      },
+      {
+        id: "e-work-give-up",
+        kind: "conditional",
+        from: "work",
+        to: "give_up",
+        route: "give-up",
+      },
+      {
+        id: "e-work-term",
+        kind: "conditional",
+        from: "work",
+        to: "term",
+        route: "success",
+      },
+      { id: "e-give-up-term", kind: "fixed", from: "give_up", to: "term" },
+    ],
+    entry_node_ids: ["start"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "term",
+  };
+}
+
+/** Entry → human-approval → single fixed edge → terminal verification. */
+export function approvalDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-approval",
+    revision_id: "rev-approval",
+    goal: "Verify human approval gate",
+    nodes: [
+      {
+        ...executableNode("entry", "agent"),
+        title: "Entry",
+      },
+      {
+        id: "approval",
+        kind: "human-approval",
+        title: "Approve release",
+        prompt: "Approve the release?",
+      },
+      {
+        ...executableNode("term", "command"),
+        title: "Terminal",
+      },
+    ],
+    edges: [
+      { id: "e-entry-approval", kind: "fixed", from: "entry", to: "approval" },
+      { id: "e-approval-term", kind: "fixed", from: "approval", to: "term" },
+    ],
+    entry_node_ids: ["entry"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "term",
+  };
+}

--- a/src/graph/__tests__/scheduler.test.ts
+++ b/src/graph/__tests__/scheduler.test.ts
@@ -1,0 +1,1952 @@
+/**
+ * Contract-authored scheduler tests (S1-S26) for Graph Core.
+ *
+ * Authored from the ralplan stage-04 revision (`pending-approval.md`); oracle
+ * `99ffe31` used only for behavioral cross-checks. S10/S20 implement the
+ * stage-04 deltas (exact approval records, persisted-sealed scheduler flow
+ * without type assertion); S21-S26 cover review-blocker adversarial cases.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  parseSealedGraphDescriptor,
+  sealGraphDescriptor,
+  verifyDescriptorHash,
+} from "../descriptor.js";
+import {
+  GraphSchedulerError,
+  applyHumanApproval,
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyApprovalActivations,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+  releaseAttemptForRetry,
+  resolveJoin,
+  traversalCounterKey,
+} from "../scheduler.js";
+import type {
+  ApplyHumanApprovalInput,
+  ApplyNodeResultInput,
+  GraphDescriptorInput,
+  GraphSchedulerErrorCode,
+  GraphSchedulerProjection,
+  SchedulerTransitionIdentities,
+  SealedGraphDescriptor,
+} from "../types.js";
+import {
+  approvalDescriptor,
+  executableNode,
+  forkJoinDescriptor,
+  loopDescriptor,
+} from "./fixtures.js";
+
+const EVIDENCE = [
+  { kind: "command", ref: "npm run test:run -- src/graph" },
+] as const;
+const sealedOf = (input: GraphDescriptorInput): SealedGraphDescriptor =>
+  sealGraphDescriptor(input);
+const ok = (
+  attemptId: string,
+): { outcome: "succeeded"; attempt_id: string; evidence_refs: [] } => ({
+  outcome: "succeeded",
+  attempt_id: attemptId,
+  evidence_refs: [],
+});
+
+function chainDescriptor(maxAttempts: number): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-sched-chain",
+    revision_id: "rev-sched-chain",
+    goal: "scheduler chain",
+    nodes: [
+      { ...executableNode("start", "agent"), max_attempts: maxAttempts },
+      { ...executableNode("work", "command"), max_attempts: maxAttempts },
+      { ...executableNode("term", "command"), max_attempts: 1 },
+    ],
+    edges: [
+      { id: "e-start-work", kind: "fixed", from: "start", to: "work" },
+      { id: "e-work-term", kind: "fixed", from: "work", to: "term" },
+    ],
+    entry_node_ids: ["start"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "term",
+  };
+}
+function retryDescriptor(maxTraversals: number): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-sched-retry",
+    revision_id: "rev-sched-retry",
+    goal: "scheduler retry loop",
+    nodes: [
+      { ...executableNode("start", "agent"), max_attempts: 1 },
+      { ...executableNode("work", "command"), max_attempts: 3 },
+      { ...executableNode("give_up", "command"), max_attempts: 1 },
+      { ...executableNode("term", "command"), max_attempts: 1 },
+    ],
+    edges: [
+      { id: "e-start-work", kind: "fixed", from: "start", to: "work" },
+      {
+        id: "e-work-retry",
+        kind: "back_edge",
+        from: "work",
+        to: "work",
+        route: "retry",
+        max_traversals: maxTraversals,
+      },
+      {
+        id: "e-work-give-up",
+        kind: "conditional",
+        from: "work",
+        to: "give_up",
+        route: "give-up",
+      },
+      {
+        id: "e-work-term",
+        kind: "conditional",
+        from: "work",
+        to: "term",
+        route: "success",
+      },
+      { id: "e-give-up-term", kind: "fixed", from: "give_up", to: "term" },
+    ],
+    entry_node_ids: ["start"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "term",
+  };
+}
+function orderingDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-sched-order",
+    revision_id: "rev-sched-order",
+    goal: "scheduler ordering",
+    nodes: [
+      { ...executableNode("Zentry", "agent"), max_attempts: 1 },
+      { ...executableNode("aentry", "command"), max_attempts: 1 },
+      { ...executableNode("zentry", "agent"), max_attempts: 1 },
+      { ...executableNode("term", "command"), max_attempts: 1 },
+    ],
+    edges: [
+      { id: "e-Z-term", kind: "fixed", from: "Zentry", to: "term" },
+      { id: "e-a-term", kind: "fixed", from: "aentry", to: "term" },
+      { id: "e-z-term", kind: "fixed", from: "zentry", to: "term" },
+    ],
+    entry_node_ids: ["Zentry", "aentry", "zentry"],
+    concurrency_limit: 3,
+    terminal_verification_node_id: "term",
+  };
+}
+function protoChainDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-proto-s",
+    revision_id: "rev-proto-s",
+    goal: "proto scheduler",
+    nodes: [
+      { ...executableNode("constructor", "command"), max_attempts: 1 },
+      { ...executableNode("prototype", "command"), max_attempts: 1 },
+      { ...executableNode("hasOwnProperty", "command"), max_attempts: 1 },
+    ],
+    edges: [
+      { id: "e1", kind: "fixed", from: "constructor", to: "prototype" },
+      { id: "e2", kind: "fixed", from: "prototype", to: "hasOwnProperty" },
+    ],
+    entry_node_ids: ["constructor"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "hasOwnProperty",
+  };
+}
+function baseProjection(
+  descriptor: SealedGraphDescriptor,
+): GraphSchedulerProjection {
+  return {
+    descriptor_hash: descriptor.descriptor_hash,
+    run_id: descriptor.run_id,
+    revision_id: descriptor.revision_id,
+    activations: {},
+    cohorts: {},
+    branch_tokens: {},
+    traversal_counts: {},
+    committed_transitions: {},
+    terminal_verification_activation_ids: [],
+  };
+}
+function expectCode(fn: () => unknown, code: GraphSchedulerErrorCode): void {
+  let thrown: unknown;
+  try {
+    fn();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(GraphSchedulerError);
+  expect((thrown as GraphSchedulerError).code).toBe(code);
+}
+const fanOutIdentities = {
+  cohort_id: "coh-1",
+  branch_token_ids: { "e-fan-b1": "tok-b1", "e-fan-b2": "tok-b2" },
+  next_activation_ids: { "e-fan-b1": "act-b1", "e-fan-b2": "act-b2" },
+};
+function driveToJoin(
+  descriptor: SealedGraphDescriptor,
+): GraphSchedulerProjection {
+  let p = initializeGraphProjection(descriptor, { fan: "act-fan" });
+  p = beginActivationAttempt(descriptor, p, {
+    activation_id: "act-fan",
+    attempt_id: "at-fan-1",
+  });
+  p = applyNodeResult(descriptor, p, {
+    activation_id: "act-fan",
+    transition_id: "tr-fan",
+    result: ok("at-fan-1"),
+    identities: fanOutIdentities,
+  }).projection;
+  p = beginActivationAttempt(descriptor, p, {
+    activation_id: "act-b1",
+    attempt_id: "at-b1-1",
+  });
+  p = applyNodeResult(descriptor, p, {
+    activation_id: "act-b1",
+    transition_id: "tr-b1",
+    result: ok("at-b1-1"),
+    identities: {},
+  }).projection;
+  p = beginActivationAttempt(descriptor, p, {
+    activation_id: "act-b2",
+    attempt_id: "at-b2-1",
+  });
+  p = applyNodeResult(descriptor, p, {
+    activation_id: "act-b2",
+    transition_id: "tr-b2",
+    result: ok("at-b2-1"),
+    identities: { join_activation_id: "act-join" },
+  }).projection;
+  return p;
+}
+function driveToApproval(
+  sealed: SealedGraphDescriptor,
+): GraphSchedulerProjection {
+  let p = initializeGraphProjection(sealed, { entry: "act-entry" });
+  p = beginActivationAttempt(sealed, p, {
+    activation_id: "act-entry",
+    attempt_id: "at-entry",
+  });
+  return applyNodeResult(sealed, p, {
+    activation_id: "act-entry",
+    transition_id: "tr-entry",
+    result: ok("at-entry"),
+    identities: { next_activation_ids: { "e-entry-approval": "act-approval" } },
+  }).projection;
+}
+function driveToWork(sealed: SealedGraphDescriptor): GraphSchedulerProjection {
+  let p = initializeGraphProjection(sealed, { start: "act-start" });
+  p = beginActivationAttempt(sealed, p, {
+    activation_id: "act-start",
+    attempt_id: "at-start",
+  });
+  return applyNodeResult(sealed, p, {
+    activation_id: "act-start",
+    transition_id: "tr-start",
+    result: ok("at-start"),
+    identities: { next_activation_ids: { "e-start-work": "act-work" } },
+  }).projection;
+}
+function cyclicIdentities(): unknown {
+  const value: Record<string, unknown> = {};
+  value.self = value;
+  return value;
+}
+
+describe("S1 - initializeGraphProjection", () => {
+  it("creates a bound projection with entry activations", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = initializeGraphProjection(sealed, { fan: "act-fan" });
+    expect(projection.descriptor_hash).toBe(sealed.descriptor_hash);
+    expect(projection.run_id).toBe(sealed.run_id);
+    expect(projection.revision_id).toBe(sealed.revision_id);
+    expect(Object.keys(projection.activations)).toEqual(["act-fan"]);
+    expect(projection.activations["act-fan"].status).toBe("ready");
+    expect(projection.activations["act-fan"].traversal_owner_id).toBe(
+      "act-fan",
+    );
+    expect(projection.committed_transitions).toEqual({});
+  });
+  it("throws missing_identity when an entry node has no identity", () => {
+    expectCode(
+      () => initializeGraphProjection(sealedOf(forkJoinDescriptor()), {}),
+      "missing_identity",
+    );
+  });
+  it("throws unexpected_identity for a non-entry identity key", () => {
+    expectCode(
+      () =>
+        initializeGraphProjection(sealedOf(forkJoinDescriptor()), {
+          fan: "act-fan",
+          b1: "act-b1",
+        }),
+      "unexpected_identity",
+    );
+  });
+  it("throws duplicate_identity when two entry nodes share an activation id", () => {
+    expectCode(
+      () =>
+        initializeGraphProjection(sealedOf(orderingDescriptor()), {
+          Zentry: "same",
+          aentry: "same",
+          zentry: "act-z",
+        }),
+      "duplicate_identity",
+    );
+  });
+});
+describe("S2 - descriptor binding", () => {
+  it("throws descriptor_mismatch when descriptor and projection have different hashes", () => {
+    const sealed = sealedOf(chainDescriptor(1));
+    const projection = initializeGraphProjection(
+      sealedOf(forkJoinDescriptor()),
+      { fan: "act-fan" },
+    );
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, projection, {
+          activation_id: "act-fan",
+          attempt_id: "at-1",
+        }),
+      "descriptor_mismatch",
+    );
+  });
+  it("throws descriptor_mismatch when the projection hash is tampered with", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = initializeGraphProjection(sealed, { fan: "act-fan" });
+    expectCode(
+      () =>
+        beginActivationAttempt(
+          sealed,
+          { ...projection, descriptor_hash: "f".repeat(64) },
+          { activation_id: "act-fan", attempt_id: "at-1" },
+        ),
+      "descriptor_mismatch",
+    );
+  });
+});
+describe("S3 - begin/release attempt identities and budget", () => {
+  it("begin creates a running attempt; release with the wrong attempt is fenced", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    let projection = initializeGraphProjection(sealed, { start: "act-start" });
+    projection = beginActivationAttempt(sealed, projection, {
+      activation_id: "act-start",
+      attempt_id: "at-1",
+    });
+    expect(projection.activations["act-start"].status).toBe("running");
+    expect(projection.activations["act-start"].active_attempt_id).toBe("at-1");
+    expectCode(
+      () =>
+        releaseAttemptForRetry(sealed, projection, {
+          activation_id: "act-start",
+          attempt_id: "at-wrong",
+        }),
+      "attempt_fenced",
+    );
+    projection = releaseAttemptForRetry(sealed, projection, {
+      activation_id: "act-start",
+      attempt_id: "at-1",
+    });
+    expect(projection.activations["act-start"].status).toBe("ready");
+    expect(
+      projection.activations["act-start"].active_attempt_id,
+    ).toBeUndefined();
+  });
+  it("begin after the descriptor-derived budget is exhausted throws max_attempts_exceeded", () => {
+    const sealed = sealedOf(chainDescriptor(2));
+    const projection: GraphSchedulerProjection = {
+      ...baseProjection(sealed),
+      activations: {
+        "act-work": {
+          activation_id: "act-work",
+          node_id: "work",
+          status: "ready",
+          attempt_no: 2,
+          attempt_ids: ["at-1", "at-2"],
+          traversal_owner_id: "act-work",
+        },
+      },
+    };
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, projection, {
+          activation_id: "act-work",
+          attempt_id: "at-3",
+        }),
+      "max_attempts_exceeded",
+    );
+  });
+  it("reusing an attempt id colliding with the global namespace throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection: GraphSchedulerProjection = {
+      ...baseProjection(sealed),
+      activations: {
+        "act-a": {
+          activation_id: "act-a",
+          node_id: "fan",
+          status: "ready",
+          attempt_no: 0,
+          attempt_ids: [],
+          traversal_owner_id: "act-a",
+        },
+        "act-b": {
+          activation_id: "act-b",
+          node_id: "b1",
+          status: "ready",
+          attempt_no: 0,
+          attempt_ids: [],
+          traversal_owner_id: "act-b",
+        },
+      },
+    };
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, projection, {
+          activation_id: "act-a",
+          attempt_id: "act-b",
+        }),
+      "duplicate_identity",
+    );
+  });
+});
+describe("S4 - begin rejects approval and join kinds", () => {
+  it("begin on a human-approval node throws unsupported_node_kind", () => {
+    expectCode(
+      () =>
+        beginActivationAttempt(
+          sealedOf(approvalDescriptor()),
+          driveToApproval(sealedOf(approvalDescriptor())),
+          { activation_id: "act-approval", attempt_id: "at-approval" },
+        ),
+      "unsupported_node_kind",
+    );
+  });
+  it("begin on a join node throws unsupported_node_kind", () => {
+    expectCode(
+      () =>
+        beginActivationAttempt(
+          sealedOf(forkJoinDescriptor()),
+          driveToJoin(sealedOf(forkJoinDescriptor())),
+          { activation_id: "act-join", attempt_id: "at-join" },
+        ),
+      "unsupported_node_kind",
+    );
+  });
+});
+describe("S5 - route selection", () => {
+  it("follows a declared conditional route", () => {
+    const sealed = sealedOf(retryDescriptor(3));
+    let projection = beginActivationAttempt(sealed, driveToWork(sealed), {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    projection = applyNodeResult(sealed, projection, {
+      activation_id: "act-work",
+      transition_id: "tr-w-success",
+      result: { ...ok("at-w1"), route: "success" },
+      identities: { next_activation_ids: { "e-work-term": "act-term" } },
+    }).projection;
+    expect(projection.activations["act-term"].node_id).toBe("term");
+    expect(
+      projection.committed_transitions["tr-w-success"].selected_edge_ids,
+    ).toEqual(["e-work-term"]);
+  });
+  it("missing route on a routed node throws route_required", () => {
+    const sealed = sealedOf(retryDescriptor(3));
+    const running = beginActivationAttempt(sealed, driveToWork(sealed), {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-work",
+          transition_id: "tr-w",
+          result: ok("at-w1"),
+        }),
+      "route_required",
+    );
+  });
+  it("undeclared route throws undeclared_route", () => {
+    const sealed = sealedOf(retryDescriptor(3));
+    const running = beginActivationAttempt(sealed, driveToWork(sealed), {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-work",
+          transition_id: "tr-w",
+          result: { ...ok("at-w1"), route: "nope" },
+        }),
+      "undeclared_route",
+    );
+  });
+  it("failed results cannot select routes", () => {
+    const sealed = sealedOf(retryDescriptor(3));
+    const running = beginActivationAttempt(sealed, driveToWork(sealed), {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-work",
+          transition_id: "tr-w",
+          result: {
+            outcome: "failed",
+            attempt_id: "at-w1",
+            route: "success",
+            evidence_refs: [],
+          },
+        }),
+      "undeclared_route",
+    );
+  });
+});
+describe("S6 - traversal bound on back edges", () => {
+  it("third retry over max_traversals: 2 throws traversal_bound_exceeded", () => {
+    const sealed = sealedOf(retryDescriptor(2));
+    let projection = driveToWork(sealed);
+    const retry = (
+      activationId: string,
+      attemptId: string,
+      transitionId: string,
+      nextId: string,
+    ): GraphSchedulerProjection =>
+      applyNodeResult(
+        sealed,
+        beginActivationAttempt(sealed, projection, {
+          activation_id: activationId,
+          attempt_id: attemptId,
+        }),
+        {
+          activation_id: activationId,
+          transition_id: transitionId,
+          result: { ...ok(attemptId), route: "retry" },
+          identities: { next_activation_ids: { "e-work-retry": nextId } },
+        },
+      ).projection;
+    projection = retry("act-work", "at-r1", "r1", "act-work-r1");
+    projection = retry("act-work-r1", "at-r2", "r2", "act-work-r2");
+    const running = beginActivationAttempt(sealed, projection, {
+      activation_id: "act-work-r2",
+      attempt_id: "at-r3",
+    });
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-work-r2",
+          transition_id: "r3",
+          result: { ...ok("at-r3"), route: "retry" },
+          identities: {
+            next_activation_ids: { "e-work-retry": "act-work-r3" },
+          },
+        }),
+      "traversal_bound_exceeded",
+    );
+  });
+});
+describe("S7 - fan-out: cohort, branch tokens, join activation", () => {
+  it("creates cohort and tokens; branch activations ready; join only after all tokens arrive", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    let p = initializeGraphProjection(sealed, { fan: "act-fan" });
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-fan",
+      attempt_id: "at-fan-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-fan",
+      transition_id: "tr-fan",
+      result: ok("at-fan-1"),
+      identities: fanOutIdentities,
+    }).projection;
+    expect(p.cohorts["coh-1"].expected_branch_token_ids).toEqual([
+      "tok-b1",
+      "tok-b2",
+    ]);
+    expect(p.cohorts["coh-1"].consumed).toBe(false);
+    expect(p.branch_tokens["tok-b1"].status).toBe("active");
+    expect(p.branch_tokens["tok-b1"].current_activation_id).toBe("act-b1");
+    expect(p.branch_tokens["tok-b2"].status).toBe("active");
+    expect(p.activations["act-b1"].status).toBe("ready");
+    expect(p.activations["act-b2"].status).toBe("ready");
+    expect(listReadyJoinActivations(sealed, p)).toEqual([]);
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-b1",
+      attempt_id: "at-b1-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-b1",
+      transition_id: "tr-b1",
+      result: ok("at-b1-1"),
+      identities: {},
+    }).projection;
+    expect(p.branch_tokens["tok-b1"].status).toBe("arrived");
+    expect(p.activations["act-join"]).toBeUndefined();
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-b2",
+      attempt_id: "at-b2-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-b2",
+      transition_id: "tr-b2",
+      result: ok("at-b2-1"),
+      identities: { join_activation_id: "act-join" },
+    }).projection;
+    expect(p.branch_tokens["tok-b2"].status).toBe("arrived");
+    expect(p.activations["act-join"].node_id).toBe("join");
+    expect(p.activations["act-join"].status).toBe("ready");
+    expect(p.activations["act-join"].cohort_id).toBe("coh-1");
+    expect(p.cohorts["coh-1"].join_activation_id).toBe("act-join");
+    expect(
+      listReadyJoinActivations(sealed, p).map(
+        (activation) => activation.activation_id,
+      ),
+    ).toEqual(["act-join"]);
+  });
+  it("branch_token_fenced when a stale token does not own the completing activation", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection: GraphSchedulerProjection = {
+      ...baseProjection(sealed),
+      activations: {
+        "act-b1": {
+          activation_id: "act-b1",
+          node_id: "b1",
+          status: "running",
+          attempt_no: 1,
+          attempt_ids: ["at-b1-1"],
+          active_attempt_id: "at-b1-1",
+          branch_token_id: "tok-b1",
+          traversal_owner_id: "act-b1",
+        },
+      },
+      branch_tokens: {
+        "tok-b1": {
+          branch_token_id: "tok-b1",
+          cohort_id: "coh-1",
+          branch_id: "br1",
+          owner_join_id: "join",
+          status: "active",
+          current_activation_id: "act-someone-else",
+        },
+      },
+      cohorts: {
+        "coh-1": {
+          cohort_id: "coh-1",
+          fan_out_node_id: "fan",
+          owner_join_id: "join",
+          expected_branch_token_ids: ["tok-b1", "tok-b2"],
+          consumed: false,
+        },
+      },
+    };
+    expectCode(
+      () =>
+        applyNodeResult(sealed, projection, {
+          activation_id: "act-b1",
+          transition_id: "tr-b1",
+          result: ok("at-b1-1"),
+        }),
+      "branch_token_fenced",
+    );
+  });
+});
+describe("S8 - resolveJoin consumes exactly once", () => {
+  it("consumes cohort and tokens exactly once and creates the next activation", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const result = resolveJoin(sealed, driveToJoin(sealed), {
+      activation_id: "act-join",
+      transition_id: "tr-join",
+      identities: { next_activation_ids: { "e-join-term": "act-term" } },
+    });
+    const projection = result.projection;
+    expect(result.transition.outcome).toBe("join_resolved");
+    if (result.transition.outcome !== "join_resolved")
+      throw new Error("unreachable");
+    expect(result.transition.cohort_id).toBe("coh-1");
+    expect(result.transition.selected_edge_ids).toEqual(["e-join-term"]);
+    expect(result.transition.created_activation_ids).toEqual(["act-term"]);
+    expect(result.transition.evidence_refs).toEqual([]);
+    expect(result.transition).not.toHaveProperty("attempt_id");
+    expect(projection.cohorts["coh-1"].consumed).toBe(true);
+    expect(projection.branch_tokens["tok-b1"].status).toBe("consumed");
+    expect(projection.branch_tokens["tok-b2"].status).toBe("consumed");
+    expect(projection.branch_tokens["tok-b1"].consumed_by_activation_id).toBe(
+      "act-join",
+    );
+    expect(projection.activations["act-join"].status).toBe("completed");
+    expect(projection.activations["act-term"].status).toBe("ready");
+  });
+  it("second resolve with a different transition id throws join_already_consumed", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = resolveJoin(sealed, driveToJoin(sealed), {
+      activation_id: "act-join",
+      transition_id: "tr-join",
+      identities: { next_activation_ids: { "e-join-term": "act-term" } },
+    }).projection;
+    expectCode(
+      () =>
+        resolveJoin(sealed, projection, {
+          activation_id: "act-join",
+          transition_id: "tr-join-2",
+          identities: { next_activation_ids: { "e-join-term": "act-term-2" } },
+        }),
+      "join_already_consumed",
+    );
+  });
+});
+describe("S9 - replay fencing on record-bearing mutations", () => {
+  const runningChain = (
+    sealed: SealedGraphDescriptor,
+  ): GraphSchedulerProjection =>
+    beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+  it("identical replay returns replayed: true with the same projection", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const input = {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-start"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    };
+    const first = applyNodeResult(sealed, runningChain(sealed), input);
+    const replay = applyNodeResult(sealed, first.projection, input);
+    expect(replay.replayed).toBe(true);
+    expect(replay.projection).toBe(first.projection);
+    expect(replay.transition).toBe(first.transition);
+  });
+  it("same transition id with changed identities throws transition_fenced", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const input = {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-start"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    };
+    const first = applyNodeResult(sealed, runningChain(sealed), input);
+    expectCode(
+      () =>
+        applyNodeResult(sealed, first.projection, {
+          ...input,
+          identities: {
+            next_activation_ids: { "e-start-work": "act-work-other" },
+          },
+        }),
+      "transition_fenced",
+    );
+  });
+  it("committed transitions carry fingerprint_version 1 and the descriptor hash", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const result = applyNodeResult(sealed, runningChain(sealed), {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-start"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    });
+    expect(result.transition.fingerprint_version).toBe(1);
+    expect(result.transition.descriptor_hash).toBe(sealed.descriptor_hash);
+    expect(result.transition.request_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+describe("S10 - dedicated human approval transition (stage-04 record shapes)", () => {
+  it("approved creates the next activation and commits an exact approved record", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    const projection = driveToApproval(sealed);
+    expect(
+      listReadyApprovalActivations(sealed, projection).map(
+        (activation) => activation.activation_id,
+      ),
+    ).toEqual(["act-approval"]);
+    const result = applyHumanApproval(sealed, projection, {
+      activation_id: "act-approval",
+      transition_id: "tr-approval",
+      decision: {
+        decision: "approved",
+        evidence_refs: [...EVIDENCE],
+        output_summary: "release approved",
+      },
+      identities: { next_activation_ids: { "e-approval-term": "act-term" } },
+    });
+    expect(result.transition.outcome).toBe("approved");
+    if (result.transition.outcome !== "approved")
+      throw new Error("unreachable");
+    expect(result.transition.evidence_refs.length).toBeGreaterThanOrEqual(1);
+    expect(result.transition.selected_edge_ids).toEqual(["e-approval-term"]);
+    expect(result.transition.created_activation_ids).toEqual(["act-term"]);
+    expect(result.transition.output_summary).toBe("release approved");
+    expect(result.transition).not.toHaveProperty("attempt_id");
+    expect(result.transition).not.toHaveProperty("summary");
+    expect(result.projection.activations["act-approval"].status).toBe(
+      "completed",
+    );
+    expect(result.projection.activations["act-term"].status).toBe("ready");
+  });
+  it("denied terminal-fails the activation and commits an exact denied record", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    const result = applyHumanApproval(sealed, driveToApproval(sealed), {
+      activation_id: "act-approval",
+      transition_id: "tr-denied",
+      decision: {
+        decision: "denied",
+        evidence_refs: [...EVIDENCE],
+        output_summary: "blocked by reviewer",
+      },
+    });
+    expect(result.transition.outcome).toBe("denied");
+    if (result.transition.outcome !== "denied") throw new Error("unreachable");
+    expect(result.transition.evidence_refs.length).toBeGreaterThanOrEqual(1);
+    expect(result.transition.selected_edge_ids).toEqual([]);
+    expect(result.transition.created_activation_ids).toEqual([]);
+    expect(result.transition.output_summary).toBe("blocked by reviewer");
+    expect(result.transition).not.toHaveProperty("attempt_id");
+    expect(result.projection.activations["act-approval"].status).toBe("failed");
+  });
+  it("approved without evidence throws terminal_evidence_required", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    expectCode(
+      () =>
+        applyHumanApproval(sealed, driveToApproval(sealed), {
+          activation_id: "act-approval",
+          transition_id: "tr-approval",
+          decision: { decision: "approved", evidence_refs: [] },
+          identities: {
+            next_activation_ids: { "e-approval-term": "act-term" },
+          },
+        }),
+      "terminal_evidence_required",
+    );
+  });
+  it("applyNodeResult on an approval node throws approval_requires_dedicated_transition", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    expectCode(
+      () =>
+        applyNodeResult(sealed, driveToApproval(sealed), {
+          activation_id: "act-approval",
+          transition_id: "tr-x",
+          result: ok("at-x"),
+        }),
+      "approval_requires_dedicated_transition",
+    );
+  });
+});
+describe("S11 - terminal verification requires evidence", () => {
+  it("terminal success without evidence throws terminal_evidence_required", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    let p = initializeGraphProjection(sealed, { start: "act-start" });
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-start",
+      attempt_id: "at-start",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-start"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-work",
+      attempt_id: "at-work",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-work",
+      transition_id: "tr-work",
+      result: ok("at-work"),
+      identities: { next_activation_ids: { "e-work-term": "act-term" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-term",
+      attempt_id: "at-term",
+    });
+    expectCode(
+      () =>
+        applyNodeResult(sealed, p, {
+          activation_id: "act-term",
+          transition_id: "tr-term",
+          result: ok("at-term"),
+        }),
+      "terminal_evidence_required",
+    );
+  });
+});
+describe("S12 - A3 retry semantics", () => {
+  it("first failure returns to ready; budget-exhausted failure terminal-fails", () => {
+    const sealed = sealedOf(chainDescriptor(2));
+    let p = beginActivationAttempt(sealed, driveToWork(sealed), {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-work",
+      transition_id: "tr-w1",
+      result: { outcome: "failed", attempt_id: "at-w1", evidence_refs: [] },
+    }).projection;
+    expect(p.activations["act-work"].status).toBe("ready");
+    expect(isGraphSucceeded(sealed, p)).toBe(false);
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-work",
+      attempt_id: "at-w2",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-work",
+      transition_id: "tr-w2",
+      result: { outcome: "failed", attempt_id: "at-w2", evidence_refs: [] },
+    }).projection;
+    expect(p.activations["act-work"].status).toBe("failed");
+    expect(p.activations["act-work"].active_attempt_id).toBeUndefined();
+    expect(isGraphSucceeded(sealed, p)).toBe(false);
+  });
+});
+describe("S13 - deterministic code-unit ordering", () => {
+  it("ready lists sort by code-unit comparison (Z < a < z), not locale", () => {
+    const sealed = sealedOf(orderingDescriptor());
+    const projection = initializeGraphProjection(sealed, {
+      Zentry: "Z-act",
+      aentry: "a-act",
+      zentry: "z-act",
+    });
+    const ids = listReadyExecutableActivations(sealed, projection).map(
+      (a) => a.activation_id,
+    );
+    expect(ids).toEqual(["Z-act", "a-act", "z-act"]);
+    expect(
+      listReadyExecutableActivations(sealed, projection).map(
+        (a) => a.activation_id,
+      ),
+    ).toEqual(ids);
+  });
+});
+describe("S14 - global identity namespace", () => {
+  const twoActivations = (
+    sealed: SealedGraphDescriptor,
+  ): GraphSchedulerProjection => ({
+    ...baseProjection(sealed),
+    activations: {
+      "act-a": {
+        activation_id: "act-a",
+        node_id: "start",
+        status: "ready",
+        attempt_no: 0,
+        attempt_ids: [],
+        traversal_owner_id: "act-a",
+      },
+      "act-b": {
+        activation_id: "act-b",
+        node_id: "work",
+        status: "ready",
+        attempt_no: 0,
+        attempt_ids: [],
+        traversal_owner_id: "act-b",
+      },
+    },
+  });
+  it("attempt id colliding with an activation id throws duplicate_identity", () => {
+    expectCode(
+      () =>
+        beginActivationAttempt(
+          sealedOf(chainDescriptor(3)),
+          twoActivations(sealedOf(chainDescriptor(3))),
+          { activation_id: "act-a", attempt_id: "act-b" },
+        ),
+      "duplicate_identity",
+    );
+  });
+  it("transition id colliding with a token id throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    expectCode(
+      () =>
+        resolveJoin(sealed, driveToJoin(sealed), {
+          activation_id: "act-join",
+          transition_id: "tok-b1",
+          identities: { next_activation_ids: { "e-join-term": "act-term" } },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("cohort id colliding with an activation id throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { fan: "act-fan" }),
+      { activation_id: "act-fan", attempt_id: "at-fan-1" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-fan",
+          transition_id: "tr-fan",
+          result: ok("at-fan-1"),
+          identities: {
+            cohort_id: "act-fan",
+            branch_token_ids: { "e-fan-b1": "tok-b1", "e-fan-b2": "tok-b2" },
+            next_activation_ids: { "e-fan-b1": "act-b1", "e-fan-b2": "act-b2" },
+          },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("undeclared identity-map key throws undeclared_identity_key", () => {
+    const sealed = sealedOf(retryDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-start",
+          result: ok("at-start"),
+          identities: { next_activation_ids: { "e-nope": "act-x" } },
+        }),
+      "undeclared_identity_key",
+    );
+  });
+  it("missing required identity throws missing_identity", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-start",
+          result: ok("at-start"),
+          identities: {},
+        }),
+      "missing_identity",
+    );
+  });
+});
+describe("S15 - purity: no mutation of inputs, including on thrown paths", () => {
+  it("leaves the input projection and descriptor unchanged after success", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    const snapshot = JSON.stringify(projection);
+    const descriptorSnapshot = JSON.stringify(sealed);
+    const running = beginActivationAttempt(sealed, projection, {
+      activation_id: "act-start",
+      attempt_id: "at-start",
+    });
+    expect(JSON.stringify(projection)).toBe(snapshot);
+    applyNodeResult(sealed, running, {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-start"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    });
+    expect(JSON.stringify(sealed)).toBe(descriptorSnapshot);
+  });
+  it("leaves the input projection unchanged after a thrown transition", () => {
+    const sealed = sealedOf(retryDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+    const snapshot = JSON.stringify(running);
+    expect(() =>
+      applyNodeResult(sealed, running, {
+        activation_id: "act-start",
+        transition_id: "tr-start",
+        result: { ...ok("at-start"), route: "nope" },
+        identities: { next_activation_ids: { "e-start-work": "act-work" } },
+      }),
+    ).toThrow(GraphSchedulerError);
+    expect(JSON.stringify(running)).toBe(snapshot);
+  });
+});
+describe("S16 - atomic final-budget release", () => {
+  it("release with budget remaining returns to ready; release at final budget terminal-fails", () => {
+    const sealed = sealedOf(chainDescriptor(2));
+    let p = beginActivationAttempt(sealed, driveToWork(sealed), {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    p = releaseAttemptForRetry(sealed, p, {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    expect(p.activations["act-work"].status).toBe("ready");
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-work",
+      attempt_id: "at-w2",
+    });
+    expect(p.activations["act-work"].status).toBe("running");
+    p = releaseAttemptForRetry(sealed, p, {
+      activation_id: "act-work",
+      attempt_id: "at-w2",
+    });
+    expect(p.activations["act-work"].status).toBe("failed");
+    expect(p.activations["act-work"].active_attempt_id).toBeUndefined();
+    expect(listReadyExecutableActivations(sealed, p)).toEqual([]);
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, p, {
+          activation_id: "act-work",
+          attempt_id: "at-w3",
+        }),
+      "activation_not_ready",
+    );
+    expect(Object.keys(p.committed_transitions)).toEqual(["tr-start"]);
+  });
+});
+describe("S17 - begin/release plain-projection scope", () => {
+  it("begin/release add no committed transitions and no begin/release outcomes exist", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    const committedBefore = JSON.stringify(projection.committed_transitions);
+    const running = beginActivationAttempt(sealed, projection, {
+      activation_id: "act-start",
+      attempt_id: "at-1",
+    });
+    expect(JSON.stringify(running.committed_transitions)).toBe(committedBefore);
+    const released = releaseAttemptForRetry(sealed, running, {
+      activation_id: "act-start",
+      attempt_id: "at-1",
+    });
+    expect(JSON.stringify(released.committed_transitions)).toBe(
+      committedBefore,
+    );
+    expect(Object.keys(released.committed_transitions)).toEqual([]);
+  });
+  it("repeated begin on an already-running activation throws activation_not_ready", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-1" },
+    );
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, running, {
+          activation_id: "act-start",
+          attempt_id: "at-2",
+        }),
+      "activation_not_ready",
+    );
+  });
+  it("begin/release inputs carry no transition_id or max_attempts (compile-time)", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    const compileTimeOnly = (): void => {
+      beginActivationAttempt(sealed, projection, {
+        activation_id: "act-start",
+        attempt_id: "at-1",
+        // @ts-expect-error BeginActivationAttemptInput carries no transition_id
+        transition_id: "tr-x",
+      });
+      beginActivationAttempt(sealed, projection, {
+        activation_id: "act-start",
+        attempt_id: "at-1",
+        // @ts-expect-error BeginActivationAttemptInput carries no max_attempts (budget is descriptor-derived)
+        max_attempts: 5,
+      });
+      releaseAttemptForRetry(sealed, projection, {
+        activation_id: "act-start",
+        attempt_id: "at-1",
+        // @ts-expect-error ReleaseAttemptForRetryInput carries no transition_id
+        transition_id: "tr-x",
+      });
+    };
+    expect(typeof compileTimeOnly).toBe("function");
+  });
+});
+describe("S18 - parser and identity failure mapping (closed errors)", () => {
+  const setup = (): {
+    sealed: SealedGraphDescriptor;
+    running: GraphSchedulerProjection;
+  } => {
+    const sealed = sealedOf(chainDescriptor(3));
+    return {
+      sealed,
+      running: beginActivationAttempt(
+        sealed,
+        initializeGraphProjection(sealed, { start: "act-start" }),
+        { activation_id: "act-start", attempt_id: "at-1" },
+      ),
+    };
+  };
+  it("malformed node results map to invalid_input, never ZodError", () => {
+    const { sealed, running } = setup();
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-1",
+          result: {
+            outcome: "succeeded",
+            attempt_id: "at-1",
+            evidence_refs: [],
+            // @ts-expect-error deliberate malformed shape
+            extra: true,
+          },
+        }),
+      "invalid_input",
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-2",
+          result: {
+            outcome: "succeeded",
+            attempt_id: "bad id!",
+            evidence_refs: [],
+          },
+        }),
+      "invalid_input",
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-3",
+          result: {
+            outcome: "succeeded",
+            attempt_id: "at-1",
+            // @ts-expect-error deliberate malformed shape
+            evidence_refs: "nope",
+          },
+        }),
+      "invalid_input",
+    );
+  });
+  it("malformed approval decisions map to invalid_input", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    expectCode(
+      () =>
+        applyHumanApproval(sealed, driveToApproval(sealed), {
+          activation_id: "act-approval",
+          transition_id: "tr-approval",
+          decision: {
+            decision: "approved",
+            evidence_refs: [],
+            // @ts-expect-error deliberate malformed shape
+            extra: true,
+          },
+        }),
+      "invalid_input",
+    );
+  });
+  it("identity values failing isValidStableId map to invalid_input", () => {
+    const { sealed, running } = setup();
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-1",
+          result: ok("at-1"),
+          identities: { next_activation_ids: { "e-start-work": "bad id!" } },
+        }),
+      "invalid_input",
+    );
+  });
+  it("malformed entry activation ids map to invalid_input", () => {
+    expectCode(
+      () =>
+        initializeGraphProjection(sealedOf(chainDescriptor(3)), {
+          start: "bad id!",
+        }),
+      "invalid_input",
+    );
+    expectCode(
+      () =>
+        initializeGraphProjection(sealedOf(chainDescriptor(3)), {
+          start: 1n as unknown as string,
+        }),
+      "invalid_input",
+    );
+    for (const malformed of [
+      null,
+      [],
+      new Date(),
+      Object.create({ start: "act-start" }),
+    ]) {
+      expectCode(
+        () =>
+          initializeGraphProjection(
+            sealedOf(chainDescriptor(3)),
+            malformed as unknown as Readonly<Record<string, string>>,
+          ),
+        "invalid_input",
+      );
+    }
+  });
+});
+describe("S19 - hash-fenced reads", () => {
+  const reads = (
+    descriptor: SealedGraphDescriptor,
+    projection: GraphSchedulerProjection,
+  ): (() => unknown)[] => [
+    () => listReadyExecutableActivations(descriptor, projection),
+    () => listReadyApprovalActivations(descriptor, projection),
+    () => listReadyJoinActivations(descriptor, projection),
+    () => isGraphSucceeded(descriptor, projection),
+  ];
+  it("all four descriptor-dependent reads throw descriptor_mismatch on hash drift", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = initializeGraphProjection(sealed, { fan: "act-fan" });
+    for (const read of reads(sealedOf(chainDescriptor(1)), projection))
+      expectCode(read, "descriptor_mismatch");
+  });
+  it("all four reads behave normally with a matching descriptor", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = initializeGraphProjection(sealed, { fan: "act-fan" });
+    expect(
+      listReadyExecutableActivations(sealed, projection).map(
+        (a) => a.activation_id,
+      ),
+    ).toEqual(["act-fan"]);
+    expect(listReadyApprovalActivations(sealed, projection)).toEqual([]);
+    expect(listReadyJoinActivations(sealed, projection)).toEqual([]);
+    expect(isGraphSucceeded(sealed, projection)).toBe(false);
+  });
+});
+describe("S20 - persisted sealed input flows into the scheduler without assertion", () => {
+  it("parseSealedGraphDescriptor output initializes a projection and drives a full happy path", () => {
+    const sealed = parseSealedGraphDescriptor(
+      JSON.parse(JSON.stringify(sealGraphDescriptor(forkJoinDescriptor()))),
+    ); // producer return type: SealedGraphDescriptor
+    let p = initializeGraphProjection(sealed, { fan: "act-fan" });
+    expect(p.descriptor_hash).toBe(sealed.descriptor_hash);
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-fan",
+      attempt_id: "at-fan-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-fan",
+      transition_id: "tr-fan",
+      result: ok("at-fan-1"),
+      identities: fanOutIdentities,
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-b1",
+      attempt_id: "at-b1-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-b1",
+      transition_id: "tr-b1",
+      result: ok("at-b1-1"),
+      identities: {},
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-b2",
+      attempt_id: "at-b2-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-b2",
+      transition_id: "tr-b2",
+      result: ok("at-b2-1"),
+      identities: { join_activation_id: "act-join" },
+    }).projection;
+    p = resolveJoin(sealed, p, {
+      activation_id: "act-join",
+      transition_id: "tr-join",
+      identities: { next_activation_ids: { "e-join-term": "act-term" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-term",
+      attempt_id: "at-term",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-term",
+      transition_id: "tr-term",
+      result: { ...ok("at-term"), evidence_refs: [...EVIDENCE] },
+    }).projection;
+    expect(isGraphSucceeded(sealed, p)).toBe(true);
+    expect(p.descriptor_hash).toBe(sealed.descriptor_hash);
+    expect(Object.keys(p.committed_transitions).sort()).toEqual(
+      ["tr-fan", "tr-b1", "tr-b2", "tr-join", "tr-term"].sort(),
+    );
+  });
+});
+describe("S20b - loop descriptor give-up exit completes successfully", () => {
+  it("loop descriptor give-up exit completes successfully with evidence", () => {
+    const sealed = sealedOf(loopDescriptor());
+    let p = initializeGraphProjection(sealed, { start: "act-start" });
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-start",
+      attempt_id: "at-start",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-start"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-work",
+      attempt_id: "at-w1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-work",
+      transition_id: "tr-w1",
+      result: { ...ok("at-w1"), route: "give-up" },
+      identities: { next_activation_ids: { "e-work-give-up": "act-give-up" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-give-up",
+      attempt_id: "at-g1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-give-up",
+      transition_id: "tr-g1",
+      result: ok("at-g1"),
+      identities: { next_activation_ids: { "e-give-up-term": "act-term" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "act-term",
+      attempt_id: "at-term",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "act-term",
+      transition_id: "tr-term",
+      result: { ...ok("at-term"), evidence_refs: [...EVIDENCE] },
+    }).projection;
+    expect(isGraphSucceeded(sealed, p)).toBe(true);
+  });
+});
+describe("S21 - same-mutation identity collisions (transition id shares the local namespace)", () => {
+  it("node result: created activation id equal to the transition id throws duplicate_identity", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "X",
+          result: ok("at-start"),
+          identities: { next_activation_ids: { "e-start-work": "X" } },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("fan-out: cohort id equal to the transition id throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { fan: "act-fan" }),
+      { activation_id: "act-fan", attempt_id: "at-fan-1" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-fan",
+          transition_id: "X",
+          result: ok("at-fan-1"),
+          identities: {
+            cohort_id: "X",
+            branch_token_ids: { "e-fan-b1": "tok-b1", "e-fan-b2": "tok-b2" },
+            next_activation_ids: { "e-fan-b1": "act-b1", "e-fan-b2": "act-b2" },
+          },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("fan-out: branch token id equal to the transition id throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { fan: "act-fan" }),
+      { activation_id: "act-fan", attempt_id: "at-fan-1" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-fan",
+          transition_id: "X",
+          result: ok("at-fan-1"),
+          identities: {
+            cohort_id: "coh-X",
+            branch_token_ids: { "e-fan-b1": "X", "e-fan-b2": "tok-b2" },
+            next_activation_ids: { "e-fan-b1": "act-b1", "e-fan-b2": "act-b2" },
+          },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("fan-out: branch activation id equal to the transition id throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { fan: "act-fan" }),
+      { activation_id: "act-fan", attempt_id: "at-fan-1" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-fan",
+          transition_id: "X",
+          result: ok("at-fan-1"),
+          identities: {
+            cohort_id: "coh-X",
+            branch_token_ids: { "e-fan-b1": "tok-b1", "e-fan-b2": "tok-b2" },
+            next_activation_ids: { "e-fan-b1": "X", "e-fan-b2": "act-b2" },
+          },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("approval: next activation id equal to the transition id throws duplicate_identity", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    expectCode(
+      () =>
+        applyHumanApproval(sealed, driveToApproval(sealed), {
+          activation_id: "act-approval",
+          transition_id: "X",
+          decision: { decision: "approved", evidence_refs: [...EVIDENCE] },
+          identities: { next_activation_ids: { "e-approval-term": "X" } },
+        }),
+      "duplicate_identity",
+    );
+  });
+  it("join: next activation id equal to the transition id throws duplicate_identity", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    expectCode(
+      () =>
+        resolveJoin(sealed, driveToJoin(sealed), {
+          activation_id: "act-join",
+          transition_id: "X",
+          identities: { next_activation_ids: { "e-join-term": "X" } },
+        }),
+      "duplicate_identity",
+    );
+  });
+});
+describe("S22 - malformed identity values map to invalid_input in all record-bearing mutations", () => {
+  it("cyclic identities map to invalid_input on applyNodeResult", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "act-start",
+          transition_id: "tr-1",
+          result: ok("at-start"),
+          identities:
+            cyclicIdentities() as unknown as SchedulerTransitionIdentities,
+        }),
+      "invalid_input",
+    );
+  });
+  it("cyclic identities map to invalid_input on applyHumanApproval", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    expectCode(
+      () =>
+        applyHumanApproval(sealed, driveToApproval(sealed), {
+          activation_id: "act-approval",
+          transition_id: "tr-1",
+          decision: { decision: "approved", evidence_refs: [...EVIDENCE] },
+          identities:
+            cyclicIdentities() as unknown as SchedulerTransitionIdentities,
+        }),
+      "invalid_input",
+    );
+  });
+  it("cyclic identities map to invalid_input on resolveJoin", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    expectCode(
+      () =>
+        resolveJoin(sealed, driveToJoin(sealed), {
+          activation_id: "act-join",
+          transition_id: "tr-1",
+          identities:
+            cyclicIdentities() as unknown as SchedulerTransitionIdentities,
+        }),
+      "invalid_input",
+    );
+  });
+  it("BigInt/function/symbol identity values map to invalid_input via validation", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-start" },
+    );
+    for (const bad of [1n, (): void => {}, Symbol("s")]) {
+      expectCode(
+        () =>
+          applyNodeResult(sealed, running, {
+            activation_id: "act-start",
+            transition_id: "tr-1",
+            result: ok("at-start"),
+            identities: {
+              next_activation_ids: { "e-start-work": bad as unknown as string },
+            },
+          }),
+        "invalid_input",
+      );
+    }
+  });
+});
+describe("S23 - run/revision mismatch fenced in all entrypoints", () => {
+  const allEntrypoints = (
+    sealed: SealedGraphDescriptor,
+    projection: GraphSchedulerProjection,
+  ): (() => unknown)[] => [
+    () =>
+      beginActivationAttempt(sealed, projection, {
+        activation_id: "act-fan",
+        attempt_id: "at-1",
+      }),
+    () =>
+      releaseAttemptForRetry(sealed, projection, {
+        activation_id: "act-fan",
+        attempt_id: "at-1",
+      }),
+    () =>
+      applyNodeResult(sealed, projection, {
+        activation_id: "act-fan",
+        transition_id: "tr-1",
+        result: ok("at-1"),
+      }),
+    () =>
+      applyHumanApproval(sealed, projection, {
+        activation_id: "act-fan",
+        transition_id: "tr-1",
+        decision: { decision: "approved", evidence_refs: [...EVIDENCE] },
+      }),
+    () =>
+      resolveJoin(sealed, projection, {
+        activation_id: "act-fan",
+        transition_id: "tr-1",
+      }),
+    () => listReadyExecutableActivations(sealed, projection),
+    () => listReadyApprovalActivations(sealed, projection),
+    () => listReadyJoinActivations(sealed, projection),
+    () => isGraphSucceeded(sealed, projection),
+  ];
+  it("run_id mismatch throws descriptor_mismatch everywhere", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = initializeGraphProjection(sealed, { fan: "act-fan" });
+    for (const call of allEntrypoints(sealed, {
+      ...projection,
+      run_id: "other-run",
+    }))
+      expectCode(call, "descriptor_mismatch");
+  });
+  it("revision_id mismatch throws descriptor_mismatch everywhere", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const projection = initializeGraphProjection(sealed, { fan: "act-fan" });
+    for (const call of allEntrypoints(sealed, {
+      ...projection,
+      revision_id: "other-rev",
+    }))
+      expectCode(call, "descriptor_mismatch");
+  });
+});
+describe("S24 - approval replay fencing", () => {
+  const approvalInput: ApplyHumanApprovalInput = {
+    activation_id: "act-approval",
+    transition_id: "tr-approval",
+    decision: { decision: "approved", evidence_refs: [...EVIDENCE] },
+    identities: { next_activation_ids: { "e-approval-term": "act-term" } },
+  };
+  it("identical approval replay returns replayed with the same projection", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    const first = applyHumanApproval(
+      sealed,
+      driveToApproval(sealed),
+      approvalInput,
+    );
+    const replay = applyHumanApproval(sealed, first.projection, approvalInput);
+    expect(replay.replayed).toBe(true);
+    expect(replay.projection).toBe(first.projection);
+    expect(replay.transition).toBe(first.transition);
+  });
+  it("changed decision throws transition_fenced", () => {
+    const sealed = sealedOf(approvalDescriptor());
+    const first = applyHumanApproval(
+      sealed,
+      driveToApproval(sealed),
+      approvalInput,
+    );
+    expectCode(
+      () =>
+        applyHumanApproval(sealed, first.projection, {
+          ...approvalInput,
+          decision: { decision: "denied", evidence_refs: [...EVIDENCE] },
+        }),
+      "transition_fenced",
+    );
+  });
+});
+describe("S25 - join replay fencing", () => {
+  const joinInput = {
+    activation_id: "act-join",
+    transition_id: "tr-join",
+    identities: { next_activation_ids: { "e-join-term": "act-term" } },
+  };
+  it("identical join replay returns replayed with the same projection", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const first = resolveJoin(sealed, driveToJoin(sealed), joinInput);
+    const replay = resolveJoin(sealed, first.projection, joinInput);
+    expect(replay.replayed).toBe(true);
+    expect(replay.projection).toBe(first.projection);
+    expect(replay.transition).toBe(first.transition);
+  });
+  it("changed identities throws transition_fenced", () => {
+    const sealed = sealedOf(forkJoinDescriptor());
+    const first = resolveJoin(sealed, driveToJoin(sealed), joinInput);
+    expectCode(
+      () =>
+        resolveJoin(sealed, first.projection, {
+          ...joinInput,
+          identities: { next_activation_ids: { "e-join-term": "act-term-2" } },
+        }),
+      "transition_fenced",
+    );
+  });
+});
+describe("S26 - prototype-named stable ids work end to end", () => {
+  it("constructor/prototype activation and transition ids drive a full path", () => {
+    const sealed = sealedOf(protoChainDescriptor());
+    expect(verifyDescriptorHash(sealed)).toBe(true);
+    let p = initializeGraphProjection(sealed, { constructor: "constructor" });
+    expect(
+      listReadyExecutableActivations(sealed, p).map((a) => a.activation_id),
+    ).toEqual(["constructor"]);
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "constructor",
+      attempt_id: "at-1",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "constructor",
+      transition_id: "t1",
+      result: ok("at-1"),
+      identities: { next_activation_ids: { e1: "prototype" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "prototype",
+      attempt_id: "at-2",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "prototype",
+      transition_id: "t2",
+      result: ok("at-2"),
+      identities: { next_activation_ids: { e2: "hasOwnProperty" } },
+    }).projection;
+    p = beginActivationAttempt(sealed, p, {
+      activation_id: "hasOwnProperty",
+      attempt_id: "at-3",
+    });
+    p = applyNodeResult(sealed, p, {
+      activation_id: "hasOwnProperty",
+      transition_id: "t3",
+      result: { ...ok("at-3"), evidence_refs: [...EVIDENCE] },
+    }).projection;
+    expect(isGraphSucceeded(sealed, p)).toBe(true);
+  });
+  it("missing prototype-named identity still throws missing_identity", () => {
+    const sealed = sealedOf(protoChainDescriptor());
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { constructor: "constructor" }),
+      { activation_id: "constructor", attempt_id: "at-1" },
+    );
+    expectCode(
+      () =>
+        applyNodeResult(sealed, running, {
+          activation_id: "constructor",
+          transition_id: "t1",
+          result: ok("at-1"),
+          identities: {},
+        }),
+      "missing_identity",
+    );
+  });
+});
+
+describe("S27 - malformed containers and projections stay inside the closed error boundary", () => {
+  it("rejects null, non-plain, and inherited identity maps as invalid_input", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const running = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-1" },
+    );
+    const base = {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-1"),
+    };
+    for (const identities of [
+      null,
+      new Date(),
+      { next_activation_ids: Object.create({ "e-start-work": "act-work" }) },
+    ]) {
+      expectCode(
+        () =>
+          applyNodeResult(sealed, running, {
+            ...base,
+            identities:
+              identities as unknown as ApplyNodeResultInput["identities"],
+          }),
+        "invalid_input",
+      );
+    }
+  });
+
+  it("maps non-cloneable caller projection values to invalid_input", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    let projection = beginActivationAttempt(
+      sealed,
+      initializeGraphProjection(sealed, { start: "act-start" }),
+      { activation_id: "act-start", attempt_id: "at-1" },
+    );
+    projection = applyNodeResult(sealed, projection, {
+      activation_id: "act-start",
+      transition_id: "tr-start",
+      result: ok("at-1"),
+      identities: { next_activation_ids: { "e-start-work": "act-work" } },
+    }).projection;
+    const transition = { ...projection.committed_transitions["tr-start"] };
+    (transition as unknown as Record<string, unknown>).non_cloneable = () =>
+      undefined;
+    const malformed = {
+      ...projection,
+      committed_transitions: {
+        ...projection.committed_transitions,
+        "tr-start": transition,
+      },
+    };
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, malformed, {
+          activation_id: "act-work",
+          attempt_id: "at-work",
+        }),
+      "invalid_input",
+    );
+  });
+});
+
+describe("S28 - non-JSON direct ids stay inside the closed error boundary", () => {
+  it("maps Symbol activation and attempt ids to invalid_input", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, projection, {
+          activation_id: Symbol("activation") as unknown as string,
+          attempt_id: "at-1",
+        }),
+      "invalid_input",
+    );
+    const running = beginActivationAttempt(sealed, projection, {
+      activation_id: "act-start",
+      attempt_id: "at-1",
+    });
+    expectCode(
+      () =>
+        releaseAttemptForRetry(sealed, running, {
+          activation_id: "act-start",
+          attempt_id: Symbol("attempt") as unknown as string,
+        }),
+      "invalid_input",
+    );
+  });
+
+  it("maps malformed projection bindings and stored traversal owners to invalid_input", () => {
+    const sealed = sealedOf(chainDescriptor(3));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    expectCode(
+      () =>
+        listReadyExecutableActivations(sealed, {
+          ...projection,
+          run_id: Symbol("run") as unknown as string,
+        }),
+      "invalid_input",
+    );
+    const malformed = {
+      ...projection,
+      activations: {
+        ...projection.activations,
+        "act-start": {
+          ...projection.activations["act-start"],
+          traversal_owner_id: Symbol("owner") as unknown as string,
+        },
+      },
+    };
+    expectCode(
+      () =>
+        beginActivationAttempt(sealed, malformed, {
+          activation_id: "act-start",
+          attempt_id: "at-1",
+        }),
+      "invalid_input",
+    );
+  });
+});
+
+describe("S29 - traversal counter key closed error boundary", () => {
+  it("returns a deterministic key for valid stable ids", () => {
+    const sealed = sealedOf(retryDescriptor(2));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    expect(
+      traversalCounterKey(projection.activations["act-start"], sealed.edges[0]),
+    ).toBe('["act-start","e-start-work"]');
+  });
+
+  it("maps non-string traversal owner and edge ids to invalid_input", () => {
+    const sealed = sealedOf(retryDescriptor(2));
+    const projection = initializeGraphProjection(sealed, {
+      start: "act-start",
+    });
+    expectCode(
+      () =>
+        traversalCounterKey(
+          {
+            ...projection.activations["act-start"],
+            traversal_owner_id: Symbol("owner") as unknown as string,
+          },
+          sealed.edges[0],
+        ),
+      "invalid_input",
+    );
+    expectCode(
+      () =>
+        traversalCounterKey(projection.activations["act-start"], {
+          ...sealed.edges[0],
+          id: 1n as unknown as string,
+        }),
+      "invalid_input",
+    );
+  });
+});

--- a/src/graph/descriptor.ts
+++ b/src/graph/descriptor.ts
@@ -1,0 +1,810 @@
+/**
+ * Graph Core descriptor sealing, structure-before-hash validation, and
+ * ownership producers.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ *
+ * Ownership flow (disjoint input classes):
+ * - `parseGraphDescriptor` — hashless draft parser; rejects hash-bearing input.
+ * - `sealGraphDescriptor` — sole draft → scheduler producer (computes the hash).
+ * - `parseSealedGraphDescriptor` — sole persisted → scheduler producer
+ *   (verifies the supplied hash; rejects mismatch; never silently recomputes).
+ * - `verifyDescriptorHash` — non-branding boolean predicate; never throws.
+ */
+
+import { createHash } from "node:crypto";
+
+import { isValidStableId, parseGraphDescriptorShape } from "./schema.js";
+import type {
+  GraphDescriptor,
+  GraphDescriptorInput,
+  GraphEdge,
+  GraphFanOutEdge,
+  GraphNode,
+  SealedGraphDescriptor,
+} from "./types.js";
+
+const DESCRIPTOR_HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+export class GraphDescriptorValidationError extends Error {
+  readonly issues: readonly string[];
+
+  constructor(issues: readonly string[]) {
+    super(`Invalid graph descriptor: ${issues.join("; ")}`);
+    this.name = "GraphDescriptorValidationError";
+    this.issues = issues;
+  }
+}
+
+/** True only for null-prototype or plain `Object.prototype` objects. */
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Serialize JSON values with object keys sorted recursively in lexical order.
+ * Strict current-dev semantics: compact output, arrays in given order; throws
+ * `TypeError` on `undefined`, non-finite numbers, symbols, functions, bigints,
+ * non-plain objects (Date/Map/Set/RegExp/class instances), and cyclic values.
+ */
+export function canonicalJson(value: unknown): string {
+  return serializeCanonical(value, new Set<object>());
+}
+
+function serializeCanonical(value: unknown, seen: Set<object>): string {
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "string"
+  ) {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("Canonical JSON requires finite numbers");
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value))
+      throw new TypeError("Canonical JSON rejects cyclic values");
+    seen.add(value);
+    const serialized = `[${value.map((item) => serializeCanonical(item, seen)).join(",")}]`;
+    seen.delete(value);
+    return serialized;
+  }
+  if (typeof value === "object") {
+    if (!isPlainObject(value)) {
+      throw new TypeError("Canonical JSON requires plain objects");
+    }
+    if (seen.has(value))
+      throw new TypeError("Canonical JSON rejects cyclic values");
+    seen.add(value);
+    const record = value as Record<string, unknown>;
+    const serialized = `{${Object.keys(record)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${serializeCanonical(record[key], seen)}`,
+      )
+      .join(",")}}`;
+    seen.delete(value);
+    return serialized;
+  }
+  throw new TypeError(
+    `Canonical JSON requires JSON-compatible values (got ${typeof value})`,
+  );
+}
+
+/** Hash payload: the nine contract fields; excludes `descriptor_hash` and runtime fields. */
+function descriptorHashPayload(
+  input: GraphDescriptorInput,
+): Omit<GraphDescriptorInput, "descriptor_hash"> {
+  return {
+    descriptor_version: input.descriptor_version,
+    run_id: input.run_id,
+    revision_id: input.revision_id,
+    goal: input.goal,
+    nodes: input.nodes,
+    edges: input.edges,
+    entry_node_ids: input.entry_node_ids,
+    concurrency_limit: input.concurrency_limit,
+    terminal_verification_node_id: input.terminal_verification_node_id,
+  };
+}
+
+/** Lowercase SHA-256 hex over the canonical compact JSON of the hash payload. */
+export function computeDescriptorHash(input: GraphDescriptorInput): string {
+  return createHash("sha256")
+    .update(canonicalJson(descriptorHashPayload(input)))
+    .digest("hex");
+}
+
+/** Recursively freeze an owned value (descriptors are trees; no cycles). */
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object") {
+    for (const key of Object.getOwnPropertyNames(value)) {
+      deepFreeze((value as Record<string, unknown>)[key]);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function isRecordWithHash(input: unknown): boolean {
+  return (
+    typeof input === "object" &&
+    input !== null &&
+    !Array.isArray(input) &&
+    "descriptor_hash" in input
+  );
+}
+
+function duplicates(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const found = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) found.add(value);
+    seen.add(value);
+  }
+  return [...found].sort();
+}
+
+function groupByFrom(edges: readonly GraphEdge[]): Map<string, GraphEdge[]> {
+  const result = new Map<string, GraphEdge[]>();
+  for (const edge of edges) {
+    const group = result.get(edge.from) ?? [];
+    group.push(edge);
+    result.set(edge.from, group);
+  }
+  return result;
+}
+
+function adjacencyFor(
+  edges: readonly GraphEdge[],
+  includeBackEdges: boolean,
+): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!includeBackEdges && edge.kind === "back_edge") continue;
+    const targets = result.get(edge.from) ?? [];
+    targets.push(edge.to);
+    result.set(edge.from, targets);
+  }
+  return result;
+}
+
+function isReachable(
+  start: string,
+  target: string,
+  adjacency: ReadonlyMap<string, readonly string[]>,
+): boolean {
+  const pending = [start];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current === target) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return false;
+}
+
+function reachableSet(
+  starts: readonly string[],
+  adjacency: ReadonlyMap<string, readonly string[]>,
+): Set<string> {
+  const pending = [...starts];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    pending.push(...(adjacency.get(current) ?? []));
+  }
+  return visited;
+}
+
+/** Detect a cycle among non-back edges; returns the cycle path or undefined. */
+function findForwardCycle(
+  nodeIds: readonly string[],
+  adjacency: ReadonlyMap<string, readonly string[]>,
+): string[] | undefined {
+  const visited = new Set<string>();
+  const active = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (nodeId: string): string[] | undefined => {
+    if (active.has(nodeId)) {
+      const start = stack.indexOf(nodeId);
+      return [...stack.slice(start), nodeId];
+    }
+    if (visited.has(nodeId)) return undefined;
+    visited.add(nodeId);
+    active.add(nodeId);
+    stack.push(nodeId);
+    for (const target of adjacency.get(nodeId) ?? []) {
+      const cycle = visit(target);
+      if (cycle) return cycle;
+    }
+    stack.pop();
+    active.delete(nodeId);
+    return undefined;
+  };
+
+  for (const nodeId of nodeIds) {
+    const cycle = visit(nodeId);
+    if (cycle) return cycle;
+  }
+  return undefined;
+}
+
+interface ForkBranchRegion {
+  readonly fanOutNodeId: string;
+  readonly joinNodeId: string;
+  readonly branchId: string;
+  readonly startNodeId: string;
+  readonly nodes: Set<string>;
+}
+
+/** Nodes reachable from the branch start without passing through the owning join. */
+function collectBranchRegion(
+  startNodeId: string,
+  allAdjacency: ReadonlyMap<string, readonly string[]>,
+  joinNodeId: string,
+): Set<string> {
+  const pending = [startNodeId];
+  const result = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (current === joinNodeId || result.has(current)) continue;
+    result.add(current);
+    pending.push(...(allAdjacency.get(current) ?? []));
+  }
+  return result;
+}
+
+function validateOutgoingContracts(
+  descriptor: GraphDescriptor,
+  nodes: ReadonlyMap<string, GraphNode>,
+  outgoing: ReadonlyMap<string, readonly GraphEdge[]>,
+  issues: string[],
+): void {
+  for (const node of descriptor.nodes) {
+    const edges = outgoing.get(node.id) ?? [];
+    if (node.id === descriptor.terminal_verification_node_id) {
+      if (edges.length > 0) {
+        issues.push(
+          `terminal verification node ${node.id} must not have outgoing edges`,
+        );
+      }
+      continue;
+    }
+    if (node.kind === "human-approval") {
+      if (edges.length !== 1 || edges[0].kind !== "fixed") {
+        issues.push(
+          `human-approval node ${node.id} must have exactly one fixed outgoing edge`,
+        );
+      }
+      continue;
+    }
+    if (node.kind === "join") {
+      if (edges.length !== 1 || edges[0].kind !== "fixed") {
+        issues.push(
+          `join node ${node.id} must have exactly one fixed outgoing edge`,
+        );
+      }
+      continue;
+    }
+    if (edges.length === 0) {
+      issues.push(
+        `node ${node.id} cannot reach terminal verification because it has no outgoing edge`,
+      );
+      continue;
+    }
+    // A node whose only outgoing edge(s) are back_edges has no forward exit:
+    // once max_traversals is exhausted the result is permanently uncommittable.
+    if (edges.every((edge) => edge.kind === "back_edge")) {
+      issues.push(
+        `node ${node.id} has no non-back-edge exit; a back-edge-only node wedges once max_traversals is exhausted`,
+      );
+    }
+
+    const kinds = new Set(edges.map((edge) => edge.kind));
+    if (kinds.has("fixed") && (edges.length !== 1 || kinds.size !== 1)) {
+      issues.push(
+        `node ${node.id} must use one fixed edge or an explicit route/fan-out set`,
+      );
+    }
+    if (kinds.has("fan_out")) {
+      if (kinds.size !== 1 || edges.length < 2) {
+        issues.push(
+          `fan-out node ${node.id} must declare at least two fan_out edges and no other edge kind`,
+        );
+      }
+    } else if (!kinds.has("fixed")) {
+      if (
+        [...kinds].some(
+          (kind) => kind !== "conditional" && kind !== "back_edge",
+        )
+      ) {
+        issues.push(
+          `node ${node.id} has an unsupported routed edge combination`,
+        );
+      }
+      const routes = edges
+        .filter(
+          (edge): edge is Extract<GraphEdge, { route: string }> =>
+            "route" in edge,
+        )
+        .map((edge) => edge.route);
+      const repeatedRoutes = duplicates(routes);
+      if (repeatedRoutes.length > 0) {
+        issues.push(
+          `node ${node.id} declares duplicate route(s): ${repeatedRoutes.join(", ")}`,
+        );
+      }
+    }
+  }
+
+  for (const edge of descriptor.edges) {
+    if (!nodes.has(edge.from)) {
+      issues.push(
+        `edge ${edge.id} references missing source node ${edge.from}`,
+      );
+    }
+    if (!nodes.has(edge.to)) {
+      issues.push(`edge ${edge.id} references missing target node ${edge.to}`);
+    }
+  }
+}
+
+function validateForkRegions(
+  descriptor: GraphDescriptor,
+  nodes: ReadonlyMap<string, GraphNode>,
+  outgoing: ReadonlyMap<string, readonly GraphEdge[]>,
+  allAdjacency: ReadonlyMap<string, readonly string[]>,
+  issues: string[],
+): ForkBranchRegion[] {
+  const fanGroups = new Map<string, GraphFanOutEdge[]>();
+  const branchOwners = new Map<string, string>();
+  for (const edge of descriptor.edges) {
+    if (edge.kind !== "fan_out") continue;
+    const group = fanGroups.get(edge.from) ?? [];
+    group.push(edge);
+    fanGroups.set(edge.from, group);
+    const existing = branchOwners.get(edge.branch_id);
+    if (existing !== undefined && existing !== edge.from) {
+      issues.push(
+        `branch ID ${edge.branch_id} is reused by fan-out nodes ${existing} and ${edge.from}`,
+      );
+    } else if (existing === undefined) {
+      branchOwners.set(edge.branch_id, edge.from);
+    }
+  }
+
+  const regions: ForkBranchRegion[] = [];
+  for (const [fanOutNodeId, fanEdges] of fanGroups) {
+    const ownerJoinIds = new Set(fanEdges.map((edge) => edge.owner_join_id));
+    if (ownerJoinIds.size !== 1) {
+      issues.push(`fan-out node ${fanOutNodeId} must have one owning join`);
+      continue;
+    }
+    const joinNodeId = fanEdges[0].owner_join_id;
+    const joinNode = nodes.get(joinNodeId);
+    if (joinNode?.kind !== "join") {
+      issues.push(
+        `fan-out node ${fanOutNodeId} references non-join owner ${joinNodeId}`,
+      );
+      continue;
+    }
+    if (joinNode.fan_out_node_id !== fanOutNodeId) {
+      issues.push(
+        `join ${joinNodeId} does not bind fan-out node ${fanOutNodeId}`,
+      );
+    }
+    const branchIds = fanEdges.map((edge) => edge.branch_id);
+    const repeatedBranches = duplicates(branchIds);
+    if (repeatedBranches.length > 0) {
+      issues.push(
+        `fan-out node ${fanOutNodeId} repeats branch ID(s): ${repeatedBranches.join(", ")}`,
+      );
+    }
+    if (
+      [...new Set(branchIds)].sort().join("\0") !==
+      [...new Set(joinNode.input_branch_ids)].sort().join("\0")
+    ) {
+      issues.push(
+        `join ${joinNodeId} input branches do not match fan-out ${fanOutNodeId}`,
+      );
+    }
+    const repeatedJoinBranches = duplicates(joinNode.input_branch_ids);
+    if (repeatedJoinBranches.length > 0) {
+      issues.push(`join ${joinNodeId} repeats an input branch ID`);
+    }
+
+    const groupRegions: ForkBranchRegion[] = fanEdges.map((edge) => ({
+      fanOutNodeId,
+      joinNodeId,
+      branchId: edge.branch_id,
+      startNodeId: edge.to,
+      nodes: collectBranchRegion(edge.to, allAdjacency, joinNodeId),
+    }));
+    regions.push(...groupRegions);
+
+    for (const region of groupRegions) {
+      if (!region.nodes.has(region.startNodeId)) {
+        issues.push(`fork branch ${region.branchId} has no region`);
+      }
+      if (!isReachable(region.startNodeId, joinNodeId, allAdjacency)) {
+        issues.push(
+          `fork branch ${region.branchId} cannot reach owning join ${joinNodeId}`,
+        );
+      }
+      for (const nodeId of region.nodes) {
+        const node = nodes.get(nodeId);
+        if (node?.kind === "join" && nodeId !== joinNodeId) {
+          issues.push(
+            `nested join ${nodeId} is not allowed inside fork region ${fanOutNodeId}`,
+          );
+        }
+        if (
+          (outgoing.get(nodeId) ?? []).some((edge) => edge.kind === "fan_out")
+        ) {
+          issues.push(
+            `nested fan-out ${nodeId} is not allowed inside fork region ${fanOutNodeId}`,
+          );
+        }
+        if (!isReachable(nodeId, joinNodeId, allAdjacency)) {
+          issues.push(
+            `fork branch ${region.branchId} contains node ${nodeId} that cannot reach its join`,
+          );
+        }
+      }
+      const hasDeclaredJoinInput = descriptor.edges.some(
+        (edge) => region.nodes.has(edge.from) && edge.to === joinNodeId,
+      );
+      if (!hasDeclaredJoinInput) {
+        issues.push(
+          `fork branch ${region.branchId} has no declared join input`,
+        );
+      }
+    }
+
+    for (let left = 0; left < groupRegions.length; left += 1) {
+      for (let right = left + 1; right < groupRegions.length; right += 1) {
+        const overlap = [...groupRegions[left].nodes].filter((id) =>
+          groupRegions[right].nodes.has(id),
+        );
+        if (overlap.length > 0) {
+          issues.push(
+            `fork branches ${groupRegions[left].branchId} and ${groupRegions[right].branchId} overlap at ${overlap.join(", ")}`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const node of descriptor.nodes) {
+    if (node.kind === "join" && !fanGroups.has(node.fan_out_node_id)) {
+      issues.push(
+        `join ${node.id} has no matching fan-out node ${node.fan_out_node_id}`,
+      );
+    }
+  }
+
+  for (let left = 0; left < regions.length; left += 1) {
+    for (let right = left + 1; right < regions.length; right += 1) {
+      if (regions[left].fanOutNodeId === regions[right].fanOutNodeId) continue;
+      const overlap = [...regions[left].nodes].some((id) =>
+        regions[right].nodes.has(id),
+      );
+      if (overlap) {
+        issues.push(
+          `fork regions ${regions[left].fanOutNodeId} and ${regions[right].fanOutNodeId} overlap or nest`,
+        );
+      }
+    }
+  }
+
+  for (const region of regions) {
+    for (const edge of descriptor.edges) {
+      if (
+        edge.kind === "fan_out" &&
+        edge.from === region.fanOutNodeId &&
+        edge.branch_id === region.branchId
+      ) {
+        continue;
+      }
+      const fromInside = region.nodes.has(edge.from);
+      const toInside = region.nodes.has(edge.to);
+      if (!fromInside && toInside) {
+        issues.push(
+          `edge ${edge.id} crosses into fork branch ${region.branchId}`,
+        );
+      }
+      if (fromInside && !toInside && edge.to !== region.joinNodeId) {
+        issues.push(
+          `edge ${edge.id} crosses out of fork branch ${region.branchId}`,
+        );
+      }
+      if (edge.kind === "back_edge" && fromInside !== toInside) {
+        issues.push(
+          `back-edge ${edge.id} crosses fork region ${region.fanOutNodeId}`,
+        );
+      }
+    }
+  }
+
+  for (const node of descriptor.nodes) {
+    if (node.kind !== "join") continue;
+    const ownerRegions = regions.filter(
+      (region) => region.joinNodeId === node.id,
+    );
+    for (const edge of descriptor.edges.filter(
+      (candidate) => candidate.to === node.id,
+    )) {
+      if (!ownerRegions.some((region) => region.nodes.has(edge.from))) {
+        issues.push(
+          `edge ${edge.id} enters join ${node.id} outside its owning fork region`,
+        );
+      }
+    }
+  }
+
+  return regions;
+}
+
+function validateEntryEligibility(
+  descriptor: GraphDescriptor,
+  nodes: ReadonlyMap<string, GraphNode>,
+  regions: readonly ForkBranchRegion[],
+  issues: string[],
+): void {
+  for (const entry of descriptor.entry_node_ids) {
+    const node = nodes.get(entry);
+    if (node === undefined) continue; // existence already reported
+    if (node.kind === "join") {
+      issues.push(`entry node ${entry} must not be a join node`);
+    } else if (regions.some((region) => region.nodes.has(entry))) {
+      issues.push(
+        `entry node ${entry} must not be inside a fork branch region`,
+      );
+    }
+  }
+}
+
+/**
+ * Structural validation. Throws `GraphDescriptorValidationError` with the
+ * joined issue list; returns the descriptor unchanged on success.
+ */
+export function validateGraphDescriptor(
+  descriptor: GraphDescriptor,
+): GraphDescriptor {
+  const issues: string[] = [];
+
+  const repeatedNodeIds = duplicates(descriptor.nodes.map((node) => node.id));
+  if (repeatedNodeIds.length > 0) {
+    issues.push(`duplicate node ID(s): ${repeatedNodeIds.join(", ")}`);
+  }
+  const repeatedEdgeIds = duplicates(descriptor.edges.map((edge) => edge.id));
+  if (repeatedEdgeIds.length > 0) {
+    issues.push(`duplicate edge ID(s): ${repeatedEdgeIds.join(", ")}`);
+  }
+  const repeatedEntries = duplicates(descriptor.entry_node_ids);
+  if (repeatedEntries.length > 0) {
+    issues.push(`duplicate entry node ID(s): ${repeatedEntries.join(", ")}`);
+  }
+
+  const invalidIds: string[] = [];
+  for (const node of descriptor.nodes) {
+    if (!isValidStableId(node.id)) invalidIds.push(node.id);
+    if (node.kind === "join") {
+      if (!isValidStableId(node.fan_out_node_id))
+        invalidIds.push(node.fan_out_node_id);
+      for (const branchId of node.input_branch_ids) {
+        if (!isValidStableId(branchId)) invalidIds.push(branchId);
+      }
+    }
+  }
+  for (const edge of descriptor.edges) {
+    if (!isValidStableId(edge.id)) invalidIds.push(edge.id);
+    if (!isValidStableId(edge.from)) invalidIds.push(edge.from);
+    if (!isValidStableId(edge.to)) invalidIds.push(edge.to);
+    if (edge.kind === "conditional" || edge.kind === "back_edge") {
+      if (!isValidStableId(edge.route)) invalidIds.push(edge.route);
+    }
+    if (edge.kind === "fan_out") {
+      if (!isValidStableId(edge.branch_id)) invalidIds.push(edge.branch_id);
+      if (!isValidStableId(edge.owner_join_id))
+        invalidIds.push(edge.owner_join_id);
+    }
+  }
+  for (const entry of descriptor.entry_node_ids) {
+    if (!isValidStableId(entry)) invalidIds.push(entry);
+  }
+  if (!isValidStableId(descriptor.terminal_verification_node_id)) {
+    invalidIds.push(descriptor.terminal_verification_node_id);
+  }
+  if (invalidIds.length > 0) {
+    issues.push(
+      `invalid stable ID(s): ${[...new Set(invalidIds)].sort().join(", ")}`,
+    );
+  }
+
+  const nodes = new Map<string, GraphNode>(
+    descriptor.nodes.map((node) => [node.id, node] as const),
+  );
+  const outgoing = groupByFrom(descriptor.edges);
+  validateOutgoingContracts(descriptor, nodes, outgoing, issues);
+
+  for (const entry of descriptor.entry_node_ids) {
+    if (!nodes.has(entry)) issues.push(`entry node ${entry} does not exist`);
+  }
+  const terminalNode = nodes.get(descriptor.terminal_verification_node_id);
+  if (terminalNode === undefined) {
+    issues.push(
+      `terminal verification node ${descriptor.terminal_verification_node_id} does not exist`,
+    );
+  } else if (terminalNode.kind !== "agent" && terminalNode.kind !== "command") {
+    issues.push(
+      "terminal verification must be an executable agent or command node",
+    );
+  }
+
+  const allAdjacency = adjacencyFor(descriptor.edges, true);
+  const forwardAdjacency = adjacencyFor(descriptor.edges, false);
+  const reachable = reachableSet(descriptor.entry_node_ids, allAdjacency);
+  const unreachable = descriptor.nodes
+    .map((node) => node.id)
+    .filter((id) => !reachable.has(id));
+  if (unreachable.length > 0) {
+    issues.push(`unreachable node(s): ${unreachable.join(", ")}`);
+  }
+
+  const cycle = findForwardCycle(
+    descriptor.nodes.map((node) => node.id),
+    forwardAdjacency,
+  );
+  if (cycle) {
+    issues.push(`non-back-edge cycle detected: ${cycle.join(" -> ")}`);
+  }
+
+  for (const edge of descriptor.edges) {
+    if (edge.kind === "back_edge") {
+      const isReturn =
+        edge.to === edge.from ||
+        isReachable(edge.to, edge.from, forwardAdjacency);
+      if (!isReturn) {
+        issues.push(
+          `back-edge ${edge.id} is not a structural return to an earlier node`,
+        );
+      }
+    }
+  }
+
+  if (terminalNode !== undefined) {
+    const cannotVerify = descriptor.nodes
+      .map((node) => node.id)
+      .filter((id) => !isReachable(id, terminalNode.id, allAdjacency));
+    if (cannotVerify.length > 0) {
+      issues.push(
+        `every successful path must reach terminal verification; failing node(s): ${cannotVerify.join(", ")}`,
+      );
+    }
+  }
+
+  const regions = validateForkRegions(
+    descriptor,
+    nodes,
+    outgoing,
+    allAdjacency,
+    issues,
+  );
+  validateEntryEligibility(descriptor, nodes, regions, issues);
+
+  if (issues.length > 0) {
+    throw new GraphDescriptorValidationError([...new Set(issues)]);
+  }
+  return descriptor;
+}
+
+/**
+ * Draft parser: strict schema parse → full validation → defensive
+ * `structuredClone` + `deepFreeze`. Input carrying a `descriptor_hash` is
+ * rejected with a directed error (use `parseSealedGraphDescriptor`).
+ */
+export function parseGraphDescriptor(input: unknown): GraphDescriptor {
+  if (isRecordWithHash(input)) {
+    throw new GraphDescriptorValidationError([
+      "sealed input must use `parseSealedGraphDescriptor`",
+    ]);
+  }
+  const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+  return deepFreeze(structuredClone(descriptor));
+}
+
+/**
+ * Sole draft → scheduler producer: strict parse → validate → compute hash →
+ * defensive `structuredClone` + `deepFreeze` with `descriptor_hash`. Input
+ * carrying a `descriptor_hash` is rejected with a directed error.
+ */
+export function sealGraphDescriptor(input: unknown): SealedGraphDescriptor {
+  if (isRecordWithHash(input)) {
+    throw new GraphDescriptorValidationError([
+      "use `parseSealedGraphDescriptor` for persisted sealed input",
+    ]);
+  }
+  const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+  const sealed: SealedGraphDescriptor = {
+    ...structuredClone(descriptor),
+    descriptor_hash: computeDescriptorHash(descriptor),
+  };
+  return deepFreeze(sealed);
+}
+
+/**
+ * Sole persisted → scheduler producer. Requires a well-formed `descriptor_hash`;
+ * strict schema parse → full validation → recompute the hash and compare with
+ * the supplied hash; a mismatch is rejected (never silently recomputed), then a
+ * defensive `structuredClone` + `deepFreeze` is returned.
+ */
+export function parseSealedGraphDescriptor(
+  input: unknown,
+): SealedGraphDescriptor {
+  const suppliedHash =
+    typeof input === "object" && input !== null && !Array.isArray(input)
+      ? (input as Record<string, unknown>).descriptor_hash
+      : undefined;
+  if (typeof suppliedHash !== "string") {
+    throw new GraphDescriptorValidationError([
+      "persisted sealed input must carry a `descriptor_hash`",
+    ]);
+  }
+  if (!DESCRIPTOR_HASH_PATTERN.test(suppliedHash)) {
+    throw new GraphDescriptorValidationError([
+      "`descriptor_hash` must be 64 lowercase hexadecimal characters",
+    ]);
+  }
+  const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+  if (computeDescriptorHash(descriptor) !== suppliedHash) {
+    throw new GraphDescriptorValidationError([
+      "descriptor hash does not match the exact revision",
+    ]);
+  }
+  const sealed: SealedGraphDescriptor = {
+    ...structuredClone(descriptor),
+    descriptor_hash: suppliedHash,
+  };
+  return deepFreeze(sealed);
+}
+
+/**
+ * Non-branding, never-throws boolean predicate. Structure-before-hash: strict
+ * schema parse → full validation → hash recompute → compare; `false` on any
+ * structural failure or mismatch. Does not clone, freeze, or mutate its input.
+ */
+export function verifyDescriptorHash(input: unknown): boolean {
+  try {
+    const descriptor = validateGraphDescriptor(
+      parseGraphDescriptorShape(input),
+    );
+    return computeDescriptorHash(descriptor) === descriptor.descriptor_hash;
+  } catch {
+    return false;
+  }
+}
+
+/** Non-throwing structural check (shape parse + validation, no hash semantics). */
+export function isGraphDescriptor(input: unknown): input is GraphDescriptor {
+  try {
+    validateGraphDescriptor(parseGraphDescriptorShape(input));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Graph Core public barrel. Exports only the Graph Core module surface;
+ * `src/index.ts` is intentionally untouched.
+ */
+export * from "./types.js";
+export * from "./schema.js";
+export * from "./descriptor.js";
+export * from "./scheduler.js";

--- a/src/graph/scheduler.ts
+++ b/src/graph/scheduler.ts
@@ -1,0 +1,1302 @@
+/**
+ * Graph Core pure deterministic scheduler (stage-04 contract).
+ *
+ * Contract-authored from the ralplan stage-04 revision (`pending-approval.md`);
+ * oracle `99ffe31` used only for behavioral cross-checks. Scheduler accepts only
+ * `SealedGraphDescriptor`; projections are descriptor-bound; record-bearing
+ * mutations are replay-fenced; begin/release commit nothing.
+ */
+
+import { createHash } from "node:crypto";
+import { canonicalJson } from "./descriptor.js";
+import {
+  isValidStableId,
+  parseGraphApprovalDecision,
+  parseGraphNodeResult,
+} from "./schema.js";
+import type {
+  ApplyHumanApprovalInput,
+  ApplyNodeResultInput,
+  BeginActivationAttemptInput,
+  GraphActivation,
+  GraphBranchToken,
+  GraphCohort,
+  GraphCommittedTransition,
+  GraphDeniedTransition,
+  GraphEdge,
+  GraphEvidenceReference,
+  GraphFailedTransition,
+  GraphJoinResolvedTransition,
+  GraphNode,
+  GraphSchedulerErrorCode,
+  GraphSchedulerProjection,
+  GraphSucceededTransition,
+  GraphApprovedTransition,
+  ReleaseAttemptForRetryInput,
+  ResolveJoinInput,
+  SchedulerApplyResult,
+  SchedulerTransitionIdentities,
+  SealedGraphDescriptor,
+} from "./types.js";
+
+export class GraphSchedulerError extends Error {
+  readonly code: GraphSchedulerErrorCode;
+  constructor(code: GraphSchedulerErrorCode, message: string) {
+    super(message);
+    this.name = "GraphSchedulerError";
+    this.code = code;
+  }
+}
+
+/** Closed-error throw helper: every scheduler failure uses exactly one code. */
+function fail(code: GraphSchedulerErrorCode, message: string): never {
+  throw new GraphSchedulerError(code, message);
+}
+
+function displayValue(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized ?? `<${typeof value}>`;
+  } catch {
+    return `<${typeof value}>`;
+  }
+}
+/** Wrap a Zod-validating parser: ZodError never escapes a scheduler entrypoint. */
+function parseSchedulerInput<T>(
+  parse: (input: unknown) => T,
+  input: unknown,
+  what: string,
+): T {
+  try {
+    return parse(input);
+  } catch (error) {
+    fail(
+      "invalid_input",
+      `invalid ${what}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/** Prototype-safe own-key lookup for state maps (callers may use plain objects). */
+function own<T>(map: Readonly<Record<string, T>>, key: string): T | undefined {
+  return Object.hasOwn(map, key) ? map[key] : undefined;
+}
+
+/** Empty null-prototype map: own-key writes can never hit Object.prototype. */
+function emptyMap<T>(): Record<string, T> {
+  return Object.create(null);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function identityField(
+  identities: SchedulerTransitionIdentities | undefined,
+  key: "cohort_id" | "join_activation_id",
+): string | undefined {
+  return identities !== undefined && Object.hasOwn(identities, key)
+    ? identities[key]
+    : undefined;
+}
+
+function identityMapValue(
+  map: Readonly<Record<string, string>> | undefined,
+  key: string,
+): string | undefined {
+  return map !== undefined && Object.hasOwn(map, key) ? map[key] : undefined;
+}
+
+function requireStableId(
+  value: unknown,
+  what: string,
+): asserts value is string {
+  if (!isValidStableId(value))
+    fail(
+      "invalid_input",
+      `${what} ${displayValue(value)} is not a stable identifier`,
+    );
+}
+
+/**
+ * Normalize a request for fingerprinting: strip undefined fields into a
+ * null-prototype accumulation and reject cycles deterministically. Values are
+ * validated strictly by `canonicalJson` afterwards.
+ */
+function toFingerprintJson(value: unknown, seen: Set<object>): unknown {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new TypeError("cyclic request value");
+    seen.add(value);
+    const normalized = value.map((item) => toFingerprintJson(item, seen));
+    seen.delete(value);
+    return normalized;
+  }
+  if (value !== null && typeof value === "object") {
+    if (seen.has(value)) throw new TypeError("cyclic request value");
+    if (!isPlainRecord(value))
+      throw new TypeError("request value must be a plain object");
+    seen.add(value);
+    const normalized: Record<string, unknown> = emptyMap();
+    for (const [key, child] of Object.entries(value)) {
+      if (child !== undefined) normalized[key] = toFingerprintJson(child, seen);
+    }
+    seen.delete(value);
+    return normalized;
+  }
+  return value;
+}
+
+/** Versioned replay fingerprint bound to the descriptor hash. */
+function requestFingerprint(
+  kind: "node_result" | "human_approval" | "resolve_join",
+  descriptorHash: string,
+  request: unknown,
+): string {
+  return createHash("sha256")
+    .update(
+      canonicalJson(
+        toFingerprintJson(
+          {
+            fingerprint_version: 1,
+            kind,
+            descriptor_hash: descriptorHash,
+            request,
+          },
+          new Set<object>(),
+        ),
+      ),
+    )
+    .digest("hex");
+}
+
+/** Fingerprint failures (unsupported or cyclic raw values) map to `invalid_input`. */
+function computeFingerprint(
+  kind: "node_result" | "human_approval" | "resolve_join",
+  descriptorHash: string,
+  request: unknown,
+): string {
+  try {
+    return requestFingerprint(kind, descriptorHash, request);
+  } catch (error) {
+    fail(
+      "invalid_input",
+      `cannot fingerprint request: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/** Locale-independent code-unit ordering for ready lists. */
+function compareIds(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function nodeById(
+  descriptor: SealedGraphDescriptor,
+  nodeId: string,
+): GraphNode | undefined {
+  return descriptor.nodes.find((node) => node.id === nodeId);
+}
+
+function outgoingEdgesOf(
+  descriptor: SealedGraphDescriptor,
+  nodeId: string,
+): GraphEdge[] {
+  return descriptor.edges.filter((edge) => edge.from === nodeId);
+}
+
+/** All identities in the projection's single global namespace (own keys only). */
+function namespaceIds(projection: GraphSchedulerProjection): Set<string> {
+  const ids = new Set<string>();
+  for (const activation of Object.values(projection.activations)) {
+    ids.add(activation.activation_id);
+    for (const attemptId of activation.attempt_ids) ids.add(attemptId);
+  }
+  for (const cohortId of Object.keys(projection.cohorts)) ids.add(cohortId);
+  for (const tokenId of Object.keys(projection.branch_tokens)) ids.add(tokenId);
+  for (const transitionId of Object.keys(projection.committed_transitions))
+    ids.add(transitionId);
+  return ids;
+}
+
+/** Descriptor binding: hash AND run/revision must match the projection. */
+function fenceDescriptor(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+): void {
+  if (!isPlainRecord(projection))
+    fail("invalid_input", "projection must be a plain object");
+  if (
+    typeof projection.descriptor_hash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(projection.descriptor_hash) ||
+    !isValidStableId(projection.run_id) ||
+    !isValidStableId(projection.revision_id)
+  )
+    fail("invalid_input", "projection descriptor binding is malformed");
+  if (
+    projection.descriptor_hash !== descriptor.descriptor_hash ||
+    projection.run_id !== descriptor.run_id ||
+    projection.revision_id !== descriptor.revision_id
+  ) {
+    fail(
+      "descriptor_mismatch",
+      `projection bound to ${displayValue(projection.run_id)}/${displayValue(projection.revision_id)}/${displayValue(projection.descriptor_hash)}, not ${descriptor.run_id}/${descriptor.revision_id}/${descriptor.descriptor_hash}`,
+    );
+  }
+}
+
+interface MutableGraphSchedulerProjection {
+  descriptor_hash: string;
+  run_id: string;
+  revision_id: string;
+  activations: Record<string, GraphActivation>;
+  cohorts: Record<string, GraphCohort>;
+  branch_tokens: Record<string, GraphBranchToken>;
+  traversal_counts: Record<string, number>;
+  committed_transitions: Record<string, GraphCommittedTransition>;
+  terminal_verification_activation_ids: string[];
+}
+
+function cloneMap<T>(
+  map: Readonly<Record<string, T>>,
+  copy: (value: T) => T,
+): Record<string, T> {
+  const result = emptyMap<T>();
+  for (const [key, value] of Object.entries(map)) result[key] = copy(value);
+  return result;
+}
+
+/** Structural deep clone; the scheduler never mutates its input projection. */
+function cloneProjection(
+  projection: GraphSchedulerProjection,
+): MutableGraphSchedulerProjection {
+  try {
+    return {
+      descriptor_hash: projection.descriptor_hash,
+      run_id: projection.run_id,
+      revision_id: projection.revision_id,
+      activations: cloneMap(projection.activations, (a) => ({
+        ...a,
+        attempt_ids: [...a.attempt_ids],
+      })),
+      cohorts: cloneMap(projection.cohorts, (c) => ({
+        ...c,
+        expected_branch_token_ids: [...c.expected_branch_token_ids],
+      })),
+      branch_tokens: cloneMap(projection.branch_tokens, (t) => ({ ...t })),
+      traversal_counts: Object.assign(
+        Object.create(null),
+        projection.traversal_counts,
+      ),
+      committed_transitions: cloneMap(
+        projection.committed_transitions,
+        (transition) => structuredClone(transition),
+      ),
+      terminal_verification_activation_ids: [
+        ...projection.terminal_verification_activation_ids,
+      ],
+    };
+  } catch {
+    fail(
+      "invalid_input",
+      "projection contains malformed or non-cloneable values",
+    );
+  }
+}
+
+/**
+ * Identity maps must key by the context node's declared outgoing edge IDs.
+ * Unknown keys → `undeclared_identity_key`; malformed values → `invalid_input`.
+ * Runs BEFORE fingerprinting so fingerprints cover only validated identities.
+ */
+function validateIdentities(
+  descriptor: SealedGraphDescriptor,
+  node: GraphNode,
+  identities: SchedulerTransitionIdentities | undefined,
+): void {
+  if (identities === undefined) return;
+  if (!isPlainRecord(identities))
+    fail("invalid_input", "identities must be a plain object");
+  const allowedKeys = new Set([
+    "next_activation_ids",
+    "cohort_id",
+    "branch_token_ids",
+    "join_activation_id",
+  ]);
+  for (const key of Object.keys(identities)) {
+    if (!allowedKeys.has(key))
+      fail("invalid_input", `identities contains unknown field ${key}`);
+  }
+  const declaredEdges = new Set(
+    outgoingEdgesOf(descriptor, node.id).map((edge) => edge.id),
+  );
+  const validateKeys = (map: unknown, what: string): void => {
+    if (map === undefined) return;
+    if (!isPlainRecord(map))
+      fail("invalid_input", `${what} must be a plain object`);
+    for (const [key, value] of Object.entries(map)) {
+      if (!declaredEdges.has(key))
+        fail(
+          "undeclared_identity_key",
+          `${what} key ${key} is not a declared outgoing edge of node ${node.id}`,
+        );
+      if (!isValidStableId(value))
+        fail(
+          "invalid_input",
+          `${what} value ${displayValue(value)} is not a stable identifier`,
+        );
+    }
+  };
+  validateKeys(identities.next_activation_ids, "next_activation_ids");
+  validateKeys(identities.branch_token_ids, "branch_token_ids");
+  for (const value of [
+    identityField(identities, "cohort_id"),
+    identityField(identities, "join_activation_id"),
+  ]) {
+    if (value !== undefined && !isValidStableId(value))
+      fail(
+        "invalid_input",
+        `${displayValue(value)} is not a stable identifier`,
+      );
+  }
+}
+
+/** Replay fence for the three record-bearing mutations. */
+function replayFence(
+  projection: GraphSchedulerProjection,
+  transitionId: string,
+  fingerprint: string,
+): GraphCommittedTransition | undefined {
+  const existing = own(projection.committed_transitions, transitionId);
+  if (existing === undefined) return undefined;
+  if (existing.request_fingerprint !== fingerprint) {
+    fail(
+      "transition_fenced",
+      `transition ${transitionId} was committed with a different request fingerprint`,
+    );
+  }
+  return existing;
+}
+
+/** Reserve a fresh id against the global namespace; throws `duplicate_identity`. */
+function assertFreshId(
+  projection: GraphSchedulerProjection,
+  id: string,
+  what: string,
+): void {
+  if (namespaceIds(projection).has(id)) {
+    fail(
+      "duplicate_identity",
+      `${what} ${id} collides with an existing identity in the global namespace`,
+    );
+  }
+}
+
+function requireActivation(
+  projection: GraphSchedulerProjection,
+  activationId: string,
+): GraphActivation {
+  requireStableId(activationId, "activation id");
+  const activation = own(projection.activations, activationId);
+  if (activation === undefined)
+    fail(
+      "activation_not_found",
+      `activation ${displayValue(activationId)} not found`,
+    );
+  requireStableId(activation.activation_id, "stored activation id");
+  requireStableId(activation.node_id, "stored node id");
+  requireStableId(activation.traversal_owner_id, "stored traversal owner id");
+  if (
+    !Array.isArray(activation.attempt_ids) ||
+    !activation.attempt_ids.every(isValidStableId)
+  )
+    fail("invalid_input", "stored activation attempt_ids are malformed");
+  if (activation.active_attempt_id !== undefined)
+    requireStableId(activation.active_attempt_id, "stored active attempt id");
+  return activation;
+}
+
+function requireNode(
+  descriptor: SealedGraphDescriptor,
+  nodeId: string,
+): GraphNode {
+  const node = nodeById(descriptor, nodeId);
+  if (node === undefined) fail("node_not_found", `node ${nodeId} not found`);
+  return node;
+}
+
+/** Post-replay transition-id guard shared by the three record-bearing mutations. */
+function guardTransitionId(
+  projection: GraphSchedulerProjection,
+  transitionId: string,
+): void {
+  if (!isValidStableId(transitionId))
+    fail(
+      "invalid_input",
+      `transition id ${displayValue(transitionId)} is not a stable identifier`,
+    );
+  assertFreshId(projection, transitionId, "transition id");
+}
+
+/**
+ * Mutation-local identity reservation. The transition id joins the same
+ * namespace as every activation/cohort/token/join id created by the mutation,
+ * so same-mutation collisions throw `duplicate_identity`.
+ */
+function reservation(
+  projection: GraphSchedulerProjection,
+  transitionId: string,
+): { reserve: (id: string, what: string) => void } {
+  const reserved = new Set<string>([transitionId]);
+  return {
+    reserve: (id: string, what: string): void => {
+      if (namespaceIds(projection).has(id) || reserved.has(id)) {
+        fail(
+          "duplicate_identity",
+          `${what} ${id} collides with an existing identity or this mutation's transition ${transitionId}`,
+        );
+      }
+      reserved.add(id);
+    },
+  };
+}
+
+/** Fields shared by every committed transition record. */
+function transitionCommon(
+  input: { activation_id: string; transition_id: string },
+  node: GraphNode,
+  fingerprint: string,
+  descriptor: SealedGraphDescriptor,
+) {
+  return {
+    transition_id: input.transition_id,
+    activation_id: input.activation_id,
+    node_id: node.id,
+    fingerprint_version: 1,
+    request_fingerprint: fingerprint,
+    descriptor_hash: descriptor.descriptor_hash,
+  } as const;
+}
+
+/** Evidence tuple required by approved/denied records (caller pre-checked non-empty). */
+function nonEmptyEvidence(
+  refs: readonly GraphEvidenceReference[],
+): [GraphEvidenceReference, ...GraphEvidenceReference[]] {
+  return [...refs] as [GraphEvidenceReference, ...GraphEvidenceReference[]];
+}
+
+/**
+ * Create a ready activation for `nodeId`, inheriting the traversal lineage and
+ * (when inside a fork branch) the branch token from the source activation.
+ */
+function createNextActivation(
+  next: MutableGraphSchedulerProjection,
+  activationId: string,
+  nodeId: string,
+  source: GraphActivation,
+  descriptor: SealedGraphDescriptor,
+  extra?: { readonly cohort_id?: string; readonly branch_token_id?: string },
+): GraphActivation {
+  const branchTokenId =
+    extra !== undefined && Object.hasOwn(extra, "branch_token_id")
+      ? extra.branch_token_id
+      : source.branch_token_id;
+  const created: GraphActivation = {
+    activation_id: activationId,
+    node_id: nodeId,
+    status: "ready",
+    attempt_no: 0,
+    attempt_ids: [],
+    traversal_owner_id: source.traversal_owner_id,
+    ...(branchTokenId !== undefined && { branch_token_id: branchTokenId }),
+    ...(extra?.cohort_id !== undefined && { cohort_id: extra.cohort_id }),
+  };
+  next.activations[activationId] = created;
+  if (nodeId === descriptor.terminal_verification_node_id)
+    next.terminal_verification_activation_ids.push(activationId);
+  const tokenId = created.branch_token_id;
+  if (tokenId !== undefined) {
+    const token = own(next.branch_tokens, tokenId);
+    if (token !== undefined && token.status === "active") {
+      next.branch_tokens[tokenId] = {
+        ...token,
+        current_activation_id: activationId,
+      };
+    }
+  }
+  return created;
+}
+
+/** Create the initial descriptor-bound projection with entry activations. */
+export function initializeGraphProjection(
+  descriptor: SealedGraphDescriptor,
+  entryActivationIds: Readonly<Record<string, string>>,
+): GraphSchedulerProjection {
+  if (!isPlainRecord(entryActivationIds))
+    fail("invalid_input", "entry activation identities must be a plain object");
+  const entrySet = new Set(descriptor.entry_node_ids);
+  for (const key of Object.keys(entryActivationIds)) {
+    if (!entrySet.has(key))
+      fail(
+        "unexpected_identity",
+        `identity supplied for non-entry node ${key}`,
+      );
+  }
+  for (const entry of descriptor.entry_node_ids) {
+    if (!Object.hasOwn(entryActivationIds, entry))
+      fail(
+        "missing_identity",
+        `missing activation identity for entry node ${entry}`,
+      );
+  }
+  const activations: Record<string, GraphActivation> = emptyMap();
+  const terminalVerificationActivationIds: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of descriptor.entry_node_ids) {
+    const activationId = identityMapValue(entryActivationIds, entry);
+    requireStableId(activationId, "activation id");
+    if (seen.has(activationId))
+      fail(
+        "duplicate_identity",
+        `activation identity ${activationId} used more than once`,
+      );
+    seen.add(activationId);
+    activations[activationId] = {
+      activation_id: activationId,
+      node_id: entry,
+      status: "ready",
+      attempt_no: 0,
+      attempt_ids: [],
+      traversal_owner_id: activationId,
+    };
+    if (entry === descriptor.terminal_verification_node_id)
+      terminalVerificationActivationIds.push(activationId);
+  }
+  return {
+    descriptor_hash: descriptor.descriptor_hash,
+    run_id: descriptor.run_id,
+    revision_id: descriptor.revision_id,
+    activations,
+    cohorts: emptyMap(),
+    branch_tokens: emptyMap(),
+    traversal_counts: emptyMap(),
+    committed_transitions: emptyMap(),
+    terminal_verification_activation_ids: terminalVerificationActivationIds,
+  };
+}
+
+/** Plain projection transform; commits no transition record. */
+export function beginActivationAttempt(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: BeginActivationAttemptInput,
+): GraphSchedulerProjection {
+  fenceDescriptor(descriptor, projection);
+  requireStableId(input.activation_id, "activation id");
+  requireStableId(input.attempt_id, "attempt id");
+  const activation = requireActivation(projection, input.activation_id);
+  if (activation.status !== "ready")
+    fail(
+      "activation_not_ready",
+      `activation ${input.activation_id} is not ready`,
+    );
+  const node = requireNode(descriptor, activation.node_id);
+  if (node.kind !== "agent" && node.kind !== "command")
+    fail(
+      "unsupported_node_kind",
+      `node ${node.id} of kind ${node.kind} cannot begin an attempt`,
+    );
+  if (activation.attempt_no >= node.max_attempts)
+    fail(
+      "max_attempts_exceeded",
+      `activation ${input.activation_id} already used its budget of ${node.max_attempts} attempts`,
+    );
+  if (!isValidStableId(input.attempt_id))
+    fail(
+      "invalid_input",
+      `attempt id ${displayValue(input.attempt_id)} is not a stable identifier`,
+    );
+  assertFreshId(projection, input.attempt_id, "attempt id");
+  const nextProjection = cloneProjection(projection);
+  nextProjection.activations[input.activation_id] = {
+    ...activation,
+    status: "running",
+    attempt_no: activation.attempt_no + 1,
+    attempt_ids: [...activation.attempt_ids, input.attempt_id],
+    active_attempt_id: input.attempt_id,
+  };
+  return nextProjection;
+}
+
+/**
+ * Atomic final-budget release: if `attempt_no >= node.max_attempts` at release
+ * time the activation goes terminal `failed` (never an unstartable ready state);
+ * otherwise it returns to `ready`. Plain projection transform; no record.
+ */
+export function releaseAttemptForRetry(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: ReleaseAttemptForRetryInput,
+): GraphSchedulerProjection {
+  fenceDescriptor(descriptor, projection);
+  requireStableId(input.activation_id, "activation id");
+  requireStableId(input.attempt_id, "attempt id");
+  const activation = requireActivation(projection, input.activation_id);
+  if (
+    activation.status !== "running" ||
+    activation.active_attempt_id !== input.attempt_id
+  )
+    fail(
+      "attempt_fenced",
+      `activation ${input.activation_id} is not running attempt ${input.attempt_id}`,
+    );
+  const node = requireNode(descriptor, activation.node_id);
+  if (node.kind !== "agent" && node.kind !== "command")
+    fail(
+      "unsupported_node_kind",
+      `node ${node.id} of kind ${node.kind} cannot release an attempt`,
+    );
+  const nextProjection = cloneProjection(projection);
+  nextProjection.activations[input.activation_id] = {
+    ...activation,
+    status: activation.attempt_no >= node.max_attempts ? "failed" : "ready",
+    active_attempt_id: undefined,
+  };
+  return nextProjection;
+}
+
+/** Record-bearing mutation for agent/command completion (replay-fenced). */
+export function applyNodeResult(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: ApplyNodeResultInput,
+): SchedulerApplyResult {
+  fenceDescriptor(descriptor, projection);
+  requireStableId(input.activation_id, "activation id");
+  const result = parseSchedulerInput(
+    parseGraphNodeResult,
+    input.result,
+    "node result",
+  );
+  const activation = requireActivation(projection, input.activation_id);
+  const node = requireNode(descriptor, activation.node_id);
+  if (node.kind === "human-approval")
+    fail(
+      "approval_requires_dedicated_transition",
+      `node ${node.id} requires applyHumanApproval`,
+    );
+  if (node.kind === "join")
+    fail("join_is_automatic", `node ${node.id} is resolved by the scheduler`);
+  validateIdentities(descriptor, node, input.identities);
+  const fingerprint = computeFingerprint(
+    "node_result",
+    descriptor.descriptor_hash,
+    {
+      activation_id: input.activation_id,
+      transition_id: input.transition_id,
+      result,
+      identities: input.identities,
+    },
+  );
+  const existing = replayFence(projection, input.transition_id, fingerprint);
+  if (existing !== undefined)
+    return { projection, transition: existing, replayed: true };
+  if (
+    activation.status !== "running" ||
+    activation.active_attempt_id !== result.attempt_id
+  )
+    fail(
+      "attempt_fenced",
+      `activation ${input.activation_id} is not running attempt ${result.attempt_id}`,
+    );
+  guardTransitionId(projection, input.transition_id);
+  const edges = outgoingEdgesOf(descriptor, node.id);
+  const edgeMode =
+    result.outcome === "failed"
+      ? "failed"
+      : edges.length === 0
+        ? "terminal"
+        : edges.some((e) => e.kind === "fan_out")
+          ? "fan_out"
+          : edges.some((e) => e.kind === "fixed")
+            ? "fixed"
+            : "routed";
+
+  if (edgeMode === "failed") {
+    if (result.route !== undefined)
+      fail("undeclared_route", "failed results cannot select routes");
+    const next = cloneProjection(projection);
+    next.activations[input.activation_id] = {
+      ...activation,
+      status: activation.attempt_no >= node.max_attempts ? "failed" : "ready",
+      active_attempt_id: undefined,
+    };
+    const transition: GraphFailedTransition = {
+      ...transitionCommon(input, node, fingerprint, descriptor),
+      outcome: "failed",
+      selected_edge_ids: [],
+      created_activation_ids: [],
+      evidence_refs: [...result.evidence_refs],
+      attempt_id: result.attempt_id,
+      ...(result.output_summary !== undefined && {
+        output_summary: result.output_summary,
+      }),
+      ...(result.external_idempotency_key !== undefined && {
+        external_idempotency_key: result.external_idempotency_key,
+      }),
+    };
+    next.committed_transitions[input.transition_id] = transition;
+    return { projection: next, transition, replayed: false };
+  }
+
+  if (
+    node.id === descriptor.terminal_verification_node_id &&
+    result.evidence_refs.length === 0
+  )
+    fail(
+      "terminal_evidence_required",
+      `terminal verification node ${node.id} requires at least one evidence reference`,
+    );
+
+  let selectedEdgeIds: string[] = [];
+  let createdActivationIds: string[] = [];
+  let cohortId: string | undefined;
+  let matchedEdge: GraphEdge | undefined;
+  const next = cloneProjection(projection);
+  const { reserve } = reservation(next, input.transition_id);
+
+  if (edgeMode === "fan_out") {
+    if (result.route !== undefined)
+      fail("undeclared_route", `node ${node.id} declares no routes`);
+    const fanEdges = edges.filter(
+      (e): e is Extract<GraphEdge, { kind: "fan_out" }> => e.kind === "fan_out",
+    );
+    if (fanEdges.length < 2)
+      fail(
+        "invalid_input",
+        `fan-out node ${node.id} has fewer than two fan_out edges`,
+      );
+    cohortId = identityField(input.identities, "cohort_id");
+    if (cohortId === undefined)
+      fail(
+        "missing_identity",
+        `fan-out node ${node.id} requires identities.cohort_id`,
+      );
+    reserve(cohortId, "cohort id");
+    const entries = fanEdges.map((fanEdge) => {
+      const tokenId = identityMapValue(
+        input.identities?.branch_token_ids,
+        fanEdge.id,
+      );
+      const branchActivationId = identityMapValue(
+        input.identities?.next_activation_ids,
+        fanEdge.id,
+      );
+      if (tokenId === undefined)
+        fail(
+          "missing_identity",
+          `fan-out node ${node.id} requires branch_token_ids[${fanEdge.id}]`,
+        );
+      if (branchActivationId === undefined)
+        fail(
+          "missing_identity",
+          `fan-out node ${node.id} requires next_activation_ids[${fanEdge.id}]`,
+        );
+      reserve(tokenId, "branch token id");
+      reserve(branchActivationId, "activation id");
+      return { fanEdge, tokenId, branchActivationId };
+    });
+    next.cohorts[cohortId] = {
+      cohort_id: cohortId,
+      fan_out_node_id: node.id,
+      owner_join_id: fanEdges[0].owner_join_id,
+      expected_branch_token_ids: entries.map((e) => e.tokenId),
+      consumed: false,
+    };
+    for (const entry of entries) {
+      next.branch_tokens[entry.tokenId] = {
+        branch_token_id: entry.tokenId,
+        cohort_id: cohortId,
+        branch_id: entry.fanEdge.branch_id,
+        owner_join_id: fanEdges[0].owner_join_id,
+        status: "active",
+        current_activation_id: entry.branchActivationId,
+      };
+      createNextActivation(
+        next,
+        entry.branchActivationId,
+        entry.fanEdge.to,
+        activation,
+        descriptor,
+        { branch_token_id: entry.tokenId },
+      );
+    }
+    selectedEdgeIds = fanEdges.map((e) => e.id);
+    createdActivationIds = entries.map((e) => e.branchActivationId);
+  } else if (edgeMode === "fixed" || edgeMode === "routed") {
+    if (edgeMode === "fixed") {
+      if (result.route !== undefined)
+        fail("undeclared_route", `node ${node.id} declares no routes`);
+      matchedEdge = edges.find((e) => e.kind === "fixed");
+    } else {
+      if (result.route === undefined)
+        fail("route_required", `node ${node.id} requires a declared route`);
+      matchedEdge = edges.find(
+        (e) =>
+          (e.kind === "conditional" || e.kind === "back_edge") &&
+          e.route === result.route,
+      );
+      if (matchedEdge === undefined)
+        fail(
+          "undeclared_route",
+          `node ${node.id} declares no route ${result.route}`,
+        );
+    }
+  } else if (result.route !== undefined) {
+    fail("undeclared_route", `node ${node.id} declares no routes`); // terminal node
+  }
+
+  next.activations[input.activation_id] = {
+    ...activation,
+    status: "completed",
+    completed_transition_id: input.transition_id,
+  };
+
+  if (matchedEdge !== undefined) {
+    selectedEdgeIds = [matchedEdge.id];
+    const targetNode = nodeById(descriptor, matchedEdge.to);
+    if (matchedEdge.kind === "back_edge") {
+      const counterKey = traversalCounterKey(activation, matchedEdge);
+      const count = next.traversal_counts[counterKey] ?? 0;
+      if (count + 1 > matchedEdge.max_traversals)
+        fail(
+          "traversal_bound_exceeded",
+          `back-edge ${matchedEdge.id} exceeded its max_traversals of ${matchedEdge.max_traversals}`,
+        );
+      next.traversal_counts[counterKey] = count + 1;
+      const nextActivationId = requireNextActivationId(
+        input.identities,
+        matchedEdge,
+      );
+      reserve(nextActivationId, "activation id");
+      createNextActivation(
+        next,
+        nextActivationId,
+        matchedEdge.to,
+        activation,
+        descriptor,
+      );
+      createdActivationIds = [nextActivationId];
+    } else if (targetNode?.kind === "join") {
+      const token = activation.branch_token_id
+        ? own(next.branch_tokens, activation.branch_token_id)
+        : undefined;
+      if (
+        token === undefined ||
+        token.status !== "active" ||
+        token.current_activation_id !== activation.activation_id
+      )
+        fail(
+          "branch_token_fenced",
+          `activation ${input.activation_id} does not own an active branch token for join ${matchedEdge.to}`,
+        );
+      next.branch_tokens[token.branch_token_id] = {
+        ...token,
+        status: "arrived",
+        current_activation_id: undefined,
+      };
+      const cohort = own(next.cohorts, token.cohort_id);
+      if (cohort === undefined)
+        fail(
+          "join_owner_missing",
+          `cohort ${token.cohort_id} for token ${token.branch_token_id} not found`,
+        );
+      const allArrived = cohort.expected_branch_token_ids.every(
+        (tokenId) => own(next.branch_tokens, tokenId)?.status === "arrived",
+      );
+      if (allArrived) {
+        const joinActivationId = identityField(
+          input.identities,
+          "join_activation_id",
+        );
+        if (joinActivationId === undefined)
+          fail(
+            "missing_identity",
+            `join ${matchedEdge.to} requires identities.join_activation_id`,
+          );
+        reserve(joinActivationId, "activation id");
+        createNextActivation(
+          next,
+          joinActivationId,
+          matchedEdge.to,
+          activation,
+          descriptor,
+          { cohort_id: cohort.cohort_id, branch_token_id: undefined },
+        );
+        next.cohorts[cohort.cohort_id] = {
+          ...cohort,
+          join_activation_id: joinActivationId,
+        };
+        createdActivationIds = [joinActivationId];
+      }
+    } else {
+      const nextActivationId = requireNextActivationId(
+        input.identities,
+        matchedEdge,
+      );
+      reserve(nextActivationId, "activation id");
+      createNextActivation(
+        next,
+        nextActivationId,
+        matchedEdge.to,
+        activation,
+        descriptor,
+      );
+      createdActivationIds = [nextActivationId];
+    }
+  }
+
+  const transition: GraphSucceededTransition = {
+    ...transitionCommon(input, node, fingerprint, descriptor),
+    outcome: "succeeded",
+    selected_edge_ids: selectedEdgeIds,
+    created_activation_ids: createdActivationIds,
+    evidence_refs: [...result.evidence_refs],
+    attempt_id: result.attempt_id,
+    ...(result.route !== undefined && { route: result.route }),
+    ...(cohortId !== undefined && { cohort_id: cohortId }),
+    ...(result.output_summary !== undefined && {
+      output_summary: result.output_summary,
+    }),
+    ...(result.external_idempotency_key !== undefined && {
+      external_idempotency_key: result.external_idempotency_key,
+    }),
+  };
+  next.committed_transitions[input.transition_id] = transition;
+  return { projection: next, transition, replayed: false };
+}
+
+function requireNextActivationId(
+  identities: SchedulerTransitionIdentities | undefined,
+  edge: GraphEdge,
+): string {
+  const activationId = identityMapValue(
+    identities?.next_activation_ids,
+    edge.id,
+  );
+  if (activationId === undefined)
+    fail(
+      "missing_identity",
+      `edge ${edge.id} requires identities.next_activation_ids[${edge.id}]`,
+    );
+  return activationId;
+}
+
+/**
+ * Dedicated human-approval transition. `approved` follows the node's single
+ * fixed outgoing edge; `denied` terminal-fails the activation. Records carry
+ * `output_summary` (never `summary`) and no `attempt_id`; both outcomes require
+ * at least one evidence reference. Replay-fenced.
+ */
+export function applyHumanApproval(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: ApplyHumanApprovalInput,
+): SchedulerApplyResult {
+  fenceDescriptor(descriptor, projection);
+  requireStableId(input.activation_id, "activation id");
+  const decision = parseSchedulerInput(
+    parseGraphApprovalDecision,
+    input.decision,
+    "approval decision",
+  );
+  const activation = requireActivation(projection, input.activation_id);
+  const node = requireNode(descriptor, activation.node_id);
+  if (node.kind !== "human-approval")
+    fail(
+      "unsupported_node_kind",
+      `node ${node.id} of kind ${node.kind} is not a human-approval node`,
+    );
+  validateIdentities(descriptor, node, input.identities);
+  const fingerprint = computeFingerprint(
+    "human_approval",
+    descriptor.descriptor_hash,
+    {
+      activation_id: input.activation_id,
+      transition_id: input.transition_id,
+      decision,
+      identities: input.identities,
+    },
+  );
+  const existing = replayFence(projection, input.transition_id, fingerprint);
+  if (existing !== undefined)
+    return { projection, transition: existing, replayed: true };
+  guardTransitionId(projection, input.transition_id);
+  if (activation.status !== "ready")
+    fail(
+      "activation_not_ready",
+      `activation ${input.activation_id} is not ready`,
+    );
+  if (decision.evidence_refs.length === 0)
+    fail(
+      "terminal_evidence_required",
+      `approval decision for node ${node.id} requires at least one evidence reference`,
+    );
+  const outgoing = outgoingEdgesOf(descriptor, node.id);
+  const fixedEdge =
+    outgoing.length === 1 && outgoing[0].kind === "fixed"
+      ? outgoing[0]
+      : undefined;
+  if (fixedEdge === undefined)
+    fail(
+      "invalid_input",
+      `human-approval node ${node.id} must have exactly one fixed outgoing edge`,
+    );
+  const next = cloneProjection(projection);
+  const { reserve } = reservation(next, input.transition_id);
+  if (decision.decision === "denied") {
+    next.activations[input.activation_id] = { ...activation, status: "failed" };
+    const transition: GraphDeniedTransition = {
+      ...transitionCommon(input, node, fingerprint, descriptor),
+      outcome: "denied",
+      selected_edge_ids: [],
+      created_activation_ids: [],
+      evidence_refs: nonEmptyEvidence(decision.evidence_refs),
+      ...(decision.output_summary !== undefined && {
+        output_summary: decision.output_summary,
+      }),
+    };
+    next.committed_transitions[input.transition_id] = transition;
+    return { projection: next, transition, replayed: false };
+  }
+  const nextActivationId = requireNextActivationId(input.identities, fixedEdge);
+  reserve(nextActivationId, "activation id");
+  next.activations[input.activation_id] = {
+    ...activation,
+    status: "completed",
+    completed_transition_id: input.transition_id,
+  };
+  createNextActivation(
+    next,
+    nextActivationId,
+    fixedEdge.to,
+    activation,
+    descriptor,
+  );
+  const transition: GraphApprovedTransition = {
+    ...transitionCommon(input, node, fingerprint, descriptor),
+    outcome: "approved",
+    selected_edge_ids: [fixedEdge.id],
+    created_activation_ids: [nextActivationId],
+    evidence_refs: nonEmptyEvidence(decision.evidence_refs),
+    ...(decision.output_summary !== undefined && {
+      output_summary: decision.output_summary,
+    }),
+  };
+  next.committed_transitions[input.transition_id] = transition;
+  return { projection: next, transition, replayed: false };
+}
+
+/** Resolve a join: consume cohort + tokens exactly once, create the next activation. */
+export function resolveJoin(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  input: ResolveJoinInput,
+): SchedulerApplyResult {
+  fenceDescriptor(descriptor, projection);
+  requireStableId(input.activation_id, "activation id");
+  const activation = requireActivation(projection, input.activation_id);
+  const node = requireNode(descriptor, activation.node_id);
+  if (node.kind !== "join")
+    fail("join_not_found", `node ${node.id} is not a join node`);
+  validateIdentities(descriptor, node, input.identities);
+  const fingerprint = computeFingerprint(
+    "resolve_join",
+    descriptor.descriptor_hash,
+    {
+      activation_id: input.activation_id,
+      transition_id: input.transition_id,
+      identities: input.identities,
+    },
+  );
+  const existing = replayFence(projection, input.transition_id, fingerprint);
+  if (existing !== undefined)
+    return { projection, transition: existing, replayed: true };
+  guardTransitionId(projection, input.transition_id);
+  const cohortId = activation.cohort_id;
+  if (cohortId === undefined)
+    fail(
+      "join_not_ready",
+      `join activation ${input.activation_id} has no cohort`,
+    );
+  const cohort = own(projection.cohorts, cohortId);
+  if (cohort === undefined)
+    fail("join_owner_missing", `cohort ${cohortId} not found`);
+  if (cohort.owner_join_id !== node.id)
+    fail(
+      "join_owner_mismatch",
+      `cohort ${cohortId} is owned by join ${cohort.owner_join_id}`,
+    );
+  if (cohort.consumed)
+    fail("join_already_consumed", `cohort ${cohortId} was already consumed`);
+  if (activation.status !== "ready")
+    fail(
+      "join_not_ready",
+      `join activation ${input.activation_id} is not ready`,
+    );
+  const tokens = cohort.expected_branch_token_ids.map((tokenId) =>
+    own(projection.branch_tokens, tokenId),
+  );
+  if (tokens.some((token) => token === undefined || token.status !== "arrived"))
+    fail(
+      "join_not_ready",
+      `join ${node.id} does not have all branch tokens arrived`,
+    );
+  const outgoing = outgoingEdgesOf(descriptor, node.id);
+  if (outgoing.length !== 1 || outgoing[0].kind !== "fixed")
+    fail(
+      "invalid_join_edge",
+      `join ${node.id} must have exactly one fixed outgoing edge`,
+    );
+  const next = cloneProjection(projection);
+  const { reserve } = reservation(next, input.transition_id);
+  const nextActivationId = requireNextActivationId(
+    input.identities,
+    outgoing[0],
+  );
+  reserve(nextActivationId, "activation id");
+  for (const tokenId of cohort.expected_branch_token_ids) {
+    const token = own(next.branch_tokens, tokenId);
+    if (token !== undefined)
+      next.branch_tokens[tokenId] = {
+        ...token,
+        status: "consumed",
+        current_activation_id: undefined,
+        consumed_by_activation_id: activation.activation_id,
+      };
+  }
+  next.cohorts[cohortId] = { ...cohort, consumed: true };
+  next.activations[input.activation_id] = {
+    ...activation,
+    status: "completed",
+    completed_transition_id: input.transition_id,
+  };
+  createNextActivation(
+    next,
+    nextActivationId,
+    outgoing[0].to,
+    activation,
+    descriptor,
+  );
+  const transition: GraphJoinResolvedTransition = {
+    ...transitionCommon(input, node, fingerprint, descriptor),
+    outcome: "join_resolved",
+    selected_edge_ids: [outgoing[0].id],
+    created_activation_ids: [nextActivationId],
+    evidence_refs: [],
+    cohort_id: cohortId,
+  };
+  next.committed_transitions[input.transition_id] = transition;
+  return { projection: next, transition, replayed: false };
+}
+
+/** Per-lineage traversal counter key (pure helper; no descriptor). */
+export function traversalCounterKey(
+  activation: GraphActivation,
+  edge: GraphEdge,
+): string {
+  requireStableId(activation.traversal_owner_id, "traversal owner id");
+  requireStableId(edge.id, "edge id");
+  return canonicalJson([activation.traversal_owner_id, edge.id]);
+}
+
+/** Hash-fenced read: ready agent/command activations in code-unit order. */
+export function listReadyExecutableActivations(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+): readonly GraphActivation[] {
+  fenceDescriptor(descriptor, projection);
+  return readyActivations(
+    descriptor,
+    projection,
+    (node) => node.kind === "agent" || node.kind === "command",
+  );
+}
+
+/** Hash-fenced read: ready human-approval activations in code-unit order. */
+export function listReadyApprovalActivations(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+): readonly GraphActivation[] {
+  fenceDescriptor(descriptor, projection);
+  return readyActivations(
+    descriptor,
+    projection,
+    (node) => node.kind === "human-approval",
+  );
+}
+
+/** Hash-fenced read: ready join activations in code-unit order. */
+export function listReadyJoinActivations(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+): readonly GraphActivation[] {
+  fenceDescriptor(descriptor, projection);
+  return readyActivations(
+    descriptor,
+    projection,
+    (node) => node.kind === "join",
+  );
+}
+
+function readyActivations(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  predicate: (node: GraphNode) => boolean,
+): GraphActivation[] {
+  const result: GraphActivation[] = [];
+  for (const activation of Object.values(projection.activations)) {
+    if (activation.status !== "ready") continue;
+    const node = nodeById(descriptor, activation.node_id);
+    if (node !== undefined && predicate(node)) result.push(activation);
+  }
+  return result.sort((a, b) => compareIds(a.activation_id, b.activation_id));
+}
+
+/**
+ * Hash-fenced read: true iff at least one terminal verification activation
+ * completed with a succeeded, evidence-bearing transition, every activation is
+ * completed, and every cohort is consumed.
+ */
+export function isGraphSucceeded(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+): boolean {
+  fenceDescriptor(descriptor, projection);
+  const terminalVerified = projection.terminal_verification_activation_ids.some(
+    (id) => {
+      const activation = own(projection.activations, id);
+      if (activation === undefined || activation.status !== "completed")
+        return false;
+      const transition = activation.completed_transition_id
+        ? own(
+            projection.committed_transitions,
+            activation.completed_transition_id,
+          )
+        : undefined;
+      return (
+        transition?.outcome === "succeeded" &&
+        transition.evidence_refs.length > 0
+      );
+    },
+  );
+  if (!terminalVerified) return false;
+  const allCompleted = Object.values(projection.activations).every(
+    (activation) => activation.status === "completed",
+  );
+  if (!allCompleted) return false;
+  return Object.values(projection.cohorts).every((cohort) => cohort.consumed);
+}

--- a/src/graph/schema.ts
+++ b/src/graph/schema.ts
@@ -1,0 +1,204 @@
+/**
+ * Graph Core strict Zod content schemas.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ *
+ * Exported parser utilities (`parseGraphDescriptorShape`, `parseGraphNodeResult`,
+ * `parseGraphApprovalDecision`, `parseGraphEvidenceReference`) throw `ZodError`
+ * BY DOCUMENTED CONTRACT; callers that need a closed error boundary wrap them.
+ */
+
+import { z } from "zod";
+
+import type {
+  GraphApprovalDecision,
+  GraphDescriptor,
+  GraphEvidenceReference,
+  GraphNodeResult,
+} from "./types.js";
+
+/** Stable identifier: 1–128 chars, ASCII alphanumeric first, then `[A-Za-z0-9._:-]`. */
+export const idSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "must be a stable identifier");
+
+/** Long-form text bound (goal, instructions, command, prompt). */
+export const textSchema = z.string().min(1).max(32_768);
+
+const sideEffectFreeSchema = z
+  .object({ policy: z.literal("side_effect_free") })
+  .strict();
+const idempotentSchema = z
+  .object({
+    policy: z.literal("idempotent"),
+    idempotency_key_template: z.string().min(1).max(512),
+  })
+  .strict();
+const reconcileSchema = z.object({ policy: z.literal("reconcile") }).strict();
+
+const graphEffectPolicySchema = z.discriminatedUnion("policy", [
+  sideEffectFreeSchema,
+  idempotentSchema,
+  reconcileSchema,
+]);
+
+const nodeBase = {
+  id: idSchema,
+  title: z.string().min(1).max(256),
+};
+const executableNodeBase = {
+  ...nodeBase,
+  timeout_ms: z.number().int().min(100).max(86_400_000),
+  max_attempts: z.number().int().min(1).max(20),
+  effect_policy: graphEffectPolicySchema,
+};
+
+export const graphAgentNodeSchema = z
+  .object({
+    ...executableNodeBase,
+    kind: z.literal("agent"),
+    instructions: textSchema,
+  })
+  .strict();
+export const graphCommandNodeSchema = z
+  .object({
+    ...executableNodeBase,
+    kind: z.literal("command"),
+    command: textSchema,
+  })
+  .strict();
+export const graphHumanApprovalNodeSchema = z
+  .object({
+    ...nodeBase,
+    kind: z.literal("human-approval"),
+    prompt: textSchema,
+  })
+  .strict();
+export const graphJoinNodeSchema = z
+  .object({
+    ...nodeBase,
+    kind: z.literal("join"),
+    fan_out_node_id: idSchema,
+    input_branch_ids: z.array(idSchema).min(2).max(64),
+  })
+  .strict();
+
+export const graphNodeSchema = z.discriminatedUnion("kind", [
+  graphAgentNodeSchema,
+  graphCommandNodeSchema,
+  graphHumanApprovalNodeSchema,
+  graphJoinNodeSchema,
+]);
+
+const edgeBase = { id: idSchema, from: idSchema, to: idSchema };
+export const graphFixedEdgeSchema = z
+  .object({ ...edgeBase, kind: z.literal("fixed") })
+  .strict();
+export const graphConditionalEdgeSchema = z
+  .object({ ...edgeBase, kind: z.literal("conditional"), route: idSchema })
+  .strict();
+export const graphFanOutEdgeSchema = z
+  .object({
+    ...edgeBase,
+    kind: z.literal("fan_out"),
+    branch_id: idSchema,
+    owner_join_id: idSchema,
+  })
+  .strict();
+export const graphBackEdgeSchema = z
+  .object({
+    ...edgeBase,
+    kind: z.literal("back_edge"),
+    route: idSchema,
+    max_traversals: z.number().int().min(1).max(100),
+  })
+  .strict();
+
+export const graphEdgeSchema = z.discriminatedUnion("kind", [
+  graphFixedEdgeSchema,
+  graphConditionalEdgeSchema,
+  graphFanOutEdgeSchema,
+  graphBackEdgeSchema,
+]);
+
+export const graphDescriptorSchema = z
+  .object({
+    descriptor_version: z.literal(1),
+    run_id: idSchema,
+    revision_id: idSchema,
+    goal: textSchema,
+    nodes: z.array(graphNodeSchema).min(1).max(1_000),
+    edges: z.array(graphEdgeSchema).max(5_000),
+    entry_node_ids: z.array(idSchema).min(1).max(64),
+    concurrency_limit: z.number().int().min(1).max(64),
+    terminal_verification_node_id: idSchema,
+    descriptor_hash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .optional(),
+  })
+  .strict();
+
+export const graphEvidenceReferenceSchema = z
+  .object({
+    kind: z.enum(["file", "command", "test", "human", "url"]),
+    ref: z.string().min(1).max(2_048),
+    summary: z.string().max(2_048).optional(),
+  })
+  .strict();
+
+export const graphNodeResultSchema = z
+  .object({
+    outcome: z.enum(["succeeded", "failed"]),
+    attempt_id: idSchema,
+    route: idSchema.optional(),
+    output_summary: z.string().max(8_192).optional(),
+    evidence_refs: z.array(graphEvidenceReferenceSchema).max(64),
+    external_idempotency_key: z.string().min(1).max(512).optional(),
+  })
+  .strict();
+
+export const graphApprovalDecisionSchema = z
+  .object({
+    decision: z.enum(["approved", "denied"]),
+    evidence_refs: z.array(graphEvidenceReferenceSchema).max(64),
+    output_summary: z.string().max(8_192).optional(),
+  })
+  .strict();
+
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphDescriptorShape(input: unknown): GraphDescriptor {
+  return graphDescriptorSchema.parse(input);
+}
+
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphNodeResult(input: unknown): GraphNodeResult {
+  return graphNodeResultSchema.parse(input);
+}
+
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphApprovalDecision(
+  input: unknown,
+): GraphApprovalDecision {
+  return graphApprovalDecisionSchema.parse(input);
+}
+
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphEvidenceReference(
+  input: unknown,
+): GraphEvidenceReference {
+  return graphEvidenceReferenceSchema.parse(input);
+}
+
+/**
+ * Non-throwing stable-id predicate: `true` iff the value is a string matching
+ * `idSchema` (1–128 chars, stable charset). Used by the scheduler for identity
+ * values, entry identity keys/values, and identity-map keys.
+ */
+export function isValidStableId(value: unknown): boolean {
+  return typeof value === "string" && idSchema.safeParse(value).success;
+}

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,354 @@
+/**
+ * Graph Core data contract — deeply readonly types.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ */
+
+/** Stable node kinds. */
+export type GraphNodeKind = "agent" | "command" | "human-approval" | "join";
+
+/** Effect policy for executable nodes (discriminated object union). */
+export interface GraphSideEffectFreePolicy {
+  readonly policy: "side_effect_free";
+}
+
+export interface GraphIdempotentPolicy {
+  readonly policy: "idempotent";
+  readonly idempotency_key_template: string;
+}
+
+export interface GraphReconcilePolicy {
+  readonly policy: "reconcile";
+}
+
+export type GraphEffectPolicy =
+  | GraphSideEffectFreePolicy
+  | GraphIdempotentPolicy
+  | GraphReconcilePolicy;
+
+/** Fields shared by every graph node. */
+export interface GraphNodeBase {
+  readonly id: string;
+  readonly kind: GraphNodeKind;
+  readonly title: string;
+}
+
+/** Fields shared by executable (agent/command) nodes. */
+export interface GraphExecutableNodeBase extends GraphNodeBase {
+  readonly timeout_ms: number;
+  readonly max_attempts: number;
+  readonly effect_policy: GraphEffectPolicy;
+}
+
+export interface GraphAgentNode extends GraphExecutableNodeBase {
+  readonly kind: "agent";
+  readonly instructions: string;
+}
+
+export interface GraphCommandNode extends GraphExecutableNodeBase {
+  readonly kind: "command";
+  readonly command: string;
+}
+
+export interface GraphHumanApprovalNode extends GraphNodeBase {
+  readonly kind: "human-approval";
+  readonly prompt: string;
+}
+
+export interface GraphJoinNode extends GraphNodeBase {
+  readonly kind: "join";
+  readonly fan_out_node_id: string;
+  readonly input_branch_ids: readonly string[];
+}
+
+export type GraphNode =
+  | GraphAgentNode
+  | GraphCommandNode
+  | GraphHumanApprovalNode
+  | GraphJoinNode;
+
+/** Fields shared by every graph edge. */
+export interface GraphEdgeBase {
+  readonly id: string;
+  readonly from: string;
+  readonly to: string;
+}
+
+export interface GraphFixedEdge extends GraphEdgeBase {
+  readonly kind: "fixed";
+}
+
+export interface GraphConditionalEdge extends GraphEdgeBase {
+  readonly kind: "conditional";
+  readonly route: string;
+}
+
+export interface GraphFanOutEdge extends GraphEdgeBase {
+  readonly kind: "fan_out";
+  readonly branch_id: string;
+  readonly owner_join_id: string;
+}
+
+export interface GraphBackEdge extends GraphEdgeBase {
+  readonly kind: "back_edge";
+  readonly route: string;
+  readonly max_traversals: number;
+}
+
+export type GraphEdge =
+  | GraphFixedEdge
+  | GraphConditionalEdge
+  | GraphFanOutEdge
+  | GraphBackEdge;
+
+/** Unsealed descriptor input accepted by the draft producers. */
+export interface GraphDescriptorInput {
+  readonly descriptor_version: 1;
+  readonly run_id: string;
+  readonly revision_id: string;
+  readonly goal: string;
+  readonly nodes: readonly GraphNode[];
+  readonly edges: readonly GraphEdge[];
+  readonly entry_node_ids: readonly string[];
+  readonly concurrency_limit: number;
+  readonly terminal_verification_node_id: string;
+  readonly descriptor_hash?: string;
+}
+
+/** Unsealed descriptor (hashless; never accepted by the scheduler). */
+export type GraphDescriptor = GraphDescriptorInput;
+
+/**
+ * Sealed descriptor: hashless shape plus a required lowercase SHA-256 hex
+ * `descriptor_hash`. The only scheduler-accepted descriptor type; owned values
+ * come exclusively from `sealGraphDescriptor` / `parseSealedGraphDescriptor`.
+ */
+export type SealedGraphDescriptor = Omit<
+  GraphDescriptorInput,
+  "descriptor_hash"
+> & {
+  readonly descriptor_hash: string;
+};
+
+export interface GraphEvidenceReference {
+  readonly kind: "file" | "command" | "test" | "human" | "url";
+  readonly ref: string;
+  readonly summary?: string;
+}
+
+export interface GraphNodeResult {
+  readonly outcome: "succeeded" | "failed";
+  readonly attempt_id: string;
+  readonly route?: string;
+  readonly output_summary?: string;
+  readonly evidence_refs: readonly GraphEvidenceReference[];
+  readonly external_idempotency_key?: string;
+}
+
+export interface GraphApprovalDecision {
+  readonly decision: "approved" | "denied";
+  readonly evidence_refs: readonly GraphEvidenceReference[];
+  readonly output_summary?: string;
+}
+
+export type GraphActivationStatus =
+  | "ready"
+  | "running"
+  | "completed"
+  | "failed";
+
+export interface GraphActivation {
+  readonly activation_id: string;
+  readonly node_id: string;
+  readonly status: GraphActivationStatus;
+  readonly attempt_no: number;
+  readonly attempt_ids: readonly string[];
+  readonly active_attempt_id?: string;
+  readonly completed_transition_id?: string;
+  readonly cohort_id?: string;
+  readonly branch_token_id?: string;
+  readonly traversal_owner_id: string;
+}
+
+export type GraphBranchTokenStatus = "active" | "arrived" | "consumed";
+
+export interface GraphBranchToken {
+  readonly branch_token_id: string;
+  readonly cohort_id: string;
+  readonly branch_id: string;
+  readonly owner_join_id: string;
+  readonly status: GraphBranchTokenStatus;
+  readonly current_activation_id?: string;
+  readonly consumed_by_activation_id?: string;
+}
+
+export interface GraphCohort {
+  readonly cohort_id: string;
+  readonly fan_out_node_id: string;
+  readonly owner_join_id: string;
+  readonly expected_branch_token_ids: readonly string[];
+  readonly join_activation_id?: string;
+  readonly consumed: boolean;
+}
+
+/** Fields shared by every committed transition record. */
+interface GraphCommittedTransitionBase {
+  readonly transition_id: string;
+  readonly activation_id: string;
+  readonly node_id: string;
+  readonly fingerprint_version: 1;
+  readonly request_fingerprint: string;
+  readonly descriptor_hash: string;
+  readonly selected_edge_ids: readonly string[];
+  readonly created_activation_ids: readonly string[];
+  readonly evidence_refs: readonly GraphEvidenceReference[];
+  readonly external_idempotency_key?: string;
+}
+
+/** Succeeded: attempt-bound; edge/activation cardinality varies (fan-out/terminal). */
+export interface GraphSucceededTransition extends GraphCommittedTransitionBase {
+  readonly outcome: "succeeded";
+  readonly attempt_id: string;
+  readonly route?: string;
+  readonly output_summary?: string;
+  readonly cohort_id?: string;
+}
+
+/** Failed: never selects or creates anything. */
+export interface GraphFailedTransition extends GraphCommittedTransitionBase {
+  readonly outcome: "failed";
+  readonly attempt_id: string;
+  readonly selected_edge_ids: readonly [];
+  readonly created_activation_ids: readonly [];
+  readonly output_summary?: string;
+}
+
+/** Approved: exactly one fixed edge selected and exactly one activation created; evidence is non-empty. */
+export interface GraphApprovedTransition extends GraphCommittedTransitionBase {
+  readonly outcome: "approved";
+  readonly selected_edge_ids: readonly [string];
+  readonly created_activation_ids: readonly [string];
+  readonly evidence_refs: readonly [
+    GraphEvidenceReference,
+    ...GraphEvidenceReference[],
+  ];
+  readonly output_summary?: string;
+}
+
+/** Denied: selects/creates nothing; evidence records the decision and is non-empty. */
+export interface GraphDeniedTransition extends GraphCommittedTransitionBase {
+  readonly outcome: "denied";
+  readonly selected_edge_ids: readonly [];
+  readonly created_activation_ids: readonly [];
+  readonly evidence_refs: readonly [
+    GraphEvidenceReference,
+    ...GraphEvidenceReference[],
+  ];
+  readonly output_summary?: string;
+}
+
+/** Join resolved: exactly one fixed edge selected and exactly one activation created; no evidence. */
+export interface GraphJoinResolvedTransition extends GraphCommittedTransitionBase {
+  readonly outcome: "join_resolved";
+  readonly cohort_id: string;
+  readonly selected_edge_ids: readonly [string];
+  readonly created_activation_ids: readonly [string];
+  readonly evidence_refs: readonly [];
+}
+
+/** Discriminated union on `outcome`; exact per-outcome fields. */
+export type GraphCommittedTransition =
+  | GraphSucceededTransition
+  | GraphFailedTransition
+  | GraphApprovedTransition
+  | GraphDeniedTransition
+  | GraphJoinResolvedTransition;
+
+/** Descriptor-bound scheduler projection. */
+export interface GraphSchedulerProjection {
+  readonly descriptor_hash: string;
+  readonly run_id: string;
+  readonly revision_id: string;
+  readonly activations: Readonly<Record<string, GraphActivation>>;
+  readonly cohorts: Readonly<Record<string, GraphCohort>>;
+  readonly branch_tokens: Readonly<Record<string, GraphBranchToken>>;
+  readonly traversal_counts: Readonly<Record<string, number>>;
+  readonly committed_transitions: Readonly<
+    Record<string, GraphCommittedTransition>
+  >;
+  readonly terminal_verification_activation_ids: readonly string[];
+}
+
+export interface BeginActivationAttemptInput {
+  readonly activation_id: string;
+  readonly attempt_id: string;
+}
+
+export interface ReleaseAttemptForRetryInput {
+  readonly activation_id: string;
+  readonly attempt_id: string;
+}
+
+export interface SchedulerTransitionIdentities {
+  readonly next_activation_ids?: Readonly<Record<string, string>>;
+  readonly cohort_id?: string;
+  readonly branch_token_ids?: Readonly<Record<string, string>>;
+  readonly join_activation_id?: string;
+}
+
+export interface ApplyNodeResultInput {
+  readonly activation_id: string;
+  readonly transition_id: string;
+  readonly result: GraphNodeResult;
+  readonly identities?: SchedulerTransitionIdentities;
+}
+
+export interface ApplyHumanApprovalInput {
+  readonly activation_id: string;
+  readonly transition_id: string;
+  readonly decision: GraphApprovalDecision;
+  readonly identities?: SchedulerTransitionIdentities;
+}
+
+export interface ResolveJoinInput {
+  readonly activation_id: string;
+  readonly transition_id: string;
+  readonly identities?: SchedulerTransitionIdentities;
+}
+
+export interface SchedulerApplyResult {
+  readonly projection: GraphSchedulerProjection;
+  readonly transition: GraphCommittedTransition;
+  readonly replayed: boolean;
+}
+
+/** Closed scheduler error-code union; every scheduler throw uses exactly one code. */
+export type GraphSchedulerErrorCode =
+  | "activation_not_found"
+  | "activation_not_ready"
+  | "max_attempts_exceeded"
+  | "attempt_fenced"
+  | "transition_fenced"
+  | "duplicate_identity"
+  | "missing_identity"
+  | "unexpected_identity"
+  | "undeclared_identity_key"
+  | "invalid_input"
+  | "descriptor_mismatch"
+  | "route_required"
+  | "undeclared_route"
+  | "traversal_bound_exceeded"
+  | "branch_token_fenced"
+  | "join_owner_missing"
+  | "join_owner_mismatch"
+  | "join_not_found"
+  | "join_not_ready"
+  | "join_already_consumed"
+  | "join_is_automatic"
+  | "invalid_join_edge"
+  | "node_not_found"
+  | "terminal_evidence_required"
+  | "approval_requires_dedicated_transition"
+  | "unsupported_node_kind";


### PR DESCRIPTION
## Summary

- add a maintainer-owned Graph Core v1 descriptor contract with strict schemas, canonical hashing, owned immutable sealing, and topology validation
- add a pure deterministic scheduler covering attempts, routes, bounded returns, fan-out/join, human approval, replay fencing, terminal evidence, and closed error boundaries
- add 143 focused tests plus ADR 03570 documenting the first-landing boundary and follow-up order

## Why this is the first landing

The 91-file reference stack couples runtime persistence, OCC fencing, control ownership, hooks, CLI/HUD/installer integration, and generated package closure. This PR deliberately re-derives only the independently buildable/testable pure core on current `dev`; commit `99ffe31` is behavioral evidence, not import authority.

## Verification

- `npm run test:run -- src/graph/__tests__` — PASS (2 files, 143 tests)
- `npx tsc --noEmit` — PASS
- `npx eslint src/graph` — PASS
- `git diff --check origin/dev...HEAD` — PASS
- final commit: `feb198166eff92290e2631ee9d72cc480d1ddaff`
- base: `06399a861df0a8007b2129c63ded86d290464d23`

## Scope

Exactly nine source/test/ADR files. No runtime persistence, claims/revisions, OCC, control ownership, platform/recovery, CLI, skill, HUD, installer, hooks, templates, `dist/`, or `bridge/` changes.

## Follow-ups

Runtime state/claims, OCC store, control ownership/recovery, runtime operations, integrations, and bounded generated closure remain separate maintainer-owned landings.

Refs #3570