### PR TITLE
fix(agents): make unnamed background agents addressable and discoverable (#3665)

### DIFF
--- a/src/__tests__/hud-agents.test.ts
+++ b/src/__tests__/hud-agents.test.ts
@@ -230,12 +230,15 @@ describe('Agents Element', () => {
       const agentsWithDesc: ActiveAgent[] = [
         {
           ...createAgent('oh-my-claudecode:architect', 'opus'),
+          id: 'ae1e2be26cb41fc74',
           description: 'Analyzing code',
         },
       ];
       const result = renderAgentsByFormat(agentsWithDesc, 'descriptions');
       expect(result).toContain('A');
-      expect(result).toContain('Analyzing code');
+      expect(result).toContain('Anal');
+      // Unnamed agents get the short id appended so the row is discoverable (#3665).
+      expect(result).toContain('(ae1e2be)');
     });
 
     it('should render named teammates distinctly from anonymous subagents', () => {
@@ -256,12 +259,15 @@ describe('Agents Element', () => {
       const agentsWithDesc: ActiveAgent[] = [
         {
           ...createAgent('oh-my-claudecode:architect', 'opus'),
+          id: 'ae1e2be26cb41fc74',
           description: 'Analyzing code',
         },
       ];
       const result = renderAgentsByFormat(agentsWithDesc, 'tasks');
       expect(result).toContain('[');
-      expect(result).toContain('Analyzing code');
+      expect(result).toContain('Anal');
+      // Unnamed agents get the short id appended so the row is discoverable (#3665).
+      expect(result).toContain('(ae1e2be)');
       expect(result).not.toContain('A:'); // tasks format doesn't show codes
     });
 
@@ -487,6 +493,35 @@ describe('Agents Element', () => {
       const result = renderAgentsMultiLine(agents);
       expect(result.detailLines).toHaveLength(1);
       expect(result.detailLines[0]).toContain('...');
+    });
+    it('should append the short id for unnamed agents so the row is addressable (#3665)', () => {
+      const agents: ActiveAgent[] = [
+        {
+          ...createAgent('oh-my-claudecode:architect', 'opus'),
+          id: 'ae1e2be26cb41fc74',
+          description: 'S2 nspin4 A/B vehicle',
+        },
+      ];
+      const result = renderAgentsMultiLine(agents);
+      expect(result.detailLines).toHaveLength(1);
+      expect(result.detailLines[0]).toContain('S2 nspin4 A/B vehicle');
+      expect(result.detailLines[0]).toContain('(ae1e2be)');
+    });
+
+    it('should not add an id suffix to explicitly named agents (#3665 backward compat)', () => {
+      const agents: ActiveAgent[] = [
+        {
+          ...createAgent('oh-my-claudecode:executor', 'sonnet'),
+          id: 'ae1e2be26cb41fc74',
+          name: 'worker-1',
+          description: 'implementing teammate task',
+        },
+      ];
+      const result = renderAgentsMultiLine(agents);
+      expect(result.detailLines).toHaveLength(1);
+      expect(result.detailLines[0]).toContain('tm:worker-1');
+      expect(result.detailLines[0]).toContain('implementing teammate task');
+      expect(result.detailLines[0]).not.toContain('(ae1e2be)');
     });
 
     it('should route to multiline from renderAgentsByFormat', () => {

--- a/src/features/agent-addressability/__tests__/addressability.test.ts
+++ b/src/features/agent-addressability/__tests__/addressability.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Agent Addressability & Discoverability Contract Tests
+ *
+ * Covers the #3665 contract surface: stable `description + id` discoverability
+ * and safe exact addressing for unnamed background agents. The matrix:
+ * duplicates, unicode/long descriptions, lifecycle, session isolation,
+ * completed/failed agents, legacy records — plus the anti-pattern guards:
+ * spoofing, truncation ambiguity, privacy leaks, and preserving explicitly
+ * named agents.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  addressFor,
+  formatAgentList,
+  hasDescription,
+  hasExplicitName,
+  listingLabel,
+  notificationReference,
+  resolveAgent,
+  shortId,
+  SHORT_ID_LENGTH,
+} from '../index.js';
+import type { AddressableAgent } from '../index.js';
+
+function agent(overrides: Partial<AddressableAgent> & { id: string }): AddressableAgent {
+  return {
+    type: 'general-purpose',
+    status: 'running',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// shortId
+// ============================================================================
+
+describe('shortId', () => {
+  it('returns the first 7 characters of a long id', () => {
+    expect(shortId('ae1e2be26cb41fc74')).toBe('ae1e2be');
+    expect(shortId('ae1e2be26cb41fc74')).toHaveLength(SHORT_ID_LENGTH);
+  });
+
+  it('returns ids shorter than the default length unchanged', () => {
+    expect(shortId('abc')).toBe('abc');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(shortId('')).toBe('');
+  });
+});
+
+// ============================================================================
+// hasExplicitName / hasDescription
+// ============================================================================
+
+describe('hasExplicitName / hasDescription', () => {
+  it('treats empty or whitespace-only names as absent (legacy records)', () => {
+    expect(hasExplicitName(agent({ id: 'a', name: '' }))).toBe(false);
+    expect(hasExplicitName(agent({ id: 'a', name: '   ' }))).toBe(false);
+    expect(hasExplicitName(agent({ id: 'a', name: 'worker-1' }))).toBe(true);
+  });
+
+  it('treats empty or whitespace-only descriptions as absent', () => {
+    expect(hasDescription(agent({ id: 'a', description: '' }))).toBe(false);
+    expect(hasDescription(agent({ id: 'a', description: '  ' }))).toBe(false);
+    expect(hasDescription(agent({ id: 'a', description: 'S2 nspin4 A/B vehicle' }))).toBe(true);
+  });
+});
+
+// ============================================================================
+// addressFor
+// ============================================================================
+
+describe('addressFor', () => {
+  it('prefers the explicit name (unchanged named-agent addressing)', () => {
+    expect(
+      addressFor(agent({ id: 'id-1', name: 'worker-1', description: 'does things' })),
+    ).toBe('worker-1');
+  });
+
+  it('falls back to the full description for unnamed agents', () => {
+    expect(
+      addressFor(agent({ id: 'id-1', description: 'S2 nspin4 A/B vehicle' })),
+    ).toBe('S2 nspin4 A/B vehicle');
+  });
+
+  it('falls back to the full id for legacy records without name/description', () => {
+    expect(addressFor(agent({ id: 'ae1e2be26cb41fc74' }))).toBe('ae1e2be26cb41fc74');
+  });
+
+  it('trims surrounding whitespace from the address', () => {
+    expect(addressFor(agent({ id: 'id-1', description: '  padded  ' }))).toBe('padded');
+  });
+
+  it('never surfaces the prompt as an address (no privacy leak)', () => {
+    // The contract only ever reads name/description/id — a prompt-like field
+    // must not be picked up as a fallback address.
+    const a = agent({ id: 'id-1' }) as AddressableAgent & { prompt: string };
+    a.prompt = 'Top-secret task instructions';
+    expect(addressFor(a)).toBe('id-1');
+    expect(addressFor(a)).not.toContain('Top-secret');
+  });
+});
+
+// ============================================================================
+// listingLabel
+// ============================================================================
+
+describe('listingLabel', () => {
+  it('keeps the explicit name as the label (backward compatible)', () => {
+    const a = agent({ id: 'id-1', name: 'worker-1', description: 'does things' });
+    expect(listingLabel(a)).toBe('worker-1');
+  });
+
+  it('shows description + short id for unnamed agents', () => {
+    const a = agent({ id: 'ae1e2be26cb41fc74', description: 'S2 nspin4 A/B vehicle' });
+    expect(listingLabel(a)).toBe('S2 nspin4 A/B vehicle (ae1e2be)');
+  });
+
+  it('shows the full id for unnamed agents without a description (legacy records)', () => {
+    expect(listingLabel(agent({ id: 'ae1e2be26cb41fc74' }))).toBe('ae1e2be26cb41fc74');
+  });
+
+  it('truncates long descriptions for display but always keeps the short id', () => {
+    const a = agent({
+      id: 'ae1e2be26cb41fc74',
+      description: 'This is a very long description that should be truncated for display',
+    });
+    const label = listingLabel(a, 30);
+    expect(label).toContain('(ae1e2be)');
+    expect(label).toContain('...');
+    // Visual width must not exceed the requested max (id suffix + ellipsis included).
+    const width = label
+      .replace(/\x1b\[[0-9;]*m/g, '')
+      .split('')
+      .reduce((sum, ch) => sum + (ch.charCodeAt(0) > 0x2e7f ? 2 : 1), 0);
+    expect(width).toBeLessThanOrEqual(30);
+  });
+
+  it('truncates CJK descriptions by visual width, preserving the short id', () => {
+    const a = agent({
+      id: 'ae1e2be26cb41fc74',
+      description: '分析并行架构并给出优化建议的详细说明文档内容',
+    });
+    const label = listingLabel(a, 24);
+    expect(label).toContain('(ae1e2be)');
+    const visible = label.replace(/\x1b\[[0-9;]*m/g, '');
+    const width = visible
+      .split('')
+      .reduce((sum, ch) => sum + (ch.charCodeAt(0) > 0x2e7f ? 2 : 1), 0);
+    expect(width).toBeLessThanOrEqual(24);
+  });
+
+  it('handles tiny max widths without dropping the short id', () => {
+    const a = agent({ id: 'ae1e2be26cb41fc74', description: 'long description here' });
+    expect(listingLabel(a, 4)).toContain('(ae1e2be)');
+  });
+});
+
+// ============================================================================
+// notificationReference
+// ============================================================================
+
+describe('notificationReference', () => {
+  it('uses the explicit name for named agents', () => {
+    expect(
+      notificationReference(agent({ id: 'id-1', name: 'worker-1', description: 'd' })),
+    ).toBe('worker-1');
+  });
+
+  it('uses full description + short id for unnamed agents — never truncated', () => {
+    const long = 'x'.repeat(500);
+    expect(notificationReference(agent({ id: 'ae1e2be26cb41fc74', description: long })))
+      .toBe(`${long} (ae1e2be)`);
+  });
+
+  it('falls back to the full id for legacy records', () => {
+    expect(notificationReference(agent({ id: 'ae1e2be26cb41fc74' }))).toBe(
+      'ae1e2be26cb41fc74',
+    );
+  });
+});
+
+// ============================================================================
+// resolveAgent — exact addressing
+// ============================================================================
+
+describe('resolveAgent', () => {
+  const issueScenario = () => [
+    agent({ id: 'ae1e2be26cb41fc74', description: 'S2 nspin4 A/B vehicle' }),
+    agent({ id: 'a31df4cfac7e5ba7f', description: 'S3 logistics payload' }),
+    agent({ id: 'a90685ed2d7441ca9', description: 'S4 comms relay' }),
+  ];
+
+  it('resolves by full description for unnamed agents (the #3665 scenario)', () => {
+    const result = resolveAgent(issueScenario(), 'S2 nspin4 A/B vehicle');
+    expect(result).toMatchObject({
+      resolved: true,
+      matchedBy: 'description',
+    });
+    if (result.resolved) {
+      expect(result.agent.id).toBe('ae1e2be26cb41fc74');
+    }
+  });
+
+  it('resolves by explicit name (unchanged named-agent addressing)', () => {
+    const agents = [agent({ id: 'id-1', name: 'worker-1', description: 'd' })];
+    const result = resolveAgent(agents, 'worker-1');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'name' });
+  });
+
+  it('resolves by full id', () => {
+    const agents = issueScenario();
+    const result = resolveAgent(agents, 'a90685ed2d7441ca9');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'id' });
+    if (result.resolved) {
+      expect(result.agent.description).toBe('S4 comms relay');
+    }
+  });
+
+  it('never resolves by short id — ids are matched in full only', () => {
+    const result = resolveAgent(issueScenario(), 'ae1e2be');
+    expect(result).toMatchObject({ resolved: false, reason: 'not_found' });
+  });
+
+  it('trims surrounding whitespace from the query', () => {
+    const result = resolveAgent(issueScenario(), '  S2 nspin4 A/B vehicle  ');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'description' });
+  });
+
+  it('rejects an empty query', () => {
+    expect(resolveAgent(issueScenario(), '')).toMatchObject({
+      resolved: false,
+      reason: 'empty',
+    });
+    expect(resolveAgent(issueScenario(), '   ')).toMatchObject({
+      resolved: false,
+      reason: 'empty',
+    });
+  });
+
+  it('returns not_found for unknown recipients', () => {
+    expect(resolveAgent(issueScenario(), 'S9 unknown vehicle')).toMatchObject({
+      resolved: false,
+      reason: 'not_found',
+    });
+  });
+
+  it('does not match a truncated description (no truncation ambiguity)', () => {
+    const result = resolveAgent(issueScenario(), 'S2 nspin4 A/B veh');
+    expect(result).toMatchObject({ resolved: false, reason: 'not_found' });
+  });
+
+  it('does not do substring matching', () => {
+    expect(resolveAgent(issueScenario(), 'nspin4')).toMatchObject({
+      resolved: false,
+      reason: 'not_found',
+    });
+  });
+
+  // --- duplicates ---------------------------------------------------------
+
+  it('refuses to resolve by description when two agents share it (ambiguous)', () => {
+    const agents = [
+      agent({ id: 'ae1e2be26cb41fc74', description: 'duplicate task' }),
+      agent({ id: 'a31df4cfac7e5ba7f', description: 'duplicate task' }),
+    ];
+    const result = resolveAgent(agents, 'duplicate task');
+    expect(result).toMatchObject({
+      resolved: false,
+      reason: 'ambiguous',
+      matchedBy: 'description',
+    });
+    if (!result.resolved) {
+      expect(result.candidates?.map((a) => a.id).sort()).toEqual([
+        'a31df4cfac7e5ba7f',
+        'ae1e2be26cb41fc74',
+      ]);
+    }
+  });
+
+  it('still resolves by id when descriptions collide', () => {
+    const agents = [
+      agent({ id: 'ae1e2be26cb41fc74', description: 'duplicate task' }),
+      agent({ id: 'a31df4cfac7e5ba7f', description: 'duplicate task' }),
+    ];
+    const result = resolveAgent(agents, 'a31df4cfac7e5ba7f');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'id' });
+  });
+
+  it('refuses to resolve by name when two agents share a name (ambiguous)', () => {
+    const agents = [
+      agent({ id: 'id-1', name: 'dup' }),
+      agent({ id: 'id-2', name: 'dup' }),
+    ];
+    expect(resolveAgent(agents, 'dup')).toMatchObject({
+      resolved: false,
+      reason: 'ambiguous',
+      matchedBy: 'name',
+    });
+  });
+
+  // --- spoofing / precedence ----------------------------------------------
+
+  it('a description that equals another agent\'s name never shadows the name', () => {
+    const agents = [
+      agent({ id: 'id-1', name: 'worker-1', description: 'd1' }),
+      agent({ id: 'id-2', description: 'worker-1' }), // tries to spoof the name
+    ];
+    const result = resolveAgent(agents, 'worker-1');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'name' });
+    if (result.resolved) {
+      expect(result.agent.id).toBe('id-1');
+    }
+  });
+
+  it('a description that equals another agent\'s id never shadows the id', () => {
+    const agents = [
+      agent({ id: 'ae1e2be26cb41fc74', description: 'd1' }),
+      agent({ id: 'id-2', description: 'ae1e2be26cb41fc74' }), // tries to spoof the id
+    ];
+    const result = resolveAgent(agents, 'ae1e2be26cb41fc74');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'id' });
+    if (result.resolved) {
+      expect(result.agent.id).toBe('ae1e2be26cb41fc74');
+    }
+  });
+
+  it('does not add description addressing to explicitly named agents', () => {
+    // Named agents keep name addressing; their description is display-only
+    // metadata and must not become a second, shadowable address.
+    const agents = [agent({ id: 'id-1', name: 'worker-1', description: 'shadowable' })];
+    expect(resolveAgent(agents, 'shadowable')).toMatchObject({
+      resolved: false,
+      reason: 'not_found',
+    });
+  });
+
+  // --- unicode / long descriptions ----------------------------------------
+
+  it('resolves CJK descriptions exactly', () => {
+    const agents = [agent({ id: 'id-1', description: '分析并行架构并给出优化建议' })];
+    const result = resolveAgent(agents, '分析并行架构并给出优化建议');
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'description' });
+  });
+
+  it('resolves emoji and symbol-heavy descriptions exactly', () => {
+    const description = '🚀 phase-2 → 🧪 a/b & (c) [d]';
+    const agents = [agent({ id: 'id-1', description })];
+    const result = resolveAgent(agents, description);
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'description' });
+  });
+
+  it('resolves very long descriptions exactly (full string, not truncated)', () => {
+    const long = 'task-' + 'z'.repeat(500);
+    const agents = [agent({ id: 'id-1', description: long })];
+    const result = resolveAgent(agents, long);
+    expect(result).toMatchObject({ resolved: true, matchedBy: 'description' });
+    // And the displayed truncation of that description must NOT resolve.
+    expect(resolveAgent(agents, `${long.slice(0, 40)}...`)).toMatchObject({
+      resolved: false,
+      reason: 'not_found',
+    });
+  });
+
+  // --- lifecycle -----------------------------------------------------------
+
+  it('still resolves completed agents by description and id', () => {
+    const agents = [
+      agent({ id: 'id-1', description: 'finished work', status: 'completed' }),
+    ];
+    expect(resolveAgent(agents, 'finished work')).toMatchObject({
+      resolved: true,
+      matchedBy: 'description',
+    });
+    expect(resolveAgent(agents, 'id-1')).toMatchObject({
+      resolved: true,
+      matchedBy: 'id',
+    });
+  });
+
+  it('still resolves failed agents by description and id', () => {
+    const agents = [
+      agent({ id: 'id-1', description: 'failed work', status: 'failed' }),
+    ];
+    expect(resolveAgent(agents, 'failed work')).toMatchObject({
+      resolved: true,
+      matchedBy: 'description',
+    });
+    expect(resolveAgent(agents, 'id-1')).toMatchObject({
+      resolved: true,
+      matchedBy: 'id',
+    });
+  });
+
+  // --- session isolation ---------------------------------------------------
+
+  it('keeps per-session address spaces isolated for identical descriptions', () => {
+    const sessionA = [agent({ id: 'sess-a-1', description: 'same task', sessionId: 'A' })];
+    const sessionB = [agent({ id: 'sess-b-1', description: 'same task', sessionId: 'B' })];
+
+    const inA = resolveAgent(sessionA, 'same task');
+    const inB = resolveAgent(sessionB, 'same task');
+    expect(inA).toMatchObject({ resolved: true, matchedBy: 'description' });
+    expect(inB).toMatchObject({ resolved: true, matchedBy: 'description' });
+    if (inA.resolved) expect(inA.agent.sessionId).toBe('A');
+    if (inB.resolved) expect(inB.agent.sessionId).toBe('B');
+
+    // Cross-session addressing must fail: B's id is not in A's address space.
+    expect(resolveAgent(sessionA, 'sess-b-1')).toMatchObject({
+      resolved: false,
+      reason: 'not_found',
+    });
+  });
+
+  // --- legacy records ------------------------------------------------------
+
+  it('handles legacy records with only an id (no name/description)', () => {
+    const agents = [agent({ id: 'ae1e2be26cb41fc74' })];
+    expect(resolveAgent(agents, 'ae1e2be26cb41fc74')).toMatchObject({
+      resolved: true,
+      matchedBy: 'id',
+    });
+    expect(resolveAgent(agents, 'ae1e2be26cb41fc74')).not.toBeUndefined();
+  });
+
+  it('treats empty-string name/description on records as absent', () => {
+    const agents = [agent({ id: 'id-1', name: '', description: '' })];
+    expect(resolveAgent(agents, 'id-1')).toMatchObject({ resolved: true, matchedBy: 'id' });
+    expect(resolveAgent(agents, '')).toMatchObject({ resolved: false, reason: 'empty' });
+  });
+});
+
+// ============================================================================
+// formatAgentList
+// ============================================================================
+
+describe('formatAgentList', () => {
+  const now = new Date('2026-08-10T03:30:00Z');
+
+  it('renders a full listing with label, type, status, started, and full id', () => {
+    const agents = [
+      agent({
+        id: 'ae1e2be26cb41fc74',
+        description: 'S2 nspin4 A/B vehicle',
+        startedAt: new Date('2026-08-10T03:11:00Z'),
+      }),
+      agent({
+        id: 'a31df4cfac7e5ba7f',
+        name: 'worker-1',
+        startedAt: new Date('2026-08-10T03:12:00Z'),
+      }),
+    ];
+
+    const listing = formatAgentList(agents, { now });
+    expect(listing).toContain('Subagents (2):');
+    expect(listing).toContain('S2 nspin4 A/B vehicle (ae1e2be) · general-purpose · running · started 19m ago · ae1e2be26cb41fc74');
+    // Named agents keep their name label (unchanged) and still expose the id.
+    expect(listing).toContain('worker-1 · general-purpose · running · started 18m ago · a31df4cfac7e5ba7f');
+  });
+
+  it('shows lifecycle status for completed and failed agents', () => {
+    const agents = [
+      agent({ id: 'id-1', description: 'done', status: 'completed' }),
+      agent({ id: 'id-2', description: 'broke', status: 'failed' }),
+    ];
+    const listing = formatAgentList(agents, { now });
+    expect(listing).toContain('done (id-1) · general-purpose · completed');
+    expect(listing).toContain('broke (id-2) · general-purpose · failed');
+  });
+
+  it('avoids duplicating the id column when the id is already the label', () => {
+    const agents = [agent({ id: 'ae1e2be26cb41fc74', startedAt: now })];
+    const listing = formatAgentList(agents, { now });
+    const row = listing.split('\n')[1];
+    expect(row).toBe('  ae1e2be26cb41fc74 · general-purpose · running · started just now');
+  });
+
+  it('renders an empty listing', () => {
+    expect(formatAgentList([], { now })).toBe('Subagents (0):\n  (none)');
+  });
+
+  it('renders relative start times', () => {
+    const cases: Array<[number, string]> = [
+      [30_000, 'started just now'],
+      [5 * 60_000, 'started 5m ago'],
+      [3 * 3600_000, 'started 3h ago'],
+      [2 * 86400_000, 'started 2d ago'],
+    ];
+    for (const [offsetMs, expected] of cases) {
+      const agents = [
+        agent({ id: 'id-1', startedAt: new Date(now.getTime() - offsetMs) }),
+      ];
+      expect(formatAgentList(agents, { now })).toContain(expected);
+    }
+  });
+
+  it('omits status/started columns when disabled', () => {
+    const agents = [agent({ id: 'id-1', status: 'failed', startedAt: now })];
+    const listing = formatAgentList(agents, {
+      now,
+      showStatus: false,
+      showStartedAt: false,
+    });
+    expect(listing).toContain('  id-1 · general-purpose');
+    expect(listing).not.toContain('failed');
+    expect(listing).not.toContain('started');
+  });
+
+  it('supports a custom title', () => {
+    const listing = formatAgentList([agent({ id: 'id-1' })], { now, title: 'Agents' });
+    expect(listing).toContain('Agents (1):');
+  });
+});

