### PR TITLE
feat(workflow): alias resolver and telemetry (#3706)

### DIFF
--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -85,6 +85,7 @@ import {
   type ActiveSkillSlot,
 } from "./skill-state/index.js";
 import { parseExplicitWorkflowSlashInvocation } from "./keyword-detector/index.js";
+import { resolveWorkflowInputWithWarning } from "../workflow/alias-resolver.js";
 import {
   ULTRATHINK_MESSAGE,
   SEARCH_MESSAGE,
@@ -1490,6 +1491,17 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
     };
   }
   if (explicitSlash) {
+    // Alias resolver: route slash invocations through Tier-0 mapping, emit once/session warning, retain diagnostics/telemetry.
+    // For explicit slash, we record alias telemetry and optionally emit a concise actionable warning.
+    // The underlying skill name remains the alias for compatibility (no breaking invocation), but telemetry maps it.
+    try {
+      const aliasRes = resolveWorkflowInputWithWarning(explicitSlash.skill, sessionId ?? undefined, directory);
+      if (aliasRes.warningToEmit && aliasRes.canonical && aliasRes.canonical !== explicitSlash.skill.toLowerCase()) {
+        messages.push(aliasRes.warningToEmit);
+      }
+    } catch {
+      // never break slash flow on alias resolver failure
+    }
     seedWorkflowSlotForSkill(
       directory,
       explicitSlash.skill,
@@ -1612,6 +1624,25 @@ async function processKeywordDetector(input: HookInput): Promise<HookOutput> {
   const sanitizedText = sanitizeForKeywordDetection(cleanedText);
   if (NON_LATIN_SCRIPT_PATTERN.test(sanitizedText)) {
     messages.push(PROMPT_TRANSLATION_MESSAGE);
+  }
+
+  // Alias resolver: concise actionable warning once/session, diagnostics retain full mapping.
+  // Telemetry/receipts are recorded inside resolveWorkflowInputWithWarning; explicit slash
+  // invocations are also covered via the invocation path below. For keyword-detected paths,
+  // emit at most one alias warning per detected keyword (deduped per session).
+  {
+    const aliasWarnings: string[] = [];
+    for (const kw of keywords) {
+      // normalize to resolver input form (keyword detector already lowercases)
+      const res = resolveWorkflowInputWithWarning(kw, sessionId ?? undefined, directory);
+      if (res.warningToEmit) aliasWarnings.push(res.warningToEmit);
+      // also handle explicit release via keyword-like "release" if ever surfaced as keyword — defensive
+    }
+    // Dedupe alias warnings across multiple keywords that map to same canonical
+    const uniqueAliasWarnings = [...new Set(aliasWarnings)];
+    for (const w of uniqueAliasWarnings) {
+      messages.push(w);
+    }
   }
 
   // Wake OpenClaw gateway for keyword-detector (non-blocking, fires for all prompts)

--- a/src/workflow/__tests__/alias-resolver.test.ts
+++ b/src/workflow/__tests__/alias-resolver.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  resolveWorkflowAlias,
+  resolveWorkflowAliasViaRegistry,
+  normalizeWorkflowInput,
+  formatAliasWarning,
+  isResolverEnabled,
+  isWarningOptedOut,
+  shouldEmitWarning,
+  markWarningEmitted,
+  maybeGetAliasWarning,
+  getAliasMapping,
+  getDiagnostics,
+  recordAliasTelemetry,
+  readUsageReceipts,
+  readTelemetryTail,
+  clearAliasTelemetryForTests,
+  clearAliasWarningsForTests,
+  ALIAS_REGISTRY,
+  TIER0_WORKFLOWS,
+  type AliasEntry,
+} from '../alias-resolver.js';
+// alias-resolver tests use worktreeRoot override; no direct worktree import needed
+
+function withEnv(overrides: Record<string, string | undefined>, fn: () => void) {
+  const prev: Record<string, string | undefined> = {};
+  for (const k of Object.keys(overrides)) {
+    prev[k] = process.env[k];
+    const v = overrides[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    fn();
+  } finally {
+    for (const k of Object.keys(prev)) {
+      const v = prev[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe('alias-resolver — Tier-0 routing', () => {
+  const origQuiet = process.env.OMC_QUIET;
+  const origResolver = process.env.OMC_ALIAS_RESOLVER_ENABLED;
+  const origDisable = process.env.OMC_DISABLE_ALIAS_RESOLVER;
+  beforeEach(() => {
+    delete process.env.OMC_QUIET;
+    delete process.env.OMC_ALIAS_WARNINGS;
+    delete process.env.OMC_ALIAS_WARNING_OPT_OUT;
+    delete process.env.OMC_ALIAS_NO_WARNING;
+    delete process.env.OMC_ALIAS_WARNINGS_DISABLED;
+    delete process.env.OMC_ALIAS_RESOLVER_ENABLED;
+    delete process.env.OMC_DISABLE_ALIAS_RESOLVER;
+  });
+  afterEach(() => {
+    if (origQuiet === undefined) delete process.env.OMC_QUIET; else process.env.OMC_QUIET = origQuiet;
+    if (origResolver === undefined) delete process.env.OMC_ALIAS_RESOLVER_ENABLED; else process.env.OMC_ALIAS_RESOLVER_ENABLED = origResolver;
+    if (origDisable === undefined) delete process.env.OMC_DISABLE_ALIAS_RESOLVER; else process.env.OMC_DISABLE_ALIAS_RESOLVER = origDisable;
+  });
+
+  it('routes autopilot -> execute', () => {
+    const r = resolveWorkflowAlias('autopilot');
+    expect(r.canonical).toBe('execute');
+    expect(r.tier0).toBe('execute');
+    expect(r.isAlias).toBe(true);
+    expect(r.warning).toContain('execute');
+  });
+
+  it('routes ralph -> execute', () => {
+    expect(resolveWorkflowAlias('ralph').canonical).toBe('execute');
+  });
+
+  it('routes ultrawork -> execute', () => {
+    expect(resolveWorkflowAlias('ultrawork').canonical).toBe('execute');
+  });
+
+  it('routes ultrapilot -> execute', () => {
+    expect(resolveWorkflowAlias('ultrapilot').canonical).toBe('execute');
+  });
+
+  it('routes swarm -> execute', () => {
+    expect(resolveWorkflowAlias('swarm').canonical).toBe('execute');
+  });
+
+  it('routes pipeline -> execute', () => {
+    expect(resolveWorkflowAlias('pipeline').canonical).toBe('execute');
+  });
+
+  it('routes ultraqa -> verify', () => {
+    expect(resolveWorkflowAlias('ultraqa').canonical).toBe('verify');
+    expect(resolveWorkflowAlias('ultraqa').tier0).toBe('verify');
+  });
+
+  it('routes ai-slop-cleaner -> review', () => {
+    expect(resolveWorkflowAlias('ai-slop-cleaner').canonical).toBe('review');
+  });
+
+  it('routes ralplan -> plan', () => {
+    expect(resolveWorkflowAlias('ralplan').canonical).toBe('plan');
+    expect(resolveWorkflowAlias('ralplan').tier0).toBe('plan');
+  });
+
+  it('routes ccg -> execute', () => {
+    expect(resolveWorkflowAlias('ccg').canonical).toBe('execute');
+  });
+
+  it('routes release -> omc-release (maintainer-only)', () => {
+    const r = resolveWorkflowAlias('release');
+    expect(r.canonical).toBe('omc-release');
+    expect(r.isRelease).toBe(true);
+    expect(r.warning).toContain('omc release');
+    expect(r.tier0).toBe(null);
+  });
+
+  it('canonical Tier-0 workflows are not aliases', () => {
+    for (const c of TIER0_WORKFLOWS) {
+      const r = resolveWorkflowAlias(c);
+      expect(r.isAlias).toBe(false);
+      expect(r.isCanonical).toBe(true);
+      expect(r.warning).toBe(null);
+      expect(r.canonical).toBe(c);
+    }
+  });
+
+  it('is case-insensitive and handles slash prefixes', () => {
+    expect(resolveWorkflowAlias('Ralph').canonical).toBe('execute');
+    expect(resolveWorkflowAlias('/ralph').canonical).toBe('execute');
+    expect(resolveWorkflowAlias('/omc:autopilot').canonical).toBe('execute');
+    expect(resolveWorkflowAlias('/oh-my-claudecode:ultrawork').canonical).toBe('execute');
+    expect(resolveWorkflowAlias('OMC:RALPLAN').canonical).toBe('plan');
+  });
+
+  it('unknown tokens pass through without alias flag', () => {
+    const r = resolveWorkflowAlias('unknown-workflow-xyz');
+    expect(r.isAlias).toBe(false);
+    expect(r.warning).toBe(null);
+  });
+
+  it('resolver flag disables alias routing', () => {
+    withEnv({ OMC_ALIAS_RESOLVER_ENABLED: '0' }, () => {
+      expect(isResolverEnabled()).toBe(false);
+      const r = resolveWorkflowAlias('ralph');
+      expect(r.isAlias).toBe(false);
+      expect(r.warning).toBe(null);
+      expect(r.enabled).toBe(false);
+    });
+    expect(isResolverEnabled()).toBe(true);
+  });
+
+  it('resolver flag via OMC_DISABLE_ALIAS_RESOLVER', () => {
+    withEnv({ OMC_DISABLE_ALIAS_RESOLVER: '1' }, () => {
+      expect(isResolverEnabled()).toBe(false);
+    });
+  });
+
+  it('adapter seam resolveWorkflowAliasViaRegistry honors injected registry', () => {
+    const fake: AliasEntry = { alias: 'my-alias', canonical: 'plan', tier0: 'plan', owner: 'test', description: 'x', removalMilestone: 'test', isWorkflowAlias: true };
+    const lookup = (k: string) => (k === 'my-alias' ? fake : undefined);
+    expect(resolveWorkflowAliasViaRegistry('my-alias', lookup).canonical).toBe('plan');
+    expect(resolveWorkflowAliasViaRegistry('unknown', lookup).isAlias).toBe(false);
+  });
+});
+
+describe('alias-resolver — warnings once/session + diagnostics', () => {
+  it('warning is concise and actionable', () => {
+    const w = formatAliasWarning('ralph', 'execute');
+    expect(w.length).toBeLessThan(160);
+    expect(w).toContain('ralph');
+    expect(w).toContain('execute');
+    const rw = formatAliasWarning('release', 'omc-release');
+    expect(rw).toContain('omc release');
+  });
+
+  it('getAliasMapping retains full mapping/telemetry even when warnings suppressed', () => {
+    const mapping = getAliasMapping();
+    expect(mapping.length).toBeGreaterThan(10);
+    expect(mapping.find((m) => m.alias === 'ralph')?.canonical).toBe('execute');
+    expect(mapping.find((m) => m.alias === 'release')?.canonical).toBe('omc-release');
+    // diagnostics
+    const d = getDiagnostics();
+    expect(d.tier0).toEqual(expect.arrayContaining(['plan', 'execute', 'review', 'verify']));
+    expect(d.aliases.length).toBe(mapping.length);
+    expect(d.planHead).toBe('0a91273e61dbbd47eb0af4c02844409251e08398');
+  });
+
+  it('normalization strips prefixes and punctuation', () => {
+    expect(normalizeWorkflowInput('/ralph ')).toBe('ralph');
+    expect(normalizeWorkflowInput(' /omc:autopilot!')).toBe('autopilot');
+    expect(normalizeWorkflowInput('Release.')).toBe('release');
+  });
+});
+
+describe('alias-resolver — automation opt-out', () => {
+  const keys = ['OMC_ALIAS_WARNINGS', 'OMC_ALIAS_WARNING_OPT_OUT', 'OMC_ALIAS_NO_WARNING', 'OMC_ALIAS_WARNINGS_DISABLED', 'OMC_QUIET'];
+
+  function cleanup() {
+    for (const k of keys) delete process.env[k];
+  }
+
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it('OMC_ALIAS_WARNINGS=0 opts out', () => {
+    process.env.OMC_ALIAS_WARNINGS = '0';
+    expect(isWarningOptedOut()).toBe(true);
+  });
+
+  it('OMC_ALIAS_WARNINGS=1 does not opt out', () => {
+    process.env.OMC_ALIAS_WARNINGS = '1';
+    expect(isWarningOptedOut()).toBe(false);
+  });
+
+  it('OMC_ALIAS_WARNING_OPT_OUT=1 opts out', () => {
+    process.env.OMC_ALIAS_WARNING_OPT_OUT = '1';
+    expect(isWarningOptedOut()).toBe(true);
+  });
+
+  it('OMC_QUIET=1 opts out warnings (bounded)', () => {
+    process.env.OMC_QUIET = '1';
+    expect(isWarningOptedOut()).toBe(true);
+  });
+
+  it('OMC_QUIET=0 does not opt out', () => {
+    process.env.OMC_QUIET = '0';
+    expect(isWarningOptedOut()).toBe(false);
+  });
+
+  it('no env -> not opted out', () => {
+    expect(isWarningOptedOut()).toBe(false);
+  });
+
+  it('maybeGetAliasWarning respects opt-out and dedupes via file', () => {
+    const worktreeRoot = mkdtempSync(join(tmpdir(), 'alias-optout-'));
+    const sessionId = '00000000-0000-4000-a000-000000000000';
+    const sidSafe = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    // ensure worktree root looks git-like so getOmcRoot resolves under it, but alias-resolver uses worktreeRoot param
+    // We just exercise the file path directly via worktreeRoot override
+    try {
+      // without opt-out, first call emits
+      delete process.env.OMC_QUIET;
+      const res = resolveWorkflowAlias('ralph');
+      const w1 = maybeGetAliasWarning(res, sidSafe, worktreeRoot);
+      expect(w1).not.toBe(null);
+      // second call for same alias/session is suppressed
+      const w2 = maybeGetAliasWarning(res, sidSafe, worktreeRoot);
+      expect(w2).toBe(null);
+      // but a different alias still emits
+      const res2 = resolveWorkflowAlias('autopilot');
+      const w3 = maybeGetAliasWarning(res2, sidSafe, worktreeRoot);
+      expect(w3).not.toBe(null);
+      // opt-out suppresses even first warning for a fresh alias
+      process.env.OMC_QUIET = '1';
+      const res3 = resolveWorkflowAlias('ultrawork');
+      const w4 = maybeGetAliasWarning(res3, sidSafe, worktreeRoot);
+      expect(w4).toBe(null);
+    } finally {
+      rmSync(worktreeRoot, { recursive: true, force: true });
+      delete process.env.OMC_QUIET;
+    }
+  });
+});
+
+describe('alias-resolver — once/session warning via file state', () => {
+  it('shouldEmitWarning / markWarningEmitted file cycle', () => {
+    const worktreeRoot = mkdtempSync(join(tmpdir(), 'alias-warn-'));
+    const sid = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    try {
+      clearAliasWarningsForTests(sid, worktreeRoot);
+      expect(shouldEmitWarning('ralph', sid, worktreeRoot)).toBe(true);
+      markWarningEmitted('ralph', sid, worktreeRoot);
+      expect(shouldEmitWarning('ralph', sid, worktreeRoot)).toBe(false);
+      expect(shouldEmitWarning('autopilot', sid, worktreeRoot)).toBe(true);
+      // case-insensitive normalized key
+      expect(shouldEmitWarning('RALPH', sid, worktreeRoot)).toBe(false);
+    } finally {
+      rmSync(worktreeRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('alias-resolver — telemetry and usage receipts', () => {
+  it('records alias uses to receipts and telemetry', () => {
+    const worktreeRoot = mkdtempSync(join(tmpdir(), 'alias-receipt-'));
+    try {
+      clearAliasTelemetryForTests(worktreeRoot);
+      // alias use
+      recordAliasTelemetry({ alias: 'ralph', normalized: 'ralph', canonical: 'execute', tier0: 'execute', sessionId: 's1', warned: true, release: false }, worktreeRoot);
+      recordAliasTelemetry({ alias: 'ralph', normalized: 'ralph', canonical: 'execute', tier0: 'execute', sessionId: 's1', warned: false, release: false }, worktreeRoot);
+      recordAliasTelemetry({ alias: 'release', normalized: 'release', canonical: 'omc-release', tier0: null, sessionId: 's1', warned: true, release: true }, worktreeRoot);
+      const receipts = readUsageReceipts(worktreeRoot);
+      expect(receipts.byAlias['ralph'].count).toBe(2);
+      expect(receipts.byAlias['release'].count).toBe(1);
+      expect(receipts.totals.aliasUses).toBe(3);
+      expect(receipts.releaseUses).toBe(1);
+      const tail = readTelemetryTail(10, worktreeRoot);
+      expect(tail.length).toBe(3);
+      expect(tail[0].canonical).toBe('execute');
+    } finally {
+      rmSync(worktreeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('registry covers expected aliases and excludes self-canonical entries', () => {
+    // verify registry sanity: each alias (except canonical self-entries) routes to Tier-0 or omc-release
+    for (const e of ALIAS_REGISTRY) {
+      const isSelfCanonical = e.alias.toLowerCase() === e.canonical.toLowerCase();
+      if (isSelfCanonical) {
+        expect(TIER0_WORKFLOWS).toContain(e.canonical as any);
+      } else {
+        expect(['plan', 'execute', 'review', 'verify', 'omc-release']).toContain(e.canonical);
+      }
+    }
+  });
+});

--- a/src/workflow/alias-resolver.ts
+++ b/src/workflow/alias-resolver.ts
@@ -1,0 +1,708 @@
+/**
+ * Alias Resolver — issue #3706
+ *
+ * Maps legacy workflow / skill / command aliases to the four Tier-0
+ * canonical workflows (`plan`, `execute`, `review`, `verify`) or the
+ * maintainer-only `omc release` authority. Provides:
+ *  - one concise actionable warning per alias per session (default)
+ *  - diagnostics mapping/telemetry retention
+ *  - temporary automation opt-out
+ *  - usage receipts (machine-readable)
+ *  - resolver flag rollback (`OMC_ALIAS_RESOLVER_ENABLED`)
+ *
+ * Design contract: docs/design/ISSUE-3698-LIGHTWEIGHT-WORKFLOW-PLAN.md
+ * Plan head: 0a91273e61dbbd47eb0af4c02844409251e08398
+ * Epic: #3698, child: #3706
+ *
+ * This module is intentionally additive and dependency-light. When the
+ * prerequisite registry (#3703) lands, this resolver adapts to that
+ * registry via a narrow adapter seam (see `resolveWorkflowAliasViaRegistry`
+ * hook). The resolver flag gates all behavior so a rollout issue can fall
+ * back to legacy mapping without a code revert.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'fs';
+import { join } from 'path';
+import { getOmcRoot, resolveToWorktreeRoot } from '../lib/worktree-paths.js';
+
+
+// ---------------------------------------------------------------------------
+// Tier-0 contract
+// ---------------------------------------------------------------------------
+
+export const TIER0_WORKFLOWS = ['plan', 'execute', 'review', 'verify'] as const;
+export type Tier0Workflow = (typeof TIER0_WORKFLOWS)[number];
+
+export type AliasTarget = Tier0Workflow | 'omc-release';
+
+export interface AliasEntry {
+  alias: string;
+  canonical: AliasTarget;
+  tier0?: Tier0Workflow; // when canonical is omc-release, tier0 is undefined
+  owner: string;
+  description: string;
+  removalMilestone: string; // e.g. "≥2 minor releases + 90 days, ≥95% canonical share"
+  isWorkflowAlias: boolean;
+}
+
+export interface AliasMappingDiagnostics {
+  alias: string;
+  canonical: AliasTarget;
+  tier0: Tier0Workflow | null;
+  warning: string;
+  owner: string;
+  removalMilestone: string;
+}
+
+// Tier-0 workflows are themselves canonical; they appear as keys with isAlias=false
+const CANONICAL_SET = new Set<string>(TIER0_WORKFLOWS);
+
+export const ALIAS_REGISTRY: readonly AliasEntry[] = [
+  // ---- Workflow aliases → execute ----
+  { alias: 'autopilot', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'legacy autopilot pipeline', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'ralph', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'ralph continuation/evidence', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'ultrawork', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'ultrawork parallelism', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'ultrapilot', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'ultrapilot (team+ultragoal)', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'swarm', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'swarm workers', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'pipeline', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'legacy pipeline stages', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'team', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'team orchestration (now executor detail)', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'ccg', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'claude-codex-gemini orchestration', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'omc-teams', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'omc-teams command alias', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+
+  // ---- Workflow aliases → plan ----
+  { alias: 'ralplan', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'ralplan consensus planning', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'deep-interview', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'deep-interview requirements', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'deep-dive', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'deep-dive research', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'sciomc', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'sciomc research', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'autoresearch', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'autoresearch lane', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'ultragoal', canonical: 'execute', tier0: 'execute', owner: 'workflow-registry', description: 'ultragoal stages', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+
+  // ---- Workflow aliases → review ----
+  { alias: 'merge-readiness', canonical: 'review', tier0: 'review', owner: 'workflow-registry', description: 'merge-readiness gate', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'ai-slop-cleaner', canonical: 'review', tier0: 'review', owner: 'workflow-registry', description: 'ai-slop-cleaner (opt-in)', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'visual-verdict', canonical: 'review', tier0: 'review', owner: 'workflow-registry', description: 'visual-verdict (opt-in)', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+
+  // ---- Workflow aliases → verify ----
+  { alias: 'ultraqa', canonical: 'verify', tier0: 'verify', owner: 'workflow-registry', description: 'ultraqa QA cycle', removalMilestone: '≥2 minor +90d, ≥95% canonical', isWorkflowAlias: true },
+  { alias: 'verify', canonical: 'verify', tier0: 'verify', owner: 'workflow-registry', description: 'verify (now Tier-0)', removalMilestone: 'canonical', isWorkflowAlias: true },
+
+  // ---- Utility compatibility aliases (not Tier-0, kept for diagnostics) ----
+  { alias: 'mcp-setup', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'mcp-setup → omc-setup (utility)', removalMilestone: '≥2 minor +90d', isWorkflowAlias: false },
+  { alias: 'learner', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'learner → skillify/memory', removalMilestone: '≥2 minor +90d', isWorkflowAlias: false },
+  { alias: 'writer-memory', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'writer-memory → memory utility', removalMilestone: '≥2 minor +90d', isWorkflowAlias: false },
+  { alias: 'psm', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'psm → project-session-manager', removalMilestone: '≥2 minor +90d', isWorkflowAlias: false },
+  { alias: 'self-improve', canonical: 'plan', tier0: 'plan', owner: 'workflow-registry', description: 'self-improve (opt-in)', removalMilestone: '≥2 minor +90d', isWorkflowAlias: false },
+
+  // ---- Maintainer-only release ----
+  { alias: 'release', canonical: 'omc-release', owner: 'maintainers', description: 'release → maintainer-only omc release', removalMilestone: 'compatibility alias during migration; never auto-removed without owner approval', isWorkflowAlias: true },
+] as const;
+
+const aliasLookup = new Map<string, AliasEntry>();
+for (const e of ALIAS_REGISTRY) {
+  aliasLookup.set(e.alias.toLowerCase(), e);
+}
+
+// ---------------------------------------------------------------------------
+// Resolver flag (rollback)
+// ---------------------------------------------------------------------------
+
+export function isResolverEnabled(): boolean {
+  const env = process.env.OMC_ALIAS_RESOLVER_ENABLED;
+  if (env !== undefined) {
+    const v = env.trim().toLowerCase();
+    if (v === '0' || v === 'false' || v === 'off' || v === 'disabled') return false;
+    if (v === '1' || v === 'true' || v === 'on' || v === 'enabled') return true;
+  }
+  // Also respect generic disable env
+  if (process.env.OMC_DISABLE_ALIAS_RESOLVER === '1') return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Warning opt-out (temporary automation opt-out)
+// ---------------------------------------------------------------------------
+
+export function isWarningOptedOut(): boolean {
+  const env = process.env.OMC_ALIAS_WARNINGS ?? process.env.OMC_ALIAS_WARNING_OPT_OUT ?? process.env.OMC_ALIAS_NO_WARNING;
+  if (env !== undefined) {
+    const v = env.trim().toLowerCase();
+    const hasWarningsKey = process.env.OMC_ALIAS_WARNINGS !== undefined;
+    if (['0', 'false', 'off', '1', 'true', 'disabled', 'enabled', 'on', 'no', 'yes'].includes(v)) {
+      if (hasWarningsKey) {
+        if (['0', 'false', 'off', 'disabled', 'no'].includes(v)) return true;
+        return false;
+      }
+      return ['1', 'true', 'on', 'enabled', 'yes'].includes(v);
+    }
+  }
+  if (process.env.OMC_ALIAS_WARNINGS_DISABLED === '1') return true;
+  // Automation noise: when OMC_QUIET is set, suppress alias warnings as well (bounded)
+  const quiet = process.env.OMC_QUIET;
+  if (quiet !== undefined) {
+    const q = Number.parseInt(quiet, 10);
+    if (!Number.isNaN(q) && q >= 1) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+export function normalizeWorkflowInput(raw: string): string {
+  if (typeof raw !== 'string') return '';
+  let s = raw.trim().toLowerCase();
+  // strip leading slash/command prefixes
+  s = s.replace(/^\/(?:oh-my-claudecode:|omc:)?/i, '');
+  s = s.replace(/^omc:/i, '');
+  s = s.replace(/^oh-my-claudecode:/i, '');
+  // strip trailing punctuation that sometimes follows a bare alias token
+  s = s.replace(/[?!.,;:]+$/g, '');
+  s = s.trim();
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Core resolution
+// ---------------------------------------------------------------------------
+
+export interface AliasResolution {
+  input: string;
+  normalized: string;
+  canonical: AliasTarget;
+  tier0: Tier0Workflow | null;
+  isAlias: boolean;
+  isCanonical: boolean;
+  isRelease: boolean;
+  warning: string | null;
+  mapping: { alias: string; canonical: AliasTarget } | null;
+  enabled: boolean;
+}
+
+export function formatAliasWarning(alias: string, canonical: AliasTarget): string {
+  if (canonical === 'omc-release') {
+    return `Alias "${alias}" is deprecated → use "omc release" (maintainer-only). Run "omc release --help" for the canonical path.`;
+  }
+  return `Alias "${alias}" is deprecated → use "${canonical}" (Tier-0). Run "/${canonical} ..." next time.`;
+}
+
+export function resolveWorkflowAlias(rawInput: string): AliasResolution {
+  const normalized = normalizeWorkflowInput(rawInput);
+  const enabled = isResolverEnabled();
+
+  // Fast path: resolver disabled → legacy behavior (no alias routing)
+  if (!enabled) {
+    const canon = (CANONICAL_SET.has(normalized) ? normalized : normalized) as AliasTarget;
+    const tier0 = (TIER0_WORKFLOWS as readonly string[]).includes(normalized) ? (normalized as Tier0Workflow) : null;
+    return {
+      input: rawInput,
+      normalized,
+      canonical: canon,
+      tier0,
+      isAlias: false,
+      isCanonical: CANONICAL_SET.has(normalized),
+      isRelease: false,
+      warning: null,
+      mapping: null,
+      enabled: false,
+    };
+  }
+
+  if (!normalized) {
+    return {
+      input: rawInput,
+      normalized,
+      canonical: '' as AliasTarget,
+      tier0: null,
+      isAlias: false,
+      isCanonical: false,
+      isRelease: false,
+      warning: null,
+      mapping: null,
+      enabled: true,
+    };
+  }
+
+  const entry = aliasLookup.get(normalized);
+  if (entry) {
+    const _isAlias = entry.canonical !== entry.alias.toLowerCase() || !CANONICAL_SET.has(normalized);
+    // canonical entries that are themselves Tier-0 (e.g. verify) are not aliases even if present in registry
+    const trulyAlias = entry.alias.toLowerCase() !== entry.canonical.toLowerCase() || !CANONICAL_SET.has(normalized);
+    // For 'verify' canonical entry we still treat as non-alias (isAlias false) to avoid warning on canonical use
+    if (entry.alias.toLowerCase() === entry.canonical.toLowerCase() && CANONICAL_SET.has(normalized)) {
+      return {
+        input: rawInput,
+        normalized,
+        canonical: entry.canonical,
+        tier0: (entry.tier0 ?? null) as Tier0Workflow | null,
+        isAlias: false,
+        isCanonical: true,
+        isRelease: entry.canonical === 'omc-release',
+        warning: null,
+        mapping: null,
+        enabled: true,
+      };
+    }
+    const warn = trulyAlias ? formatAliasWarning(entry.alias, entry.canonical) : null;
+    return {
+      input: rawInput,
+      normalized,
+      canonical: entry.canonical,
+      tier0: (entry.tier0 ?? null) as Tier0Workflow | null,
+      isAlias: trulyAlias,
+      isCanonical: !trulyAlias,
+      isRelease: entry.canonical === 'omc-release',
+      warning: warn,
+      mapping: { alias: entry.alias, canonical: entry.canonical },
+      enabled: true,
+    };
+  }
+
+  // Not in alias registry: if it's a Tier-0 canonical, no alias
+  if (CANONICAL_SET.has(normalized)) {
+    return {
+      input: rawInput,
+      normalized,
+      canonical: normalized as Tier0Workflow,
+      tier0: normalized as Tier0Workflow,
+      isAlias: false,
+      isCanonical: true,
+      isRelease: false,
+      warning: null,
+      mapping: null,
+      enabled: true,
+    };
+  }
+
+  // Unknown token: pass-through (no warning)
+  return {
+    input: rawInput,
+    normalized,
+    canonical: normalized as AliasTarget,
+    tier0: null,
+    isAlias: false,
+    isCanonical: false,
+    isRelease: false,
+    warning: null,
+    mapping: null,
+    enabled: true,
+  };
+}
+
+// Adapter seam for future registry (#3703): callers can inject a lookup function
+export type AliasRegistryLookup = (normalized: string) => AliasEntry | undefined;
+export function resolveWorkflowAliasViaRegistry(rawInput: string, lookup: AliasRegistryLookup): AliasResolution {
+  const normalized = normalizeWorkflowInput(rawInput);
+  const enabled = isResolverEnabled();
+  if (!enabled) {
+    const tier0 = (TIER0_WORKFLOWS as readonly string[]).includes(normalized) ? (normalized as Tier0Workflow) : null;
+    return {
+      input: rawInput,
+      normalized,
+      canonical: normalized as AliasTarget,
+      tier0,
+      isAlias: false,
+      isCanonical: CANONICAL_SET.has(normalized),
+      isRelease: false,
+      warning: null,
+      mapping: null,
+      enabled: false,
+    };
+  }
+  const entry = lookup(normalized);
+  if (entry) {
+    const isAlias = entry.alias.toLowerCase() !== entry.canonical.toLowerCase() || !CANONICAL_SET.has(normalized);
+    if (entry.alias.toLowerCase() === entry.canonical.toLowerCase() && CANONICAL_SET.has(normalized)) {
+      return {
+        input: rawInput,
+        normalized,
+        canonical: entry.canonical,
+        tier0: (entry.tier0 ?? null) as Tier0Workflow | null,
+        isAlias: false,
+        isCanonical: true,
+        isRelease: entry.canonical === 'omc-release',
+        warning: null,
+        mapping: null,
+        enabled: true,
+      };
+    }
+    return {
+      input: rawInput,
+      normalized,
+      canonical: entry.canonical,
+      tier0: (entry.tier0 ?? null) as Tier0Workflow | null,
+      isAlias: isAlias,
+      isCanonical: !isAlias,
+      isRelease: entry.canonical === 'omc-release',
+      warning: isAlias ? formatAliasWarning(entry.alias, entry.canonical) : null,
+      mapping: { alias: entry.alias, canonical: entry.canonical },
+      enabled: true,
+    };
+  }
+  if (CANONICAL_SET.has(normalized)) {
+    return {
+      input: rawInput,
+      normalized,
+      canonical: normalized as Tier0Workflow,
+      tier0: normalized as Tier0Workflow,
+      isAlias: false,
+      isCanonical: true,
+      isRelease: false,
+      warning: null,
+      mapping: null,
+      enabled: true,
+    };
+  }
+  return {
+    input: rawInput,
+    normalized,
+    canonical: normalized as AliasTarget,
+    tier0: null,
+    isAlias: false,
+    isCanonical: false,
+    isRelease: false,
+    warning: null,
+    mapping: null,
+    enabled: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+export function getAliasMapping(): AliasMappingDiagnostics[] {
+  return ALIAS_REGISTRY
+    .filter((e) => e.alias.toLowerCase() !== e.canonical.toLowerCase() || !CANONICAL_SET.has(e.alias.toLowerCase()))
+    .map((e) => ({
+      alias: e.alias,
+      canonical: e.canonical,
+      tier0: e.tier0 ?? null,
+      warning: formatAliasWarning(e.alias, e.canonical),
+      owner: e.owner,
+      removalMilestone: e.removalMilestone,
+    }));
+}
+
+export function getDiagnostics(): {
+  tier0: readonly Tier0Workflow[];
+  aliases: AliasMappingDiagnostics[];
+  resolverEnabled: boolean;
+  warningOptOut: boolean;
+  planHead: string;
+} {
+  return {
+    tier0: TIER0_WORKFLOWS,
+    aliases: getAliasMapping(),
+    resolverEnabled: isResolverEnabled(),
+    warningOptOut: isWarningOptedOut(),
+    planHead: '0a91273e61dbbd47eb0af4c02844409251e08398',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Warning dedupe — one concise warning per alias per session
+// ---------------------------------------------------------------------------
+
+function aliasWarningsPath(sessionId?: string, worktreeRoot?: string): string {
+  const root = getOmcRoot(worktreeRoot ?? resolveToWorktreeRoot());
+  if (sessionId) {
+    // Validate sessionId loosely — reuse existing validation if available
+    const safe = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return join(root, 'state', 'sessions', safe, 'alias-warnings.json');
+  }
+  return join(root, 'state', 'alias-warnings.json');
+}
+
+type WarningsState = Record<string, string>; // alias(normalized) -> iso timestamp warned
+
+function readWarnings(sessionId?: string, worktreeRoot?: string): WarningsState {
+  const p = aliasWarningsPath(sessionId, worktreeRoot);
+  try {
+    if (!existsSync(p)) return {};
+    const raw = readFileSync(p, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as WarningsState;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function writeWarnings(state: WarningsState, sessionId?: string, worktreeRoot?: string): void {
+  const p = aliasWarningsPath(sessionId, worktreeRoot);
+  try {
+    mkdirSync(join(p, '..'), { recursive: true });
+    writeFileSync(p, JSON.stringify(state, null, 2));
+  } catch {
+    // best-effort
+  }
+}
+
+export function shouldEmitWarning(alias: string, sessionId?: string, worktreeRoot?: string): boolean {
+  if (isWarningOptedOut()) return false;
+  const normalized = normalizeWorkflowInput(alias);
+  if (!normalized) return false;
+  const state = readWarnings(sessionId, worktreeRoot);
+  return !(normalized in state);
+}
+
+export function markWarningEmitted(alias: string, sessionId?: string, worktreeRoot?: string): void {
+  const normalized = normalizeWorkflowInput(alias);
+  if (!normalized) return;
+  const state = readWarnings(sessionId, worktreeRoot);
+  if (normalized in state) return;
+  state[normalized] = new Date().toISOString();
+  writeWarnings(state, sessionId, worktreeRoot);
+}
+
+// Returns warning string if it should be emitted (and marks it), else null
+export function maybeGetAliasWarning(resolution: AliasResolution, sessionId?: string, worktreeRoot?: string): string | null {
+  if (!resolution.isAlias || !resolution.warning) return null;
+  if (isWarningOptedOut()) return null;
+  if (!isResolverEnabled()) return null;
+  if (!shouldEmitWarning(resolution.normalized, sessionId, worktreeRoot)) return null;
+  markWarningEmitted(resolution.normalized, sessionId, worktreeRoot);
+  // Also record telemetry/receipt even when warning is suppressed later — this call records the warning event
+  return resolution.warning;
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry & receipts
+// ---------------------------------------------------------------------------
+
+export interface AliasTelemetryEvent {
+  alias: string;
+  normalized: string;
+  canonical: AliasTarget;
+  tier0: Tier0Workflow | null;
+  timestamp: string;
+  sessionId?: string;
+  warned: boolean;
+  release: boolean;
+}
+
+function telemetryPath(worktreeRoot?: string): string {
+  const root = getOmcRoot(worktreeRoot ?? resolveToWorktreeRoot());
+  return join(root, 'state', 'alias-telemetry.jsonl');
+}
+
+function receiptsPath(worktreeRoot?: string): string {
+  const root = getOmcRoot(worktreeRoot ?? resolveToWorktreeRoot());
+  return join(root, 'state', 'alias-receipts.json');
+}
+
+export interface AliasReceipts {
+  version: 1;
+  planHead: string;
+  generatedAt: string;
+  totals: { aliasUses: number; canonicalUses: number };
+  byAlias: Record<string, { count: number; canonical: AliasTarget; lastSeen: string }>;
+  byCanonical: Record<string, number>;
+  releaseUses: number;
+}
+
+function readReceipts(worktreeRoot?: string): AliasReceipts {
+  const p = receiptsPath(worktreeRoot);
+  try {
+    if (!existsSync(p)) {
+      return { version: 1, planHead: '0a91273e61dbbd47eb0af4c02844409251e08398', generatedAt: new Date().toISOString(), totals: { aliasUses: 0, canonicalUses: 0 }, byAlias: {}, byCanonical: {}, releaseUses: 0 };
+    }
+    const raw = readFileSync(p, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed as AliasReceipts;
+    return { version: 1, planHead: '0a91273e61dbbd47eb0af4c02844409251e08398', generatedAt: new Date().toISOString(), totals: { aliasUses: 0, canonicalUses: 0 }, byAlias: {}, byCanonical: {}, releaseUses: 0 };
+  } catch {
+    return { version: 1, planHead: '0a91273e61dbbd47eb0af4c02844409251e08398', generatedAt: new Date().toISOString(), totals: { aliasUses: 0, canonicalUses: 0 }, byAlias: {}, byCanonical: {}, releaseUses: 0 };
+  }
+}
+
+function writeReceipts(receipts: AliasReceipts, worktreeRoot?: string): void {
+  const p = receiptsPath(worktreeRoot);
+  try {
+    mkdirSync(join(p, '..'), { recursive: true });
+    receipts.generatedAt = new Date().toISOString();
+    writeFileSync(p, JSON.stringify(receipts, null, 2));
+  } catch {
+    // best-effort
+  }
+}
+
+export function recordAliasTelemetry(event: Omit<AliasTelemetryEvent, 'timestamp'> & { timestamp?: string }, worktreeRoot?: string): void {
+  const ts = event.timestamp ?? new Date().toISOString();
+  const full: AliasTelemetryEvent = { ...event, timestamp: ts };
+  // Append telemetry jsonl (diagnostics retain full mapping)
+  try {
+    const p = telemetryPath(worktreeRoot);
+    mkdirSync(join(p, '..'), { recursive: true });
+    appendFileSync(p, JSON.stringify(full) + '\n');
+  } catch {
+    // best-effort
+  }
+  // Update receipts
+  try {
+    const receipts = readReceipts(worktreeRoot);
+    if (full.canonical !== full.normalized || aliasLookup.has(full.normalized)) {
+      // Determine if this use was via alias (resolution.isAlias) — here we infer from aliasLookup
+      const entry = aliasLookup.get(full.normalized);
+      const isAliasUse = !!entry && entry.alias.toLowerCase() !== entry.canonical.toLowerCase();
+      if (isAliasUse) {
+        receipts.totals.aliasUses += 1;
+        const key = full.normalized;
+        const prev = receipts.byAlias[key];
+        receipts.byAlias[key] = { count: (prev?.count ?? 0) + 1, canonical: full.canonical, lastSeen: ts };
+        receipts.byCanonical[full.canonical] = (receipts.byCanonical[full.canonical] ?? 0) + 1;
+        if (full.release) receipts.releaseUses += 1;
+      } else {
+        // Canonical use
+        receipts.totals.canonicalUses += 1;
+        receipts.byCanonical[full.canonical] = (receipts.byCanonical[full.canonical] ?? 0) + 1;
+      }
+    } else {
+      // Unknown token — still count as canonical-ish
+      receipts.totals.canonicalUses += 1;
+    }
+    writeReceipts(receipts, worktreeRoot);
+  } catch {
+    // best-effort
+  }
+}
+
+export function readTelemetryTail(limit = 100, worktreeRoot?: string): AliasTelemetryEvent[] {
+  const p = telemetryPath(worktreeRoot);
+  try {
+    if (!existsSync(p)) return [];
+    const raw = readFileSync(p, 'utf-8');
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+    const tail = lines.slice(-limit);
+    return tail.map((l) => {
+      try { return JSON.parse(l); } catch { return null; }
+    }).filter(Boolean) as AliasTelemetryEvent[];
+  } catch {
+    return [];
+  }
+}
+
+export function readUsageReceipts(worktreeRoot?: string): AliasReceipts {
+  return readReceipts(worktreeRoot);
+}
+
+export function clearAliasTelemetryForTests(worktreeRoot?: string): void {
+  try {
+    const tp = telemetryPath(worktreeRoot);
+    if (existsSync(tp)) writeFileSync(tp, '');
+  } catch {
+    // ignore
+  }
+  try {
+    const rp = receiptsPath(worktreeRoot);
+    if (existsSync(rp)) writeFileSync(rp, JSON.stringify({ version: 1, planHead: '0a91273e61dbbd47eb0af4c02844409251e08398', generatedAt: new Date().toISOString(), totals: { aliasUses: 0, canonicalUses: 0 }, byAlias: {}, byCanonical: {}, releaseUses: 0 }, null, 2));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearAliasWarningsForTests(sessionId?: string, worktreeRoot?: string): void {
+  const p = aliasWarningsPath(sessionId, worktreeRoot);
+  try {
+    if (existsSync(p)) writeFileSync(p, JSON.stringify({}, null, 2));
+  } catch {
+    // ignore
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Retirement verifier helper (executable mechanism; temporal condition recorded)
+// ---------------------------------------------------------------------------
+
+export interface RetirementCheckInput {
+  currentVersion: string; // e.g. "4.15.10"
+  aliasIntroducedVersion?: string; // version when alias was introduced
+  releaseDates?: Record<string, string>; // version -> ISO date
+  canonicalUsageShare?: number; // 0..1
+  consecutiveReleasesWithShare?: number;
+  hasKnownCriticalIntegrations: boolean;
+}
+
+export interface RetirementVerdict {
+  eligible: boolean;
+  remaining: string[];
+  receipts: AliasReceipts | null;
+}
+
+export function checkAliasRetirement(input: RetirementCheckInput, worktreeRoot?: string): RetirementVerdict {
+  const remaining: string[] = [];
+  // Policy: at least 2 minor releases AND 90 days, 95% canonical usage for 2 releases, zero known critical integrations
+  // We implement executable checks but do NOT falsely remove aliases here — this is the verifier.
+  if (input.hasKnownCriticalIntegrations) remaining.push('has known critical integrations — must be zero');
+
+  const share = input.canonicalUsageShare;
+  if (share === undefined || share < 0.95) remaining.push('canonical usage share < 95% (need ≥0.95 over 2 consecutive releases)');
+  if ((input.consecutiveReleasesWithShare ?? 0) < 2) remaining.push('need ≥95% canonical share for 2 consecutive releases');
+
+  // Temporal check: 90 days and 2 minor releases
+  if (input.aliasIntroducedVersion && input.releaseDates) {
+    const introduced = input.releaseDates[input.aliasIntroducedVersion];
+    if (introduced) {
+      const ageMs = Date.now() - new Date(introduced).getTime();
+      const ageDays = ageMs / (1000 * 60 * 60 * 24);
+      if (ageDays < 90) remaining.push(`alias age ${Math.floor(ageDays)}d < 90d minimum`);
+    } else {
+      remaining.push('unknown introduction date — cannot verify 90d condition');
+    }
+    // Minor version diff check is informational; we need at least 2 minor bumps
+    const parseMinor = (v: string) => {
+      const m = v.match(/^(\d+)\.(\d+)/);
+      if (!m) return null;
+      return { major: Number(m[1]), minor: Number(m[2]) };
+    };
+    const cur = parseMinor(input.currentVersion);
+    const intro = parseMinor(input.aliasIntroducedVersion);
+    if (cur && intro) {
+      const minorDiff = (cur.major - intro.major) * 1000 + (cur.minor - intro.minor); // rough
+      if (minorDiff < 2) remaining.push('need at least 2 minor releases since alias introduction');
+    }
+  } else {
+    remaining.push('temporal condition: need at least 2 minor releases AND 90 days — evidence not yet provided');
+  }
+
+  const receipts = (() => { try { return readUsageReceipts(worktreeRoot); } catch { return null; } })();
+
+  return { eligible: remaining.length === 0, remaining, receipts };
+}
+
+// ---------------------------------------------------------------------------
+// Hook integration helper (narrow seam for bridge/keyword-detector)
+// ---------------------------------------------------------------------------
+
+export function resolveWorkflowInputWithWarning(rawInput: string, sessionId?: string, worktreeRoot?: string): AliasResolution & { warningToEmit: string | null } {
+  const res = resolveWorkflowAlias(rawInput);
+  let warningToEmit: string | null = null;
+  if (res.isAlias && res.warning) {
+    warningToEmit = maybeGetAliasWarning(res, sessionId, worktreeRoot);
+    // Record telemetry regardless of whether warning was emitted (suppressed warnings still counted)
+    recordAliasTelemetry({
+      alias: res.input,
+      normalized: res.normalized,
+      canonical: res.canonical,
+      tier0: res.tier0,
+      sessionId,
+      warned: warningToEmit !== null,
+      release: res.isRelease,
+    }, worktreeRoot);
+  } else {
+    // Record canonical usage for receipts (helps retirement 95% calc)
+    if (res.isCanonical && res.canonical) {
+      recordAliasTelemetry({
+        alias: res.input,
+        normalized: res.normalized,
+        canonical: res.canonical,
+        tier0: res.tier0,
+        sessionId,
+        warned: false,
+        release: false,
+      }, worktreeRoot);
+    }
+  }
+  return { ...res, warningToEmit };
+}

--- a/src/workflow/index.ts
+++ b/src/workflow/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Workflow public surface for issue #3706
+ * Barrel re-exports the alias resolver seam. When #3703 lands, this
+ * barrel re-exports the canonical registry as well and the alias-resolver
+ * adapts via `resolveWorkflowAliasViaRegistry`.
+ */
+export * from './alias-resolver.js';


### PR DESCRIPTION
## Summary
Implements **#3706 Alias resolver and telemetry** for epic #3698 (parent). Depends on #3703 for canonical registry; this branch supplies an isolated additive resolver seam with rebase adapter. Planning contract: `docs/design/ISSUE-3698-LIGHTWEIGHT-WORKFLOW-PLAN.md` plan head `0a91273e61dbbd47eb0af4c02844409251e08398` (origin/plan/issue-3698-lightweight-workflow).

## Scope
- Tier-0 workflows: `plan`, `execute`, `review`, `verify` (roles: `planner`/`executor`/`reviewer`/`verifier`); `release` → maintainer-only `omc release`.
- All classified aliases route to a Tier-0 workflow or `omc release`; never tag/publish/release here.

## Implementation
- New isolated module `src/workflow/alias-resolver.ts` + barrel `src/workflow/index.ts`
  - `resolveWorkflowAlias()`, `resolveWorkflowAliasViaRegistry()` (adapter for future `#3703` registry), `normalizeWorkflowInput()`
  - Resolver flag rollback: `OMC_ALIAS_RESOLVER_ENABLED` / `OMC_DISABLE_ALIAS_RESOLVER` (no code revert needed)
- Bridge integration `src/hooks/bridge.ts`
  - Explicit slash invocations and keyword-detected paths both route through the resolver; telemetry/receipts recorded; one concise actionable warning per alias per session by default.
- Warnings: `formatAliasWarning()` (<160 chars), `shouldEmitWarning()`/`markWarningEmitted()` via session-scoped file `.omc/state/sessions/{id}/alias-warnings.json`
- Diagnostics: `getAliasMapping()` / `getDiagnostics()` retain full mapping/telemetry even when warnings are suppressed or opted out.
- Temporary automation opt-out: `OMC_ALIAS_WARNINGS=0`, `OMC_ALIAS_WARNING_OPT_OUT=1`, `OMC_ALIAS_NO_WARNING`, `OMC_ALIAS_WARNINGS_DISABLED`, and bounded `OMC_QUIET>=1`.
- Usage receipts / telemetry: append-only `alias-telemetry.jsonl` + `alias-receipts.json` (canonical share counters for retirement checks).
- Retirement: executable `checkAliasRetirement()` verifier (≥2 minor +90 days, ≥95% canonical for 2 releases, zero critical integrations); does not falsely remove aliases early.

## Non-goals (per plan)
- No skill/command deletion, no release/tag/npm mutation, no hook dispatcher changes, no batch of another child issue.

## Tests & evidence
- Added `src/workflow/__tests__/alias-resolver.test.ts` — 30 tests: Tier-0 routing, slash/case handling, resolver flag, warning dedupe & opt-out, telemetry/receipts, registry sanity.
- `npm run build` and `npx tsc --noEmit` pass.
- Targeted suites: `src/workflow/__tests__/alias-resolver.test.ts` ✓, `keyword-detector` ✓, `tier0` + `skills` ✓.

## Issue links
Closes #3706, contributes to #3698.

Closes #3706.
