### PR TITLE
fix(hooks): reap Windows generic hooks after runner death

### DIFF
--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -273,9 +273,7 @@ function reapTree(child, childIdentity) {
   // before killing its process group. If the PID was reused by the OS after
   // the child exited, processIdentityMatches returns false and we skip the
   // kill entirely, relying on child.unref() for fail-open exit.
-  if (childIdentity && !processIdentityMatches(child.pid, childIdentity)) {
-    return;
-  }
+  if (childIdentity && !processIdentityMatches(child.pid, childIdentity)) return;
   if (process.platform === 'win32') {
     // Fire-and-forget: a slow, denied, or missing taskkill must not block the
     // runner past the outer hooks.json budget. The runner still exits fail-open
@@ -306,16 +304,60 @@ function reapTree(child, childIdentity) {
 }
 
 const RUNNER_TERMINATION_SIGNALS = ['SIGTERM', 'SIGINT', 'SIGHUP'];
+function resolveGenericChildCommand(targetPath, extraArgs, platform = process.platform) {
+  return platform === 'win32'
+    ? [__filename, '--generic-child-supervisor', targetPath, ...extraArgs]
+    : [targetPath, ...extraArgs];
+}
+
+function releaseGenericChild(child) {
+  try {
+    if (child.connected) child.disconnect();
+  } catch {
+    // The child may already have exited or closed its IPC channel.
+  }
+  try { child.unref(); } catch { /* handle already released */ }
+}
+
+function superviseGenericChild(targetPath, extraArgs) {
+  let terminal = false;
+  const child = spawn(process.execPath, [targetPath, ...extraArgs], {
+    stdio: 'inherit',
+    env: process.env,
+    windowsHide: true,
+    detached: process.platform !== 'win32',
+  });
+  const childIdentity = child.pid ? captureProcessStartIdentity(child.pid) : null;
+  const finish = (status) => {
+    if (terminal) return;
+    terminal = true;
+    process.exitCode = status;
+    if (process.connected) process.disconnect();
+  };
+
+  // The supervisor is a detached Windows child of run.cjs. Its IPC channel is
+  // closed by the OS even when run.cjs is externally terminated without JS
+  // cleanup, so it can reap only the hook tree that it created.
+  process.once('disconnect', () => {
+    if (terminal) return;
+    terminal = true;
+    reapTree(child, childIdentity);
+    try { child.unref(); } catch { /* handle already released */ }
+  });
+  child.once('exit', code => finish(typeof code === 'number' ? code : 0));
+  child.once('error', () => finish(0));
+}
+
 
 function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
   return new Promise(resolve => {
     let terminal = false;
     let timer;
-    const child = spawn(process.execPath, [targetPath, ...extraArgs], {
-      stdio: 'inherit',
+    const child = spawn(process.execPath, resolveGenericChildCommand(targetPath, extraArgs), {
+      stdio: process.platform === 'win32' ? ['inherit', 'inherit', 'inherit', 'ipc'] : 'inherit',
       env: process.env,
       windowsHide: true,
-      detached: process.platform !== 'win32',
+      detached: true,
     });
     // Capture the durable start identity immediately so reapTree can reject
     // a PID that was reused after the child exited.
@@ -350,8 +392,9 @@ function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
       reapTree(child, childIdentity);
       // The runner MUST exit fail-open even if the tree reap did not (or could
       // not) complete — the core #3493 symptom is run.cjs parents living for
-      // tens of minutes. unref() releases the child handle from the event loop.
-      try { child.unref(); } catch { /* handle already released */ }
+      // tens of minutes. Closing the Windows IPC channel also tells the
+      // supervisor to reap the hook tree if taskkill did not complete.
+      releaseGenericChild(child);
       writeTimeoutDiagnostic(targetPath, manifestHook, timeoutMs);
       resolve(0);
     }, timeoutMs);
@@ -460,34 +503,38 @@ async function runWorker(targetPath, manifestHook, timeoutMs) {
 
 if (require.main === module) {
   const target = process.argv[2];
-  if (!target) {
+  if (target === '--generic-child-supervisor') {
+    const supervisedTarget = process.argv[3];
+    if (supervisedTarget) superviseGenericChild(supervisedTarget, process.argv.slice(4));
+    else process.exitCode = 0;
+  } else if (!target) {
     process.exit(0);
-  }
-
-  const resolution = resolveTarget(target);
-  if (!resolution) {
-    process.exitCode = 0;
   } else {
-    const extraArgs = process.argv.slice(3);
-    const workerManifestHook = resolveWorkerTarget(resolution, extraArgs);
-    if (workerManifestHook) {
-      const workerTimeoutMs = resolveTrustedPromptWorkerTimeoutMs(resolution.targetPath, workerManifestHook, resolution.trustedPluginRoot);
-      runWorker(resolution.targetPath, workerManifestHook, workerTimeoutMs).then(status => {
-        process.exitCode = status;
-      });
+    const resolution = resolveTarget(target);
+    if (!resolution) {
+      process.exitCode = 0;
     } else {
-      const sessionEndManifestHook = resolveTrustedSessionEndTarget(resolution, extraArgs);
-      if (sessionEndManifestHook) {
-        const timeoutMs = Math.min(resolveGenericTimeoutMs(sessionEndManifestHook), 300);
-        runWorker(resolution.targetPath, sessionEndManifestHook, timeoutMs).then(status => {
+      const extraArgs = process.argv.slice(3);
+      const workerManifestHook = resolveWorkerTarget(resolution, extraArgs);
+      if (workerManifestHook) {
+        const workerTimeoutMs = resolveTrustedPromptWorkerTimeoutMs(resolution.targetPath, workerManifestHook, resolution.trustedPluginRoot);
+        runWorker(resolution.targetPath, workerManifestHook, workerTimeoutMs).then(status => {
           process.exitCode = status;
         });
       } else {
-      const manifestHook = resolveHookTimeoutMs(resolution.targetPath, extraArgs);
-      const timeoutMs = resolveGenericTimeoutMs(manifestHook);
-      runGenericChild(resolution.targetPath, extraArgs, timeoutMs, manifestHook).then(status => {
-        process.exitCode = status;
-      });
+        const sessionEndManifestHook = resolveTrustedSessionEndTarget(resolution, extraArgs);
+        if (sessionEndManifestHook) {
+          const timeoutMs = Math.min(resolveGenericTimeoutMs(sessionEndManifestHook), 300);
+          runWorker(resolution.targetPath, sessionEndManifestHook, timeoutMs).then(status => {
+            process.exitCode = status;
+          });
+        } else {
+          const manifestHook = resolveHookTimeoutMs(resolution.targetPath, extraArgs);
+          const timeoutMs = resolveGenericTimeoutMs(manifestHook);
+          runGenericChild(resolution.targetPath, extraArgs, timeoutMs, manifestHook).then(status => {
+            process.exitCode = status;
+          });
+        }
       }
     }
   }
@@ -500,6 +547,8 @@ module.exports = {
   resolveHookTimeoutMs,
   resolveGenericTimeoutMs,
   runGenericChild,
+  resolveGenericChildCommand,
+  releaseGenericChild,
   DEFAULT_GENERIC_TIMEOUT_MS,
   resolveTrustedSessionEndTarget,
 };

--- a/src/__tests__/run-cjs-generic-timeout.test.ts
+++ b/src/__tests__/run-cjs-generic-timeout.test.ts
@@ -47,6 +47,80 @@ describe('run.cjs generic hook timeout supervisor', () => {
     expect(runCjs.resolveGenericTimeoutMs(manifestHook)).toBe(2500);
   });
 
+  it('uses the source-owned supervisor only for Windows generic hooks', () => {
+    expect(runCjs.resolveGenericChildCommand(HUNG_PARENT, ['argument'], 'win32')).toEqual([
+      RUN_CJS_PATH,
+      '--generic-child-supervisor',
+      HUNG_PARENT,
+      'argument',
+    ]);
+    expect(runCjs.resolveGenericChildCommand(HUNG_PARENT, ['argument'], 'linux')).toEqual([
+      HUNG_PARENT,
+      'argument',
+    ]);
+  });
+
+  it('releases the Windows supervisor IPC channel after an inner timeout', () => {
+    let disconnected = 0;
+    let unreferenced = 0;
+    runCjs.releaseGenericChild({
+      connected: true,
+      disconnect: () => { disconnected += 1; },
+      unref: () => { unreferenced += 1; },
+    });
+    expect(disconnected).toBe(1);
+    expect(unreferenced).toBe(1);
+  });
+
+  it('reaps the supervised hook tree when its IPC parent disappears', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-supervisor-parent-death-'));
+    const pidfile = join(directory, 'grandchild.pid');
+    let grandchildPid: number | undefined;
+    const supervisor = spawn(process.execPath, [RUN_CJS_PATH, '--generic-child-supervisor', HUNG_PARENT], {
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+      detached: true,
+      env: { ...process.env, OMC_TEST_PIDFILE: pidfile },
+    });
+    try {
+      const deadline = Date.now() + 4000;
+      while (Date.now() < deadline && !existsSync(pidfile)) {
+        await new Promise(resolve => setTimeout(resolve, 25));
+      }
+      expect(existsSync(pidfile)).toBe(true);
+      grandchildPid = Number(readFileSync(pidfile, 'utf8'));
+      expect(grandchildPid).toBeGreaterThan(0);
+
+      const supervisorExit = new Promise<void>(resolve => supervisor.once('exit', () => resolve()));
+      supervisor.disconnect();
+      await waitForDeath(grandchildPid);
+      await Promise.race([
+        supervisorExit,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('supervisor did not exit after IPC disconnect')), 5000)),
+      ]);
+    } finally {
+      killIfAlive(grandchildPid);
+      try { supervisor.kill('SIGKILL'); } catch { /* already gone */ }
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves normal child completion through the supervisor', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-supervisor-normal-exit-'));
+    const fixture = join(directory, 'numeric-exit.cjs');
+    writeFileSync(fixture, 'process.exit(3);');
+    const supervisor = spawn(process.execPath, [RUN_CJS_PATH, '--generic-child-supervisor', fixture], {
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+      detached: process.platform !== 'win32',
+    });
+    try {
+      const code = await new Promise<number | null>(resolve => supervisor.once('exit', resolve));
+      expect(code).toBe(3);
+    } finally {
+      try { supervisor.kill('SIGKILL'); } catch { /* already gone */ }
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('reaps a timed-out generic hook and its POSIX grandchild', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'omc-hung-generic-'));
     const pidfile = join(directory, 'grandchild.pid');


### PR DESCRIPTION
Fixes #3675.

- Run Windows generic hooks under a detached source-owned IPC supervisor.
- Reap the supervisor-owned hook tree when the runner disappears without JS cleanup.
- Preserve normal completion, inner timeout fail-open behavior, and existing POSIX dispatch.

Validation:
- `npx vitest run src/__tests__/run-cjs-generic-timeout.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (19 pre-existing warnings, no errors)
- `npm run build`
- `npm run plugin:shipping:verify`

The full suite was also run: 657 passed / 3 skipped, with 4 unrelated pre-existing failures (37 assertions) in state/workflow-profile tests under shared `/tmp` state.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*