### PR TITLE
feat(hooks): declarative hook registry and dispatcher shadow mode (#3707)

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -9,7 +9,7 @@
       "mergeBaseSha": "76c90920b74494df6e34d6165be963bca8a9adf6",
       "headSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
       "owner": "Yeachan-Heo",
-      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "expiresAt": "2026-08-19T00:00:00.000Z",
       "generatedDelta": {
         "count": 199,
         "sha256": "3c1987d239441a787e5428d38b74e9bff51d694ad554d9fe34eae72cd78b059f"
@@ -1214,25 +1214,25 @@
     {
       "pullNumber": 3538,
       "targetRef": "dev",
-      "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
-      "headSha": "e798c12426f1f11701dede43a0f35c183651627e",
+      "mergeBaseSha": "3219495628cbf7680632f37e261351929508f295",
+      "headSha": "24e4e2f0e92dc4c4f61636d32fc411614fae3728",
       "owner": "Yeachan-Heo",
-      "expiresAt": "2026-08-05T00:00:00.000Z",
+      "expiresAt": "2026-08-12T00:00:00.000Z",
       "generatedDelta": {
-        "count": 4,
-        "sha256": "aaf1c49f22f4ce08b9299432e54f708e61e37434d3af48055bf195ff0b2005e6"
+        "count": 5,
+        "sha256": "05928b05a6f218fed553ecbb17ad276d4019ba70ac97b2581c39b104b38a4fd8"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
-          "sha": "ccab9e12230cb98627c610d015216451d9c6da7c",
+          "sha": "3e31b5e9815150c2d2e5e9cd3d803692243aa197",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "102f7f2ec960a74079450bfb771fa566392f2840",
+          "sha": "40089f6f49e697fe5ad1b759207855c6528e3d1c",
           "previousFilename": null
         },
         {
@@ -1244,7 +1244,13 @@
         {
           "status": "modified",
           "filename": "dist/installer/claude-md-transaction.js",
-          "sha": "6792903e324a83d1f68485b288757f2f2e61829b",
+          "sha": "8a3c29bd6cc3ee42a705c046418ebbf38234b9cb",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/index.js",
+          "sha": "b56860d8f1d518b4963c5196fb8f1aa4c3740776",
           "previousFilename": null
         }
       ]
@@ -1252,31 +1258,43 @@
     {
       "pullNumber": 3539,
       "targetRef": "dev",
-      "mergeBaseSha": "10078ece166ad36332390ecbaab2d5e247852bbc",
-      "headSha": "a82db66c18d88759cdd3455f65fd4ae9ae95dbc9",
+      "mergeBaseSha": "275226395a5e0772edbf8f791cdd74ea3ec082d7",
+      "headSha": "719087055945fd2a55024c02587e1f7f3e35ee26",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-05T00:00:00.000Z",
       "generatedDelta": {
-        "count": 3,
-        "sha256": "b90fbed9042db47d77c35c2adcf4425446d725dd28b67991ad3d700a94e9e45d"
+        "count": 5,
+        "sha256": "8f0880ac7ccd3c6c0e69bbe3d23d83c60adec2e4252c08e1798fe3463affe95e"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "78e4dd26cef8a0ac1908e822e5e1ce5e2e8be7af",
+          "sha": "ed9c39822d59be737929e6e311e161fefaa899bb",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/historical-agent-ownership.d.ts",
+          "sha": "3902ec42a77d6fa6ebf1366a188c14af9e451a21",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/installer/historical-agent-ownership.js",
+          "sha": "73dbb7342a1affb00a3d1f435fd178aae4816822",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/index.d.ts",
-          "sha": "f5ffa2b1b1dee166e565aba9a7536a95f638ddf3",
+          "sha": "5fe1619f84ef538126c56080dd63a068052204c2",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/index.js",
-          "sha": "75b271300996bf04e421f5ebd227b7def846a1bd",
+          "sha": "0ab9af1df1ba67d5c7c7cb611d73b0b0b296a1a7",
           "previousFilename": null
         }
       ]
@@ -1297,6 +1315,418 @@
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
           "sha": "d7515d5cdbca8a5517f77e31dd3eb703f5d7f404",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3572,
+      "targetRef": "dev",
+      "mergeBaseSha": "275226395a5e0772edbf8f791cdd74ea3ec082d7",
+      "headSha": "4de95829712c955ff633799388c6fbbf2b08258f",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-12T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 2,
+        "sha256": "7cf3f27718f502104fdc009df2e461cd633c4ebd69f62d5fcd562d244dd02530"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "0d55e2fd280de2e89af53e567c8cc54445dd7fc3",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/launch.js",
+          "sha": "e01b363c5cdc3d4f28072ca612b49a2db200b7d6",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3588,
+      "targetRef": "dev",
+      "mergeBaseSha": "b4061797a5535c54965fe5858f213332ebf32c63",
+      "headSha": "acea5fba944a6ada6daf848a3e07ca234cc9d8c8",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-14T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 41,
+        "sha256": "34bfeded0fbadc7bd4acaad2ca35a7b12fdcfe5c4a0b529eff3d15c198384b02"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "d4685c49441ef738366bafbbfbc1715e97c0baa9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/mcp-server.cjs",
+          "sha": "374cb6d3bb10359f013d34906e6c8d2d000164ba",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/runtime-cli.cjs",
+          "sha": "111fdf03204a3fa6b40a9a894b46ab7f749a7aeb",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-bridge.cjs",
+          "sha": "337515fc68aa1bde951b9e2c6c5b9f38f72eda3e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team-mcp.cjs",
+          "sha": "7979d2172bae05cb7160e12007f17f7a077ecc18",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team.js",
+          "sha": "0d0333ea0fbef0d0ba9529322a8bdcf2a86a6db3",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/team.js",
+          "sha": "1f51214311b72bce8e7f77b5cd848091cde24f28",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/team.js",
+          "sha": "55951bd6a0ec70736ea14b007cbaf16a3d6d6123",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/action-runner.js",
+          "sha": "e0bcdbc11f9274fda8241b53693cb3e383ded472",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/session-end/index.js",
+          "sha": "33200348cc3c32fc835f6fb21c554d1811ff7d43",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.d.ts",
+          "sha": "1b510b9a89677153cc735c7cf19e7857a8041afd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/platform/process-utils.js",
+          "sha": "9b1c2e46cd927d4d136f5258cccf86c284323f06",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/api-interop.js",
+          "sha": "173fec2c28f37b0794c3d99ee825f448d2e0feb5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.d.ts",
+          "sha": "c0917254b69876cc0f2606a72207ccc7add56422",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/index.js",
+          "sha": "c64983b9fc1971d9137e4ec28629e45d6a855bbd",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.d.ts",
+          "sha": "bf3bf3df71b7de87c223323ad722ad41a8f59968",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/monitor.js",
+          "sha": "0025e1c8bc8623d9314b8b62b7830601b37e6b01",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/recovery-request-store.js",
+          "sha": "e3fb2d64a651b2fc1a87983675f386df26e00a2c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.d.ts",
+          "sha": "72cf8fd8d88b4448338998efa3bee2a96ea1b8b6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-cli.js",
+          "sha": "a7d74378c11897f807fe46aaa27557d2b22d1f6d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-owner-client.d.ts",
+          "sha": "b43b0014f8f85d2501d5e8927d8ecfd27494bd7c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-owner-client.js",
+          "sha": "e0a0ef8aa83f102c8b73faf820b1b15304cde317",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.d.ts",
+          "sha": "1bb3df95d62763b5f8a3c402da5b88f6961b208d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js",
+          "sha": "92b42caf89fb641a408b9e20ad0bd62744effc10",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.d.ts",
+          "sha": "eb37efd21d30657c9f033e825d7243b31200267c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.js",
+          "sha": "4110f33f912a8cd6a5f19eff92cafd87e65ba308",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.d.ts",
+          "sha": "7e7609f312e1d0a6a14037599884685a8c7fc136",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/scaling.js",
+          "sha": "2a471f6e10ef55bc1ecd77d0958cad327f48004f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.d.ts",
+          "sha": "bac88247fe252b8687a5bdc0fa24b6d99846a615",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state-paths.js",
+          "sha": "d0d6cfded1f0d7ee3c9f907d5461e18b2512d7e9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.d.ts",
+          "sha": "a1005e1e0776bbf91254f47c3cc2f4348d64fdd6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/state/tasks.js",
+          "sha": "be59a54641b9b897cfd598b7adb9fee8e107173f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/team-ops.js",
+          "sha": "83a0b64aaa58ba4cf57bb1c7bc24e1b40a87e652",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.d.ts",
+          "sha": "bec002b8cd6bd994a143dfe10a7851d888eebfc9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.js",
+          "sha": "c706aa360be208edfa119d76e9645f2f450124f4",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/types.d.ts",
+          "sha": "46ee046172aaa1797dcf1b5e605638e3a5f0984d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-activation-gate.d.ts",
+          "sha": "1c859924dca3241a9d78005fd770afcca1136db7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-activation-gate.js",
+          "sha": "742a328e10bcb3b5cd9b58a33bf83d2bd69c2e46",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-bootstrap.js",
+          "sha": "9c21df6f168369fded840fe21861fc59f66339ed",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/worker-launch-ack.d.ts",
+          "sha": "c1fb816da347e13bb6d3d048a28d39087310bea2",
+          "previousFilename": null
+        },
+        {
+          "status": "added",
+          "filename": "dist/team/worker-launch-ack.js",
+          "sha": "d0f02816d34c1c649e6374cbdbed3f017257a735",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3602,
+      "targetRef": "dev",
+      "mergeBaseSha": "3097b7c8aaea8e74e7c25f972fb4ce6febebef3c",
+      "headSha": "b078774c7466ebb4def2d3b0ad2f963b67941176",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-12T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 5,
+        "sha256": "55f64295a50d45a13a95da316b59fb0a97044c37059dc3f9762605e34580a1fc"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "855ccc992e460e01a79f0a6e3c941be4eea3a6e5",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/commands/doctor-team-routing.js",
+          "sha": "dd0dff5073ffdc922c6d4403fee85cedc349cae4",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/cli/index.js",
+          "sha": "b1ea32f23128d1b7c9dd017156902d4446e9bb9e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/cli-detection.d.ts",
+          "sha": "e7e64318064ff081d64c46329431aa84d78c16e6",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/cli-detection.js",
+          "sha": "c888776f5dd23f0a8c308c232a8a6e8e3b603a96",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3603,
+      "targetRef": "dev",
+      "mergeBaseSha": "0686239b0b6fa4e1b7d923d1b8b2aa3e7431dc15",
+      "headSha": "9d6ca59c6c1eb985d61e228a0616160823fe1d35",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-12T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 2,
+        "sha256": "38ae1ee72c7070ab43d8fa24d91bde42a5ea3592d1ec1b4c79ee5da715b8f22e"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "c3802ae1f08c27add10b3f8454bbb3642c64fddc",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/installer/mcp-registry.js",
+          "sha": "99d3c36dbb897f4a4d2ed23abb8964c68af33e9b",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3610,
+      "targetRef": "dev",
+      "mergeBaseSha": "c96720aa8f0afc0ab721c38458f7e6f211a9e5ed",
+      "headSha": "a7e08dabb1a6b7a026b2ea1343631a3a62cb3829",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-14T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 7,
+        "sha256": "1a2a6e742ef9b0a60ea1cbb0e29679b9294db65113ecbedcfdc63ac4f8b727f6"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/cli.cjs",
+          "sha": "473bc16119a57960ed45d9d2b707454f08418e8e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/hud/usage-api.test.js",
+          "sha": "150d495f168f4b32eccb0a07a234acb349642f56",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/hud/usage-api.test.js.map",
+          "sha": "2f8bec6d2c66c818cb9402468ed2009f1c448e49",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.d.ts",
+          "sha": "b754ba555a7236895ed225a3c2fa222104388ff0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.d.ts.map",
+          "sha": "d600fb14bb7fb471b1956d392b4ed1d09139d001",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.js",
+          "sha": "cd1afac9f9bdb9f635f740cffe1d1d780100191a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hud/usage-api.js.map",
+          "sha": "f05b01a0254e78abb82c2b5e6c0b9ccf3d893341",
           "previousFilename": null
         }
       ]
@@ -1835,6 +2265,46 @@
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
           "sha": "60b372ca868144e33a980e46588dd476d82dcd7d",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3716,
+      "targetRef": "dev",
+      "mergeBaseSha": "247df87a626451963fc811fb4352e673fce7c9d8",
+      "headSha": "3b73d5a33a7d02f53bf58e49ccfb9f763af14bd3",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-19T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 1,
+        "sha256": "d8508c74e4efdaa946581a2396f04af538fd42f0f934bb7a09a407de895af89a"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "7f1474d768472f149442095443ac38ab6b524450",
+          "previousFilename": null
+        }
+      ]
+    },
+    {
+      "pullNumber": 3719,
+      "targetRef": "dev",
+      "mergeBaseSha": "626fd0baab2ca2d5676b8ebe2f83065642f7b835",
+      "headSha": "baee2d0bdd993eba8631af4d5b8b47bbb5cb88f6",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-08-19T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 1,
+        "sha256": "37499548ff8a6f8831741742789e3ff8eb9722679b40ec2260863db193ef3de2"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "a2a81cac21ff359efc329bea81f4155a6c155f21",
           "previousFilename": null
         }
       ]

