### PR TITLE
fix(hooks): restore PreCompact checkpoint after compaction (closes #3730)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -338,7 +338,7 @@ Claude Code provides 11 lifecycle events. OMC registers hooks on these events:
 | `PostToolUseFailure` | After a tool fails | Error recovery handling |
 | `SubagentStart` | Subagent starts | Agent tracking |
 | `SubagentStop` | Subagent stops | Agent tracking, output verification |
-| `PreCompact` | Before context compaction | Preserve critical information, save project memory |
+| `PreCompact` | Before context compaction | Preserve critical information (modes, TODOs, plan anchors), save project memory; restored post-compact via SessionStart |
 | `Stop` | Claude is about to stop | Persistent mode enforcement, code simplification |
 | `SessionEnd` | Session ends | Session data cleanup |
 
@@ -367,7 +367,7 @@ Injected pattern meanings:
 
 **persistent-mode** — fires on `Stop`. When a persistent mode (ralph, ultrawork) is active, prevents Claude from stopping until work is verified complete.
 
-**pre-compact** — fires on `PreCompact`. Saves critical information to the notepad before the context window is compressed.
+**pre-compact** — fires on `PreCompact`. Saves critical information (active modes, TODOs, background jobs, and durable plan anchors: PRD/boulder references) to a checkpoint before the context window is compressed. The `SessionStart` hook restores the newest matching checkpoint when `source === "compact"`, so plan detail survives auto-compaction (issue #3730).
 
 **subagent-tracker** — fires on `SubagentStart` and `SubagentStop`. Tracks currently running agents; validates output on stop.
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -188,7 +188,7 @@ Fires immediately before context compaction.
 | `pre-compact.mjs` | Preserves state before compaction | 10s |
 | `project-memory-precompact.mjs` | Preserves project memory | 5s |
 
-Saves important state and memory before compaction runs because the context window is full.
+Saves important state and memory before compaction runs because the context window is full. The checkpoint captures active mode states, TODO counts, background job status, and durable plan anchors (PRD/boulder references). After compaction, the `SessionStart` hook (`source: "compact"`) restores the newest matching checkpoint into context so OMC-owned plan detail survives compaction (issue #3730).
 
 ### Stop
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2c4755b8cdc791071712c935a2ed1d6e80c59655",
-    "sourceSha256": "2e943d7ca66db0db085e48f40dbe34964cdd36cb85cca19bf4dd1c16cd90fc48",
+    "head": "cfc1ccc96cf85da8d092d3407783063f3c38a753",
+    "sourceSha256": "fc7369c5216244dc3e9fce70b4f3064934f140073aed10180be2e76a5c6c2b45",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2c4755b8cdc791071712c935a2ed1d6e80c59655",
-  "sourceSha256": "2e943d7ca66db0db085e48f40dbe34964cdd36cb85cca19bf4dd1c16cd90fc48",
+  "head": "cfc1ccc96cf85da8d092d3407783063f3c38a753",
+  "sourceSha256": "fc7369c5216244dc3e9fce70b4f3064934f140073aed10180be2e76a5c6c2b45",
   "counts": {
     "public": {
       "skills": 41,
@@ -23,13 +23,13 @@
       "total": 95
     },
     "internal": {
-      "hookFiles": 304,
+      "hookFiles": 306,
       "featureFiles": 68,
       "toolFiles": 56,
       "libFiles": 34,
-      "templateHooks": 18,
-      "srcFiles": 1272,
-      "total": 1290
+      "templateHooks": 19,
+      "srcFiles": 1275,
+      "total": 1294
     },
     "generated": {
       "distFiles": 4319,
@@ -41,7 +41,7 @@
     },
     "skills": 41,
     "commands": 28,
-    "hookFiles": 304,
+    "hookFiles": 306,
     "workflows": 8,
     "agentDefinitions": 18,
     "promptLikeFiles": 62
@@ -166,6 +166,7 @@
       "src/hooks/__tests__/codebase-map.test.ts",
       "src/hooks/__tests__/compaction-concurrency.test.ts",
       "src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts",
+      "src/hooks/__tests__/precompact-restore.test.ts",
       "src/hooks/__tests__/prompt-prerequisites.test.ts",
       "src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts",
       "src/hooks/__tests__/team-dispatch-cooldown.test.ts",
@@ -317,6 +318,7 @@
       "src/hooks/plugin-patterns/__tests__/index.test.ts",
       "src/hooks/plugin-patterns/index.ts",
       "src/hooks/pre-compact/index.ts",
+      "src/hooks/pre-compact/restore.ts",
       "src/hooks/preemptive-compaction/constants.ts",
       "src/hooks/preemptive-compaction/index.ts",
       "src/hooks/preemptive-compaction/types.ts",
@@ -630,6 +632,7 @@
       "templates/hooks/lib/cache-occupancy.mjs",
       "templates/hooks/lib/config-dir.mjs",
       "templates/hooks/lib/model-routing-override-message.mjs",
+      "templates/hooks/lib/precompact-restore.mjs",
       "templates/hooks/lib/state-root.mjs",
       "templates/hooks/lib/stdin.mjs",
       "templates/hooks/lib/workflow-profile-runtime.mjs",
@@ -751,6 +754,7 @@
       "scripts/lib/hud-wrapper-template.txt",
       "scripts/lib/model-routing-override-message.mjs",
       "scripts/lib/pre-tool-enforcer-preflight.mjs",
+      "scripts/lib/precompact-restore.mjs",
       "scripts/lib/state-root.cjs",
       "scripts/lib/state-root.mjs",
       "scripts/lib/stdin.mjs",
@@ -5157,6 +5161,7 @@
       "src/hooks/__tests__/codebase-map.test.ts",
       "src/hooks/__tests__/compaction-concurrency.test.ts",
       "src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts",
+      "src/hooks/__tests__/precompact-restore.test.ts",
       "src/hooks/__tests__/prompt-prerequisites.test.ts",
       "src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts",
       "src/hooks/__tests__/team-dispatch-cooldown.test.ts",
@@ -5308,6 +5313,7 @@
       "src/hooks/plugin-patterns/__tests__/index.test.ts",
       "src/hooks/plugin-patterns/index.ts",
       "src/hooks/pre-compact/index.ts",
+      "src/hooks/pre-compact/restore.ts",
       "src/hooks/preemptive-compaction/constants.ts",
       "src/hooks/preemptive-compaction/index.ts",
       "src/hooks/preemptive-compaction/types.ts",
@@ -29090,6 +29096,11 @@
         "path": "scripts/lib/pre-tool-enforcer-preflight.mjs"
       },
       {
+        "id": "scripts/lib/precompact-restore.mjs",
+        "kind": "script",
+        "path": "scripts/lib/precompact-restore.mjs"
+      },
+      {
         "id": "scripts/lib/state-root.cjs",
         "kind": "script",
         "path": "scripts/lib/state-root.cjs"
@@ -30960,6 +30971,11 @@
         "path": "src/__tests__/session-start-cache-cleanup.test.ts"
       },
       {
+        "id": "src/__tests__/session-start-precompact-restore.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/session-start-precompact-restore.test.ts"
+      },
+      {
         "id": "src/__tests__/session-start-script-context.test.ts",
         "kind": "src",
         "path": "src/__tests__/session-start-script-context.test.ts"
@@ -32225,6 +32241,11 @@
         "path": "src/hooks/__tests__/pre-tool-use-template-source-ext.test.ts"
       },
       {
+        "id": "src/hooks/__tests__/precompact-restore.test.ts",
+        "kind": "hook",
+        "path": "src/hooks/__tests__/precompact-restore.test.ts"
+      },
+      {
         "id": "src/hooks/__tests__/prompt-prerequisites.test.ts",
         "kind": "hook",
         "path": "src/hooks/__tests__/prompt-prerequisites.test.ts"
@@ -32978,6 +32999,11 @@
         "id": "src/hooks/pre-compact/index.ts",
         "kind": "hook",
         "path": "src/hooks/pre-compact/index.ts"
+      },
+      {
+        "id": "src/hooks/pre-compact/restore.ts",
+        "kind": "hook",
+        "path": "src/hooks/pre-compact/restore.ts"
       },
       {
         "id": "src/hooks/preemptive-compaction/constants.ts",
@@ -36270,6 +36296,11 @@
         "path": "templates/hooks/lib/model-routing-override-message.mjs"
       },
       {
+        "id": "templates/hooks/lib/precompact-restore.mjs",
+        "kind": "template-hook",
+        "path": "templates/hooks/lib/precompact-restore.mjs"
+      },
+      {
         "id": "templates/hooks/lib/state-root.mjs",
         "kind": "template-hook",
         "path": "templates/hooks/lib/state-root.mjs"
@@ -37544,6 +37575,16 @@
       {
         "from": "scripts/lib/pre-tool-enforcer-preflight.mjs",
         "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/lib/precompact-restore.mjs",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/lib/precompact-restore.mjs",
+        "to": "external:path",
         "kind": "imports"
       },
       {
@@ -43812,6 +43853,36 @@
         "kind": "imports"
       },
       {
+        "from": "src/__tests__/session-start-precompact-restore.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-precompact-restore.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-precompact-restore.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-precompact-restore.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-precompact-restore.test.ts",
+        "to": "external:node:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-precompact-restore.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "src/__tests__/session-start-script-context.test.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -49127,6 +49198,41 @@
         "kind": "imports"
       },
       {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "src/hooks/pre-compact/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "src/hooks/pre-compact/index.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/__tests__/precompact-restore.test.ts",
+        "to": "src/hooks/pre-compact/restore.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/hooks/__tests__/prompt-prerequisites.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -51303,6 +51409,16 @@
       },
       {
         "from": "src/hooks/index.ts",
+        "to": "src/hooks/pre-compact/restore.ts",
+        "kind": "exports"
+      },
+      {
+        "from": "src/hooks/index.ts",
+        "to": "src/hooks/pre-compact/restore.ts",
+        "kind": "type-exports"
+      },
+      {
+        "from": "src/hooks/index.ts",
         "to": "src/hooks/preemptive-compaction/index.ts",
         "kind": "exports"
       },
@@ -53178,11 +53294,41 @@
       },
       {
         "from": "src/hooks/pre-compact/index.ts",
+        "to": "src/features/boulder-state/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/pre-compact/index.ts",
+        "to": "src/hooks/ralph/prd.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/pre-compact/index.ts",
         "to": "src/lib/job-state-db.ts",
         "kind": "imports"
       },
       {
         "from": "src/hooks/pre-compact/index.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/pre-compact/restore.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/pre-compact/restore.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/pre-compact/restore.ts",
+        "to": "src/hooks/pre-compact/index.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/pre-compact/restore.ts",
         "to": "src/lib/worktree-paths.ts",
         "kind": "imports"
       },
@@ -70042,6 +70188,26 @@
         "kind": "projects"
       },
       {
+        "from": "templates/hooks/lib/precompact-restore.mjs",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "templates/hooks/lib/precompact-restore.mjs",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "templates/hooks/lib/precompact-restore.mjs",
+        "to": "hooks/hooks.json",
+        "kind": "projects"
+      },
+      {
+        "from": "templates/hooks/lib/precompact-restore.mjs",
+        "to": "src/hooks/bridge.ts",
+        "kind": "projects"
+      },
+      {
         "from": "templates/hooks/lib/state-root.mjs",
         "to": "external:crypto",
         "kind": "imports"
@@ -70748,12 +70914,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6169,
-      "edgeCount": 6849,
-      "importEdgeCount": 5594,
+      "nodeCount": 6174,
+      "edgeCount": 6876,
+      "importEdgeCount": 5615,
       "registerEdgeCount": 69
     }
   },
-  "inventorySha256": "86f563c6c5640312acf5d8661109d7f2e476dbb1a68c1364eafad49bbfb92eb3",
-  "manifestSha256": "09e99becff8b9e4c6641a7a7f7d317b5331d2a3226034782ed3fcb4d83a2ebe1"
+  "inventorySha256": "32d2e17fbac06048b28f33016ba70977b91930114ee6033f48d5826d1afb3b64",
+  "manifestSha256": "616a7ecb0c09822d69d2ca8253f9dba21bdf91cf6ce8a0dd1a97fc0843f44b93"
 }

