### PR TITLE
fix(docs): deduplicate verification guidance

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -8,7 +8,7 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 
 <operating_principles>
 - Delegate specialized work to the most appropriate agent.
-- Prefer evidence over assumptions: verify outcomes before final claims.
+- Prefer evidence over assumptions.
 - Choose the lightest-weight path that preserves quality.
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "e622a4f41b3708eea7ccd6c6e8070e9b6ed77715",
-    "sourceSha256": "fa677d665a59db0505dfc324a4ff9d827892ea2a8456566ac3a279333b06edf5",
+    "head": "edc1975faa14b6b71156a7b974e907e7a171635f",
+    "sourceSha256": "cd6714562626187f468e3b48e262bf68a34ce79c9a8329e624791c5d4679ccd7",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "e622a4f41b3708eea7ccd6c6e8070e9b6ed77715",
-  "sourceSha256": "fa677d665a59db0505dfc324a4ff9d827892ea2a8456566ac3a279333b06edf5",
+  "head": "edc1975faa14b6b71156a7b974e907e7a171635f",
+  "sourceSha256": "cd6714562626187f468e3b48e262bf68a34ce79c9a8329e624791c5d4679ccd7",
   "counts": {
     "public": {
       "skills": 41,
@@ -70524,5 +70524,5 @@
     }
   },
   "inventorySha256": "fcfaffe5d6182694f4b8f6006bb88236da3a9720c22cc4b9a2a63a70df5099d5",
-  "manifestSha256": "75117d03b4c8314e171246e508d0aa2548b0887324811426871125403fdb4133"
+  "manifestSha256": "bbeb8c20bf1e1c539cfa75b70d0748b9b9e0f15a37c3578ee527585a8d54490f"
 }

--- a/src/__tests__/tier0-docs-consistency.test.ts
+++ b/src/__tests__/tier0-docs-consistency.test.ts
@@ -72,6 +72,12 @@ describe('Tier-0 contract docs consistency', () => {
     expect(claudeDoc).toContain('`test.skip`/`.only`, stub tests');
   });
 
+  it('owns final-claims verification guidance in the verification contract', () => {
+    expect(claudeDoc).toContain('<verification>\nVerify before claiming completion.');
+    expect(claudeDoc).not.toContain('verify outcomes before final claims');
+    expect(claudeDoc).toContain('Before concluding: zero pending tasks, tests passing, verifier evidence collected.');
+  });
+
   it('keeps install and update guidance aligned on canonical setup entrypoints', () => {
     const localPluginDoc = readProjectFile('docs', 'LOCAL_PLUGIN_INSTALL.md');
 


### PR DESCRIPTION
Fixes #3680.

## Scope
- Consolidates the repeated final-claims verification wording into the existing `<verification>` contract in shipped `docs/CLAUDE.md`.
- Preserves verification sizing, failure iteration, final evidence checklist, separation of duties, Deep Interview/Ralplan distinctions, and safety/release boundaries.
- Regenerates the digest-pinned coordinator and adds a focused regression assertion.
- Does not add a marker engine, persistent model-conditional CLAUDE.md variants, or model-routing behavior.

## Evidence
- `npx vitest run src/agents/prompt-ssot/__tests__/prompt-ssot.test.ts src/__tests__/installer.test.ts src/__tests__/tier0-docs-consistency.test.ts src/__tests__/plugin-shipping-surface.test.ts src/__tests__/setup-claude-md-script.test.ts` — 147 passed
- `npm run prompt-ssot:check` — 5 projections fresh
- `node bridge/claude-md-coordinator.cjs --handshake` — source SHA matches regenerated `docs/CLAUDE.md`
- `node scripts/plugin-shipping-surface.mjs verify` — passed
- `npx tsc --noEmit` — passed
- `npm run lint` — 0 errors, 19 existing warnings
- Independent frozen-diff architect review — CLEAR / APPROVE

---
*[repo owner's gaebal-gajae (clawdbot) 🦞]*