### PR TITLE
fix(rules-injector): bound upward rule walk when no project root exists

### DIFF
--- a/src/hooks/rules-injector/finder.test.ts
+++ b/src/hooks/rules-injector/finder.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for issue #3653: rules-injector unbounded upward walk
+ * when no project root exists.
+ *
+ * findRuleFiles(projectRoot, currentFile) used to ascend from the current
+ * file's directory all the way to the filesystem root whenever projectRoot
+ * was null, so unrelated ancestor .cursor/rules, .claude/rules, and
+ * .github/instructions directories were treated as project rules. With no
+ * project root, only the current file's own directory's project-rule
+ * subdirectories are in scope; the explicit user-level
+ * [$CLAUDE_CONFIG_DIR|~/.claude]/rules lookup is separate and unchanged.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { findProjectRoot, findRuleFiles } from './finder.js';
+import type { RuleFileCandidate } from './types.js';
+
+const PROJECT_RULE_SUBDIRS: [string, string][] = [
+  ['.github', 'instructions'],
+  ['.cursor', 'rules'],
+  ['.claude', 'rules'],
+];
+
+function tmpDir(): string {
+  const p = join(
+    tmpdir(),
+    `omc-3653-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(p, { recursive: true });
+  return p;
+}
+
+/** Write a rule file into <dir>/<parent>/<subdir>/<name>. */
+function addRule(
+  dir: string,
+  parent: string,
+  subdir: string,
+  name: string,
+): string {
+  const ruleDir = join(dir, parent, subdir);
+  mkdirSync(ruleDir, { recursive: true });
+  const full = join(ruleDir, name);
+  writeFileSync(full, `# ${name}\nRule content`);
+  return full;
+}
+
+function addFile(dir: string, relPath: string): string {
+  const full = join(dir, relPath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, '// test');
+  return full;
+}
+
+function nonGlobal(candidates: RuleFileCandidate[]): RuleFileCandidate[] {
+  return candidates.filter((c) => !c.isGlobal);
+}
+
+describe('findRuleFiles with no project root (issue #3653)', () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('does not discover ancestor rules when projectRoot is null', () => {
+    // Ancestor dir with all three project-rule subdir kinds, but NO project
+    // marker anywhere, and the current file deep beneath them.
+    const ancestor = join(base, 'ancestor');
+    for (const [parent, subdir] of PROJECT_RULE_SUBDIRS) {
+      const name =
+        subdir === 'instructions'
+          ? 'coding.instructions.md'
+          : `ancestor-${subdir}.mdc`;
+      addRule(ancestor, parent, subdir, name);
+    }
+
+    const currentFile = addFile(
+      ancestor,
+      'sub/deep/no-marker-project/src/current.ts',
+    );
+
+    expect(findProjectRoot(currentFile)).toBeNull();
+
+    const candidates = findRuleFiles(null, currentFile);
+    const projectRules = nonGlobal(candidates);
+
+    for (const rule of projectRules) {
+      expect(rule.path).not.toContain('ancestor');
+    }
+    expect(projectRules).toHaveLength(0);
+  });
+
+  it.each(PROJECT_RULE_SUBDIRS)(
+    'still inspects the current file\'s own directory for %s/%s',
+    (parent, subdir) => {
+      const own = join(base, 'own');
+      const name =
+        subdir === 'instructions' ? 'coding.instructions.md' : 'own.mdc';
+      addRule(own, parent, subdir, name);
+      const currentFile = addFile(own, 'current.ts');
+
+      expect(findProjectRoot(currentFile)).toBeNull();
+
+      const candidates = findRuleFiles(null, currentFile);
+      const projectRules = nonGlobal(candidates);
+
+      expect(projectRules).toHaveLength(1);
+      expect(projectRules[0].path).toBe(join(own, parent, subdir, name));
+      expect(projectRules[0].isGlobal).toBe(false);
+      expect(projectRules[0].distance).toBe(0);
+    },
+  );
+
+  it('preserves explicit user-level CLAUDE_CONFIG_DIR/rules discovery', () => {
+    const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    try {
+      // Unrelated ancestor .claude/rules that must NOT be treated as project
+      // rules when no project root exists.
+      addRule(join(base, 'ancestor'), '.claude', 'rules', 'ancestor.mdc');
+      const currentFile = addFile(base, 'sub/no-marker/src/current.ts');
+
+      const configDir = join(base, 'config');
+      const userRule = addRule(configDir, '.', 'rules', 'user-rule.md');
+      process.env.CLAUDE_CONFIG_DIR = configDir;
+
+      expect(findProjectRoot(currentFile)).toBeNull();
+
+      const candidates = findRuleFiles(null, currentFile);
+      const globalRules = candidates.filter((c) => c.isGlobal);
+      const projectRules = nonGlobal(candidates);
+
+      expect(projectRules).toHaveLength(0);
+      expect(globalRules.some((c) => c.path === userRule)).toBe(true);
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+      }
+    }
+  });
+});
+
+describe('findRuleFiles with a project root (unchanged bounded walk)', () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = tmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('discovers rules up to the project root but never above it', () => {
+    // A rule dir ABOVE the project root must stay out of scope.
+    addRule(join(base, 'parent'), '.cursor', 'rules', 'parent-ancestor.mdc');
+
+    const project = join(base, 'parent', 'project');
+    mkdirSync(join(project, '.git'), { recursive: true });
+    const projectRule = addRule(project, '.claude', 'rules', 'project.mdc');
+
+    const currentFile = addFile(project, 'src/deep/current.ts');
+
+    expect(findProjectRoot(currentFile)).toBe(project);
+
+    const candidates = findRuleFiles(project, currentFile);
+    const projectRules = nonGlobal(candidates);
+
+    expect(projectRules.some((c) => c.path === projectRule)).toBe(true);
+    expect(projectRules.some((c) => c.path.includes('parent-ancestor'))).toBe(
+      false,
+    );
+  });
+
+  it('computes distance from the current file up to the rule directory', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.git'), { recursive: true });
+    addRule(project, '.cursor', 'rules', 'root.mdc');
+
+    // One level deep: current.ts sits in <root>/src, rule in <root>/.cursor.
+    const currentFile = addFile(project, 'src/current.ts');
+
+    const candidates = findRuleFiles(project, currentFile);
+    const projectRules = nonGlobal(candidates);
+
+    expect(projectRules).toHaveLength(1);
+    // src -> root is one ascent step.
+    expect(projectRules[0].distance).toBe(1);
+  });
+});

