### PR TITLE
fix(purge): protect live no-sibling plugin cache

### DIFF
--- a/scripts/lib/cache-occupancy.mjs
+++ b/scripts/lib/cache-occupancy.mjs
@@ -1,0 +1,75 @@
+import { existsSync, readdirSync, readFileSync, unlinkSync, mkdirSync, writeFileSync, renameSync } from 'fs';
+import { join, resolve } from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { spawnSync } from 'child_process';
+
+const NAME = /^[a-f0-9]{64}\.json$/;
+
+function identity(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  if (process.platform === 'linux') {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const close = stat.lastIndexOf(')');
+      return close < 0 ? null : (stat.substring(close + 2).split(' ')[19] || null);
+    } catch { return null; }
+  }
+  if (process.platform === 'darwin') {
+    try {
+      const result = spawnSync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8', timeout: 2000 });
+      if (result.status !== 0) return null;
+      const value = new Date(result.stdout.trim()).getTime();
+      return Number.isFinite(value) ? String(value) : null;
+    } catch { return null; }
+  }
+  if (process.platform === 'win32') {
+    try {
+      const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', `$p=Get-Process -Id ${pid} -ErrorAction Stop; $p.StartTime.ToUniversalTime().Ticks`], { encoding: 'utf8', timeout: 3000, windowsHide: true });
+      const ticks = result.stdout?.trim().match(/^\d+$/)?.[0];
+      return ticks ? `ticks:${ticks}` : null;
+    } catch { return null; }
+  }
+  return null;
+}
+function alive(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error?.code === 'EPERM'; }
+}
+
+function registryDir(configDir) { return join(configDir, '.omc', 'cache-occupancy'); }
+function fileName(root, pid, start) { return `${createHash('sha256').update(`${root}\0${pid}\0${start}`).digest('hex')}.json`; }
+
+export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid) {
+  const root = resolve(pluginRoot || '');
+  const start = identity(pid);
+  if (!root || !start) return false;
+  const dir = registryDir(configDir);
+  const target = join(dir, fileName(root, pid, start));
+  const temp = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(temp, JSON.stringify({ version: 1, pid, processStartIdentity: start, pluginRoot: root, updatedAt: new Date().toISOString() }), { mode: 0o600 });
+    renameSync(temp, target);
+    return true;
+  } catch { try { unlinkSync(temp); } catch {} return false; }
+}
+
+export function readOccupiedPluginRoots(configDir) {
+  const dir = registryDir(configDir);
+  let names;
+  try { names = readdirSync(dir).filter(name => NAME.test(name)); } catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
+  const roots = new Set();
+  for (const name of names) {
+    const path = join(dir, name);
+    let record;
+    try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch {} continue; }
+    const age = Date.now() - Date.parse(record?.updatedAt);
+    const current = identity(record?.pid);
+    if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid) || (current && current !== record.processStartIdentity)) {
+      try { unlinkSync(path); } catch {}
+      continue;
+    }
+    roots.add(resolve(record.pluginRoot));
+  }
+  return { roots, unavailable: false };
+}

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -13,6 +13,7 @@ import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { getClaudeConfigDir, getUpdateCheckCachePath } from './lib/config-dir.mjs';
 import { resolveOmcStateRoot } from './lib/state-root.mjs';
+import { publishCacheOccupancy, readOccupiedPluginRoots } from './lib/cache-occupancy.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -918,6 +919,9 @@ async function main() {
     const projectMemoryModules = await loadProjectMemoryModules();
 
     writeSessionStartedMarker(omcRoot, directory, sessionId);
+    if (process.env.CLAUDE_PLUGIN_ROOT) {
+      publishCacheOccupancy(process.env.CLAUDE_PLUGIN_ROOT, configDir);
+    }
     reconcileAbandonedSessionStarts(omcRoot, sessionId);
     reconcileSessionEndJobsInBackground(getRuntimeBaseDir(), directory);
 
@@ -1118,6 +1122,7 @@ ${cleanContent}
     // plugin update whose CLAUDE_PLUGIN_ROOT still points to the old version.
     try {
       const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+      const occupancy = readOccupiedPluginRoots(configDir);
       let versions = [];
       if (existsSync(cacheBase)) {
         versions = readdirSync(cacheBase)
@@ -1159,6 +1164,7 @@ ${cleanContent}
                   }
                 }
               } else if (stat.isDirectory()) {
+                if (occupancy.unavailable || occupancy.roots.has(resolve(versionPath))) continue;
                 // Directory → symlink: cannot be atomic, but run.cjs now
                 // handles missing targets gracefully (issue #1007).
                 rmSync(versionPath, { recursive: true, force: true });

--- a/src/__tests__/auto-update.test.ts
+++ b/src/__tests__/auto-update.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-vi.mock('child_process', () => ({
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
   execSync: vi.fn(),
   execFileSync: vi.fn(),
 }));

--- a/src/__tests__/auto-upgrade-prompt.test.ts
+++ b/src/__tests__/auto-upgrade-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('child_process', () => ({
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('child_process')>()),
   execSync: vi.fn(),
 }));
 