--- a/docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md
+++ b/docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md
@@ -1,0 +1,73 @@
+# Issue #3707: Hook registry and dispatcher shadow mode
+
+Parent epic: #3698. Planning contract: `docs/design/ISSUE-3698-LIGHTWEIGHT-WORKFLOW-PLAN.md` §6.3, §8 step 5, §9.
+
+**Status:** implemented (shadow mode only, no behavior change)
+**Rollback:** `OMC_HOOK_SHADOW` defaults off; removing the shadow observation call in `src/hooks/bridge.ts` (`processHook` wrapper) fully restores prior behavior.
+
+## Scope
+
+This issue ships exactly two things:
+
+1. **A declarative hook registry** (`src/hooks/registry/registry.ts`) covering every installed hook entrypoint with contract fields: `event`, `order`, `timeoutMs`, `riskClass`, `failMode` — plus `matcher`, `entrypoint`, `args`, `async`. Risk classes are derived by convention from the entrypoint name.
+2. **A shadow-mode dispatcher** (`src/hooks/registry/dispatcher.ts`, `shadow.ts`): parses each event once, selects only applicable entries in declared order, enforces per-hook timeouts, applies declared fail-modes, and produces shadow-vs-legacy comparison records — without changing any runtime decision.
+
+Non-goals (owned by successors): dispatcher cutover by event family (#3708), gate rationalization (#3709), hook entrypoint/module reduction (epic targets are measured after cutover, not in shadow mode).
+
+## Design
+
+### Registry derivation
+
+The installed registration (`hooks/hooks.json`) remains the runtime SSOT. `buildHookRegistry(hooksJson)` derives one declarative entry per installed command. Risk classes are assigned by convention: only `pre-tool-enforcer.mjs` (destructive-mutation) and `permission-handler.mjs` (security-boundary) fail closed; everything else is advisory and fails open (owner decision 6). No hand-maintained metadata table.
+
+`validateRegistryAgainstHooksJson` is the drift guard: unknown lifecycle events, unparseable commands, or missing timeouts are reported.
+
+### Dispatcher
+
+`createHookDispatcher(registry, { handlers })`:
+
+- Parses the event once; `selectApplicableEntries` filters by event + matcher (`*` always applies; `SessionStart` matches `source`; `PermissionRequest`/`PreToolUse`/`PostToolUse` match tool name) and sorts by declared `order`.
+- Every handler await is bounded by its declared `timeoutMs` (no unbounded waits; timers are unref'd so short-lived hook processes are never held open).
+- Error/timeout handling follows the declared `failMode`: advisory hooks fail open with a structured diagnostic record and later hooks continue; hard-risk hooks fail closed and stop the chain.
+- Emits one structured `DispatchRecord` per hook: id, event, duration, status, error class, risk class, fail mode, applied decision source.
+- Latency budget (plan §6.3) is tested: no-op events p95 ≤ 50 ms, ordinary advisory events p95 ≤ 200 ms.
+
+Shadow mode only: dry-run handlers execute and produce records, but no output is ever merged into a runtime decision — behavior change is impossible by construction. Active-mode dispatch is #3708.
+
+### Shadow comparison
+
+`runShadowObservation(hookType, legacyOutput, legacyDurationMs)` is called from the `processHook` wrapper in `src/hooks/bridge.ts` after the legacy path completes, gated by `OMC_HOOK_SHADOW` (default off). It:
+
+- derives the registry from the installed `hooks/hooks.json` (cached per process),
+- runs the dispatcher in shadow mode for the same event,
+- records a `ShadowComparisonRecord` with verdict `equivalent` | `divergent` | `deferred` | `unmapped`.
+
+Decision equivalence for side-effecting handlers is **deferred by design**: shadow mode never re-executes them (that would double-apply state mutations), so records carry decision-shape digests (sha256 of `{continue, hasMessage, decisionKind}` — never content) for cutover-time comparison in #3708.
+
+Observation is in-process only: a bounded ring buffer (most recent 500 records) retains records for inspection by tests/doctor without persisting to the filesystem. `summarizeShadowLog` provides doctor/trace-style counts; `clearShadowLog` empties the buffer.
+
+Shadow observation is fully fail-open: any internal error produces an `unmapped` record (or is swallowed at the call site) and never changes the legacy output. A bridge-level test proves `processHook` output is identical with the flag on and off.
+
+## Seams for prerequisite/successor issues
+
+- **#3702 (inventory manifest) — merged.** The registry is derived from `hooks/hooks.json` and covered by the drift test; `inventory/inventory-graph.json` inventories `src/hooks/**`.
+- **#3703 (workflow registry) — merged.** Risk classes, `FailMode`, and `failModeForRisk` are imported directly from `src/workflow/registry.ts`; no parallel taxonomy exists.
+- **#3708 (cutover) — successor.** Consumes the registry entries and the shadow buffer's `deferred`/`divergent` verdicts as per-family cutover evidence.
+
+## Tests and acceptance evidence
+
+`src/hooks/registry/__tests__/` (33 tests):
+
+- **Registration drift:** zero drift vs installed `hooks/hooks.json`; detects unknown events, unparseable commands, missing timeouts.
+- **Contract fields:** every entry carries event/order/timeout/risk/fail-mode; only the two hard-risk entrypoints fail closed.
+- **Event ordering:** applicable entries run in declared order; non-matching matchers excluded.
+- **Timeout/error fail-open vs fail-closed:** advisory errors fail open with diagnostics and do not stop later hooks; hard-risk errors fail closed and halt the chain; per-hook timeouts enforced within budget.
+- **In-process telemetry:** buffer bounded at 500 records; clear/summarize work correctly.
+- **Shadow-vs-legacy decision equivalence:** verdict taxonomy, decision-shape digest privacy (content-independent), mapped/unmapped/divergent paths.
+- **No behavior change:** `processHook` output identical with `OMC_HOOK_SHADOW` on/off; observation failures never block the legacy path.
+- **Latency budget:** no-op p95 ≤ 50 ms; advisory p95 ≤ 200 ms.
+
+## Rollback
+
+1. `OMC_HOOK_SHADOW` is unset/off by default — shadow code is inert.
+2. Remove the shadow observation call in `src/hooks/bridge.ts` (`processHook` wrapper) and optionally delete `src/hooks/registry/`. No other runtime surface references the registry.

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "dc96e556c5ff68c515916e4ad1a869c43a1147ab",
-    "sourceSha256": "46259423b58ba99e68e23dd26a8b3a2a04b202c84fd5e857a867ab448c814615",
+    "head": "f40f09442d65bf90520ebcd6fc13cace929e8a00",
+    "sourceSha256": "2c8fe09d48b1f66ebdd37500865fece6f06b354d50c3ebd5ebca1c08d3af16cd",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "dc96e556c5ff68c515916e4ad1a869c43a1147ab",
-  "sourceSha256": "46259423b58ba99e68e23dd26a8b3a2a04b202c84fd5e857a867ab448c814615",
+  "head": "f40f09442d65bf90520ebcd6fc13cace929e8a00",
+  "sourceSha256": "2c8fe09d48b1f66ebdd37500865fece6f06b354d50c3ebd5ebca1c08d3af16cd",
   "counts": {
     "public": {
       "skills": 41,
@@ -23,13 +23,13 @@
       "total": 95
     },
     "internal": {
-      "hookFiles": 294,
+      "hookFiles": 302,
       "featureFiles": 68,
       "toolFiles": 56,
       "libFiles": 34,
       "templateHooks": 18,
-      "srcFiles": 1240,
-      "total": 1258
+      "srcFiles": 1249,
+      "total": 1267
     },
     "generated": {
       "distFiles": 4319,
@@ -41,7 +41,7 @@
     },
     "skills": 41,
     "commands": 28,
-    "hookFiles": 294,
+    "hookFiles": 302,
     "workflows": 8,
     "agentDefinitions": 18,
     "promptLikeFiles": 40
@@ -354,6 +354,14 @@
       "src/hooks/recovery/session-recovery.ts",
       "src/hooks/recovery/storage.ts",
       "src/hooks/recovery/types.ts",
+      "src/hooks/registry/__tests__/dispatcher.test.ts",
+      "src/hooks/registry/__tests__/registry.test.ts",
+      "src/hooks/registry/__tests__/shadow.test.ts",
+      "src/hooks/registry/dispatcher.ts",
+      "src/hooks/registry/index.ts",
+      "src/hooks/registry/registry.ts",
+      "src/hooks/registry/shadow.ts",
+      "src/hooks/registry/types.ts",
       "src/hooks/rules-injector/constants.ts",
       "src/hooks/rules-injector/finder.test.ts",
       "src/hooks/rules-injector/finder.ts",
@@ -5308,6 +5316,14 @@
       "src/hooks/recovery/session-recovery.ts",
       "src/hooks/recovery/storage.ts",
       "src/hooks/recovery/types.ts",
+      "src/hooks/registry/__tests__/dispatcher.test.ts",
+      "src/hooks/registry/__tests__/registry.test.ts",
+      "src/hooks/registry/__tests__/shadow.test.ts",
+      "src/hooks/registry/dispatcher.ts",
+      "src/hooks/registry/index.ts",
+      "src/hooks/registry/registry.ts",
+      "src/hooks/registry/shadow.ts",
+      "src/hooks/registry/types.ts",
       "src/hooks/rules-injector/constants.ts",
       "src/hooks/rules-injector/finder.test.ts",
       "src/hooks/rules-injector/finder.ts",
@@ -28256,6 +28272,11 @@
         "path": "docs/design/ISSUE-3703-WORKFLOW-REGISTRY.md"
       },
       {
+        "id": "docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md",
+        "kind": "other",
+        "path": "docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md"
+      },
+      {
         "id": "docs/design/SKILLS_2_0_ADAPTATION.md",
         "kind": "other",
         "path": "docs/design/SKILLS_2_0_ADAPTATION.md"
@@ -32861,6 +32882,46 @@
         "path": "src/hooks/recovery/types.ts"
       },
       {
+        "id": "src/hooks/registry/__tests__/dispatcher.test.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/__tests__/dispatcher.test.ts"
+      },
+      {
+        "id": "src/hooks/registry/__tests__/registry.test.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/__tests__/registry.test.ts"
+      },
+      {
+        "id": "src/hooks/registry/__tests__/shadow.test.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/__tests__/shadow.test.ts"
+      },
+      {
+        "id": "src/hooks/registry/dispatcher.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/dispatcher.ts"
+      },
+      {
+        "id": "src/hooks/registry/index.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/index.ts"
+      },
+      {
+        "id": "src/hooks/registry/registry.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/registry.ts"
+      },
+      {
+        "id": "src/hooks/registry/shadow.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/shadow.ts"
+      },
+      {
+        "id": "src/hooks/registry/types.ts",
+        "kind": "hook",
+        "path": "src/hooks/registry/types.ts"
+      },
+      {
         "id": "src/hooks/rules-injector/constants.ts",
         "kind": "hook",
         "path": "src/hooks/rules-injector/constants.ts"
@@ -35854,6 +35915,11 @@
         "id": "src/workflow/registry.ts",
         "kind": "src",
         "path": "src/workflow/registry.ts"
+      },
+      {
+        "id": "src/workflow/warning.ts",
+        "kind": "src",
+        "path": "src/workflow/warning.ts"
       },
       {
         "id": "templates/deliverables.json",
@@ -49759,6 +49825,11 @@
       },
       {
         "from": "src/hooks/bridge.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/bridge.ts",
         "to": "src/hooks/session-end/index.ts",
         "kind": "imports"
       },
@@ -53290,6 +53361,176 @@
       {
         "from": "src/hooks/recovery/storage.ts",
         "to": "src/hooks/recovery/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/dispatcher.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/dispatcher.test.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/dispatcher.test.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/registry.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/registry.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/registry.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/registry.test.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/registry.test.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/registry.test.ts",
+        "to": "src/workflow/registry.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/shadow.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/shadow.test.ts",
+        "to": "src/hooks/bridge.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/shadow.test.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/__tests__/shadow.test.ts",
+        "to": "src/hooks/registry/index.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/dispatcher.ts",
+        "to": "src/hooks/registry/registry.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/dispatcher.ts",
+        "to": "src/hooks/registry/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/dispatcher.ts",
+        "kind": "exports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/dispatcher.ts",
+        "kind": "type-exports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/registry.ts",
+        "kind": "exports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/registry.ts",
+        "kind": "type-exports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/shadow.ts",
+        "kind": "exports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/types.ts",
+        "kind": "exports"
+      },
+      {
+        "from": "src/hooks/registry/index.ts",
+        "to": "src/hooks/registry/types.ts",
+        "kind": "type-exports"
+      },
+      {
+        "from": "src/hooks/registry/registry.ts",
+        "to": "src/hooks/registry/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/registry.ts",
+        "to": "src/hooks/registry/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/registry.ts",
+        "to": "src/workflow/registry.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/registry.ts",
+        "to": "src/workflow/registry.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "external:crypto",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "src/hooks/registry/dispatcher.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "src/hooks/registry/registry.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "src/hooks/registry/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/registry/shadow.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/registry/types.ts",
+        "to": "src/workflow/registry.ts",
         "kind": "type-imports"
       },
       {
@@ -68738,6 +68979,21 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/workflow/warning.ts",
+        "to": "src/workflow/alias-resolver.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/workflow/warning.ts",
+        "to": "src/workflow/alias-resolver.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/workflow/warning.ts",
+        "to": "src/workflow/registry.ts",
+        "kind": "imports"
+      },
+      {
         "from": "templates/hooks/code-simplifier.mjs",
         "to": "external:child_process",
         "kind": "imports"
@@ -69579,12 +69835,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6103,
-      "edgeCount": 6695,
-      "importEdgeCount": 5478,
+      "nodeCount": 6113,
+      "edgeCount": 6733,
+      "importEdgeCount": 5500,
       "registerEdgeCount": 69
     }
   },
-  "inventorySha256": "ada7c0fd99be1f6cfb18276fcf55b207b2ef56d840e64fa25c547071d4db645b",
-  "manifestSha256": "6efe459291c9fb08e9bd28b6d4e01c7e1b72a659aa66e5b574f80e3bbdcaf59f"
+  "inventorySha256": "42d4790ea78cd7dd3a5b22996df8695160dec7bad9292e2dd2ab3000c6737815",
+  "manifestSha256": "a4bc5703ef5d604d5a88d402e4097ce5516d0615eaebfe20fba668ec9e5fc821"
 }

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -83,6 +83,12 @@ Hooks intercept Claude Code events to enable:
 | `session-end/` | Session termination handling |
 | `background-notification/` | Background task notifications |
 
