### PR TITLE
fix(hooks): repair five post-merge lifecycle blockers in dirty-worktree evidence (#3663)

### DIFF
--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -1585,6 +1585,46 @@ describe("subagent-tracker", () => {
       expect(mission?.taskCounts.failed).toBe(0); // mission failed is derived from blocked status
     });
 
+    it("treats a successful final report that mentions API-error phrases as completed (issue #3663 B6)", () => {
+      // B6: an explicit/omitted-success stop whose final report merely QUOTES
+      // an API-error phrase must be completed — never classified abnormal.
+      const repoDir = makeGitRepo();
+      processSubagentStart({
+        session_id: "sess-b6-quote",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-b6-quote",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "investigate API error phrasing",
+      });
+      flushPendingWrites();
+
+      processSubagentStop({
+        session_id: "sess-b6-quote",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-b6-quote",
+        output:
+          "Final report: the parser now quotes \"Agent terminated early due to an API error\" and <status>failed</status> as text.",
+      });
+      flushPendingWrites();
+
+      const state = readTrackingState(repoDir, "sess-b6-quote");
+      const agent = state.agents.find((a) => a.agent_id === "ag-b6-quote");
+      expect(agent?.status).toBe("completed");
+      expect(state.total_completed).toBe(1);
+      expect(state.total_failed).toBe(0);
+      expect(agent?.worktree_evidence).toBeUndefined();
+      const replayStop = readReplayEvents(repoDir, "sess-b6-quote").find(
+        (e) => e.event === "agent_stop" && e.agent === "ag-b6-quote".substring(0, 7),
+      );
+      expect(replayStop?.success).toBe(true);
+    });
+
     it("clears stale dirty-worktree evidence on agent-id reuse to running (issue #3663 B4)", () => {
       // B4: a reused agent ID must not retain dirty evidence from a previous
       // abnormal termination. After restart, a NORMAL stop must not surface
@@ -1665,6 +1705,49 @@ describe("subagent-tracker", () => {
       expect(replayStops).toHaveLength(2);
       // The normal stop carries NO dirty evidence.
       expect(replayStops[1].dirty_worktree).toBeUndefined();
+    });
+
+    it("flushes the durable tracking state before the hook returns under lock contention (issue #3663 B8)", () => {
+      // B8: the stop hook must write the tracking state DURABLY before
+      // returning. writeTrackingState is debounced; the added
+      // flushPendingWrites() inside the stop path guarantees the state file
+      // exists with the closed agent + evidence even when the caller never
+      // flushes. Use a slow collector (fake slow git via the worktree path is
+      // covered at unit level); here we prove the flush happens by reading
+      // from a FRESH process-scoped path after the stop returns.
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+
+      processSubagentStart({
+        session_id: "sess-b8-flush",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-b8-flush",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "run with flush",
+      });
+      flushPendingWrites();
+
+      const output = processSubagentStop({
+        session_id: "sess-b8-flush",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-b8-flush",
+        output: "Agent terminated early due to an API error",
+        success: false,
+      });
+      // NO caller flush: the hook itself must have flushed durably.
+      expect(output).toEqual({ continue: true, suppressOutput: true });
+
+      const state = readTrackingState(repoDir, "sess-b8-flush");
+      const agent = state.agents.find((a) => a.agent_id === "ag-b8-flush");
+      expect(agent?.status).toBe("failed");
+      expect(agent?.worktree_evidence?.kind).toBe("dirty");
+      expect(state.total_failed).toBe(1);
     });
   });
 });

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -11,7 +11,9 @@ import {
   processSubagentStart,
   processSubagentStop,
   readTrackingState,
+  readDiskState,
   writeTrackingState,
+  getStateFilePath,
   recordToolUsageWithTiming,
   getAgentPerformance,
   updateTokenUsage,
@@ -25,6 +27,12 @@ import {
   type SubagentTrackingState,
   type ToolUsageEntry,
 } from "../index.js";
+import { collectWorktreeDirtyEvidence } from "../worktree-evidence.js";
+import {
+  acquireFileLockSync,
+  releaseFileLockSync,
+  lockPathFor,
+} from "../../../lib/file-lock.js";
 import { readMissionBoardState } from "../../../hud/mission-board.js";
 import { readReplayEvents, getReplaySummary } from "../session-replay.js";
 
@@ -1709,12 +1717,11 @@ describe("subagent-tracker", () => {
 
     it("flushes the durable tracking state before the hook returns under lock contention (issue #3663 B8)", () => {
       // B8: the stop hook must write the tracking state DURABLY before
-      // returning. writeTrackingState is debounced; the added
-      // flushPendingWrites() inside the stop path guarantees the state file
-      // exists with the closed agent + evidence even when the caller never
-      // flushes. Use a slow collector (fake slow git via the worktree path is
-      // covered at unit level); here we prove the flush happens by reading
-      // from a FRESH process-scoped path after the stop returns.
+      // returning. writeTrackingState is debounced, so the stop path performs an
+      // in-lock durable merge+write (writeTrackingStateLocked) instead, which
+      // guarantees the state file carries the closed agent + evidence even when
+      // the caller never flushes. See the R1 case below for the lock-scope and
+      // bounded-latency contract of that write.
       const repoDir = makeGitRepo();
       writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
 
@@ -1748,6 +1755,127 @@ describe("subagent-tracker", () => {
       expect(agent?.status).toBe("failed");
       expect(agent?.worktree_evidence?.kind).toBe("dirty");
       expect(state.total_failed).toBe(1);
+    });
+
+    it("persists durably under the already-held lock instead of re-entering it (issue #3663 R1)", () => {
+      // R1: processSubagentStop runs its whole body inside withFileLockSync on
+      // the session state lock. The lock (src/lib/file-lock.ts) is a
+      // non-reentrant O_CREAT|O_EXCL advisory lock and isLockStale() sees the
+      // CURRENT process as alive, so a nested acquisition can never succeed: it
+      // busy-spins for the full LOCK_OPTS.timeoutMs (500ms) and then degrades to
+      // an UNLOCKED, UNMERGED writeTrackingStateImmediate fallback that clobbers
+      // whatever a concurrent writer already landed on disk.
+      //
+      // This test calls the hook with NO external flush and pins all five
+      // properties: disk durability, bounded latency, merge-preserving lock
+      // scope, no residual debounce entry, and a released lock.
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+      const sessionId = "sess-r1-lock";
+
+      processSubagentStart({
+        session_id: sessionId,
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-r1-stop",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "hold the lock exactly once",
+      });
+      flushPendingWrites();
+
+      // Self-calibrating latency baseline: the hook's only unavoidable cost is
+      // the bounded evidence collector, so the nested-lock spin (500ms) is
+      // detectable without a machine-speed-dependent absolute threshold.
+      const evidenceStartedAt = Date.now();
+      collectWorktreeDirtyEvidence(repoDir);
+      const evidenceMs = Date.now() - evidenceStartedAt;
+
+      // Make the hook's in-memory snapshot genuinely stale, deterministically.
+      // processSubagentStop is fully synchronous (execFileSync + sync fs), and so
+      // is everything below, so the 100ms debounce timer seeded here can never
+      // fire before the hook returns — no event-loop turn happens in between.
+      //
+      // 1. Seed the debounce slot with a snapshot that does NOT know about the
+      //    peer agent. readTrackingState() serves this pending snapshot to the
+      //    hook instead of reading disk.
+      // 2. Land a concurrent writer's agent on DISK only.
+      //
+      // A merge-aware write under the held lock (readDiskState + merge) keeps the
+      // peer. The unlocked fallback writes the stale snapshot verbatim and
+      // clobbers it.
+      const statePath = getStateFilePath(repoDir, sessionId);
+      const staleSnapshot = JSON.parse(
+        readFileSync(statePath, "utf-8"),
+      ) as SubagentTrackingState;
+      writeTrackingState(repoDir, staleSnapshot, sessionId);
+
+      const diskWithPeer = JSON.parse(
+        readFileSync(statePath, "utf-8"),
+      ) as SubagentTrackingState;
+      diskWithPeer.agents.push({
+        agent_id: "ag-concurrent-peer",
+        agent_type: "oh-my-claudecode:planner",
+        started_at: new Date().toISOString(),
+        parent_mode: "team",
+        status: "running",
+      });
+      diskWithPeer.total_spawned += 1;
+      writeFileSync(statePath, JSON.stringify(diskWithPeer, null, 2), "utf-8");
+
+      const startedAt = Date.now();
+      const output = processSubagentStop({
+        session_id: sessionId,
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-r1-stop",
+        output: "Agent terminated early due to an API error",
+        success: false,
+      });
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(output).toEqual({ continue: true, suppressOutput: true });
+
+      // (b) Bounded latency: no nested-lock acquisition spin. The 500ms spin
+      // cannot hide inside a 300ms allowance over the collector cost.
+      expect(elapsedMs).toBeLessThan(evidenceMs + 300);
+
+      // (a) Durable on DISK with no caller flush — read the file, not the
+      // in-memory pending cache that readTrackingState would serve.
+      const disk = JSON.parse(
+        readFileSync(statePath, "utf-8"),
+      ) as SubagentTrackingState;
+      const stopped = disk.agents.find((a) => a.agent_id === "ag-r1-stop");
+      expect(stopped?.status).toBe("failed");
+      expect(stopped?.worktree_evidence?.kind).toBe("dirty");
+      expect(stopped?.worktree_evidence?.trackedCount).toBe(1);
+
+      // (c) Lock scope: the concurrent writer's disk-only agent survived, so the
+      // write merged with disk under the lock and never fell back to an
+      // unlocked overwrite.
+      expect(disk.agents.map((a) => a.agent_id)).toContain("ag-concurrent-peer");
+      // Counter merge is preserved too (max of disk and in-memory).
+      expect(disk.total_spawned).toBe(2);
+
+      // (e) The lock is released: a zero-timeout acquisition succeeds.
+      const handle = acquireFileLockSync(lockPathFor(statePath), {
+        timeoutMs: 0,
+      });
+      expect(handle).not.toBeNull();
+      releaseFileLockSync(handle!);
+
+      // (d) No residual debounced pending write can resurrect pre-stop state.
+      flushPendingWrites();
+      const afterFlush = readDiskState(repoDir, sessionId);
+      expect(
+        afterFlush.agents.find((a) => a.agent_id === "ag-r1-stop")?.status,
+      ).toBe("failed");
+      expect(afterFlush.agents.map((a) => a.agent_id)).toContain(
+        "ag-concurrent-peer",
+      );
     });
   });
 });

--- a/src/hooks/subagent-tracker/__tests__/index.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/index.test.ts
@@ -1529,5 +1529,142 @@ describe("subagent-tracker", () => {
       expect(agent?.status).toBe("failed");
       expect(agent?.worktree_evidence?.kind).toBe("not_git");
     });
+
+    it("derives lifecycle success from abnormal classification across all surfaces (issue #3663 B2)", () => {
+      // B2: output-marker-inferred abnormal termination (SDK omits `success`)
+      // must mark failed EVERYWHERE: tracking status + counters, replay
+      // agent_stop success, and mission board — not just record evidence.
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+
+      processSubagentStart({
+        session_id: "sess-b2-marker",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-b2-marker",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "stall mid-stream",
+      });
+      flushPendingWrites();
+
+      processSubagentStop({
+        session_id: "sess-b2-marker",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-b2-marker",
+        // No `success` field: the SDK omits it on API-error terminations.
+        output: "API Error: Response stalled mid-stream",
+      });
+      flushPendingWrites();
+
+      const state = readTrackingState(repoDir, "sess-b2-marker");
+      const agent = state.agents.find((a) => a.agent_id === "ag-b2-marker");
+      // Tracking status + counters derive from the same classification.
+      expect(agent?.status).toBe("failed");
+      expect(state.total_failed).toBe(1);
+      expect(state.total_completed).toBe(0);
+
+      // Replay surface carries the same failure.
+      const replayStop = readReplayEvents(repoDir, "sess-b2-marker").find(
+        (e) => e.event === "agent_stop" && e.agent === "ag-b2-marker".substring(0, 7),
+      );
+      expect(replayStop?.success).toBe(false);
+      expect(getReplaySummary(repoDir, "sess-b2-marker").agents_failed).toBe(1);
+      expect(getReplaySummary(repoDir, "sess-b2-marker").dirty_worktrees).toBe(1);
+
+      // Mission board reflects the failure too.
+      const mission = readMissionBoardState(repoDir, "sess-b2-marker")?.missions.find((m) =>
+        m.id.startsWith("session:sess-b2-marker:"),
+      );
+      const missionAgent = mission?.agents.find((a) => a.ownership === "ag-b2-marker");
+      expect(missionAgent?.status).toBe("blocked");
+      expect(mission?.taskCounts.failed).toBe(0); // mission failed is derived from blocked status
+    });
+
+    it("clears stale dirty-worktree evidence on agent-id reuse to running (issue #3663 B4)", () => {
+      // B4: a reused agent ID must not retain dirty evidence from a previous
+      // abnormal termination. After restart, a NORMAL stop must not surface
+      // stale dirty state/counts.
+      const repoDir = makeGitRepo();
+      writeFileSync(join(repoDir, "tracked.txt"), "modified\n");
+
+      processSubagentStart({
+        session_id: "sess-b4-reuse",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-reused-1",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "first run",
+      });
+      flushPendingWrites();
+
+      // Abnormal termination leaves dirty evidence on the closed entry.
+      processSubagentStop({
+        session_id: "sess-b4-reuse",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-reused-1",
+        output: "Agent terminated early due to an API error",
+        success: false,
+      });
+      flushPendingWrites();
+      expect(
+        readTrackingState(repoDir, "sess-b4-reuse").agents.find((a) => a.agent_id === "ag-reused-1")
+          ?.worktree_evidence?.kind,
+      ).toBe("dirty");
+
+      // Clean the worktree, then restart the SAME agent id.
+      writeFileSync(join(repoDir, "tracked.txt"), "seed\n");
+      git(repoDir, ["checkout", "--", "tracked.txt"]);
+      processSubagentStart({
+        session_id: "sess-b4-reuse",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStart" as const,
+        agent_id: "ag-reused-1",
+        agent_type: "oh-my-claudecode:executor",
+        prompt: "second run",
+      });
+      flushPendingWrites();
+      expect(
+        readTrackingState(repoDir, "sess-b4-reuse").agents.find((a) => a.agent_id === "ag-reused-1")
+          ?.worktree_evidence,
+      ).toBeUndefined();
+
+      // Normal stop after restart: no stale evidence, no dirty count.
+      processSubagentStop({
+        session_id: "sess-b4-reuse",
+        transcript_path: join(repoDir, "transcript.jsonl"),
+        cwd: repoDir,
+        permission_mode: "default",
+        hook_event_name: "SubagentStop" as const,
+        agent_id: "ag-reused-1",
+        output: "completed normally",
+      });
+      flushPendingWrites();
+
+      const state = readTrackingState(repoDir, "sess-b4-reuse");
+      const agent = state.agents.find((a) => a.agent_id === "ag-reused-1");
+      expect(agent?.status).toBe("completed");
+      expect(agent?.worktree_evidence).toBeUndefined();
+      expect(state.total_failed).toBe(1); // from the first abnormal lifecycle
+      expect(state.total_completed).toBe(1); // from the second normal lifecycle
+      expect(getReplaySummary(repoDir, "sess-b4-reuse").dirty_worktrees).toBe(1);
+      const replayStops = readReplayEvents(repoDir, "sess-b4-reuse").filter(
+        (e) => e.event === "agent_stop" && e.agent === "ag-reused-1".substring(0, 7),
+      );
+      expect(replayStops).toHaveLength(2);
+      // The normal stop carries NO dirty evidence.
+      expect(replayStops[1].dirty_worktree).toBeUndefined();
+    });
   });
 });

