### PR TITLE
fix(hooks): stop DELEGATION NOTICE from firing on read-only bash commands

### DIFF
--- a/src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts
+++ b/src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts
@@ -45,4 +45,38 @@ describe('pre-tool-use template source extension detection', () => {
       'Bash command may modify source files',
     );
   });
+
+  describe('read-only commands stay quiet', () => {
+    it.each([
+      ['grep over source files with a stderr redirect', 'grep -n foo *.mjs 2>/dev/null | head'],
+      ['cat of a source file with a stderr redirect', 'cat src/app.mjs 2>/dev/null | head -20'],
+      ['find for source files with a stderr redirect', 'ls -la; find . -name "*.mjs" 2>/dev/null'],
+      ['write and source mention in different segments', 'echo hi > notes.txt; grep -n pattern app.ts'],
+      ['non-source write followed by a source read', 'printf "%s" x > README.md && node --check hooks/run.mjs'],
+    ])('does not warn: %s', (_label, command) => {
+      const output = runPreToolUseHook(command);
+
+      expect(output.continue).toBe(true);
+      expect(output.hookSpecificOutput).toBeUndefined();
+    });
+  });
+
+  describe('real source writes still warn', () => {
+    it.each([
+      ['in-place sed', 'sed -i s/a/b/ src/app.ts'],
+      ['redirect into a source file', 'echo "x" > lib/util.js'],
+      ['append into a source file', 'cat fragment.txt >> src/index.mjs'],
+      ['source write after a read-only segment', 'ls -la | head; sed -i s/x/y/ src/main.py'],
+    ])('warns: %s', (_label, command) => {
+      const output = runPreToolUseHook(command);
+      const hookSpecificOutput = output.hookSpecificOutput as
+        | { additionalContext?: string }
+        | undefined;
+
+      expect(output.continue).toBe(true);
+      expect(hookSpecificOutput?.additionalContext).toContain(
+        'Bash command may modify source files',
+      );
+    });
+  });
 });

--- a/src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts
+++ b/src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts
@@ -61,6 +61,33 @@ describe('pre-tool-use template source extension detection', () => {
     });
   });
 
