### PR TITLE
ci(auth): authorize generated artifacts for release PR #3660

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1822,6 +1822,344 @@
           "previousFilename": null
         }
       ]
+    },
+    {
+      "pullNumber": 3660,
+      "targetRef": "dev",
+      "mergeBaseSha": "3c232b64ee10910ba50d450ff8ebbe883a59b2c6",
+      "headSha": "3a37a65d13973bcf0758f6a92d3dca54c0bca83d",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-17T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 54,
+        "sha256": "8c71fdafeffbd4398e81f4f681d7675c40de83b00ae1d645b925fbcd0fef1180"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "94f2910bdcfeb7b0ce5903a1dac83e1d9f388384",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "4148a380b8724bb276c0138c204ecf5e30a92aed",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/mcp-server.cjs",
+          "sha": "bd75bdad5eb75d5baff95c234ae2575c011c22ba",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/runtime-cli.cjs",
+          "sha": "d11c4b7e92f14ebc922f8cf8f9bb4d7859b57ec6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-bridge.cjs",
+          "sha": "337515fc68aa1bde951b9e2c6c5b9f38f72eda3e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-mcp.cjs",
+          "sha": "7979d2172bae05cb7160e12007f17f7a077ecc18",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team.js",
+          "sha": "296db74af1f1719561614649d856105aa468fdcd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/team.js",
+          "sha": "1f51214311b72bce8e7f77b5cd848091cde24f28",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/hud-watch.js",
+          "sha": "8d5566686195c2c734f46d050b87c24a09d18bd8",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/team.js",
+          "sha": "55951bd6a0ec70736ea14b007cbaf16a3d6d6123",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/rules-injector/finder.js",
+          "sha": "27629a76a83f51c877c07075d13c5205fdc6b08b",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/rules-injector/finder.test.d.ts",
+          "sha": "3ae90290310119b8fa6cb4c1393781f4497a284d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/action-runner.js",
+          "sha": "e0bcdbc11f9274fda8241b53693cb3e383ded472",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/index.js",
+          "sha": "33200348cc3c32fc835f6fb21c554d1811ff7d43",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/custom-rate-provider.d.ts",
+          "sha": "941781967da6c4cc61ba3bc4316ebc85ddc6df04",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/custom-rate-provider.js",
+          "sha": "38c5be75d5ea597ece3e9c22a89e52176b3c11a1",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.js",
+          "sha": "3c9f473cbe2033ac3ec4016fe46530476bd7318e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.d.ts",
+          "sha": "1b510b9a89677153cc735c7cf19e7857a8041afd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.js",
+          "sha": "9b1c2e46cd927d4d136f5258cccf86c284323f06",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/api-interop.js",
+          "sha": "173fec2c28f37b0794c3d99ee825f448d2e0feb5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.d.ts",
+          "sha": "c0917254b69876cc0f2606a72207ccc7add56422",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.js",
+          "sha": "c64983b9fc1971d9137e4ec28629e45d6a855bbd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.d.ts",
+          "sha": "bf3bf3df71b7de87c223323ad722ad41a8f59968",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.js",
+          "sha": "0025e1c8bc8623d9314b8b62b7830601b37e6b01",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/recovery-request-store.js",
+          "sha": "e3fb2d64a651b2fc1a87983675f386df26e00a2c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.d.ts",
+          "sha": "72cf8fd8d88b4448338998efa3bee2a96ea1b8b6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.js",
+          "sha": "a7d74378c11897f807fe46aaa27557d2b22d1f6d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-owner-client.d.ts",
+          "sha": "b43b0014f8f85d2501d5e8927d8ecfd27494bd7c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-owner-client.js",
+          "sha": "e0a0ef8aa83f102c8b73faf820b1b15304cde317",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.d.ts",
+          "sha": "1bb3df95d62763b5f8a3c402da5b88f6961b208d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js",
+          "sha": "3e54048036e634cc4db722ff6fd0e596a160df6d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.d.ts",
+          "sha": "eb37efd21d30657c9f033e825d7243b31200267c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.js",
+          "sha": "4110f33f912a8cd6a5f19eff92cafd87e65ba308",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.d.ts",
+          "sha": "7e7609f312e1d0a6a14037599884685a8c7fc136",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.js",
+          "sha": "2a471f6e10ef55bc1ecd77d0958cad327f48004f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.d.ts",
+          "sha": "bac88247fe252b8687a5bdc0fa24b6d99846a615",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.js",
+          "sha": "d0d6cfded1f0d7ee3c9f907d5461e18b2512d7e9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.d.ts",
+          "sha": "a1005e1e0776bbf91254f47c3cc2f4348d64fdd6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.js",
+          "sha": "be59a54641b9b897cfd598b7adb9fee8e107173f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/team-ops.js",
+          "sha": "83a0b64aaa58ba4cf57bb1c7bc24e1b40a87e652",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.d.ts",
+          "sha": "bec002b8cd6bd994a143dfe10a7851d888eebfc9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.js",
+          "sha": "d0ac28cd1d9c73cf90e8553b79e16f9efa98189e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/types.d.ts",
+          "sha": "46ee046172aaa1797dcf1b5e605638e3a5f0984d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-activation-gate.d.ts",
+          "sha": "1c859924dca3241a9d78005fd770afcca1136db7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-activation-gate.js",
+          "sha": "742a328e10bcb3b5cd9b58a33bf83d2bd69c2e46",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-bootstrap.js",
+          "sha": "9c21df6f168369fded840fe21861fc59f66339ed",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-launch-ack.d.ts",
+          "sha": "5f0d995ffa2e3a042a5b3b8ef07fde7905fe585a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-launch-ack.js",
+          "sha": "f6cc07162d36711731f71b9c6bdc7de9df5d80bc",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/ast-tools.js",
+          "sha": "e9178feecc64dfa22128a2154fa543503b22f983",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/index.d.ts",
+          "sha": "43547212ef0d18b0561467adedd23e9e8112d934",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/index.js",
+          "sha": "ce92d49a4e9843be5f6a00eb2a18ded784bd34af",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/servers.d.ts",
+          "sha": "7c0b7cc21f3b51e94f220177fc4644c592be6ec7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/servers.js",
+          "sha": "7b393f406fb42c8cd65c303f1daa8a7fe82e4f99",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/state-tools.js",
+          "sha": "98dee70e3540923d615809515c65618c8dc74873",
+          "previousFilename": null
+        }
+      ]
     }
   ]
 }

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -297,6 +297,7 @@ describe('generated-artifact base trust root workflow', () => {
       [3603, 'dev'],
       [3610, 'dev'],
       [3651, 'dev'],
+      [3660, 'dev'],
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',


### PR DESCRIPTION
Pre-authorizes the generated-artifact closure (54 files: 7 `bridge/` + 47 `dist/`) for release PR #3660 (`release/v4.15.10` → `dev`, head `3a37a65d1`), per the `pull_request_target` generated-artifact authorization workflow. Entry lands on `dev` before the release PR so the verifier's base-owned manifest lookup succeeds.

- mergeBase: `3c232b64e` (current `dev` HEAD)
- head: `3a37a65d1`
- generatedDelta: `{ "count": 54, "sha256": "8c71fdafeffbd4398e81f4f681d7675c40de83b00ae1d645b925fbcd0fef1180" }`
