### PR TITLE
fix(security): harden live-data command execution

### DIFF
--- a/docs/superpowers/plans/2026-08-12-live-data-command-execution-hardening-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-12-live-data-command-execution-hardening-implementation-plan.md
@@ -1,0 +1,455 @@
+# Live-Data Command Execution Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent single-line live-data directives and substituted slash-command arguments from escaping an allowlisted executable into shell command execution.
+
+**Architecture:** Parse each single-line directive once into an executable and argument vector, authorize the parsed executable plus the original command text, and invoke it with `execFileSync` without a shell. Keep multi-line script blocks on their existing explicit shell path and keep cache/display keys based on the original command string.
+
+**Tech Stack:** TypeScript, Node.js `child_process`, Vitest, npm, ESLint, esbuild.
+
+## Global Constraints
+
+- Base feature work on `upstream/dev`; the repository contribution guide targets feature PRs to `dev`.
+- Add no production dependency.
+- Use TDD: every production behavior change must be preceded by a test that fails for the expected reason.
+- Keep multi-line live-data script-block behavior unchanged.
+- Preserve caching, conditions, output formatting, HTML escaping, timeout, and output-size behavior.
+- Use English for file names, documentation, tests, and code comments.
+- Do not commit generated `dist/` or `bridge/` artifacts in an ordinary PR; build them for verification, then restore them as required by `CONTRIBUTING.md`.
+- Keep the PR limited to the live-data command-execution vulnerability.
+
+---
+
+## File Structure
+
+- Modify `src/hooks/auto-slash-command/live-data.ts`: add the shell-free parser, pass the parsed executable into policy checks, and replace single-line `execSync` with `execFileSync`.
+- Modify `src/__tests__/live-data.test.ts`: add injection/parser regressions and update ordinary single-line expectations to the shell-free process API while preserving script-block expectations on `execSync`.
+- Create `src/__tests__/auto-slash-live-data-security.test.ts`: prove that `$ARGUMENTS` substitution cannot introduce a second command through a project-local slash command.
+- Verify but do not commit generated changes beneath `dist/` and `bridge/`.
+
+### Task 1: Secure single-line live-data execution
+
+**Files:**
+
+- Modify: `src/hooks/auto-slash-command/live-data.ts`
+- Modify: `src/__tests__/live-data.test.ts`
+- Create: `src/__tests__/auto-slash-live-data-security.test.ts`
+- Reference: `docs/superpowers/specs/2026-08-12-live-data-command-execution-hardening-design.md`
+
+**Interfaces:**
+
+- Consumes: the existing `SecurityPolicy`, `ParsedDirective`, `resolveLiveData(content: string): string`, and `executeSlashCommand(parsed: ParsedSlashCommand): ExecuteResult` contracts.
+- Produces internally: `ParsedCommandInvocation`, `CommandParseResult`, and `parseCommandInvocation(command: string): CommandParseResult`.
+- Preserves publicly: `resolveLiveData`, `isLiveDataLine`, `clearCache`, and `resetSecurityPolicy` signatures.
+
+- [ ] **Step 1: Rebase the documentation commits onto the current development branch**
+
+Add the canonical upstream remote if it is absent, fetch it, and rebase the feature branch before implementation:
+
+```bash
+git remote add upstream https://github.com/Yeachan-Heo/oh-my-claudecode.git  # only when absent
+git fetch upstream dev
+git rebase upstream/dev
+```
+
+Expected: `git merge-base --is-ancestor upstream/dev HEAD` exits 0, and the two design commits remain on `fix/live-data-command-injection`.
+
+- [ ] **Step 2: Install the reviewed dependency graph and establish a clean baseline**
+
+Run:
+
+```bash
+npm ci
+npm run test:run -- src/__tests__/live-data.test.ts src/__tests__/auto-slash-aliases.test.ts
+```
+
+Expected: dependency installation succeeds and the existing targeted tests pass before the new regression tests are added. If the baseline fails, stop and investigate rather than attributing failures to this change.
+
+- [ ] **Step 3: Add failing shell-control regression tests**
+
+In `src/__tests__/live-data.test.ts`, add a table-driven test under `resolveLiveData - security`:
+
+```ts
+it.each([
+  ['semicolon', 'git status; node -e "process.exit(99)"'],
+  ['background', 'git status & node -e "process.exit(99)"'],
+  ['and', 'git status && node -e "process.exit(99)"'],
+  ['or', 'git status || node -e "process.exit(99)"'],
+  ['pipe', 'git status | node -e "process.exit(99)"'],
+  ['input redirect', 'git status < secrets.txt'],
+  ['output redirect', 'git status > stolen.txt'],
+  ['carriage return', 'git status\rnode -e "process.exit(99)"'],
+  ['backticks', 'git status `node -e "process.exit(99)"`'],
+  ['command substitution', 'git status $(node -e "process.exit(99)")'],
+])('blocks %s shell syntax before process execution', (_name, command) => {
+  setupPolicy({ allowed_commands: ['git'] });
+
+  const result = resolveLiveData(`!${command}`);
+
+  expect(result).toContain('error="true"');
+  expect(result).toContain('blocked:');
+  expect(mockedExecSync).not.toHaveBeenCalled();
+  expect(mockedExecFileSync).not.toHaveBeenCalled();
+});
+```
+
+Add malformed-input cases:
+
+```ts
+it.each([
+  ['unterminated single quote', "echo 'unterminated"],
+  ['unterminated double quote', 'echo "unterminated'],
+  ['trailing escape', 'echo trailing\\'],
+])('fails closed for %s', (_name, command) => {
+  setupPolicy({ allowed_commands: ['echo'] });
+  const result = resolveLiveData(`!${command}`);
+  expect(result).toContain('error="true"');
+  expect(mockedExecSync).not.toHaveBeenCalled();
+  expect(mockedExecFileSync).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 4: Add a failing `$ARGUMENTS` end-to-end regression test**
+
+Create `src/__tests__/auto-slash-live-data-security.test.ts` with an isolated project command and real policy files:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as childProcess from 'child_process';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+  };
+});
+
+const mockedExecSync = vi.mocked(childProcess.execSync);
+const mockedExecFileSync = vi.mocked(childProcess.execFileSync);
+const originalCwd = process.cwd();
+const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+let projectDir: string;
+let configDir: string;
+
+describe('auto slash live-data security', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    projectDir = join(tmpdir(), `omc-live-data-project-${process.pid}-${Date.now()}`);
+    configDir = join(tmpdir(), `omc-live-data-config-${process.pid}-${Date.now()}`);
+    mkdirSync(join(projectDir, '.claude', 'commands'), { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n!git status $ARGUMENTS\n',
+    );
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['git'] }),
+    );
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('blocks shell syntax introduced through $ARGUMENTS', async () => {
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '; node -e "process.exit(99)"',
+      raw: '/live-test ; node -e "process.exit(99)"',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked:');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 5: Run the new tests and verify RED**
+
+Run:
+
+```bash
+npm run test:run -- src/__tests__/live-data.test.ts src/__tests__/auto-slash-live-data-security.test.ts
+```
+
+Expected: the new injection tests fail because `execSync` executes the complete shell string. Confirm the failure is behavioral—not a fixture, import, or syntax error—before writing production code.
+
+- [ ] **Step 6: Add the minimal shell-free parser**
+
+In `src/hooks/auto-slash-command/live-data.ts`, remove `WHITESPACE_SPLIT_PATTERN` and add these internal result types near the other types:
+
+```ts
+interface ParsedCommandInvocation {
+  executable: string;
+  args: string[];
+}
+
+type CommandParseResult =
+  | { ok: true; invocation: ParsedCommandInvocation }
+  | { ok: false; reason: string };
+```
+
+Add `parseCommandInvocation(command: string): CommandParseResult` before the security-policy functions. Implement one left-to-right state machine with:
+
+```ts
+let quote: 'single' | 'double' | null = null;
+let escaped = false;
+let tokenStarted = false;
+let token = '';
+const tokens: string[] = [];
+```
+
+For each character:
+
+1. Treat unquoted space and tab as token boundaries.
+2. Preserve characters inside single quotes literally until the closing quote.
+3. In double quotes, support backslash escaping but reject backticks and `$(`.
+4. Outside quotes, support backslash escaping; reject backticks, `$(`, and any character in `;&|<>`.
+5. Reject ASCII control characters other than an unquoted delimiter tab.
+6. Track `tokenStarted` so `''` and `""` produce an empty argument.
+7. At EOF, reject a pending escape or open quote, flush the final token, and reject an empty token list.
+
+Return stable reasons such as `empty command`, `unterminated single quote`, `unterminated double quote`, `trailing escape`, `control character rejected`, `command substitution rejected`, or `shell operator rejected: ;`.
+
+- [ ] **Step 7: Authorize the parsed executable instead of a whitespace prefix**
+
+Change the security helper to accept the parsed executable:
+
+```ts
+function checkSecurity(
+  command: string,
+  executable: string,
+): { allowed: boolean; reason?: string } {
+  const policy = loadSecurityPolicy();
+  // denied_patterns continue to inspect command
+  // denied_commands and allowed_commands compare executable
+}
+```
+
+Keep `allowed_patterns` and `denied_patterns` on the original command string and retain the existing `safe-regex` checks. For multi-line script blocks, call `checkSecurity(block.shell, block.shell)` so their behavior remains unchanged.
+
+- [ ] **Step 8: Replace single-line shell execution with `execFileSync`**
+
+Change the single-line executor to consume the parsed invocation:
+
+```ts
+function executeCommand(
+  invocation: ParsedCommandInvocation,
+): { stdout: string; error: boolean } {
+  try {
+    const stdout = execFileSync(invocation.executable, invocation.args, {
+      shell: false,
+      timeout: TIMEOUT_MS,
+      maxBuffer: MAX_OUTPUT_BYTES + 1024,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    // retain the existing truncation logic
+  } catch (err: unknown) {
+    // retain the existing stderr/message handling
+  }
+}
+```
+
+In `resolveLiveData`, parse `directive.command` before `checkSecurity`. On parse failure, emit the existing escaped blocked-result shape and continue. On success, retain the parsed invocation and pass it to every `executeCommand` branch. Do not reparse per cache/condition branch.
+
+- [ ] **Step 9: Update existing single-line test expectations without changing script-block coverage**
+
+For ordinary single-line tests, return output from `mockedExecFileSync` and assert executable plus argv, for example:
+
+```ts
+mockedExecFileSync.mockReturnValue('hello world\n');
+const result = resolveLiveData('!echo hello');
+expect(result).toBe('<live-data command="echo hello">hello world\n</live-data>');
+expect(mockedExecFileSync).toHaveBeenCalledWith(
+  'echo',
+  ['hello'],
+  expect.objectContaining({ shell: false, timeout: 10_000, windowsHide: true }),
+);
+expect(mockedExecSync).not.toHaveBeenCalled();
+```
+
+Add argv parsing coverage:
+
+```ts
+it('parses quoted, escaped, and empty arguments without a shell', () => {
+  mockedExecFileSync.mockReturnValue('ok\n');
+  resolveLiveData(`!echo "two words" 'literal $HOME' escaped\\ space ""`);
+  expect(mockedExecFileSync).toHaveBeenCalledWith(
+    'echo',
+    ['two words', 'literal $HOME', 'escaped space', ''],
+    expect.objectContaining({ shell: false }),
+  );
+});
+
+it('keeps quoted shell metacharacters as literal argument data', () => {
+  mockedExecFileSync.mockReturnValue('ok\n');
+  resolveLiveData('!echo "; & | < >"');
+  expect(mockedExecFileSync).toHaveBeenCalledWith(
+    'echo',
+    ['; & | < >'],
+    expect.objectContaining({ shell: false }),
+  );
+});
+```
+
+Update the existing tag-injection test so `<`, `>`, and `&` occur inside one quoted argument; its purpose is markup escaping, not shell syntax. Keep all multi-line script tests on `mockedExecSync`, including the `input` body assertion.
+
+- [ ] **Step 10: Run targeted tests and verify GREEN**
+
+Run:
+
+```bash
+npm run test:run -- src/__tests__/live-data.test.ts src/__tests__/auto-slash-live-data-security.test.ts src/__tests__/auto-slash-aliases.test.ts
+```
+
+Expected: all targeted tests pass, single-line assertions use `execFileSync`, script-block assertions use `execSync`, and output contains no unexpected warnings.
+
+- [ ] **Step 11: Refactor only after GREEN**
+
+Remove duplicated blocked-result construction only if a tiny helper makes parser and policy failures clearer. Keep parsing, authorization, execution, and formatting as distinct functions. Do not extract a general shell library or change public exports.
+
+Re-run the targeted test command after refactoring and require the same green result.
+
+- [ ] **Step 12: Commit the implementation task**
+
+Run:
+
+```bash
+git add src/hooks/auto-slash-command/live-data.ts \
+  src/__tests__/live-data.test.ts \
+  src/__tests__/auto-slash-live-data-security.test.ts
+git commit -m "fix(security): harden live-data command execution"
+```
+
+Expected: one focused implementation commit containing source and tests, with no generated artifacts.
+
+### Task 2: Verify repository integration and PR hygiene
+
+**Files:**
+
+- Verify: all source and test files from Task 1
+- Temporarily generate, then restore: `dist/`, `bridge/`
+- Modify only if a verification or independent review identifies a defect: Task 1 files
+
+**Interfaces:**
+
+- Consumes: the completed Task 1 commit and repository build scripts.
+- Produces: fresh verification evidence and a review-ready branch with no generated-artifact delta.
+
+- [ ] **Step 1: Run static checks and the full test suite**
+
+Run:
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run test:run
+```
+
+Expected: all commands exit 0. Record exact test counts from Vitest output for the final report.
+
+- [ ] **Step 2: Build and verify the shipped surface**
+
+Run:
+
+```bash
+npm run build
+npm run plugin:shipping:verify
+```
+
+Expected: both commands exit 0 and generated code contains the shell-free execution path.
+
+- [ ] **Step 3: Restore ordinary-PR generated artifacts and confirm the source diff remains intact**
+
+Run:
+
+```bash
+git restore dist/ bridge/
+git status --short
+git diff upstream/dev...HEAD --check
+```
+
+Expected: `dist/` and `bridge/` are absent from status; only the approved design/plan and Task 1 source/test commits differ from `upstream/dev`.
+
+- [ ] **Step 4: Request an independent code and security review**
+
+Provide the reviewer with:
+
+```text
+DESCRIPTION: Replaced shell-backed single-line live-data execution with parsed argv and execFileSync; added shell-operator and $ARGUMENTS regressions.
+PLAN: docs/superpowers/plans/2026-08-12-live-data-command-execution-hardening-implementation-plan.md
+BASE_SHA: upstream/dev
+HEAD_SHA: current feature HEAD
+```
+
+Require the reviewer to verify spec compliance first, then inspect parser edge cases, process API use, pattern authorization, output escaping, and unchanged multi-line script behavior. Fix every Critical or Important finding using a new RED/GREEN cycle, then request review again.
+
+- [ ] **Step 5: Run final fresh verification after all review fixes**
+
+Run again on the exact tree to be pushed:
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run test:run
+npm run build
+npm run plugin:shipping:verify
+git restore dist/ bridge/
+git diff upstream/dev...HEAD --check
+git status --short --branch
+```
+
+Expected: every command exits 0, generated artifacts are restored, and the worktree is clean.
+
+- [ ] **Step 6: Prepare the PR**
+
+Use title:
+
+```text
+fix(security): harden live-data command execution
+```
+
+The PR body must include:
+
+```markdown
+## Summary
+- execute single-line live-data commands without a shell
+- reject shell control syntax before policy authorization
+- cover direct and `$ARGUMENTS`-based command injection
+
+## Security impact
+An `allowed_commands` entry previously authorized only the first token while `execSync` executed the complete string, allowing appended commands to run with the OMC process privileges.
+
+## Testing
+- `npm run lint`
+- `npx tsc --noEmit`
+- `npm run test:run`
+- `npm run build`
+- `npm run plugin:shipping:verify`
+```
+
+Push `fix/live-data-command-injection` to the contributor fork and create the PR against `Yeachan-Heo/oh-my-claudecode:dev`. Keep the working branch for review feedback.

--- a/docs/superpowers/specs/2026-08-12-live-data-command-execution-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-12-live-data-command-execution-hardening-design.md
@@ -51,7 +51,7 @@ The parser rejects:
 
 - empty commands;
 - unterminated quotes or a trailing escape;
-- unquoted `;`, `&&`, `||`, `|`, `<`, and `>`;
+- unquoted `;`, `&`, `&&`, `||`, `|`, `<`, and `>`;
 - CR, LF, NUL, and other ASCII control characters;
 - backtick command substitution;
 - `$(` command substitution outside single-quoted literal text.

--- a/docs/superpowers/specs/2026-08-12-live-data-command-execution-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-12-live-data-command-execution-hardening-design.md
@@ -1,0 +1,137 @@
+# Live-Data Command Execution Hardening Design
+
+## Summary
+
+The live-data command allowlist currently authorizes only the first whitespace-delimited token but executes the complete directive through a shell. A directive such as `!git status; attacker-command` therefore passes an `allowed_commands: ["git"]` policy and executes both commands. Slash-command `$ARGUMENTS` substitution can introduce the same payload into an otherwise trusted command template.
+
+This change makes every single-line live-data directive shell-free. It parses an authorized directive into an executable and argument vector, then invokes `execFileSync` without a shell. Shell control syntax is rejected before authorization or execution.
+
+## Goals
+
+- Prevent shell-command injection through live-data directives and substituted slash-command arguments.
+- Preserve ordinary live-data commands, quoted arguments, caching, conditions, output formatting, and existing security-policy fields.
+- Fail closed on malformed quoting, shell control operators, command substitution, and control characters.
+- Add no production dependency.
+- Keep the patch focused on the confirmed live-data vulnerability.
+
+## Non-Goals
+
+- Changing multi-line live-data script-block behavior. Script blocks explicitly authorize and invoke a shell interpreter and remain outside this focused fix.
+- Fixing the separately identified team-state path traversal, project-memory isolation, notification-secret handling, updater, CI pinning, or dependency advisories.
+- Providing a general POSIX shell parser or preserving shell expansion in single-line directives.
+
+## Threat Model
+
+The attacker controls all or part of a slash-command argument or project command template. The operator has configured `allowed_commands` or `allowed_patterns` for ordinary live-data commands. The attacker attempts to append a second command, redirect data, create a pipeline, or invoke command substitution while retaining an allowed first executable.
+
+The security boundary is the live-data policy plus the new shell-free parser. An allowed executable may still perform dangerous operations through its own legitimate arguments; that remains the policy author's responsibility. The fix guarantees that the authorization of one executable cannot implicitly authorize an additional shell program.
+
+## Design
+
+### Shell-Free Command Parser
+
+Add an internal parser in `src/hooks/auto-slash-command/live-data.ts` that converts a command string into:
+
+```ts
+interface ParsedCommandInvocation {
+  executable: string;
+  args: string[];
+}
+```
+
+The parser supports:
+
+- unquoted arguments separated by ASCII whitespace;
+- single-quoted literal arguments;
+- double-quoted arguments;
+- backslash escaping for the following character;
+- empty quoted arguments.
+
+The parser rejects:
+
+- empty commands;
+- unterminated quotes or a trailing escape;
+- unquoted `;`, `&&`, `||`, `|`, `<`, and `>`;
+- CR, LF, NUL, and other ASCII control characters;
+- backtick command substitution;
+- `$(` command substitution outside single-quoted literal text.
+
+Quoted shell metacharacters are ordinary argument content. Environment-variable expansion, glob expansion, tilde expansion, and command substitution do not occur because no shell is started.
+
+### Authorization Flow
+
+For single-line directives:
+
+1. Parse the directive command into an executable and arguments.
+2. If parsing fails, render a blocked live-data result and do not call a process API.
+3. Apply `denied_patterns` to the original command string.
+4. Apply `denied_commands` to the parsed executable.
+5. Authorize when either `allowed_commands` contains the executable or a safe `allowed_patterns` expression matches the original command string.
+6. Execute only the parsed executable and argument vector.
+
+This preserves both policy mechanisms while ensuring neither mechanism can re-enable shell interpretation.
+
+### Execution
+
+Replace shell-backed `execSync(command, options)` for single-line directives with:
+
+```ts
+execFileSync(invocation.executable, invocation.args, {
+  shell: false,
+  timeout: TIMEOUT_MS,
+  maxBuffer: MAX_OUTPUT_BYTES + 1024,
+  encoding: "utf-8",
+  stdio: ["pipe", "pipe", "pipe"],
+  windowsHide: true,
+});
+```
+
+The existing output truncation and error rendering remain unchanged. Cache keys and displayed command text continue to use the original normalized command so observable output remains stable.
+
+### Multi-Line Script Blocks
+
+Multi-line script blocks keep their current execution path. They are an explicitly shell-oriented feature: the policy author must allow the named interpreter, and the block body is intentionally supplied on standard input. This PR does not broaden or redesign that trust model.
+
+## Error Handling
+
+Parser failures return an escaped `<live-data ... error="true">` result beginning with `blocked:` and a stable reason. No process invocation occurs. Process failures continue to surface captured stderr or the thrown error message, using the existing HTML escaping and output-size limit.
+
+The implementation must not echo unescaped directive content or error text into markup.
+
+## Compatibility
+
+Ordinary commands such as `git status`, `git log --oneline`, and `echo "hello world"` remain supported. Single-line directives that depend on shell pipelines, redirection, chaining, command substitution, variable expansion, globbing, or tilde expansion stop working and fail closed.
+
+A repository search found no committed live-data command templates or policies that rely on those shell features. The compatibility impact is therefore limited to downstream user-authored templates.
+
+## Testing
+
+Use test-driven development in `src/__tests__/live-data.test.ts`:
+
+- prove the current implementation executes an appended `;` payload;
+- cover `&&`, `||`, pipe, redirects, newline, backticks, and `$()` as blocked inputs;
+- verify no process API is called for blocked inputs;
+- verify ordinary arguments, quoted arguments, escaped whitespace, and empty quoted arguments become the expected `execFileSync` argv;
+- verify quoted metacharacters remain literal argument data;
+- verify malformed quotes and trailing escapes fail closed;
+- preserve denied-command, denied-pattern, allowed-command, allowed-pattern, cache, condition, formatting, truncation, and error behavior;
+- add an executor-level regression proving injected `$ARGUMENTS` cannot trigger a second command.
+
+After the targeted red-green cycle, run lint, TypeScript compilation, the full unit suite, the build, and generated-artifact verification required by the repository.
+
+## Files Expected to Change
+
+- `src/hooks/auto-slash-command/live-data.ts`: parser, authorization result, and shell-free execution.
+- `src/__tests__/live-data.test.ts`: parser and injection regression coverage.
+- The narrowest existing executor test file that can cover `$ARGUMENTS` substitution, if the behavior is not already covered through `resolveLiveData`.
+- Generated bridge artifacts only when the repository build identifies them as derived from the modified source.
+
+## Security Properties
+
+The completed change must establish all of the following:
+
+- an `allowed_commands` entry authorizes exactly one executable invocation;
+- `allowed_patterns` cannot restore shell parsing;
+- attacker-controlled arguments cannot add a second process through shell syntax;
+- blocked directives never reach `execSync`, `execFileSync`, or another process API;
+- normal authorized commands retain timeout, output-limit, escaping, and error semantics.

--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as childProcess from 'child_process';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../lib/worktree-paths.js', () => ({
+  getWorktreeRoot: () => null,
+  getOmcRoot: () => `${process.cwd()}/.omc`,
+}));
+
+const mockedExecSync = vi.mocked(childProcess.execSync);
+const mockedExecFileSync = vi.mocked(childProcess.execFileSync);
+const originalCwd = process.cwd();
+const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+let projectDir: string;
+let configDir: string;
+
+describe('auto slash live-data security', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    projectDir = join(tmpdir(), `omc-live-data-project-${process.pid}-${Date.now()}`);
+    configDir = join(tmpdir(), `omc-live-data-config-${process.pid}-${Date.now()}`);
+    mkdirSync(join(projectDir, '.claude', 'commands'), { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n!git status $ARGUMENTS\n',
+    );
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['git'] }),
+    );
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('blocks shell syntax introduced through $ARGUMENTS', async () => {
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '; node -e "process.exit(99)"',
+      raw: '/live-test ; node -e "process.exit(99)"',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked:');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -71,4 +71,44 @@ describe('auto slash live-data security', () => {
     expect(mockedExecSync).not.toHaveBeenCalled();
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['line feed', '\n!git status'],
+    ['carriage return', '\r!git status'],
+  ])('blocks a live-data directive introduced through $ARGUMENTS with %s', async (_name, args) => {
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args,
+      raw: `/live-test ${args}`,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: control character rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('blocks a script block introduced through $ARGUMENTS', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['git', 'bash'] }),
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const args = '\n!begin-script bash\nnode -e "process.exit(99)"\n!end-script';
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args,
+      raw: `/live-test ${args}`,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: control character rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -56,14 +56,19 @@ describe('isLiveDataLine', () => {
 
 describe('resolveLiveData - basic', () => {
   it('replaces a basic !command with live-data output', () => {
-    mockedExecSync.mockReturnValue('hello world\n');
+    mockedExecFileSync.mockReturnValue('hello world\n');
     const result = resolveLiveData('!echo hello');
     expect(result).toBe('<live-data command="echo hello">hello world\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledWith('echo hello', expect.objectContaining({ timeout: 10_000 }));
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['hello'],
+      expect.objectContaining({ shell: false, timeout: 10_000, windowsHide: true }),
+    );
+    expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
   it('handles multiple commands', () => {
-    mockedExecSync.mockReturnValueOnce('output1\n').mockReturnValueOnce('output2\n');
+    mockedExecFileSync.mockReturnValueOnce('output1\n').mockReturnValueOnce('output2\n');
     const input = 'before\n!cmd1\nmiddle\n!cmd2\nafter';
     const result = resolveLiveData(input);
     expect(result).toContain('<live-data command="cmd1">output1\n</live-data>');
@@ -74,12 +79,12 @@ describe('resolveLiveData - basic', () => {
   });
 
   it('skips !lines inside code blocks', () => {
-    mockedExecSync.mockReturnValue('ran\n');
+    mockedExecFileSync.mockReturnValue('ran\n');
     const input = '```\n!echo skip-me\n```\n!echo run-me';
     const result = resolveLiveData(input);
     expect(result).toContain('!echo skip-me');
     expect(result).toContain('<live-data command="echo run-me">ran\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('skips !lines inside an unclosed/unterminated fenced code block', () => {
@@ -103,39 +108,39 @@ describe('resolveLiveData - basic', () => {
   it('handles failed commands with error attribute', () => {
     const error = new Error('command failed') as Error & { stderr: string };
     error.stderr = 'permission denied\n';
-    mockedExecSync.mockImplementation(() => { throw error; });
+    mockedExecFileSync.mockImplementation(() => { throw error; });
     const result = resolveLiveData('!bad-cmd');
     expect(result).toBe('<live-data command="bad-cmd" error="true">permission denied\n</live-data>');
   });
 
   it('handles timeout errors', () => {
-    mockedExecSync.mockImplementation(() => { throw new Error('ETIMEDOUT'); });
+    mockedExecFileSync.mockImplementation(() => { throw new Error('ETIMEDOUT'); });
     const result = resolveLiveData('!slow-cmd');
     expect(result).toContain('error="true"');
     expect(result).toContain('ETIMEDOUT');
   });
 
   it('truncates output exceeding 50KB', () => {
-    mockedExecSync.mockReturnValue('x'.repeat(60 * 1024));
+    mockedExecFileSync.mockReturnValue('x'.repeat(60 * 1024));
     const result = resolveLiveData('!big-cmd');
     expect(result).toContain('[output truncated at 50KB]');
     expect(result).toContain('<live-data command="big-cmd">');
   });
 
   it('handles empty output', () => {
-    mockedExecSync.mockReturnValue('');
+    mockedExecFileSync.mockReturnValue('');
     const result = resolveLiveData('!empty-cmd');
     expect(result).toBe('<live-data command="empty-cmd"></live-data>');
   });
 
   it('does not re-scan output for ! prefixes', () => {
-    mockedExecSync.mockReturnValue('!nested-cmd\n');
+    mockedExecFileSync.mockReturnValue('!nested-cmd\n');
     resolveLiveData('!echo nested');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('handles indented !commands', () => {
-    mockedExecSync.mockReturnValue('output\n');
+    mockedExecFileSync.mockReturnValue('output\n');
     const result = resolveLiveData('  !git diff');
     expect(result).toContain('<live-data command="git diff">');
   });
@@ -152,31 +157,31 @@ describe('resolveLiveData - basic', () => {
 
 describe('resolveLiveData - caching', () => {
   it('caches output with !cache directive', () => {
-    mockedExecSync.mockReturnValue('log output\n');
+    mockedExecFileSync.mockReturnValue('log output\n');
     const input = '!cache 300s git log -10';
 
     const result1 = resolveLiveData(input);
     expect(result1).toContain('<live-data command="git log -10">log output\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
 
     // Second call should use cache
     const result2 = resolveLiveData(input);
     expect(result2).toContain('cached="true"');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1); // no additional call
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1); // no additional call
   });
 
   it('uses default TTL for known commands like git status', () => {
-    mockedExecSync.mockReturnValue('clean\n');
+    mockedExecFileSync.mockReturnValue('clean\n');
 
     resolveLiveData('!git status');
     resolveLiveData('!git status');
 
     // git status has default TTL of 1s, should be cached within same tick
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('expires cache after TTL', () => {
-    mockedExecSync.mockReturnValue('output\n');
+    mockedExecFileSync.mockReturnValue('output\n');
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValueOnce(now).mockReturnValueOnce(now + 400_000);
 
@@ -184,18 +189,18 @@ describe('resolveLiveData - caching', () => {
     resolveLiveData('!cache 300s mycommand');
 
     // Cache expired (400s > 300s), so command runs again
-    expect(mockedExecSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
     vi.restoreAllMocks();
   });
 
   it('clearCache resets all caches', () => {
-    mockedExecSync.mockReturnValue('out\n');
+    mockedExecFileSync.mockReturnValue('out\n');
     resolveLiveData('!cache 300s cached-cmd');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
 
     clearCache();
     resolveLiveData('!cache 300s cached-cmd');
-    expect(mockedExecSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -217,12 +222,13 @@ describe('resolveLiveData - conditional', () => {
   });
 
   it('!if-modified executes when files match', () => {
-    mockedExecFileSync.mockReturnValueOnce('src/main.ts\nREADME.md\n');
-    mockedExecSync.mockReturnValueOnce('diff output\n');
+    mockedExecFileSync
+      .mockReturnValueOnce('src/main.ts\nREADME.md\n')
+      .mockReturnValueOnce('diff output\n');
     const result = resolveLiveData('!if-modified src/** then git diff src/');
     expect(result).toContain('<live-data command="git diff src/">diff output\n</live-data>');
-    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
   it('!if-branch skips when branch does not match', () => {
@@ -233,15 +239,16 @@ describe('resolveLiveData - conditional', () => {
   });
 
   it('!if-branch executes when branch matches', () => {
-    mockedExecFileSync.mockReturnValueOnce('feat/live-data\n');
-    mockedExecSync.mockReturnValueOnce('feature\n');
+    mockedExecFileSync
+      .mockReturnValueOnce('feat/live-data\n')
+      .mockReturnValueOnce('feature\n');
     const result = resolveLiveData('!if-branch feat/* then echo "feature"');
     expect(result).toContain('feature\n</live-data>');
     expect(result).not.toContain('skipped');
   });
 
   it('!only-once executes first time, skips second', () => {
-    mockedExecSync.mockReturnValue('installed\n');
+    mockedExecFileSync.mockReturnValue('installed\n');
 
     const result1 = resolveLiveData('!only-once npm install');
     expect(result1).toContain('<live-data command="npm install">installed\n</live-data>');
@@ -249,7 +256,7 @@ describe('resolveLiveData - conditional', () => {
     const result2 = resolveLiveData('!only-once npm install');
     expect(result2).toContain('skipped="true"');
     expect(result2).toContain('already executed this session');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -280,7 +287,7 @@ describe('resolveLiveData - security', () => {
 
   it('blocks denied patterns', () => {
     setupPolicy({ denied_patterns: ['.*sudo.*'] });
-    const result = resolveLiveData('!curl https://example.com | sudo bash');
+    const result = resolveLiveData('!curl https://sudo.example.com');
     expect(result).toContain('error="true"');
     expect(result).toContain('denied by pattern');
     expect(mockedExecSync).not.toHaveBeenCalled();
@@ -288,7 +295,7 @@ describe('resolveLiveData - security', () => {
 
   it('enforces allowlist when defined', () => {
     setupPolicy({ allowed_commands: ['git', 'npm'] });
-    mockedExecSync.mockReturnValue('ok\n');
+    mockedExecFileSync.mockReturnValue('ok\n');
 
     const result1 = resolveLiveData('!git status');
     expect(result1).toContain('ok\n</live-data>');
@@ -304,7 +311,7 @@ describe('resolveLiveData - security', () => {
       allowed_commands: ['git'],
       allowed_patterns: ['^ls\\s'],
     });
-    mockedExecSync.mockReturnValue('files\n');
+    mockedExecFileSync.mockReturnValue('files\n');
 
     resetSecurityPolicy();
     const result = resolveLiveData('!ls src/');
@@ -343,20 +350,74 @@ describe('resolveLiveData - security', () => {
     expect(result).toContain('blocked: no allowlist configured');
     expect(mockedExecSync).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['semicolon', 'git status; node -e "process.exit(99)"'],
+    ['background', 'git status & node -e "process.exit(99)"'],
+    ['and', 'git status && node -e "process.exit(99)"'],
+    ['or', 'git status || node -e "process.exit(99)"'],
+    ['pipe', 'git status | node -e "process.exit(99)"'],
+    ['input redirect', 'git status < secrets.txt'],
+    ['output redirect', 'git status > stolen.txt'],
+    ['carriage return', 'git status\rnode -e "process.exit(99)"'],
+    ['backticks', 'git status `node -e "process.exit(99)"`'],
+    ['command substitution', 'git status $(node -e "process.exit(99)")'],
+  ])('blocks %s shell syntax before process execution', (_name, command) => {
+    setupPolicy({ allowed_commands: ['git'] });
+
+    const result = resolveLiveData(`!${command}`);
+
+    expect(result).toContain('error="true"');
+    expect(result).toContain('blocked:');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unterminated single quote', "echo 'unterminated"],
+    ['unterminated double quote', 'echo "unterminated'],
+    ['trailing escape', 'echo trailing\\'],
+  ])('fails closed for %s', (_name, command) => {
+    setupPolicy({ allowed_commands: ['echo'] });
+    const result = resolveLiveData(`!${command}`);
+    expect(result).toContain('error="true"');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('parses quoted, escaped, and empty arguments without a shell', () => {
+    mockedExecFileSync.mockReturnValue('ok\n');
+    resolveLiveData(`!echo "two words" 'literal $HOME' escaped\\ space ""`);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['two words', 'literal $HOME', 'escaped space', ''],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
+  it('keeps quoted shell metacharacters as literal argument data', () => {
+    mockedExecFileSync.mockReturnValue('ok\n');
+    resolveLiveData('!echo "; & | < >"');
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['; & | < >'],
+      expect.objectContaining({ shell: false }),
+    );
+  });
 });
 
 // ─── Output Parsing ──────────────────────────────────────────────────────────
 
 describe('resolveLiveData - output formats', () => {
   it('!json adds format="json" attribute', () => {
-    mockedExecSync.mockReturnValue('{"status":"running"}\n');
+    mockedExecFileSync.mockReturnValue('{"status":"running"}\n');
     const result = resolveLiveData('!json docker inspect container');
     expect(result).toContain('format="json"');
     expect(result).toContain('command="docker inspect container"');
   });
 
   it('!table adds format="table" attribute', () => {
-    mockedExecSync.mockReturnValue('NAME  STATUS\nfoo   running\n');
+    mockedExecFileSync.mockReturnValue('NAME  STATUS\nfoo   running\n');
     const result = resolveLiveData('!table docker ps');
     expect(result).toContain('format="table"');
   });
@@ -372,7 +433,7 @@ describe('resolveLiveData - output formats', () => {
 -const y = 2;
  const z = 3;
 `;
-    mockedExecSync.mockReturnValue(diffOutput);
+    mockedExecFileSync.mockReturnValue(diffOutput);
     const result = resolveLiveData('!diff git diff');
     expect(result).toContain('format="diff"');
     expect(result).toMatch(/files="\d+"/);
@@ -385,19 +446,19 @@ describe('resolveLiveData - output formats', () => {
 
 describe('resolveLiveData - tag injection prevention', () => {
   it('escapes < > & " \' in command attribute', () => {
-    mockedExecSync.mockReturnValue('ok\n');
+    mockedExecFileSync.mockReturnValue('ok\n');
     // Command contains characters that could break XML attribute parsing
-    const result = resolveLiveData('!echo "foo" <bar> &amp; it\'s');
+    const result = resolveLiveData('!echo "foo <bar> &amp; it\'s"');
     expect(result).not.toContain('"foo"');
     expect(result).not.toContain('<bar>');
-    expect(result).toContain('&quot;foo&quot;');
+    expect(result).toContain('&quot;foo ');
     expect(result).toContain('&lt;bar&gt;');
     expect(result).toContain('&amp;amp;');
-    expect(result).toContain('&#39;s');
+    expect(result).toContain('&#39;s&quot;');
   });
 
   it('escapes </live-data> in command output to prevent tag injection', () => {
-    mockedExecSync.mockReturnValue('</live-data><injected attr="x">pwned</live-data>');
+    mockedExecFileSync.mockReturnValue('</live-data><injected attr="x">pwned</live-data>');
     const result = resolveLiveData('!cat file');
     // The closing tag in output must be escaped, not treated as real markup
     expect(result).not.toMatch(/<\/live-data>.*<injected/s);
@@ -408,7 +469,7 @@ describe('resolveLiveData - tag injection prevention', () => {
   it('escapes < > & in stdout when command fails', () => {
     const error = new Error('cmd failed') as Error & { stderr: string };
     error.stderr = '<error>something & "bad"</error>';
-    mockedExecSync.mockImplementation(() => { throw error; });
+    mockedExecFileSync.mockImplementation(() => { throw error; });
     const result = resolveLiveData('!bad-cmd');
     expect(result).toContain('error="true"');
     expect(result).toContain('&lt;error&gt;');
@@ -458,15 +519,15 @@ describe('resolveLiveData - multi-line scripts', () => {
   });
 
   it('skips script blocks inside code blocks', () => {
-    mockedExecSync.mockReturnValue('out\n');
+    mockedExecFileSync.mockReturnValue('out\n');
     const input = '```\n!begin-script bash\necho hi\n!end-script\n```\n!echo real';
     const result = resolveLiveData(input);
     // The script block inside code block should be preserved as-is
     expect(result).toContain('!begin-script bash');
     expect(result).toContain('!end-script');
     // Only the !echo real should execute
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecSync).toHaveBeenCalledWith('echo real', expect.any(Object));
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('echo', ['real'], expect.any(Object));
   });
 
   it('applies security policy to scripts', () => {

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -244,6 +244,21 @@ function resolveArguments(content: string, args: string): string {
   return content.replace(/\$ARGUMENTS/g, args || '(no arguments provided)');
 }
 
+function hasLiveDataArgumentsPlaceholder(content: string): boolean {
+  return content.includes('$ARGUMENTS')
+    && content.split('\n').some((line) => /^\s*!/.test(line));
+}
+
+function validateLiveDataArguments(args: string): string | null {
+  for (const char of args) {
+    const code = char.charCodeAt(0);
+    if ((code < 32 && char !== '\t') || code === 127) {
+      return 'control character rejected';
+    }
+  }
+  return null;
+}
+
 function hasInvocationFlag(args: string, flag: string): boolean {
   const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(`(^|\\s)${escaped}(?=\\s|$)`).test(args);
@@ -289,6 +304,12 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   const displayArgs = isDeepInterviewAutoresearch
     ? stripInvocationFlag(args, '--autoresearch')
     : args;
+  const liveDataArgumentError = hasLiveDataArgumentsPlaceholder(cmd.content || '')
+    ? validateLiveDataArguments(displayArgs)
+    : null;
+  const renderedArgs = liveDataArgumentError
+    ? `[blocked: ${liveDataArgumentError}]`
+    : displayArgs;
 
   sections.push(`<command-name>/${cmd.name}</command-name>\n`);
 
@@ -296,8 +317,8 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
     sections.push(`**Description**: ${cmd.metadata.description}\n`);
   }
 
-  if (displayArgs) {
-    sections.push(`**Arguments**: ${displayArgs}\n`);
+  if (renderedArgs) {
+    sections.push(`**Arguments**: ${renderedArgs}\n`);
   }
 
   if (cmd.metadata.model) {
@@ -320,7 +341,9 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
 
   // Resolve arguments in content, then execute any live-data commands
   const resolvedContent = resolveArguments(cmd.content || '', displayArgs);
-  const baseContent = resolveLiveData(resolvedContent);
+  const baseContent = liveDataArgumentError
+    ? `<live-data command="$ARGUMENTS" error="true">blocked: ${liveDataArgumentError}</live-data>`
+    : resolveLiveData(resolvedContent);
   const injectedContent = cmd.scope === 'skill'
     ? renderBundledSkillBody(cmd.metadata.name, baseContent)
     : rewriteOmcCliInvocations(baseContent);
@@ -342,10 +365,10 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
       .join('\n\n')
   );
 
-  if (displayArgs && !cmd.content?.includes('$ARGUMENTS')) {
+  if (renderedArgs && !cmd.content?.includes('$ARGUMENTS')) {
     sections.push('\n\n---\n');
     sections.push('## User Request\n');
-    sections.push(displayArgs);
+    sections.push(renderedArgs);
   }
 
   return sections.join('\n');

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -41,7 +41,6 @@ const DIFF_FILE_HEADER_PATTERN = /^(?:diff --git|---|\+\+\+) [ab]\/(.+)/gm;
 const DIFF_HEADER_PREFIX_PATTERN = /^(?:diff --git|---|\+\+\+) [ab]\//;
 const SCRIPT_BEGIN_PATTERN = /^\s*!begin-script\s+(\S+)\s*$/;
 const SCRIPT_END_PATTERN = /^\s*!end-script\s*$/;
-const WHITESPACE_SPLIT_PATTERN = /\s/;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -61,6 +60,15 @@ interface SecurityPolicy {
 }
 
 type OutputFormat = "json" | "table" | "diff" | null;
+
+interface ParsedCommandInvocation {
+  executable: string;
+  args: string[];
+}
+
+type CommandParseResult =
+  | { ok: true; invocation: ParsedCommandInvocation }
+  | { ok: false; reason: string };
 
 // ─── Cache ───────────────────────────────────────────────────────────────────
 
@@ -129,6 +137,122 @@ export function clearCache(): void {
   onceCommands.clear();
 }
 
+function parseCommandInvocation(command: string): CommandParseResult {
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+  let tokenStarted = false;
+  let token = "";
+  const tokens: string[] = [];
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+    const isUnquotedTabDelimiter = char === "\t" && quote === null && !escaped;
+
+    if ((char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127) && !isUnquotedTabDelimiter) {
+      return { ok: false, reason: "control character rejected" };
+    }
+
+    if (escaped) {
+      token += char;
+      tokenStarted = true;
+      escaped = false;
+      continue;
+    }
+
+    if (quote === "single") {
+      if (char === "'") {
+        quote = null;
+      } else {
+        token += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+
+    if (quote === "double") {
+      if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        quote = null;
+      } else if (char === "`") {
+        return { ok: false, reason: "command substitution rejected" };
+      } else if (char === "$" && command[i + 1] === "(") {
+        return { ok: false, reason: "command substitution rejected" };
+      } else {
+        token += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === " " || char === "\t") {
+      if (tokenStarted) {
+        tokens.push(token);
+        token = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      quote = "single";
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === '"') {
+      quote = "double";
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "`" || (char === "$" && command[i + 1] === "(")) {
+      return { ok: false, reason: "command substitution rejected" };
+    }
+
+    if (";&|<>".includes(char)) {
+      return { ok: false, reason: `shell operator rejected: ${char}` };
+    }
+
+    token += char;
+    tokenStarted = true;
+  }
+
+  if (escaped) {
+    return { ok: false, reason: "trailing escape" };
+  }
+
+  if (quote === "single") {
+    return { ok: false, reason: "unterminated single quote" };
+  }
+
+  if (quote === "double") {
+    return { ok: false, reason: "unterminated double quote" };
+  }
+
+  if (tokenStarted) {
+    tokens.push(token);
+  }
+
+  if (tokens.length === 0) {
+    return { ok: false, reason: "empty command" };
+  }
+
+  return {
+    ok: true,
+    invocation: {
+      executable: tokens[0],
+      args: tokens.slice(1),
+    },
+  };
+}
+
 // ─── Security ────────────────────────────────────────────────────────────────
 
 let cachedPolicy: SecurityPolicy | null = null;
@@ -162,9 +286,11 @@ export function resetSecurityPolicy(): void {
   policyLoadedFrom = null;
 }
 
-function checkSecurity(command: string): { allowed: boolean; reason?: string } {
+function checkSecurity(
+  command: string,
+  executable: string,
+): { allowed: boolean; reason?: string } {
   const policy = loadSecurityPolicy();
-  const cmdBase = command.split(WHITESPACE_SPLIT_PATTERN)[0];
 
   // Check denied patterns first (always enforced)
   if (policy.denied_patterns) {
@@ -185,8 +311,8 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   }
 
   if (policy.denied_commands) {
-    if (policy.denied_commands.includes(cmdBase)) {
-      return { allowed: false, reason: `command '${cmdBase}' is denied` };
+    if (policy.denied_commands.includes(executable)) {
+      return { allowed: false, reason: `command '${executable}' is denied` };
     }
   }
 
@@ -208,7 +334,7 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   let patternAllowed = false;
 
   if (policy.allowed_commands) {
-    baseAllowed = policy.allowed_commands.includes(cmdBase);
+    baseAllowed = policy.allowed_commands.includes(executable);
   }
 
   if (policy.allowed_patterns) {
@@ -233,7 +359,7 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   if (!baseAllowed && !patternAllowed) {
     return {
       allowed: false,
-      reason: `command '${cmdBase}' not in allowlist`,
+      reason: `command '${executable}' not in allowlist`,
     };
   }
 
@@ -380,13 +506,17 @@ function checkIfBranch(pattern: string): boolean {
 
 // ─── Execution ───────────────────────────────────────────────────────────────
 
-function executeCommand(command: string): { stdout: string; error: boolean } {
+function executeCommand(
+  invocation: ParsedCommandInvocation,
+): { stdout: string; error: boolean } {
   try {
-    const stdout = execSync(command, {
+    const stdout = execFileSync(invocation.executable, invocation.args, {
+      shell: false,
       timeout: TIMEOUT_MS,
       maxBuffer: MAX_OUTPUT_BYTES + 1024,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let output = stdout ?? "";
@@ -518,7 +648,7 @@ export function resolveLiveData(content: string): string {
       scriptLineSet.add(i);
     }
 
-    const security = checkSecurity(block.shell);
+    const security = checkSecurity(block.shell, block.shell);
     if (!security.allowed) {
       scriptReplacements.set(
         block.startLine,
@@ -570,8 +700,16 @@ export function resolveLiveData(content: string): string {
 
     const directive = parseDirective(line);
 
-    // Security check
-    const security = checkSecurity(directive.command);
+    const parsed = parseCommandInvocation(directive.command);
+    if (!parsed.ok) {
+      result.push(
+        `<live-data command="${escapeHtml(directive.command)}" error="true">blocked: ${escapeHtml(parsed.reason)}</live-data>`,
+      );
+      continue;
+    }
+
+    const invocation = parsed.invocation;
+    const security = checkSecurity(directive.command, invocation.executable);
     if (!security.allowed) {
       result.push(
         `<live-data command="${escapeHtml(directive.command)}" error="true">blocked: ${escapeHtml(security.reason ?? "")}</live-data>`,
@@ -586,7 +724,7 @@ export function resolveLiveData(content: string): string {
             `<live-data command="${escapeHtml(directive.command)}" skipped="true">condition not met: no files matching '${escapeHtml(directive.pattern!)}' modified</live-data>`,
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
         break;
@@ -598,7 +736,7 @@ export function resolveLiveData(content: string): string {
             `<live-data command="${escapeHtml(directive.command)}" skipped="true">condition not met: branch does not match '${escapeHtml(directive.pattern!)}'</live-data>`,
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
         break;
@@ -611,7 +749,7 @@ export function resolveLiveData(content: string): string {
           );
         } else {
           markCommandExecuted(directive.command);
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
         break;
@@ -630,7 +768,7 @@ export function resolveLiveData(content: string): string {
             ).replace("<live-data", '<live-data cached="true"'),
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           setCache(directive.command, stdout, error, ttl);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
@@ -650,7 +788,7 @@ export function resolveLiveData(content: string): string {
             ).replace("<live-data", '<live-data cached="true"'),
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           if (ttl > 0) setCache(directive.command, stdout, error, ttl);
           result.push(
             formatOutput(directive.command, stdout, error, directive.format!),
@@ -673,7 +811,7 @@ export function resolveLiveData(content: string): string {
             ).replace("<live-data", '<live-data cached="true"'),
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           if (ttl > 0) setCache(directive.command, stdout, error, ttl);
           result.push(formatOutput(directive.command, stdout, error, null));
         }


### PR DESCRIPTION
## Summary

- execute single-line live-data commands without a shell
- reject shell control syntax before policy authorization
- block control-character directive injection through `$ARGUMENTS`
- cover direct, quoted-argument, malformed-input, and script-block injection cases

## Security impact

An `allowed_commands` entry previously authorized only the first whitespace-delimited token while `execSync` executed the complete string. A directive such as `!git status; attacker-command` could therefore execute an appended command with the OMC process privileges. Verbatim `$ARGUMENTS` substitution could also introduce a new live-data directive or shell-backed script block through line breaks.

Single-line directives are now parsed into one executable plus an argument vector, authorized using that executable and the original command text, and invoked with `execFileSync(..., { shell: false })`. Multi-line script blocks retain their explicit interpreter-backed behavior.

## Testing

- `npm ci` under Node 24
- `npm run lint` — 0 errors (19 pre-existing unrelated warnings)
- `npx tsc --noEmit`
- focused live-data security suite — 59/59 passed
- task-level live-data and slash-command suite — 69/69 passed
- `npm run build`
- `npm run plugin:shipping:verify` — 1,146 runtime artifacts verified
- `git diff upstream/dev...HEAD --check`

The exact local full-suite command remains non-green in this macOS sandbox. The same five isolated failures reproduce on exact `upstream/dev` under the same Node 24 installation; they are in credential symlink, persistent-mode lock, and team process-identity tests and are unrelated to the files changed here. GitHub CI remains the supported-environment integration gate for this PR.
