### PR TITLE
fix(team): never report a worker as plainly idle with undelivered directed work

### DIFF
--- a/src/hooks/__tests__/team-worker-idle-outstanding.test.ts
+++ b/src/hooks/__tests__/team-worker-idle-outstanding.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Regression tests for issue #3662: a worker with queued/unanswered directed
+ * messages or an undelivered owed report must never be reported as plainly
+ * idle/available. OMC worker-idle notifications carry observable
+ * outstanding-work metadata instead.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { maybeNotifyLeaderWorkerIdle, maybeNotifyLeaderAllWorkersIdle, type TmuxRunner } from '../team-worker-hook.js';
+
+const TEAM = 'test-team';
+const WORKER = 'worker-1';
+const OTHER_WORKER = 'worker-2';
+
+interface SeedOptions {
+  state?: string;
+  prevState?: string;
+  mailboxFor?: string;
+  otherWorkerMailbox?: boolean;
+  outboundReportToLeader?: boolean;
+  deliveredInbound?: boolean;
+  malformedMailbox?: boolean;
+  heartbeat?: boolean;
+}
+
+function makeTestEnv() {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'omc-worker-idle-outstanding-'));
+  const stateDir = join(tmpDir, '.omc', 'state');
+  const teamDir = join(stateDir, 'team', TEAM);
+  mkdirSync(join(teamDir, 'workers', WORKER), { recursive: true });
+  mkdirSync(join(teamDir, 'workers', OTHER_WORKER), { recursive: true });
+
+  writeFileSync(
+    join(teamDir, 'config.json'),
+    JSON.stringify({
+      workers: [{ name: WORKER }, { name: OTHER_WORKER }],
+      tmux_session: 'test-session',
+      leader_pane_id: '%99',
+    }),
+  );
+  return { tmpDir, stateDir, teamDir };
+}
+
+function seed(options: SeedOptions, teamDir: string, stateDir: string): void {
+  const nowIso = new Date().toISOString();
+
+  // status.json
+  const status = {
+    state: options.state ?? 'idle',
+    updated_at: nowIso,
+    ...(options.state === 'done' ? { reason: 'completed' } : {}),
+  };
+  writeFileSync(join(teamDir, 'workers', WORKER, 'status.json'), JSON.stringify(status));
+
+  // prev-notify-state.json: force the working->idle transition
+  writeFileSync(
+    join(teamDir, 'workers', WORKER, 'prev-notify-state.json'),
+    JSON.stringify({ state: options.prevState ?? 'working', updated_at: nowIso }),
+  );
+
+  // heartbeat.json (fresh)
+  if (options.heartbeat !== false) {
+    writeFileSync(
+      join(teamDir, 'workers', WORKER, 'heartbeat.json'),
+      JSON.stringify({ pid: process.pid, last_turn_at: nowIso, turn_count: 1, alive: true }),
+    );
+    writeFileSync(
+      join(teamDir, 'workers', OTHER_WORKER, 'heartbeat.json'),
+      JSON.stringify({ pid: process.pid, last_turn_at: nowIso, turn_count: 1, alive: true }),
+    );
+  }
+
+  // mailbox: {worker}.json with an undelivered directed message
+  const mailboxDir = join(stateDir, 'team', TEAM, 'mailbox');
+  mkdirSync(mailboxDir, { recursive: true });
+
+  const inboundMessage = (delivered: boolean) => ({
+    message_id: 'msg-inbound-1',
+    from_worker: OTHER_WORKER,
+    to_worker: WORKER,
+    body: 'Please review this diff and report findings.',
+    created_at: nowIso,
+    ...(delivered ? { delivered_at: nowIso } : {}),
+  });
+  const outboundReport = {
+    message_id: 'msg-report-1',
+    from_worker: WORKER,
+    to_worker: 'leader-fixed',
+    body: 'Review findings: approval-gated.',
+    created_at: nowIso,
+  };
+
+  if (options.malformedMailbox) {
+    writeFileSync(join(mailboxDir, `${WORKER}.json`), '{not valid json');
+  } else if (options.mailboxFor === 'inbound') {
+    const messages: unknown[] = [inboundMessage(!!options.deliveredInbound)];
+    writeFileSync(
+      join(mailboxDir, `${WORKER}.json`),
+      JSON.stringify({ worker: WORKER, messages }),
+    );
+  }
+
+  if (options.otherWorkerMailbox) {
+    writeFileSync(
+      join(mailboxDir, `${OTHER_WORKER}.json`),
+      JSON.stringify({
+        worker: OTHER_WORKER,
+        messages: [{ ...inboundMessage(false), message_id: 'msg-inbound-other', to_worker: OTHER_WORKER, from_worker: 'leader-fixed' }],
+      }),
+    );
+  }
+
+  if (options.outboundReportToLeader) {
+    writeFileSync(
+      join(mailboxDir, 'leader-fixed.json'),
+      JSON.stringify({
+        worker: 'leader-fixed',
+        messages: [outboundReport],
+      }),
+    );
+  }
+}
+
+function makeTmux(): { tmux: TmuxRunner; sent: Array<{ target: string; text: string }> } {
+  const sent: Array<{ target: string; text: string }> = [];
+  const tmux: TmuxRunner = {
+    async sendKeys(target: string, text: string) {
+      // Ignore the trailing Enter keystrokes the hook sends after the message.
+      if (text !== 'C-m') sent.push({ target, text });
+    },
+  };
+  return { tmux, sent };
+}
+
+describe('team-worker-hook idle outstanding metadata (issue #3662)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let teamDir: string;
+
+  beforeEach(() => {
+    const env = makeTestEnv();
+    tmpDir = env.tmpDir;
+    stateDir = env.stateDir;
+    teamDir = env.teamDir;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('annotates idle notification with undelivered inbound count (queued directed message)', async () => {
+    seed({ mailboxFor: 'inbound' }, teamDir, stateDir);
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    const text = sent[0]!.text;
+    // Must NOT be a plain "idle" claim: it must carry outstanding-work metadata.
+    expect(text).toContain(`[OMC] ${WORKER} idle`);
+    expect(text).toContain('outstanding: 1 unanswered');
+    expect(text).toContain('[OMC_TMUX_INJECT]');
+  });
+
+  it('writes undelivered_inbound_count into the worker_idle event', async () => {
+    seed({ mailboxFor: 'inbound' }, teamDir, stateDir);
+    const { tmux } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    const eventsPath = join(teamDir, 'events', 'events.ndjson');
+    expect(existsSync(eventsPath)).toBe(true);
+    const raw = readFileSync(eventsPath, 'utf-8');
+    expect(raw).toContain('"type":"worker_idle"');
+    expect(raw).toContain('"undelivered_inbound_count":1');
+    expect(raw).toContain('"undelivered_outbound_count":0');
+  });
+
+  it('annotates idle notification with undelivered owed report (completion without output)', async () => {
+    seed({ outboundReportToLeader: true }, teamDir, stateDir);
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    expect(sent[0]!.text).toContain('undelivered reports: 1');
+  });
+
+  it('reports plain idle after delivery/ack transition (no false outstanding state)', async () => {
+    seed({ mailboxFor: 'inbound', deliveredInbound: true }, teamDir, stateDir);
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    const text = sent[0]!.text;
+    expect(text).toContain(`[OMC] ${WORKER} idle`);
+    expect(text).not.toContain('outstanding');
+    expect(text).not.toContain('undelivered');
+  });
+
+  it('does not re-notify on repeated idle signals (transition dedupe preserved)', async () => {
+    seed({}, teamDir, stateDir); // no outstanding
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+    expect(sent.length).toBe(1);
+
+    // Second signal: prev-notify-state is now idle -> no duplicate notify.
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+    expect(sent.length).toBe(1);
+  });
+
+  it('survives a malformed mailbox (race tolerance) and still notifies plainly', async () => {
+    seed({ malformedMailbox: true }, teamDir, stateDir);
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    expect(sent[0]!.text).toContain(`[OMC] ${WORKER} idle`);
+    expect(sent[0]!.text).not.toContain('outstanding');
+  });
+
+  it('does not count other workers directed messages against this worker (session isolation)', async () => {
+    seed({ otherWorkerMailbox: true }, teamDir, stateDir);
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderWorkerIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    expect(sent[0]!.text).not.toContain('outstanding');
+    expect(sent[0]!.text).not.toContain('undelivered');
+  });
+
+  it('qualifies the all-workers-idle readiness claim when any worker has undelivered directed messages', async () => {
+    seed({ mailboxFor: 'inbound' }, teamDir, stateDir);
+    // All workers need fresh status+heartbeat for the all-idle gate.
+    const nowIso = new Date().toISOString();
+    writeFileSync(
+      join(teamDir, 'workers', OTHER_WORKER, 'status.json'),
+      JSON.stringify({ state: 'idle', updated_at: nowIso }),
+    );
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderAllWorkersIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    const text = sent[0]!.text;
+    expect(text).toContain('All 2 workers idle');
+    // Never a plain "ready for next instructions" while work is outstanding.
+    // 2 = 1 inbound queued for worker-1 + 1 outbound owed by worker-2 (sender).
+    expect(text).toContain('outstanding: 2 undelivered directed messages');
+    expect(text).not.toContain('Ready for next instructions');
+  });
+
+  it('keeps the plain all-workers-idle claim when nothing is outstanding', async () => {
+    seed({}, teamDir, stateDir);
+    const nowIso = new Date().toISOString();
+    writeFileSync(
+      join(teamDir, 'workers', OTHER_WORKER, 'status.json'),
+      JSON.stringify({ state: 'idle', updated_at: nowIso }),
+    );
+    const { tmux, sent } = makeTmux();
+
+    await maybeNotifyLeaderAllWorkersIdle({
+      cwd: tmpDir,
+      stateDir,
+      parsedTeamWorker: { teamName: TEAM, workerName: WORKER },
+      tmux,
+    });
+
+    expect(sent.length).toBe(1);
+    expect(sent[0]!.text).toContain('Ready for next instructions');
+  });
+});

--- a/src/hooks/team-leader-nudge-hook.ts
+++ b/src/hooks/team-leader-nudge-hook.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { appendTeamEvent } from '../team/events.js';
 import { deriveTeamLeaderGuidance } from '../team/leader-nudge-guidance.js';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
+import { scanMailboxOutstanding } from '../team/mailbox-outstanding.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -151,6 +152,11 @@ export async function checkLeaderStaleness(params: {
   let aliveWorkerCount = 0;
   let nonReportingWorkerCount = 0;
 
+  // Outstanding directed-work metadata (issue #3662): a worker with
+  // queued/unanswered directed mailbox messages is not idle/available.
+  const mailboxDir = join(teamDir, 'mailbox');
+  const outstandingByWorker = await scanMailboxOutstanding(mailboxDir);
+
   for (const worker of workers) {
     const statusPath = join(teamDir, 'workers', worker.name, 'status.json');
     const status = await readJsonSafe<{ state?: string; updated_at?: string }>(statusPath, {});
@@ -167,7 +173,11 @@ export async function checkLeaderStaleness(params: {
     }
 
     if (status.state === 'idle' || status.state === 'done') {
-      idleWorkerCount++;
+      // Queued/unanswered directed work means the worker is not truly idle.
+      const outstanding = outstandingByWorker[worker.name]?.undeliveredInbound ?? 0;
+      if (outstanding === 0) {
+        idleWorkerCount++;
+      }
     }
   }
 

--- a/src/hooks/team-worker-hook.ts
+++ b/src/hooks/team-worker-hook.ts
@@ -18,6 +18,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 import { getOmcRoot } from '../lib/worktree-paths.js';
+import { countOutstandingForWorker, scanMailboxOutstanding } from '../team/mailbox-outstanding.js';
 
 // ── Env helpers ────────────────────────────────────────────────────────────
 
@@ -327,11 +328,19 @@ export async function maybeNotifyLeaderWorkerIdle(params: {
   const { leaderPaneId } = teamInfo;
   if (!leaderPaneId) return;
 
+  // Outstanding directed-work metadata (issue #3662): a worker with queued
+  // or unanswered inbound messages, or an undelivered owed report, must not
+  // be announced as plainly idle/available.
+  const mailboxDir = join(stateDir, 'team', teamName, 'mailbox');
+  const outstanding = await countOutstandingForWorker(mailboxDir, workerName);
+
   // Build notification message
   const parts = [`[OMC] ${workerName} idle`];
   if (prevState && prevState !== 'unknown') parts.push(`(was: ${prevState})`);
   if (currentTaskId) parts.push(`task: ${currentTaskId}`);
   if (currentReason) parts.push(`reason: ${currentReason}`);
+  if (outstanding.undeliveredInbound > 0) parts.push(`outstanding: ${outstanding.undeliveredInbound} unanswered`);
+  if (outstanding.undeliveredOutbound > 0) parts.push(`undelivered reports: ${outstanding.undeliveredOutbound}`);
   const message = `${parts.join('. ')}. ${DEFAULT_MARKER}`;
   const logWorkerIdlePersistenceFailure = createSwallowedErrorLogger(
     'hooks.team-worker maybeNotifyLeaderWorkerIdle persistence failed',
@@ -364,6 +373,8 @@ export async function maybeNotifyLeaderWorkerIdle(params: {
         prev_state: prevState,
         task_id: currentTaskId || null,
         reason: currentReason || null,
+        undelivered_inbound_count: outstanding.undeliveredInbound,
+        undelivered_outbound_count: outstanding.undeliveredOutbound,
         created_at: nowIso,
       };
       await appendFile(eventsPath, JSON.stringify(event) + '\n');
@@ -415,8 +426,20 @@ export async function maybeNotifyLeaderAllWorkersIdle(params: {
 
   if (!leaderPaneId) return;
 
+  // Outstanding directed-work metadata (issue #3662): never claim plain
+  // readiness while any worker has queued/unanswered directed messages or an
+  // undelivered owed report.
+  const mailboxDir = join(stateDir, 'team', teamName, 'mailbox');
+  const outstandingByWorker = await scanMailboxOutstanding(mailboxDir);
+  const totalOutstanding = Object.values(outstandingByWorker).reduce(
+    (sum, counts) => sum + counts.undeliveredInbound + counts.undeliveredOutbound,
+    0,
+  );
+
   const N = workers.length;
-  const message = `[OMC] All ${N} worker${N === 1 ? '' : 's'} idle. Ready for next instructions. ${DEFAULT_MARKER}`;
+  const message = totalOutstanding > 0
+    ? `[OMC] All ${N} worker${N === 1 ? '' : 's'} idle (outstanding: ${totalOutstanding} undelivered directed messages). ${DEFAULT_MARKER}`
+    : `[OMC] All ${N} worker${N === 1 ? '' : 's'} idle. Ready for next instructions. ${DEFAULT_MARKER}`;
   const logAllWorkersIdlePersistenceFailure = createSwallowedErrorLogger(
     'hooks.team-worker maybeNotifyLeaderAllWorkersIdle persistence failed',
   );
@@ -446,6 +469,7 @@ export async function maybeNotifyLeaderAllWorkersIdle(params: {
         type: 'all_workers_idle',
         worker: workerName,
         worker_count: N,
+        outstanding_count: totalOutstanding,
         created_at: nowIso,
       };
       await appendFile(eventsPath, JSON.stringify(event) + '\n');

--- a/src/team/__tests__/events.outstanding.test.ts
+++ b/src/team/__tests__/events.outstanding.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for issue #3662: the monitor-derived worker_idle event
+ * must carry observable outstanding-work metadata (undelivered directed
+ * messages in the worker's mailbox).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { emitMonitorDerivedEvents, readTeamEventsByType } from '../events.js';
+
+const TEAM = 'demo-team';
+const WORKER = 'worker-1';
+
+function seed(cwd: string, options: { undeliveredInbound?: boolean; undeliveredOutbound?: boolean } = {}): string {
+  const stateDir = join(cwd, '.omc', 'state');
+  const teamDir = join(stateDir, 'team', TEAM);
+  const mailboxDir = join(teamDir, 'mailbox');
+  const nowIso = new Date().toISOString();
+
+  mkdirSync(mailboxDir, { recursive: true });
+  const messages: unknown[] = [];
+  if (options.undeliveredInbound) {
+    messages.push({
+      message_id: 'msg-in-1',
+      from_worker: 'leader-fixed',
+      to_worker: WORKER,
+      body: 'Review this diff.',
+      created_at: nowIso,
+    });
+  }
+  writeFileSync(
+    join(mailboxDir, `${WORKER}.json`),
+    JSON.stringify({ worker: WORKER, messages }),
+  );
+
+  if (options.undeliveredOutbound) {
+    writeFileSync(
+      join(mailboxDir, 'leader-fixed.json'),
+      JSON.stringify({
+        worker: 'leader-fixed',
+        messages: [{
+          message_id: 'msg-out-1',
+          from_worker: WORKER,
+          to_worker: 'leader-fixed',
+          body: 'Review findings.',
+          created_at: nowIso,
+        }],
+      }),
+    );
+  }
+
+  return stateDir;
+}
+
+describe('emitMonitorDerivedEvents worker_idle outstanding metadata (issue #3662)', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'omc-events-outstanding-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('includes undelivered directed-message counts on the worker_idle event', async () => {
+    seed(cwd, { undeliveredInbound: true, undeliveredOutbound: true });
+
+    await emitMonitorDerivedEvents(
+      TEAM,
+      [],
+      [{ name: WORKER, alive: true, status: { state: 'idle' } }],
+      {
+        taskStatusById: {},
+        workerAliveByName: { [WORKER]: true },
+        workerStateByName: { [WORKER]: 'working' },
+      },
+      cwd,
+    );
+
+    const events = await readTeamEventsByType(TEAM, 'worker_idle', cwd);
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.worker).toBe(WORKER);
+    expect(event.undelivered_inbound_count).toBe(1);
+    expect(event.undelivered_outbound_count).toBe(1);
+  });
+
+  it('reports zero outstanding when the mailbox is empty or missing', async () => {
+    seed(cwd);
+
+    await emitMonitorDerivedEvents(
+      TEAM,
+      [],
+      [{ name: WORKER, alive: true, status: { state: 'idle' } }],
+      {
+        taskStatusById: {},
+        workerAliveByName: { [WORKER]: true },
+        workerStateByName: { [WORKER]: 'working' },
+      },
+      cwd,
+    );
+
+    const events = await readTeamEventsByType(TEAM, 'worker_idle', cwd);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.undelivered_inbound_count).toBe(0);
+    expect(events[0]!.undelivered_outbound_count).toBe(0);
+  });
+});

--- a/src/team/__tests__/mailbox-outstanding.test.ts
+++ b/src/team/__tests__/mailbox-outstanding.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for mailbox outstanding-work scanning (issue #3662).
+ * Covers mailbox format variants, delivery/ack transitions, and
+ * race tolerance (malformed/missing files must never throw).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  scanMailboxOutstanding,
+  countOutstandingForWorker,
+  ZERO_OUTSTANDING,
+} from '../mailbox-outstanding.js';
+
+describe('scanMailboxOutstanding', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'omc-mailbox-outstanding-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('counts undelivered inbound and outbound directed messages per worker', async () => {
+    const nowIso = new Date().toISOString();
+    writeFileSync(
+      join(dir, 'worker-1.json'),
+      JSON.stringify({
+        worker: 'worker-1',
+        messages: [
+          { message_id: 'm1', from_worker: 'leader-fixed', to_worker: 'worker-1', body: 'review', created_at: nowIso },
+          { message_id: 'm2', from_worker: 'worker-2', to_worker: 'worker-1', body: 'ping', created_at: nowIso },
+          { message_id: 'm3', from_worker: 'leader-fixed', to_worker: 'worker-1', body: 'acked', created_at: nowIso, delivered_at: nowIso },
+        ],
+      }),
+    );
+    writeFileSync(
+      join(dir, 'leader-fixed.json'),
+      JSON.stringify({
+        worker: 'leader-fixed',
+        messages: [
+          { message_id: 'm4', from_worker: 'worker-1', to_worker: 'leader-fixed', body: 'report', created_at: nowIso },
+        ],
+      }),
+    );
+
+    const result = await scanMailboxOutstanding(dir);
+    expect(result['worker-1']).toEqual({ undeliveredInbound: 2, undeliveredOutbound: 1 });
+    expect(result['worker-2']).toEqual({ undeliveredInbound: 0, undeliveredOutbound: 1 });
+    expect(result['leader-fixed']).toEqual({ undeliveredInbound: 1, undeliveredOutbound: 1 });
+  });
+
+  it('treats delivered messages as non-outstanding (ack transition clears)', async () => {
+    const nowIso = new Date().toISOString();
+    writeFileSync(
+      join(dir, 'worker-1.json'),
+      JSON.stringify({
+        worker: 'worker-1',
+        messages: [
+          { message_id: 'm1', from_worker: 'leader-fixed', to_worker: 'worker-1', body: 'review', created_at: nowIso, delivered_at: nowIso },
+        ],
+      }),
+    );
+
+    const result = await scanMailboxOutstanding(dir);
+    expect(result['worker-1']).toEqual({ undeliveredInbound: 0, undeliveredOutbound: 0 });
+  });
+
+  it('supports legacy JSONL mailboxes and bare-array JSON mailboxes', async () => {
+    const nowIso = new Date().toISOString();
+    writeFileSync(
+      join(dir, 'worker-1.jsonl'),
+      `${JSON.stringify({ message_id: 'j1', from_worker: 'leader-fixed', to_worker: 'worker-1', body: 'jsonl', created_at: nowIso })}\n${JSON.stringify({ message_id: 'j2', from_worker: 'worker-1', to_worker: 'leader-fixed', body: 'report', created_at: nowIso, delivered_at: nowIso })}\n`,
+    );
+    writeFileSync(
+      join(dir, 'worker-2.json'),
+      JSON.stringify([
+        { message_id: 'b1', from_worker: 'leader-fixed', to_worker: 'worker-2', body: 'bare', created_at: nowIso },
+      ]),
+    );
+
+    const result = await scanMailboxOutstanding(dir);
+    expect(result['worker-1']).toEqual({ undeliveredInbound: 1, undeliveredOutbound: 0 });
+    expect(result['worker-2']).toEqual({ undeliveredInbound: 1, undeliveredOutbound: 0 });
+  });
+
+  it('tolerates missing directories, missing files, and malformed JSON (race)', async () => {
+    const result = await scanMailboxOutstanding(join(dir, 'does-not-exist'));
+    expect(result).toEqual({});
+
+    writeFileSync(join(dir, 'worker-1.json'), '{broken json');
+    const mixed = await scanMailboxOutstanding(dir);
+    expect(mixed['worker-1']).toEqual({ undeliveredInbound: 0, undeliveredOutbound: 0 });
+
+    const single = await countOutstandingForWorker(dir, 'worker-1');
+    expect(single).toEqual(ZERO_OUTSTANDING);
+  });
+
+  it('skips lock/dotfiles and unknown extensions', async () => {
+    const nowIso = new Date().toISOString();
+    writeFileSync(join(dir, '.lock-worker-1'), 'lock');
+    writeFileSync(join(dir, 'worker-1.txt'), 'ignored');
+    writeFileSync(
+      join(dir, 'worker-1.json'),
+      JSON.stringify({ worker: 'worker-1', messages: [{ message_id: 'm1', from_worker: 'x', to_worker: 'worker-1', body: 'b', created_at: nowIso }] }),
+    );
+
+    const result = await scanMailboxOutstanding(dir);
+    expect(result['worker-1']).toEqual({ undeliveredInbound: 1, undeliveredOutbound: 0 });
+    // 'x' appears as the sender-ledger key for the undelivered message; lock
+    // and unknown-extension files are never parsed as mailboxes.
+    expect(Object.keys(result).sort()).toEqual(['worker-1', 'x']);
+  });
+
+  it('returns zero for an unknown or empty worker name', async () => {
+    expect(await countOutstandingForWorker(dir, '')).toEqual(ZERO_OUTSTANDING);
+    expect(await countOutstandingForWorker(dir, 'ghost')).toEqual(ZERO_OUTSTANDING);
+  });
+});

--- a/src/team/__tests__/team-leader-nudge-outstanding.test.ts
+++ b/src/team/__tests__/team-leader-nudge-outstanding.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression tests for issue #3662: leader-nudge idle accounting must not
+ * classify a worker with queued/unanswered directed mailbox messages as
+ * idle/available.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { checkLeaderStaleness, maybeNudgeLeader, type TmuxRunner } from '../../hooks/team-leader-nudge-hook.js';
+
+const TEAM = 'demo-team';
+const WORKER = 'worker-1';
+
+function writeJsonSync(path: string, value: unknown): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+function seedTeam(cwd: string, options: { undeliveredInbound?: boolean; deliveredInbound?: boolean } = {}): string {
+  const stateDir = join(cwd, '.omc', 'state');
+  const teamDir = join(stateDir, 'team', TEAM);
+  const nowIso = new Date().toISOString();
+
+  writeJsonSync(join(teamDir, 'config.json'), {
+    workers: [{ name: WORKER }],
+    leader_pane_id: '%1',
+  });
+  writeJsonSync(join(teamDir, 'workers', WORKER, 'status.json'), {
+    state: 'idle',
+    updated_at: nowIso,
+  });
+  writeJsonSync(join(teamDir, 'workers', WORKER, 'heartbeat.json'), {
+    alive: true,
+    last_turn_at: nowIso,
+  });
+  writeJsonSync(join(teamDir, 'tasks', 'task-1.json'), {
+    status: 'pending',
+  });
+
+  if (options.undeliveredInbound || options.deliveredInbound) {
+    writeJsonSync(join(teamDir, 'mailbox', `${WORKER}.json`), {
+      worker: WORKER,
+      messages: [{
+        message_id: 'msg-1',
+        from_worker: 'leader-fixed',
+        to_worker: WORKER,
+        body: 'Deliver the review findings.',
+        created_at: nowIso,
+        ...(options.deliveredInbound ? { delivered_at: nowIso } : {}),
+      }],
+    });
+  }
+
+  return stateDir;
+}
+
+describe('team leader nudge outstanding-work classification (issue #3662)', () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'omc-leader-nudge-outstanding-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('does not count a worker with undelivered inbound messages as idle', async () => {
+    const stateDir = seedTeam(cwd, { undeliveredInbound: true });
+    const staleness = await checkLeaderStaleness({ stateDir, teamName: TEAM, nowMs: Date.now() });
+
+    expect(staleness.idleWorkerCount).toBe(0);
+    expect(staleness.stale).toBe(false);
+  });
+
+  it('does not nudge "all workers idle" while a worker owes a response to a queued message', async () => {
+    const stateDir = seedTeam(cwd, { undeliveredInbound: true });
+    const sent: string[] = [];
+    const tmux: TmuxRunner = {
+      async sendKeys(_target, text) {
+        sent.push(text);
+      },
+    };
+
+    const result = await maybeNudgeLeader({ cwd, stateDir, teamName: TEAM, tmux });
+
+    expect(result.nudged).toBe(false);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('restores the idle classification once the message is delivered (ack transition)', async () => {
+    const stateDir = seedTeam(cwd, { deliveredInbound: true });
+    const staleness = await checkLeaderStaleness({ stateDir, teamName: TEAM, nowMs: Date.now() });
+
+    expect(staleness.idleWorkerCount).toBe(1);
+    expect(staleness.stale).toBe(true);
+    expect(staleness.reason).toContain('all_workers_idle_with_active_tasks');
+  });
+
+  it('preserves existing nudge behavior when there is no mailbox at all', async () => {
+    const stateDir = seedTeam(cwd);
+    const sent: string[] = [];
+    const tmux: TmuxRunner = {
+      async sendKeys(_target, text) {
+        sent.push(text);
+      },
+    };
+
+    const result = await maybeNudgeLeader({ cwd, stateDir, teamName: TEAM, tmux });
+
+    expect(result.nudged).toBe(true);
+    expect(sent[0]).toContain('Leader nudge');
+  });
+});

--- a/src/team/events.ts
+++ b/src/team/events.ts
@@ -17,6 +17,7 @@ import type { TeamEventType } from './contracts.js';
 import type { TeamEvent } from './types.js';
 import type { WorkerPaneLiveness } from './tmux-session.js';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
+import { countOutstandingForWorker } from './mailbox-outstanding.js';
 
 /**
  * Append a team event to the JSONL event log.
@@ -140,10 +141,14 @@ export async function emitMonitorDerivedEvents(
     }
 
     if (prevState === 'working' && worker.status.state === 'idle') {
+      const mailboxDir = dirname(absPath(cwd, TeamPaths.mailbox(teamName, worker.name)));
+      const outstanding = await countOutstandingForWorker(mailboxDir, worker.name);
       await appendTeamEvent(teamName, {
         type: 'worker_idle',
         worker: worker.name,
         reason: `state_transition:${prevState}->${worker.status.state}`,
+        undelivered_inbound_count: outstanding.undeliveredInbound,
+        undelivered_outbound_count: outstanding.undeliveredOutbound,
       }, cwd).catch(logDerivedEventFailure);
     }
   }

--- a/src/team/mailbox-outstanding.ts
+++ b/src/team/mailbox-outstanding.ts
@@ -1,0 +1,164 @@
+// src/team/mailbox-outstanding.ts
+
+/**
+ * Outstanding directed-work accounting for team mailboxes.
+ *
+ * A worker still owes work when its mailbox holds directed messages that
+ * have not been delivered (`delivered_at` unset):
+ *   - inbound:  messages addressed TO the worker (queued/unanswered work)
+ *   - outbound: messages FROM the worker (reports/acks awaiting delivery)
+ *
+ * OMC idle surfaces (worker-idle notifications, all-workers-idle claims,
+ * worker_idle events, leader-nudge idle accounting) must not report such a
+ * worker as plainly idle/available: they either carry this observable
+ * metadata or classify the worker as not idle. See issue #3662.
+ */
+
+import { readFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export interface OutstandingMailboxCount {
+  /** Messages directed TO the worker that are not yet delivered (queued/unanswered work). */
+  undeliveredInbound: number;
+  /** Messages FROM the worker that are not yet delivered (owed reports/acks). */
+  undeliveredOutbound: number;
+}
+
+export const ZERO_OUTSTANDING: OutstandingMailboxCount = Object.freeze({
+  undeliveredInbound: 0,
+  undeliveredOutbound: 0,
+});
+
+function safeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function isUndelivered(message: unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const candidate = message as Record<string, unknown>;
+  const deliveredAt = safeString(
+    candidate.delivered_at ?? candidate.deliveredAt ?? candidate.delivered,
+  ).trim();
+  return deliveredAt === '';
+}
+
+function messageFromWorker(message: unknown): string {
+  if (!message || typeof message !== 'object') return '';
+  const candidate = message as Record<string, unknown>;
+  return safeString(candidate.from_worker ?? candidate.from).trim();
+}
+
+function messageToWorker(message: unknown): string {
+  if (!message || typeof message !== 'object') return '';
+  const candidate = message as Record<string, unknown>;
+  return safeString(candidate.to_worker ?? candidate.to).trim();
+}
+
+/** Parse the canonical mailbox JSON shape ({ worker, messages: [] } or a bare array). */
+async function readMailboxFileMessages(filePath: string): Promise<unknown[]> {
+  try {
+    if (!existsSync(filePath)) return [];
+    const raw = await readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>).messages)) {
+      return (parsed as Record<string, unknown>).messages as unknown[];
+    }
+    return [];
+  } catch {
+    // A malformed mailbox (e.g. mid-write) must never break idle accounting.
+    return [];
+  }
+}
+
+/** Parse the legacy JSONL mailbox shape (one message per line). */
+async function readMailboxFileMessagesJsonl(filePath: string): Promise<unknown[]> {
+  try {
+    if (!existsSync(filePath)) return [];
+    const raw = await readFile(filePath, 'utf-8');
+    const messages: unknown[] = [];
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        messages.push(JSON.parse(trimmed) as unknown);
+      } catch {
+        // skip malformed legacy row
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Scan the team mailbox directory and compute undelivered directed-work
+ * counts for every worker, reading each `{recipient}.json` / `{recipient}.jsonl`
+ * mailbox at most once.
+ *
+ * Missing directories and malformed files are tolerated (counted as zero)
+ * so a transient mailbox write never crashes an idle notification.
+ */
+export async function scanMailboxOutstanding(
+  mailboxDir: string,
+): Promise<Record<string, OutstandingMailboxCount>> {
+  const result: Record<string, OutstandingMailboxCount> = {};
+  let entries: string[] = [];
+  try {
+    entries = await readdir(mailboxDir);
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith('.')) continue;
+    let recipient = '';
+    let messages: unknown[] = [];
+    if (entry.endsWith('.json')) {
+      recipient = entry.slice(0, -'.json'.length);
+      messages = await readMailboxFileMessages(join(mailboxDir, entry));
+    } else if (entry.endsWith('.jsonl')) {
+      recipient = entry.slice(0, -'.jsonl'.length);
+      messages = await readMailboxFileMessagesJsonl(join(mailboxDir, entry));
+    } else {
+      continue;
+    }
+    if (!recipient) continue;
+
+    let inbound = 0;
+    const outboundBySender = new Map<string, number>();
+    for (const message of messages) {
+      if (!isUndelivered(message)) continue;
+      if (messageToWorker(message) === recipient) inbound += 1;
+      const from = messageFromWorker(message);
+      if (from) outboundBySender.set(from, (outboundBySender.get(from) ?? 0) + 1);
+    }
+
+    const recipientEntry = result[recipient] ?? { undeliveredInbound: 0, undeliveredOutbound: 0 };
+    result[recipient] = {
+      undeliveredInbound: recipientEntry.undeliveredInbound + inbound,
+      undeliveredOutbound: recipientEntry.undeliveredOutbound,
+    };
+    for (const [sender, count] of outboundBySender) {
+      const senderEntry = result[sender] ?? { undeliveredInbound: 0, undeliveredOutbound: 0 };
+      result[sender] = {
+        undeliveredInbound: senderEntry.undeliveredInbound,
+        undeliveredOutbound: senderEntry.undeliveredOutbound + count,
+      };
+    }
+  }
+
+  return result;
+}
+
+/** Outstanding directed-work counts for a single worker (0/0 when absent or unreadable). */
+export async function countOutstandingForWorker(
+  mailboxDir: string,
+  workerName: string,
+): Promise<OutstandingMailboxCount> {
+  if (!workerName) return ZERO_OUTSTANDING;
+  const scanned = await scanMailboxOutstanding(mailboxDir);
+  return scanned[workerName] ?? ZERO_OUTSTANDING;
+}

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -615,6 +615,10 @@ export interface TeamEvent {
   reason?: string;
   next_action?: TeamLeaderNextAction;
   message?: string;
+  /** Undelivered directed messages addressed TO the worker (issue #3662). */
+  undelivered_inbound_count?: number;
+  /** Undelivered directed messages FROM the worker (owed reports/acks, issue #3662). */
+  undelivered_outbound_count?: number;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes #3662 — idle_notification (and OMC's own idle surfaces) reported a teammate as available/idle while it still owed an undelivered report or had queued, unanswered directed messages. The dispatching worker asked for findings 3x (no response), the worker closed out, and the coordinator received {"type":"idle_notification","from":"wsp-review","idleReason":"available"} 3x while 4 direct SendMessage requests were answered with "already running; queued your message for its next turn."

## Root cause

The exact idle_notification/idleReason JSON surface comes from the native Claude Code teammate layer (absent from this repo), but OMC's own idle surfaces — the worker-idle hook notification, the worker_idle monitor event, the all-workers-idle readiness claim, and the leader-nudge idle accounting — all declared a worker idle without ever consulting the team mailbox for undelivered directed messages or owed reports.

## Change (narrow, backward-compatible)

New src/team/mailbox-outstanding.ts: scans the team mailbox (.omc/state/team/{team}/mailbox/{worker}.json, plus legacy .jsonl and bare-array forms) and counts undelivered directed messages per worker — inbound (queued/unanswered work) and outbound (owed reports/acks). Missing/malformed mailbox files count as zero and never break idle accounting.

Wired into every OMC idle surface:

1. Worker-idle notification (src/hooks/team-worker-hook.ts) — annotated with "outstanding: N unanswered" / "undelivered reports: N" when > 0; plain idle text is unchanged when nothing is outstanding.
2. worker_idle event — new observable fields undelivered_inbound_count / undelivered_outbound_count (both in the hook event and the monitor-derived event in src/team/events.ts; TeamEvent extended with two optional fields).
3. All-workers-idle notification — "Ready for next instructions" is qualified when any undelivered directed message exists ("(outstanding: N undelivered directed messages)"); the plain claim is preserved when nothing is outstanding. Event gains outstanding_count.
4. Leader-nudge idle accounting (src/hooks/team-leader-nudge-hook.ts) — a worker with queued/unanswered inbound messages is no longer counted as idle, so "all workers idle" nudges cannot fire while work is still owed.

Native Claude teammate message formats are untouched (external to this repo); the contract is expressed in OMC's own observable state and notifications.

## Tests

- src/team/__tests__/mailbox-outstanding.test.ts — format variants (JSON/JSONL/bare-array), delivery/ack transition clears, race tolerance (malformed/missing files), lock/unknown files skipped.
- src/hooks/__tests__/team-worker-idle-outstanding.test.ts — queued directed messages annotate idle notification + event; owed report (completion without output) annotated; delivery clears; repeated idle signals dedupe; malformed mailbox race; session isolation; all-workers-idle qualified vs plain.
- src/team/__tests__/team-leader-nudge-outstanding.test.ts — idle classification excludes queued-inbound workers; ack restores it; no-mailbox behavior preserved.
- src/team/__tests__/events.outstanding.test.ts — monitor-derived worker_idle event carries the counts.

All new tests pass (21), related existing suites pass (20), tsc --noEmit clean, ESLint clean. Full suite: 12129/12131 pass — the 2 failures are pre-existing/environmental (post-tool-verifier fails identically on the base tree; python-sandbox is a spawn timeout flake that passes in isolation).

## Verification

- [x] Reproduced the mailbox/undelivered-message state on dev HEAD via deterministic tests
- [x] New regression tests pass
- [x] tsc --noEmit clean
- [x] ESLint clean
- [x] Related suites + bounded full suite green except pre-existing/env failures

Fixes #3662

— GJC (Bellman)