--- a/src/features/agent-addressability/index.ts
+++ b/src/features/agent-addressability/index.ts
@@ -1,0 +1,293 @@
+/**
+ * Agent Addressability & Discoverability Contract
+ *
+ * Fixes #3665: background agents spawned via the Agent tool with a
+ * `description` but no explicit `name` are unaddressable — listings show raw
+ * ids only, while notifications refer to them by description. This module is
+ * the narrow contract those surfaces share:
+ *
+ * - Discoverability: unnamed agents are listed as `description (short-id)` so
+ *   the coordinator can map the work it reasoned about back to an id.
+ * - Addressability: exact resolution by explicit name (unchanged), full id,
+ *   or — for unnamed agents only — the full description, when unambiguous.
+ *
+ * Safety rules baked into the contract:
+ * - Exact matching only: never prefix, substring, or truncated matching, so a
+ *   truncated display string can never accidentally resolve (no truncation
+ *   ambiguity).
+ * - Explicit names are authoritative: a description can never shadow or spoof
+ *   a named agent's address, and ids take precedence over descriptions.
+ * - Duplicate descriptions never resolve by description — the result is
+ *   `ambiguous` and the caller must disambiguate with the id.
+ * - Explicitly named agents are addressed exactly as before (backward
+ *   compatible); the contract only ADDS description-based addressing for
+ *   agents without a name.
+ * - Only the user-supplied `description` field is ever surfaced — never the
+ *   prompt or output (no privacy leaks).
+ *
+ * All functions are pure and operate on agent lists supplied by the caller,
+ * so per-session address spaces stay isolated: resolve within the list of the
+ * session you are addressing.
+ */
+
+import { truncateToWidth } from '../../utils/string-width.js';
+
+/** Lifecycle status of an agent. */
+export type AgentStatus = 'running' | 'completed' | 'failed';
+
+/** Minimal agent shape the addressability contract operates on. */
+export interface AddressableAgent {
+  /** Stable opaque agent id (Claude Code agent_id / tool_use block id). */
+  id: string;
+  /** Agent type/role (e.g. "general-purpose", "oh-my-claudecode:executor"). */
+  type?: string;
+  /** Explicit user-chosen name (Agent tool `name`). Authoritative address. */
+  name?: string;
+  /** User-supplied description (Agent tool `description`). */
+  description?: string;
+  /** Lifecycle status. */
+  status?: AgentStatus;
+  /** Owning session id — used to keep per-session address spaces isolated. */
+  sessionId?: string;
+  /** Start time, used for "started Xm ago" rendering. */
+  startedAt?: Date | string;
+}
+
+/** Length of the short-id suffix used in listings and notification references. */
+export const SHORT_ID_LENGTH = 7;
+
+/**
+ * First `length` characters of an agent id. Short ids are for DISPLAY and
+ * disambiguation only — they are never valid addresses (see `resolveAgent`).
+ */
+export function shortId(id: string, length: number = SHORT_ID_LENGTH): string {
+  if (!id) return '';
+  return id.length <= length ? id : id.slice(0, length);
+}
+
+function trimmed(value: string | undefined): string {
+  return (value ?? '').trim();
+}
+
+/** True when the agent carries a usable explicit name. */
+export function hasExplicitName(agent: AddressableAgent): boolean {
+  return trimmed(agent.name).length > 0;
+}
+
+/** True when the agent carries a usable description. */
+export function hasDescription(agent: AddressableAgent): boolean {
+  return trimmed(agent.description).length > 0;
+}
+
+/**
+ * Full, exact address for an agent: explicit name when present, else the full
+ * description (unnamed agents), else the full id. Never truncated.
+ */
+export function addressFor(agent: AddressableAgent): string {
+  const name = trimmed(agent.name);
+  if (name) return name;
+  const description = trimmed(agent.description);
+  if (description) return description;
+  return agent.id;
+}
+
+/**
+ * Display label for a listing row.
+ * - Named agents: their name (unchanged — backward compatible).
+ * - Unnamed with description: `description (short-id)` — the short id makes
+ *   the row disambiguable at a glance (the full id remains the address).
+ * - Unnamed without description: the full id.
+ *
+ * Truncation applies to display only and always preserves the id suffix.
+ */
+export function listingLabel(agent: AddressableAgent, maxWidth: number = 40): string {
+  const name = trimmed(agent.name);
+  if (name) return name;
+
+  const description = trimmed(agent.description);
+  if (description) {
+    const suffix = ` (${shortId(agent.id)})`;
+    // Reserve room for " (short-id)" (10 columns) plus the ellipsis that
+    // truncateToWidth may append, so the label never exceeds maxWidth.
+    const budget = Math.max(4, maxWidth - SHORT_ID_LENGTH - 3 - 3);
+    return `${truncateToWidth(description, budget)}${suffix}`;
+  }
+
+  return agent.id;
+}
+
+/**
+ * Stable, full reference for notifications. Unlike `listingLabel` this is
+ * NEVER truncated: the string shown in a notification can be passed back to a
+ * messaging surface and resolved exactly.
+ */
+export function notificationReference(agent: AddressableAgent): string {
+  const name = trimmed(agent.name);
+  if (name) return name;
+  const description = trimmed(agent.description);
+  if (description) return `${description} (${shortId(agent.id)})`;
+  return agent.id;
+}
+
+/** Which address kind matched in `resolveAgent`. */
+export type MatchKind = 'name' | 'id' | 'description';
+
+export type ResolveResult =
+  | { resolved: true; agent: AddressableAgent; matchedBy: MatchKind }
+  | {
+      resolved: false;
+      reason: 'empty' | 'not_found' | 'ambiguous';
+      matchedBy?: MatchKind;
+      /** Colliding candidates when the query is ambiguous (ids included). */
+      candidates?: AddressableAgent[];
+    };
+
+function exactlyOne<T>(matches: T[]): T | null {
+  return matches.length === 1 ? matches[0] : null;
+}
+
+/**
+ * Resolve a recipient string to an agent using EXACT matching only.
+ *
+ * Precedence:
+ * 1. explicit `name` — authoritative; unchanged behavior for named agents
+ * 2. full `id` — stable, always available
+ * 3. full `description` — unnamed agents only, and only when unique
+ *
+ * Never prefix, substring, or truncated matching. Duplicate names or
+ * descriptions resolve as `ambiguous`; the caller must disambiguate with the
+ * id (both colliding agents are surfaced in `candidates`).
+ *
+ * Pass the agent list of the session you are addressing so address spaces
+ * stay isolated across sessions.
+ */
+export function resolveAgent(
+  agents: readonly AddressableAgent[],
+  query: string,
+): ResolveResult {
+  const needle = trimmed(query);
+  if (!needle) return { resolved: false, reason: 'empty' };
+
+  // 1. Explicit names are authoritative — a description can never spoof one.
+  const byName = agents.filter(
+    (agent) => hasExplicitName(agent) && trimmed(agent.name) === needle,
+  );
+  if (byName.length > 0) {
+    const single = exactlyOne(byName);
+    return single
+      ? { resolved: true, agent: single, matchedBy: 'name' }
+      : {
+          resolved: false,
+          reason: 'ambiguous',
+          matchedBy: 'name',
+          candidates: byName,
+        };
+  }
+
+  // 2. Full ids (short ids are NOT addresses — ids are matched in full).
+  const byId = agents.filter((agent) => agent.id === needle);
+  if (byId.length > 0) {
+    const single = exactlyOne(byId);
+    return single
+      ? { resolved: true, agent: single, matchedBy: 'id' }
+      : {
+          resolved: false,
+          reason: 'ambiguous',
+          matchedBy: 'id',
+          candidates: byId,
+        };
+  }
+
+  // 3. Full description — unnamed agents only. Named agents keep name
+  //    addressing; their descriptions must not shadow other addresses.
+  const byDescription = agents.filter(
+    (agent) =>
+      !hasExplicitName(agent) &&
+      hasDescription(agent) &&
+      trimmed(agent.description) === needle,
+  );
+  if (byDescription.length > 0) {
+    const single = exactlyOne(byDescription);
+    return single
+      ? { resolved: true, agent: single, matchedBy: 'description' }
+      : {
+          resolved: false,
+          reason: 'ambiguous',
+          matchedBy: 'description',
+          candidates: byDescription,
+        };
+  }
+
+  return { resolved: false, reason: 'not_found' };
+}
+
+export interface FormatAgentListOptions {
+  /** Listing title (default: "Subagents"). */
+  title?: string;
+  /** Show lifecycle status column (default: true). */
+  showStatus?: boolean;
+  /** Show "started Xm ago" column (default: true). */
+  showStartedAt?: boolean;
+  /** Clock for relative-time rendering (default: new Date()). */
+  now?: Date;
+}
+
+function formatAgo(
+  startedAt: Date | string | undefined,
+  now: Date,
+): string | null {
+  if (startedAt === undefined) return null;
+  const start =
+    startedAt instanceof Date ? startedAt.getTime() : new Date(startedAt).getTime();
+  if (!Number.isFinite(start)) return null;
+  const elapsedSec = Math.max(0, Math.floor((now.getTime() - start) / 1000));
+  if (elapsedSec < 60) return 'just now';
+  if (elapsedSec < 3600) return `${Math.floor(elapsedSec / 60)}m ago`;
+  if (elapsedSec < 86400) return `${Math.floor(elapsedSec / 3600)}h ago`;
+  return `${Math.floor(elapsedSec / 86400)}d ago`;
+}
+
+/**
+ * Render a ListAgents-style listing. Every row carries the full id so any row
+ * can be used to address the agent exactly:
+ *
+ *   Subagents (3):
+ *     S2 nspin4 A/B vehicle · general-purpose · running · started 19m ago · ae1e2be26cb41fc74
+ *     worker-1 · general-purpose · running · started 18m ago · a31df4cfac7e5ba7f
+ *
+ * Named agents keep their name as the label (unchanged); unnamed agents get
+ * `description (short-id)`.
+ */
+export function formatAgentList(
+  agents: readonly AddressableAgent[],
+  options: FormatAgentListOptions = {},
+): string {
+  const {
+    title = 'Subagents',
+    showStatus = true,
+    showStartedAt = true,
+    now = new Date(),
+  } = options;
+
+  const header = `${title} (${agents.length}):`;
+  if (agents.length === 0) return `${header}\n  (none)`;
+
+  const rows = agents.map((agent) => {
+    const label = listingLabel(agent, 48);
+    const parts: string[] = [label];
+    const type = trimmed(agent.type);
+    if (type) parts.push(type);
+    if (showStatus && agent.status) parts.push(agent.status);
+    if (showStartedAt) {
+      const ago = formatAgo(agent.startedAt, now);
+      if (ago) parts.push(`started ${ago}`);
+    }
+    // Full id always present so the row is directly addressable. Omit the
+    // trailing id column when the id is already the label (unnamed agent with
+    // no description) to avoid duplication.
+    if (label !== agent.id) parts.push(agent.id);
+    return `  ${parts.join(' · ')}`;
+  });
+
+  return `${header}\n${rows.join('\n')}`;
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -322,4 +322,21 @@ export {
   type SessionHistorySearchOptions,
   type SessionHistorySearchReport,
 } from './session-history-search/index.js';
+// Agent Addressability & Discoverability - unnamed agent addressing/listing contract (#3665)
+export {
+  shortId,
+  hasExplicitName,
+  hasDescription,
+  addressFor,
+  listingLabel,
+  notificationReference,
+  resolveAgent,
+  formatAgentList,
+  SHORT_ID_LENGTH,
+  type AgentStatus,
+  type AddressableAgent,
+  type MatchKind,
+  type ResolveResult,
+  type FormatAgentListOptions,
+} from './agent-addressability/index.js';
 

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -3165,6 +3165,8 @@ export async function processHook(
           hook_event_name: "SubagentStart",
           prompt: normalized.prompt as string | undefined,
           model: normalized.model as string | undefined,
+          name: normalized.name as string | undefined,
+          description: normalized.description as string | undefined,
         };
         // recordAgentStart is already called inside processSubagentStart,
         // so we don't call it here to avoid duplicate session replay entries.

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -630,6 +630,56 @@ describe("subagent-tracker", () => {
         persistedState.agents.filter((agent) => agent.status === "running"),
       ).toHaveLength(1);
     });
