### PR TITLE
fix(hooks): honor generic cancellation during lock contention

### DIFF
--- a/scripts/lib/atomic-write.mjs
+++ b/scripts/lib/atomic-write.mjs
@@ -162,6 +162,10 @@ function guardedLockRemoval(lockPath, operation, owner) {
   return 'unverifiable';
 }
 
+export function isStateFileLockingSupported() {
+  return Boolean(flockPath());
+}
+
 function acquireLockAt(lockPath, attempts = 50, requireExclusive = false) {
   ensureDirSync(dirname(lockPath));
   if (!flockPath()) return requireExclusive ? null : { unlocked: true };

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -96,7 +96,7 @@ process.on("unhandledRejection", (error) => {
   forceSafeExit(`[persistent-mode] Unhandled rejection: ${error?.message || error}`);
 });
 const { advanceWorkflowOnStop, isValidWorkflowDescriptor, isValidWorkflowTrackingState, isWorkflowRuntimeSupported, refreshWorkflowBoundaryForCommit, resolveWorkflowStagePrompt, takeWorkflowTranscriptFailure } = await import(pathToFileURL(join(__dirname, "lib", "workflow-profile-runtime.mjs")).href);
-const { acquireStateFileLockSync, atomicWriteFileSync, releaseStateFileLockSync, withStateFileLockSync } = await import(pathToFileURL(join(__dirname, "lib", "atomic-write.mjs")).href);
+const { acquireStateFileLockSync, atomicWriteFileSync, isStateFileLockingSupported, releaseStateFileLockSync, withStateFileLockSync } = await import(pathToFileURL(join(__dirname, "lib", "atomic-write.mjs")).href);
 
 const { getClaudeConfigDir } = await import(pathToFileURL(join(__dirname, "lib", "config-dir.mjs")).href);
 const { readStdin } = await import(
@@ -792,7 +792,12 @@ function isSessionCancelInProgress(stateDir, sessionId, currentAutopilotPath, ca
     if (!existsSync(signalPath)) return false;
     if (!currentAutopilotPath || !cancellationContext) return validateSignal(signalPath, null);
     const stateLock = acquireStateFileLockSync(currentAutopilotPath, 50, true);
-    if (!stateLock) return false;
+    if (!stateLock) {
+      if (isStateFileLockingSupported()) return false;
+      const currentAutopilot = readJsonFile(currentAutopilotPath);
+      if (isEnforceableAutopilotCancellationTarget(currentAutopilot, cancellationContext.directory, cancellationContext.isGlobal, cancellationContext.hasValidSessionId, sessionId)) return false;
+      return validateSignal(signalPath, null);
+    }
     try {
       const currentAutopilot = readJsonFile(currentAutopilotPath);
       if (!isEnforceableAutopilotCancellationTarget(currentAutopilot, cancellationContext.directory, cancellationContext.isGlobal, cancellationContext.hasValidSessionId, sessionId)) return validateSignal(signalPath, null);

--- a/templates/hooks/lib/atomic-write.mjs
+++ b/templates/hooks/lib/atomic-write.mjs
@@ -162,6 +162,10 @@ function guardedLockRemoval(lockPath, operation, owner) {
   return 'unverifiable';
 }
 
+export function isStateFileLockingSupported() {
+  return Boolean(flockPath());
+}
+
 function acquireLockAt(lockPath, attempts = 50, requireExclusive = false) {
   ensureDirSync(dirname(lockPath));
   if (!flockPath()) return requireExclusive ? null : { unlocked: true };

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -98,7 +98,7 @@ const { readStdin } = await import(
 );
 const { resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, "lib", "state-root.mjs")).href);
 const { advanceWorkflowOnStop, isValidWorkflowDescriptor, isValidWorkflowTrackingState, isWorkflowRuntimeSupported, refreshWorkflowBoundaryForCommit, resolveWorkflowStagePrompt, takeWorkflowTranscriptFailure } = await import(pathToFileURL(join(__dirname, "lib", "workflow-profile-runtime.mjs")).href);
-const { acquireStateFileLockSync, atomicWriteFileSync, releaseStateFileLockSync, withStateFileLockSync } = await import(pathToFileURL(join(__dirname, "lib", "atomic-write.mjs")).href);
+const { acquireStateFileLockSync, atomicWriteFileSync, isStateFileLockingSupported, releaseStateFileLockSync, withStateFileLockSync } = await import(pathToFileURL(join(__dirname, "lib", "atomic-write.mjs")).href);
 
 function readJsonFile(path) {
   try {
@@ -460,7 +460,12 @@ function isSessionCancelInProgress(stateDir, sessionId, currentAutopilotPath, ca
     if (!existsSync(signalPath)) return false;
     if (!currentAutopilotPath || !cancellationContext) return validateSignal(signalPath, null);
     const stateLock = acquireStateFileLockSync(currentAutopilotPath, 50, true);
-    if (!stateLock) return false;
+    if (!stateLock) {
+      if (isStateFileLockingSupported()) return false;
+      const currentAutopilot = readJsonFile(currentAutopilotPath);
+      if (isEnforceableAutopilotCancellationTarget(currentAutopilot, cancellationContext.directory, cancellationContext.isGlobal, cancellationContext.hasValidSessionId, sessionId)) return false;
+      return validateSignal(signalPath, null);
+    }
     try {
       const currentAutopilot = readJsonFile(currentAutopilotPath);
       if (!isEnforceableAutopilotCancellationTarget(currentAutopilot, cancellationContext.directory, cancellationContext.isGlobal, cancellationContext.hasValidSessionId, sessionId)) return validateSignal(signalPath, null);

--- a/tests/integration/workflow-profile-stop-transition.test.ts
+++ b/tests/integration/workflow-profile-stop-transition.test.ts
@@ -446,6 +446,99 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
     expect(invoke(f)).toEqual({ continue: true, suppressOutput: true });
   });
 
+  it('honors a targetless generic cancellation when exclusive locking is unavailable and no autopilot state exists', () => {
+    const f = fixture(kind);
+    writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
+      active: true,
+      source: 'state_clear',
+      requested_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30_000).toISOString(),
+    }));
+
+    expect(invoke(f, {}, { OMC_TEST_FLOCK_AVAILABLE: '0' })).toEqual({ continue: true, suppressOutput: true });
+  });
+
+  it('fails closed for a targetless generic cancellation while the absent autopilot state remains locked', () => {
+    const f = fixture(kind);
+    writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
+      active: true,
+      source: 'state_clear',
+      requested_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30_000).toISOString(),
+    }));
+    writeFileSync(`${f.statePath}.mutation.lock`, liveLockOwner());
+
+    expect(invoke(f)).toMatchObject({ decision: 'block' });
+  });
+
+  it('rechecks a generic cancellation after concurrent autopilot activation commits under the state lock', async () => {
+    const f = fixture(kind);
+    writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
+      active: true,
+      source: 'state_clear',
+      requested_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30_000).toISOString(),
+    }));
+    const lockPath = `${f.statePath}.mutation.lock`;
+    writeFileSync(lockPath, liveLockOwner());
+    const pending = invokeAsync(f);
+    await new Promise(resolve => setTimeout(resolve, 75));
+    writeState(f, workflowState(f));
+    unlinkSync(lockPath);
+
+    expect(await pending).toMatchObject({ continue: false, decision: 'block', reason: expectedStagePrompt('ralplan') });
+  });
+
+  it('fails closed when concurrent autopilot activation commits after lock retries expire', async () => {
+    const f = fixture(kind);
+    writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
+      active: true,
+      source: 'state_clear',
+      requested_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30_000).toISOString(),
+    }));
+    const lockPath = `${f.statePath}.mutation.lock`;
+    writeFileSync(lockPath, liveLockOwner());
+    const pending = invokeAsync(f);
+    await new Promise(resolve => setTimeout(resolve, 600));
+    writeState(f, workflowState(f));
+    unlinkSync(lockPath);
+
+    expect(await pending).toMatchObject({ decision: 'block' });
+  });
+
+  it('does not let a target-bound autopilot signal cancel Ralph when the absent autopilot state is locked', () => {
+    const f = fixture(kind);
+    writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
+      active: true,
+      mode: 'autopilot',
+      source: 'state_clear',
+      requested_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      target_state_sha256: '0'.repeat(64),
+    }));
+    writeFileSync(`${f.statePath}.mutation.lock`, liveLockOwner());
+
+    expect(invoke(f)).toMatchObject({ decision: 'block' });
+  });
+
+  it('does not let a generic cancellation bypass an active autopilot when exclusive locking is unavailable', () => {
+    const f = fixture(kind);
+    writeState(f, workflowState(f));
+    writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
+      active: true,
+      source: 'state_clear',
+      requested_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 30_000).toISOString(),
+    }));
+
+    expect(invoke(f, {}, { OMC_TEST_FLOCK_AVAILABLE: '0' }).reason).toBe(expectedStagePrompt('ralplan'));
+  });
+
   it('does not let an absent-generation exact autopilot signal suppress concurrent activation', async () => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({


### PR DESCRIPTION
## Summary

Repairs dev CI run `31444103313`: the installed-template stop hook could fall through to active Ralph when it could not acquire the lock for an absent autopilot state. It now validates only a targetless generic cancellation in that fallback; target-bound autopilot signals remain rejected without target authentication.

The shipped plugin and installed-template hooks use the same repair. A regression covers a fresh generic signal while the absent autopilot state lock is contended, alongside the existing targeted-signal Ralph guards.

## Verification

- `npx vitest run tests/integration/workflow-profile-stop-transition.test.ts --reporter=dot` — 174 passed
- `npm run build` — passed

## CI context

Dev head `a9295a5fdd83f5e63fecf3f6b432eb4f47b80a84` failed only `tests/integration/workflow-profile-stop-transition.test.ts:446` in installed-template execution; this repair is based on `a928331fdbe311de6a0733b019e120b78a132596`.

Refs #3682