### PR TITLE
fix(ralph): disambiguate bare /ralph when official ralph-loop plugin is installed (#3668)

### DIFF
--- a/docs/issues/issue-3668-ralph-namespace.md
+++ b/docs/issues/issue-3668-ralph-namespace.md
@@ -64,13 +64,14 @@ today.
 - Files: `scripts/keyword-detector.mjs` and `templates/hooks/keyword-detector.mjs`
   (the two packaged artifacts that are kept in lockstep — see
   `src/installer/__tests__/hook-templates.test.ts`).
-- Behavior: only when `ralph` is the routed skill AND the official plugin is
+- Behavior: only when `ralph` is among the routed skills (single-skill or
+  multi-skill routing such as `/ralph ultrawork`) AND the official plugin is
   installed and enabled, the invocation guide gains one line:
 
   > Note: the official Anthropic \`ralph-loop\` plugin is also installed.
   > \`/ralph\` runs OMC's ralph; use \`/ralph-loop\` for the official plugin.
 
-- Verified matrix (both artifacts, automated regression test A–N):
+- Verified matrix (both artifacts, automated regression test A–P3):
   | Case | Outcome |
   |---|---|
   | A. installed + enabled (`enabledPlugins` map) | notice present |
@@ -89,9 +90,16 @@ today.
   | L. legacy `plugins` map | notice present |
   | M. malformed settings.json | silent (fail closed) |
   | N. config root via `HOME` (no `CLAUDE_CONFIG_DIR`) | notice present |
+  | O. same-named community plugin enabled, official `false` | silent (ids match on the full `name@marketplace` id) |
+  | O2. `enabledPlugins` array with only `ralph-loop@community` | silent |
+  | O3. bare marketplace-less `ralph-loop` id | silent (not the official id) |
+  | O4. canonical `enabledPlugins: false` + legacy `plugins: true` | silent (canonical field wins) |
+  | P. multi-skill routing (`/ralph ultrawork`) | notice present (no multi-skill bypass) |
+  | P2. multi-skill routing without ralph | silent |
+  | P3. multi-skill routing, official disabled | silent |
 - `/ralph` routing and the full invocation text are unchanged except the note.
-- Suites: `hook-templates.test.ts` 18/18, `keyword-detector-script.test.ts` +
-  `skills.test.ts` 154/154, ESLint + `tsc --noEmit` clean.
+- Suites: `hook-templates.test.ts` 18/18, `keyword-detector-script.test.ts`
+  53/53, `skills.test.ts` 53/53, `npm run lint` (0 errors) + `tsc --noEmit` clean.
 
 ## Option comparison: notice (implemented) vs rename/alias
 

--- a/docs/issues/issue-3668-ralph-namespace.md
+++ b/docs/issues/issue-3668-ralph-namespace.md
@@ -1,0 +1,110 @@
+# #3668 — `ralph` vs official `ralph-loop` namespace: evaluation + owner-decision hold
+
+Status: **owner-decision hold** (no rename/removal of bare `ralph`; no release files)
+Branch: `fix/issue-3668-ralph-namespace` (dev `656d855ef`)
+Date: 2026-08-10
+Owner decision required: see **Recommendation**.
+
+## Summary
+
+omc ships the bare skill name `ralph` (`/ralph`). The official Anthropic
+`claude-plugins-official` plugin ships the same technique as `ralph-loop`
+(`/ralph-loop`). When both plugins are installed, a user typing `/ralph`
+gets omc's loop with no indication that a second implementation is installed.
+#3668 records this as a namespace/product decision for the owner.
+
+This branch evaluates the options with exact evidence and implements the
+cheapest non-breaking mitigation (Option 1: concise invocation-time notice),
+leaving the rename (Option 2) as an explicit owner decision.
+
+## Reproduced layout (both plugins installed)
+
+```
+~/.claude/plugins/cache/claude-plugins-official/ralph-loop/1.0.0/
+  commands/ralph-loop.md        -> /ralph-loop   (official)
+~/.claude/plugins/cache/omc/oh-my-claudecode/<version>/skills/ralph/SKILL.md
+  name: ralph                   -> /ralph        (omc)
+~/.claude/plugins/installed_plugins.json  (machine-readable registry)
+  "ralph-loop@claude-plugins-official": [{ installPath, version, enabled }]
+  "oh-my-claudecode@omc": [{ installPath, version, enabled }]
+```
+
+Before this change, the omc keyword-detector emitted `[MAGIC KEYWORD: RALPH]`
+with zero mention of the official plugin.
+
+## What OMC can reliably detect at `/ralph` invocation (no private-payload scan)
+
+Signal: **the installed-plugins registry + one file-existence check**, both
+already-familiar OMC surfaces:
+
+- Read `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the
+  file OMC's installer/auto-update already owns for plugin-cache bookkeeping).
+- Look up exactly the official id `ralph-loop@claude-plugins-official`.
+- Verify `commands/ralph-loop.md` exists under the entry's `installPath`.
+- Respect `enabled: false` (do not nag about disabled plugins).
+- Never open any SKILL.md / command body / payload.
+
+Measured cost (invocation-time only, no startup scan): ~0.08 ms median for the
+registry read + existence probes vs ~150-335 ms total hook invocation. When the
+official plugin is absent the added cost is one `existsSync` on the registry
+path (~microseconds) and the output is byte-identical to today.
+
+## Implemented option (G002): non-breaking disambiguation notice
+
+- Files: `scripts/keyword-detector.mjs` and `templates/hooks/keyword-detector.mjs`
+  (the two packaged artifacts that are kept in lockstep — see
+  `src/installer/__tests__/hook-templates.test.ts`).
+- Behavior: only when `ralph` is the routed skill AND the official plugin is
+  installed and enabled, the invocation guide gains one line:
+
+  > Note: the official Anthropic \`ralph-loop\` plugin is also installed.
+  > \`/ralph\` runs OMC's ralph; use \`/ralph-loop\` for the official plugin.
+
+- Verified matrix (both artifacts, automated regression test A–G):
+  | Case | Outcome |
+  |---|---|
+  | A. both enabled | notice present |
+  | B. official absent | silent (identical output) |
+  | C. official disabled | silent |
+  | D. registry entry, payload missing | silent (no fabrication) |
+  | E. lookalike id only (`my-ralph-loop@community`) | silent |
+  | F. no registry | silent |
+  | G. non-ralph skill (autopilot) | silent |
+- `/ralph` routing and the full invocation text are unchanged except the note.
+- Suites: `hook-templates.test.ts` 18/18, `keyword-detector-script.test.ts` +
+  `skills.test.ts` 154/154, ESLint + `tsc --noEmit` clean.
+
+## Option comparison: notice (implemented) vs rename/alias
+
+| Dimension | Option 1: notice (implemented) | Option 2: rename to `omc-ralph` / alias |
+|---|---|---|
+| Command surface delta | none | `/ralph` disappears or becomes an alias; every muscle-memory user breaks |
+| Keyword activation (`ralph` / 랄프 / ラルフ) | unchanged | must be re-pointed in 3 detector copies (93 `ralph` pattern references in keyword-detector artifacts) |
+| Mode/state keys (`mode="ralph"`, `ralph-state.json`) | unchanged | would orphan live session state; cancel skill's `state_read/state_clear(mode="ralph")` cascade breaks without a migration |
+| Workflow-slot registry (`CANONICAL_WORKFLOW_SKILLS`, bridge slash list, workflow-stage enum) | unchanged | 14+ command-surface files must change in lockstep |
+| `keywordDetector.disabled` config (`["ralph"]`) | unchanged | silently stops matching; user configs break |
+| Plugin-cache upgrade | n/a | every version dir is a full payload copy; rename only applies on the *next* cache version, leaving mixed old/new names across stale-cache symlinks until purge |
+| Docs surface | none required | 8+ user-facing docs must be rewritten; README command table changes |
+| Owner risk | minimal, additive | high: material command-surface change |
+
+Quantified surface for a rename: 246 non-test files reference `ralph`
+(14 command-surface files, 24 mode/state-key files, 8 user docs) plus the
+`skills/ralph/` directory move and the plugin.json skill entry.
+
+## Recommendation (owner decision)
+
+1. **Adopt Option 1** — the notice is live on this branch, non-breaking,
+   and removes the silent substitution for exactly the affected population.
+2. **Do not rename/remove bare `ralph`** without an explicit owner decision;
+   the rename breaks keyword activation, live session state, cancel cascade,
+   workflow slots, user `keywordDetector.disabled` configs, and docs — a
+   material command-surface change that this branch must not merge on its own.
+3. If the owner later wants Option 2, it should be a separate explicit
+   migration (alias first, deprecate over ≥1 release, migrate state keys,
+   update 3 detector copies + slots + docs), never a rename-only PR.
+
+## Files changed on this branch
+
+- `scripts/keyword-detector.mjs` — notice helper + ralph wiring
+- `templates/hooks/keyword-detector.mjs` — same, lockstep artifact
+- `src/installer/__tests__/hook-templates.test.ts` — regression A–G for both artifacts

--- a/docs/issues/issue-3668-ralph-namespace.md
+++ b/docs/issues/issue-3668-ralph-namespace.md
@@ -44,11 +44,21 @@ installer's `hasEnabledOmcPlugin` semantics (`src/installer/index.ts`):
    The registry's own `enabled` flag is **deliberately not consulted**: it does
    not authoritatively encode enablement (a plugin disabled through canonical
    settings can still carry `enabled: true`, and vice versa).
-2. **ENABLED** — `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` lists the plugin
-   in the canonical `enabledPlugins` field (legacy `plugins` field accepted for
-   backward compatibility), either as an array of plugin ids or as a map whose
-   value is not `false`. Missing, malformed, or field-less settings.json is
-   treated as **not enabled**, exactly like the installer.
+2. **ENABLED** — the effective Claude Code settings for the *active project*
+   enable the plugin. Scopes are consulted highest-precedence-first, exactly as
+   Claude Code resolves settings: `<project>/.claude/settings.local.json`,
+   `<project>/.claude/settings.json`, then
+   `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json`. The first scope that mentions
+   the official id decides; scopes that never mention it are transparent. Within
+   a file, the canonical `enabledPlugins` field decides (legacy `plugins` field
+   accepted for backward compatibility), either as an array of plugin ids or as
+   a map whose value is not `false`. Missing, malformed, or field-less settings
+   are treated as **not enabled**, exactly like the installer.
+
+   The project root comes from the hook payload's `cwd`/`directory`, which is
+   caller-supplied: only an absolute path is accepted, so a relative or
+   traversal fragment can never be joined onto the hook process cwd to read
+   settings from an arbitrary directory (it falls back to the hook's own cwd).
 
 Never open any SKILL.md / command body / payload — the only file-existence
 probe is `existsSync` on `commands/ralph-loop.md`.
@@ -97,9 +107,17 @@ today.
   | P. multi-skill routing (`/ralph ultrawork`) | notice present (no multi-skill bypass) |
   | P2. multi-skill routing without ralph | silent |
   | P3. multi-skill routing, official disabled | silent |
+  | Q1. project `.claude/settings.json` disables, user enables | silent (project wins, single + multi-skill) |
+  | Q2. project `settings.local.json` enables, project `settings.json` disables | notice present (local wins) |
+  | Q3. project enables, user scope absent | notice present |
+  | Q4. project scope never mentions the plugin | user scope still decides |
+  | Q5. malformed project settings | silent (fail closed) |
+  | Q6. privacy: notice carries no settings path or settings content | notice present, no path/field leakage |
+  | Q7. relative / traversal payload cwd | ignored (absolute-only), same dir as absolute path IS honored |
 - `/ralph` routing and the full invocation text are unchanged except the note.
 - Suites: `hook-templates.test.ts` 18/18, `keyword-detector-script.test.ts`
-  53/53, `skills.test.ts` 53/53, `npm run lint` (0 errors) + `tsc --noEmit` clean.
+  101/101, `src/installer/__tests__` + keyword-detector suites 411/411,
+  `npm run lint` (0 errors) + `tsc --noEmit` clean.
 
 ## Option comparison: notice (implemented) vs rename/alias
 

--- a/docs/issues/issue-3668-ralph-namespace.md
+++ b/docs/issues/issue-3668-ralph-namespace.md
@@ -34,20 +34,30 @@ with zero mention of the official plugin.
 
 ## What OMC can reliably detect at `/ralph` invocation (no private-payload scan)
 
-Signal: **the installed-plugins registry + one file-existence check**, both
-already-familiar OMC surfaces:
+Two independent signals, both already-familiar OMC surfaces, mirroring the
+installer's `hasEnabledOmcPlugin` semantics (`src/installer/index.ts`):
 
-- Read `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the
-  file OMC's installer/auto-update already owns for plugin-cache bookkeeping).
-- Look up exactly the official id `ralph-loop@claude-plugins-official`.
-- Verify `commands/ralph-loop.md` exists under the entry's `installPath`.
-- Respect `enabled: false` (do not nag about disabled plugins).
-- Never open any SKILL.md / command body / payload.
+1. **INSTALLED** — `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json`
+   (the file OMC's installer/auto-update already owns for plugin-cache
+   bookkeeping) contains the exact official id `ralph-loop@claude-plugins-official`
+   and `commands/ralph-loop.md` exists under the entry's `installPath`.
+   The registry's own `enabled` flag is **deliberately not consulted**: it does
+   not authoritatively encode enablement (a plugin disabled through canonical
+   settings can still carry `enabled: true`, and vice versa).
+2. **ENABLED** — `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` lists the plugin
+   in the canonical `enabledPlugins` field (legacy `plugins` field accepted for
+   backward compatibility), either as an array of plugin ids or as a map whose
+   value is not `false`. Missing, malformed, or field-less settings.json is
+   treated as **not enabled**, exactly like the installer.
+
+Never open any SKILL.md / command body / payload — the only file-existence
+probe is `existsSync` on `commands/ralph-loop.md`.
 
 Measured cost (invocation-time only, no startup scan): ~0.08 ms median for the
-registry read + existence probes vs ~150-335 ms total hook invocation. When the
-official plugin is absent the added cost is one `existsSync` on the registry
-path (~microseconds) and the output is byte-identical to today.
+registry read + settings read + existence probes vs ~150-335 ms total hook
+invocation. When the official plugin is absent or disabled the added cost is
+two `existsSync` probes (~microseconds) and the output is byte-identical to
+today.
 
 ## Implemented option (G002): non-breaking disambiguation notice
 
@@ -60,16 +70,25 @@ path (~microseconds) and the output is byte-identical to today.
   > Note: the official Anthropic \`ralph-loop\` plugin is also installed.
   > \`/ralph\` runs OMC's ralph; use \`/ralph-loop\` for the official plugin.
 
-- Verified matrix (both artifacts, automated regression test A–G):
+- Verified matrix (both artifacts, automated regression test A–N):
   | Case | Outcome |
   |---|---|
-  | A. both enabled | notice present |
-  | B. official absent | silent (identical output) |
-  | C. official disabled | silent |
+  | A. installed + enabled (`enabledPlugins` map) | notice present |
+  | A2. `enabledPlugins` as array of ids | notice present |
+  | B. official absent from registry (settings enables) | silent (identical output) |
+  | C. disabled in settings (`enabledPlugins: false`) | silent — enablement from settings, not registry flag |
+  | C2. settings has neither field | silent |
   | D. registry entry, payload missing | silent (no fabrication) |
-  | E. lookalike id only (`my-ralph-loop@community`) | silent |
+  | E. lookalike id only (`my-ralph-loop@community`) | silent (settings-side lookalike too) |
   | F. no registry | silent |
   | G. non-ralph skill (autopilot) | silent |
+  | H. official `/ralph-loop` command | never routes to OMC, never carries notice |
+  | I. `/omc-ralph` alias | routes to OMC ralph with notice |
+  | J. registry `enabled: false` + settings enabled | notice present (settings wins) |
+  | K. registry `enabled: true` + settings missing | silent (missing settings = not enabled) |
+  | L. legacy `plugins` map | notice present |
+  | M. malformed settings.json | silent (fail closed) |
+  | N. config root via `HOME` (no `CLAUDE_CONFIG_DIR`) | notice present |
 - `/ralph` routing and the full invocation text are unchanged except the note.
 - Suites: `hook-templates.test.ts` 18/18, `keyword-detector-script.test.ts` +
   `skills.test.ts` 154/154, ESLint + `tsc --noEmit` clean.

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1277,23 +1277,76 @@ function isTeamEnabled() {
 }
 
 /**
- * Detect an installed official Anthropic `ralph-loop` plugin that exposes a
- * `/ralph-loop` command, without scanning any plugin payloads.
+ * Detect an installed AND enabled official Anthropic `ralph-loop` plugin
+ * that exposes a `/ralph-loop` command, without scanning any plugin payloads.
  *
- * Reads only the machine-readable plugin registry
- * `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the same
- * file OMC already uses for plugin-cache bookkeeping) and checks for the
- * existence of the plugin's command file. No SKILL.md body, command body, or
- * private payload is ever read. The official plugin's registry id is
- * `ralph-loop@claude-plugins-official`; lookalike ids that merely contain
- * "ralph" (e.g. a user skill directory named ralph-loop) are not treated as
- * the official plugin.
+ * Two independent signals, following existing installer semantics
+ * (`hasEnabledOmcPlugin` in src/installer/index.ts):
+ *
+ * 1. INSTALLED: the machine-readable plugin registry
+ *    `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` contains
+ *    the official id `ralph-loop@claude-plugins-official` with a real
+ *    `commands/ralph-loop.md` payload under its installPath. The registry's
+ *    own `enabled` flag is deliberately NOT consulted: it does not
+ *    authoritatively encode enablement (a plugin disabled through canonical
+ *    settings can still carry `enabled: true`, and vice versa).
+ * 2. ENABLED: `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` lists the
+ *    plugin in the canonical `enabledPlugins` field (legacy `plugins` field
+ *    accepted for backward compatibility), as an array of plugin ids or a
+ *    map whose value is not `false`. Missing or malformed settings.json is
+ *    treated as not enabled, exactly like the installer.
+ *
+ * No SKILL.md body, command body, or private payload is ever read. Only the
+ * plugin-name token is matched, so lookalike ids (`my-ralph-loop@community`,
+ * `ralph-loop-fork@community`) are not treated as the official plugin.
  *
  * Returns a short notice string, or '' when the official plugin is not