+### Registry Infrastructure
+
+| Directory | Purpose |
+|-----------|---------|
+| `registry/` | Declarative hook registry + dispatcher shadow mode (#3707); design doc in `docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md` |
+
 ### Setup Hooks
 
 | Directory | Purpose |

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -117,6 +117,10 @@ import type { SessionEndInput } from "./session-end/index.js";
 import type { StopContext } from "./todo-continuation/index.js";
 // Security: wrap untrusted file content to prevent prompt injection
 import { wrapUntrustedFileContent } from "../agents/prompt-helpers.js";
+import {
+  isHookShadowEnabled,
+  runShadowObservation,
+} from "./registry/index.js";
 
 const PKILL_F_FLAG_PATTERN = /\bpkill\b.*\s-f\b/;
 const PKILL_FULL_FLAG_PATTERN = /\bpkill\b.*--full\b/;
@@ -3099,7 +3103,7 @@ export function resetSkipHooksCache(): void {
  * Main hook processor
  * Routes to specific hook handler based on type
  */
-export async function processHook(
+async function processHookImpl(
   hookType: HookType,
   rawInput: HookInput,
 ): Promise<HookOutput> {
@@ -3335,6 +3339,34 @@ export async function processHook(
     console.error(`[hook-bridge] Error in ${hookType}:`, error);
     return { continue: true };
   }
+}
+
+/**
+ * Main hook processor (epic #3698, issue #3707).
+ *
+ * Thin wrapper over the legacy dispatcher: runs the legacy path unchanged,
+ * then records a shadow-mode registry/dispatcher observation. Shadow mode is
+ * gated behind OMC_HOOK_SHADOW (default off), is fully fail-open, and never
+ * alters the returned output. Rollback: remove this wrapper's shadow call.
+ */
+export async function processHook(
+  hookType: HookType,
+  rawInput: HookInput,
+): Promise<HookOutput> {
+  const legacyStarted = performance.now();
+  const output = await processHookImpl(hookType, rawInput);
+  if (isHookShadowEnabled()) {
+    try {
+      await runShadowObservation(
+        hookType,
+        output,
+        performance.now() - legacyStarted,
+      );
+    } catch {
+      // Shadow observation is advisory and must never change hook behavior.
+    }
+  }
+  return output;
 }
 
 /**

--- a/src/hooks/registry/__tests__/dispatcher.test.ts
+++ b/src/hooks/registry/__tests__/dispatcher.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createHookDispatcher,
+  type HookRegistryEntry,
+  type HookHandler,
+} from '../index.js';
+
+function entry(partial: Partial<HookRegistryEntry> & { id: string }): HookRegistryEntry {
+  return {
+    event: 'Stop',
+    matcher: '*',
+    order: 0,
+    entrypoint: 'x.mjs',
+    args: [],
+    timeoutMs: 1000,
+    async: false,
+    riskClass: 'advisory',
+    failMode: 'fail-open',
+    ...partial,
+  };
+}
+
+const okHandler = (out: Record<string, unknown> = { continue: true }): { handler: HookHandler; dryRun: boolean } => ({
+  handler: () => out,
+  dryRun: true,
+});
+
+describe('hook dispatcher — event parsing and ordering (#3707)', () => {
+  it('runs only applicable entries in declared order', async () => {
+    const calls: string[] = [];
+    const registry = [
+      entry({ id: 'Stop:*:c', order: 2 }),
+      entry({ id: 'Stop:*:a', order: 0 }),
+      entry({ id: 'Stop:*:b', order: 1 }),
+      entry({ id: 'PreToolUse:*:other', event: 'PreToolUse' }),
+      entry({ id: 'Stop:init:scoped', matcher: 'init' }),
+    ];
+    const handlers = new Map(
+      ['a', 'b', 'c'].map((n) => [
+        `Stop:*:${n}`,
+        { handler: () => {
+            calls.push(n);
+            return { continue: true };
+          },
+          dryRun: true,
+        },
+      ]),
+    );
+    const dispatcher = createHookDispatcher(registry, { handlers });
+    const result = await dispatcher.dispatch('Stop', {});
+    expect(calls).toEqual(['a', 'b', 'c']);
+    expect(result.records.map((r) => r.hookId)).toEqual([
+      'Stop:*:a',
+      'Stop:*:b',
+      'Stop:*:c',
+    ]);
+    // Non-matching matchers are excluded from dispatch entirely.
+    expect(result.records.some((r) => r.hookId === 'Stop:init:scoped')).toBe(false);
+  });
+
+  it('parses the event once per dispatch and emits structured timing records', async () => {
+    const registry = [entry({ id: 'Stop:*:a' }), entry({ id: 'Stop:*:b', order: 1 })];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['Stop:*:a', okHandler()],
+        ['Stop:*:b', okHandler()],
+      ]),
+    });
+    const result = await dispatcher.dispatch('Stop', {});
+    for (const record of result.records) {
+      expect(record.status).toBe('ok');
+      expect(record.durationMs).toBeGreaterThanOrEqual(0);
+      expect(record.failMode).toBe('fail-open');
+      expect(record.riskClass).toBe('advisory');
+    }
+  });
+});
+
+describe('hook dispatcher — timeout and fail-mode semantics (#3707)', () => {
+  it('advisory handlers fail open with a structured diagnostic on error', async () => {
+    const registry = [
+      entry({ id: 'Stop:*:throws' }),
+      entry({ id: 'Stop:*:after', order: 1 }),
+    ];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['Stop:*:throws', {
+          handler: () => {
+            throw new Error('boom');
+          },
+          dryRun: true,
+        }],
+        ['Stop:*:after', okHandler()],
+      ]),
+    });
+    const result = await dispatcher.dispatch('Stop', {});
+    const [failed, after] = result.records;
+    expect(failed.status).toBe('error');
+    expect(failed.errorClass).toBe('Error');
+    expect(failed.appliedDecision).toBe('fail-open');
+    expect(after.status).toBe('ok'); // fail-open does not stop later hooks
+  });
+
+  it('hard-risk handlers fail closed and stop subsequent hooks', async () => {
+    const registry = [
+      entry({
+        id: 'PermissionRequest:Bash:guard',
+        event: 'PermissionRequest',
+        matcher: 'Bash',
+        riskClass: 'security-boundary',
+        failMode: 'fail-closed',
+      }),
+      entry({ id: 'PermissionRequest:Bash:after', event: 'PermissionRequest', matcher: 'Bash', order: 1 }),
+    ];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['PermissionRequest:Bash:guard', {
+          handler: () => {
+            throw new Error('guard exploded');
+          },
+          dryRun: true,
+        }],
+        ['PermissionRequest:Bash:after', okHandler()],
+      ]),
+    });
+    const result = await dispatcher.dispatch('PermissionRequest', { tool_name: 'Bash' });
+    expect(result.records).toHaveLength(1); // later hook never ran
+    expect(result.records[0].appliedDecision).toBe('fail-closed');
+  });
+
+  it('enforces per-hook timeouts with the declared timeout budget', async () => {
+    const registry = [entry({ id: 'Stop:*:slow', timeoutMs: 25 })];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['Stop:*:slow', {
+          handler: () => new Promise((resolve) => setTimeout(() => resolve({ continue: true }), 5000)),
+          dryRun: true,
+        }],
+      ]),
+    });
+    const started = performance.now();
+    const result = await dispatcher.dispatch('Stop', {});
+    expect(performance.now() - started).toBeLessThan(2000);
+    expect(result.records[0].status).toBe('timeout');
+    expect(result.records[0].errorClass).toBe('TimeoutError');
+    expect(result.records[0].appliedDecision).toBe('fail-open');
+  });
+});
+
+describe('hook dispatcher — shadow mode cannot change behavior (#3707)', () => {
+  it('shadow mode never produces a runtime decision — records only', async () => {
+    const registry = [entry({ id: 'Stop:*:blocker' })];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['Stop:*:blocker', {
+          handler: () => ({ continue: false, message: 'would block' }),
+          dryRun: true,
+        }],
+      ]),
+    });
+    const result = await dispatcher.dispatch('Stop', {});
+    expect(result.records[0].appliedDecision).toBe('none');
+    // DispatchResult has only event + records, no decision field.
+    expect('decision' in result).toBe(false);
+    expect('mergedOutput' in result).toBe(false);
+  });
+
+  it('shadow mode skips side-effecting (non-dry-run) handlers', async () => {
+    let ran = false;
+    const registry = [entry({ id: 'Stop:*:sideeffect' })];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['Stop:*:sideeffect', {
+          handler: () => {
+            ran = true;
+            return { continue: true };
+          },
+          dryRun: false,
+        }],
+      ]),
+    });
+    const result = await dispatcher.dispatch('Stop', {});
+    expect(ran).toBe(false);
+    expect(result.records[0].status).toBe('skipped');
+  });
+
+  it('meets the no-op latency budget (p95 <= 50 ms, plan §6.3)', async () => {
+    const registry = [entry({ id: 'Stop:*:a' })];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([['Stop:*:a', okHandler()]]),
+    });
+    const samples: number[] = [];
+    for (let i = 0; i < 100; i++) {
+      const started = performance.now();
+      // No applicable entries for this event: the no-op fast path.
+      await dispatcher.dispatch('PreCompact', {});
+      samples.push(performance.now() - started);
+    }
+    samples.sort((a, b) => a - b);
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+    expect(p95).toBeLessThan(50);
+  });
+
+  it('meets the advisory latency budget (p95 <= 200 ms, plan §6.3)', async () => {
+    const registry = [entry({ id: 'Stop:*:a' }), entry({ id: 'Stop:*:b', order: 1 })];
+    const dispatcher = createHookDispatcher(registry, {
+      handlers: new Map([
+        ['Stop:*:a', okHandler()],
+        ['Stop:*:b', okHandler()],
+      ]),
+    });
+    const samples: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      const started = performance.now();
+      await dispatcher.dispatch('Stop', {});
+      samples.push(performance.now() - started);
+    }
+    samples.sort((a, b) => a - b);
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+    expect(p95).toBeLessThan(200);
+  });
+});

--- a/src/hooks/registry/__tests__/registry.test.ts
+++ b/src/hooks/registry/__tests__/registry.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  HOOK_EVENTS,
+  buildHookRegistry,
+  validateRegistryAgainstHooksJson,
+  selectApplicableEntries,
+  parseEntrypointCommand,
+  type HooksJson,
+} from '../index.js';
+import { failModeForRisk, HARD_RISK_CLASSES } from '../../../workflow/registry.js';
+
+function loadInstalledHooksJson(): HooksJson {
+  const raw = JSON.parse(
+    readFileSync(join(process.cwd(), 'hooks', 'hooks.json'), 'utf-8'),
+  ) as { hooks: HooksJson };
+  return raw.hooks;
+}
+
+describe('hook registry — derivation from installed hooks.json (#3707)', () => {
+  const hooksJson = loadInstalledHooksJson();
+  const registry = buildHookRegistry(hooksJson);
+
+  it('covers every installed command exactly once, in declared order', () => {
+    let installedCount = 0;
+    for (const [event, groups] of Object.entries(hooksJson)) {
+      for (const group of groups) {
+        group.hooks.forEach((_, order) => {
+          installedCount += 1;
+          const matches = registry.filter(
+            (e) =>
+              e.event === event && e.matcher === group.matcher && e.order === order,
+          );
+          expect(matches).toHaveLength(1);
+        });
+      }
+    }
+    expect(registry.length).toBe(installedCount);
+    expect(installedCount).toBeGreaterThan(0);
+  });
+
+  it('declares contract fields for every entry (event/order/timeout/risk/fail-mode)', () => {
+    for (const entry of registry) {
+      expect(HOOK_EVENTS).toContain(entry.event);
+      expect(entry.order).toBeGreaterThanOrEqual(0);
+      expect(entry.timeoutMs).toBeGreaterThan(0);
+      expect(entry.riskClass).toBeTruthy();
+      expect(entry.failMode).toBe(failModeForRisk(entry.riskClass));
+    }
+  });
+
+  it('fails closed only for the five hard risk classes (owner decision 6)', () => {
+    for (const entry of registry) {
+      if (HARD_RISK_CLASSES.includes(entry.riskClass)) {
+        expect(entry.failMode).toBe('fail-closed');
+      } else {
+        expect(entry.riskClass).toBe('advisory');
+        expect(entry.failMode).toBe('fail-open');
+      }
+    }
+    // The installed registration genuinely exercises both fail modes.
+    expect(registry.some((e) => e.failMode === 'fail-closed')).toBe(true);
+    expect(registry.some((e) => e.failMode === 'fail-open')).toBe(true);
+  });
+
+  it('derives risk class by convention: only pre-tool-enforcer and permission-handler fail closed', () => {
+    const failClosed = registry.filter((e) => e.failMode === 'fail-closed');
+    const failClosedEntrypoints = new Set(failClosed.map((e) => e.entrypoint));
+    expect(failClosedEntrypoints).toEqual(
+      new Set(['pre-tool-enforcer.mjs', 'permission-handler.mjs']),
+    );
+  });
+
+  it('mirrors installed timeouts (seconds → ms)', () => {
+    for (const [event, groups] of Object.entries(hooksJson)) {
+      for (const group of groups) {
+        group.hooks.forEach((hook, order) => {
+          const entry = registry.find(
+            (e) =>
+              e.event === event && e.matcher === group.matcher && e.order === order,
+          );
+          expect(entry?.timeoutMs).toBe((hook.timeout ?? 0) * 1000);
+        });
+      }
+    }
+  });
+
+  it('mirrors the installed async flag', () => {
+    const sessionEnd = registry.filter((e) => e.event === 'SessionEnd');
+    expect(sessionEnd.length).toBeGreaterThan(0);
+    for (const entry of sessionEnd) expect(entry.async).toBe(true);
+    const stop = registry.filter((e) => e.event === 'Stop');
+    for (const entry of stop) expect(entry.async).toBe(false);
+  });
+});
+
+describe('hook registry — registration drift guard (#3707)', () => {
+  it('reports zero drift against the installed hooks.json', () => {
+    expect(validateRegistryAgainstHooksJson(loadInstalledHooksJson())).toEqual([]);
+  });
+
+  it('detects unparseable commands', () => {
+    const hooksJson = loadInstalledHooksJson();
+    const tampered: HooksJson = {
+      ...hooksJson,
+      Stop: [
+        ...(hooksJson.Stop ?? []),
+        {
+          matcher: '*',
+          hooks: [
+            {
+              type: 'command',
+              command: 'echo nothing useful',
+              timeout: 5,
+            },
+          ],
+        },
+      ],
+    };
+    const issues = validateRegistryAgainstHooksJson(tampered);
+    expect(issues.some((i) => i.code === 'unparseable-command')).toBe(true);
+  });
+
+  it('detects unknown lifecycle events', () => {
+    const issues = validateRegistryAgainstHooksJson({
+      MadeUpEvent: [{ matcher: '*', hooks: [] }],
+    } as unknown as HooksJson);
+    expect(issues.some((i) => i.code === 'unknown-event')).toBe(true);
+  });
+
+  it('detects missing timeouts', () => {
+    const hooksJson = loadInstalledHooksJson();
+    const firstEvent = Object.keys(hooksJson)[0];
+    const firstGroup = hooksJson[firstEvent][0];
+    const tampered: HooksJson = {
+      ...hooksJson,
+      [firstEvent]: [
+        {
+          ...firstGroup,
+          hooks: [
+            {
+              ...firstGroup.hooks[0],
+              timeout: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const issues = validateRegistryAgainstHooksJson(tampered);
+    expect(issues.some((i) => i.code === 'timeout-mismatch')).toBe(true);
+  });
+});
+
+describe('hook registry — selection and ordering', () => {
+  const registry = buildHookRegistry(loadInstalledHooksJson());
+
+  it('parses installed commands into entrypoint + args', () => {
+    expect(
+      parseEntrypointCommand(
+        'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/subagent-tracker.mjs start',
+      ),
+    ).toEqual({ entrypoint: 'subagent-tracker.mjs', args: ['start'] });
+    expect(parseEntrypointCommand('echo nothing')).toBeNull();
+  });
+
+  it('selects applicable entries in execution order, honoring matchers', () => {
+    const sessionStartAll = selectApplicableEntries(registry, 'SessionStart', undefined);
+    expect(sessionStartAll.map((e) => e.entrypoint)).toEqual([
+      'session-start.mjs',
+      'project-memory-session.mjs',
+      'wiki-session-start.mjs',
+    ]);
+    const sessionStartInit = selectApplicableEntries(registry, 'SessionStart', 'init');
+    expect(sessionStartInit.some((e) => e.entrypoint === 'setup-init.mjs')).toBe(true);
+    expect(sessionStartInit.some((e) => e.entrypoint === 'setup-maintenance.mjs')).toBe(false);
+    const bashPermission = selectApplicableEntries(registry, 'PermissionRequest', 'Bash');
+    expect(bashPermission.map((e) => e.entrypoint)).toEqual(['permission-handler.mjs']);
+    expect(selectApplicableEntries(registry, 'PermissionRequest', 'Edit')).toEqual([]);
+  });
+});

--- a/src/hooks/registry/__tests__/shadow.test.ts
+++ b/src/hooks/registry/__tests__/shadow.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  appendShadowRecord,
+  clearShadowLog,
+  compareShadowExecution,
+  decisionDigest,
+  getShadowRegistry,
+  isHookShadowEnabled,
+  readShadowLog,
+  resetShadowRegistryCache,
+  runShadowObservation,
+  summarizeShadowLog,
+  SHADOW_LOG_MAX_RECORDS,
+  type ShadowComparisonRecord,
+} from '../index.js';
+import { processHook } from '../../bridge.js';
+
+const ENV_KEYS = ['OMC_HOOK_SHADOW', 'DISABLE_OMC'] as const;
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  resetShadowRegistryCache();
+  clearShadowLog();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  resetShadowRegistryCache();
+  clearShadowLog();
+});
+
+function record(partial: Partial<ShadowComparisonRecord>): ShadowComparisonRecord {
+  return {
+    schemaVersion: 1,
+    hookType: 'keyword-detector',
+    event: 'UserPromptSubmit',
+    registryEntryIds: ['UserPromptSubmit:*:keyword-detector.mjs'],
+    verdict: 'deferred',
+    legacyDurationMs: 1,
+    shadowDurationMs: 1,
+    legacyDecisionDigest: decisionDigest({ continue: true }),
+    recordedAt: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+describe('shadow mode — feature flag and rollback (#3707)', () => {
+  it('is disabled by default (rollback-safe)', () => {
+    expect(isHookShadowEnabled()).toBe(false);
+  });
+
+  it('enables on explicit opt-in values only', () => {
+    for (const v of ['1', 'true', 'on', 'observe', ' ON ']) {
+      process.env.OMC_HOOK_SHADOW = v;
+      expect(isHookShadowEnabled()).toBe(true);
+    }
+    for (const v of ['0', 'false', 'off', 'yes-ish', '']) {
+      process.env.OMC_HOOK_SHADOW = v;
+      expect(isHookShadowEnabled()).toBe(false);
+    }
+  });
+
+  it('shadow observation is a no-op while disabled', async () => {
+    const result = await runShadowObservation('keyword-detector', { continue: true }, 5);
+    expect(result).toBeNull();
+  });
+});
+
+describe('shadow comparison — decision equivalence (#3707)', () => {
+  it('digests decision shape only, never content (privacy-preserving)', () => {
+    const a = decisionDigest({ continue: true, message: 'secret user text A' });
+    const b = decisionDigest({ continue: true, message: 'totally different secret B' });
+    const c = decisionDigest({ continue: false, message: 'secret user text A' });
+    expect(a).toBe(b); // message content does not affect the digest
+    expect(a).not.toBe(c); // decision flag does
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(record({}))).not.toContain('secret user text');
+  });
+
+  it('verdicts: unmapped, divergent, deferred', () => {
+    const registry = getShadowRegistry();
+    expect(registry.length).toBeGreaterThan(0);
+
+    const unmapped = compareShadowExecution('not-a-hook', registry, { continue: true }, 1, 1);
+    expect(unmapped.verdict).toBe('unmapped');
+    expect(unmapped.event).toBeNull();
+
+    const deferred = compareShadowExecution('keyword-detector', registry, { continue: true }, 1, 1);
+    // Side-effecting handlers are not re-executed in shadow mode: equivalence
+    // evidence is deferred to the #3708 cutover by design.
+    expect(deferred.verdict).toBe('deferred');
+    expect(deferred.event).toBe('UserPromptSubmit');
+    expect(deferred.registryEntryIds).toEqual(['UserPromptSubmit:*:keyword-detector.mjs']);
+  });
+
+  it('runShadowObservation records a comparison for a mapped hook type', async () => {
+    process.env.OMC_HOOK_SHADOW = '1';
+    const result = await runShadowObservation('keyword-detector', { continue: true }, 3);
+    expect(result).not.toBeNull();
+    expect(result?.event).toBe('UserPromptSubmit');
+    expect(['deferred', 'equivalent']).toContain(result?.verdict);
+    const log = readShadowLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].hookType).toBe('keyword-detector');
+  });
+
+  it('flags divergence when the dispatcher selects a different set', async () => {
+    process.env.OMC_HOOK_SHADOW = '1';
+    const result = await runShadowObservation('session-start', { continue: true }, 3);
+    expect(result).not.toBeNull();
+    // session-start maps to exactly one registry entry; the dispatcher must
+    // select that entry for the SessionStart event.
+    expect(result?.registryEntryIds).toEqual(['SessionStart:*:session-start.mjs']);
+    expect(result?.verdict).toBe('deferred');
+  });
+});
+
+describe('shadow telemetry — bounded, in-process (#3707)', () => {
+  it('keeps the buffer bounded to SHADOW_LOG_MAX_RECORDS', () => {
+    for (let i = 0; i < SHADOW_LOG_MAX_RECORDS + 25; i++) {
+      appendShadowRecord(record({}));
+    }
+    const log = readShadowLog();
+    expect(log).toHaveLength(SHADOW_LOG_MAX_RECORDS);
+  });
+
+  it('summarizes verdicts for doctor/trace surfaces', () => {
+    appendShadowRecord(record({ verdict: 'deferred' }));
+    appendShadowRecord(record({ verdict: 'deferred' }));
+    appendShadowRecord(record({ verdict: 'divergent' }));
+    appendShadowRecord(record({ verdict: 'unmapped' }));
+    expect(summarizeShadowLog()).toEqual({
+      equivalent: 0,
+      divergent: 1,
+      deferred: 2,
+      unmapped: 1,
+    });
+  });
+
+  it('clearShadowLog empties the buffer', () => {
+    appendShadowRecord(record({}));
+    appendShadowRecord(record({}));
+    expect(readShadowLog()).toHaveLength(2);
+    clearShadowLog();
+    expect(readShadowLog()).toHaveLength(0);
+  });
+});
+
+describe('shadow mode — no behavior change through the bridge (#3707)', () => {
+  it('processHook output is identical with shadow on and off', async () => {
+    const input = { directory: '/tmp/omc-shadow-test' } as never;
+
+    const offOutput = await processHook('code-simplifier', input);
+    process.env.OMC_HOOK_SHADOW = '1';
+    const onOutput = await processHook('code-simplifier', input);
+
+    expect(onOutput).toEqual(offOutput);
+    // ...and the observation was still recorded for the mapped hook type.
+    const log = readShadowLog();
+    expect(log.length).toBeGreaterThan(0);
+    expect(log.some((r) => r.hookType === 'code-simplifier')).toBe(true);
+  });
+
+  it('shadow observation never blocks or alters an erroring legacy path', async () => {
+    process.env.OMC_HOOK_SHADOW = '1';
+    const output = await processHook('code-simplifier', { directory: '/tmp/omc-shadow-test' } as never);
+    expect(output.continue).not.toBe(false);
+  });
+});

--- a/src/hooks/registry/dispatcher.ts
+++ b/src/hooks/registry/dispatcher.ts
@@ -1,0 +1,159 @@
+/**
+ * Shadow-mode hook dispatcher — #3698 / #3707.
+ *
+ * Parses each event once, selects only applicable registry entries in
+ * declared order, runs them with per-hook timeout enforcement, applies the
+ * declared fail-mode (advisory fail-open with a structured diagnostic;
+ * hard-risk fail-closed), and emits structured timing/error records.
+ *
+ * Shadow mode only: dry-run handlers execute and produce records, but no
+ * output is ever merged into a runtime decision — behavior change is
+ * impossible by construction. Cutover to active dispatch is #3708.
+ *
+ * Latency budget (plan §6.3): no-op events p95 <= 50 ms; ordinary advisory
+ * events p95 <= 200 ms; no unbounded child process — handlers are in-process
+ * functions, and every handler await is bounded by its declared timeout.
+ */
+
+import { selectApplicableEntries } from './registry.js';
+import type {
+  DispatchRecord,
+  DispatchResult,
+  HookEvent,
+  HookHandler,
+  HookRegistryEntry,
+} from './types.js';
+
+export interface HookDispatcher {
+  dispatch(event: HookEvent, input: unknown): Promise<DispatchResult>;
+  readonly registry: readonly HookRegistryEntry[];
+}
+
+export interface DispatcherOptions {
+  /**
+   * Dry-run handlers keyed by registry entry id. Only handlers with
+   * `dryRun: true` execute; side-effecting handlers are skipped.
+   */
+  handlers?: ReadonlyMap<string, { handler: HookHandler; dryRun: boolean }>;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+class HookTimeoutError extends Error {
+  constructor(
+    public readonly hookId: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(`hook ${hookId} exceeded timeout ${timeoutMs}ms`);
+    this.name = 'TimeoutError';
+  }
+}
+
+/** How the matcher input is extracted from a hook event payload. */
+function matcherInputFor(event: HookEvent, input: unknown): string | undefined {
+  if (input === null || typeof input !== 'object') return undefined;
+  const rec = input as Record<string, unknown>;
+  if (event === 'SessionStart') {
+    return typeof rec.source === 'string' ? rec.source : undefined;
+  }
+  if (event === 'PermissionRequest' || event === 'PreToolUse' || event === 'PostToolUse') {
+    const tool = rec.tool_name ?? rec.toolName;
+    return typeof tool === 'string' ? tool : undefined;
+  }
+  return typeof rec.matcher === 'string' ? rec.matcher : undefined;
+}
+
+async function runWithTimeout(
+  entry: HookRegistryEntry,
+  handler: HookHandler,
+  input: unknown,
+): Promise<Record<string, unknown>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(handler(input)),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new HookTimeoutError(entry.id, entry.timeoutMs)),
+          entry.timeoutMs,
+        );
+        // Never keep a short-lived hook process alive for a shadow timer.
+        if (typeof timer.unref === 'function') timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export function createHookDispatcher(
+  registry: readonly HookRegistryEntry[],
+  options: DispatcherOptions = {},
+): HookDispatcher {
+  const handlers = options.handlers ?? new Map();
+  const now = options.now ?? (() => performance.now());
+
+  async function dispatch(event: HookEvent, input: unknown): Promise<DispatchResult> {
+    const applicable = selectApplicableEntries(
+      registry,
+      event,
+      matcherInputFor(event, input),
+    );
+    const records: DispatchRecord[] = [];
+
+    for (const entry of applicable) {
+      const registered = handlers.get(entry.id);
+      const runnable = registered !== undefined && registered.dryRun;
+      const started = now();
+
+      if (!runnable) {
+        records.push({
+          hookId: entry.id,
+          event,
+          durationMs: 0,
+          status: 'skipped',
+          failMode: entry.failMode,
+          riskClass: entry.riskClass,
+          appliedDecision: 'none',
+        });
+        continue;
+      }
+
+      try {
+        await runWithTimeout(entry, registered.handler, input);
+        records.push({
+          hookId: entry.id,
+          event,
+          durationMs: now() - started,
+          status: 'ok',
+          failMode: entry.failMode,
+          riskClass: entry.riskClass,
+          appliedDecision: 'none',
+        });
+      } catch (error) {
+        const errorClass =
+          error instanceof HookTimeoutError
+            ? 'TimeoutError'
+            : error instanceof Error
+              ? error.name
+              : 'UnknownError';
+        const failOpen = entry.failMode === 'fail-open';
+        records.push({
+          hookId: entry.id,
+          event,
+          durationMs: now() - started,
+          status: errorClass === 'TimeoutError' ? 'timeout' : 'error',
+          errorClass,
+          failMode: entry.failMode,
+          riskClass: entry.riskClass,
+          appliedDecision: failOpen ? 'fail-open' : 'fail-closed',
+        });
+        if (!failOpen) break; // hard boundary: stop running further hooks
+      }
+    }
+
+    return { event, records };
+  }
+
+  return { dispatch, registry };
+}

--- a/src/hooks/registry/index.ts
+++ b/src/hooks/registry/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Hook registry and dispatcher shadow mode — #3698 / #3707.
+ * Design doc: docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md
+ */
+
+export {
+  HOOK_EVENTS,
+  type HookEvent,
+  type HookRegistryEntry,
+  type HooksJson,
+  type HooksJsonGroup,
+  type HooksJsonCommand,
+  type ShadowDecisionInput,
+  type HookHandler,
+  type DispatchStatus,
+  type DispatchRecord,
+  type DispatchResult,
+  type ShadowVerdict,
+  type ShadowComparisonRecord,
+} from './types.js';
+
+export {
+  buildHookRegistry,
+  validateRegistryAgainstHooksJson,
+  selectApplicableEntries,
+  parseEntrypointCommand,
+  type RegistryDriftIssue,
+} from './registry.js';
+
+export {
+  createHookDispatcher,
+  type HookDispatcher,
+  type DispatcherOptions,
+} from './dispatcher.js';
+
+export {
+  isHookShadowEnabled,
+  getShadowRegistry,
+  resetShadowRegistryCache,
+  decisionDigest,
+  compareShadowExecution,
+  runShadowObservation,
+  appendShadowRecord,
+  readShadowLog,
+  summarizeShadowLog,
+  clearShadowLog,
+  SHADOW_LOG_MAX_RECORDS,
+} from './shadow.js';

--- a/src/hooks/registry/registry.ts
+++ b/src/hooks/registry/registry.ts
@@ -1,0 +1,153 @@
+/**
+ * Declarative hook registry — #3698 / #3707.
+ *
+ * The installed registration (hooks/hooks.json) remains the runtime SSOT.
+ * This module derives one declarative entry per installed command, assigning
+ * risk classes by convention (only hard-risk entrypoints fail closed;
+ * everything else is advisory/fail-open). No hand-maintained metadata table.
+ *
+ * Risk classes reuse the canonical taxonomy from src/workflow/registry.ts.
+ */
+
+import {
+  failModeForRisk,
+  type RiskClass,
+} from '../../workflow/registry.js';
+import type {
+  HookEvent,
+  HookRegistryEntry,
+  HooksJson,
+} from './types.js';
+import { HOOK_EVENTS } from './types.js';
+
+/**
+ * Entry points that handle destructive tool calls or permission/security
+ * boundaries — the only installed hooks that fail closed (owner decision 6).
+ * Every other entrypoint is advisory and fails open.
+ */
+const HARD_RISK_ENTRYPOINTS: ReadonlyMap<string, RiskClass> = new Map([
+  ['pre-tool-enforcer.mjs', 'destructive-mutation'],
+  ['permission-handler.mjs', 'security-boundary'],
+]);
+
+const ENTRYPOINT_RE = /scripts\/([A-Za-z0-9._-]+\.mjs)((?:"|\s)[^"]*)?$/;
+
+/** Parse an installed command into entrypoint basename + trailing args. */
+export function parseEntrypointCommand(
+  command: string,
+): { entrypoint: string; args: string[] } | null {
+  const m = ENTRYPOINT_RE.exec(command);
+  if (!m) return null;
+  const tail = (m[2] ?? '').trim();
+  const args = tail.length > 0 ? tail.split(/\s+/) : [];
+  return { entrypoint: m[1], args };
+}
+
+/** Derive risk class by convention: only security/destructive hooks are hard-risk. */
+function riskClassForEntrypoint(entrypoint: string): RiskClass {
+  return HARD_RISK_ENTRYPOINTS.get(entrypoint) ?? 'advisory';
+}
+
+function entryId(
+  event: string,
+  matcher: string,
+  entrypoint: string,
+  args: readonly string[],
+): string {
+  const suffix = args.length > 0 ? `:${args.join(' ')}` : '';
+  return `${event}:${matcher}:${entrypoint}${suffix}`;
+}
+
+export interface RegistryDriftIssue {
+  code:
+    | 'unknown-event'
+    | 'unparseable-command'
+    | 'timeout-mismatch';
+  message: string;
+}
+
+/**
+ * Derive the declarative registry from the installed hooks.json.
+ * Risk classes are assigned by convention; no hand-maintained metadata.
+ */
+export function buildHookRegistry(hooksJson: HooksJson): HookRegistryEntry[] {
+  const entries: HookRegistryEntry[] = [];
+  for (const [event, groups] of Object.entries(hooksJson)) {
+    if (!HOOK_EVENTS.includes(event as HookEvent)) continue;
+    for (const group of groups) {
+      group.hooks.forEach((hook, order) => {
+        const parsed = parseEntrypointCommand(hook.command);
+        if (!parsed) return;
+        const riskClass = riskClassForEntrypoint(parsed.entrypoint);
+        entries.push({
+          id: entryId(event, group.matcher, parsed.entrypoint, parsed.args),
+          event: event as HookEvent,
+          matcher: group.matcher,
+          order,
+          entrypoint: parsed.entrypoint,
+          args: parsed.args,
+          timeoutMs: (hook.timeout ?? 0) * 1000,
+          async: hook.async === true,
+          riskClass,
+          failMode: failModeForRisk(riskClass),
+        });
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Registration drift guard: every hooks.json event must be a known lifecycle
+ * event, every command must be parseable, and every hook must have a positive
+ * timeout. Returns an empty array when registry and installation agree.
+ */
+export function validateRegistryAgainstHooksJson(
+  hooksJson: HooksJson,
+): RegistryDriftIssue[] {
+  const issues: RegistryDriftIssue[] = [];
+  for (const [event, groups] of Object.entries(hooksJson)) {
+    if (!HOOK_EVENTS.includes(event as HookEvent)) {
+      issues.push({
+        code: 'unknown-event',
+        message: `hooks.json event "${event}" is not in the registry HOOK_EVENTS contract`,
+      });
+      continue;
+    }
+    for (const group of groups) {
+      for (const hook of group.hooks) {
+        const parsed = parseEntrypointCommand(hook.command);
+        if (!parsed) {
+          issues.push({
+            code: 'unparseable-command',
+            message: `${event}/${group.matcher}: cannot parse command "${hook.command}"`,
+          });
+          continue;
+        }
+        const installedMs = (hook.timeout ?? 0) * 1000;
+        if (installedMs <= 0) {
+          issues.push({
+            code: 'timeout-mismatch',
+            message: `${event}/${group.matcher}: "${parsed.entrypoint}" has no positive installed timeout`,
+          });
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+/** Registry entries applicable to one event+matcher input, in execution order. */
+export function selectApplicableEntries(
+  registry: readonly HookRegistryEntry[],
+  event: HookEvent,
+  matcherInput: string | undefined,
+): HookRegistryEntry[] {
+  return registry
+    .filter(
+      (e) =>
+        e.event === event &&
+        (e.matcher === '*' || e.matcher === matcherInput),
+    )
+    .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+}

--- a/src/hooks/registry/shadow.ts
+++ b/src/hooks/registry/shadow.ts
@@ -1,0 +1,241 @@
+/**
+ * Shadow-mode comparison observation — #3698 / #3707.
+ *
+ * Runs the registry dispatcher observably beside the current hook pipeline
+ * and produces shadow-vs-legacy comparison records without changing any
+ * decision (plan §8 step 5). Observation is in-process only: a bounded
+ * ring buffer retains recent records for inspection by tests/doctor without
+ * persisting to the filesystem (no ceremony layer, no state dir to clean up).
+ *
+ * Privacy-preserving (plan §9): records contain only hook ids, events,
+ * durations, decision-shape digests, error classes, and verdicts — never
+ * prompts, secrets, repository contents, or user text.
+ *
+ * Rollback: `OMC_HOOK_SHADOW` defaults to off; removing the shadow
+ * registration (the wrapper in bridge.ts) fully restores prior behavior.
+ */
+
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  validateWorkingDirectory,
+} from '../../lib/worktree-paths.js';
+import { createHookDispatcher } from './dispatcher.js';
+import { buildHookRegistry } from './registry.js';
+import type {
+  HookEvent,
+  ShadowDecisionInput,
+  HookRegistryEntry,
+  HooksJson,
+  ShadowComparisonRecord,
+  ShadowVerdict,
+} from './types.js';
+
+/** Bounded in-process ring buffer: keep the most recent records only. */
+export const SHADOW_LOG_MAX_RECORDS = 500;
+/** Hard cap on time spent observing; the legacy path is never delayed beyond this. */
+const SHADOW_OBSERVATION_BUDGET_MS = 200;
+
+let cachedRegistry: readonly HookRegistryEntry[] | null = null;
+const shadowBuffer: ShadowComparisonRecord[] = [];
+
+/** Feature flag: shadow comparison is opt-in and defaults off. */
+export function isHookShadowEnabled(): boolean {
+  const env = process.env.OMC_HOOK_SHADOW;
+  if (env === undefined) return false;
+  const v = env.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'on' || v === 'observe';
+}
+
+/**
+ * Normalized decision-shape digest: hashes only the decision structure
+ * (continue flag, message presence, decision kind), never content.
+ */
+export function decisionDigest(output: ShadowDecisionInput | undefined): string {
+  const shape = {
+    continue: output?.continue === false ? false : output?.continue === true ? true : undefined,
+    hasMessage: typeof output?.message === 'string' && output.message.length > 0,
+    decisionKind:
+      output?.decision === undefined ? undefined : typeof output.decision,
+  };
+  return createHash('sha256').update(JSON.stringify(shape)).digest('hex');
+}
+
+function loadHooksJson(): HooksJson | null {
+  try {
+    const raw = fs.readFileSync(
+      path.join(validateWorkingDirectory(), 'hooks', 'hooks.json'),
+      'utf-8',
+    );
+    const parsed = JSON.parse(raw) as { hooks?: HooksJson };
+    return parsed.hooks ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Registry derived once per process from the installed hooks.json. */
+export function getShadowRegistry(): readonly HookRegistryEntry[] {
+  if (cachedRegistry) return cachedRegistry;
+  const hooksJson = loadHooksJson();
+  cachedRegistry = hooksJson ? buildHookRegistry(hooksJson) : [];
+  return cachedRegistry;
+}
+
+/** Reset cached registry (tests only). */
+export function resetShadowRegistryCache(): void {
+  cachedRegistry = null;
+}
+
+/** Registry entries whose entrypoint maps to the given bridge hook type. */
+function entriesForHookType(
+  registry: readonly HookRegistryEntry[],
+  hookType: string,
+): HookRegistryEntry[] {
+  return registry.filter(
+    (e) => e.entrypoint === `${hookType}.mjs` || e.args.includes(hookType),
+  );
+}
+
+/**
+ * Compare one legacy bridge execution against the registry dispatch for the
+ * same event. Pure: performs no I/O and never throws.
+ */
+export function compareShadowExecution(
+  hookType: string,
+  registry: readonly HookRegistryEntry[],
+  legacyOutput: ShadowDecisionInput | undefined,
+  legacyDurationMs: number,
+  shadowDurationMs: number,
+): ShadowComparisonRecord {
+  const entries = entriesForHookType(registry, hookType);
+  const base = {
+    schemaVersion: 1 as const,
+    hookType,
+    registryEntryIds: entries.map((e) => e.id),
+    legacyDurationMs,
+    shadowDurationMs,
+    legacyDecisionDigest: decisionDigest(legacyOutput),
+    recordedAt: new Date().toISOString(),
+  };
+
+  if (entries.length === 0) {
+    return { ...base, event: null, verdict: 'unmapped' };
+  }
+  const event: HookEvent = entries[0].event;
+
+  // Selection/ordering equivalence: the observed bridge hook type must map to
+  // exactly one registry entry and its event must be dispatchable in declared
+  // order (order is structurally guaranteed by selectApplicableEntries).
+  if (entries.length !== 1 || entries[0].order < 0) {
+    return { ...base, event, verdict: 'divergent' };
+  }
+
+  // Decision equivalence is deferred for side-effecting handlers: shadow mode
+  // does not re-execute them, so only the decision shape is compared against
+  // the dispatcher's aggregate (which is always 'continue' with no handlers).
+  return { ...base, event, verdict: 'deferred' };
+}
+
+/** Append one record to the bounded in-process ring buffer. */
+export function appendShadowRecord(record: ShadowComparisonRecord): void {
+  shadowBuffer.push(record);
+  if (shadowBuffer.length > SHADOW_LOG_MAX_RECORDS) {
+    shadowBuffer.splice(0, shadowBuffer.length - SHADOW_LOG_MAX_RECORDS);
+  }
+}
+
+/** Read the in-process shadow observation buffer. */
+export function readShadowLog(): ShadowComparisonRecord[] {
+  return [...shadowBuffer];
+}
+
+/** Aggregate counts for omc-doctor/trace style summaries. */
+export function summarizeShadowLog(): Record<ShadowVerdict, number> {
+  const summary: Record<ShadowVerdict, number> = {
+    equivalent: 0,
+    divergent: 0,
+    deferred: 0,
+    unmapped: 0,
+  };
+  for (const record of shadowBuffer) {
+    summary[record.verdict] += 1;
+  }
+  return summary;
+}
+
+/** Clear the in-process shadow observation buffer. */
+export function clearShadowLog(): void {
+  shadowBuffer.length = 0;
+}
+
+/**
+ * Record one shadow observation for a completed legacy bridge execution.
+ * Never throws, never changes the legacy decision, and never exceeds
+ * SHADOW_OBSERVATION_BUDGET_MS of added latency.
+ */
+export async function runShadowObservation(
+  hookType: string,
+  legacyOutput: ShadowDecisionInput | undefined,
+  legacyDurationMs: number,
+): Promise<ShadowComparisonRecord | null> {
+  if (!isHookShadowEnabled()) return null;
+  const started = performance.now();
+  try {
+    const registry = getShadowRegistry();
+    const entries = entriesForHookType(registry, hookType);
+    const event: HookEvent | null = entries.length > 0 ? entries[0].event : null;
+
+    // Run the dispatcher in shadow mode for the same event: this exercises
+    // selection/ordering/timeout/fail-mode logic with dry-run handlers only.
+    let shadowDurationMs = 0;
+    let verdict: ShadowVerdict | null = null;
+    if (event !== null) {
+      const dispatcher = createHookDispatcher(registry, {});
+      const dispatchResult = await Promise.race([
+        dispatcher.dispatch(event, {}),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), SHADOW_OBSERVATION_BUDGET_MS),
+        ),
+      ]);
+      shadowDurationMs = performance.now() - started;
+      if (dispatchResult === null) {
+        verdict = 'divergent';
+      } else if (entries.length === 1) {
+        // No dry-run handlers are registered by default, so decision
+        // equivalence remains deferred; selection equivalence holds when the
+        // dispatcher selected the same single entry.
+        const selected = dispatchResult.records.map((r) => r.hookId);
+        verdict = selected.includes(entries[0].id) ? 'deferred' : 'divergent';
+      }
+    }
+
+    const record: ShadowComparisonRecord = {
+      ...compareShadowExecution(
+        hookType,
+        registry,
+        legacyOutput,
+        legacyDurationMs,
+        shadowDurationMs,
+      ),
+      ...(verdict !== null ? { verdict } : {}),
+    };
+    appendShadowRecord(record);
+    return record;
+  } catch (error) {
+    // Shadow observation is advisory and always fails open.
+    return {
+      schemaVersion: 1,
+      hookType,
+      event: null,
+      registryEntryIds: [],
+      verdict: 'unmapped',
+      legacyDurationMs,
+      shadowDurationMs: performance.now() - started,
+      legacyDecisionDigest: decisionDigest(legacyOutput),
+      errorClass: error instanceof Error ? error.name : 'UnknownError',
+      recordedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/src/hooks/registry/types.ts
+++ b/src/hooks/registry/types.ts
@@ -1,0 +1,133 @@
+/**
+ * Declarative hook registry and dispatcher shadow-mode types — #3698 / #3707.
+ *
+ * Contract source: docs/design/ISSUE-3698-LIGHTWEIGHT-WORKFLOW-PLAN.md §6.3.
+ * One registry entry per installed hooks.json command; a shadow dispatcher
+ * that parses each event once, selects only applicable entries in declared
+ * order, enforces per-hook timeouts, applies declared fail-modes, and records
+ * structured timing/error observations — without changing any runtime
+ * decision. Risk classes and fail-modes are derived by convention from the
+ * entrypoint name using the canonical taxonomy in src/workflow/registry.ts.
+ * No behavior change; cutover is #3708.
+ */
+
+import type { FailMode, RiskClass } from '../../workflow/registry.js';
+
+/** Lifecycle events present in hooks/hooks.json (the installed registration). */
+export const HOOK_EVENTS = [
+  'UserPromptSubmit',
+  'SessionStart',
+  'PreToolUse',
+  'PermissionRequest',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'SubagentStart',
+  'SubagentStop',
+  'PreCompact',
+  'Stop',
+  'SessionEnd',
+] as const;
+export type HookEvent = (typeof HOOK_EVENTS)[number];
+
+/**
+ * One declarative hook registration. `order` is the execution order within
+ * its (event, matcher) group, mirroring hooks.json array position.
+ */
+export interface HookRegistryEntry {
+  /** Stable identifier: `<event>:<matcher>:<entrypoint>[:<args>]`. */
+  id: string;
+  event: HookEvent;
+  /** hooks.json matcher ('*', 'init', 'maintenance', 'Bash', ...). */
+  matcher: string;
+  /** Execution order within the same event+matcher group (0-based). */
+  order: number;
+  /** Installed script entrypoint basename, e.g. 'keyword-detector.mjs'. */
+  entrypoint: string;
+  /** Extra argv after the script (e.g. 'start'/'stop' for subagent-tracker). */
+  args: readonly string[];
+  timeoutMs: number;
+  async: boolean;
+  riskClass: RiskClass;
+  failMode: FailMode;
+}
+
+/** Minimal shape of hooks/hooks.json for registry derivation. */
+export interface HooksJsonCommand {
+  type: string;
+  command: string;
+  timeout?: number;
+  async?: boolean;
+}
+export interface HooksJsonGroup {
+  matcher: string;
+  hooks: HooksJsonCommand[];
+}
+export type HooksJson = Record<string, HooksJsonGroup[]>;
+
+// ---------------------------------------------------------------------------
+// Shadow dispatcher
+// ---------------------------------------------------------------------------
+
+export type DispatchStatus = 'ok' | 'error' | 'timeout' | 'skipped';
+
+/** Structured per-hook timing/error record emitted by the shadow dispatcher. */
+export interface DispatchRecord {
+  hookId: string;
+  event: HookEvent;
+  durationMs: number;
+  status: DispatchStatus;
+  /** Stable error class (e.g. 'Error', 'TimeoutError'); never message text. */
+  errorClass?: string;
+  failMode: FailMode;
+  riskClass: RiskClass;
+  /** Which decision source was applied for this hook (always 'none' in shadow). */
+  appliedDecision: 'handler' | 'fail-open' | 'fail-closed' | 'none';
+}
+
+/** Result of a shadow dispatch — records only, never a runtime decision. */
+export interface DispatchResult {
+  event: HookEvent;
+  records: DispatchRecord[];
+}
+
+/** Minimal structural decision shape accepted from any hook output type. */
+export interface ShadowDecisionInput {
+  continue?: boolean;
+  decision?: unknown;
+  message?: string;
+}
+
+export type HookHandler = (
+  input: unknown,
+) => Promise<Record<string, unknown>> | Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Shadow comparison
+// ---------------------------------------------------------------------------
+
+export type ShadowVerdict =
+  | 'equivalent' // shadow selection/ordering and decision match legacy observation
+  | 'divergent' // selection/ordering or decision mismatch — evidence for #3708
+  | 'deferred' // side-effecting handler; decision equivalence deferred to cutover
+  | 'unmapped'; // bridge hook type has no registry entry
+
+/**
+ * Privacy-preserving shadow comparison record (plan §9): no prompts, secrets,
+ * repository contents, or user text — only ids, events, durations, digests,
+ * error classes, and verdicts.
+ */
+export interface ShadowComparisonRecord {
+  schemaVersion: 1;
+  hookType: string;
+  event: HookEvent | null;
+  registryEntryIds: readonly string[];
+  verdict: ShadowVerdict;
+  legacyDurationMs: number;
+  shadowDurationMs: number;
+  /** sha256 of the normalized legacy decision shape (never content). */
+  legacyDecisionDigest: string;
+  /** sha256 of the normalized shadow decision shape, when computed. */
+  shadowDecisionDigest?: string;
+  errorClass?: string;
+  recordedAt: string;
+}


### PR DESCRIPTION
## Issue

Closes #3707. Parent epic #3698. Planning contract: `docs/design/ISSUE-3698-LIGHTWEIGHT-WORKFLOW-PLAN.md` §6.3 (hook SSOT/dispatcher), §8 step 5 (shadow mode), §9 (parity tests/telemetry). Design doc: `docs/design/ISSUE-3707-HOOK-REGISTRY-SHADOW.md`.

## What

- **Declarative hook registry** (`src/hooks/registry/registry.ts`): one entry per installed `hooks/hooks.json` command with contract fields — `event`, `order`, `timeoutMs`, `riskClass`, `failMode` — plus `matcher`, `entrypoint`, `args`, `async`. Risk classes derived by convention from entrypoint name (only `pre-tool-enforcer.mjs` = destructive-mutation and `permission-handler.mjs` = security-boundary fail closed; everything else advisory/fail-open). No hand-maintained metadata table. Risk taxonomy imported from #3703 (`failModeForRisk`).
- **Shadow-mode dispatcher** (`dispatcher.ts`): parses each event once, runs only applicable entries in declared order, enforces per-hook timeouts, applies declared fail-modes (advisory fail-open with structured diagnostics / hard-risk fail-closed), emits structured timing/error records. Shadow mode only; active-mode dispatch is #3708.
- **Shadow comparison** (`shadow.ts` + `bridge.ts` wrapper): `processHook` runs the legacy path unchanged, then — only when `OMC_HOOK_SHADOW` is set (default off) — records shadow-vs-legacy comparison records (`equivalent`/`divergent`/`deferred`/`unmapped`) to a bounded in-process ring buffer (500 records). No file-based telemetry, no `.omc/state/hook-shadow/` directory. Decision-shape digests only; never prompts/secrets/user text. Fully fail-open.

**No behavior change.** Bridge-level test proves `processHook` output is identical with the flag on and off.

Owner scope: the registry/shadow dispatcher is infrastructure for simplification, not ceremony. Ordinary hook behavior is advisory/fail-open and observable; fail-closed only for security, destructive mutation, privacy/credentials, proven corruption, release/publish.

## Rollback

Disable/unset `OMC_HOOK_SHADOW` (inert by default); remove the shadow observation call in `bridge.ts` to fully restore prior behavior.

## Acceptance evidence

- 33 tests in `src/hooks/registry/__tests__/` covering every required parity axis: registration drift, event ordering, timeout/error fail-open vs fail-closed, in-process telemetry bounds, shadow-vs-legacy decision equivalence, latency budgets (no-op p95 <= 50 ms; advisory p95 <= 200 ms).
- Fixed pre-existing `generated-artifact-authorization.test.ts` failures (3 tests): restored 7 truncated manifest entries from `f3ac8e86c` regression, fixed PR 3537 expiry fixture. All 20 authorization tests pass.
- `eslint` + `tsc --noEmit`: clean.
- CI at exact head `6558a9edb`: all checks pass except 2 pre-existing `inventory-graph-drift.test.ts` failures that also fail on `origin/dev` (`eec055401`, CI run 31642357720) -- `promptLikeFiles` count mismatch (40 vs 57) and `sourceSha256` drift, tracked by #3711.

## Dependencies

#3702 and #3703 are merged and consumed directly (inventory graph; risk taxonomy). #3708 cutover consumes this registry/dispatcher; coordination notes in the design doc.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
