### PR TITLE
fix(ultragoal): honor positional goal id

### DIFF
--- a/skills/ultragoal/SKILL.md
+++ b/skills/ultragoal/SKILL.md
@@ -53,9 +53,9 @@ Claude Code `/goal` is a session-scoped Stop hook: it blocks the session from st
 
 2. Start (or resume) the next story:
    ```
-   omc ultragoal complete-goals
+   omc ultragoal complete-goals [<goal-id>]
    ```
-   This prints a model-facing handoff. The active Claude agent must read it and:
+   With no goal id, this preserves the default behavior of resuming the active story or starting the first pending story. With a goal id, OMC targets exactly that named eligible story (a pending story may be started out of order); it never falls through to another story. An active different story, unknown id, completed or review-blocked story, or failed story without `--retry-failed` is rejected without state mutation. An in-progress named story is resumed without changing its attempt. This prints a model-facing handoff. The active Claude agent must read it and:
    - Set the native Claude `/goal` for this session — in standalone Claude Code neither the
      shell nor the agent can do it, so ask the user to type `/goal <aggregate objective>` and
      wait. `--claude-goal-json` (below) reconciles the ledger only and does not satisfy the

--- a/src/cli/commands/__tests__/ultragoal.test.ts
+++ b/src/cli/commands/__tests__/ultragoal.test.ts
@@ -98,6 +98,31 @@ describe('omc ultragoal CLI', () => {
     });
   });
 
