### PR TITLE
test(hooks): unset OMC_QUIET in the pre-tool-enforcer harness

### DIFF
--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -34,6 +34,10 @@ function runPreToolEnforcerWithEnv(
       NODE_ENV: 'test',
       DISABLE_OMC: '',
       OMC_SKIP_HOOKS: '',
+      // Advisory verbosity: unset it so a contributor running with OMC_QUIET
+      // exported does not silence the advisories these tests assert on.
+      // The OMC_QUIET suites pass their own value via `env`, which wins below.
+      OMC_QUIET: '',
       // Reset Bedrock/routing env vars so tests are isolated from the host environment.
       // Tests that exercise Bedrock model-routing behaviour set these explicitly via `env`.
       OMC_AGENT_PREFLIGHT_CONTEXT_THRESHOLD: '',


### PR DESCRIPTION
## Problem

`src/__tests__/pre-tool-enforcer.test.ts` spawns the hook with `...process.env` and then resets the env vars that would otherwise leak host state — `DISABLE_OMC`, `OMC_SKIP_HOOKS`, the Bedrock/routing chain, the tier-alias chain.

`OMC_QUIET` is missing from that list.

`OMC_QUIET` is the documented switch for silencing routine advisory chatter (`getQuietLevel()` in `scripts/pre-tool-enforcer.mjs`), so it is a reasonable thing for a contributor to export in their shell or in `settings.json`. When they do, most tests in this file assert advisory text that the hook now suppresses:

```
$ OMC_QUIET=2 npx vitest run src/__tests__/pre-tool-enforcer.test.ts
Tests  41 failed | 105 passed (146)

$ npx vitest run src/__tests__/pre-tool-enforcer.test.ts
Tests  146 passed (146)
```

Reproduced on a clean `dev` checkout (`6618d54`) — nothing else in the tree changed.

## Fix

Add `OMC_QUIET: ''` to the same reset block. The suites that deliberately exercise quiet mode (`OMC_QUIET=1`, `OMC_QUIET=2`) pass their value through the `env` parameter, which is spread last and still wins.

## Verification

| | before | after |
|---|---|---|
| ambient `OMC_QUIET=2` | 41 failed / 105 passed | **146 passed** |
| `OMC_QUIET` unset | 146 passed | **146 passed** |

`eslint src` and `tsc --noEmit` clean.

## Note

Found while verifying #3699 — unrelated to that change, so it is split out here. #3699 does not depend on this.
