### PR TITLE
fix(hooks): surface dirty-worktree evidence on abnormal agent termination (#3663)

### DIFF
--- a/src/__tests__/tools/trace-tools.test.ts
+++ b/src/__tests__/tools/trace-tools.test.ts
@@ -154,6 +154,21 @@ describe('trace-tools', () => {
       expect(text).toContain('untracked-native-fork agent stop was untracked');
     });
 
+    it('surfaces dirty-worktree stops from abnormal termination (issue #3663)', async () => {
+      appendReplayEvent(testDir, 'dirty-sum', {
+        agent: 'ab12345', event: 'agent_stop', agent_type: 'executor', success: false,
+        dirty_worktree: { tracked: 1, untracked: 2, ignored: 0, worktree_root: '/tmp/wt-1', truncated: false },
+      });
+
+      const result = await traceSummaryTool.handler({ sessionId: 'dirty-sum', workingDirectory: testDir });
+      const text = result.content[0].text;
+
+      expect(text).toContain('1 failed');
+      expect(text).toContain('Dirty worktrees on stop');
+      expect(text).toContain('1 agent(s) terminated leaving uncommitted work');
+      expect(text).toContain('preserve before reset/cleanup');
+    });
+
     it('should show flow trace statistics', async () => {
       appendReplayEvent(testDir, 'flow-sum', { agent: 'system', event: 'hook_fire', hook: 'test' });
       appendReplayEvent(testDir, 'flow-sum', { agent: 'system', event: 'keyword_detected', keyword: 'ultrawork' });

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync } from "fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -25,7 +26,7 @@ import {
   type ToolUsageEntry,
 } from "../index.js";
 import { readMissionBoardState } from "../../../hud/mission-board.js";
-import { readReplayEvents } from "../session-replay.js";
+import { readReplayEvents, getReplaySummary } from "../session-replay.js";
 
 describe("subagent-tracker", () => {
   let testDir: string;
@@ -1308,6 +1309,225 @@ describe("subagent-tracker", () => {
       expect(observatory.lines.length).toBeGreaterThan(0);
       expect(observatory.lines[0]).toContain("executor");
       expect(observatory.lines[0]).toContain("$0.05");
+    });
+  });
+
+  describe("processSubagentStop — worktree dirty evidence (#3663)", () => {
+    function git(cwd: string, args: string[]): string {
+      return execFileSync("git", args, {
+        cwd,
+        encoding: "utf-8",
+        stdio: "pipe",
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Test",
+          GIT_AUTHOR_EMAIL: "test@test.com",
+          GIT_COMMITTER_NAME: "Test",
+          GIT_COMMITTER_EMAIL: "test@test.com",
+          GIT_CONFIG_GLOBAL: "/dev/null",
+          GIT_CONFIG_SYSTEM: "/dev/null",
+        },
+      }).trim();
+    }
+
+    function makeGitRepo(): string {
+      const repoDir = join(testDir, `repo-${Math.random().toString(36).slice(2)}`);
+      mkdirSync(join(repoDir, ".omc", "state"), { recursive: true });
+      git(repoDir, ["init"]);
+      git(repoDir, ["config", "user.email", "test@test.com"]);
+      git(repoDir, ["config", "user.name", "Test"]);
+      git(repoDir, ["config", "commit.gpgsign", "false"]);
+      writeFileSync(join(repoDir, ".gitignore"), ".omc/\n");
+      writeFileSync(join(repoDir, "tracked.txt"), "seed\n");
+      git(repoDir, ["add", ".gitignore", "tracked.txt"]);
+      git(repoDir, ["commit", "-m", "seed"]);
+      return repoDir;
+    }
+
+    it("records bounded dirty-worktree evidence on abnormal stop", () => {
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+      writeFileSync(join(repoDir, "new.txt"), "untracked work\n");
+
+      processSubagentStart({
+        session_id: "sess-dirty-1",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-dirty-1",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "build a harness",
+      });
+      flushPendingWrites();
+
+      const output = processSubagentStop({
+        session_id: "sess-dirty-1",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-dirty-1",
+        output: "Agent terminated early due to an API error",
+        success: false,
+      });
+      flushPendingWrites();
+
+      // The hook never blocks and never injects context into the dying agent.
+      expect(output).toEqual({ continue: true, suppressOutput: true });
+
+      const state = readTrackingState(repoDir, "sess-dirty-1");
+      const agent = state.agents.find((a) => a.agent_id === "ag-dirty-1");
+      expect(agent?.status).toBe("failed");
+      expect(agent?.worktree_evidence?.kind).toBe("dirty");
+      expect(agent?.worktree_evidence?.trackedCount).toBe(1);
+      expect(agent?.worktree_evidence?.untrackedCount).toBe(1);
+      expect(agent?.worktree_evidence?.worktreeRoot).toBe(repoDir);
+
+      // Replay JSONL carries the bounded record for /trace.
+      const events = readReplayEvents(repoDir, "sess-dirty-1");
+      const stop = events.find((e) => e.event === "agent_stop" && e.agent === "ag-dirty-1".substring(0, 7));
+      expect(stop?.dirty_worktree).toMatchObject({
+        tracked: 1,
+        untracked: 1,
+        worktree_root: repoDir,
+      });
+
+      // The trace summary surfaces the count.
+      expect(getReplaySummary(repoDir, "sess-dirty-1").dirty_worktrees).toBe(1);
+
+      // The worktree is untouched: no commit, no stash, same status.
+      expect(git(repoDir, ["status", "--porcelain"])).toContain("tracked.txt");
+      expect(git(repoDir, ["rev-list", "--count", "HEAD"])).toBe("1");
+      expect(git(repoDir, ["stash", "list"])).toBe("");
+    });
+
+    it("detects abnormal termination from the API-error output marker even without success flag", () => {
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+
+      processSubagentStart({
+        session_id: "sess-dirty-2",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-dirty-2",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "stall mid-stream",
+      });
+      flushPendingWrites();
+
+      // SDK omits `success` for API-error terminations (Bug #1 default would
+      // mark it completed) — the output marker is what makes it abnormal.
+      processSubagentStop({
+        session_id: "sess-dirty-2",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-dirty-2",
+        output: "API Error: Response stalled mid-stream",
+      });
+      flushPendingWrites();
+
+      const state = readTrackingState(repoDir, "sess-dirty-2");
+      const agent = state.agents.find((a) => a.agent_id === "ag-dirty-2");
+      expect(agent?.worktree_evidence?.kind).toBe("dirty");
+      expect(agent?.worktree_evidence?.trackedCount).toBe(1);
+    });
+
+    it("does not record evidence on normal completion or cancel-like stops", () => {
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+
+      processSubagentStart({
+        session_id: "sess-clean-3",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-clean-3",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "normal task",
+      });
+      flushPendingWrites();
+
+      processSubagentStop({
+        session_id: "sess-clean-3",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-clean-3",
+        output: "completed normally",
+      });
+      flushPendingWrites();
+
+      const state = readTrackingState(repoDir, "sess-clean-3");
+      const agent = state.agents.find((a) => a.agent_id === "ag-clean-3");
+      expect(agent?.status).toBe("completed");
+      expect(agent?.worktree_evidence).toBeUndefined();
+
+      // Cancel-like stop (no failure markers) also records nothing.
+      processSubagentStart({
+        session_id: "sess-cancel-3",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-cancel-3",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "cancel me",
+      });
+      flushPendingWrites();
+      processSubagentStop({
+        session_id: "sess-cancel-3",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-cancel-3",
+        output: "Interrupted by user — cancelling task",
+      });
+      flushPendingWrites();
+
+      const state2 = readTrackingState(repoDir, "sess-cancel-3");
+      const agent2 = state2.agents.find((a) => a.agent_id === "ag-cancel-3");
+      expect(agent2?.worktree_evidence).toBeUndefined();
+      expect(agent2?.status).toBe("completed");
+    });
+
+    it("records non-dirty evidence kinds without failing on non-git stops", () => {
+      // Non-git directory: abnormal stop must not break and must not mark dirty.
+      processSubagentStart({
+        session_id: "sess-ng-4",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-ng-4",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "non-git task",
+      });
+      flushPendingWrites();
+      const output = processSubagentStop({
+        session_id: "sess-ng-4",
+        transcript_path: join(testDir, "transcript.jsonl"),
+        cwd: testDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-ng-4",
+        output: "Agent terminated early due to an API error",
+        success: false,
+      });
+      flushPendingWrites();
+      expect(output).toEqual({ continue: true, suppressOutput: true });
+
+      const state = readTrackingState(testDir, "sess-ng-4");
+      const agent = state.agents.find((a) => a.agent_id === "ag-ng-4");
+      expect(agent?.status).toBe("failed");
+      expect(agent?.worktree_evidence?.kind).toBe("not_git");
     });
   });
 });

