### PR TITLE
fix(team): deliver POSIX supervised worker launch through attempt descriptor (#3655)

### DIFF
--- a/src/team/__tests__/tmux-session.startup.test.ts
+++ b/src/team/__tests__/tmux-session.startup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -34,10 +34,11 @@ vi.mock('../../cli/tmux-utils.js', async importOriginal => {
       }
       if (args[0] === 'send-keys' && args.includes('-l')) {
         const command = String(args.at(-1) ?? '');
-        const encoded = command.match(/OMC_WORKER_LAUNCH_SPEC_B64(?:=|=")'?([A-Za-z0-9+/=]+)/)?.[1];
-        const raw = command.match(/OMC_WORKER_LAUNCH_SPEC='([^']+)'/)?.[1];
-        if (encoded || raw) {
-          const spec = JSON.parse(encoded ? Buffer.from(encoded, 'base64').toString('utf8') : raw!);
+        const descriptorMatch = command.match(/OMC_WORKER_LAUNCH_SPEC_FILE='([^']+)'/);
+        if (descriptorMatch) {
+          // Supervised launches (issue #3655) deliver the attempt-owned
+          // descriptor by path; the runtime CLI reads it from disk.
+          const spec = JSON.parse(await readFile(descriptorMatch[1], 'utf8'));
           tmuxState.activeAttempt = {
             schema_version: spec.schema_version,
             attempt_id: spec.attempt_id,
@@ -59,6 +60,33 @@ vi.mock('../../cli/tmux-utils.js', async importOriginal => {
             runtimeCliPath: '/runtime-cli.js',
             context: spec.context,
           };
+        } else {
+          const encoded = command.match(/OMC_WORKER_LAUNCH_SPEC_B64(?:=|=")'?([A-Za-z0-9+/=]+)/)?.[1];
+          const raw = command.match(/OMC_WORKER_LAUNCH_SPEC='([^']+)'/)?.[1];
+          if (encoded || raw) {
+            const spec = JSON.parse(encoded ? Buffer.from(encoded, 'base64').toString('utf8') : raw!);
+            tmuxState.activeAttempt = {
+              schema_version: spec.schema_version,
+              attempt_id: spec.attempt_id,
+              nonce: spec.nonce,
+              team_name: spec.team_name,
+              worker_name: spec.worker_name,
+              pane_id: spec.pane_id,
+              provider: spec.provider,
+              created_at: spec.created_at,
+              currentPath: spec.current_path,
+              expectedPath: spec.expected_path,
+              ackPath: spec.ack_path,
+              decisionPath: spec.decision_path,
+              startedPath: spec.started_path,
+              transportOwnerPath: spec.transport_owner_path,
+              bootstrapDescriptorPath: spec.bootstrap_descriptor_path,
+              wrapperPath: spec.wrapper_path,
+              transportCleanupCompletePath: spec.transport_cleanup_complete_path,
+              runtimeCliPath: '/runtime-cli.js',
+              context: spec.context,
+            };
+          }
         }
       }
       if (args[0] === 'send-keys' && args.at(-1) === 'Enter' && tmuxState.activeAttempt) {
@@ -287,6 +315,46 @@ describe('worker pane startup safety', () => {
     expect(tmuxState.paneStatus).toBe('0 cmd\n');
   });
 
+  it('POSIX supervised writer delivers an attempt-owned descriptor the runtime CLI accepts', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'startup-posix-descriptor-'));
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    const attempt = await prepareWorkerLaunchAttempt({
+      cwd,
+      teamName: 'startup-team',
+      workerName: 'worker-1',
+      paneId: '%2',
+      provider: 'codex',
+      runtimeCliPath: '/runtime-cli.cjs',
+    });
+
+    await expect(spawnWorkerInPane('startup:0', '%2', {
+      teamName: 'startup-team',
+      workerName: 'worker-1',
+      envVars: { OMC_TEAM_WORKER: 'startup-team/worker-1' },
+      launchBinary: '/usr/bin/codex',
+      launchArgs: ['--full-auto'],
+      cwd,
+      provider: 'codex',
+      launchAttempt: attempt,
+    })).resolves.toBeUndefined();
+
+    const launchSend = tmuxState.args.find(args => args[0] === 'send-keys' && args.includes('-l'));
+    const cmd = String(launchSend?.at(-1) ?? '');
+    // The delivered command references the attempt-owned descriptor by path;
+    // the bootstrap spec never travels inline (issue #3655).
+    expect(cmd).toContain("OMC_WORKER_LAUNCH_SPEC_FILE='");
+    expect(cmd).not.toContain('OMC_WORKER_LAUNCH_SPEC=');
+    expect(cmd).not.toContain('--full-auto');
+    const descriptorPath = cmd.match(/OMC_WORKER_LAUNCH_SPEC_FILE='([^']+)'/)?.[1];
+    expect(descriptorPath).toBe(attempt.bootstrapDescriptorPath);
+    const descriptor = JSON.parse(await readFile(descriptorPath!, 'utf8')) as Record<string, unknown>;
+    expect(descriptor.attempt_id).toBe(attempt.attempt_id);
+    expect(descriptor.provider_argv).toEqual(['/usr/bin/codex', '--full-auto']);
+    expect(Buffer.byteLength(cmd, 'utf8')).toBeLessThan(2_048);
+    // POSIX delivery does not need the Windows-native post-enter capture pass;
+    // readiness is proven through the ack/provider-start handoff instead.
+    expect(tmuxState.args.some(args => args[0] === 'capture-pane')).toBe(false);
+  });
   it('clears an exact Codex directory selector before typing the inbox trigger', async () => {
     const context = await acceptedContext('codex');
     tmuxState.captures = [

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -185,13 +185,16 @@ describe('buildWorkerStartCommand', () => {
       },
     });
 
-    expect(cmd).toContain("OMC_WORKER_LAUNCH_SPEC='");
+    // Supervised POSIX launches reference the attempt-owned descriptor by path
+    // (issue #3655); the bootstrap spec itself must never travel inline.
+    expect(cmd).toContain("OMC_WORKER_LAUNCH_SPEC_FILE='/tmp/bootstrap.json'");
+    expect(cmd).not.toContain('OMC_WORKER_LAUNCH_SPEC=');
     expect(cmd).toContain("exec \"$@\"");
     expect(cmd).toContain("'--worker-launch'");
     expect(cmd).toContain("'/opt/omc/runtime-cli.cjs'");
   });
 
-  it('preserves native Windows percent and quote escaping inside the bootstrap specification', () => {
+  it('keeps provider percent/quote metacharacters out of the native Windows cmd command', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
     const cmd = buildWorkerStartCommand({
@@ -225,21 +228,14 @@ describe('buildWorkerStartCommand', () => {
     });
 
     expect(cmd).toContain('C:\\Windows\\System32\\cmd.exe /d /s /c');
-    const marker = 'set "OMC_WORKER_LAUNCH_SPEC_B64=';
-    const encodedStart = cmd.indexOf(marker) + marker.length;
-    const encodedEnd = cmd.indexOf('" &&', encodedStart);
-    const decodedSpec = Buffer.from(cmd.slice(encodedStart, encodedEnd), 'base64').toString('utf8');
-    const spec = JSON.parse(decodedSpec);
-    expect(spec.pane_id).toBe('%2');
-    expect(spec.provider_argv).toEqual([
-      'C:\\Program Files\\Codex\\codex.exe',
-      '--label',
-      '100% ready %USERPROFILE%',
-      '--title="quoted"',
-    ]);
+    // Supervised launches deliver the attempt-owned descriptor by path; the
+    // bootstrap spec (and its percent/quote metacharacters) never travels in
+    // the command line or cmd environment (issue #3655).
+    expect(cmd).toContain('set "OMC_WORKER_LAUNCH_SPEC_FILE=C:\\state\\bootstrap.json"');
+    expect(cmd).not.toContain('OMC_WORKER_LAUNCH_SPEC_B64=');
+    expect(cmd).not.toContain('OMC_WORKER_LAUNCH_SPEC=');
     expect(cmd).not.toContain('100% ready %USERPROFILE%');
     expect(cmd).not.toContain('pane_id=%%2');
-    expect(cmd).not.toContain('OMC_WORKER_LAUNCH_SPEC=');
   });
 
   it('escapes psmux cmd.exe env vars and quoted launch args without PowerShell syntax', () => {

--- a/src/team/__tests__/worker-launch-posix-transport.test.ts
+++ b/src/team/__tests__/worker-launch-posix-transport.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Regression suite for issue #3655 — POSIX supervised worker launch transport.
+ *
+ * v4.15.8/v4.15.9 introduced the attempt-owned descriptor transport on the
+ * runtime-cli reader side (`runWorkerLaunchFromEnvironment` rejects any
+ * inline-only launch spec with `worker_launch_descriptor_required`), but the
+ * POSIX supervised writer (`buildWorkerStartCommand` via
+ * `spawnWorkerInPane`) still delivered the bootstrap spec inline through
+ * `OMC_WORKER_LAUNCH_SPEC`. Every supervised POSIX worker launch therefore
+ * failed before provider startup. This suite pins the writer/reader contract:
+ * the POSIX writer must materialize an attempt-owned descriptor and hand the
+ * runtime CLI its path, exactly like the native Windows path already does.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildWorkerStartCommand } from '../tmux-session.js';
+import {
+  awaitWorkerLaunchAcknowledgement,
+  cleanupWorkerLaunchTransport,
+  materializeWorkerLaunchTransport,
+  prepareWorkerLaunchAttempt,
+  readAndConsumeWorkerLaunchDescriptor,
+  type WorkerLaunchAttempt,
+} from '../worker-launch-ack.js';
+import { runWorkerLaunchFromEnvironment } from '../runtime-cli.js';
+
+let cwd = '';
+let originalPlatform: PropertyDescriptor | undefined;
+let exitSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+/** Undo the writer's single-quote shell escaping for one env assignment. */
+function extractEnvAssignment(command: string, key: string): string | undefined {
+  const pattern = new RegExp(`(?:^|\\s)${key}=('(?:[^']|'"'"')*')`);
+  const match = command.match(pattern);
+  if (!match) return undefined;
+  return match[1]!.slice(1, -1).replace(/'"'"'/g, "'");
+}
+
+/** Simulate the pane shell: apply the writer's env assignments to process.env. */
+function applyEnvAssignments(command: string, keys: readonly string[]): void {
+  for (const key of keys) {
+    const value = extractEnvAssignment(command, key);
+    if (value !== undefined) process.env[key] = value;
+  }
+}
+
+async function makeAttempt(): Promise<WorkerLaunchAttempt> {
+  cwd = await mkdtemp(join(tmpdir(), 'worker-launch-posix-transport-'));
+  return prepareWorkerLaunchAttempt({
+    cwd,
+    teamName: 'posix-team',
+    workerName: 'worker-1',
+    paneId: '%2',
+    provider: 'codex',
+    runtimeCliPath: '/runtime-cli.cjs',
+  });
+}
+
+afterEach(async () => {
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  originalPlatform = undefined;
+  exitSpy?.mockRestore();
+  exitSpy = undefined;
+  for (const key of ['OMC_WORKER_LAUNCH_SPEC', 'OMC_WORKER_LAUNCH_SPEC_B64', 'OMC_WORKER_LAUNCH_SPEC_FILE']) {
+    delete process.env[key];
+  }
+  vi.unstubAllEnvs();
+  if (cwd) await rm(cwd, { recursive: true, force: true });
+  cwd = '';
+});
+
+describe('POSIX supervised worker-launch transport (issue #3655)', () => {
+  it('supervised POSIX writer materializes a descriptor the runtime CLI reader accepts and executes', async () => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    vi.stubEnv('SHELL', '/bin/bash');
+    vi.stubEnv('HOME', '/home/tester');
+
+    const attempt = await makeAttempt();
+    const providerMarker = join(cwd, 'provider-ran.json');
+    const providerScript = `require('node:fs').writeFileSync(${JSON.stringify(providerMarker)},JSON.stringify({attempt:process.env.OMC_WORKER_LAUNCH_ATTEMPT_ID,transport:process.env.OMC_WORKER_LAUNCH_SPEC_FILE??null}));setTimeout(()=>process.exit(0),200)`;
+    const config = {
+      teamName: 'posix-team',
+      workerName: 'worker-1',
+      envVars: {
+        OMC_TEAM_WORKER: 'posix-team/worker-1',
+        OMC_WORKER_LAUNCH_ATTEMPT_ID: attempt.attempt_id,
+      },
+      launchBinary: process.execPath,
+      launchArgs: ['-e', providerScript],
+      cwd,
+      provider: 'codex' as const,
+      launchAttempt: attempt,
+    };
+
+    // The writer seam (spawnWorkerInPane) materializes the attempt transport
+    // before building the start command — identical to the native Windows path.
+    const materialized = await materializeWorkerLaunchTransport({
+      attempt,
+      providerArgv: [process.execPath, '-e', providerScript],
+      cwd,
+      providerEnv: config.envVars,
+    });
+    const startCmd = buildWorkerStartCommand(config);
+
+    // Writer contract: the delivered POSIX command references the attempt-owned
+    // descriptor; it must NOT inline the bootstrap spec (secrets stay off the
+    // process list and out of tmux scrollback; command size stays bounded).
+    const descriptorPath = extractEnvAssignment(startCmd, 'OMC_WORKER_LAUNCH_SPEC_FILE');
+    expect(descriptorPath).toBe(materialized.bootstrapDescriptorPath);
+    expect(startCmd).not.toContain('OMC_WORKER_LAUNCH_SPEC=');
+    expect(startCmd).not.toContain(providerScript);
+    expect(Buffer.byteLength(startCmd, 'utf8')).toBeLessThan(2_048);
+
+    // Reader contract: run the runtime CLI exactly as the pane would, with the
+    // env assignments the writer emitted.
+    applyEnvAssignments(startCmd, ['OMC_WORKER_LAUNCH_SPEC_FILE', 'OMC_TEAM_WORKER', 'OMC_WORKER_LAUNCH_ATTEMPT_ID']);
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    const bootstrap = runWorkerLaunchFromEnvironment();
+    await expect(awaitWorkerLaunchAcknowledgement(attempt, { timeoutMs: 5_000, pollIntervalMs: 5 }))
+      .resolves.toEqual({ ok: true });
+    await expect(bootstrap).resolves.toBeUndefined();
+
+    // The validated bootstrap ran: the provider stub executed and saw the
+    // attempt identity while the internal descriptor env var stayed filtered.
+    const marker = JSON.parse(await readFile(providerMarker, 'utf8')) as { attempt: string; transport: string | null };
+    expect(marker.attempt).toBe(attempt.attempt_id);
+    expect(marker.transport).toBeNull();
+
+    // Consume semantics: the runtime CLI consumed the descriptor after
+    // validation; the transport owner/wrapper remain until explicit retire.
+    await expect(readFile(materialized.bootstrapDescriptorPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(cleanupWorkerLaunchTransport(attempt, 'test_cleanup')).resolves.toBe(true);
+    await expect(readFile(materialized.wrapperPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('accepts the materialized descriptor and consumes it exactly once', async () => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const attempt = await makeAttempt();
+    const materialized = await materializeWorkerLaunchTransport({
+      attempt,
+      providerArgv: [process.execPath, '-e', 'process.exit(0)'],
+      cwd,
+    });
+
+    const consumed = await readAndConsumeWorkerLaunchDescriptor(materialized.bootstrapDescriptorPath) as Record<string, unknown>;
+    expect(consumed).toMatchObject({ attempt_id: attempt.attempt_id, provider: 'codex' });
+    // Second consume fails closed: the descriptor is gone.
+    await expect(readAndConsumeWorkerLaunchDescriptor(materialized.bootstrapDescriptorPath))
+      .rejects.toThrow('worker_launch_descriptor_missing');
+    await expect(cleanupWorkerLaunchTransport(attempt, 'test_cleanup_after_consume')).resolves.toBe(true);
+  });
+
+  it('keeps descriptor/source conflict and invalid JSON fail-closed at the runtime CLI', async () => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    process.env.OMC_WORKER_LAUNCH_SPEC = '{"provider_argv":["codex"],';
+    await expect(runWorkerLaunchFromEnvironment()).rejects.toThrow('worker_launch_invalid_spec_json');
+    delete process.env.OMC_WORKER_LAUNCH_SPEC;
+
+    process.env.OMC_WORKER_LAUNCH_SPEC = '{}';
+    process.env.OMC_WORKER_LAUNCH_SPEC_FILE = join(cwd ?? '', 'conflicting-worker-launch.json');
+    await expect(runWorkerLaunchFromEnvironment()).rejects.toThrow('worker_launch_spec_source_conflict');
+    delete process.env.OMC_WORKER_LAUNCH_SPEC;
+    delete process.env.OMC_WORKER_LAUNCH_SPEC_FILE;
+
+    // An inline-only spec (the pre-fix POSIX writer behavior) stays rejected.
+    process.env.OMC_WORKER_LAUNCH_SPEC = '{"provider_argv":["codex"]}';
+    await expect(runWorkerLaunchFromEnvironment()).rejects.toThrow('worker_launch_descriptor_required');
+  });
+
+  it('delivers a bounded command for a provider environment with a large value', async () => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    vi.stubEnv('SHELL', '/bin/bash');
+    vi.stubEnv('HOME', '/home/tester');
+
+    const attempt = await makeAttempt();
+    const longValue = `long-${'x'.repeat(12_000)}`;
+    // A large provider argv/env is written into the attempt descriptor, exactly
+    // as the supervised writer does; the delivered command must only reference
+    // the descriptor path and stay small (issue #3655).
+    const materialized = await materializeWorkerLaunchTransport({
+      attempt,
+      providerArgv: [process.execPath, '--token', longValue],
+      providerEnv: { OMC_TEAM_WORKER: 'posix-team/worker-1', PROVIDER_LONG: longValue },
+      cwd,
+    });
+    expect(Buffer.byteLength(await readFile(materialized.bootstrapDescriptorPath, 'utf8'), 'utf8')).toBeGreaterThan(12_000);
+
+    const startCmd = buildWorkerStartCommand({
+      teamName: 'posix-team',
+      workerName: 'worker-1',
+      envVars: { OMC_TEAM_WORKER: 'posix-team/worker-1' },
+      launchBinary: process.execPath,
+      launchArgs: ['--version'],
+      cwd,
+      provider: 'codex',
+      launchAttempt: attempt,
+    });
+
+    const descriptorPath = extractEnvAssignment(startCmd, 'OMC_WORKER_LAUNCH_SPEC_FILE');
+    expect(descriptorPath).toBe(attempt.bootstrapDescriptorPath);
+    expect(startCmd).not.toContain(longValue);
+    expect(Buffer.byteLength(startCmd, 'utf8')).toBeLessThan(2_048);
+  });
+});

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -22,7 +22,6 @@ import type { CliAgentType } from './model-contract.js';
 import {
   awaitWorkerLaunchAcknowledgement,
   awaitWorkerLaunchProviderStarted,
-  buildWorkerLaunchBootstrapSpec,
   cleanupWorkerLaunchTransport,
   isWorkerLaunchAttemptAccepted,
   isWorkerLaunchAttemptCurrent,
@@ -779,12 +778,11 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
   const envVars = config.launchAttempt
     ? {
         ...config.envVars,
-        OMC_WORKER_LAUNCH_SPEC: JSON.stringify(buildWorkerLaunchBootstrapSpec(
-          config.launchAttempt,
-          providerLaunchWords,
-          config.cwd,
-          { releaseAfterSpawn: Boolean(config.envVars?.OMC_RECOVERY_GATE_SPEC) },
-        )),
+        // Supervised launches carry the attempt-owned bootstrap descriptor by
+        // path (never inline): secrets stay out of the process list and tmux
+        // scrollback, and the delivered command stays small. The runtime CLI
+        // validates and consumes the descriptor before running the provider.
+        OMC_WORKER_LAUNCH_SPEC_FILE: config.launchAttempt.bootstrapDescriptorPath,
       }
     : config.envVars;
   const shouldSourceRc = process.env.OMC_TEAM_NO_RC !== '1';
@@ -1327,6 +1325,7 @@ export async function spawnWorkerInPane(
     && !isUnixLikeOnWindows()
     && Boolean(config.launchAttempt)
     && !isCmuxSurfaceTarget(paneId);
+  const supervisedLaunch = Boolean(config.launchAttempt);
   const requireAcknowledgement = async (): Promise<void> => {
     if (!config.launchAttempt) return;
     const accepted = await awaitWorkerLaunchAcknowledgement(config.launchAttempt);
@@ -1339,24 +1338,36 @@ export async function spawnWorkerInPane(
   };
 
   try {
-    if (nativeAttemptTransport && config.launchAttempt) {
+    if (supervisedLaunch && config.launchAttempt) {
+      // Every supervised launch (Windows native, cmux surface, or POSIX tmux)
+      // materializes the attempt-owned transport: owner + bootstrap descriptor
+      // + wrapper. Native Windows then delivers the wrapper command; POSIX and
+      // cmux deliver the runtime CLI invocation pointing at the descriptor.
       materializedTransport = await materializeWorkerLaunchTransport({
         attempt: config.launchAttempt,
         providerArgv: getLaunchWords(config),
         cwd: config.cwd,
         providerEnv: config.envVars,
         releaseAfterSpawn: Boolean(config.envVars.OMC_RECOVERY_GATE_SPEC),
+        windowsDelivery: nativeAttemptTransport,
       });
-      startCmd = materializedTransport.wrapperRelativePath;
+      startCmd = nativeAttemptTransport
+        ? materializedTransport.wrapperRelativePath
+        : buildWorkerStartCommand(config);
     } else {
       startCmd = buildWorkerStartCommand(config);
     }
+    const transportKind = nativeAttemptTransport
+      ? 'attempt_wrapper'
+      : supervisedLaunch
+        ? 'attempt_descriptor'
+        : 'inline';
     fingerprint = commandFingerprint(startCmd);
     const commandBytes = Buffer.byteLength(startCmd, 'utf8');
     logWorkerSpawnDiagnostic(
       `worker start delivery begin session=${sessionName} pane=${paneId} ` +
       `worker=${config.workerName} cmdSha=${fingerprint} cmdBytes=${commandBytes} ` +
-      `transport=${nativeAttemptTransport ? 'attempt_wrapper' : 'inline'}`,
+      `transport=${transportKind}`,
     );
 
     if (isCmuxSurfaceTarget(paneId)) {
@@ -1424,7 +1435,7 @@ export async function spawnWorkerInPane(
     if (config.launchAttempt) {
       await revokeWorkerLaunchAttempt(config.launchAttempt, 'launch_failed').catch(() => undefined);
     }
-    if (nativeAttemptTransport && config.launchAttempt
+    if (config.launchAttempt
       && (!materializedTransport || existsSync(materializedTransport.bootstrapDescriptorPath))) {
       const cleaned = await cleanupWorkerLaunchTransport(config.launchAttempt, 'launch_failed')
         .catch(() => false);

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -568,6 +568,10 @@ export async function materializeWorkerLaunchTransport(input: {
   cwd: string;
   providerEnv?: NodeJS.ProcessEnv | Record<string, string>;
   releaseAfterSpawn?: boolean;
+  /** Native-Windows delivery resolves a cwd-relative wrapper command. POSIX
+   *  delivery launches the runtime CLI with OMC_WORKER_LAUNCH_SPEC_FILE, so
+   *  the wrapper relative path is neither computed nor returned. */
+  windowsDelivery?: boolean;
 }): Promise<MaterializedWorkerLaunchTransport> {
   const { attempt } = input;
   if (!attemptTransportPathsAreDeterministic(attempt)) throw new Error('worker_launch_transport_paths_invalid');
@@ -575,12 +579,15 @@ export async function materializeWorkerLaunchTransport(input: {
     providerEnv: input.providerEnv,
     releaseAfterSpawn: input.releaseAfterSpawn,
   });
+  const windowsDelivery = input.windowsDelivery !== false;
   const owner: WorkerLaunchTransportOwner = {
     ...identityOf(attempt),
     kind: WORKER_LAUNCH_TRANSPORT_OWNER_KIND,
     authority_digest: spec.authority_digest,
   };
-  const wrapperRelativePath = windowsWrapperRelativePath(input.cwd, attempt.wrapperPath);
+  const wrapperRelativePath = windowsDelivery
+    ? windowsWrapperRelativePath(input.cwd, attempt.wrapperPath)
+    : '';
   const wrapper = buildWorkerLaunchWrapper(attempt);
   let ownerCreated = false;
   let descriptorCreated = false;
@@ -1556,7 +1563,11 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
       };
       const cleanupSignals: NodeJS.Signals[] = ['SIGHUP', 'SIGINT', 'SIGTERM'];
       const onBootstrapSignal = () => { void terminateProvider(); };
-      const ownsSignalLifecycle = Boolean(process.env.OMC_WORKER_LAUNCH_SPEC || process.env.OMC_WORKER_LAUNCH_SPEC_B64);
+      const ownsSignalLifecycle = Boolean(
+        process.env.OMC_WORKER_LAUNCH_SPEC
+        || process.env.OMC_WORKER_LAUNCH_SPEC_B64
+        || process.env.OMC_WORKER_LAUNCH_SPEC_FILE,
+      );
       if (ownsSignalLifecycle) {
         for (const signal of cleanupSignals) process.once(signal, onBootstrapSignal);
         void completion.finally(() => {


### PR DESCRIPTION
## Fixes #3655 — POSIX team worker spawn regression (v4.15.8 / v4.15.9)

### Defect

`72c59d793` (#3588, shipped in v4.15.8) made the runtime-cli reader require an
attempt-owned **bootstrap descriptor file** (`OMC_WORKER_LAUNCH_SPEC_FILE`)
and reject any inline-only launch spec with `worker_launch_descriptor_required`.
The POSIX supervised writer was never updated: `buildWorkerStartCommand()` still
delivered the bootstrap spec inline via `OMC_WORKER_LAUNCH_SPEC`. Native Windows
materializes the descriptor transport (`launch.cmd` wrapper → `bootstrap.json`);
POSIX did not.

Result: **every supervised POSIX (tmux/cmux) worker launch dies before provider
startup** with `worker_launch_descriptor_required`. v4.15.7 is unaffected.

### Reproduction (proven on base `0f40fa50`)

- Source-level regression suite `src/team/__tests__/worker-launch-posix-transport.test.ts`
  is **red on base**: the POSIX writer command carries no
  `OMC_WORKER_LAUNCH_SPEC_FILE`, so the runtime CLI rejects it.
- Real-tmux POSIX smoke (bounded, harmless provider stub) on base: pane dies
  with `worker_launch_descriptor_required`; no ack, no provider start.

### Fix (narrowest, unifies supervised launch transport)

- `spawnWorkerInPane` now materializes the attempt transport (owner +
  bootstrap descriptor + wrapper) for **every supervised launch** — Windows
  native, cmux surface, and POSIX tmux. POSIX/cmux deliver the runtime CLI
  invocation pointing at the descriptor; native Windows keeps its wrapper
  delivery **unchanged**.
- `buildWorkerStartCommand` sets `OMC_WORKER_LAUNCH_SPEC_FILE` instead of the
  inline spec: secrets stay out of the process list and tmux scrollback, and
  delivered command size drops from ~3.1 KB (inline spec) to ~0.5 KB.
- `materializeWorkerLaunchTransport` gains `windowsDelivery` so the Windows
  wrapper-relative path is not computed on POSIX.
- Runtime-cli bootstrap signal lifecycle now also follows the descriptor
  transport (`OMC_WORKER_LAUNCH_SPEC_FILE`), preserving provider-group cleanup
  on pane signal — matching the inline/B64 behavior.
- **Fail-closed reader behavior is unchanged**: inline-only specs still reject
  with `worker_launch_descriptor_required`; descriptor/source conflict and
  invalid JSON still reject.

### Verification

- Focused suites: `tmux-session`, `tmux-session.startup`, `runtime-cli`,
  `worker-launch-ack`, `worker-launch-posix-transport` — all green
  (186 passed / 4 skipped).
- Full `src/team` directory: 121 files, 1629 tests green.
- Full suite (`npx vitest run`): **653 files, 12,111 tests, 0 failures**
  (two consecutive runs).
- Windows path suite (CI `test-windows` file list): 244 tests green.
- Typecheck (`tsc --noEmit`): clean. Lint: 0 errors. `npm run build`: clean.
- `npm pack` + `npm install -g` smoke: `omc --version` / `--help` OK.
- Post-fix real-tmux POSIX smoke: **spawn → ack → provider start → shutdown**,
  descriptor consumed, retire + transport cleanup verified, **no leaked tmux
  state**.

### Rollback

`git revert 62258ad04` (or `git reset --hard 0f40fa50` on this branch).

### Not in scope

The dev CI red at `0f40fa50` in `src/__tests__/doctor-conflicts.test.ts` is a
separate regression tracked in **#3656** (indirect CLAUDE.md references after
#3654) with its own lane. It does not touch any file in this PR; locally it is
non-reproducible (green in two full-suite runs and five isolated runs).

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
