### PR TITLE
chore(release): v4.15.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "oh-my-claudecode",
       "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
-      "version": "4.15.8",
+      "version": "4.15.9",
       "author": {
         "name": "Yeachan Heo",
         "email": "hurrc04@gmail.com"
@@ -27,5 +27,5 @@
       ]
     }
   ],
-  "version": "4.15.8"
+  "version": "4.15.9"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claudecode",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "description": "Multi-agent orchestration system for Claude Code",
   "author": {
     "name": "oh-my-claudecode contributors"

--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,54 +1,33 @@
-# oh-my-claudecode v4.15.8: add Kimi usage
+# oh-my-claudecode v4.15.9: land pure Graph, add evidence-safe efficiency, add bounded basedpyright
 
 ## Release Notes
 
-Release with **1 new feature**, **11 bug fixes**, **17 other changes** across **30 merged PRs**.
+Release with **3 new features**, **2 bug fixes** across **6 merged PRs**.
 
 ### Highlights
 
-- **feat(hud): add Kimi usage monitoring** (#3610)
+- **feat(graph): land pure Graph Core contract** (#3649)
+- **feat(benchmarks): add evidence-safe efficiency diagnostics** (#3650)
+- **feat(lsp): add bounded basedpyright selection** (#3647)
 
 ### New Features
 
-- **feat(hud): add Kimi usage monitoring** (#3610)
+- **feat(graph): land pure Graph Core contract** (#3649)
+- **feat(benchmarks): add evidence-safe efficiency diagnostics** (#3650)
+- **feat(lsp): add bounded basedpyright selection** (#3647)
 
 ### Bug Fixes
 
-- **fix(ultragoal): restore fail-closed recovery when /goal guard blocks tools** (#3632)
-- **fix(ast-tools): surface unavailable languages** (#3628)
-- **fix(team): make worker startup acknowledgement durable** (#3588)
-- **fix(doctor): make team-routing provider probes Windows-safe** (#3602)
-- **fix(installer): accept TOML literal strings in Codex MCP registry parser** (#3603)
-- **fix(installer): install hooks when settings.json has none** (#3599)
-- **fix(installer): allow contained symlink config roots** (#3538)
-- **fix(launch): stop omc re-login from isolated profile auth drift** (#3572)
-- **fix(installer): preserve custom agent definitions** (#3539)
-- **fix(hud): parse per-model weekly quotas from limits[] weekly_scoped entries** (#3577)
-- **fix(post-tool-verifier): key background detection off tool_input** (#3579)
+- **fix(installer): prune duplicate plugin hooks** (#3645)
+- **fix(release): widen bounded npm registry propagation retry** (#3636)
 
-### Other Changes
+### Documentation
 
-- **ci: authorize final reconciled head for PR #3588** (#3616)
-- **ci: authorize post-merge head for PR #3588** (#3615)
-- **ci: authorize reconciled head for PR #3588** (#3614)
-- **ci: authorize terminal head for PR #3603** (#3604)
-- **ci: authorize terminal generated head for PR #3588** (#3598)
-- **ci: authorize signed final head for PR #3588** (#3596)
-- **ci: authorize final generated head for PR #3588** (#3594)
-- **ci: authorize corrected head for PR #3538** (#3593)
-- **ci: authorize signed generated head for PR #3588** (#3592)
-- **ci: authorize exact generated head for PR #3588** (#3590)
-- **ci: authorize rebased head for PR #3538** (#3589)
-- **ci: authorize exact generated closure for PR #3572** (#3587)
-- **ci: authorize rebased head for PR #3539** (#3585)
-- **ci: restore exact-head authorization for PR #3539** (#3583)
-- **ci: authorize signed merge head for PR #3539** (#3582)
-- **ci: authorize repaired closure for PR #3539** (#3581)
-- **ci: authorize exact generated closure for PR #3539 (dev)** (#3580)
+- **docs(skills): clarify independent consensus review sequencing** (#3646)
 
 ### Stats
 
-- **30 PRs merged** | **1 new feature** | **11 bug fixes** | **0 security/hardening improvements** | **17 other changes**
+- **6 PRs merged** | **3 new features** | **2 bug fixes** | **0 security/hardening improvements** | **0 other changes**
 
 ### Install / Update
 
@@ -57,7 +36,7 @@ The npm CLI and the Claude Code marketplace/plugin are separate install tracks, 
 **CLI / runtime:**
 
 ```bash
-npm install -g oh-my-claude-sisyphus@4.15.8
+npm install -g oh-my-claude-sisyphus@4.15.9
 ```
 
 **Claude Code plugin:**
@@ -66,10 +45,10 @@ npm install -g oh-my-claude-sisyphus@4.15.8
 /plugin marketplace update omc
 ```
 
-**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.7...v4.15.8
+**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.8...v4.15.9
 
 ## Contributors
 
 Thank you to all contributors who made this release possible!
 
-@ltspace @Yeachan-Heo
+@Yeachan-Heo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,51 +1,30 @@
-# oh-my-claudecode v4.15.8: add Kimi usage
+# oh-my-claudecode v4.15.9: land pure Graph, add evidence-safe efficiency, add bounded basedpyright
 
 ## Release Notes
 
-Release with **1 new feature**, **11 bug fixes**, **17 other changes** across **30 merged PRs**.
+Release with **3 new features**, **2 bug fixes** across **6 merged PRs**.
 
 ### Highlights
 
-- **feat(hud): add Kimi usage monitoring** (#3610)
+- **feat(graph): land pure Graph Core contract** (#3649)
+- **feat(benchmarks): add evidence-safe efficiency diagnostics** (#3650)
+- **feat(lsp): add bounded basedpyright selection** (#3647)
 
 ### New Features
 
-- **feat(hud): add Kimi usage monitoring** (#3610)
+- **feat(graph): land pure Graph Core contract** (#3649)
+- **feat(benchmarks): add evidence-safe efficiency diagnostics** (#3650)
+- **feat(lsp): add bounded basedpyright selection** (#3647)
 
 ### Bug Fixes
 
-- **fix(ultragoal): restore fail-closed recovery when /goal guard blocks tools** (#3632)
-- **fix(ast-tools): surface unavailable languages** (#3628)
-- **fix(team): make worker startup acknowledgement durable** (#3588)
-- **fix(doctor): make team-routing provider probes Windows-safe** (#3602)
-- **fix(installer): accept TOML literal strings in Codex MCP registry parser** (#3603)
-- **fix(installer): install hooks when settings.json has none** (#3599)
-- **fix(installer): allow contained symlink config roots** (#3538)
-- **fix(launch): stop omc re-login from isolated profile auth drift** (#3572)
-- **fix(installer): preserve custom agent definitions** (#3539)
-- **fix(hud): parse per-model weekly quotas from limits[] weekly_scoped entries** (#3577)
-- **fix(post-tool-verifier): key background detection off tool_input** (#3579)
+- **fix(installer): prune duplicate plugin hooks** (#3645)
+- **fix(release): widen bounded npm registry propagation retry** (#3636)
 
-### Other Changes
+### Documentation
 
-- **ci: authorize final reconciled head for PR #3588** (#3616)
-- **ci: authorize post-merge head for PR #3588** (#3615)
-- **ci: authorize reconciled head for PR #3588** (#3614)
-- **ci: authorize terminal head for PR #3603** (#3604)
-- **ci: authorize terminal generated head for PR #3588** (#3598)
-- **ci: authorize signed final head for PR #3588** (#3596)
-- **ci: authorize final generated head for PR #3588** (#3594)
-- **ci: authorize corrected head for PR #3538** (#3593)
-- **ci: authorize signed generated head for PR #3588** (#3592)
-- **ci: authorize exact generated head for PR #3588** (#3590)
-- **ci: authorize rebased head for PR #3538** (#3589)
-- **ci: authorize exact generated closure for PR #3572** (#3587)
-- **ci: authorize rebased head for PR #3539** (#3585)
-- **ci: restore exact-head authorization for PR #3539** (#3583)
-- **ci: authorize signed merge head for PR #3539** (#3582)
-- **ci: authorize repaired closure for PR #3539** (#3581)
-- **ci: authorize exact generated closure for PR #3539 (dev)** (#3580)
+- **docs(skills): clarify independent consensus review sequencing** (#3646)
 
 ### Stats
 
-- **30 PRs merged** | **1 new feature** | **11 bug fixes** | **0 security/hardening improvements** | **17 other changes**
+- **6 PRs merged** | **3 new features** | **2 bug fixes** | **0 security/hardening improvements** | **0 other changes**

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -875,8 +875,8 @@ function executeClaudeMdTransaction(request) {
 
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
-var COMPILED_ENGINE_VERSION = true ? "4.15.8" : "";
-var COMPILED_SOURCE_SHA256 = true ? "4cbb3ffaf4dd4769ce7c1c5163d3c1167d215f767868a00ea58aed1dde5cab2b" : "";
+var COMPILED_ENGINE_VERSION = true ? "4.15.9" : "";
+var COMPILED_SOURCE_SHA256 = true ? "3de15fac902d6648b0494b3bc89124d23e93c48392f330bb8641b2a2b71e3991" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/dist/graph/descriptor.d.ts
+++ b/dist/graph/descriptor.d.ts
@@ -1,0 +1,62 @@
+/**
+ * Graph Core descriptor sealing, structure-before-hash validation, and
+ * ownership producers.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ *
+ * Ownership flow (disjoint input classes):
+ * - `parseGraphDescriptor` — hashless draft parser; rejects hash-bearing input.
+ * - `sealGraphDescriptor` — sole draft → scheduler producer (computes the hash).
+ * - `parseSealedGraphDescriptor` — sole persisted → scheduler producer
+ *   (verifies the supplied hash; rejects mismatch; never silently recomputes).
+ * - `verifyDescriptorHash` — non-branding boolean predicate; never throws.
+ */
+import type { GraphDescriptor, GraphDescriptorInput, SealedGraphDescriptor } from "./types.js";
+export declare class GraphDescriptorValidationError extends Error {
+    readonly issues: readonly string[];
+    constructor(issues: readonly string[]);
+}
+/**
+ * Serialize JSON values with object keys sorted recursively in lexical order.
+ * Strict current-dev semantics: compact output, arrays in given order; throws
+ * `TypeError` on `undefined`, non-finite numbers, symbols, functions, bigints,
+ * non-plain objects (Date/Map/Set/RegExp/class instances), and cyclic values.
+ */
+export declare function canonicalJson(value: unknown): string;
+/** Lowercase SHA-256 hex over the canonical compact JSON of the hash payload. */
+export declare function computeDescriptorHash(input: GraphDescriptorInput): string;
+/**
+ * Structural validation. Throws `GraphDescriptorValidationError` with the
+ * joined issue list; returns the descriptor unchanged on success.
+ */
+export declare function validateGraphDescriptor(descriptor: GraphDescriptor): GraphDescriptor;
+/**
+ * Draft parser: strict schema parse → full validation → defensive
+ * `structuredClone` + `deepFreeze`. Input carrying a `descriptor_hash` is
+ * rejected with a directed error (use `parseSealedGraphDescriptor`).
+ */
+export declare function parseGraphDescriptor(input: unknown): GraphDescriptor;
+/**
+ * Sole draft → scheduler producer: strict parse → validate → compute hash →
+ * defensive `structuredClone` + `deepFreeze` with `descriptor_hash`. Input
+ * carrying a `descriptor_hash` is rejected with a directed error.
+ */
+export declare function sealGraphDescriptor(input: unknown): SealedGraphDescriptor;
+/**
+ * Sole persisted → scheduler producer. Requires a well-formed `descriptor_hash`;
+ * strict schema parse → full validation → recompute the hash and compare with
+ * the supplied hash; a mismatch is rejected (never silently recomputed), then a
+ * defensive `structuredClone` + `deepFreeze` is returned.
+ */
+export declare function parseSealedGraphDescriptor(input: unknown): SealedGraphDescriptor;
+/**
+ * Non-branding, never-throws boolean predicate. Structure-before-hash: strict
+ * schema parse → full validation → hash recompute → compare; `false` on any
+ * structural failure or mismatch. Does not clone, freeze, or mutate its input.
+ */
+export declare function verifyDescriptorHash(input: unknown): boolean;
+/** Non-throwing structural check (shape parse + validation, no hash semantics). */
+export declare function isGraphDescriptor(input: unknown): input is GraphDescriptor;
+//# sourceMappingURL=descriptor.d.ts.map

--- a/dist/graph/descriptor.js
+++ b/dist/graph/descriptor.js
@@ -1,0 +1,620 @@
+/**
+ * Graph Core descriptor sealing, structure-before-hash validation, and
+ * ownership producers.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ *
+ * Ownership flow (disjoint input classes):
+ * - `parseGraphDescriptor` — hashless draft parser; rejects hash-bearing input.
+ * - `sealGraphDescriptor` — sole draft → scheduler producer (computes the hash).
+ * - `parseSealedGraphDescriptor` — sole persisted → scheduler producer
+ *   (verifies the supplied hash; rejects mismatch; never silently recomputes).
+ * - `verifyDescriptorHash` — non-branding boolean predicate; never throws.
+ */
+import { createHash } from "node:crypto";
+import { isValidStableId, parseGraphDescriptorShape } from "./schema.js";
+const DESCRIPTOR_HASH_PATTERN = /^[a-f0-9]{64}$/;
+export class GraphDescriptorValidationError extends Error {
+    issues;
+    constructor(issues) {
+        super(`Invalid graph descriptor: ${issues.join("; ")}`);
+        this.name = "GraphDescriptorValidationError";
+        this.issues = issues;
+    }
+}
+/** True only for null-prototype or plain `Object.prototype` objects. */
+function isPlainObject(value) {
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+/**
+ * Serialize JSON values with object keys sorted recursively in lexical order.
+ * Strict current-dev semantics: compact output, arrays in given order; throws
+ * `TypeError` on `undefined`, non-finite numbers, symbols, functions, bigints,
+ * non-plain objects (Date/Map/Set/RegExp/class instances), and cyclic values.
+ */
+export function canonicalJson(value) {
+    return serializeCanonical(value, new Set());
+}
+function serializeCanonical(value, seen) {
+    if (value === null ||
+        typeof value === "boolean" ||
+        typeof value === "string") {
+        return JSON.stringify(value);
+    }
+    if (typeof value === "number") {
+        if (!Number.isFinite(value)) {
+            throw new TypeError("Canonical JSON requires finite numbers");
+        }
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        if (seen.has(value))
+            throw new TypeError("Canonical JSON rejects cyclic values");
+        seen.add(value);
+        const serialized = `[${value.map((item) => serializeCanonical(item, seen)).join(",")}]`;
+        seen.delete(value);
+        return serialized;
+    }
+    if (typeof value === "object") {
+        if (!isPlainObject(value)) {
+            throw new TypeError("Canonical JSON requires plain objects");
+        }
+        if (seen.has(value))
+            throw new TypeError("Canonical JSON rejects cyclic values");
+        seen.add(value);
+        const record = value;
+        const serialized = `{${Object.keys(record)
+            .sort()
+            .map((key) => `${JSON.stringify(key)}:${serializeCanonical(record[key], seen)}`)
+            .join(",")}}`;
+        seen.delete(value);
+        return serialized;
+    }
+    throw new TypeError(`Canonical JSON requires JSON-compatible values (got ${typeof value})`);
+}
+/** Hash payload: the nine contract fields; excludes `descriptor_hash` and runtime fields. */
+function descriptorHashPayload(input) {
+    return {
+        descriptor_version: input.descriptor_version,
+        run_id: input.run_id,
+        revision_id: input.revision_id,
+        goal: input.goal,
+        nodes: input.nodes,
+        edges: input.edges,
+        entry_node_ids: input.entry_node_ids,
+        concurrency_limit: input.concurrency_limit,
+        terminal_verification_node_id: input.terminal_verification_node_id,
+    };
+}
+/** Lowercase SHA-256 hex over the canonical compact JSON of the hash payload. */
+export function computeDescriptorHash(input) {
+    return createHash("sha256")
+        .update(canonicalJson(descriptorHashPayload(input)))
+        .digest("hex");
+}
+/** Recursively freeze an owned value (descriptors are trees; no cycles). */
+function deepFreeze(value) {
+    if (value !== null && typeof value === "object") {
+        for (const key of Object.getOwnPropertyNames(value)) {
+            deepFreeze(value[key]);
+        }
+        Object.freeze(value);
+    }
+    return value;
+}
+function isRecordWithHash(input) {
+    return (typeof input === "object" &&
+        input !== null &&
+        !Array.isArray(input) &&
+        "descriptor_hash" in input);
+}
+function duplicates(values) {
+    const seen = new Set();
+    const found = new Set();
+    for (const value of values) {
+        if (seen.has(value))
+            found.add(value);
+        seen.add(value);
+    }
+    return [...found].sort();
+}
+function groupByFrom(edges) {
+    const result = new Map();
+    for (const edge of edges) {
+        const group = result.get(edge.from) ?? [];
+        group.push(edge);
+        result.set(edge.from, group);
+    }
+    return result;
+}
+function adjacencyFor(edges, includeBackEdges) {
+    const result = new Map();
+    for (const edge of edges) {
+        if (!includeBackEdges && edge.kind === "back_edge")
+            continue;
+        const targets = result.get(edge.from) ?? [];
+        targets.push(edge.to);
+        result.set(edge.from, targets);
+    }
+    return result;
+}
+function isReachable(start, target, adjacency) {
+    const pending = [start];
+    const visited = new Set();
+    while (pending.length > 0) {
+        const current = pending.pop();
+        if (current === target)
+            return true;
+        if (visited.has(current))
+            continue;
+        visited.add(current);
+        pending.push(...(adjacency.get(current) ?? []));
+    }
+    return false;
+}
+function reachableSet(starts, adjacency) {
+    const pending = [...starts];
+    const visited = new Set();
+    while (pending.length > 0) {
+        const current = pending.pop();
+        if (visited.has(current))
+            continue;
+        visited.add(current);
+        pending.push(...(adjacency.get(current) ?? []));
+    }
+    return visited;
+}
+/** Detect a cycle among non-back edges; returns the cycle path or undefined. */
+function findForwardCycle(nodeIds, adjacency) {
+    const visited = new Set();
+    const active = new Set();
+    const stack = [];
+    const visit = (nodeId) => {
+        if (active.has(nodeId)) {
+            const start = stack.indexOf(nodeId);
+            return [...stack.slice(start), nodeId];
+        }
+        if (visited.has(nodeId))
+            return undefined;
+        visited.add(nodeId);
+        active.add(nodeId);
+        stack.push(nodeId);
+        for (const target of adjacency.get(nodeId) ?? []) {
+            const cycle = visit(target);
+            if (cycle)
+                return cycle;
+        }
+        stack.pop();
+        active.delete(nodeId);
+        return undefined;
+    };
+    for (const nodeId of nodeIds) {
+        const cycle = visit(nodeId);
+        if (cycle)
+            return cycle;
+    }
+    return undefined;
+}
+/** Nodes reachable from the branch start without passing through the owning join. */
+function collectBranchRegion(startNodeId, allAdjacency, joinNodeId) {
+    const pending = [startNodeId];
+    const result = new Set();
+    while (pending.length > 0) {
+        const current = pending.pop();
+        if (current === joinNodeId || result.has(current))
+            continue;
+        result.add(current);
+        pending.push(...(allAdjacency.get(current) ?? []));
+    }
+    return result;
+}
+function validateOutgoingContracts(descriptor, nodes, outgoing, issues) {
+    for (const node of descriptor.nodes) {
+        const edges = outgoing.get(node.id) ?? [];
+        if (node.id === descriptor.terminal_verification_node_id) {
+            if (edges.length > 0) {
+                issues.push(`terminal verification node ${node.id} must not have outgoing edges`);
+            }
+            continue;
+        }
+        if (node.kind === "human-approval") {
+            if (edges.length !== 1 || edges[0].kind !== "fixed") {
+                issues.push(`human-approval node ${node.id} must have exactly one fixed outgoing edge`);
+            }
+            continue;
+        }
+        if (node.kind === "join") {
+            if (edges.length !== 1 || edges[0].kind !== "fixed") {
+                issues.push(`join node ${node.id} must have exactly one fixed outgoing edge`);
+            }
+            continue;
+        }
+        if (edges.length === 0) {
+            issues.push(`node ${node.id} cannot reach terminal verification because it has no outgoing edge`);
+            continue;
+        }
+        // A node whose only outgoing edge(s) are back_edges has no forward exit:
+        // once max_traversals is exhausted the result is permanently uncommittable.
+        if (edges.every((edge) => edge.kind === "back_edge")) {
+            issues.push(`node ${node.id} has no non-back-edge exit; a back-edge-only node wedges once max_traversals is exhausted`);
+        }
+        const kinds = new Set(edges.map((edge) => edge.kind));
+        if (kinds.has("fixed") && (edges.length !== 1 || kinds.size !== 1)) {
+            issues.push(`node ${node.id} must use one fixed edge or an explicit route/fan-out set`);
+        }
+        if (kinds.has("fan_out")) {
+            if (kinds.size !== 1 || edges.length < 2) {
+                issues.push(`fan-out node ${node.id} must declare at least two fan_out edges and no other edge kind`);
+            }
+        }
+        else if (!kinds.has("fixed")) {
+            if ([...kinds].some((kind) => kind !== "conditional" && kind !== "back_edge")) {
+                issues.push(`node ${node.id} has an unsupported routed edge combination`);
+            }
+            const routes = edges
+                .filter((edge) => "route" in edge)
+                .map((edge) => edge.route);
+            const repeatedRoutes = duplicates(routes);
+            if (repeatedRoutes.length > 0) {
+                issues.push(`node ${node.id} declares duplicate route(s): ${repeatedRoutes.join(", ")}`);
+            }
+        }
+    }
+    for (const edge of descriptor.edges) {
+        if (!nodes.has(edge.from)) {
+            issues.push(`edge ${edge.id} references missing source node ${edge.from}`);
+        }
+        if (!nodes.has(edge.to)) {
+            issues.push(`edge ${edge.id} references missing target node ${edge.to}`);
+        }
+    }
+}
+function validateForkRegions(descriptor, nodes, outgoing, allAdjacency, issues) {
+    const fanGroups = new Map();
+    const branchOwners = new Map();
+    for (const edge of descriptor.edges) {
+        if (edge.kind !== "fan_out")
+            continue;
+        const group = fanGroups.get(edge.from) ?? [];
+        group.push(edge);
+        fanGroups.set(edge.from, group);
+        const existing = branchOwners.get(edge.branch_id);
+        if (existing !== undefined && existing !== edge.from) {
+            issues.push(`branch ID ${edge.branch_id} is reused by fan-out nodes ${existing} and ${edge.from}`);
+        }
+        else if (existing === undefined) {
+            branchOwners.set(edge.branch_id, edge.from);
+        }
+    }
+    const regions = [];
+    for (const [fanOutNodeId, fanEdges] of fanGroups) {
+        const ownerJoinIds = new Set(fanEdges.map((edge) => edge.owner_join_id));
+        if (ownerJoinIds.size !== 1) {
+            issues.push(`fan-out node ${fanOutNodeId} must have one owning join`);
+            continue;
+        }
+        const joinNodeId = fanEdges[0].owner_join_id;
+        const joinNode = nodes.get(joinNodeId);
+        if (joinNode?.kind !== "join") {
+            issues.push(`fan-out node ${fanOutNodeId} references non-join owner ${joinNodeId}`);
+            continue;
+        }
+        if (joinNode.fan_out_node_id !== fanOutNodeId) {
+            issues.push(`join ${joinNodeId} does not bind fan-out node ${fanOutNodeId}`);
+        }
+        const branchIds = fanEdges.map((edge) => edge.branch_id);
+        const repeatedBranches = duplicates(branchIds);
+        if (repeatedBranches.length > 0) {
+            issues.push(`fan-out node ${fanOutNodeId} repeats branch ID(s): ${repeatedBranches.join(", ")}`);
+        }
+        if ([...new Set(branchIds)].sort().join("\0") !==
+            [...new Set(joinNode.input_branch_ids)].sort().join("\0")) {
+            issues.push(`join ${joinNodeId} input branches do not match fan-out ${fanOutNodeId}`);
+        }
+        const repeatedJoinBranches = duplicates(joinNode.input_branch_ids);
+        if (repeatedJoinBranches.length > 0) {
+            issues.push(`join ${joinNodeId} repeats an input branch ID`);
+        }
+        const groupRegions = fanEdges.map((edge) => ({
+            fanOutNodeId,
+            joinNodeId,
+            branchId: edge.branch_id,
+            startNodeId: edge.to,
+            nodes: collectBranchRegion(edge.to, allAdjacency, joinNodeId),
+        }));
+        regions.push(...groupRegions);
+        for (const region of groupRegions) {
+            if (!region.nodes.has(region.startNodeId)) {
+                issues.push(`fork branch ${region.branchId} has no region`);
+            }
+            if (!isReachable(region.startNodeId, joinNodeId, allAdjacency)) {
+                issues.push(`fork branch ${region.branchId} cannot reach owning join ${joinNodeId}`);
+            }
+            for (const nodeId of region.nodes) {
+                const node = nodes.get(nodeId);
+                if (node?.kind === "join" && nodeId !== joinNodeId) {
+                    issues.push(`nested join ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+                }
+                if ((outgoing.get(nodeId) ?? []).some((edge) => edge.kind === "fan_out")) {
+                    issues.push(`nested fan-out ${nodeId} is not allowed inside fork region ${fanOutNodeId}`);
+                }
+                if (!isReachable(nodeId, joinNodeId, allAdjacency)) {
+                    issues.push(`fork branch ${region.branchId} contains node ${nodeId} that cannot reach its join`);
+                }
+            }
+            const hasDeclaredJoinInput = descriptor.edges.some((edge) => region.nodes.has(edge.from) && edge.to === joinNodeId);
+            if (!hasDeclaredJoinInput) {
+                issues.push(`fork branch ${region.branchId} has no declared join input`);
+            }
+        }
+        for (let left = 0; left < groupRegions.length; left += 1) {
+            for (let right = left + 1; right < groupRegions.length; right += 1) {
+                const overlap = [...groupRegions[left].nodes].filter((id) => groupRegions[right].nodes.has(id));
+                if (overlap.length > 0) {
+                    issues.push(`fork branches ${groupRegions[left].branchId} and ${groupRegions[right].branchId} overlap at ${overlap.join(", ")}`);
+                }
+            }
+        }
+    }
+    for (const node of descriptor.nodes) {
+        if (node.kind === "join" && !fanGroups.has(node.fan_out_node_id)) {
+            issues.push(`join ${node.id} has no matching fan-out node ${node.fan_out_node_id}`);
+        }
+    }
+    for (let left = 0; left < regions.length; left += 1) {
+        for (let right = left + 1; right < regions.length; right += 1) {
+            if (regions[left].fanOutNodeId === regions[right].fanOutNodeId)
+                continue;
+            const overlap = [...regions[left].nodes].some((id) => regions[right].nodes.has(id));
+            if (overlap) {
+                issues.push(`fork regions ${regions[left].fanOutNodeId} and ${regions[right].fanOutNodeId} overlap or nest`);
+            }
+        }
+    }
+    for (const region of regions) {
+        for (const edge of descriptor.edges) {
+            if (edge.kind === "fan_out" &&
+                edge.from === region.fanOutNodeId &&
+                edge.branch_id === region.branchId) {
+                continue;
+            }
+            const fromInside = region.nodes.has(edge.from);
+            const toInside = region.nodes.has(edge.to);
+            if (!fromInside && toInside) {
+                issues.push(`edge ${edge.id} crosses into fork branch ${region.branchId}`);
+            }
+            if (fromInside && !toInside && edge.to !== region.joinNodeId) {
+                issues.push(`edge ${edge.id} crosses out of fork branch ${region.branchId}`);
+            }
+            if (edge.kind === "back_edge" && fromInside !== toInside) {
+                issues.push(`back-edge ${edge.id} crosses fork region ${region.fanOutNodeId}`);
+            }
+        }
+    }
+    for (const node of descriptor.nodes) {
+        if (node.kind !== "join")
+            continue;
+        const ownerRegions = regions.filter((region) => region.joinNodeId === node.id);
+        for (const edge of descriptor.edges.filter((candidate) => candidate.to === node.id)) {
+            if (!ownerRegions.some((region) => region.nodes.has(edge.from))) {
+                issues.push(`edge ${edge.id} enters join ${node.id} outside its owning fork region`);
+            }
+        }
+    }
+    return regions;
+}
+function validateEntryEligibility(descriptor, nodes, regions, issues) {
+    for (const entry of descriptor.entry_node_ids) {
+        const node = nodes.get(entry);
+        if (node === undefined)
+            continue; // existence already reported
+        if (node.kind === "join") {
+            issues.push(`entry node ${entry} must not be a join node`);
+        }
+        else if (regions.some((region) => region.nodes.has(entry))) {
+            issues.push(`entry node ${entry} must not be inside a fork branch region`);
+        }
+    }
+}
+/**
+ * Structural validation. Throws `GraphDescriptorValidationError` with the
+ * joined issue list; returns the descriptor unchanged on success.
+ */
+export function validateGraphDescriptor(descriptor) {
+    const issues = [];
+    const repeatedNodeIds = duplicates(descriptor.nodes.map((node) => node.id));
+    if (repeatedNodeIds.length > 0) {
+        issues.push(`duplicate node ID(s): ${repeatedNodeIds.join(", ")}`);
+    }
+    const repeatedEdgeIds = duplicates(descriptor.edges.map((edge) => edge.id));
+    if (repeatedEdgeIds.length > 0) {
+        issues.push(`duplicate edge ID(s): ${repeatedEdgeIds.join(", ")}`);
+    }
+    const repeatedEntries = duplicates(descriptor.entry_node_ids);
+    if (repeatedEntries.length > 0) {
+        issues.push(`duplicate entry node ID(s): ${repeatedEntries.join(", ")}`);
+    }
+    const invalidIds = [];
+    for (const node of descriptor.nodes) {
+        if (!isValidStableId(node.id))
+            invalidIds.push(node.id);
+        if (node.kind === "join") {
+            if (!isValidStableId(node.fan_out_node_id))
+                invalidIds.push(node.fan_out_node_id);
+            for (const branchId of node.input_branch_ids) {
+                if (!isValidStableId(branchId))
+                    invalidIds.push(branchId);
+            }
+        }
+    }
+    for (const edge of descriptor.edges) {
+        if (!isValidStableId(edge.id))
+            invalidIds.push(edge.id);
+        if (!isValidStableId(edge.from))
+            invalidIds.push(edge.from);
+        if (!isValidStableId(edge.to))
+            invalidIds.push(edge.to);
+        if (edge.kind === "conditional" || edge.kind === "back_edge") {
+            if (!isValidStableId(edge.route))
+                invalidIds.push(edge.route);
+        }
+        if (edge.kind === "fan_out") {
+            if (!isValidStableId(edge.branch_id))
+                invalidIds.push(edge.branch_id);
+            if (!isValidStableId(edge.owner_join_id))
+                invalidIds.push(edge.owner_join_id);
+        }
+    }
+    for (const entry of descriptor.entry_node_ids) {
+        if (!isValidStableId(entry))
+            invalidIds.push(entry);
+    }
+    if (!isValidStableId(descriptor.terminal_verification_node_id)) {
+        invalidIds.push(descriptor.terminal_verification_node_id);
+    }
+    if (invalidIds.length > 0) {
+        issues.push(`invalid stable ID(s): ${[...new Set(invalidIds)].sort().join(", ")}`);
+    }
+    const nodes = new Map(descriptor.nodes.map((node) => [node.id, node]));
+    const outgoing = groupByFrom(descriptor.edges);
+    validateOutgoingContracts(descriptor, nodes, outgoing, issues);
+    for (const entry of descriptor.entry_node_ids) {
+        if (!nodes.has(entry))
+            issues.push(`entry node ${entry} does not exist`);
+    }
+    const terminalNode = nodes.get(descriptor.terminal_verification_node_id);
+    if (terminalNode === undefined) {
+        issues.push(`terminal verification node ${descriptor.terminal_verification_node_id} does not exist`);
+    }
+    else if (terminalNode.kind !== "agent" && terminalNode.kind !== "command") {
+        issues.push("terminal verification must be an executable agent or command node");
+    }
+    const allAdjacency = adjacencyFor(descriptor.edges, true);
+    const forwardAdjacency = adjacencyFor(descriptor.edges, false);
+    const reachable = reachableSet(descriptor.entry_node_ids, allAdjacency);
+    const unreachable = descriptor.nodes
+        .map((node) => node.id)
+        .filter((id) => !reachable.has(id));
+    if (unreachable.length > 0) {
+        issues.push(`unreachable node(s): ${unreachable.join(", ")}`);
+    }
+    const cycle = findForwardCycle(descriptor.nodes.map((node) => node.id), forwardAdjacency);
+    if (cycle) {
+        issues.push(`non-back-edge cycle detected: ${cycle.join(" -> ")}`);
+    }
+    for (const edge of descriptor.edges) {
+        if (edge.kind === "back_edge") {
+            const isReturn = edge.to === edge.from ||
+                isReachable(edge.to, edge.from, forwardAdjacency);
+            if (!isReturn) {
+                issues.push(`back-edge ${edge.id} is not a structural return to an earlier node`);
+            }
+        }
+    }
+    if (terminalNode !== undefined) {
+        const cannotVerify = descriptor.nodes
+            .map((node) => node.id)
+            .filter((id) => !isReachable(id, terminalNode.id, allAdjacency));
+        if (cannotVerify.length > 0) {
+            issues.push(`every successful path must reach terminal verification; failing node(s): ${cannotVerify.join(", ")}`);
+        }
+    }
+    const regions = validateForkRegions(descriptor, nodes, outgoing, allAdjacency, issues);
+    validateEntryEligibility(descriptor, nodes, regions, issues);
+    if (issues.length > 0) {
+        throw new GraphDescriptorValidationError([...new Set(issues)]);
+    }
+    return descriptor;
+}
+/**
+ * Draft parser: strict schema parse → full validation → defensive
+ * `structuredClone` + `deepFreeze`. Input carrying a `descriptor_hash` is
+ * rejected with a directed error (use `parseSealedGraphDescriptor`).
+ */
+export function parseGraphDescriptor(input) {
+    if (isRecordWithHash(input)) {
+        throw new GraphDescriptorValidationError([
+            "sealed input must use `parseSealedGraphDescriptor`",
+        ]);
+    }
+    const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+    return deepFreeze(structuredClone(descriptor));
+}
+/**
+ * Sole draft → scheduler producer: strict parse → validate → compute hash →
+ * defensive `structuredClone` + `deepFreeze` with `descriptor_hash`. Input
+ * carrying a `descriptor_hash` is rejected with a directed error.
+ */
+export function sealGraphDescriptor(input) {
+    if (isRecordWithHash(input)) {
+        throw new GraphDescriptorValidationError([
+            "use `parseSealedGraphDescriptor` for persisted sealed input",
+        ]);
+    }
+    const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+    const sealed = {
+        ...structuredClone(descriptor),
+        descriptor_hash: computeDescriptorHash(descriptor),
+    };
+    return deepFreeze(sealed);
+}
+/**
+ * Sole persisted → scheduler producer. Requires a well-formed `descriptor_hash`;
+ * strict schema parse → full validation → recompute the hash and compare with
+ * the supplied hash; a mismatch is rejected (never silently recomputed), then a
+ * defensive `structuredClone` + `deepFreeze` is returned.
+ */
+export function parseSealedGraphDescriptor(input) {
+    const suppliedHash = typeof input === "object" && input !== null && !Array.isArray(input)
+        ? input.descriptor_hash
+        : undefined;
+    if (typeof suppliedHash !== "string") {
+        throw new GraphDescriptorValidationError([
+            "persisted sealed input must carry a `descriptor_hash`",
+        ]);
+    }
+    if (!DESCRIPTOR_HASH_PATTERN.test(suppliedHash)) {
+        throw new GraphDescriptorValidationError([
+            "`descriptor_hash` must be 64 lowercase hexadecimal characters",
+        ]);
+    }
+    const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+    if (computeDescriptorHash(descriptor) !== suppliedHash) {
+        throw new GraphDescriptorValidationError([
+            "descriptor hash does not match the exact revision",
+        ]);
+    }
+    const sealed = {
+        ...structuredClone(descriptor),
+        descriptor_hash: suppliedHash,
+    };
+    return deepFreeze(sealed);
+}
+/**
+ * Non-branding, never-throws boolean predicate. Structure-before-hash: strict
+ * schema parse → full validation → hash recompute → compare; `false` on any
+ * structural failure or mismatch. Does not clone, freeze, or mutate its input.
+ */
+export function verifyDescriptorHash(input) {
+    try {
+        const descriptor = validateGraphDescriptor(parseGraphDescriptorShape(input));
+        return computeDescriptorHash(descriptor) === descriptor.descriptor_hash;
+    }
+    catch {
+        return false;
+    }
+}
+/** Non-throwing structural check (shape parse + validation, no hash semantics). */
+export function isGraphDescriptor(input) {
+    try {
+        validateGraphDescriptor(parseGraphDescriptorShape(input));
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+//# sourceMappingURL=descriptor.js.map

--- a/dist/graph/index.d.ts
+++ b/dist/graph/index.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Graph Core public barrel. Exports only the Graph Core module surface;
+ * `src/index.ts` is intentionally untouched.
+ */
+export * from "./types.js";
+export * from "./schema.js";
+export * from "./descriptor.js";
+export * from "./scheduler.js";
+//# sourceMappingURL=index.d.ts.map

--- a/dist/graph/index.js
+++ b/dist/graph/index.js
@@ -1,0 +1,9 @@
+/**
+ * Graph Core public barrel. Exports only the Graph Core module surface;
+ * `src/index.ts` is intentionally untouched.
+ */
+export * from "./types.js";
+export * from "./schema.js";
+export * from "./descriptor.js";
+export * from "./scheduler.js";
+//# sourceMappingURL=index.js.map

--- a/dist/graph/scheduler.d.ts
+++ b/dist/graph/scheduler.d.ts
@@ -1,0 +1,49 @@
+/**
+ * Graph Core pure deterministic scheduler (stage-04 contract).
+ *
+ * Contract-authored from the ralplan stage-04 revision (`pending-approval.md`);
+ * oracle `99ffe31` used only for behavioral cross-checks. Scheduler accepts only
+ * `SealedGraphDescriptor`; projections are descriptor-bound; record-bearing
+ * mutations are replay-fenced; begin/release commit nothing.
+ */
+import type { ApplyHumanApprovalInput, ApplyNodeResultInput, BeginActivationAttemptInput, GraphActivation, GraphEdge, GraphSchedulerErrorCode, GraphSchedulerProjection, ReleaseAttemptForRetryInput, ResolveJoinInput, SchedulerApplyResult, SealedGraphDescriptor } from "./types.js";
+export declare class GraphSchedulerError extends Error {
+    readonly code: GraphSchedulerErrorCode;
+    constructor(code: GraphSchedulerErrorCode, message: string);
+}
+/** Create the initial descriptor-bound projection with entry activations. */
+export declare function initializeGraphProjection(descriptor: SealedGraphDescriptor, entryActivationIds: Readonly<Record<string, string>>): GraphSchedulerProjection;
+/** Plain projection transform; commits no transition record. */
+export declare function beginActivationAttempt(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection, input: BeginActivationAttemptInput): GraphSchedulerProjection;
+/**
+ * Atomic final-budget release: if `attempt_no >= node.max_attempts` at release
+ * time the activation goes terminal `failed` (never an unstartable ready state);
+ * otherwise it returns to `ready`. Plain projection transform; no record.
+ */
+export declare function releaseAttemptForRetry(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection, input: ReleaseAttemptForRetryInput): GraphSchedulerProjection;
+/** Record-bearing mutation for agent/command completion (replay-fenced). */
+export declare function applyNodeResult(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection, input: ApplyNodeResultInput): SchedulerApplyResult;
+/**
+ * Dedicated human-approval transition. `approved` follows the node's single
+ * fixed outgoing edge; `denied` terminal-fails the activation. Records carry
+ * `output_summary` (never `summary`) and no `attempt_id`; both outcomes require
+ * at least one evidence reference. Replay-fenced.
+ */
+export declare function applyHumanApproval(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection, input: ApplyHumanApprovalInput): SchedulerApplyResult;
+/** Resolve a join: consume cohort + tokens exactly once, create the next activation. */
+export declare function resolveJoin(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection, input: ResolveJoinInput): SchedulerApplyResult;
+/** Per-lineage traversal counter key (pure helper; no descriptor). */
+export declare function traversalCounterKey(activation: GraphActivation, edge: GraphEdge): string;
+/** Hash-fenced read: ready agent/command activations in code-unit order. */
+export declare function listReadyExecutableActivations(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection): readonly GraphActivation[];
+/** Hash-fenced read: ready human-approval activations in code-unit order. */
+export declare function listReadyApprovalActivations(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection): readonly GraphActivation[];
+/** Hash-fenced read: ready join activations in code-unit order. */
+export declare function listReadyJoinActivations(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection): readonly GraphActivation[];
+/**
+ * Hash-fenced read: true iff at least one terminal verification activation
+ * completed with a succeeded, evidence-bearing transition, every activation is
+ * completed, and every cohort is consumed.
+ */
+export declare function isGraphSucceeded(descriptor: SealedGraphDescriptor, projection: GraphSchedulerProjection): boolean;
+//# sourceMappingURL=scheduler.d.ts.map

--- a/dist/graph/scheduler.js
+++ b/dist/graph/scheduler.js
@@ -1,0 +1,847 @@
+/**
+ * Graph Core pure deterministic scheduler (stage-04 contract).
+ *
+ * Contract-authored from the ralplan stage-04 revision (`pending-approval.md`);
+ * oracle `99ffe31` used only for behavioral cross-checks. Scheduler accepts only
+ * `SealedGraphDescriptor`; projections are descriptor-bound; record-bearing
+ * mutations are replay-fenced; begin/release commit nothing.
+ */
+import { createHash } from "node:crypto";
+import { canonicalJson } from "./descriptor.js";
+import { isValidStableId, parseGraphApprovalDecision, parseGraphNodeResult, } from "./schema.js";
+export class GraphSchedulerError extends Error {
+    code;
+    constructor(code, message) {
+        super(message);
+        this.name = "GraphSchedulerError";
+        this.code = code;
+    }
+}
+/** Closed-error throw helper: every scheduler failure uses exactly one code. */
+function fail(code, message) {
+    throw new GraphSchedulerError(code, message);
+}
+function displayValue(value) {
+    if (typeof value === "string")
+        return JSON.stringify(value);
+    try {
+        const serialized = JSON.stringify(value);
+        return serialized ?? `<${typeof value}>`;
+    }
+    catch {
+        return `<${typeof value}>`;
+    }
+}
+/** Wrap a Zod-validating parser: ZodError never escapes a scheduler entrypoint. */
+function parseSchedulerInput(parse, input, what) {
+    try {
+        return parse(input);
+    }
+    catch (error) {
+        fail("invalid_input", `invalid ${what}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+/** Prototype-safe own-key lookup for state maps (callers may use plain objects). */
+function own(map, key) {
+    return Object.hasOwn(map, key) ? map[key] : undefined;
+}
+/** Empty null-prototype map: own-key writes can never hit Object.prototype. */
+function emptyMap() {
+    return Object.create(null);
+}
+function isPlainRecord(value) {
+    if (value === null || typeof value !== "object" || Array.isArray(value))
+        return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+}
+function identityField(identities, key) {
+    return identities !== undefined && Object.hasOwn(identities, key)
+        ? identities[key]
+        : undefined;
+}
+function identityMapValue(map, key) {
+    return map !== undefined && Object.hasOwn(map, key) ? map[key] : undefined;
+}
+function requireStableId(value, what) {
+    if (!isValidStableId(value))
+        fail("invalid_input", `${what} ${displayValue(value)} is not a stable identifier`);
+}
+/**
+ * Normalize a request for fingerprinting: strip undefined fields into a
+ * null-prototype accumulation and reject cycles deterministically. Values are
+ * validated strictly by `canonicalJson` afterwards.
+ */
+function toFingerprintJson(value, seen) {
+    if (Array.isArray(value)) {
+        if (seen.has(value))
+            throw new TypeError("cyclic request value");
+        seen.add(value);
+        const normalized = value.map((item) => toFingerprintJson(item, seen));
+        seen.delete(value);
+        return normalized;
+    }
+    if (value !== null && typeof value === "object") {
+        if (seen.has(value))
+            throw new TypeError("cyclic request value");
+        if (!isPlainRecord(value))
+            throw new TypeError("request value must be a plain object");
+        seen.add(value);
+        const normalized = emptyMap();
+        for (const [key, child] of Object.entries(value)) {
+            if (child !== undefined)
+                normalized[key] = toFingerprintJson(child, seen);
+        }
+        seen.delete(value);
+        return normalized;
+    }
+    return value;
+}
+/** Versioned replay fingerprint bound to the descriptor hash. */
+function requestFingerprint(kind, descriptorHash, request) {
+    return createHash("sha256")
+        .update(canonicalJson(toFingerprintJson({
+        fingerprint_version: 1,
+        kind,
+        descriptor_hash: descriptorHash,
+        request,
+    }, new Set())))
+        .digest("hex");
+}
+/** Fingerprint failures (unsupported or cyclic raw values) map to `invalid_input`. */
+function computeFingerprint(kind, descriptorHash, request) {
+    try {
+        return requestFingerprint(kind, descriptorHash, request);
+    }
+    catch (error) {
+        fail("invalid_input", `cannot fingerprint request: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+/** Locale-independent code-unit ordering for ready lists. */
+function compareIds(a, b) {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+function nodeById(descriptor, nodeId) {
+    return descriptor.nodes.find((node) => node.id === nodeId);
+}
+function outgoingEdgesOf(descriptor, nodeId) {
+    return descriptor.edges.filter((edge) => edge.from === nodeId);
+}
+/** All identities in the projection's single global namespace (own keys only). */
+function namespaceIds(projection) {
+    const ids = new Set();
+    for (const activation of Object.values(projection.activations)) {
+        ids.add(activation.activation_id);
+        for (const attemptId of activation.attempt_ids)
+            ids.add(attemptId);
+    }
+    for (const cohortId of Object.keys(projection.cohorts))
+        ids.add(cohortId);
+    for (const tokenId of Object.keys(projection.branch_tokens))
+        ids.add(tokenId);
+    for (const transitionId of Object.keys(projection.committed_transitions))
+        ids.add(transitionId);
+    return ids;
+}
+/** Descriptor binding: hash AND run/revision must match the projection. */
+function fenceDescriptor(descriptor, projection) {
+    if (!isPlainRecord(projection))
+        fail("invalid_input", "projection must be a plain object");
+    if (typeof projection.descriptor_hash !== "string" ||
+        !/^[a-f0-9]{64}$/.test(projection.descriptor_hash) ||
+        !isValidStableId(projection.run_id) ||
+        !isValidStableId(projection.revision_id))
+        fail("invalid_input", "projection descriptor binding is malformed");
+    if (projection.descriptor_hash !== descriptor.descriptor_hash ||
+        projection.run_id !== descriptor.run_id ||
+        projection.revision_id !== descriptor.revision_id) {
+        fail("descriptor_mismatch", `projection bound to ${displayValue(projection.run_id)}/${displayValue(projection.revision_id)}/${displayValue(projection.descriptor_hash)}, not ${descriptor.run_id}/${descriptor.revision_id}/${descriptor.descriptor_hash}`);
+    }
+}
+function cloneMap(map, copy) {
+    const result = emptyMap();
+    for (const [key, value] of Object.entries(map))
+        result[key] = copy(value);
+    return result;
+}
+/** Structural deep clone; the scheduler never mutates its input projection. */
+function cloneProjection(projection) {
+    try {
+        return {
+            descriptor_hash: projection.descriptor_hash,
+            run_id: projection.run_id,
+            revision_id: projection.revision_id,
+            activations: cloneMap(projection.activations, (a) => ({
+                ...a,
+                attempt_ids: [...a.attempt_ids],
+            })),
+            cohorts: cloneMap(projection.cohorts, (c) => ({
+                ...c,
+                expected_branch_token_ids: [...c.expected_branch_token_ids],
+            })),
+            branch_tokens: cloneMap(projection.branch_tokens, (t) => ({ ...t })),
+            traversal_counts: Object.assign(Object.create(null), projection.traversal_counts),
+            committed_transitions: cloneMap(projection.committed_transitions, (transition) => structuredClone(transition)),
+            terminal_verification_activation_ids: [
+                ...projection.terminal_verification_activation_ids,
+            ],
+        };
+    }
+    catch {
+        fail("invalid_input", "projection contains malformed or non-cloneable values");
+    }
+}
+/**
+ * Identity maps must key by the context node's declared outgoing edge IDs.
+ * Unknown keys → `undeclared_identity_key`; malformed values → `invalid_input`.
+ * Runs BEFORE fingerprinting so fingerprints cover only validated identities.
+ */
+function validateIdentities(descriptor, node, identities) {
+    if (identities === undefined)
+        return;
+    if (!isPlainRecord(identities))
+        fail("invalid_input", "identities must be a plain object");
+    const allowedKeys = new Set([
+        "next_activation_ids",
+        "cohort_id",
+        "branch_token_ids",
+        "join_activation_id",
+    ]);
+    for (const key of Object.keys(identities)) {
+        if (!allowedKeys.has(key))
+            fail("invalid_input", `identities contains unknown field ${key}`);
+    }
+    const declaredEdges = new Set(outgoingEdgesOf(descriptor, node.id).map((edge) => edge.id));
+    const validateKeys = (map, what) => {
+        if (map === undefined)
+            return;
+        if (!isPlainRecord(map))
+            fail("invalid_input", `${what} must be a plain object`);
+        for (const [key, value] of Object.entries(map)) {
+            if (!declaredEdges.has(key))
+                fail("undeclared_identity_key", `${what} key ${key} is not a declared outgoing edge of node ${node.id}`);
+            if (!isValidStableId(value))
+                fail("invalid_input", `${what} value ${displayValue(value)} is not a stable identifier`);
+        }
+    };
+    validateKeys(identities.next_activation_ids, "next_activation_ids");
+    validateKeys(identities.branch_token_ids, "branch_token_ids");
+    for (const value of [
+        identityField(identities, "cohort_id"),
+        identityField(identities, "join_activation_id"),
+    ]) {
+        if (value !== undefined && !isValidStableId(value))
+            fail("invalid_input", `${displayValue(value)} is not a stable identifier`);
+    }
+}
+/** Replay fence for the three record-bearing mutations. */
+function replayFence(projection, transitionId, fingerprint) {
+    const existing = own(projection.committed_transitions, transitionId);
+    if (existing === undefined)
+        return undefined;
+    if (existing.request_fingerprint !== fingerprint) {
+        fail("transition_fenced", `transition ${transitionId} was committed with a different request fingerprint`);
+    }
+    return existing;
+}
+/** Reserve a fresh id against the global namespace; throws `duplicate_identity`. */
+function assertFreshId(projection, id, what) {
+    if (namespaceIds(projection).has(id)) {
+        fail("duplicate_identity", `${what} ${id} collides with an existing identity in the global namespace`);
+    }
+}
+function requireActivation(projection, activationId) {
+    requireStableId(activationId, "activation id");
+    const activation = own(projection.activations, activationId);
+    if (activation === undefined)
+        fail("activation_not_found", `activation ${displayValue(activationId)} not found`);
+    requireStableId(activation.activation_id, "stored activation id");
+    requireStableId(activation.node_id, "stored node id");
+    requireStableId(activation.traversal_owner_id, "stored traversal owner id");
+    if (!Array.isArray(activation.attempt_ids) ||
+        !activation.attempt_ids.every(isValidStableId))
+        fail("invalid_input", "stored activation attempt_ids are malformed");
+    if (activation.active_attempt_id !== undefined)
+        requireStableId(activation.active_attempt_id, "stored active attempt id");
+    return activation;
+}
+function requireNode(descriptor, nodeId) {
+    const node = nodeById(descriptor, nodeId);
+    if (node === undefined)
+        fail("node_not_found", `node ${nodeId} not found`);
+    return node;
+}
+/** Post-replay transition-id guard shared by the three record-bearing mutations. */
+function guardTransitionId(projection, transitionId) {
+    if (!isValidStableId(transitionId))
+        fail("invalid_input", `transition id ${displayValue(transitionId)} is not a stable identifier`);
+    assertFreshId(projection, transitionId, "transition id");
+}
+/**
+ * Mutation-local identity reservation. The transition id joins the same
+ * namespace as every activation/cohort/token/join id created by the mutation,
+ * so same-mutation collisions throw `duplicate_identity`.
+ */
+function reservation(projection, transitionId) {
+    const reserved = new Set([transitionId]);
+    return {
+        reserve: (id, what) => {
+            if (namespaceIds(projection).has(id) || reserved.has(id)) {
+                fail("duplicate_identity", `${what} ${id} collides with an existing identity or this mutation's transition ${transitionId}`);
+            }
+            reserved.add(id);
+        },
+    };
+}
+/** Fields shared by every committed transition record. */
+function transitionCommon(input, node, fingerprint, descriptor) {
+    return {
+        transition_id: input.transition_id,
+        activation_id: input.activation_id,
+        node_id: node.id,
+        fingerprint_version: 1,
+        request_fingerprint: fingerprint,
+        descriptor_hash: descriptor.descriptor_hash,
+    };
+}
+/** Evidence tuple required by approved/denied records (caller pre-checked non-empty). */
+function nonEmptyEvidence(refs) {
+    return [...refs];
+}
+/**
+ * Create a ready activation for `nodeId`, inheriting the traversal lineage and
+ * (when inside a fork branch) the branch token from the source activation.
+ */
+function createNextActivation(next, activationId, nodeId, source, descriptor, extra) {
+    const branchTokenId = extra !== undefined && Object.hasOwn(extra, "branch_token_id")
+        ? extra.branch_token_id
+        : source.branch_token_id;
+    const created = {
+        activation_id: activationId,
+        node_id: nodeId,
+        status: "ready",
+        attempt_no: 0,
+        attempt_ids: [],
+        traversal_owner_id: source.traversal_owner_id,
+        ...(branchTokenId !== undefined && { branch_token_id: branchTokenId }),
+        ...(extra?.cohort_id !== undefined && { cohort_id: extra.cohort_id }),
+    };
+    next.activations[activationId] = created;
+    if (nodeId === descriptor.terminal_verification_node_id)
+        next.terminal_verification_activation_ids.push(activationId);
+    const tokenId = created.branch_token_id;
+    if (tokenId !== undefined) {
+        const token = own(next.branch_tokens, tokenId);
+        if (token !== undefined && token.status === "active") {
+            next.branch_tokens[tokenId] = {
+                ...token,
+                current_activation_id: activationId,
+            };
+        }
+    }
+    return created;
+}
+/** Create the initial descriptor-bound projection with entry activations. */
+export function initializeGraphProjection(descriptor, entryActivationIds) {
+    if (!isPlainRecord(entryActivationIds))
+        fail("invalid_input", "entry activation identities must be a plain object");
+    const entrySet = new Set(descriptor.entry_node_ids);
+    for (const key of Object.keys(entryActivationIds)) {
+        if (!entrySet.has(key))
+            fail("unexpected_identity", `identity supplied for non-entry node ${key}`);
+    }
+    for (const entry of descriptor.entry_node_ids) {
+        if (!Object.hasOwn(entryActivationIds, entry))
+            fail("missing_identity", `missing activation identity for entry node ${entry}`);
+    }
+    const activations = emptyMap();
+    const terminalVerificationActivationIds = [];
+    const seen = new Set();
+    for (const entry of descriptor.entry_node_ids) {
+        const activationId = identityMapValue(entryActivationIds, entry);
+        requireStableId(activationId, "activation id");
+        if (seen.has(activationId))
+            fail("duplicate_identity", `activation identity ${activationId} used more than once`);
+        seen.add(activationId);
+        activations[activationId] = {
+            activation_id: activationId,
+            node_id: entry,
+            status: "ready",
+            attempt_no: 0,
+            attempt_ids: [],
+            traversal_owner_id: activationId,
+        };
+        if (entry === descriptor.terminal_verification_node_id)
+            terminalVerificationActivationIds.push(activationId);
+    }
+    return {
+        descriptor_hash: descriptor.descriptor_hash,
+        run_id: descriptor.run_id,
+        revision_id: descriptor.revision_id,
+        activations,
+        cohorts: emptyMap(),
+        branch_tokens: emptyMap(),
+        traversal_counts: emptyMap(),
+        committed_transitions: emptyMap(),
+        terminal_verification_activation_ids: terminalVerificationActivationIds,
+    };
+}
+/** Plain projection transform; commits no transition record. */
+export function beginActivationAttempt(descriptor, projection, input) {
+    fenceDescriptor(descriptor, projection);
+    requireStableId(input.activation_id, "activation id");
+    requireStableId(input.attempt_id, "attempt id");
+    const activation = requireActivation(projection, input.activation_id);
+    if (activation.status !== "ready")
+        fail("activation_not_ready", `activation ${input.activation_id} is not ready`);
+    const node = requireNode(descriptor, activation.node_id);
+    if (node.kind !== "agent" && node.kind !== "command")
+        fail("unsupported_node_kind", `node ${node.id} of kind ${node.kind} cannot begin an attempt`);
+    if (activation.attempt_no >= node.max_attempts)
+        fail("max_attempts_exceeded", `activation ${input.activation_id} already used its budget of ${node.max_attempts} attempts`);
+    if (!isValidStableId(input.attempt_id))
+        fail("invalid_input", `attempt id ${displayValue(input.attempt_id)} is not a stable identifier`);
+    assertFreshId(projection, input.attempt_id, "attempt id");
+    const nextProjection = cloneProjection(projection);
+    nextProjection.activations[input.activation_id] = {
+        ...activation,
+        status: "running",
+        attempt_no: activation.attempt_no + 1,
+        attempt_ids: [...activation.attempt_ids, input.attempt_id],
+        active_attempt_id: input.attempt_id,
+    };
+    return nextProjection;
+}
+/**
+ * Atomic final-budget release: if `attempt_no >= node.max_attempts` at release
+ * time the activation goes terminal `failed` (never an unstartable ready state);
+ * otherwise it returns to `ready`. Plain projection transform; no record.
+ */
+export function releaseAttemptForRetry(descriptor, projection, input) {
+    fenceDescriptor(descriptor, projection);
+    requireStableId(input.activation_id, "activation id");
+    requireStableId(input.attempt_id, "attempt id");
+    const activation = requireActivation(projection, input.activation_id);
+    if (activation.status !== "running" ||
+        activation.active_attempt_id !== input.attempt_id)
+        fail("attempt_fenced", `activation ${input.activation_id} is not running attempt ${input.attempt_id}`);
+    const node = requireNode(descriptor, activation.node_id);
+    if (node.kind !== "agent" && node.kind !== "command")
+        fail("unsupported_node_kind", `node ${node.id} of kind ${node.kind} cannot release an attempt`);
+    const nextProjection = cloneProjection(projection);
+    nextProjection.activations[input.activation_id] = {
+        ...activation,
+        status: activation.attempt_no >= node.max_attempts ? "failed" : "ready",
+        active_attempt_id: undefined,
+    };
+    return nextProjection;
+}
+/** Record-bearing mutation for agent/command completion (replay-fenced). */
+export function applyNodeResult(descriptor, projection, input) {
+    fenceDescriptor(descriptor, projection);
+    requireStableId(input.activation_id, "activation id");
+    const result = parseSchedulerInput(parseGraphNodeResult, input.result, "node result");
+    const activation = requireActivation(projection, input.activation_id);
+    const node = requireNode(descriptor, activation.node_id);
+    if (node.kind === "human-approval")
+        fail("approval_requires_dedicated_transition", `node ${node.id} requires applyHumanApproval`);
+    if (node.kind === "join")
+        fail("join_is_automatic", `node ${node.id} is resolved by the scheduler`);
+    validateIdentities(descriptor, node, input.identities);
+    const fingerprint = computeFingerprint("node_result", descriptor.descriptor_hash, {
+        activation_id: input.activation_id,
+        transition_id: input.transition_id,
+        result,
+        identities: input.identities,
+    });
+    const existing = replayFence(projection, input.transition_id, fingerprint);
+    if (existing !== undefined)
+        return { projection, transition: existing, replayed: true };
+    if (activation.status !== "running" ||
+        activation.active_attempt_id !== result.attempt_id)
+        fail("attempt_fenced", `activation ${input.activation_id} is not running attempt ${result.attempt_id}`);
+    guardTransitionId(projection, input.transition_id);
+    const edges = outgoingEdgesOf(descriptor, node.id);
+    const edgeMode = result.outcome === "failed"
+        ? "failed"
+        : edges.length === 0
+            ? "terminal"
+            : edges.some((e) => e.kind === "fan_out")
+                ? "fan_out"
+                : edges.some((e) => e.kind === "fixed")
+                    ? "fixed"
+                    : "routed";
+    if (edgeMode === "failed") {
+        if (result.route !== undefined)
+            fail("undeclared_route", "failed results cannot select routes");
+        const next = cloneProjection(projection);
+        next.activations[input.activation_id] = {
+            ...activation,
+            status: activation.attempt_no >= node.max_attempts ? "failed" : "ready",
+            active_attempt_id: undefined,
+        };
+        const transition = {
+            ...transitionCommon(input, node, fingerprint, descriptor),
+            outcome: "failed",
+            selected_edge_ids: [],
+            created_activation_ids: [],
+            evidence_refs: [...result.evidence_refs],
+            attempt_id: result.attempt_id,
+            ...(result.output_summary !== undefined && {
+                output_summary: result.output_summary,
+            }),
+            ...(result.external_idempotency_key !== undefined && {
+                external_idempotency_key: result.external_idempotency_key,
+            }),
+        };
+        next.committed_transitions[input.transition_id] = transition;
+        return { projection: next, transition, replayed: false };
+    }
+    if (node.id === descriptor.terminal_verification_node_id &&
+        result.evidence_refs.length === 0)
+        fail("terminal_evidence_required", `terminal verification node ${node.id} requires at least one evidence reference`);
+    let selectedEdgeIds = [];
+    let createdActivationIds = [];
+    let cohortId;
+    let matchedEdge;
+    const next = cloneProjection(projection);
+    const { reserve } = reservation(next, input.transition_id);
+    if (edgeMode === "fan_out") {
+        if (result.route !== undefined)
+            fail("undeclared_route", `node ${node.id} declares no routes`);
+        const fanEdges = edges.filter((e) => e.kind === "fan_out");
+        if (fanEdges.length < 2)
+            fail("invalid_input", `fan-out node ${node.id} has fewer than two fan_out edges`);
+        cohortId = identityField(input.identities, "cohort_id");
+        if (cohortId === undefined)
+            fail("missing_identity", `fan-out node ${node.id} requires identities.cohort_id`);
+        reserve(cohortId, "cohort id");
+        const entries = fanEdges.map((fanEdge) => {
+            const tokenId = identityMapValue(input.identities?.branch_token_ids, fanEdge.id);
+            const branchActivationId = identityMapValue(input.identities?.next_activation_ids, fanEdge.id);
+            if (tokenId === undefined)
+                fail("missing_identity", `fan-out node ${node.id} requires branch_token_ids[${fanEdge.id}]`);
+            if (branchActivationId === undefined)
+                fail("missing_identity", `fan-out node ${node.id} requires next_activation_ids[${fanEdge.id}]`);
+            reserve(tokenId, "branch token id");
+            reserve(branchActivationId, "activation id");
+            return { fanEdge, tokenId, branchActivationId };
+        });
+        next.cohorts[cohortId] = {
+            cohort_id: cohortId,
+            fan_out_node_id: node.id,
+            owner_join_id: fanEdges[0].owner_join_id,
+            expected_branch_token_ids: entries.map((e) => e.tokenId),
+            consumed: false,
+        };
+        for (const entry of entries) {
+            next.branch_tokens[entry.tokenId] = {
+                branch_token_id: entry.tokenId,
+                cohort_id: cohortId,
+                branch_id: entry.fanEdge.branch_id,
+                owner_join_id: fanEdges[0].owner_join_id,
+                status: "active",
+                current_activation_id: entry.branchActivationId,
+            };
+            createNextActivation(next, entry.branchActivationId, entry.fanEdge.to, activation, descriptor, { branch_token_id: entry.tokenId });
+        }
+        selectedEdgeIds = fanEdges.map((e) => e.id);
+        createdActivationIds = entries.map((e) => e.branchActivationId);
+    }
+    else if (edgeMode === "fixed" || edgeMode === "routed") {
+        if (edgeMode === "fixed") {
+            if (result.route !== undefined)
+                fail("undeclared_route", `node ${node.id} declares no routes`);
+            matchedEdge = edges.find((e) => e.kind === "fixed");
+        }
+        else {
+            if (result.route === undefined)
+                fail("route_required", `node ${node.id} requires a declared route`);
+            matchedEdge = edges.find((e) => (e.kind === "conditional" || e.kind === "back_edge") &&
+                e.route === result.route);
+            if (matchedEdge === undefined)
+                fail("undeclared_route", `node ${node.id} declares no route ${result.route}`);
+        }
+    }
+    else if (result.route !== undefined) {
+        fail("undeclared_route", `node ${node.id} declares no routes`); // terminal node
+    }
+    next.activations[input.activation_id] = {
+        ...activation,
+        status: "completed",
+        completed_transition_id: input.transition_id,
+    };
+    if (matchedEdge !== undefined) {
+        selectedEdgeIds = [matchedEdge.id];
+        const targetNode = nodeById(descriptor, matchedEdge.to);
+        if (matchedEdge.kind === "back_edge") {
+            const counterKey = traversalCounterKey(activation, matchedEdge);
+            const count = next.traversal_counts[counterKey] ?? 0;
+            if (count + 1 > matchedEdge.max_traversals)
+                fail("traversal_bound_exceeded", `back-edge ${matchedEdge.id} exceeded its max_traversals of ${matchedEdge.max_traversals}`);
+            next.traversal_counts[counterKey] = count + 1;
+            const nextActivationId = requireNextActivationId(input.identities, matchedEdge);
+            reserve(nextActivationId, "activation id");
+            createNextActivation(next, nextActivationId, matchedEdge.to, activation, descriptor);
+            createdActivationIds = [nextActivationId];
+        }
+        else if (targetNode?.kind === "join") {
+            const token = activation.branch_token_id
+                ? own(next.branch_tokens, activation.branch_token_id)
+                : undefined;
+            if (token === undefined ||
+                token.status !== "active" ||
+                token.current_activation_id !== activation.activation_id)
+                fail("branch_token_fenced", `activation ${input.activation_id} does not own an active branch token for join ${matchedEdge.to}`);
+            next.branch_tokens[token.branch_token_id] = {
+                ...token,
+                status: "arrived",
+                current_activation_id: undefined,
+            };
+            const cohort = own(next.cohorts, token.cohort_id);
+            if (cohort === undefined)
+                fail("join_owner_missing", `cohort ${token.cohort_id} for token ${token.branch_token_id} not found`);
+            const allArrived = cohort.expected_branch_token_ids.every((tokenId) => own(next.branch_tokens, tokenId)?.status === "arrived");
+            if (allArrived) {
+                const joinActivationId = identityField(input.identities, "join_activation_id");
+                if (joinActivationId === undefined)
+                    fail("missing_identity", `join ${matchedEdge.to} requires identities.join_activation_id`);
+                reserve(joinActivationId, "activation id");
+                createNextActivation(next, joinActivationId, matchedEdge.to, activation, descriptor, { cohort_id: cohort.cohort_id, branch_token_id: undefined });
+                next.cohorts[cohort.cohort_id] = {
+                    ...cohort,
+                    join_activation_id: joinActivationId,
+                };
+                createdActivationIds = [joinActivationId];
+            }
+        }
+        else {
+            const nextActivationId = requireNextActivationId(input.identities, matchedEdge);
+            reserve(nextActivationId, "activation id");
+            createNextActivation(next, nextActivationId, matchedEdge.to, activation, descriptor);
+            createdActivationIds = [nextActivationId];
+        }
+    }
+    const transition = {
+        ...transitionCommon(input, node, fingerprint, descriptor),
+        outcome: "succeeded",
+        selected_edge_ids: selectedEdgeIds,
+        created_activation_ids: createdActivationIds,
+        evidence_refs: [...result.evidence_refs],
+        attempt_id: result.attempt_id,
+        ...(result.route !== undefined && { route: result.route }),
+        ...(cohortId !== undefined && { cohort_id: cohortId }),
+        ...(result.output_summary !== undefined && {
+            output_summary: result.output_summary,
+        }),
+        ...(result.external_idempotency_key !== undefined && {
+            external_idempotency_key: result.external_idempotency_key,
+        }),
+    };
+    next.committed_transitions[input.transition_id] = transition;
+    return { projection: next, transition, replayed: false };
+}
+function requireNextActivationId(identities, edge) {
+    const activationId = identityMapValue(identities?.next_activation_ids, edge.id);
+    if (activationId === undefined)
+        fail("missing_identity", `edge ${edge.id} requires identities.next_activation_ids[${edge.id}]`);
+    return activationId;
+}
+/**
+ * Dedicated human-approval transition. `approved` follows the node's single
+ * fixed outgoing edge; `denied` terminal-fails the activation. Records carry
+ * `output_summary` (never `summary`) and no `attempt_id`; both outcomes require
+ * at least one evidence reference. Replay-fenced.
+ */
+export function applyHumanApproval(descriptor, projection, input) {
+    fenceDescriptor(descriptor, projection);
+    requireStableId(input.activation_id, "activation id");
+    const decision = parseSchedulerInput(parseGraphApprovalDecision, input.decision, "approval decision");
+    const activation = requireActivation(projection, input.activation_id);
+    const node = requireNode(descriptor, activation.node_id);
+    if (node.kind !== "human-approval")
+        fail("unsupported_node_kind", `node ${node.id} of kind ${node.kind} is not a human-approval node`);
+    validateIdentities(descriptor, node, input.identities);
+    const fingerprint = computeFingerprint("human_approval", descriptor.descriptor_hash, {
+        activation_id: input.activation_id,
+        transition_id: input.transition_id,
+        decision,
+        identities: input.identities,
+    });
+    const existing = replayFence(projection, input.transition_id, fingerprint);
+    if (existing !== undefined)
+        return { projection, transition: existing, replayed: true };
+    guardTransitionId(projection, input.transition_id);
+    if (activation.status !== "ready")
+        fail("activation_not_ready", `activation ${input.activation_id} is not ready`);
+    if (decision.evidence_refs.length === 0)
+        fail("terminal_evidence_required", `approval decision for node ${node.id} requires at least one evidence reference`);
+    const outgoing = outgoingEdgesOf(descriptor, node.id);
+    const fixedEdge = outgoing.length === 1 && outgoing[0].kind === "fixed"
+        ? outgoing[0]
+        : undefined;
+    if (fixedEdge === undefined)
+        fail("invalid_input", `human-approval node ${node.id} must have exactly one fixed outgoing edge`);
+    const next = cloneProjection(projection);
+    const { reserve } = reservation(next, input.transition_id);
+    if (decision.decision === "denied") {
+        next.activations[input.activation_id] = { ...activation, status: "failed" };
+        const transition = {
+            ...transitionCommon(input, node, fingerprint, descriptor),
+            outcome: "denied",
+            selected_edge_ids: [],
+            created_activation_ids: [],
+            evidence_refs: nonEmptyEvidence(decision.evidence_refs),
+            ...(decision.output_summary !== undefined && {
+                output_summary: decision.output_summary,
+            }),
+        };
+        next.committed_transitions[input.transition_id] = transition;
+        return { projection: next, transition, replayed: false };
+    }
+    const nextActivationId = requireNextActivationId(input.identities, fixedEdge);
+    reserve(nextActivationId, "activation id");
+    next.activations[input.activation_id] = {
+        ...activation,
+        status: "completed",
+        completed_transition_id: input.transition_id,
+    };
+    createNextActivation(next, nextActivationId, fixedEdge.to, activation, descriptor);
+    const transition = {
+        ...transitionCommon(input, node, fingerprint, descriptor),
+        outcome: "approved",
+        selected_edge_ids: [fixedEdge.id],
+        created_activation_ids: [nextActivationId],
+        evidence_refs: nonEmptyEvidence(decision.evidence_refs),
+        ...(decision.output_summary !== undefined && {
+            output_summary: decision.output_summary,
+        }),
+    };
+    next.committed_transitions[input.transition_id] = transition;
+    return { projection: next, transition, replayed: false };
+}
+/** Resolve a join: consume cohort + tokens exactly once, create the next activation. */
+export function resolveJoin(descriptor, projection, input) {
+    fenceDescriptor(descriptor, projection);
+    requireStableId(input.activation_id, "activation id");
+    const activation = requireActivation(projection, input.activation_id);
+    const node = requireNode(descriptor, activation.node_id);
+    if (node.kind !== "join")
+        fail("join_not_found", `node ${node.id} is not a join node`);
+    validateIdentities(descriptor, node, input.identities);
+    const fingerprint = computeFingerprint("resolve_join", descriptor.descriptor_hash, {
+        activation_id: input.activation_id,
+        transition_id: input.transition_id,
+        identities: input.identities,
+    });
+    const existing = replayFence(projection, input.transition_id, fingerprint);
+    if (existing !== undefined)
+        return { projection, transition: existing, replayed: true };
+    guardTransitionId(projection, input.transition_id);
+    const cohortId = activation.cohort_id;
+    if (cohortId === undefined)
+        fail("join_not_ready", `join activation ${input.activation_id} has no cohort`);
+    const cohort = own(projection.cohorts, cohortId);
+    if (cohort === undefined)
+        fail("join_owner_missing", `cohort ${cohortId} not found`);
+    if (cohort.owner_join_id !== node.id)
+        fail("join_owner_mismatch", `cohort ${cohortId} is owned by join ${cohort.owner_join_id}`);
+    if (cohort.consumed)
+        fail("join_already_consumed", `cohort ${cohortId} was already consumed`);
+    if (activation.status !== "ready")
+        fail("join_not_ready", `join activation ${input.activation_id} is not ready`);
+    const tokens = cohort.expected_branch_token_ids.map((tokenId) => own(projection.branch_tokens, tokenId));
+    if (tokens.some((token) => token === undefined || token.status !== "arrived"))
+        fail("join_not_ready", `join ${node.id} does not have all branch tokens arrived`);
+    const outgoing = outgoingEdgesOf(descriptor, node.id);
+    if (outgoing.length !== 1 || outgoing[0].kind !== "fixed")
+        fail("invalid_join_edge", `join ${node.id} must have exactly one fixed outgoing edge`);
+    const next = cloneProjection(projection);
+    const { reserve } = reservation(next, input.transition_id);
+    const nextActivationId = requireNextActivationId(input.identities, outgoing[0]);
+    reserve(nextActivationId, "activation id");
+    for (const tokenId of cohort.expected_branch_token_ids) {
+        const token = own(next.branch_tokens, tokenId);
+        if (token !== undefined)
+            next.branch_tokens[tokenId] = {
+                ...token,
+                status: "consumed",
+                current_activation_id: undefined,
+                consumed_by_activation_id: activation.activation_id,
+            };
+    }
+    next.cohorts[cohortId] = { ...cohort, consumed: true };
+    next.activations[input.activation_id] = {
+        ...activation,
+        status: "completed",
+        completed_transition_id: input.transition_id,
+    };
+    createNextActivation(next, nextActivationId, outgoing[0].to, activation, descriptor);
+    const transition = {
+        ...transitionCommon(input, node, fingerprint, descriptor),
+        outcome: "join_resolved",
+        selected_edge_ids: [outgoing[0].id],
+        created_activation_ids: [nextActivationId],
+        evidence_refs: [],
+        cohort_id: cohortId,
+    };
+    next.committed_transitions[input.transition_id] = transition;
+    return { projection: next, transition, replayed: false };
+}
+/** Per-lineage traversal counter key (pure helper; no descriptor). */
+export function traversalCounterKey(activation, edge) {
+    requireStableId(activation.traversal_owner_id, "traversal owner id");
+    requireStableId(edge.id, "edge id");
+    return canonicalJson([activation.traversal_owner_id, edge.id]);
+}
+/** Hash-fenced read: ready agent/command activations in code-unit order. */
+export function listReadyExecutableActivations(descriptor, projection) {
+    fenceDescriptor(descriptor, projection);
+    return readyActivations(descriptor, projection, (node) => node.kind === "agent" || node.kind === "command");
+}
+/** Hash-fenced read: ready human-approval activations in code-unit order. */
+export function listReadyApprovalActivations(descriptor, projection) {
+    fenceDescriptor(descriptor, projection);
+    return readyActivations(descriptor, projection, (node) => node.kind === "human-approval");
+}
+/** Hash-fenced read: ready join activations in code-unit order. */
+export function listReadyJoinActivations(descriptor, projection) {
+    fenceDescriptor(descriptor, projection);
+    return readyActivations(descriptor, projection, (node) => node.kind === "join");
+}
+function readyActivations(descriptor, projection, predicate) {
+    const result = [];
+    for (const activation of Object.values(projection.activations)) {
+        if (activation.status !== "ready")
+            continue;
+        const node = nodeById(descriptor, activation.node_id);
+        if (node !== undefined && predicate(node))
+            result.push(activation);
+    }
+    return result.sort((a, b) => compareIds(a.activation_id, b.activation_id));
+}
+/**
+ * Hash-fenced read: true iff at least one terminal verification activation
+ * completed with a succeeded, evidence-bearing transition, every activation is
+ * completed, and every cohort is consumed.
+ */
+export function isGraphSucceeded(descriptor, projection) {
+    fenceDescriptor(descriptor, projection);
+    const terminalVerified = projection.terminal_verification_activation_ids.some((id) => {
+        const activation = own(projection.activations, id);
+        if (activation === undefined || activation.status !== "completed")
+            return false;
+        const transition = activation.completed_transition_id
+            ? own(projection.committed_transitions, activation.completed_transition_id)
+            : undefined;
+        return (transition?.outcome === "succeeded" &&
+            transition.evidence_refs.length > 0);
+    });
+    if (!terminalVerified)
+        return false;
+    const allCompleted = Object.values(projection.activations).every((activation) => activation.status === "completed");
+    if (!allCompleted)
+        return false;
+    return Object.values(projection.cohorts).every((cohort) => cohort.consumed);
+}
+//# sourceMappingURL=scheduler.js.map

--- a/dist/graph/schema.d.ts
+++ b/dist/graph/schema.d.ts
@@ -1,0 +1,974 @@
+/**
+ * Graph Core strict Zod content schemas.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ *
+ * Exported parser utilities (`parseGraphDescriptorShape`, `parseGraphNodeResult`,
+ * `parseGraphApprovalDecision`, `parseGraphEvidenceReference`) throw `ZodError`
+ * BY DOCUMENTED CONTRACT; callers that need a closed error boundary wrap them.
+ */
+import { z } from "zod";
+import type { GraphApprovalDecision, GraphDescriptor, GraphEvidenceReference, GraphNodeResult } from "./types.js";
+/** Stable identifier: 1–128 chars, ASCII alphanumeric first, then `[A-Za-z0-9._:-]`. */
+export declare const idSchema: z.ZodString;
+/** Long-form text bound (goal, instructions, command, prompt). */
+export declare const textSchema: z.ZodString;
+export declare const graphAgentNodeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"agent">;
+    instructions: z.ZodString;
+    timeout_ms: z.ZodNumber;
+    max_attempts: z.ZodNumber;
+    effect_policy: z.ZodDiscriminatedUnion<"policy", [z.ZodObject<{
+        policy: z.ZodLiteral<"side_effect_free">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "side_effect_free";
+    }, {
+        policy: "side_effect_free";
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"idempotent">;
+        idempotency_key_template: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"reconcile">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "reconcile";
+    }, {
+        policy: "reconcile";
+    }>]>;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    id: string;
+    instructions: string;
+    kind: "agent";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}, {
+    title: string;
+    id: string;
+    instructions: string;
+    kind: "agent";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}>;
+export declare const graphCommandNodeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"command">;
+    command: z.ZodString;
+    timeout_ms: z.ZodNumber;
+    max_attempts: z.ZodNumber;
+    effect_policy: z.ZodDiscriminatedUnion<"policy", [z.ZodObject<{
+        policy: z.ZodLiteral<"side_effect_free">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "side_effect_free";
+    }, {
+        policy: "side_effect_free";
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"idempotent">;
+        idempotency_key_template: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"reconcile">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "reconcile";
+    }, {
+        policy: "reconcile";
+    }>]>;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    command: string;
+    id: string;
+    kind: "command";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}, {
+    title: string;
+    command: string;
+    id: string;
+    kind: "command";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}>;
+export declare const graphHumanApprovalNodeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"human-approval">;
+    prompt: z.ZodString;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    prompt: string;
+    id: string;
+    kind: "human-approval";
+}, {
+    title: string;
+    prompt: string;
+    id: string;
+    kind: "human-approval";
+}>;
+export declare const graphJoinNodeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"join">;
+    fan_out_node_id: z.ZodString;
+    input_branch_ids: z.ZodArray<z.ZodString, "many">;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    id: string;
+    kind: "join";
+    fan_out_node_id: string;
+    input_branch_ids: string[];
+}, {
+    title: string;
+    id: string;
+    kind: "join";
+    fan_out_node_id: string;
+    input_branch_ids: string[];
+}>;
+export declare const graphNodeSchema: z.ZodDiscriminatedUnion<"kind", [z.ZodObject<{
+    kind: z.ZodLiteral<"agent">;
+    instructions: z.ZodString;
+    timeout_ms: z.ZodNumber;
+    max_attempts: z.ZodNumber;
+    effect_policy: z.ZodDiscriminatedUnion<"policy", [z.ZodObject<{
+        policy: z.ZodLiteral<"side_effect_free">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "side_effect_free";
+    }, {
+        policy: "side_effect_free";
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"idempotent">;
+        idempotency_key_template: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"reconcile">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "reconcile";
+    }, {
+        policy: "reconcile";
+    }>]>;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    id: string;
+    instructions: string;
+    kind: "agent";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}, {
+    title: string;
+    id: string;
+    instructions: string;
+    kind: "agent";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}>, z.ZodObject<{
+    kind: z.ZodLiteral<"command">;
+    command: z.ZodString;
+    timeout_ms: z.ZodNumber;
+    max_attempts: z.ZodNumber;
+    effect_policy: z.ZodDiscriminatedUnion<"policy", [z.ZodObject<{
+        policy: z.ZodLiteral<"side_effect_free">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "side_effect_free";
+    }, {
+        policy: "side_effect_free";
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"idempotent">;
+        idempotency_key_template: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }, {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    }>, z.ZodObject<{
+        policy: z.ZodLiteral<"reconcile">;
+    }, "strict", z.ZodTypeAny, {
+        policy: "reconcile";
+    }, {
+        policy: "reconcile";
+    }>]>;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    command: string;
+    id: string;
+    kind: "command";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}, {
+    title: string;
+    command: string;
+    id: string;
+    kind: "command";
+    timeout_ms: number;
+    max_attempts: number;
+    effect_policy: {
+        policy: "side_effect_free";
+    } | {
+        policy: "idempotent";
+        idempotency_key_template: string;
+    } | {
+        policy: "reconcile";
+    };
+}>, z.ZodObject<{
+    kind: z.ZodLiteral<"human-approval">;
+    prompt: z.ZodString;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    prompt: string;
+    id: string;
+    kind: "human-approval";
+}, {
+    title: string;
+    prompt: string;
+    id: string;
+    kind: "human-approval";
+}>, z.ZodObject<{
+    kind: z.ZodLiteral<"join">;
+    fan_out_node_id: z.ZodString;
+    input_branch_ids: z.ZodArray<z.ZodString, "many">;
+    id: z.ZodString;
+    title: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    title: string;
+    id: string;
+    kind: "join";
+    fan_out_node_id: string;
+    input_branch_ids: string[];
+}, {
+    title: string;
+    id: string;
+    kind: "join";
+    fan_out_node_id: string;
+    input_branch_ids: string[];
+}>]>;
+export declare const graphFixedEdgeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"fixed">;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "fixed";
+    from: string;
+    to: string;
+}, {
+    id: string;
+    kind: "fixed";
+    from: string;
+    to: string;
+}>;
+export declare const graphConditionalEdgeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"conditional">;
+    route: z.ZodString;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "conditional";
+    from: string;
+    to: string;
+    route: string;
+}, {
+    id: string;
+    kind: "conditional";
+    from: string;
+    to: string;
+    route: string;
+}>;
+export declare const graphFanOutEdgeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"fan_out">;
+    branch_id: z.ZodString;
+    owner_join_id: z.ZodString;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "fan_out";
+    from: string;
+    to: string;
+    branch_id: string;
+    owner_join_id: string;
+}, {
+    id: string;
+    kind: "fan_out";
+    from: string;
+    to: string;
+    branch_id: string;
+    owner_join_id: string;
+}>;
+export declare const graphBackEdgeSchema: z.ZodObject<{
+    kind: z.ZodLiteral<"back_edge">;
+    route: z.ZodString;
+    max_traversals: z.ZodNumber;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "back_edge";
+    from: string;
+    to: string;
+    route: string;
+    max_traversals: number;
+}, {
+    id: string;
+    kind: "back_edge";
+    from: string;
+    to: string;
+    route: string;
+    max_traversals: number;
+}>;
+export declare const graphEdgeSchema: z.ZodDiscriminatedUnion<"kind", [z.ZodObject<{
+    kind: z.ZodLiteral<"fixed">;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "fixed";
+    from: string;
+    to: string;
+}, {
+    id: string;
+    kind: "fixed";
+    from: string;
+    to: string;
+}>, z.ZodObject<{
+    kind: z.ZodLiteral<"conditional">;
+    route: z.ZodString;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "conditional";
+    from: string;
+    to: string;
+    route: string;
+}, {
+    id: string;
+    kind: "conditional";
+    from: string;
+    to: string;
+    route: string;
+}>, z.ZodObject<{
+    kind: z.ZodLiteral<"fan_out">;
+    branch_id: z.ZodString;
+    owner_join_id: z.ZodString;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "fan_out";
+    from: string;
+    to: string;
+    branch_id: string;
+    owner_join_id: string;
+}, {
+    id: string;
+    kind: "fan_out";
+    from: string;
+    to: string;
+    branch_id: string;
+    owner_join_id: string;
+}>, z.ZodObject<{
+    kind: z.ZodLiteral<"back_edge">;
+    route: z.ZodString;
+    max_traversals: z.ZodNumber;
+    id: z.ZodString;
+    from: z.ZodString;
+    to: z.ZodString;
+}, "strict", z.ZodTypeAny, {
+    id: string;
+    kind: "back_edge";
+    from: string;
+    to: string;
+    route: string;
+    max_traversals: number;
+}, {
+    id: string;
+    kind: "back_edge";
+    from: string;
+    to: string;
+    route: string;
+    max_traversals: number;
+}>]>;
+export declare const graphDescriptorSchema: z.ZodObject<{
+    descriptor_version: z.ZodLiteral<1>;
+    run_id: z.ZodString;
+    revision_id: z.ZodString;
+    goal: z.ZodString;
+    nodes: z.ZodArray<z.ZodDiscriminatedUnion<"kind", [z.ZodObject<{
+        kind: z.ZodLiteral<"agent">;
+        instructions: z.ZodString;
+        timeout_ms: z.ZodNumber;
+        max_attempts: z.ZodNumber;
+        effect_policy: z.ZodDiscriminatedUnion<"policy", [z.ZodObject<{
+            policy: z.ZodLiteral<"side_effect_free">;
+        }, "strict", z.ZodTypeAny, {
+            policy: "side_effect_free";
+        }, {
+            policy: "side_effect_free";
+        }>, z.ZodObject<{
+            policy: z.ZodLiteral<"idempotent">;
+            idempotency_key_template: z.ZodString;
+        }, "strict", z.ZodTypeAny, {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        }, {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        }>, z.ZodObject<{
+            policy: z.ZodLiteral<"reconcile">;
+        }, "strict", z.ZodTypeAny, {
+            policy: "reconcile";
+        }, {
+            policy: "reconcile";
+        }>]>;
+        id: z.ZodString;
+        title: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        title: string;
+        id: string;
+        instructions: string;
+        kind: "agent";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    }, {
+        title: string;
+        id: string;
+        instructions: string;
+        kind: "agent";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    }>, z.ZodObject<{
+        kind: z.ZodLiteral<"command">;
+        command: z.ZodString;
+        timeout_ms: z.ZodNumber;
+        max_attempts: z.ZodNumber;
+        effect_policy: z.ZodDiscriminatedUnion<"policy", [z.ZodObject<{
+            policy: z.ZodLiteral<"side_effect_free">;
+        }, "strict", z.ZodTypeAny, {
+            policy: "side_effect_free";
+        }, {
+            policy: "side_effect_free";
+        }>, z.ZodObject<{
+            policy: z.ZodLiteral<"idempotent">;
+            idempotency_key_template: z.ZodString;
+        }, "strict", z.ZodTypeAny, {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        }, {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        }>, z.ZodObject<{
+            policy: z.ZodLiteral<"reconcile">;
+        }, "strict", z.ZodTypeAny, {
+            policy: "reconcile";
+        }, {
+            policy: "reconcile";
+        }>]>;
+        id: z.ZodString;
+        title: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        title: string;
+        command: string;
+        id: string;
+        kind: "command";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    }, {
+        title: string;
+        command: string;
+        id: string;
+        kind: "command";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    }>, z.ZodObject<{
+        kind: z.ZodLiteral<"human-approval">;
+        prompt: z.ZodString;
+        id: z.ZodString;
+        title: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        title: string;
+        prompt: string;
+        id: string;
+        kind: "human-approval";
+    }, {
+        title: string;
+        prompt: string;
+        id: string;
+        kind: "human-approval";
+    }>, z.ZodObject<{
+        kind: z.ZodLiteral<"join">;
+        fan_out_node_id: z.ZodString;
+        input_branch_ids: z.ZodArray<z.ZodString, "many">;
+        id: z.ZodString;
+        title: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        title: string;
+        id: string;
+        kind: "join";
+        fan_out_node_id: string;
+        input_branch_ids: string[];
+    }, {
+        title: string;
+        id: string;
+        kind: "join";
+        fan_out_node_id: string;
+        input_branch_ids: string[];
+    }>]>, "many">;
+    edges: z.ZodArray<z.ZodDiscriminatedUnion<"kind", [z.ZodObject<{
+        kind: z.ZodLiteral<"fixed">;
+        id: z.ZodString;
+        from: z.ZodString;
+        to: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        id: string;
+        kind: "fixed";
+        from: string;
+        to: string;
+    }, {
+        id: string;
+        kind: "fixed";
+        from: string;
+        to: string;
+    }>, z.ZodObject<{
+        kind: z.ZodLiteral<"conditional">;
+        route: z.ZodString;
+        id: z.ZodString;
+        from: z.ZodString;
+        to: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        id: string;
+        kind: "conditional";
+        from: string;
+        to: string;
+        route: string;
+    }, {
+        id: string;
+        kind: "conditional";
+        from: string;
+        to: string;
+        route: string;
+    }>, z.ZodObject<{
+        kind: z.ZodLiteral<"fan_out">;
+        branch_id: z.ZodString;
+        owner_join_id: z.ZodString;
+        id: z.ZodString;
+        from: z.ZodString;
+        to: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        id: string;
+        kind: "fan_out";
+        from: string;
+        to: string;
+        branch_id: string;
+        owner_join_id: string;
+    }, {
+        id: string;
+        kind: "fan_out";
+        from: string;
+        to: string;
+        branch_id: string;
+        owner_join_id: string;
+    }>, z.ZodObject<{
+        kind: z.ZodLiteral<"back_edge">;
+        route: z.ZodString;
+        max_traversals: z.ZodNumber;
+        id: z.ZodString;
+        from: z.ZodString;
+        to: z.ZodString;
+    }, "strict", z.ZodTypeAny, {
+        id: string;
+        kind: "back_edge";
+        from: string;
+        to: string;
+        route: string;
+        max_traversals: number;
+    }, {
+        id: string;
+        kind: "back_edge";
+        from: string;
+        to: string;
+        route: string;
+        max_traversals: number;
+    }>]>, "many">;
+    entry_node_ids: z.ZodArray<z.ZodString, "many">;
+    concurrency_limit: z.ZodNumber;
+    terminal_verification_node_id: z.ZodString;
+    descriptor_hash: z.ZodOptional<z.ZodString>;
+}, "strict", z.ZodTypeAny, {
+    run_id: string;
+    goal: string;
+    descriptor_version: 1;
+    revision_id: string;
+    nodes: ({
+        title: string;
+        id: string;
+        instructions: string;
+        kind: "agent";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    } | {
+        title: string;
+        command: string;
+        id: string;
+        kind: "command";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    } | {
+        title: string;
+        prompt: string;
+        id: string;
+        kind: "human-approval";
+    } | {
+        title: string;
+        id: string;
+        kind: "join";
+        fan_out_node_id: string;
+        input_branch_ids: string[];
+    })[];
+    edges: ({
+        id: string;
+        kind: "fixed";
+        from: string;
+        to: string;
+    } | {
+        id: string;
+        kind: "conditional";
+        from: string;
+        to: string;
+        route: string;
+    } | {
+        id: string;
+        kind: "fan_out";
+        from: string;
+        to: string;
+        branch_id: string;
+        owner_join_id: string;
+    } | {
+        id: string;
+        kind: "back_edge";
+        from: string;
+        to: string;
+        route: string;
+        max_traversals: number;
+    })[];
+    entry_node_ids: string[];
+    concurrency_limit: number;
+    terminal_verification_node_id: string;
+    descriptor_hash?: string | undefined;
+}, {
+    run_id: string;
+    goal: string;
+    descriptor_version: 1;
+    revision_id: string;
+    nodes: ({
+        title: string;
+        id: string;
+        instructions: string;
+        kind: "agent";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    } | {
+        title: string;
+        command: string;
+        id: string;
+        kind: "command";
+        timeout_ms: number;
+        max_attempts: number;
+        effect_policy: {
+            policy: "side_effect_free";
+        } | {
+            policy: "idempotent";
+            idempotency_key_template: string;
+        } | {
+            policy: "reconcile";
+        };
+    } | {
+        title: string;
+        prompt: string;
+        id: string;
+        kind: "human-approval";
+    } | {
+        title: string;
+        id: string;
+        kind: "join";
+        fan_out_node_id: string;
+        input_branch_ids: string[];
+    })[];
+    edges: ({
+        id: string;
+        kind: "fixed";
+        from: string;
+        to: string;
+    } | {
+        id: string;
+        kind: "conditional";
+        from: string;
+        to: string;
+        route: string;
+    } | {
+        id: string;
+        kind: "fan_out";
+        from: string;
+        to: string;
+        branch_id: string;
+        owner_join_id: string;
+    } | {
+        id: string;
+        kind: "back_edge";
+        from: string;
+        to: string;
+        route: string;
+        max_traversals: number;
+    })[];
+    entry_node_ids: string[];
+    concurrency_limit: number;
+    terminal_verification_node_id: string;
+    descriptor_hash?: string | undefined;
+}>;
+export declare const graphEvidenceReferenceSchema: z.ZodObject<{
+    kind: z.ZodEnum<["file", "command", "test", "human", "url"]>;
+    ref: z.ZodString;
+    summary: z.ZodOptional<z.ZodString>;
+}, "strict", z.ZodTypeAny, {
+    kind: "file" | "command" | "test" | "url" | "human";
+    ref: string;
+    summary?: string | undefined;
+}, {
+    kind: "file" | "command" | "test" | "url" | "human";
+    ref: string;
+    summary?: string | undefined;
+}>;
+export declare const graphNodeResultSchema: z.ZodObject<{
+    outcome: z.ZodEnum<["succeeded", "failed"]>;
+    attempt_id: z.ZodString;
+    route: z.ZodOptional<z.ZodString>;
+    output_summary: z.ZodOptional<z.ZodString>;
+    evidence_refs: z.ZodArray<z.ZodObject<{
+        kind: z.ZodEnum<["file", "command", "test", "human", "url"]>;
+        ref: z.ZodString;
+        summary: z.ZodOptional<z.ZodString>;
+    }, "strict", z.ZodTypeAny, {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }, {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }>, "many">;
+    external_idempotency_key: z.ZodOptional<z.ZodString>;
+}, "strict", z.ZodTypeAny, {
+    attempt_id: string;
+    outcome: "failed" | "succeeded";
+    evidence_refs: {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }[];
+    route?: string | undefined;
+    output_summary?: string | undefined;
+    external_idempotency_key?: string | undefined;
+}, {
+    attempt_id: string;
+    outcome: "failed" | "succeeded";
+    evidence_refs: {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }[];
+    route?: string | undefined;
+    output_summary?: string | undefined;
+    external_idempotency_key?: string | undefined;
+}>;
+export declare const graphApprovalDecisionSchema: z.ZodObject<{
+    decision: z.ZodEnum<["approved", "denied"]>;
+    evidence_refs: z.ZodArray<z.ZodObject<{
+        kind: z.ZodEnum<["file", "command", "test", "human", "url"]>;
+        ref: z.ZodString;
+        summary: z.ZodOptional<z.ZodString>;
+    }, "strict", z.ZodTypeAny, {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }, {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }>, "many">;
+    output_summary: z.ZodOptional<z.ZodString>;
+}, "strict", z.ZodTypeAny, {
+    decision: "approved" | "denied";
+    evidence_refs: {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }[];
+    output_summary?: string | undefined;
+}, {
+    decision: "approved" | "denied";
+    evidence_refs: {
+        kind: "file" | "command" | "test" | "url" | "human";
+        ref: string;
+        summary?: string | undefined;
+    }[];
+    output_summary?: string | undefined;
+}>;
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export declare function parseGraphDescriptorShape(input: unknown): GraphDescriptor;
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export declare function parseGraphNodeResult(input: unknown): GraphNodeResult;
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export declare function parseGraphApprovalDecision(input: unknown): GraphApprovalDecision;
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export declare function parseGraphEvidenceReference(input: unknown): GraphEvidenceReference;
+/**
+ * Non-throwing stable-id predicate: `true` iff the value is a string matching
+ * `idSchema` (1–128 chars, stable charset). Used by the scheduler for identity
+ * values, entry identity keys/values, and identity-map keys.
+ */
+export declare function isValidStableId(value: unknown): boolean;
+//# sourceMappingURL=schema.d.ts.map

--- a/dist/graph/schema.js
+++ b/dist/graph/schema.js
@@ -1,0 +1,175 @@
+/**
+ * Graph Core strict Zod content schemas.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ *
+ * Exported parser utilities (`parseGraphDescriptorShape`, `parseGraphNodeResult`,
+ * `parseGraphApprovalDecision`, `parseGraphEvidenceReference`) throw `ZodError`
+ * BY DOCUMENTED CONTRACT; callers that need a closed error boundary wrap them.
+ */
+import { z } from "zod";
+/** Stable identifier: 1–128 chars, ASCII alphanumeric first, then `[A-Za-z0-9._:-]`. */
+export const idSchema = z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "must be a stable identifier");
+/** Long-form text bound (goal, instructions, command, prompt). */
+export const textSchema = z.string().min(1).max(32_768);
+const sideEffectFreeSchema = z
+    .object({ policy: z.literal("side_effect_free") })
+    .strict();
+const idempotentSchema = z
+    .object({
+    policy: z.literal("idempotent"),
+    idempotency_key_template: z.string().min(1).max(512),
+})
+    .strict();
+const reconcileSchema = z.object({ policy: z.literal("reconcile") }).strict();
+const graphEffectPolicySchema = z.discriminatedUnion("policy", [
+    sideEffectFreeSchema,
+    idempotentSchema,
+    reconcileSchema,
+]);
+const nodeBase = {
+    id: idSchema,
+    title: z.string().min(1).max(256),
+};
+const executableNodeBase = {
+    ...nodeBase,
+    timeout_ms: z.number().int().min(100).max(86_400_000),
+    max_attempts: z.number().int().min(1).max(20),
+    effect_policy: graphEffectPolicySchema,
+};
+export const graphAgentNodeSchema = z
+    .object({
+    ...executableNodeBase,
+    kind: z.literal("agent"),
+    instructions: textSchema,
+})
+    .strict();
+export const graphCommandNodeSchema = z
+    .object({
+    ...executableNodeBase,
+    kind: z.literal("command"),
+    command: textSchema,
+})
+    .strict();
+export const graphHumanApprovalNodeSchema = z
+    .object({
+    ...nodeBase,
+    kind: z.literal("human-approval"),
+    prompt: textSchema,
+})
+    .strict();
+export const graphJoinNodeSchema = z
+    .object({
+    ...nodeBase,
+    kind: z.literal("join"),
+    fan_out_node_id: idSchema,
+    input_branch_ids: z.array(idSchema).min(2).max(64),
+})
+    .strict();
+export const graphNodeSchema = z.discriminatedUnion("kind", [
+    graphAgentNodeSchema,
+    graphCommandNodeSchema,
+    graphHumanApprovalNodeSchema,
+    graphJoinNodeSchema,
+]);
+const edgeBase = { id: idSchema, from: idSchema, to: idSchema };
+export const graphFixedEdgeSchema = z
+    .object({ ...edgeBase, kind: z.literal("fixed") })
+    .strict();
+export const graphConditionalEdgeSchema = z
+    .object({ ...edgeBase, kind: z.literal("conditional"), route: idSchema })
+    .strict();
+export const graphFanOutEdgeSchema = z
+    .object({
+    ...edgeBase,
+    kind: z.literal("fan_out"),
+    branch_id: idSchema,
+    owner_join_id: idSchema,
+})
+    .strict();
+export const graphBackEdgeSchema = z
+    .object({
+    ...edgeBase,
+    kind: z.literal("back_edge"),
+    route: idSchema,
+    max_traversals: z.number().int().min(1).max(100),
+})
+    .strict();
+export const graphEdgeSchema = z.discriminatedUnion("kind", [
+    graphFixedEdgeSchema,
+    graphConditionalEdgeSchema,
+    graphFanOutEdgeSchema,
+    graphBackEdgeSchema,
+]);
+export const graphDescriptorSchema = z
+    .object({
+    descriptor_version: z.literal(1),
+    run_id: idSchema,
+    revision_id: idSchema,
+    goal: textSchema,
+    nodes: z.array(graphNodeSchema).min(1).max(1_000),
+    edges: z.array(graphEdgeSchema).max(5_000),
+    entry_node_ids: z.array(idSchema).min(1).max(64),
+    concurrency_limit: z.number().int().min(1).max(64),
+    terminal_verification_node_id: idSchema,
+    descriptor_hash: z
+        .string()
+        .regex(/^[a-f0-9]{64}$/)
+        .optional(),
+})
+    .strict();
+export const graphEvidenceReferenceSchema = z
+    .object({
+    kind: z.enum(["file", "command", "test", "human", "url"]),
+    ref: z.string().min(1).max(2_048),
+    summary: z.string().max(2_048).optional(),
+})
+    .strict();
+export const graphNodeResultSchema = z
+    .object({
+    outcome: z.enum(["succeeded", "failed"]),
+    attempt_id: idSchema,
+    route: idSchema.optional(),
+    output_summary: z.string().max(8_192).optional(),
+    evidence_refs: z.array(graphEvidenceReferenceSchema).max(64),
+    external_idempotency_key: z.string().min(1).max(512).optional(),
+})
+    .strict();
+export const graphApprovalDecisionSchema = z
+    .object({
+    decision: z.enum(["approved", "denied"]),
+    evidence_refs: z.array(graphEvidenceReferenceSchema).max(64),
+    output_summary: z.string().max(8_192).optional(),
+})
+    .strict();
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphDescriptorShape(input) {
+    return graphDescriptorSchema.parse(input);
+}
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphNodeResult(input) {
+    return graphNodeResultSchema.parse(input);
+}
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphApprovalDecision(input) {
+    return graphApprovalDecisionSchema.parse(input);
+}
+/** Strict shape parse; throws `ZodError` by documented contract. */
+export function parseGraphEvidenceReference(input) {
+    return graphEvidenceReferenceSchema.parse(input);
+}
+/**
+ * Non-throwing stable-id predicate: `true` iff the value is a string matching
+ * `idSchema` (1–128 chars, stable charset). Used by the scheduler for identity
+ * values, entry identity keys/values, and identity-map keys.
+ */
+export function isValidStableId(value) {
+    return typeof value === "string" && idSchema.safeParse(value).success;
+}
+//# sourceMappingURL=schema.js.map

--- a/dist/graph/types.d.ts
+++ b/dist/graph/types.d.ts
@@ -1,0 +1,260 @@
+/**
+ * Graph Core data contract — deeply readonly types.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ */
+/** Stable node kinds. */
+export type GraphNodeKind = "agent" | "command" | "human-approval" | "join";
+/** Effect policy for executable nodes (discriminated object union). */
+export interface GraphSideEffectFreePolicy {
+    readonly policy: "side_effect_free";
+}
+export interface GraphIdempotentPolicy {
+    readonly policy: "idempotent";
+    readonly idempotency_key_template: string;
+}
+export interface GraphReconcilePolicy {
+    readonly policy: "reconcile";
+}
+export type GraphEffectPolicy = GraphSideEffectFreePolicy | GraphIdempotentPolicy | GraphReconcilePolicy;
+/** Fields shared by every graph node. */
+export interface GraphNodeBase {
+    readonly id: string;
+    readonly kind: GraphNodeKind;
+    readonly title: string;
+}
+/** Fields shared by executable (agent/command) nodes. */
+export interface GraphExecutableNodeBase extends GraphNodeBase {
+    readonly timeout_ms: number;
+    readonly max_attempts: number;
+    readonly effect_policy: GraphEffectPolicy;
+}
+export interface GraphAgentNode extends GraphExecutableNodeBase {
+    readonly kind: "agent";
+    readonly instructions: string;
+}
+export interface GraphCommandNode extends GraphExecutableNodeBase {
+    readonly kind: "command";
+    readonly command: string;
+}
+export interface GraphHumanApprovalNode extends GraphNodeBase {
+    readonly kind: "human-approval";
+    readonly prompt: string;
+}
+export interface GraphJoinNode extends GraphNodeBase {
+    readonly kind: "join";
+    readonly fan_out_node_id: string;
+    readonly input_branch_ids: readonly string[];
+}
+export type GraphNode = GraphAgentNode | GraphCommandNode | GraphHumanApprovalNode | GraphJoinNode;
+/** Fields shared by every graph edge. */
+export interface GraphEdgeBase {
+    readonly id: string;
+    readonly from: string;
+    readonly to: string;
+}
+export interface GraphFixedEdge extends GraphEdgeBase {
+    readonly kind: "fixed";
+}
+export interface GraphConditionalEdge extends GraphEdgeBase {
+    readonly kind: "conditional";
+    readonly route: string;
+}
+export interface GraphFanOutEdge extends GraphEdgeBase {
+    readonly kind: "fan_out";
+    readonly branch_id: string;
+    readonly owner_join_id: string;
+}
+export interface GraphBackEdge extends GraphEdgeBase {
+    readonly kind: "back_edge";
+    readonly route: string;
+    readonly max_traversals: number;
+}
+export type GraphEdge = GraphFixedEdge | GraphConditionalEdge | GraphFanOutEdge | GraphBackEdge;
+/** Unsealed descriptor input accepted by the draft producers. */
+export interface GraphDescriptorInput {
+    readonly descriptor_version: 1;
+    readonly run_id: string;
+    readonly revision_id: string;
+    readonly goal: string;
+    readonly nodes: readonly GraphNode[];
+    readonly edges: readonly GraphEdge[];
+    readonly entry_node_ids: readonly string[];
+    readonly concurrency_limit: number;
+    readonly terminal_verification_node_id: string;
+    readonly descriptor_hash?: string;
+}
+/** Unsealed descriptor (hashless; never accepted by the scheduler). */
+export type GraphDescriptor = GraphDescriptorInput;
+/**
+ * Sealed descriptor: hashless shape plus a required lowercase SHA-256 hex
+ * `descriptor_hash`. The only scheduler-accepted descriptor type; owned values
+ * come exclusively from `sealGraphDescriptor` / `parseSealedGraphDescriptor`.
+ */
+export type SealedGraphDescriptor = Omit<GraphDescriptorInput, "descriptor_hash"> & {
+    readonly descriptor_hash: string;
+};
+export interface GraphEvidenceReference {
+    readonly kind: "file" | "command" | "test" | "human" | "url";
+    readonly ref: string;
+    readonly summary?: string;
+}
+export interface GraphNodeResult {
+    readonly outcome: "succeeded" | "failed";
+    readonly attempt_id: string;
+    readonly route?: string;
+    readonly output_summary?: string;
+    readonly evidence_refs: readonly GraphEvidenceReference[];
+    readonly external_idempotency_key?: string;
+}
+export interface GraphApprovalDecision {
+    readonly decision: "approved" | "denied";
+    readonly evidence_refs: readonly GraphEvidenceReference[];
+    readonly output_summary?: string;
+}
+export type GraphActivationStatus = "ready" | "running" | "completed" | "failed";
+export interface GraphActivation {
+    readonly activation_id: string;
+    readonly node_id: string;
+    readonly status: GraphActivationStatus;
+    readonly attempt_no: number;
+    readonly attempt_ids: readonly string[];
+    readonly active_attempt_id?: string;
+    readonly completed_transition_id?: string;
+    readonly cohort_id?: string;
+    readonly branch_token_id?: string;
+    readonly traversal_owner_id: string;
+}
+export type GraphBranchTokenStatus = "active" | "arrived" | "consumed";
+export interface GraphBranchToken {
+    readonly branch_token_id: string;
+    readonly cohort_id: string;
+    readonly branch_id: string;
+    readonly owner_join_id: string;
+    readonly status: GraphBranchTokenStatus;
+    readonly current_activation_id?: string;
+    readonly consumed_by_activation_id?: string;
+}
+export interface GraphCohort {
+    readonly cohort_id: string;
+    readonly fan_out_node_id: string;
+    readonly owner_join_id: string;
+    readonly expected_branch_token_ids: readonly string[];
+    readonly join_activation_id?: string;
+    readonly consumed: boolean;
+}
+/** Fields shared by every committed transition record. */
+interface GraphCommittedTransitionBase {
+    readonly transition_id: string;
+    readonly activation_id: string;
+    readonly node_id: string;
+    readonly fingerprint_version: 1;
+    readonly request_fingerprint: string;
+    readonly descriptor_hash: string;
+    readonly selected_edge_ids: readonly string[];
+    readonly created_activation_ids: readonly string[];
+    readonly evidence_refs: readonly GraphEvidenceReference[];
+    readonly external_idempotency_key?: string;
+}
+/** Succeeded: attempt-bound; edge/activation cardinality varies (fan-out/terminal). */
+export interface GraphSucceededTransition extends GraphCommittedTransitionBase {
+    readonly outcome: "succeeded";
+    readonly attempt_id: string;
+    readonly route?: string;
+    readonly output_summary?: string;
+    readonly cohort_id?: string;
+}
+/** Failed: never selects or creates anything. */
+export interface GraphFailedTransition extends GraphCommittedTransitionBase {
+    readonly outcome: "failed";
+    readonly attempt_id: string;
+    readonly selected_edge_ids: readonly [];
+    readonly created_activation_ids: readonly [];
+    readonly output_summary?: string;
+}
+/** Approved: exactly one fixed edge selected and exactly one activation created; evidence is non-empty. */
+export interface GraphApprovedTransition extends GraphCommittedTransitionBase {
+    readonly outcome: "approved";
+    readonly selected_edge_ids: readonly [string];
+    readonly created_activation_ids: readonly [string];
+    readonly evidence_refs: readonly [
+        GraphEvidenceReference,
+        ...GraphEvidenceReference[]
+    ];
+    readonly output_summary?: string;
+}
+/** Denied: selects/creates nothing; evidence records the decision and is non-empty. */
+export interface GraphDeniedTransition extends GraphCommittedTransitionBase {
+    readonly outcome: "denied";
+    readonly selected_edge_ids: readonly [];
+    readonly created_activation_ids: readonly [];
+    readonly evidence_refs: readonly [
+        GraphEvidenceReference,
+        ...GraphEvidenceReference[]
+    ];
+    readonly output_summary?: string;
+}
+/** Join resolved: exactly one fixed edge selected and exactly one activation created; no evidence. */
+export interface GraphJoinResolvedTransition extends GraphCommittedTransitionBase {
+    readonly outcome: "join_resolved";
+    readonly cohort_id: string;
+    readonly selected_edge_ids: readonly [string];
+    readonly created_activation_ids: readonly [string];
+    readonly evidence_refs: readonly [];
+}
+/** Discriminated union on `outcome`; exact per-outcome fields. */
+export type GraphCommittedTransition = GraphSucceededTransition | GraphFailedTransition | GraphApprovedTransition | GraphDeniedTransition | GraphJoinResolvedTransition;
+/** Descriptor-bound scheduler projection. */
+export interface GraphSchedulerProjection {
+    readonly descriptor_hash: string;
+    readonly run_id: string;
+    readonly revision_id: string;
+    readonly activations: Readonly<Record<string, GraphActivation>>;
+    readonly cohorts: Readonly<Record<string, GraphCohort>>;
+    readonly branch_tokens: Readonly<Record<string, GraphBranchToken>>;
+    readonly traversal_counts: Readonly<Record<string, number>>;
+    readonly committed_transitions: Readonly<Record<string, GraphCommittedTransition>>;
+    readonly terminal_verification_activation_ids: readonly string[];
+}
+export interface BeginActivationAttemptInput {
+    readonly activation_id: string;
+    readonly attempt_id: string;
+}
+export interface ReleaseAttemptForRetryInput {
+    readonly activation_id: string;
+    readonly attempt_id: string;
+}
+export interface SchedulerTransitionIdentities {
+    readonly next_activation_ids?: Readonly<Record<string, string>>;
+    readonly cohort_id?: string;
+    readonly branch_token_ids?: Readonly<Record<string, string>>;
+    readonly join_activation_id?: string;
+}
+export interface ApplyNodeResultInput {
+    readonly activation_id: string;
+    readonly transition_id: string;
+    readonly result: GraphNodeResult;
+    readonly identities?: SchedulerTransitionIdentities;
+}
+export interface ApplyHumanApprovalInput {
+    readonly activation_id: string;
+    readonly transition_id: string;
+    readonly decision: GraphApprovalDecision;
+    readonly identities?: SchedulerTransitionIdentities;
+}
+export interface ResolveJoinInput {
+    readonly activation_id: string;
+    readonly transition_id: string;
+    readonly identities?: SchedulerTransitionIdentities;
+}
+export interface SchedulerApplyResult {
+    readonly projection: GraphSchedulerProjection;
+    readonly transition: GraphCommittedTransition;
+    readonly replayed: boolean;
+}
+/** Closed scheduler error-code union; every scheduler throw uses exactly one code. */
+export type GraphSchedulerErrorCode = "activation_not_found" | "activation_not_ready" | "max_attempts_exceeded" | "attempt_fenced" | "transition_fenced" | "duplicate_identity" | "missing_identity" | "unexpected_identity" | "undeclared_identity_key" | "invalid_input" | "descriptor_mismatch" | "route_required" | "undeclared_route" | "traversal_bound_exceeded" | "branch_token_fenced" | "join_owner_missing" | "join_owner_mismatch" | "join_not_found" | "join_not_ready" | "join_already_consumed" | "join_is_automatic" | "invalid_join_edge" | "node_not_found" | "terminal_evidence_required" | "approval_requires_dedicated_transition" | "unsupported_node_kind";
+export {};
+//# sourceMappingURL=types.d.ts.map

--- a/dist/graph/types.js
+++ b/dist/graph/types.js
@@ -1,0 +1,9 @@
+/**
+ * Graph Core data contract — deeply readonly types.
+ *
+ * Contract-authored from spec `deep-interview-issue-3570-graph-core.md` and the
+ * ralplan stage-04 revision (`pending-approval.md`); oracle `99ffe31` used only
+ * for behavioral cross-checks, never as import authority or copied structure.
+ */
+export {};
+//# sourceMappingURL=types.js.map

--- a/dist/team/worker-launch-ack.d.ts
+++ b/dist/team/worker-launch-ack.d.ts
@@ -1,0 +1,151 @@
+import type { CliAgentType } from './model-contract.js';
+declare const WORKER_LAUNCH_SCHEMA_VERSION: 1;
+export declare function buildWindowsSupervisorSource(): string;
+interface WorkerLaunchIdentity {
+    schema_version: typeof WORKER_LAUNCH_SCHEMA_VERSION;
+    attempt_id: string;
+    nonce: string;
+    team_name: string;
+    worker_name: string;
+    pane_id: string;
+    provider: CliAgentType;
+    created_at: string;
+}
+export type WorkerLaunchContext = {
+    kind: 'initial';
+} | {
+    kind: 'recovery';
+    recovery_id: string;
+    replacement_generation: number;
+    pane_attempt_id: string;
+};
+export interface WorkerLaunchAttempt extends WorkerLaunchIdentity {
+    currentPath: string;
+    expectedPath: string;
+    ackPath: string;
+    decisionPath: string;
+    startedPath: string;
+    transportOwnerPath: string;
+    bootstrapDescriptorPath: string;
+    wrapperPath: string;
+    transportCleanupCompletePath: string;
+    runtimeCliPath: string;
+    context?: WorkerLaunchContext;
+}
+export interface WorkerLaunchBootstrapSpec extends WorkerLaunchIdentity {
+    current_path: string;
+    expected_path: string;
+    ack_path: string;
+    decision_path: string;
+    started_path: string;
+    transport_owner_path: string;
+    bootstrap_descriptor_path: string;
+    wrapper_path: string;
+    transport_cleanup_complete_path: string;
+    provider_argv: string[];
+    provider_env: Record<string, string>;
+    cwd: string;
+    decision_timeout_ms: number;
+    release_after_spawn: boolean;
+    authority_digest: string;
+    containment_nonce: string;
+    supervisor_source_sha256: string;
+}
+export type WorkerLaunchAcceptance = {
+    ok: true;
+} | {
+    ok: false;
+    reason: 'ack_timeout' | 'ack_malformed' | 'ack_mismatch' | 'decision_conflict' | 'expected_record_invalid' | 'attempt_superseded';
+};
+export type WorkerLaunchBootstrapResult = {
+    outcome: 'ran';
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+} | {
+    outcome: 'invalid_spec' | 'expected_record_invalid' | 'ack_conflict' | 'decision_timeout' | 'revoked' | 'superseded' | 'provider_spawn_failed' | 'provider_cleanup_unverified';
+};
+export interface ProviderSpawnInvocation {
+    command: string;
+    args: string[];
+    batchScript?: string;
+}
+export interface MaterializedProviderSpawnInvocation {
+    command: string;
+    args: string[];
+    cleanup: () => Promise<void>;
+    completionPath?: string;
+    stdinPayload?: string;
+}
+export interface MaterializedWorkerLaunchTransport {
+    wrapperPath: string;
+    bootstrapDescriptorPath: string;
+    wrapperRelativePath: string;
+}
+export declare function buildProviderEnvironment(providerEnv: NodeJS.ProcessEnv | Record<string, string> | undefined, sourceEnv?: NodeJS.ProcessEnv, platform?: NodeJS.Platform): Record<string, string>;
+export declare function prepareWorkerLaunchAttempt(input: {
+    cwd: string;
+    teamName: string;
+    workerName: string;
+    paneId: string;
+    provider: CliAgentType;
+    runtimeCliPath: string;
+    context?: WorkerLaunchContext;
+}): Promise<WorkerLaunchAttempt>;
+export declare function loadWorkerLaunchAttempt(input: {
+    cwd: string;
+    teamName: string;
+    workerName: string;
+    paneId: string;
+    provider: CliAgentType;
+    attemptId: string;
+    runtimeCliPath: string;
+}): Promise<WorkerLaunchAttempt | null>;
+export declare function loadCurrentWorkerLaunchAttempt(input: {
+    cwd: string;
+    teamName: string;
+    workerName: string;
+    provider: CliAgentType;
+}): Promise<WorkerLaunchAttempt | null>;
+export declare function buildWorkerLaunchBootstrapSpec(attempt: WorkerLaunchAttempt, providerArgv: string[], cwd: string, options?: {
+    releaseAfterSpawn?: boolean;
+    providerEnv?: NodeJS.ProcessEnv | Record<string, string>;
+}): WorkerLaunchBootstrapSpec;
+export declare function materializeWorkerLaunchTransport(input: {
+    attempt: WorkerLaunchAttempt;
+    providerArgv: string[];
+    cwd: string;
+    providerEnv?: NodeJS.ProcessEnv | Record<string, string>;
+    releaseAfterSpawn?: boolean;
+}): Promise<MaterializedWorkerLaunchTransport>;
+export declare function cleanupWorkerLaunchTransport(attempt: WorkerLaunchAttempt, reason?: string): Promise<boolean>;
+export declare function readAndConsumeWorkerLaunchDescriptor(descriptorPath: string): Promise<unknown>;
+export declare function revokeWorkerLaunchAttempt(attempt: WorkerLaunchAttempt, reason: string): Promise<boolean>;
+export declare function awaitWorkerLaunchAcknowledgement(attempt: WorkerLaunchAttempt, options?: {
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+}): Promise<WorkerLaunchAcceptance>;
+export declare function isWorkerLaunchAttemptAccepted(attempt: WorkerLaunchAttempt): Promise<boolean>;
+export declare function isWorkerLaunchAttemptCurrent(attempt: WorkerLaunchAttempt): Promise<boolean>;
+export declare function withWorkerLaunchAttemptFence<T>(attempt: WorkerLaunchAttempt, fn: () => Promise<T>): Promise<{
+    ok: true;
+    value: T;
+} | {
+    ok: false;
+}>;
+export declare function retireWorkerLaunchAttempt(attempt: WorkerLaunchAttempt, reason: string): Promise<boolean>;
+export declare function retireAndCleanupCurrentWorkerLaunchAttempt(attempt: WorkerLaunchAttempt, reason: string, cleanup: () => Promise<boolean>): Promise<boolean>;
+export declare function terminateWorkerLaunchProvider(attempt: WorkerLaunchAttempt, timeoutMs?: number): Promise<boolean>;
+export declare function awaitWorkerLaunchProviderStarted(attempt: WorkerLaunchAttempt, options?: {
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+}): Promise<boolean>;
+export declare function isWorkerLaunchProviderStarted(attempt: WorkerLaunchAttempt): Promise<boolean>;
+export declare function quoteWindowsCreateProcessArgument(value: string): string;
+export declare function buildProviderSpawnInvocation(providerArgv: readonly string[], platform?: NodeJS.Platform, env?: NodeJS.ProcessEnv): ProviderSpawnInvocation;
+export declare function materializeProviderSpawnInvocation(invocation: ProviderSpawnInvocation, options?: {
+    superviseWindowsTree?: boolean;
+    superviseProcessTree?: boolean;
+}): Promise<MaterializedProviderSpawnInvocation>;
+export declare function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLaunchBootstrapResult>;
+export {};
+//# sourceMappingURL=worker-launch-ack.d.ts.map

--- a/dist/team/worker-launch-ack.js
+++ b/dist/team/worker-launch-ack.js
@@ -1,0 +1,1565 @@
+import { spawn } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { constants, existsSync } from 'node:fs';
+import { link, mkdir, mkdtemp, open, readFile, rm, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { captureOwnedProcessGroup, getProcessStartIdentitySync, isProcessAlive, isProcessIdentityLive, terminateOwnedProcessGroup } from '../platform/process-utils.js';
+import { absPath, TeamPaths } from './state-paths.js';
+import { atomicWriteJson } from '../lib/atomic-write.js';
+import { lockPathFor, withFileLock } from '../lib/file-lock.js';
+const WORKER_LAUNCH_SCHEMA_VERSION = 1;
+const DEFAULT_ACK_TIMEOUT_MS = 8_000;
+const DEFAULT_POLL_INTERVAL_MS = 25;
+const DEFAULT_DECISION_TIMEOUT_MS = 15_000;
+const WORKER_LAUNCH_TRANSPORT_OWNER_KIND = 'worker_launch_transport_owner';
+const WORKER_LAUNCH_TRANSPORT_CLEANUP_KIND = 'worker_launch_transport_cleanup_complete';
+const WORKER_LAUNCH_BOOTSTRAP_DESCRIPTOR_FILE = 'bootstrap.json';
+const WORKER_LAUNCH_INTERNAL_ENV_KEYS = new Set([
+    'OMC_WORKER_LAUNCH_SPEC',
+    'OMC_WORKER_LAUNCH_SPEC_B64',
+    'OMC_WORKER_LAUNCH_SPEC_FILE',
+]);
+const WORKER_LAUNCH_AUTHORITY_PROTOCOL = 'worker-launch-authority-v1';
+const WINDOWS_SUPERVISOR_PROTOCOL = 'worker-launch-windows-supervisor-v1';
+export function buildWindowsSupervisorSource() {
+    return [
+        '$ErrorActionPreference = "Stop"',
+        '$payload = [Console]::In.ReadLine() | ConvertFrom-Json',
+        '$json = $payload.canonical_json',
+        '$hash = ([Security.Cryptography.SHA256]::Create().ComputeHash([Text.Encoding]::UTF8.GetBytes($json)) | ForEach-Object { $_.ToString("x2") }) -join ""',
+        'if ($hash -ne $payload.authority_digest) { throw "worker_launch_authority_digest_mismatch" }',
+        'Add-Type @"',
+        'using System; using System.Text; using System.Runtime.InteropServices;',
+        `public static class O { [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct STARTUPINFO { public int cb; public IntPtr lpReserved; public IntPtr lpDesktop; public IntPtr lpTitle; public int dwX; public int dwY; public int dwXSize; public int dwYSize; public int dwXCountChars; public int dwYCountChars; public int dwFillAttribute; public int dwFlags; public short wShowWindow; public short cbReserved2; public IntPtr lpReserved2; public IntPtr hStdInput; public IntPtr hStdOutput; public IntPtr hStdError; } [StructLayout(LayoutKind.Sequential)] public struct PROCESS_INFORMATION { public IntPtr hProcess; public IntPtr hThread; public uint dwProcessId; public uint dwThreadId; } [StructLayout(LayoutKind.Sequential)] public struct JOBOBJECT_BASIC_LIMIT_INFORMATION { public long PerProcessUserTimeLimit; public long PerJobUserTimeLimit; public uint LimitFlags; public UIntPtr MinimumWorkingSetSize; public UIntPtr MaximumWorkingSetSize; public uint ActiveProcessLimit; public UIntPtr Affinity; public uint PriorityClass; public uint SchedulingClass; } [StructLayout(LayoutKind.Sequential)] public struct IO_COUNTERS { public ulong ReadOperationCount; public ulong WriteOperationCount; public ulong OtherOperationCount; public ulong ReadTransferCount; public ulong WriteTransferCount; public ulong OtherTransferCount; } [StructLayout(LayoutKind.Sequential)] public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION { public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation; public IO_COUNTERS IoInfo; public UIntPtr ProcessMemoryLimit; public UIntPtr JobMemoryLimit; public UIntPtr PeakProcessMemoryUsed; public UIntPtr PeakJobMemoryUsed; } [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)] public static extern bool CreateProcessW(string app, StringBuilder cmd, IntPtr pa, IntPtr ta, bool inherit, uint flags, IntPtr env, string dir, ref STARTUPINFO si, out PROCESS_INFORMATION pi); [DllImport("kernel32.dll", SetLastError=true)] public static extern IntPtr CreateJobObjectW(IntPtr a, string n); [DllImport("kernel32.dll", SetLastError=true)] public static extern bool SetInformationJobObject(IntPtr j, int c, IntPtr i, uint l); [DllImport("kernel32.dll", SetLastError=true)] public static extern bool AssignProcessToJobObject(IntPtr j, IntPtr p); [DllImport("kernel32.dll", SetLastError=true)] public static extern uint ResumeThread(IntPtr h); [DllImport("kernel32.dll", SetLastError=true)] public static extern bool TerminateJobObject(IntPtr j, uint c); [DllImport("kernel32.dll", SetLastError=true)] public static extern bool TerminateProcess(IntPtr p, uint c); [DllImport("kernel32.dll", SetLastError=true)] public static extern uint WaitForSingleObject(IntPtr h, uint ms); [DllImport("kernel32.dll", SetLastError=true)] public static extern bool GetExitCodeProcess(IntPtr h, out uint code); [DllImport("kernel32.dll")] public static extern bool CloseHandle(IntPtr h); public static string Quote(string value) { var b = new StringBuilder(); b.Append('\"'); int slashes = 0; foreach (var c in value) { if (c == '\\') { slashes++; continue; } if (c == '\"') { b.Append('\\', slashes * 2 + 1); b.Append('\"'); slashes = 0; continue; } b.Append('\\', slashes); slashes = 0; b.Append(c); } b.Append('\\', slashes * 2); b.Append('\"'); return b.ToString(); } public static string BuildCommandLine(string[] argv) { var b = new StringBuilder(); for (var i = 0; i < argv.Length; i++) { if (i != 0) b.Append(' '); b.Append(Quote(argv[i])); } return b.ToString(); } }`,
+        '"@',
+        '$pi = New-Object O+PROCESS_INFORMATION; $job = [IntPtr]::Zero; $envPtr = [IntPtr]::Zero; $cmd = $null',
+        'try {',
+        '  $cmd = [O]::BuildCommandLine([string[]]$payload.provider_argv)',
+        '  $envPairs = @($payload.provider_env.psobject.Properties | Sort-Object Name | ForEach-Object { "$($_.Name)=$($_.Value)" }); $envText = (($envPairs -join [char]0) + [char]0 + [char]0); $envBytes = [Text.Encoding]::Unicode.GetBytes($envText); $envPtr = [Runtime.InteropServices.Marshal]::AllocHGlobal($envBytes.Length); [Runtime.InteropServices.Marshal]::Copy($envBytes, 0, $envPtr, $envBytes.Length)',
+        '  $si = New-Object O+STARTUPINFO; $si.cb = [Runtime.InteropServices.Marshal]::SizeOf($si); $flags = 0x00000004 -bor 0x00000400; if (-not [O]::CreateProcessW($null, $cmd, [IntPtr]::Zero, [IntPtr]::Zero, $false, $flags, $envPtr, $payload.cwd, [ref]$si, [ref]$pi)) { throw "worker_launch_create_process_failed" }',
+        '  $job = [O]::CreateJobObjectW([IntPtr]::Zero, $null); if ($job -eq [IntPtr]::Zero) { throw "worker_launch_create_job_failed" }; $info = New-Object O+JOBOBJECT_EXTENDED_LIMIT_INFORMATION; $info.BasicLimitInformation.LimitFlags = 0x2000; $ptr = [Runtime.InteropServices.Marshal]::AllocHGlobal([Runtime.InteropServices.Marshal]::SizeOf($info)); try { [Runtime.InteropServices.Marshal]::StructureToPtr($info, $ptr, $false); if (-not [O]::SetInformationJobObject($job, 9, $ptr, [Runtime.InteropServices.Marshal]::SizeOf($info))) { throw "worker_launch_job_config_failed" } } finally { [Runtime.InteropServices.Marshal]::FreeHGlobal($ptr) }; if (-not [O]::AssignProcessToJobObject($job, $pi.hProcess)) { throw "worker_launch_assign_job_failed" }; if ([O]::ResumeThread($pi.hThread) -eq [uint32]0xffffffff) { throw "worker_launch_resume_failed" }',
+        '  $ticks = ([DateTime]((Get-Process -Id $pi.dwProcessId).StartTime)).ToUniversalTime().Ticks; $ready = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="ready"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; process_start_identity=("ticks:" + $ticks) } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($ready); [Console]::Out.Flush()',
+        '  $readTask = [Console]::In.ReadLineAsync(); while ($true) { if ([O]::WaitForSingleObject($pi.hProcess, 50) -eq 0) { $exitCode = [uint32]0; [O]::GetExitCodeProcess($pi.hProcess, [ref]$exitCode) | Out-Null; [O]::TerminateJobObject($job, $exitCode) | Out-Null; $terminal = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="terminal"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; outcome="exit"; cleanup_verified=$true; exit_code=$exitCode } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($terminal); [Console]::Out.Flush(); break }; if (-not $readTask.IsCompleted) { continue }; $line = $readTask.Result; if ($null -eq $line) { throw "worker_launch_authority_lost" }; $readTask = [Console]::In.ReadLineAsync(); if ([string]::IsNullOrWhiteSpace($line) -or $line.Length -gt 4096) { continue }; try { $msg = $line | ConvertFrom-Json } catch { continue }; if ($msg.protocol -ne "' + WINDOWS_SUPERVISOR_PROTOCOL + '" -or $msg.attempt_id -ne $payload.identity.attempt_id -or $msg.authority_digest -ne $payload.authority_digest -or $msg.containment_nonce -ne $payload.containment_nonce -or $msg.kind -ne "terminate") { continue }; [O]::TerminateJobObject($job, 1) | Out-Null; [O]::WaitForSingleObject($pi.hProcess, 5000) | Out-Null; $terminal = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="terminal"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; outcome="terminated"; cleanup_verified=$true } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($terminal); [Console]::Out.Flush(); break }',
+        '} catch { if ($pi.hProcess -ne [IntPtr]::Zero) { if ($job -ne [IntPtr]::Zero) { [O]::TerminateJobObject($job, 1) | Out-Null } else { [O]::TerminateProcess($pi.hProcess, 1) | Out-Null }; [O]::WaitForSingleObject($pi.hProcess, 5000) | Out-Null }; throw } finally { if ($envPtr -ne [IntPtr]::Zero) { [Runtime.InteropServices.Marshal]::FreeHGlobal($envPtr) }; if ($pi.hThread -ne [IntPtr]::Zero) { [O]::CloseHandle($pi.hThread) | Out-Null }; if ($pi.hProcess -ne [IntPtr]::Zero) { [O]::CloseHandle($pi.hProcess) | Out-Null }; if ($job -ne [IntPtr]::Zero) { [O]::CloseHandle($job) | Out-Null } }',
+    ].join("`n");
+}
+function encodePowerShell(source) {
+    return Buffer.from(source, 'utf16le').toString('base64');
+}
+const WINDOWS_RESERVED_ENV_KEYS = new Set([...WORKER_LAUNCH_INTERNAL_ENV_KEYS, 'SystemRoot'].map(key => key.toUpperCase()));
+const SAFE_BASELINE_ENV_KEYS = ['PATH', 'SystemRoot', 'SYSTEMROOT', 'TEMP', 'TMP'];
+function canonicalAuthorityDigest(input) {
+    const env = Object.fromEntries(Object.entries(input.providerEnv).sort(([a], [b]) => a.localeCompare(b)));
+    const payload = JSON.stringify({ protocol: WORKER_LAUNCH_AUTHORITY_PROTOCOL, nonce: input.containmentNonce ?? '', supervisor_source_sha256: input.supervisorSourceSha256 ?? '', identity: identityOf(input.identity), provider_argv: [...input.providerArgv], provider_env: env, cwd: resolve(input.cwd) });
+    return createHash('sha256').update(payload, 'utf8').digest('hex');
+}
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+function isExactText(value) {
+    return typeof value === 'string' && value.length > 0 && value === value.trim();
+}
+function isValidEnvironmentKey(key) {
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(key);
+}
+function normalizeProviderEnvironment(value, platform = process.platform) {
+    const normalized = {};
+    const seen = new Set();
+    const windows = platform === 'win32';
+    for (const [key, entry] of Object.entries(value ?? {})) {
+        const compareKey = windows ? key.toUpperCase() : key;
+        if (seen.has(compareKey))
+            throw new Error('worker_launch_provider_env_key_alias_conflict');
+        seen.add(compareKey);
+        if (windows && WINDOWS_RESERVED_ENV_KEYS.has(compareKey))
+            throw new Error('worker_launch_provider_env_reserved');
+        if (WORKER_LAUNCH_INTERNAL_ENV_KEYS.has(key))
+            continue;
+        if (!isValidEnvironmentKey(key))
+            throw new Error('worker_launch_provider_env_key_invalid');
+        if (typeof entry !== 'string')
+            throw new Error('worker_launch_provider_env_value_invalid');
+        normalized[key] = entry;
+    }
+    return normalized;
+}
+function isValidProviderEnvironment(value, platform = process.platform) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    try {
+        normalizeProviderEnvironment(value, platform);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+export function buildProviderEnvironment(providerEnv, sourceEnv = process.env, platform = process.platform) {
+    const normalized = normalizeProviderEnvironment(providerEnv, platform);
+    const baseline = {};
+    for (const key of SAFE_BASELINE_ENV_KEYS) {
+        const value = sourceEnv[key];
+        if (typeof value === 'string' && value.length > 0)
+            baseline[key] = value;
+    }
+    if (platform === 'win32') {
+        const systemRoot = sourceEnv.SystemRoot ?? sourceEnv.SYSTEMROOT;
+        if (typeof systemRoot === 'string' && /^[A-Za-z]:\\/.test(systemRoot))
+            baseline.SystemRoot = systemRoot;
+    }
+    return { ...baseline, ...normalized };
+}
+function isUuid(value) {
+    return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+function isProvider(value) {
+    return value === 'claude' || value === 'codex' || value === 'gemini'
+        || value === 'cursor' || value === 'grok' || value === 'antigravity';
+}
+function identityMatches(value, expected) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const record = value;
+    return record.schema_version === WORKER_LAUNCH_SCHEMA_VERSION
+        && record.attempt_id === expected.attempt_id
+        && record.nonce === expected.nonce
+        && record.team_name === expected.team_name
+        && record.worker_name === expected.worker_name
+        && record.pane_id === expected.pane_id
+        && record.provider === expected.provider
+        && record.created_at === expected.created_at;
+}
+function isValidIdentity(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const record = value;
+    return record.schema_version === WORKER_LAUNCH_SCHEMA_VERSION
+        && isUuid(record.attempt_id)
+        && isUuid(record.nonce)
+        && isExactText(record.team_name)
+        && isExactText(record.worker_name)
+        && isExactText(record.pane_id)
+        && isProvider(record.provider)
+        && typeof record.created_at === 'string'
+        && Number.isFinite(Date.parse(record.created_at));
+}
+function isValidLaunchContext(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return false;
+    const record = value;
+    if (record.kind === 'initial')
+        return true;
+    return record.kind === 'recovery'
+        && isExactText(record.recovery_id)
+        && Number.isSafeInteger(record.replacement_generation)
+        && Number(record.replacement_generation) >= 1
+        && isExactText(record.pane_attempt_id);
+}
+function identityOf(attempt) {
+    return {
+        schema_version: attempt.schema_version,
+        attempt_id: attempt.attempt_id,
+        nonce: attempt.nonce,
+        team_name: attempt.team_name,
+        worker_name: attempt.worker_name,
+        pane_id: attempt.pane_id,
+        provider: attempt.provider,
+        created_at: attempt.created_at,
+    };
+}
+async function readJson(path) {
+    try {
+        return { kind: 'value', value: JSON.parse(await readFile(path, 'utf8')) };
+    }
+    catch (error) {
+        if (error.code === 'ENOENT')
+            return { kind: 'absent' };
+        return { kind: 'malformed' };
+    }
+}
+async function isCurrentLaunchIdentity(currentPath, identity) {
+    const current = await readJson(currentPath);
+    return current.kind === 'value' && identityMatches(current.value, identity);
+}
+async function writeExclusiveAtomic(path, value) {
+    await mkdir(dirname(path), { recursive: true });
+    const candidate = `${path}.candidate.${process.pid}.${randomUUID()}`;
+    const handle = await open(candidate, 'wx', 0o600);
+    try {
+        await handle.writeFile(JSON.stringify(value), 'utf8');
+        await handle.sync();
+    }
+    finally {
+        await handle.close();
+    }
+    try {
+        await link(candidate, path);
+    }
+    finally {
+        await unlink(candidate).catch(() => undefined);
+    }
+}
+async function writeExclusiveTextAtomic(path, value) {
+    await mkdir(dirname(path), { recursive: true });
+    const candidate = `${path}.candidate.${process.pid}.${randomUUID()}`;
+    const handle = await open(candidate, 'wx', 0o600);
+    try {
+        await handle.writeFile(value, 'utf8');
+        await handle.sync();
+    }
+    finally {
+        await handle.close();
+    }
+    try {
+        await link(candidate, path);
+    }
+    finally {
+        await unlink(candidate).catch(() => undefined);
+    }
+}
+function resolvePositiveInteger(value, fallback) {
+    const parsed = Number.parseInt(value ?? '', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+export async function prepareWorkerLaunchAttempt(input) {
+    const attemptId = randomUUID();
+    const identity = {
+        schema_version: WORKER_LAUNCH_SCHEMA_VERSION,
+        attempt_id: attemptId,
+        nonce: randomUUID(),
+        team_name: input.teamName,
+        worker_name: input.workerName,
+        pane_id: input.paneId,
+        provider: input.provider,
+        created_at: new Date().toISOString(),
+    };
+    const attempt = {
+        ...identity,
+        currentPath: absPath(input.cwd, TeamPaths.workerLaunchCurrent(input.teamName, input.workerName)),
+        expectedPath: absPath(input.cwd, TeamPaths.workerLaunchExpected(input.teamName, input.workerName, attemptId)),
+        ackPath: absPath(input.cwd, TeamPaths.workerLaunchAck(input.teamName, input.workerName, attemptId)),
+        decisionPath: absPath(input.cwd, TeamPaths.workerLaunchDecision(input.teamName, input.workerName, attemptId)),
+        startedPath: absPath(input.cwd, TeamPaths.workerLaunchStarted(input.teamName, input.workerName, attemptId)),
+        transportOwnerPath: absPath(input.cwd, TeamPaths.workerLaunchTransportOwner(input.teamName, input.workerName, attemptId)),
+        bootstrapDescriptorPath: absPath(input.cwd, TeamPaths.workerLaunchBootstrapDescriptor(input.teamName, input.workerName, attemptId)),
+        wrapperPath: absPath(input.cwd, TeamPaths.workerLaunchWrapper(input.teamName, input.workerName, attemptId)),
+        transportCleanupCompletePath: absPath(input.cwd, TeamPaths.workerLaunchTransportCleanupComplete(input.teamName, input.workerName, attemptId)),
+        runtimeCliPath: input.runtimeCliPath,
+        ...(input.context ? { context: input.context } : {}),
+    };
+    if (existsSync(attempt.expectedPath) || existsSync(attempt.ackPath)
+        || existsSync(attempt.decisionPath) || existsSync(attempt.startedPath)
+        || existsSync(attempt.transportOwnerPath) || existsSync(attempt.bootstrapDescriptorPath)
+        || existsSync(attempt.wrapperPath) || existsSync(attempt.transportCleanupCompletePath)) {
+        throw new Error('worker_launch_attempt_path_conflict');
+    }
+    await writeExclusiveAtomic(attempt.expectedPath, identity);
+    try {
+        await withFileLock(lockPathFor(attempt.currentPath), async () => {
+            await atomicWriteJson(attempt.currentPath, {
+                ...identity,
+                runtime_cli_path: input.runtimeCliPath,
+                ...(input.context ? { context: input.context } : {}),
+            });
+        });
+    }
+    catch (error) {
+        await unlink(attempt.expectedPath).catch(() => undefined);
+        throw error;
+    }
+    return attempt;
+}
+export async function loadWorkerLaunchAttempt(input) {
+    const expectedPath = absPath(input.cwd, TeamPaths.workerLaunchExpected(input.teamName, input.workerName, input.attemptId));
+    const expected = await readJson(expectedPath);
+    if (expected.kind !== 'value' || !isValidIdentity(expected.value))
+        return null;
+    const identity = expected.value;
+    if (identity.attempt_id !== input.attemptId || identity.team_name !== input.teamName
+        || identity.worker_name !== input.workerName || identity.pane_id !== input.paneId
+        || identity.provider !== input.provider)
+        return null;
+    return {
+        ...identity,
+        currentPath: absPath(input.cwd, TeamPaths.workerLaunchCurrent(input.teamName, input.workerName)),
+        expectedPath,
+        ackPath: absPath(input.cwd, TeamPaths.workerLaunchAck(input.teamName, input.workerName, input.attemptId)),
+        decisionPath: absPath(input.cwd, TeamPaths.workerLaunchDecision(input.teamName, input.workerName, input.attemptId)),
+        startedPath: absPath(input.cwd, TeamPaths.workerLaunchStarted(input.teamName, input.workerName, input.attemptId)),
+        transportOwnerPath: absPath(input.cwd, TeamPaths.workerLaunchTransportOwner(input.teamName, input.workerName, input.attemptId)),
+        bootstrapDescriptorPath: absPath(input.cwd, TeamPaths.workerLaunchBootstrapDescriptor(input.teamName, input.workerName, input.attemptId)),
+        wrapperPath: absPath(input.cwd, TeamPaths.workerLaunchWrapper(input.teamName, input.workerName, input.attemptId)),
+        transportCleanupCompletePath: absPath(input.cwd, TeamPaths.workerLaunchTransportCleanupComplete(input.teamName, input.workerName, input.attemptId)),
+        runtimeCliPath: input.runtimeCliPath,
+    };
+}
+export async function loadCurrentWorkerLaunchAttempt(input) {
+    const currentPath = absPath(input.cwd, TeamPaths.workerLaunchCurrent(input.teamName, input.workerName));
+    try {
+        return await withFileLock(lockPathFor(currentPath), async () => {
+            const current = await readJson(currentPath);
+            if (current.kind !== 'value' || !isValidIdentity(current.value))
+                return null;
+            const record = current.value;
+            if (record.team_name !== input.teamName || record.worker_name !== input.workerName
+                || record.provider !== input.provider || !isExactText(record.runtime_cli_path)
+                || (record.context !== undefined && !isValidLaunchContext(record.context)))
+                return null;
+            const attempt = await loadWorkerLaunchAttempt({
+                cwd: input.cwd,
+                teamName: input.teamName,
+                workerName: input.workerName,
+                paneId: record.pane_id,
+                provider: input.provider,
+                attemptId: record.attempt_id,
+                runtimeCliPath: record.runtime_cli_path,
+            });
+            if (!attempt || !await isWorkerLaunchAttemptAccepted(attempt)
+                || !await isWorkerLaunchProviderStarted(attempt)
+                || !await isCurrentLaunchIdentity(currentPath, attempt))
+                return null;
+            return {
+                ...attempt,
+                ...(record.context ? { context: record.context } : {}),
+            };
+        });
+    }
+    catch {
+        return null;
+    }
+}
+export function buildWorkerLaunchBootstrapSpec(attempt, providerArgv, cwd, options = {}) {
+    const providerEnv = buildProviderEnvironment(options.providerEnv);
+    const absoluteCwd = resolve(cwd);
+    const containmentNonce = randomUUID();
+    const supervisorSourceSha256 = createHash('sha256').update(buildWindowsSupervisorSource(), 'utf8').digest('hex');
+    return {
+        ...identityOf(attempt),
+        current_path: attempt.currentPath,
+        expected_path: attempt.expectedPath,
+        ack_path: attempt.ackPath,
+        decision_path: attempt.decisionPath,
+        started_path: attempt.startedPath,
+        transport_owner_path: attempt.transportOwnerPath,
+        bootstrap_descriptor_path: attempt.bootstrapDescriptorPath,
+        wrapper_path: attempt.wrapperPath,
+        transport_cleanup_complete_path: attempt.transportCleanupCompletePath,
+        provider_argv: [...providerArgv],
+        provider_env: providerEnv,
+        cwd: absoluteCwd,
+        decision_timeout_ms: resolvePositiveInteger(process.env.OMC_TEAM_START_ACK_DECISION_TIMEOUT_MS, DEFAULT_DECISION_TIMEOUT_MS),
+        release_after_spawn: options.releaseAfterSpawn === true,
+        containment_nonce: containmentNonce,
+        authority_digest: canonicalAuthorityDigest({ identity: attempt, providerArgv, providerEnv, cwd: absoluteCwd, containmentNonce, supervisorSourceSha256 }),
+        supervisor_source_sha256: supervisorSourceSha256,
+    };
+}
+function attemptTransportPathsAreDeterministic(attempt) {
+    const expectedRoot = dirname(attempt.expectedPath);
+    return isDeterministicTransportPath(attempt.expectedPath, attempt.transportOwnerPath, 'transport-owner.json')
+        && isDeterministicTransportPath(attempt.expectedPath, attempt.bootstrapDescriptorPath, WORKER_LAUNCH_BOOTSTRAP_DESCRIPTOR_FILE)
+        && isDeterministicTransportPath(attempt.expectedPath, attempt.wrapperPath, 'launch.cmd')
+        && isDeterministicTransportPath(attempt.expectedPath, attempt.transportCleanupCompletePath, 'transport-cleanup-complete.json')
+        && resolve(attempt.expectedPath) === resolve(join(expectedRoot, 'expected.json'));
+}
+function transportOwnerMatches(value, attempt, authorityDigest) {
+    if (!identityMatches(value, attempt)
+        || typeof value !== 'object' || value === null
+        || value.kind !== WORKER_LAUNCH_TRANSPORT_OWNER_KIND)
+        return false;
+    return authorityDigest === undefined || value.authority_digest === authorityDigest;
+}
+function cleanupProofMatches(value, attempt) {
+    return identityMatches(value, attempt)
+        && typeof value === 'object' && value !== null
+        && value.kind === WORKER_LAUNCH_TRANSPORT_CLEANUP_KIND
+        && isExactText(value.reason)
+        && typeof value.written_at === 'string'
+        && Number.isFinite(Date.parse(value.written_at));
+}
+function windowsWrapperRelativePath(cwd, wrapperPath) {
+    const relativePath = relative(resolve(cwd), resolve(wrapperPath)).replace(/\//g, '\\');
+    if (!relativePath || relativePath.startsWith('\\') || /^[A-Za-z]:/.test(relativePath)
+        || !/^[A-Za-z0-9._\\-]+$/.test(relativePath)) {
+        throw new Error('worker_launch_transport_relative_path_invalid');
+    }
+    return relativePath;
+}
+function buildWorkerLaunchWrapper(attempt) {
+    const runtimeCli = quoteWindowsCmdArgument(attempt.runtimeCliPath);
+    const nodeExecutable = quoteWindowsCmdArgument(process.execPath);
+    return [
+        '@echo off',
+        'setlocal DisableDelayedExpansion',
+        'set "OMC_WORKER_LAUNCH_SPEC_FILE=%~dp0bootstrap.json"',
+        `${nodeExecutable} ${runtimeCli} --worker-launch`,
+        'set "_OMC_WORKER_LAUNCH_EXIT=%ERRORLEVEL%"',
+        'del /f /q "%~f0" >nul 2>&1',
+        'endlocal & exit /b %_OMC_WORKER_LAUNCH_EXIT%',
+        '',
+    ].join('\\r\\n');
+}
+export async function materializeWorkerLaunchTransport(input) {
+    const { attempt } = input;
+    if (!attemptTransportPathsAreDeterministic(attempt))
+        throw new Error('worker_launch_transport_paths_invalid');
+    const spec = buildWorkerLaunchBootstrapSpec(attempt, input.providerArgv, input.cwd, {
+        providerEnv: input.providerEnv,
+        releaseAfterSpawn: input.releaseAfterSpawn,
+    });
+    const owner = {
+        ...identityOf(attempt),
+        kind: WORKER_LAUNCH_TRANSPORT_OWNER_KIND,
+        authority_digest: spec.authority_digest,
+    };
+    const wrapperRelativePath = windowsWrapperRelativePath(input.cwd, attempt.wrapperPath);
+    const wrapper = buildWorkerLaunchWrapper(attempt);
+    let ownerCreated = false;
+    let descriptorCreated = false;
+    let wrapperCreated = false;
+    try {
+        await withFileLock(lockPathFor(attempt.currentPath), async () => {
+            if (!await isCurrentLaunchIdentity(attempt.currentPath, attempt)
+                || (await readJson(`${attempt.decisionPath}.retired`)).kind !== 'absent') {
+                throw new Error('worker_launch_attempt_inactive');
+            }
+            const existingOwner = await readJson(attempt.transportOwnerPath);
+            if (existingOwner.kind === 'malformed'
+                || (existingOwner.kind === 'value' && !transportOwnerMatches(existingOwner.value, attempt, spec.authority_digest))) {
+                throw new Error('worker_launch_transport_owner_conflict');
+            }
+            if (existingOwner.kind === 'absent') {
+                await writeExclusiveAtomic(attempt.transportOwnerPath, owner);
+                ownerCreated = true;
+            }
+            if (existsSync(attempt.bootstrapDescriptorPath) || existsSync(attempt.wrapperPath)) {
+                throw new Error('worker_launch_transport_path_conflict');
+            }
+            await writeExclusiveAtomic(attempt.bootstrapDescriptorPath, spec);
+            descriptorCreated = true;
+            await writeExclusiveTextAtomic(attempt.wrapperPath, wrapper);
+            wrapperCreated = true;
+        });
+    }
+    catch (error) {
+        let cleanupVerified = true;
+        if (wrapperCreated) {
+            await unlink(attempt.wrapperPath).catch(() => { cleanupVerified = false; });
+            cleanupVerified &&= !existsSync(attempt.wrapperPath);
+        }
+        if (descriptorCreated) {
+            await unlink(attempt.bootstrapDescriptorPath).catch(() => { cleanupVerified = false; });
+            cleanupVerified &&= !existsSync(attempt.bootstrapDescriptorPath);
+        }
+        if (ownerCreated) {
+            await unlink(attempt.transportOwnerPath).catch(() => { cleanupVerified = false; });
+            cleanupVerified &&= !existsSync(attempt.transportOwnerPath);
+        }
+        if (!cleanupVerified) {
+            const cleanupError = new Error('worker_launch_transport_partial_cleanup_unverified');
+            cleanupError.cause = error;
+            throw cleanupError;
+        }
+        throw error;
+    }
+    return {
+        wrapperPath: attempt.wrapperPath,
+        bootstrapDescriptorPath: attempt.bootstrapDescriptorPath,
+        wrapperRelativePath,
+    };
+}
+async function cleanupWorkerLaunchTransportUnlocked(attempt, reason) {
+    const owner = await readJson(attempt.transportOwnerPath);
+    const proof = await readJson(attempt.transportCleanupCompletePath);
+    if (owner.kind === 'malformed' || proof.kind === 'malformed')
+        return false;
+    if (owner.kind === 'value' && !transportOwnerMatches(owner.value, attempt))
+        return false;
+    if (proof.kind === 'value' && !cleanupProofMatches(proof.value, attempt))
+        return false;
+    const hasTransportFiles = existsSync(attempt.bootstrapDescriptorPath) || existsSync(attempt.wrapperPath);
+    if (owner.kind === 'absent') {
+        return !hasTransportFiles && (proof.kind === 'absent' || cleanupProofMatches(proof.value, attempt));
+    }
+    await unlink(attempt.bootstrapDescriptorPath).catch(error => {
+        if (error.code !== 'ENOENT')
+            throw error;
+    });
+    await unlink(attempt.wrapperPath).catch(error => {
+        if (error.code !== 'ENOENT')
+            throw error;
+    });
+    if (existsSync(attempt.bootstrapDescriptorPath) || existsSync(attempt.wrapperPath))
+        return false;
+    if (proof.kind === 'absent') {
+        await writeExclusiveAtomic(attempt.transportCleanupCompletePath, {
+            ...identityOf(attempt),
+            kind: WORKER_LAUNCH_TRANSPORT_CLEANUP_KIND,
+            reason,
+            written_at: new Date().toISOString(),
+        });
+    }
+    const completed = await readJson(attempt.transportCleanupCompletePath);
+    return completed.kind === 'value' && cleanupProofMatches(completed.value, attempt)
+        && !existsSync(attempt.bootstrapDescriptorPath) && !existsSync(attempt.wrapperPath);
+}
+export async function cleanupWorkerLaunchTransport(attempt, reason = 'transport_cleanup') {
+    if (!attemptTransportPathsAreDeterministic(attempt))
+        return false;
+    try {
+        return await withFileLock(lockPathFor(attempt.currentPath), () => cleanupWorkerLaunchTransportUnlocked(attempt, reason), { timeoutMs: 5_000, retryDelayMs: 10 });
+    }
+    catch {
+        return false;
+    }
+}
+export async function readAndConsumeWorkerLaunchDescriptor(descriptorPath) {
+    let parsed;
+    let handle;
+    try {
+        handle = await open(descriptorPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+        const info = await handle.stat();
+        if (!info.isFile() || info.nlink !== 1)
+            throw new Error('worker_launch_descriptor_invalid');
+        parsed = JSON.parse(await handle.readFile('utf8'));
+    }
+    catch (error) {
+        if (error instanceof Error && error.message.startsWith('worker_launch_descriptor_'))
+            throw error;
+        throw new Error(error.code === 'ENOENT' ? 'worker_launch_descriptor_missing' : 'worker_launch_descriptor_invalid');
+    }
+    finally {
+        await handle?.close().catch(() => undefined);
+    }
+    if (!isValidBootstrapSpec(parsed))
+        throw new Error('worker_launch_descriptor_invalid');
+    const spec = parsed;
+    if (resolve(descriptorPath) !== resolve(spec.bootstrap_descriptor_path))
+        throw new Error('worker_launch_descriptor_path_mismatch');
+    const owner = await readJson(spec.transport_owner_path);
+    if (owner.kind !== 'value' || !transportOwnerMatches(owner.value, spec, spec.authority_digest) || !existsSync(spec.wrapper_path))
+        throw new Error('worker_launch_descriptor_owner_invalid');
+    try {
+        await withFileLock(lockPathFor(spec.current_path), async () => {
+            const currentOwner = await readJson(spec.transport_owner_path);
+            if (currentOwner.kind !== 'value' || !transportOwnerMatches(currentOwner.value, spec, spec.authority_digest)
+                || !await isCurrentLaunchIdentity(spec.current_path, spec)
+                || (await readJson(`${spec.decision_path}.retired`)).kind !== 'absent')
+                throw new Error('worker_launch_descriptor_owner_invalid');
+            await unlink(descriptorPath);
+        });
+    }
+    catch (error) {
+        if (error instanceof Error && error.message.startsWith('worker_launch_descriptor_'))
+            throw error;
+        throw new Error('worker_launch_descriptor_remove_failed');
+    }
+    return spec;
+}
+async function publishDecision(attempt, decision, reason) {
+    const record = {
+        ...identityOf(attempt),
+        kind: 'worker_launch_decision',
+        decision,
+        reason,
+        written_at: new Date().toISOString(),
+    };
+    try {
+        await writeExclusiveAtomic(attempt.decisionPath, record);
+        return true;
+    }
+    catch (error) {
+        if (error.code !== 'EEXIST')
+            throw error;
+        const existing = await readJson(attempt.decisionPath);
+        return existing.kind === 'value'
+            && identityMatches(existing.value, attempt)
+            && existing.value.kind === 'worker_launch_decision'
+            && existing.value.decision === decision;
+    }
+}
+export async function revokeWorkerLaunchAttempt(attempt, reason) {
+    return publishDecision(attempt, 'revoked', reason).catch(() => false);
+}
+async function rejectWorkerLaunchAttempt(attempt, reason) {
+    return await revokeWorkerLaunchAttempt(attempt, reason)
+        ? { ok: false, reason }
+        : { ok: false, reason: 'decision_conflict' };
+}
+function acknowledgementResult(value, attempt) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return { ok: false, reason: 'ack_malformed' };
+    const record = value;
+    if (record.kind !== 'worker_launch_ack' || typeof record.written_at !== 'string'
+        || !Number.isFinite(Date.parse(record.written_at)))
+        return { ok: false, reason: 'ack_malformed' };
+    return identityMatches(record, attempt) ? null : { ok: false, reason: 'ack_mismatch' };
+}
+async function acceptObservedAcknowledgement(attempt, read) {
+    if (read.kind === 'absent')
+        return null;
+    if (read.kind === 'malformed')
+        return { ok: false, reason: 'ack_malformed' };
+    const invalid = acknowledgementResult(read.value, attempt);
+    if (invalid)
+        return invalid;
+    try {
+        return await withFileLock(lockPathFor(attempt.currentPath), async () => {
+            if (!await isCurrentLaunchIdentity(attempt.currentPath, attempt)) {
+                return { ok: false, reason: 'attempt_superseded' };
+            }
+            return await publishDecision(attempt, 'accepted', 'ack_valid')
+                ? { ok: true }
+                : { ok: false, reason: 'decision_conflict' };
+        });
+    }
+    catch {
+        return { ok: false, reason: 'decision_conflict' };
+    }
+}
+export async function awaitWorkerLaunchAcknowledgement(attempt, options = {}) {
+    const expected = await readJson(attempt.expectedPath);
+    if (expected.kind !== 'value' || !identityMatches(expected.value, attempt)) {
+        return rejectWorkerLaunchAttempt(attempt, 'expected_record_invalid');
+    }
+    const timeoutMs = options.timeoutMs ?? resolvePositiveInteger(process.env.OMC_TEAM_START_ACK_TIMEOUT_MS, DEFAULT_ACK_TIMEOUT_MS);
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const result = await acceptObservedAcknowledgement(attempt, await readJson(attempt.ackPath));
+        if (result) {
+            return result.ok ? result : rejectWorkerLaunchAttempt(attempt, result.reason);
+        }
+        await sleep(pollIntervalMs);
+    }
+    const finalResult = await acceptObservedAcknowledgement(attempt, await readJson(attempt.ackPath));
+    if (finalResult) {
+        return finalResult.ok ? finalResult : rejectWorkerLaunchAttempt(attempt, finalResult.reason);
+    }
+    return rejectWorkerLaunchAttempt(attempt, 'ack_timeout');
+}
+export async function isWorkerLaunchAttemptAccepted(attempt) {
+    const decision = await readJson(attempt.decisionPath);
+    return decision.kind === 'value'
+        && identityMatches(decision.value, attempt)
+        && decision.value.kind === 'worker_launch_decision'
+        && decision.value.decision === 'accepted';
+}
+export async function isWorkerLaunchAttemptCurrent(attempt) {
+    try {
+        return await withFileLock(lockPathFor(attempt.currentPath), () => isCurrentLaunchIdentity(attempt.currentPath, attempt));
+    }
+    catch {
+        return false;
+    }
+}
+export async function withWorkerLaunchAttemptFence(attempt, fn) {
+    try {
+        return await withFileLock(lockPathFor(attempt.currentPath), async () => {
+            if (!await isCurrentLaunchIdentity(attempt.currentPath, attempt)
+                || !await isWorkerLaunchAttemptAccepted(attempt))
+                return { ok: false };
+            return { ok: true, value: await fn() };
+        });
+    }
+    catch {
+        return { ok: false };
+    }
+}
+export async function retireWorkerLaunchAttempt(attempt, reason) {
+    const retiredPath = `${attempt.decisionPath}.retired`;
+    try {
+        return await withFileLock(lockPathFor(attempt.currentPath), async () => {
+            const existing = await readJson(retiredPath);
+            if (existing.kind === 'value') {
+                if (!identityMatches(existing.value, attempt))
+                    return false;
+            }
+            else if (existing.kind === 'malformed') {
+                return false;
+            }
+            else {
+                await writeExclusiveAtomic(retiredPath, {
+                    ...identityOf(attempt),
+                    kind: 'worker_launch_retired',
+                    reason,
+                    written_at: new Date().toISOString(),
+                });
+            }
+            if (!await cleanupWorkerLaunchTransportUnlocked(attempt, reason))
+                return false;
+            if (await isCurrentLaunchIdentity(attempt.currentPath, attempt)) {
+                await unlink(attempt.currentPath).catch(() => { });
+            }
+            return true;
+        }, { timeoutMs: 5_000, retryDelayMs: 10 });
+    }
+    catch {
+        return false;
+    }
+}
+export async function retireAndCleanupCurrentWorkerLaunchAttempt(attempt, reason, cleanup) {
+    const retiredPath = `${attempt.decisionPath}.retired`;
+    const cleanupCompletePath = `${retiredPath}.cleanup-complete`;
+    const cleanupIsComplete = async () => {
+        const completed = await readJson(cleanupCompletePath);
+        return completed.kind === 'value'
+            && identityMatches(completed.value, attempt)
+            && completed.value.kind === 'worker_launch_cleanup_complete';
+    };
+    if (await cleanupIsComplete())
+        return true;
+    try {
+        return await withFileLock(lockPathFor(attempt.currentPath), async () => {
+            if (!await isCurrentLaunchIdentity(attempt.currentPath, attempt))
+                return cleanupIsComplete();
+            if (!await isWorkerLaunchAttemptAccepted(attempt))
+                return false;
+            const existing = await readJson(retiredPath);
+            if (existing.kind === 'value') {
+                if (!identityMatches(existing.value, attempt))
+                    return false;
+            }
+            else if (existing.kind === 'malformed') {
+                return false;
+            }
+            else {
+                await writeExclusiveAtomic(retiredPath, {
+                    ...identityOf(attempt), kind: 'worker_launch_retired', reason, written_at: new Date().toISOString(),
+                });
+            }
+            if (!await terminateWorkerLaunchProvider(attempt))
+                return false;
+            if (!await cleanup())
+                return false;
+            if (!await cleanupWorkerLaunchTransportUnlocked(attempt, reason))
+                return false;
+            const completed = await readJson(cleanupCompletePath);
+            if (completed.kind === 'absent') {
+                await writeExclusiveAtomic(cleanupCompletePath, {
+                    ...identityOf(attempt), kind: 'worker_launch_cleanup_complete', reason, written_at: new Date().toISOString(),
+                });
+            }
+            else if (completed.kind !== 'value'
+                || !identityMatches(completed.value, attempt)
+                || completed.value.kind !== 'worker_launch_cleanup_complete')
+                return false;
+            if (!await isCurrentLaunchIdentity(attempt.currentPath, attempt))
+                return false;
+            await unlink(attempt.currentPath);
+            return true;
+        }, { timeoutMs: 10_000, retryDelayMs: 10 });
+    }
+    catch {
+        return false;
+    }
+}
+function isValidProcessStartIdentity(value) {
+    return typeof value === 'string' && (/^\d+$/.test(value) || /^ticks:\d+$/.test(value)
+        || /^dmtf:\d{14}\.\d{6}[+-]\d{3}$/.test(value));
+}
+async function readWorkerLaunchCleanupProof(attempt, started) {
+    const startedPath = 'startedPath' in attempt ? attempt.startedPath : attempt.started_path;
+    const terminal = await readJson(`${startedPath}.terminal`);
+    if (terminal.kind === 'value') {
+        const value = terminal.value;
+        const matchesStarted = !started || (value.pid === started.pid
+            && value.process_start_identity === started.process_start_identity);
+        if (matchesStarted && identityMatches(value, attempt) && value.kind === 'worker_launch_provider_terminal'
+            && value.outcome === 'exit' && value.cleanup_verified === true
+            && Number.isSafeInteger(value.pid) && Number(value.pid) > 0
+            && isValidProcessStartIdentity(value.process_start_identity))
+            return true;
+    }
+    const completed = await readJson(`${startedPath}.termination-complete`);
+    if (completed.kind === 'value') {
+        const value = completed.value;
+        const matchesStarted = !started || (value.pid === started.pid
+            && value.process_start_identity === started.process_start_identity);
+        if (matchesStarted && identityMatches(value, attempt) && value.kind === 'worker_launch_termination_complete'
+            && value.cleanup_verified === true && Number.isSafeInteger(value.pid) && Number(value.pid) > 0
+            && isValidProcessStartIdentity(value.process_start_identity))
+            return true;
+    }
+    return false;
+}
+export async function terminateWorkerLaunchProvider(attempt, timeoutMs = 2_000) {
+    const started = await readJson(attempt.startedPath);
+    const terminalCleanupVerified = await readWorkerLaunchCleanupProof(attempt, started.kind === 'value' ? started.value : undefined);
+    if (started.kind === 'absent')
+        return terminalCleanupVerified;
+    if (started.kind !== 'value')
+        return false;
+    const record = started.value;
+    if (!identityMatches(record, attempt)
+        || record.kind !== 'worker_launch_provider_started'
+        || !Number.isSafeInteger(record.pid)
+        || Number(record.pid) <= 0
+        || !isValidProcessStartIdentity(record.process_start_identity))
+        return false;
+    if (terminalCleanupVerified)
+        return true;
+    if (process.platform !== 'win32' && (!Number.isSafeInteger(record.process_group_id) || Number(record.process_group_id) <= 0))
+        return false;
+    const terminationRequestPath = `${attempt.startedPath}.termination-request`;
+    const terminationCompletePath = `${attempt.startedPath}.termination-complete`;
+    const existingRequest = await readJson(terminationRequestPath);
+    let hadExistingValidTerminationRequest = false;
+    if (process.platform === 'win32') {
+        if (existingRequest.kind === 'absent') {
+            try {
+                await writeExclusiveAtomic(terminationRequestPath, {
+                    ...identityOf(attempt), kind: 'worker_launch_termination_request', operation: 'terminate',
+                    pid: record.pid, process_start_identity: record.process_start_identity,
+                    authority_digest: record.authority_digest ?? '', containment_nonce: record.containment_nonce ?? attempt.nonce,
+                    written_at: new Date().toISOString(),
+                });
+            }
+            catch {
+                return false;
+            }
+        }
+        else if (existingRequest.kind !== 'value')
+            return false;
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            const complete = await readJson(terminationCompletePath);
+            if (complete.kind === 'value') {
+                const proof = complete.value;
+                if (identityMatches(proof, attempt)
+                    && proof.kind === 'worker_launch_termination_complete'
+                    && proof.cleanup_verified === true
+                    && proof.pid === record.pid
+                    && proof.process_start_identity === record.process_start_identity
+                    && proof.authority_digest === record.authority_digest
+                    && proof.containment_nonce === record.containment_nonce)
+                    return true;
+            }
+            await sleep(20);
+        }
+        return false;
+    }
+    if (existingRequest.kind === 'absent') {
+        try {
+            await writeExclusiveAtomic(terminationRequestPath, {
+                ...identityOf(attempt), kind: 'worker_launch_termination_request', pid: record.pid,
+                process_start_identity: record.process_start_identity, containment_nonce: record.containment_nonce ?? attempt.nonce, written_at: new Date().toISOString(),
+            });
+        }
+        catch {
+            return false;
+        }
+    }
+    else {
+        const value = existingRequest.kind === 'value'
+            ? existingRequest.value
+            : null;
+        if (!value || !identityMatches(value, attempt) || value.kind !== 'worker_launch_termination_request'
+            || value.pid !== record.pid || value.process_start_identity !== record.process_start_identity)
+            return false;
+        hadExistingValidTerminationRequest = true;
+    }
+    const deadlineAt = new Date(Date.now() + timeoutMs).toISOString();
+    const result = await terminateOwnedProcessGroup({
+        pid: record.pid, expectedStartIdentity: record.process_start_identity,
+        processGroupId: record.process_group_id, deadlineAt, force: true,
+    });
+    if (result === 'already-dead' || result === 'identity-mismatch') {
+        return terminalCleanupVerified || (hadExistingValidTerminationRequest
+            && isProcessGroupAbsent(record.process_group_id)
+            && await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record));
+    }
+    if (result !== 'terminated')
+        return false;
+    if (!await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record)) {
+        // The completion-record write failed after a successful termination.
+        // Retry: verify the process is dead, then re-attempt the write so a
+        // later retry can safely resume from the termination-request + proven
+        // process absence. Never infer from PID absence without request identity.
+        const deadline = Date.parse(deadlineAt);
+        const liveness = await isProcessIdentityLive(record.pid, record.process_start_identity, deadline);
+        if ((liveness === 'dead' || liveness === 'mismatch')
+            && await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record))
+            return true;
+        return false;
+    }
+    const deadline = Date.parse(deadlineAt);
+    while (Date.now() < deadline) {
+        const liveness = await isProcessIdentityLive(record.pid, record.process_start_identity, deadline);
+        if (liveness === 'dead' || liveness === 'mismatch')
+            return true;
+        if (liveness === 'unknown')
+            return false;
+        await sleep(20);
+    }
+    return false;
+}
+function isProcessGroupAbsent(processGroupId) {
+    if (process.platform === 'win32' || !Number.isSafeInteger(processGroupId) || Number(processGroupId) <= 0)
+        return false;
+    try {
+        process.kill(-Number(processGroupId), 0);
+        return false;
+    }
+    catch (error) {
+        return error.code === 'ESRCH';
+    }
+}
+async function publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record) {
+    const existingComplete = await readJson(terminationCompletePath);
+    if (existingComplete.kind === 'absent') {
+        try {
+            await writeExclusiveAtomic(terminationCompletePath, {
+                ...identityOf(attempt), kind: 'worker_launch_termination_complete', cleanup_verified: true,
+                pid: record.pid, process_start_identity: record.process_start_identity, written_at: new Date().toISOString(),
+            });
+            return true;
+        }
+        catch {
+            return false;
+        }
+    }
+    const value = existingComplete.kind === 'value'
+        ? existingComplete.value
+        : null;
+    return !!value && identityMatches(value, attempt) && value.kind === 'worker_launch_termination_complete'
+        && value.cleanup_verified === true && value.pid === record.pid
+        && value.process_start_identity === record.process_start_identity;
+}
+async function readValidProviderStarted(attempt) {
+    const started = await readJson(attempt.startedPath);
+    if ((await readJson(`${attempt.startedPath}.terminal`)).kind !== 'absent')
+        return null;
+    if (started.kind !== 'value')
+        return null;
+    const record = started.value;
+    if (record.supervisor_completion_path !== undefined
+        && (typeof record.supervisor_completion_path !== 'string'
+            || record.supervisor_completion_path.trim().length === 0
+            || existsSync(record.supervisor_completion_path)))
+        return null;
+    return identityMatches(record, attempt)
+        && record.kind === 'worker_launch_provider_started'
+        && Number.isSafeInteger(record.pid)
+        && record.pid > 0
+        && typeof record.process_start_identity === 'string'
+        && record.process_start_identity.trim().length > 0
+        && (record.containment_nonce === undefined || isExactText(record.containment_nonce))
+        && typeof record.written_at === 'string'
+        && Number.isFinite(Date.parse(record.written_at))
+        ? record
+        : null;
+}
+export async function awaitWorkerLaunchProviderStarted(attempt, options = {}) {
+    const timeoutMs = options.timeoutMs ?? resolvePositiveInteger(process.env.OMC_TEAM_START_ACK_TIMEOUT_MS, DEFAULT_ACK_TIMEOUT_MS);
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const published = await readValidProviderStarted(attempt);
+        if (published)
+            try {
+                const handedOff = await withFileLock(lockPathFor(attempt.currentPath), async () => {
+                    if (!await isCurrentLaunchIdentity(attempt.currentPath, attempt)
+                        || !await isWorkerLaunchAttemptAccepted(attempt))
+                        return false;
+                    const started = await readValidProviderStarted(attempt);
+                    if (!started)
+                        return false;
+                    return await isProcessIdentityLive(started.pid, started.process_start_identity, deadline) === 'live';
+                });
+                if (handedOff)
+                    return true;
+            }
+            catch {
+                // Bootstrap still owns the launch fence; retry within the bounded window.
+            }
+        if ((await readJson(`${attempt.decisionPath}.retired`)).kind !== 'absent')
+            return false;
+        await sleep(pollIntervalMs);
+    }
+    return false;
+}
+export async function isWorkerLaunchProviderStarted(attempt) {
+    return (await readValidProviderStarted(attempt)) !== null;
+}
+function isDeterministicTransportPath(expectedPath, candidate, fileName) {
+    return isExactText(candidate)
+        && resolve(candidate) === resolve(join(dirname(expectedPath), fileName));
+}
+function isValidBootstrapSpec(value) {
+    if (!isValidIdentity(value))
+        return false;
+    const spec = value;
+    return isExactText(spec.current_path)
+        && isExactText(spec.expected_path)
+        && isExactText(spec.ack_path)
+        && isExactText(spec.decision_path)
+        && isExactText(spec.started_path)
+        && isDeterministicTransportPath(spec.expected_path, spec.transport_owner_path, 'transport-owner.json')
+        && isDeterministicTransportPath(spec.expected_path, spec.bootstrap_descriptor_path, WORKER_LAUNCH_BOOTSTRAP_DESCRIPTOR_FILE)
+        && isDeterministicTransportPath(spec.expected_path, spec.wrapper_path, 'launch.cmd')
+        && isDeterministicTransportPath(spec.expected_path, spec.transport_cleanup_complete_path, 'transport-cleanup-complete.json')
+        && Array.isArray(spec.provider_argv)
+        && spec.provider_argv.length > 0
+        && isExactText(spec.provider_argv[0])
+        && spec.provider_argv.slice(1).every(argument => typeof argument === 'string')
+        && isValidProviderEnvironment(spec.provider_env)
+        && typeof spec.cwd === 'string'
+        && spec.cwd.length > 0
+        && Number.isSafeInteger(spec.decision_timeout_ms)
+        && typeof spec.release_after_spawn === 'boolean'
+        && Number(spec.decision_timeout_ms) > 0
+        && typeof spec.containment_nonce === 'string'
+        && spec.containment_nonce.length > 0
+        && typeof spec.supervisor_source_sha256 === 'string'
+        && /^[0-9a-f]{64}$/.test(spec.supervisor_source_sha256)
+        && spec.supervisor_source_sha256 === createHash('sha256').update(buildWindowsSupervisorSource(), 'utf8').digest('hex')
+        && typeof spec.authority_digest === 'string'
+        && /^[0-9a-f]{64}$/.test(spec.authority_digest)
+        && spec.authority_digest === canonicalAuthorityDigest({ identity: spec, providerArgv: spec.provider_argv, providerEnv: spec.provider_env, cwd: spec.cwd, containmentNonce: spec.containment_nonce, supervisorSourceSha256: spec.supervisor_source_sha256 });
+}
+async function publishAcknowledgement(spec) {
+    const acknowledgement = {
+        schema_version: spec.schema_version,
+        attempt_id: spec.attempt_id,
+        nonce: spec.nonce,
+        team_name: spec.team_name,
+        worker_name: spec.worker_name,
+        pane_id: spec.pane_id,
+        provider: spec.provider,
+        created_at: spec.created_at,
+        kind: 'worker_launch_ack',
+        written_at: new Date().toISOString(),
+    };
+    try {
+        await writeExclusiveAtomic(spec.ack_path, acknowledgement);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+async function waitForBootstrapDecision(spec) {
+    const deadline = Date.now() + spec.decision_timeout_ms;
+    while (Date.now() < deadline) {
+        const read = await readJson(spec.decision_path);
+        if (read.kind === 'value' && identityMatches(read.value, spec)
+            && read.value.kind === 'worker_launch_decision') {
+            const decision = read.value.decision;
+            if (decision === 'accepted' || decision === 'revoked')
+                return decision;
+        }
+        await sleep(DEFAULT_POLL_INTERVAL_MS);
+    }
+    return 'timeout';
+}
+function buildWindowsSupervisorInvocation(spec) {
+    const env = Object.fromEntries(Object.entries(spec.provider_env).sort(([a], [b]) => a.localeCompare(b)));
+    const canonical_json = JSON.stringify({
+        protocol: WORKER_LAUNCH_AUTHORITY_PROTOCOL,
+        nonce: spec.containment_nonce,
+        supervisor_source_sha256: spec.supervisor_source_sha256,
+        identity: identityOf(spec),
+        provider_argv: [...spec.provider_argv],
+        provider_env: env,
+        cwd: resolve(spec.cwd),
+    });
+    const payload = Buffer.from(JSON.stringify({
+        canonical_json,
+        authority_digest: spec.authority_digest,
+        containment_nonce: spec.containment_nonce,
+        supervisor_source_sha256: spec.supervisor_source_sha256,
+        identity: identityOf(spec),
+        provider_argv: [...spec.provider_argv],
+        provider_env: env,
+        cwd: resolve(spec.cwd),
+    }), 'utf8').toString('base64');
+    const systemRoot = spec.provider_env.SystemRoot ?? spec.provider_env.SYSTEMROOT;
+    if (!systemRoot || !/^[A-Za-z]:\\/.test(systemRoot))
+        throw new Error('worker_launch_powershell_authority_missing');
+    return {
+        command: `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+        args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', encodePowerShell(buildWindowsSupervisorSource())],
+        stdinPayload: Buffer.from(payload, 'base64').toString('utf8'),
+        cleanup: async () => { },
+    };
+}
+function quoteWindowsCmdArgument(value) {
+    if (/[\r\n]/.test(value))
+        throw new Error('worker_launch_provider_argv_invalid');
+    return `"${value.replace(/%/g, '%%').replace(/"/g, '""')}"`;
+}
+export function quoteWindowsCreateProcessArgument(value) {
+    if (/[\r\n]/.test(value))
+        throw new Error('worker_launch_provider_argv_invalid');
+    let result = '"';
+    let slashes = 0;
+    for (const char of value) {
+        if (char === '\\') {
+            slashes++;
+            continue;
+        }
+        if (char === '"') {
+            result += '\\'.repeat(slashes * 2 + 1) + '"';
+            slashes = 0;
+            continue;
+        }
+        result += '\\'.repeat(slashes) + char;
+        slashes = 0;
+    }
+    return result + '\\'.repeat(slashes * 2) + '"';
+}
+export function buildProviderSpawnInvocation(providerArgv, platform = process.platform, env = {}) {
+    const [command, ...args] = providerArgv;
+    if (!command)
+        throw new Error('worker_launch_provider_argv_missing');
+    if (platform === 'win32') {
+        const comSpec = env.ComSpec ?? env.COMSPEC ?? 'cmd.exe';
+        const batchScript = ['@echo off', `start "" /b /wait ${providerArgv.map(quoteWindowsCmdArgument).join(' ')}`, ''].join('\r\n');
+        return { command: comSpec, args: ['/d', '/v:off', '/s', '/c'], batchScript };
+    }
+    return { command, args };
+}
+async function awaitExternalTerminationCompletion(spec, timeoutMs = 2_000) {
+    const request = await readJson(`${spec.started_path}.termination-request`);
+    if (request.kind !== 'value' || !identityMatches(request.value, spec)
+        || request.value.containment_nonce !== spec.containment_nonce
+        || request.value.authority_digest !== spec.authority_digest)
+        return false;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const completed = await readJson(`${spec.started_path}.termination-complete`);
+        if (completed.kind === 'value'
+            && identityMatches(completed.value, spec)
+            && completed.value.cleanup_verified === true)
+            return true;
+        if (completed.kind === 'malformed')
+            return false;
+        await sleep(10);
+    }
+    return false;
+}
+async function isCorrelatedTerminationDead(spec) {
+    const [request, started] = await Promise.all([
+        readJson(`${spec.started_path}.termination-request`),
+        readJson(spec.started_path),
+    ]);
+    if (request.kind !== 'value' || started.kind !== 'value'
+        || !identityMatches(request.value, spec)
+        || !identityMatches(started.value, spec))
+        return false;
+    const requestRecord = request.value;
+    const startedRecord = started.value;
+    if (requestRecord.kind !== 'worker_launch_termination_request'
+        || requestRecord.pid !== startedRecord.pid
+        || requestRecord.process_start_identity !== startedRecord.process_start_identity
+        || !Number.isSafeInteger(startedRecord.pid)
+        || !isValidProcessStartIdentity(startedRecord.process_start_identity))
+        return false;
+    const liveness = await isProcessIdentityLive(startedRecord.pid, startedRecord.process_start_identity, Date.now() + 500);
+    return liveness === 'dead' || liveness === 'mismatch';
+}
+export async function materializeProviderSpawnInvocation(invocation, options = {}) {
+    const superviseProcessTree = options.superviseProcessTree ?? options.superviseWindowsTree ?? false;
+    if (!invocation.batchScript && !superviseProcessTree) {
+        return { command: invocation.command, args: invocation.args, cleanup: async () => { } };
+    }
+    const wrapperDir = await mkdtemp(join(tmpdir(), 'omc-provider-'));
+    try {
+        const completionPath = superviseProcessTree ? join(wrapperDir, 'provider-exit.txt') : undefined;
+        if (invocation.batchScript) {
+            const wrapperPath = join(wrapperDir, 'launch.cmd');
+            const completionScript = completionPath
+                ? `set "_OMC_EXIT=%ERRORLEVEL%"\r\n> ${quoteWindowsCmdArgument(completionPath)} echo %_OMC_EXIT%\r\n:omc_hold\r\nping -n 3600 127.0.0.1 >nul\r\ngoto omc_hold\r\n`
+                : '';
+            await writeFile(wrapperPath, `${invocation.batchScript}${completionScript}`, { encoding: 'utf8', mode: 0o600 });
+            return {
+                command: invocation.command,
+                args: [...invocation.args, `"${wrapperPath}"`],
+                ...(completionPath ? { completionPath } : {}),
+                cleanup: async () => { await rm(wrapperDir, { recursive: true, force: true }); },
+            };
+        }
+        const wrapperPath = join(wrapperDir, 'launch.sh');
+        const quotedCompletion = `'${completionPath.replace(/'/g, `'"'"'`)}'`;
+        await writeFile(wrapperPath, `#!/bin/sh\n"$@"\n_omc_exit=$?\nprintf '%s\\n' "$_omc_exit" > ${quotedCompletion}\nwhile :; do sleep 3600; done\n`, { encoding: 'utf8', mode: 0o700 });
+        return { command: '/bin/sh', args: [wrapperPath, invocation.command, ...invocation.args], completionPath, cleanup: async () => { await rm(wrapperDir, { recursive: true, force: true }); } };
+    }
+    catch (error) {
+        await rm(wrapperDir, { recursive: true, force: true }).catch(() => undefined);
+        throw error;
+    }
+}
+async function publishProviderStarted(spec, pid, processStartIdentity, supervisorCompletionPath, processGroupId) {
+    const record = {
+        schema_version: spec.schema_version,
+        attempt_id: spec.attempt_id,
+        nonce: spec.nonce,
+        team_name: spec.team_name,
+        worker_name: spec.worker_name,
+        pane_id: spec.pane_id,
+        provider: spec.provider,
+        created_at: spec.created_at,
+        kind: 'worker_launch_provider_started',
+        pid: Number.isSafeInteger(pid) ? pid : null,
+        process_start_identity: processStartIdentity,
+        containment_nonce: spec.containment_nonce,
+        ...(supervisorCompletionPath ? { supervisor_completion_path: supervisorCompletionPath } : {}),
+        written_at: new Date().toISOString(),
+        authority_digest: spec.authority_digest,
+        ...(processGroupId !== undefined ? { process_group_id: processGroupId } : {}),
+    };
+    try {
+        await writeExclusiveAtomic(spec.started_path, record);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+export async function runWorkerLaunchBootstrap(value) {
+    if (!isValidBootstrapSpec(value))
+        return { outcome: 'invalid_spec' };
+    const spec = value;
+    const expected = await readJson(spec.expected_path);
+    if (expected.kind !== 'value' || !identityMatches(expected.value, spec))
+        return { outcome: 'expected_record_invalid' };
+    if (!await publishAcknowledgement(spec))
+        return { outcome: 'ack_conflict' };
+    const decision = await waitForBootstrapDecision(spec);
+    if (decision === 'timeout')
+        return { outcome: 'decision_timeout' };
+    if (decision === 'revoked')
+        return { outcome: 'revoked' };
+    const providerEnv = { ...spec.provider_env };
+    try {
+        const launched = await withFileLock(lockPathFor(spec.current_path), async () => {
+            if (!await isCurrentLaunchIdentity(spec.current_path, spec)
+                || (await readJson(`${spec.decision_path}.retired`)).kind !== 'absent') {
+                return { outcome: 'superseded' };
+            }
+            const invocation = process.platform === 'win32'
+                ? buildWindowsSupervisorInvocation(spec)
+                : await materializeProviderSpawnInvocation(buildProviderSpawnInvocation(spec.provider_argv, process.platform, providerEnv), { superviseProcessTree: true });
+            const child = spawn(invocation.command, invocation.args, {
+                cwd: spec.cwd,
+                env: providerEnv,
+                stdio: process.platform === 'win32' ? ['pipe', 'pipe', 'pipe'] : 'inherit',
+                detached: process.platform !== 'win32',
+            });
+            if (process.platform === 'win32' && invocation.stdinPayload && child.stdin?.writable) {
+                child.stdin.write(`${invocation.stdinPayload}\n`);
+            }
+            let settled = false;
+            let providerPid = null;
+            let providerStartIdentity = null;
+            let supervisedExitCode = null;
+            let launchGroup = null;
+            let supervisorTimer;
+            let terminationResult = null;
+            let resolveCompletion;
+            let resolveWindowsReady;
+            let resolveWindowsTerminal;
+            const windowsReady = new Promise(resolve => { resolveWindowsReady = resolve; });
+            const windowsTerminal = new Promise(resolve => { resolveWindowsTerminal = resolve; });
+            if (process.platform === 'win32' && child.stdout) {
+                let buffered = '';
+                child.stdout.setEncoding('utf8');
+                child.stdout.on('data', chunk => {
+                    buffered += String(chunk);
+                    if (buffered.length > 16_384) {
+                        buffered = '';
+                        resolveWindowsReady(false);
+                        resolveWindowsTerminal(false);
+                        return;
+                    }
+                    for (;;) {
+                        const newline = buffered.indexOf('\n');
+                        if (newline < 0)
+                            break;
+                        const line = buffered.slice(0, newline).trim();
+                        buffered = buffered.slice(newline + 1);
+                        if (!line)
+                            continue;
+                        let message;
+                        try {
+                            message = JSON.parse(line);
+                        }
+                        catch {
+                            continue;
+                        }
+                        const matches = message.protocol === WINDOWS_SUPERVISOR_PROTOCOL
+                            && message.attempt_id === spec.attempt_id
+                            && message.authority_digest === spec.authority_digest
+                            && message.containment_nonce === spec.containment_nonce;
+                        if (!matches)
+                            continue;
+                        if (message.kind === 'ready' && Number.isSafeInteger(message.pid) && Number(message.pid) > 0
+                            && isValidProcessStartIdentity(message.process_start_identity)) {
+                            providerPid = Number(message.pid);
+                            providerStartIdentity = String(message.process_start_identity);
+                            resolveWindowsReady(true);
+                        }
+                        else if (message.kind === 'terminal' && message.pid === providerPid
+                            && (message.outcome === 'terminated' || message.outcome === 'exit')
+                            && message.cleanup_verified === true) {
+                            void writeExclusiveAtomic(`${spec.started_path}.termination-complete`, {
+                                ...identityOf(spec), kind: 'worker_launch_termination_complete', cleanup_verified: true,
+                                pid: providerPid, process_start_identity: providerStartIdentity,
+                                authority_digest: spec.authority_digest, containment_nonce: spec.containment_nonce,
+                                outcome: message.outcome,
+                                ...(Number.isSafeInteger(message.exit_code) ? { exit_code: message.exit_code } : {}),
+                                written_at: new Date().toISOString(),
+                            }).catch(() => undefined);
+                            resolveWindowsTerminal(true);
+                        }
+                    }
+                });
+            }
+            const completion = new Promise(resolve => {
+                resolveCompletion = resolve;
+                child.once('exit', async (exitCode, signal) => {
+                    if (settled)
+                        return;
+                    settled = true;
+                    if (supervisorTimer)
+                        clearInterval(supervisorTimer);
+                    if (process.platform === 'win32') {
+                        resolveWindowsReady(false);
+                        resolveWindowsTerminal(false);
+                    }
+                    const effectiveExitCode = supervisedExitCode ?? exitCode;
+                    const effectiveSignal = supervisedExitCode === null ? signal : null;
+                    const cleanupVerified = process.platform === 'win32'
+                        ? await awaitExternalTerminationCompletion(spec) || await readWorkerLaunchCleanupProof(spec)
+                        : terminationResult
+                            ? ['terminated', 'already-dead', 'identity-mismatch'].includes(await terminationResult)
+                            : await awaitExternalTerminationCompletion(spec) || await readWorkerLaunchCleanupProof(spec)
+                                || await isCorrelatedTerminationDead(spec);
+                    await atomicWriteJson(`${spec.started_path}.terminal`, {
+                        ...identityOf(spec), kind: 'worker_launch_provider_terminal',
+                        outcome: cleanupVerified ? 'exit' : 'cleanup_unverified', cleanup_verified: cleanupVerified,
+                        pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity, exit_code: effectiveExitCode, signal: effectiveSignal, written_at: new Date().toISOString(),
+                    }).catch(() => undefined);
+                    await invocation.cleanup().catch(() => undefined);
+                    resolve(cleanupVerified
+                        ? { outcome: 'ran', exitCode: effectiveExitCode, signal: effectiveSignal }
+                        : { outcome: 'provider_cleanup_unverified' });
+                });
+                child.once('error', async () => {
+                    if (settled)
+                        return;
+                    settled = true;
+                    if (supervisorTimer)
+                        clearInterval(supervisorTimer);
+                    resolveWindowsReady(false);
+                    resolveWindowsTerminal(false);
+                    await atomicWriteJson(`${spec.started_path}.terminal`, {
+                        ...identityOf(spec), kind: 'worker_launch_provider_terminal', outcome: 'error', cleanup_verified: false,
+                        pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity, written_at: new Date().toISOString(),
+                    }).catch(() => undefined);
+                    await invocation.cleanup().catch(() => undefined);
+                    resolve({ outcome: 'provider_spawn_failed' });
+                });
+            });
+            const terminateProvider = async () => {
+                if (settled)
+                    return process.platform !== 'win32';
+                if (process.platform === 'win32') {
+                    if (!providerPid || !providerStartIdentity || !child.stdin?.writable)
+                        return false;
+                    const frame = JSON.stringify({
+                        protocol: WINDOWS_SUPERVISOR_PROTOCOL, kind: 'terminate', attempt_id: spec.attempt_id,
+                        authority_digest: spec.authority_digest, containment_nonce: spec.containment_nonce,
+                    });
+                    child.stdin.write(`${frame}\n`);
+                    return await Promise.race([
+                        windowsTerminal,
+                        new Promise(resolve => setTimeout(() => resolve(false), 5_000)),
+                    ]);
+                }
+                if (child.pid && providerStartIdentity && launchGroup) {
+                    terminationResult ??= terminateOwnedProcessGroup({
+                        pid: launchGroup.pid, expectedStartIdentity: launchGroup.processStartIdentity,
+                        processGroupId: launchGroup.processGroupId,
+                        deadlineAt: new Date(Date.now() + 2_000).toISOString(), force: true,
+                    });
+                    const terminated = ['terminated', 'already-dead', 'identity-mismatch'].includes(await terminationResult);
+                    const completed = await new Promise(resolve => {
+                        const timer = setTimeout(() => resolve(false), 2_000);
+                        void completion.then(result => {
+                            clearTimeout(timer);
+                            resolve(result.outcome !== 'provider_cleanup_unverified');
+                        });
+                    });
+                    return terminated && completed;
+                }
+                return false;
+            };
+            const cleanupSignals = ['SIGHUP', 'SIGINT', 'SIGTERM'];
+            const onBootstrapSignal = () => { void terminateProvider(); };
+            const ownsSignalLifecycle = Boolean(process.env.OMC_WORKER_LAUNCH_SPEC || process.env.OMC_WORKER_LAUNCH_SPEC_B64);
+            if (ownsSignalLifecycle) {
+                for (const signal of cleanupSignals)
+                    process.once(signal, onBootstrapSignal);
+                void completion.finally(() => {
+                    for (const signal of cleanupSignals)
+                        process.removeListener(signal, onBootstrapSignal);
+                });
+            }
+            const spawned = await new Promise(resolve => {
+                child.once('spawn', () => resolve(true));
+                child.once('error', () => resolve(false));
+            });
+            if (!spawned) {
+                await completion;
+                return { outcome: 'provider_spawn_failed' };
+            }
+            if (process.platform === 'win32') {
+                const ready = await Promise.race([
+                    windowsReady,
+                    new Promise(resolve => setTimeout(() => resolve(false), 10_000)),
+                ]);
+                if (!ready || !providerPid || !providerStartIdentity || settled) {
+                    if (!await terminateProvider())
+                        return { outcome: 'provider_cleanup_unverified' };
+                    return { outcome: 'provider_spawn_failed' };
+                }
+            }
+            else {
+                // Bind identity immediately after spawn, before an async handoff can race PID reuse.
+                providerPid = child.pid ?? null;
+                providerStartIdentity = child.pid ? getProcessStartIdentitySync(child.pid) : null;
+                if (!child.pid || !providerStartIdentity || settled || !isProcessAlive(child.pid)) {
+                    if (!await terminateProvider())
+                        return { outcome: 'provider_cleanup_unverified' };
+                    return { outcome: 'provider_spawn_failed' };
+                }
+                launchGroup = captureOwnedProcessGroup(child.pid);
+                if (!launchGroup) {
+                    if (!await terminateProvider())
+                        return { outcome: 'provider_cleanup_unverified' };
+                    return { outcome: 'provider_spawn_failed' };
+                }
+                if (!spec.release_after_spawn)
+                    await new Promise(resolve => setTimeout(resolve, 75));
+                if (settled)
+                    return { completion };
+                const reboundIdentity = getProcessStartIdentitySync(child.pid);
+                if (!reboundIdentity || reboundIdentity !== providerStartIdentity || !isProcessAlive(child.pid)) {
+                    if (!await terminateProvider())
+                        return { outcome: 'provider_cleanup_unverified' };
+                    return { outcome: 'provider_spawn_failed' };
+                }
+            }
+            if (invocation.completionPath && existsSync(invocation.completionPath)) {
+                const exitCode = Number(await readFile(invocation.completionPath, 'utf8').catch(() => ''));
+                if (Number.isSafeInteger(exitCode))
+                    supervisedExitCode = exitCode;
+                if (!await terminateProvider())
+                    return { outcome: 'provider_cleanup_unverified' };
+                return { outcome: 'provider_spawn_failed' };
+            }
+            if (!await isCurrentLaunchIdentity(spec.current_path, spec)
+                || (await readJson(`${spec.decision_path}.retired`)).kind !== 'absent') {
+                if (!await terminateProvider())
+                    return { outcome: 'provider_cleanup_unverified' };
+                return { outcome: 'superseded' };
+            }
+            try {
+                if (!await publishProviderStarted(spec, providerPid ?? child.pid, providerStartIdentity, invocation.completionPath, launchGroup?.processGroupId)) {
+                    if (!await terminateProvider())
+                        return { outcome: 'provider_cleanup_unverified' };
+                    return { outcome: 'provider_spawn_failed' };
+                }
+            }
+            catch {
+                if (!await terminateProvider())
+                    return { outcome: 'provider_cleanup_unverified' };
+                return { outcome: 'provider_spawn_failed' };
+            }
+            if (invocation.completionPath && existsSync(invocation.completionPath)) {
+                const exitCode = Number(await readFile(invocation.completionPath, 'utf8').catch(() => ''));
+                if (Number.isSafeInteger(exitCode))
+                    supervisedExitCode = exitCode;
+                if (!await terminateProvider())
+                    return { outcome: 'provider_cleanup_unverified' };
+                await unlink(spec.started_path).catch(() => { });
+                return { outcome: 'provider_spawn_failed' };
+            }
+            if (!await isCurrentLaunchIdentity(spec.current_path, spec)
+                || (await readJson(`${spec.decision_path}.retired`)).kind !== 'absent') {
+                if (!await terminateProvider())
+                    return { outcome: 'provider_cleanup_unverified' };
+                await unlink(spec.started_path).catch(() => { });
+                return { outcome: 'superseded' };
+            }
+            if (invocation.completionPath) {
+                let pollingCompletion = false;
+                supervisorTimer = setInterval(() => {
+                    if (pollingCompletion || settled || !providerStartIdentity || !child.pid)
+                        return;
+                    pollingCompletion = true;
+                    void readFile(invocation.completionPath, 'utf8').then(async (raw) => {
+                        const exitCode = Number(raw.trim());
+                        if (!Number.isSafeInteger(exitCode))
+                            return;
+                        supervisedExitCode = exitCode;
+                        const cleaned = await terminateProvider();
+                        if (!cleaned && !settled) {
+                            settled = true;
+                            if (supervisorTimer)
+                                clearInterval(supervisorTimer);
+                            await atomicWriteJson(`${spec.started_path}.terminal`, {
+                                ...identityOf(spec), kind: 'worker_launch_provider_terminal', outcome: 'cleanup_unverified', cleanup_verified: false,
+                                pid: child.pid ?? null, process_start_identity: providerStartIdentity, exit_code: exitCode, signal: null, written_at: new Date().toISOString(),
+                            }).catch(() => undefined);
+                            await invocation.cleanup().catch(() => undefined);
+                            resolveCompletion({ outcome: 'provider_cleanup_unverified' });
+                        }
+                    }).catch(() => undefined).finally(() => { pollingCompletion = false; });
+                }, DEFAULT_POLL_INTERVAL_MS);
+                supervisorTimer.unref();
+            }
+            if (process.platform === 'win32') {
+                let pollingTermination = false;
+                supervisorTimer = setInterval(() => {
+                    if (pollingTermination || settled || !providerPid || !providerStartIdentity)
+                        return;
+                    pollingTermination = true;
+                    void readJson(`${spec.started_path}.termination-request`).then(async (request) => {
+                        if (request.kind !== 'value')
+                            return;
+                        const record = request.value;
+                        if (!identityMatches(record, spec) || record.kind !== 'worker_launch_termination_request'
+                            || record.operation !== 'terminate' || record.pid !== providerPid
+                            || record.process_start_identity !== providerStartIdentity
+                            || record.authority_digest !== spec.authority_digest
+                            || record.containment_nonce !== spec.containment_nonce)
+                            return;
+                        const cleaned = await terminateProvider();
+                        if (!cleaned && !settled) {
+                            await atomicWriteJson(`${spec.started_path}.terminal`, {
+                                ...identityOf(spec), kind: 'worker_launch_provider_terminal', outcome: 'cleanup_unverified', cleanup_verified: false,
+                                pid: providerPid, process_start_identity: providerStartIdentity, exit_code: null, signal: null, written_at: new Date().toISOString(),
+                            }).catch(() => undefined);
+                        }
+                    }).catch(() => undefined).finally(() => { pollingTermination = false; });
+                }, DEFAULT_POLL_INTERVAL_MS);
+                supervisorTimer.unref();
+            }
+            return { completion };
+        });
+        if ('completion' in launched) {
+            if (!launched.completion)
+                return { outcome: 'provider_spawn_failed' };
+            return await launched.completion;
+        }
+        return launched;
+    }
+    catch {
+        return { outcome: 'provider_spawn_failed' };
+    }
+}
+//# sourceMappingURL=worker-launch-ack.js.map

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- OMC:START -->
-<!-- OMC:VERSION:4.15.8 -->
+<!-- OMC:VERSION:4.15.9 -->
 
 # oh-my-claudecode - Intelligent Multi-Agent Orchestration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-claude-sisyphus",
-      "version": "4.15.8",
+      "version": "4.15.9",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-claude-sisyphus",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "description": "Multi-agent orchestration system for Claude Code - Inspired by oh-my-opencode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
# oh-my-claudecode v4.15.9: land pure Graph, add evidence-safe efficiency, add bounded basedpyright

## Release Notes

Release with **3 new features**, **2 bug fixes** across **6 merged PRs**.

### Highlights

- **feat(graph): land pure Graph Core contract** (#3649)
- **feat(benchmarks): add evidence-safe efficiency diagnostics** (#3650)
- **feat(lsp): add bounded basedpyright selection** (#3647)

### New Features

- **feat(graph): land pure Graph Core contract** (#3649)
- **feat(benchmarks): add evidence-safe efficiency diagnostics** (#3650)
- **feat(lsp): add bounded basedpyright selection** (#3647)

### Bug Fixes

- **fix(installer): prune duplicate plugin hooks** (#3645)
- **fix(release): widen bounded npm registry propagation retry** (#3636)

### Documentation

- **docs(skills): clarify independent consensus review sequencing** (#3646)

### Stats

- **6 PRs merged** | **3 new features** | **2 bug fixes** | **0 security/hardening improvements** | **0 other changes**

### Install / Update

The npm CLI and the Claude Code marketplace/plugin are separate install tracks, not either/or replacements. Update whichever track you use; if you have both installed, update both. CLI-dependent skill paths such as `ask`, `ccg`, and CLI-backed `team` require the `omc` CLI from the npm package.

**CLI / runtime:**

```bash
npm install -g oh-my-claude-sisyphus@4.15.9
```

**Claude Code plugin:**

```text
/plugin marketplace update omc
```

**Full Changelog**: https://github.com/Yeachan-Heo/oh-my-claudecode/compare/v4.15.8...v4.15.9

## Contributors

Thank you to all contributors who made this release possible!

@Yeachan-Heo