- * installed. A disabled registry entry (`enabled: false`) is treated as not
- * installed so the notice does not nag about plugins the user turned off.
+ * installed and enabled.
  */
+const OFFICIAL_RALPH_LOOP_PLUGIN_ID = 'ralph-loop@claude-plugins-official';
+
+function normalizeRalphLoopPluginId(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  const at = trimmed.lastIndexOf('@');
+  return (at === -1 ? trimmed : trimmed.slice(0, at)).trim().toLowerCase();
+}
+
+function isOfficialRalphLoopEnabledInSettings(settings) {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
+  for (const candidate of [settings.enabledPlugins, settings.plugins]) {
+    if (Array.isArray(candidate)) {
+      if (candidate.some((id) => normalizeRalphLoopPluginId(id) === 'ralph-loop')) {
+        return true;
+      }
+    } else if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+      if (Object.entries(candidate).some(([id, value]) =>
+        normalizeRalphLoopPluginId(id) === 'ralph-loop' && value !== false
+      )) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isOfficialRalphLoopEnabledInSettingsFile() {
+  const settingsPath = join(getClaudeConfigDir(), 'settings.json');
+  if (!existsSync(settingsPath)) return false;
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    return false;
+  }
+  return isOfficialRalphLoopEnabledInSettings(settings);
+}
+
 function findOfficialRalphLoopNotice() {
+  if (!isOfficialRalphLoopEnabledInSettingsFile()) {
+    return '';
+  }
+
   const installedPluginsPath = join(getClaudeConfigDir(), 'plugins', 'installed_plugins.json');
   if (!existsSync(installedPluginsPath)) {
     return '';
@@ -1314,15 +1367,13 @@ function findOfficialRalphLoopNotice() {
     return '';
   }
 
-  const officialId = 'ralph-loop@claude-plugins-official';
-  const entries = plugins[officialId];
+  const entries = plugins[OFFICIAL_RALPH_LOOP_PLUGIN_ID];
   if (!Array.isArray(entries) || entries.length === 0) {
     return '';
   }
 
   for (const entry of entries) {
     if (!entry || typeof entry !== 'object') continue;
-    if (entry.enabled === false) continue;
     const installPath = entry.installPath;
     if (typeof installPath !== 'string' || installPath.length === 0) continue;
     const commandFile = join(installPath, 'commands', 'ralph-loop.md');

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -24,7 +24,7 @@
  */
 
 import { writeFileSync, readFileSync, mkdirSync, existsSync, unlinkSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, isAbsolute } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { getClaudeConfigDir } from './lib/config-dir.mjs';
@@ -1290,11 +1290,14 @@ function isTeamEnabled() {
  *    own `enabled` flag is deliberately NOT consulted: it does not
  *    authoritatively encode enablement (a plugin disabled through canonical
  *    settings can still carry `enabled: true`, and vice versa).
- * 2. ENABLED: `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` lists the
- *    plugin in the canonical `enabledPlugins` field (legacy `plugins` field
- *    accepted for backward compatibility), as an array of plugin ids or a
- *    map whose value is not `false`. Missing or malformed settings.json is
- *    treated as not enabled, exactly like the installer.
+ * 2. ENABLED: the official id is enabled by the effective Claude Code settings
+ *    for the active project, resolved highest-precedence-first across
+ *    `<project>/.claude/settings.local.json`, `<project>/.claude/settings.json`
+ *    and `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json`. Within a file the
+ *    canonical `enabledPlugins` field decides (legacy `plugins` field accepted
+ *    for backward compatibility), as an array of plugin ids or a map whose
+ *    value is not `false`. Missing or malformed settings are treated as not
+ *    enabled, exactly like the installer.
  *
  * Both signals match the FULL plugin id exactly, marketplace suffix included.
  * The suffix is never stripped, so a same-named community plugin
@@ -1330,31 +1333,59 @@ function officialRalphLoopEnablementIn(field) {
   return null;
 }
 
-function isOfficialRalphLoopEnabledInSettings(settings) {
-  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
+function officialRalphLoopEnablementInSettings(settings) {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return null;
   // Canonical `enabledPlugins` wins outright when it mentions the official id;
   // the legacy `plugins` field only decides when canonical is silent about it.
   for (const field of [settings.enabledPlugins, settings.plugins]) {
     const verdict = officialRalphLoopEnablementIn(field);
     if (verdict !== null) return verdict;
   }
+  return null;
+}
+
+/**
+ * A hook payload's cwd is caller-supplied. Only an absolute path is a usable
+ * project root; anything else would silently resolve a caller-controlled
+ * fragment against the hook process cwd, so it is rejected in favour of the
+ * hook's own cwd.
+ */
+function resolveSettingsProjectRoot(directory) {
+  return typeof directory === 'string' && directory.length > 0 && isAbsolute(directory)
+    ? directory
+    : process.cwd();
+}
+
+/**
+ * Claude Code resolves `enabledPlugins` across settings scopes, so a project may
+ * enable a plugin the user scope never mentions, or disable one the user scope
+ * enables. Highest precedence first; the first scope that mentions the official
+ * id decides, scopes that never mention it are transparent, and a malformed
+ * file fails closed (no notice).
+ */
+function isOfficialRalphLoopEnabledForProject(directory) {
+  const projectRoot = resolveSettingsProjectRoot(directory);
+  const settingsPaths = [
+    join(projectRoot, '.claude', 'settings.local.json'),
+    join(projectRoot, '.claude', 'settings.json'),
+    join(getClaudeConfigDir(), 'settings.json'),
+  ];
+  for (const settingsPath of settingsPaths) {
+    if (!existsSync(settingsPath)) continue;
+    let settings;
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    } catch {
+      return false;
+    }
+    const verdict = officialRalphLoopEnablementInSettings(settings);
+    if (verdict !== null) return verdict;
+  }
   return false;
 }
 
-function isOfficialRalphLoopEnabledInSettingsFile() {
-  const settingsPath = join(getClaudeConfigDir(), 'settings.json');
-  if (!existsSync(settingsPath)) return false;
-  let settings;
-  try {
-    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-  } catch {
-    return false;
-  }
-  return isOfficialRalphLoopEnabledInSettings(settings);
-}
-
-function findOfficialRalphLoopNotice() {
-  if (!isOfficialRalphLoopEnabledInSettingsFile()) {
+function findOfficialRalphLoopNotice(directory) {
+  if (!isOfficialRalphLoopEnabledForProject(directory)) {
     return '';
   }
 
@@ -1510,14 +1541,14 @@ function loadDisabledKeywords(directory) {
  * Create a compact skill invocation guide without inlining SKILL.md bodies.
  * Full skill text remains available by path, avoiding UserPromptSubmit token blowups.
  */
-function createSkillInvocation(skillName, originalPrompt, args = '') {
+function createSkillInvocation(skillName, originalPrompt, args = '', directory = '') {
   const argsSection = args ? `
 Arguments: ${args}` : '';
   const skillPath = resolveSkillPath(skillName);
   const pathStatus = existsSync(skillPath)
     ? `Read fallback: open ${skillPath} and follow its SKILL.md instructions.`
     : `Read fallback: locate skills/${skillName}/SKILL.md in the active oh-my-claudecode plugin/install and follow it.`;
-  const ralphLoopNotice = skillName === 'ralph' ? findOfficialRalphLoopNotice() : '';
+  const ralphLoopNotice = skillName === 'ralph' ? findOfficialRalphLoopNotice(directory) : '';
 
   return `[MAGIC KEYWORD: ${skillName.toUpperCase()}]
 
@@ -1536,10 +1567,10 @@ IMPORTANT: Start the ${skillName} workflow immediately. If the slash invocation 
 /**
  * Create multi-skill invocation message for combined keywords
  */
-function createMultiSkillInvocation(skills, originalPrompt) {
+function createMultiSkillInvocation(skills, originalPrompt, directory = '') {
   if (skills.length === 0) return '';
   if (skills.length === 1) {
-    return createSkillInvocation(skills[0].name, originalPrompt, skills[0].args);
+    return createSkillInvocation(skills[0].name, originalPrompt, skills[0].args, directory);
   }
 
   const skillBlocks = skills.map((s, i) => {
@@ -1555,7 +1586,7 @@ ${pathStatus}`;
   // Multi-skill routing (e.g. `/ralph ultrawork`) must carry the same
   // disambiguation notice as the single-skill path, or it becomes a bypass.
   const ralphLoopNotice = skills.some((s) => s.name === 'ralph')
-    ? findOfficialRalphLoopNotice()
+    ? findOfficialRalphLoopNotice(directory)
     : '';
 
   return `[MAGIC KEYWORDS DETECTED: ${skills.map(s => s.name.toUpperCase()).join(', ')}]
@@ -1570,18 +1601,6 @@ User request (compact echo; original prompt remains authoritative):
 ${compactHookText(originalPrompt)}
 
 IMPORTANT: Complete ALL skills listed above in order. Start with the first skill IMMEDIATELY.`;
-}
-
-/**
- * Create combined output for multiple skill matches
- */
-function createCombinedOutput(skillMatches, originalPrompt) {
-  const parts = [];
-  if (skillMatches.length > 0) {
-    parts.push('## Section 1: Skill Invocations\n\n' + createMultiSkillInvocation(skillMatches, originalPrompt));
-  }
-  const allNames = skillMatches.map(m => m.name.toUpperCase());
-  return `[MAGIC KEYWORDS DETECTED: ${allNames.join(', ')}]\n\n${parts.join('\n\n---\n\n')}\n\nIMPORTANT: Complete ALL sections above in order.`;
 }
 
 /**
@@ -1707,7 +1726,7 @@ async function main() {
         `[RALPLAN INIT]\n` +
         `Explicit /ralplan invoke detected during UserPromptSubmit.\n` +
         `ralplan state has been initialized immediately and marked awaiting confirmation so the stop hook will not block this startup path.\n\n` +
-        createSkillInvocation('ralplan', prompt)
+        createSkillInvocation('ralplan', prompt, '', directory)
       )));
       return;
     }
@@ -1891,11 +1910,11 @@ async function main() {
         });
 
         if (isTeamFollowup) {
-          console.log(JSON.stringify(createHookOutput(createSkillInvocation('team', prompt))));
+          console.log(JSON.stringify(createHookOutput(createSkillInvocation('team', prompt, '', directory))));
           return;
         }
         if (isRalphFollowup) {
-          console.log(JSON.stringify(createHookOutput(createSkillInvocation('ralph', prompt))));
+          console.log(JSON.stringify(createHookOutput(createSkillInvocation('ralph', prompt, '', directory))));
           return;
         }
 
@@ -1929,7 +1948,7 @@ async function main() {
 
     // Route cancellation without mutating state; the cancel workflow commits the primary mode first.
     if (resolved.length > 0 && resolved[0].name === 'cancel') {
-      console.log(JSON.stringify(createHookOutput(createSkillInvocation('cancel', prompt))));
+      console.log(JSON.stringify(createHookOutput(createSkillInvocation('cancel', prompt, '', directory))));
       return;
     }
 
@@ -1972,7 +1991,7 @@ async function main() {
     }
 
     if (resolved.length > 0) {
-      additionalContextParts.push(createMultiSkillInvocation(resolved, prompt));
+      additionalContextParts.push(createMultiSkillInvocation(resolved, prompt, directory));
     }
 
     if (additionalContextParts.length > 0) {

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1296,36 +1296,47 @@ function isTeamEnabled() {
  *    map whose value is not `false`. Missing or malformed settings.json is
  *    treated as not enabled, exactly like the installer.
  *
- * No SKILL.md body, command body, or private payload is ever read. Only the
- * plugin-name token is matched, so lookalike ids (`my-ralph-loop@community`,
- * `ralph-loop-fork@community`) are not treated as the official plugin.
+ * Both signals match the FULL plugin id exactly, marketplace suffix included.
+ * The suffix is never stripped, so a same-named community plugin
+ * (`ralph-loop@community`) can never stand in for the official one — not even
+ * when the official plugin is installed and explicitly disabled.
+ *
+ * No SKILL.md body, command body, or private payload is ever read.
  *
  * Returns a short notice string, or '' when the official plugin is not
  * installed and enabled.
  */
 const OFFICIAL_RALPH_LOOP_PLUGIN_ID = 'ralph-loop@claude-plugins-official';
 
-function normalizeRalphLoopPluginId(value) {
-  if (typeof value !== 'string') return '';
-  const trimmed = value.trim();
-  const at = trimmed.lastIndexOf('@');
-  return (at === -1 ? trimmed : trimmed.slice(0, at)).trim().toLowerCase();
+function isOfficialRalphLoopPluginId(value) {
+  return typeof value === 'string'
+    && value.trim().toLowerCase() === OFFICIAL_RALPH_LOOP_PLUGIN_ID;
+}
+
+/**
+ * Enablement verdict of a single settings field for the official plugin:
+ * `true`/`false` when the field mentions the official id, `null` when it does
+ * not mention it at all (so the next field may decide).
+ */
+function officialRalphLoopEnablementIn(field) {
+  if (Array.isArray(field)) {
+    return field.some((id) => isOfficialRalphLoopPluginId(id)) ? true : null;
+  }
+  if (field && typeof field === 'object') {
+    for (const [id, value] of Object.entries(field)) {
+      if (isOfficialRalphLoopPluginId(id)) return value !== false;
+    }
+  }
+  return null;
 }
 
 function isOfficialRalphLoopEnabledInSettings(settings) {
   if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
-  for (const candidate of [settings.enabledPlugins, settings.plugins]) {
-    if (Array.isArray(candidate)) {
-      if (candidate.some((id) => normalizeRalphLoopPluginId(id) === 'ralph-loop')) {
-        return true;
-      }
-    } else if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
-      if (Object.entries(candidate).some(([id, value]) =>
-        normalizeRalphLoopPluginId(id) === 'ralph-loop' && value !== false
-      )) {
-        return true;
-      }
-    }
+  // Canonical `enabledPlugins` wins outright when it mentions the official id;
+  // the legacy `plugins` field only decides when canonical is silent about it.
+  for (const field of [settings.enabledPlugins, settings.plugins]) {
+    const verdict = officialRalphLoopEnablementIn(field);
+    if (verdict !== null) return verdict;
   }
   return false;
 }
@@ -1541,12 +1552,19 @@ function createMultiSkillInvocation(skills, originalPrompt) {
 Preferred invocation: /oh-my-claudecode:${s.name}${argsText}
 ${pathStatus}`;
   }).join('\n\n');
+  // Multi-skill routing (e.g. `/ralph ultrawork`) must carry the same
+  // disambiguation notice as the single-skill path, or it becomes a bypass.
+  const ralphLoopNotice = skills.some((s) => s.name === 'ralph')
+    ? findOfficialRalphLoopNotice()
+    : '';
 
   return `[MAGIC KEYWORDS DETECTED: ${skills.map(s => s.name.toUpperCase()).join(', ')}]
 
 Execute ALL detected workflows in order using compact invocation guidance. Do not inline full SKILL.md files into the prompt.
 
-${skillBlocks}
+${skillBlocks}${ralphLoopNotice ? `
+
+${ralphLoopNotice}` : ''}
 
 User request (compact echo; original prompt remains authoritative):
 ${compactHookText(originalPrompt)}

--- a/scripts/keyword-detector.mjs
+++ b/scripts/keyword-detector.mjs
@@ -1276,6 +1276,64 @@ function isTeamEnabled() {
   }
 }
 
+/**
+ * Detect an installed official Anthropic `ralph-loop` plugin that exposes a
+ * `/ralph-loop` command, without scanning any plugin payloads.
+ *
+ * Reads only the machine-readable plugin registry
+ * `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the same
+ * file OMC already uses for plugin-cache bookkeeping) and checks for the
+ * existence of the plugin's command file. No SKILL.md body, command body, or
+ * private payload is ever read. The official plugin's registry id is
+ * `ralph-loop@claude-plugins-official`; lookalike ids that merely contain
+ * "ralph" (e.g. a user skill directory named ralph-loop) are not treated as
+ * the official plugin.
+ *
+ * Returns a short notice string, or '' when the official plugin is not
+ * installed. A disabled registry entry (`enabled: false`) is treated as not
+ * installed so the notice does not nag about plugins the user turned off.
+ */
+function findOfficialRalphLoopNotice() {
+  const installedPluginsPath = join(getClaudeConfigDir(), 'plugins', 'installed_plugins.json');
+  if (!existsSync(installedPluginsPath)) {
+    return '';
+  }
+
+  let registry;
+  try {
+    registry = JSON.parse(readFileSync(installedPluginsPath, 'utf-8'));
+  } catch {
+    return '';
+  }
+  if (!registry || typeof registry !== 'object' || Array.isArray(registry)) {
+    return '';
+  }
+
+  const plugins = registry.plugins ?? registry;
+  if (!plugins || typeof plugins !== 'object' || Array.isArray(plugins)) {
+    return '';
+  }
+
+  const officialId = 'ralph-loop@claude-plugins-official';
+  const entries = plugins[officialId];
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return '';
+  }
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (entry.enabled === false) continue;
+    const installPath = entry.installPath;
+    if (typeof installPath !== 'string' || installPath.length === 0) continue;
+    const commandFile = join(installPath, 'commands', 'ralph-loop.md');
+    if (existsSync(commandFile)) {
+      return 'Note: the official Anthropic `ralph-loop` plugin is also installed. `/ralph` runs OMC\'s ralph; use `/ralph-loop` for the official plugin.';
+    }
+  }
+
+  return '';
+}
+
 // Read the OMC JSONC config the way src/config/loader.ts does, inlined so the
 // standalone hook stays build-independent (mirrors scripts/lib/agent-model-config.mjs).
 function getOmcUserConfigDir() {
@@ -1397,12 +1455,15 @@ Arguments: ${args}` : '';
   const pathStatus = existsSync(skillPath)
     ? `Read fallback: open ${skillPath} and follow its SKILL.md instructions.`
     : `Read fallback: locate skills/${skillName}/SKILL.md in the active oh-my-claudecode plugin/install and follow it.`;
+  const ralphLoopNotice = skillName === 'ralph' ? findOfficialRalphLoopNotice() : '';
 
   return `[MAGIC KEYWORD: ${skillName.toUpperCase()}]
 
 Skill routing detected: ${skillName}
 Preferred invocation: /oh-my-claudecode:${skillName}${args ? ` ${args}` : ''}
-${pathStatus}${argsSection}
+${pathStatus}${argsSection}${ralphLoopNotice ? `
+
+${ralphLoopNotice}` : ''}
 
 User request (compact echo; original prompt remains authoritative):
 ${compactHookText(originalPrompt)}

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -612,6 +612,111 @@ OMC Ultrawork = "특수부대 작전 반"
       for (const scriptPath of [templatePath, pluginPath]) {
         expect(contextOf(runIn(scriptPath, `ralph-multi-disabled-${basename(scriptPath)}`, '/ralph ultrawork fix the parser'))).not.toContain('ralph-loop');
       }
+
+      // Q. Plugin enablement is resolved across Claude Code settings scopes, not
+      //    just the user config: project `.claude/settings.json` and
+      //    `.claude/settings.local.json` override the user scope.
+      const projectSettingsPath = join(projectDir, '.claude', 'settings.json');
+      const projectLocalSettingsPath = join(projectDir, '.claude', 'settings.local.json');
+      const writeProjectSettings = (path: string, content: unknown) => {
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, JSON.stringify(content, null, 2));
+      };
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+
+      // Q1. Project scope disables what the user scope enables -> silent, on both
+      //     the single-skill and the multi-skill path.
+      writeProjectSettings(projectSettingsPath, { enabledPlugins: { 'ralph-loop@claude-plugins-official': false } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-proj-off-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+        expect(contextOf(runIn(scriptPath, `ralph-proj-off-multi-${basename(scriptPath)}`, '/ralph ultrawork fix the parser'))).not.toContain('ralph-loop');
+      }
+
+      // Q2. `.claude/settings.local.json` outranks `.claude/settings.json`.
+      writeProjectSettings(projectLocalSettingsPath, { enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-proj-local-on-${basename(scriptPath)}`))).toContain('ralph-loop');
+      }
+      rmSync(projectLocalSettingsPath, { force: true });
+
+      // Q3. Project-only enablement is honored even when the user scope is absent.
+      rmSync(settingsPath, { force: true });
+      writeProjectSettings(projectSettingsPath, { enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-proj-only-${basename(scriptPath)}`))).toContain('ralph-loop');
+      }
+
+      // Q4. A project scope that never mentions the plugin is transparent: the
+      //     user scope still decides.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      writeProjectSettings(projectSettingsPath, { permissions: { allow: [] } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-proj-silent-${basename(scriptPath)}`))).toContain('ralph-loop');
+      }
+
+      // Q5. Malformed project settings fail closed.
+      mkdirSync(dirname(projectSettingsPath), { recursive: true });
+      writeFileSync(projectSettingsPath, '{ not json');
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-proj-malformed-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+      rmSync(projectSettingsPath, { force: true });
+
+      // Q6. Privacy: an enabled project scope produces the notice without ever
+      //     echoing settings paths or settings content into the context.
+      writeProjectSettings(projectSettingsPath, { enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const context = contextOf(runIn(scriptPath, `ralph-proj-privacy-${basename(scriptPath)}`));
+        expect(context).toContain('official Anthropic `ralph-loop` plugin is also installed');
+        expect(context).not.toContain('enabledPlugins');
+        expect(context).not.toContain('settings.local.json');
+        expect(context).not.toContain(projectSettingsPath);
+        expect(context).not.toContain(registryPath);
+      }
+      rmSync(projectSettingsPath, { force: true });
+
+      // Q7. Path safety: the payload cwd is caller-supplied, so only an absolute
+      //     path may be used as a project root. A relative fragment must never be
+      //     joined onto the hook process cwd to read settings from an arbitrary
+      //     directory.
+      const sandboxCwd = mkdtempSync(join(tmpdir(), 'keyword-hook-ralph-loop-sandbox-'));
+      try {
+        writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+        writeProjectSettings(
+          join(sandboxCwd, 'evil', '.claude', 'settings.json'),
+          { enabledPlugins: { 'ralph-loop@claude-plugins-official': false } },
+        );
+        const runFromSandbox = (scriptPath: string, sessionId: string, payloadCwd: string) => JSON.parse(
+          execFileSync('node', [scriptPath], {
+            cwd: sandboxCwd,
+            env: {
+              ...process.env,
+              HOME: fakeHome,
+              XDG_CONFIG_HOME: join(fakeHome, '.xdg'),
+              CLAUDE_CONFIG_DIR: configDir,
+            },
+            input: JSON.stringify({
+              prompt: '/ralph fix the parser',
+              cwd: payloadCwd,
+              directory: payloadCwd,
+              session_id: sessionId,
+            }),
+            encoding: 'utf-8',
+          }),
+        ) as { hookSpecificOutput?: { additionalContext?: string } };
+
+        for (const scriptPath of [templatePath, pluginPath]) {
+          // Relative payload cwd is rejected -> the user scope still decides.
+          expect(contextOf(runFromSandbox(scriptPath, `ralph-relcwd-${basename(scriptPath)}`, 'evil'))).toContain('ralph-loop');
+          // Traversal fragments are equally rejected.
+          expect(contextOf(runFromSandbox(scriptPath, `ralph-traversal-${basename(scriptPath)}`, join('..', basename(sandboxCwd), 'evil')))).toContain('ralph-loop');
+          // Control: the very same directory as an absolute path IS honored,
+          // proving the assertions above are not vacuous.
+          expect(contextOf(runFromSandbox(scriptPath, `ralph-abscwd-${basename(scriptPath)}`, join(sandboxCwd, 'evil')))).not.toContain('ralph-loop');
+        }
+      } finally {
+        rmSync(sandboxCwd, { recursive: true, force: true });
+      }
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -544,6 +544,74 @@ OMC Ultrawork = "특수부대 작전 반"
         });
         expect(result.hookSpecificOutput?.additionalContext ?? '').toContain('ralph-loop');
       }
+
+      // O. Same-named COMMUNITY plugin enabled while the official one is explicitly
+      //    disabled -> silent. Plugin ids are matched on the full id including the
+      //    marketplace suffix, so `ralph-loop@community` never stands in for the
+      //    official plugin (Codex P2: name-token matching allowed this bypass).
+      writeSettings({
+        enabledPlugins: {
+          'ralph-loop@claude-plugins-official': false,
+          'ralph-loop@community': true,
+        },
+      });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'ralph-loop@community': [{ installPath: officialRoot, version: '2.0.0', enabled: true }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-community-same-name-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // O2. Array form: only the same-named community id is enabled -> silent.
+      writeSettings({ enabledPlugins: ['ralph-loop@community', 'other-plugin@foo'] });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-community-array-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // O3. Bare, marketplace-less `ralph-loop` id is not the official id -> silent.
+      writeSettings({ enabledPlugins: { 'ralph-loop': true } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-bare-id-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // O4. Canonical `enabledPlugins` disabling the official plugin wins over a
+      //     stale legacy `plugins` entry that still enables it.
+      writeSettings({
+        enabledPlugins: { 'ralph-loop@claude-plugins-official': false },
+        plugins: { 'ralph-loop@claude-plugins-official': true },
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-canonical-wins-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // P. Multi-skill routing (`ralph ultrawork`) carries the same notice as the
+      //    single-skill path; otherwise combining keywords bypasses disambiguation.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const context = contextOf(runIn(scriptPath, `ralph-multi-${basename(scriptPath)}`, '/ralph ultrawork fix the parser'));
+        expect(context).toContain('[MAGIC KEYWORDS DETECTED: RALPH, ULTRAWORK]');
+        expect(context).toContain('official Anthropic `ralph-loop` plugin is also installed');
+        expect(context).toContain('use `/ralph-loop` for the official plugin');
+      }
+
+      // P2. Multi-skill routing without ralph never carries the notice.
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const context = contextOf(runIn(scriptPath, `nonralph-multi-${basename(scriptPath)}`, 'autopilot and ultrawork this repo'));
+        expect(context).toContain('[MAGIC KEYWORDS DETECTED:');
+        expect(context).not.toContain('ralph-loop');
+      }
+
+      // P3. Multi-skill routing stays silent when the official plugin is disabled.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': false } });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-multi-disabled-${basename(scriptPath)}`, '/ralph ultrawork fix the parser'))).not.toContain('ralph-loop');
+      }
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'child_process';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { KEYWORD_DETECTOR_SCRIPT_NODE } from '../hooks.js';
@@ -313,6 +313,152 @@ OMC Ultrawork = "특수부대 작전 반"
       rmSync(emptyXdg, { recursive: true, force: true });
       rmSync(disabledDir, { recursive: true, force: true });
       rmSync(controlDir, { recursive: true, force: true });
+    }
+  });
+
+  it('disambiguates bare ralph when the official ralph-loop plugin is installed (#3668)', () => {
+    const templatePath = join(packageRoot, 'templates', 'hooks', 'keyword-detector.mjs');
+    const pluginPath = join(packageRoot, 'scripts', 'keyword-detector.mjs');
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'keyword-hook-ralph-loop-home-'));
+    const projectDir = mkdtempSync(join(tmpdir(), 'keyword-hook-ralph-loop-project-'));
+    const officialRoot = join(fakeHome, '.claude', 'plugins', 'cache', 'claude-plugins-official', 'ralph-loop', '1.0.0');
+    const omcRoot = join(fakeHome, '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.15.4');
+    const registryPath = join(fakeHome, '.claude', 'plugins', 'installed_plugins.json');
+    const runIn = (scriptPath: string, sessionId: string, prompt = '/ralph fix the parser') => JSON.parse(
+      execFileSync('node', [scriptPath], {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+          XDG_CONFIG_HOME: join(fakeHome, '.xdg'),
+          CLAUDE_CONFIG_DIR: join(fakeHome, '.claude'),
+        },
+        input: JSON.stringify({
+          prompt,
+          cwd: projectDir,
+          directory: projectDir,
+          session_id: sessionId,
+        }),
+        encoding: 'utf-8',
+      }),
+    ) as { continue?: boolean; suppressOutput?: boolean; hookSpecificOutput?: { additionalContext?: string } };
+
+    const contextOf = (result: { continue?: boolean; hookSpecificOutput?: { additionalContext?: string } }) =>
+      result.hookSpecificOutput?.additionalContext ?? '';
+    const writeRegistry = (plugins: Record<string, unknown[]>) => {
+      mkdirSync(dirname(registryPath), { recursive: true });
+      writeFileSync(registryPath, JSON.stringify({ version: 2, plugins }, null, 2));
+    };
+    try {
+      mkdirSync(join(officialRoot, 'commands'), { recursive: true });
+      writeFileSync(join(officialRoot, 'commands', 'ralph-loop.md'), '# official ralph-loop\n');
+      mkdirSync(join(omcRoot, 'skills', 'ralph'), { recursive: true });
+      writeFileSync(join(omcRoot, 'skills', 'ralph', 'SKILL.md'), '---\nname: ralph\n---\nOMC ralph\n');
+
+      // A. Both installed and enabled -> the notice fires exactly once per invocation
+      //    (this hook output is per UserPromptSubmit; the session dedup lives in the
+      //    Claude Code slash pipeline, so the assert is "notice present when enabled").
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const context = contextOf(runIn(scriptPath, `ralph-both-${basename(scriptPath)}`));
+        expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+        expect(context).toContain('official Anthropic `ralph-loop` plugin is also installed');
+        expect(context).toContain('use `/ralph-loop` for the official plugin');
+        expect(context).toContain('ralph-loop');
+      }
+
+      // B. Official plugin absent -> stay silent, same ralph routing.
+      writeRegistry({
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-absent-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // C. Official plugin disabled -> stay silent (installed but turned off).
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: false }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-disabled-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // D. Registry points at an install whose command payload is missing -> silent,
+      //    proving we never fabricate a notice from registry metadata alone.
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': [{ installPath: join(officialRoot, '..', '9.9.9'), version: '9.9.9', enabled: true }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-missing-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // E. A community plugin merely named like ralph-loop is not the official one.
+      writeRegistry({
+        'my-ralph-loop@community': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-lookalike-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // F. No registry at all -> silent.
+      rmSync(registryPath, { recursive: true, force: true });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-noreg-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // G. Non-ralph skills never carry the notice even when the official plugin is installed.
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const result = JSON.parse(
+          execFileSync('node', [scriptPath], {
+            cwd: packageRoot,
+            env: { ...process.env, HOME: fakeHome, XDG_CONFIG_HOME: join(fakeHome, '.xdg'), CLAUDE_CONFIG_DIR: join(fakeHome, '.claude') },
+            input: JSON.stringify({ prompt: 'autopilot build me a CLI', cwd: projectDir, directory: projectDir, session_id: `autopilot-${basename(scriptPath)}` }),
+            encoding: 'utf-8',
+          }),
+        ) as { continue?: boolean; hookSpecificOutput?: { additionalContext?: string } };
+        expect(result.hookSpecificOutput?.additionalContext ?? '').not.toContain('ralph-loop');
+      }
+
+      // H. The official `/ralph-loop` command never routes to OMC's ralph and never
+      //    carries the notice (it is the other plugin's surface, not an alias).
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const result = JSON.parse(
+          execFileSync('node', [scriptPath], {
+            cwd: packageRoot,
+            env: { ...process.env, HOME: fakeHome, XDG_CONFIG_HOME: join(fakeHome, '.xdg'), CLAUDE_CONFIG_DIR: join(fakeHome, '.claude') },
+            input: JSON.stringify({ prompt: '/ralph-loop fix the parser', cwd: projectDir, directory: projectDir, session_id: `ralphloop-cmd-${basename(scriptPath)}` }),
+            encoding: 'utf-8',
+          }),
+        ) as { continue?: boolean; suppressOutput?: boolean; hookSpecificOutput?: { additionalContext?: string } };
+        expect(result).toEqual({ continue: true, suppressOutput: true });
+      }
+
+      // I. An omc-aliased `/omc-ralph` invocation still routes to OMC's ralph and
+      //    carries the notice when the official plugin is installed (the alias is
+      //    OMC's surface, so the disambiguation note still applies).
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const context = contextOf(runIn(scriptPath, `omcralph-${basename(scriptPath)}`, '/omc-ralph fix the parser'));
+        expect(context).toContain('[MAGIC KEYWORD: RALPH]');
+        expect(context).toContain('official Anthropic `ralph-loop` plugin is also installed');
+      }
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -316,23 +316,26 @@ OMC Ultrawork = "특수부대 작전 반"
     }
   });
 