+    it("persists Agent-tool name/description for unnamed-agent addressability (#3665)", () => {
+      const startInput = {
+        session_id: "session-3665",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ae1e2be26cb41fc74",
+        agent_type: "general-purpose",
+        prompt: "Coordinate the S2 nspin4 A/B vehicle analysis",
+        name: "",
+        description: "S2 nspin4 A/B vehicle",
+      };
+      processSubagentStart(startInput);
+      flushPendingWrites();
+
+      const state = readTrackingState(testDir);
+      const tracked = state.agents.find((a) => a.agent_id === "ae1e2be26cb41fc74");
+      expect(tracked).toBeDefined();
+      // Empty-string name is treated as absent (legacy/partial payloads).
+      expect(tracked?.name).toBeUndefined();
+      expect(tracked?.description).toBe("S2 nspin4 A/B vehicle");
+
+      // Dashboard shows the description with the short id for disambiguation.
+      const dashboard = getAgentDashboard(testDir);
+      expect(dashboard).toContain("S2 nspin4 A/B vehicle (ae1e2be)");
+    });
+
+    it("records the Agent-tool description in the session replay stream (#3665)", () => {
+      const startInput = {
+        session_id: "session-3665-replay",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "a31df4cfac7e5ba7f",
+        agent_type: "general-purpose",
+        prompt: "Ship logistics payload",
+        name: undefined,
+        description: "S3 logistics payload",
+      };
+      processSubagentStart(startInput);
+      flushPendingWrites();
+
+      const events = readReplayEvents(testDir, "session-3665-replay");
+      const start = events.find((e) => e.event === "agent_start");
+      expect(start).toBeDefined();
+      expect(start?.agent).toBe("a31df4c");
+      expect(start?.description).toBe("S3 logistics payload");
+    });
 
     it("routes mission-state writes to the hook session id (not getProcessSessionId/PID fallback)", () => {
       // Regression: subagent-tracker previously omitted the sessionId arg when

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -37,6 +37,10 @@ export interface SubagentInfo {
   started_at: string;
   parent_mode: string; // 'autopilot' | 'ultrawork' | 'team' | 'ralph' | 'none'
   task_description?: string;
+  /** Explicit user-chosen name (Agent tool `name`) — authoritative address. */
+  name?: string;
+  /** User-supplied description (Agent tool `description`) — display/address fallback (#3665). */
+  description?: string;
   file_ownership?: string[];
   status: "running" | "completed" | "failed";
   completed_at?: string;
@@ -96,6 +100,10 @@ export interface SubagentStartInput {
   hook_event_name: "SubagentStart";
   agent_id: string;
   agent_type: string;
+  /** Explicit user-chosen name (Agent tool `name`) — authoritative address. */
+  name?: string;
+  /** User-supplied description (Agent tool `description`) — display/address fallback (#3665). */
+  description?: string;
   prompt?: string;
   model?: string;
 }
@@ -623,6 +631,9 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
       const parentMode = detectParentMode(input.cwd);
       const startedAt = new Date().toISOString();
       const taskDescription = input.prompt?.substring(0, 200); // Truncate for storage
+      // Agent-tool name/description (may be absent for legacy hook payloads).
+      const agentName = input.name?.trim() || undefined;
+      const agentDescription = input.description?.trim() || undefined;
       const existingAgent = state.agents.find((agent) => agent.agent_id === input.agent_id);
       const isDuplicateRunningStart = existingAgent?.status === "running";
       let trackedAgent: SubagentInfo;
@@ -632,6 +643,10 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
         existingAgent.parent_mode = parentMode;
         existingAgent.task_description = taskDescription;
         existingAgent.model = input.model;
+        // Only overwrite identity fields when the payload carries them, so a
+        // legacy/partial payload cannot wipe previously recorded name/description.
+        if (agentName) existingAgent.name = agentName;
+        if (agentDescription) existingAgent.description = agentDescription;
 
         if (existingAgent.status !== "running") {
           existingAgent.status = "running";
@@ -652,6 +667,8 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
           task_description: taskDescription,
           status: "running",
           model: input.model,
+          name: agentName,
+          description: agentDescription,
         };
 
         // Add to state
@@ -666,7 +683,7 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
       if (!isDuplicateRunningStart) {
         // Record to session replay JSONL for /trace
         try {
-          recordAgentStart(input.cwd, input.session_id, input.agent_id, input.agent_type, input.prompt, parentMode, input.model);
+          recordAgentStart(input.cwd, input.session_id, input.agent_id, input.agent_type, input.prompt, parentMode, input.model, input.description, input.name);
         } catch { /* best-effort */ }
 
         try {
@@ -1089,9 +1106,13 @@ export function getAgentDashboard(directory: string, sessionId?: string): string
     const toolCount = agent.tool_usage?.length || 0;
     const lastTool =
       agent.tool_usage?.[agent.tool_usage.length - 1]?.tool_name || "-";
-    const desc = agent.task_description
-      ? ` "${agent.task_description.substring(0, 60)}"`
-      : "";
+    // Prefer the Agent-tool description (with short id for disambiguation,
+    // #3665) over the prompt-derived task description when available.
+    const desc = agent.description
+      ? ` "${agent.description.substring(0, 60)} (${agent.agent_id.substring(0, 7)})"`
+      : agent.task_description
+        ? ` "${agent.task_description.substring(0, 60)}"`
+        : "";
 
     lines.push(
       `  [${agent.agent_id.substring(0, 7)}] ${shortType} (${elapsed}s) tools:${toolCount} last:${lastTool}${desc}`,

--- a/src/hooks/subagent-tracker/session-replay.ts
+++ b/src/hooks/subagent-tracker/session-replay.ts
@@ -42,6 +42,10 @@ export interface ReplayEvent {
   telemetry_status?: "unmatched_stop";
   parent_mode?: string;
   model?: string;
+  /** Agent-tool description (unnamed-agent address fallback, #3665). */
+  description?: string;
+  /** Agent-tool explicit name (authoritative address). */
+  name?: string;
   /** Hook name (e.g., "keyword-detector") */
   hook?: string;
   /** Claude Code event (e.g., "UserPromptSubmit") */
@@ -182,7 +186,9 @@ export function recordAgentStart(
   agentType: string,
   task?: string,
   parentMode?: string,
-  model?: string
+  model?: string,
+  description?: string,
+  name?: string
 ): void {
   appendReplayEvent(directory, sessionId, {
     agent: agentId.substring(0, 7),
@@ -191,6 +197,8 @@ export function recordAgentStart(
     task: task?.substring(0, 100),
     parent_mode: parentMode,
     model,
+    description: description?.substring(0, 200),
+    name,
   });
 }
 

--- a/src/hud/elements/agents.ts
+++ b/src/hud/elements/agents.ts
@@ -10,6 +10,7 @@
 import type { ActiveAgent, AgentsFormat } from '../types.js';
 import { dim, RESET, getModelTierColor, getDurationColor } from '../colors.js';
 import { truncateToWidth } from '../../utils/string-width.js';
+import { shortId } from '../../features/agent-addressability/index.js';
 
 const CYAN = '\x1b[36m';
 
@@ -331,6 +332,24 @@ function truncateDescription(desc: string | undefined, maxWidth: number = 20): s
   // Use CJK-aware truncation (maxWidth is visual columns, not character count)
   return truncateToWidth(desc, maxWidth);
 }
+/**
+ * Truncated description for an UNNAMED agent with the short id appended, so
+ * the row stays discoverable and addressable (#3665). Display-only: the short
+ * id is never a valid address — addresses are always full and exact.
+ * Named agents keep their existing rendering (their name is the address).
+ */
+function truncateDescriptionWithId(
+  desc: string | undefined,
+  id: string,
+  maxWidth: number,
+): string {
+  const suffix = ` (${shortId(id)})`; // " (short-id)" = 10 visual columns
+  if (!desc) return `...${suffix}`;
+  // Reserve room for the suffix plus the ellipsis truncateToWidth may append,
+  // so the rendered label never exceeds maxWidth.
+  const budget = Math.max(4, maxWidth - 10 - 3);
+  return `${truncateToWidth(desc, budget)}${suffix}`;
+}
 
 /**
  * Get short agent type name.
@@ -419,7 +438,11 @@ export function renderAgentsWithDescriptions(agents: ActiveAgent[]): string | nu
     const color = getAgentDisplayColor(a);
     const teammateName = getTeammateName(a);
     const displayName = getAgentDisplayName(a);
-    const desc = truncateDescription(a.description, teammateName ? 30 : 25);
+    // Unnamed agents get the short id appended so the row maps back to an
+    // addressable agent (#3665); named agents keep their existing label.
+    const desc = teammateName
+      ? truncateDescription(a.description, 30)
+      : truncateDescriptionWithId(a.description, a.id, 25);
     const label = teammateName
       ? `${displayName}${desc ? ` ${desc}` : ""}`
       : desc;
@@ -460,7 +483,13 @@ export function renderAgentsDescOnly(agents: ActiveAgent[]): string | null {
   const descriptions = running.map((a) => {
     const color = getAgentDisplayColor(a);
     const shortName = getAgentDisplayName(a);
-    const desc = a.description ? truncateDescription(a.description, 20) : shortName;
+    // Unnamed agents get the short id appended (discoverability, #3665);
+    // named agents keep their existing rendering.
+    const desc = getTeammateName(a)
+      ? a.description
+        ? truncateDescription(a.description, 20)
+        : shortName
+      : truncateDescriptionWithId(a.description, a.id, 20);
     const durationMs = now - a.startTime.getTime();
     const duration = formatDuration(durationMs);
 
@@ -541,9 +570,12 @@ export function renderAgentsMultiLine(
     const duration = formatDurationPadded(durationMs);
     const durationColor = getDurationColor(durationMs);
 
-    const desc = a.description || '...';
-    // Use CJK-aware truncation (45 visual columns)
-    const truncatedDesc = truncateToWidth(desc, 45);
+    // Named agents keep their existing description column; unnamed agents get
+    // the short id appended so the row maps back to an addressable agent
+    // (#3665). CJK-aware truncation (45 visual columns).
+    const truncatedDesc = getTeammateName(a)
+      ? truncateToWidth(a.description || '...', 45)
+      : truncateDescriptionWithId(a.description, a.id, 45);
 
     detailLines.push(
       `${dim(prefix)} ${color}${code}${RESET} ${dim(shortName)}${durationColor}${duration}${RESET}  ${truncatedDesc}`


### PR DESCRIPTION
Fixes #3665

## Problem
Background agents spawned via the Agent tool with a `description` but no explicit `name` are unaddressable: `ListAgents` shows raw ids only, while task-completion notifications refer to them by description. `SendMessage({to: "<description>"})` fails, and with several concurrent agents the coordinator cannot map opaque ids back to the work it reasoned about.

## Approach
Narrow, backward-compatible addressability/discoverability contract:

**New contract module** `src/features/agent-addressability/`
- `resolveAgent(agents, query)` — exact matching only (never prefix/substring/truncated), precedence: explicit `name` → full `id` → full `description` for **unnamed agents only**.
- `listingLabel` / `notificationReference` — unnamed agents render as `description (short-id)`; the full id stays the address. Notification references are never truncated.
- `formatAgentList` — ListAgents-style rows: `description (short-id) · type · status · started · <full id>`.

**Safety guarantees** (each covered by tests):
- No collision: duplicate descriptions/names resolve as `ambiguous` with colliding candidates surfaced; ids always disambiguate.
- No spoofing: ids and names take precedence over descriptions.
- No truncation ambiguity: a truncated display string can never resolve.
- No privacy leaks: only the user-supplied `description` is ever surfaced — never the prompt or output.
- Explicitly named agents are untouched: name addressing unchanged, descriptions never become a second address for them.

**Integration surfaces**
- HUD agents element (`descriptions`/`tasks`/`multiline` formats): unnamed agents show `description (short-id)`.
- subagent-tracker: spawn records Agent `name`/`description` (legacy payloads never wipe identity fields); dashboard prefers description with short-id; session-replay start events carry them.
- bridge: `SubagentStart` hook passes `name`/`description` through.

## Test matrix
duplicates, unicode/CJK + long descriptions, lifecycle (completed/failed), per-session isolation, legacy records (id only), spoofing, truncation ambiguity, named-agent preservation. 49 new contract tests + HUD/subagent-tracker integration tests.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint` on all touched files — clean
- 200 targeted tests pass (agent-addressability, HUD agents, subagent-tracker suites)
- Full-suite failures in `post-tool-verifier.test.mjs`, `python-sandbox.test.ts`, `smoke-slack-and-state.test.ts` proven pre-existing on a clean tree (stash-verified) and unrelated to this change.