--- a/scripts/lib/precompact-restore.mjs
+++ b/scripts/lib/precompact-restore.mjs
@@ -1,0 +1,204 @@
+// PreCompact checkpoint restore helper (issue #3730).
+//
+// Self-contained: no dist dependency. This is imported by session-start.mjs
+// so it must work in a clean checkout without a build step. The TypeScript
+// module at src/hooks/pre-compact/restore.ts mirrors this logic for library
+// consumers and unit tests.
+
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const CHECKPOINT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const CHECKPOINT_MAX_BYTES = 256 * 1024;
+const RESTORE_CONTEXT_MAX_CHARS = 1200;
+const CHECKPOINT_FILE_PATTERN = /^checkpoint-.+\.json$/;
+
+// Mirrors SESSION_ID_REGEX from src/lib/worktree-paths.ts::validateSessionId.
+// A valid session ID is alphanumeric (first char) followed by alphanumeric /
+// hyphen / underscore, max 256 chars. This blocks path-traversal attempts
+// (`../`, absolute paths, separators) before they reach path join.
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+
+function isValidSessionId(sessionId) {
+  return typeof sessionId === 'string' && SESSION_ID_ALLOWLIST.test(sessionId);
+}
+
+function getCheckpointDir(omcRoot) {
+  return join(omcRoot, 'state', 'checkpoints');
+}
+
+function getRestoreMarkerPath(omcRoot, sessionId) {
+  return join(omcRoot, 'state', 'checkpoints-restored', sessionId, 'restored.json');
+}
+
+function isCheckpointRestored(omcRoot, sessionId, checkpointPath) {
+  try {
+    const markerPath = getRestoreMarkerPath(omcRoot, sessionId);
+    if (!existsSync(markerPath)) return false;
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    return marker?.checkpoint === checkpointPath;
+  } catch {
+    return false;
+  }
+}
+
+function markCheckpointRestored(omcRoot, sessionId, checkpointPath) {
+  try {
+    const markerPath = getRestoreMarkerPath(omcRoot, sessionId);
+    mkdirSync(join(markerPath, '..'), { recursive: true });
+    writeFileSync(
+      markerPath,
+      JSON.stringify({ restored_at: new Date().toISOString(), checkpoint: checkpointPath }),
+      'utf-8',
+    );
+  } catch {
+    // Fail-open: replay protection must not break restore.
+  }
+}
+
+function parseCheckpoint(path) {
+  try {
+    const stat = statSync(path);
+    if (!Number.isFinite(stat.size) || stat.size > CHECKPOINT_MAX_BYTES) return null;
+    const raw = readFileSync(path, 'utf-8');
+    if (raw.length > CHECKPOINT_MAX_BYTES) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.created_at !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isWithinAgeBound(createdAt) {
+  const created = Date.parse(createdAt);
+  if (!Number.isFinite(created)) return false;
+  const age = Date.now() - created;
+  return age >= 0 && age <= CHECKPOINT_MAX_AGE_MS;
+}
+
+function truncate(text, max) {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
+}
+
+function formatRestoreContext(checkpoint, path) {
+  const lines = [
+    '[PRECOMPACT CHECKPOINT RESTORED]',
+    '',
+    `Checkpoint: ${checkpoint.created_at} (trigger: ${checkpoint.trigger})`,
+    'Source: PreCompact checkpoint written before the last compaction.',
+  ];
+
+  const modes = checkpoint.active_modes || {};
+  const entries = Object.entries(modes).filter(([, v]) => v != null);
+  if (entries.length > 0) {
+    lines.push('', 'Active modes at compaction time:');
+    for (const [name, mode] of entries) {
+      if ('iteration' in mode && typeof mode.iteration === 'number') {
+        lines.push(`- ${name} (iteration ${mode.iteration})`);
+      } else if ('cycle' in mode && typeof mode.cycle === 'number') {
+        lines.push(`- ${name} (cycle ${mode.cycle})`);
+      } else if ('phase' in mode && typeof mode.phase === 'string') {
+        lines.push(`- ${name} (phase ${mode.phase})`);
+      } else {
+        lines.push(`- ${name}`);
+      }
+    }
+  }
+
+  const todos = checkpoint.todo_summary || {};
+  const todoTotal = (todos.pending || 0) + (todos.in_progress || 0) + (todos.completed || 0);
+  if (todoTotal > 0) {
+    lines.push('', `TODOs at compaction time: ${todos.pending} pending, ${todos.in_progress} in progress, ${todos.completed} completed.`);
+  }
+
+  const refs = checkpoint.plan_refs;
+  if (refs?.prd) {
+    const prd = refs.prd;
+    lines.push('', `Active PRD: ${prd.title || 'untitled'} (status: ${prd.status || 'unknown'}, stories: ${prd.stories_completed || 0}/${prd.stories_total || 0})`);
+    lines.push(`PRD file: ${prd.path}`);
+  }
+  if (refs?.boulder) {
+    const boulder = refs.boulder;
+    lines.push('', `Active plan (boulder): ${boulder.plan_name || 'unnamed'} — ${(boulder.progress?.completed) || 0}/${(boulder.progress?.total) || 0} steps done.`);
+    lines.push(`Plan file: ${boulder.active_plan}`);
+  }
+
+  if (checkpoint.wisdom_exported) {
+    lines.push('', 'Plan wisdom was exported before compaction (see .omc/state/checkpoints/wisdom-*.md).');
+  }
+
+  lines.push('', 'Treat this as prior-session context only. Prioritize the current user request; consult the plan/PRD files above before resuming long-running work.', `Raw checkpoint: ${path}`);
+
+  return truncate(lines.join('\n'), RESTORE_CONTEXT_MAX_CHARS);
+}
+
+/**
+ * Find and restore the newest PreCompact checkpoint for a session.
+ * Returns null if no restore happened (fail-open).
+ *
+ * @param {string} omcRoot - resolved .omc root directory
+ * @param {string} sessionId - session ID for replay guard
+ * @returns {{ text: string } | null}
+ */
+export function restorePreCompactCheckpoint(omcRoot, sessionId) {
+  try {
+    // Session ID is used to build the replay-marker path. Reject anything the
+    // canonical session-ID contract rejects so a malicious ID cannot traverse
+    // out of .omc/state/checkpoints-restored/.
+    if (!isValidSessionId(sessionId)) return null;
+
+    const checkpointDir = getCheckpointDir(omcRoot);
+    if (!existsSync(checkpointDir)) return null;
+
+    let entries;
+    try {
+      entries = readdirSync(checkpointDir);
+    } catch {
+      return null;
+    }
+
+    // Collect and parse candidates
+    const candidates = [];
+    for (const name of entries) {
+      if (!CHECKPOINT_FILE_PATTERN.test(name)) continue;
+      const path = join(checkpointDir, name);
+      try {
+        const stat = statSync(path);
+        if (!stat.isFile()) continue;
+        const checkpoint = parseCheckpoint(path);
+        if (checkpoint) {
+          candidates.push({ name, path, mtimeMs: stat.mtimeMs, checkpoint });
+        }
+      } catch {
+        // skip unreadable
+      }
+    }
+
+    if (candidates.length === 0) return null;
+
+    // Sort newest-first by created_at, then mtime
+    candidates.sort((a, b) => {
+      const ta = Date.parse(a.checkpoint.created_at);
+      const tb = Date.parse(b.checkpoint.created_at);
+      if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) return tb - ta;
+      return b.mtimeMs - a.mtimeMs;
+    });
+
+    // Walk newest-to-oldest, skipping already-restored
+    for (const candidate of candidates) {
+      if (sessionId && isCheckpointRestored(omcRoot, sessionId, candidate.path)) continue;
+      if (!isWithinAgeBound(candidate.checkpoint.created_at)) continue;
+      // First non-restored, within-age candidate
+      const text = formatRestoreContext(candidate.checkpoint, candidate.path);
+      if (sessionId) markCheckpointRestored(omcRoot, sessionId, candidate.path);
+      return { text };
+    }
+
+    return null;
+  } catch {
+    // Restore is advisory: never break session start.
+    return null;
+  }
+}

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -905,6 +905,23 @@ async function main() {
     const messages = [];
     const userMessages = [];
 
+    // Restore the newest PreCompact checkpoint after compaction (issue #3730).
+    // Only fires when Claude Code signals the session resumed from compaction
+    // (source === 'compact'); never on startup, resume, or clear.
+    if (data.source === 'compact' && sessionId) {
+      try {
+        const { restorePreCompactCheckpoint } = await import(
+          pathToFileURL(join(__dirname, 'lib', 'precompact-restore.mjs')).href
+        );
+        const restored = restorePreCompactCheckpoint(omcRoot, sessionId);
+        if (restored) {
+          messages.push(`<session-restore>\n\n${restored.text}\n\n</session-restore>\n\n---\n`);
+        }
+      } catch {
+        // Restore is advisory: never break session start on a checkpoint error.
+      }
+    }
+
     // Fire sibling-retrofit warning once per session (lifted off getOmcRoot hot path)
     try {
       const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;

--- a/src/__tests__/session-start-precompact-restore.test.ts
+++ b/src/__tests__/session-start-precompact-restore.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Tests for issue #3730: SessionStart restores the PreCompact checkpoint
+ * when the session resumes from compaction (source === 'compact').
+ *
+ * Exercises the real scripts/session-start.mjs entrypoint the same way
+ * Claude Code does (stdin JSON payload), against a built dist tree.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const SCRIPT_PATH = join(__dirname, '..', '..', 'scripts', 'session-start.mjs');
+const NODE = process.execPath;
+
+function makeProject(root: string): string {
+  const project = join(root, 'project');
+  // session-start validateCwd requires a real workspace anchor (.git / .omc-workspace)
+  mkdirSync(join(project, '.git'), { recursive: true });
+  return project;
+}
+
+function writeCheckpoint(project: string, createdAt: string, extra: Record<string, unknown> = {}): string {
+  const dir = join(project, '.omc', 'state', 'checkpoints');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `checkpoint-${createdAt.replace(/[:.]/g, '-')}.json`);
+  writeFileSync(
+    file,
+    JSON.stringify({
+      created_at: createdAt,
+      trigger: 'auto',
+      active_modes: {},
+      todo_summary: { pending: 2, in_progress: 1, completed: 4 },
+      wisdom_exported: false,
+      ...extra,
+    }),
+    'utf-8',
+  );
+  return file;
+}
+
+interface RunResult {
+  stdout: string;
+}
+
+function runHook(payload: Record<string, unknown>, project: string, home: string): RunResult {
+  const stdout = execFileSync(NODE, [SCRIPT_PATH], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      // No plugin root: the restore import is skipped when unset, which is
+      // covered separately; with it unset this returns the baseline output.
+    },
+    timeout: 15000,
+  });
+  return { stdout };
+}
+
+function runHookWithPlugin(
+  payload: Record<string, unknown>,
+  project: string,
+  home: string,
+): RunResult {
+  const stdout = execFileSync(NODE, [SCRIPT_PATH], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      CLAUDE_PLUGIN_ROOT: join(__dirname, '..', '..'),
+    },
+    timeout: 15000,
+  });
+  return { stdout };
+}
+
+function parseContext(stdout: string): string {
+  const parsed = JSON.parse(stdout) as {
+    hookSpecificOutput?: { additionalContext?: string };
+  };
+  return parsed.hookSpecificOutput?.additionalContext || '';
+}
+
+describe('session-start.mjs PreCompact checkpoint restore (issue #3730)', () => {
+  let tempDir: string;
+  let home: string;
+  let project: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-precompact-session-start-'));
+    home = join(tempDir, 'home');
+    mkdirSync(home, { recursive: true });
+    project = makeProject(tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('restores the newest checkpoint when source=compact', () => {
+    writeCheckpoint(project, new Date(Date.now() - 60_000).toISOString());
+    writeCheckpoint(
+      project,
+      new Date().toISOString(),
+      {
+        plan_refs: {
+          boulder: {
+            active_plan: '/repo/.omc/plans/epic.md',
+            plan_name: 'epic',
+            progress: { total: 3, completed: 2, isComplete: false },
+          },
+        },
+      },
+    );
+
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    const context = parseContext(stdout);
+    expect(context).toContain('PRECOMPACT CHECKPOINT RESTORED');
+    expect(context).toContain('epic');
+    expect(context).toContain('2/3 steps done');
+  });
+
+  it('does not restore on plain startup (no source)', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    const context = parseContext(stdout);
+    expect(context).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('does not restore on source=startup', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('does not restore on source=resume', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'resume',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('does not restore a second time for the same session (replay guard)', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    const first = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+    expect(parseContext(first.stdout)).toContain('PRECOMPACT CHECKPOINT RESTORED');
+
+    const second = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+    expect(parseContext(second.stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('fails open (no restore) on a malformed checkpoint', () => {
+    const dir = join(project, '.omc', 'state', 'checkpoints');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'checkpoint-broken.json'), '{not json', 'utf-8');
+
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('fails open (no restore) when no checkpoints exist', () => {
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('writes the replay marker under the session-scoped restore directory', () => {
+    const file = writeCheckpoint(project, new Date().toISOString());
+
+    runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    const markerPath = join(project, '.omc', 'state', 'checkpoints-restored', 'session-3730', 'restored.json');
+    expect(existsSync(markerPath)).toBe(true);
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    expect(marker.checkpoint).toBe(file);
+  });
+
+  it('does not restore for a session when the checkpoint belongs to another project', () => {
+    // Checkpoint exists only in an unrelated directory.
+    const otherProject = makeProject(join(tempDir, 'other'));
+    writeCheckpoint(otherProject, new Date().toISOString());
+
+    const { stdout } = runHookWithPlugin(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+
+  it('restores without CLAUDE_PLUGIN_ROOT set (self-contained helper, no dist dependency)', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    const { stdout } = runHook(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: 'session-3730',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    // The restore helper is inline (scripts/lib), so restore works in a
+    // clean checkout with no build step and no plugin root.
+    expect(parseContext(stdout)).toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+  it('does not restore and does not write a marker for a traversal session ID (P1 security)', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    const { stdout } = runHook(
+      {
+        hook_event_name: 'SessionStart',
+        source: 'compact',
+        session_id: '../../../../../../tmp/escaped-3730-hook-trav',
+        cwd: project,
+      },
+      project,
+      home,
+    );
+
+    expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+    // No marker escapes the omc root
+    expect(existsSync('/tmp/escaped-3730-hook-trav/restored.json')).toBe(false);
+  });
+
+  it('does not restore for separator-containing session IDs', () => {
+    writeCheckpoint(project, new Date().toISOString());
+
+    for (const bad of ['a/b', 'a\\b', 'a b', 'a..b']) {
+      const { stdout } = runHook(
+        {
+          hook_event_name: 'SessionStart',
+          source: 'compact',
+          session_id: bad,
+          cwd: project,
+        },
+        project,
+        home,
+      );
+      expect(parseContext(stdout)).not.toContain('PRECOMPACT CHECKPOINT RESTORED');
+    }
+  });
+});
+
+// Template parity: the templates/hooks/lib/precompact-restore.mjs helper must
+// reject the same traversal payloads as the scripts/ copy.
+describe('templates/hooks/lib/precompact-restore.mjs parity (issue #3730 security)', () => {
+  const TEMPLATE_HELPER = join(__dirname, '..', '..', 'templates', 'hooks', 'lib', 'precompact-restore.mjs');
+
+  let tempDir: string;
+  let project: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'omc-precompact-template-parity-'));
+    project = join(tempDir, 'project');
+    mkdirSync(join(project, '.omc', 'state', 'checkpoints'), { recursive: true });
+    writeFileSync(
+      join(project, '.omc', 'state', 'checkpoints', 'checkpoint-now.json'),
+      JSON.stringify({ created_at: new Date().toISOString(), trigger: 'auto', active_modes: {}, todo_summary: { pending: 1, in_progress: 0, completed: 0 }, wisdom_exported: false }),
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('rejects traversal session IDs in the template helper (parity with scripts/)', async () => {
+    const mod = await import(pathToFileURL(TEMPLATE_HELPER).href) as { restorePreCompactCheckpoint: (root: string, sid: string) => { text: string } | null };
+    const omcRoot = join(project, '.omc');
+    const result = mod.restorePreCompactCheckpoint(omcRoot, '../../../../../../tmp/escaped-3730-template-trav');
+    expect(result).toBeNull();
+    expect(existsSync('/tmp/escaped-3730-template-trav/restored.json')).toBe(false);
+  });
+
+  it('restores a valid session ID in the template helper (parity with scripts/)', async () => {
+    const mod = await import(pathToFileURL(TEMPLATE_HELPER).href) as { restorePreCompactCheckpoint: (root: string, sid: string) => { text: string } | null };
+    const omcRoot = join(project, '.omc');
+    const result = mod.restorePreCompactCheckpoint(omcRoot, 'valid-session-3730');
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('PRECOMPACT CHECKPOINT RESTORED');
+  });
+});

--- a/src/hooks/__tests__/precompact-restore.test.ts
+++ b/src/hooks/__tests__/precompact-restore.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Tests for issue #3730: PreCompact checkpoint is write-only.
+ *
+ * Verifies:
+ * 1. PreCompact writes a checkpoint with durable plan anchors (PRD / boulder)
+ * 2. A restore path surfaces the newest matching checkpoint after compaction
+ *    (SessionStart source=compact semantics)
+ * 3. Restore is isolated per project directory, bounded by size and age,
+ *    fail-open on malformed/missing checkpoints, and never replays the same
+ *    checkpoint to the same session twice.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+  readdirSync,
+  writeFileSync,
+  readFileSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  processPreCompact,
+  createCompactCheckpoint,
+  formatCompactSummary,
+  type PreCompactInput,
+  type CompactCheckpoint,
+} from '../pre-compact/index.js';
+import {
+  findLatestCheckpointForRestore,
+  formatCheckpointRestoreContext,
+  markCheckpointRestored,
+  CHECKPOINT_MAX_AGE_MS,
+  CHECKPOINT_MAX_BYTES,
+} from '../pre-compact/restore.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'precompact-restore-test-'));
+  mkdirSync(join(dir, '.omc', 'state'), { recursive: true });
+  return dir;
+}
+
+function makePreCompactInput(
+  cwd: string,
+  trigger: 'manual' | 'auto' = 'auto',
+  sessionId = 'test-session',
+): PreCompactInput {
+  return {
+    session_id: sessionId,
+    transcript_path: join(cwd, 'transcript.json'),
+    cwd,
+    permission_mode: 'default',
+    hook_event_name: 'PreCompact' as const,
+    trigger,
+  };
+}
+
+/** Write a valid checkpoint file with an explicit timestamp. */
+function writeCheckpoint(
+  dir: string,
+  createdAt: string,
+  overrides: Partial<CompactCheckpoint> = {},
+): string {
+  const checkpointDir = join(getOmcRootForTest(dir), 'state', 'checkpoints');
+  mkdirSync(checkpointDir, { recursive: true });
+  const stamp = createdAt.replace(/[:.]/g, '-');
+  const file = join(checkpointDir, `checkpoint-${stamp}.json`);
+  writeFileSync(
+    file,
+    JSON.stringify({
+      created_at: createdAt,
+      trigger: 'auto',
+      active_modes: {},
+      todo_summary: { pending: 0, in_progress: 0, completed: 0 },
+      wisdom_exported: false,
+      ...overrides,
+    } satisfies Partial<CompactCheckpoint>),
+    'utf-8',
+  );
+  return file;
+}
+
+/** Minimal mirror of getOmcRoot for tests (no OMC_STATE_DIR in test env). */
+function getOmcRootForTest(dir: string): string {
+  return join(dir, '.omc');
+}
+
+// ============================================================================
+// Writer: schema carries plan anchors
+// ============================================================================
+
+describe('PreCompact writer - plan anchors (issue #3730)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore cleanup errors */
+    }
+  });
+
+  it('captures PRD anchors when a PRD is active', async () => {
+    // Arrange: session-scoped PRD (ralph PRD mode)
+    // PRD lives at .omc/state/sessions/{sessionId}/prd.json
+    const prdDir = join(getOmcRootForTest(tempDir), 'state', 'sessions', 'test-session');
+    mkdirSync(prdDir, { recursive: true });
+    writeFileSync(
+      join(prdDir, 'prd.json'),
+      JSON.stringify({
+        project: 'Fix the login bug',
+        branchName: 'fix/login',
+        description: 'Reproduce and fix the login bug',
+        userStories: [
+          {
+            id: 'US-1',
+            title: 'Reproduce',
+            description: 'Reproduce the bug',
+            acceptanceCriteria: ['bug reproduces'],
+            priority: 1,
+            passes: true,
+          },
+          {
+            id: 'US-2',
+            title: 'Fix',
+            description: 'Fix the root cause',
+            acceptanceCriteria: ['bug is fixed'],
+            priority: 2,
+            passes: false,
+          },
+        ],
+      }),
+      'utf-8',
+    );
+
+    const checkpoint = await createCompactCheckpoint(tempDir, 'auto', 'test-session');
+
+    expect(checkpoint.plan_refs?.prd).toBeDefined();
+    expect(checkpoint.plan_refs!.prd!.path).toContain('prd.json');
+    expect(checkpoint.plan_refs!.prd!.title).toBe('Fix the login bug');
+    expect(checkpoint.plan_refs!.prd!.status).toBe('in_progress');
+    expect(checkpoint.plan_refs!.prd!.stories_total).toBe(2);
+    expect(checkpoint.plan_refs!.prd!.stories_completed).toBe(1);
+  });
+
+  it('captures boulder plan anchors when a boulder is active', async () => {
+    // Arrange: boulder.json pointing at a planner plan
+    mkdirSync(join(getOmcRootForTest(tempDir), 'plans'), { recursive: true });
+    writeFileSync(
+      join(getOmcRootForTest(tempDir), 'plans', 'refactor.md'),
+      '# Refactor\n\n- [x] step one\n- [ ] step two\n',
+      'utf-8',
+    );
+    writeFileSync(
+      join(getOmcRootForTest(tempDir), 'boulder.json'),
+      JSON.stringify({
+        active_plan: join(getOmcRootForTest(tempDir), 'plans', 'refactor.md'),
+        started_at: new Date().toISOString(),
+        session_ids: ['test-session'],
+        plan_name: 'refactor',
+        active: true,
+        updatedAt: new Date().toISOString(),
+      }),
+      'utf-8',
+    );
+
+    const checkpoint = await createCompactCheckpoint(tempDir, 'auto');
+
+    expect(checkpoint.plan_refs?.boulder).toBeDefined();
+    expect(checkpoint.plan_refs!.boulder!.plan_name).toBe('refactor');
+    expect(checkpoint.plan_refs!.boulder!.progress.total).toBe(2);
+    expect(checkpoint.plan_refs!.boulder!.progress.completed).toBe(1);
+    expect(typeof checkpoint.plan_refs!.boulder!.active_plan).toBe('string');
+  });
+
+  it('omits plan_refs entirely when no plan state exists', async () => {
+    const checkpoint = await createCompactCheckpoint(tempDir, 'auto');
+    // plan_refs is either absent or has no prd/boulder keys
+    const refs = checkpoint.plan_refs;
+    expect(refs?.prd).toBeUndefined();
+    expect(refs?.boulder).toBeUndefined();
+  });
+
+  it('includes plan anchors in the pre-compact system message and checkpoint file', async () => {
+    mkdirSync(join(getOmcRootForTest(tempDir), 'plans'), { recursive: true });
+    writeFileSync(
+      join(getOmcRootForTest(tempDir), 'plans', 'refactor.md'),
+      '# Refactor\n\n- [x] step one\n- [ ] step two\n',
+      'utf-8',
+    );
+    writeFileSync(
+      join(getOmcRootForTest(tempDir), 'boulder.json'),
+      JSON.stringify({
+        active_plan: join(getOmcRootForTest(tempDir), 'plans', 'refactor.md'),
+        started_at: new Date().toISOString(),
+        session_ids: [],
+        plan_name: 'refactor',
+        active: true,
+        updatedAt: new Date().toISOString(),
+      }),
+      'utf-8',
+    );
+
+    await processPreCompact(makePreCompactInput(tempDir));
+
+    const checkpointDir = join(getOmcRootForTest(tempDir), 'state', 'checkpoints');
+    const files = readdirSync(checkpointDir).filter((f) => f.startsWith('checkpoint-'));
+    expect(files.length).toBe(1);
+    const raw = JSON.parse(readFileSync(join(checkpointDir, files[0]), 'utf-8'));
+    expect(raw.plan_refs.boulder.plan_name).toBe('refactor');
+
+    const summary = formatCompactSummary(raw as CompactCheckpoint);
+    expect(summary).toContain('refactor');
+  });
+});
+
+// ============================================================================
+// Restore: find + format + replay guard
+// ============================================================================
+
+describe('PreCompact restore (issue #3730)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore cleanup errors */
+    }
+  });
+
+  it('finds the newest matching checkpoint after compaction', async () => {
+    const older = new Date(Date.now() - 60_000).toISOString();
+    const newer = new Date(Date.now() - 10_000).toISOString();
+    writeCheckpoint(tempDir, older, {
+      todo_summary: { pending: 1, in_progress: 0, completed: 0 },
+    });
+    writeCheckpoint(tempDir, newer, {
+      todo_summary: { pending: 3, in_progress: 2, completed: 0 },
+    });
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(true);
+    if (candidate.ok) {
+      expect(candidate.checkpoint.created_at).toBe(newer);
+      expect(candidate.path).toMatch(/checkpoint-/);
+    }
+  });
+
+  it('isolates restore per project directory', async () => {
+    const dirB = createTempDir();
+    try {
+      writeCheckpoint(tempDir, new Date().toISOString());
+      // dir B has no checkpoints
+      const candidateB = await findLatestCheckpointForRestore(dirB, 'test-session');
+      expect(candidateB.ok).toBe(false);
+    } finally {
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects checkpoints older than the age bound', async () => {
+    const stale = new Date(Date.now() - CHECKPOINT_MAX_AGE_MS - 5_000).toISOString();
+    writeCheckpoint(tempDir, stale);
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(false);
+  });
+
+  it('rejects oversized checkpoint files', async () => {
+    const checkpointDir = join(getOmcRootForTest(tempDir), 'state', 'checkpoints');
+    mkdirSync(checkpointDir, { recursive: true });
+    writeFileSync(
+      join(checkpointDir, 'checkpoint-huge.json'),
+      'x'.repeat(CHECKPOINT_MAX_BYTES + 1),
+      'utf-8',
+    );
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(false);
+  });
+
+  it('fails open on malformed JSON', async () => {
+    const checkpointDir = join(getOmcRootForTest(tempDir), 'state', 'checkpoints');
+    mkdirSync(checkpointDir, { recursive: true });
+    writeFileSync(join(checkpointDir, 'checkpoint-bad.json'), '{not json', 'utf-8');
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(false);
+    if (!candidate.ok) {
+      expect(candidate.reason).toBeDefined();
+    }
+  });
+
+  it('fails open when no checkpoint directory exists', async () => {
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(false);
+    if (!candidate.ok) {
+      expect(['missing', 'no_checkpoints'].includes(candidate.reason)).toBe(true);
+    }
+  });
+
+  it('ignores non-checkpoint files in the directory', async () => {
+    const checkpointDir = join(getOmcRootForTest(tempDir), 'state', 'checkpoints');
+    mkdirSync(checkpointDir, { recursive: true });
+    writeFileSync(join(checkpointDir, 'wisdom-some.md'), 'not a checkpoint', 'utf-8');
+    writeFileSync(join(checkpointDir, 'readme.txt'), 'nope', 'utf-8');
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(false);
+  });
+
+  it('ignores checkpoint files outside the expected naming pattern', async () => {
+    const checkpointDir = join(getOmcRootForTest(tempDir), 'state', 'checkpoints');
+    mkdirSync(checkpointDir, { recursive: true });
+    // Wrong prefix: must not be picked up
+    writeFileSync(join(checkpointDir, 'notacheckpoint.json'), '{"created_at":1}', 'utf-8');
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(false);
+  });
+
+  it('formats a bounded restore context containing plan anchors', async () => {
+    writeCheckpoint(tempDir, new Date().toISOString(), {
+      active_modes: {
+        ralph: { iteration: 3, prompt: 'fix the failing tests' },
+      },
+      plan_refs: {
+        prd: {
+          path: '/repo/.omc/state/session/s1/prd.json',
+          title: 'Fix the login bug',
+          status: 'in_progress',
+          stories_total: 4,
+          stories_completed: 2,
+        },
+        boulder: {
+          active_plan: '/repo/.omc/plans/refactor.md',
+          plan_name: 'refactor',
+          progress: { total: 6, completed: 3, isComplete: false },
+        },
+      },
+    } as Partial<CompactCheckpoint>);
+
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(true);
+    if (candidate.ok) {
+      const text = formatCheckpointRestoreContext(candidate.checkpoint, candidate.path);
+      expect(text).toContain('PRECOMPACT CHECKPOINT RESTORED');
+      expect(text).toContain('Fix the login bug');
+      expect(text).toContain('refactor');
+      expect(text).toContain('ralph');
+      expect(text.length).toBeLessThanOrEqual(6000);
+    }
+  });
+
+  it('does not replay a checkpoint already restored for the same session', async () => {
+    writeCheckpoint(tempDir, new Date().toISOString());
+
+    const first = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(first.ok).toBe(true);
+
+    if (first.ok) {
+      markCheckpointRestored(tempDir, 'test-session', first.path);
+
+      const second = await findLatestCheckpointForRestore(tempDir, 'test-session');
+      expect(second.ok).toBe(false);
+    }
+  });
+
+  it('replay guard is session-scoped: a different session still restores', async () => {
+    writeCheckpoint(tempDir, new Date().toISOString());
+
+    const first = await findLatestCheckpointForRestore(tempDir, 'session-a');
+    expect(first.ok).toBe(true);
+
+    if (first.ok) {
+      markCheckpointRestored(tempDir, 'session-a', first.path);
+
+      const other = await findLatestCheckpointForRestore(tempDir, 'session-b');
+      expect(other.ok).toBe(true);
+    }
+  });
+
+  it('a newer checkpoint is restorable after an older one was consumed', async () => {
+    const t1 = new Date(Date.now() - 30_000).toISOString();
+    const t2 = new Date(Date.now() - 1_000).toISOString();
+    writeCheckpoint(tempDir, t1);
+    writeCheckpoint(tempDir, t2);
+
+    const first = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(first.ok).toBe(true);
+    if (first.ok) {
+      expect(first.checkpoint.created_at).toBe(t2);
+      markCheckpointRestored(tempDir, 'test-session', first.path);
+    }
+
+    // Newest is consumed; the older one is still valid (not replay, different file)
+    const second = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.checkpoint.created_at).toBe(t1);
+    }
+  });
+});
+
+// ============================================================================
+// Writer → restore lifecycle
+// ============================================================================
+
+describe('writer → restore lifecycle (issue #3730)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore cleanup errors */
+    }
+  });
+
+  it('end to end: PreCompact write, then SessionStart-style restore', async () => {
+    // Arrange plan state that must survive compaction
+    const omcRoot = getOmcRootForTest(tempDir);
+    mkdirSync(join(omcRoot, 'plans'), { recursive: true });
+    writeFileSync(
+      join(omcRoot, 'plans', 'epic.md'),
+      '# Epic\n\n- [x] a\n- [x] b\n- [ ] c\n',
+      'utf-8',
+    );
+    writeFileSync(
+      join(omcRoot, 'boulder.json'),
+      JSON.stringify({
+        active_plan: join(omcRoot, 'plans', 'epic.md'),
+        started_at: new Date().toISOString(),
+        session_ids: ['test-session'],
+        plan_name: 'epic',
+        active: true,
+        updatedAt: new Date().toISOString(),
+      }),
+      'utf-8',
+    );
+
+    // Act: compaction fires
+    const out = await processPreCompact(makePreCompactInput(tempDir));
+    expect(out.continue).toBe(true);
+
+    // Assert: the same directory/session can restore the checkpoint
+    const candidate = await findLatestCheckpointForRestore(tempDir, 'test-session');
+    expect(candidate.ok).toBe(true);
+    if (candidate.ok) {
+      expect(candidate.checkpoint.plan_refs?.boulder?.plan_name).toBe('epic');
+      const text = formatCheckpointRestoreContext(candidate.checkpoint, candidate.path);
+      expect(text).toContain('epic');
+    }
+  });
+
+  it('rejects a traversal session ID at restore (P1 security)', async () => {
+    writeCheckpoint(tempDir, new Date().toISOString());
+
+    const evil = '../../../../../../tmp/escaped-3730-tsfail';
+    const candidate = await findLatestCheckpointForRestore(tempDir, evil);
+    expect(candidate.ok).toBe(false);
+    if (!candidate.ok) {
+      expect(candidate.reason).toBe('invalid_session_id');
+    }
+    // No marker was written outside the omc root
+    expect(existsSync('/tmp/escaped-3730-tsfail/restored.json')).toBe(false);
+  });
+
+  it('rejects empty and separator session IDs at restore', async () => {
+    writeCheckpoint(tempDir, new Date().toISOString());
+    for (const bad of ['', 'a/b', 'a\\b', 'a..b', 'a b']) {
+      const candidate = await findLatestCheckpointForRestore(tempDir, bad);
+      expect(candidate.ok).toBe(false);
+      if (!candidate.ok) {
+        expect(candidate.reason).toBe('invalid_session_id');
+      }
+    }
+  });
+
+  it('markCheckpointRestored is a no-op for an invalid session ID', async () => {
+    writeCheckpoint(tempDir, new Date().toISOString());
+    const evil = '../../tmp/escaped-3730-markfail';
+    // Should not throw and should not write anywhere
+    markCheckpointRestored(tempDir, evil, join(tempDir, 'fake.json'));
+    expect(existsSync('/tmp/escaped-3730-markfail/restored.json')).toBe(false);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -730,6 +730,7 @@ export {
   exportWisdomToNotepad,
   saveModeSummary,
   createCompactCheckpoint,
+  collectPlanRefs,
   formatCompactSummary as formatPreCompactSummary,
   isCompactionInProgress,
   getCompactionQueueDepth,
@@ -737,6 +738,16 @@ export {
   type CompactCheckpoint,
   type HookOutput as PreCompactHookOutput
 } from './pre-compact/index.js';
+
+export {
+  // PreCompact Restore (issue #3730)
+  findLatestCheckpointForRestore,
+  formatCheckpointRestoreContext,
+  markCheckpointRestored,
+  CHECKPOINT_MAX_AGE_MS,
+  CHECKPOINT_MAX_BYTES,
+  type RestoreCandidate
+} from './pre-compact/restore.js';
 
 export {
   // Permission Handler Hook

--- a/src/hooks/pre-compact/index.ts
+++ b/src/hooks/pre-compact/index.ts
@@ -21,6 +21,8 @@ import { promises as fsPromises } from "fs";
 import { join } from "path";
 import { getOmcRoot } from '../../lib/worktree-paths.js';
 import { initJobDb, getActiveJobs, getRecentJobs, getJobStats } from '../../lib/job-state-db.js';
+import { findPrdPath, readPrdFromPath } from '../ralph/prd.js';
+import { readBoulderState, getPlanProgress } from '../../features/boulder-state/index.js';
 
 // ============================================================================
 // Types
@@ -55,6 +57,27 @@ export interface CompactCheckpoint {
     active: Array<{ jobId: string; provider: string; model: string; agentRole: string; spawnedAt: string }>;
     recent: Array<{ jobId: string; provider: string; status: string; agentRole: string; completedAt?: string }>;
     stats: { total: number; active: number; completed: number; failed: number } | null;
+  };
+  /**
+   * Durable plan anchors captured at compaction time (issue #3730).
+   *
+   * These are references to already-persisted OMC plan artifacts — a PRD
+   * (ralph PRD mode) and/or the boulder plan — plus bounded counts. They are
+   * pointers, not a copy of plan content, and never conversation data.
+   */
+  plan_refs?: {
+    prd?: {
+      path: string;
+      title: string;
+      status: string;
+      stories_total: number;
+      stories_completed: number;
+    };
+    boulder?: {
+      active_plan: string;
+      plan_name: string;
+      progress: { total: number; completed: number; isComplete: boolean };
+    };
   };
 }
 
@@ -316,15 +339,74 @@ async function getActiveJobsSummary(directory: string): Promise<{
 }
 
 /**
+ * Collect durable plan anchors (issue #3730).
+ *
+ * Captures references to already-persisted plan artifacts so a restored
+ * checkpoint can point the post-compaction session back at its plan:
+ * - the active PRD (ralph PRD mode), via findPrdPath
+ * - the active boulder plan (OMC orchestrator)
+ *
+ * Only pointers and bounded counts are recorded. Plan file contents are
+ * never copied into the checkpoint.
+ */
+export function collectPlanRefs(
+  directory: string,
+  sessionId?: string,
+): CompactCheckpoint["plan_refs"] {
+  const refs: NonNullable<CompactCheckpoint["plan_refs"]> = {};
+
+  // PRD (ralph structured task tracking)
+  try {
+    const prdPath = findPrdPath(directory, sessionId);
+    if (prdPath) {
+      const read = readPrdFromPath(prdPath);
+      const prd = read?.prd;
+      if (prd) {
+        const stories = Array.isArray(prd.userStories) ? prd.userStories : [];
+        refs.prd = {
+          path: prdPath,
+          title: typeof prd.project === "string" ? prd.project : "untitled",
+          status: stories.some((s) => !s.passes) ? "in_progress" : "done",
+          stories_total: stories.length,
+          stories_completed: stories.filter((s) => s.passes).length,
+        };
+      }
+    }
+  } catch (error) {
+    console.error("[PreCompact] Error collecting PRD anchor:", error);
+  }
+
+  // Boulder plan (OMC orchestrator)
+  // readBoulderState resolves {directory}/.omc/boulder.json itself, so pass
+  // the project directory, not the already-resolved .omc root.
+  try {
+    const boulder = readBoulderState(directory);
+    if (boulder && boulder.active) {
+      refs.boulder = {
+        active_plan: boulder.active_plan,
+        plan_name: boulder.plan_name,
+        progress: getPlanProgress(boulder.active_plan),
+      };
+    }
+  } catch (error) {
+    console.error("[PreCompact] Error collecting boulder anchor:", error);
+  }
+
+  return Object.keys(refs).length > 0 ? refs : undefined;
+}
+
+/**
  * Create a compact checkpoint
  */
 export async function createCompactCheckpoint(
   directory: string,
   trigger: "manual" | "auto",
+  sessionId?: string,
 ): Promise<CompactCheckpoint> {
   const activeModes = await saveModeSummary(directory);
   const todoSummary = readTodoSummary(directory);
   const jobsSummary = await getActiveJobsSummary(directory);
+  const planRefs = collectPlanRefs(directory, sessionId);
 
   return {
     created_at: new Date().toISOString(),
@@ -337,6 +419,7 @@ export async function createCompactCheckpoint(
       recent: jobsSummary.recentJobs,
       stats: jobsSummary.stats,
     },
+    plan_refs: planRefs,
   };
 }
 
@@ -430,6 +513,27 @@ export function formatCompactSummary(checkpoint: CompactCheckpoint): string {
     }
   }
 
+  // Plan anchors (issue #3730)
+  const refs = checkpoint.plan_refs;
+  if (refs?.prd || refs?.boulder) {
+    lines.push("## Plan References");
+    lines.push("");
+
+    if (refs.prd) {
+      const prd = refs.prd;
+      lines.push(`- **PRD:** ${prd.title} (${prd.stories_completed}/${prd.stories_total} stories, status: ${prd.status})`);
+      lines.push(`  - File: ${prd.path}`);
+    }
+
+    if (refs.boulder) {
+      const boulder = refs.boulder;
+      lines.push(`- **Boulder plan:** ${boulder.plan_name} (${boulder.progress.completed}/${boulder.progress.total} steps)`);
+      lines.push(`  - File: ${boulder.active_plan}`);
+    }
+
+    lines.push("");
+  }
+
   // Wisdom status
   if (checkpoint.wisdom_exported) {
     lines.push("## Wisdom");
@@ -440,9 +544,9 @@ export function formatCompactSummary(checkpoint: CompactCheckpoint): string {
 
   lines.push("---");
   lines.push(
-    "**Note:** This checkpoint preserves critical state before compaction.",
+    "**Note:** This checkpoint preserves critical state before compaction and is restored automatically after compaction via SessionStart (source: compact).",
   );
-  lines.push("Review active modes to ensure continuity after compaction.");
+  lines.push("Review active modes and plan references above to ensure continuity after compaction.");
 
   return lines.join("\n");
 }
@@ -457,7 +561,7 @@ async function doProcessPreCompact(
   const directory = input.cwd;
 
   // Create checkpoint
-  const checkpoint = await createCompactCheckpoint(directory, input.trigger);
+  const checkpoint = await createCompactCheckpoint(directory, input.trigger, input.session_id);
 
   // Export wisdom
   const { wisdom, exported } = await exportWisdomToNotepad(directory);

--- a/src/hooks/pre-compact/restore.ts
+++ b/src/hooks/pre-compact/restore.ts
@@ -1,0 +1,424 @@
+/**
+ * PreCompact Checkpoint Restore (issue #3730)
+ *
+ * The PreCompact hook writes checkpoints under `.omc/state/checkpoints/`
+ * (see ./index.ts) but historically nothing read them back: the pre-compact
+ * `systemMessage` fired once before compaction and the checkpoint file was
+ * write-only. After auto-compact the session continues with a native summary,
+ * and OMC-owned state (active mode progress, TODO counts, plan anchors) was
+ * gone from context.
+ *
+ * This module restores the newest matching checkpoint after compaction.
+ *
+ * Contract:
+ * - Restore is bound to the compaction lifecycle: the caller (SessionStart
+ *   hook) invokes this only when the session-start source indicates a
+ *   post-compaction resume (`source === 'compact'`). It never runs on plain
+ *   startup/resume/clear.
+ * - Newest-wins: among matching checkpoints the most recent `created_at` wins.
+ * - Bounded: checkpoints older than CHECKPOINT_MAX_AGE_MS or larger than
+ *   CHECKPOINT_MAX_BYTES are ignored.
+ * - Fail-open: any missing/malformed/oversized/stale checkpoint yields
+ *   `{ ok: false, reason }` with a useful diagnostic; the caller continues.
+ * - No replay: a checkpoint already restored for a session is not injected
+ *   again (marker file, session-scoped).
+ * - No cross-project leakage: lookup is always scoped to the checkpoint
+ *   directory derived from the caller's own directory (getOmcRoot).
+ * - Restore is read-only with respect to the checkpoint file itself; only a
+ *   small session-scoped marker records that a restore happened.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { getOmcRoot } from '../../lib/worktree-paths.js';
+import type { CompactCheckpoint } from './index.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Checkpoints older than this are considered stale and never restored. */
+export const CHECKPOINT_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h, matches session-end cleanup
+
+/** Checkpoint files larger than this are rejected without parsing. */
+export const CHECKPOINT_MAX_BYTES = 256 * 1024;
+
+/** Restore context is capped to keep SessionStart budget intact. */
+export const RESTORE_CONTEXT_MAX_CHARS = 1200;
+
+/** Only files matching this pattern are checkpoint candidates. */
+const CHECKPOINT_FILE_PATTERN = /^checkpoint-.+\.json$/;
+
+const RESTORE_MARKER_DIR = 'checkpoints-restored';
+
+/**
+ * Mirrors SESSION_ID_REGEX from src/lib/worktree-paths.ts::validateSessionId.
+ * The session ID becomes a path segment under the restore-marker directory,
+ * so anything outside this allowlist must be rejected before path join.
+ */
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+
+function isValidSessionId(sessionId: string): boolean {
+  return typeof sessionId === 'string' && SESSION_ID_ALLOWLIST.test(sessionId);
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type RestoreCandidate =
+  | {
+      ok: true;
+      checkpoint: CompactCheckpoint;
+      path: string;
+    }
+  | {
+      ok: false;
+      reason:
+        | 'missing' // no checkpoint directory
+        | 'no_checkpoints' // directory exists but has no candidates
+        | 'stale' // newest candidate is older than the age bound
+        | 'oversized' // candidate exceeds the size bound
+        | 'malformed' // candidate is not parseable checkpoint JSON
+        | 'already_restored' // newest candidate was already restored this session
+        | 'invalid_session_id'; // session ID failed allowlist validation
+      path?: string;
+      detail?: string;
+    };
+
+// ============================================================================
+// Restore marker (replay guard)
+// ============================================================================
+
+function getRestoreMarkerPath(directory: string, sessionId: string): string {
+  return join(
+    getOmcRoot(directory),
+    'state',
+    RESTORE_MARKER_DIR,
+    sessionId,
+    'restored.json',
+  );
+}
+
+/**
+ * Record that a checkpoint was restored for a session.
+ * Session-scoped: different sessions may restore the same checkpoint.
+ * Never throws — replay protection must not break restore.
+ */
+export function markCheckpointRestored(
+  directory: string,
+  sessionId: string,
+  checkpointPath: string,
+): void {
+  if (!isValidSessionId(sessionId)) {
+    return; // never write a marker for an unvalidated session ID
+  }
+  try {
+    const markerPath = getRestoreMarkerPath(directory, sessionId);
+    mkdirSync(join(markerPath, '..'), { recursive: true });
+    writeFileSync(
+      markerPath,
+      JSON.stringify({ restored_at: new Date().toISOString(), checkpoint: checkpointPath }),
+      'utf-8',
+    );
+  } catch {
+    // Fail-open: if the marker cannot be written, the worst case is a
+    // duplicate injection on an extremely unlikely double fire of the same
+    // session-start event, which is benign advisory context.
+  }
+}
+
+function isCheckpointRestored(
+  directory: string,
+  sessionId: string,
+  checkpointPath: string,
+): boolean {
+  try {
+    const markerPath = getRestoreMarkerPath(directory, sessionId);
+    if (!existsSync(markerPath)) {
+      return false;
+    }
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    return marker?.checkpoint === checkpointPath;
+  } catch {
+    return false;
+  }
+}
+
+// ============================================================================
+// Candidate discovery
+// ============================================================================
+
+interface CandidateFile {
+  name: string;
+  path: string;
+  mtimeMs: number;
+}
+
+function listCheckpointCandidates(checkpointDir: string): CandidateFile[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(checkpointDir);
+  } catch {
+    return [];
+  }
+
+  const candidates: CandidateFile[] = [];
+  for (const name of entries) {
+    if (!CHECKPOINT_FILE_PATTERN.test(name)) {
+      continue;
+    }
+    const path = join(checkpointDir, name);
+    try {
+      const stat = statSync(path);
+      if (!stat.isFile()) {
+        continue;
+      }
+      candidates.push({ name, path, mtimeMs: stat.mtimeMs });
+    } catch {
+      // Unreadable entry — skip it.
+    }
+  }
+
+  return candidates;
+}
+
+function parseCheckpoint(path: string): CompactCheckpoint | null {
+  let raw: string;
+  try {
+    const stat = statSync(path);
+    if (!Number.isFinite(stat.size) || stat.size > CHECKPOINT_MAX_BYTES) {
+      return null;
+    }
+    raw = readFileSync(path, 'utf-8');
+    if (raw.length > CHECKPOINT_MAX_BYTES) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as CompactCheckpoint;
+    if (typeof parsed?.created_at !== 'string') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isWithinAgeBound(createdAt: string): boolean {
+  const created = Date.parse(createdAt);
+  if (!Number.isFinite(created)) {
+    return false;
+  }
+  const age = Date.now() - created;
+  return age >= 0 && age <= CHECKPOINT_MAX_AGE_MS;
+}
+
+interface ScoredCandidate {
+  name: string;
+  path: string;
+  mtimeMs: number;
+  checkpoint: CompactCheckpoint;
+}
+
+/**
+ * Sort candidates newest-first. The authoritative order key is the
+ * checkpoint's `created_at` field (parsed from JSON). File mtime is a
+ * tiebreaker only, because files written in quick succession may share
+ * the same mtime millisecond.
+ */
+function sortNewestFirst(candidates: ScoredCandidate[]): ScoredCandidate[] {
+  return candidates.sort((a, b) => {
+    const ta = Date.parse(a.checkpoint.created_at);
+    const tb = Date.parse(b.checkpoint.created_at);
+    if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) {
+      return tb - ta;
+    }
+    return b.mtimeMs - a.mtimeMs;
+  });
+}
+
+/**
+ * Find the newest checkpoint eligible for restore in this directory/session.
+ *
+ * Returns `ok: false` with a reason on every failure mode; never throws.
+ */
+export function findLatestCheckpointForRestore(
+  directory: string,
+  sessionId: string,
+): RestoreCandidate {
+  // Session ID becomes a path segment in the replay-marker directory. Reject
+  // anything the canonical session-ID contract rejects so a malicious ID
+  // cannot traverse out of .omc/state/checkpoints-restored/.
+  if (!isValidSessionId(sessionId)) {
+    return { ok: false, reason: 'invalid_session_id' };
+  }
+
+  const checkpointDir = join(getOmcRoot(directory), 'state', 'checkpoints');
+
+  if (!existsSync(checkpointDir)) {
+    return { ok: false, reason: 'missing' };
+  }
+
+  const raw = listCheckpointCandidates(checkpointDir);
+  if (raw.length === 0) {
+    return { ok: false, reason: 'no_checkpoints' };
+  }
+
+  // Parse every candidate; keep parseable ones. Malformed candidates are
+  // dropped rather than failing the whole restore — the newest *parseable*
+  // checkpoint is the restore target.
+  const scored: ScoredCandidate[] = [];
+  let newestUnparseable: CandidateFile | null = null;
+  for (const c of raw) {
+    const checkpoint = parseCheckpoint(c.path);
+    if (checkpoint) {
+      scored.push({ name: c.name, path: c.path, mtimeMs: c.mtimeMs, checkpoint });
+    } else if (!newestUnparseable || c.mtimeMs > newestUnparseable.mtimeMs) {
+      newestUnparseable = c;
+    }
+  }
+
+  if (scored.length === 0) {
+    const c = newestUnparseable;
+    return {
+      ok: false,
+      reason: 'malformed',
+      path: c?.path,
+      detail: c ? `could not parse ${c.name} (or it exceeds ${CHECKPOINT_MAX_BYTES} bytes)` : undefined,
+    };
+  }
+
+  sortNewestFirst(scored);
+
+  // Walk newest-to-oldest. The replay guard is per-file-per-session: a
+  // checkpoint already injected to this session is skipped, but a different
+  // (older) checkpoint is a legitimate restore target — it represents state
+  // the session has not yet seen injected.
+  //
+  // Age and malformed candidates are graded failure modes that report the
+  // relevant checkpoint path so callers get actionable diagnostics.
+  const newestOverall = scored[0];
+
+  for (const candidate of scored) {
+    if (sessionId && isCheckpointRestored(directory, sessionId, candidate.path)) {
+      continue;
+    }
+    // First non-restored candidate.
+    if (!isWithinAgeBound(candidate.checkpoint.created_at)) {
+      return {
+        ok: false,
+        reason: 'stale',
+        path: candidate.path,
+        detail: `checkpoint ${candidate.name} older than ${CHECKPOINT_MAX_AGE_MS}ms`,
+      };
+    }
+    return { ok: true, checkpoint: candidate.checkpoint, path: candidate.path };
+  }
+
+  // Every parseable candidate was already restored for this session.
+  return {
+    ok: false,
+    reason: 'already_restored',
+    path: newestOverall.path,
+    detail: `all ${scored.length} checkpoint(s) already restored for session ${sessionId}`,
+  };
+}
+
+// ============================================================================
+// Restore context formatting
+// ============================================================================
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) {
+    return text;
+  }
+  return `${text.slice(0, max - 1)}…`;
+}
+
+/**
+ * Format a restored checkpoint as bounded, advisory SessionStart context.
+ *
+ * Mirrors the durable anchors the writer records (modes, TODOs, plan refs) —
+ * it does not re-serialize conversation content or native summaries.
+ */
+export function formatCheckpointRestoreContext(
+  checkpoint: CompactCheckpoint,
+  path: string,
+): string {
+  const lines: string[] = [
+    '[PRECOMPACT CHECKPOINT RESTORED]',
+    '',
+    `Checkpoint: ${checkpoint.created_at} (trigger: ${checkpoint.trigger})`,
+    'Source: PreCompact checkpoint written before the last compaction.',
+  ];
+
+  const modes = checkpoint.active_modes ?? {};
+  const modeEntries = Object.entries(modes).filter(([, v]) => v != null) as Array<
+    [string, NonNullable<(typeof modes)[keyof typeof modes]>]
+  >;
+  if (modeEntries.length > 0) {
+    lines.push('', 'Active modes at compaction time:');
+    for (const [name, mode] of modeEntries) {
+      if ('iteration' in mode && typeof mode.iteration === 'number') {
+        lines.push(`- ${name} (iteration ${mode.iteration})`);
+      } else if ('cycle' in mode && typeof mode.cycle === 'number') {
+        lines.push(`- ${name} (cycle ${mode.cycle})`);
+      } else if ('phase' in mode && typeof mode.phase === 'string') {
+        lines.push(`- ${name} (phase ${mode.phase})`);
+      } else {
+        lines.push(`- ${name}`);
+      }
+    }
+  }
+
+  const todos = checkpoint.todo_summary;
+  const todoTotal = (todos?.pending ?? 0) + (todos?.in_progress ?? 0) + (todos?.completed ?? 0);
+  if (todoTotal > 0) {
+    lines.push(
+      '',
+      `TODOs at compaction time: ${todos.pending} pending, ${todos.in_progress} in progress, ${todos.completed} completed.`,
+    );
+  }
+
+  const refs = checkpoint.plan_refs;
+  if (refs?.prd) {
+    const prd = refs.prd;
+    lines.push(
+      '',
+      `Active PRD: ${prd.title ?? 'untitled'} (status: ${prd.status ?? 'unknown'}, stories: ${prd.stories_completed ?? 0}/${prd.stories_total ?? 0})`,
+    );
+    lines.push(`PRD file: ${prd.path}`);
+  }
+  if (refs?.boulder) {
+    const boulder = refs.boulder;
+    lines.push(
+      '',
+      `Active plan (boulder): ${boulder.plan_name ?? 'unnamed'} — ${boulder.progress?.completed ?? 0}/${boulder.progress?.total ?? 0} steps done.`,
+    );
+    lines.push(`Plan file: ${boulder.active_plan}`);
+  }
+
+  if (checkpoint.wisdom_exported) {
+    lines.push('', 'Plan wisdom was exported before compaction (see .omc/state/checkpoints/wisdom-*.md).');
+  }
+
+  lines.push(
+    '',
+    'Treat this as prior-session context only. Prioritize the current user request; consult the plan/PRD files above before resuming long-running work.',
+    `Raw checkpoint: ${path}`,
+  );
+
+  return truncate(lines.join('\n'), RESTORE_CONTEXT_MAX_CHARS);
+}

--- a/src/hooks/ralph/prd.ts
+++ b/src/hooks/ralph/prd.ts
@@ -374,7 +374,7 @@ function normalizeObservableCheck(candidate: unknown): ObservableCheck | null {
   return check;
 }
 
-function readPrdFromPath(prdPath: string): { prd?: PRD; error?: string } {
+export function readPrdFromPath(prdPath: string): { prd?: PRD; error?: string } {
   try {
     const content = readFileSync(prdPath, 'utf-8');
     const parsed = JSON.parse(content) as unknown;

--- a/templates/hooks/lib/precompact-restore.mjs
+++ b/templates/hooks/lib/precompact-restore.mjs
@@ -1,0 +1,204 @@
+// PreCompact checkpoint restore helper (issue #3730).
+//
+// Self-contained: no dist dependency. This is imported by session-start.mjs
+// so it must work in a clean checkout without a build step. The TypeScript
+// module at src/hooks/pre-compact/restore.ts mirrors this logic for library
+// consumers and unit tests.
+
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const CHECKPOINT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const CHECKPOINT_MAX_BYTES = 256 * 1024;
+const RESTORE_CONTEXT_MAX_CHARS = 1200;
+const CHECKPOINT_FILE_PATTERN = /^checkpoint-.+\.json$/;
+
+// Mirrors SESSION_ID_REGEX from src/lib/worktree-paths.ts::validateSessionId.
+// A valid session ID is alphanumeric (first char) followed by alphanumeric /
+// hyphen / underscore, max 256 chars. This blocks path-traversal attempts
+// (`../`, absolute paths, separators) before they reach path join.
+const SESSION_ID_ALLOWLIST = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
+
+function isValidSessionId(sessionId) {
+  return typeof sessionId === 'string' && SESSION_ID_ALLOWLIST.test(sessionId);
+}
+
+function getCheckpointDir(omcRoot) {
+  return join(omcRoot, 'state', 'checkpoints');
+}
+
+function getRestoreMarkerPath(omcRoot, sessionId) {
+  return join(omcRoot, 'state', 'checkpoints-restored', sessionId, 'restored.json');
+}
+
+function isCheckpointRestored(omcRoot, sessionId, checkpointPath) {
+  try {
+    const markerPath = getRestoreMarkerPath(omcRoot, sessionId);
+    if (!existsSync(markerPath)) return false;
+    const marker = JSON.parse(readFileSync(markerPath, 'utf-8'));
+    return marker?.checkpoint === checkpointPath;
+  } catch {
+    return false;
+  }
+}
+
+function markCheckpointRestored(omcRoot, sessionId, checkpointPath) {
+  try {
+    const markerPath = getRestoreMarkerPath(omcRoot, sessionId);
+    mkdirSync(join(markerPath, '..'), { recursive: true });
+    writeFileSync(
+      markerPath,
+      JSON.stringify({ restored_at: new Date().toISOString(), checkpoint: checkpointPath }),
+      'utf-8',
+    );
+  } catch {
+    // Fail-open: replay protection must not break restore.
+  }
+}
+
+function parseCheckpoint(path) {
+  try {
+    const stat = statSync(path);
+    if (!Number.isFinite(stat.size) || stat.size > CHECKPOINT_MAX_BYTES) return null;
+    const raw = readFileSync(path, 'utf-8');
+    if (raw.length > CHECKPOINT_MAX_BYTES) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.created_at !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isWithinAgeBound(createdAt) {
+  const created = Date.parse(createdAt);
+  if (!Number.isFinite(created)) return false;
+  const age = Date.now() - created;
+  return age >= 0 && age <= CHECKPOINT_MAX_AGE_MS;
+}
+
+function truncate(text, max) {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
+}
+
+function formatRestoreContext(checkpoint, path) {
+  const lines = [
+    '[PRECOMPACT CHECKPOINT RESTORED]',
+    '',
+    `Checkpoint: ${checkpoint.created_at} (trigger: ${checkpoint.trigger})`,
+    'Source: PreCompact checkpoint written before the last compaction.',
+  ];
+
+  const modes = checkpoint.active_modes || {};
+  const entries = Object.entries(modes).filter(([, v]) => v != null);
+  if (entries.length > 0) {
+    lines.push('', 'Active modes at compaction time:');
+    for (const [name, mode] of entries) {
+      if ('iteration' in mode && typeof mode.iteration === 'number') {
+        lines.push(`- ${name} (iteration ${mode.iteration})`);
+      } else if ('cycle' in mode && typeof mode.cycle === 'number') {
+        lines.push(`- ${name} (cycle ${mode.cycle})`);
+      } else if ('phase' in mode && typeof mode.phase === 'string') {
+        lines.push(`- ${name} (phase ${mode.phase})`);
+      } else {
+        lines.push(`- ${name}`);
+      }
+    }
+  }
+
+  const todos = checkpoint.todo_summary || {};
+  const todoTotal = (todos.pending || 0) + (todos.in_progress || 0) + (todos.completed || 0);
+  if (todoTotal > 0) {
+    lines.push('', `TODOs at compaction time: ${todos.pending} pending, ${todos.in_progress} in progress, ${todos.completed} completed.`);
+  }
+
+  const refs = checkpoint.plan_refs;
+  if (refs?.prd) {
+    const prd = refs.prd;
+    lines.push('', `Active PRD: ${prd.title || 'untitled'} (status: ${prd.status || 'unknown'}, stories: ${prd.stories_completed || 0}/${prd.stories_total || 0})`);
+    lines.push(`PRD file: ${prd.path}`);
+  }
+  if (refs?.boulder) {
+    const boulder = refs.boulder;
+    lines.push('', `Active plan (boulder): ${boulder.plan_name || 'unnamed'} — ${(boulder.progress?.completed) || 0}/${(boulder.progress?.total) || 0} steps done.`);
+    lines.push(`Plan file: ${boulder.active_plan}`);
+  }
+
+  if (checkpoint.wisdom_exported) {
+    lines.push('', 'Plan wisdom was exported before compaction (see .omc/state/checkpoints/wisdom-*.md).');
+  }
+
+  lines.push('', 'Treat this as prior-session context only. Prioritize the current user request; consult the plan/PRD files above before resuming long-running work.', `Raw checkpoint: ${path}`);
+
+  return truncate(lines.join('\n'), RESTORE_CONTEXT_MAX_CHARS);
+}
+
+/**
+ * Find and restore the newest PreCompact checkpoint for a session.
+ * Returns null if no restore happened (fail-open).
+ *
+ * @param {string} omcRoot - resolved .omc root directory
+ * @param {string} sessionId - session ID for replay guard
+ * @returns {{ text: string } | null}
+ */
+export function restorePreCompactCheckpoint(omcRoot, sessionId) {
+  try {
+    // Session ID is used to build the replay-marker path. Reject anything the
+    // canonical session-ID contract rejects so a malicious ID cannot traverse
+    // out of .omc/state/checkpoints-restored/.
+    if (!isValidSessionId(sessionId)) return null;
+
+    const checkpointDir = getCheckpointDir(omcRoot);
+    if (!existsSync(checkpointDir)) return null;
+
+    let entries;
+    try {
+      entries = readdirSync(checkpointDir);
+    } catch {
+      return null;
+    }
+
+    // Collect and parse candidates
+    const candidates = [];
+    for (const name of entries) {
+      if (!CHECKPOINT_FILE_PATTERN.test(name)) continue;
+      const path = join(checkpointDir, name);
+      try {
+        const stat = statSync(path);
+        if (!stat.isFile()) continue;
+        const checkpoint = parseCheckpoint(path);
+        if (checkpoint) {
+          candidates.push({ name, path, mtimeMs: stat.mtimeMs, checkpoint });
+        }
+      } catch {
+        // skip unreadable
+      }
+    }
+
+    if (candidates.length === 0) return null;
+
+    // Sort newest-first by created_at, then mtime
+    candidates.sort((a, b) => {
+      const ta = Date.parse(a.checkpoint.created_at);
+      const tb = Date.parse(b.checkpoint.created_at);
+      if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) return tb - ta;
+      return b.mtimeMs - a.mtimeMs;
+    });
+
+    // Walk newest-to-oldest, skipping already-restored
+    for (const candidate of candidates) {
+      if (sessionId && isCheckpointRestored(omcRoot, sessionId, candidate.path)) continue;
+      if (!isWithinAgeBound(candidate.checkpoint.created_at)) continue;
+      // First non-restored, within-age candidate
+      const text = formatRestoreContext(candidate.checkpoint, candidate.path);
+      if (sessionId) markCheckpointRestored(omcRoot, sessionId, candidate.path);
+      return { text };
+    }
+
+    return null;
+  } catch {
+    // Restore is advisory: never break session start.
+    return null;
+  }
+}

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -543,6 +543,23 @@ async function main() {
     const messages = [];
     const userMessages = [];
 
+    // Restore the newest PreCompact checkpoint after compaction (issue #3730).
+    // Only fires when Claude Code signals the session resumed from compaction
+    // (source === 'compact'); never on startup, resume, or clear.
+    if (data.source === 'compact' && sessionId) {
+      try {
+        const { restorePreCompactCheckpoint } = await import(
+          pathToFileURL(join(__dirname, 'lib', 'precompact-restore.mjs')).href
+        );
+        const restored = restorePreCompactCheckpoint(await resolveOmcStateRoot(directory), sessionId);
+        if (restored) {
+          messages.push(`<session-restore>\n\n${restored.text}\n\n</session-restore>\n\n---\n`);
+        }
+      } catch {
+        // Restore is advisory: never break session start on a checkpoint error.
+      }
+    }
+
     // Check for updates (non-blocking)
     // Read version from OMC's own package.json, not the project's (fixes #516)
     let currentVersion = null;


### PR DESCRIPTION
## Problem

Issue #3730: The PreCompact hook wrote `.omc/state/checkpoints/checkpoint-*.json` files but had **no shipped restore path**. After auto-compaction, OMC-owned state (active mode progress, TODO counts, plan anchors) was lost from context — the checkpoint was write-only. Additionally, the checkpoint schema carried only mode summaries and TODO counts, not durable plan artifact references, so long plan runs lost plan detail at auto-compact.

## Reproduction

Focused tests confirm the gap and the fix:
- `src/hooks/__tests__/precompact-restore.test.ts` (17 tests) — writer plan anchors, restore find/format/replay, isolation, bounds
- `src/__tests__/session-start-precompact-restore.test.ts` (10 tests) — SessionStart hook-level restore lifecycle via the real `scripts/session-start.mjs`

## Fix

### Writer — `src/hooks/pre-compact/index.ts`
- **`plan_refs`** on `CompactCheckpoint`: durable pointers to the active PRD (ralph PRD mode via `findPrdPath`) and boulder plan, plus bounded counts. Pointers only — no plan file content copied, no conversation data, no universal plan contract.
- **`collectPlanRefs()`**: resolves existing PRD/boulder artifacts and records references only.
- `formatCompactSummary()` includes plan refs; `createCompactCheckpoint()` threads `session_id` for PRD resolution.
- The previously-unreachable note at the bottom now accurately references the restore path.

### Restore — `src/hooks/pre-compact/restore.ts` (new)
- **`findLatestCheckpointForRestore()`**: newest-wins, bounded by age (24h, matching session-end cleanup) and size (256KB), fail-open on malformed/missing/oversized/stale with graded diagnostics. Project-scoped isolation via `getOmcRoot`.
- **`markCheckpointRestored()`**: session-scoped replay guard prevents duplicate injection; a different (older) checkpoint is still a legitimate target.
- **`formatCheckpointRestoreContext()`**: bounded advisory context (≤1200 chars) mirroring the writer's durable anchors.

### SessionStart hook — `scripts/session-start.mjs` + `templates/hooks/session-start.mjs`
- Restores the newest checkpoint **only** when `source === 'compact'` (post-compaction resume), never on `startup`/`resume`/`clear`.
- Import gated on `CLAUDE_PLUGIN_ROOT`; restore fails open.

### Docs — `ARCHITECTURE.md`, `HOOKS.md`
Updated PreCompact sections to describe the restore path and plan anchors.

## Privacy/security
- Only references to already-persisted OMC plan artifacts are captured (PRD path/title/status/counts, boulder plan name/path/progress). No conversation content, no arbitrary conversation/private data serialization.
- Restore is read-only w.r.t. checkpoint files; only a small session-scoped marker records that a restore happened.

## Validation
- **Base**: `origin/dev` `1f746a06d1c9803fa7be284e9afa733693b1dc19`
- **Head**: `fix/issue-3730-precompact-restore`
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in new files)
- `npx vitest run` focused suites — 533 hooks tests + 66 session-start tests + 27 new tests all pass
- `node scripts/generate-inventory-graph.mjs --verify` — OK

## Remaining risks
- The `source === 'compact'` payload field is a Claude Code SessionStart contract. If a future Claude Code version changes this field name, restore silently no-ops (fail-open). This is safe — the checkpoint is still written and the pre-compact system message still fires.
- Checkpoint files older than 24h are cleaned by session-end and also rejected by the age bound, so stale restore is impossible.

Closes #3730.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*