### PR TITLE
fix(hud): keep watch mode running between polls

### DIFF
--- a/src/cli/__tests__/hud-watch.test.ts
+++ b/src/cli/__tests__/hud-watch.test.ts
@@ -66,4 +66,42 @@ describe('runHudWatchLoop', () => {
     expect(hudMain).toHaveBeenNthCalledWith(1, true, false);
     expect(hudMain).toHaveBeenNthCalledWith(2, true, true);
   });
+
+  it('keeps the polling timer referenced while watch mode is active', async () => {
+    const intervalMs = 60_000;
+    let shutdownHandler: ((reason: string) => Promise<void>) | undefined;
+    const registerShutdownHandlers = vi.fn((options: RegisterStandaloneShutdownHandlersOptions) => {
+      const onShutdown = async (reason: string): Promise<void> => {
+        await options.onShutdown(reason);
+      };
+      shutdownHandler = onShutdown;
+      return { shutdown: onShutdown };
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const loopPromise = runHudWatchLoop({
+      intervalMs,
+      hudMain: vi.fn(async () => {}),
+      registerShutdownHandlers,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === intervalMs)).toBe(true);
+      });
+
+      const pollingTimers = setTimeoutSpy.mock.calls.flatMap(([, delay], index) =>
+        delay === intervalMs
+          ? [setTimeoutSpy.mock.results[index]?.value as NodeJS.Timeout]
+          : []
+      );
+
+      expect(pollingTimers).toHaveLength(1);
+      expect(pollingTimers[0]?.hasRef()).toBe(true);
+    } finally {
+      await shutdownHandler?.('SIGTERM');
+      await loopPromise;
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });

--- a/src/cli/hud-watch.ts
+++ b/src/cli/hud-watch.ts
@@ -46,8 +46,6 @@ export async function runHudWatchLoop(options: HudWatchLoopOptions): Promise<voi
         wakeSleep = null;
         resolve();
       };
-
-      (timer as { unref?: () => void }).unref?.();
     });
   }
 }


### PR DESCRIPTION
## Summary

- Fixes: Running `omc hud --watch` renders once and then the foreground CLI can exit before the next polling interval, so the requested continuous HUD never updates.
- Root cause: The watch loop unreferences its only foreground polling timer. The signal listeners and separately unreferenced parent-process watcher do not keep Node's event loop alive, so the process has no referenced handle between renders.

## Regression evidence

- Before: `env PATH=<verified-node-v24-bin>:/opt/homebrew/bin:/usr/bin:/bin npm run test:run -- src/cli/__tests__/hud-watch.test.ts -t "keeps the polling timer referenced while watch mode is active"` exited `1`

- After: `env PATH=<verified-node-v24-bin>:/opt/homebrew/bin:/usr/bin:/bin npm run test:run -- src/cli/__tests__/hud-watch.test.ts -t "keeps the polling timer referenced while watch mode is active"` exited `0`

## Verification

- `env PATH=<verified-node-v24-bin>:/opt/homebrew/bin:/usr/bin:/bin npm run test:run -- src/cli/__tests__/hud-watch.test.ts`
- `env PATH=<verified-node-v24-bin>:/opt/homebrew/bin:/usr/bin:/bin npm run lint`
- `env PATH=<verified-node-v24-bin>:/opt/homebrew/bin:/usr/bin:/bin npm run build`
- `git diff --cached --check`

## Scope

- 2 files changed, +38 / -2 lines