-  it('disambiguates bare ralph when the official ralph-loop plugin is installed (#3668)', () => {
+  it('disambiguates bare ralph when the official ralph-loop plugin is installed and enabled (#3668)', () => {
     const templatePath = join(packageRoot, 'templates', 'hooks', 'keyword-detector.mjs');
     const pluginPath = join(packageRoot, 'scripts', 'keyword-detector.mjs');
 
     const fakeHome = mkdtempSync(join(tmpdir(), 'keyword-hook-ralph-loop-home-'));
     const projectDir = mkdtempSync(join(tmpdir(), 'keyword-hook-ralph-loop-project-'));
-    const officialRoot = join(fakeHome, '.claude', 'plugins', 'cache', 'claude-plugins-official', 'ralph-loop', '1.0.0');
-    const omcRoot = join(fakeHome, '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.15.4');
-    const registryPath = join(fakeHome, '.claude', 'plugins', 'installed_plugins.json');
-    const runIn = (scriptPath: string, sessionId: string, prompt = '/ralph fix the parser') => JSON.parse(
+    const configDir = join(fakeHome, '.claude');
+    const officialRoot = join(configDir, 'plugins', 'cache', 'claude-plugins-official', 'ralph-loop', '1.0.0');
+    const omcRoot = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.15.4');
+    const registryPath = join(configDir, 'plugins', 'installed_plugins.json');
+    const settingsPath = join(configDir, 'settings.json');
+    const runWithEnv = (scriptPath: string, sessionId: string, prompt: string, env: Record<string, string | undefined>) => JSON.parse(
       execFileSync('node', [scriptPath], {
         cwd: packageRoot,
         env: {
           ...process.env,
           HOME: fakeHome,
           XDG_CONFIG_HOME: join(fakeHome, '.xdg'),
-          CLAUDE_CONFIG_DIR: join(fakeHome, '.claude'),
+          CLAUDE_CONFIG_DIR: configDir,
+          ...env,
         },
         input: JSON.stringify({
           prompt,
@@ -343,24 +346,31 @@ OMC Ultrawork = "특수부대 작전 반"
         encoding: 'utf-8',
       }),
     ) as { continue?: boolean; suppressOutput?: boolean; hookSpecificOutput?: { additionalContext?: string } };
-
+    const runIn = (scriptPath: string, sessionId: string, prompt = '/ralph fix the parser') =>
+      runWithEnv(scriptPath, sessionId, prompt, {});
     const contextOf = (result: { continue?: boolean; hookSpecificOutput?: { additionalContext?: string } }) =>
       result.hookSpecificOutput?.additionalContext ?? '';
     const writeRegistry = (plugins: Record<string, unknown[]>) => {
       mkdirSync(dirname(registryPath), { recursive: true });
       writeFileSync(registryPath, JSON.stringify({ version: 2, plugins }, null, 2));
     };
+    const writeSettings = (content: unknown) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(settingsPath, JSON.stringify(content, null, 2));
+    };
+    const officialEntry = (enabledFlag?: boolean) => [
+      { installPath: officialRoot, version: '1.0.0', ...(enabledFlag === undefined ? {} : { enabled: enabledFlag }) },
+    ];
     try {
       mkdirSync(join(officialRoot, 'commands'), { recursive: true });
       writeFileSync(join(officialRoot, 'commands', 'ralph-loop.md'), '# official ralph-loop\n');
       mkdirSync(join(omcRoot, 'skills', 'ralph'), { recursive: true });
       writeFileSync(join(omcRoot, 'skills', 'ralph', 'SKILL.md'), '---\nname: ralph\n---\nOMC ralph\n');
 
-      // A. Both installed and enabled -> the notice fires exactly once per invocation
-      //    (this hook output is per UserPromptSubmit; the session dedup lives in the
-      //    Claude Code slash pipeline, so the assert is "notice present when enabled").
+      // A. Installed AND enabled via canonical settings.enabledPlugins map -> notice fires.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
       writeRegistry({
-        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
+        'ralph-loop@claude-plugins-official': officialEntry(true),
         'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
       });
       for (const scriptPath of [templatePath, pluginPath]) {
@@ -371,7 +381,14 @@ OMC Ultrawork = "특수부대 작전 반"
         expect(context).toContain('ralph-loop');
       }
 
-      // B. Official plugin absent -> stay silent, same ralph routing.
+      // A2. enabledPlugins as an array of plugin id strings also enables the notice.
+      writeSettings({ enabledPlugins: ['ralph-loop@claude-plugins-official', 'other-plugin@foo'] });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-array-${basename(scriptPath)}`))).toContain('ralph-loop');
+      }
+
+      // B. Official plugin absent from registry (even though settings enables it) -> silent.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
       writeRegistry({
         'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
       });
@@ -379,17 +396,30 @@ OMC Ultrawork = "특수부대 작전 반"
         expect(contextOf(runIn(scriptPath, `ralph-absent-${basename(scriptPath)}`))).not.toContain('ralph-loop');
       }
 
-      // C. Official plugin disabled -> stay silent (installed but turned off).
+      // C. Installed but DISABLED in canonical settings (enabledPlugins: false) -> silent.
+      //    This is the Codex P2 fix: enablement comes from settings, not the registry flag.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': false } });
       writeRegistry({
-        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: false }],
+        'ralph-loop@claude-plugins-official': officialEntry(true),
         'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
       });
       for (const scriptPath of [templatePath, pluginPath]) {
         expect(contextOf(runIn(scriptPath, `ralph-disabled-${basename(scriptPath)}`))).not.toContain('ralph-loop');
       }
 
-      // D. Registry points at an install whose command payload is missing -> silent,
-      //    proving we never fabricate a notice from registry metadata alone.
+      // C2. Settings has neither field -> treated as not enabled (installer semantics).
+      writeSettings({ env: {}, model: 'opus' });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-noenable-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // D. Settings enables, registry entry present, but command payload missing -> silent,
+      //    proving we never fabricate a notice from metadata alone.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
       writeRegistry({
         'ralph-loop@claude-plugins-official': [{ installPath: join(officialRoot, '..', '9.9.9'), version: '9.9.9', enabled: true }],
         'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
@@ -398,7 +428,9 @@ OMC Ultrawork = "특수부대 작전 반"
         expect(contextOf(runIn(scriptPath, `ralph-missing-${basename(scriptPath)}`))).not.toContain('ralph-loop');
       }
 
-      // E. A community plugin merely named like ralph-loop is not the official one.
+      // E. A community plugin merely named like ralph-loop is not the official one
+      //    (settings-side lookalike must not enable the notice either).
+      writeSettings({ enabledPlugins: { 'my-ralph-loop@community': true } });
       writeRegistry({
         'my-ralph-loop@community': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
         'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
@@ -407,22 +439,24 @@ OMC Ultrawork = "특수부대 작전 반"
         expect(contextOf(runIn(scriptPath, `ralph-lookalike-${basename(scriptPath)}`))).not.toContain('ralph-loop');
       }
 
-      // F. No registry at all -> silent.
+      // F. Settings enables but no registry at all -> silent.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
       rmSync(registryPath, { recursive: true, force: true });
       for (const scriptPath of [templatePath, pluginPath]) {
         expect(contextOf(runIn(scriptPath, `ralph-noreg-${basename(scriptPath)}`))).not.toContain('ralph-loop');
       }
 
-      // G. Non-ralph skills never carry the notice even when the official plugin is installed.
+      // G. Non-ralph skills never carry the notice even when the official plugin is installed+enabled.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
       writeRegistry({
-        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
+        'ralph-loop@claude-plugins-official': officialEntry(true),
         'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
       });
       for (const scriptPath of [templatePath, pluginPath]) {
         const result = JSON.parse(
           execFileSync('node', [scriptPath], {
             cwd: packageRoot,
-            env: { ...process.env, HOME: fakeHome, XDG_CONFIG_HOME: join(fakeHome, '.xdg'), CLAUDE_CONFIG_DIR: join(fakeHome, '.claude') },
+            env: { ...process.env, HOME: fakeHome, XDG_CONFIG_HOME: join(fakeHome, '.xdg'), CLAUDE_CONFIG_DIR: configDir },
             input: JSON.stringify({ prompt: 'autopilot build me a CLI', cwd: projectDir, directory: projectDir, session_id: `autopilot-${basename(scriptPath)}` }),
             encoding: 'utf-8',
           }),
@@ -432,15 +466,11 @@ OMC Ultrawork = "특수부대 작전 반"
 
       // H. The official `/ralph-loop` command never routes to OMC's ralph and never
       //    carries the notice (it is the other plugin's surface, not an alias).
-      writeRegistry({
-        'ralph-loop@claude-plugins-official': [{ installPath: officialRoot, version: '1.0.0', enabled: true }],
-        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
-      });
       for (const scriptPath of [templatePath, pluginPath]) {
         const result = JSON.parse(
           execFileSync('node', [scriptPath], {
             cwd: packageRoot,
-            env: { ...process.env, HOME: fakeHome, XDG_CONFIG_HOME: join(fakeHome, '.xdg'), CLAUDE_CONFIG_DIR: join(fakeHome, '.claude') },
+            env: { ...process.env, HOME: fakeHome, XDG_CONFIG_HOME: join(fakeHome, '.xdg'), CLAUDE_CONFIG_DIR: configDir },
             input: JSON.stringify({ prompt: '/ralph-loop fix the parser', cwd: projectDir, directory: projectDir, session_id: `ralphloop-cmd-${basename(scriptPath)}` }),
             encoding: 'utf-8',
           }),
@@ -449,12 +479,70 @@ OMC Ultrawork = "특수부대 작전 반"
       }
 
       // I. An omc-aliased `/omc-ralph` invocation still routes to OMC's ralph and
-      //    carries the notice when the official plugin is installed (the alias is
-      //    OMC's surface, so the disambiguation note still applies).
+      //    carries the notice when the official plugin is installed+enabled.
       for (const scriptPath of [templatePath, pluginPath]) {
         const context = contextOf(runIn(scriptPath, `omcralph-${basename(scriptPath)}`, '/omc-ralph fix the parser'));
         expect(context).toContain('[MAGIC KEYWORD: RALPH]');
         expect(context).toContain('official Anthropic `ralph-loop` plugin is also installed');
+      }
+
+      // J. Registry flag disagreement: registry says enabled:false but canonical
+      //    settings says enabled -> the settings signal wins (registry is not
+      //    authoritative for enablement).
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(false),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-regflag-${basename(scriptPath)}`))).toContain('ralph-loop');
+      }
+
+      // K. Registry flag disagreement (reverse): registry says enabled:true but
+      //    settings.json is missing -> treated as not enabled (installer semantics).
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      rmSync(settingsPath, { recursive: true, force: true });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-nosettings-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // L. Legacy `plugins` map (pre-1.x field name) also enables the notice.
+      writeSettings({ plugins: { 'ralph-loop@claude-plugins-official': true } });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-legacy-${basename(scriptPath)}`))).toContain('ralph-loop');
+      }
+
+      // M. Malformed settings.json -> fail closed (not enabled), no notice.
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(settingsPath, '{ this is not valid json');
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        expect(contextOf(runIn(scriptPath, `ralph-malformed-${basename(scriptPath)}`))).not.toContain('ralph-loop');
+      }
+
+      // N. Config-root variant: settings lives at HOME/.claude and CLAUDE_CONFIG_DIR is
+      //    unset (HOME-derived root) -> the notice still resolves the same config root.
+      writeSettings({ enabledPlugins: { 'ralph-loop@claude-plugins-official': true } });
+      writeRegistry({
+        'ralph-loop@claude-plugins-official': officialEntry(true),
+        'oh-my-claudecode@omc': [{ installPath: omcRoot, version: '4.15.4', enabled: true }],
+      });
+      for (const scriptPath of [templatePath, pluginPath]) {
+        const result = runWithEnv(scriptPath, `ralph-homeroot-${basename(scriptPath)}`, '/ralph fix the parser', {
+          CLAUDE_CONFIG_DIR: undefined,
+        });
+        expect(result.hookSpecificOutput?.additionalContext ?? '').toContain('ralph-loop');
       }
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -1139,11 +1139,19 @@ Preferred invocation: /oh-my-claudecode:${s.name}${argsText}
 ${pathStatus}`;
   }).join('\n\n');
 
+  // Multi-skill routing (e.g. `/ralph ultrawork`) must carry the same
+  // disambiguation notice as the single-skill path, or it becomes a bypass.
+  const ralphLoopNotice = skills.some((s) => s.name === 'ralph')
+    ? findOfficialRalphLoopNotice()
+    : '';
+
   return `[MAGIC KEYWORDS DETECTED: ${skills.map(s => s.name.toUpperCase()).join(', ')}]
 
 Execute ALL detected workflows in order using compact invocation guidance. Do not inline full SKILL.md files into the prompt.
 
-${skillBlocks}
+${skillBlocks}${ralphLoopNotice ? `
+
+${ralphLoopNotice}` : ''}
 
 User request (compact echo; original prompt remains authoritative):
 ${compactHookText(originalPrompt)}
@@ -1247,36 +1255,47 @@ function isTeamEnabled() {
  *    map whose value is not `false`. Missing or malformed settings.json is
  *    treated as not enabled, exactly like the installer.
  *
- * No SKILL.md body, command body, or private payload is ever read. Only the
- * plugin-name token is matched, so lookalike ids (`my-ralph-loop@community`,
- * `ralph-loop-fork@community`) are not treated as the official plugin.
+ * Both signals match the FULL plugin id exactly, marketplace suffix included.
+ * The suffix is never stripped, so a same-named community plugin
+ * (`ralph-loop@community`) can never stand in for the official one — not even
+ * when the official plugin is installed and explicitly disabled.
+ *
+ * No SKILL.md body, command body, or private payload is ever read.
  *
  * Returns a short notice string, or '' when the official plugin is not
  * installed and enabled.
  */
 const OFFICIAL_RALPH_LOOP_PLUGIN_ID = 'ralph-loop@claude-plugins-official';
 
-function normalizeRalphLoopPluginId(value) {
-  if (typeof value !== 'string') return '';
-  const trimmed = value.trim();
-  const at = trimmed.lastIndexOf('@');
-  return (at === -1 ? trimmed : trimmed.slice(0, at)).trim().toLowerCase();
+function isOfficialRalphLoopPluginId(value) {
+  return typeof value === 'string'
+    && value.trim().toLowerCase() === OFFICIAL_RALPH_LOOP_PLUGIN_ID;
+}
+
+/**
+ * Enablement verdict of a single settings field for the official plugin:
+ * `true`/`false` when the field mentions the official id, `null` when it does
+ * not mention it at all (so the next field may decide).
+ */
+function officialRalphLoopEnablementIn(field) {
+  if (Array.isArray(field)) {
+    return field.some((id) => isOfficialRalphLoopPluginId(id)) ? true : null;
+  }
+  if (field && typeof field === 'object') {
+    for (const [id, value] of Object.entries(field)) {
+      if (isOfficialRalphLoopPluginId(id)) return value !== false;
+    }
+  }
+  return null;
 }
 
 function isOfficialRalphLoopEnabledInSettings(settings) {
   if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
-  for (const candidate of [settings.enabledPlugins, settings.plugins]) {
-    if (Array.isArray(candidate)) {
-      if (candidate.some((id) => normalizeRalphLoopPluginId(id) === 'ralph-loop')) {
-        return true;
-      }
-    } else if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
-      if (Object.entries(candidate).some(([id, value]) =>
-        normalizeRalphLoopPluginId(id) === 'ralph-loop' && value !== false
-      )) {
-        return true;
-      }
-    }
+  // Canonical `enabledPlugins` wins outright when it mentions the official id;
+  // the legacy `plugins` field only decides when canonical is silent about it.
+  for (const field of [settings.enabledPlugins, settings.plugins]) {
+    const verdict = officialRalphLoopEnablementIn(field);
+    if (verdict !== null) return verdict;
   }
   return false;
 }

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -1228,23 +1228,76 @@ function isTeamEnabled() {
 }
 
 /**
- * Detect an installed official Anthropic `ralph-loop` plugin that exposes a
- * `/ralph-loop` command, without scanning any plugin payloads.
+ * Detect an installed AND enabled official Anthropic `ralph-loop` plugin
+ * that exposes a `/ralph-loop` command, without scanning any plugin payloads.
  *
- * Reads only the machine-readable plugin registry
- * `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the same
- * file OMC already uses for plugin-cache bookkeeping) and checks for the
- * existence of the plugin's command file. No SKILL.md body, command body, or
- * private payload is ever read. The official plugin's registry id is
- * `ralph-loop@claude-plugins-official`; lookalike ids that merely contain
- * "ralph" (e.g. a user skill directory named ralph-loop) are not treated as
- * the official plugin.
+ * Two independent signals, following existing installer semantics
+ * (`hasEnabledOmcPlugin` in src/installer/index.ts):
+ *
+ * 1. INSTALLED: the machine-readable plugin registry
+ *    `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` contains
+ *    the official id `ralph-loop@claude-plugins-official` with a real
+ *    `commands/ralph-loop.md` payload under its installPath. The registry's
+ *    own `enabled` flag is deliberately NOT consulted: it does not
+ *    authoritatively encode enablement (a plugin disabled through canonical
+ *    settings can still carry `enabled: true`, and vice versa).
+ * 2. ENABLED: `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` lists the
+ *    plugin in the canonical `enabledPlugins` field (legacy `plugins` field
+ *    accepted for backward compatibility), as an array of plugin ids or a
+ *    map whose value is not `false`. Missing or malformed settings.json is
+ *    treated as not enabled, exactly like the installer.
+ *
+ * No SKILL.md body, command body, or private payload is ever read. Only the
+ * plugin-name token is matched, so lookalike ids (`my-ralph-loop@community`,
+ * `ralph-loop-fork@community`) are not treated as the official plugin.
  *
  * Returns a short notice string, or '' when the official plugin is not
