### PR TITLE
fix(ralph): detect and reconcile stale unfinished PRDs (#3669)

### DIFF
--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -47,6 +47,24 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 **Deslop opt-out:** If `{{PROMPT}}` contains `--no-deslop`, skip the mandatory post-review deslop pass entirely. Use this only when the cleanup pass is intentionally out of scope for the run.
 
 **Reviewer selection:** Pass `--critic=architect`, `--critic=critic`, or `--critic=codex` in the Ralph prompt to choose the completion reviewer for that run. `architect` remains the default.
+
+**Stale-state detection & reconciliation (#3669):** If a PRD is left unfinished by an abnormal/non-Step 8 exit (crash, force-kill, cancel before `/oh-my-claudecode:cancel`, session end), Ralph surfaces an explicit `[STALE PRD WARNING]` at startup/resume, in the continuation context, and at session end — with unfinished counts, last-touched age, and stale-pointer signals (PRD `branchName` merged/gone). Completion is NEVER inferred from PR/branch/merge status alone; git state is a warning signal only. A story is auto-reconciled to `passes: true` ONLY when the PRD carries configured observable evidence and every check passes:
+
+```json
+{
+  "reconciliation": {
+    "staleAfterMs": 7200000,
+    "observableChecks": {
+      "US-001": [
+        { "type": "fileContains", "path": "src/landed.ts", "pattern": "LANDED_SYMBOL" },
+        { "type": "gitGrep", "ref": "origin/dev", "pattern": "LANDED_SYMBOL" }
+      ]
+    }
+  }
+}
+```
+
+Check types: `fileExists` / `fileContains` (working tree) and `gitGrep` (content at a ref — this is "verified by content on trunk", never PR status). Stories without configured checks are never auto-marked. Reconciled stories keep `architectVerified: false` and still require Step 7 reviewer verification before Step 8; every decision is appended to the `prd-reconciliation.jsonl` audit log and summarized in the story notes.
 </PRD_Mode>
 
 <Execution_Policy>

--- a/src/__tests__/ralph-prd-stale.test.ts
+++ b/src/__tests__/ralph-prd-stale.test.ts
@@ -1,0 +1,554 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  detectStalePrd,
+  formatStalePrdWarning,
+  getSessionEndStalePrdWarning,
+  reconcileStalePrd,
+  reconcileStalePrdForStartup,
+  runObservableCheck,
+  PRD_RECONCILIATION_AUDIT_FILENAME,
+  DEFAULT_STALE_PRD_AFTER_MS,
+  readPrd,
+  writePrd,
+  getPrdStatus,
+  shouldCompleteByPrd,
+  ensurePrdForStartup,
+  getRalphContext,
+  writeRalphState,
+  createRalphLoopHook,
+  getSessionPrdPath,
+  type PRD,
+  type ObservableCheck,
+} from '../hooks/ralph/index.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makePrd(overrides?: Partial<PRD>): PRD {
+  return {
+    project: 'TestProject',
+    branchName: 'ralph/test-feature',
+    description: 'Test feature',
+    userStories: [
+      { id: 'US-001', title: 'Story one', description: '', acceptanceCriteria: [], priority: 1, passes: false, architectVerified: false },
+      { id: 'US-002', title: 'Story two', description: '', acceptanceCriteria: [], priority: 2, passes: false, architectVerified: false },
+    ],
+    ...overrides,
+  };
+}
+
+function backdateFile(filePath: string, msAgo: number): void {
+  const past = new Date(Date.now() - msAgo);
+  utimesSync(filePath, past, past);
+}
+
+function backdatePrd(directory: string, sessionId?: string, msAgo = 1000): void {
+  const prd = readPrd(directory, sessionId);
+  expect(prd).not.toBeNull();
+  const prdPath = sessionId ? getSessionPrdPath(directory, sessionId) : join(directory, '.omc', 'prd.json');
+  backdateFile(prdPath, msAgo);
+}
+
+function initGitRepo(directory: string): void {
+  execFileSync('git', ['init', '-q'], { cwd: directory });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: directory });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: directory });
+}
+
+function gitCommitAll(directory: string, message: string): void {
+  execFileSync('git', ['add', '-A'], { cwd: directory });
+  execFileSync('git', ['commit', '-q', '-m', message], { cwd: directory });
+}
+
+function readAuditEntries(directory: string, sessionId?: string): Record<string, unknown>[] {
+  const auditDir = sessionId
+    ? join(directory, '.omc', 'state', 'sessions', sessionId)
+    : join(directory, '.omc', 'state');
+  const auditPath = join(auditDir, PRD_RECONCILIATION_AUDIT_FILENAME);
+  if (!existsSync(auditPath)) {
+    return [];
+  }
+  return readFileSync(auditPath, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('Ralph PRD Stale-State Detection & Reconciliation (#3669)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `ralph-prd-stale-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // ==========================================================================
+  // Reproduction: all-false-but-landed PRD stays silent today
+  // ==========================================================================
+
+  it('reproduces #3669: an all-false PRD whose work actually landed is not complete and produced no warning', () => {
+    // Work "landed": the symbol the PR was supposed to introduce exists on trunk.
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const LANDED_SYMBOL = 42;\n');
+
+    const prd = makePrd({
+      // No reconciliation config: this is the "before the fix" shape.
+      userStories: [
+        { id: 'US-001', title: 'Land story', description: '', acceptanceCriteria: [], priority: 1, passes: false, architectVerified: false },
+        { id: 'US-002', title: 'Land story two', description: '', acceptanceCriteria: [], priority: 2, passes: false, architectVerified: false },
+      ],
+    });
+    expect(writePrd(testDir, prd)).toBe(true);
+
+    // Completion is never inferred from landed state alone.
+    expect(getPrdStatus(prd).allComplete).toBe(false);
+    expect(shouldCompleteByPrd(testDir)).toBe(false);
+
+    // Before the fix there was no warning surface at all; today the detector
+    // flags the divergence only when a stale signal exists.
+    expect(detectStalePrd(testDir)?.stale).toBe(false); // fresh file, no signals
+
+    // A stale PRD (old + unfinished) IS detected, and with configured content
+    // evidence the story is reconciled instead of silently left outstanding.
+    const prdWithChecks = makePrd({
+      branchName: 'ralph/landed-work',
+      reconciliation: {
+        staleAfterMs: 1,
+        observableChecks: {
+          'US-001': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'LANDED_SYMBOL' }],
+          'US-002': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'LANDED_SYMBOL' }],
+        },
+      },
+    });
+    expect(writePrd(testDir, prdWithChecks)).toBe(true);
+    backdatePrd(testDir);
+
+    const detection = detectStalePrd(testDir);
+    expect(detection?.stale).toBe(true);
+    expect(detection?.unfinished).toEqual(['US-001', 'US-002']);
+
+    const result = reconcileStalePrd(testDir);
+    expect(result?.reconciled).toEqual(['US-001', 'US-002']);
+    expect(result?.warning).toBeNull();
+
+    const reconciled = readPrd(testDir);
+    expect(reconciled?.userStories.every(s => s.passes === true)).toBe(true);
+    // Reconciled stories still require Step 7 reviewer verification.
+    expect(getPrdStatus(reconciled as PRD).allComplete).toBe(false);
+  });
+
+  // ==========================================================================
+  // Never infer completion from PR status / branch state alone
+  // ==========================================================================
+
+  it('never infers completion from PR status alone: branch/merge signals warn but never auto-complete', () => {
+    initGitRepo(testDir);
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const LANDED_SYMBOL = 42;\n');
+    gitCommitAll(testDir, 'land work');
+
+    // PRD points at a branch that does not exist and has no reconciliation config.
+    const prd = makePrd({ branchName: 'feature/merged-elsewhere' });
+    expect(writePrd(testDir, prd)).toBe(true);
+
+    const detection = detectStalePrd(testDir);
+    expect(detection?.stale).toBe(true); // stale pointer signal, fresh file
+    expect(detection?.stalePointers.length).toBeGreaterThan(0);
+
+    const result = reconcileStalePrd(testDir);
+    expect(result?.reconciled).toEqual([]);
+    expect(result?.skipped).toHaveLength(2);
+    expect(result?.skipped.every(s => s.reason.includes('no configured observable evidence'))).toBe(true);
+    expect(result?.warning).not.toBeNull();
+
+    // No story was auto-marked: PR status/branch state is a signal, not evidence.
+    const prdAfter = readPrd(testDir);
+    expect(prdAfter?.userStories.every(s => s.passes === false)).toBe(true);
+    expect(getPrdStatus(prdAfter as PRD).allComplete).toBe(false);
+  });
+
+  // ==========================================================================
+  // Observable checks
+  // ==========================================================================
+
+  it('runs observable checks fail-closed (fileExists / fileContains / gitGrep / traversal)', () => {
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const LANDED_SYMBOL = 42;\n');
+
+    expect(runObservableCheck({ type: 'fileExists', path: 'src/landed.ts' }, testDir)).toMatchObject({ passed: true });
+    expect(runObservableCheck({ type: 'fileExists', path: 'src/missing.ts' }, testDir)).toMatchObject({ passed: false });
+    expect(runObservableCheck({ type: 'fileContains', path: 'src/landed.ts', pattern: 'LANDED_SYMBOL' }, testDir)).toMatchObject({ passed: true });
+    expect(runObservableCheck({ type: 'fileContains', path: 'src/landed.ts', pattern: 'MISSING_SYMBOL' }, testDir)).toMatchObject({ passed: false });
+    // Path traversal is rejected, not resolved outside the project root.
+    expect(runObservableCheck({ type: 'fileExists', path: '../escape.txt' }, testDir)).toMatchObject({ passed: false });
+    // Unknown types fail closed.
+    expect(runObservableCheck({ type: 'bogus' as ObservableCheck['type'] }, testDir)).toMatchObject({ passed: false });
+
+    initGitRepo(testDir);
+    gitCommitAll(testDir, 'land work');
+    expect(runObservableCheck({ type: 'gitGrep', ref: 'HEAD', pattern: 'LANDED_SYMBOL' }, testDir)).toMatchObject({ passed: true });
+    expect(runObservableCheck({ type: 'gitGrep', ref: 'HEAD', pattern: 'MISSING_SYMBOL' }, testDir)).toMatchObject({ passed: false });
+  });
+
+  // ==========================================================================
+  // all-false-but-landed evidence (content on trunk, gitGrep)
+  // ==========================================================================
+
+  it('reconciles all-false-but-landed stories from git content evidence with an audit trail', () => {
+    initGitRepo(testDir);
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const S1_SYMBOL = 1; export const S2_SYMBOL = 2;\n');
+    gitCommitAll(testDir, 'land work');
+
+    const prd = makePrd({
+      reconciliation: {
+        staleAfterMs: 1,
+        observableChecks: {
+          'US-001': [{ type: 'gitGrep', ref: 'HEAD', pattern: 'S1_SYMBOL', description: 'S1 symbol on trunk' }],
+          'US-002': [{ type: 'gitGrep', ref: 'HEAD', pattern: 'S2_SYMBOL' }],
+        },
+      },
+    });
+    expect(writePrd(testDir, prd)).toBe(true);
+    backdatePrd(testDir);
+
+    const result = reconcileStalePrd(testDir);
+    expect(result?.reconciled).toEqual(['US-001', 'US-002']);
+    expect(result?.skipped).toEqual([]);
+    expect(result?.warning).toBeNull();
+    expect(result?.auditPath).not.toBeNull();
+
+    const entries = readAuditEntries(testDir);
+    expect(entries).toHaveLength(2);
+    expect(entries.every(e => e.decision === 'reconciled' && e.newPasses === true)).toBe(true);
+    expect(entries.every(e => typeof e.evidence === 'string' && (e.evidence.includes('S1_SYMBOL') || e.evidence.includes('S2_SYMBOL')))).toBe(true);
+
+    const prdAfter = readPrd(testDir);
+    expect(prdAfter?.userStories[0].passes).toBe(true);
+    expect(prdAfter?.userStories[0].architectVerified).toBe(false);
+    expect(prdAfter?.userStories[0].notes).toContain('Reconciled from observable evidence');
+    // Audit trail preserved: reconciliation config survives the round trip.
+    expect(prdAfter?.reconciliation?.observableChecks?.['US-001']).toBeDefined();
+  });
+
+  // ==========================================================================
+  // Partial reconciliation
+  // ==========================================================================
+
+  it('reconciles only stories whose configured evidence passes; others are skipped with a warning', () => {
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const S1_SYMBOL = 1;\n');
+
+    const prd = makePrd({
+      reconciliation: {
+        staleAfterMs: 1,
+        observableChecks: {
+          'US-001': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'S1_SYMBOL' }],
+          'US-002': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'S2_SYMBOL' }], // fails
+        },
+      },
+    });
+    // US-003 has no configured checks at all.
+    prd.userStories.push({ id: 'US-003', title: 'Unverifiable', description: '', acceptanceCriteria: [], priority: 3, passes: false, architectVerified: false });
+    expect(writePrd(testDir, prd)).toBe(true);
+    backdatePrd(testDir);
+
+    const result = reconcileStalePrd(testDir);
+    expect(result?.reconciled).toEqual(['US-001']);
+    expect(result?.skipped.map(s => s.storyId).sort()).toEqual(['US-002', 'US-003']);
+    expect(result?.warning).not.toBeNull();
+    expect(result?.warning).toContain('US-002');
+    expect(result?.warning).toContain('US-003');
+
+    const prdAfter = readPrd(testDir);
+    expect(prdAfter?.userStories.find(s => s.id === 'US-001')?.passes).toBe(true);
+    expect(prdAfter?.userStories.find(s => s.id === 'US-002')?.passes).toBe(false);
+    expect(prdAfter?.userStories.find(s => s.id === 'US-003')?.passes).toBe(false);
+
+    const entries = readAuditEntries(testDir);
+    expect(entries).toHaveLength(3);
+    expect(entries.filter(e => e.decision === 'reconciled')).toHaveLength(1);
+    expect(entries.filter(e => e.decision === 'skipped')).toHaveLength(2);
+  });
+
+  // ==========================================================================
+  // Stale pointers
+  // ==========================================================================
+
+  it('flags a dead branch pointer and a merged branch pointer as staleness signals', () => {
+    initGitRepo(testDir);
+    writeFileSync(join(testDir, 'a.txt'), 'a\n');
+    gitCommitAll(testDir, 'base');
+    // feature/landed points at the current HEAD → "already merged" pointer.
+    execFileSync('git', ['branch', 'feature/landed'], { cwd: testDir });
+
+    const deadBranchPrd = makePrd({ branchName: 'feature/dead' });
+    expect(writePrd(testDir, deadBranchPrd)).toBe(true);
+    const dead = detectStalePrd(testDir);
+    expect(dead?.stale).toBe(true);
+    expect(dead?.stalePointers.join(' ')).toContain('no longer exists');
+    expect(formatStalePrdWarning(dead!)).toContain('no longer exists');
+
+    const mergedBranchPrd = makePrd({ branchName: 'feature/landed' });
+    expect(writePrd(testDir, mergedBranchPrd)).toBe(true);
+    const merged = detectStalePrd(testDir);
+    expect(merged?.stale).toBe(true);
+    expect(merged?.stalePointers.join(' ')).toContain('already merged');
+  });
+
+  it('does not flag the current working branch as a stale pointer', () => {
+    initGitRepo(testDir);
+    writeFileSync(join(testDir, 'a.txt'), 'a\n');
+    gitCommitAll(testDir, 'base');
+    const current = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: testDir }).toString().trim();
+
+    const prd = makePrd({ branchName: current });
+    expect(writePrd(testDir, prd)).toBe(true);
+    expect(detectStalePrd(testDir)?.stale).toBe(false); // fresh + current branch
+  });
+
+  // ==========================================================================
+  // Normal Step 8 → no warning
+  // ==========================================================================
+
+  it('emits no session-end warning after a normal Step 8 (all stories complete, ralph state cleared)', () => {
+    const prd = makePrd({
+      userStories: [
+        { id: 'US-001', title: 'Done', description: '', acceptanceCriteria: [], priority: 1, passes: true, architectVerified: true },
+        { id: 'US-002', title: 'Done', description: '', acceptanceCriteria: [], priority: 2, passes: true, architectVerified: true },
+      ],
+    });
+    expect(writePrd(testDir, prd, 'session-step8')).toBe(true);
+
+    expect(getSessionEndStalePrdWarning(testDir, 'session-step8')).toBeNull();
+    expect(detectStalePrd(testDir, 'session-step8')?.stale).toBe(false);
+  });
+
+  // ==========================================================================
+  // Cancel / crash
+  // ==========================================================================
+
+  it('warns on session end when the PRD was left unfinished by a cancel (ralph state cleared)', () => {
+    expect(writePrd(testDir, makePrd(), 'session-cancel')).toBe(true);
+
+    const warning = getSessionEndStalePrdWarning(testDir, 'session-cancel');
+    expect(warning).not.toBeNull();
+    expect(warning).toContain('2/2 unfinished stories');
+    expect(warning).toContain('US-001');
+    expect(warning).toContain('US-002');
+  });
+
+  it('flags an abnormal exit when the ralph loop state is still active (crash/force-kill)', () => {
+    expect(writePrd(testDir, makePrd(), 'session-crash')).toBe(true);
+    expect(writeRalphState(testDir, { active: true, iteration: 3, max_iterations: 10, started_at: new Date().toISOString(), prompt: 'task', session_id: 'session-crash' }, 'session-crash')).toBe(true);
+
+    const detection = detectStalePrd(testDir, 'session-crash');
+    expect(detection?.abnormalExit).toBe(true);
+    expect(detection?.stale).toBe(true);
+    expect(detection?.reasons.join(' ')).toContain('Step 8 cancel never ran');
+
+    const warning = getSessionEndStalePrdWarning(testDir, 'session-crash');
+    expect(warning).not.toBeNull();
+    expect(warning).toContain('Ralph loop state is still active');
+  });
+
+  it('excludes the active-loop signal from the continuation context, so a live loop is not spammed', () => {
+    // Fresh unfinished PRD with an active ralph state: this is a healthy live
+    // loop, so the continuation context must NOT warn.
+    expect(writePrd(testDir, makePrd(), 'session-live')).toBe(true);
+    expect(writeRalphState(testDir, { active: true, iteration: 2, max_iterations: 10, started_at: new Date().toISOString(), prompt: 'task', session_id: 'session-live' }, 'session-live')).toBe(true);
+
+    const context = getRalphContext(testDir, 'session-live');
+    expect(context).not.toContain('<stale-prd-warning>');
+
+    // The same setup DOES warn when staleness has a real signal (old PRD).
+    backdatePrd(testDir, 'session-live', DEFAULT_STALE_PRD_AFTER_MS + 60_000);
+    const staleContext = getRalphContext(testDir, 'session-live');
+    expect(staleContext).toContain('<stale-prd-warning>');
+    expect(staleContext).toContain('unfinished stories');
+  });
+
+  // ==========================================================================
+  // Session isolation
+  // ==========================================================================
+
+  it('keeps detection, reconciliation, and audit strictly session-scoped', () => {
+    const prdA = makePrd({
+      reconciliation: { staleAfterMs: 1, observableChecks: { 'US-001': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'A_SYMBOL' }] } },
+    });
+    const prdB = makePrd({});
+
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const A_SYMBOL = 1;\n');
+    expect(writePrd(testDir, prdA, 'session-a')).toBe(true);
+    expect(writePrd(testDir, prdB, 'session-b')).toBe(true);
+    backdatePrd(testDir, 'session-a');
+
+    const result = reconcileStalePrd(testDir, 'session-a');
+    // US-001 has passing evidence; US-002 has no configured checks → skipped.
+    expect(result?.reconciled).toEqual(['US-001']);
+    expect(result?.skipped.map(s => s.storyId)).toEqual(['US-002']);
+
+    const prdARead = readPrd(testDir, 'session-a');
+    expect(prdARead?.userStories[0].passes).toBe(true);
+    const prdBRead = readPrd(testDir, 'session-b');
+    expect(prdBRead?.userStories.every(s => s.passes === false)).toBe(true);
+
+    // Audit log is per-session; session-b has none.
+    expect(readAuditEntries(testDir, 'session-a').length).toBeGreaterThan(0);
+    expect(readAuditEntries(testDir, 'session-b')).toEqual([]);
+  });
+
+  // ==========================================================================
+  // Legacy schema (project-level prd.json, no session)
+  // ==========================================================================
+
+  it('supports legacy project-level PRDs without a session and round-trips reconciliation config', () => {
+    const legacy = makePrd({
+      branchName: 'feature/legacy',
+      reconciliation: {
+        staleAfterMs: 1,
+        observableChecks: {
+          'US-001': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'LEGACY_SYMBOL', description: 'legacy evidence' }],
+        },
+      },
+    });
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const LEGACY_SYMBOL = 1;\n');
+    expect(writePrd(testDir, legacy)).toBe(true);
+
+    // Round trip preserves the reconciliation config.
+    const read = readPrd(testDir);
+    expect(read?.reconciliation?.staleAfterMs).toBe(1);
+    expect(read?.reconciliation?.observableChecks?.['US-001']?.[0]).toMatchObject({ type: 'fileContains', path: 'src/landed.ts' });
+    backdatePrd(testDir);
+    const result = reconcileStalePrd(testDir);
+    expect(result?.reconciled).toEqual(['US-001']); // US-002 has no configured checks
+    expect(result?.skipped.map(s => s.storyId)).toEqual(['US-002']);
+    const after = readPrd(testDir);
+    expect(after?.userStories.find(s => s.id === 'US-001')?.passes).toBe(true);
+    expect(after?.userStories.find(s => s.id === 'US-002')?.passes).toBe(false);
+  });
+
+  it('keeps legacy PRDs without reconciliation config readable and never auto-marks them', () => {
+    // Old-shape PRD: literally no reconciliation field anywhere.
+    const legacyRaw = {
+      project: 'Legacy',
+      branchName: 'ralph/legacy',
+      description: 'old',
+      userStories: [
+        { id: 'US-001', title: 'A', description: '', acceptanceCriteria: [], priority: 1, passes: false, architectVerified: false },
+      ],
+    };
+    mkdirSync(join(testDir, '.omc'), { recursive: true });
+    writeFileSync(join(testDir, '.omc', 'prd.json'), JSON.stringify(legacyRaw, null, 2));
+
+    const prd = readPrd(testDir);
+    expect(prd?.userStories[0].passes).toBe(false);
+    expect(prd?.reconciliation).toBeUndefined();
+
+    backdatePrd(testDir, undefined, DEFAULT_STALE_PRD_AFTER_MS + 60_000);
+    const detection = detectStalePrd(testDir);
+    expect(detection?.stale).toBe(true);
+    expect(detection?.unfinished).toEqual(['US-001']);
+
+    const result = reconcileStalePrd(testDir);
+    expect(result?.reconciled).toEqual([]);
+    expect(result?.skipped[0]?.reason).toContain('no configured observable evidence');
+    expect(readPrd(testDir)?.userStories[0].passes).toBe(false);
+  });
+
+  it('migrates a legacy PRD into a session scope carrying the reconciliation config, without mutating the legacy file', () => {
+    const legacy = makePrd({
+      reconciliation: { staleAfterMs: 1, observableChecks: { 'US-001': [{ type: 'fileExists', path: 'src/landed.ts' }] } },
+    });
+    mkdirSync(join(testDir, '.omc'), { recursive: true });
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'x');
+    writeFileSync(join(testDir, '.omc', 'prd.json'), JSON.stringify(legacy, null, 2));
+    const legacyPath = join(testDir, '.omc', 'prd.json');
+    const legacyBefore = readFileSync(legacyPath, 'utf-8');
+
+    const result = ensurePrdForStartup(testDir, 'Project', 'branch', 'task', undefined, 'session-migrate');
+    expect(result.ok).toBe(true);
+    expect(result.path).toBe(getSessionPrdPath(testDir, 'session-migrate'));
+
+    const migrated = readPrd(testDir, 'session-migrate');
+    expect(migrated?.reconciliation?.observableChecks?.['US-001']).toBeDefined();
+    // Legacy file untouched.
+    expect(readFileSync(legacyPath, 'utf-8')).toBe(legacyBefore);
+  });
+
+  // ==========================================================================
+  // Startup integration (startLoop)
+  // ==========================================================================
+
+  it('reconciles a stale session PRD at Ralph startup and surfaces no residual warning when all evidence passes', () => {
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'export const START_SYMBOL = 1;\n');
+
+    const prd = makePrd({
+      reconciliation: {
+        staleAfterMs: 1,
+        observableChecks: {
+          'US-001': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'START_SYMBOL' }],
+          'US-002': [{ type: 'fileContains', path: 'src/landed.ts', pattern: 'START_SYMBOL' }],
+        },
+      },
+    });
+    expect(writePrd(testDir, prd, 'session-start')).toBe(true);
+    backdatePrd(testDir, 'session-start');
+
+    const hook = createRalphLoopHook(testDir);
+    const started = hook.startLoop('session-start', 'reconcile me');
+    expect(started).toBe(true);
+
+    const prdAfter = readPrd(testDir, 'session-start');
+    expect(prdAfter?.userStories.every(s => s.passes === true)).toBe(true);
+  });
+
+  it('reconcileStalePrdForStartup never throws and reports the remaining warning', () => {
+    mkdirSync(join(testDir, 'src'), { recursive: true });
+    writeFileSync(join(testDir, 'src', 'landed.ts'), 'x');
+    const prd = makePrd({
+      reconciliation: { staleAfterMs: 1, observableChecks: { 'US-001': [{ type: 'fileExists', path: 'src/landed.ts' }] } },
+    });
+    expect(writePrd(testDir, prd, 'session-warn')).toBe(true);
+    backdatePrd(testDir, 'session-warn');
+
+    const result = reconcileStalePrdForStartup(testDir, 'session-warn');
+    expect(result.warning).not.toBeNull();
+    expect(result.warning).toContain('US-002');
+  });
+
+  // ==========================================================================
+  // Warning format
+  // ==========================================================================
+
+  it('formats the explicit stale-unfinished-PRD warning with counts, ids, and age', () => {
+    const prd = makePrd();
+    expect(writePrd(testDir, prd, 'session-fmt')).toBe(true);
+    backdatePrd(testDir, 'session-fmt', 3 * 60 * 60 * 1000);
+
+    const detection = detectStalePrd(testDir, 'session-fmt')!;
+    const warning = formatStalePrdWarning(detection);
+    expect(warning).toContain('[STALE PRD WARNING]');
+    expect(warning).toContain('2/2 unfinished stories');
+    expect(warning).toContain('US-001, US-002');
+    expect(warning).toContain('last touched');
+    expect(warning).toContain('3 hours ago');
+    expect(warning).toContain('Step 5');
+    expect(DEFAULT_STALE_PRD_AFTER_MS).toBe(2 * 60 * 60 * 1000);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -38,6 +38,15 @@ export {
   recordStoryProgress,
   recordPattern,
   shouldCompleteByPrd,
+  // PRD Stale-State Detection & Reconciliation (#3669)
+  detectStalePrd,
+  formatStalePrdWarning,
+  getSessionEndStalePrdWarning,
+  reconcileStalePrd,
+  reconcileStalePrdForStartup,
+  runObservableCheck,
+  PRD_RECONCILIATION_AUDIT_FILENAME,
+  DEFAULT_STALE_PRD_AFTER_MS,
   // PRD (Structured Task Tracking)
   readPrd,
   writePrd,

--- a/src/hooks/ralph/index.ts
+++ b/src/hooks/ralph/index.ts
@@ -153,3 +153,31 @@ export {
   // Types
   type VerificationState
 } from './verifier.js';
+
+// ============================================================================
+// Ralph PRD Stale-State Detection & Reconciliation (#3669)
+// ============================================================================
+
+export {
+  // Detection
+  detectStalePrd,
+  formatStalePrdWarning,
+  getSessionEndStalePrdWarning,
+
+  // Reconciliation
+  reconcileStalePrd,
+  reconcileStalePrdForStartup,
+  runObservableCheck,
+
+  // Constants
+  PRD_RECONCILIATION_AUDIT_FILENAME,
+  DEFAULT_STALE_PRD_AFTER_MS,
+
+  // Types
+  type ObservableCheck,
+  type ObservableCheckResult,
+  type PrdReconciliationConfig,
+  type StalePrdDetection,
+  type ReconciliationAuditEntry,
+  type ReconcileStalePrdResult
+} from './stale-prd.js';

--- a/src/hooks/ralph/loop.ts
+++ b/src/hooks/ralph/loop.ts
@@ -29,6 +29,11 @@ import {
   type UserStory,
 } from "./prd.js";
 import {
+  detectStalePrd,
+  formatStalePrdWarning,
+  reconcileStalePrdForStartup,
+} from "./stale-prd.js";
+import {
   findProgressPath,
   getProgressContext,
   appendProgress,
@@ -323,6 +328,15 @@ export function createRalphLoopHook(directory: string): RalphLoopHook {
       return false;
     }
 
+    // Stale-state reconciliation (#3669): if the active PRD was left unfinished
+    // by an abnormal/non-Step 8 exit, reconcile it from configured observable
+    // evidence (bounded: content checks only, never PR/merge status) and
+    // surface any remaining divergence at the moment it is cheapest to fix.
+    const staleReconcile = reconcileStalePrdForStartup(directory, sessionId);
+    if (staleReconcile.warning) {
+      console.error(staleReconcile.warning);
+    }
+
     if (!findProgressPath(directory)) {
       initProgress(directory);
     }
@@ -440,6 +454,14 @@ export function getPrdCompletionStatus(directory: string, sessionId?: string): {
  */
 export function getRalphContext(directory: string, sessionId?: string): string {
   const parts: string[] = [];
+
+  // Add stale-unfinished-PRD warning (#3669): the live loop excludes the
+  // active-ralph-state signal (it is the normal case here) and only reports
+  // divergence backed by age / stale-pointer signals.
+  const staleDetection = detectStalePrd(directory, sessionId, { includeAbnormalExit: false });
+  if (staleDetection?.stale) {
+    parts.push(`<stale-prd-warning>\n${formatStalePrdWarning(staleDetection)}\n</stale-prd-warning>\n`);
+  }
 
   // Add progress context (patterns, learnings)
   const progressContext = getProgressContext(directory);

--- a/src/hooks/ralph/prd.ts
+++ b/src/hooks/ralph/prd.ts
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { ensureSessionStateDir, getOmcRoot, getSessionStateDir } from '../../lib/worktree-paths.js';
+import type { ObservableCheck, PrdReconciliationConfig } from './stale-prd.js';
 
 // ============================================================================
 // Types
@@ -48,6 +49,12 @@ export interface PRD {
   description: string;
   /** List of user stories */
   userStories: UserStory[];
+  /**
+   * Optional stale-state reconciliation configuration (#3669). Carried inside
+   * the PRD so it travels with the stories and stays session-scoped. Legacy
+   * PRDs without this field read back as undefined and are fully supported.
+   */
+  reconciliation?: PrdReconciliationConfig;
 }
 
 export interface PRDStatus {
@@ -133,12 +140,90 @@ function normalizePrd(candidate: unknown): PRD | null {
     return null;
   }
 
+  const reconciliation = normalizeReconciliation(prd.reconciliation);
+
   return {
     project: prd.project,
     branchName: prd.branchName,
     description: prd.description,
-    userStories: userStories as UserStory[]
+    userStories: userStories as UserStory[],
+    ...(reconciliation ? { reconciliation } : {})
   };
+}
+
+/**
+ * Validate and preserve the optional reconciliation config. Returns undefined
+ * for legacy PRDs (no field) or malformed values — a malformed config must not
+ * invalidate an otherwise valid PRD, it just disables auto-reconciliation.
+ */
+function normalizeReconciliation(candidate: unknown): PrdReconciliationConfig | undefined {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return undefined;
+  }
+
+  const raw = candidate as Record<string, unknown>;
+  const config: PrdReconciliationConfig = {};
+
+  if (typeof raw.staleAfterMs === 'number' && Number.isFinite(raw.staleAfterMs) && raw.staleAfterMs > 0) {
+    config.staleAfterMs = raw.staleAfterMs;
+  }
+
+  if (typeof raw.autoReconcile === 'boolean') {
+    config.autoReconcile = raw.autoReconcile;
+  }
+
+  if (raw.observableChecks && typeof raw.observableChecks === 'object' && !Array.isArray(raw.observableChecks)) {
+    const checksByStory = raw.observableChecks as Record<string, unknown>;
+    const observableChecks: Record<string, unknown> = {};
+    for (const [storyId, checks] of Object.entries(checksByStory)) {
+      if (!Array.isArray(checks)) {
+        continue;
+      }
+      const normalizedChecks = checks
+        .map(c => normalizeObservableCheck(c))
+        .filter((c): c is ObservableCheck => c !== null);
+      if (normalizedChecks.length > 0) {
+        observableChecks[storyId] = normalizedChecks;
+      }
+    }
+    if (Object.keys(observableChecks).length > 0) {
+      config.observableChecks = observableChecks as PrdReconciliationConfig['observableChecks'];
+    }
+  }
+
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+/**
+ * Validate a single observable check. Unknown check types or missing required
+ * fields are dropped rather than failing the whole PRD.
+ */
+function normalizeObservableCheck(candidate: unknown): ObservableCheck | null {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return null;
+  }
+
+  const raw = candidate as Record<string, unknown>;
+  const type = raw.type;
+  if (type !== 'fileExists' && type !== 'fileContains' && type !== 'gitGrep') {
+    return null;
+  }
+
+  const check: ObservableCheck = { type };
+  if (typeof raw.path === 'string' && raw.path.length > 0) {
+    check.path = raw.path;
+  }
+  if (typeof raw.ref === 'string' && raw.ref.length > 0) {
+    check.ref = raw.ref;
+  }
+  if (typeof raw.pattern === 'string' && raw.pattern.length > 0) {
+    check.pattern = raw.pattern;
+  }
+  if (typeof raw.description === 'string' && raw.description.length > 0) {
+    check.description = raw.description;
+  }
+
+  return check;
 }
 
 function readPrdFromPath(prdPath: string): { prd?: PRD; error?: string } {

--- a/src/hooks/ralph/stale-prd.ts
+++ b/src/hooks/ralph/stale-prd.ts
@@ -1,0 +1,661 @@
+/**
+ * Ralph PRD Stale-State Detection & Reconciliation (#3669)
+ *
+ * A Ralph PRD can diverge from reality with no detection: work lands outside the
+ * loop (campaign branches + PRs + coordinator merges) while prd.json still
+ * records `passes: false`, and abnormal exits (crash, force-kill, cancel before
+ * Step 8, session end without `/oh-my-claudecode:cancel`) leave the divergence
+ * invisible. Anyone resuming the session then reads an authoritative-looking but
+ * false record and either redoes landed work or spends effort disproving it.
+ *
+ * This module detects that stale state and — only when configured observable
+ * evidence exists — reconciles it. It never infers completion by itself.
+ *
+ * ============================================================================
+ * Ralph completion / session-end hook map
+ * ============================================================================
+ *
+ * - Step 5 (mark `passes: true`): the ralph agent edits prd.json directly.
+ *   There is no code path that re-derives `passes` from observable state —
+ *   that gap is the root cause of #3669.
+ * - Step 6 (all stories pass): `src/hooks/persistent-mode/index.ts` evaluates
+ *   `getPrdCompletionStatus()`; `allComplete` gates final verification.
+ * - Step 7 (reviewer verification): `src/hooks/ralph/verifier.ts`
+ *   `startVerification()` + architect/critic approval; approval clears the
+ *   verification state.
+ * - Step 8 (`/oh-my-claudecode:cancel`): `createRalphLoopHook().cancelLoop()`
+ *   clears ralph state (`clearRalphState`) plus linked ultrawork state. Step 8
+ *   is the ONLY clean exit; every other end leaves ralph state active and/or
+ *   the PRD unfinished.
+ * - Session end: `src/hooks/session-end/index.ts` `processSessionEnd()` →
+ *   `runForegroundSessionEndCleanup()` → `cleanupModeStates()` removes active
+ *   ralph mode state. The session-scoped PRD
+ *   (`.omc/state/sessions/{id}/prd.json`) is NOT removed and survives into the
+ *   next session — which is how a stale PRD gets resumed as if the work were
+ *   outstanding. `processSessionEnd` therefore surfaces the warning *before*
+ *   mode-state cleanup.
+ *
+ * ============================================================================
+ * Design contract
+ * ============================================================================
+ *
+ * - Detection NEVER infers completion from PR/merge/branch status alone. Git
+ *   state is a *stale signal* (stale pointers) only.
+ * - Reconciliation marks a story `passes: true` ONLY when configured observable
+ *   evidence (content checks: `fileExists` / `fileContains` / `gitGrep`) all
+ *   pass. Stories without configured checks are never auto-marked.
+ * - Reconciled stories get `architectVerified: false` and must still pass the
+ *   Step 7 reviewer verification before final completion. Reconciliation
+ *   repairs Step 5; it never bypasses Steps 6–8.
+ * - Every reconciliation decision is appended to an audit log
+ *   (`prd-reconciliation.jsonl`) and summarized in the story notes, preserving
+ *   the audit trail the PRD exists for.
+ * - All checks are bounded: git invocations carry a timeout and run with
+ *   `windowsHide` (per repo convention), and file checks are confined to the
+ *   repository root.
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, statSync, mkdirSync, appendFileSync } from 'fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'path';
+import { readModeState } from '../../lib/mode-state-io.js';
+import { ensureSessionStateDir, getOmcRoot, getSessionStateDir } from '../../lib/worktree-paths.js';
+import {
+  findPrdPath,
+  readPrd,
+  writePrd,
+} from './prd.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Audit log file name, stored next to the PRD in the session state dir. */
+export const PRD_RECONCILIATION_AUDIT_FILENAME = 'prd-reconciliation.jsonl';
+
+/** Default age after which an unfinished PRD counts as stale (2h, matching the repo stale-state convention). */
+export const DEFAULT_STALE_PRD_AFTER_MS = 2 * 60 * 60 * 1000;
+
+/** Bound for each observable check (git/file). */
+const CHECK_TIMEOUT_MS = 5_000;
+
+const GIT_MAX_BUFFER = 1024 * 1024;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A single observable-evidence check. Checks are content-based on purpose:
+ * branch/PR merge status is a detection signal only, never completion evidence.
+ */
+export interface ObservableCheck {
+  /** Check kind. `fileExists`/`fileContains` inspect the working tree; `gitGrep` inspects content at a ref. */
+  type: 'fileExists' | 'fileContains' | 'gitGrep';
+  /** Repository-relative path for `fileExists` / `fileContains`. */
+  path?: string;
+  /** Git ref for `gitGrep` (default: `HEAD`). */
+  ref?: string;
+  /** Substring pattern for `fileContains` / `gitGrep`. */
+  pattern?: string;
+  /** Optional human-readable description of the evidence being checked. */
+  description?: string;
+}
+
+/**
+ * Per-PRD reconciliation configuration. Lives under `prd.reconciliation` so it
+ * travels with the PRD and stays session-scoped alongside the stories.
+ */
+export interface PrdReconciliationConfig {
+  /** Per-story observable-evidence checks. A story reconciles only when ALL of its checks pass. */
+  observableChecks?: Record<string, ObservableCheck[]>;
+  /** Age (ms) after which an unfinished PRD counts as stale even without an abnormal-exit signal. */
+  staleAfterMs?: number;
+  /** Auto-reconcile stories whose checks all pass (default true when checks exist). */
+  autoReconcile?: boolean;
+}
+
+/** Signals that a PRD may have diverged from observable reality. */
+export interface StalePrdDetection {
+  /** True when the PRD has unfinished stories AND at least one stale signal applies. */
+  stale: boolean;
+  /** Human-readable reasons for the stale verdict. */
+  reasons: string[];
+  /** True when the session's ralph loop state is still active (Step 8 cancel never ran). */
+  abnormalExit: boolean;
+  /** Story IDs never marked passes:true — the divergence-relevant set (#3669). Stories awaiting Step 7 review (passes:true) are normal pipeline, not stale. */
+  unfinished: string[];
+  /** Total story count. */
+  total: number;
+  /** Completed story count. */
+  completed: number;
+  /** Milliseconds since the PRD file was last written. */
+  ageMs: number;
+  /** ISO timestamp of the last PRD write, when known. */
+  lastTouchedAt: string | null;
+  /** Stale-pointer signals, e.g. the PRD's branchName no longer exists or was merged. */
+  stalePointers: string[];
+  /** Absolute path of the PRD file that was inspected. */
+  prdPath: string;
+}
+
+/** One audited reconciliation decision. */
+export interface ReconciliationAuditEntry {
+  timestamp: string;
+  sessionId?: string;
+  storyId: string;
+  decision: 'reconciled' | 'skipped';
+  previousPasses: boolean;
+  newPasses: boolean;
+  checks: { check: ObservableCheck; passed: boolean; detail?: string }[];
+  evidence: string;
+  reason?: string;
+}
+
+/** Outcome of a bounded reconciliation pass. */
+export interface ReconcileStalePrdResult {
+  detection: StalePrdDetection;
+  /** Story IDs marked `passes: true` from passing observable evidence. */
+  reconciled: string[];
+  /** Story IDs left unfinished, with the reason. */
+  skipped: { storyId: string; reason: string }[];
+  /** Absolute path of the audit log (null when nothing was audited). */
+  auditPath: string | null;
+  /** Remaining stale warning, or null when no unfinished story is left to warn about. */
+  warning: string | null;
+}
+
+export interface ObservableCheckResult {
+  passed: boolean;
+  detail: string;
+}
+
+// ============================================================================
+// Observable checks (bounded, content-based)
+// ============================================================================
+
+function isPathWithinRoot(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel !== '' && !rel.startsWith('..' + sep) && rel !== '..' && !isAbsolute(rel);
+}
+
+function resolveCheckPath(directory: string, checkPath: string): string | null {
+  // File checks are anchored at the project/worktree root the caller means
+  // (in production the git worktree root; in tests the temp project dir) — the
+  // same root git commands run against. Confinement prevents a configured check
+  // from reading outside the project.
+  const root = resolve(directory);
+  const candidate = resolve(root, checkPath);
+  return isPathWithinRoot(root, candidate) ? candidate : null;
+}
+
+function runGit(args: string[], directory: string): { exitCode: number; detail: string } {
+  try {
+    execFileSync('git', args, {
+      cwd: directory,
+      encoding: 'utf-8',
+      timeout: CHECK_TIMEOUT_MS,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: GIT_MAX_BUFFER,
+    });
+    return { exitCode: 0, detail: '' };
+  } catch (error) {
+    const err = error as { status?: number; stderr?: string | Buffer; message?: string };
+    if (typeof err.status === 'number' && err.status !== 0) {
+      // git grep exits 1 when no match; git merge-base --is-ancestor exits 1 when not an ancestor.
+      return { exitCode: err.status, detail: err.status === 1 ? '' : String(err.stderr ?? '') };
+    }
+    return { exitCode: -1, detail: err.message ?? String(error) };
+  }
+}
+
+function checkFileExists(check: ObservableCheck, directory: string): ObservableCheckResult {
+  if (!check.path) {
+    return { passed: false, detail: 'fileExists check requires a path' };
+  }
+  const resolved = resolveCheckPath(directory, check.path);
+  if (!resolved) {
+    return { passed: false, detail: `path escapes repository root: ${check.path}` };
+  }
+  if (!existsSync(resolved) || !statSync(resolved).isFile()) {
+    return { passed: false, detail: `file not found: ${check.path}` };
+  }
+  return { passed: true, detail: `file exists: ${check.path}` };
+}
+
+function checkFileContains(check: ObservableCheck, directory: string): ObservableCheckResult {
+  const fileResult = checkFileExists(check, directory);
+  if (!fileResult.passed) {
+    return fileResult;
+  }
+  if (!check.pattern) {
+    return { passed: false, detail: 'fileContains check requires a pattern' };
+  }
+  const resolved = resolveCheckPath(directory, check.path as string) as string;
+  try {
+    const content = readFileSync(resolved, 'utf-8');
+    return content.includes(check.pattern)
+      ? { passed: true, detail: `pattern found in ${check.path}` }
+      : { passed: false, detail: `pattern not found in ${check.path}` };
+  } catch (error) {
+    return { passed: false, detail: `failed to read ${check.path}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function checkGitGrep(check: ObservableCheck, directory: string): ObservableCheckResult {
+  if (!check.pattern) {
+    return { passed: false, detail: 'gitGrep check requires a pattern' };
+  }
+  const ref = check.ref ?? 'HEAD';
+  const result = runGit(['grep', '-q', '-e', check.pattern, ref], directory);
+  if (result.exitCode === 0) {
+    return { passed: true, detail: `git grep ${check.pattern} at ${ref}: found` };
+  }
+  if (result.exitCode === 1) {
+    return { passed: false, detail: `git grep ${check.pattern} at ${ref}: not found` };
+  }
+  return { passed: false, detail: `git grep failed: ${result.detail || 'git unavailable'}` };
+}
+
+/**
+ * Run a single observable check. All checks are bounded and fail closed.
+ */
+export function runObservableCheck(check: ObservableCheck, directory: string): ObservableCheckResult {
+  switch (check.type) {
+    case 'fileExists':
+      return checkFileExists(check, directory);
+    case 'fileContains':
+      return checkFileContains(check, directory);
+    case 'gitGrep':
+      return checkGitGrep(check, directory);
+    default:
+      return { passed: false, detail: `unknown check type: ${(check as { type: string }).type}` };
+  }
+}
+
+// ============================================================================
+// Stale detection
+// ============================================================================
+
+function isGitRepository(directory: string): boolean {
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd: directory,
+      encoding: 'utf-8',
+      timeout: CHECK_TIMEOUT_MS,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function currentBranch(directory: string): string | null {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: directory,
+      encoding: 'utf-8',
+      timeout: CHECK_TIMEOUT_MS,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out && out !== 'HEAD' ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+function branchExists(directory: string, branch: string): boolean {
+  const result = runGit(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], directory);
+  if (result.exitCode === 0) {
+    return true;
+  }
+  const remoteResult = runGit(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`], directory);
+  return remoteResult.exitCode === 0;
+}
+
+function isBranchMergedIntoHead(directory: string, branch: string): boolean {
+  const result = runGit(['merge-base', '--is-ancestor', branch, 'HEAD'], directory);
+  return result.exitCode === 0;
+}
+
+/**
+ * Detect whether the active PRD has diverged from observable reality.
+ *
+ * Returns null when no PRD exists. A returned detection always carries the full
+ * picture even when `stale` is false (callers use `unfinished` to decide whether
+ * an exit-time warning is warranted).
+ *
+ * `includeAbnormalExit` (default true) treats a still-active ralph loop state
+ * as an abnormal-exit signal. The live-loop continuation path passes false —
+ * while the loop is legitimately running, an active state is the normal case,
+ * so only age and stale-pointer signals count there.
+ */
+export function detectStalePrd(
+  directory: string,
+  sessionId?: string,
+  options?: { includeAbnormalExit?: boolean },
+): StalePrdDetection | null {
+  const includeAbnormalExit = options?.includeAbnormalExit !== false;
+  const prdPath = findPrdPath(directory, sessionId);
+  if (!prdPath) {
+    return null;
+  }
+
+  const prd = readPrd(directory, sessionId);
+  if (!prd) {
+    return null;
+  }
+
+  let ageMs = 0;
+  let lastTouchedAt: string | null = null;
+  try {
+    const stat = statSync(prdPath);
+    ageMs = Date.now() - stat.mtimeMs;
+    lastTouchedAt = new Date(stat.mtimeMs).toISOString();
+  } catch {
+    // Unreadable file: age unknown, treated as fresh so detection stays conservative.
+  }
+
+  const unfinished = prd.userStories.filter(s => s.passes !== true).map(s => s.id);
+  const total = prd.userStories.length;
+  const completed = total - unfinished.length;
+
+  const reasons: string[] = [];
+  const stalePointers: string[] = [];
+
+  // Abnormal exit: the ralph loop state for this session is still active, so
+  // Step 8 (`/oh-my-claudecode:cancel`) never ran.
+  const ralphState = readModeState<{ active?: boolean }>('ralph', directory, sessionId);
+  const abnormalExit = includeAbnormalExit && ralphState?.active === true;
+  if (abnormalExit) {
+    reasons.push('Ralph loop state is still active (Step 8 cancel never ran)');
+  }
+
+  const staleAfterMs = prd.reconciliation?.staleAfterMs ?? DEFAULT_STALE_PRD_AFTER_MS;
+  if (ageMs > staleAfterMs) {
+    reasons.push(`PRD was last touched ${formatAge(ageMs)} ago`);
+  }
+
+  // Stale pointers: the PRD's branchName no longer exists or has been merged
+  // into the current branch. Detection signal only — never completion evidence.
+  if (prd.branchName && isGitRepository(directory)) {
+    const head = currentBranch(directory);
+    if (head !== prd.branchName) {
+      if (!branchExists(directory, prd.branchName)) {
+        stalePointers.push(`branch "${prd.branchName}" no longer exists`);
+      } else if (isBranchMergedIntoHead(directory, prd.branchName)) {
+        stalePointers.push(`branch "${prd.branchName}" is already merged into ${head ?? 'HEAD'}`);
+      }
+    }
+  }
+  if (stalePointers.length > 0) {
+    reasons.push('stale pointer(s): ' + stalePointers.join('; '));
+  }
+
+  const stale = unfinished.length > 0 && reasons.length > 0;
+
+  return {
+    stale,
+    reasons,
+    abnormalExit,
+    unfinished,
+    total,
+    completed,
+    ageMs,
+    lastTouchedAt,
+    stalePointers,
+    prdPath,
+  };
+}
+
+// ============================================================================
+// Audit trail
+// ============================================================================
+
+function getAuditLogPath(directory: string, sessionId?: string): string {
+  if (sessionId) {
+    ensureSessionStateDir(sessionId, directory);
+    return resolve(getSessionStateDir(sessionId, directory), PRD_RECONCILIATION_AUDIT_FILENAME);
+  }
+  const stateDir = resolve(getOmcRoot(directory), 'state');
+  if (!existsSync(stateDir)) {
+    try {
+      mkdirSync(stateDir, { recursive: true });
+    } catch {
+      // Audit is best-effort; callers treat a missing log as null.
+    }
+  }
+  return resolve(stateDir, PRD_RECONCILIATION_AUDIT_FILENAME);
+}
+
+function appendAuditEntry(directory: string, entry: ReconciliationAuditEntry, sessionId?: string): string | null {
+  const auditPath = getAuditLogPath(directory, sessionId);
+  try {
+    mkdirSync(dirname(auditPath), { recursive: true });
+    appendFileSync(auditPath, JSON.stringify(entry) + '\n', 'utf-8');
+    return auditPath;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Warning formatting
+// ============================================================================
+
+function formatAge(ms: number): string {
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) {
+    return 'less than a minute';
+  }
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes === 0
+    ? `${hours} hour${hours === 1 ? '' : 's'}`
+    : `${hours} hour${hours === 1 ? '' : 's'} ${remMinutes} minute${remMinutes === 1 ? '' : 's'}`;
+}
+
+/**
+ * Format an explicit stale-unfinished-PRD warning. Surfaces the divergence at
+ * the moment it is cheapest to fix: abnormal/non-Step 8 exit and Ralph startup.
+ */
+export function formatStalePrdWarning(detection: StalePrdDetection): string {
+  const { unfinished, total, completed } = detection;
+  const storyList = unfinished.length > 0 ? ` (${unfinished.join(', ')})` : '';
+  const touched = detection.lastTouchedAt
+    ? ` and was last touched ${formatAge(detection.ageMs)} ago`
+    : '';
+  const reasons = detection.reasons.length > 0
+    ? ` Signals: ${detection.reasons.join('; ')}.`
+    : '';
+
+  const lines = [
+    `[STALE PRD WARNING] prd.json (${detection.prdPath}) has ${unfinished.length}/${total} unfinished stories${storyList}, ${completed}/${total} complete${touched}.${reasons}`,
+    `Ralph completion is only recorded when a story is marked passes:true in prd.json (Step 5); work landed outside the loop (e.g. campaign PRs) or an abnormal/non-Step 8 exit leaves this file stale.`,
+    `Do NOT treat these stories as outstanding — verify against observable state (merged PR content, files on trunk) before redoing them. Configure observableChecks under prd.reconciliation to auto-reconcile from content evidence.`,
+  ];
+
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Reconciliation
+// ============================================================================
+
+function buildEvidence(checks: ObservableCheck[], results: ObservableCheckResult[]): string {
+  return checks
+    .map((check, i) => {
+      const label = check.description ?? `${check.type}${check.path ? ` ${check.path}` : ''}${check.pattern ? ` ${check.pattern}` : ''}`;
+      return `${label}: ${results[i].passed ? 'PASS' : 'FAIL'}${results[i].detail ? ` (${results[i].detail})` : ''}`;
+    })
+    .join('; ');
+}
+
+/**
+ * Bounded stale-state reconciliation.
+ *
+ * A story is marked `passes: true` ONLY when the PRD carries configured
+ * observable evidence for it and every configured check passes. Stories without
+ * configured evidence, or with failing checks, are left untouched. Every
+ * decision is audited. Never infers completion from PR/merge status.
+ */
+export function reconcileStalePrd(directory: string, sessionId?: string): ReconcileStalePrdResult | null {
+  const detection = detectStalePrd(directory, sessionId);
+  if (!detection || !detection.stale) {
+    return detection ? { detection, reconciled: [], skipped: [], auditPath: null, warning: null } : null;
+  }
+
+  const prd = readPrd(directory, sessionId);
+  if (!prd) {
+    return null;
+  }
+
+  const checksByStory = prd.reconciliation?.observableChecks ?? {};
+  const autoReconcile = prd.reconciliation?.autoReconcile !== false;
+  const reconciled: string[] = [];
+  const skipped: { storyId: string; reason: string }[] = [];
+  let auditPath: string | null = null;
+  const entries: ReconciliationAuditEntry[] = [];
+
+  for (const story of prd.userStories) {
+    // Reconciliation repairs Step 5: it only ever touches stories that were
+    // never marked passes:true. Stories already passes:true (even while
+    // awaiting Step 7 review) are part of the normal pipeline, not stale.
+    if (story.passes === true) {
+      continue;
+    }
+
+    const checks = checksByStory[story.id];
+    if (!checks || checks.length === 0) {
+      skipped.push({ storyId: story.id, reason: 'no configured observable evidence (prd.reconciliation.observableChecks)' });
+      entries.push({
+        timestamp: new Date().toISOString(),
+        sessionId,
+        storyId: story.id,
+        decision: 'skipped',
+        previousPasses: story.passes,
+        newPasses: story.passes,
+        checks: [],
+        evidence: '',
+        reason: 'no configured observable evidence',
+      });
+      continue;
+    }
+
+    const results = checks.map(check => runObservableCheck(check, directory));
+    const allPass = results.every(r => r.passed);
+    const evidence = buildEvidence(checks, results);
+
+    if (autoReconcile && allPass) {
+      story.passes = true;
+      story.architectVerified = false;
+      story.notes = appendStoryNote(story.notes, `Reconciled from observable evidence on ${new Date().toISOString()}: ${evidence}`);
+      reconciled.push(story.id);
+      entries.push({
+        timestamp: new Date().toISOString(),
+        sessionId,
+        storyId: story.id,
+        decision: 'reconciled',
+        previousPasses: false,
+        newPasses: true,
+        checks: checks.map((check, i) => ({ check, passed: results[i].passed, detail: results[i].detail })),
+        evidence,
+      });
+    } else {
+      skipped.push({
+        storyId: story.id,
+        reason: autoReconcile ? `observable evidence check failed: ${evidence}` : 'autoReconcile disabled',
+      });
+      entries.push({
+        timestamp: new Date().toISOString(),
+        sessionId,
+        storyId: story.id,
+        decision: 'skipped',
+        previousPasses: story.passes,
+        newPasses: story.passes,
+        checks: checks.map((check, i) => ({ check, passed: results[i].passed, detail: results[i].detail })),
+        evidence,
+        reason: autoReconcile ? 'observable evidence check failed' : 'autoReconcile disabled',
+      });
+    }
+  }
+
+  const prdChanged = reconciled.length > 0;
+  if (prdChanged && !writePrd(directory, prd, sessionId)) {
+    // Write failure: do not claim success. The audit log records the true
+    // outcome (nothing changed) so it cannot be misread as a completed run.
+    for (const entry of entries) {
+      if (entry.decision === 'reconciled') {
+        entry.decision = 'skipped';
+        entry.newPasses = entry.previousPasses;
+        entry.reason = 'prd write failed after checks passed';
+      }
+      const path = appendAuditEntry(directory, entry, sessionId);
+      if (path) auditPath = path;
+    }
+    return {
+      detection,
+      reconciled: [],
+      skipped: [...skipped, ...reconciled.map(storyId => ({ storyId, reason: 'prd write failed after checks passed' }))],
+      auditPath,
+      warning: formatStalePrdWarning(detection),
+    };
+  }
+
+  for (const entry of entries) {
+    const path = appendAuditEntry(directory, entry, sessionId);
+    if (path) auditPath = path;
+  }
+
+  const remaining = prd.userStories.filter(s => s.passes !== true).map(s => s.id);
+  const warning =
+    remaining.length > 0
+      ? formatStalePrdWarning({ ...detection, unfinished: remaining, completed: prd.userStories.length - remaining.length, stale: true })
+      : null;
+
+  return { detection, reconciled, skipped, auditPath, warning };
+}
+
+function appendStoryNote(notes: string | undefined, addition: string): string {
+  return notes ? `${notes}\n${addition}` : addition;
+}
+
+/**
+ * Session-end integration: returns the stale-unfinished-PRD warning for the
+ * ending session, or null when there is nothing to warn about. Must be called
+ * BEFORE mode-state cleanup removes the ralph state file (the abnormal-exit
+ * signal). Never throws; session end must never be blocked by this check.
+ */
+export function getSessionEndStalePrdWarning(directory: string, sessionId: string): string | null {
+  try {
+    const detection = detectStalePrd(directory, sessionId);
+    if (!detection || detection.unfinished.length === 0) {
+      return null;
+    }
+    return formatStalePrdWarning(detection);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ralph startup/resume integration: detect a stale PRD, reconcile it when
+ * configured observable evidence exists, and surface the remaining warning.
+ * Never throws; ralph startup must not be blocked by this check.
+ */
+export function reconcileStalePrdForStartup(directory: string, sessionId?: string): { warning: string | null } {
+  try {
+    const result = reconcileStalePrd(directory, sessionId);
+    return { warning: result?.warning ?? null };
+  } catch {
+    return { warning: null };
+  }
+}
+

--- a/src/hooks/session-end/index.ts
+++ b/src/hooks/session-end/index.ts
@@ -12,6 +12,7 @@ import { clearModeStateFile, readModeState } from '../../lib/mode-state-io.js';
 import { completeForegroundCleanup, completeForegroundCleanupAndSealCore, prepareCoreManifest, readSessionEndJob, sealWikiManifest } from './cleanup-manifest.js';
 import { spawnSessionEndWorker } from './worker.js';
 import { buildWikiSessionEndCaptureIntent } from '../wiki/session-hooks.js';
+import { getSessionEndStalePrdWarning } from '../ralph/stale-prd.js';
 
 export interface SessionEndInput {
   session_id: string;
@@ -898,6 +899,15 @@ function buildDurableSessionEndPayload(directory: string, input: SessionEndInput
 
 export async function processSessionEnd(input: SessionEndInput): Promise<HookOutput> {
   const directory = resolveToWorktreeRoot(input.cwd);
+
+  // Stale-unfinished-PRD warning (#3669): surface the divergence at session end
+  // BEFORE mode-state cleanup removes the ralph state (the abnormal-exit
+  // signal). Never blocks session end.
+  const stalePrdWarning = getSessionEndStalePrdWarning(directory, input.session_id);
+  if (stalePrdWarning) {
+    console.warn(stalePrdWarning);
+  }
+
   const metrics = recordSessionMetrics(directory, input);
   const payload = buildDurableSessionEndPayload(directory, input, metrics);
   const manifest = prepareCoreManifest(directory, input.session_id, payload);


### PR DESCRIPTION
Fixes #3669

## Problem

A Ralph PRD can diverge completely from reality with no detection and no warning: all four stories finished, merged, and were verified by content on trunk, while `prd.json` still records all four as `passes: false`. Nothing noticed, nothing blocked, nothing complained.

Root cause: Ralph's completion model is write-once — Step 5 (`passes: true` in prd.json) is the only place "done" gets recorded. When execution lands outside the loop (campaign branches + PRs + coordinator merges), or the session exits abnormally (crash, force-kill, cancel before `/oh-my-claudecode:cancel`, session end without Step 8), the PRD quietly stops tracking reality and stays stale with no surface.

## Hook map (where completion/session-end are decided)

| Moment | Where | Behavior |
|---|---|---|
| Step 5 (mark passes) | ralph agent edits `prd.json` | Only place completion is recorded; nothing re-derives from observable state (the gap) |
| Step 6 (all stories pass) | `src/hooks/persistent-mode/index.ts` → `getPrdCompletionStatus` | `allComplete` gates final verification |
| Step 7 (reviewer verification) | `src/hooks/ralph/verifier.ts` `startVerification` + critic approval | Approval clears verification state |
| Step 8 (`/oh-my-claudecode:cancel`) | `createRalphLoopHook.cancelLoop` → `clearRalphState` | Only clean exit |
| Session end | `src/hooks/session-end/index.ts` `processSessionEnd` → `cleanupModeStates` | Removes ralph state; the session-scoped PRD survives into the next session — how stale PRDs get resumed as if outstanding |

## Fix

New `src/hooks/ralph/stale-prd.ts` — bounded stale-state detection and reconciliation:

- **Detection** (never completion): abnormal/non-Step 8 exit (ralph loop state still active at session end), PRD age past the configured threshold, and stale pointers (PRD `branchName` merged into HEAD or gone).
- **Never infers completion from PR status alone**: branch/merge state is a warning signal only, never completion evidence.
- **Reconciliation** requires **configured observable evidence**: a story is marked `passes: true` ONLY when all its configured content checks pass (`fileExists` / `fileContains` / `gitGrep` at a ref — "verified by content on trunk"). Stories without configured checks are never auto-marked.
- **Preserves the audit trail**: every decision appends to `prd-reconciliation.jsonl` and is summarized in the story notes.
- **Bounded**: reconciled stories keep `architectVerified: false` and must still pass Step 7 reviewer verification before Step 8 — reconciliation repairs Step 5, it never bypasses the pipeline.
- **Explicit warning on abnormal/non-Step 8 exit**: `[STALE PRD WARNING]` surfaced at session end (before mode-state cleanup), at Ralph startup/resume, and in the continuation context when age/pointer signals apply.

## Tests

`src/__tests__/ralph-prd-stale.test.ts` (18 tests): all-false-but-landed evidence, partial reconciliation, stale pointers, normal Step 8 (no warning), cancel/crash, session isolation, legacy project-level schema (round-trip + migration), observable-check fail-closed behavior, startup integration, and warning formatting. Existing ralph suites (ralph-prd, ralph-prd-mandatory, bridge-routing, session-end, persistent-mode) all pass.

Coordinated conceptually with #3664 (criterion amendment) but kept as an independent branch/PR.

## Verification

- `tsc --noEmit` clean
- ralph suites: 91 tests green (18 new + 73 existing); bridge-routing 420 green; session-end/ralph/state-manager 120 green
- ESLint clean on all changed files
- `npm run plugin:shipping:verify` passes (new `stale-prd` dist artifacts flagged as awaiting release staging — no dist/bridge changes in this PR, per CI `check-no-committed-build-artifacts`)
- No release files touched (no CHANGELOG/version bumps)