--- a/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  collectWorktreeDirtyEvidence,
+  buildDirtyWorktreeNotice,
+  isAbnormalTermination,
+  MAX_EVIDENCE_ENTRIES,
+  type WorktreeDirtyEvidence,
+} from "../worktree-evidence.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix = "omc-wt-evidence-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: "pipe",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@test.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@test.com",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+    },
+  }).trim();
+}
+
+function initRepo(dir: string): void {
+  git(dir, ["init"]);
+  git(dir, ["config", "user.email", "test@test.com"]);
+  git(dir, ["config", "user.name", "Test"]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  git(dir, ["add", "."]);
+  git(dir, ["commit", "-m", "initial"]);
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("collectWorktreeDirtyEvidence", () => {
+  it("returns clean for a pristine git worktree", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("clean");
+    expect(evidence.trackedCount).toBe(0);
+    expect(evidence.untrackedCount).toBe(0);
+    expect(evidence.ignoredCount).toBe(0);
+    expect(evidence.entries).toEqual([]);
+    expect(evidence.truncated).toBe(false);
+    expect(evidence.worktreeRoot).toBe(repo);
+  });
+
+  it("flags dirty when a tracked file is modified", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    writeFileSync(join(repo, "README.md"), "# modified\n");
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.trackedCount).toBe(1);
+    expect(evidence.untrackedCount).toBe(0);
+    expect(evidence.entries).toContain("README.md");
+  });
+
+  it("flags dirty for untracked files", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    writeFileSync(join(repo, "campaign.md"), "new work\n");
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.untrackedCount).toBe(1);
+    expect(evidence.entries).toContain("campaign.md");
+  });
+
+  it("counts ignored files separately and does NOT treat them as at-risk work", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    writeFileSync(join(repo, ".gitignore"), "build/\n");
+    git(repo, ["add", ".gitignore"]);
+    git(repo, ["commit", "-m", "ignore build"]);
+    mkdirSync(join(repo, "build"), { recursive: true });
+    writeFileSync(join(repo, "build", "out.txt"), "artifact\n");
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("clean");
+    expect(evidence.trackedCount).toBe(0);
+    expect(evidence.untrackedCount).toBe(0);
+    expect(evidence.ignoredCount).toBe(1);
+  });
+
+  it("combines tracked, untracked, and ignored counts", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    writeFileSync(join(repo, ".gitignore"), "build/\n");
+    git(repo, ["add", ".gitignore"]);
+    git(repo, ["commit", "-m", "ignore build"]);
+    writeFileSync(join(repo, "README.md"), "# modified\n");
+    writeFileSync(join(repo, "new.txt"), "untracked\n");
+    mkdirSync(join(repo, "build"), { recursive: true });
+    writeFileSync(join(repo, "build", "out.txt"), "artifact\n");
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.trackedCount).toBe(1);
+    expect(evidence.untrackedCount).toBe(1);
+    expect(evidence.ignoredCount).toBe(1);
+  });
+
+  it("returns not_git for a non-repository directory", () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "file.txt"), "not a repo\n");
+
+    const evidence = collectWorktreeDirtyEvidence(dir);
+    expect(evidence.kind).toBe("not_git");
+  });
+
+  it("returns cwd_missing for a deleted working directory", () => {
+    const missing = join(makeTempDir(), "deleted-cwd");
+    const evidence = collectWorktreeDirtyEvidence(missing);
+    expect(evidence.kind).toBe("cwd_missing");
+  });
+
+  it("returns git_unavailable when the git binary cannot run", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+
+    const evidence = collectWorktreeDirtyEvidence(repo, {
+      gitCommand: join(repo, "no-such-git-binary"),
+    });
+    expect(evidence.kind).toBe("git_unavailable");
+    expect(evidence.error).toContain("git_unavailable");
+  });
+
+  it("identifies linked git worktrees as isolated worktrees", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    const worktree = join(repo, ".omc", "team", "demo-team", "worktrees", "worker-1");
+    mkdirSync(worktree, { recursive: true });
+    git(repo, ["worktree", "add", "-b", "linked-branch", worktree]);
+
+    const evidence = collectWorktreeDirtyEvidence(worktree);
+    expect(evidence.isLinkedWorktree).toBe(true);
+    expect(evidence.worktreeRoot).toBe(worktree);
+    expect(evidence.kind).toBe("clean");
+
+    // Dirty the linked worktree.
+    writeFileSync(join(worktree, "README.md"), "# modified in worktree\n");
+    const dirty = collectWorktreeDirtyEvidence(worktree);
+    expect(dirty.kind).toBe("dirty");
+    expect(dirty.trackedCount).toBe(1);
+  });
+
+  it("bounds entries and marks truncation", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    for (let i = 0; i < MAX_EVIDENCE_ENTRIES + 5; i++) {
+      writeFileSync(join(repo, `untracked-${i}.txt`), `content ${i}\n`);
+    }
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.untrackedCount).toBe(MAX_EVIDENCE_ENTRIES + 5);
+    expect(evidence.entries.length).toBe(MAX_EVIDENCE_ENTRIES);
+    expect(evidence.truncated).toBe(true);
+  });
+
+  it("never mutates the repository while collecting evidence", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    writeFileSync(join(repo, "README.md"), "# modified\n");
+    writeFileSync(join(repo, "new.txt"), "untracked\n");
+    const statusBefore = git(repo, ["status", "--porcelain"]);
+    const headBefore = git(repo, ["rev-parse", "HEAD"]);
+    const stashBefore = git(repo, ["stash", "list"]);
+
+    collectWorktreeDirtyEvidence(repo);
+
+    expect(git(repo, ["status", "--porcelain"])).toBe(statusBefore);
+    expect(git(repo, ["rev-parse", "HEAD"])).toBe(headBefore);
+    expect(git(repo, ["stash", "list"])).toBe(stashBefore);
+    // No new commits were created by the collector.
+    expect(git(repo, ["rev-list", "--count", "HEAD"])).toBe("1");
+  });
+
+  it("is fail-closed and never throws", () => {
+    expect(() => collectWorktreeDirtyEvidence(join(makeTempDir(), "nope"))).not.toThrow();
+    const repo = makeTempDir();
+    initRepo(repo);
+    expect(() =>
+      collectWorktreeDirtyEvidence(repo, { gitCommand: "/nonexistent/git" }),
+    ).not.toThrow();
+  });
+});
+
+describe("buildDirtyWorktreeNotice", () => {
+  const agentId = "agent-abcdef123456789";
+  const agentType = "oh-my-claudecode:executor";
+
+  it("builds a bounded notice for dirty evidence", () => {
+    const evidence: WorktreeDirtyEvidence = {
+      kind: "dirty",
+      worktreeRoot: "/tmp/omc/worktree-1",
+      isLinkedWorktree: true,
+      trackedCount: 1,
+      untrackedCount: 2,
+      ignoredCount: 0,
+      entries: ["a.txt"],
+      truncated: false,
+    };
+
+    const notice = buildDirtyWorktreeNotice(evidence, agentId, agentType);
+    expect(notice).toBeTruthy();
+    expect(notice).toContain("agent-a");
+    expect(notice).toContain("3 uncommitted file(s)");
+    expect(notice).toContain("1 tracked, 2 untracked");
+    expect(notice).toContain("/tmp/omc/worktree-1");
+    expect(notice).not.toContain("\n");
+  });
+
+  it("returns null for non-dirty kinds", () => {
+    const base: WorktreeDirtyEvidence = {
+      kind: "clean",
+      worktreeRoot: "/tmp/omc/worktree-1",
+      isLinkedWorktree: true,
+      trackedCount: 0,
+      untrackedCount: 0,
+      ignoredCount: 0,
+      entries: [],
+      truncated: false,
+    };
+    expect(buildDirtyWorktreeNotice(base, agentId, agentType)).toBeNull();
+    expect(
+      buildDirtyWorktreeNotice({ ...base, kind: "not_git" }, agentId, agentType),
+    ).toBeNull();
+    expect(
+      buildDirtyWorktreeNotice({ ...base, kind: "cwd_missing" }, agentId, agentType),
+    ).toBeNull();
+    expect(
+      buildDirtyWorktreeNotice(
+        { ...base, kind: "git_unavailable", error: "git_unavailable" },
+        agentId,
+        agentType,
+      ),
+    ).toBeNull();
+  });
+
+  it("redacts file content from the notice", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    writeFileSync(join(repo, "secrets.env"), "SUPER_SECRET_TOKEN=hunter2\n");
+    const evidence = collectWorktreeDirtyEvidence(repo);
+
+    const notice = buildDirtyWorktreeNotice(evidence, agentId, agentType);
+    expect(evidence.kind).toBe("dirty");
+    expect(notice).not.toContain("SUPER_SECRET_TOKEN");
+    expect(notice).not.toContain("hunter2");
+  });
+});
+
+describe("isAbnormalTermination", () => {
+  it("treats explicit failure as abnormal", () => {
+    expect(isAbnormalTermination({ success: false })).toBe(true);
+    expect(isAbnormalTermination({ success: false, output: "any output" })).toBe(true);
+  });
+
+  it("detects API-error termination markers in the stop output", () => {
+    expect(
+      isAbnormalTermination({ output: "Agent terminated early due to an API error" }),
+    ).toBe(true);
+    expect(
+      isAbnormalTermination({ output: "API Error: Response stalled mid-stream" }),
+    ).toBe(true);
+    expect(
+      isAbnormalTermination({
+        output: "<task-notification><status>failed</status></task-notification>",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats normal completion and cancel-like stops as non-abnormal", () => {
+    expect(isAbnormalTermination({})).toBe(false);
+    expect(isAbnormalTermination({ success: true, output: "done" })).toBe(false);
+    expect(
+      isAbnormalTermination({ output: "Interrupted by user — cancelling task" }),
+    ).toBe(false);
+    expect(isAbnormalTermination({ output: "" })).toBe(false);
+  });
+});

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -26,6 +26,11 @@ import { resolveSessionId } from '../../lib/session-id.js';
 import { withFileLockSync, lockPathFor } from '../../lib/file-lock.js';
 import { recordAgentStart, recordAgentStop } from './session-replay.js';
 import { recordMissionAgentStart, recordMissionAgentStop } from '../../hud/mission-board.js';
+import {
+  collectWorktreeDirtyEvidence,
+  isAbnormalTermination,
+  type WorktreeDirtyEvidence,
+} from './worktree-evidence.js';
 
 // ============================================================================
 // Types
@@ -52,6 +57,8 @@ export interface SubagentInfo {
   synthetic?: boolean;
   telemetry_status?: "unmatched_stop";
   telemetry_note?: string;
+  /** Bounded dirty-worktree evidence recorded on abnormal termination (#3663). */
+  worktree_evidence?: WorktreeDirtyEvidence;
 }
 
 export interface ToolUsageEntry {
@@ -775,6 +782,18 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
   ensureParentDir(writePath);
   const lockPath = lockPathFor(writePath);
 
+  // Issue #3663: collect dirty-worktree evidence OUTSIDE the session-state
+  // lock. The collector is bounded (two read-only `git status` calls, up to a
+  // few seconds on abnormal stops) but holding the lock that long would drop
+  // concurrent stop hooks (LOCK_OPTS.timeoutMs is 500ms). READ-ONLY and
+  // fail-closed: never commits, resets, or removes anything, and never throws.
+  let abnormalEvidence: WorktreeDirtyEvidence | undefined;
+  if (isAbnormalTermination(input)) {
+    try {
+      abnormalEvidence = collectWorktreeDirtyEvidence(input.cwd);
+    } catch { /* evidence is best-effort; never break the stop hook */ }
+  }
+
   try {
     return withFileLockSync(lockPath, () => {
       const state = readTrackingState(input.cwd, sessionId);
@@ -850,6 +869,14 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
       const stoppedAgent =
         agentIndex !== -1 ? state.agents[agentIndex] : undefined;
 
+      // Issue #3663: attach the dirty-worktree evidence collected outside the
+      // lock to the closed agent entry BEFORE the state write so the
+      // coordinator can see uncommitted work in the agent's (isolated) worktree
+      // before running destructive cleanup. READ-ONLY and fail-closed.
+      if (stoppedAgent && abnormalEvidence) {
+        stoppedAgent.worktree_evidence = abnormalEvidence;
+      }
+
       // Evict oldest completed agents if over limit
       const completedAgents = state.agents.filter(
         (a) => a.status === "completed" || a.status === "failed",
@@ -876,9 +903,23 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
         // Fix: SDK doesn't populate agent_type in SubagentStop, so use tracked state
         try {
           const agentType = stoppedAgent?.agent_type || input.agent_type || UNTRACKED_NATIVE_FORK_AGENT_TYPE;
-          recordAgentStop(input.cwd, input.session_id, input.agent_id, agentType, succeeded, stoppedAgent?.duration_ms, stoppedAgent?.synthetic
+          const baseStopMetadata = stoppedAgent?.synthetic
             ? { synthetic: true, telemetry_status: stoppedAgent.telemetry_status, reason: stoppedAgent.telemetry_note }
-            : undefined);
+            : undefined;
+          const evidence = stoppedAgent?.worktree_evidence;
+          const stopMetadata = evidence && evidence.kind === "dirty"
+            ? {
+                ...(baseStopMetadata ?? {}),
+                dirty_worktree: {
+                  tracked: evidence.trackedCount,
+                  untracked: evidence.untrackedCount,
+                  ignored: evidence.ignoredCount,
+                  worktree_root: evidence.worktreeRoot ?? "",
+                  truncated: evidence.truncated,
+                },
+              }
+            : baseStopMetadata;
+          recordAgentStop(input.cwd, input.session_id, input.agent_id, agentType, succeeded, stoppedAgent?.duration_ms, stopMetadata);
         } catch { /* best-effort */ }
 
         try {

--- a/src/hooks/subagent-tracker/session-replay.ts
+++ b/src/hooks/subagent-tracker/session-replay.ts
@@ -46,6 +46,14 @@ export interface ReplayEvent {
   description?: string;
   /** Agent-tool explicit name (authoritative address). */
   name?: string;
+  /** Bounded dirty-worktree evidence recorded on abnormal termination (#3663). */
+  dirty_worktree?: {
+    tracked: number;
+    untracked: number;
+    ignored: number;
+    worktree_root: string;
+    truncated: boolean;
+  };
   /** Hook name (e.g., "keyword-detector") */
   hook?: string;
   /** Claude Code event (e.g., "UserPromptSubmit") */
@@ -82,6 +90,8 @@ export interface ReplaySummary {
   agents_completed: number;
   agents_failed: number;
   agents_untracked_stops?: number;
+  /** Number of agent stops that left a dirty worktree behind (#3663). */
+  dirty_worktrees?: number;
   tool_summary: Record<string, { count: number; total_ms: number; avg_ms: number; max_ms: number }>;
   bottlenecks: Array<{ tool: string; agent: string; avg_ms: number }>;
   timeline_range: { start: number; end: number };
@@ -206,6 +216,14 @@ export interface AgentStopReplayMetadata {
   synthetic?: boolean;
   telemetry_status?: "unmatched_stop";
   reason?: string;
+  /** Bounded dirty-worktree evidence (issue #3663). */
+  dirty_worktree?: {
+    tracked: number;
+    untracked: number;
+    ignored: number;
+    worktree_root: string;
+    truncated: boolean;
+  };
 }
 
 /**
@@ -229,6 +247,7 @@ export function recordAgentStop(
     synthetic: metadata?.synthetic,
     telemetry_status: metadata?.telemetry_status,
     reason: metadata?.reason,
+    dirty_worktree: metadata?.dirty_worktree,
   });
 }
 
@@ -395,6 +414,9 @@ export function getReplaySummary(directory: string, sessionId: string): ReplaySu
         }
         if (event.success) summary.agents_completed++;
         else summary.agents_failed++;
+        if (event.dirty_worktree) {
+          summary.dirty_worktrees = (summary.dirty_worktrees || 0) + 1;
+        }
         if (event.agent_type && event.duration_ms) {
           const stats = agentTypeStats.get(event.agent_type);
           if (stats) stats.total_ms += event.duration_ms;

--- a/src/hooks/subagent-tracker/worktree-evidence.ts
+++ b/src/hooks/subagent-tracker/worktree-evidence.ts
@@ -1,0 +1,253 @@
+/**
+ * Worktree dirty-evidence collection for abnormal agent termination (issue #3663).
+ *
+ * When a background agent terminates abnormally (API error / stalled mid-stream
+ * / failed task-notification), its isolated git worktree can be left holding
+ * uncommitted work with no checkpoint and no warning to the coordinator. This
+ * module records bounded, READ-ONLY evidence about that dirty state at
+ * SubagentStop time so a coordinator can see the work exists BEFORE running
+ * destructive cleanup (`git reset --hard`, worktree removal, campaign clean,
+ * ...).
+ *
+ * Safety contract:
+ *  - READ-ONLY: never stages, commits, stashes, resets, or removes anything.
+ *  - BOUNDED: path lists are capped and file CONTENT is never read or emitted.
+ *  - FAIL-CLOSED: any git failure degrades to a structured non-dirty kind and
+ *    never throws out of the hook boundary.
+ *  - NO AUTO-COMMIT: checkpointing agent work is deliberately left to the
+ *    coordinator. Authorship, secrets, hooks, ignored files, and partially
+ *    written content are not safely boundable from this hook surface, so a
+ *    silent WIP commit is never created here.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export const MAX_EVIDENCE_ENTRIES = 20;
+export const GIT_TIMEOUT_MS = 2500;
+export const MAX_EVIDENCE_PATH_LENGTH = 200;
+
+/** Kinds of evidence a stop hook can produce (never throws). */
+export type WorktreeEvidenceKind =
+  | "dirty"
+  | "clean"
+  | "not_git"
+  | "cwd_missing"
+  | "git_unavailable";
+
+export interface WorktreeDirtyEvidence {
+  kind: WorktreeEvidenceKind;
+  /** Git toplevel (worktree root) when resolvable. */
+  worktreeRoot?: string;
+  /** True when the toplevel is a linked git worktree (`.git` is a file). */
+  isLinkedWorktree: boolean;
+  /** Number of changed tracked files. */
+  trackedCount: number;
+  /** Number of untracked files (`??`). */
+  untrackedCount: number;
+  /** Number of ignored files (`!!`) — informational, NOT at-risk work. */
+  ignoredCount: number;
+  /** Bounded relative paths (redacted: paths only, never content). */
+  entries: string[];
+  /** True when entries were capped at MAX_EVIDENCE_ENTRIES. */
+  truncated: boolean;
+  /** Bounded reason when git could not be queried. */
+  error?: string;
+}
+
+export interface WorktreeEvidenceOptions {
+  /** Git binary path (test seam). Defaults to "git". */
+  gitCommand?: string;
+  /** Per-call git timeout in ms (test seam). Defaults to GIT_TIMEOUT_MS. */
+  timeoutMs?: number;
+}
+
+/** Markers of abnormal agent termination inside a stop `output` summary. */
+export const ABNORMAL_TERMINATION_MARKERS =
+  /(<status>failed<\/status>|Agent terminated early due to an API error|Response stalled mid-stream|API error: Response)/i;
+
+/**
+ * Whether a SubagentStop input represents an abnormal termination.
+ *
+ * The Claude Code SDK does not reliably set `success` on SubagentStop (it
+ * defaults to "completed" when undefined), so abnormal termination is inferred
+ * from an explicit failure flag OR from the failure markers Claude Code emits
+ * in the stop output summary for API-error terminations (issue #3663).
+ * User-initiated cancels / interrupts are NOT treated as abnormal.
+ */
+export function isAbnormalTermination(input: {
+  success?: boolean;
+  output?: string;
+}): boolean {
+  if (input.success === false) return true;
+  if (typeof input.output !== "string" || input.output.trim() === "") {
+    return false;
+  }
+  return ABNORMAL_TERMINATION_MARKERS.test(input.output);
+}
+
+function runGit(
+  cwd: string,
+  args: string[],
+  opts: WorktreeEvidenceOptions,
+): string {
+  const git = opts.gitCommand || "git";
+  const timeoutMs = opts.timeoutMs ?? GIT_TIMEOUT_MS;
+  // GIT_TERMINAL_PROMPT=0 prevents credential prompts from hanging the hook;
+  // GIT_OPTIONAL_LOCKS=0 keeps `git status` from taking optional index locks
+  // (read-only, no contention with a concurrent coordinator).
+  return execFileSync(git, args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+    timeout: timeoutMs,
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_OPTIONAL_LOCKS: "0",
+    },
+  });
+}
+
+function isLinkedWorktree(toplevel: string): boolean {
+  try {
+    // A linked worktree's toplevel has a `.git` FILE (gitdir: ...); the main
+    // repo has a `.git` directory.
+    return statSync(join(toplevel, ".git")).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sanitizePathPart(value: string): string {
+  return value
+    .replace(/[\u0000-\u001f\u007f]/g, "?")
+    .trim()
+    .substring(0, MAX_EVIDENCE_PATH_LENGTH);
+}
+
+/** Extract the path from a `git status --porcelain` line (rename-aware). */
+function statusEntryPath(line: string): string {
+  const payload = line.slice(3);
+  const renameSeparator = " -> ";
+  const renameIndex = payload.indexOf(renameSeparator);
+  const raw = renameIndex >= 0
+    ? payload.slice(renameIndex + renameSeparator.length)
+    : payload;
+  return sanitizePathPart(raw);
+}
+
+const empty = (): WorktreeDirtyEvidence => ({
+  kind: "clean",
+  isLinkedWorktree: false,
+  trackedCount: 0,
+  untrackedCount: 0,
+  ignoredCount: 0,
+  entries: [],
+  truncated: false,
+});
+
+/**
+ * Collect bounded dirty-worktree evidence for a directory. READ-ONLY and
+ * fail-closed: never throws, never mutates the repository.
+ */
+export function collectWorktreeDirtyEvidence(
+  cwd: string,
+  opts: WorktreeEvidenceOptions = {},
+): WorktreeDirtyEvidence {
+  try {
+    if (!existsSync(cwd)) {
+      return { ...empty(), kind: "cwd_missing", error: "cwd_missing" };
+    }
+
+    let toplevel: string;
+    try {
+      toplevel = runGit(cwd, ["rev-parse", "--show-toplevel"], opts).trim();
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        return {
+          ...empty(),
+          kind: "git_unavailable",
+          error: `git_unavailable:${String(code)}`,
+        };
+      }
+      return { ...empty(), kind: "not_git", error: "not_git" };
+    }
+    if (!toplevel) return { ...empty(), kind: "not_git", error: "not_git" };
+
+    const linked = isLinkedWorktree(toplevel);
+
+    // Two bounded read-only calls: regular status (tracked+untracked) and
+    // ignored status (informational — ignored files are not at-risk work).
+    const status = runGit(toplevel, ["status", "--porcelain"], opts);
+    const ignoredStatus = runGit(
+      toplevel,
+      ["status", "--porcelain", "--ignored=matching"],
+      opts,
+    );
+
+    const tracked: string[] = [];
+    const untracked: string[] = [];
+    const ignored: string[] = [];
+    for (const line of status.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (trimmed.startsWith("??")) {
+        untracked.push(statusEntryPath(line));
+      } else {
+        tracked.push(statusEntryPath(line));
+      }
+    }
+    for (const line of ignoredStatus.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (trimmed.startsWith("!!")) {
+        ignored.push(statusEntryPath(line));
+      }
+    }
+
+    const all = [...tracked, ...untracked, ...ignored];
+    const truncated = all.length > MAX_EVIDENCE_ENTRIES;
+    const entries = all.slice(0, MAX_EVIDENCE_ENTRIES);
+
+    return {
+      kind: tracked.length + untracked.length > 0 ? "dirty" : "clean",
+      worktreeRoot: sanitizePathPart(toplevel),
+      isLinkedWorktree: linked,
+      trackedCount: tracked.length,
+      untrackedCount: untracked.length,
+      ignoredCount: ignored.length,
+      entries,
+      truncated,
+    };
+  } catch {
+    // Fail-closed: any unexpected git/filesystem failure must not break the
+    // stop hook and must not claim the worktree is dirty.
+    return { ...empty(), kind: "git_unavailable", error: "evidence_failed" };
+  }
+}
+
+/**
+ * Build a bounded, redacted coordinator-facing notice for dirty-worktree
+ * evidence. Returns null when there is nothing to warn about (clean, non-git,
+ * missing cwd, git unavailable).
+ */
+export function buildDirtyWorktreeNotice(
+  evidence: WorktreeDirtyEvidence,
+  agentId: string,
+  agentType: string,
+): string | null {
+  if (evidence.kind !== "dirty" || !evidence.worktreeRoot) return null;
+  const total = evidence.trackedCount + evidence.untrackedCount;
+  const shortId = sanitizePathPart(agentId).substring(0, 7) || "agent";
+  const type = sanitizePathPart(agentType).substring(0, 40) || "subagent";
+  return (
+    `[OMC] Agent ${shortId} (${type}) terminated with ${total} uncommitted file(s) ` +
+    `(${evidence.trackedCount} tracked, ${evidence.untrackedCount} untracked) in ` +
+    `${evidence.worktreeRoot}. Preserve this worktree before destructive cleanup; ` +
+    `OMC does not auto-commit agent work.`
+  );
+}

--- a/src/tools/trace-tools.ts
+++ b/src/tools/trace-tools.ts
@@ -347,6 +347,9 @@ export const traceSummaryTool: ToolDefinition<{
         `- **Duration:** ${summary.duration_seconds.toFixed(1)}s`,
         `- **Total Events:** ${summary.total_events}`,
         `- **Agents:** ${summary.agents_spawned} spawned, ${summary.agents_completed} completed, ${summary.agents_failed} failed${summary.agents_untracked_stops ? `, ${summary.agents_untracked_stops} untracked stop(s)` : ''}`,
+        ...(summary.dirty_worktrees
+          ? [`- **Dirty worktrees on stop:** ${summary.dirty_worktrees} agent(s) terminated leaving uncommitted work (issue #3663) — preserve before reset/cleanup; see subagent-tracking state`]
+          : []),
         '',
       ];
 


### PR DESCRIPTION
## Summary

Fixes #3663. When a background agent terminates abnormally (API error / `Response stalled mid-stream` / failed task-notification), its isolated git worktree can be left holding uncommitted work with no checkpoint and no warning — and a coordinator routinely running `git reset --hard`, `campaign.sh clean`, or worktree removals has no signal that the work exists.

This PR makes the **SubagentStop hook** (the OMC-controlled layer that observes every agent termination and its `cwd`) record **bounded, read-only dirty-worktree evidence** on abnormal termination:

- **`src/hooks/subagent-tracker/worktree-evidence.ts`** (new): fail-closed collector producing structured kinds (`dirty` / `clean` / `not_git` / `cwd_missing` / `git_unavailable`) with tracked/untracked/ignored counts, capped paths (max 20), linked-worktree detection, and a redacted one-line notice builder. It **never commits, resets, stashes, or removes anything** and never throws out of the hook boundary.
- **`processSubagentStop`**: on abnormal termination, attaches the evidence to the closed agent entry in `subagent-tracking-state.json`, passes `dirty_worktree` metadata into the `agent_stop` replay event, and surfaces a `Dirty worktrees on stop` count in the `/trace` summary.
- **Abnormal-termination detection**: Claude Code's `SubagentStop` payload does not reliably set `success` (SDK omits it; stops default to "completed"). Abnormal termination is inferred from `success === false` **or** the failure markers Claude Code emits in the stop output summary (`Agent terminated early due to an API error`, `Response stalled mid-stream`, `<status>failed</status>`). User-initiated cancels/interrupts are **not** treated as abnormal.

## Design decisions / boundaries (documented)

- **No auto-WIP commit.** Authorship, secrets, hooks, ignored files, and partially written content are not safely boundable from this hook surface, and the coordinator's intent is unknown — so checkpointing agent work is deliberately left to the coordinator (the issue's higher-risk option). The shipped contract is: bounded evidence + preservation guidance, not a surprise commit.
- **Claude-native task notifications cannot be rewritten.** The `<task-notification>` block is emitted by Claude Code, not OMC. The coordinator-visible surfaces here are the durable OMC artifacts the coordinator and `/trace` read: tracking state, replay JSONL, and the trace summary count. OMC's own destructive cleanup already preserves dirty worktrees (`worktree_dirty` in `git-worktree.ts`) — this adds the warning/evidence layer on top.
- **Hot path unchanged.** Normal completions and cancels do not run git — evidence collection only runs on abnormal stops (two bounded read-only `git status` calls with a 2.5s timeout and `GIT_OPTIONAL_LOCKS=0`).

## Tests

- 18 new unit tests for the evidence collector/notice builder (clean/dirty worktrees, tracked/untracked/ignored files, git unavailable/non-repo, deleted cwd, linked worktrees, redaction of file content, no destructive mutation, bounded truncation, API-error vs normal/cancel classification).
- 4 new `processSubagentStop` wiring tests (evidence persisted to tracking state + replay + trace summary; output-marker detection without `success`; normal/cancel produce nothing; non-git abnormal stop stays non-dirty and non-blocking).
- 1 new trace-summary rendering test.
- Verified locally on Node 20: `tsc --noEmit` clean, ESLint clean, `plugin-shipping-surface verify` clean, full `src/hooks` + tools/contract suites pass (3044 tests), and the full `vitest run --exclude tests/perf/**` suite is green.

No release/version/generated-authorization files are touched; generated `bridge/*.cjs` bundles are intentionally left to the release-authorization workflow.