### PR TITLE
fix(security): harden live-data command execution

### DIFF
--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as childProcess from 'child_process';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(),
+    execFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../lib/worktree-paths.js', () => ({
+  getWorktreeRoot: () => null,
+  getOmcRoot: () => `${process.cwd()}/.omc`,
+}));
+
+const mockedExecSync = vi.mocked(childProcess.execSync);
+const mockedExecFileSync = vi.mocked(childProcess.execFileSync);
+const originalCwd = process.cwd();
+const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+let projectDir: string;
+let configDir: string;
+
+describe('auto slash live-data security', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    projectDir = join(tmpdir(), `omc-live-data-project-${process.pid}-${Date.now()}`);
+    configDir = join(tmpdir(), `omc-live-data-config-${process.pid}-${Date.now()}`);
+    mkdirSync(join(projectDir, '.claude', 'commands'), { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n!git status $ARGUMENTS\n',
+    );
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['git'] }),
+    );
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    process.chdir(projectDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+    rmSync(projectDir, { recursive: true, force: true });
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('blocks shell syntax introduced through $ARGUMENTS', async () => {
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '; node -e "process.exit(99)"',
+      raw: '/live-test ; node -e "process.exit(99)"',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked:');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -71,4 +71,44 @@ describe('auto slash live-data security', () => {
     expect(mockedExecSync).not.toHaveBeenCalled();
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['line feed', '\n!git status'],
+    ['carriage return', '\r!git status'],
+  ])('blocks a live-data directive introduced through $ARGUMENTS with %s', async (_name, args) => {
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args,
+      raw: `/live-test ${args}`,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: control character rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('blocks a script block introduced through $ARGUMENTS', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['git', 'bash'] }),
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const args = '\n!begin-script bash\nnode -e "process.exit(99)"\n!end-script';
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args,
+      raw: `/live-test ${args}`,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: control character rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -72,6 +72,25 @@ describe('auto slash live-data security', () => {
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
+  it('allows safe arguments on an explicitly authored live-data directive', async () => {
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '--short',
+      raw: '/live-test --short',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).not.toContain('error="true"');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['status', '--short'],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
   it.each([
     ['line feed', '\n!git status'],
     ['carriage return', '\r!git status'],
@@ -108,6 +127,87 @@ describe('auto slash live-data security', () => {
     expect(result.success).toBe(true);
     expect(result.replacementText).toContain('error="true"');
     expect(result.replacementText).toContain('blocked: control character rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('blocks a live-data directive introduced into a placeholder-only template', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n$ARGUMENTS\n',
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '\n!git status',
+      raw: '/live-test \n!git status',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: control character rejected');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('blocks a live-data directive after slash-command parsing normalizes the newline', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n$ARGUMENTS\n',
+    );
+    const { detectSlashCommand } = await import('../hooks/auto-slash-command/detector.js');
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+    const parsed = detectSlashCommand('/live-test\n!git status');
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.args).toBe('!git status');
+
+    const result = executeSlashCommand(parsed!);
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: live-data directive introduced by arguments');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('keeps a placeholder that renders inside a code fence as plain text', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n```text\n$ARGUMENTS\n```\n',
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '!git status',
+      raw: '/live-test !git status',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('!git status');
+    expect(result.replacementText).not.toContain('error="true"');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('blocks arguments that close a code fence and expose a live-data directive', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n```text\n$ARGUMENTS\n!git status\n```\n',
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '```',
+      raw: '/live-test ```',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: live-data directive introduced by arguments');
     expect(mockedExecSync).not.toHaveBeenCalled();
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });

--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -224,6 +224,30 @@ describe('auto slash live-data security', () => {
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
+  it('blocks promotion of an authored directive into a script block', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n!$ARGUMENTS\necho safe\n!end-script\n',
+    );
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_patterns: ['^bash'] }),
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: 'begin-script bash;node',
+      raw: '/live-test begin-script bash;node',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain('blocked: live-data directive introduced by arguments');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
   it('keeps a placeholder that renders inside a code fence as plain text', async () => {
     writeFileSync(
       join(projectDir, '.claude', 'commands', 'live-test.md'),

--- a/src/__tests__/auto-slash-live-data-security.test.ts
+++ b/src/__tests__/auto-slash-live-data-security.test.ts
@@ -131,6 +131,58 @@ describe('auto slash live-data security', () => {
     expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 
+  it('blocks $ARGUMENTS interpolation inside an authored script block', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n!begin-script bash\ngit status $ARGUMENTS\n!end-script\n',
+    );
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['bash', 'git'] }),
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: '; node -e "process.exit(99)"',
+      raw: '/live-test ; node -e "process.exit(99)"',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain(
+      'blocked: arguments are not supported in live-data script blocks',
+    );
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('blocks $ARGUMENTS interpolation in an authored script shell declaration', async () => {
+    writeFileSync(
+      join(projectDir, '.claude', 'commands', 'live-test.md'),
+      '---\ndescription: Security regression fixture\n---\n!begin-script $ARGUMENTS\necho safe\n!end-script\n',
+    );
+    writeFileSync(
+      join(projectDir, '.claude', 'live-data-policy.json'),
+      JSON.stringify({ allowed_commands: ['bash'] }),
+    );
+    const { executeSlashCommand } = await import('../hooks/auto-slash-command/executor.js');
+
+    const result = executeSlashCommand({
+      command: 'live-test',
+      args: 'bash',
+      raw: '/live-test bash',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('error="true"');
+    expect(result.replacementText).toContain(
+      'blocked: arguments are not supported in live-data script blocks',
+    );
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
   it('blocks a live-data directive introduced into a placeholder-only template', async () => {
     writeFileSync(
       join(projectDir, '.claude', 'commands', 'live-test.md'),

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -56,14 +56,19 @@ describe('isLiveDataLine', () => {
 
 describe('resolveLiveData - basic', () => {
   it('replaces a basic !command with live-data output', () => {
-    mockedExecSync.mockReturnValue('hello world\n');
+    mockedExecFileSync.mockReturnValue('hello world\n');
     const result = resolveLiveData('!echo hello');
     expect(result).toBe('<live-data command="echo hello">hello world\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledWith('echo hello', expect.objectContaining({ timeout: 10_000 }));
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['hello'],
+      expect.objectContaining({ shell: false, timeout: 10_000, windowsHide: true }),
+    );
+    expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
   it('handles multiple commands', () => {
-    mockedExecSync.mockReturnValueOnce('output1\n').mockReturnValueOnce('output2\n');
+    mockedExecFileSync.mockReturnValueOnce('output1\n').mockReturnValueOnce('output2\n');
     const input = 'before\n!cmd1\nmiddle\n!cmd2\nafter';
     const result = resolveLiveData(input);
     expect(result).toContain('<live-data command="cmd1">output1\n</live-data>');
@@ -74,12 +79,12 @@ describe('resolveLiveData - basic', () => {
   });
 
   it('skips !lines inside code blocks', () => {
-    mockedExecSync.mockReturnValue('ran\n');
+    mockedExecFileSync.mockReturnValue('ran\n');
     const input = '```\n!echo skip-me\n```\n!echo run-me';
     const result = resolveLiveData(input);
     expect(result).toContain('!echo skip-me');
     expect(result).toContain('<live-data command="echo run-me">ran\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('skips !lines inside an unclosed/unterminated fenced code block', () => {
@@ -103,39 +108,39 @@ describe('resolveLiveData - basic', () => {
   it('handles failed commands with error attribute', () => {
     const error = new Error('command failed') as Error & { stderr: string };
     error.stderr = 'permission denied\n';
-    mockedExecSync.mockImplementation(() => { throw error; });
+    mockedExecFileSync.mockImplementation(() => { throw error; });
     const result = resolveLiveData('!bad-cmd');
     expect(result).toBe('<live-data command="bad-cmd" error="true">permission denied\n</live-data>');
   });
 
   it('handles timeout errors', () => {
-    mockedExecSync.mockImplementation(() => { throw new Error('ETIMEDOUT'); });
+    mockedExecFileSync.mockImplementation(() => { throw new Error('ETIMEDOUT'); });
     const result = resolveLiveData('!slow-cmd');
     expect(result).toContain('error="true"');
     expect(result).toContain('ETIMEDOUT');
   });
 
   it('truncates output exceeding 50KB', () => {
-    mockedExecSync.mockReturnValue('x'.repeat(60 * 1024));
+    mockedExecFileSync.mockReturnValue('x'.repeat(60 * 1024));
     const result = resolveLiveData('!big-cmd');
     expect(result).toContain('[output truncated at 50KB]');
     expect(result).toContain('<live-data command="big-cmd">');
   });
 
   it('handles empty output', () => {
-    mockedExecSync.mockReturnValue('');
+    mockedExecFileSync.mockReturnValue('');
     const result = resolveLiveData('!empty-cmd');
     expect(result).toBe('<live-data command="empty-cmd"></live-data>');
   });
 
   it('does not re-scan output for ! prefixes', () => {
-    mockedExecSync.mockReturnValue('!nested-cmd\n');
+    mockedExecFileSync.mockReturnValue('!nested-cmd\n');
     resolveLiveData('!echo nested');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('handles indented !commands', () => {
-    mockedExecSync.mockReturnValue('output\n');
+    mockedExecFileSync.mockReturnValue('output\n');
     const result = resolveLiveData('  !git diff');
     expect(result).toContain('<live-data command="git diff">');
   });
@@ -152,31 +157,31 @@ describe('resolveLiveData - basic', () => {
 
 describe('resolveLiveData - caching', () => {
   it('caches output with !cache directive', () => {
-    mockedExecSync.mockReturnValue('log output\n');
+    mockedExecFileSync.mockReturnValue('log output\n');
     const input = '!cache 300s git log -10';
 
     const result1 = resolveLiveData(input);
     expect(result1).toContain('<live-data command="git log -10">log output\n</live-data>');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
 
     // Second call should use cache
     const result2 = resolveLiveData(input);
     expect(result2).toContain('cached="true"');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1); // no additional call
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1); // no additional call
   });
 
   it('uses default TTL for known commands like git status', () => {
-    mockedExecSync.mockReturnValue('clean\n');
+    mockedExecFileSync.mockReturnValue('clean\n');
 
     resolveLiveData('!git status');
     resolveLiveData('!git status');
 
     // git status has default TTL of 1s, should be cached within same tick
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 
   it('expires cache after TTL', () => {
-    mockedExecSync.mockReturnValue('output\n');
+    mockedExecFileSync.mockReturnValue('output\n');
     const now = Date.now();
     vi.spyOn(Date, 'now').mockReturnValueOnce(now).mockReturnValueOnce(now + 400_000);
 
@@ -184,18 +189,18 @@ describe('resolveLiveData - caching', () => {
     resolveLiveData('!cache 300s mycommand');
 
     // Cache expired (400s > 300s), so command runs again
-    expect(mockedExecSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
     vi.restoreAllMocks();
   });
 
   it('clearCache resets all caches', () => {
-    mockedExecSync.mockReturnValue('out\n');
+    mockedExecFileSync.mockReturnValue('out\n');
     resolveLiveData('!cache 300s cached-cmd');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
 
     clearCache();
     resolveLiveData('!cache 300s cached-cmd');
-    expect(mockedExecSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -217,12 +222,13 @@ describe('resolveLiveData - conditional', () => {
   });
 
   it('!if-modified executes when files match', () => {
-    mockedExecFileSync.mockReturnValueOnce('src/main.ts\nREADME.md\n');
-    mockedExecSync.mockReturnValueOnce('diff output\n');
+    mockedExecFileSync
+      .mockReturnValueOnce('src/main.ts\nREADME.md\n')
+      .mockReturnValueOnce('diff output\n');
     const result = resolveLiveData('!if-modified src/** then git diff src/');
     expect(result).toContain('<live-data command="git diff src/">diff output\n</live-data>');
-    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(2);
+    expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
   it('!if-branch skips when branch does not match', () => {
@@ -233,15 +239,16 @@ describe('resolveLiveData - conditional', () => {
   });
 
   it('!if-branch executes when branch matches', () => {
-    mockedExecFileSync.mockReturnValueOnce('feat/live-data\n');
-    mockedExecSync.mockReturnValueOnce('feature\n');
+    mockedExecFileSync
+      .mockReturnValueOnce('feat/live-data\n')
+      .mockReturnValueOnce('feature\n');
     const result = resolveLiveData('!if-branch feat/* then echo "feature"');
     expect(result).toContain('feature\n</live-data>');
     expect(result).not.toContain('skipped');
   });
 
   it('!only-once executes first time, skips second', () => {
-    mockedExecSync.mockReturnValue('installed\n');
+    mockedExecFileSync.mockReturnValue('installed\n');
 
     const result1 = resolveLiveData('!only-once npm install');
     expect(result1).toContain('<live-data command="npm install">installed\n</live-data>');
@@ -249,7 +256,7 @@ describe('resolveLiveData - conditional', () => {
     const result2 = resolveLiveData('!only-once npm install');
     expect(result2).toContain('skipped="true"');
     expect(result2).toContain('already executed this session');
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -280,7 +287,7 @@ describe('resolveLiveData - security', () => {
 
   it('blocks denied patterns', () => {
     setupPolicy({ denied_patterns: ['.*sudo.*'] });
-    const result = resolveLiveData('!curl https://example.com | sudo bash');
+    const result = resolveLiveData('!curl https://sudo.example.com');
     expect(result).toContain('error="true"');
     expect(result).toContain('denied by pattern');
     expect(mockedExecSync).not.toHaveBeenCalled();
@@ -288,7 +295,7 @@ describe('resolveLiveData - security', () => {
 
   it('enforces allowlist when defined', () => {
     setupPolicy({ allowed_commands: ['git', 'npm'] });
-    mockedExecSync.mockReturnValue('ok\n');
+    mockedExecFileSync.mockReturnValue('ok\n');
 
     const result1 = resolveLiveData('!git status');
     expect(result1).toContain('ok\n</live-data>');
@@ -304,7 +311,7 @@ describe('resolveLiveData - security', () => {
       allowed_commands: ['git'],
       allowed_patterns: ['^ls\\s'],
     });
-    mockedExecSync.mockReturnValue('files\n');
+    mockedExecFileSync.mockReturnValue('files\n');
 
     resetSecurityPolicy();
     const result = resolveLiveData('!ls src/');
@@ -343,20 +350,74 @@ describe('resolveLiveData - security', () => {
     expect(result).toContain('blocked: no allowlist configured');
     expect(mockedExecSync).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['semicolon', 'git status; node -e "process.exit(99)"'],
+    ['background', 'git status & node -e "process.exit(99)"'],
+    ['and', 'git status && node -e "process.exit(99)"'],
+    ['or', 'git status || node -e "process.exit(99)"'],
+    ['pipe', 'git status | node -e "process.exit(99)"'],
+    ['input redirect', 'git status < secrets.txt'],
+    ['output redirect', 'git status > stolen.txt'],
+    ['carriage return', 'git status\rnode -e "process.exit(99)"'],
+    ['backticks', 'git status `node -e "process.exit(99)"`'],
+    ['command substitution', 'git status $(node -e "process.exit(99)")'],
+  ])('blocks %s shell syntax before process execution', (_name, command) => {
+    setupPolicy({ allowed_commands: ['git'] });
+
+    const result = resolveLiveData(`!${command}`);
+
+    expect(result).toContain('error="true"');
+    expect(result).toContain('blocked:');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unterminated single quote', "echo 'unterminated"],
+    ['unterminated double quote', 'echo "unterminated'],
+    ['trailing escape', 'echo trailing\\'],
+  ])('fails closed for %s', (_name, command) => {
+    setupPolicy({ allowed_commands: ['echo'] });
+    const result = resolveLiveData(`!${command}`);
+    expect(result).toContain('error="true"');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('parses quoted, escaped, and empty arguments without a shell', () => {
+    mockedExecFileSync.mockReturnValue('ok\n');
+    resolveLiveData(`!echo "two words" 'literal $HOME' escaped\\ space ""`);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['two words', 'literal $HOME', 'escaped space', ''],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
+  it('keeps quoted shell metacharacters as literal argument data', () => {
+    mockedExecFileSync.mockReturnValue('ok\n');
+    resolveLiveData('!echo "; & | < >"');
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['; & | < >'],
+      expect.objectContaining({ shell: false }),
+    );
+  });
 });
 
 // ─── Output Parsing ──────────────────────────────────────────────────────────
 
 describe('resolveLiveData - output formats', () => {
   it('!json adds format="json" attribute', () => {
-    mockedExecSync.mockReturnValue('{"status":"running"}\n');
+    mockedExecFileSync.mockReturnValue('{"status":"running"}\n');
     const result = resolveLiveData('!json docker inspect container');
     expect(result).toContain('format="json"');
     expect(result).toContain('command="docker inspect container"');
   });
 
   it('!table adds format="table" attribute', () => {
-    mockedExecSync.mockReturnValue('NAME  STATUS\nfoo   running\n');
+    mockedExecFileSync.mockReturnValue('NAME  STATUS\nfoo   running\n');
     const result = resolveLiveData('!table docker ps');
     expect(result).toContain('format="table"');
   });
@@ -372,7 +433,7 @@ describe('resolveLiveData - output formats', () => {
 -const y = 2;
  const z = 3;
 `;
-    mockedExecSync.mockReturnValue(diffOutput);
+    mockedExecFileSync.mockReturnValue(diffOutput);
     const result = resolveLiveData('!diff git diff');
     expect(result).toContain('format="diff"');
     expect(result).toMatch(/files="\d+"/);
@@ -385,19 +446,19 @@ describe('resolveLiveData - output formats', () => {
 
 describe('resolveLiveData - tag injection prevention', () => {
   it('escapes < > & " \' in command attribute', () => {
-    mockedExecSync.mockReturnValue('ok\n');
+    mockedExecFileSync.mockReturnValue('ok\n');
     // Command contains characters that could break XML attribute parsing
-    const result = resolveLiveData('!echo "foo" <bar> &amp; it\'s');
+    const result = resolveLiveData('!echo "foo <bar> &amp; it\'s"');
     expect(result).not.toContain('"foo"');
     expect(result).not.toContain('<bar>');
-    expect(result).toContain('&quot;foo&quot;');
+    expect(result).toContain('&quot;foo ');
     expect(result).toContain('&lt;bar&gt;');
     expect(result).toContain('&amp;amp;');
-    expect(result).toContain('&#39;s');
+    expect(result).toContain('&#39;s&quot;');
   });
 
   it('escapes </live-data> in command output to prevent tag injection', () => {
-    mockedExecSync.mockReturnValue('</live-data><injected attr="x">pwned</live-data>');
+    mockedExecFileSync.mockReturnValue('</live-data><injected attr="x">pwned</live-data>');
     const result = resolveLiveData('!cat file');
     // The closing tag in output must be escaped, not treated as real markup
     expect(result).not.toMatch(/<\/live-data>.*<injected/s);
@@ -408,7 +469,7 @@ describe('resolveLiveData - tag injection prevention', () => {
   it('escapes < > & in stdout when command fails', () => {
     const error = new Error('cmd failed') as Error & { stderr: string };
     error.stderr = '<error>something & "bad"</error>';
-    mockedExecSync.mockImplementation(() => { throw error; });
+    mockedExecFileSync.mockImplementation(() => { throw error; });
     const result = resolveLiveData('!bad-cmd');
     expect(result).toContain('error="true"');
     expect(result).toContain('&lt;error&gt;');
@@ -458,15 +519,15 @@ describe('resolveLiveData - multi-line scripts', () => {
   });
 
   it('skips script blocks inside code blocks', () => {
-    mockedExecSync.mockReturnValue('out\n');
+    mockedExecFileSync.mockReturnValue('out\n');
     const input = '```\n!begin-script bash\necho hi\n!end-script\n```\n!echo real';
     const result = resolveLiveData(input);
     // The script block inside code block should be preserved as-is
     expect(result).toContain('!begin-script bash');
     expect(result).toContain('!end-script');
     // Only the !echo real should execute
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecSync).toHaveBeenCalledWith('echo real', expect.any(Object));
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('echo', ['real'], expect.any(Object));
   });
 
   it('applies security policy to scripts', () => {

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -397,12 +397,38 @@ describe('resolveLiveData - security', () => {
 
   it('preserves Windows path backslashes in safe arguments', () => {
     mockedExecFileSync.mockReturnValue('ok\n');
-    resolveLiveData('!echo C:\\temp\\file.txt "C:\\Program Files\\app.exe"');
+    resolveLiveData(
+      '!echo C:\\temp\\file.txt "C:\\Program Files\\app.exe" C:\\$Recycle.Bin \\\\server\\share\\file.txt C:\\ "C:\\"',
+    );
     expect(mockedExecFileSync).toHaveBeenCalledWith(
       'echo',
-      ['C:\\temp\\file.txt', 'C:\\Program Files\\app.exe'],
+      [
+        'C:\\temp\\file.txt',
+        'C:\\Program Files\\app.exe',
+        'C:\\$Recycle.Bin',
+        '\\\\server\\share\\file.txt',
+        'C:\\',
+        'C:\\',
+      ],
       expect.objectContaining({ shell: false }),
     );
+  });
+
+  it('reports unsupported Windows command shims without enabling a shell', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    mockedExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('spawn EINVAL'), { code: 'EINVAL' });
+    });
+
+    try {
+      const result = resolveLiveData('!npm --version');
+      expect(result).toContain('error="true"');
+      expect(result).toContain('Windows .cmd/.bat launchers are unsupported');
+      expect(mockedExecSync).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
   });
 
   it('keeps quoted shell metacharacters as literal argument data', () => {

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -519,7 +519,7 @@ describe('resolveLiveData - tag injection prevention', () => {
 
 describe('resolveLiveData - multi-line scripts', () => {
   it('executes !begin-script/!end-script blocks', () => {
-    mockedExecSync.mockReturnValue('script output\n');
+    mockedExecFileSync.mockReturnValue('script output\n');
     const input = [
       'before',
       '!begin-script bash',
@@ -534,19 +534,22 @@ describe('resolveLiveData - multi-line scripts', () => {
     expect(result).toContain('after');
     expect(result).toContain('<live-data command="script:bash">script output\n</live-data>');
 
-    // Should call execSync with the shell and input body
-    expect(mockedExecSync).toHaveBeenCalledWith(
+    // Should launch the allowlisted interpreter without a shell and send the body on stdin.
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
       'bash',
+      [],
       expect.objectContaining({
         input: 'echo "hello"\necho "world"',
+        shell: false,
       })
     );
+    expect(mockedExecSync).not.toHaveBeenCalled();
   });
 
   it('handles script errors', () => {
     const error = new Error('script failed') as Error & { stderr: string };
     error.stderr = 'syntax error\n';
-    mockedExecSync.mockImplementation(() => { throw error; });
+    mockedExecFileSync.mockImplementation(() => { throw error; });
 
     const input = '!begin-script bash\nexit 1\n!end-script';
     const result = resolveLiveData(input);
@@ -583,5 +586,17 @@ describe('resolveLiveData - multi-line scripts', () => {
     expect(result).toContain('error="true"');
     expect(result).toContain('blocked');
     expect(mockedExecSync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['operator-bearing interpreter', 'bash;node'],
+    ['interpreter arguments', 'bash -e'],
+  ])('blocks %s before script execution', (_name, interpreter) => {
+    const input = `!begin-script ${interpreter}\necho safe\n!end-script`;
+    const result = resolveLiveData(input);
+    expect(result).toContain('error="true"');
+    expect(result).toContain('blocked:');
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -395,6 +395,16 @@ describe('resolveLiveData - security', () => {
     );
   });
 
+  it('preserves Windows path backslashes in safe arguments', () => {
+    mockedExecFileSync.mockReturnValue('ok\n');
+    resolveLiveData('!echo C:\\temp\\file.txt "C:\\Program Files\\app.exe"');
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'echo',
+      ['C:\\temp\\file.txt', 'C:\\Program Files\\app.exe'],
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
   it('keeps quoted shell metacharacters as literal argument data', () => {
     mockedExecFileSync.mockReturnValue('ok\n');
     resolveLiveData('!echo "; & | < >"');

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -244,6 +244,21 @@ function resolveArguments(content: string, args: string): string {
   return content.replace(/\$ARGUMENTS/g, args || '(no arguments provided)');
 }
 
+function hasLiveDataArgumentsPlaceholder(content: string): boolean {
+  return content.includes('$ARGUMENTS')
+    && content.split('\n').some((line) => /^\s*!/.test(line));
+}
+
+function validateLiveDataArguments(args: string): string | null {
+  for (const char of args) {
+    const code = char.charCodeAt(0);
+    if ((code < 32 && char !== '\t') || code === 127) {
+      return 'control character rejected';
+    }
+  }
+  return null;
+}
+
 function hasInvocationFlag(args: string, flag: string): boolean {
   const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(`(^|\\s)${escaped}(?=\\s|$)`).test(args);
@@ -289,6 +304,12 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   const displayArgs = isDeepInterviewAutoresearch
     ? stripInvocationFlag(args, '--autoresearch')
     : args;
+  const liveDataArgumentError = hasLiveDataArgumentsPlaceholder(cmd.content || '')
+    ? validateLiveDataArguments(displayArgs)
+    : null;
+  const renderedArgs = liveDataArgumentError
+    ? `[blocked: ${liveDataArgumentError}]`
+    : displayArgs;
 
   sections.push(`<command-name>/${cmd.name}</command-name>\n`);
 
@@ -296,8 +317,8 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
     sections.push(`**Description**: ${cmd.metadata.description}\n`);
   }
 
-  if (displayArgs) {
-    sections.push(`**Arguments**: ${displayArgs}\n`);
+  if (renderedArgs) {
+    sections.push(`**Arguments**: ${renderedArgs}\n`);
   }
 
   if (cmd.metadata.model) {
@@ -320,7 +341,9 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
 
   // Resolve arguments in content, then execute any live-data commands
   const resolvedContent = resolveArguments(cmd.content || '', displayArgs);
-  const baseContent = resolveLiveData(resolvedContent);
+  const baseContent = liveDataArgumentError
+    ? `<live-data command="$ARGUMENTS" error="true">blocked: ${liveDataArgumentError}</live-data>`
+    : resolveLiveData(resolvedContent);
   const injectedContent = cmd.scope === 'skill'
     ? renderBundledSkillBody(cmd.metadata.name, baseContent)
     : rewriteOmcCliInvocations(baseContent);
@@ -342,10 +365,10 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
       .join('\n\n')
   );
 
-  if (displayArgs && !cmd.content?.includes('$ARGUMENTS')) {
+  if (renderedArgs && !cmd.content?.includes('$ARGUMENTS')) {
     sections.push('\n\n---\n');
     sections.push('## User Request\n');
-    sections.push(displayArgs);
+    sections.push(renderedArgs);
   }
 
   return sections.join('\n');

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -17,7 +17,11 @@ import type {
   CommandScope,
   ExecuteResult,
 } from './types.js';
-import { introducesLiveDataDirective, resolveLiveData } from './live-data.js';
+import {
+  hasLiveDataScriptArgumentPlaceholder,
+  introducesLiveDataDirective,
+  resolveLiveData,
+} from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
 import { rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
@@ -301,8 +305,12 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
     : args;
   const commandContent = cmd.content || '';
   const hasArgumentsPlaceholder = commandContent.includes('$ARGUMENTS');
+  const hasScriptArgumentsPlaceholder = hasArgumentsPlaceholder
+    && hasLiveDataScriptArgumentPlaceholder(commandContent);
   const argumentValidationError = hasArgumentsPlaceholder
-    ? validateLiveDataArguments(displayArgs)
+    ? hasScriptArgumentsPlaceholder
+      ? 'arguments are not supported in live-data script blocks'
+      : validateLiveDataArguments(displayArgs)
     : null;
   const resolvedContent = resolveArguments(commandContent, displayArgs);
   const liveDataArgumentError = argumentValidationError

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -17,7 +17,7 @@ import type {
   CommandScope,
   ExecuteResult,
 } from './types.js';
-import { resolveLiveData } from './live-data.js';
+import { introducesLiveDataDirective, resolveLiveData } from './live-data.js';
 import { parseFrontmatter, parseFrontmatterAliases, stripOptionalQuotes } from '../../utils/frontmatter.js';
 import { rewriteOmcCliInvocations } from '../../utils/omc-cli-rendering.js';
 import { parseSkillPipelineMetadata, renderSkillPipelineGuidance } from '../../utils/skill-pipeline.js';
@@ -244,11 +244,6 @@ function resolveArguments(content: string, args: string): string {
   return content.replace(/\$ARGUMENTS/g, args || '(no arguments provided)');
 }
 
-function hasLiveDataArgumentsPlaceholder(content: string): boolean {
-  return content.includes('$ARGUMENTS')
-    && content.split('\n').some((line) => /^\s*!/.test(line));
-}
-
 function validateLiveDataArguments(args: string): string | null {
   for (const char of args) {
     const code = char.charCodeAt(0);
@@ -304,9 +299,16 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   const displayArgs = isDeepInterviewAutoresearch
     ? stripInvocationFlag(args, '--autoresearch')
     : args;
-  const liveDataArgumentError = hasLiveDataArgumentsPlaceholder(cmd.content || '')
+  const commandContent = cmd.content || '';
+  const hasArgumentsPlaceholder = commandContent.includes('$ARGUMENTS');
+  const argumentValidationError = hasArgumentsPlaceholder
     ? validateLiveDataArguments(displayArgs)
     : null;
+  const resolvedContent = resolveArguments(commandContent, displayArgs);
+  const liveDataArgumentError = argumentValidationError
+    ?? (hasArgumentsPlaceholder && introducesLiveDataDirective(commandContent, resolvedContent)
+      ? 'live-data directive introduced by arguments'
+      : null);
   const renderedArgs = liveDataArgumentError
     ? `[blocked: ${liveDataArgumentError}]`
     : displayArgs;
@@ -340,7 +342,6 @@ function formatCommandTemplate(cmd: CommandInfo, args: string): string {
   sections.push('---\n');
 
   // Resolve arguments in content, then execute any live-data commands
-  const resolvedContent = resolveArguments(cmd.content || '', displayArgs);
   const baseContent = liveDataArgumentError
     ? `<live-data command="$ARGUMENTS" error="true">blocked: ${liveDataArgumentError}</live-data>`
     : resolveLiveData(resolvedContent);

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -41,7 +41,6 @@ const DIFF_FILE_HEADER_PATTERN = /^(?:diff --git|---|\+\+\+) [ab]\/(.+)/gm;
 const DIFF_HEADER_PREFIX_PATTERN = /^(?:diff --git|---|\+\+\+) [ab]\//;
 const SCRIPT_BEGIN_PATTERN = /^\s*!begin-script\s+(\S+)\s*$/;
 const SCRIPT_END_PATTERN = /^\s*!end-script\s*$/;
-const WHITESPACE_SPLIT_PATTERN = /\s/;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -61,6 +60,15 @@ interface SecurityPolicy {
 }
 
 type OutputFormat = "json" | "table" | "diff" | null;
+
+interface ParsedCommandInvocation {
+  executable: string;
+  args: string[];
+}
+
+type CommandParseResult =
+  | { ok: true; invocation: ParsedCommandInvocation }
+  | { ok: false; reason: string };
 
 // ─── Cache ───────────────────────────────────────────────────────────────────
 
@@ -129,6 +137,122 @@ export function clearCache(): void {
   onceCommands.clear();
 }
 
+function parseCommandInvocation(command: string): CommandParseResult {
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+  let tokenStarted = false;
+  let token = "";
+  const tokens: string[] = [];
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+    const isUnquotedTabDelimiter = char === "\t" && quote === null && !escaped;
+
+    if ((char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127) && !isUnquotedTabDelimiter) {
+      return { ok: false, reason: "control character rejected" };
+    }
+
+    if (escaped) {
+      token += char;
+      tokenStarted = true;
+      escaped = false;
+      continue;
+    }
+
+    if (quote === "single") {
+      if (char === "'") {
+        quote = null;
+      } else {
+        token += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+
+    if (quote === "double") {
+      if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        quote = null;
+      } else if (char === "`") {
+        return { ok: false, reason: "command substitution rejected" };
+      } else if (char === "$" && command[i + 1] === "(") {
+        return { ok: false, reason: "command substitution rejected" };
+      } else {
+        token += char;
+      }
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === " " || char === "\t") {
+      if (tokenStarted) {
+        tokens.push(token);
+        token = "";
+        tokenStarted = false;
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      quote = "single";
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === '"') {
+      quote = "double";
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      tokenStarted = true;
+      continue;
+    }
+
+    if (char === "`" || (char === "$" && command[i + 1] === "(")) {
+      return { ok: false, reason: "command substitution rejected" };
+    }
+
+    if (";&|<>".includes(char)) {
+      return { ok: false, reason: `shell operator rejected: ${char}` };
+    }
+
+    token += char;
+    tokenStarted = true;
+  }
+
+  if (escaped) {
+    return { ok: false, reason: "trailing escape" };
+  }
+
+  if (quote === "single") {
+    return { ok: false, reason: "unterminated single quote" };
+  }
+
+  if (quote === "double") {
+    return { ok: false, reason: "unterminated double quote" };
+  }
+
+  if (tokenStarted) {
+    tokens.push(token);
+  }
+
+  if (tokens.length === 0) {
+    return { ok: false, reason: "empty command" };
+  }
+
+  return {
+    ok: true,
+    invocation: {
+      executable: tokens[0],
+      args: tokens.slice(1),
+    },
+  };
+}
+
 // ─── Security ────────────────────────────────────────────────────────────────
 
 let cachedPolicy: SecurityPolicy | null = null;
@@ -162,9 +286,11 @@ export function resetSecurityPolicy(): void {
   policyLoadedFrom = null;
 }
 
-function checkSecurity(command: string): { allowed: boolean; reason?: string } {
+function checkSecurity(
+  command: string,
+  executable: string,
+): { allowed: boolean; reason?: string } {
   const policy = loadSecurityPolicy();
-  const cmdBase = command.split(WHITESPACE_SPLIT_PATTERN)[0];
 
   // Check denied patterns first (always enforced)
   if (policy.denied_patterns) {
@@ -185,8 +311,8 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   }
 
   if (policy.denied_commands) {
-    if (policy.denied_commands.includes(cmdBase)) {
-      return { allowed: false, reason: `command '${cmdBase}' is denied` };
+    if (policy.denied_commands.includes(executable)) {
+      return { allowed: false, reason: `command '${executable}' is denied` };
     }
   }
 
@@ -208,7 +334,7 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   let patternAllowed = false;
 
   if (policy.allowed_commands) {
-    baseAllowed = policy.allowed_commands.includes(cmdBase);
+    baseAllowed = policy.allowed_commands.includes(executable);
   }
 
   if (policy.allowed_patterns) {
@@ -233,7 +359,7 @@ function checkSecurity(command: string): { allowed: boolean; reason?: string } {
   if (!baseAllowed && !patternAllowed) {
     return {
       allowed: false,
-      reason: `command '${cmdBase}' not in allowlist`,
+      reason: `command '${executable}' not in allowlist`,
     };
   }
 
@@ -380,13 +506,17 @@ function checkIfBranch(pattern: string): boolean {
 
 // ─── Execution ───────────────────────────────────────────────────────────────
 
-function executeCommand(command: string): { stdout: string; error: boolean } {
+function executeCommand(
+  invocation: ParsedCommandInvocation,
+): { stdout: string; error: boolean } {
   try {
-    const stdout = execSync(command, {
+    const stdout = execFileSync(invocation.executable, invocation.args, {
+      shell: false,
       timeout: TIMEOUT_MS,
       maxBuffer: MAX_OUTPUT_BYTES + 1024,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let output = stdout ?? "";
@@ -518,7 +648,7 @@ export function resolveLiveData(content: string): string {
       scriptLineSet.add(i);
     }
 
-    const security = checkSecurity(block.shell);
+    const security = checkSecurity(block.shell, block.shell);
     if (!security.allowed) {
       scriptReplacements.set(
         block.startLine,
@@ -570,8 +700,16 @@ export function resolveLiveData(content: string): string {
 
     const directive = parseDirective(line);
 
-    // Security check
-    const security = checkSecurity(directive.command);
+    const parsed = parseCommandInvocation(directive.command);
+    if (!parsed.ok) {
+      result.push(
+        `<live-data command="${escapeHtml(directive.command)}" error="true">blocked: ${escapeHtml(parsed.reason)}</live-data>`,
+      );
+      continue;
+    }
+
+    const invocation = parsed.invocation;
+    const security = checkSecurity(directive.command, invocation.executable);
     if (!security.allowed) {
       result.push(
         `<live-data command="${escapeHtml(directive.command)}" error="true">blocked: ${escapeHtml(security.reason ?? "")}</live-data>`,
@@ -586,7 +724,7 @@ export function resolveLiveData(content: string): string {
             `<live-data command="${escapeHtml(directive.command)}" skipped="true">condition not met: no files matching '${escapeHtml(directive.pattern!)}' modified</live-data>`,
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
         break;
@@ -598,7 +736,7 @@ export function resolveLiveData(content: string): string {
             `<live-data command="${escapeHtml(directive.command)}" skipped="true">condition not met: branch does not match '${escapeHtml(directive.pattern!)}'</live-data>`,
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
         break;
@@ -611,7 +749,7 @@ export function resolveLiveData(content: string): string {
           );
         } else {
           markCommandExecuted(directive.command);
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
         break;
@@ -630,7 +768,7 @@ export function resolveLiveData(content: string): string {
             ).replace("<live-data", '<live-data cached="true"'),
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           setCache(directive.command, stdout, error, ttl);
           result.push(formatOutput(directive.command, stdout, error, null));
         }
@@ -650,7 +788,7 @@ export function resolveLiveData(content: string): string {
             ).replace("<live-data", '<live-data cached="true"'),
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           if (ttl > 0) setCache(directive.command, stdout, error, ttl);
           result.push(
             formatOutput(directive.command, stdout, error, directive.format!),
@@ -673,7 +811,7 @@ export function resolveLiveData(content: string): string {
             ).replace("<live-data", '<live-data cached="true"'),
           );
         } else {
-          const { stdout, error } = executeCommand(directive.command);
+          const { stdout, error } = executeCommand(invocation);
           if (ttl > 0) setCache(directive.command, stdout, error, ttl);
           result.push(formatOutput(directive.command, stdout, error, null));
         }

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -15,7 +15,7 @@
  * - Security allowlist via .omc/config/live-data-policy.json
  */
 
-import { execFileSync, execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import safe from "safe-regex";
@@ -39,7 +39,7 @@ const DIFF_ADDED_LINES_PATTERN = /^\+[^+]/gm;
 const DIFF_DELETED_LINES_PATTERN = /^-[^-]/gm;
 const DIFF_FILE_HEADER_PATTERN = /^(?:diff --git|---|\+\+\+) [ab]\/(.+)/gm;
 const DIFF_HEADER_PREFIX_PATTERN = /^(?:diff --git|---|\+\+\+) [ab]\//;
-const SCRIPT_BEGIN_PATTERN = /^\s*!begin-script\s+(\S+)\s*$/;
+const SCRIPT_BEGIN_PATTERN = /^\s*!begin-script\s+(.+?)\s*$/;
 const SCRIPT_END_PATTERN = /^\s*!end-script\s*$/;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -688,6 +688,12 @@ function getExecutableLiveDataLineIndexes(content: string): Set<number> {
   return executableLineIndexes;
 }
 
+function getExecutableScriptStartIndexes(content: string): Set<number> {
+  const lines = content.split("\n");
+  const codeBlockRanges = getCodeBlockRanges(lines);
+  return new Set(extractScriptBlocks(lines, codeBlockRanges).map((block) => block.startLine));
+}
+
 /**
  * Return whether placeholder replacement made a previously non-executable line
  * become an executable live-data directive.
@@ -707,6 +713,14 @@ export function introducesLiveDataDirective(
 
   const templateExecutableLines = getExecutableLiveDataLineIndexes(templateContent);
   const resolvedExecutableLines = getExecutableLiveDataLineIndexes(resolvedContent);
+  const templateScriptStarts = getExecutableScriptStartIndexes(templateContent);
+  const resolvedScriptStarts = getExecutableScriptStartIndexes(resolvedContent);
+
+  for (const lineIndex of resolvedScriptStarts) {
+    if (!templateScriptStarts.has(lineIndex)) {
+      return true;
+    }
+  }
 
   for (const lineIndex of resolvedExecutableLines) {
     if (!templateExecutableLines.has(lineIndex)) {
@@ -737,7 +751,20 @@ export function resolveLiveData(content: string): string {
       scriptLineSet.add(i);
     }
 
-    const security = checkSecurity(block.shell, block.shell);
+    const parsedShell = parseCommandInvocation(block.shell);
+    if (!parsedShell.ok || parsedShell.invocation.args.length > 0) {
+      const reason = parsedShell.ok
+        ? "script interpreter arguments are not supported"
+        : parsedShell.reason;
+      scriptReplacements.set(
+        block.startLine,
+        `<live-data command="script:${escapeHtml(block.shell)}" error="true">blocked: ${escapeHtml(reason)}</live-data>`,
+      );
+      continue;
+    }
+
+    const shellExecutable = parsedShell.invocation.executable;
+    const security = checkSecurity(block.shell, shellExecutable);
     if (!security.allowed) {
       scriptReplacements.set(
         block.startLine,
@@ -746,14 +773,16 @@ export function resolveLiveData(content: string): string {
       continue;
     }
 
-    // Write script to stdin of shell
+    // Write the authored script body to the explicitly allowlisted interpreter.
     try {
-      const result = execSync(block.shell, {
+      const result = execFileSync(shellExecutable, [], {
         input: block.body,
+        shell: false,
         timeout: TIMEOUT_MS,
         maxBuffer: MAX_OUTPUT_BYTES + 1024,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
       });
       scriptReplacements.set(
         block.startLine,

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -171,7 +171,12 @@ function parseCommandInvocation(command: string): CommandParseResult {
 
     if (quote === "double") {
       if (char === "\\") {
-        escaped = true;
+        const next = command[i + 1];
+        if (next === undefined || '"\\`$'.includes(next)) {
+          escaped = true;
+        } else {
+          token += char;
+        }
       } else if (char === '"') {
         quote = null;
       } else if (char === "`") {
@@ -207,7 +212,17 @@ function parseCommandInvocation(command: string): CommandParseResult {
     }
 
     if (char === "\\") {
-      escaped = true;
+      const next = command[i + 1];
+      if (
+        next === undefined ||
+        next === " " ||
+        next === "\t" ||
+        "'\"\\;&|<>`$".includes(next)
+      ) {
+        escaped = true;
+      } else {
+        token += char;
+      }
       tokenStarted = true;
       continue;
     }

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -70,6 +70,10 @@ type CommandParseResult =
   | { ok: true; invocation: ParsedCommandInvocation }
   | { ok: false; reason: string };
 
+function isWindowsPathToken(token: string): boolean {
+  return /^[A-Za-z]:/.test(token) || token.startsWith("\\");
+}
+
 // ─── Cache ───────────────────────────────────────────────────────────────────
 
 const cache = new Map<string, CacheEntry>();
@@ -172,7 +176,9 @@ function parseCommandInvocation(command: string): CommandParseResult {
     if (quote === "double") {
       if (char === "\\") {
         const next = command[i + 1];
-        if (next === undefined || '"\\`$'.includes(next)) {
+        if (isWindowsPathToken(token) || (token === "" && next === "\\")) {
+          token += char;
+        } else if (next === undefined || '"\\`$'.includes(next)) {
           escaped = true;
         } else {
           token += char;
@@ -213,7 +219,9 @@ function parseCommandInvocation(command: string): CommandParseResult {
 
     if (char === "\\") {
       const next = command[i + 1];
-      if (
+      if (isWindowsPathToken(token) || (token === "" && next === "\\")) {
+        token += char;
+      } else if (
         next === undefined ||
         next === " " ||
         next === "\t" ||
@@ -549,10 +557,13 @@ function executeCommand(
 
     return { stdout: output, error: false };
   } catch (err: unknown) {
+    const executionError = err as Error & { code?: string; stderr?: string };
     const message =
-      err instanceof Error
-        ? (err as { stderr?: string }).stderr || err.message
-        : String(err);
+      process.platform === "win32" && executionError?.code === "EINVAL"
+        ? "Windows .cmd/.bat launchers are unsupported for shell-free live-data execution"
+        : err instanceof Error
+          ? executionError.stderr || err.message
+          : String(err);
     return { stdout: String(message), error: true };
   }
 }
@@ -641,6 +652,14 @@ function extractScriptBlocks(
     }
   }
   return blocks;
+}
+
+export function hasLiveDataScriptArgumentPlaceholder(content: string): boolean {
+  const lines = content.split("\n");
+  const codeBlockRanges = getCodeBlockRanges(lines);
+  return extractScriptBlocks(lines, codeBlockRanges).some(
+    (block) => block.shell.includes("$ARGUMENTS") || block.body.includes("$ARGUMENTS"),
+  );
 }
 
 function getExecutableLiveDataLineIndexes(content: string): Set<number> {

--- a/src/hooks/auto-slash-command/live-data.ts
+++ b/src/hooks/auto-slash-command/live-data.ts
@@ -628,6 +628,61 @@ function extractScriptBlocks(
   return blocks;
 }
 
+function getExecutableLiveDataLineIndexes(content: string): Set<number> {
+  const lines = content.split("\n");
+  const codeBlockRanges = getCodeBlockRanges(lines);
+  const scriptBlocks = extractScriptBlocks(lines, codeBlockRanges);
+  const scriptLineIndexes = new Set<number>();
+  const executableLineIndexes = new Set<number>();
+
+  for (const block of scriptBlocks) {
+    executableLineIndexes.add(block.startLine);
+    for (let i = block.startLine; i <= block.endLine; i++) {
+      scriptLineIndexes.add(i);
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (scriptLineIndexes.has(i) || isInsideCodeBlock(i, codeBlockRanges)) {
+      continue;
+    }
+    if (isLiveDataLine(lines[i])) {
+      executableLineIndexes.add(i);
+    }
+  }
+
+  return executableLineIndexes;
+}
+
+/**
+ * Return whether placeholder replacement made a previously non-executable line
+ * become an executable live-data directive.
+ */
+export function introducesLiveDataDirective(
+  templateContent: string,
+  resolvedContent: string,
+): boolean {
+  const templateLines = templateContent.split("\n");
+  const resolvedLines = resolvedContent.split("\n");
+
+  // Argument validation should keep line counts stable. Fail closed if a caller
+  // skips that validation or a future replacement mechanism changes this rule.
+  if (templateLines.length !== resolvedLines.length) {
+    return true;
+  }
+
+  const templateExecutableLines = getExecutableLiveDataLineIndexes(templateContent);
+  const resolvedExecutableLines = getExecutableLiveDataLineIndexes(resolvedContent);
+
+  for (const lineIndex of resolvedExecutableLines) {
+    if (!templateExecutableLines.has(lineIndex)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 // ─── Main Resolver ───────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- execute single-line live-data commands with `execFileSync(..., { shell: false })` after strict token parsing
- apply allow/deny checks to the parsed executable and reject shell operators, substitutions, malformed quoting, and control characters
- reject `$ARGUMENTS` expansion whenever it introduces a new executable live-data directive, including placeholder-only templates and code-fence boundary changes
- add end-to-end regressions for the reported command-injection paths while preserving safe arguments on explicitly authored directives

## Security impact

Previously, an allowlisted executable such as `git` could be followed by shell syntax that was executed by `execSync`. In addition, a command template containing `$ARGUMENTS` but no literal live-data line could expand user input into a new `!command` directive. This change removes shell interpretation for single-line commands and prevents arguments from creating executable live-data directives that were not present in the authored template.

## Verification

- `npm test -- --run src/__tests__/auto-slash-live-data-security.test.ts src/__tests__/live-data.test.ts src/__tests__/auto-slash-aliases.test.ts` — 74 passed
- `npx tsc --noEmit` — passed
- focused ESLint — passed
- `npm run build` — passed
- `npm run plugin:shipping:verify` — passed
- independent review — no Critical or Important findings

The full repository suite is not green in this restricted macOS environment because unrelated platform-dependent tests require Linux `/proc`, localhost socket binding, and non-canonicalized temp paths. The focused affected surface is green.

This is a clean successor to #3693. It addresses the requested `$ARGUMENTS` change and omits the design/plan documents from the PR history.

Refs: #3693