### PR TITLE
ci: authorize exact generated closure for PR #3690 (main)

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1300,6 +1300,524 @@
           "previousFilename": null
         }
       ]
+    },
+    {
+      "pullNumber": 3690,
+      "targetRef": "main",
+      "mergeBaseSha": "41a4c0f77144c5beb5f5f000a89cff379c680606",
+      "headSha": "1a08dc0c2c64fc03bf14536524b297ad662d16ae",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-26T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 84,
+        "sha256": "32281aa849db09ae8d5b349bb6fc3b662386029aea2beec1ee9e2d8b6ab0dda5"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "94f2910bdcfeb7b0ce5903a1dac83e1d9f388384",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "4148a380b8724bb276c0138c204ecf5e30a92aed",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/mcp-server.cjs",
+          "sha": "bd75bdad5eb75d5baff95c234ae2575c011c22ba",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/runtime-cli.cjs",
+          "sha": "d11c4b7e92f14ebc922f8cf8f9bb4d7859b57ec6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-bridge.cjs",
+          "sha": "337515fc68aa1bde951b9e2c6c5b9f38f72eda3e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-mcp.cjs",
+          "sha": "7979d2172bae05cb7160e12007f17f7a077ecc18",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team.js",
+          "sha": "296db74af1f1719561614649d856105aa468fdcd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/hud/usage-api.test.js",
+          "sha": "150d495f168f4b32eccb0a07a234acb349642f56",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/hud/usage-api.test.js.map",
+          "sha": "2f8bec6d2c66c818cb9402468ed2009f1c448e49",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/doctor-team-routing.js",
+          "sha": "dd0dff5073ffdc922c6d4403fee85cedc349cae4",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/team.js",
+          "sha": "1f51214311b72bce8e7f77b5cd848091cde24f28",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/hud-watch.js",
+          "sha": "8d5566686195c2c734f46d050b87c24a09d18bd8",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/index.js",
+          "sha": "b1ea32f23128d1b7c9dd017156902d4446e9bb9e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/launch.js",
+          "sha": "e01b363c5cdc3d4f28072ca612b49a2db200b7d6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/team.js",
+          "sha": "55951bd6a0ec70736ea14b007cbaf16a3d6d6123",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/descriptor.d.ts",
+          "sha": "0ce86398621ca86f51f02f4c4c75cf4f3c5112e4",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/descriptor.js",
+          "sha": "f738a965d033c4f03513bb95503b9e7190efb981",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/index.d.ts",
+          "sha": "3d6a726347026939eb721de09e7d1d479f6ae2ed",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/index.js",
+          "sha": "e43a84a4dfbc2f7ba2880e09a4a7e30c783b2288",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/scheduler.d.ts",
+          "sha": "dfaf2eab292b119ca3ee09b12ebd644aa807ccae",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/scheduler.js",
+          "sha": "cf1d0ab516d4167ad18bd435380d1c486a9512fd",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/schema.d.ts",
+          "sha": "8ca025e94723464eb9bce83cce58c8dadbcd6c1a",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/schema.js",
+          "sha": "f8c0e2d28df3f0f41eaf881a5959a70ca458476a",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/types.d.ts",
+          "sha": "847eee9a34bcf20b1eff77d4cb536632a8339fca",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/graph/types.js",
+          "sha": "310bb754cb2fe67e5529915d61b0662f00363b4c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/rules-injector/finder.js",
+          "sha": "27629a76a83f51c877c07075d13c5205fdc6b08b",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/hooks/rules-injector/finder.test.d.ts",
+          "sha": "3ae90290310119b8fa6cb4c1393781f4497a284d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/action-runner.js",
+          "sha": "e0bcdbc11f9274fda8241b53693cb3e383ded472",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/index.js",
+          "sha": "33200348cc3c32fc835f6fb21c554d1811ff7d43",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/custom-rate-provider.d.ts",
+          "sha": "941781967da6c4cc61ba3bc4316ebc85ddc6df04",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/custom-rate-provider.js",
+          "sha": "38c5be75d5ea597ece3e9c22a89e52176b3c11a1",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/elements/limits.js",
+          "sha": "9fdb51c9d66ae0370f1ab05c6b966acdaa1be7e4",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/stdin.js",
+          "sha": "2b555b6d81d66909a62ce734fc6498f68ae38032",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/types.d.ts",
+          "sha": "4738afeac85def9d24c5560ebbe781175e2027ec",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.d.ts",
+          "sha": "b754ba555a7236895ed225a3c2fa222104388ff0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.d.ts.map",
+          "sha": "d600fb14bb7fb471b1956d392b4ed1d09139d001",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.js",
+          "sha": "cd1afac9f9bdb9f635f740cffe1d1d780100191a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.js.map",
+          "sha": "f05b01a0254e78abb82c2b5e6c0b9ccf3d893341",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/claude-md-transaction.d.ts",
+          "sha": "91f44678af2a904d691d7bd61fdad5eae478a923",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/claude-md-transaction.js",
+          "sha": "8a3c29bd6cc3ee42a705c046418ebbf38234b9cb",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/historical-agent-ownership.d.ts",
+          "sha": "3902ec42a77d6fa6ebf1366a188c14af9e451a21",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/historical-agent-ownership.js",
+          "sha": "73dbb7342a1affb00a3d1f435fd178aae4816822",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.d.ts",
+          "sha": "5fe1619f84ef538126c56080dd63a068052204c2",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.js",
+          "sha": "3c9f473cbe2033ac3ec4016fe46530476bd7318e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/mcp-registry.js",
+          "sha": "99d3c36dbb897f4a4d2ed23abb8964c68af33e9b",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.d.ts",
+          "sha": "1b510b9a89677153cc735c7cf19e7857a8041afd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.js",
+          "sha": "9b1c2e46cd927d4d136f5258cccf86c284323f06",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/api-interop.js",
+          "sha": "173fec2c28f37b0794c3d99ee825f448d2e0feb5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/cli-detection.d.ts",
+          "sha": "e7e64318064ff081d64c46329431aa84d78c16e6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/cli-detection.js",
+          "sha": "c888776f5dd23f0a8c308c232a8a6e8e3b603a96",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.d.ts",
+          "sha": "c0917254b69876cc0f2606a72207ccc7add56422",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.js",
+          "sha": "c64983b9fc1971d9137e4ec28629e45d6a855bbd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.d.ts",
+          "sha": "bf3bf3df71b7de87c223323ad722ad41a8f59968",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.js",
+          "sha": "0025e1c8bc8623d9314b8b62b7830601b37e6b01",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/recovery-request-store.js",
+          "sha": "e3fb2d64a651b2fc1a87983675f386df26e00a2c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.d.ts",
+          "sha": "72cf8fd8d88b4448338998efa3bee2a96ea1b8b6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.js",
+          "sha": "a7d74378c11897f807fe46aaa27557d2b22d1f6d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-owner-client.d.ts",
+          "sha": "b43b0014f8f85d2501d5e8927d8ecfd27494bd7c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-owner-client.js",
+          "sha": "e0a0ef8aa83f102c8b73faf820b1b15304cde317",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.d.ts",
+          "sha": "1bb3df95d62763b5f8a3c402da5b88f6961b208d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js",
+          "sha": "3e54048036e634cc4db722ff6fd0e596a160df6d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.d.ts",
+          "sha": "eb37efd21d30657c9f033e825d7243b31200267c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.js",
+          "sha": "4110f33f912a8cd6a5f19eff92cafd87e65ba308",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.d.ts",
+          "sha": "7e7609f312e1d0a6a14037599884685a8c7fc136",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.js",
+          "sha": "2a471f6e10ef55bc1ecd77d0958cad327f48004f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.d.ts",
+          "sha": "bac88247fe252b8687a5bdc0fa24b6d99846a615",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.js",
+          "sha": "d0d6cfded1f0d7ee3c9f907d5461e18b2512d7e9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.d.ts",
+          "sha": "a1005e1e0776bbf91254f47c3cc2f4348d64fdd6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.js",
+          "sha": "be59a54641b9b897cfd598b7adb9fee8e107173f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/team-ops.js",
+          "sha": "83a0b64aaa58ba4cf57bb1c7bc24e1b40a87e652",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.d.ts",
+          "sha": "bec002b8cd6bd994a143dfe10a7851d888eebfc9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.js",
+          "sha": "d0ac28cd1d9c73cf90e8553b79e16f9efa98189e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/types.d.ts",
+          "sha": "46ee046172aaa1797dcf1b5e605638e3a5f0984d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-activation-gate.d.ts",
+          "sha": "1c859924dca3241a9d78005fd770afcca1136db7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-activation-gate.js",
+          "sha": "742a328e10bcb3b5cd9b58a33bf83d2bd69c2e46",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-bootstrap.js",
+          "sha": "9c21df6f168369fded840fe21861fc59f66339ed",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/worker-launch-ack.d.ts",
+          "sha": "5f0d995ffa2e3a042a5b3b8ef07fde7905fe585a",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/worker-launch-ack.js",
+          "sha": "f6cc07162d36711731f71b9c6bdc7de9df5d80bc",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/ast-tools.js",
+          "sha": "e9178feecc64dfa22128a2154fa543503b22f983",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/index.d.ts",
+          "sha": "43547212ef0d18b0561467adedd23e9e8112d934",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/index.js",
+          "sha": "ce92d49a4e9843be5f6a00eb2a18ded784bd34af",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/servers.d.ts",
+          "sha": "7c0b7cc21f3b51e94f220177fc4644c592be6ec7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/lsp/servers.js",
+          "sha": "7b393f406fb42c8cd65c303f1daa8a7fe82e4f99",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/tools/state-tools.js",
+          "sha": "98dee70e3540923d615809515c65618c8dc74873",
+          "previousFilename": null
+        }
+      ]
     }
   ]
 }

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -247,6 +247,7 @@ describe('generated-artifact base trust root workflow', () => {
       [3538, 'dev'],
       [3539, 'dev'],
       [3541, 'dev'],
+      [3690, 'main'],
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',


### PR DESCRIPTION
## Summary

Add the base-owned generated-artifact authorization record for PR #3690 targeting main.

PR #3690 promotes the exact released v4.15.10 tree to main, resolving the marketplace symptom in issue #3676 (plugin users stuck on 4.15.7).

**Owner authority:** Discord 1537024580429021226 authorizes the exact v4.15.10 protected-main promotion.

## Authorization binding

| Field | Value |
|---|---|
| pullNumber | 3690 |
| targetRef | main |
| mergeBaseSha | `41a4c0f77144c5beb5f5f000a89cff379c680606` |
| headSha | `1a08dc0c2c64fc03bf14536524b297ad662d16ae` |
| generatedDelta.count | 84 |
| generatedDelta.sha256 | `32281aa849db09ae8d5b349bb6fc3b662386029aea2beec1ee9e2d8b6ab0dda5` |
| expiresAt | 2026-08-26T00:00:00.000Z |

All deterministic fields computed with the repository canonical verifier (`calculateGeneratedDelta` / `validateAuthorizationManifest`).

The manifest membership guard test is updated to include the new main-target record. No existing authorizations are modified.

—

*[repo owner's gaebal-gajae (clawdbot) 🦞]*