+  describe('notice payload is bounded', () => {
+    it('truncates a long command and reports its real length', () => {
+      const filler = 'x'.repeat(500);
+      const command = `sed -i "s/${filler}/y/" src/app.ts`;
+      const output = runPreToolUseHook(command);
+      const additionalContext = (
+        output.hookSpecificOutput as { additionalContext?: string } | undefined
+      )?.additionalContext;
+
+      expect(additionalContext).toContain('Bash command may modify source files');
+      expect(additionalContext).toContain(`(${command.length} chars)`);
+      expect(additionalContext).not.toContain(filler);
+    });
+
+    it('leaves a short command intact', () => {
+      const command = 'sed -i s/a/b/ src/app.ts';
+      const additionalContext = (
+        runPreToolUseHook(command).hookSpecificOutput as
+          | { additionalContext?: string }
+          | undefined
+      )?.additionalContext;
+
+      expect(additionalContext).toContain(command);
+      expect(additionalContext).not.toContain('chars)');
+    });
+  });
+
   describe('real source writes still warn', () => {
     it.each([
       ['in-place sed', 'sed -i s/a/b/ src/app.ts'],

--- a/templates/hooks/pre-tool-use.mjs
+++ b/templates/hooks/pre-tool-use.mjs
@@ -233,13 +233,31 @@ function workerCommandViolation(command) {
   return null;
 }
 
-function checkBashCommand(command) {
-  // Check if command might modify files
-  const mayModify = FILE_MODIFY_PATTERNS.some(pattern => pattern.test(command));
-  if (!mayModify) return null;
+// Redirects to /dev/* are not writes. The generic `>` rule already excludes
+// them, but the cat/echo/printf rules use an unanchored `.*>`, so a trailing
+// `2>/dev/null` on a read-only command satisfies them.
+const DEV_REDIRECT_PATTERN = /\d*>&?\s*\d*\s*\/dev\/(null|stderr|stdout)\b/g;
+const FD_DUP_PATTERN = /\d+>&\d+/g;
 
-  // Check if it might affect source files
-  if (SOURCE_EXT_PATTERN.test(command)) {
+// A pipeline is a sequence of independent commands. Only the segment that
+// performs the write can be the one touching a source file.
+const PIPELINE_SPLIT_PATTERN = /(?:&&|\|\||;|\|)/;
+
+function checkBashCommand(command) {
+  const probe = String(command || '')
+    .replace(DEV_REDIRECT_PATTERN, ' ')
+    .replace(FD_DUP_PATTERN, ' ');
+
+  // The write and the source-file mention must land in the SAME segment,
+  // otherwise `echo hi > notes.txt; grep x app.ts` reads as a source edit.
+  const offending = probe
+    .split(PIPELINE_SPLIT_PATTERN)
+    .find(segment =>
+      FILE_MODIFY_PATTERNS.some(pattern => pattern.test(segment)) &&
+      SOURCE_EXT_PATTERN.test(segment)
+    );
+
+  if (offending) {
     return `[DELEGATION NOTICE] Bash command may modify source files: ${command}
 
 Recommended: Delegate to executor agent instead:

--- a/templates/hooks/pre-tool-use.mjs
+++ b/templates/hooks/pre-tool-use.mjs
@@ -243,6 +243,17 @@ const FD_DUP_PATTERN = /\d+>&\d+/g;
 // performs the write can be the one touching a source file.
 const PIPELINE_SPLIT_PATTERN = /(?:&&|\|\||;|\|)/;
 
+// The notice stays in the transcript and is re-sent on every later turn, so a
+// heredoc or generated command would keep paying for its whole body.
+const NOTICE_COMMAND_MAX = 200;
+
+function summarizeCommand(command) {
+  const text = String(command || '');
+  return text.length > NOTICE_COMMAND_MAX
+    ? `${text.slice(0, NOTICE_COMMAND_MAX)}… (${text.length} chars)`
+    : text;
+}
+
 function checkBashCommand(command) {
   const probe = String(command || '')
     .replace(DEV_REDIRECT_PATTERN, ' ')
@@ -258,7 +269,7 @@ function checkBashCommand(command) {
     );
 
   if (offending) {
-    return `[DELEGATION NOTICE] Bash command may modify source files: ${command}
+    return `[DELEGATION NOTICE] Bash command may modify source files: ${summarizeCommand(command)}
 
 Recommended: Delegate to executor agent instead:
   Task(subagent_type="oh-my-claudecode:executor", model="sonnet", prompt="...")


### PR DESCRIPTION
## Problem

`checkBashCommand()` in `templates/hooks/pre-tool-use.mjs` warns on read-only commands. The notice is injected into the conversation and then re-sent on every subsequent turn of that session, so each false positive keeps costing context for the rest of the session.

Two independent causes:

**1. `2>/dev/null` counts as a write.** The generic `>` rule excludes `/dev/*`:

```js
/>(?!\s*\/dev\/(null|stderr|stdout)\b)\s*[^&]/
```

but the `cat` / `echo` / `printf` rules do not, and their `.*` is unanchored:

```js
/cat\s+.*>\s*/,
/echo\s+.*>\s*/,
/printf\s+.*>\s*/,
```

So `cat src/app.mjs 2>/dev/null | head` matches `cat\s+.*>\s*`.

**2. The write and the source file are matched across the whole command.** `FILE_MODIFY_PATTERNS` and `SOURCE_EXT_PATTERN` are each tested against the entire command string, so a write in one pipeline segment pairs with a source filename in a completely different one:

```bash
echo hi > notes.txt; grep -n pattern app.ts   # writes notes.txt, reads app.ts
```

This is the same bug class as the `.json` case fixed in `src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts` — that fix narrowed `SOURCE_EXT_PATTERN`, which handled extensions but not redirects or segment scope.

## Impact

Counted across one user's local transcripts (40 sessions, 136 MB of `~/.claude/projects/*/*.jsonl`): **2,738 `[DELEGATION NOTICE]` injections**, the large majority on read-only `grep` / `cat` / `find` calls. Because the hook message persists in the transcript, the cost compounds with session length.

## Changes

**`fix(hooks): stop DELEGATION NOTICE from firing on read-only bash commands`**

1. Strip `/dev/*` redirects and fd duplications before pattern testing.
2. Split on `&&`, `||`, `;`, `|` and require the write pattern and the source extension to match **within the same segment**.

No change to `FILE_MODIFY_PATTERNS` or `SOURCE_EXT_PATTERN`, and no change to the warning text or the soft-warning semantics.

**`fix(hooks): bound the command echoed into the DELEGATION NOTICE`**

The notice interpolated the full command (`${command}`), so a heredoc or generated command put its whole body into the transcript — and hook context is re-sent every later turn. Truncates at 200 chars with the real length appended; shorter commands are untouched. Split into its own commit so it can be dropped independently if you'd rather keep the full echo.

## Tests

Extended `src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts` from 2 to 13 cases.

| Case | before | after |
|---|---|---|
| `grep -n foo *.mjs 2>/dev/null \| head` | ⚠️ warn | ✅ quiet |
| `cat src/app.mjs 2>/dev/null \| head -20` | ⚠️ warn | ✅ quiet |
| `ls -la; find . -name "*.mjs" 2>/dev/null` | ⚠️ warn | ✅ quiet |
| `echo hi > notes.txt; grep -n pattern app.ts` | ⚠️ warn | ✅ quiet |
| `printf "%s" x > README.md && node --check hooks/run.mjs` | ⚠️ warn | ✅ quiet |
| `cat ~/.claude/settings.json 2>/dev/null \| python3 -m json.tool` | ✅ quiet | ✅ quiet |
| `sed -i s/a/b/ src/app.ts` | ✅ warn | ✅ warn |
| `echo "x" > lib/util.js` | ✅ warn | ✅ warn |
| `cat fragment.txt >> src/index.mjs` | ✅ warn | ✅ warn |
| `ls -la \| head; sed -i s/x/y/ src/main.py` | ✅ warn | ✅ warn |
| `cat src/app.js > /tmp/out.txt` | ✅ warn | ✅ warn |

5 false positives removed, 0 true positives lost, plus 2 cases covering the truncation boundary.

Verified locally against `upstream/dev`:

- `vitest run src/__tests__/pre-tool-enforcer.test.ts src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts` → **159 passed**
- `eslint src` → clean
- `tsc --noEmit` → clean
- `plugin-shipping-surface.mjs check-pr` → verified, 0 generated artifact changes

## Known limits

Regex over shell text still misreads a `>` inside a quoted string or format specifier (e.g. `printf '%-60s -> %s\n'`). Fixing that needs real shell parsing, which seems out of proportion for a soft warning — flagging it rather than attempting it here.