+  it('complete-goals positional id starts exactly the named pending goal', async () => {
+    await withTempCwd(async (cwd) => {
+      await ultragoalCommand(['create-goals', '--brief', 'brief', '--goal', 'First::first', '--goal', 'Second::second', '--goal', 'Third::third']);
+      captured.out.length = 0;
+      await ultragoalCommand(['complete-goals', 'G003-third', '--json']);
+      const result = JSON.parse(captured.out.join('')) as { goal: { id: string } };
+      expect(result.goal.id).toBe('G003-third');
+      const plan = JSON.parse(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')) as { activeGoalId?: string; goals: Array<{ id: string; status: string; attempt: number }> };
+      expect(plan.activeGoalId).toBe('G003-third');
+      expect(plan.goals.find((goal) => goal.id === 'G001-first')?.status).toBe('pending');
+      expect(plan.goals.find((goal) => goal.id === 'G003-third')?.attempt).toBe(1);
+    });
+  });
+
+  it('rejects an unknown positional id without mutating artifacts', async () => {
+    await withTempCwd(async (cwd) => {
+      await ultragoalCommand(['create-goals', '--brief', 'brief', '--goal', 'First::first', '--goal', 'Second::second']);
+      const before = await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8');
+      await ultragoalCommand(['complete-goals', 'G999-missing']);
+      expect(process.exitCode).toBe(1);
+      expect(captured.err.join('\n')).toMatch(/Unknown ultragoal id: G999-missing/);
+      expect(await readFile(join(cwd, '.omc/ultragoal/goals.json'), 'utf-8')).toBe(before);
+    });
+  });
+
   it('checkpoint accepts a Claude /goal snapshot via inline JSON', async () => {
     await withTempCwd(async (cwd) => {
       await ultragoalCommand([

--- a/src/cli/commands/ultragoal.ts
+++ b/src/cli/commands/ultragoal.ts
@@ -24,7 +24,7 @@ export const ULTRAGOAL_HELP = `omc ultragoal - Durable repo-native multi-goal wo
 
 Usage:
   omc ultragoal create-goals [--brief <text> | --brief-file <path> | --from-stdin] [--goal <title::objective>] [--claude-goal-mode <aggregate|per-story>] [--force] [--plan-id <id> | --auto-plan-id] [--json]
-  omc ultragoal complete-goals [--retry-failed] [--plan-id <id>] [--json]
+  omc ultragoal complete-goals [<goal-id>] [--retry-failed] [--plan-id <id>] [--json]
   omc ultragoal add-goal --title <title> --objective <text> [--evidence <text>] [--plan-id <id>] [--json]
   omc ultragoal record-review-blockers --goal-id <id> --title <title> --objective <text> --evidence <review-findings> --claude-goal-json <active-json-or-path> [--plan-id <id>] [--json]
   omc ultragoal checkpoint --goal-id <id> --status <complete|failed|blocked> [--evidence <text>] [--claude-goal-json <json-or-path>] [--quality-gate-json <json-or-path>] [--plan-id <id>] [--json]
@@ -107,6 +107,7 @@ function positionalText(args: readonly string[]): string {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (valueTaking.has(arg)) { i += 1; continue; }
+    if ([...valueTaking].some((flag) => arg.startsWith(`${flag}=`))) continue;
     if (arg.startsWith('--')) continue;
     words.push(arg);
   }
@@ -267,7 +268,9 @@ export async function ultragoalCommand(args: string[]): Promise<void> {
 
     if (command === 'complete' || command === 'complete-goals' || command === 'next' || command === 'start-next') {
       const planId = await resolveActivePlanId(cwd, readValue(rest, '--plan-id'));
-      const result = await startNextUltragoal(cwd, { retryFailed: hasFlag(rest, '--retry-failed'), planId });
+      const goalId = positionalText(rest);
+      if (goalId.split(/\s+/).filter(Boolean).length > 1) throw new UltragoalError('Expected at most one positional ultragoal id.');
+      const result = await startNextUltragoal(cwd, { retryFailed: hasFlag(rest, '--retry-failed'), goalId: goalId || undefined, planId });
       if (!result.goal) {
         if (json) printJson({ ok: true, done: result.done, summary: summarizeUltragoalPlan(result.plan) });
         else console.log(result.done ? 'ultragoal: all goals complete' : 'ultragoal: no pending goals (use --retry-failed to retry failed goals)');

--- a/src/ultragoal/__tests__/artifacts.test.ts
+++ b/src/ultragoal/__tests__/artifacts.test.ts
@@ -95,6 +95,41 @@ describe('ultragoal artifacts', () => {
     });
   });
 
+  it('targets named goals, preserves attempts on resume, and rejects conflicting or ineligible ids', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, {
+        brief: 'brief',
+        goals: [
+          { title: 'First', objective: 'first' },
+          { title: 'Second', objective: 'second' },
+          { title: 'Third', objective: 'third' },
+        ],
+      });
+      const named = await startNextUltragoal(cwd, { goalId: 'G003-third' });
+      expect(named.goal?.id).toBe('G003-third');
+      expect(named.goal?.attempt).toBe(1);
+      const resumed = await startNextUltragoal(cwd, { goalId: 'G003-third' });
+      expect(resumed.resumed).toBe(true);
+      expect(resumed.goal?.attempt).toBe(1);
+      await expect(startNextUltragoal(cwd, { goalId: 'G002-second' })).rejects.toThrow(/active goal G003-third/);
+      const unchanged = await readUltragoalPlan(cwd);
+      expect(unchanged.activeGoalId).toBe('G003-third');
+      expect(unchanged.goals.find((goal) => goal.id === 'G002-second')?.status).toBe('pending');
+    });
+  });
+
+  it('requires explicit retry for a named failed goal', async () => {
+    await withTempRepo(async (cwd) => {
+      await createUltragoalPlan(cwd, { brief: 'brief', goals: [{ title: 'First', objective: 'first' }] });
+      const started = await startNextUltragoal(cwd);
+      await checkpointUltragoal(cwd, { goalId: started.goal!.id, status: 'failed', evidence: 'failed' });
+      await expect(startNextUltragoal(cwd, { goalId: started.goal!.id })).rejects.toThrow(/without --retry-failed/);
+      const retried = await startNextUltragoal(cwd, { goalId: started.goal!.id, retryFailed: true });
+      expect(retried.goal?.id).toBe(started.goal!.id);
+      expect(retried.goal?.attempt).toBe(2);
+    });
+  });
+
   it('checkpoints success, advances, and supports failed-goal retry', async () => {
     await withTempRepo(async (cwd) => {
       await createUltragoalPlan(cwd, {

--- a/src/ultragoal/artifacts.ts
+++ b/src/ultragoal/artifacts.ts
@@ -123,6 +123,7 @@ export interface CreateUltragoalOptions {
 export interface StartNextOptions {
   now?: Date;
   retryFailed?: boolean;
+  goalId?: string;
   planId?: string;
 }
 
@@ -575,17 +576,36 @@ function validateQualityGate(value: unknown): UltragoalQualityGate {
 export async function startNextUltragoal(cwd: string, options: StartNextOptions = {}): Promise<{ plan: UltragoalPlan; goal: UltragoalItem | null; resumed: boolean; done: boolean }> {
   const plan = await readUltragoalPlan(cwd, options.planId);
   const now = iso(options.now);
+  const named = options.goalId ? plan.goals.find((goal) => goal.id === options.goalId) : undefined;
+  if (options.goalId && !named) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+  if (named?.status === 'complete') throw new UltragoalError(`Cannot start ultragoal ${named.id}: it is already complete.`);
+  if (named?.status === 'review_blocked') throw new UltragoalError(`Cannot start ultragoal ${named.id}: it is review-blocked.`);
   if (plan.aggregateCompletion?.status === 'complete') return { plan, goal: null, resumed: false, done: true };
   const existing = plan.goals.find((goal) => goal.status === 'in_progress');
   if (existing) {
+    if (options.goalId && options.goalId !== existing.id) {
+      throw new UltragoalError(`Cannot start ultragoal ${options.goalId}: active goal ${existing.id} is already in progress.`);
+    }
     await appendLedger(cwd, { ts: now, event: 'goal_resumed', goalId: existing.id, status: existing.status, message: 'Resuming active ultragoal' }, plan.planId);
     return { plan, goal: existing, resumed: true, done: false };
   }
 
-  let next = plan.goals.find((goal) => goal.status === 'pending');
-  if (!next && options.retryFailed) {
-    next = plan.goals.find((goal) => goal.status === 'failed');
-    if (next) await appendLedger(cwd, { ts: now, event: 'goal_retried', goalId: next.id, status: 'pending', message: next.failureReason }, plan.planId);
+  let next: UltragoalItem | undefined;
+  if (options.goalId) {
+    next = named;
+    if (!next) throw new UltragoalError(`Unknown ultragoal id: ${options.goalId}`);
+    if (next.status === 'failed' && !options.retryFailed) {
+      throw new UltragoalError(`Cannot start failed ultragoal ${next.id} without --retry-failed.`);
+    }
+    if (next.status !== 'pending' && next.status !== 'failed') {
+      throw new UltragoalError(`Cannot start ultragoal ${next.id} while it is ${next.status}.`);
+    }
+  } else {
+    next = plan.goals.find((goal) => goal.status === 'pending');
+    if (!next && options.retryFailed) next = plan.goals.find((goal) => goal.status === 'failed');
+  }
+  if (next?.status === 'failed') {
+    await appendLedger(cwd, { ts: now, event: 'goal_retried', goalId: next.id, status: 'pending', message: next.failureReason }, plan.planId);
   }
   if (!next) return { plan, goal: null, resumed: false, done: isUltragoalDone(plan) };
 


### PR DESCRIPTION
Fixes #3717

`complete-goals <goal-id>` now targets exactly the named eligible goal through the artifact layer. No-argument behavior remains unchanged; invalid, blocked, completed, failed-without-retry, and active-conflict requests fail safely without mutation. Added CLI/artifact regression coverage and updated skill help.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*