### PR TITLE
test(doctor): isolate companion checks from global registry

### DIFF
--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -517,6 +517,8 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
     mkdirSync(TEST_PROJECT_CLAUDE_DIR, { recursive: true });
     process.env.CLAUDE_CONFIG_DIR = TEST_CLAUDE_DIR;
     process.env.CLAUDE_MCP_CONFIG_PATH = join(TEST_CLAUDE_DIR, '..', '.claude.json');
+    process.env.OMC_MCP_REGISTRY_PATH = join(TEST_PROJECT_DIR, '.omc-home', 'mcp-registry.json');
+    process.env.CODEX_HOME = join(TEST_PROJECT_DIR, '.codex');
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(TEST_PROJECT_DIR);
   });
 
@@ -524,7 +526,7 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
     cwdSpy?.mockRestore();
     delete process.env.CLAUDE_CONFIG_DIR;
     delete process.env.CLAUDE_MCP_CONFIG_PATH;
-    delete process.env.OMC_HOME;
+    delete process.env.OMC_MCP_REGISTRY_PATH;
     delete process.env.CODEX_HOME;
     for (const dir of [TEST_CLAUDE_DIR, TEST_PROJECT_DIR]) {
       if (dir && existsSync(dir)) {
@@ -617,7 +619,11 @@ describe('doctor-conflicts: CLAUDE.md companion file detection (issue #1101)', (
     const status = checkClaudeMdStatus();
     expect(status!.companionFile).toBe(missingPath);
     expect(status!.files).toHaveLength(1);
-    expect(runConflictCheck().hasConflicts).toBe(false);
+
+    const report = runConflictCheck();
+    expect(report.mcpRegistrySync.registryPath).toBe(join(TEST_PROJECT_DIR, '.omc-home', 'mcp-registry.json'));
+    expect(report.mcpRegistrySync.codexConfigPath).toBe(join(TEST_PROJECT_DIR, '.codex', 'config.toml'));
+    expect(report.hasConflicts).toBe(false);
   });
 
   it.each(corpus.variants)('classifies exact legacy %s in main and CRLF companion files without claiming guide ownership', async variant => {


### PR DESCRIPTION
## Summary
- isolate the CLAUDE.md companion test from inherited unified MCP registry and Codex state
- pin the registry/config paths inside the per-test sandbox
- assert the exact sandbox paths in the indirect-reference regression

## Root cause
`runConflictCheck()` aggregates MCP registry drift with CLAUDE.md diagnostics. The companion test sandboxed Claude config paths but still inherited the process-wide MCP registry/Codex locations, so populated host or order-leaked state made `hasConflicts` true even though direct/indirect companion parsing remained correct.

## Verification
- hostile inherited `OMC_MCP_REGISTRY_PATH` exact regression: pass
- shuffled `doctor-conflicts.test.ts` with seed 3656: 78/78 pass
- focused doctor/config/MCP/CLAUDE/rules cohort: 192/192 pass
- `npx tsc --noEmit`: pass
- focused ESLint: pass
- `npm run build`: pass
- full lint: 0 errors, 19 pre-existing warnings outside the changed file

Fixes #3656

—
*[repo owner’s gaebal-gajae (clawdbot) 🦞]*