### PR TITLE
fix(purge): keep the pinned plugin path alive when a relink loses a race

### DIFF
--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -287,7 +287,12 @@ describe('invariant across every cache shape', () => {
   });
 });
 
-describe('syscall semantics this implementation relies on', () => {
+// POSIX only. Windows reports a rename collision as EPERM/EACCES and needs a
+// privilege or developer mode for symlinkSync, so these exact codes are not the
+// contract there — OCCUPIED_CODES widens for win32 instead. This file is not in
+// the Windows CI allowlist in .github/workflows/ci.yml; the guard keeps it safe
+// if it is ever added.
+describe.skipIf(process.platform === 'win32')('syscall semantics this implementation relies on', () => {
   let root: string;
   beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'omc-posix-')); });
   afterEach(() => { rmSync(root, { recursive: true, force: true }); });

--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -221,6 +221,66 @@ describe('purgeStalePluginCacheVersions on a real filesystem', () => {
     expect(existsSync(aside)).toBe(false);
   });
 
+  it('never destroys the namespace for an aside entry with no version prefix', () => {
+    // A bare `.omc-stale-<pid>` has an empty prefix, so the "original" path is the
+    // plugin namespace itself.  Renaming the entry over its own parent reports
+    // ENOTEMPTY, which the placement helper would read as an occupied path and
+    // clear recursively — taking the active version and every sibling with it.
+    const stale = writeVersion(STALE);
+    makeStale(stale);
+    const orphan = join(pluginDir, '.omc-stale-999994');
+    mkdirSync(join(orphan, 'scripts'), { recursive: true });
+    writeFileSync(join(orphan, 'scripts', 'run.cjs'), '//\n');
+    makeStale(orphan);
+
+    const result = purgeStalePluginCacheVersions();
+
+    // The namespace and the active version survive — this is the whole assertion
+    expect(existsSync(pluginDir)).toBe(true);
+    expect(hookResolves(ACTIVE)).toBe(true);
+    expect(readdirSync(pluginDir)).toContain(ACTIVE);
+    // The unattributable entry is left alone rather than acted on
+    expect(existsSync(orphan)).toBe(true);
+    expect(result.restored).toBe(0);
+  });
+
+  it('keeps the backup when the path redirects to a directory that is not a plugin root', () => {
+    // existsSync only proves the link resolves.  The runner validates the
+    // resolved root, so a redirect into some unrelated directory cannot run
+    // hooks and must not count as a reason to discard the backup.
+    const elsewhere = join(configDir, 'not-a-plugin');
+    mkdirSync(join(elsewhere, 'random'), { recursive: true });
+
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-999993`;
+    renameSync(stale, aside);
+    symlinkSync(elsewhere, stale, 'dir');
+    expect(existsSync(stale)).toBe(true);       // the link resolves…
+    expect(hookResolves(STALE)).toBe(false);    // …but it is not a root
+    makeStale(aside);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(hookResolves(STALE)).toBe(true);
+    expect(existsSync(aside)).toBe(false);
+  });
+
+  it('discards the backup when the path redirects to a real plugin root', () => {
+    // The counter-case: a completed redirect is usable and the backup is litter.
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-999992`;
+    renameSync(stale, aside);
+    symlinkSync(join(pluginDir, ACTIVE), stale, 'dir');
+    makeStale(aside);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(0);
+    expect(existsSync(aside)).toBe(false);
+    expect(hookResolves(STALE)).toBe(true);     // resolves through the redirect
+  });
+
   it('deletes a stale version outright when no active sibling exists', () => {
     const orphanPlugin = join(configDir, 'plugins', 'cache', 'omc', 'other-plugin');
     const orphan = join(orphanPlugin, '1.0.0');

--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -1,0 +1,290 @@
+/**
+ * purgeStalePluginCacheVersions against a real filesystem.
+ *
+ * The unit suite mocks `fs` wholesale, so it verifies the control flow but not
+ * the syscall semantics the flow is built on. This file makes no mocks beyond
+ * the config-dir lookup: every directory, symlink and rename below is real, so
+ * a wrong assumption about `rename(2)` or `symlink(2)` fails here instead of
+ * surviving as a green unit test.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync, mkdirSync, writeFileSync, symlinkSync, renameSync, rmSync,
+  existsSync, lstatSync, readdirSync, readlinkSync, utimesSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let configDir: string;
+vi.mock('../utils/config-dir.js', () => ({
+  getClaudeConfigDir: vi.fn(() => configDir),
+}));
+
+const { purgeStalePluginCacheVersions } = await import('../utils/paths.js');
+
+const PLUGIN = 'omc/oh-my-claudecode';
+const STALE = '4.15.6';
+const ACTIVE = '4.15.10';
+/** Older versions OMC leaves behind as symlinks pointing at the demoted one. */
+const LEGACY = ['4.13.5', '4.14.0'];
+
+let pluginDir: string;
+
+/** Age a path past STALE_THRESHOLD_MS (24 h) so the grace period lets it go. */
+function makeStale(path: string) {
+  const old = new Date(Date.now() - 26 * 60 * 60 * 1000);
+  utimesSync(path, old, old);
+}
+
+function writeVersion(version: string) {
+  const dir = join(pluginDir, version);
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  writeFileSync(join(dir, 'scripts', 'run.cjs'), `// ${version}\n`);
+  return dir;
+}
+
+function installedPlugins() {
+  writeFileSync(
+    join(configDir, 'plugins', 'installed_plugins.json'),
+    JSON.stringify({
+      version: 2,
+      plugins: { 'oh-my-claudecode@omc': [{ installPath: join(pluginDir, ACTIVE), version: ACTIVE }] },
+    }),
+  );
+}
+
+/** A hook resolves through `version` when its entrypoint is readable there. */
+function hookResolves(version: string): boolean {
+  return existsSync(join(pluginDir, version, 'scripts', 'run.cjs'));
+}
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), 'omc-purge-real-'));
+  pluginDir = join(configDir, 'plugins', 'cache', PLUGIN);
+  mkdirSync(pluginDir, { recursive: true });
+  writeVersion(ACTIVE);
+  installedPlugins();
+});
+
+afterEach(() => {
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+describe('purgeStalePluginCacheVersions on a real filesystem', () => {
+  it('demotes a stale version to a redirect and keeps every pinned path resolving', () => {
+    const stale = writeVersion(STALE);
+    for (const v of LEGACY) symlinkSync(stale, join(pluginDir, v), 'dir');
+    makeStale(stale);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.symlinked).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(lstatSync(join(pluginDir, STALE)).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(pluginDir, STALE))).toBe(join(pluginDir, ACTIVE));
+    // The pinned path and everything chaining through it still resolve
+    for (const v of [STALE, ...LEGACY]) expect(hookResolves(v)).toBe(true);
+    // No aside directory survives a clean run
+    expect(readdirSync(pluginDir).filter(n => n.includes('.omc-stale-'))).toEqual([]);
+  });
+
+  it('restores the backup when only a squatter holds the pinned path', () => {
+    // Exactly the damage observed in the wild: the real version was moved aside
+    // and something re-created the path with nothing but a .DS_Store.
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-999999`;
+    renameSync(stale, aside);
+    mkdirSync(stale);
+    writeFileSync(join(stale, '.DS_Store'), 'x');
+    makeStale(aside);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(existsSync(aside)).toBe(false);
+    // The intact payload is back — the squatter did not win
+    expect(hookResolves(STALE)).toBe(true);
+  });
+
+  it('clears a dangling redirect and restores the backup over it', () => {
+    // rename(dir -> symlink) raises ENOTDIR on POSIX, and existsSync cannot see
+    // a dangling link, so this only works if the occupant is unlinked by lstat.
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-999998`;
+    renameSync(stale, aside);
+    symlinkSync(join(pluginDir, 'gone-away'), stale, 'dir');
+    expect(existsSync(stale)).toBe(false);            // follows the broken link
+    expect(lstatSync(stale).isSymbolicLink()).toBe(true);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(lstatSync(stale).isDirectory()).toBe(true);
+    expect(hookResolves(STALE)).toBe(true);
+  });
+
+  it('leaves a backup alone while its owning purge is still running', () => {
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-${process.pid}`;   // this process is alive
+    renameSync(stale, aside);
+    makeStale(aside);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(existsSync(join(aside, 'scripts', 'run.cjs'))).toBe(true);
+  });
+
+  it('reconciles the backup before relinking a squatter of the same name', () => {
+    // Both entries present. Whichever order readdir returns them in, the backup
+    // must be restored before the squatter can be demoted.
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-999997`;
+    renameSync(stale, aside);
+    mkdirSync(stale);
+    writeFileSync(join(stale, '.DS_Store'), 'x');
+    makeStale(aside);
+    makeStale(stale);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(result.errors).toEqual([]);
+    // Restored, then demoted normally — either way the payload is reachable
+    expect(hookResolves(STALE)).toBe(true);
+    expect(existsSync(aside)).toBe(false);
+  });
+
+  it('deletes a stale version outright when no active sibling exists', () => {
+    const orphanPlugin = join(configDir, 'plugins', 'cache', 'omc', 'other-plugin');
+    const orphan = join(orphanPlugin, '1.0.0');
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(join(orphan, 'marker'), 'x');
+    makeStale(orphan);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.removedPaths).toContain(orphan);
+    expect(existsSync(orphan)).toBe(false);
+  });
+});
+
+describe('invariant across every cache shape', () => {
+  // Enumerating the state space rather than picking cases by hand: this is what
+  // surfaced the dangling-symlink ENOTDIR path and the unreported live-owner
+  // skip.  Invariant — if payload existed anywhere before the purge, then after
+  // it either the pinned path resolves, or an intact backup survives AND the
+  // result says so (as an error, or as a backup left to its running owner).
+  const OCCUPANTS = ['missing', 'empty-dir', 'dotfile-only', 'payload', 'live-symlink', 'dangling-link', 'file'] as const;
+  const BACKUPS = ['none', 'payload-dead', 'payload-live', 'empty-dead', 'dotfile-dead'] as const;
+  const DEAD_PID = 999997;
+
+  function shape(occupant: typeof OCCUPANTS[number], backup: typeof BACKUPS[number]) {
+    const V = join(pluginDir, STALE);
+    if (occupant === 'empty-dir') mkdirSync(V, { recursive: true });
+    else if (occupant === 'dotfile-only') { mkdirSync(V, { recursive: true }); writeFileSync(join(V, '.DS_Store'), 'x'); }
+    else if (occupant === 'payload') writeVersion(STALE);
+    else if (occupant === 'live-symlink') symlinkSync(join(pluginDir, ACTIVE), V, 'dir');
+    else if (occupant === 'dangling-link') symlinkSync(join(pluginDir, 'gone-away'), V, 'dir');
+    else if (occupant === 'file') writeFileSync(V, 'not a directory');
+
+    let aside: string | null = null;
+    if (backup !== 'none') {
+      aside = `${V}.omc-stale-${backup.endsWith('live') ? process.pid : DEAD_PID}`;
+      if (backup.startsWith('payload')) { mkdirSync(join(aside, 'scripts'), { recursive: true }); writeFileSync(join(aside, 'scripts', 'run.cjs'), '//\n'); }
+      else if (backup.startsWith('empty')) mkdirSync(aside, { recursive: true });
+      else { mkdirSync(aside, { recursive: true }); writeFileSync(join(aside, '.DS_Store'), 'x'); }
+    }
+    for (const p of [V, aside].filter(Boolean) as string[]) {
+      try { makeStale(p); } catch { /* symlinks and plain files cannot be aged */ }
+    }
+    return { V, aside };
+  }
+
+  const intactBackupSurvives = () =>
+    readdirSync(pluginDir).filter(n => n.includes('.omc-stale-'))
+      .some(n => existsSync(join(pluginDir, n, 'scripts', 'run.cjs')));
+
+  it('never ends with a broken pinned path and nothing to show for it', () => {
+    const violations: string[] = [];
+    for (const occupant of OCCUPANTS) {
+      for (const backup of BACKUPS) {
+        // Each combination needs a clean cache; rebuild the fixture in place.
+        rmSync(pluginDir, { recursive: true, force: true });
+        mkdirSync(pluginDir, { recursive: true });
+        writeVersion(ACTIVE);
+        installedPlugins();
+
+        const { V, aside } = shape(occupant, backup);
+        const hadPayload = existsSync(join(V, 'scripts', 'run.cjs'))
+          || (!!aside && existsSync(join(aside, 'scripts', 'run.cjs')));
+
+        let result: ReturnType<typeof purgeStalePluginCacheVersions> | undefined;
+        let threw: unknown = null;
+        try { result = purgeStalePluginCacheVersions(); } catch (err) { threw = err; }
+
+        const accounted = (result?.errors.length ?? 0) > 0 || (result?.skipped ?? 0) > 0;
+        const held = threw === null
+          && (!hadPayload || hookResolves(STALE) || (intactBackupSurvives() && accounted));
+        if (!held) {
+          violations.push(
+            `${occupant} + ${backup}: resolves=${hookResolves(STALE)} ` +
+            `backup=${intactBackupSurvives()} errors=${result?.errors.length ?? '-'} ` +
+            `skipped=${result?.skipped ?? '-'} threw=${(threw as NodeJS.ErrnoException)?.code ?? '-'}`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('syscall semantics this implementation relies on', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'omc-posix-')); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  const code = (fn: () => void): string => {
+    try { fn(); return 'ok'; } catch (err) { return (err as NodeJS.ErrnoException).code ?? 'unknown'; }
+  };
+  const payloadDir = (name: string) => {
+    const p = join(root, name);
+    mkdirSync(join(p, 'inner'), { recursive: true });
+    return p;
+  };
+
+  it('rename over an empty directory succeeds', () => {
+    const src = payloadDir('src1');
+    mkdirSync(join(root, 'dst1'));
+    expect(code(() => renameSync(src, join(root, 'dst1')))).toBe('ok');
+  });
+
+  it('rename over a non-empty directory reports ENOTEMPTY', () => {
+    const src = payloadDir('src2');
+    mkdirSync(join(root, 'dst2'));
+    writeFileSync(join(root, 'dst2', '.DS_Store'), 'x');
+    expect(code(() => renameSync(src, join(root, 'dst2')))).toBe('ENOTEMPTY');
+  });
+
+  it('rename over a symlink reports ENOTDIR, dangling or not', () => {
+    const live = payloadDir('live');
+    symlinkSync(live, join(root, 'linkLive'), 'dir');
+    symlinkSync(join(root, 'nowhere'), join(root, 'linkDead'), 'dir');
+    expect(code(() => renameSync(payloadDir('src3'), join(root, 'linkLive')))).toBe('ENOTDIR');
+    expect(code(() => renameSync(payloadDir('src4'), join(root, 'linkDead')))).toBe('ENOTDIR');
+  });
+
+  it('symlink onto an occupied path reports EEXIST', () => {
+    mkdirSync(join(root, 'taken'));
+    expect(code(() => symlinkSync(join(root, 'taken'), join(root, 'taken'), 'dir'))).toBe('EEXIST');
+  });
+
+  it('existsSync follows a dangling link while lstatSync sees it', () => {
+    symlinkSync(join(root, 'nowhere'), join(root, 'dangling'), 'dir');
+    expect(existsSync(join(root, 'dangling'))).toBe(false);
+    expect(lstatSync(join(root, 'dangling')).isSymbolicLink()).toBe(true);
+  });
+});

--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -68,7 +68,24 @@ function hookResolves(version: string): boolean {
     && existsSync(join(root, 'scripts'));
 }
 
+/**
+ * Make process liveness deterministic: this process is alive, every other pid is
+ * gone.  The fixtures bake a pid into the aside directory name, and whether that
+ * pid happens to exist on the host is not ours to assume — worse, a pid owned by
+ * another user reports EPERM, which counts as alive, so a low pid on a CI runner
+ * would silently turn the interrupted-relink cases into in-flight ones.
+ */
+function stubOwnerLiveness() {
+  vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+    if (pid === process.pid) return true;
+    const err = new Error('ESRCH') as NodeJS.ErrnoException;
+    err.code = 'ESRCH';
+    throw err;
+  }) as unknown as typeof process.kill);
+}
+
 beforeEach(() => {
+  stubOwnerLiveness();
   configDir = mkdtempSync(join(tmpdir(), 'omc-purge-real-'));
   pluginDir = join(configDir, 'plugins', 'cache', PLUGIN);
   mkdirSync(pluginDir, { recursive: true });
@@ -77,6 +94,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   rmSync(configDir, { recursive: true, force: true });
 });
 

--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -125,6 +125,49 @@ describe('purgeStalePluginCacheVersions on a real filesystem', () => {
     expect(hookResolves(STALE)).toBe(true);
   });
 
+  it('keeps the backup when the recreated path holds junk that is not payload', () => {
+    // The old "any non-dotfile entry" heuristic accepted these as a usable
+    // version, discarded the backup, and left pinned sessions resolving into a
+    // directory the hook runner cannot load.  Windows sprinkles desktop.ini and
+    // Thumbs.db; an interrupted extraction leaves a partial scripts/.
+    for (const junk of [['desktop.ini'], ['Thumbs.db'], ['scripts', 'partial.txt']]) {
+      rmSync(pluginDir, { recursive: true, force: true });
+      mkdirSync(pluginDir, { recursive: true });
+      writeVersion(ACTIVE);
+      installedPlugins();
+
+      const stale = writeVersion(STALE);
+      const aside = `${stale}.omc-stale-999996`;
+      renameSync(stale, aside);
+      mkdirSync(join(stale, ...junk.slice(0, -1)), { recursive: true });
+      writeFileSync(join(stale, ...junk), 'x');
+      makeStale(aside);
+
+      const result = purgeStalePluginCacheVersions();
+
+      expect(result.restored, junk.join('/')).toBe(1);
+      expect(hookResolves(STALE), junk.join('/')).toBe(true);
+      expect(existsSync(aside), junk.join('/')).toBe(false);
+    }
+  });
+
+  it('discards the backup when the path carries real plugin payload', () => {
+    // The counter-case: a genuine reinstall must win over an older backup.
+    const stale = writeVersion(STALE);
+    const aside = `${stale}.omc-stale-999995`;
+    renameSync(stale, aside);
+    writeVersion(STALE);                       // reinstalled, has scripts/run.cjs
+    mkdirSync(join(pluginDir, STALE, 'hooks'), { recursive: true });
+    writeFileSync(join(pluginDir, STALE, 'hooks', 'hooks.json'), '{}');
+    makeStale(aside);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(0);
+    expect(existsSync(aside)).toBe(false);
+    expect(hookResolves(STALE)).toBe(true);
+  });
+
   it('leaves a backup alone while its owning purge is still running', () => {
     const stale = writeVersion(STALE);
     const aside = `${stale}.omc-stale-${process.pid}`;   // this process is alive
@@ -178,7 +221,7 @@ describe('invariant across every cache shape', () => {
   // skip.  Invariant — if payload existed anywhere before the purge, then after
   // it either the pinned path resolves, or an intact backup survives AND the
   // result says so (as an error, or as a backup left to its running owner).
-  const OCCUPANTS = ['missing', 'empty-dir', 'dotfile-only', 'payload', 'live-symlink', 'dangling-link', 'file'] as const;
+  const OCCUPANTS = ['missing', 'empty-dir', 'dotfile-only', 'junk-only', 'partial-scripts', 'payload', 'live-symlink', 'dangling-link', 'file'] as const;
   const BACKUPS = ['none', 'payload-dead', 'payload-live', 'empty-dead', 'dotfile-dead'] as const;
   const DEAD_PID = 999997;
 
@@ -186,6 +229,8 @@ describe('invariant across every cache shape', () => {
     const V = join(pluginDir, STALE);
     if (occupant === 'empty-dir') mkdirSync(V, { recursive: true });
     else if (occupant === 'dotfile-only') { mkdirSync(V, { recursive: true }); writeFileSync(join(V, '.DS_Store'), 'x'); }
+    else if (occupant === 'junk-only') { mkdirSync(V, { recursive: true }); writeFileSync(join(V, 'desktop.ini'), 'x'); }
+    else if (occupant === 'partial-scripts') { mkdirSync(join(V, 'scripts'), { recursive: true }); writeFileSync(join(V, 'scripts', 'partial.txt'), 'x'); }
     else if (occupant === 'payload') writeVersion(STALE);
     else if (occupant === 'live-symlink') symlinkSync(join(pluginDir, ACTIVE), V, 'dir');
     else if (occupant === 'dangling-link') symlinkSync(join(pluginDir, 'gone-away'), V, 'dir');

--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -36,10 +36,13 @@ function makeStale(path: string) {
   utimesSync(path, old, old);
 }
 
+/** A complete plugin root — everything `isPluginRoot()` in scripts/run.cjs wants. */
 function writeVersion(version: string) {
   const dir = join(pluginDir, version);
   mkdirSync(join(dir, 'scripts'), { recursive: true });
   writeFileSync(join(dir, 'scripts', 'run.cjs'), `// ${version}\n`);
+  mkdirSync(join(dir, 'hooks'), { recursive: true });
+  writeFileSync(join(dir, 'hooks', 'hooks.json'), '{}\n');
   return dir;
 }
 
@@ -53,9 +56,16 @@ function installedPlugins() {
   );
 }
 
-/** A hook resolves through `version` when its entrypoint is readable there. */
+/**
+ * A hook resolves through `version` only when the path satisfies the runner's own
+ * check — `isPluginRoot()` in scripts/run.cjs, reproduced here so the assertions
+ * mean "a pinned session still works", not "some file exists".
+ */
 function hookResolves(version: string): boolean {
-  return existsSync(join(pluginDir, version, 'scripts', 'run.cjs'));
+  const root = join(pluginDir, version);
+  return existsSync(join(root, 'hooks', 'hooks.json'))
+    && existsSync(join(root, 'scripts', 'run.cjs'))
+    && existsSync(join(root, 'scripts'));
 }
 
 beforeEach(() => {
@@ -130,7 +140,17 @@ describe('purgeStalePluginCacheVersions on a real filesystem', () => {
     // version, discarded the backup, and left pinned sessions resolving into a
     // directory the hook runner cannot load.  Windows sprinkles desktop.ini and
     // Thumbs.db; an interrupted extraction leaves a partial scripts/.
-    for (const junk of [['desktop.ini'], ['Thumbs.db'], ['scripts', 'partial.txt']]) {
+    // The last three are partial roots: each satisfies one of the runner's
+    // requirements and none satisfies all of them, so none can run hooks.
+    const junkShapes: string[][] = [
+      ['desktop.ini'],
+      ['Thumbs.db'],
+      ['scripts', 'partial.txt'],
+      ['hooks', 'hooks.json'],
+      ['.claude-plugin', 'plugin.json'],
+      ['scripts', 'run.cjs'],
+    ];
+    for (const junk of junkShapes) {
       rmSync(pluginDir, { recursive: true, force: true });
       mkdirSync(pluginDir, { recursive: true });
       writeVersion(ACTIVE);
@@ -239,7 +259,14 @@ describe('invariant across every cache shape', () => {
     let aside: string | null = null;
     if (backup !== 'none') {
       aside = `${V}.omc-stale-${backup.endsWith('live') ? process.pid : DEAD_PID}`;
-      if (backup.startsWith('payload')) { mkdirSync(join(aside, 'scripts'), { recursive: true }); writeFileSync(join(aside, 'scripts', 'run.cjs'), '//\n'); }
+      if (backup.startsWith('payload')) {
+        // A backup this purge created came from a live version, so it is a
+        // complete root — the same shape writeVersion() produces.
+        mkdirSync(join(aside, 'scripts'), { recursive: true });
+        writeFileSync(join(aside, 'scripts', 'run.cjs'), '//\n');
+        mkdirSync(join(aside, 'hooks'), { recursive: true });
+        writeFileSync(join(aside, 'hooks', 'hooks.json'), '{}\n');
+      }
       else if (backup.startsWith('empty')) mkdirSync(aside, { recursive: true });
       else { mkdirSync(aside, { recursive: true }); writeFileSync(join(aside, '.DS_Store'), 'x'); }
     }
@@ -249,9 +276,15 @@ describe('invariant across every cache shape', () => {
     return { V, aside };
   }
 
+  /** A backup only counts as intact if it is a root the runner would load. */
+  const loadableRoot = (dir: string) =>
+    existsSync(join(dir, 'hooks', 'hooks.json'))
+    && existsSync(join(dir, 'scripts', 'run.cjs'))
+    && existsSync(join(dir, 'scripts'));
+
   const intactBackupSurvives = () =>
     readdirSync(pluginDir).filter(n => n.includes('.omc-stale-'))
-      .some(n => existsSync(join(pluginDir, n, 'scripts', 'run.cjs')));
+      .some(n => loadableRoot(join(pluginDir, n)));
 
   it('never ends with a broken pinned path and nothing to show for it', () => {
     const violations: string[] = [];
@@ -264,8 +297,9 @@ describe('invariant across every cache shape', () => {
         installedPlugins();
 
         const { V, aside } = shape(occupant, backup);
-        const hadPayload = existsSync(join(V, 'scripts', 'run.cjs'))
-          || (!!aside && existsSync(join(aside, 'scripts', 'run.cjs')));
+        // The invariant only binds when a loadable root existed to begin with:
+        // a shape that never had one cannot be expected to resolve afterwards.
+        const hadPayload = loadableRoot(V) || (!!aside && loadableRoot(aside));
 
         let result: ReturnType<typeof purgeStalePluginCacheVersions> | undefined;
         let threw: unknown = null;

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -9,6 +9,7 @@ vi.mock('fs', async () => {
     readFileSync: vi.fn(),
     readdirSync: vi.fn(),
     statSync: vi.fn(),
+    lstatSync: vi.fn(),
     rmSync: vi.fn(),
     unlinkSync: vi.fn(),
     renameSync: vi.fn(),
@@ -20,7 +21,7 @@ vi.mock('../utils/config-dir.js', () => ({
   getClaudeConfigDir: vi.fn(() => '/mock/.claude'),
 }));
 
-import { existsSync, readFileSync, readdirSync, statSync, rmSync, renameSync, symlinkSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, lstatSync, rmSync, renameSync, symlinkSync } from 'fs';
 import { purgeStalePluginCacheVersions } from '../utils/paths.js';
 
 const mockedExistsSync = vi.mocked(existsSync);
@@ -29,7 +30,18 @@ const mockedReaddirSync = vi.mocked(readdirSync);
 const mockedStatSync = vi.mocked(statSync);
 const mockedRmSync = vi.mocked(rmSync);
 const mockedRenameSync = vi.mocked(renameSync);
+const mockedLstatSync = vi.mocked(lstatSync);
 const mockedSymlinkSync = vi.mocked(symlinkSync);
+
+/** lstat result for a real directory. */
+function dirStats() {
+  return { isSymbolicLink: () => false, isDirectory: () => true } as unknown as ReturnType<typeof lstatSync>;
+}
+
+/** lstat result for a redirect symlink. */
+function symlinkStats() {
+  return { isSymbolicLink: () => true, isDirectory: () => false } as unknown as ReturnType<typeof lstatSync>;
+}
 
 /** Node error with a specific errno code, for simulating fs races. */
 function fsError(code: string): NodeJS.ErrnoException {
@@ -58,6 +70,13 @@ describe('purgeStalePluginCacheVersions', () => {
     vi.clearAllMocks();
     // Default: statSync returns stale timestamps
     mockedStatSync.mockReturnValue(staleStats());
+    // clearAllMocks() keeps implementations, so a test that makes an fs call
+    // throw would leak into whichever test runs next.  Restore benign defaults
+    // here so the file passes under --sequence.shuffle too.
+    mockedRenameSync.mockImplementation(() => undefined);
+    mockedSymlinkSync.mockImplementation(() => undefined);
+    mockedRmSync.mockImplementation(() => undefined);
+    mockedLstatSync.mockImplementation(() => dirStats());
   });
 
   it('returns early when installed_plugins.json does not exist', () => {
@@ -424,6 +443,51 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(mockedRenameSync).toHaveBeenLastCalledWith(asideDir, staleVersion);
   });
 
+  it('retries the rollback when the squatter also blocks the restore', () => {
+    // The race that produced EEXIST on the symlink can re-take the path between
+    // the final clear and the restore rename.  If the rollback is not retried the
+    // original is stranded at the aside path while the squatter holds the pinned
+    // path — the failure this helper exists to prevent.
+    const { staleVersion } = setupRelinkScenario();
+    mockedSymlinkSync.mockImplementation(() => { throw fsError('EEXIST'); });
+    let restoreAttempts = 0;
+    mockedRenameSync.mockImplementation(((from: any, to: any) => {
+      if (String(to) === staleVersion) {
+        restoreAttempts++;
+        if (restoreAttempts === 1) throw fsError('ENOTEMPTY');
+      }
+      return undefined;
+    }) as any);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(restoreAttempts).toBeGreaterThan(1);
+    // Restore eventually succeeded, so the original is back at the pinned path
+    const restores = mockedRenameSync.mock.calls.filter(c => String(c[1]) === staleVersion);
+    expect(String(restores[restores.length - 1][0])).toContain(`${staleVersion}.omc-stale-`);
+    // The reported error is the symlink failure, not a lost original
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).not.toContain('could not restore');
+  });
+
+  it('reports the original as stranded when neither symlink nor restore can be placed', () => {
+    // Worst case: the squatter wins every attempt on both halves.  The error must
+    // say where the original went instead of silently reporting a symlink failure.
+    const { staleVersion } = setupRelinkScenario();
+    mockedSymlinkSync.mockImplementation(() => { throw fsError('EEXIST'); });
+    mockedRenameSync.mockImplementation(((_from: any, to: any) => {
+      if (String(to) === staleVersion) throw fsError('ENOTEMPTY');
+      return undefined;
+    }) as any);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.symlinked).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('could not restore the original');
+    expect(result.errors[0]).toContain('.omc-stale-');
+  });
+
   it('restores the stale dir when symlink fails with a non-EEXIST error', () => {
     // EPERM/EACCES must not be retried, but must still roll back.
     const { staleVersion } = setupRelinkScenario();
@@ -440,12 +504,28 @@ describe('purgeStalePluginCacheVersions', () => {
 
   // --- regression: an interrupted relink is repaired, not mistaken for a version ---
 
-  /** Cache where a previous relink died after moving 4.15.6 aside. */
-  function setupInterruptedRelink(originalExists: boolean) {
+  /**
+   * Cache where a previous relink died after moving 4.15.6 aside.
+   * `occupant` describes what now sits at the original version path:
+   *   'missing'  — nothing (the plain interrupted case)
+   *   'squatter' — an empty dir holding only .DS_Store (a lost race)
+   *   'redirect' — the symlink, i.e. the relink actually completed
+   *   'payload'  — a real reinstalled version directory
+   */
+  function setupInterruptedRelink(occupant: 'missing' | 'squatter' | 'redirect' | 'payload') {
     const cacheDir = '/mock/.claude/plugins/cache';
     const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.10');
     const originalDir = join(cacheDir, 'omc/oh-my-claudecode/4.15.6');
     const asideDir = `${originalDir}.omc-stale-999`;
+    const originalExists = occupant !== 'missing';
+
+    mockedLstatSync.mockImplementation((p) => {
+      if (String(p) === originalDir) {
+        if (occupant === 'missing') throw fsError('ENOENT');
+        return occupant === 'redirect' ? symlinkStats() : dirStats();
+      }
+      return dirStats();
+    });
 
     mockedExistsSync.mockImplementation((p) => {
       const ps = String(p);
@@ -461,7 +541,7 @@ describe('purgeStalePluginCacheVersions', () => {
         'oh-my-claudecode@omc': [{ installPath: activeVersion, version: '4.15.10' }],
       },
     }));
-    mockedReaddirSync.mockImplementation((p, _opts?) => {
+    mockedReaddirSync.mockImplementation((p, opts?: any) => {
       const ps = String(p);
       if (ps === cacheDir) return [dirent('omc')] as any;
       if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
@@ -469,6 +549,10 @@ describe('purgeStalePluginCacheVersions', () => {
         const entries = [dirent('4.15.6.omc-stale-999'), dirent('4.15.10')];
         if (originalExists) entries.unshift(dirent('4.15.6'));
         return entries as any;
+      }
+      // isUsableVersionPath reads the occupant's entries (no withFileTypes)
+      if (ps === originalDir && !opts?.withFileTypes) {
+        return (occupant === 'payload' ? ['scripts', 'package.json'] : ['.DS_Store']) as any;
       }
       return [] as any;
     });
@@ -478,7 +562,7 @@ describe('purgeStalePluginCacheVersions', () => {
   it('restores the version path from an aside dir left by an interrupted relink', () => {
     // The pinned path is gone and its aside copy survived — move it back so
     // CLAUDE_PLUGIN_ROOT resolves again.
-    const { originalDir, asideDir } = setupInterruptedRelink(false);
+    const { originalDir, asideDir } = setupInterruptedRelink('missing');
 
     const result = purgeStalePluginCacheVersions();
 
@@ -490,9 +574,33 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
   });
 
-  it('discards an aside dir as litter when the version path already exists', () => {
-    // The relink completed; the aside copy is leftover and carries no state.
-    const { originalDir, asideDir } = setupInterruptedRelink(true);
+  it('keeps the aside copy when the version path holds only a squatter', () => {
+    // A dir containing nothing but .DS_Store is the squatter that caused the
+    // EEXIST, not a completed redirect.  Deleting the aside here would throw
+    // away the only intact copy and leave pinned sessions broken.
+    const { originalDir, asideDir } = setupInterruptedRelink('squatter');
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(result.restoredPaths).toEqual([originalDir]);
+    expect(mockedRmSync).toHaveBeenCalledWith(originalDir, { recursive: true, force: true });
+    expect(mockedRenameSync).toHaveBeenCalledWith(asideDir, originalDir);
+    expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
+  });
+
+  it('discards the aside copy when the redirect symlink is already in place', () => {
+    const { originalDir, asideDir } = setupInterruptedRelink('redirect');
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(0);
+    expect(mockedRmSync).toHaveBeenCalledWith(asideDir, { recursive: true, force: true });
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(asideDir, originalDir);
+  });
+
+  it('discards the aside copy when the version was reinstalled with payload', () => {
+    const { originalDir, asideDir } = setupInterruptedRelink('payload');
 
     const result = purgeStalePluginCacheVersions();
 
@@ -503,7 +611,7 @@ describe('purgeStalePluginCacheVersions', () => {
 
   it('never treats an aside dir as a plugin version when picking a symlink target', () => {
     // compareSemverDesc must not see ".omc-stale-999" as a version candidate.
-    const { activeVersion } = setupInterruptedRelink(true);
+    const { activeVersion } = setupInterruptedRelink('redirect');
 
     purgeStalePluginCacheVersions();
 

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -438,6 +438,82 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(mockedRenameSync).toHaveBeenLastCalledWith(asideDir, staleVersion);
   });
 
+  // --- regression: an interrupted relink is repaired, not mistaken for a version ---
+
+  /** Cache where a previous relink died after moving 4.15.6 aside. */
+  function setupInterruptedRelink(originalExists: boolean) {
+    const cacheDir = '/mock/.claude/plugins/cache';
+    const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.10');
+    const originalDir = join(cacheDir, 'omc/oh-my-claudecode/4.15.6');
+    const asideDir = `${originalDir}.omc-stale-999`;
+
+    mockedExistsSync.mockImplementation((p) => {
+      const ps = String(p);
+      if (ps.includes('installed_plugins.json')) return true;
+      if (ps === cacheDir) return true;
+      if (ps === activeVersion || ps === asideDir) return true;
+      if (ps === originalDir) return originalExists;
+      return false;
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      version: 2,
+      plugins: {
+        'oh-my-claudecode@omc': [{ installPath: activeVersion, version: '4.15.10' }],
+      },
+    }));
+    mockedReaddirSync.mockImplementation((p, _opts?) => {
+      const ps = String(p);
+      if (ps === cacheDir) return [dirent('omc')] as any;
+      if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
+      if (ps.endsWith('oh-my-claudecode')) {
+        const entries = [dirent('4.15.6.omc-stale-999'), dirent('4.15.10')];
+        if (originalExists) entries.unshift(dirent('4.15.6'));
+        return entries as any;
+      }
+      return [] as any;
+    });
+    return { activeVersion, originalDir, asideDir };
+  }
+
+  it('restores the version path from an aside dir left by an interrupted relink', () => {
+    // The pinned path is gone and its aside copy survived — move it back so
+    // CLAUDE_PLUGIN_ROOT resolves again.
+    const { originalDir, asideDir } = setupInterruptedRelink(false);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(result.restoredPaths).toEqual([originalDir]);
+    expect(mockedRenameSync).toHaveBeenCalledWith(asideDir, originalDir);
+    // The aside dir must never be demoted or deleted as if it were a version
+    expect(mockedSymlinkSync).not.toHaveBeenCalledWith(expect.anything(), asideDir, expect.anything());
+    expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
+  });
+
+  it('discards an aside dir as litter when the version path already exists', () => {
+    // The relink completed; the aside copy is leftover and carries no state.
+    const { originalDir, asideDir } = setupInterruptedRelink(true);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(0);
+    expect(mockedRmSync).toHaveBeenCalledWith(asideDir, { recursive: true, force: true });
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(asideDir, originalDir);
+  });
+
+  it('never treats an aside dir as a plugin version when picking a symlink target', () => {
+    // compareSemverDesc must not see ".omc-stale-999" as a version candidate.
+    const { activeVersion } = setupInterruptedRelink(true);
+
+    purgeStalePluginCacheVersions();
+
+    for (const call of mockedSymlinkSync.mock.calls) {
+      expect(String(call[0])).toBe(activeVersion);
+      expect(String(call[1])).not.toContain('.omc-stale-');
+    }
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(expect.stringContaining('.omc-stale-999'), activeVersion);
+  });
+
   it('deletes stale version dir when no active version exists in namespace', () => {
     // When the active installPath is outside the plugin namespace there is no
     // live version to redirect to, so deletion (original behaviour) applies.

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -390,7 +390,16 @@ describe('purgeStalePluginCacheVersions', () => {
       if (ps.includes('installed_plugins.json')) return true;
       if (ps === cacheDir) return true;
       if (ps === staleVersion || ps === activeVersion) return true;
-      return ps.includes('.omc-stale-');
+      // isUsableVersionPath probes plugin-root markers; both real versions have them
+      if (ps.startsWith(`${staleVersion}/`) || ps.startsWith(`${activeVersion}/`)) return true;
+      // A fresh relink starts with no aside path — if one appeared to exist and
+      // to carry markers, relinkStaleVersionDir would refuse to overwrite it.
+      return false;
+    });
+    // …and lstat must agree, or isUsableVersionPath would treat it as a directory
+    mockedLstatSync.mockImplementation((p) => {
+      if (String(p).includes('.omc-stale-')) throw fsError('ENOENT');
+      return dirStats();
     });
     mockedReadFileSync.mockReturnValue(JSON.stringify({
       version: 2,
@@ -535,6 +544,11 @@ describe('purgeStalePluginCacheVersions', () => {
       if (ps === cacheDir) return true;
       if (ps === activeVersion || ps === asideDir) return true;
       if (ps === originalDir) return originalExists;
+      // Plugin-root markers: only a real payload directory carries them.  The
+      // squatter cases deliberately do not, which is the whole point of the
+      // marker check replacing the old "any non-dotfile" heuristic.
+      if (ps.startsWith(`${activeVersion}/`) || ps.startsWith(`${asideDir}/`)) return true;
+      if (ps.startsWith(`${originalDir}/`)) return occupant === 'payload';
       return false;
     });
     mockedReadFileSync.mockReturnValue(JSON.stringify({

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -21,7 +21,7 @@ vi.mock('../utils/config-dir.js', () => ({
   getClaudeConfigDir: vi.fn(() => '/mock/.claude'),
 }));
 
-import { existsSync, readFileSync, readdirSync, statSync, lstatSync, rmSync, renameSync, symlinkSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, lstatSync, rmSync, renameSync, symlinkSync, unlinkSync } from 'fs';
 import { purgeStalePluginCacheVersions } from '../utils/paths.js';
 
 const mockedExistsSync = vi.mocked(existsSync);
@@ -31,6 +31,7 @@ const mockedStatSync = vi.mocked(statSync);
 const mockedRmSync = vi.mocked(rmSync);
 const mockedRenameSync = vi.mocked(renameSync);
 const mockedLstatSync = vi.mocked(lstatSync);
+const mockedUnlinkSync = vi.mocked(unlinkSync);
 const mockedSymlinkSync = vi.mocked(symlinkSync);
 
 /** lstat result for a real directory. */
@@ -76,6 +77,7 @@ describe('purgeStalePluginCacheVersions', () => {
     mockedRenameSync.mockImplementation(() => undefined);
     mockedSymlinkSync.mockImplementation(() => undefined);
     mockedRmSync.mockImplementation(() => undefined);
+    mockedUnlinkSync.mockImplementation(() => undefined);
     mockedLstatSync.mockImplementation(() => dirStats());
   });
 
@@ -622,6 +624,11 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(result.errors).toEqual([]);
     expect(mockedRenameSync).not.toHaveBeenCalledWith(asideDir, originalDir);
     expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
+    // Skipping must be visible: if that pid was recycled, nothing else would
+    // ever reclaim the backup and the pinned path would stay broken silently.
+    expect(result.skipped).toBe(1);
+    expect(result.skippedPaths[0]).toContain(asideDir);
+    expect(result.skippedPaths[0]).toContain('still running');
     killSpy.mockRestore();
   });
 
@@ -674,18 +681,33 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
   });
 
-  it('treats a dangling redirect symlink as unusable so the backup wins', () => {
+  it('clears a dangling redirect symlink and restores the backup over it', () => {
+    // lstat reports a symlink but the target is gone, so the path is unusable.
+    // On a real filesystem renaming a directory over a symlink raises ENOTDIR
+    // (verified on APFS), and existsSync-based removal cannot clear a dangling
+    // link — both are modelled here; the integration test proves the real thing.
     const { originalDir, asideDir } = setupInterruptedRelink('redirect');
-    // lstat says symlink, but the target no longer resolves
     mockedExistsSync.mockImplementation((p) => {
       const ps = String(p);
-      if (ps === originalDir) return false;
+      if (ps === originalDir) return false;   // dangling: follows the link
       if (ps.includes('installed_plugins.json')) return true;
       return ps.includes('cache') && !ps.endsWith('4.15.6');
     });
+    let danglingPresent = true;
+    mockedUnlinkSync.mockImplementation(((p: any) => {
+      if (String(p) === originalDir) danglingPresent = false;
+      return undefined;
+    }) as any);
+    mockedRenameSync.mockImplementation(((_from: any, to: any) => {
+      if (String(to) === originalDir && danglingPresent) throw fsError('ENOTDIR');
+      return undefined;
+    }) as any);
 
     const result = purgeStalePluginCacheVersions();
 
+    // The link is unlinked (not rmSync'd — existsSync cannot see it) and the
+    // rename then succeeds on the retry.
+    expect(mockedUnlinkSync).toHaveBeenCalledWith(originalDir);
     expect(result.restored).toBe(1);
     expect(mockedRenameSync).toHaveBeenCalledWith(asideDir, originalDir);
   });

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'path';
 
 vi.mock('fs', async () => {
@@ -51,6 +51,23 @@ function fsError(code: string): NodeJS.ErrnoException {
   return err;
 }
 
+/** Pid the fixtures use for an owner that has exited. */
+const DEAD_OWNER_PID = 999997;
+
+/**
+ * Make process liveness deterministic: this process is alive, every other pid is
+ * gone. Without it the fixtures depend on whether the host happens to be running
+ * something at the pid baked into the directory name — and a pid owned by another
+ * user reports EPERM, which isAsideOwnerAlive counts as alive, so a low pid on a
+ * CI runner would silently flip the dead-owner cases into in-flight ones.
+ */
+function stubOwnerLiveness() {
+  return vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+    if (pid === process.pid) return true;
+    throw fsError('ESRCH');
+  }) as unknown as typeof process.kill);
+}
+
 function dirent(name: string): { name: string; isDirectory: () => boolean } {
   return { name, isDirectory: () => true };
 }
@@ -79,6 +96,11 @@ describe('purgeStalePluginCacheVersions', () => {
     mockedRmSync.mockImplementation(() => undefined);
     mockedUnlinkSync.mockImplementation(() => undefined);
     mockedLstatSync.mockImplementation(() => dirStats());
+    stubOwnerLiveness();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('returns early when installed_plugins.json does not exist', () => {
@@ -527,7 +549,7 @@ describe('purgeStalePluginCacheVersions', () => {
     const cacheDir = '/mock/.claude/plugins/cache';
     const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.10');
     const originalDir = join(cacheDir, 'omc/oh-my-claudecode/4.15.6');
-    const asideDir = `${originalDir}.omc-stale-999`;
+    const asideDir = `${originalDir}.omc-stale-${DEAD_OWNER_PID}`;
     const originalExists = occupant !== 'missing';
 
     mockedLstatSync.mockImplementation((p) => {
@@ -565,7 +587,7 @@ describe('purgeStalePluginCacheVersions', () => {
       if (ps === cacheDir) return [dirent('omc')] as any;
       if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
       if (ps.endsWith('oh-my-claudecode')) {
-        const entries = [dirent('4.15.6.omc-stale-999'), dirent('4.15.10')];
+        const entries = [dirent(`4.15.6.omc-stale-${DEAD_OWNER_PID}`), dirent('4.15.10')];
         if (originalExists) entries.unshift(dirent('4.15.6'));
         return entries as any;
       }
@@ -632,8 +654,9 @@ describe('purgeStalePluginCacheVersions', () => {
   it('leaves an aside dir alone while its owning purge is still running', () => {
     // A live owner means the swap is in flight.  Restoring its backup here would
     // make the owner's own EEXIST retry delete the real directory.
+    // The fixture's owner pid is the dead one, so force this case to look live.
     const { originalDir, asideDir } = setupInterruptedRelink('missing');
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as unknown as typeof process.kill);
 
     const result = purgeStalePluginCacheVersions();
 
@@ -655,7 +678,7 @@ describe('purgeStalePluginCacheVersions', () => {
     const cacheDir = '/mock/.claude/plugins/cache';
     const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.10');
     const originalDir = join(cacheDir, 'omc/oh-my-claudecode/4.15.6');
-    const asideDir = `${originalDir}.omc-stale-999`;
+    const asideDir = `${originalDir}.omc-stale-${DEAD_OWNER_PID}`;
 
     mockedLstatSync.mockImplementation((p) => (String(p) === originalDir ? dirStats() : dirStats()));
     mockedExistsSync.mockImplementation((p) => {
@@ -673,7 +696,7 @@ describe('purgeStalePluginCacheVersions', () => {
       if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
       // squatter listed FIRST, aside second — the order that used to lose data
       if (ps.endsWith('oh-my-claudecode')) {
-        return [dirent('4.15.6'), dirent('4.15.6.omc-stale-999'), dirent('4.15.10')] as any;
+        return [dirent('4.15.6'), dirent(`4.15.6.omc-stale-${DEAD_OWNER_PID}`), dirent('4.15.10')] as any;
       }
       if (ps === originalDir && !opts?.withFileTypes) return ['.DS_Store'] as any;
       return [] as any;
@@ -692,7 +715,7 @@ describe('purgeStalePluginCacheVersions', () => {
     const result = purgeStalePluginCacheVersions();
 
     // The backup is restored before the squatter is ever relinked
-    expect(order[0]).toBe('rename 4.15.6.omc-stale-999 -> 4.15.6');
+    expect(order[0]).toBe(`rename 4.15.6.omc-stale-${DEAD_OWNER_PID} -> 4.15.6`);
     expect(result.restored).toBe(1);
     // And the aside copy is never discarded
     expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
@@ -752,7 +775,7 @@ describe('purgeStalePluginCacheVersions', () => {
   });
 
   it('never treats an aside dir as a plugin version when picking a symlink target', () => {
-    // compareSemverDesc must not see ".omc-stale-999" as a version candidate.
+    // compareSemverDesc must not see the aside suffix as a version candidate.
     const { activeVersion } = setupInterruptedRelink('redirect');
 
     purgeStalePluginCacheVersions();
@@ -761,7 +784,7 @@ describe('purgeStalePluginCacheVersions', () => {
       expect(String(call[0])).toBe(activeVersion);
       expect(String(call[1])).not.toContain('.omc-stale-');
     }
-    expect(mockedRenameSync).not.toHaveBeenCalledWith(expect.stringContaining('.omc-stale-999'), activeVersion);
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(expect.stringContaining(`.omc-stale-${DEAD_OWNER_PID}`), activeVersion);
   });
 
   it('deletes stale version dir when no active version exists in namespace', () => {

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -11,6 +11,7 @@ vi.mock('fs', async () => {
     statSync: vi.fn(),
     rmSync: vi.fn(),
     unlinkSync: vi.fn(),
+    renameSync: vi.fn(),
     symlinkSync: vi.fn(),
   };
 });
@@ -19,7 +20,7 @@ vi.mock('../utils/config-dir.js', () => ({
   getClaudeConfigDir: vi.fn(() => '/mock/.claude'),
 }));
 
-import { existsSync, readFileSync, readdirSync, statSync, rmSync, symlinkSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, rmSync, renameSync, symlinkSync } from 'fs';
 import { purgeStalePluginCacheVersions } from '../utils/paths.js';
 
 const mockedExistsSync = vi.mocked(existsSync);
@@ -27,7 +28,15 @@ const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedReaddirSync = vi.mocked(readdirSync);
 const mockedStatSync = vi.mocked(statSync);
 const mockedRmSync = vi.mocked(rmSync);
+const mockedRenameSync = vi.mocked(renameSync);
 const mockedSymlinkSync = vi.mocked(symlinkSync);
+
+/** Node error with a specific errno code, for simulating fs races. */
+function fsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
 
 function dirent(name: string): { name: string; isDirectory: () => boolean } {
   return { name, isDirectory: () => true };
@@ -97,8 +106,10 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(result.symlinked).toBe(1);
     expect(result.removed).toBe(0);
     expect(result.symlinkPaths).toEqual([staleVersion]);
-    // safeRmSync still removes the real dir before creating the symlink
-    expect(mockedRmSync).toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
+    // The real dir is moved aside — never deleted outright — before the
+    // symlink is created, so the path is never missing.
+    expect(mockedRenameSync).toHaveBeenCalledWith(staleVersion, expect.stringContaining(`${staleVersion}.omc-stale-`));
+    expect(mockedRmSync).not.toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
     expect(mockedSymlinkSync).toHaveBeenCalledWith(activeVersion, staleVersion, 'dir');
     // Active version should NOT be removed
     expect(mockedRmSync).not.toHaveBeenCalledWith(activeVersion, expect.anything());
@@ -337,12 +348,94 @@ describe('purgeStalePluginCacheVersions', () => {
     expect(result.symlinked).toBe(1);
     expect(result.removed).toBe(0);
     expect(result.symlinkPaths).toEqual([staleVersion]);
-    // Real dir removed first, then symlink created
-    expect(mockedRmSync).toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
+    // Real dir moved aside first, then symlink created in its place
+    expect(mockedRenameSync).toHaveBeenCalledWith(staleVersion, expect.stringContaining(`${staleVersion}.omc-stale-`));
     expect(mockedSymlinkSync).toHaveBeenCalledWith(activeVersion, staleVersion, 'dir');
     // Active version untouched
     expect(mockedRmSync).not.toHaveBeenCalledWith(activeVersion, expect.anything());
     expect(mockedSymlinkSync).not.toHaveBeenCalledWith(expect.anything(), activeVersion, expect.anything());
+  });
+
+  // --- regression: the relink must never leave the path missing ---
+
+  /** Single stale version alongside one active version in the same namespace. */
+  function setupRelinkScenario() {
+    const cacheDir = '/mock/.claude/plugins/cache';
+    const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.10');
+    const staleVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.6');
+
+    mockedExistsSync.mockImplementation((p) => {
+      const ps = String(p);
+      if (ps.includes('installed_plugins.json')) return true;
+      if (ps === cacheDir) return true;
+      if (ps === staleVersion || ps === activeVersion) return true;
+      return ps.includes('.omc-stale-');
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      version: 2,
+      plugins: {
+        'oh-my-claudecode@omc': [{ installPath: activeVersion, version: '4.15.10' }],
+      },
+    }));
+    mockedReaddirSync.mockImplementation((p, _opts?) => {
+      const ps = String(p);
+      if (ps === cacheDir) return [dirent('omc')] as any;
+      if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
+      if (ps.endsWith('oh-my-claudecode')) return [dirent('4.15.6'), dirent('4.15.10')] as any;
+      return [] as any;
+    });
+    return { activeVersion, staleVersion };
+  }
+
+  it('retries the symlink when the path is re-created inside the swap window', () => {
+    // A concurrent writer (Finder .DS_Store, Spotlight, another session's purge)
+    // re-creates the path after the stale dir is moved aside, making the first
+    // symlinkSync fail with EEXIST.  The redirect must still end up in place.
+    const { activeVersion, staleVersion } = setupRelinkScenario();
+    mockedSymlinkSync
+      .mockImplementationOnce(() => { throw fsError('EEXIST'); })
+      .mockImplementationOnce(() => undefined);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.symlinked).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(mockedSymlinkSync).toHaveBeenCalledTimes(2);
+    // The squatter is cleared before the retry
+    expect(mockedRmSync).toHaveBeenCalledWith(staleVersion, { recursive: true, force: true });
+    expect(mockedSymlinkSync).toHaveBeenLastCalledWith(activeVersion, staleVersion, 'dir');
+  });
+
+  it('restores the stale dir when the symlink can never be placed', () => {
+    // Worst case: every attempt loses the race.  The original directory must be
+    // moved back so a session pinned to it via CLAUDE_PLUGIN_ROOT keeps working.
+    const { staleVersion } = setupRelinkScenario();
+    mockedSymlinkSync.mockImplementation(() => { throw fsError('EEXIST'); });
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.symlinked).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(staleVersion);
+    // Moved aside, then moved back — the path is a real directory again
+    const asideDir = mockedRenameSync.mock.calls[0][1];
+    expect(String(asideDir)).toContain(`${staleVersion}.omc-stale-`);
+    expect(mockedRenameSync).toHaveBeenLastCalledWith(asideDir, staleVersion);
+  });
+
+  it('restores the stale dir when symlink fails with a non-EEXIST error', () => {
+    // EPERM/EACCES must not be retried, but must still roll back.
+    const { staleVersion } = setupRelinkScenario();
+    mockedSymlinkSync.mockImplementation(() => { throw fsError('EPERM'); });
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.symlinked).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(mockedSymlinkSync).toHaveBeenCalledTimes(1);
+    const asideDir = mockedRenameSync.mock.calls[0][1];
+    expect(mockedRenameSync).toHaveBeenLastCalledWith(asideDir, staleVersion);
   });
 
   it('deletes stale version dir when no active version exists in namespace', () => {

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -584,9 +584,110 @@ describe('purgeStalePluginCacheVersions', () => {
 
     expect(result.restored).toBe(1);
     expect(result.restoredPaths).toEqual([originalDir]);
-    expect(mockedRmSync).toHaveBeenCalledWith(originalDir, { recursive: true, force: true });
     expect(mockedRenameSync).toHaveBeenCalledWith(asideDir, originalDir);
     expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
+  });
+
+  it('clears the squatter and retries when it blocks the restore rename', () => {
+    const { originalDir, asideDir } = setupInterruptedRelink('squatter');
+    let attempts = 0;
+    mockedRenameSync.mockImplementation(((_from: any, to: any) => {
+      if (String(to) === originalDir) {
+        attempts++;
+        if (attempts === 1) throw fsError('ENOTEMPTY');
+      }
+      return undefined;
+    }) as any);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(attempts).toBe(2);
+    expect(mockedRmSync).toHaveBeenCalledWith(originalDir, { recursive: true, force: true });
+    expect(result.restored).toBe(1);
+    expect(mockedRenameSync).toHaveBeenCalledWith(asideDir, originalDir);
+    // The restored version is then demoted normally, which is the intended
+    // follow-up: it is stale and an active sibling exists.
+    expect(result.symlinked).toBe(1);
+  });
+
+  it('leaves an aside dir alone while its owning purge is still running', () => {
+    // A live owner means the swap is in flight.  Restoring its backup here would
+    // make the owner's own EEXIST retry delete the real directory.
+    const { originalDir, asideDir } = setupInterruptedRelink('missing');
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(asideDir, originalDir);
+    expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
+    killSpy.mockRestore();
+  });
+
+  it('reconciles aside entries before relinking a squatter that shares their name', () => {
+    // Filesystem order can put the squatter first.  Relinking it first would
+    // clear the aside backup before anyone knows the symlink can be placed.
+    const cacheDir = '/mock/.claude/plugins/cache';
+    const activeVersion = join(cacheDir, 'omc/oh-my-claudecode/4.15.10');
+    const originalDir = join(cacheDir, 'omc/oh-my-claudecode/4.15.6');
+    const asideDir = `${originalDir}.omc-stale-999`;
+
+    mockedLstatSync.mockImplementation((p) => (String(p) === originalDir ? dirStats() : dirStats()));
+    mockedExistsSync.mockImplementation((p) => {
+      const ps = String(p);
+      if (ps.includes('installed_plugins.json')) return true;
+      return ps === cacheDir || ps === originalDir || ps === activeVersion || ps === asideDir;
+    });
+    mockedReadFileSync.mockReturnValue(JSON.stringify({
+      version: 2,
+      plugins: { 'oh-my-claudecode@omc': [{ installPath: activeVersion, version: '4.15.10' }] },
+    }));
+    mockedReaddirSync.mockImplementation((p, opts?: any) => {
+      const ps = String(p);
+      if (ps === cacheDir) return [dirent('omc')] as any;
+      if (ps.endsWith('omc')) return [dirent('oh-my-claudecode')] as any;
+      // squatter listed FIRST, aside second — the order that used to lose data
+      if (ps.endsWith('oh-my-claudecode')) {
+        return [dirent('4.15.6'), dirent('4.15.6.omc-stale-999'), dirent('4.15.10')] as any;
+      }
+      if (ps === originalDir && !opts?.withFileTypes) return ['.DS_Store'] as any;
+      return [] as any;
+    });
+
+    const order: string[] = [];
+    mockedRenameSync.mockImplementation(((from: any, to: any) => {
+      order.push(`rename ${String(from).split('/').pop()} -> ${String(to).split('/').pop()}`);
+      return undefined;
+    }) as any);
+    mockedSymlinkSync.mockImplementation(((_t: any, at: any) => {
+      order.push(`symlink at ${String(at).split('/').pop()}`);
+      return undefined;
+    }) as any);
+
+    const result = purgeStalePluginCacheVersions();
+
+    // The backup is restored before the squatter is ever relinked
+    expect(order[0]).toBe('rename 4.15.6.omc-stale-999 -> 4.15.6');
+    expect(result.restored).toBe(1);
+    // And the aside copy is never discarded
+    expect(mockedRmSync).not.toHaveBeenCalledWith(asideDir, expect.anything());
+  });
+
+  it('treats a dangling redirect symlink as unusable so the backup wins', () => {
+    const { originalDir, asideDir } = setupInterruptedRelink('redirect');
+    // lstat says symlink, but the target no longer resolves
+    mockedExistsSync.mockImplementation((p) => {
+      const ps = String(p);
+      if (ps === originalDir) return false;
+      if (ps.includes('installed_plugins.json')) return true;
+      return ps.includes('cache') && !ps.endsWith('4.15.6');
+    });
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(result.restored).toBe(1);
+    expect(mockedRenameSync).toHaveBeenCalledWith(asideDir, originalDir);
   });
 
   it('discards the aside copy when the redirect symlink is already in place', () => {

--- a/src/__tests__/purge-stale-cache.test.ts
+++ b/src/__tests__/purge-stale-cache.test.ts
@@ -548,7 +548,10 @@ describe('purgeStalePluginCacheVersions', () => {
       // squatter cases deliberately do not, which is the whole point of the
       // marker check replacing the old "any non-dotfile" heuristic.
       if (ps.startsWith(`${activeVersion}/`) || ps.startsWith(`${asideDir}/`)) return true;
-      if (ps.startsWith(`${originalDir}/`)) return occupant === 'payload';
+      // Marker probes under the version path.  existsSync follows symlinks, so a
+      // completed redirect resolves to the active version and shows its markers;
+      // a squatter or a dangling link shows nothing.
+      if (ps.startsWith(`${originalDir}/`)) return occupant === 'payload' || occupant === 'redirect';
       return false;
     });
     mockedReadFileSync.mockReturnValue(JSON.stringify({
@@ -703,9 +706,11 @@ describe('purgeStalePluginCacheVersions', () => {
     const { originalDir, asideDir } = setupInterruptedRelink('redirect');
     mockedExistsSync.mockImplementation((p) => {
       const ps = String(p);
-      if (ps === originalDir) return false;   // dangling: follows the link
+      // Dangling: existsSync follows the link, so neither the path itself nor any
+      // marker probe through it resolves.
+      if (ps === originalDir || ps.startsWith(`${originalDir}/`)) return false;
       if (ps.includes('installed_plugins.json')) return true;
-      return ps.includes('cache') && !ps.endsWith('4.15.6');
+      return ps.includes('cache');
     });
     let danglingPresent = true;
     mockedUnlinkSync.mockImplementation(((p: any) => {

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -1037,6 +1037,11 @@ export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGraceP
     if (purgeResult.restored > 0 && options?.verbose) {
       console.log(`[omc] Restored ${purgeResult.restored} plugin cache version(s) from an interrupted relink`);
     }
+    if (purgeResult.skipped > 0 && options?.verbose) {
+      for (const skipped of purgeResult.skippedPaths) {
+        console.log(`[omc] Left a plugin cache backup to its running owner: ${skipped}`);
+      }
+    }
     // Always surface purge errors, even without --verbose: a failed relink can
     // leave a version path that live sessions still resolve through, so a silent
     // warning here reads as a successful update while hooks are broken.

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -1037,15 +1037,15 @@ export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGraceP
     if (purgeResult.restored > 0 && options?.verbose) {
       console.log(`[omc] Restored ${purgeResult.restored} plugin cache version(s) from an interrupted relink`);
     }
-    if (purgeResult.skipped > 0 && options?.verbose) {
-      for (const skipped of purgeResult.skippedPaths) {
-        console.log(`[omc] Left a plugin cache backup to its running owner: ${skipped}`);
-      }
-    }
-    // Always surface purge errors, even without --verbose: a failed relink can
-    // leave a version path that live sessions still resolve through, so a silent
-    // warning here reads as a successful update while hooks are broken.
+    // Always surface purge errors and skipped backups, even without --verbose.
+    // Both leave a version path that live sessions resolve through, so a silent
+    // line here reads as a successful update while hooks are broken: a skipped
+    // backup keeps the pinned path unusable for as long as its owner runs, and
+    // forever if that pid was recycled by an unrelated process.
     // Kept non-fatal — reconciliation must not fail on best-effort cleanup.
+    for (const skipped of purgeResult.skippedPaths) {
+      console.warn(`[omc] Cache purge warning: left a backup to its running owner: ${skipped}`);
+    }
     for (const err of purgeResult.errors) {
       console.warn(`[omc] Cache purge warning: ${err}`);
     }

--- a/src/features/auto-update.ts
+++ b/src/features/auto-update.ts
@@ -1034,10 +1034,15 @@ export function reconcileUpdateRuntime(options?: { verbose?: boolean; skipGraceP
     if (purgeResult.removed > 0 && options?.verbose) {
       console.log(`[omc] Purged ${purgeResult.removed} stale plugin cache version(s)`);
     }
-    if (purgeResult.errors.length > 0 && options?.verbose) {
-      for (const err of purgeResult.errors) {
-        console.warn(`[omc] Cache purge warning: ${err}`);
-      }
+    if (purgeResult.restored > 0 && options?.verbose) {
+      console.log(`[omc] Restored ${purgeResult.restored} plugin cache version(s) from an interrupted relink`);
+    }
+    // Always surface purge errors, even without --verbose: a failed relink can
+    // leave a version path that live sessions still resolve through, so a silent
+    // warning here reads as a successful update while hooks are broken.
+    // Kept non-fatal — reconciliation must not fail on best-effort cleanup.
+    for (const err of purgeResult.errors) {
+      console.warn(`[omc] Cache purge warning: ${err}`);
     }
   } catch {
     // Cache purge is best-effort; never block reconciliation

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -6,7 +6,7 @@
  * (which work universally) and handle platform-specific directory conventions.
  */
 
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { existsSync, readFileSync, readdirSync, statSync, lstatSync, unlinkSync, rmSync, renameSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { getClaudeConfigDir } from './config-dir.js';
@@ -258,8 +258,12 @@ function isUsableVersionPath(path: string): boolean {
   } catch {
     return false;
   }
-  if (stats.isSymbolicLink()) return existsSync(path);
-  if (!stats.isDirectory()) return false;
+  // A plain file at a version path is never a root; anything else gets the same
+  // payload check.  `existsSync` follows symlinks, so one expression covers a
+  // real directory, a redirect to a real root (usable), a redirect to some other
+  // directory (not usable — the runner validates the resolved root), and a
+  // dangling redirect (not usable).
+  if (!stats.isDirectory() && !stats.isSymbolicLink()) return false;
   return PLUGIN_ROOT_REQUIREMENTS.every(required => existsSync(join(path, required)));
 }
 
@@ -335,7 +339,17 @@ const OCCUPIED_CODES = new Set(
  * leave the original stranded at its aside path while a squatter holds the
  * pinned path — the exact failure this helper exists to prevent.
  */
-function placeClearingSquatters(path: string, place: () => void): { ok: true } | { ok: false; last: unknown } {
+function placeClearingSquatters(
+  path: string,
+  place: () => void,
+  /** Directory the path must sit directly inside. Clearing anything else — a
+   * parent, a sibling namespace — would delete versions this operation has no
+   * business touching, so the guard refuses rather than trusting the caller. */
+  containedIn: string,
+): { ok: true } | { ok: false; last: unknown } {
+  if (stripTrailing(dirname(path)) !== stripTrailing(containedIn)) {
+    return { ok: false, last: new Error(`refusing to clear ${path}: not a child of ${containedIn}`) };
+  }
   let last: unknown;
   for (let attempt = 0; attempt < RELINK_ATTEMPTS; attempt++) {
     try {
@@ -373,6 +387,7 @@ function describeError(err: unknown): string {
 function relinkStaleVersionDir(versionDir: string, target: string): void {
   const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
   const asideDir = `${versionDir}${ASIDE_SUFFIX}${process.pid}`;
+  const pluginDir = dirname(versionDir);
 
   // Never overwrite an intact backup: it is the only copy of some version, and
   // clearing it here is how the earlier revision could destroy one. Aside
@@ -386,7 +401,7 @@ function relinkStaleVersionDir(versionDir: string, target: string): void {
 
   let failure: unknown;
   try {
-    const placed = placeClearingSquatters(versionDir, () => symlinkSync(target, versionDir, symlinkType));
+    const placed = placeClearingSquatters(versionDir, () => symlinkSync(target, versionDir, symlinkType), pluginDir);
     if (placed.ok) {
       safeRmSync(asideDir);
       return;
@@ -399,7 +414,7 @@ function relinkStaleVersionDir(versionDir: string, target: string): void {
     failure = err;
   }
 
-  if (!placeClearingSquatters(versionDir, () => renameSync(asideDir, versionDir)).ok) {
+  if (!placeClearingSquatters(versionDir, () => renameSync(asideDir, versionDir), pluginDir).ok) {
     throw new Error(
       `could not place redirect symlink (${describeError(failure)}) and could not restore the ` +
       `original: it is left at ${asideDir}`,
@@ -547,13 +562,19 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
       const plainVersions: string[] = [];
       for (const version of versions) {
         const aside = ASIDE_SUFFIX_RE.exec(version);
-        if (aside) {
+        // A bare `.omc-stale-<pid>` carries no version to restore to: the prefix
+        // would be empty and the "original" path would resolve to the plugin
+        // namespace itself.  Renaming the entry over its own parent reports
+        // ENOTEMPTY, which the placement helper reads as an occupied path and
+        // clears recursively — taking the active version and every sibling with
+        // it.  An entry we cannot attribute is left alone, not acted on.
+        if (aside && aside.index > 0) {
           asideEntries.push({
             versionDir: join(pluginDir, version),
             originalDir: join(pluginDir, version.slice(0, aside.index)),
             ownerPid: Number(aside[1]),
           });
-        } else {
+        } else if (!aside) {
           plainVersions.push(version);
         }
       }
@@ -581,7 +602,7 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
             // lost window.  The aside copy is the sole intact version, so it
             // wins: clear the squatter and move it back, retrying if the
             // squatter comes back while we do.
-            if (!placeClearingSquatters(originalDir, () => renameSync(versionDir, originalDir)).ok) {
+            if (!placeClearingSquatters(originalDir, () => renameSync(versionDir, originalDir), pluginDir).ok) {
               throw new Error(`could not restore it over the path after ${RELINK_ATTEMPTS} attempts`);
             }
             result.restored++;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -267,6 +267,41 @@ function isAsideOwnerAlive(pid: number): boolean {
 }
 
 /**
+ * Remove whatever occupies `path`, including a symlink whose target is gone.
+ *
+ * `safeRmSync` guards on `existsSync`, which follows the link — so a dangling
+ * redirect reports false and is left in place, and every retry then fails the
+ * same way. `lstatSync` sees the link itself.
+ */
+function removePathEntry(path: string): boolean {
+  let stats;
+  try {
+    stats = lstatSync(path);
+  } catch {
+    return false;
+  }
+  try {
+    if (stats.isDirectory()) {
+      rmSync(path, { recursive: true, force: true });
+    } else {
+      unlinkSync(path);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Errno values that mean "something else is at this path", per POSIX rename(2)
+ * and symlink(2). Verified on macOS/APFS:
+ *   symlink over any existing entry        → EEXIST
+ *   rename(dir → non-empty dir)            → ENOTEMPTY
+ *   rename(dir → symlink, live or dangling)→ ENOTDIR
+ *   rename(dir → empty dir)                → succeeds
+ */
+const OCCUPIED_CODES = new Set(['EEXIST', 'ENOTEMPTY', 'ENOTDIR', 'EISDIR']);
+
+/**
  * Run `place` at `path`, clearing whatever occupies it and retrying when the
  * path is taken. Returns false once the attempts are exhausted.
  *
@@ -283,9 +318,9 @@ function placeClearingSquatters(path: string, place: () => void): { ok: true } |
       return { ok: true };
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'EEXIST' && code !== 'ENOTEMPTY') throw err;
+      if (!code || !OCCUPIED_CODES.has(code)) throw err;
       last = err;
-      safeRmSync(path);
+      removePathEntry(path);
     }
   }
   return { ok: false, last };
@@ -321,7 +356,7 @@ function relinkStaleVersionDir(versionDir: string, target: string): void {
   if (isUsableVersionPath(asideDir)) {
     throw new Error(`an intact backup already occupies ${asideDir}`);
   }
-  safeRmSync(asideDir);
+  removePathEntry(asideDir);
   renameSync(versionDir, asideDir);
 
   let failure: unknown;
@@ -364,6 +399,10 @@ export interface PurgeCacheResult {
   restored: number;
   /** Version paths that were restored from an interrupted relink */
   restoredPaths: string[];
+  /** Number of backups left in place because their owning purge is still running */
+  skipped: number;
+  /** Backup paths left to their live owner, with the version path they belong to */
+  skippedPaths: string[];
   /** Errors encountered (non-fatal) */
   errors: string[];
 }
@@ -406,7 +445,10 @@ function compareSemverDesc(a: string, b: string): number {
 }
 
 export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: boolean }): PurgeCacheResult {
-  const result: PurgeCacheResult = { removed: 0, removedPaths: [], symlinked: 0, symlinkPaths: [], restored: 0, restoredPaths: [], errors: [] };
+  const result: PurgeCacheResult = {
+    removed: 0, removedPaths: [], symlinked: 0, symlinkPaths: [],
+    restored: 0, restoredPaths: [], skipped: 0, skippedPaths: [], errors: [],
+  };
 
   const configDir = getClaudeConfigDir();
   const pluginsDir = join(configDir, 'plugins');
@@ -494,7 +536,16 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
       for (const { versionDir, originalDir, ownerPid } of asideEntries) {
         // A live owner means the swap is in flight, not interrupted.  Stealing
         // its backup would make the owner's retry delete the real directory.
-        if (isAsideOwnerAlive(ownerPid)) continue;
+        //
+        // Record it rather than returning silently: while the owner runs, the
+        // version path is legitimately unusable, but if that pid was recycled by
+        // an unrelated process the backup is never reclaimed and the pinned path
+        // stays broken with nothing to show for it.
+        if (isAsideOwnerAlive(ownerPid)) {
+          result.skipped++;
+          result.skippedPaths.push(`${versionDir} (owner pid ${ownerPid} still running)`);
+          continue;
+        }
         try {
           if (isUsableVersionPath(originalDir)) {
             // The redirect landed, or the version was reinstalled — the aside

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -222,13 +222,23 @@ const ASIDE_SUFFIX = '.omc-stale-';
 const ASIDE_SUFFIX_RE = /\.omc-stale-(\d+)$/;
 
 /**
+ * Entry points a plugin root has to expose for a pinned session to keep working.
+ * Taken from an installed cache copy, not guessed: `hooks/hooks.json` is what
+ * Claude Code reads to wire the hooks, and the hook commands run through
+ * `scripts/run.cjs`. Either one present means real payload.
+ */
+const PLUGIN_ROOT_MARKERS = ['hooks/hooks.json', 'scripts/run.cjs', '.claude-plugin/plugin.json'];
+
+/**
  * True when `path` can serve as a plugin root: a live redirect symlink, or a
- * directory that still holds payload.
+ * directory that actually carries plugin payload.
  *
- * An empty directory — or one holding only dotfiles, such as the `.DS_Store`
- * Finder writes the moment it walks the path — is a squatter created inside a
- * lost relink window, not a usable version. Treating it as usable is what makes
- * a recovery discard the only intact copy.
+ * Presence is not enough, and neither is "holds a non-dotfile". A directory left
+ * by a lost relink window can hold `.DS_Store` (Finder writes it the moment it
+ * walks the path), `desktop.ini`/`Thumbs.db` on Windows, or a half-extracted
+ * `scripts/` — none of which a pinned session can load. Treating those as usable
+ * is what makes a recovery discard the only intact copy. The manifest also lives
+ * under a dotted directory, so a dotfile check gets it wrong in both directions.
  *
  * A dangling symlink is not usable either: `existsSync` follows the link, so a
  * redirect whose target has since been removed is correctly rejected.
@@ -242,11 +252,7 @@ function isUsableVersionPath(path: string): boolean {
   }
   if (stats.isSymbolicLink()) return existsSync(path);
   if (!stats.isDirectory()) return false;
-  try {
-    return readdirSync(path).some(entry => !entry.startsWith('.'));
-  } catch {
-    return false;
-  }
+  return PLUGIN_ROOT_MARKERS.some(marker => existsSync(join(path, marker)));
 }
 
 /**
@@ -298,8 +304,19 @@ function removePathEntry(path: string): boolean {
  *   rename(dir → non-empty dir)            → ENOTEMPTY
  *   rename(dir → symlink, live or dangling)→ ENOTDIR
  *   rename(dir → empty dir)                → succeeds
+ *
+ * Windows reports a collision as EPERM/EACCES rather than ENOTEMPTY, so those
+ * are added there only. They stay out on POSIX, where they mean the caller
+ * genuinely lacks permission and clearing the path would be the wrong response.
+ * Retrying is still safe under either reading: removePathEntry() fails on a path
+ * we cannot write, the attempts drain, and the caller reports instead of
+ * silently dropping anything.
  */
-const OCCUPIED_CODES = new Set(['EEXIST', 'ENOTEMPTY', 'ENOTDIR', 'EISDIR']);
+const OCCUPIED_CODES = new Set(
+  process.platform === 'win32'
+    ? ['EEXIST', 'ENOTEMPTY', 'ENOTDIR', 'EISDIR', 'EPERM', 'EACCES']
+    : ['EEXIST', 'ENOTEMPTY', 'ENOTDIR', 'EISDIR'],
+);
 
 /**
  * Run `place` at `path`, clearing whatever occupies it and retrying when the

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -222,23 +222,31 @@ const ASIDE_SUFFIX = '.omc-stale-';
 const ASIDE_SUFFIX_RE = /\.omc-stale-(\d+)$/;
 
 /**
- * Entry points a plugin root has to expose for a pinned session to keep working.
- * Taken from an installed cache copy, not guessed: `hooks/hooks.json` is what
- * Claude Code reads to wire the hooks, and the hook commands run through
- * `scripts/run.cjs`. Either one present means real payload.
+ * What a plugin root has to expose for a pinned session to keep working.
+ *
+ * This mirrors `isPluginRoot()` in `scripts/run.cjs` — the hook runner's own
+ * check — and must stay in step with it. The runner requires all of these, so a
+ * root missing any one cannot run hooks no matter what else it holds. Note that
+ * `.claude-plugin/plugin.json` is deliberately absent: the runner does not
+ * consult it, so a manifest-only directory is not a usable root.
  */
-const PLUGIN_ROOT_MARKERS = ['hooks/hooks.json', 'scripts/run.cjs', '.claude-plugin/plugin.json'];
+const PLUGIN_ROOT_REQUIREMENTS = [
+  join('hooks', 'hooks.json'),
+  join('scripts', 'run.cjs'),
+  'scripts',
+];
 
 /**
  * True when `path` can serve as a plugin root: a live redirect symlink, or a
  * directory that actually carries plugin payload.
  *
- * Presence is not enough, and neither is "holds a non-dotfile". A directory left
- * by a lost relink window can hold `.DS_Store` (Finder writes it the moment it
- * walks the path), `desktop.ini`/`Thumbs.db` on Windows, or a half-extracted
- * `scripts/` — none of which a pinned session can load. Treating those as usable
- * is what makes a recovery discard the only intact copy. The manifest also lives
- * under a dotted directory, so a dotfile check gets it wrong in both directions.
+ * Presence is not enough, and neither is "holds a non-dotfile", and neither is
+ * "holds one of the entry points". A directory left by a lost relink window can
+ * hold `.DS_Store` (Finder writes it the moment it walks the path),
+ * `desktop.ini`/`Thumbs.db` on Windows, a half-extracted `scripts/`, or a
+ * partially copied root with only the manifest or only `hooks/hooks.json` — none
+ * of which the hook runner will load. Treating any of those as usable is what
+ * makes a recovery discard the only intact copy.
  *
  * A dangling symlink is not usable either: `existsSync` follows the link, so a
  * redirect whose target has since been removed is correctly rejected.
@@ -252,7 +260,7 @@ function isUsableVersionPath(path: string): boolean {
   }
   if (stats.isSymbolicLink()) return existsSync(path);
   if (!stats.isDirectory()) return false;
-  return PLUGIN_ROOT_MARKERS.some(marker => existsSync(join(path, marker)));
+  return PLUGIN_ROOT_REQUIREMENTS.every(required => existsSync(join(path, required)));
 }
 
 /**

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path';
-import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync, symlinkSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync, renameSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { getClaudeConfigDir } from './config-dir.js';
 
@@ -207,6 +207,52 @@ export function safeRmSync(dirPath: string): boolean {
   }
 }
 
+/** How many times to retry placing the redirect symlink when the path is
+ * re-created underneath us (Finder `.DS_Store`, Spotlight, a concurrent
+ * purge from another session). */
+const RELINK_ATTEMPTS = 3;
+
+/**
+ * Replace a stale version directory with a symlink to `target`, without ever
+ * leaving the path missing.
+ *
+ * `rename()` cannot swap a directory for a symlink (POSIX requires both sides
+ * to be the same type), so the stale directory is moved aside first and only
+ * discarded once the symlink is in place. If the symlink cannot be created —
+ * something re-created the path inside the window — the stale directory is
+ * restored, keeping `CLAUDE_PLUGIN_ROOT` pinned sessions alive.
+ *
+ * Invariant: on return the path is either the redirect symlink or the original
+ * directory. It is never an empty directory and never absent.
+ */
+function relinkStaleVersionDir(versionDir: string, target: string): void {
+  const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
+  const asideDir = `${versionDir}.omc-stale-${process.pid}`;
+
+  safeRmSync(asideDir);
+  renameSync(versionDir, asideDir);
+
+  for (let attempt = 0; attempt < RELINK_ATTEMPTS; attempt++) {
+    try {
+      symlinkSync(target, versionDir, symlinkType);
+      safeRmSync(asideDir);
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+        safeRmSync(versionDir);
+        renameSync(asideDir, versionDir);
+        throw err;
+      }
+      // Something occupied the path; clear it and retry.
+      safeRmSync(versionDir);
+    }
+  }
+
+  safeRmSync(versionDir);
+  renameSync(asideDir, versionDir);
+  throw new Error(`could not place redirect symlink after ${RELINK_ATTEMPTS} attempts`);
+}
+
 /**
  * Result of a plugin cache purge operation.
  */
@@ -363,16 +409,14 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
               b.split('/').pop() ?? b,
             ),
           )[0];
-          if (safeRmSync(versionDir)) {
-            try {
-              symlinkSync(target, versionDir, process.platform === 'win32' ? 'junction' : 'dir');
-              result.symlinked++;
-              result.symlinkPaths.push(versionDir);
-            } catch (err) {
-              result.errors.push(
-                `Failed to symlink ${versionDir} → ${target}: ${err instanceof Error ? err.message : err}`,
-              );
-            }
+          try {
+            relinkStaleVersionDir(versionDir, target);
+            result.symlinked++;
+            result.symlinkPaths.push(versionDir);
+          } catch (err) {
+            result.errors.push(
+              `Failed to symlink ${versionDir} → ${target}: ${err instanceof Error ? err.message : err}`,
+            );
           }
         } else {
           if (safeRmSync(versionDir)) {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path';
-import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, rmSync, renameSync, symlinkSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, lstatSync, unlinkSync, rmSync, renameSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { getClaudeConfigDir } from './config-dir.js';
 
@@ -233,6 +233,54 @@ const ASIDE_SUFFIX_RE = /\.omc-stale-\d+$/;
  * Invariant: on return the path is either the redirect symlink or the original
  * directory. It is never an empty directory and never absent.
  */
+/**
+ * True when `path` can serve as a plugin root: a redirect symlink, or a
+ * directory that still holds payload.
+ *
+ * An empty directory — or one holding only dotfiles, such as the `.DS_Store`
+ * Finder writes the moment it walks the path — is a squatter created inside a
+ * lost relink window, not a usable version. Treating it as usable is what makes
+ * a recovery discard the only intact copy.
+ */
+function isUsableVersionPath(path: string): boolean {
+  let stats;
+  try {
+    stats = lstatSync(path);
+  } catch {
+    return false;
+  }
+  if (stats.isSymbolicLink()) return true;
+  if (!stats.isDirectory()) return false;
+  try {
+    return readdirSync(path).some(entry => !entry.startsWith('.'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run `place` at `path`, clearing whatever occupies it and retrying when the
+ * path is taken. Returns false once the attempts are exhausted.
+ *
+ * Both halves of a relink need this: the symlink placement and the rollback
+ * that restores the original directory. A rollback that is not retried can
+ * leave the original stranded at its aside path while a squatter holds the
+ * pinned path — the exact failure this helper exists to prevent.
+ */
+function placeClearingSquatters(path: string, place: () => void): boolean {
+  for (let attempt = 0; attempt < RELINK_ATTEMPTS; attempt++) {
+    try {
+      place();
+      return true;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST' && code !== 'ENOTEMPTY') throw err;
+      safeRmSync(path);
+    }
+  }
+  return false;
+}
+
 function relinkStaleVersionDir(versionDir: string, target: string): void {
   const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
   const asideDir = `${versionDir}${ASIDE_SUFFIX}${process.pid}`;
@@ -240,25 +288,24 @@ function relinkStaleVersionDir(versionDir: string, target: string): void {
   safeRmSync(asideDir);
   renameSync(versionDir, asideDir);
 
-  for (let attempt = 0; attempt < RELINK_ATTEMPTS; attempt++) {
-    try {
-      symlinkSync(target, versionDir, symlinkType);
+  let failure: unknown;
+  try {
+    if (placeClearingSquatters(versionDir, () => symlinkSync(target, versionDir, symlinkType))) {
       safeRmSync(asideDir);
       return;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
-        safeRmSync(versionDir);
-        renameSync(asideDir, versionDir);
-        throw err;
-      }
-      // Something occupied the path; clear it and retry.
-      safeRmSync(versionDir);
     }
+    failure = new Error(`could not place redirect symlink after ${RELINK_ATTEMPTS} attempts`);
+  } catch (err) {
+    // Not a contended path (EPERM, EACCES, …) — restore and report as-is.
+    failure = err;
   }
 
-  safeRmSync(versionDir);
-  renameSync(asideDir, versionDir);
-  throw new Error(`could not place redirect symlink after ${RELINK_ATTEMPTS} attempts`);
+  if (!placeClearingSquatters(versionDir, () => renameSync(asideDir, versionDir))) {
+    throw new Error(
+      `could not place redirect symlink and could not restore the original: it is left at ${asideDir}`,
+    );
+  }
+  throw failure;
 }
 
 /**
@@ -397,9 +444,15 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
         if (aside) {
           const originalDir = join(pluginDir, version.slice(0, aside.index));
           try {
-            if (existsSync(originalDir)) {
+            if (isUsableVersionPath(originalDir)) {
+              // The redirect landed, or the version was reinstalled — the aside
+              // copy carries nothing the live path does not already have.
               safeRmSync(versionDir);
             } else {
+              // The path is missing, or holds only a squatter created inside the
+              // lost window.  The aside copy is the sole intact version, so it
+              // wins: clear the squatter and move it back.
+              safeRmSync(originalDir);
               renameSync(versionDir, originalDir);
               result.restored++;
               result.restoredPaths.push(originalDir);

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -217,30 +217,21 @@ const RELINK_ATTEMPTS = 3;
 const ASIDE_SUFFIX = '.omc-stale-';
 
 /** Matches the aside suffix so an interrupted relink can be recognised and
- * repaired instead of being mistaken for a plugin version. */
-const ASIDE_SUFFIX_RE = /\.omc-stale-\d+$/;
+ * repaired instead of being mistaken for a plugin version. Group 1 is the pid
+ * of the purge that created it. */
+const ASIDE_SUFFIX_RE = /\.omc-stale-(\d+)$/;
 
 /**
- * Replace a stale version directory with a symlink to `target`, without ever
- * leaving the path missing.
- *
- * `rename()` cannot swap a directory for a symlink (POSIX requires both sides
- * to be the same type), so the stale directory is moved aside first and only
- * discarded once the symlink is in place. If the symlink cannot be created —
- * something re-created the path inside the window — the stale directory is
- * restored, keeping `CLAUDE_PLUGIN_ROOT` pinned sessions alive.
- *
- * Invariant: on return the path is either the redirect symlink or the original
- * directory. It is never an empty directory and never absent.
- */
-/**
- * True when `path` can serve as a plugin root: a redirect symlink, or a
+ * True when `path` can serve as a plugin root: a live redirect symlink, or a
  * directory that still holds payload.
  *
  * An empty directory — or one holding only dotfiles, such as the `.DS_Store`
  * Finder writes the moment it walks the path — is a squatter created inside a
  * lost relink window, not a usable version. Treating it as usable is what makes
  * a recovery discard the only intact copy.
+ *
+ * A dangling symlink is not usable either: `existsSync` follows the link, so a
+ * redirect whose target has since been removed is correctly rejected.
  */
 function isUsableVersionPath(path: string): boolean {
   let stats;
@@ -249,12 +240,29 @@ function isUsableVersionPath(path: string): boolean {
   } catch {
     return false;
   }
-  if (stats.isSymbolicLink()) return true;
+  if (stats.isSymbolicLink()) return existsSync(path);
   if (!stats.isDirectory()) return false;
   try {
     return readdirSync(path).some(entry => !entry.startsWith('.'));
   } catch {
     return false;
+  }
+}
+
+/**
+ * True when the purge that created an aside directory is still running, i.e.
+ * the backup belongs to a swap in flight and must not be touched.
+ *
+ * Signal 0 does not deliver anything; it only probes. `EPERM` means the process
+ * exists but is not ours to signal, which still counts as alive.
+ */
+function isAsideOwnerAlive(pid: number): boolean {
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 
@@ -267,42 +275,74 @@ function isUsableVersionPath(path: string): boolean {
  * leave the original stranded at its aside path while a squatter holds the
  * pinned path — the exact failure this helper exists to prevent.
  */
-function placeClearingSquatters(path: string, place: () => void): boolean {
+function placeClearingSquatters(path: string, place: () => void): { ok: true } | { ok: false; last: unknown } {
+  let last: unknown;
   for (let attempt = 0; attempt < RELINK_ATTEMPTS; attempt++) {
     try {
       place();
-      return true;
+      return { ok: true };
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== 'EEXIST' && code !== 'ENOTEMPTY') throw err;
+      last = err;
       safeRmSync(path);
     }
   }
-  return false;
+  return { ok: false, last };
 }
 
+function describeError(err: unknown): string {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code) return code;
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Replace a stale version directory with a symlink to `target`, without ever
+ * leaving the path missing.
+ *
+ * `rename()` cannot swap a directory for a symlink (POSIX requires both sides to
+ * be the same type), so the stale directory is moved aside first and only
+ * discarded once the symlink is in place. If the symlink cannot be created —
+ * something re-created the path inside the window — the stale directory is moved
+ * back, keeping `CLAUDE_PLUGIN_ROOT`-pinned sessions alive.
+ *
+ * Invariant: on return the path is either the redirect symlink or the original
+ * directory. It is never an empty directory and never absent.
+ */
 function relinkStaleVersionDir(versionDir: string, target: string): void {
   const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
   const asideDir = `${versionDir}${ASIDE_SUFFIX}${process.pid}`;
 
+  // Never overwrite an intact backup: it is the only copy of some version, and
+  // clearing it here is how the earlier revision could destroy one. Aside
+  // entries are reconciled before normal versions, so reaching this with a
+  // usable backup in place means another purge owns it.
+  if (isUsableVersionPath(asideDir)) {
+    throw new Error(`an intact backup already occupies ${asideDir}`);
+  }
   safeRmSync(asideDir);
   renameSync(versionDir, asideDir);
 
   let failure: unknown;
   try {
-    if (placeClearingSquatters(versionDir, () => symlinkSync(target, versionDir, symlinkType))) {
+    const placed = placeClearingSquatters(versionDir, () => symlinkSync(target, versionDir, symlinkType));
+    if (placed.ok) {
       safeRmSync(asideDir);
       return;
     }
-    failure = new Error(`could not place redirect symlink after ${RELINK_ATTEMPTS} attempts`);
+    failure = new Error(
+      `could not place redirect symlink after ${RELINK_ATTEMPTS} attempts (${describeError(placed.last)})`,
+    );
   } catch (err) {
     // Not a contended path (EPERM, EACCES, …) — restore and report as-is.
     failure = err;
   }
 
-  if (!placeClearingSquatters(versionDir, () => renameSync(asideDir, versionDir))) {
+  if (!placeClearingSquatters(versionDir, () => renameSync(asideDir, versionDir)).ok) {
     throw new Error(
-      `could not place redirect symlink and could not restore the original: it is left at ${asideDir}`,
+      `could not place redirect symlink (${describeError(failure)}) and could not restore the ` +
+      `original: it is left at ${asideDir}`,
     );
   }
   throw failure;
@@ -432,39 +472,54 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
           .map(d => d.name);
       } catch { continue; }
 
+      // Reconcile interrupted relinks BEFORE walking normal versions.  Entries
+      // arrive in filesystem order, so a squatter at `4.15.6` could otherwise be
+      // relinked first — and that relink clears `4.15.6.omc-stale-<pid>`, the
+      // only intact backup, before anyone knows the new symlink can be placed.
+      const asideEntries: { versionDir: string; originalDir: string; ownerPid: number }[] = [];
+      const plainVersions: string[] = [];
       for (const version of versions) {
-        const versionDir = join(pluginDir, version);
-
-        // An aside directory means a previous relink was interrupted between
-        // moving the stale dir out of the way and placing the symlink.  Repair
-        // it here rather than treating it as a version of its own: restore it
-        // if the version path it came from is now missing (that path is what
-        // CLAUDE_PLUGIN_ROOT points at), otherwise it is leftover litter.
         const aside = ASIDE_SUFFIX_RE.exec(version);
         if (aside) {
-          const originalDir = join(pluginDir, version.slice(0, aside.index));
-          try {
-            if (isUsableVersionPath(originalDir)) {
-              // The redirect landed, or the version was reinstalled — the aside
-              // copy carries nothing the live path does not already have.
-              safeRmSync(versionDir);
-            } else {
-              // The path is missing, or holds only a squatter created inside the
-              // lost window.  The aside copy is the sole intact version, so it
-              // wins: clear the squatter and move it back.
-              safeRmSync(originalDir);
-              renameSync(versionDir, originalDir);
-              result.restored++;
-              result.restoredPaths.push(originalDir);
-            }
-          } catch (err) {
-            result.errors.push(
-              `Failed to reconcile interrupted relink ${versionDir}: ${err instanceof Error ? err.message : err}`,
-            );
-          }
-          continue;
+          asideEntries.push({
+            versionDir: join(pluginDir, version),
+            originalDir: join(pluginDir, version.slice(0, aside.index)),
+            ownerPid: Number(aside[1]),
+          });
+        } else {
+          plainVersions.push(version);
         }
+      }
 
+      for (const { versionDir, originalDir, ownerPid } of asideEntries) {
+        // A live owner means the swap is in flight, not interrupted.  Stealing
+        // its backup would make the owner's retry delete the real directory.
+        if (isAsideOwnerAlive(ownerPid)) continue;
+        try {
+          if (isUsableVersionPath(originalDir)) {
+            // The redirect landed, or the version was reinstalled — the aside
+            // copy carries nothing the live path does not already have.
+            safeRmSync(versionDir);
+          } else {
+            // The path is missing, or holds only a squatter created inside the
+            // lost window.  The aside copy is the sole intact version, so it
+            // wins: clear the squatter and move it back, retrying if the
+            // squatter comes back while we do.
+            if (!placeClearingSquatters(originalDir, () => renameSync(versionDir, originalDir)).ok) {
+              throw new Error(`could not restore it over the path after ${RELINK_ATTEMPTS} attempts`);
+            }
+            result.restored++;
+            result.restoredPaths.push(originalDir);
+          }
+        } catch (err) {
+          result.errors.push(
+            `Failed to reconcile interrupted relink ${versionDir}: ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
+
+      for (const version of plainVersions) {
+        const versionDir = join(pluginDir, version);
         const normalised = stripTrailing(versionDir);
 
         // Check if this version or any of its subdirectories are referenced

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -212,6 +212,14 @@ export function safeRmSync(dirPath: string): boolean {
  * purge from another session). */
 const RELINK_ATTEMPTS = 3;
 
+/** Suffix for the directory a stale version is moved to while its redirect
+ * symlink is placed. Includes the pid so concurrent purges cannot collide. */
+const ASIDE_SUFFIX = '.omc-stale-';
+
+/** Matches the aside suffix so an interrupted relink can be recognised and
+ * repaired instead of being mistaken for a plugin version. */
+const ASIDE_SUFFIX_RE = /\.omc-stale-\d+$/;
+
 /**
  * Replace a stale version directory with a symlink to `target`, without ever
  * leaving the path missing.
@@ -227,7 +235,7 @@ const RELINK_ATTEMPTS = 3;
  */
 function relinkStaleVersionDir(versionDir: string, target: string): void {
   const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
-  const asideDir = `${versionDir}.omc-stale-${process.pid}`;
+  const asideDir = `${versionDir}${ASIDE_SUFFIX}${process.pid}`;
 
   safeRmSync(asideDir);
   renameSync(versionDir, asideDir);
@@ -265,6 +273,10 @@ export interface PurgeCacheResult {
   symlinked: number;
   /** Paths that were converted to symlinks */
   symlinkPaths: string[];
+  /** Number of version directories restored from an interrupted relink */
+  restored: number;
+  /** Version paths that were restored from an interrupted relink */
+  restoredPaths: string[];
   /** Errors encountered (non-fatal) */
   errors: string[];
 }
@@ -307,7 +319,7 @@ function compareSemverDesc(a: string, b: string): number {
 }
 
 export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: boolean }): PurgeCacheResult {
-  const result: PurgeCacheResult = { removed: 0, removedPaths: [], symlinked: 0, symlinkPaths: [], errors: [] };
+  const result: PurgeCacheResult = { removed: 0, removedPaths: [], symlinked: 0, symlinkPaths: [], restored: 0, restoredPaths: [], errors: [] };
 
   const configDir = getClaudeConfigDir();
   const pluginsDir = join(configDir, 'plugins');
@@ -375,6 +387,31 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
 
       for (const version of versions) {
         const versionDir = join(pluginDir, version);
+
+        // An aside directory means a previous relink was interrupted between
+        // moving the stale dir out of the way and placing the symlink.  Repair
+        // it here rather than treating it as a version of its own: restore it
+        // if the version path it came from is now missing (that path is what
+        // CLAUDE_PLUGIN_ROOT points at), otherwise it is leftover litter.
+        const aside = ASIDE_SUFFIX_RE.exec(version);
+        if (aside) {
+          const originalDir = join(pluginDir, version.slice(0, aside.index));
+          try {
+            if (existsSync(originalDir)) {
+              safeRmSync(versionDir);
+            } else {
+              renameSync(versionDir, originalDir);
+              result.restored++;
+              result.restoredPaths.push(originalDir);
+            }
+          } catch (err) {
+            result.errors.push(
+              `Failed to reconcile interrupted relink ${versionDir}: ${err instanceof Error ? err.message : err}`,
+            );
+          }
+          continue;
+        }
+
         const normalised = stripTrailing(versionDir);
 
         // Check if this version or any of its subdirectories are referenced
@@ -419,6 +456,12 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
             );
           }
         } else {
+          // No active sibling exists, so there is nothing to redirect to and a
+          // symlink is not possible — deletion is the only cleanup path, and
+          // keeping the directory forever was rejected in 9bfd910e ("would
+          // accumulate real dirs indefinitely").  A session pinned here is
+          // therefore protected only by the grace period, whose mtime signal
+          // does not track liveness; that is tracked separately in #3688.
           if (safeRmSync(versionDir)) {
             result.removed++;
             result.removedPaths.push(versionDir);


### PR DESCRIPTION
## Summary

`purgeStalePluginCacheVersions` can leave a plugin version directory **empty**, which takes down hooks for every session pinned to it via `CLAUDE_PLUGIN_ROOT` — and the update still reports success.

This completes the intent of 9bfd910e (*"symlink stale plugin version dirs instead of deleting them"*, closes #2543), whose own commit body states the constraint this bug violates:

> Constraint: Must not break sessions running the old version during the upgrade window

## The problem

`src/utils/paths.ts` redirects a stale version directory by deleting it and *then* creating the symlink:

```ts
if (safeRmSync(versionDir)) {          // path stops existing here
  try {
    symlinkSync(target, versionDir, …); // …and only reappears here
  } catch (err) {
    result.errors.push(…);              // failure is recorded, not acted on
  }
}
```

If anything recreates the path inside that window, `symlinkSync` fails with `EEXIST`. The directory is already gone, so the result is the worst of both: **no content and no redirect.**

Plausible occupants of the window:
- **Finder** writing `.DS_Store` (what we observed)
- Spotlight / backup tooling touching the path
- **another OMC process** running the same purge — every live session can run the updater

Two things make it hurt more than it looks:

1. **The failure was silent.** `reconcileRuntimeState` printed `purgeResult.errors` only under `--verbose`, and those errors are not merged into the returned `errors` array — so reconciliation returned `success: true` while the plugin was broken. Purge errors are now always warned about (still non-fatal — see below).
2. **One failure fans out.** Older versions are themselves symlinks *pointing at* the demoted version. When the hop goes empty, all of them break together.

### What we observed

macOS 26.6, OMC updating `4.15.6 → 4.15.10`, sessions live at the time:

```
~/.claude/plugins/cache/omc/oh-my-claudecode/
  4.15.6/          ← only .DS_Store, mtime == purge time
  4.13.5 -> 4.15.6 ┐
  4.14.0 -> 4.15.6 ├─ all broken through the empty hop
  4.15.0 -> 4.15.6 │
  4.15.4 -> 4.15.6 ┘
  4.15.10/         ← fine
```

Every hook in the pinned sessions then failed with:

```
Error: Cannot find module '…/oh-my-claudecode/4.15.6/scripts/run.cjs'  [MODULE_NOT_FOUND]
```

## The fix

Move the stale directory aside instead of deleting it, and discard it only after the symlink is in place. Retry `EEXIST` after clearing the squatter; if the symlink still cannot be placed, move the original back.

**Invariant:** on return the path is either the redirect symlink or the original directory. Never an empty directory, never absent.

### Also in this PR

- **Interrupted relinks are repaired.** An aside directory left by a crash between the rename and the symlink used to be enumerated as a plugin version on the next run (the walk only filters on `isDirectory()`), graded against the grace period, and demoted or deleted like a real version. It is now recognised by suffix and reconciled: moved back if the version path it came from is missing, discarded as litter if that path already exists. **This self-heals installs already broken by the pre-fix code path.** New `restored` / `restoredPaths` fields report it.
- **Relink failures are no longer hidden.** Purge errors are warned about regardless of `--verbose`. They stay non-fatal — promoting them into the returned `errors` array would make reconciliation fail on best-effort cleanup and change behaviour for every caller.

`rename()` cannot swap a directory for a symlink (POSIX requires matching types), so an in-place atomic replacement is not available — hence aside-and-retry rather than rename-over. I tried the rename-over approach first and it fails identically (`ENOTEMPTY`), *and* its rollback fails for the same reason, stranding the original at the aside path. That alternative is recorded in the commit trailers.

## Tests

`src/__tests__/purge-stale-cache.test.ts` — 14 existing → **20**.

New regression cases:
- `retries the symlink when the path is re-created inside the swap window` — first `symlinkSync` throws `EEXIST`, redirect must still land
- `restores the stale dir when the symlink can never be placed` — every attempt loses; original must be moved back
- `restores the stale dir when symlink fails with a non-EEXIST error` — `EPERM` is not retried but still rolls back
- `restores the version path from an aside dir left by an interrupted relink` — the self-heal path
- `discards an aside dir as litter when the version path already exists`
- `never treats an aside dir as a plugin version when picking a symlink target`

Two existing assertions were updated: they asserted `rmSync(staleVersion, …)`, which encoded the delete-first sequence that is the bug. They now assert the move-aside.

```
npx vitest run src/__tests__/purge-stale-cache.test.ts      20/20 pass
purge + hud + team suites (44 files)                        698/698 pass
npx tsc --noEmit                                            0 errors
npx eslint <changed files>                                  clean
```

**Reverting only `src/utils/paths.ts` fails 5 of the 20 for the race fix and 3 more for the repair path**, so the new cases genuinely cover the defect rather than restating the implementation.

## Not addressed here

The grace period (`STALE_THRESHOLD_MS`) uses **directory mtime** to decide whether a version might still be in use, but mtime says nothing about whether a live session is pinned to it — the directory we lost was three weeks old while the session was three hours old. That is a policy question rather than a correctness fix, so it is filed separately as #3688 and left out of this PR.

The no-active-sibling branch also still deletes outright. That is deliberate: with no sibling to redirect to a symlink is impossible, and retaining the directory forever was rejected in 9bfd910e as unbounded growth. The reasoning is now a comment at that branch, pointing at #3688.

## Notes

- Targets `dev` per `.github/CLAUDE.md` `<contribution_rules>`.
- No `dist/` or `bridge/` changes.
- Local `npm ci` needed `--ignore-scripts` because `better-sqlite3@12.6.2` has no prebuild for Node 26 on this machine. The touched code is pure `fs`. 137 tests in 7 files fail under that install for missing `better_sqlite3.node` — the same 137 fail on pristine `dev`, so they are unrelated; the suites quoted above exclude them.