- * installed. A disabled registry entry (`enabled: false`) is treated as not
- * installed so the notice does not nag about plugins the user turned off.
+ * installed and enabled.
  */
+const OFFICIAL_RALPH_LOOP_PLUGIN_ID = 'ralph-loop@claude-plugins-official';
+
+function normalizeRalphLoopPluginId(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  const at = trimmed.lastIndexOf('@');
+  return (at === -1 ? trimmed : trimmed.slice(0, at)).trim().toLowerCase();
+}
+
+function isOfficialRalphLoopEnabledInSettings(settings) {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
+  for (const candidate of [settings.enabledPlugins, settings.plugins]) {
+    if (Array.isArray(candidate)) {
+      if (candidate.some((id) => normalizeRalphLoopPluginId(id) === 'ralph-loop')) {
+        return true;
+      }
+    } else if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+      if (Object.entries(candidate).some(([id, value]) =>
+        normalizeRalphLoopPluginId(id) === 'ralph-loop' && value !== false
+      )) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isOfficialRalphLoopEnabledInSettingsFile() {
+  const settingsPath = join(getClaudeConfigDir(), 'settings.json');
+  if (!existsSync(settingsPath)) return false;
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    return false;
+  }
+  return isOfficialRalphLoopEnabledInSettings(settings);
+}
+
 function findOfficialRalphLoopNotice() {
+  if (!isOfficialRalphLoopEnabledInSettingsFile()) {
+    return '';
+  }
+
   const installedPluginsPath = join(getClaudeConfigDir(), 'plugins', 'installed_plugins.json');
   if (!existsSync(installedPluginsPath)) {
     return '';
@@ -1265,15 +1318,13 @@ function findOfficialRalphLoopNotice() {
     return '';
   }
 
-  const officialId = 'ralph-loop@claude-plugins-official';
-  const entries = plugins[officialId];
+  const entries = plugins[OFFICIAL_RALPH_LOOP_PLUGIN_ID];
   if (!Array.isArray(entries) || entries.length === 0) {
     return '';
   }
 
   for (const entry of entries) {
     if (!entry || typeof entry !== 'object') continue;
-    if (entry.enabled === false) continue;
     const installPath = entry.installPath;
     if (typeof installPath !== 'string' || installPath.length === 0) continue;
     const commandFile = join(installPath, 'commands', 'ralph-loop.md');

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -1103,12 +1103,15 @@ Arguments: ${args}` : '';
   const pathStatus = existsSync(skillPath)
     ? `Read fallback: open ${skillPath} and follow its SKILL.md instructions.`
     : `Read fallback: locate skills/${skillName}/SKILL.md in the active oh-my-claudecode plugin/install and follow it.`;
+  const ralphLoopNotice = skillName === 'ralph' ? findOfficialRalphLoopNotice() : '';
 
   return `[MAGIC KEYWORD: ${skillName.toUpperCase()}]
 
 Skill routing detected: ${skillName}
 Preferred invocation: /oh-my-claudecode:${skillName}${args ? ` ${args}` : ''}
-${pathStatus}${argsSection}
+${pathStatus}${argsSection}${ralphLoopNotice ? `
+
+${ralphLoopNotice}` : ''}
 
 User request (compact echo; original prompt remains authoritative):
 ${compactHookText(originalPrompt)}
@@ -1222,6 +1225,64 @@ function isTeamEnabled() {
     }
     return false;
   } catch { return false; }
+}
+
+/**
+ * Detect an installed official Anthropic `ralph-loop` plugin that exposes a
+ * `/ralph-loop` command, without scanning any plugin payloads.
+ *
+ * Reads only the machine-readable plugin registry
+ * `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the same
+ * file OMC already uses for plugin-cache bookkeeping) and checks for the
+ * existence of the plugin's command file. No SKILL.md body, command body, or
+ * private payload is ever read. The official plugin's registry id is
+ * `ralph-loop@claude-plugins-official`; lookalike ids that merely contain
+ * "ralph" (e.g. a user skill directory named ralph-loop) are not treated as
+ * the official plugin.
+ *
+ * Returns a short notice string, or '' when the official plugin is not
+ * installed. A disabled registry entry (`enabled: false`) is treated as not
+ * installed so the notice does not nag about plugins the user turned off.
+ */
+function findOfficialRalphLoopNotice() {
+  const installedPluginsPath = join(getClaudeConfigDir(), 'plugins', 'installed_plugins.json');
+  if (!existsSync(installedPluginsPath)) {
+    return '';
+  }
+
+  let registry;
+  try {
+    registry = JSON.parse(readFileSync(installedPluginsPath, 'utf-8'));
+  } catch {
+    return '';
+  }
+  if (!registry || typeof registry !== 'object' || Array.isArray(registry)) {
+    return '';
+  }
+
+  const plugins = registry.plugins ?? registry;
+  if (!plugins || typeof plugins !== 'object' || Array.isArray(plugins)) {
+    return '';
+  }
+
+  const officialId = 'ralph-loop@claude-plugins-official';
+  const entries = plugins[officialId];
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return '';
+  }
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (entry.enabled === false) continue;
+    const installPath = entry.installPath;
+    if (typeof installPath !== 'string' || installPath.length === 0) continue;
+    const commandFile = join(installPath, 'commands', 'ralph-loop.md');
+    if (existsSync(commandFile)) {
+      return 'Note: the official Anthropic `ralph-loop` plugin is also installed. `/ralph` runs OMC\'s ralph; use `/ralph-loop` for the official plugin.';
+    }
+  }
+
+  return '';
 }
 
 // Read the OMC JSONC config the way src/config/loader.ts does, inlined so the