--- a/src/__tests__/purge-stale-cache.integration.test.ts
+++ b/src/__tests__/purge-stale-cache.integration.test.ts
@@ -14,6 +14,7 @@ import {
 } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { publishCacheOccupancy } from '../utils/cache-occupancy.js';
 
 let configDir: string;
 vi.mock('../utils/config-dir.js', () => ({
@@ -310,6 +311,20 @@ describe('purgeStalePluginCacheVersions on a real filesystem', () => {
 
     expect(result.removedPaths).toContain(orphan);
     expect(existsSync(orphan)).toBe(false);
+  });
+
+  it('does not delete a stale no-sibling root occupied by a live session', async () => {
+    const orphanPlugin = join(configDir, 'plugins', 'cache', 'omc', 'occupied-plugin');
+    const orphan = join(orphanPlugin, '1.0.0');
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(join(orphan, 'marker'), 'x');
+    makeStale(orphan);
+    expect(await publishCacheOccupancy(orphan, configDir)).toBe(true);
+
+    const result = purgeStalePluginCacheVersions();
+
+    expect(existsSync(orphan)).toBe(true);
+    expect(result.skippedPaths).toContain(orphan);
   });
 });
 

--- a/src/utils/__tests__/cache-occupancy.test.ts
+++ b/src/utils/__tests__/cache-occupancy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { publishCacheOccupancy, readOccupiedPluginRoots } from '../cache-occupancy.js';
+
+describe('cache occupancy registry', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'omc-occupancy-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('publishes an atomic, privacy-bounded record and reads the occupied root', async () => {
+    const root = join(dir, 'plugins', '1.0.0');
+    mkdirSync(root, { recursive: true });
+    expect(await publishCacheOccupancy(root, dir)).toBe(true);
+    const result = readOccupiedPluginRoots(dir);
+    expect(result.unavailable).toBe(false);
+    expect(result.roots).toEqual(new Set([root]));
+    const files = readdirSync(join(dir, '.omc', 'cache-occupancy'));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^[a-f0-9]{64}\.json$/);
+  });
+
+  it('drops corrupt records without exposing their contents', () => {
+    const registry = join(dir, '.omc', 'cache-occupancy');
+    mkdirSync(registry, { recursive: true });
+    writeFileSync(join(registry, `${'a'.repeat(64)}.json`), '{broken');
+    expect(readOccupiedPluginRoots(dir).roots.size).toBe(0);
+    expect(readdirSync(registry)).toEqual([]);
+  });
+});

