### PR TITLE
test: make generated authorization tests deterministic

### DIFF
--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -11,6 +11,7 @@ const LIVE_BASE_SHA = '21a6e488ce12d79b9a22d37e1093ac8e79f21029';
 const HEAD_SHA = '10078ece166ad36332390ecbaab2d5e247852bbc';
 const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const PULL_NUMBER = 3537;
+const FIXTURE_NOW = new Date('2026-08-01T00:00:00.000Z');
 const ROOT = process.cwd();
 const WORKFLOW_PATH = join(ROOT, '.github', 'workflows', 'generated-artifact-authorization.yml');
 const MANIFEST_PATH = join(ROOT, '.github', 'generated-artifact-authorizations.json');
@@ -49,6 +50,7 @@ type ApiFile = {
 };
 
 type MutableInput = {
+  now: Date;
   environment: {
     githubEventName: string;
     githubRepository: string;
@@ -183,6 +185,7 @@ function apiFiles(records = exactAuthorization.generatedFiles): ApiFile[] {
 function authorizedInput(): MutableInput {
   const files = apiFiles();
   return {
+    now: new Date(FIXTURE_NOW),
     environment: {
       githubEventName: 'pull_request_target',
       githubRepository: REPOSITORY,
@@ -593,6 +596,16 @@ describe('generated-artifact base-owned authorization decision', () => {
       input.files.push({ status: 'added', filename: 'dist/extra.js', sha: 'd'.repeat(40) });
       input.livePull.changed_files += 1;
     }, 'authorized closure');
+  });
+
+  it('keeps expiry validation effective after the frozen fixture date', () => {
+    const input = authorizedInput();
+    input.now = new Date('2026-08-20T00:00:00.000Z');
+
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toEqual({
+      allowed: false,
+      reason: 'generated-artifact authorization has expired',
+    });
   });
 
   it('requires exact authorization for generated-path rename, copy, and deletion records', () => {


### PR DESCRIPTION
Fixes #3694

The generated-artifact authorization fixture for retained PR #3537 used a real wall clock, so the exact positive case and derived closure tests began failing after its manifest expiry. This freezes only the test fixture clock and adds a regression that advances the injected verifier time and confirms the expired authorization remains denied. Production expiry validation and the #3690 authorization are unchanged.

Verification: focused Vitest/Bun authorization suite (20 passed), full source lint (0 errors, 19 pre-existing warnings), build, and npm pack --dry-run.