--- a/templates/hooks/keyword-detector.mjs
+++ b/templates/hooks/keyword-detector.mjs
@@ -24,7 +24,7 @@
  */
 
 import { writeFileSync, mkdirSync, existsSync, unlinkSync, readFileSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, isAbsolute } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -1096,14 +1096,14 @@ async function linkRalphTeam(directory, sessionId) {
  * Create a compact skill invocation guide without inlining SKILL.md bodies.
  * Full skill text remains available by path, avoiding UserPromptSubmit token blowups.
  */
-function createSkillInvocation(skillName, originalPrompt, args = '') {
+function createSkillInvocation(skillName, originalPrompt, args = '', directory = '') {
   const argsSection = args ? `
 Arguments: ${args}` : '';
   const skillPath = resolveSkillPath(skillName);
   const pathStatus = existsSync(skillPath)
     ? `Read fallback: open ${skillPath} and follow its SKILL.md instructions.`
     : `Read fallback: locate skills/${skillName}/SKILL.md in the active oh-my-claudecode plugin/install and follow it.`;
-  const ralphLoopNotice = skillName === 'ralph' ? findOfficialRalphLoopNotice() : '';
+  const ralphLoopNotice = skillName === 'ralph' ? findOfficialRalphLoopNotice(directory) : '';
 
   return `[MAGIC KEYWORD: ${skillName.toUpperCase()}]
 
@@ -1122,10 +1122,10 @@ IMPORTANT: Start the ${skillName} workflow immediately. If the slash invocation 
 /**
  * Create multi-skill invocation message for combined keywords
  */
-function createMultiSkillInvocation(skills, originalPrompt) {
+function createMultiSkillInvocation(skills, originalPrompt, directory = '') {
   if (skills.length === 0) return '';
   if (skills.length === 1) {
-    return createSkillInvocation(skills[0].name, originalPrompt, skills[0].args);
+    return createSkillInvocation(skills[0].name, originalPrompt, skills[0].args, directory);
   }
 
   const skillBlocks = skills.map((s, i) => {
@@ -1142,7 +1142,7 @@ ${pathStatus}`;
   // Multi-skill routing (e.g. `/ralph ultrawork`) must carry the same
   // disambiguation notice as the single-skill path, or it becomes a bypass.
   const ralphLoopNotice = skills.some((s) => s.name === 'ralph')
-    ? findOfficialRalphLoopNotice()
+    ? findOfficialRalphLoopNotice(directory)
     : '';
 
   return `[MAGIC KEYWORDS DETECTED: ${skills.map(s => s.name.toUpperCase()).join(', ')}]
@@ -1157,18 +1157,6 @@ User request (compact echo; original prompt remains authoritative):
 ${compactHookText(originalPrompt)}
 
 IMPORTANT: Complete ALL skills listed above in order. Start with the first skill IMMEDIATELY.`;
-}
-
-/**
- * Create combined output for multiple skill matches
- */
-function createCombinedOutput(skillMatches, originalPrompt) {
-  const parts = [];
-  if (skillMatches.length > 0) {
-    parts.push('## Section 1: Skill Invocations\n\n' + createMultiSkillInvocation(skillMatches, originalPrompt));
-  }
-  const allNames = skillMatches.map(m => m.name.toUpperCase());
-  return `[MAGIC KEYWORDS DETECTED: ${allNames.join(', ')}]\n\n${parts.join('\n\n---\n\n')}\n\nIMPORTANT: Complete ALL sections above in order.`;
 }
 
 /**
@@ -1249,11 +1237,14 @@ function isTeamEnabled() {
  *    own `enabled` flag is deliberately NOT consulted: it does not
  *    authoritatively encode enablement (a plugin disabled through canonical
  *    settings can still carry `enabled: true`, and vice versa).
- * 2. ENABLED: `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json` lists the
- *    plugin in the canonical `enabledPlugins` field (legacy `plugins` field
- *    accepted for backward compatibility), as an array of plugin ids or a
- *    map whose value is not `false`. Missing or malformed settings.json is
- *    treated as not enabled, exactly like the installer.
+ * 2. ENABLED: the official id is enabled by the effective Claude Code settings
+ *    for the active project, resolved highest-precedence-first across
+ *    `<project>/.claude/settings.local.json`, `<project>/.claude/settings.json`
+ *    and `[$CLAUDE_CONFIG_DIR|~/.claude]/settings.json`. Within a file the
+ *    canonical `enabledPlugins` field decides (legacy `plugins` field accepted
+ *    for backward compatibility), as an array of plugin ids or a map whose
+ *    value is not `false`. Missing or malformed settings are treated as not
+ *    enabled, exactly like the installer.
  *
  * Both signals match the FULL plugin id exactly, marketplace suffix included.
  * The suffix is never stripped, so a same-named community plugin
@@ -1289,31 +1280,59 @@ function officialRalphLoopEnablementIn(field) {
   return null;
 }
 
-function isOfficialRalphLoopEnabledInSettings(settings) {
-  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
+function officialRalphLoopEnablementInSettings(settings) {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return null;
   // Canonical `enabledPlugins` wins outright when it mentions the official id;
   // the legacy `plugins` field only decides when canonical is silent about it.
   for (const field of [settings.enabledPlugins, settings.plugins]) {
     const verdict = officialRalphLoopEnablementIn(field);
     if (verdict !== null) return verdict;
   }
+  return null;
+}
+
+/**
+ * A hook payload's cwd is caller-supplied. Only an absolute path is a usable
+ * project root; anything else would silently resolve a caller-controlled
+ * fragment against the hook process cwd, so it is rejected in favour of the
+ * hook's own cwd.
+ */
+function resolveSettingsProjectRoot(directory) {
+  return typeof directory === 'string' && directory.length > 0 && isAbsolute(directory)
+    ? directory
+    : process.cwd();
+}
+
+/**
+ * Claude Code resolves `enabledPlugins` across settings scopes, so a project may
+ * enable a plugin the user scope never mentions, or disable one the user scope
+ * enables. Highest precedence first; the first scope that mentions the official
+ * id decides, scopes that never mention it are transparent, and a malformed
+ * file fails closed (no notice).
+ */
+function isOfficialRalphLoopEnabledForProject(directory) {
+  const projectRoot = resolveSettingsProjectRoot(directory);
+  const settingsPaths = [
+    join(projectRoot, '.claude', 'settings.local.json'),
+    join(projectRoot, '.claude', 'settings.json'),
+    join(getClaudeConfigDir(), 'settings.json'),
+  ];
+  for (const settingsPath of settingsPaths) {
+    if (!existsSync(settingsPath)) continue;
+    let settings;
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    } catch {
+      return false;
+    }
+    const verdict = officialRalphLoopEnablementInSettings(settings);
+    if (verdict !== null) return verdict;
+  }
   return false;
 }
 
-function isOfficialRalphLoopEnabledInSettingsFile() {
-  const settingsPath = join(getClaudeConfigDir(), 'settings.json');
-  if (!existsSync(settingsPath)) return false;
-  let settings;
-  try {
-    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-  } catch {
-    return false;
-  }
-  return isOfficialRalphLoopEnabledInSettings(settings);
-}
-
-function findOfficialRalphLoopNotice() {
-  if (!isOfficialRalphLoopEnabledInSettingsFile()) {
+function findOfficialRalphLoopNotice(directory) {
+  if (!isOfficialRalphLoopEnabledForProject(directory)) {
     return '';
   }
 
@@ -1662,7 +1681,7 @@ async function main() {
 
     // Route cancellation without mutating state; the cancel workflow commits the primary mode first.
     if (resolved.length > 0 && resolved[0].name === 'cancel') {
-      console.log(JSON.stringify(createHookOutput(createSkillInvocation('cancel', prompt))));
+      console.log(JSON.stringify(createHookOutput(createSkillInvocation('cancel', prompt, '', directory))));
       return;
     }
 
@@ -1706,7 +1725,7 @@ async function main() {
     }
 
     if (resolved.length > 0) {
-      additionalContextParts.push(createMultiSkillInvocation(resolved, prompt));
+      additionalContextParts.push(createMultiSkillInvocation(resolved, prompt, directory));
     }
 
     if (additionalContextParts.length > 0) {


### PR DESCRIPTION
## Summary

Fixes #3668 — omc's skill owns the bare name `ralph` (`/ralph`) while the official Anthropic `claude-plugins-official` plugin exposes the same technique as `ralph-loop` (`/ralph-loop`). With both plugins installed, `/ralph` resolves to omc's loop with **no indication that a second implementation exists**.

This PR implements the non-breaking, evidence-backed disambiguation option the maintainer identified as the first target: at `/ralph` invocation time, when the official `ralph-loop` plugin is also installed and enabled, the compact skill-invocation guide names both commands.

> Note: the official Anthropic \`ralph-loop\` plugin is also installed. \`/ralph\` runs OMC's ralph; use \`/ralph-loop\` for the official plugin.

## What is detected, and how (no payload scan, no startup noise)

- Reads only the machine-readable plugin registry `[$CLAUDE_CONFIG_DIR|~/.claude]/plugins/installed_plugins.json` (the same file OMC already uses for plugin-cache bookkeeping) and checks `existsSync` on `commands/ralph-loop.md` under the registry entry's `installPath`.
- Matches exactly the official registry id `ralph-loop@claude-plugins-official`; lookalike ids (`my-ralph-loop@community`, a bare `ralph-loop` key) are ignored.
- Respects `enabled: false` — no nagging about plugins the user disabled.
- Never opens any SKILL.md / command body / private payload.
- Invocation-time only: zero cost when the official plugin is absent, no session-start scan.

## Backward compatibility

- `/ralph` routing is unchanged; the bare skill name is **not** renamed or removed.
- When the official plugin is absent or disabled, output is byte-identical to today.
- The official `/ralph-loop` command never routes to OMC's ralph; the `/omc-ralph` alias still routes to OMC's ralph and carries the notice.

## Files changed

- `scripts/keyword-detector.mjs` — notice helper + ralph wiring (plugin-payload artifact)
- `templates/hooks/keyword-detector.mjs` — same, lockstep standalone artifact
- `src/installer/__tests__/hook-templates.test.ts` — deterministic regression tests A–I
- `docs/issues/issue-3668-ralph-namespace.md` — option comparison + owner-decision hold on any rename of bare ralph

## Tests

Regression matrix A–I (both packaged artifacts): only-OMC silent · both installed → notice · official absent silent · disabled silent · registry-but-missing-payload silent · lookalike id silent · no registry silent · non-ralph skills silent · official `/ralph-loop` never routes · `/omc-ralph` alias routes with notice.

- `hook-templates.test.ts` 18/18
- `keyword-detector-script.test.ts` 101/101
- `standalone-hook-reconcile.test.ts` 26/26
- `skills.test.ts`, `auto-slash-aliases.test.ts`, `skills-frontmatter-regression.test.ts` clean
- ESLint + `tsc --noEmit` clean

## Note to owner

A rename of bare `ralph` (option 2 in #3668) would be a material command-surface change (keyword activation, live session state, cancel cascade, workflow slots, `keywordDetector.disabled` configs, docs). It is intentionally **not** performed here and remains an explicit owner decision — see `docs/issues/issue-3668-ralph-namespace.md`.
