### PR TITLE
feat(benchmarks): add evidence-safe efficiency diagnostics

### DIFF
--- a/benchmarks/code-reviewer/run-benchmark.ts
+++ b/benchmarks/code-reviewer/run-benchmark.ts
@@ -25,6 +25,7 @@ import {
   runBenchmark,
   printSummaryTable,
   writeReports,
+  exitCodeForResults,
 } from '../shared/runner.ts';
 import { parseGenericOutput } from '../shared/parser.ts';
 import type { ParsedAgentOutput } from '../shared/types.ts';
@@ -53,7 +54,7 @@ function buildUserMessage(fixtureContent: string): string {
 // Parser
 // ============================================================
 
-function parseOutput(rawOutput: string, _agentType: string): ParsedAgentOutput {
+function parseOutput(rawOutput: string): ParsedAgentOutput {
   return parseGenericOutput(rawOutput);
 }
 
@@ -104,6 +105,8 @@ async function main(): Promise<void> {
     cliArgs.agents[1] ?? cliArgs.agents[0],
     cliArgs.model,
   );
+
+  process.exitCode = exitCodeForResults(results);
 
   console.log('\nBenchmark complete.\n');
 }

--- a/benchmarks/debugger/run-benchmark.ts
+++ b/benchmarks/debugger/run-benchmark.ts
@@ -25,6 +25,7 @@ import {
   runBenchmark,
   printSummaryTable,
   writeReports,
+  exitCodeForResults,
 } from '../shared/runner.ts';
 import { parseGenericOutput } from '../shared/parser.ts';
 import type { ParsedAgentOutput } from '../shared/types.ts';
@@ -53,7 +54,7 @@ function buildUserMessage(fixtureContent: string): string {
 // Parser
 // ============================================================
 
-function parseOutput(rawOutput: string, _agentType: string): ParsedAgentOutput {
+function parseOutput(rawOutput: string): ParsedAgentOutput {
   return parseGenericOutput(rawOutput);
 }
 
@@ -104,6 +105,8 @@ async function main(): Promise<void> {
     cliArgs.agents[1] ?? cliArgs.agents[0],
     cliArgs.model,
   );
+
+  process.exitCode = exitCodeForResults(results);
 
   console.log('\nBenchmark complete.\n');
 }

--- a/benchmarks/executor/run-benchmark.ts
+++ b/benchmarks/executor/run-benchmark.ts
@@ -25,6 +25,7 @@ import {
   runBenchmark,
   printSummaryTable,
   writeReports,
+  exitCodeForResults,
 } from '../shared/runner.ts';
 import { parseGenericOutput } from '../shared/parser.ts';
 import type { ParsedAgentOutput } from '../shared/types.ts';
@@ -53,7 +54,7 @@ function buildUserMessage(fixtureContent: string): string {
 // Parser
 // ============================================================
 
-function parseOutput(rawOutput: string, _agentType: string): ParsedAgentOutput {
+function parseOutput(rawOutput: string): ParsedAgentOutput {
   return parseGenericOutput(rawOutput);
 }
 
@@ -104,6 +105,8 @@ async function main(): Promise<void> {
     cliArgs.agents[1] ?? cliArgs.agents[0],
     cliArgs.model,
   );
+
+  process.exitCode = exitCodeForResults(results);
 
   console.log('\nBenchmark complete.\n');
 }

--- a/benchmarks/shared/reporter.ts
+++ b/benchmarks/shared/reporter.ts
@@ -1,162 +1,306 @@
-/**
- * Generalized report generator for agent benchmark results.
- *
- * Produces both machine-readable JSON and human-readable markdown
- * comparing two agent variants (e.g., old prompt vs new prompt).
- */
-
 import type {
   AgentType,
   BenchmarkScores,
   ComparisonReport,
+  CompletedFixtureResult,
+  DiagnosticComparison,
+  FailureReason,
   FixtureResult,
-  AgentBenchmarkReport,
-} from './types.ts';
-import { aggregateScores } from './scorer.ts';
+  NumericDiagnostic,
+  TokenDimensionDiagnostic,
+} from "./types.ts";
+import { aggregateScoresUnknownCapable } from "./scorer.ts";
 
-// ============================================================
-// Public: generateAgentReport
-// ============================================================
+const NUMERIC_SCORE_KEYS: Array<keyof BenchmarkScores> = [
+  "truePositiveRate",
+  "falsePositiveRate",
+  "falseNegativeRate",
+  "severityAccuracy",
+  "missingCoverage",
+  "perspectiveCoverage",
+  "evidenceRate",
+  "compositeScore",
+];
 
-/**
- * Build a single-agent benchmark report.
- */
-export function generateAgentReport(
+export class DuplicateFixtureKeyError extends Error {
+  constructor(side: string, key: string) {
+    super(`Duplicate fixture key on ${side}: ${key}`);
+    this.name = "DuplicateFixtureKeyError";
+  }
+}
+
+export function keyOf(
+  result: Pick<FixtureResult, "domain" | "fixtureId">,
+): string {
+  return `${result.domain}:${result.fixtureId}`;
+}
+
+function uniqueByKey(
   results: FixtureResult[],
-  agentType: AgentType,
-  model: string,
-): AgentBenchmarkReport {
+  side: string,
+): Map<string, FixtureResult> {
+  const map = new Map<string, FixtureResult>();
+  for (const result of results) {
+    const key = keyOf(result);
+    if (map.has(key)) throw new DuplicateFixtureKeyError(side, key);
+    map.set(key, result);
+  }
+  return map;
+}
+
+export function pairResults(
+  aResults: FixtureResult[],
+  bResults: FixtureResult[],
+): {
+  paired: Array<{ key: string; a: FixtureResult; b: FixtureResult }>;
+  aOnlyKeys: string[];
+  bOnlyKeys: string[];
+} {
+  const aByKey = uniqueByKey(aResults, "A");
+  const bByKey = uniqueByKey(bResults, "B");
+  const paired: Array<{ key: string; a: FixtureResult; b: FixtureResult }> = [];
+  const aOnlyKeys: string[] = [];
+  const bOnlyKeys: string[] = [];
+
+  for (const [key, a] of aByKey) {
+    const b = bByKey.get(key);
+    if (b) paired.push({ key, a, b });
+    else aOnlyKeys.push(key);
+  }
+  for (const key of bByKey.keys()) {
+    if (!aByKey.has(key)) bOnlyKeys.push(key);
+  }
+
+  paired.sort((left, right) => left.key.localeCompare(right.key));
+  aOnlyKeys.sort();
+  bOnlyKeys.sort();
+  return { paired, aOnlyKeys, bOnlyKeys };
+}
+
+function aggregate(values: number[], kind: "sum" | "mean"): number | undefined {
+  if (values.length === 0) return undefined;
+  const total = values.reduce((current, value) => current + value, 0);
+  return kind === "sum" ? total : total / values.length;
+}
+
+function numericDiagnostic(
+  pairs: Array<{ a: FixtureResult; b: FixtureResult }>,
+  selector: (result: FixtureResult) => number | undefined,
+  unit: NumericDiagnostic["unit"],
+  aggregateKind: "sum" | "mean",
+): NumericDiagnostic {
+  const aValues: number[] = [];
+  const bValues: number[] = [];
+  for (const pair of pairs) {
+    const aValue = selector(pair.a);
+    const bValue = selector(pair.b);
+    if (aValue === undefined || bValue === undefined) continue;
+    aValues.push(aValue);
+    bValues.push(bValue);
+  }
+  const a = aggregate(aValues, aggregateKind);
+  const b = aggregate(bValues, aggregateKind);
   return {
-    timestamp: new Date().toISOString(),
-    model,
-    agentType,
-    results,
-    aggregateScores: aggregateScores(results),
+    a,
+    b,
+    delta: a !== undefined && b !== undefined ? a - b : undefined,
+    pairedCount: aValues.length,
+    unit,
+    status: aValues.length > 0 ? "compared" : "insufficient",
   };
 }
 
-// ============================================================
-// Public: generateComparisonReport
-// ============================================================
+function tokenDimension(
+  pairs: Array<{ a: FixtureResult; b: FixtureResult }>,
+  selector: (result: FixtureResult) => number | undefined,
+): TokenDimensionDiagnostic {
+  return {
+    total: numericDiagnostic(pairs, selector, "tokens", "sum"),
+    perFixtureMean: numericDiagnostic(pairs, selector, "tokens", "mean"),
+  };
+}
 
-/**
- * Build a comparison report between two agent variants.
- */
+function failureReasons(
+  results: FixtureResult[],
+): Partial<Record<FailureReason, number>> {
+  const counts: Partial<Record<FailureReason, number>> = {};
+  for (const result of results) {
+    if (result.completion !== "failed") continue;
+    counts[result.failureReason] = (counts[result.failureReason] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function buildDiagnostics(
+  aResults: FixtureResult[],
+  bResults: FixtureResult[],
+  paired: Array<{ a: FixtureResult; b: FixtureResult }>,
+  aOnlyKeys: string[],
+  bOnlyKeys: string[],
+  sameAgent: boolean,
+): DiagnosticComparison {
+  const qualityPairs = paired.filter(
+    (pair) =>
+      pair.a.completion === "completed" && pair.b.completion === "completed",
+  );
+  const measurementPairs = sameAgent ? [] : paired;
+  const tokenCost = {
+    input: tokenDimension(measurementPairs, (result) => result.inputTokens),
+    output: tokenDimension(measurementPairs, (result) => result.outputTokens),
+    all: tokenDimension(measurementPairs, (result) => result.totalTokens),
+  };
+  const apiLatency = numericDiagnostic(
+    measurementPairs,
+    (result) => result.latencyMs,
+    "milliseconds",
+    "mean",
+  );
+  const harnessOverhead = numericDiagnostic(
+    measurementPairs,
+    (result) => result.harnessOverheadMs,
+    "milliseconds",
+    "mean",
+  );
+
+  const reasons: string[] = [];
+  if (sameAgent) reasons.push("comparison requires two distinct agents");
+  if (paired.length === 0) reasons.push("no paired fixture observations");
+  if (aOnlyKeys.length > 0 || bOnlyKeys.length > 0)
+    reasons.push("fixture populations differ");
+  if (
+    paired.some(
+      (pair) =>
+        pair.a.completion === "failed" || pair.b.completion === "failed",
+    )
+  ) {
+    reasons.push("one or more paired runs failed");
+  }
+  if (
+    !sameAgent &&
+    [tokenCost.input, tokenCost.output, tokenCost.all].some(
+      (dimension) => dimension.total.pairedCount !== paired.length,
+    )
+  ) {
+    reasons.push("token telemetry is incomplete");
+  }
+  if (!sameAgent && apiLatency.pairedCount !== paired.length) {
+    reasons.push("API latency telemetry is incomplete");
+  }
+  if (!sameAgent && harnessOverhead.pairedCount !== paired.length) {
+    reasons.push("harness overhead telemetry is incomplete");
+  }
+
+  return {
+    completion: {
+      completedA: aResults.filter((result) => result.completion === "completed")
+        .length,
+      failedA: aResults.filter((result) => result.completion === "failed")
+        .length,
+      completedB: bResults.filter((result) => result.completion === "completed")
+        .length,
+      failedB: bResults.filter((result) => result.completion === "failed")
+        .length,
+      failureReasonsA: failureReasons(aResults),
+      failureReasonsB: failureReasons(bResults),
+      pairedFixtures: paired.length,
+      aOnlyKeys,
+      bOnlyKeys,
+    },
+    qualityPairedCount: sameAgent ? 0 : qualityPairs.length,
+    tokenCost,
+    apiLatency,
+    harnessOverhead,
+    validity: reasons.length === 0 ? "valid" : "inconclusive",
+    reasons,
+  };
+}
+
 export function generateComparisonReport(
   results: FixtureResult[],
   agentA: AgentType,
   agentB: AgentType,
   model: string,
 ): ComparisonReport {
-  const aResults = results.filter((r) => r.agentType === agentA);
-  const bResults = results.filter((r) => r.agentType === agentB);
-
-  const aAggregate = aggregateScores(aResults);
-  const bAggregate = aggregateScores(bResults);
-
-  const aggregateScoresMap: Record<AgentType, BenchmarkScores> = {
+  const sameAgent = agentA === agentB;
+  const aResults = results.filter((result) => result.agentType === agentA);
+  const bResults = results.filter((result) => result.agentType === agentB);
+  const pairing = pairResults(aResults, bResults);
+  const qualityPairs = pairing.paired.filter(
+    (
+      pair,
+    ): pair is {
+      key: string;
+      a: CompletedFixtureResult;
+      b: CompletedFixtureResult;
+    } => pair.a.completion === "completed" && pair.b.completion === "completed",
+  );
+  const aAggregate = sameAgent
+    ? null
+    : aggregateScoresUnknownCapable(qualityPairs.map((pair) => pair.a));
+  const bAggregate = sameAgent
+    ? null
+    : aggregateScoresUnknownCapable(qualityPairs.map((pair) => pair.b));
+  const aggregateScores: Record<AgentType, BenchmarkScores | null> = {
     [agentA]: aAggregate,
     [agentB]: bAggregate,
   };
-
-  // Per-metric deltas (A minus B) for numeric fields only
-  const numericKeys: Array<keyof BenchmarkScores> = [
-    'truePositiveRate',
-    'falsePositiveRate',
-    'falseNegativeRate',
-    'severityAccuracy',
-    'missingCoverage',
-    'perspectiveCoverage',
-    'evidenceRate',
-    'compositeScore',
-  ];
-
   const deltas: Partial<Record<keyof BenchmarkScores, number>> = {};
-  for (const key of numericKeys) {
-    const aVal = aAggregate[key];
-    const bVal = bAggregate[key];
-    if (typeof aVal === 'number' && typeof bVal === 'number') {
-      deltas[key] = aVal - bVal;
+  if (aAggregate && bAggregate) {
+    for (const key of NUMERIC_SCORE_KEYS) {
+      const aValue = aAggregate[key];
+      const bValue = bAggregate[key];
+      if (typeof aValue === "number" && typeof bValue === "number") {
+        deltas[key] = aValue - bValue;
+      }
     }
   }
 
-  // Head-to-head per fixture
-  const fixtureIds = Array.from(new Set(results.map((r) => r.fixtureId)));
-  const headToHead: ComparisonReport['headToHead'] = fixtureIds.map((fixtureId) => {
-    const a = aResults.find((r) => r.fixtureId === fixtureId);
-    const b = bResults.find((r) => r.fixtureId === fixtureId);
-
-    const aScore = a?.scores.compositeScore ?? 0;
-    const bScore = b?.scores.compositeScore ?? 0;
-    const delta = aScore - bScore;
-
-    let winner: AgentType | 'tie';
-    if (Math.abs(delta) < 0.001) {
-      winner = 'tie';
-    } else if (delta > 0) {
-      winner = agentA;
-    } else {
-      winner = agentB;
-    }
-
-    return { fixtureId, winner, delta };
-  });
+  const headToHead: ComparisonReport["headToHead"] = sameAgent
+    ? []
+    : qualityPairs.map(({ a, b }) => {
+        const delta = a.scores.compositeScore - b.scores.compositeScore;
+        return {
+          fixtureId: a.fixtureId,
+          domain: a.domain,
+          winner: Math.abs(delta) < 0.001 ? "tie" : delta > 0 ? agentA : agentB,
+          delta,
+        };
+      });
 
   return {
     timestamp: new Date().toISOString(),
     model,
     results,
-    aggregateScores: aggregateScoresMap,
+    aggregateScores,
     deltas,
     headToHead,
+    diagnostics: buildDiagnostics(
+      aResults,
+      bResults,
+      pairing.paired,
+      pairing.aOnlyKeys,
+      pairing.bOnlyKeys,
+      sameAgent,
+    ),
   };
 }
-
-// ============================================================
-// Markdown formatting helpers
-// ============================================================
 
 function pct(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-function sign(value: number): string {
-  return value >= 0 ? `+${pct(value)}` : `-${pct(Math.abs(value))}`;
+function numberOrNA(value: number | undefined, digits = 1): string {
+  return value === undefined ? "n/a" : value.toFixed(digits);
 }
 
-function bool(value: boolean): string {
-  return value ? 'yes' : 'no';
+function diagnosticRow(
+  label: string,
+  diagnostic: NumericDiagnostic,
+  digits = 1,
+): string {
+  return `| ${label} | ${numberOrNA(diagnostic.a, digits)} | ${numberOrNA(diagnostic.b, digits)} | ${numberOrNA(diagnostic.delta, digits)} | ${diagnostic.pairedCount} | ${diagnostic.status} |`;
 }
 
-const METRIC_LABELS: Partial<Record<keyof BenchmarkScores, string>> = {
-  truePositiveRate: 'True Positive Rate',
-  falseNegativeRate: 'False Negative Rate',
-  falsePositiveRate: 'False Positive Rate',
-  severityAccuracy: 'Severity Accuracy',
-  missingCoverage: 'Missing Coverage',
-  perspectiveCoverage: 'Perspective Coverage',
-  evidenceRate: 'Evidence Rate',
-  compositeScore: 'Composite Score',
-};
-
-const SUMMARY_METRICS: Array<keyof BenchmarkScores> = [
-  'truePositiveRate',
-  'falseNegativeRate',
-  'falsePositiveRate',
-  'severityAccuracy',
-  'missingCoverage',
-  'perspectiveCoverage',
-  'evidenceRate',
-  'compositeScore',
-];
-
-// ============================================================
-// Public: generateMarkdownReport
-// ============================================================
-
-/**
- * Render a human-readable markdown comparison report.
- */
 export function generateMarkdownReport(
   report: ComparisonReport,
   agentA: AgentType,
@@ -164,102 +308,71 @@ export function generateMarkdownReport(
 ): string {
   const a = report.aggregateScores[agentA];
   const b = report.aggregateScores[agentB];
+  const d = report.diagnostics;
+  const lines = [
+    `# ${agentA} vs ${agentB} Benchmark Report`,
+    "",
+    `**Date**: ${report.timestamp}`,
+    `**Model**: ${report.model}`,
+    `**Validity**: ${d.validity.toUpperCase()}`,
+    ...(d.reasons.length > 0 ? [`**Reasons**: ${d.reasons.join("; ")}`] : []),
+    "",
+    "## Evidence-Safe Diagnostic",
+    "",
+    `| Dimension | ${agentA} | ${agentB} | Delta | Paired | Status |`,
+    "|---|---:|---:|---:|---:|---|",
+    `| Completion | ${d.completion.completedA} completed / ${d.completion.failedA} failed | ${d.completion.completedB} completed / ${d.completion.failedB} failed | n/a | ${d.completion.pairedFixtures} | ${d.validity} |`,
+    `| Scorer quality | ${a ? pct(a.compositeScore) : "n/a"} | ${b ? pct(b.compositeScore) : "n/a"} | ${typeof report.deltas.compositeScore === "number" ? pct(report.deltas.compositeScore) : "n/a"} | ${d.qualityPairedCount} | ${d.qualityPairedCount > 0 ? "compared" : "insufficient"} |`,
+    diagnosticRow("Input tokens (total)", d.tokenCost.input.total, 0),
+    diagnosticRow(
+      "Input tokens (per-fixture mean)",
+      d.tokenCost.input.perFixtureMean,
+    ),
+    diagnosticRow("Output tokens (total)", d.tokenCost.output.total, 0),
+    diagnosticRow(
+      "Output tokens (per-fixture mean)",
+      d.tokenCost.output.perFixtureMean,
+    ),
+    diagnosticRow("All tokens (total)", d.tokenCost.all.total, 0),
+    diagnosticRow(
+      "All tokens (per-fixture mean)",
+      d.tokenCost.all.perFixtureMean,
+    ),
+    diagnosticRow("API latency mean (ms)", d.apiLatency),
+    diagnosticRow("Harness overhead mean (ms)", d.harnessOverhead),
+    "",
+    `Unpaired ${agentA}: ${d.completion.aOnlyKeys.join(", ") || "none"}`,
+    `Unpaired ${agentB}: ${d.completion.bOnlyKeys.join(", ") || "none"}`,
+    "",
+    "## Per-Fixture Results",
+    "",
+  ];
 
-  if (!a || !b) {
-    return `# Benchmark Report\n\nError: Missing aggregate scores for agents "${agentA}" and/or "${agentB}".\n`;
-  }
-
-  const fixtureCount = new Set(report.results.map((r) => r.fixtureId)).size;
-
-  const lines: string[] = [];
-
-  // ---- Header ----
-  lines.push(`# ${agentA} vs ${agentB} Benchmark Report`);
-  lines.push('');
-  lines.push(`**Date**: ${report.timestamp}`);
-  lines.push(`**Model**: ${report.model}`);
-  lines.push(`**Fixtures**: ${fixtureCount}`);
-  lines.push('');
-
-  // ---- Summary Table ----
-  lines.push('## Summary Table');
-  lines.push('');
-  lines.push(`| Metric | ${agentA} | ${agentB} | Delta |`);
-  lines.push('|--------|-------------|--------|-------|');
-
-  for (const key of SUMMARY_METRICS) {
-    const label = METRIC_LABELS[key] ?? key;
-    const aVal = a[key];
-    const bVal = b[key];
-    if (typeof aVal === 'number' && typeof bVal === 'number') {
-      const delta = aVal - bVal;
-      lines.push(`| ${label} | ${pct(aVal)} | ${pct(bVal)} | ${sign(delta)} |`);
+  for (const result of [...report.results].sort((left, right) =>
+    keyOf(left).localeCompare(keyOf(right)),
+  )) {
+    lines.push(
+      `- **${keyOf(result)} / ${result.agentType}**: ${result.completion}`,
+    );
+    if (result.completion === "completed") {
+      lines.push(`  - Composite quality: ${pct(result.scores.compositeScore)}`);
+    } else {
+      lines.push(`  - Failure reason: ${result.failureReason}`);
     }
+    lines.push(
+      `  - Tokens: input=${result.inputTokens ?? "n/a"}, output=${result.outputTokens ?? "n/a"}, total=${result.totalTokens ?? "n/a"}`,
+    );
+    lines.push(
+      `  - API latency: ${result.latencyMs === undefined ? "n/a" : `${result.latencyMs.toFixed(1)}ms`}`,
+    );
+    lines.push(
+      `  - Harness overhead: ${result.harnessOverheadMs === undefined ? "n/a" : `${result.harnessOverheadMs.toFixed(1)}ms`}`,
+    );
   }
 
-  lines.push(`| Pre-Commitment | ${bool(a.hasPreCommitment)} | ${bool(b.hasPreCommitment)} | - |`);
-  lines.push(`| Multi-Perspective | ${bool(a.hasMultiPerspective)} | ${bool(b.hasMultiPerspective)} | - |`);
-  lines.push(`| Gap Analysis | ${bool(a.hasGapAnalysis)} | ${bool(b.hasGapAnalysis)} | - |`);
-  lines.push('');
-
-  // ---- Per-Fixture Results ----
-  lines.push('## Per-Fixture Results');
-  lines.push('');
-
-  const fixtureIds = Array.from(new Set(report.results.map((r) => r.fixtureId))).sort();
-
-  for (const fixtureId of fixtureIds) {
-    lines.push(`### ${fixtureId}`);
-    lines.push('');
-
-    for (const agentType of [agentA, agentB]) {
-      const result = report.results.find(
-        (r) => r.fixtureId === fixtureId && r.agentType === agentType,
-      );
-      if (!result) continue;
-
-      const s = result.scores;
-      lines.push(
-        `- **${agentType}**: composite=${pct(s.compositeScore)} ` +
-          `tp=${pct(s.truePositiveRate)} fn=${pct(s.falseNegativeRate)} ` +
-          `fp=${pct(s.falsePositiveRate)}`,
-      );
-      lines.push(
-        `  - Matched: ${result.matchedFindings.length}/${result.matchedFindings.length + result.missedFindings.length} findings`,
-      );
-
-      if (result.missedFindings.length > 0) {
-        lines.push(`  - Missed: ${result.missedFindings.join(', ')}`);
-      }
-      if (result.spuriousFindings.length > 0) {
-        const preview = result.spuriousFindings
-          .slice(0, 3)
-          .map((t) => t.slice(0, 60).replace(/\n/g, ' '))
-          .join('; ');
-        lines.push(`  - Spurious: ${preview}${result.spuriousFindings.length > 3 ? ' ...' : ''}`);
-      }
-
-      if (result.latencyMs !== undefined) {
-        lines.push(`  - Latency: ${(result.latencyMs / 1000).toFixed(1)}s`);
-      }
-    }
-    lines.push('');
-  }
-
-  // ---- Statistical Summary ----
-  lines.push('## Statistical Summary');
-  lines.push('');
-
-  const meanDelta = report.headToHead.reduce((acc, h) => acc + h.delta, 0) /
-    Math.max(report.headToHead.length, 1);
-
-  const wins = report.headToHead.filter((h) => h.winner === agentA).length;
-  const losses = report.headToHead.filter((h) => h.winner === agentB).length;
-  const ties = report.headToHead.filter((h) => h.winner === 'tie').length;
-
-  lines.push(`- Mean composite delta: ${sign(meanDelta)}`);
-  lines.push(`- Win/Loss/Tie (${agentA} perspective): ${wins}/${losses}/${ties}`);
-  lines.push('');
-
-  return lines.join('\n');
+  lines.push("");
+  lines.push(
+    "This diagnostic reports separate observed dimensions. It does not prove an Opus regression or attribute timing to model compute, network, or harness internals beyond the stated boundaries.",
+  );
+  return lines.join("\n");
 }

--- a/benchmarks/shared/runner.ts
+++ b/benchmarks/shared/runner.ts
@@ -1,48 +1,39 @@
-/**
- * Shared runner utilities for agent benchmarks.
- *
- * Provides common logic for:
- * - CLI argument parsing
- * - Fixture/ground-truth loading
- * - Anthropic API calls with retry
- * - Console formatting
- * - Report generation and file output
- */
-
-import Anthropic from '@anthropic-ai/sdk';
+import Anthropic from "@anthropic-ai/sdk";
 import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
   existsSync,
+  mkdirSync,
+  readFileSync,
   readdirSync,
-} from 'fs';
-import { join, dirname, resolve } from 'path';
+  statSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { performance } from "perf_hooks";
 
 import type {
-  AgentType,
   BenchmarkScores,
+  Domain,
+  FailedFixtureResult,
+  FailureReason,
   FixtureResult,
   GroundTruth,
   ParsedAgentOutput,
-} from './types.ts';
-import { scoreFixture, matchFindings } from './scorer.ts';
-import { generateComparisonReport, generateMarkdownReport } from './reporter.ts';
-
-// ============================================================
-// CLI argument parsing
-// ============================================================
+} from "./types.ts";
+import {
+  matchFindingsShared,
+  scoreFixtureShared,
+  validateSharedGroundTruth,
+} from "./scorer.ts";
+import {
+  generateComparisonReport,
+  generateMarkdownReport,
+} from "./reporter.ts";
 
 export interface BenchmarkCliArgs {
-  /** Which agent variant(s) to run */
   agents: string[];
-  /** Run a single fixture only */
   fixture: string | null;
-  /** Where to write results */
   outputDir: string;
-  /** Claude model to use */
   model: string;
-  /** Load fixtures and ground truth but skip API calls */
   dryRun: boolean;
 }
 
@@ -55,159 +46,159 @@ export function parseCliArgs(
     agents: defaultAgents,
     fixture: null,
     outputDir: defaultOutputDir,
-    model: 'claude-opus-4-6',
+    model: "claude-opus-4-6",
     dryRun: false,
   };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     switch (arg) {
-      case '--agent':
+      case "--agent":
         result.agents = [args[++i]];
         break;
-      case '--agents':
-        result.agents = args[++i].split(',');
+      case "--agents":
+        result.agents = args[++i].split(",");
         break;
-      case '--fixture':
+      case "--fixture":
         result.fixture = args[++i];
         break;
-      case '--output-dir':
+      case "--output-dir":
         result.outputDir = args[++i];
         break;
-      case '--model':
+      case "--model":
         result.model = args[++i];
         break;
-      case '--dry-run':
+      case "--dry-run":
         result.dryRun = true;
         break;
       default:
-        // Ignore unknown args — the top-level runner may pass extra flags
+        // Top-level runners intentionally pass through unrelated flags.
         break;
     }
   }
-
   return result;
 }
 
-// ============================================================
-// Fixture loading
-// ============================================================
+const FIXTURE_DIRECTORY_TO_DOMAIN = new Map<string, Domain>([
+  ["code", "code"],
+  ["analysis", "analysis"],
+  ["plans", "plan"],
+  ["bugs", "bug"],
+  ["tasks", "task"],
+]);
+
+export class InvalidFixtureDirectoryError extends Error {
+  constructor(directory: string) {
+    super(`Unsupported fixture directory: ${directory}`);
+    this.name = "InvalidFixtureDirectoryError";
+  }
+}
+
+export function fixtureDomainFromDirectory(directory: string): Domain {
+  const domain = FIXTURE_DIRECTORY_TO_DOMAIN.get(directory);
+  if (!domain) throw new InvalidFixtureDirectoryError(directory);
+  return domain;
+}
 
 export interface Fixture {
   id: string;
   content: string;
-  domain: string;
+  domain: Domain;
 }
 
-/**
- * Load fixtures from a benchmark directory.
- * Scans all subdirectories under fixtures/.
- */
 export function loadFixtures(
   benchmarkDir: string,
   fixtureFilter: string | null,
 ): Fixture[] {
-  const fixturesDir = join(benchmarkDir, 'fixtures');
+  const fixturesDir = join(benchmarkDir, "fixtures");
   const fixtures: Fixture[] = [];
+  if (!existsSync(fixturesDir))
+    throw new Error(`Fixtures directory not found: ${fixturesDir}`);
 
-  if (!existsSync(fixturesDir)) {
-    console.error(`Error: Fixtures directory not found: ${fixturesDir}`);
-    process.exit(1);
-  }
-
-  const domains = readdirSync(fixturesDir);
-
-  for (const domain of domains) {
-    const domainDir = join(fixturesDir, domain);
-    let files: string[];
-    try {
-      files = readdirSync(domainDir);
-    } catch {
-      continue;
-    }
-
+  for (const directory of readdirSync(fixturesDir)) {
+    const domainDir = join(fixturesDir, directory);
+    if (!statSync(domainDir).isDirectory()) continue;
+    const files = readdirSync(domainDir);
+    const domain = fixtureDomainFromDirectory(directory);
     for (const file of files) {
-      if (!file.endsWith('.md') && !file.endsWith('.ts')) continue;
-      const id = file.replace(/\.(md|ts)$/, '');
+      if (!file.endsWith(".md") && !file.endsWith(".ts")) continue;
+      const id = file.replace(/\.(md|ts)$/, "");
       if (fixtureFilter !== null && id !== fixtureFilter) continue;
-
-      const filePath = join(domainDir, file);
-      const content = readFileSync(filePath, 'utf-8');
-      fixtures.push({ id, content, domain });
+      fixtures.push({
+        id,
+        content: readFileSync(join(domainDir, file), "utf-8"),
+        domain,
+      });
     }
   }
 
   if (fixtures.length === 0) {
-    if (fixtureFilter !== null) {
-      console.error(`Error: Fixture "${fixtureFilter}" not found in ${fixturesDir}`);
-    } else {
-      console.error(`Error: No fixtures found in ${fixturesDir}`);
-    }
-    process.exit(1);
+    throw new Error(
+      fixtureFilter
+        ? `Fixture "${fixtureFilter}" not found`
+        : "No fixtures found",
+    );
   }
-
   return fixtures;
 }
 
-// ============================================================
-// Ground truth loading
-// ============================================================
+function isEnoent(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
 
-export function loadGroundTruth(
-  benchmarkDir: string,
-  fixtureId: string,
-): GroundTruth | null {
-  const gtPath = join(benchmarkDir, 'ground-truth', `${fixtureId}.json`);
-  if (!existsSync(gtPath)) {
-    return null;
-  }
+function readOptionalText(path: string): string | null {
   try {
-    const raw = readFileSync(gtPath, 'utf-8');
-    return JSON.parse(raw) as GroundTruth;
-  } catch (err) {
-    console.error(`Error: Failed to parse ground truth for "${fixtureId}": ${err}`);
-    process.exit(1);
-    return null;
+    return readFileSync(path, "utf-8");
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
   }
 }
 
-// ============================================================
-// Agent prompt loading
-// ============================================================
+export function loadGroundTruth(
+  groundTruthDir: string,
+  fixture: Pick<Fixture, "id" | "domain">,
+): GroundTruth | null {
+  if (!statSync(groundTruthDir).isDirectory()) {
+    throw new Error(`Ground-truth path is not a directory: ${groundTruthDir}`);
+  }
+  const gtPath = join(groundTruthDir, `${fixture.id}.json`);
+  const raw = readOptionalText(gtPath);
+  if (raw === null) return null;
+  const parsed = validateSharedGroundTruth(JSON.parse(raw));
+  if (parsed.fixtureId !== fixture.id || parsed.domain !== fixture.domain) {
+    throw new Error(
+      `Ground truth identity mismatch: expected ${fixture.domain}:${fixture.id}, got ${parsed.domain}:${parsed.fixtureId}`,
+    );
+  }
+  return parsed;
+}
 
 export function stripFrontmatter(content: string): string {
   const match = content.match(/^---[\s\S]*?---\s*([\s\S]*)$/);
   return match ? match[1].trim() : content.trim();
 }
 
-/**
- * Load an agent prompt from the agents/ directory or a benchmark prompts/ archive.
- */
 export function loadAgentPrompt(
   agentName: string,
   benchmarkDir: string,
   repoRoot: string,
 ): string {
-  const candidatePaths = [
-    join(repoRoot, 'agents', `${agentName}.md`),
-    join(benchmarkDir, 'prompts', `${agentName}.md`),
-  ];
-  for (const agentPath of candidatePaths) {
-    try {
-      const content = readFileSync(agentPath, 'utf-8');
-      return stripFrontmatter(content);
-    } catch {
-      // Try the next candidate path
-    }
-  }
-  console.error(`Error: Could not load agent prompt for "${agentName}" from any known path`);
-  process.exit(1);
-  return '';
-}
+  const primaryPath = join(repoRoot, "agents", `${agentName}.md`);
+  const primary = readOptionalText(primaryPath);
+  if (primary !== null) return stripFrontmatter(primary);
 
-// ============================================================
-// Claude API call
-// ============================================================
+  const archivePath = join(benchmarkDir, "prompts", `${agentName}.md`);
+  const archive = readOptionalText(archivePath);
+  if (archive !== null) return stripFrontmatter(archive);
+
+  throw new Error(`Could not load agent prompt for "${agentName}"`);
+}
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -215,8 +206,8 @@ async function sleep(ms: number): Promise<void> {
 
 export interface ApiCallResult {
   text: string;
-  inputTokens: number;
-  outputTokens: number;
+  inputTokens?: number;
+  outputTokens?: number;
 }
 
 export async function callClaude(
@@ -232,116 +223,122 @@ export async function callClaude(
         model,
         max_tokens: 8192,
         system: systemPrompt,
-        messages: [
-          {
-            role: 'user',
-            content: userMessage,
-          },
-        ],
+        messages: [{ role: "user", content: userMessage }],
       });
-
-      const textBlock = response.content.find((b) => b.type === 'text');
-      if (!textBlock || textBlock.type !== 'text') {
-        throw new Error('No text content in Claude response');
-      }
+      const textBlock = response.content.find((block) => block.type === "text");
+      if (!textBlock || textBlock.type !== "text")
+        throw new Error("No text content in Claude response");
       return {
         text: textBlock.text,
-        inputTokens: response.usage?.input_tokens ?? 0,
-        outputTokens: response.usage?.output_tokens ?? 0,
+        inputTokens: response.usage?.input_tokens,
+        outputTokens: response.usage?.output_tokens,
       };
-    } catch (err: unknown) {
-      const isRetryable =
-        err instanceof Error &&
-        (err.message.includes('529') ||
-          err.message.includes('overloaded') ||
-          err.message.includes('rate') ||
-          err.message.includes('500'));
-      if (isRetryable && attempt < maxRetries) {
+    } catch (error: unknown) {
+      const retryable =
+        error instanceof Error &&
+        ["529", "overloaded", "rate", "500"].some((token) =>
+          error.message.includes(token),
+        );
+      if (retryable && attempt < maxRetries) {
         const delayMs = Math.min(1000 * 2 ** attempt, 60000);
-        process.stdout.write(`\n    Retrying in ${(delayMs / 1000).toFixed(0)}s (attempt ${attempt + 1}/${maxRetries})... `);
+        process.stdout.write(
+          `\n    Retrying in ${delayMs / 1000}s (attempt ${attempt + 1}/${maxRetries})... `,
+        );
         await sleep(delayMs);
         continue;
       }
-      throw err;
+      throw error;
     }
   }
-  throw new Error('Exhausted retries');
+  throw new Error("Exhausted retries");
 }
 
-/**
- * Create an Anthropic client, respecting environment variables.
- */
 export function createClient(): Anthropic {
-  const apiKey = process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN;
-  const baseURL = process.env.ANTHROPIC_BASE_URL;
-
-  if (!apiKey) {
-    console.error(
-      'Error: ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN environment variable is not set.\n' +
-      'Set it before running the benchmark.',
-    );
-    process.exit(1);
-  }
-
-  const opts: Record<string, unknown> = { apiKey };
-  if (baseURL) {
-    opts.baseURL = baseURL;
-  }
-
-  return new Anthropic(opts as ConstructorParameters<typeof Anthropic>[0]);
+  const apiKey =
+    process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN;
+  if (!apiKey)
+    throw new Error("ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN is not set");
+  const options: ConstructorParameters<typeof Anthropic>[0] = { apiKey };
+  if (process.env.ANTHROPIC_BASE_URL)
+    options.baseURL = process.env.ANTHROPIC_BASE_URL;
+  return new Anthropic(options);
 }
-
-// ============================================================
-// Console formatting helpers
-// ============================================================
 
 export function pct(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-export function padEnd(str: string, len: number): string {
-  return str.length >= len ? str : str + ' '.repeat(len - str.length);
+export function padEnd(value: string, length: number): string {
+  return value.length >= length
+    ? value
+    : value + " ".repeat(length - value.length);
 }
 
-export function printSummaryTable(results: FixtureResult[], agentTypes: string[]): void {
-  const fixtureIds = Array.from(new Set(results.map((r) => r.fixtureId))).sort();
-
-  console.log('\n=== Benchmark Results ===\n');
-  console.log(
-    padEnd('Fixture', 30) +
-    padEnd('Agent', 20) +
-    padEnd('Composite', 12) +
-    padEnd('TP Rate', 10) +
-    padEnd('FN Rate', 10) +
-    padEnd('Latency', 10),
+export function printSummaryTable(
+  results: FixtureResult[],
+  agentTypes: string[],
+): void {
+  const fixtureIdentities = Array.from(
+    new Map(
+      results.map((result) => [
+        `${result.domain}:${result.fixtureId}`,
+        { domain: result.domain, fixtureId: result.fixtureId },
+      ]),
+    ).values(),
+  ).sort((left, right) =>
+    `${left.domain}:${left.fixtureId}`.localeCompare(
+      `${right.domain}:${right.fixtureId}`,
+    ),
   );
-  console.log('-'.repeat(92));
+  console.log("\n=== Benchmark Results ===\n");
+  console.log(
+    padEnd("Fixture", 28) +
+      padEnd("Agent", 18) +
+      padEnd("Status", 10) +
+      padEnd("Quality", 10) +
+      padEnd("Tokens", 10) +
+      padEnd("API", 10) +
+      padEnd("Harness", 10),
+  );
+  console.log("-".repeat(96));
 
-  for (const fixtureId of fixtureIds) {
+  for (const { domain, fixtureId } of fixtureIdentities) {
     for (const agentType of agentTypes) {
       const result = results.find(
-        (r) => r.fixtureId === fixtureId && r.agentType === agentType,
+        (candidate) =>
+          candidate.domain === domain &&
+          candidate.fixtureId === fixtureId &&
+          candidate.agentType === agentType,
       );
       if (!result) continue;
-      const s = result.scores;
-      const latency = result.latencyMs ? `${(result.latencyMs / 1000).toFixed(1)}s` : '-';
       console.log(
-        padEnd(fixtureId, 30) +
-        padEnd(agentType, 20) +
-        padEnd(pct(s.compositeScore), 12) +
-        padEnd(pct(s.truePositiveRate), 10) +
-        padEnd(pct(s.falseNegativeRate), 10) +
-        padEnd(latency, 10),
+        padEnd(`${result.domain}:${fixtureId}`, 28) +
+          padEnd(agentType, 18) +
+          padEnd(result.completion, 10) +
+          padEnd(
+            result.completion === "completed"
+              ? pct(result.scores.compositeScore)
+              : "-",
+            10,
+          ) +
+          padEnd(result.totalTokens?.toString() ?? "-", 10) +
+          padEnd(
+            result.latencyMs === undefined
+              ? "-"
+              : `${result.latencyMs.toFixed(1)}ms`,
+            10,
+          ) +
+          padEnd(
+            result.harnessOverheadMs === undefined
+              ? "-"
+              : `${result.harnessOverheadMs.toFixed(1)}ms`,
+            10,
+          ),
       );
     }
   }
-
-  console.log('');
+  console.log("");
 }
-
-// ============================================================
-// Report file output
-// ============================================================
 
 export function writeReports(
   outputDir: string,
@@ -350,137 +347,252 @@ export function writeReports(
   agentB: string,
   model: string,
 ): void {
-  if (!existsSync(outputDir)) {
-    mkdirSync(outputDir, { recursive: true });
-  }
-
+  if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
   const jsonReport = generateComparisonReport(results, agentA, agentB, model);
   const markdownReport = generateMarkdownReport(jsonReport, agentA, agentB);
-
   const timestamp = new Date()
     .toISOString()
-    .replace(/[:.]/g, '-')
-    .replace('T', '_')
+    .replace(/[:.]/g, "-")
+    .replace("T", "_")
     .slice(0, 19);
-
-  const jsonPath = join(outputDir, `results_${timestamp}.json`);
-  const mdPath = join(outputDir, `report_${timestamp}.md`);
-  const latestJsonPath = join(outputDir, 'results.json');
-  const latestMdPath = join(outputDir, 'report.md');
-
-  writeFileSync(jsonPath, JSON.stringify(jsonReport, null, 2), 'utf-8');
-  writeFileSync(mdPath, markdownReport, 'utf-8');
-  writeFileSync(latestJsonPath, JSON.stringify(jsonReport, null, 2), 'utf-8');
-  writeFileSync(latestMdPath, markdownReport, 'utf-8');
-
-  console.log(`  Written: ${jsonPath}`);
-  console.log(`  Written: ${mdPath}`);
-  console.log(`  Latest:  ${latestJsonPath}`);
-  console.log(`  Latest:  ${latestMdPath}`);
+  for (const [path, content] of [
+    [
+      join(outputDir, `results_${timestamp}.json`),
+      JSON.stringify(jsonReport, null, 2),
+    ],
+    [join(outputDir, `report_${timestamp}.md`), markdownReport],
+    [join(outputDir, "results.json"), JSON.stringify(jsonReport, null, 2)],
+    [join(outputDir, "report.md"), markdownReport],
+  ] as const) {
+    writeFileSync(path, content, "utf-8");
+  }
 }
 
-// ============================================================
-// Generic benchmark runner
-// ============================================================
-
 export interface AgentConfig {
-  /** Agent type identifier for results labeling */
   agentType: string;
-  /** System prompt to use */
   systemPrompt: string;
-  /** User message template — receives fixture content as input */
   userMessageTemplate: (fixtureContent: string) => string;
 }
 
-/**
- * Run a full benchmark: iterate agents x fixtures, parse, score, report.
- */
-export async function runBenchmark(opts: {
+export interface Clock {
+  now(): number;
+}
+
+interface RunBenchmarkOptions {
   benchmarkDir: string;
   agents: AgentConfig[];
   fixtures: Fixture[];
   groundTruthDir: string;
   parseFn: (rawOutput: string, agentType: string) => ParsedAgentOutput;
   cliArgs: BenchmarkCliArgs;
-}): Promise<FixtureResult[]> {
-  const { agents, fixtures, parseFn, cliArgs } = opts;
+  clock?: Clock;
+  callApi?: (
+    systemPrompt: string,
+    userMessage: string,
+    model: string,
+  ) => Promise<ApiCallResult>;
+  scoreFn?: typeof scoreFixtureShared;
+  matchFn?: typeof matchFindingsShared;
+}
 
+function totalTokens(result: ApiCallResult | undefined): number | undefined {
+  return result?.inputTokens !== undefined && result.outputTokens !== undefined
+    ? result.inputTokens + result.outputTokens
+    : undefined;
+}
+
+function failedResult(input: {
+  fixture: Fixture;
+  agentType: string;
+  reason: FailureReason;
+  apiResult?: ApiCallResult;
+  latencyMs?: number;
+  harnessOverheadMs?: number;
+  groundTruthMissing?: boolean;
+}): FailedFixtureResult {
+  return {
+    fixtureId: input.fixture.id,
+    domain: input.fixture.domain,
+    agentType: input.agentType,
+    completion: "failed",
+    failureReason: input.reason,
+    groundTruthMissing: input.groundTruthMissing,
+    matchedFindings: [],
+    missedFindings: [],
+    spuriousFindings: [],
+    latencyMs: input.latencyMs,
+    harnessOverheadMs: input.harnessOverheadMs,
+    inputTokens: input.apiResult?.inputTokens,
+    outputTokens: input.apiResult?.outputTokens,
+    totalTokens: totalTokens(input.apiResult),
+  };
+}
+
+export function countFailures(results: FixtureResult[]): number {
+  return results.filter((result) => result.completion === "failed").length;
+}
+
+export function exitCodeForResults(results: FixtureResult[]): 0 | 1 {
+  return countFailures(results) > 0 ? 1 : 0;
+}
+
+export async function runBenchmark(
+  options: RunBenchmarkOptions,
+): Promise<FixtureResult[]> {
+  const { agents, fixtures, parseFn, cliArgs } = options;
   if (cliArgs.dryRun) {
-    console.log('\nDry run complete. Pipeline validated — skipping API calls.');
-    console.log(`  Agents:     ${agents.map((a) => a.agentType).join(', ')}`);
-    console.log(`  Fixtures:   ${fixtures.map((f) => f.id).join(', ')}`);
-    console.log(`  Model:      ${cliArgs.model}`);
-    console.log(`  Output dir: ${cliArgs.outputDir}`);
+    console.log("\nDry run complete. Pipeline validated — skipping API calls.");
     return [];
   }
 
-  const client = createClient();
+  const clock = options.clock ?? { now: () => performance.now() };
+  const invoke =
+    options.callApi ??
+    (() => {
+      const client = createClient();
+      return (systemPrompt: string, userMessage: string, model: string) =>
+        callClaude(client, systemPrompt, userMessage, model);
+    })();
+  const scoreFn = options.scoreFn ?? scoreFixtureShared;
+  const matchFn = options.matchFn ?? matchFindingsShared;
   const allResults: FixtureResult[] = [];
-  const totalRuns = fixtures.length * agents.length;
-
-  console.log(
-    `\nRunning benchmark: ${totalRuns} run(s) total` +
-    ` (${agents.map((a) => a.agentType).join(', ')} x ${fixtures.length} fixture(s))...\n`,
-  );
 
   for (const agent of agents) {
     for (const fixture of fixtures) {
-      const label = `${agent.agentType} on ${fixture.id}`;
-      process.stdout.write(`Running ${label}... `);
-      const startMs = Date.now();
-
-      let apiResult: ApiCallResult;
+      process.stdout.write(`Running ${agent.agentType} on ${fixture.id}... `);
+      let userMessage: string;
       try {
-        apiResult = await callClaude(
-          client,
-          agent.systemPrompt,
-          agent.userMessageTemplate(fixture.content),
-          cliArgs.model,
+        userMessage = agent.userMessageTemplate(fixture.content);
+      } catch (error) {
+        console.log("FAILED (prompt)");
+        console.error(error);
+        allResults.push(
+          failedResult({
+            fixture,
+            agentType: agent.agentType,
+            reason: "prompt",
+          }),
         );
-      } catch (err) {
-        const elapsedS = ((Date.now() - startMs) / 1000).toFixed(1);
-        console.log(`FAILED (${elapsedS}s)`);
-        console.error(`  Error calling Claude API: ${err}`);
-        process.exit(1);
+        continue;
       }
 
-      const elapsedMs = Date.now() - startMs;
-      console.log(`done (${(elapsedMs / 1000).toFixed(1)}s)`);
+      const apiStart = clock.now();
+      let apiResult: ApiCallResult;
+      try {
+        apiResult = await invoke(
+          agent.systemPrompt,
+          userMessage,
+          cliArgs.model,
+        );
+      } catch (error) {
+        const latencyMs = clock.now() - apiStart;
+        console.log(`FAILED (${latencyMs.toFixed(1)}ms)`);
+        console.error(error);
+        allResults.push(
+          failedResult({
+            fixture,
+            agentType: agent.agentType,
+            reason: "api",
+            latencyMs,
+          }),
+        );
+        continue;
+      }
+      const latencyMs = clock.now() - apiStart;
+      const overheadStart = clock.now();
 
-      // Parse agent output
-      const parsedOutput = parseFn(apiResult.text, agent.agentType);
+      let parsedOutput: ParsedAgentOutput;
+      try {
+        parsedOutput = parseFn(apiResult.text, agent.agentType);
+      } catch (error) {
+        console.log("FAILED (parse)");
+        console.error(error);
+        allResults.push(
+          failedResult({
+            fixture,
+            agentType: agent.agentType,
+            reason: "parse",
+            apiResult,
+            latencyMs,
+            harnessOverheadMs: clock.now() - overheadStart,
+          }),
+        );
+        continue;
+      }
 
-      // Load ground truth
-      const groundTruth: GroundTruth = loadGroundTruth(opts.benchmarkDir, fixture.id) ?? {
+      const groundTruth = loadGroundTruth(options.groundTruthDir, fixture);
+      if (!groundTruth) {
+        console.log("FAILED (missing ground truth)");
+        allResults.push(
+          failedResult({
+            fixture,
+            agentType: agent.agentType,
+            reason: "missing-ground-truth",
+            apiResult,
+            latencyMs,
+            harnessOverheadMs: clock.now() - overheadStart,
+            groundTruthMissing: true,
+          }),
+        );
+        continue;
+      }
+
+      let scores: BenchmarkScores;
+      try {
+        scores = scoreFn(parsedOutput, groundTruth);
+      } catch (error) {
+        console.log("FAILED (score)");
+        console.error(error);
+        allResults.push(
+          failedResult({
+            fixture,
+            agentType: agent.agentType,
+            reason: "score",
+            apiResult,
+            latencyMs,
+            harnessOverheadMs: clock.now() - overheadStart,
+          }),
+        );
+        continue;
+      }
+
+      let matchResult: ReturnType<typeof matchFindingsShared>;
+      try {
+        matchResult = matchFn(parsedOutput, groundTruth);
+      } catch (error) {
+        console.log("FAILED (match)");
+        console.error(error);
+        allResults.push(
+          failedResult({
+            fixture,
+            agentType: agent.agentType,
+            reason: "match",
+            apiResult,
+            latencyMs,
+            harnessOverheadMs: clock.now() - overheadStart,
+          }),
+        );
+        continue;
+      }
+
+      allResults.push({
         fixtureId: fixture.id,
-        fixturePath: fixture.id,
-        domain: fixture.domain as GroundTruth['domain'],
-        expectedVerdict: 'REJECT',
-        findings: [],
-        isCleanBaseline: false,
-      };
-
-      // Score
-      const scores = scoreFixture(parsedOutput, groundTruth);
-      const matchResult = matchFindings(parsedOutput, groundTruth);
-
-      const fixtureResult: FixtureResult = {
-        fixtureId: fixture.id,
-        domain: groundTruth.domain,
+        domain: fixture.domain,
         agentType: agent.agentType,
+        completion: "completed",
         parsedOutput,
         scores,
         matchedFindings: matchResult.matchedIds,
         missedFindings: matchResult.missedIds,
         spuriousFindings: matchResult.spuriousTexts,
-        latencyMs: elapsedMs,
+        latencyMs,
+        harnessOverheadMs: clock.now() - overheadStart,
         inputTokens: apiResult.inputTokens,
         outputTokens: apiResult.outputTokens,
-      };
-
-      allResults.push(fixtureResult);
+        totalTokens: totalTokens(apiResult),
+      });
+      console.log(`done (${latencyMs.toFixed(1)}ms)`);
     }
   }
-
   return allResults;
 }

--- a/benchmarks/shared/scorer.ts
+++ b/benchmarks/shared/scorer.ts
@@ -1,12 +1,222 @@
-/**
- * Shared scorer — re-exports from harsh-critic scoring module.
- *
- * The harsh-critic scorer is the reference implementation. This module
- * re-exports its functions so all agent benchmarks use the same scoring logic.
- */
+import {
+  aggregateScores as aggregateCanonicalScores,
+  matchFindings as matchCanonicalFindings,
+  scoreFixture as scoreCanonicalFixture,
+} from "../harsh-critic/scoring/scorer.ts";
+import type {
+  AgentType as CanonicalAgentType,
+  Domain as CanonicalDomain,
+  FixtureResult as CanonicalFixtureResult,
+  GroundTruth as CanonicalGroundTruth,
+  HarshCriticVerdict,
+} from "../harsh-critic/scoring/types.ts";
+import type {
+  BenchmarkScores,
+  CompletedFixtureResult,
+  Domain,
+  FixtureResult,
+  GroundTruth,
+  GroundTruthFinding,
+  ParsedAgentOutput,
+} from "./types.ts";
 
-export {
-  matchFindings,
-  scoreFixture,
-  aggregateScores,
-} from '../harsh-critic/scoring/scorer.ts';
+const CANONICAL_DOMAIN_PROJECTION: Record<Domain, CanonicalDomain> = {
+  plan: "plan",
+  code: "code",
+  analysis: "analysis",
+  bug: "analysis",
+  task: "analysis",
+};
+
+function canonicalVerdict(value: string | undefined): HarshCriticVerdict {
+  return value === "REJECT" ||
+    value === "REVISE" ||
+    value === "ACCEPT" ||
+    value === "ACCEPT-WITH-RESERVATIONS"
+    ? value
+    : "REJECT";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isDomain(value: unknown): value is Domain {
+  return (
+    value === "plan" ||
+    value === "code" ||
+    value === "analysis" ||
+    value === "bug" ||
+    value === "task"
+  );
+}
+
+function validateFinding(value: unknown, index: number): GroundTruthFinding {
+  if (!isRecord(value))
+    throw new Error(`Ground truth finding ${index} must be an object`);
+  if (typeof value.id !== "string" || value.id.length === 0) {
+    throw new Error(`Ground truth finding ${index} has no id`);
+  }
+  if (
+    !Array.isArray(value.keywords) ||
+    value.keywords.some((keyword) => typeof keyword !== "string")
+  ) {
+    throw new Error(`Ground truth finding ${index} has invalid keywords`);
+  }
+  if (value.keywords.length === 0) {
+    throw new Error(
+      `Ground truth finding ${index} must have at least one keyword`,
+    );
+  }
+  const severity = value.severity;
+  if (severity !== "CRITICAL" && severity !== "MAJOR" && severity !== "MINOR") {
+    throw new Error(`Ground truth finding ${index} has invalid severity`);
+  }
+  const category = value.category;
+  if (
+    category !== "finding" &&
+    category !== "missing" &&
+    category !== "perspective"
+  ) {
+    throw new Error(`Ground truth finding ${index} has invalid category`);
+  }
+  const perspective = value.perspective;
+  if (
+    perspective !== undefined &&
+    perspective !== "security" &&
+    perspective !== "new-hire" &&
+    perspective !== "ops"
+  ) {
+    throw new Error(`Ground truth finding ${index} has invalid perspective`);
+  }
+  if (
+    typeof value.summary !== "string" ||
+    typeof value.explanation !== "string"
+  ) {
+    throw new Error(`Ground truth finding ${index} has invalid text fields`);
+  }
+  if (value.location !== undefined && typeof value.location !== "string") {
+    throw new Error(`Ground truth finding ${index} has invalid location`);
+  }
+  return {
+    id: value.id,
+    severity,
+    category,
+    perspective,
+    summary: value.summary,
+    keywords: value.keywords.map((keyword) => String(keyword)),
+    location: value.location,
+    explanation: value.explanation,
+  };
+}
+
+export function validateSharedGroundTruth(value: unknown): GroundTruth {
+  if (!isRecord(value)) throw new Error("Ground truth must be an object");
+  if (typeof value.fixtureId !== "string" || value.fixtureId.length === 0) {
+    throw new Error("Ground truth fixtureId is required");
+  }
+  if (typeof value.fixturePath !== "string" || value.fixturePath.length === 0) {
+    throw new Error("Ground truth fixturePath is required");
+  }
+  if (!isDomain(value.domain))
+    throw new Error(`Unsupported ground truth domain: ${String(value.domain)}`);
+  if (!Array.isArray(value.findings))
+    throw new Error("Ground truth findings must be an array");
+  if (typeof value.isCleanBaseline !== "boolean") {
+    throw new Error("Ground truth isCleanBaseline must be boolean");
+  }
+  const findings = value.findings.map(validateFinding);
+  const findingIds = new Set<string>();
+  for (const finding of findings) {
+    if (findingIds.has(finding.id)) {
+      throw new Error(`Duplicate ground truth finding id: ${finding.id}`);
+    }
+    findingIds.add(finding.id);
+  }
+  return {
+    fixtureId: value.fixtureId,
+    fixturePath: value.fixturePath,
+    domain: value.domain,
+    expectedVerdict:
+      typeof value.expectedVerdict === "string"
+        ? value.expectedVerdict
+        : undefined,
+    findings,
+    isCleanBaseline: value.isCleanBaseline,
+  };
+}
+
+export function normalizeForSharedScoring(
+  groundTruth: GroundTruth,
+): CanonicalGroundTruth {
+  const validated = validateSharedGroundTruth(groundTruth);
+  return {
+    fixtureId: validated.fixtureId,
+    fixturePath: validated.fixturePath,
+    domain: CANONICAL_DOMAIN_PROJECTION[validated.domain],
+    // The canonical scorer does not read this field. Keep non-canonical placeholders private.
+    expectedVerdict: canonicalVerdict(validated.expectedVerdict),
+    findings: validated.findings.map((finding) => ({
+      id: finding.id,
+      severity: finding.severity,
+      category: finding.category,
+      perspective: finding.perspective,
+      summary: finding.summary,
+      keywords: [...finding.keywords],
+      location: finding.location,
+      explanation: finding.explanation,
+    })),
+    isCleanBaseline: validated.isCleanBaseline,
+  };
+}
+
+export function scoreFixtureShared(
+  parsedOutput: ParsedAgentOutput,
+  groundTruth: GroundTruth,
+): BenchmarkScores {
+  return scoreCanonicalFixture(
+    parsedOutput,
+    normalizeForSharedScoring(groundTruth),
+  );
+}
+
+export function matchFindingsShared(
+  parsedOutput: ParsedAgentOutput,
+  groundTruth: GroundTruth,
+): { matchedIds: string[]; missedIds: string[]; spuriousTexts: string[] } {
+  const result = matchCanonicalFindings(
+    parsedOutput,
+    normalizeForSharedScoring(groundTruth),
+  );
+  return {
+    matchedIds: result.matchedIds,
+    missedIds: result.missedIds,
+    spuriousTexts: result.spuriousTexts,
+  };
+}
+
+function toCanonicalResult(
+  result: CompletedFixtureResult,
+): CanonicalFixtureResult {
+  return {
+    fixtureId: result.fixtureId,
+    domain: CANONICAL_DOMAIN_PROJECTION[result.domain],
+    agentType: "critic" satisfies CanonicalAgentType,
+    parsedOutput: result.parsedOutput,
+    scores: result.scores,
+    matchedFindings: [...result.matchedFindings],
+    missedFindings: [...result.missedFindings],
+    spuriousFindings: [...result.spuriousFindings],
+  };
+}
+
+export function aggregateScoresUnknownCapable(
+  results: FixtureResult[],
+): BenchmarkScores | null {
+  const completed = results.filter(
+    (result): result is CompletedFixtureResult =>
+      result.completion === "completed",
+  );
+  if (completed.length === 0) return null;
+  return aggregateCanonicalScores(completed.map(toCanonicalResult));
+}

--- a/benchmarks/shared/types.ts
+++ b/benchmarks/shared/types.ts
@@ -1,244 +1,178 @@
-/**
- * Generalized Benchmark Scoring Types for Agent Evaluation
- *
- * Extends the harsh-critic scoring types to support all agent benchmarks:
- * code-reviewer, debugger, executor, and critic/harsh-critic.
- */
+// Generalized benchmark scoring types for shared agent evaluations.
 
-// ============================================================
-// GROUND TRUTH
-// ============================================================
-
-export type Severity = 'CRITICAL' | 'MAJOR' | 'MINOR';
-
-export type FindingCategory = 'finding' | 'missing' | 'perspective';
-
-export type Perspective = 'security' | 'new-hire' | 'ops';
-
-/** Domains across all agent types */
-export type Domain = 'plan' | 'code' | 'analysis' | 'bug' | 'task';
-
-/** Agent type is a free-form string to support any agent benchmark */
+export type Severity = "CRITICAL" | "MAJOR" | "MINOR";
+export type FindingCategory = "finding" | "missing" | "perspective";
+export type Perspective = "security" | "new-hire" | "ops";
+export type Domain = "plan" | "code" | "analysis" | "bug" | "task";
 export type AgentType = string;
 
-/**
- * A single expected finding in a fixture's ground truth.
- * Each finding has keywords that must appear in a matching agent output.
- */
 export interface GroundTruthFinding {
-  /** Unique identifier, e.g. "AUTH-CRIT-1" */
   id: string;
-  /** Expected severity level */
   severity: Severity;
-  /** Whether this is a direct finding, a missing item, or a perspective-specific finding */
   category: FindingCategory;
-  /** Which perspective this finding relates to (if category is 'perspective') */
   perspective?: Perspective;
-  /** Short description of the embedded flaw */
   summary: string;
-  /** Keywords that must appear in a matching agent finding (>= 2 must match) */
   keywords: string[];
-  /** File:line or section reference if applicable */
   location?: string;
-  /** Why this is a real issue (for documentation) */
   explanation: string;
 }
 
-/**
- * Ground truth for a single fixture.
- * Generalized to support all agent types.
- */
 export interface GroundTruth {
-  /** Fixture identifier matching the filename (without extension) */
   fixtureId: string;
-  /** Path to the fixture file relative to the benchmark directory */
   fixturePath: string;
-  /** Domain of the fixture */
   domain: Domain;
-  /** Expected verdict/classification from the agent (optional — not all agents produce verdicts) */
   expectedVerdict?: string;
-  /** All expected findings embedded in the fixture */
   findings: GroundTruthFinding[];
-  /** Whether this is a clean baseline (for false-positive testing) */
   isCleanBaseline: boolean;
 }
 
-// ============================================================
-// PARSED AGENT OUTPUT
-// ============================================================
-
-/**
- * A single finding extracted from agent output.
- */
 export interface ParsedFinding {
-  /** Raw text of the finding */
   text: string;
-  /** Severity as stated by the agent */
   severity: Severity;
-  /** Whether the finding includes file:line or specific code references */
   hasEvidence: boolean;
-  /** ID of the matched ground-truth finding (set during scoring) */
   matchedGroundTruth?: string;
 }
 
-/**
- * Structured representation of an agent's output.
- * Generalized to cover all agent types — not all fields are relevant for all agents.
- */
 export interface ParsedAgentOutput {
-  /** The agent's verdict/classification string (if applicable) */
   verdict: string;
-  /** Findings categorized by severity */
   criticalFindings: ParsedFinding[];
   majorFindings: ParsedFinding[];
   minorFindings: ParsedFinding[];
-  /** Items from the "What's Missing" section */
   missingItems: string[];
-  /** Multi-perspective notes (critic/reviewer agents) */
   perspectiveNotes: {
     security: string[];
     newHire: string[];
     ops: string[];
   };
-  /** Whether the agent made pre-commitment predictions before investigation */
   hasPreCommitment: boolean;
-  /** Whether the agent's output includes a gap analysis section */
   hasGapAnalysis: boolean;
-  /** Whether the agent addressed multiple perspectives */
   hasMultiPerspective: boolean;
-  /** Raw output text (for debugging) */
   rawOutput: string;
 }
 
-// ============================================================
-// SCORING
-// ============================================================
-
-/**
- * Scores for a single agent run against a single fixture.
- */
 export interface BenchmarkScores {
-  // Core detection metrics (0-1 scale)
-  /** Findings that match ground truth / total ground truth */
   truePositiveRate: number;
-  /** Findings that don't match any ground truth / total agent findings */
   falsePositiveRate: number;
-  /** Ground truth items not found / total ground truth */
   falseNegativeRate: number;
-
-  // Severity accuracy
-  /** Correct severity rating / total matched findings */
   severityAccuracy: number;
-
-  // Gap detection (the key differentiator)
-  /** "What's Missing" items matching ground truth / total missing-category ground truth */
   missingCoverage: number;
-  /** Perspective findings matching ground truth / total perspective-category ground truth */
   perspectiveCoverage: number;
-
-  // Evidence quality
-  /** CRITICAL+MAJOR findings with file:line evidence / total CRITICAL+MAJOR findings */
   evidenceRate: number;
-
-  // Process compliance (boolean flags)
-  /** Pre-commitment predictions present */
   hasPreCommitment: boolean;
-  /** All 3 perspectives addressed */
   hasMultiPerspective: boolean;
-  /** "What's Missing" section present and non-empty */
   hasGapAnalysis: boolean;
-
-  // Aggregate
-  /** Weighted combination of all metrics */
   compositeScore: number;
 }
 
-/**
- * Result of running one agent against one fixture.
- */
-export interface FixtureResult {
+export type RunCompletion = "completed" | "failed";
+export type FailureReason =
+  | "api"
+  | "prompt"
+  | "parse"
+  | "score"
+  | "match"
+  | "missing-ground-truth";
+
+export interface FixtureResultBase {
   fixtureId: string;
   domain: Domain;
   agentType: AgentType;
+  completion: RunCompletion;
+  matchedFindings: string[];
+  missedFindings: string[];
+  spuriousFindings: string[];
+  /** Retry-inclusive API-call span. It is not pure model compute time. */
+  latencyMs?: number;
+  /** Non-API processing after the API response. */
+  harnessOverheadMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Present only when both input and output usage are available. */
+  totalTokens?: number;
+  groundTruthMissing?: boolean;
+}
+
+export interface CompletedFixtureResult extends FixtureResultBase {
+  completion: "completed";
   parsedOutput: ParsedAgentOutput;
   scores: BenchmarkScores;
-  /** Ground truth findings that were matched */
-  matchedFindings: string[];
-  /** Ground truth findings that were missed */
-  missedFindings: string[];
-  /** Agent findings that didn't match any ground truth */
-  spuriousFindings: string[];
-  /** Latency in milliseconds */
-  latencyMs?: number;
-  /** Input tokens consumed */
-  inputTokens?: number;
-  /** Output tokens consumed */
-  outputTokens?: number;
 }
 
-/**
- * Aggregated result for a single agent across all fixtures.
- */
-export interface AgentBenchmarkReport {
-  /** Timestamp of the benchmark run */
-  timestamp: string;
-  /** Model used for the benchmark */
-  model: string;
-  /** Agent being benchmarked */
-  agentType: AgentType;
-  /** Per-fixture results */
-  results: FixtureResult[];
-  /** Aggregate scores */
-  aggregateScores: BenchmarkScores;
+export interface FailedFixtureResult extends FixtureResultBase {
+  completion: "failed";
+  failureReason: FailureReason;
+  parsedOutput?: never;
+  scores?: never;
 }
 
-/**
- * Comparison report between two agents (old vs new prompt).
- */
+export type FixtureResult = CompletedFixtureResult | FailedFixtureResult;
+
+export interface CompletionCoverage {
+  completedA: number;
+  failedA: number;
+  completedB: number;
+  failedB: number;
+  failureReasonsA: Partial<Record<FailureReason, number>>;
+  failureReasonsB: Partial<Record<FailureReason, number>>;
+  pairedFixtures: number;
+  aOnlyKeys: string[];
+  bOnlyKeys: string[];
+}
+
+export interface NumericDiagnostic {
+  a?: number;
+  b?: number;
+  delta?: number;
+  pairedCount: number;
+  unit: "tokens" | "milliseconds";
+  status: "compared" | "insufficient";
+}
+
+export interface TokenDimensionDiagnostic {
+  total: NumericDiagnostic;
+  perFixtureMean: NumericDiagnostic;
+}
+
+export interface TokenDiagnostic {
+  input: TokenDimensionDiagnostic;
+  output: TokenDimensionDiagnostic;
+  all: TokenDimensionDiagnostic;
+}
+
+export interface DiagnosticComparison {
+  completion: CompletionCoverage;
+  qualityPairedCount: number;
+  tokenCost: TokenDiagnostic;
+  apiLatency: NumericDiagnostic;
+  harnessOverhead: NumericDiagnostic;
+  validity: "valid" | "inconclusive";
+  reasons: string[];
+}
+
 export interface ComparisonReport {
-  /** Timestamp of the benchmark run */
   timestamp: string;
-  /** Model used for the benchmark */
   model: string;
-  /** Per-fixture results for each agent */
   results: FixtureResult[];
-  /** Aggregate scores per agent */
-  aggregateScores: Record<AgentType, BenchmarkScores>;
-  /** Per-metric deltas (agent A minus agent B) */
+  aggregateScores: Record<AgentType, BenchmarkScores | null>;
   deltas: Partial<Record<keyof BenchmarkScores, number>>;
-  /** Per-fixture win/loss/tie */
   headToHead: Array<{
     fixtureId: string;
-    winner: AgentType | 'tie';
+    domain: Domain;
+    winner: AgentType | "tie";
     delta: number;
   }>;
+  diagnostics: DiagnosticComparison;
 }
 
-// ============================================================
-// SCORING WEIGHTS
-// ============================================================
-
-/**
- * Weights for composite score calculation.
- * Sum to 1.0.
- */
 export const SCORING_WEIGHTS = {
   truePositiveRate: 0.25,
-  falseNegativeRate: 0.15,   // inverted: lower is better
-  falsePositiveRate: 0.10,   // inverted: lower is better
-  missingCoverage: 0.20,     // key differentiator
-  perspectiveCoverage: 0.10,
-  evidenceRate: 0.10,
-  processCompliance: 0.10,
+  falseNegativeRate: 0.15,
+  falsePositiveRate: 0.1,
+  missingCoverage: 0.2,
+  perspectiveCoverage: 0.1,
+  evidenceRate: 0.1,
+  processCompliance: 0.1,
 } as const;
 
-/**
- * Minimum keyword matches required to consider a ground truth finding "matched".
- */
 export const MIN_KEYWORD_MATCHES = 2;
-
-/**
- * Whether severity must match exactly or can be within 1 level.
- * Adjacent severities: CRITICAL<->MAJOR, MAJOR<->MINOR
- */
 export const ALLOW_ADJACENT_SEVERITY = true;

--- a/docs/PERFORMANCE-MONITORING.md
+++ b/docs/PERFORMANCE-MONITORING.md
@@ -274,6 +274,24 @@ console.log(`Active: ${eff.active}, Stale: ${eff.stale}, Total: ${eff.total}`);
 - **<80%**: Some agents stale or waiting
 - **<50%**: Significant parallelization issues
 
+This score is a live activity/health signal. It is not a benchmark of model quality, token cost, latency, or harness overhead.
+
+### Benchmark Efficiency Diagnostic
+
+The TypeScript agent benchmarks under `benchmarks/` report these dimensions separately:
+
+- **Run completion**: whether each agent/fixture run completed or failed.
+- **Scorer quality**: ground-truth-based benchmark scores for completed paired runs.
+- **Token cost proxy**: API-reported input, output, and combined tokens, shown as paired totals and per-fixture means; missing usage is `insufficient`/unavailable, never zero.
+- **API latency**: the retry-inclusive API-call span. It is not pure model compute time.
+- **Harness overhead**: measured non-API processing after the API response, including parsing, ground-truth loading, scoring, matching, and result construction.
+
+Comparison deltas use matching `(domain, fixtureId)` observations for each dimension. Unpaired fixtures, failed runs, or missing telemetry make the diagnostic `INCONCLUSIVE`; they are not treated as improvements or regressions. The report deliberately does not collapse these dimensions into one efficiency score.
+
+Prompt, fixture, and ground-truth I/O failures fail closed instead of silently changing the compared inputs. An absent per-fixture label is reported as a recoverable failed run, while a missing label root or malformed/invalid label is fatal configuration evidence. Recoverable per-fixture failures remain visible in the report, and the shared benchmark CLI exits nonzero after writing the diagnostic when any run failed.
+
+A diagnostic report alone cannot prove that a particular model, including Opus, regressed. A model claim requires controlled paired runs with the same fixtures, prompts, model identity, configuration, and complete measurements. Even then, the timing fields do not attribute differences to model compute, network conditions, provider queues, retries, or harness internals beyond their documented boundaries.
+
 ### Stale Agent Cleanup
 
 Clean up agents that exceed the timeout threshold:

--- a/tests/benchmark-diagnostics.test.ts
+++ b/tests/benchmark-diagnostics.test.ts
@@ -1,0 +1,789 @@
+import type Anthropic from "@anthropic-ai/sdk";
+
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DuplicateFixtureKeyError,
+  generateComparisonReport,
+  generateMarkdownReport,
+  keyOf,
+  pairResults,
+} from "../benchmarks/shared/reporter.ts";
+import {
+  countFailures,
+  callClaude,
+  exitCodeForResults,
+  fixtureDomainFromDirectory,
+  loadGroundTruth,
+  parseCliArgs,
+  printSummaryTable,
+  runBenchmark,
+  type Clock,
+} from "../benchmarks/shared/runner.ts";
+import {
+  normalizeForSharedScoring,
+  matchFindingsShared,
+  scoreFixtureShared,
+  validateSharedGroundTruth,
+} from "../benchmarks/shared/scorer.ts";
+import type {
+  BenchmarkScores,
+  CompletedFixtureResult,
+  FixtureResult,
+  GroundTruth,
+  ParsedAgentOutput,
+} from "../benchmarks/shared/types.ts";
+
+const scores: BenchmarkScores = {
+  truePositiveRate: 1,
+  falsePositiveRate: 0,
+  falseNegativeRate: 0,
+  severityAccuracy: 1,
+  missingCoverage: 1,
+  perspectiveCoverage: 1,
+  evidenceRate: 1,
+  hasPreCommitment: true,
+  hasMultiPerspective: true,
+  hasGapAnalysis: true,
+  compositeScore: 1,
+};
+
+const parsed: ParsedAgentOutput = {
+  verdict: "OKAY",
+  criticalFindings: [],
+  majorFindings: [],
+  minorFindings: [],
+  missingItems: [],
+  perspectiveNotes: { security: [], newHire: [], ops: [] },
+  hasPreCommitment: true,
+  hasGapAnalysis: true,
+  hasMultiPerspective: true,
+  rawOutput: "OKAY",
+};
+
+const groundTruth: GroundTruth = {
+  fixtureId: "fixture-1",
+  fixturePath: "fixture-1.json",
+  domain: "code",
+  expectedVerdict: "OKAY",
+  findings: [],
+  isCleanBaseline: true,
+};
+
+function completed(
+  agentType: string,
+  overrides: Partial<CompletedFixtureResult> = {},
+): CompletedFixtureResult {
+  return {
+    fixtureId: "fixture-1",
+    domain: "code",
+    agentType,
+    completion: "completed",
+    parsedOutput: parsed,
+    scores,
+    matchedFindings: [],
+    missedFindings: [],
+    spuriousFindings: [],
+    latencyMs: 20,
+    harnessOverheadMs: 5,
+    inputTokens: 10,
+    outputTokens: 4,
+    totalTokens: 14,
+    ...overrides,
+  };
+}
+
+function benchmarkDir(): string {
+  const directory = mkdtempSync(join(tmpdir(), "benchmark-diagnostic-"));
+  mkdirSync(join(directory, "ground-truth"));
+  return directory;
+}
+
+describe("benchmark diagnostic contracts", () => {
+  it("maps fixture directories without inherited-key fallthrough", () => {
+    expect(fixtureDomainFromDirectory("code")).toBe("code");
+    expect(fixtureDomainFromDirectory("bugs")).toBe("bug");
+    expect(fixtureDomainFromDirectory("tasks")).toBe("task");
+    expect(fixtureDomainFromDirectory("plans")).toBe("plan");
+    expect(() => fixtureDomainFromDirectory("bug")).toThrow(
+      "Unsupported fixture directory",
+    );
+    expect(() => fixtureDomainFromDirectory("toString")).toThrow(
+      "Unsupported fixture directory",
+    );
+  });
+
+  it("preserves unknown CLI argument passthrough", () => {
+    const originalArgv = process.argv;
+    process.argv = ["node", "runner", "--external-flag", "value", "--dry-run"];
+    try {
+      expect(parseCliArgs(["a", "b"], "results")).toMatchObject({
+        agents: ["a", "b"],
+        dryRun: true,
+      });
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it("validates shared ground truth and rejects unsupported domains", () => {
+    expect(validateSharedGroundTruth(groundTruth)).toEqual(groundTruth);
+    expect(() =>
+      validateSharedGroundTruth({ ...groundTruth, domain: "unknown" }),
+    ).toThrow("Unsupported ground truth domain");
+    expect(() =>
+      validateSharedGroundTruth({
+        ...groundTruth,
+        findings: [
+          {
+            id: "empty",
+            severity: "MINOR",
+            category: "finding",
+            summary: "x",
+            keywords: [],
+            explanation: "x",
+          },
+        ],
+      }),
+    ).toThrow("must have at least one keyword");
+    const duplicateFinding = {
+      id: "duplicate",
+      severity: "MINOR" as const,
+      category: "finding" as const,
+      summary: "x",
+      keywords: ["x"],
+      explanation: "x",
+    };
+    expect(() =>
+      validateSharedGroundTruth({
+        ...groundTruth,
+        findings: [duplicateFinding, duplicateFinding],
+      }),
+    ).toThrow("Duplicate ground truth finding id");
+  });
+
+  it("projects bug and task domains only for canonical scoring", () => {
+    const bug = normalizeForSharedScoring({
+      ...groundTruth,
+      fixtureId: "bug-1",
+      fixturePath: "bug-1.json",
+      domain: "bug",
+      expectedVerdict: "root-cause",
+    });
+    const task = normalizeForSharedScoring({
+      ...groundTruth,
+      fixtureId: "task-1",
+      fixturePath: "task-1.json",
+      domain: "task",
+      expectedVerdict: "trivial",
+    });
+    expect(bug.domain).toBe("analysis");
+    expect(task.domain).toBe("analysis");
+    expect(bug.expectedVerdict).toBe("REJECT");
+    expect(
+      normalizeForSharedScoring({ ...groundTruth, expectedVerdict: "REVISE" })
+        .expectedVerdict,
+    ).toBe("REVISE");
+    expect(
+      normalizeForSharedScoring({
+        ...groundTruth,
+        expectedVerdict: "ACCEPT-WITH-RESERVATIONS",
+      }).expectedVerdict,
+    ).toBe("ACCEPT-WITH-RESERVATIONS");
+  });
+
+  it("projects real debugger and executor labels without changing identity", () => {
+    const bug = loadGroundTruth(
+      join(process.cwd(), "benchmarks", "debugger", "ground-truth"),
+      { id: "bug-redis-intermittent", domain: "bug" },
+    );
+    const task = loadGroundTruth(
+      join(process.cwd(), "benchmarks", "executor", "ground-truth"),
+      { id: "task-add-timestamp", domain: "task" },
+    );
+    if (!bug || !task)
+      throw new Error("Expected real debugger and executor labels");
+    expect(normalizeForSharedScoring(bug)).toMatchObject({
+      fixtureId: "bug-redis-intermittent",
+      domain: "analysis",
+    });
+    expect(normalizeForSharedScoring(task)).toMatchObject({
+      fixtureId: "task-add-timestamp",
+      domain: "analysis",
+    });
+    expect(scoreFixtureShared(parsed, bug)).toEqual(
+      scoreFixtureShared(parsed, { ...bug, domain: "analysis" }),
+    );
+    expect(matchFindingsShared(parsed, task)).toEqual(
+      matchFindingsShared(parsed, { ...task, domain: "analysis" }),
+    );
+  });
+
+  it("pairs by domain and fixture id without zero-filling missing observations", () => {
+    const a = completed("a");
+    const b = completed("b");
+    expect(keyOf(a)).toBe("code:fixture-1");
+    expect(pairResults([a], [b])).toMatchObject({
+      aOnlyKeys: [],
+      bOnlyKeys: [],
+    });
+
+    const unpaired = pairResults(
+      [a],
+      [completed("b", { fixtureId: "fixture-2" })],
+    );
+    expect(unpaired.paired).toHaveLength(0);
+    expect(unpaired.aOnlyKeys).toEqual(["code:fixture-1"]);
+    expect(unpaired.bOnlyKeys).toEqual(["code:fixture-2"]);
+  });
+
+  it("rejects duplicate fixture keys on either comparison side", () => {
+    expect(() =>
+      pairResults([completed("a"), completed("a")], [completed("b")]),
+    ).toThrow(DuplicateFixtureKeyError);
+    expect(() =>
+      pairResults([completed("a")], [completed("b"), completed("b")]),
+    ).toThrow("Duplicate fixture key on B");
+  });
+
+  it("reports quality, input/output/total tokens, latency, and overhead separately", () => {
+    const report = generateComparisonReport(
+      [
+        completed("a"),
+        completed("b", {
+          inputTokens: 15,
+          outputTokens: 5,
+          totalTokens: 20,
+          latencyMs: 30,
+          harnessOverheadMs: 8,
+        }),
+      ],
+      "a",
+      "b",
+      "model",
+    );
+    expect(report.diagnostics.validity).toBe("valid");
+    expect(report.diagnostics.tokenCost.input.total).toMatchObject({
+      a: 10,
+      b: 15,
+      delta: -5,
+    });
+    expect(report.diagnostics.tokenCost.output.total).toMatchObject({
+      a: 4,
+      b: 5,
+      delta: -1,
+    });
+    expect(report.diagnostics.tokenCost.all.total).toMatchObject({
+      a: 14,
+      b: 20,
+      delta: -6,
+    });
+    expect(report.diagnostics.tokenCost.all.perFixtureMean).toMatchObject({
+      a: 14,
+      b: 20,
+      delta: -6,
+    });
+    expect(report.diagnostics.apiLatency).toMatchObject({
+      a: 20,
+      b: 30,
+      delta: -10,
+    });
+    expect(report.diagnostics.harnessOverhead).toMatchObject({
+      a: 5,
+      b: 8,
+      delta: -3,
+    });
+    expect(generateMarkdownReport(report, "a", "b")).toContain(
+      "does not prove an Opus regression",
+    );
+    expect(JSON.stringify(report)).not.toContain("expectedVerdict");
+    expect(JSON.stringify(report)).not.toContain('"REJECT"');
+    expect(generateMarkdownReport(report, "a", "b")).not.toContain("REJECT");
+  });
+
+  it("marks empty and same-agent comparisons inconclusive", () => {
+    const empty = generateComparisonReport([], "a", "b", "model");
+    expect(empty.diagnostics).toMatchObject({
+      validity: "inconclusive",
+      reasons: ["no paired fixture observations"],
+    });
+    const same = generateComparisonReport([completed("a")], "a", "a", "model");
+    expect(same.diagnostics.validity).toBe("inconclusive");
+    expect(same.diagnostics.reasons).toContain(
+      "comparison requires two distinct agents",
+    );
+    expect(same.aggregateScores.a).toBeNull();
+    expect(same.headToHead).toEqual([]);
+    expect(same.diagnostics.tokenCost.all.total.status).toBe("insufficient");
+    expect(same.diagnostics.apiLatency.status).toBe("insufficient");
+    expect(generateMarkdownReport(same, "a", "a")).toContain("insufficient");
+  });
+
+  it("keeps partial token telemetry visible but total comparison insufficient", () => {
+    const report = generateComparisonReport(
+      [
+        completed("a", { outputTokens: undefined, totalTokens: undefined }),
+        completed("b", { outputTokens: undefined, totalTokens: undefined }),
+      ],
+      "a",
+      "b",
+      "model",
+    );
+    expect(report.diagnostics.tokenCost.input.total).toMatchObject({
+      a: 10,
+      b: 10,
+      status: "compared",
+    });
+    expect(report.diagnostics.tokenCost.output.total.status).toBe(
+      "insufficient",
+    );
+    expect(report.diagnostics.tokenCost.all.total.status).toBe("insufficient");
+    expect(report.diagnostics.validity).toBe("inconclusive");
+  });
+
+  it("makes total-only token telemetry inconclusive", () => {
+    const report = generateComparisonReport(
+      [
+        completed("a", {
+          inputTokens: undefined,
+          outputTokens: undefined,
+          totalTokens: 14,
+        }),
+        completed("b", {
+          inputTokens: undefined,
+          outputTokens: undefined,
+          totalTokens: 14,
+        }),
+      ],
+      "a",
+      "b",
+      "model",
+    );
+    expect(report.diagnostics.tokenCost.all.total.status).toBe("compared");
+    expect(report.diagnostics.tokenCost.input.total.status).toBe(
+      "insufficient",
+    );
+    expect(report.diagnostics.validity).toBe("inconclusive");
+  });
+
+  it("uses independent eligible pairs for each measured dimension", () => {
+    const report = generateComparisonReport(
+      [
+        completed("a", { fixtureId: "tokens", latencyMs: undefined }),
+        completed("b", { fixtureId: "tokens", latencyMs: undefined }),
+        completed("a", {
+          fixtureId: "latency",
+          inputTokens: undefined,
+          outputTokens: undefined,
+          totalTokens: undefined,
+          latencyMs: 40,
+        }),
+        completed("b", {
+          fixtureId: "latency",
+          inputTokens: undefined,
+          outputTokens: undefined,
+          totalTokens: undefined,
+          latencyMs: 60,
+        }),
+      ],
+      "a",
+      "b",
+      "model",
+    );
+    expect(report.diagnostics.tokenCost.all.total.pairedCount).toBe(1);
+    expect(report.diagnostics.tokenCost.all.perFixtureMean.a).toBe(14);
+    expect(report.diagnostics.apiLatency).toMatchObject({
+      pairedCount: 1,
+      a: 40,
+      b: 60,
+    });
+    expect(report.diagnostics.validity).toBe("inconclusive");
+  });
+
+  it("marks failed runs inconclusive and records failure reasons", () => {
+    const failed: FixtureResult = {
+      fixtureId: "fixture-1",
+      domain: "code",
+      agentType: "b",
+      completion: "failed",
+      failureReason: "api",
+      matchedFindings: [],
+      missedFindings: [],
+      spuriousFindings: [],
+      latencyMs: 10,
+    };
+    const report = generateComparisonReport(
+      [completed("a"), failed],
+      "a",
+      "b",
+      "model",
+    );
+    expect(report.diagnostics.validity).toBe("inconclusive");
+    expect(report.diagnostics.completion.failureReasonsB).toEqual({ api: 1 });
+    expect(report.aggregateScores.b).toBeNull();
+    expect(report.headToHead).toEqual([]);
+    expect(countFailures(report.results)).toBe(1);
+    expect(exitCodeForResults(report.results)).toBe(1);
+    expect(exitCodeForResults([completed("a")])).toBe(0);
+  });
+
+  it("uses the configured ground-truth directory", async () => {
+    const directory = benchmarkDir();
+    const labels = join(directory, "labels");
+    mkdirSync(labels);
+    writeFileSync(join(labels, "fixture-1.json"), JSON.stringify(groundTruth));
+    const ticks = [0, 10, 12, 17];
+    const results = await runBenchmark({
+      benchmarkDir: directory,
+      groundTruthDir: labels,
+      agents: [
+        {
+          agentType: "agent-a",
+          systemPrompt: "system",
+          userMessageTemplate: (content) => content,
+        },
+      ],
+      fixtures: [{ id: "fixture-1", content: "fixture", domain: "code" }],
+      parseFn: () => parsed,
+      cliArgs: {
+        agents: ["agent-a"],
+        fixture: null,
+        outputDir: join(directory, "results"),
+        model: "model",
+        dryRun: false,
+      },
+      clock: { now: () => ticks.shift() ?? 17 },
+      callApi: async () => ({ text: "OKAY", inputTokens: 7, outputTokens: 3 }),
+    });
+    expect(results[0]).toMatchObject({
+      completion: "completed",
+      totalTokens: 10,
+    });
+    expect(results[0]).toMatchObject({ latencyMs: 10, harnessOverheadMs: 5 });
+  });
+
+  it("retries retryable Claude calls before returning usage", async () => {
+    vi.useFakeTimers();
+    try {
+      const create = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("529 overloaded"))
+        .mockResolvedValue({
+          content: [{ type: "text", text: "OKAY" }],
+          usage: { input_tokens: 8, output_tokens: 2 },
+        });
+      const promise = callClaude(
+        { messages: { create } } as unknown as Anthropic,
+        "system",
+        "fixture",
+        "model",
+        1,
+      );
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toEqual({
+        text: "OKAY",
+        inputTokens: 8,
+        outputTokens: 2,
+      });
+      expect(create).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("measures API time after prompt construction and preserves zero durations", async () => {
+    const directory = benchmarkDir();
+    writeFileSync(
+      join(directory, "ground-truth", "fixture-1.json"),
+      JSON.stringify(groundTruth),
+    );
+    let now = 0;
+    const measured = await runBenchmark({
+      benchmarkDir: directory,
+      groundTruthDir: join(directory, "ground-truth"),
+      agents: [
+        {
+          agentType: "a",
+          systemPrompt: "system",
+          userMessageTemplate: (content) => {
+            now += 50;
+            return content;
+          },
+        },
+      ],
+      fixtures: [{ id: "fixture-1", content: "fixture", domain: "code" }],
+      parseFn: () => {
+        now += 10;
+        return parsed;
+      },
+      cliArgs: {
+        agents: ["a"],
+        fixture: null,
+        outputDir: "",
+        model: "model",
+        dryRun: false,
+      },
+      clock: { now: () => now },
+      callApi: async () => {
+        now += 100;
+        return { text: "OKAY" };
+      },
+    });
+    expect(measured[0]).toMatchObject({
+      latencyMs: 100,
+      harnessOverheadMs: 10,
+    });
+
+    const constantClock = { now: () => 5 };
+    const zero = await runBenchmark({
+      benchmarkDir: directory,
+      groundTruthDir: join(directory, "ground-truth"),
+      agents: [
+        {
+          agentType: "a",
+          systemPrompt: "system",
+          userMessageTemplate: (content) => content,
+        },
+      ],
+      fixtures: [{ id: "fixture-1", content: "fixture", domain: "code" }],
+      parseFn: () => parsed,
+      cliArgs: {
+        agents: ["a"],
+        fixture: null,
+        outputDir: "",
+        model: "model",
+        dryRun: false,
+      },
+      clock: constantClock,
+      callApi: async () => ({ text: "OKAY" }),
+    });
+    expect(zero[0]).toMatchObject({ latencyMs: 0, harnessOverheadMs: 0 });
+  });
+
+  it("keeps malformed ground truth fatal", async () => {
+    const directory = benchmarkDir();
+    writeFileSync(
+      join(directory, "ground-truth", "fixture-1.json"),
+      "{not-json",
+    );
+    await expect(
+      runBenchmark({
+        benchmarkDir: directory,
+        groundTruthDir: join(directory, "ground-truth"),
+        agents: [
+          {
+            agentType: "agent-a",
+            systemPrompt: "system",
+            userMessageTemplate: (content) => content,
+          },
+        ],
+        fixtures: [{ id: "fixture-1", content: "fixture", domain: "code" }],
+        parseFn: () => parsed,
+        cliArgs: {
+          agents: ["agent-a"],
+          fixture: null,
+          outputDir: "",
+          model: "model",
+          dryRun: false,
+        },
+        callApi: async () => ({
+          text: "OKAY",
+          inputTokens: 7,
+          outputTokens: 3,
+        }),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("keeps a missing ground-truth root fatal", () => {
+    const directory = benchmarkDir();
+    expect(() =>
+      loadGroundTruth(join(directory, "not-a-directory"), {
+        id: "fixture-1",
+        domain: "code",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects mismatched ground-truth identity", () => {
+    const directory = benchmarkDir();
+    writeFileSync(
+      join(directory, "ground-truth", "fixture-1.json"),
+      JSON.stringify({ ...groundTruth, domain: "bug" }),
+    );
+    expect(() =>
+      loadGroundTruth(join(directory, "ground-truth"), {
+        id: "fixture-1",
+        domain: "code",
+      }),
+    ).toThrow("Ground truth identity mismatch");
+  });
+
+  it("preserves typed identity and telemetry for missing ground truth", async () => {
+    const directory = benchmarkDir();
+    const ticks = [0, 10, 12, 17];
+    const clock: Clock = { now: () => ticks.shift() ?? 17 };
+    const results = await runBenchmark({
+      benchmarkDir: directory,
+      groundTruthDir: join(directory, "ground-truth"),
+      agents: [
+        {
+          agentType: "agent-a",
+          systemPrompt: "system",
+          userMessageTemplate: (content) => content,
+        },
+      ],
+      fixtures: [{ id: "missing", content: "fixture", domain: "task" }],
+      parseFn: () => parsed,
+      cliArgs: {
+        agents: ["agent-a"],
+        fixture: null,
+        outputDir: join(directory, "results"),
+        model: "model",
+        dryRun: false,
+      },
+      clock,
+      callApi: async () => ({ text: "OKAY", inputTokens: 7, outputTokens: 3 }),
+    });
+    expect(results).toEqual([
+      expect.objectContaining({
+        domain: "task",
+        completion: "failed",
+        failureReason: "missing-ground-truth",
+        groundTruthMissing: true,
+        latencyMs: 10,
+        harnessOverheadMs: 5,
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+      }),
+    ]);
+  });
+
+  it("records prompt and parse failures without fabricated quality", async () => {
+    const directory = benchmarkDir();
+    const promptFailure = await runBenchmark({
+      benchmarkDir: directory,
+      groundTruthDir: join(directory, "ground-truth"),
+      agents: [
+        {
+          agentType: "a",
+          systemPrompt: "system",
+          userMessageTemplate: () => {
+            throw new Error("prompt");
+          },
+        },
+      ],
+      fixtures: [{ id: "fixture-1", content: "fixture", domain: "code" }],
+      parseFn: () => parsed,
+      cliArgs: {
+        agents: ["a"],
+        fixture: null,
+        outputDir: "",
+        model: "model",
+        dryRun: false,
+      },
+      callApi: async () => ({ text: "OKAY" }),
+    });
+    expect(promptFailure[0]).toMatchObject({
+      completion: "failed",
+      failureReason: "prompt",
+    });
+
+    const parseFailure = await runBenchmark({
+      benchmarkDir: directory,
+      groundTruthDir: join(directory, "ground-truth"),
+      agents: [
+        {
+          agentType: "a",
+          systemPrompt: "system",
+          userMessageTemplate: (content) => content,
+        },
+      ],
+      fixtures: [{ id: "fixture-1", content: "fixture", domain: "code" }],
+      parseFn: () => {
+        throw new Error("parse");
+      },
+      cliArgs: {
+        agents: ["a"],
+        fixture: null,
+        outputDir: "",
+        model: "model",
+        dryRun: false,
+      },
+      callApi: async () => ({ text: "OKAY", inputTokens: 2, outputTokens: 1 }),
+    });
+    expect(parseFailure[0]).toMatchObject({
+      completion: "failed",
+      failureReason: "parse",
+      totalTokens: 3,
+    });
+  });
+
+  it("classifies score and match failures while preserving API telemetry", async () => {
+    const directory = benchmarkDir();
+    writeFileSync(
+      join(directory, "ground-truth", "fixture-1.json"),
+      JSON.stringify(groundTruth),
+    );
+    const common = {
+      benchmarkDir: directory,
+      groundTruthDir: join(directory, "ground-truth"),
+      agents: [
+        {
+          agentType: "a",
+          systemPrompt: "system",
+          userMessageTemplate: (content: string) => content,
+        },
+      ],
+      fixtures: [
+        { id: "fixture-1", content: "fixture", domain: "code" as const },
+      ],
+      parseFn: () => parsed,
+      cliArgs: {
+        agents: ["a"],
+        fixture: null,
+        outputDir: "",
+        model: "model",
+        dryRun: false,
+      },
+      callApi: async () => ({ text: "OKAY", inputTokens: 2, outputTokens: 1 }),
+    };
+    const scoreFailure = await runBenchmark({
+      ...common,
+      scoreFn: () => {
+        throw new Error("score");
+      },
+    });
+    expect(scoreFailure[0]).toMatchObject({
+      failureReason: "score",
+      totalTokens: 3,
+    });
+
+    const matchFailure = await runBenchmark({
+      ...common,
+      matchFn: () => {
+        throw new Error("match");
+      },
+    });
+    expect(matchFailure[0]).toMatchObject({
+      failureReason: "match",
+      totalTokens: 3,
+    });
+  });
+
+  it("prints separate rows for identical fixture ids in different domains", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    printSummaryTable(
+      [completed("a"), completed("a", { domain: "bug" })],
+      ["a"],
+    );
+    const output = log.mock.calls.flat().join("\n");
+    log.mockRestore();
+    expect(output).toContain("code:fixture-1");
+    expect(output).toContain("bug:fixture-1");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an evidence-safe diagnostic to the existing TypeScript benchmark harness so reports distinguish:

- run completion and failure reasons;
- scorer-derived quality;
- input, output, and combined token usage as the stable cost proxy, including paired totals and per-fixture means;
- retry-inclusive API-call latency;
- measured non-API harness overhead;
- per-dimension paired `(domain, fixtureId)` coverage, unmatched observations, and inconclusive evidence.

The code-reviewer, debugger, and executor benchmark CLIs now write typed failure results where recovery is valid and exit nonzero after report generation when any run failed. Missing telemetry remains unavailable rather than becoming zero. Malformed benchmark configuration remains fatal.

Closes #3633.

## Evidence and behavior

- Shared scoring delegates to the canonical harsh-critic scorer.
- `bug` and `task` identities remain unchanged for pairing and are projected privately to canonical `analysis` only at the scorer boundary.
- Duplicate comparison identities fail fast.
- Empty, same-agent, failed, unmatched, or telemetry-incomplete comparisons are `INCONCLUSIVE`.
- JSON and Markdown reports keep completion, quality, tokens, API latency, and harness overhead separate.
- Reports explicitly state that the diagnostic does not prove an Opus regression or attribute API timing beyond the measured boundaries.

## Validation

- `npx vitest run tests/benchmark-diagnostics.test.ts` — 23 passed
- `npx vitest run --config vitest.config.ts` from `benchmarks/harsh-critic` — 28 passed
- targeted ESLint over changed benchmark/test files — passed with 0 warnings
- `npx tsc --noEmit -p tsconfig.json` — passed
- code-reviewer, debugger, and executor `--dry-run` CLI checks — passed, 3 fixtures each
- `npm run build` — passed
- `npm run lint` — 0 errors; 19 pre-existing warnings outside this change
- full `npm run test:run` observation — 11,907 passed, 16 skipped, with two active-session/state failures unrelated to this diff; the state test passed on isolated rerun, while the remaining post-tool verifier assertion depends on the session's accumulated background-task count

Final frozen-source review joined AI-slop cleanup `passed`, Architect `CLEAR / APPROVE`, Executor QA/red-team `passed`, and terminal Critic `OKAY`.

## Limitations

No controlled live Opus comparison was run. This PR adds the repository-owned measurement and reporting contract needed to collect comparable evidence; it does not claim Opus 5 is more or less efficient.

API latency includes retries and waiting inside the API-call span. It does not isolate model compute, network latency, or provider queueing. Harness overhead covers measured post-response parsing, ground-truth loading, scoring, matching, and result construction.

## Explicit non-goals

- no USD pricing table;
- no scalar efficiency score;
- no Python harness retrofit;
- no `benchmarks/run-all.ts` change;
- no latency field rename;
- no new dependency;
- no causal model-regression attribution.