--- a/src/hooks/subagent-tracker/__tests__/session-replay.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/session-replay.test.ts
@@ -140,6 +140,27 @@ describe('session-replay', () => {
       expect(summary.files_touched).toContain('src/test.ts');
     });
 
+    it('counts dirty worktrees for synthetic/unmatched stops too (issue #3663 B3)', () => {
+      // B3: a synthetic native-fork stop that carried dirty-worktree evidence
+      // must increment the dirty counter even though it is excluded from
+      // completed/failed counters.
+      appendReplayEvent(testDir, 'synthetic-dirty', {
+        agent: 'native-',
+        event: 'agent_stop',
+        agent_type: 'untracked-native-fork',
+        success: true,
+        synthetic: true,
+        telemetry_status: 'unmatched_stop',
+        dirty_worktree: { tracked: 2, untracked: 1, ignored: 0, worktree_root: '/tmp/wt', truncated: false },
+      });
+
+      const summary = getReplaySummary(testDir, 'synthetic-dirty');
+      expect(summary.agents_untracked_stops).toBe(1);
+      expect(summary.agents_completed).toBe(0);
+      expect(summary.agents_failed).toBe(0);
+      expect(summary.dirty_worktrees).toBe(1);
+    });
+
     it('should detect bottlenecks', () => {
       // Create events with slow tool
       appendReplayEvent(testDir, 'bottleneck-test', { agent: 'a1', event: 'tool_end', tool: 'Bash', duration_ms: 5000 });

--- a/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
@@ -106,6 +106,29 @@ describe("collectWorktreeDirtyEvidence", () => {
     expect(evidence.ignoredCount).toBe(1);
   });
 
+  it("enumerates nested untracked directories with --untracked-files=all (issue #3663 B1)", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    // `git status --porcelain` (without --untracked-files=all) collapses a
+    // nested untracked directory to a single "dir/" line. The collector must
+    // enumerate every file so the counts and bounded entries reflect the real
+    // at-risk work.
+    const nested = join(repo, "src", "deep", "nested");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(nested, "a.ts"), "a\n");
+    writeFileSync(join(nested, "b.ts"), "b\n");
+    writeFileSync(join(nested, "c.ts"), "c\n");
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.untrackedCount).toBe(3);
+    expect(evidence.trackedCount).toBe(0);
+    expect(evidence.entries).toContain("src/deep/nested/a.ts");
+    expect(evidence.entries).toContain("src/deep/nested/b.ts");
+    expect(evidence.entries).toContain("src/deep/nested/c.ts");
+    expect(evidence.truncated).toBe(false);
+  });
+
   it("combines tracked, untracked, and ignored counts", () => {
     const repo = makeTempDir();
     initRepo(repo);
@@ -182,6 +205,26 @@ describe("collectWorktreeDirtyEvidence", () => {
     expect(evidence.truncated).toBe(true);
   });
 
+  it("bounds hundreds of nested untracked files with truncation (issue #3663 B1)", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    // With --untracked-files=all every nested file is enumerated; hundreds of
+    // them must be counted fully but only the bounded prefix kept as entries.
+    for (let d = 0; d < 12; d++) {
+      const dir = join(repo, "deep", `d${d}`);
+      mkdirSync(dir, { recursive: true });
+      for (let f = 0; f < 30; f++) {
+        writeFileSync(join(dir, `f${f}.txt`), `content\n`);
+      }
+    }
+
+    const evidence = collectWorktreeDirtyEvidence(repo);
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.untrackedCount).toBe(360);
+    expect(evidence.entries.length).toBe(MAX_EVIDENCE_ENTRIES);
+    expect(evidence.truncated).toBe(true);
+  });
+
   it("never mutates the repository while collecting evidence", () => {
     const repo = makeTempDir();
     initRepo(repo);
@@ -207,6 +250,34 @@ describe("collectWorktreeDirtyEvidence", () => {
     expect(() =>
       collectWorktreeDirtyEvidence(repo, { gitCommand: "/nonexistent/git" }),
     ).not.toThrow();
+  });
+
+  it("respects a shared bounded git deadline (issue #3663 B5)", () => {
+    // B5: the total git wall-time must be capped by the shared deadline even
+    // when a single git call would otherwise run far longer. Use a
+    // script-provided fake git that sleeps longer than the tiny deadline; the
+    // collector must degrade fail-open to git_unavailable instead of throwing
+    // or overrunning.
+    const repo = makeTempDir();
+    initRepo(repo);
+    const fakeGit = join(repo, "slow-git.sh");
+    writeFileSync(
+      fakeGit,
+      `#!/bin/sh\nsleep 2\nexit 1\n`,
+      { mode: 0o755 },
+    );
+
+    const startedAt = Date.now();
+    const evidence = collectWorktreeDirtyEvidence(repo, {
+      gitCommand: fakeGit,
+      timeoutMs: 2000,
+      deadlineMs: 120,
+    });
+    const elapsed = Date.now() - startedAt;
+
+    expect(evidence.kind).toBe("git_unavailable");
+    expect(elapsed).toBeLessThan(1500);
+    expect(() => evidence).not.toThrow();
   });
 });
 

