### PR TITLE
ci: rebind generated closure to reconciled PR #3690 head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1304,8 +1304,8 @@
     {
       "pullNumber": 3690,
       "targetRef": "main",
-      "mergeBaseSha": "41a4c0f77144c5beb5f5f000a89cff379c680606",
-      "headSha": "1a08dc0c2c64fc03bf14536524b297ad662d16ae",
+      "mergeBaseSha": "10ad9ce5f8882e3c3856b4d349adb078bccdfa73",
+      "headSha": "4b33235381036f76fb918d75ce75417cbdf94b6a",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-26T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Base-owned authorization update for the current PR #3690 head after reconciling with main.

- Exact PR head: `4b33235381036f76fb918d75ce75417cbdf94b6a`
- Exact target/base: `main@10ad9ce5f8882e3c3856b4d349adb078bccdfa73`
- Generated closure remains the existing 84-file v4.15.10 delta and digest.
- No verifier or candidate-side classifier changes.

Required before merge: protected base authorization check for PR #3690 must pass.