### PR TITLE
fix(hooks): precise Skill-tool error when subagent_type names a bundled skill

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -127,6 +127,7 @@ Fires immediately before Claude uses a tool.
 | `pre-tool-enforcer.mjs` | Validates rules before tool use | 3s |
 
 Runs on all tool calls (`matcher: "*"`). Enforces agent permission restrictions (e.g., blocking Write/Edit for read-only agents).
+Denies Task/Agent calls whose `subagent_type` names a bundled skill (issue #3667): instead of Claude Code's generic native "Agent type not found", the hook returns a precise error naming the Skill tool and the correct identifier, and forbids closest-match agent substitution.
 
 ### PermissionRequest
 

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -217,58 +217,72 @@ function agentDefinitionExists(agentType, directory, namespaced) {
 }
 
 /**
- * Extract the primary `name` and full identifier set (name + aliases) from a
- * bundled SKILL.md YAML frontmatter block. Mirrors readAgentDefinitionModel's
- * frontmatter extraction: only the first `--- ... ---` block is inspected, so
- * `name:` lines in the skill body cannot create false matches.
+ * Extract the primary `name` and raw alias list from a bundled SKILL.md YAML
+ * frontmatter block. Mirrors readAgentDefinitionModel's frontmatter
+ * extraction: only the first `--- ... ---` block is inspected, so `name:`
+ * lines in the skill body cannot create false matches.
  */
 function parseSkillFrontmatterIdentifiers(content) {
   const fmMatch = content.match(/^---[\r\n]+([\s\S]*?)[\r\n]+---/);
-  if (!fmMatch) return { names: new Set(), primary: null };
+  if (!fmMatch) return { aliases: [], primary: null };
   const fm = fmMatch[1];
   const nameMatch = fm.match(/^name:\s*(\S+)/m);
   const primary = nameMatch ? nameMatch[1].trim().replace(/^["']|["']$/g, '') : null;
-  const names = new Set();
-  if (primary) names.add(primary.toLowerCase());
   const aliasMatch = fm.match(/^aliases:\s*(.+)$/m);
+  const aliases = [];
   if (aliasMatch) {
     const raw = aliasMatch[1].trim();
     const tokens = raw.startsWith('[')
       ? raw.slice(1, raw.indexOf(']') === -1 ? raw.length : raw.indexOf(']')).split(',')
       : [raw.split(/\s+/)[0]];
     for (const token of tokens) {
-      const clean = token.trim().replace(/^["']|["']$/g, '').toLowerCase();
-      if (clean) names.add(clean);
+      const clean = token.trim().replace(/^["']|["']$/g, '');
+      if (clean) aliases.push(clean);
     }
   }
-  return { names, primary };
+  return { aliases, primary };
 }
 
 /**
- * Resolve a Task/Agent subagent_type against the bundled skill registry.
- * Returns { primary } when the identifier names a bundled skill (exact match
- * only — no fuzzy/closest-match substitution), or null otherwise.
+ * Claude Code native command names that must not be shadowed by OMC skill
+ * short names. Mirrors src/features/builtin-skills/skills.ts:CC_NATIVE_COMMANDS
+ * and toSafeSkillName (plan -> omc-plan).
  */
-function resolveBundledSkill(subagentType, directory) {
-  const { name, namespaced } = splitAgentNamespace(subagentType);
-  if (!SKILL_IDENTIFIER_PATTERN.test(name)) return null;
-  // A real agent definition wins over a skill with the same name.
-  if (agentDefinitionExists(name, directory, namespaced)) return null;
-  // Fast path: the identifier names a skill directory directly.
-  for (const skillsDir of getPluginSkillsDirs()) {
-    const directPath = join(skillsDir, name, 'SKILL.md');
-    if (existsSync(directPath)) {
-      let primary = name;
-      try {
-        const parsed = parseSkillFrontmatterIdentifiers(readFileSync(directPath, 'utf-8'));
-        if (parsed.primary) primary = parsed.primary;
-      } catch {
-        // Keep the directory name when the file cannot be parsed.
-      }
-      return { primary };
-    }
-  }
-  // Full scan: matches alias names and renamed skill dirs (e.g. plan -> omc-plan).
+const CC_NATIVE_SKILL_COMMANDS = new Set([
+  'review',
+  'plan',
+  'security-review',
+  'init',
+  'doctor',
+  'help',
+  'config',
+  'clear',
+  'compact',
+  'memory',
+]);
+
+function toSafeSkillName(name) {
+  const normalized = name.trim();
+  return CC_NATIVE_SKILL_COMMANDS.has(normalized.toLowerCase()) ? `omc-${normalized}` : normalized;
+}
+
+let cachedCanonicalSkillRegistry = null;
+
+/**
+ * Build the canonical bundled-skill registry exactly like the runtime loader
+ * (src/features/builtin-skills/skills.ts loadSkillsFromDirectory +
+ * loadSkillFromFile):
+ * - `skillify` sorts first so it claims its deprecated alias `learner` before
+ *   the legacy skills/learner directory is seen;
+ * - primary names and aliases are normalized with toSafeSkillName;
+ * - the first claim of a name wins (seenNames dedup), so a directory whose
+ *   name is claimed as another skill's alias is not registered under its own
+ *   name.
+ * Returns Map<lowercaseName, primaryName>.
+ */
+function buildCanonicalSkillRegistry() {
+  if (cachedCanonicalSkillRegistry) return cachedCanonicalSkillRegistry;
+  const registry = new Map();
   for (const skillsDir of getPluginSkillsDirs()) {
     let entries = [];
     try {
@@ -276,6 +290,11 @@ function resolveBundledSkill(subagentType, directory) {
     } catch {
       continue;
     }
+    entries.sort((a, b) => {
+      if (a.name === 'skillify') return -1;
+      if (b.name === 'skillify') return 1;
+      return a.name.localeCompare(b.name);
+    });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const skillPath = join(skillsDir, entry.name, 'SKILL.md');
@@ -286,9 +305,52 @@ function resolveBundledSkill(subagentType, directory) {
       } catch {
         continue;
       }
-      if (parsed.names.has(name.toLowerCase())) {
-        return { primary: parsed.primary || entry.name };
+      const primary = toSafeSkillName(parsed.primary || entry.name);
+      const allNames = [primary, ...parsed.aliases.map(toSafeSkillName)];
+      for (const candidate of allNames) {
+        const key = candidate.toLowerCase();
+        if (registry.has(key)) continue;
+        registry.set(key, primary);
       }
+    }
+  }
+  cachedCanonicalSkillRegistry = registry;
+  return registry;
+}
+
+/**
+ * Resolve a Task/Agent subagent_type against the bundled skill registry.
+ * Returns { primary } when the identifier names a bundled skill (exact match
+ * only — no fuzzy/closest-match substitution), or null otherwise.
+ *
+ * Canonical registry precedence wins before any directory shortcut: a name
+ * claimed as a deprecated alias (e.g. `learner` owned by `skillify`) resolves
+ * to its canonical primary even when a directory with the same name exists
+ * (skills/learner). The directory shortcut only serves names that exist as
+ * skill directories but are not canonical claims (e.g. `plan` -> `omc-plan`).
+ */
+function resolveBundledSkill(subagentType, directory) {
+  const { name, namespaced } = splitAgentNamespace(subagentType);
+  if (!SKILL_IDENTIFIER_PATTERN.test(name)) return null;
+  // A real agent definition wins over a skill with the same name.
+  if (agentDefinitionExists(name, directory, namespaced)) return null;
+  // Canonical registry first: covers primaries and aliases (incl. collisions
+  // like learner -> skillify, cancel-ralph -> cancel).
+  const canonicalPrimary = buildCanonicalSkillRegistry().get(name.toLowerCase());
+  if (canonicalPrimary) return { primary: canonicalPrimary };
+  // Directory shortcut fallback only for names the canonical registry does not
+  // claim (e.g. the plan/ dir whose frontmatter registers as omc-plan).
+  for (const skillsDir of getPluginSkillsDirs()) {
+    const directPath = join(skillsDir, name, 'SKILL.md');
+    if (existsSync(directPath)) {
+      let primary = name;
+      try {
+        const parsed = parseSkillFrontmatterIdentifiers(readFileSync(directPath, 'utf-8'));
+        if (parsed.primary) primary = parsed.primary;
+      } catch {
+        // Keep the directory name when the file cannot be parsed.
+      }
+      return { primary: toSafeSkillName(primary) };
     }
   }
   return null;

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -309,10 +309,13 @@ function evaluateSkillAsAgentCall(toolName, toolInput, directory) {
   const skill = resolveBundledSkill(subagentType, directory);
   if (!skill) return null;
 
-  const { name, namespaced } = splitAgentNamespace(subagentType);
-  // Mirror the caller's namespace form, but always use the canonical OMC
-  // plugin namespace (`oh-my-claudecode:`) for the suggested identifier.
-  const skillIdentifier = namespaced ? `oh-my-claudecode:${skill.primary}` : skill.primary;
+  const { name } = splitAgentNamespace(subagentType);
+  // Always suggest the canonical plugin-namespaced identifier. A bare skill
+  // name can resolve to a different project/user skill or fail: bundled
+  // skills are exposed under the `oh-my-claudecode:` namespace (issue #3667
+  // review), so the recovery must be unambiguous regardless of the caller's
+  // input namespace form.
+  const skillIdentifier = `oh-my-claudecode:${skill.primary}`;
   const queriedName = name === skill.primary
     ? `"${subagentType}"`
     : `"${subagentType}" (alias of "${skill.primary}")`;

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -164,6 +164,173 @@ function readAgentDefinitionModel(subagentType) {
     return null;
   }
 }
+// ---------------------------------------------------------------------------
+// Skill vs agent namespace guard (issue #3667)
+//
+// Task/Agent subagent_type identifiers and bundled skills share the same
+// `oh-my-claudecode:` namespace, so a caller can hand a skill name to
+// Task(subagent_type=...) and receive only Claude Code's generic native
+// "Agent type not found". OMC owns both registries (agents/*.md and
+// skills/*/SKILL.md), so the PreToolUse hook denies the call BEFORE the
+// native boundary with an error that names the Skill tool and the exact
+// identifier, and forbids closest-match substitution.
+// ---------------------------------------------------------------------------
+
+const SKILL_AGENT_NAMESPACE_PREFIXES = ['oh-my-claudecode:', 'omc:'];
+const SKILL_IDENTIFIER_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function splitAgentNamespace(subagentType) {
+  for (const prefix of SKILL_AGENT_NAMESPACE_PREFIXES) {
+    if (subagentType.startsWith(prefix)) {
+      return { name: subagentType.slice(prefix.length), namespaced: true };
+    }
+  }
+  return { name: subagentType, namespaced: false };
+}
+
+function getPluginAgentDirs() {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const scriptAgentsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'agents');
+  return pluginRoot ? [join(pluginRoot, 'agents'), scriptAgentsDir] : [scriptAgentsDir];
+}
+
+function getPluginSkillsDirs() {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  const scriptSkillsDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'skills');
+  return pluginRoot ? [join(pluginRoot, 'skills'), scriptSkillsDir] : [scriptSkillsDir];
+}
+
+/**
+ * Whether an agent definition resolves for the given identifier.
+ * Namespaced identifiers (oh-my-claudecode:X / omc:X) resolve only against
+ * plugin agents; bare identifiers resolve through the full native chain
+ * (plugin, project .claude/agents, user config agents). A real agent always
+ * wins over a bundled skill with the same name (collision rule).
+ */
+function agentDefinitionExists(agentType, directory, namespaced) {
+  const agentDirs = getPluginAgentDirs();
+  if (!namespaced) {
+    agentDirs.push(join(directory, '.claude', 'agents'));
+    agentDirs.push(join(getClaudeConfigDir(), 'agents'));
+  }
+  return agentDirs.some((agentsDir) => existsSync(join(agentsDir, `${agentType}.md`)));
+}
+
+/**
+ * Extract the primary `name` and full identifier set (name + aliases) from a
+ * bundled SKILL.md YAML frontmatter block. Mirrors readAgentDefinitionModel's
+ * frontmatter extraction: only the first `--- ... ---` block is inspected, so
+ * `name:` lines in the skill body cannot create false matches.
+ */
+function parseSkillFrontmatterIdentifiers(content) {
+  const fmMatch = content.match(/^---[\r\n]+([\s\S]*?)[\r\n]+---/);
+  if (!fmMatch) return { names: new Set(), primary: null };
+  const fm = fmMatch[1];
+  const nameMatch = fm.match(/^name:\s*(\S+)/m);
+  const primary = nameMatch ? nameMatch[1].trim().replace(/^["']|["']$/g, '') : null;
+  const names = new Set();
+  if (primary) names.add(primary.toLowerCase());
+  const aliasMatch = fm.match(/^aliases:\s*(.+)$/m);
+  if (aliasMatch) {
+    const raw = aliasMatch[1].trim();
+    const tokens = raw.startsWith('[')
+      ? raw.slice(1, raw.indexOf(']') === -1 ? raw.length : raw.indexOf(']')).split(',')
+      : [raw.split(/\s+/)[0]];
+    for (const token of tokens) {
+      const clean = token.trim().replace(/^["']|["']$/g, '').toLowerCase();
+      if (clean) names.add(clean);
+    }
+  }
+  return { names, primary };
+}
+
+/**
+ * Resolve a Task/Agent subagent_type against the bundled skill registry.
+ * Returns { primary } when the identifier names a bundled skill (exact match
+ * only — no fuzzy/closest-match substitution), or null otherwise.
+ */
+function resolveBundledSkill(subagentType, directory) {
+  const { name, namespaced } = splitAgentNamespace(subagentType);
+  if (!SKILL_IDENTIFIER_PATTERN.test(name)) return null;
+  // A real agent definition wins over a skill with the same name.
+  if (agentDefinitionExists(name, directory, namespaced)) return null;
+  // Fast path: the identifier names a skill directory directly.
+  for (const skillsDir of getPluginSkillsDirs()) {
+    const directPath = join(skillsDir, name, 'SKILL.md');
+    if (existsSync(directPath)) {
+      let primary = name;
+      try {
+        const parsed = parseSkillFrontmatterIdentifiers(readFileSync(directPath, 'utf-8'));
+        if (parsed.primary) primary = parsed.primary;
+      } catch {
+        // Keep the directory name when the file cannot be parsed.
+      }
+      return { primary };
+    }
+  }
+  // Full scan: matches alias names and renamed skill dirs (e.g. plan -> omc-plan).
+  for (const skillsDir of getPluginSkillsDirs()) {
+    let entries = [];
+    try {
+      entries = readdirSync(skillsDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillPath = join(skillsDir, entry.name, 'SKILL.md');
+      if (!existsSync(skillPath)) continue;
+      let parsed;
+      try {
+        parsed = parseSkillFrontmatterIdentifiers(readFileSync(skillPath, 'utf-8'));
+      } catch {
+        continue;
+      }
+      if (parsed.names.has(name.toLowerCase())) {
+        return { primary: parsed.primary || entry.name };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Preflight contract for #3667: when a Task/Agent call names a bundled skill
+ * as its subagent_type, deny the call with a precise, non-substitutable error
+ * that names the Skill tool and the correct identifier.
+ */
+function evaluateSkillAsAgentCall(toolName, toolInput, directory) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const rawSubagentType = toolInput.subagent_type;
+  if (typeof rawSubagentType !== 'string') return null;
+  const subagentType = rawSubagentType.trim();
+  if (subagentType.length === 0) return null;
+
+  const skill = resolveBundledSkill(subagentType, directory);
+  if (!skill) return null;
+
+  const { name, namespaced } = splitAgentNamespace(subagentType);
+  // Mirror the caller's namespace form, but always use the canonical OMC
+  // plugin namespace (`oh-my-claudecode:`) for the suggested identifier.
+  const skillIdentifier = namespaced ? `oh-my-claudecode:${skill.primary}` : skill.primary;
+  const queriedName = name === skill.primary
+    ? `"${subagentType}"`
+    : `"${subagentType}" (alias of "${skill.primary}")`;
+  const reason =
+    `[SKILL vs AGENT] ${queriedName} is a Skill, not an agent. ` +
+    `Do NOT call it via ${toolName}(subagent_type=...) — that subagent type does not exist, ` +
+    `and Claude Code will fail the call with a generic "Agent type not found". ` +
+    `Use the Skill tool instead: Skill(skill="${skillIdentifier}"). ` +
+    `Do NOT substitute a similarly-named agent as a "closest match".`;
+  return {
+    continue: true,
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  };
+}
 
 
 const SLOP_RISK_TOOL_NAMES = new Set([
@@ -1435,6 +1602,14 @@ async function main() {
     //   DENY  no-model calls when the session model itself has [1m] — guide to OMC_SUBAGENT_MODEL
     if (toolName === 'Task' || toolName === 'Agent') {
       const toolInput = data.toolInput || data.tool_input || {};
+      // Skill vs agent namespace guard (issue #3667): deny BEFORE the native
+      // boundary when a bundled skill name is passed as subagent_type, with an
+      // error that names the Skill tool and the correct identifier.
+      const skillAgentDeny = evaluateSkillAsAgentCall(toolName, toolInput, directory);
+      if (skillAgentDeny) {
+        console.log(JSON.stringify(skillAgentDeny));
+        return;
+      }
       const toolModel = toolInput.model;
       if (isForceInheritEnabled()) {
         // Check both vars: if either carries [1m] the session model is unsafe for sub-agents.

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -180,8 +180,9 @@ const SKILL_AGENT_NAMESPACE_PREFIXES = ['oh-my-claudecode:', 'omc:'];
 const SKILL_IDENTIFIER_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 function splitAgentNamespace(subagentType) {
+  const folded = subagentType.toLowerCase();
   for (const prefix of SKILL_AGENT_NAMESPACE_PREFIXES) {
-    if (subagentType.startsWith(prefix)) {
+    if (folded.startsWith(prefix.toLowerCase())) {
       return { name: subagentType.slice(prefix.length), namespaced: true };
     }
   }
@@ -282,7 +283,9 @@ function isSkininthegamebrosUser() {
  * suggested as invocable, even when their directory exists on disk.
  */
 function isSkillVisibleToUser(skillName) {
-  return !SKININTHEGAMEBROS_ONLY_SKILLS.has(skillName) || isSkininthegamebrosUser();
+  // Case-fold before the Set lookup: identifiers are matched case-insensitively
+  // while filesystem lookup is case-insensitive on Windows/macOS.
+  return !SKININTHEGAMEBROS_ONLY_SKILLS.has(skillName.toLowerCase()) || isSkininthegamebrosUser();
 }
 
 let cachedCanonicalSkillRegistry = null;
@@ -353,21 +356,25 @@ function buildCanonicalSkillRegistry() {
 function resolveBundledSkill(subagentType, directory) {
   const { name, namespaced } = splitAgentNamespace(subagentType);
   if (!SKILL_IDENTIFIER_PATTERN.test(name)) return null;
+  // Case-fold once, before every check: registry, alias, visibility, and
+  // filesystem lookups must agree even on case-insensitive filesystems
+  // (Windows/macOS), where a case-variant identifier resolves the same dir.
+  const foldedName = name.toLowerCase();
   // A real agent definition wins over a skill with the same name.
-  if (agentDefinitionExists(name, directory, namespaced)) return null;
+  if (agentDefinitionExists(foldedName, directory, namespaced)) return null;
   // Canonical registry first: covers primaries and aliases (incl. collisions
   // like learner -> skillify, cancel-ralph -> cancel).
-  const canonicalPrimary = buildCanonicalSkillRegistry().get(name.toLowerCase());
+  const canonicalPrimary = buildCanonicalSkillRegistry().get(foldedName);
   if (canonicalPrimary) return { primary: canonicalPrimary };
   // Directory shortcut fallback only for names the canonical registry does not
   // claim (e.g. the plan/ dir whose frontmatter registers as omc-plan).
   // Fail closed: a directory that is hidden from this user must never be
   // suggested as an invocable bundled skill, even though it exists on disk.
-  if (!isSkillVisibleToUser(name)) return null;
+  if (!isSkillVisibleToUser(foldedName)) return null;
   for (const skillsDir of getPluginSkillsDirs()) {
-    const directPath = join(skillsDir, name, 'SKILL.md');
+    const directPath = join(skillsDir, foldedName, 'SKILL.md');
     if (existsSync(directPath)) {
-      let primary = name;
+      let primary = foldedName;
       try {
         const parsed = parseSkillFrontmatterIdentifiers(readFileSync(directPath, 'utf-8'));
         if (parsed.primary) primary = parsed.primary;
@@ -402,7 +409,8 @@ function evaluateSkillAsAgentCall(toolName, toolInput, directory) {
   // review), so the recovery must be unambiguous regardless of the caller's
   // input namespace form.
   const skillIdentifier = `oh-my-claudecode:${skill.primary}`;
-  const queriedName = name === skill.primary
+  const isPrimaryMatch = name.toLowerCase() === skill.primary.toLowerCase();
+  const queriedName = isPrimaryMatch
     ? `"${subagentType}"`
     : `"${subagentType}" (alias of "${skill.primary}")`;
   const reason =

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -265,6 +265,25 @@ function toSafeSkillName(name) {
   const normalized = name.trim();
   return CC_NATIVE_SKILL_COMMANDS.has(normalized.toLowerCase()) ? `omc-${normalized}` : normalized;
 }
+/**
+ * Skills exposed only to skininthegamebros users. Mirrors
+ * src/features/builtin-skills/skills.ts:SKININTHEGAMEBROS_ONLY_SKILLS: the
+ * runtime loader deliberately hides these directories from everyone else.
+ */
+const SKININTHEGAMEBROS_ONLY_SKILLS = new Set(['remember', 'verify', 'debug']);
+
+function isSkininthegamebrosUser() {
+  return process.env.USER_TYPE === 'ant';
+}
+
+/**
+ * Whether a bundled skill directory is visible to the current user, mirroring
+ * loadSkillsFromDirectory's entitlement filter. Hidden skills must never be
+ * suggested as invocable, even when their directory exists on disk.
+ */
+function isSkillVisibleToUser(skillName) {
+  return !SKININTHEGAMEBROS_ONLY_SKILLS.has(skillName) || isSkininthegamebrosUser();
+}
 
 let cachedCanonicalSkillRegistry = null;
 
@@ -297,6 +316,8 @@ function buildCanonicalSkillRegistry() {
     });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
+      // Entitlement filter: hidden skills are not registered for this user.
+      if (!isSkillVisibleToUser(entry.name)) continue;
       const skillPath = join(skillsDir, entry.name, 'SKILL.md');
       if (!existsSync(skillPath)) continue;
       let parsed;
@@ -340,6 +361,9 @@ function resolveBundledSkill(subagentType, directory) {
   if (canonicalPrimary) return { primary: canonicalPrimary };
   // Directory shortcut fallback only for names the canonical registry does not
   // claim (e.g. the plan/ dir whose frontmatter registers as omc-plan).
+  // Fail closed: a directory that is hidden from this user must never be
+  // suggested as an invocable bundled skill, even though it exists on disk.
+  if (!isSkillVisibleToUser(name)) return null;
   for (const skillsDir of getPluginSkillsDirs()) {
     const directPath = join(skillsDir, name, 'SKILL.md');
     if (existsSync(directPath)) {

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -350,8 +350,17 @@ function buildCanonicalSkillRegistry() {
  * Canonical registry precedence wins before any directory shortcut: a name
  * claimed as a deprecated alias (e.g. `learner` owned by `skillify`) resolves
  * to its canonical primary even when a directory with the same name exists
- * (skills/learner). The directory shortcut only serves names that exist as
- * skill directories but are not canonical claims (e.g. `plan` -> `omc-plan`).
+ * (skills/learner).
+ *
+ * Bare (un-namespaced) identifiers are denied ONLY on canonical registry
+ * claims. The directory shortcut would otherwise mistake legitimate runtime
+ * agents for skills: Claude Code's built-in `Plan` agent and session-defined
+ * agents are not visible to file-based plugin/project/user agent discovery,
+ * yet `skills/plan` exists (registering `omc-plan`). Bare names therefore
+ * never consult the directory shortcut; explicitly namespaced identifiers
+ * (`oh-my-claudecode:` / `omc:`) are pinned to the OMC plugin namespace and
+ * keep the full canonical + shortcut resolution (e.g. `oh-my-claudecode:plan`
+ * -> `omc-plan`).
  */
 function resolveBundledSkill(subagentType, directory) {
   const { name, namespaced } = splitAgentNamespace(subagentType);
@@ -366,6 +375,10 @@ function resolveBundledSkill(subagentType, directory) {
   // like learner -> skillify, cancel-ralph -> cancel).
   const canonicalPrimary = buildCanonicalSkillRegistry().get(foldedName);
   if (canonicalPrimary) return { primary: canonicalPrimary };
+  // Bare identifiers stop here: the directory shortcut is reserved for the
+  // pinned plugin namespace so native/session-defined agents (e.g. `Plan`)
+  // are never denied (issue #3667 P1).
+  if (!namespaced) return null;
   // Directory shortcut fallback only for names the canonical registry does not
   // claim (e.g. the plan/ dir whose frontmatter registers as omc-plan).
   // Fail closed: a directory that is hidden from this user must never be

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -113,8 +113,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 
 7.5 **Mandatory Deslop Pass** (runs unconditionally after Step 7 approval, unless `{{PROMPT}}` contains `--no-deslop`):
 
-- **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`.** Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
-- **ai-slop-cleaner is a SKILL, not an agent.** Do NOT call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")` — that subagent type does not exist and the call will fail with "Agent type not found". If you see that error, retry with the Skill tool — do NOT substitute a similarly-named agent like `code-simplifier` as a "closest match".
+- **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`** — it is a Skill, not an agent. If you mistakenly call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")`, OMC's PreToolUse hook denies the call with the correct Skill-tool identifier; do not substitute a similarly-named agent. Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
 - Keep the scope bounded to the Ralph changed-file set; do not broaden the cleanup pass to unrelated files.
 - If the reviewer approved the implementation but the deslop pass introduces follow-up edits, keep those edits inside the same changed-file scope before proceeding.
 
@@ -138,7 +137,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 - Skip architect consultation for simple feature additions, well-tested changes, or time-critical verification
 - Proceed with architect agent verification alone -- never block on unavailable tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
-- **Skill vs agent invocation**: `ai-slop-cleaner` is a skill, invoke via `Skill("ai-slop-cleaner")`. `architect`, `critic`, `executor` etc. are agents, invoke via `Task(subagent_type="oh-my-claudecode:<name>")`. If you ever get "Agent type ... not found" for an `oh-my-claudecode:<name>` identifier, the item is a skill — retry with the Skill tool. Do NOT substitute a similarly-named agent as a "closest match".
+- **Skill vs agent invocation**: skills (e.g. `ai-slop-cleaner`) are invoked via the Skill tool: `Skill("ai-slop-cleaner")`; agents (e.g. `architect`, `critic`, `executor`) via `Task(subagent_type="oh-my-claudecode:<name>")`. OMC's PreToolUse hook denies a Task/Agent call whose `subagent_type` names a bundled skill and returns the correct Skill-tool identifier — do not substitute a similarly-named agent as a "closest match".
   </Tool_Usage>
 
 <Examples>

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -113,7 +113,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 
 7.5 **Mandatory Deslop Pass** (runs unconditionally after Step 7 approval, unless `{{PROMPT}}` contains `--no-deslop`):
 
-- **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("ai-slop-cleaner")`** — it is a Skill, not an agent. If you mistakenly call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")`, OMC's PreToolUse hook denies the call with the correct Skill-tool identifier; do not substitute a similarly-named agent. Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
+- **Invoke the `ai-slop-cleaner` skill via the Skill tool: `Skill("oh-my-claudecode:ai-slop-cleaner")`** — it is a Skill, not an agent. If you mistakenly call it via `Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")`, OMC's PreToolUse hook denies the call with the correct Skill-tool identifier; do not substitute a similarly-named agent. Run in standard mode (not `--review`) on the files changed during the current Ralph session only.
 - Keep the scope bounded to the Ralph changed-file set; do not broaden the cleanup pass to unrelated files.
 - If the reviewer approved the implementation but the deslop pass introduces follow-up edits, keep those edits inside the same changed-file scope before proceeding.
 
@@ -137,7 +137,7 @@ By default, ralph operates in PRD mode. A scaffold `prd.json` is auto-generated 
 - Skip architect consultation for simple feature additions, well-tested changes, or time-critical verification
 - Proceed with architect agent verification alone -- never block on unavailable tools
 - Use `state_write` / `state_read` for ralph mode state persistence between iterations
-- **Skill vs agent invocation**: skills (e.g. `ai-slop-cleaner`) are invoked via the Skill tool: `Skill("ai-slop-cleaner")`; agents (e.g. `architect`, `critic`, `executor`) via `Task(subagent_type="oh-my-claudecode:<name>")`. OMC's PreToolUse hook denies a Task/Agent call whose `subagent_type` names a bundled skill and returns the correct Skill-tool identifier — do not substitute a similarly-named agent as a "closest match".
+- **Skill vs agent invocation**: skills (e.g. `ai-slop-cleaner`) are invoked via the Skill tool: `Skill("oh-my-claudecode:ai-slop-cleaner")`; agents (e.g. `architect`, `critic`, `executor`) via `Task(subagent_type="oh-my-claudecode:<name>")`. OMC's PreToolUse hook denies a Task/Agent call whose `subagent_type` names a bundled skill and returns the correct Skill-tool identifier — do not substitute a similarly-named agent as a "closest match".
   </Tool_Usage>
 
 <Examples>

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -285,6 +285,28 @@ describe('delegation-enforcer', () => {
         expect(visible!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
         expect(hidden!.message).not.toContain('Skill(skill=');
       });
+
+      it('case-folds identifiers before visibility and resolution (Windows/macOS semantics, issue #3667)', () => {
+        delete process.env.USER_TYPE;
+        clearSkillsCache();
+        const hiddenMixedCase = thrownFor('oh-my-claudecode:Remember');
+        expect(hiddenMixedCase!.message).not.toContain('Skill(skill=');
+
+        const visibleMixedCase = thrownFor('oh-my-claudecode:Plan');
+        expect(visibleMixedCase!.message).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+
+        const aliasMixedCase = thrownFor('oh-my-claudecode:LEARNER');
+        expect(aliasMixedCase!.message).toContain('Skill(skill="oh-my-claudecode:skillify")');
+      });
+
+      it('case-folds the namespace prefix and hidden skills for USER_TYPE=ant', () => {
+        process.env.USER_TYPE = 'ant';
+        clearSkillsCache();
+        const hiddenMixedCase = thrownFor('oh-my-claudecode:Remember');
+        expect(hiddenMixedCase!.message).toContain('Skill(skill="oh-my-claudecode:remember")');
+        const omcPrefix = thrownFor('OMC:ai-slop-cleaner');
+        expect(omcPrefix!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+      });
     });
 
     it('logs warning only when OMC_DEBUG=true', () => {

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -307,6 +307,55 @@ describe('delegation-enforcer', () => {
         const omcPrefix = thrownFor('OMC:ai-slop-cleaner');
         expect(omcPrefix!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
       });
+      it('preserves bare native identifiers (no Skill guidance for plan/general-purpose, issue #3667 P1)', () => {
+        delete process.env.USER_TYPE;
+        clearSkillsCache();
+        for (const bare of ['plan', 'Plan', 'general-purpose']) {
+          const thrown = thrownFor(bare);
+          expect(thrown).toBeDefined();
+          expect(thrown!.message).toContain('Unknown agent type');
+          expect(thrown!.message).not.toContain('Skill(skill=');
+        }
+      });
+
+      it('validates skill names even with an explicit model (issue #3667 P2)', () => {
+        delete process.env.USER_TYPE;
+        clearSkillsCache();
+        let thrown: Error | undefined;
+        try {
+          enforceModel({
+            description: 't',
+            prompt: 'p',
+            subagent_type: 'oh-my-claudecode:ai-slop-cleaner',
+            model: 'sonnet',
+          });
+        } catch (error) {
+          thrown = error as Error;
+        }
+        expect(thrown).toBeDefined();
+        expect(thrown!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+      });
+
+      it('validates skill names under force-inherit routing (issue #3667 P2)', () => {
+        delete process.env.USER_TYPE;
+        process.env.OMC_ROUTING_FORCE_INHERIT = 'true';
+        clearSkillsCache();
+        let thrown: Error | undefined;
+        try {
+          enforceModel({ description: 't', prompt: 'p', subagent_type: 'oh-my-claudecode:ai-slop-cleaner' });
+        } catch (error) {
+          thrown = error as Error;
+        }
+        expect(thrown).toBeDefined();
+        expect(thrown!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+        delete process.env.OMC_ROUTING_FORCE_INHERIT;
+      });
+
+      it('keeps valid agents passing validation with an explicit model', () => {
+        const result = enforceModel({ description: 't', prompt: 'p', subagent_type: 'executor', model: 'haiku' });
+        expect(result.modifiedInput.model).toBe('haiku');
+        expect(result.injected).toBe(false);
+      });
     });
 
     it('logs warning only when OMC_DEBUG=true', () => {

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -10,6 +10,7 @@ import {
   getModelForAgent,
   type AgentInput
 } from '../features/delegation-enforcer.js';
+import { clearSkillsCache } from '../features/builtin-skills/skills.js';
 import { resolveDelegation } from '../features/delegation-routing/resolver.js';
 
 describe('delegation-enforcer', () => {
@@ -226,6 +227,64 @@ describe('delegation-enforcer', () => {
 
       expect(thrown).toBeDefined();
       expect(thrown!.message).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+    });
+    describe('runtime-hidden skill visibility (USER_TYPE entitlement, issue #3667)', () => {
+      let savedUserType: string | undefined;
+
+      beforeEach(() => {
+        savedUserType = process.env.USER_TYPE;
+        clearSkillsCache();
+      });
+
+      afterEach(() => {
+        if (savedUserType === undefined) {
+          delete process.env.USER_TYPE;
+        } else {
+          process.env.USER_TYPE = savedUserType;
+        }
+        clearSkillsCache();
+      });
+
+      function thrownFor(subagentType: string): Error | undefined {
+        try {
+          enforceModel({ description: 't', prompt: 'p', subagent_type: subagentType });
+        } catch (error) {
+          return error as Error;
+        }
+        return undefined;
+      }
+
+      it.each(['remember', 'verify', 'debug'])(
+        'does NOT add Skill guidance for the runtime-hidden %s skill when USER_TYPE != ant',
+        (hiddenSkill) => {
+          delete process.env.USER_TYPE;
+          clearSkillsCache();
+          const thrown = thrownFor(`oh-my-claudecode:${hiddenSkill}`);
+          expect(thrown).toBeDefined();
+          expect(thrown!.message).toContain('Unknown agent type');
+          expect(thrown!.message).not.toContain('Skill(skill=');
+        },
+      );
+
+      it.each(['remember', 'verify', 'debug'])(
+        'adds Skill guidance for the %s skill when USER_TYPE=ant',
+        (hiddenSkill) => {
+          process.env.USER_TYPE = 'ant';
+          clearSkillsCache();
+          const thrown = thrownFor(`oh-my-claudecode:${hiddenSkill}`);
+          expect(thrown).toBeDefined();
+          expect(thrown!.message).toContain(`Skill(skill="oh-my-claudecode:${hiddenSkill}")`);
+        },
+      );
+
+      it('keeps guidance for visible skills while hidden ones stay unsuggested in the same process', () => {
+        delete process.env.USER_TYPE;
+        clearSkillsCache();
+        const visible = thrownFor('oh-my-claudecode:ai-slop-cleaner');
+        const hidden = thrownFor('oh-my-claudecode:remember');
+        expect(visible!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+        expect(hidden!.message).not.toContain('Skill(skill=');
+      });
     });
 
     it('logs warning only when OMC_DEBUG=true', () => {

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -149,6 +149,47 @@ describe('delegation-enforcer', () => {
 
       expect(() => enforceModel(input)).toThrow('Unknown agent type');
     });
+    it('throws error for a bundled skill name with Skill-tool guidance (issue #3667)', () => {
+      const input: AgentInput = {
+        description: 'Deslop changed files',
+        prompt: 'Run the cleaner',
+        subagent_type: 'oh-my-claudecode:ai-slop-cleaner'
+      };
+
+      let thrown: Error | undefined;
+      try {
+        enforceModel(input);
+      } catch (error) {
+        thrown = error as Error;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown!.message).toContain('Unknown agent type');
+      expect(thrown!.message).toContain('ai-slop-cleaner');
+      expect(thrown!.message).toContain('Skill');
+      expect(thrown!.message).toContain('Skill(skill="ai-slop-cleaner")');
+      expect(thrown!.message).toContain('do NOT substitute a similarly-named agent');
+    });
+
+    it('does not add Skill guidance for genuinely unknown agents (no closest-match substitution)', () => {
+      const input: AgentInput = {
+        description: 'Test task',
+        prompt: 'Do something',
+        subagent_type: 'oh-my-claudecode:ai-slop-cleanr'
+      };
+
+      let thrown: Error | undefined;
+      try {
+        enforceModel(input);
+      } catch (error) {
+        thrown = error as Error;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown!.message).toContain('Unknown agent type');
+      expect(thrown!.message).not.toContain('Skill');
+      expect(thrown!.message).not.toContain('closest match');
+    });
 
     it('logs warning only when OMC_DEBUG=true', () => {
       const input: AgentInput = {

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -190,6 +190,43 @@ describe('delegation-enforcer', () => {
       expect(thrown!.message).not.toContain('Skill');
       expect(thrown!.message).not.toContain('closest match');
     });
+    it('resolves the learner directory/canonical collision to skillify in the guidance (issue #3667)', () => {
+      const input: AgentInput = {
+        description: 'Learner task',
+        prompt: 'Run it',
+        subagent_type: 'oh-my-claudecode:learner'
+      };
+
+      let thrown: Error | undefined;
+      try {
+        enforceModel(input);
+      } catch (error) {
+        thrown = error as Error;
+      }
+
+      expect(thrown).toBeDefined();
+      // Canonical registry precedence: skillify owns the deprecated alias.
+      expect(thrown!.message).toContain('Skill(skill="oh-my-claudecode:skillify")');
+      expect(thrown!.message).not.toContain('Skill(skill="oh-my-claudecode:learner")');
+    });
+
+    it('resolves the dir-only plan name to omc-plan in the guidance (hook parity)', () => {
+      const input: AgentInput = {
+        description: 'Plan task',
+        prompt: 'Run it',
+        subagent_type: 'oh-my-claudecode:plan'
+      };
+
+      let thrown: Error | undefined;
+      try {
+        enforceModel(input);
+      } catch (error) {
+        thrown = error as Error;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown!.message).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+    });
 
     it('logs warning only when OMC_DEBUG=true', () => {
       const input: AgentInput = {

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -167,7 +167,7 @@ describe('delegation-enforcer', () => {
       expect(thrown!.message).toContain('Unknown agent type');
       expect(thrown!.message).toContain('ai-slop-cleaner');
       expect(thrown!.message).toContain('Skill');
-      expect(thrown!.message).toContain('Skill(skill="ai-slop-cleaner")');
+      expect(thrown!.message).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
       expect(thrown!.message).toContain('do NOT substitute a similarly-named agent');
     });
 

--- a/src/__tests__/delegation-enforcer.test.ts
+++ b/src/__tests__/delegation-enforcer.test.ts
@@ -546,6 +546,14 @@ describe('delegation-enforcer', () => {
     it('throws error for unknown agent', () => {
       expect(() => getModelForAgent('unknown')).toThrow('Unknown agent type');
     });
+
+    it('guides namespaced bundled skills to the canonical Skill invocation (issue #3667 P2)', () => {
+      for (const skillType of ['oh-my-claudecode:plan', 'omc:plan']) {
+        expect(() => getModelForAgent(skillType)).toThrow(
+          'Skill(skill="oh-my-claudecode:omc-plan")',
+        );
+      }
+    });
   });
 
   describe('deprecated alias routing', () => {

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2681,4 +2681,95 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
     expect(denyReason(visible)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
     expect((hidden.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
   });
+  describe('case-insensitive identifier folding (Windows/macOS semantics, issue #3667)', () => {
+    it('does NOT suggest a runtime-hidden skill when a case-variant identifier resolves its directory (case-insensitive-faithful harness)', () => {
+      // Simulate a case-insensitive filesystem: the plugin root holds the
+      // hidden skill at the case-variant path `skills/Remember/SKILL.md`,
+      // exactly as a case-insensitive fs would resolve `skills/remember`.
+      const pluginRoot = join(tempDir, 'ci-plugin');
+      mkdirSync(join(pluginRoot, 'skills', 'Remember'), { recursive: true });
+      writeFileSync(
+        join(pluginRoot, 'skills', 'Remember', 'SKILL.md'),
+        '---\nname: remember\n---\nhidden skill body\n',
+      );
+
+      const run = (subagentType: string, env: Record<string, string>) =>
+        runPreToolEnforcerWithEnv(
+          {
+            tool_name: 'Task',
+            cwd: tempDir,
+            session_id: 'session-3667-ci',
+            transcript_path: '',
+            toolInput: { subagent_type: subagentType, description: 'd', prompt: 'p' },
+          },
+          { CLAUDE_PLUGIN_ROOT: pluginRoot, USER_TYPE: '', ...env },
+        );
+
+      const nonAnt = run('oh-my-claudecode:Remember', {});
+      const nonAntLower = run('oh-my-claudecode:remember', {});
+      const ant = run('oh-my-claudecode:Remember', { USER_TYPE: 'ant' });
+
+      expect((nonAnt.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+      expect(JSON.stringify(nonAnt)).not.toContain('[SKILL vs AGENT]');
+      expect((nonAntLower.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+      // Canonical lowercase output spelling is preserved for the entitled user.
+      expect((ant.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+      expect(denyReason(ant)).toContain('Skill(skill="oh-my-claudecode:remember")');
+    });
+
+    it.each([
+      ['oh-my-claudecode:Plan', 'oh-my-claudecode:omc-plan'],
+      ['oh-my-claudecode:LEARNER', 'oh-my-claudecode:skillify'],
+      ['oh-my-claudecode:AI-Slop-Cleaner', 'oh-my-claudecode:ai-slop-cleaner'],
+      ['oh-my-claudecode:Cancel-Ralph', 'oh-my-claudecode:cancel'],
+      ['oh-my-claudecode:PSM', 'oh-my-claudecode:project-session-manager'],
+    ])('denies mixed-case %s with the canonical namespaced identifier %s', (input, expected) => {
+      const output = runTask(input, 'Task', {}, { USER_TYPE: '' });
+      const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+      expect(hookOutput.permissionDecision).toBe('deny');
+      expect(denyReason(output)).toContain(`Skill(skill="${expected}")`);
+    });
+
+    it.each(['Remember', 'VERIFY', 'Debug'])(
+      'does NOT suggest the mixed-case runtime-hidden %s skill for a non-ant user',
+      (hiddenSkill) => {
+        const output = runTask(`oh-my-claudecode:${hiddenSkill}`, 'Task', {}, { USER_TYPE: '' });
+        expect((output.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+        expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+      },
+    );
+
+    it('recognizes case-variant namespace aliases (OMC: / OH-MY-CLAUDECODE:)', () => {
+      const omcUpper = runTask('OMC:ai-slop-cleaner', 'Task', {}, { USER_TYPE: '' });
+      const fullUpper = runTask('OH-MY-CLAUDECODE:Remember', 'Task', {}, { USER_TYPE: '' });
+
+      expect((omcUpper.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+      expect(denyReason(omcUpper)).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+      // Hidden skill with a case-variant full namespace still fails closed.
+      expect((fullUpper.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+    });
+
+    it('applies case folding before explicit-model and force-inherit routing', () => {
+      const withModel = runTask('oh-my-claudecode:Plan', 'Task', { model: 'sonnet' }, { USER_TYPE: '' });
+      expect((withModel.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+      expect(denyReason(withModel)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+
+      const forceInheritVisible = runTask(
+        'oh-my-claudecode:Plan',
+        'Task',
+        {},
+        { USER_TYPE: '', OMC_ROUTING_FORCE_INHERIT: 'true' },
+      );
+      expect((forceInheritVisible.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+      expect(denyReason(forceInheritVisible)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+
+      const forceInheritHidden = runTask(
+        'oh-my-claudecode:Remember',
+        'Task',
+        {},
+        { USER_TYPE: '', OMC_ROUTING_FORCE_INHERIT: 'true' },
+      );
+      expect((forceInheritHidden.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+    });
+  });
 });

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2648,4 +2648,37 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
     expect(numeric.hookSpecificOutput as Record<string, unknown>).not.toHaveProperty('permissionDecision');
     expect(empty.hookSpecificOutput as Record<string, unknown>).not.toHaveProperty('permissionDecision');
   });
+  it.each(['remember', 'verify', 'debug'])(
+    'does NOT suggest the runtime-hidden %s skill for a non-skininthegamebros user (USER_TYPE != ant)',
+    (hiddenSkill) => {
+      const namespaced = runTask(`oh-my-claudecode:${hiddenSkill}`, 'Task', {}, { USER_TYPE: '' });
+      const bare = runTask(hiddenSkill, 'Task', {}, { USER_TYPE: '' });
+
+      for (const output of [namespaced, bare]) {
+        expect(output.continue).toBe(true);
+        expect((output.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+        expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+      }
+    },
+  );
+
+  it.each(['remember', 'verify', 'debug'])(
+    'denies the %s skill for a skininthegamebros user (USER_TYPE=ant)',
+    (hiddenSkill) => {
+      const output = runTask(`oh-my-claudecode:${hiddenSkill}`, 'Task', {}, { USER_TYPE: 'ant' });
+      const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+      expect(hookOutput.permissionDecision).toBe('deny');
+      expect(denyReason(output)).toContain(`Skill(skill="oh-my-claudecode:${hiddenSkill}")`);
+    },
+  );
+
+  it('still denies visible skills for a non-skininthegamebros user while hidden ones pass through', () => {
+    const visible = runTask('oh-my-claudecode:plan', 'Task', {}, { USER_TYPE: '' });
+    const hidden = runTask('oh-my-claudecode:remember', 'Task', {}, { USER_TYPE: '' });
+
+    expect((visible.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+    expect(denyReason(visible)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+    expect((hidden.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+  });
 });

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2772,4 +2772,48 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
       expect((forceInheritHidden.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
     });
   });
+  describe('native/session-defined bare agent boundary (issue #3667 P1)', () => {
+    it.each(['plan', 'Plan', 'general-purpose'])(
+      'does NOT deny the bare %s identifier (native Claude agents are not file-discoverable)',
+      (nativeAgent) => {
+        const output = runTask(nativeAgent, 'Task', {}, { USER_TYPE: '' });
+        expect((output.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+        expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+      },
+    );
+
+    it('denies the plugin-namespaced plan identifier while preserving bare plan', () => {
+      const namespaced = runTask('oh-my-claudecode:plan', 'Task', {}, { USER_TYPE: '' });
+      const omcAlias = runTask('omc:plan', 'Task', {}, { USER_TYPE: '' });
+      const bare = runTask('plan', 'Task', {}, { USER_TYPE: '' });
+
+      expect((namespaced.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+      expect(denyReason(namespaced)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+      expect((omcAlias.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+      expect(denyReason(omcAlias)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+      expect((bare.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+    });
+
+    it('still denies bare canonical-registry skill claims (omc-plan, learner, ai-slop-cleaner)', () => {
+      for (const [input, expected] of [
+        ['omc-plan', 'oh-my-claudecode:omc-plan'],
+        ['learner', 'oh-my-claudecode:skillify'],
+        ['ai-slop-cleaner', 'oh-my-claudecode:ai-slop-cleaner'],
+      ] as const) {
+        const output = runTask(input, 'Task', {}, { USER_TYPE: '' });
+        const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+        expect(hookOutput.permissionDecision).toBe('deny');
+        expect(denyReason(output)).toContain(`Skill(skill="${expected}")`);
+      }
+    });
+
+    it('keeps plugin/project agent collisions winning over skills for bare names', () => {
+      // Project agent named `wiki` (also a canonical skill claim) must win.
+      mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+      writeFileSync(join(tempDir, '.claude', 'agents', 'wiki.md'), '---\nname: wiki\n---\nagent body\n');
+      const output = runTask('wiki', 'Task', {}, { USER_TYPE: '' });
+      expect((output.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBeUndefined();
+      expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+    });
+  });
 });

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2540,6 +2540,31 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
     expect(denyReason(output)).toContain('omc-plan');
     expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
   });
+  it('resolves the learner directory/canonical collision to skillify (canonical precedence over directory shortcut)', () => {
+    // skills/learner/SKILL.md exists, but the canonical registry claims
+    // `learner` as a deprecated alias owned by skillify (skillify sorts first).
+    const namespaced = runTask('oh-my-claudecode:learner');
+    const bare = runTask('learner');
+    const owner = runTask('oh-my-claudecode:skillify');
+
+    for (const output of [namespaced, bare, owner]) {
+      const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+      expect(hookOutput.permissionDecision).toBe('deny');
+      expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:skillify")');
+    }
+    expect(denyReason(namespaced)).not.toContain('Skill(skill="oh-my-claudecode:learner")');
+    expect(denyReason(bare)).not.toContain('Skill(skill="oh-my-claudecode:learner")');
+  });
+
+  it('resolves the understanding-gate and psm alias claims to their canonical owners', () => {
+    const gate = runTask('oh-my-claudecode:understanding-gate');
+    const psm = runTask('oh-my-claudecode:psm');
+
+    expect((gate.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+    expect(denyReason(gate)).toContain('Skill(skill="oh-my-claudecode:merge-readiness")');
+    expect((psm.hookSpecificOutput as Record<string, unknown>).permissionDecision).toBe('deny');
+    expect(denyReason(psm)).toContain('Skill(skill="oh-my-claudecode:project-session-manager")');
+  });
 
   it('does NOT deny a real agent identifier (code-simplifier passes through)', () => {
     const output = runTask('oh-my-claudecode:code-simplifier');

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2488,12 +2488,15 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
     expect(hookOutput.permissionDecisionReason as string).not.toContain('code-simplifier');
   });
 
-  it('denies Agent call with a bare bundled skill identifier', () => {
+  it('denies Agent call with a bare bundled skill identifier and suggests the canonical namespaced identifier', () => {
     const output = runTask('ai-slop-cleaner', 'Agent');
     const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
 
     expect(hookOutput.permissionDecision).toBe('deny');
-    expect(denyReason(output)).toContain('Skill(skill="ai-slop-cleaner")');
+    // Recovery must be unambiguous: always the plugin-namespaced form, never a
+    // bare skill name that could resolve to a different project/user skill.
+    expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+    expect(denyReason(output)).not.toContain('Skill(skill="ai-slop-cleaner")');
   });
 
   it('recognizes the omc: namespace alias and suggests the canonical oh-my-claudecode: identifier', () => {
@@ -2611,7 +2614,7 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
     const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
 
     expect(hookOutput.permissionDecision).toBe('deny');
-    expect(denyReason(output)).toContain('Skill(skill="wiki")');
+    expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:wiki")');
   });
 
   it('does NOT deny non-string or empty subagent_type values', () => {

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2432,3 +2432,192 @@ describe('pre-tool-enforcer agents.<name>.model injection (issue #3242)', () => 
     expect(updatedModel(throttled)).toBe('sonnet');
   });
 });
+describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pre-tool-enforcer-skill-agent-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function runTask(
+    subagentType: unknown,
+    toolName = 'Task',
+    extraInput: Record<string, unknown> = {},
+    env: Record<string, string> = {},
+  ): Record<string, unknown> {
+    return runPreToolEnforcerWithEnv(
+      {
+        tool_name: toolName,
+        cwd: tempDir,
+        session_id: 'session-3667',
+        transcript_path: '',
+        toolInput: {
+          subagent_type: subagentType,
+          description: 'Some task',
+          prompt: 'Do something',
+          ...extraInput,
+        },
+      },
+      env,
+    );
+  }
+
+  function denyReason(output: Record<string, unknown>): string {
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+    return String(hookOutput.permissionDecisionReason ?? '');
+  }
+
+  it('denies Task call whose subagent_type names a bundled skill (oh-my-claudecode:ai-slop-cleaner)', () => {
+    const output = runTask('oh-my-claudecode:ai-slop-cleaner');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(hookOutput.permissionDecisionReason as string).toContain('[SKILL vs AGENT]');
+    expect(hookOutput.permissionDecisionReason as string).toContain('ai-slop-cleaner');
+    // Names the correct tool and identifier — no generic "Agent type not found".
+    expect(hookOutput.permissionDecisionReason as string).toContain(
+      'Skill(skill="oh-my-claudecode:ai-slop-cleaner")',
+    );
+    // Forbids closest-match substitution (code-simplifier is the attractive wrong answer).
+    expect(hookOutput.permissionDecisionReason as string).toContain('closest match');
+    expect(hookOutput.permissionDecisionReason as string).not.toContain('code-simplifier');
+  });
+
+  it('denies Agent call with a bare bundled skill identifier', () => {
+    const output = runTask('ai-slop-cleaner', 'Agent');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('Skill(skill="ai-slop-cleaner")');
+  });
+
+  it('recognizes the omc: namespace alias and suggests the canonical oh-my-claudecode: identifier', () => {
+    const output = runTask('omc:ai-slop-cleaner');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:ai-slop-cleaner")');
+  });
+
+  it('denies skill-as-agent even when an explicit model is present (guard precedes model routing)', () => {
+    const output = runTask('oh-my-claudecode:ai-slop-cleaner', 'Task', { model: 'sonnet' });
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('[SKILL vs AGENT]');
+  });
+
+  it('denies skill-as-agent even under force-inherit routing', () => {
+    const output = runTask('oh-my-claudecode:ai-slop-cleaner', 'Task', {}, { OMC_ROUTING_FORCE_INHERIT: 'true' });
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('[SKILL vs AGENT]');
+  });
+
+  it('maps a skill alias to its primary name in the Skill-tool identifier', () => {
+    const output = runTask('oh-my-claudecode:cancel-ralph');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('alias of "cancel"');
+    expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:cancel")');
+  });
+
+  it('recognizes the renamed plan skill dir through its registered name omc-plan', () => {
+    const output = runTask('oh-my-claudecode:plan');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('omc-plan');
+    expect(denyReason(output)).toContain('Skill(skill="oh-my-claudecode:omc-plan")');
+  });
+
+  it('does NOT deny a real agent identifier (code-simplifier passes through)', () => {
+    const output = runTask('oh-my-claudecode:code-simplifier');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+  });
+
+  it('does NOT deny a genuinely unknown agent identifier', () => {
+    const output = runTask('oh-my-claudecode:nonexistent-agent-xyz');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+  });
+
+  it('does NOT fuzzy-match a typo to a skill (no unsafe closest-match substitution)', () => {
+    const output = runTask('oh-my-claudecode:ai-slop-cleanr');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+  });
+
+  it('lets a plugin agent with the same name as a skill win the collision (namespaced call)', () => {
+    const pluginRoot = join(tempDir, 'plugin');
+    mkdirSync(join(pluginRoot, 'agents'), { recursive: true });
+    mkdirSync(join(pluginRoot, 'skills', 'wiki'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'agents', 'wiki.md'), '---\nname: wiki\n---\nagent body\n');
+    writeFileSync(join(pluginRoot, 'skills', 'wiki', 'SKILL.md'), '---\nname: wiki\n---\nskill body\n');
+
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Task',
+        cwd: tempDir,
+        session_id: 'session-3667-collision',
+        transcript_path: '',
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:wiki',
+          description: 'Some task',
+          prompt: 'Do something',
+        },
+      },
+      { CLAUDE_PLUGIN_ROOT: pluginRoot },
+    );
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+  });
+
+  it('lets a project agent with the same name as a skill win the collision (bare call)', () => {
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'agents', 'wiki.md'), '---\nname: wiki\n---\nagent body\n');
+
+    const output = runTask('wiki');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(output.continue).toBe(true);
+    expect(hookOutput.permissionDecision).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('[SKILL vs AGENT]');
+  });
+
+  it('denies a bare bundled skill name when no agent definition resolves it anywhere', () => {
+    // tempDir has no .claude/agents and no user-config agents; wiki resolves only as a skill.
+    const output = runTask('wiki');
+    const hookOutput = output.hookSpecificOutput as Record<string, unknown>;
+
+    expect(hookOutput.permissionDecision).toBe('deny');
+    expect(denyReason(output)).toContain('Skill(skill="wiki")');
+  });
+
+  it('does NOT deny non-string or empty subagent_type values', () => {
+    const numeric = runTask(42 as unknown as string);
+    const empty = runTask('   ');
+    expect(numeric.hookSpecificOutput as Record<string, unknown>).not.toHaveProperty('permissionDecision');
+    expect(empty.hookSpecificOutput as Record<string, unknown>).not.toHaveProperty('permissionDecision');
+  });
+});

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -171,7 +171,9 @@ const SKININTHEGAMEBROS_ONLY_SKILLS = new Set(['remember', 'verify', 'debug']);
  * suggested as invocable, even when their directory exists on disk.
  */
 function isSkillVisibleToUser(skillName: string): boolean {
-  return !SKININTHEGAMEBROS_ONLY_SKILLS.has(skillName) || isSkininthegamebrosUser();
+  // Case-fold before the Set lookup: identifiers are matched case-insensitively
+  // while filesystem lookup is case-insensitive on Windows/macOS.
+  return !SKININTHEGAMEBROS_ONLY_SKILLS.has(skillName.toLowerCase()) || isSkininthegamebrosUser();
 }
 
 /**
@@ -186,19 +188,29 @@ function isSkillVisibleToUser(skillName: string): boolean {
  * Exact match only — no fuzzy substitution.
  */
 function resolveBundledSkillPrimary(agentType: string): string | null {
+  // Strip the OMC namespace aliases case-insensitively, then case-fold once
+  // before every check: registry, alias, visibility, and filesystem lookups
+  // must agree even on case-insensitive filesystems (Windows/macOS), where a
+  // case-variant identifier resolves the same directory.
+  const foldedInput = agentType.toLowerCase();
+  const stripped = foldedInput.startsWith('oh-my-claudecode:')
+    ? foldedInput.slice('oh-my-claudecode:'.length)
+    : foldedInput.startsWith('omc:')
+      ? foldedInput.slice('omc:'.length)
+      : foldedInput;
   const skills = createBuiltinSkills();
-  const match = skills.find((s) => s.name.toLowerCase() === agentType.toLowerCase());
+  const match = skills.find((s) => s.name.toLowerCase() === stripped);
   if (match) {
     return match.aliasOf ?? match.name;
   }
   // Fail closed before the directory shortcut: a hidden skill directory must
   // never be recommended as an invocable bundled skill.
-  if (!isSkillVisibleToUser(agentType)) {
+  if (!isSkillVisibleToUser(stripped)) {
     return null;
   }
   // Directory shortcut parity with the hook: names that exist as skill
   // directories but are not canonical claims (e.g. plan -> omc-plan).
-  const directPath = join(getSkillsDir(), agentType, 'SKILL.md');
+  const directPath = join(getSkillsDir(), stripped, 'SKILL.md');
   if (!existsSync(directPath)) {
     return null;
   }
@@ -214,7 +226,7 @@ function resolveBundledSkillPrimary(agentType: string): string | null {
   } catch {
     // Fall through to the directory name.
   }
-  return agentType;
+  return stripped;
 }
 
 /**

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -407,7 +407,7 @@ export function getModelForAgent(agentType: string): string {
   const agentDef = agentDefs[normalizedType];
 
   if (!agentDef) {
-    const hint = skillInvocationHint(normalizedType);
+    const hint = skillInvocationHint(normalizedType, agentType);
     throw new Error(hint ? `Unknown agent type: ${normalizedType} —${hint}.` : `Unknown agent type: ${normalizedType}`);
   }
 

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -13,11 +13,13 @@
  * Claude-specific tier names (sonnet/opus/haiku) that the provider won't recognize.
  */
 
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { getAgentDefinitions } from '../agents/definitions.js';
 import { normalizeDelegationRole } from './delegation-routing/types.js';
 import { loadConfig } from '../config/loader.js';
 import { isProviderSpecificModelId, resolveClaudeFamily } from '../config/models.js';
-import { createBuiltinSkills } from './builtin-skills/index.js';
+import { createBuiltinSkills, getSkillsDir } from './builtin-skills/skills.js';
 import type { PluginConfig } from '../shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -149,13 +151,47 @@ function canonicalizeSubagentType(subagentType: string): string {
  * Exact match only — no fuzzy substitution.
  */
 function skillInvocationHint(agentType: string): string | null {
-  const skills = createBuiltinSkills();
-  const match = skills.find((s) => s.name.toLowerCase() === agentType.toLowerCase());
-  if (!match) {
+  const primary = resolveBundledSkillPrimary(agentType);
+  if (!primary) {
     return null;
   }
-  const primary = match.aliasOf ?? match.name;
   return ` "${agentType}" is a bundled Skill, not an agent — invoke it with the Skill tool (Skill(skill="oh-my-claudecode:${primary}")) instead of Task/Agent subagent_type, and do NOT substitute a similarly-named agent`;
+}
+
+/**
+ * Resolve the canonical primary name for a bundled-skill identifier, mirroring
+ * the PreToolUse hook's resolution order (issue #3667): canonical registry
+ * precedence wins before any directory shortcut. `learner` therefore resolves
+ * to its canonical owner `skillify` (deprecated alias claimed before the
+ * legacy skills/learner directory), while dir-only names such as `plan` fall
+ * back to their registered name (`omc-plan`). Exact match only — no fuzzy
+ * substitution.
+ */
+function resolveBundledSkillPrimary(agentType: string): string | null {
+  const skills = createBuiltinSkills();
+  const match = skills.find((s) => s.name.toLowerCase() === agentType.toLowerCase());
+  if (match) {
+    return match.aliasOf ?? match.name;
+  }
+  // Directory shortcut parity with the hook: names that exist as skill
+  // directories but are not canonical claims (e.g. plan -> omc-plan).
+  const directPath = join(getSkillsDir(), agentType, 'SKILL.md');
+  if (!existsSync(directPath)) {
+    return null;
+  }
+  try {
+    const content = readFileSync(directPath, 'utf-8').replace(/^\uFEFF/, '');
+    const fmMatch = content.match(/^---[\r\n]+([\s\S]*?)[\r\n]+---/);
+    if (fmMatch) {
+      const nameMatch = fmMatch[1].match(/^name:\s*(\S+)/m);
+      if (nameMatch) {
+        return nameMatch[1].trim().replace(/^["']|["']$/g, '');
+      }
+    }
+  } catch {
+    // Fall through to the directory name.
+  }
+  return agentType;
 }
 
 /**

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -20,6 +20,7 @@ import { normalizeDelegationRole } from './delegation-routing/types.js';
 import { loadConfig } from '../config/loader.js';
 import { isProviderSpecificModelId, resolveClaudeFamily } from '../config/models.js';
 import { createBuiltinSkills, getSkillsDir } from './builtin-skills/skills.js';
+import { isSkininthegamebrosUser } from '../utils/skininthegamebros-user.js';
 import type { PluginConfig } from '../shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -159,19 +160,41 @@ function skillInvocationHint(agentType: string): string | null {
 }
 
 /**
+ * Skills exposed only to skininthegamebros users. Mirrors
+ * src/features/builtin-skills/skills.ts:SKININTHEGAMEBROS_ONLY_SKILLS.
+ */
+const SKININTHEGAMEBROS_ONLY_SKILLS = new Set(['remember', 'verify', 'debug']);
+
+/**
+ * Whether a bundled skill directory is visible to the current user, mirroring
+ * loadSkillsFromDirectory's entitlement filter. Hidden skills must never be
+ * suggested as invocable, even when their directory exists on disk.
+ */
+function isSkillVisibleToUser(skillName: string): boolean {
+  return !SKININTHEGAMEBROS_ONLY_SKILLS.has(skillName) || isSkininthegamebrosUser();
+}
+
+/**
  * Resolve the canonical primary name for a bundled-skill identifier, mirroring
  * the PreToolUse hook's resolution order (issue #3667): canonical registry
  * precedence wins before any directory shortcut. `learner` therefore resolves
  * to its canonical owner `skillify` (deprecated alias claimed before the
  * legacy skills/learner directory), while dir-only names such as `plan` fall
- * back to their registered name (`omc-plan`). Exact match only — no fuzzy
- * substitution.
+ * back to their registered name (`omc-plan`). The same visibility/entitlement
+ * filter as the runtime loader applies, failing closed for runtime-hidden
+ * skills (`remember`, `verify`, `debug` for non-skininthegamebros users).
+ * Exact match only — no fuzzy substitution.
  */
 function resolveBundledSkillPrimary(agentType: string): string | null {
   const skills = createBuiltinSkills();
   const match = skills.find((s) => s.name.toLowerCase() === agentType.toLowerCase());
   if (match) {
     return match.aliasOf ?? match.name;
+  }
+  // Fail closed before the directory shortcut: a hidden skill directory must
+  // never be recommended as an invocable bundled skill.
+  if (!isSkillVisibleToUser(agentType)) {
+    return null;
   }
   // Directory shortcut parity with the hook: names that exist as skill
   // directories but are not canonical claims (e.g. plan -> omc-plan).

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -17,6 +17,7 @@ import { getAgentDefinitions } from '../agents/definitions.js';
 import { normalizeDelegationRole } from './delegation-routing/types.js';
 import { loadConfig } from '../config/loader.js';
 import { isProviderSpecificModelId, resolveClaudeFamily } from '../config/models.js';
+import { createBuiltinSkills } from './builtin-skills/index.js';
 import type { PluginConfig } from '../shared/types.js';
 
 // ---------------------------------------------------------------------------
@@ -137,6 +138,25 @@ function canonicalizeSubagentType(subagentType: string): string {
   const canonicalAgentType = normalizeDelegationRole(rawAgentType);
   return hasPrefix ? `oh-my-claudecode:${canonicalAgentType}` : canonicalAgentType;
 }
+/**
+ * Bundled-skill guidance for an unknown agent identifier (issue #3667).
+ *
+ * Task/Agent subagent_type identifiers and bundled skills share the
+ * `oh-my-claudecode:` namespace. When an identifier resolves to a bundled
+ * skill rather than an agent, the error names the Skill tool and the correct
+ * identifier instead of a generic "Unknown agent type", so the caller cannot
+ * mistake the failure for a typo and substitute a closest-match agent.
+ * Exact match only — no fuzzy substitution.
+ */
+function skillInvocationHint(agentType: string): string | null {
+  const skills = createBuiltinSkills();
+  const match = skills.find((s) => s.name.toLowerCase() === agentType.toLowerCase());
+  if (!match) {
+    return null;
+  }
+  const primary = match.aliasOf ?? match.name;
+  return ` "${agentType}" is a bundled Skill, not an agent — invoke it with the Skill tool (Skill(skill="${primary}")) instead of Task/Agent subagent_type, and do NOT substitute a similarly-named agent`;
+}
 
 /**
  * Enforce model parameter for an agent delegation call
@@ -183,7 +203,12 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
   const agentDef = agentDefs[agentType];
 
   if (!agentDef) {
-    throw new Error(`Unknown agent type: ${agentType} (from ${agentInput.subagent_type})`);
+    const hint = skillInvocationHint(agentType);
+    throw new Error(
+      hint
+        ? `Unknown agent type: ${agentType} (from ${agentInput.subagent_type}) —${hint}.`
+        : `Unknown agent type: ${agentType} (from ${agentInput.subagent_type})`,
+    );
   }
 
   if (!agentDef.model) {
@@ -297,7 +322,8 @@ export function getModelForAgent(agentType: string): string {
   const agentDef = agentDefs[normalizedType];
 
   if (!agentDef) {
-    throw new Error(`Unknown agent type: ${normalizedType}`);
+    const hint = skillInvocationHint(normalizedType);
+    throw new Error(hint ? `Unknown agent type: ${normalizedType} —${hint}.` : `Unknown agent type: ${normalizedType}`);
   }
 
   if (!agentDef.model) {

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -151,8 +151,8 @@ function canonicalizeSubagentType(subagentType: string): string {
  * mistake the failure for a typo and substitute a closest-match agent.
  * Exact match only — no fuzzy substitution.
  */
-function skillInvocationHint(agentType: string): string | null {
-  const primary = resolveBundledSkillPrimary(agentType);
+function skillInvocationHint(agentType: string, originalSubagentType?: string): string | null {
+  const primary = resolveBundledSkillPrimary(agentType, originalSubagentType);
   if (!primary) {
     return null;
   }
@@ -187,7 +187,10 @@ function isSkillVisibleToUser(skillName: string): boolean {
  * skills (`remember`, `verify`, `debug` for non-skininthegamebros users).
  * Exact match only — no fuzzy substitution.
  */
-function resolveBundledSkillPrimary(agentType: string): string | null {
+function resolveBundledSkillPrimary(
+  agentType: string,
+  originalSubagentType?: string,
+): string | null {
   // Strip the OMC namespace aliases case-insensitively, then case-fold once
   // before every check: registry, alias, visibility, and filesystem lookups
   // must agree even on case-insensitive filesystems (Windows/macOS), where a
@@ -202,6 +205,15 @@ function resolveBundledSkillPrimary(agentType: string): string | null {
   const match = skills.find((s) => s.name.toLowerCase() === stripped);
   if (match) {
     return match.aliasOf ?? match.name;
+  }
+  // Bare (un-namespaced) identifiers stop here: the directory shortcut is
+  // reserved for the pinned plugin namespace so native/session-defined agents
+  // (e.g. Claude Code's built-in `Plan` vs the skills/plan dir registering
+  // omc-plan) are never mistaken for skills (issue #3667 P1, JS/TS parity).
+  const wasNamespaced = typeof originalSubagentType === 'string'
+    && /^(?:oh-my-claudecode|omc):/i.test(originalSubagentType.trim());
+  if (!wasNamespaced) {
+    return null;
   }
   // Fail closed before the directory shortcut: a hidden skill directory must
   // never be recommended as an invocable bundled skill.
@@ -241,10 +253,25 @@ function resolveBundledSkillPrimary(agentType: string): string | null {
  */
 export function enforceModel(agentInput: AgentInput): EnforcementResult {
   const canonicalSubagentType = canonicalizeSubagentType(agentInput.subagent_type);
+  const agentType = canonicalSubagentType.replace(/^oh-my-claudecode:/, '');
+
+  // Validate the agent BEFORE any routing early-return so the unknown-agent
+  // error and Skill-tool guidance fire even when an explicit model or
+  // forceInherit would otherwise short-circuit (issue #3667 P2).
+  const config = getCachedConfig();
+  const agentDefs = getAgentDefinitions({ config });
+  const agentDef = agentDefs[agentType];
+  if (!agentDef) {
+    const hint = skillInvocationHint(agentType, agentInput.subagent_type);
+    throw new Error(
+      hint
+        ? `Unknown agent type: ${agentType} (from ${agentInput.subagent_type}) —${hint}.`
+        : `Unknown agent type: ${agentType} (from ${agentInput.subagent_type})`,
+    );
+  }
 
   // If forceInherit is enabled, skip model injection entirely so agents
   // inherit the user's Claude Code model setting (issue #1135)
-  const config = getCachedConfig();
   if (config.routing?.forceInherit) {
     const { model: _existing, ...rest } = agentInput;
     const cleanedInput: AgentInput = { ...(rest as AgentInput), subagent_type: canonicalSubagentType };
@@ -267,19 +294,6 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
       injected: false,
       model: normalizedModel,
     };
-  }
-
-  const agentType = canonicalSubagentType.replace(/^oh-my-claudecode:/, '');
-  const agentDefs = getAgentDefinitions({ config });
-  const agentDef = agentDefs[agentType];
-
-  if (!agentDef) {
-    const hint = skillInvocationHint(agentType);
-    throw new Error(
-      hint
-        ? `Unknown agent type: ${agentType} (from ${agentInput.subagent_type}) —${hint}.`
-        : `Unknown agent type: ${agentType} (from ${agentInput.subagent_type})`,
-    );
   }
 
   if (!agentDef.model) {

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -155,7 +155,7 @@ function skillInvocationHint(agentType: string): string | null {
     return null;
   }
   const primary = match.aliasOf ?? match.name;
-  return ` "${agentType}" is a bundled Skill, not an agent — invoke it with the Skill tool (Skill(skill="${primary}")) instead of Task/Agent subagent_type, and do NOT substitute a similarly-named agent`;
+  return ` "${agentType}" is a bundled Skill, not an agent — invoke it with the Skill tool (Skill(skill="oh-my-claudecode:${primary}")) instead of Task/Agent subagent_type, and do NOT substitute a similarly-named agent`;
 }
 
 /**


### PR DESCRIPTION
Fixes #3667

## Problem

`Task(subagent_type="oh-my-claudecode:ai-slop-cleaner")` fails only at the native Claude Code boundary with a generic "Agent type not found". OMC owns both registries (`agents/*.md` and bundled `skills/*/SKILL.md`) and intercepts every Task/Agent call in the PreToolUse hook, so the failure was silent and recoverable-by-substitution — exactly the design smell #3667 reports.

## Reproduction (before)

```
{"continue":true,"hookSpecificOutput":{"additionalContext":"Spawning agent: oh-my-claudecode:ai-slop-cleaner (inherit) | ..."}}
```

The call passes straight through; native CC then fails with the generic error and the model may substitute `code-simplifier` as a "closest match".

## Fix

`scripts/pre-tool-enforcer.mjs` now denies the call BEFORE the native boundary with a precise, non-substitutable error naming the Skill tool and the correct identifier:

```
[SKILL vs AGENT] "oh-my-claudecode:ai-slop-cleaner" is a Skill, not an agent. Do NOT call it via Task(subagent_type=...) — that subagent type does not exist ... Use the Skill tool instead: Skill(skill="oh-my-claudecode:ai-slop-cleaner"). Do NOT substitute a similarly-named agent as a "closest match".
```

Contract coverage (deterministic tests in `pre-tool-enforcer.test.ts`):
- bundled skill name as `subagent_type` (namespaced, bare, `omc:` alias) → denied
- genuine unknown agent → passes through to native CC
- real agent (`code-simplifier`) → passes through
- skill/agent name collision (plugin agent, project agent) → agent wins
- typo (`ai-slop-cleanr`) → NOT fuzzy-matched → passes through (no unsafe closest-match substitution)
- alias name (`cancel-ralph`) → denied naming primary (`cancel`); renamed dir (`plan` → `omc-plan`) handled
- deny fires even with explicit `model` and under force-inherit routing

`src/features/delegation-enforcer.ts` (TS mirror of the "Unknown agent type" error) reports the same Skill-tool guidance. `skills/ralph/SKILL.md` Step 7.5 and `<Tool_Usage>` shrink to one line each, as the issue requested.

## Boundary / limitation

This is the closest OMC-controlled preflight contract: Claude Code's hook protocol cannot rewrite the native Task error, but OMC intercepts the call first and denies with precise guidance via `permissionDecision: "deny"`. No release files touched; no `dist/`/`bridge/` build artifacts committed.

## Verification

- `pre-tool-enforcer.test.ts`: 120 passed (14 new)
- `delegation-enforcer.test.ts`: 44 passed (2 new)
- routing/integration suites: 99 passed, 7 skipped
- `tsc --noEmit` clean; `eslint` clean on changed files
- full `npm test -- --run`: only pre-existing/flaky failures in unrelated areas (reproduced on clean tree: post-tool-verifier background detection, session-end process-exit timing, python sandbox, state smoke isolation)