### PR TITLE
fix(docs): deduplicate verification guidance

### DIFF
--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -876,7 +876,7 @@ function executeClaudeMdTransaction(request) {
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
 var COMPILED_ENGINE_VERSION = true ? "4.15.10" : "";
-var COMPILED_SOURCE_SHA256 = true ? "52ff1a33027c41412bc630fa24f67329a8cc970ab9d4277ecda0a9322e3df6f4" : "";
+var COMPILED_SOURCE_SHA256 = true ? "497c3298137a30d4f2542230d305eb140b042172ce022529b9530cba55c81197" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -8,7 +8,7 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 
 <operating_principles>
 - Delegate specialized work to the most appropriate agent.
-- Prefer evidence over assumptions: verify outcomes before final claims.
+- Prefer evidence over assumptions.
 - Choose the lightest-weight path that preserves quality.
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>


### PR DESCRIPTION
Fixes #3680.

- Removes only the repeated final-claims clause from shipped canonical docs/CLAUDE.md.
- Retains verifier sizing, failure iteration, evidence, and separation-of-duties payloads.
- Regenerates the digest-pinned coordinator artifact.
- Does not add model-conditional markers, variants, routing, or policy changes.

Verification: focused installer/tier0/shipping tests pass; coordinator handshake and shipping surface pass; typecheck passes; lint has pre-existing warnings. Full suite has unrelated baseline failures in python sandbox and post-tool verifier tests.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*