--- a/src/utils/cache-occupancy.ts
+++ b/src/utils/cache-occupancy.ts
@@ -1,0 +1,119 @@
+import { readdirSync, readFileSync, unlinkSync } from 'fs';
+import { mkdir, writeFile, rename, rm } from 'fs/promises';
+import { createHash, randomUUID } from 'crypto';
+import { execFileSync } from 'node:child_process';
+import { join, resolve } from 'path';
+import { getClaudeConfigDir } from './config-dir.js';
+
+const REGISTRY_VERSION = 1;
+const RECORD_PATTERN = /^[a-f0-9]{64}\.json$/;
+
+function processStartIdentity(pid: number): string | null {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  if (process.platform === 'linux') {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const closeParen = stat.lastIndexOf(')');
+      return closeParen === -1 ? null : stat.substring(closeParen + 2).split(' ')[19] || null;
+    } catch { return null; }
+  }
+  if (process.platform === 'darwin') {
+    try {
+      return String(Number(new Date(execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8' }).trim()).getTime()));
+    } catch { return null; }
+  }
+  if (process.platform === 'win32') {
+    try {
+      const output = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', `$p=Get-Process -Id ${pid} -ErrorAction Stop; $p.StartTime.ToUniversalTime().Ticks`], { encoding: 'utf8', windowsHide: true });
+      const ticks = output.trim().match(/^\d+$/)?.[0];
+      return ticks ? `ticks:${ticks}` : null;
+    } catch { return null; }
+  }
+  return null;
+}
+
+function processAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return (error as NodeJS.ErrnoException).code === 'EPERM'; }
+}
+
+export interface CacheOccupancyRecord {
+  version: 1;
+  pid: number;
+  processStartIdentity: string;
+  pluginRoot: string;
+  updatedAt: string;
+}
+
+export function getCacheOccupancyDir(configDir = getClaudeConfigDir()): string {
+  return join(configDir, '.omc', 'cache-occupancy');
+}
+
+function recordName(pluginRoot: string, pid: number, identity: string): string {
+  return `${createHash('sha256').update(`${pluginRoot}\0${pid}\0${identity}`).digest('hex')}.json`;
+}
+
+function recordPath(pluginRoot: string, pid: number, identity: string, configDir?: string): string {
+  return join(getCacheOccupancyDir(configDir), recordName(pluginRoot, pid, identity));
+}
+
+export async function publishCacheOccupancy(pluginRoot: string, configDir?: string): Promise<boolean> {
+  const normalizedRoot = resolve(pluginRoot);
+  const identity = processStartIdentity(process.pid);
+  if (!identity) return false;
+  const record: CacheOccupancyRecord = {
+    version: REGISTRY_VERSION,
+    pid: process.pid,
+    processStartIdentity: identity,
+    pluginRoot: normalizedRoot,
+    updatedAt: new Date().toISOString(),
+  };
+  const target = recordPath(normalizedRoot, process.pid, identity, configDir);
+  const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await mkdir(getCacheOccupancyDir(configDir), { recursive: true, mode: 0o700 });
+    await writeFile(temporary, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
+    await rename(temporary, target);
+    return true;
+  } catch {
+    await rm(temporary, { force: true }).catch(() => {});
+    return false;
+  }
+}
+
+function validRecord(value: unknown): value is CacheOccupancyRecord {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<CacheOccupancyRecord>;
+  return record.version === REGISTRY_VERSION && Number.isSafeInteger(record.pid) && typeof record.pid === 'number' && record.pid > 0
+    && typeof record.processStartIdentity === 'string' && record.processStartIdentity.length > 0
+    && typeof record.pluginRoot === 'string' && record.pluginRoot.length > 0
+    && typeof record.updatedAt === 'string' && Number.isFinite(Date.parse(record.updatedAt));
+}
+
+export function readOccupiedPluginRoots(configDir = getClaudeConfigDir()): { roots: Set<string>; unavailable: boolean } {
+  const directory = getCacheOccupancyDir(configDir);
+  let names: string[];
+  try {
+    names = readdirSync(directory).filter(name => RECORD_PATTERN.test(name));
+  } catch (error) {
+    return { roots: new Set(), unavailable: (error as NodeJS.ErrnoException).code !== 'ENOENT' };
+  }
+
+  const roots = new Set<string>();
+  const now = Date.now();
+  for (const name of names) {
+    const path = join(directory, name);
+    let record: unknown;
+    try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch { /* best effort */ } continue; }
+    if (!validRecord(record)) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
+    const age = now - Date.parse(record.updatedAt);
+    if (age < -5 * 60 * 1000) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
+    if (!processAlive(record.pid)) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
+    const currentIdentity = processStartIdentity(record.pid);
+    if (currentIdentity && currentIdentity !== record.processStartIdentity) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
+    // A live process whose identity cannot be read (including EPERM) is retained
+    // conservatively; only a proven-dead PID or proven mismatch self-invalidates.
+    roots.add(resolve(record.pluginRoot));
+  }
+  return { roots, unavailable: false };
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -6,10 +6,11 @@
  * (which work universally) and handle platform-specific directory conventions.
  */
 
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { existsSync, readFileSync, readdirSync, statSync, lstatSync, unlinkSync, rmSync, renameSync, symlinkSync } from 'fs';
 import { homedir } from 'os';
 import { getClaudeConfigDir } from './config-dir.js';