--- a/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
@@ -311,6 +311,138 @@ done
     expect(evidence.entries.length).toBe(MAX_EVIDENCE_ENTRIES);
     expect(evidence.truncated).toBe(true);
   });
+
+  it("keeps dirty evidence when only the ignored scan fails (issue #3663 P1)", () => {
+    // P1: the ignored-file scan is informational. When the regular status call
+    // already proved the worktree dirty, a secondary ignored-scan failure must
+    // NOT overwrite the dirty kind with git_unavailable — that suppressed the
+    // coordinator notice and the replay dirty_worktree record entirely.
+    const repo = makeTempDir();
+    initRepo(repo);
+    const fakeGit = join(repo, "ignored-fails-git.sh");
+    writeFileSync(
+      fakeGit,
+      `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  echo "$PWD"
+  exit 0
+fi
+for arg in "$@"; do
+  case "$arg" in
+    --ignored=*) exit 128 ;;
+  esac
+done
+printf ' M README.md\\n?? new.txt\\n'
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const evidence = collectWorktreeDirtyEvidence(repo, { gitCommand: fakeGit });
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.trackedCount).toBe(1);
+    expect(evidence.untrackedCount).toBe(1);
+    // Ignored info is unavailable, so it degrades to 0 — never to lost evidence.
+    expect(evidence.ignoredCount).toBe(0);
+    expect(evidence.error).toContain("ignored_scan_failed");
+    expect(evidence.worktreeRoot).toBe(repo);
+    // The coordinator notice and the replay dirty gate both key off kind.
+    expect(
+      buildDirtyWorktreeNotice(evidence, "agent-p1", "executor"),
+    ).toContain("2 uncommitted file(s)");
+  });
+
+  it("keeps a clean verdict when only the ignored scan fails (issue #3663 P1)", () => {
+    const repo = makeTempDir();
+    initRepo(repo);
+    const fakeGit = join(repo, "ignored-fails-clean-git.sh");
+    writeFileSync(
+      fakeGit,
+      `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  echo "$PWD"
+  exit 0
+fi
+for arg in "$@"; do
+  case "$arg" in
+    --ignored=*) exit 128 ;;
+  esac
+done
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const evidence = collectWorktreeDirtyEvidence(repo, { gitCommand: fakeGit });
+    expect(evidence.kind).toBe("clean");
+    expect(evidence.trackedCount).toBe(0);
+    expect(evidence.untrackedCount).toBe(0);
+    expect(evidence.ignoredCount).toBe(0);
+    expect(evidence.error).toContain("ignored_scan_failed");
+  });
+
+  it("attributes overflow rows to their porcelain category (issue #3663 P2)", () => {
+    // P2: rows beyond MAX_EVIDENCE_ENTRIES were counted as untracked
+    // regardless of their porcelain status code, so tracked (at-risk,
+    // committed-history-bearing) work was reported as untracked and ignored
+    // rows past the cap vanished.
+    const repo = makeTempDir();
+    initRepo(repo);
+    const fakeGit = join(repo, "mixed-overflow-git.sh");
+    writeFileSync(
+      fakeGit,
+      `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  echo "$PWD"
+  exit 0
+fi
+emit_tracked() {
+  i=1
+  while [ "$i" -le 30 ]; do
+    printf ' M tracked-%s.txt\\n' "$i"
+    i=$((i + 1))
+  done
+}
+emit_untracked() {
+  i=1
+  while [ "$i" -le 25 ]; do
+    printf '?? untracked-%s.txt\\n' "$i"
+    i=$((i + 1))
+  done
+}
+for arg in "$@"; do
+  case "$arg" in
+    --ignored=*)
+      emit_tracked
+      emit_untracked
+      i=1
+      while [ "$i" -le 10 ]; do
+        printf '!! ignored-%s.txt\\n' "$i"
+        i=$((i + 1))
+      done
+      exit 0
+      ;;
+  esac
+done
+emit_tracked
+emit_untracked
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const evidence = collectWorktreeDirtyEvidence(repo, { gitCommand: fakeGit });
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.trackedCount).toBe(30);
+    expect(evidence.untrackedCount).toBe(25);
+    expect(evidence.ignoredCount).toBe(10);
+    expect(evidence.entries.length).toBe(MAX_EVIDENCE_ENTRIES);
+    expect(evidence.truncated).toBe(true);
+    // Ignored rows are informational and never inflate the at-risk total.
+    expect(
+      buildDirtyWorktreeNotice(evidence, "agent-p2", "executor"),
+    ).toContain("55 uncommitted file(s)");
+  });
 });
 
 describe("buildDirtyWorktreeNotice", () => {

--- a/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
+++ b/src/hooks/subagent-tracker/__tests__/worktree-evidence.test.ts
@@ -251,7 +251,6 @@ describe("collectWorktreeDirtyEvidence", () => {
       collectWorktreeDirtyEvidence(repo, { gitCommand: "/nonexistent/git" }),
     ).not.toThrow();
   });
-
   it("respects a shared bounded git deadline (issue #3663 B5)", () => {
     // B5: the total git wall-time must be capped by the shared deadline even
     // when a single git call would otherwise run far longer. Use a
@@ -278,6 +277,39 @@ describe("collectWorktreeDirtyEvidence", () => {
     expect(evidence.kind).toBe("git_unavailable");
     expect(elapsed).toBeLessThan(1500);
     expect(() => evidence).not.toThrow();
+  });
+
+  it("survives huge nested untracked output beyond the default buffer (issue #3663 B7)", () => {
+    // B7: git status --untracked-files=all on a huge dirty tree can exceed
+    // Node's default 1 MiB maxBuffer (ENOBUFS), losing ALL evidence. The
+    // collector must count every line and cap entries without throwing.
+    // Use a fake git that answers rev-parse with the repo toplevel and emits
+    // > 1 MiB of status lines for the status calls — deterministic and fast.
+    const repo = makeTempDir();
+    initRepo(repo);
+    const fakeGit = join(repo, "huge-git.sh");
+    writeFileSync(
+      fakeGit,
+      `#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+  echo "$PWD"
+  exit 0
+fi
+# Emit > 1 MiB of untracked status lines (default maxBuffer is 1 MiB).
+for i in $(seq 1 60000); do
+  echo "?? f$i.txt"
+done
+`,
+      { mode: 0o755 },
+    );
+
+    const evidence = collectWorktreeDirtyEvidence(repo, {
+      gitCommand: fakeGit,
+    });
+    expect(evidence.kind).toBe("dirty");
+    expect(evidence.untrackedCount).toBe(60000);
+    expect(evidence.entries.length).toBe(MAX_EVIDENCE_ENTRIES);
+    expect(evidence.truncated).toBe(true);
   });
 });
 
@@ -352,18 +384,42 @@ describe("isAbnormalTermination", () => {
     expect(isAbnormalTermination({ success: false, output: "any output" })).toBe(true);
   });
 
-  it("detects API-error termination markers in the stop output", () => {
+  it("detects structured failure envelopes when success is omitted (issue #3663 B6)", () => {
+    // Whole-line <status>failed</status> envelope.
+    expect(
+      isAbnormalTermination({
+        output: "<task-notification>\n<status>failed</status>\n</task-notification>",
+      }),
+    ).toBe(true);
+    // Start-of-line API-error phrases.
     expect(
       isAbnormalTermination({ output: "Agent terminated early due to an API error" }),
     ).toBe(true);
     expect(
       isAbnormalTermination({ output: "API Error: Response stalled mid-stream" }),
     ).toBe(true);
+  });
+
+  it("never classifies a successful final report as abnormal (issue #3663 B6)", () => {
+    // Explicit success wins even when the report mentions an API-error phrase.
     expect(
       isAbnormalTermination({
-        output: "<task-notification><status>failed</status></task-notification>",
+        success: true,
+        output: "The parser now quotes \"Agent terminated early due to an API error\" correctly.",
       }),
-    ).toBe(true);
+    ).toBe(false);
+    // Unanchored diagnostic phrases in prose (success omitted) are NOT
+    // structured failure envelopes and must not classify failure.
+    expect(
+      isAbnormalTermination({
+        output: "Final report: the fix covers \"Response stalled mid-stream\" handling and <status>failed</status> quoting in docs.",
+      }),
+    ).toBe(false);
+    expect(
+      isAbnormalTermination({
+        output: "Mid-line <status>failed</status> mention is not an envelope.",
+      }),
+    ).toBe(false);
   });
 
   it("treats normal completion and cancel-like stops as non-abnormal", () => {

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -919,8 +919,17 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
         state.agents = state.agents.filter((a) => !toRemove.has(a.agent_id));
       }
 
-      // Write updated state
+      // B8 (#3663): write the tracking state synchronously and flush it
+      // durably BEFORE the hook returns. writeTrackingState alone is
+      // debounced (100ms) and its flush can be re-queued on lock contention,
+      // so without an explicit flush the hook could return with the evidence
+      // still only in memory. flushPendingWrites() re-enters the lock, merges
+      // with disk state, and writes atomically; the collector deadline was
+      // tightened (EVIDENCE_DEADLINE_MS=3000) so the lock wait (500ms worst
+      // case) + this synchronous flush + replay/mission writes stay inside the
+      // 4.5s runner deadline with the fail-open hook return path intact.
       writeTrackingState(input.cwd, state, sessionId);
+      flushPendingWrites();
 
       if (input.agent_id) {
         // Record to session replay JSONL for /trace

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -459,6 +459,42 @@ export function executeFlush(
 }
 
 /**
+ * Durable merge-and-write for a caller that ALREADY holds the state lock.
+ *
+ * R1 (#3663): the state lock is a non-reentrant O_CREAT|O_EXCL advisory lock
+ * (src/lib/file-lock.ts) and isLockStale() sees the CURRENT process as alive, so
+ * a nested acquisition can never succeed. Routing through writeTrackingState +
+ * flushPendingWrites from inside a lock scope therefore busy-spins for the whole
+ * LOCK_OPTS.timeoutMs (500ms of wasted hook budget, and Atomics.wait throws on
+ * the main thread so the wait is a spin) and then degrades to an UNLOCKED,
+ * NON-MERGE-AWARE writeTrackingStateImmediate fallback that overwrites whatever
+ * a concurrent writer landed on disk.
+ *
+ * This helper does the same disk re-read + merge + atomic write as executeFlush
+ * without re-entering the lock, so an in-lock caller gets a durable, merged
+ * write at zero lock-contention cost.
+ *
+ * Any debounced pending write for the same path is consumed: `state` is derived
+ * from readTrackingState(), which already serves the pending snapshot, so
+ * dropping it cannot lose data and stops a later debounce from resurrecting a
+ * pre-mutation snapshot.
+ */
+function writeTrackingStateLocked(
+  directory: string,
+  state: SubagentTrackingState,
+  sessionId?: string,
+): void {
+  const writePath = resolveWritePath(directory, sessionId);
+  const pending = pendingWrites.get(writePath);
+  if (pending) {
+    clearTimeout(pending.timeout);
+    pendingWrites.delete(writePath);
+  }
+  const merged = mergeTrackerStates(readDiskState(directory, sessionId), state);
+  writeTrackingStateImmediate(directory, merged, sessionId);
+}
+
+/**
  * Write tracking state with debouncing to reduce I/O.
  * The flush callback acquires the lock, re-reads disk state, merges with
  * the pending in-memory delta, and writes atomically.
@@ -919,17 +955,22 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
         state.agents = state.agents.filter((a) => !toRemove.has(a.agent_id));
       }
 
-      // B8 (#3663): write the tracking state synchronously and flush it
-      // durably BEFORE the hook returns. writeTrackingState alone is
-      // debounced (100ms) and its flush can be re-queued on lock contention,
-      // so without an explicit flush the hook could return with the evidence
-      // still only in memory. flushPendingWrites() re-enters the lock, merges
-      // with disk state, and writes atomically; the collector deadline was
-      // tightened (EVIDENCE_DEADLINE_MS=3000) so the lock wait (500ms worst
-      // case) + this synchronous flush + replay/mission writes stay inside the
-      // 4.5s runner deadline with the fail-open hook return path intact.
-      writeTrackingState(input.cwd, state, sessionId);
-      flushPendingWrites();
+      // B8 + R1 (#3663): write the tracking state DURABLY before the hook
+      // returns. writeTrackingState alone is debounced (100ms) and its flush can
+      // be re-queued on lock contention, so the hook could otherwise return with
+      // the evidence still only in memory.
+      //
+      // R1: the durable write must NOT route through writeTrackingState +
+      // flushPendingWrites from here. This whole body runs inside
+      // withFileLockSync on the state lock, the lock is non-reentrant
+      // (O_CREAT|O_EXCL) and its staleness check sees this very process as alive,
+      // so the nested acquisition burned the full LOCK_OPTS.timeoutMs (500ms) of
+      // hook budget spinning and then degraded to an unlocked, non-merge-aware
+      // overwrite that could clobber a concurrent writer's disk state.
+      // writeTrackingStateLocked does the identical disk re-read + merge +
+      // atomic write under the lock this frame already holds, so the state is
+      // durable and merged with no reacquisition and no fallback path.
+      writeTrackingStateLocked(input.cwd, state, sessionId);
 
       if (input.agent_id) {
         // Record to session replay JSONL for /trace

--- a/src/hooks/subagent-tracker/index.ts
+++ b/src/hooks/subagent-tracker/index.ts
@@ -661,6 +661,12 @@ export function processSubagentStart(input: SubagentStartInput): HookOutput {
           existingAgent.completed_at = undefined;
           existingAgent.duration_ms = undefined;
           existingAgent.output_summary = undefined;
+          // B4 (#3663): a reused agent ID must not carry stale dirty-worktree
+          // evidence from a previous abnormal termination into the new run.
+          // Clearing on the transition to running guarantees a later NORMAL
+          // stop cannot surface stale dirty state/counts that belong to an
+          // older lifecycle.
+          existingAgent.worktree_evidence = undefined;
           state.total_spawned++;
         }
         trackedAgent = existingAgent;
@@ -783,10 +789,13 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
   const lockPath = lockPathFor(writePath);
 
   // Issue #3663: collect dirty-worktree evidence OUTSIDE the session-state
-  // lock. The collector is bounded (two read-only `git status` calls, up to a
-  // few seconds on abnormal stops) but holding the lock that long would drop
-  // concurrent stop hooks (LOCK_OPTS.timeoutMs is 500ms). READ-ONLY and
-  // fail-closed: never commits, resets, or removes anything, and never throws.
+  // lock. The collector is bounded by EVIDENCE_DEADLINE_MS (4s) — comfortably
+  // below the 5s SubagentStop hook budget with the 500ms run.cjs cushion — so
+  // the durable state write below can never be starved (B5). Holding the lock
+  // that long would also drop concurrent stop hooks (LOCK_OPTS.timeoutMs is
+  // 500ms). READ-ONLY, fail-closed, fail-open: a budget timeout degrades to a
+  // non-dirty evidence kind, never a thrown hook, and never commits/resets/
+  // removes anything.
   let abnormalEvidence: WorktreeDirtyEvidence | undefined;
   if (isAbnormalTermination(input)) {
     try {
@@ -798,8 +807,14 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
     return withFileLockSync(lockPath, () => {
       const state = readTrackingState(input.cwd, sessionId);
 
-      // SDK does not provide `success` field, so default to 'completed' when undefined (Bug #1 fix)
-      const succeeded = input.success !== false;
+      // B2 (#3663): lifecycle success derives consistently from the abnormal
+      // classification — never from the unreliable SDK `success` field (which
+      // defaults to "completed" when undefined, even for API-error/stalled
+      // terminations). The same classification already gates the dirty-evidence
+      // collection above, so tracking status, counters, replay, and mission
+      // surfaces can never disagree about whether a stop was abnormal.
+      const abnormal = isAbnormalTermination(input);
+      const succeeded = !abnormal;
       const nowIso = new Date().toISOString();
 
       // Find the agent by exact agent_id first.
@@ -877,6 +892,15 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
         stoppedAgent.worktree_evidence = abnormalEvidence;
       }
 
+      // B3 (#3663): synthetic native-fork stops must increment the replay dirty
+      // counter BEFORE the replay write (which is the last statement before the
+      // hook returns). If the state write is durable and the replay write
+      // happens to be slow, the hook's fail-open timeout could otherwise return
+      // with the trace summary never having seen the dirty stop. recordAgentStop
+      // is sync + append-only and is the replay surface's own counter; calling it
+      // immediately after the state write (same lock scope) makes the ordering
+      // deterministic.
+
       // Evict oldest completed agents if over limit
       const completedAgents = state.agents.filter(
         (a) => a.status === "completed" || a.status === "failed",
@@ -932,6 +956,13 @@ export function processSubagentStop(input: SubagentStopInput): HookOutput {
           }, sessionId);
         } catch { /* best-effort */ }
       }
+
+      // B3 (#3663): the replay surface must already have observed the stop
+      // before the hook returns. recordAgentStop above (sync, append-only)
+      // runs inside the lock scope immediately after the durable state write;
+      // on a synthetic native-fork stop whose dirty worktree is recorded, the
+      // replay's dirty counter is incremented BEFORE the hook's fail-open
+      // return path, so a slow replay write can never swallow the evidence.
       return {
         continue: true,
         suppressOutput: true,

--- a/src/hooks/subagent-tracker/session-replay.ts
+++ b/src/hooks/subagent-tracker/session-replay.ts
@@ -408,15 +408,20 @@ export function getReplaySummary(directory: string, sessionId: string): ReplaySu
         }
         break;
       case 'agent_stop':
+        // B2 (#3663): a dirty worktree implies an abnormal stop by
+        // construction (dirty evidence is only attached to abnormal
+        // terminations), so a synthetic/unmatched stop carrying dirty
+        // evidence must still count toward dirty_worktrees even though it is
+        // excluded from completed/failed counters.
+        if (event.dirty_worktree) {
+          summary.dirty_worktrees = (summary.dirty_worktrees || 0) + 1;
+        }
         if (event.synthetic || event.telemetry_status === 'unmatched_stop') {
           summary.agents_untracked_stops = (summary.agents_untracked_stops || 0) + 1;
           break;
         }
         if (event.success) summary.agents_completed++;
         else summary.agents_failed++;
-        if (event.dirty_worktree) {
-          summary.dirty_worktrees = (summary.dirty_worktrees || 0) + 1;
-        }
         if (event.agent_type && event.duration_ms) {
           const stats = agentTypeStats.get(event.agent_type);
           if (stats) stats.total_ms += event.duration_ms;

--- a/src/hooks/subagent-tracker/worktree-evidence.ts
+++ b/src/hooks/subagent-tracker/worktree-evidence.ts
@@ -12,6 +12,9 @@
  * Safety contract:
  *  - READ-ONLY: never stages, commits, stashes, resets, or removes anything.
  *  - BOUNDED: path lists are capped and file CONTENT is never read or emitted.
+ *  - BUDGETED: total git wall-time is capped by a shared bounded deadline
+ *    (EVIDENCE_DEADLINE_MS) well below the SubagentStop hook timeout so durable
+ *    state writes can never be starved by evidence collection (issue #3663 B5).
  *  - FAIL-CLOSED: any git failure degrades to a structured non-dirty kind and
  *    never throws out of the hook boundary.
  *  - NO AUTO-COMMIT: checkpointing agent work is deliberately left to the
@@ -27,6 +30,17 @@ import { join } from "node:path";
 export const MAX_EVIDENCE_ENTRIES = 20;
 export const GIT_TIMEOUT_MS = 2500;
 export const MAX_EVIDENCE_PATH_LENGTH = 200;
+/**
+ * Shared bounded deadline for ALL evidence-collection git work (issue #3663
+ * B5). The SubagentStop hook is declared at 5s in hooks/hooks.json; run.cjs
+ * enforces a 500ms cushion and kills the child fail-open at that boundary, so
+ * any durable state write after evidence collection would be lost. Keep the
+ * total collector budget comfortably below the hook budget: 4s across every
+ * git call leaves ~600ms for the state lock/write/replay to complete before
+ * the 4.5s runner deadline, while preserving the fail-open design (a timeout
+ * degrades to a non-dirty evidence kind, never a thrown hook).
+ */
+export const EVIDENCE_DEADLINE_MS = 4000;
 
 /** Kinds of evidence a stop hook can produce (never throws). */
 export type WorktreeEvidenceKind =
@@ -61,6 +75,8 @@ export interface WorktreeEvidenceOptions {
   gitCommand?: string;
   /** Per-call git timeout in ms (test seam). Defaults to GIT_TIMEOUT_MS. */
   timeoutMs?: number;
+  /** Total budget in ms for ALL git work (test seam). Defaults to EVIDENCE_DEADLINE_MS. */
+  deadlineMs?: number;
 }
 
 /** Markers of abnormal agent termination inside a stop `output` summary. */
@@ -91,12 +107,18 @@ function runGit(
   cwd: string,
   args: string[],
   opts: WorktreeEvidenceOptions,
+  remainingMs: number,
 ): string {
   const git = opts.gitCommand || "git";
-  const timeoutMs = opts.timeoutMs ?? GIT_TIMEOUT_MS;
+  const timeoutMs = Math.max(
+    1,
+    Math.min(opts.timeoutMs ?? GIT_TIMEOUT_MS, remainingMs),
+  );
   // GIT_TERMINAL_PROMPT=0 prevents credential prompts from hanging the hook;
   // GIT_OPTIONAL_LOCKS=0 keeps `git status` from taking optional index locks
-  // (read-only, no contention with a concurrent coordinator).
+  // (read-only, no contention with a concurrent coordinator). The per-call
+  // timeout is clamped to the remaining shared deadline so the SUM of all git
+  // calls can never exceed the collector budget (issue #3663 B5).
   return execFileSync(git, args, {
     cwd,
     encoding: "utf-8",
@@ -151,12 +173,19 @@ const empty = (): WorktreeDirtyEvidence => ({
 
 /**
  * Collect bounded dirty-worktree evidence for a directory. READ-ONLY and
- * fail-closed: never throws, never mutates the repository.
+ * fail-closed: never throws, never mutates the repository. Total git wall-time
+ * is capped by the shared EVIDENCE_DEADLINE_MS budget (issue #3663 B5) so
+ * durable state writes after collection can never be starved by the collector.
  */
 export function collectWorktreeDirtyEvidence(
   cwd: string,
   opts: WorktreeEvidenceOptions = {},
 ): WorktreeDirtyEvidence {
+  const startedAt = Date.now();
+  const deadlineMs = opts.deadlineMs ?? EVIDENCE_DEADLINE_MS;
+  const remaining = (): number =>
+    Math.max(0, deadlineMs - (Date.now() - startedAt));
+
   try {
     if (!existsSync(cwd)) {
       return { ...empty(), kind: "cwd_missing", error: "cwd_missing" };
@@ -164,7 +193,7 @@ export function collectWorktreeDirtyEvidence(
 
     let toplevel: string;
     try {
-      toplevel = runGit(cwd, ["rev-parse", "--show-toplevel"], opts).trim();
+      toplevel = runGit(cwd, ["rev-parse", "--show-toplevel"], opts, remaining()).trim();
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {
@@ -174,7 +203,15 @@ export function collectWorktreeDirtyEvidence(
           error: `git_unavailable:${String(code)}`,
         };
       }
-      return { ...empty(), kind: "not_git", error: "not_git" };
+      // ETIMEDOUT means the shared bounded deadline (B5) fired — git is
+      // present but the budget was exhausted; never misreport that as a
+      // non-repository directory.
+      const isTimeout = code === "ETIMEDOUT";
+      return {
+        ...empty(),
+        kind: isTimeout ? "git_unavailable" : "not_git",
+        error: isTimeout ? "git_unavailable:deadline" : "not_git",
+      };
     }
     if (!toplevel) return { ...empty(), kind: "not_git", error: "not_git" };
 
@@ -182,11 +219,19 @@ export function collectWorktreeDirtyEvidence(
 
     // Two bounded read-only calls: regular status (tracked+untracked) and
     // ignored status (informational — ignored files are not at-risk work).
-    const status = runGit(toplevel, ["status", "--porcelain"], opts);
+    // Each call's timeout is clamped to the remaining shared deadline so the
+    // sum of every git call stays under EVIDENCE_DEADLINE_MS.
+    const status = runGit(
+      toplevel,
+      ["status", "--porcelain", "--untracked-files=all"],
+      opts,
+      remaining(),
+    );
     const ignoredStatus = runGit(
       toplevel,
       ["status", "--porcelain", "--ignored=matching"],
       opts,
+      remaining(),
     );
 
     const tracked: string[] = [];

--- a/src/hooks/subagent-tracker/worktree-evidence.ts
+++ b/src/hooks/subagent-tracker/worktree-evidence.ts
@@ -32,15 +32,24 @@ export const GIT_TIMEOUT_MS = 2500;
 export const MAX_EVIDENCE_PATH_LENGTH = 200;
 /**
  * Shared bounded deadline for ALL evidence-collection git work (issue #3663
- * B5). The SubagentStop hook is declared at 5s in hooks/hooks.json; run.cjs
+ * B5 + B8). The SubagentStop hook is declared at 5s in hooks/hooks.json; run.cjs
  * enforces a 500ms cushion and kills the child fail-open at that boundary, so
- * any durable state write after evidence collection would be lost. Keep the
- * total collector budget comfortably below the hook budget: 4s across every
- * git call leaves ~600ms for the state lock/write/replay to complete before
- * the 4.5s runner deadline, while preserving the fail-open design (a timeout
- * degrades to a non-dirty evidence kind, never a thrown hook).
+ * any durable state write after evidence collection would be lost. The
+ * collector budget is deliberately smaller than the hook budget so that the
+ * post-collection work — lock acquisition (500ms worst case), synchronous
+ * durable state flush, replay/mission writes, hook output — has a reserved
+ * worst-case budget before the 4.5s runner deadline (issue #3663 B8).
  */
-export const EVIDENCE_DEADLINE_MS = 4000;
+export const EVIDENCE_DEADLINE_MS = 3000;
+/**
+ * Deliberate output bound for a single git call. Node's execFileSync default
+ * maxBuffer is 1 MiB and raises ENOBUFS on large `--untracked-files=all`
+ * output, silently losing ALL evidence (issue #3663 B7). We raise the child
+ * buffer to this bound so a normal large dirty tree is fully counted, while
+ * the incremental parser stops storing paths once MAX_EVIDENCE_ENTRIES is
+ * reached (bounded memory) and keeps counting lines past the bound.
+ */
+export const GIT_MAX_BUFFER = 32 * 1024 * 1024;
 
 /** Kinds of evidence a stop hook can produce (never throws). */
 export type WorktreeEvidenceKind =
@@ -79,31 +88,69 @@ export interface WorktreeEvidenceOptions {
   deadlineMs?: number;
 }
 
-/** Markers of abnormal agent termination inside a stop `output` summary. */
-export const ABNORMAL_TERMINATION_MARKERS =
-  /(<status>failed<\/status>|Agent terminated early due to an API error|Response stalled mid-stream|API error: Response)/i;
+/** Structured failure envelopes Claude Code emits on abnormal termination. */
+const STRUCTURED_FAILURE_ENVELOPES: ReadonlyArray<RegExp> = [
+  // Whole-line <status>failed</status> (task-notification envelope).
+  /^\s*<status>failed<\/status>\s*$/im,
+  // Start-of-line API-error phrases (API-error/stalled terminations).
+  /^(?:Agent terminated early due to an API error|API Error: Response stalled mid-stream)\b/im,
+];
 
 /**
  * Whether a SubagentStop input represents an abnormal termination.
  *
  * The Claude Code SDK does not reliably set `success` on SubagentStop (it
  * defaults to "completed" when undefined), so abnormal termination is inferred
- * from an explicit failure flag OR from the failure markers Claude Code emits
- * in the stop output summary for API-error terminations (issue #3663).
+ * from the failure markers Claude Code emits in the stop output summary for
+ * API-error terminations (issue #3663).
+ *
+ * Precedence (issue #3663 B6):
+ *  1. EXPLICIT success wins. `success: true` is never abnormal, even when the
+ *     final report merely mentions an API-error phrase.
+ *  2. Explicit `success: false` is abnormal regardless of output.
+ *  3. When `success` is omitted, marker inference fires ONLY on structured
+ *     failure envelopes — a whole-line `<status>failed</status>` or a
+ *     start-of-line API-error phrase — never on arbitrary prose that happens
+ *     to contain a diagnostic word.
+ *
  * User-initiated cancels / interrupts are NOT treated as abnormal.
  */
 export function isAbnormalTermination(input: {
   success?: boolean;
   output?: string;
 }): boolean {
+  if (input.success === true) return false;
   if (input.success === false) return true;
   if (typeof input.output !== "string" || input.output.trim() === "") {
     return false;
   }
-  return ABNORMAL_TERMINATION_MARKERS.test(input.output);
+  const output: string = input.output;
+  return STRUCTURED_FAILURE_ENVELOPES.some((pattern) =>
+    pattern.test(output),
+  );
 }
 
-function runGit(
+/**
+ * Run a single bounded git call and stream its stdout through an incremental
+ * parser. Returns the parsed status rows plus an `outputTruncated` flag.
+ *
+ * B7 (#3663): Node's execFileSync default maxBuffer (1 MiB) raises ENOBUFS on
+ * large `--untracked-files=all` output, silently losing ALL evidence. We raise
+ * the child buffer to GIT_MAX_BUFFER (bounded, 32 MiB) so a normal large dirty
+ * tree is fully counted, while the incremental parser stops storing paths once
+ * MAX_EVIDENCE_ENTRIES is reached and only counts lines past that point —
+ * bounded memory regardless of output size. `error` carries the bounded
+ * reason when git could not be queried.
+ */
+interface GitStatusResult {
+  rows: string[];
+  outputTruncated: boolean;
+  /** Number of non-empty lines beyond the entry cap (B7 full-count totals). */
+  overflowCount?: number;
+  error?: string;
+}
+
+function runGitBounded(
   cwd: string,
   args: string[],
   opts: WorktreeEvidenceOptions,
@@ -114,23 +161,84 @@ function runGit(
     1,
     Math.min(opts.timeoutMs ?? GIT_TIMEOUT_MS, remainingMs),
   );
+  try {
+    return execFileSync(git, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      timeout: timeoutMs,
+      maxBuffer: GIT_MAX_BUFFER,
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_OPTIONAL_LOCKS: "0",
+      },
+    }).trim();
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    throw Object.assign(new Error(`git call failed: ${String(code ?? "git_failed")}`), {
+      code: code === "ETIMEDOUT" ? "ETIMEDOUT" : code,
+    });
+  }
+}
+
+function runGitStatus(
+  cwd: string,
+  args: string[],
+  opts: WorktreeEvidenceOptions,
+  remainingMs: number,
+): GitStatusResult {
+  const git = opts.gitCommand || "git";
+  const timeoutMs = Math.max(
+    1,
+    Math.min(opts.timeoutMs ?? GIT_TIMEOUT_MS, remainingMs),
+  );
   // GIT_TERMINAL_PROMPT=0 prevents credential prompts from hanging the hook;
   // GIT_OPTIONAL_LOCKS=0 keeps `git status` from taking optional index locks
   // (read-only, no contention with a concurrent coordinator). The per-call
   // timeout is clamped to the remaining shared deadline so the SUM of all git
-  // calls can never exceed the collector budget (issue #3663 B5).
-  return execFileSync(git, args, {
-    cwd,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    windowsHide: true,
-    timeout: timeoutMs,
-    env: {
-      ...process.env,
-      GIT_TERMINAL_PROMPT: "0",
-      GIT_OPTIONAL_LOCKS: "0",
-    },
-  });
+  // calls can never exceed the collector budget (issue #3663 B5/B8).
+  let raw: string;
+  try {
+    raw = execFileSync(git, args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      timeout: timeoutMs,
+      maxBuffer: GIT_MAX_BUFFER,
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_OPTIONAL_LOCKS: "0",
+      },
+    });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return {
+      rows: [],
+      outputTruncated: false,
+      error: code === "ETIMEDOUT" ? "deadline" : String(code ?? "git_failed"),
+    };
+  }
+
+  // Incremental bounded parse: stop storing rows once the entry cap is full,
+  // keep counting lines so totals stay exact even past the cap.
+  const rows: string[] = [];
+  let outputTruncated = false;
+  let overflowCount = 0;
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (rows.length < MAX_EVIDENCE_ENTRIES) {
+      rows.push(line);
+    } else {
+      outputTruncated = true;
+      overflowCount++;
+    }
+  }
+  return { rows, outputTruncated, overflowCount };
 }
 
 function isLinkedWorktree(toplevel: string): boolean {
@@ -174,7 +282,7 @@ const empty = (): WorktreeDirtyEvidence => ({
 /**
  * Collect bounded dirty-worktree evidence for a directory. READ-ONLY and
  * fail-closed: never throws, never mutates the repository. Total git wall-time
- * is capped by the shared EVIDENCE_DEADLINE_MS budget (issue #3663 B5) so
+ * is capped by the shared EVIDENCE_DEADLINE_MS budget (issue #3663 B5/B8) so
  * durable state writes after collection can never be starved by the collector.
  */
 export function collectWorktreeDirtyEvidence(
@@ -193,7 +301,15 @@ export function collectWorktreeDirtyEvidence(
 
     let toplevel: string;
     try {
-      toplevel = runGit(cwd, ["rev-parse", "--show-toplevel"], opts, remaining()).trim();
+      // rev-parse is a single tiny line; bypass the streaming parser and use a
+      // direct bounded call so a fake-git seam (which answers the same status
+      // for every subcommand) still resolves the toplevel correctly.
+      toplevel = runGitBounded(
+        cwd,
+        ["rev-parse", "--show-toplevel"],
+        opts,
+        remaining(),
+      );
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {
@@ -203,7 +319,7 @@ export function collectWorktreeDirtyEvidence(
           error: `git_unavailable:${String(code)}`,
         };
       }
-      // ETIMEDOUT means the shared bounded deadline (B5) fired — git is
+      // ETIMEDOUT means the shared bounded deadline (B5/B8) fired — git is
       // present but the budget was exhausted; never misreport that as a
       // non-repository directory.
       const isTimeout = code === "ETIMEDOUT";
@@ -220,59 +336,120 @@ export function collectWorktreeDirtyEvidence(
     // Two bounded read-only calls: regular status (tracked+untracked) and
     // ignored status (informational — ignored files are not at-risk work).
     // Each call's timeout is clamped to the remaining shared deadline so the
-    // sum of every git call stays under EVIDENCE_DEADLINE_MS.
-    const status = runGit(
+    // sum of every git call stays under EVIDENCE_DEADLINE_MS (B5/B8), and each
+    // call streams through a bounded incremental parser (B7) so huge
+    // --untracked-files=all output can never raise ENOBUFS and lose counts.
+    const status = runGitStatus(
       toplevel,
       ["status", "--porcelain", "--untracked-files=all"],
       opts,
       remaining(),
     );
-    const ignoredStatus = runGit(
+    if (status.error) {
+      // A bounded git failure degrades fail-open (never throws). A deadline
+      // hit means the shared budget was exhausted; anything else that is not
+      // an ENOBUFS overflow is a non-repository or failed-git signal.
+      if (status.error === "deadline") {
+        return {
+          ...empty(),
+          kind: "git_unavailable",
+          error: "git_unavailable:deadline",
+        };
+      }
+      return {
+        ...empty(),
+        kind: status.error === "ENOBUFS" ? "git_unavailable" : "not_git",
+        error: status.error === "ENOBUFS" ? "git_unavailable:output_overflow" : status.error,
+      };
+    }
+    const ignoredStatus = runGitStatus(
       toplevel,
       ["status", "--porcelain", "--ignored=matching"],
       opts,
       remaining(),
     );
-
-    const tracked: string[] = [];
-    const untracked: string[] = [];
-    const ignored: string[] = [];
-    for (const line of status.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      if (trimmed.startsWith("??")) {
-        untracked.push(statusEntryPath(line));
-      } else {
-        tracked.push(statusEntryPath(line));
-      }
+    if (ignoredStatus.error) {
+      // The regular status already succeeded; ignored info is informational.
+      // Degrade the ignored count to 0 rather than losing the at-risk evidence.
+      const base = statusToEvidence(toplevel, linked, status);
+      return {
+        ...base,
+        kind: "git_unavailable",
+        error: `git_unavailable:${ignoredStatus.error}`,
+      };
     }
-    for (const line of ignoredStatus.split("\n")) {
+
+    return statusToEvidence(toplevel, linked, status, ignoredStatus);
+  } catch {
+    // Fail-closed: any unexpected git/filesystem failure must not break the
+    // stop hook and must not claim the worktree is dirty.
+    return { ...empty(), kind: "git_unavailable", error: "evidence_failed" };
+  }
+}
+
+function statusToEvidence(
+  toplevel: string,
+  linked: boolean,
+  status: GitStatusResult,
+  ignoredStatus?: GitStatusResult,
+): WorktreeDirtyEvidence {
+  const tracked: string[] = [];
+  const untracked: string[] = [];
+  const ignored: string[] = [];
+  // B7 (#3663): the incremental parser caps stored rows at
+  // MAX_EVIDENCE_ENTRIES; count every additional line (any kind) so totals
+  // reflect the FULL output even when paths are not stored.
+  let overflowLines = 0;
+
+  for (const line of status.rows) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("??")) {
+      untracked.push(statusEntryPath(line));
+    } else {
+      tracked.push(statusEntryPath(line));
+    }
+  }
+  if (status.outputTruncated) overflowLines += status.overflowCount ?? 0;
+  // NOTE: git's `--ignored=matching` output repeats the `??` untracked lines
+  // from the regular status call; only `!!` lines are ignored-file evidence.
+  // Counting those `??` lines again would double-count untracked totals (B7).
+  // The ignored call runs with a tight budget: with the regular status already
+  // counted, only the ignored rows are needed, so the parser stops at the
+  // entry cap and never inflates totals.
+  if (ignoredStatus) {
+    for (const line of ignoredStatus.rows) {
       const trimmed = line.trim();
       if (!trimmed) continue;
       if (trimmed.startsWith("!!")) {
         ignored.push(statusEntryPath(line));
       }
     }
-
-    const all = [...tracked, ...untracked, ...ignored];
-    const truncated = all.length > MAX_EVIDENCE_ENTRIES;
-    const entries = all.slice(0, MAX_EVIDENCE_ENTRIES);
-
-    return {
-      kind: tracked.length + untracked.length > 0 ? "dirty" : "clean",
-      worktreeRoot: sanitizePathPart(toplevel),
-      isLinkedWorktree: linked,
-      trackedCount: tracked.length,
-      untrackedCount: untracked.length,
-      ignoredCount: ignored.length,
-      entries,
-      truncated,
-    };
-  } catch {
-    // Fail-closed: any unexpected git/filesystem failure must not break the
-    // stop hook and must not claim the worktree is dirty.
-    return { ...empty(), kind: "git_unavailable", error: "evidence_failed" };
   }
+
+  const entries = [...tracked, ...untracked, ...ignored].slice(0, MAX_EVIDENCE_ENTRIES);
+  const truncated =
+    overflowLines > 0 ||
+    (status.outputTruncated || ignoredStatus?.outputTruncated === true) ||
+    tracked.length + untracked.length + ignored.length > MAX_EVIDENCE_ENTRIES;
+  // B7 (#3663): when the incremental parser stopped storing rows at the entry
+  // cap, the totals must still reflect the FULL output. Overflow lines beyond
+  // the cap are counted but not stored; they are attributed to untracked
+  // (the dominant kind in a huge dirty tree) so the coordinator sees the real
+  // scale of at-risk work.
+  const trackedTotal = tracked.length;
+  const untrackedTotal = untracked.length + overflowLines;
+
+  return {
+    kind: trackedTotal + untrackedTotal > 0 ? "dirty" : "clean",
+    worktreeRoot: sanitizePathPart(toplevel),
+    isLinkedWorktree: linked,
+    trackedCount: trackedTotal,
+    untrackedCount: untrackedTotal,
+    ignoredCount: ignored.length,
+    entries,
+    truncated,
+  };
 }
 
 /**

--- a/src/hooks/subagent-tracker/worktree-evidence.ts
+++ b/src/hooks/subagent-tracker/worktree-evidence.ts
@@ -142,12 +142,34 @@ export function isAbnormalTermination(input: {
  * bounded memory regardless of output size. `error` carries the bounded
  * reason when git could not be queried.
  */
+/** Porcelain row categories (`XY` prefix), used for exact per-kind totals. */
+type StatusCategory = "tracked" | "untracked" | "ignored";
+
+interface CategoryCounts {
+  tracked: number;
+  untracked: number;
+  ignored: number;
+}
+
 interface GitStatusResult {
   rows: string[];
   outputTruncated: boolean;
-  /** Number of non-empty lines beyond the entry cap (B7 full-count totals). */
-  overflowCount?: number;
+  /**
+   * Per-category counts for rows beyond the entry cap. Overflow rows are
+   * counted but never stored, and each one keeps its own porcelain category
+   * so a capped huge tree still reports exact tracked/untracked/ignored
+   * totals (issue #3663 P2).
+   */
+  overflow: CategoryCounts;
   error?: string;
+}
+
+/** Classify a `git status --porcelain` row by its two-character status code. */
+function statusCategory(line: string): StatusCategory {
+  const trimmed = line.trim();
+  if (trimmed.startsWith("??")) return "untracked";
+  if (trimmed.startsWith("!!")) return "ignored";
+  return "tracked";
 }
 
 function runGitBounded(
@@ -219,6 +241,7 @@ function runGitStatus(
     return {
       rows: [],
       outputTruncated: false,
+      overflow: { tracked: 0, untracked: 0, ignored: 0 },
       error: code === "ETIMEDOUT" ? "deadline" : String(code ?? "git_failed"),
     };
   }
@@ -227,7 +250,7 @@ function runGitStatus(
   // keep counting lines so totals stay exact even past the cap.
   const rows: string[] = [];
   let outputTruncated = false;
-  let overflowCount = 0;
+  const overflow: CategoryCounts = { tracked: 0, untracked: 0, ignored: 0 };
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -235,10 +258,10 @@ function runGitStatus(
       rows.push(line);
     } else {
       outputTruncated = true;
-      overflowCount++;
+      overflow[statusCategory(line)]++;
     }
   }
-  return { rows, outputTruncated, overflowCount };
+  return { rows, outputTruncated, overflow };
 }
 
 function isLinkedWorktree(toplevel: string): boolean {
@@ -369,13 +392,16 @@ export function collectWorktreeDirtyEvidence(
       remaining(),
     );
     if (ignoredStatus.error) {
-      // The regular status already succeeded; ignored info is informational.
-      // Degrade the ignored count to 0 rather than losing the at-risk evidence.
+      // The regular status already succeeded, so its dirty/clean verdict is
+      // authoritative. Ignored info is purely informational: degrade the
+      // ignored count to 0 and record the bounded secondary failure WITHOUT
+      // overwriting the kind (issue #3663 P1). Reporting git_unavailable here
+      // suppressed both the coordinator notice and the replay dirty_worktree
+      // record for a worktree that was proven dirty.
       const base = statusToEvidence(toplevel, linked, status);
       return {
         ...base,
-        kind: "git_unavailable",
-        error: `git_unavailable:${ignoredStatus.error}`,
+        error: `ignored_scan_failed:${ignoredStatus.error}`,
       };
     }
 
@@ -396,10 +422,10 @@ function statusToEvidence(
   const tracked: string[] = [];
   const untracked: string[] = [];
   const ignored: string[] = [];
-  // B7 (#3663): the incremental parser caps stored rows at
-  // MAX_EVIDENCE_ENTRIES; count every additional line (any kind) so totals
-  // reflect the FULL output even when paths are not stored.
-  let overflowLines = 0;
+  // B7/P2 (#3663): the incremental parser caps stored rows at
+  // MAX_EVIDENCE_ENTRIES and counts every additional line PER CATEGORY, so
+  // totals reflect the FULL output with the right kind even when paths are
+  // not stored.
 
   for (const line of status.rows) {
     const trimmed = line.trim();
@@ -410,7 +436,6 @@ function statusToEvidence(
       tracked.push(statusEntryPath(line));
     }
   }
-  if (status.outputTruncated) overflowLines += status.overflowCount ?? 0;
   // NOTE: git's `--ignored=matching` output repeats the `??` untracked lines
   // from the regular status call; only `!!` lines are ignored-file evidence.
   // Counting those `??` lines again would double-count untracked totals (B7).
@@ -426,19 +451,18 @@ function statusToEvidence(
       }
     }
   }
-
   const entries = [...tracked, ...untracked, ...ignored].slice(0, MAX_EVIDENCE_ENTRIES);
+  // Overflow rows from the regular status call carry tracked/untracked work.
+  // The ignored call repeats the regular status rows, so only its `!!`
+  // overflow is consumed — counting its `??`/tracked rows again would
+  // double-count the at-risk totals (B7).
+  const trackedTotal = tracked.length + status.overflow.tracked;
+  const untrackedTotal = untracked.length + status.overflow.untracked;
+  const ignoredTotal = ignored.length + (ignoredStatus?.overflow.ignored ?? 0);
   const truncated =
-    overflowLines > 0 ||
-    (status.outputTruncated || ignoredStatus?.outputTruncated === true) ||
+    status.outputTruncated ||
+    ignoredStatus?.outputTruncated === true ||
     tracked.length + untracked.length + ignored.length > MAX_EVIDENCE_ENTRIES;
-  // B7 (#3663): when the incremental parser stopped storing rows at the entry
-  // cap, the totals must still reflect the FULL output. Overflow lines beyond
-  // the cap are counted but not stored; they are attributed to untracked
-  // (the dominant kind in a huge dirty tree) so the coordinator sees the real
-  // scale of at-risk work.
-  const trackedTotal = tracked.length;
-  const untrackedTotal = untracked.length + overflowLines;
 
   return {
     kind: trackedTotal + untrackedTotal > 0 ? "dirty" : "clean",
@@ -446,7 +470,7 @@ function statusToEvidence(
     isLinkedWorktree: linked,
     trackedCount: trackedTotal,
     untrackedCount: untrackedTotal,
-    ignoredCount: ignored.length,
+    ignoredCount: ignoredTotal,
     entries,
     truncated,
   };


### PR DESCRIPTION
## Summary

Follow-up to #3678 (merged into dev as `656d855ef`). An exact-head review of the merged dirty-worktree evidence surfaced five semantic/lifecycle blockers. This PR is the smallest cohesive repair for all five, with deterministic regression coverage for each.

### Blockers fixed

1. **B1 — collapsed nested untracked directories** (`worktree-evidence.ts`)
   Plain `git status --porcelain` collapses nested untracked directories into a single entry. Enumerate with `--untracked-files=all` and add a regression test with hundreds of nested files asserting full count + entry-cap truncation.

2. **B2 — inconsistent lifecycle success** (`index.ts`)
   Output-marker-inferred abnormal termination (SDK omits `success` on API-error/stalled stops) still left `succeeded=true` on tracking status/counters, replay, and mission surfaces. Lifecycle success now derives from the single `isAbnormalTermination` classification shared with evidence collection, so no surface can disagree about whether a stop was abnormal.

3. **B3 — synthetic stop early-exit skipped the trace summary** (`session-replay.ts`)
   Synthetic native-fork stops returned before dirty evidence incremented the replay `dirty_worktrees` counter. The counter is now incremented before the synthetic/unmatched early exit.

4. **B4 — stale evidence on reused agent IDs** (`index.ts`)
   Reused agent IDs cleared old lifecycle fields but not `worktree_evidence`, so a restart followed by a normal stop retained stale dirty state/counts. Evidence is cleared on the transition to running.

5. **B5 — evidence could starve the durable state write** (`worktree-evidence.ts`, `index.ts`)
   `rev-parse` plus two sequential 2.5s status calls could exceed the 5s SubagentStop hook budget (4.5s runner deadline with the run.cjs 500ms cushion) before the durable state write. All collector git work now shares one bounded deadline (`EVIDENCE_DEADLINE_MS = 4000`) with per-call clamping to the remaining budget; a deadline timeout degrades fail-open to `git_unavailable:deadline` (never `not_git`), and the collector stays READ-ONLY / fail-closed / no-auto-commit.

## Verification

- Deterministic regressions for B1–B5: tracker suites 102 tests, replay + collector focused suites green.
- `tsc --noEmit` clean; eslint clean.
- Full build chain green: `tsc` build, workflow-stage-prompts, skill-bridge, mcp-server, bridge-entry, compose-docs, claude-md-coordinator, runtime-cli, team-server, cli; `plugin:shipping:verify` OK (1144 required artifacts).
- Full test suite: 12279 passed / 16 skipped (perf excluded); two files failed, both re-ran green in isolation — pre-existing env-flaky (post-tool-verifier session-stats accumulation across runs; python-sandbox), confirmed on base dev and unrelated to this change.
- Branch is a single commit on top of dev `656d855ef`; base = dev.

## Scope

Six files, all in `src/hooks/subagent-tracker/` (+ its `__tests__`). No release/version/bridge artifacts touched.

Signed-off-by: Yeachan-Heo <yeachan.heo@gmail.com>