--- a/src/hooks/rules-injector/finder.ts
+++ b/src/hooks/rules-injector/finder.ts
@@ -186,6 +186,10 @@ export function findRuleFiles(
         });
       }
     }
+    // Without a project root, only the current file's own directory is in
+    // scope. Ascending further would let unrelated ancestor .cursor/rules,
+    // .claude/rules, or .github/instructions masquerade as project rules.
+    if (!projectRoot) break;
 
     // Stop at project root or filesystem root
     if (projectRoot && currentDir === projectRoot) break;


### PR DESCRIPTION
## Summary

`findRuleFiles(projectRoot, currentFile)` in `src/hooks/rules-injector/finder.ts` walked from the current file's directory all the way to the filesystem root whenever `projectRoot` was `null`. That let unrelated ancestor `.cursor/rules`, `.claude/rules`, or `.github/instructions` directories be treated as project rules for files in directories with no project marker (`.git`, `package.json`, …).

## Reproduction (independent, on base `6dc2989d1`)

Temp tree with an ancestor rule dir and a no-marker current file beneath it:

```
tmp/
  ancestor-project/
    .cursor/rules/ancestor-rules.mdc
    .claude/rules/ancestor-rules.mdc
    .github/instructions/coding.instructions.md
    sub/deep/no-marker-project/src/current-file.ts   ← no project marker anywhere
```

- `findProjectRoot(currentFile)` → `null` ✓ (no marker exists)
- `findRuleFiles(null, currentFile)` on base **wrongly returned all three ancestor rules** (verified before the fix).
- After the fix, the same call returns **zero** project (non-global) rules.

## Fix (4 lines in finder.ts only)

When `projectRoot` is null, after inspecting the current file's own directory's project-rule subdirectories, the walk stops instead of ascending. Bounded upward discovery within a real project root is byte-for-byte unchanged, and the explicit user-level `[$CLAUDE_CONFIG_DIR|~/.claude]/rules` lookup is untouched (separate code path, still runs).

## Regression tests (`src/hooks/rules-injector/finder.test.ts`)

- No project root: ancestor `.cursor/rules`, `.claude/rules`, and `.github/instructions` are **not** discovered (covers all three subdir kinds).
- No project root: the current file's own directory's rule subdirs **are** still inspected (distance 0).
- No project root: explicit user-level `$CLAUDE_CONFIG_DIR/rules` discovery is preserved.
- With a project root: rules found up to the root but never above it; distance semantics unchanged.

The ancestor-leak test fails on the unfixed code (`expected ...ancestor... not to contain 'ancestor'`) and passes with the fix (red → green verified).

## Verification (all local, Node 20.20.2)

- `vitest run src/hooks/rules-injector/ src/__tests__/config-dir.test.ts src/__tests__/context-bloat-2577.test.ts` → 35/35 pass
- Full suite `npm test -- --run` → 651 files / 12103 tests pass, 0 failures
- `tsc --noEmit` → clean; `eslint src` → 0 errors (no new warnings)
- `npm run build` → clean (no generated `dist/`/`bridge/` changes committed — source-only PR)
- `npm run plugin:shipping:verify` → verified

Fixes #3653