+import { readOccupiedPluginRoots } from './cache-occupancy.js';
 
 /**
  * Convert a path to use forward slashes (for JSON/config files)
@@ -465,10 +466,8 @@ function stripTrailing(p: string): string {
   return toForwardSlash(p).replace(/\/+$/, '');
 }
 
-/** Default grace period: skip directories modified within the last 24 hours.
- * Extended from 1 hour to 24 hours to avoid deleting cache directories that
- * are still referenced by long-running sessions via CLAUDE_PLUGIN_ROOT. */
-const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+/** Short install/update race guard. Session occupancy is the liveness source. */
+const STALE_THRESHOLD_MS = 10 * 60 * 1000;
 
 /**
  * Compare two semver-like version strings descending (higher version first).
@@ -534,6 +533,7 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
   }
 
   const now = Date.now();
+  const occupancy = readOccupiedPluginRoots(configDir);
   const activePathsArray = [...activePaths];
 
   for (const marketplace of marketplaces) {
@@ -667,6 +667,14 @@ export function purgeStalePluginCacheVersions(options?: { skipGracePeriod?: bool
           // accumulate real dirs indefinitely").  A session pinned here is
           // therefore protected only by the grace period, whose mtime signal
           // does not track liveness; that is tracked separately in #3688.
+          // A no-sibling directory is the only destructive cleanup path.  A
+          // session-start occupancy record protects it; registry failures also
+          // fail closed rather than treating mtime as a liveness signal.
+          if (occupancy.unavailable || occupancy.roots.has(resolve(versionDir))) {
+            result.skipped++;
+            result.skippedPaths.push(versionDir);
+            continue;
+          }
           if (safeRmSync(versionDir)) {
             result.removed++;
             result.removedPaths.push(versionDir);

--- a/templates/hooks/lib/cache-occupancy.mjs
+++ b/templates/hooks/lib/cache-occupancy.mjs
@@ -1,0 +1,32 @@
+import { existsSync, readdirSync, readFileSync, unlinkSync, mkdirSync, writeFileSync, renameSync } from 'fs';
+import { join, resolve } from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { spawnSync } from 'child_process';
+
+const NAME = /^[a-f0-9]{64}\.json$/;
+function identity(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  if (process.platform === 'linux') { try { const stat = readFileSync(`/proc/${pid}/stat`, 'utf8'); const close = stat.lastIndexOf(')'); return close < 0 ? null : (stat.substring(close + 2).split(' ')[19] || null); } catch { return null; } }
+  if (process.platform === 'darwin') { try { const result = spawnSync('ps', ['-p', String(pid), '-o', 'lstart='], { encoding: 'utf8', timeout: 2000 }); const value = new Date(result.stdout?.trim()).getTime(); return result.status === 0 && Number.isFinite(value) ? String(value) : null; } catch { return null; } }
+  if (process.platform === 'win32') { try { const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', `$p=Get-Process -Id ${pid} -ErrorAction Stop; $p.StartTime.ToUniversalTime().Ticks`], { encoding: 'utf8', timeout: 3000, windowsHide: true }); const ticks = result.stdout?.trim().match(/^\d+$/)?.[0]; return ticks ? `ticks:${ticks}` : null; } catch { return null; } }
+  return null;
+}
+function alive(pid) {
+  try { process.kill(pid, 0); return true; }
+  catch (error) { return error?.code === 'EPERM'; }
+}
+
+function registryDir(configDir) { return join(configDir, '.omc', 'cache-occupancy'); }
+function fileName(root, pid, start) { return `${createHash('sha256').update(`${root}\0${pid}\0${start}`).digest('hex')}.json`; }
+export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid) {
+  const root = resolve(pluginRoot || ''); const start = identity(pid); if (!root || !start) return false;
+  const dir = registryDir(configDir); const target = join(dir, fileName(root, pid, start)); const temp = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  try { mkdirSync(dir, { recursive: true, mode: 0o700 }); writeFileSync(temp, JSON.stringify({ version: 1, pid, processStartIdentity: start, pluginRoot: root, updatedAt: new Date().toISOString() }), { mode: 0o600 }); renameSync(temp, target); return true; } catch { try { unlinkSync(temp); } catch {} return false; }
+}
+export function readOccupiedPluginRoots(configDir) {
+  const dir = registryDir(configDir); let names;
+  try { names = readdirSync(dir).filter(name => typeof name === 'string' && NAME.test(name)); } catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
+  const roots = new Set();
+  for (const name of names) { const path = join(dir, name); let record; try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch {} continue; } const age = Date.now() - Date.parse(record?.updatedAt); const current = identity(record?.pid); if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid) || (current && current !== record.processStartIdentity)) { try { unlinkSync(path); } catch {} continue; } roots.add(resolve(record.pluginRoot)); }
+  return { roots, unavailable: false };
+}

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -13,6 +13,7 @@ const __dirname = dirname(__filename);
 const { getClaudeConfigDir, getUpdateCheckCachePath } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
 const configDir = getClaudeConfigDir();
 const { resolveSessionStatePathsForHook, resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
+const { publishCacheOccupancy } = await import(pathToFileURL(join(__dirname, 'lib', 'cache-occupancy.mjs')).href);
 
 // Import timeout-protected stdin reader (prevents hangs on Linux/Windows, see issue #240, #524)
 let readStdin;
@@ -536,6 +537,9 @@ async function main() {
       return;
     }
     const sessionId = data.sessionId || data.session_id || data.sessionid || '';
+    if (process.env.CLAUDE_PLUGIN_ROOT) {
+      publishCacheOccupancy(process.env.CLAUDE_PLUGIN_ROOT, configDir);
+    }
     const messages = [];
     const userMessages = [];
 


### PR DESCRIPTION
Closes #3688

Owner approval: comment 5264651820.

Adds a privacy-bounded cross-platform occupancy registry keyed by hashed plugin root, PID, and process-start identity. Session start publishes atomically; purge removes corrupt/dead/PID-reused records and fails closed for destructive no-sibling deletion when the registry cannot be read. Retains a short mtime install/update race guard and leaves sibling demotion unchanged.

Validation: npx tsc --noEmit; focused Vitest suites (64 tests); npm run build; npm run plugin:shipping:verify.