### PR TITLE
fix(hooks): resolve task-store identity and session-scoped tracking read (Fixes #3732)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0670a9729a740c6bf3394428274c09777dd1d2a2",
-    "sourceSha256": "059e74d0fee69b1bf5bfb676a7e3a0e3bdd9067b4edd1753647deb429c289c62",
+    "head": "5f14364343d52aa2f08da4c917d3b83d05a7311d",
+    "sourceSha256": "89f8db52245769c3cc5faff3286a7046d188494a3c66a335bbe425c8bdf7ec69",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0670a9729a740c6bf3394428274c09777dd1d2a2",
-  "sourceSha256": "059e74d0fee69b1bf5bfb676a7e3a0e3bdd9067b4edd1753647deb429c289c62",
+  "head": "5f14364343d52aa2f08da4c917d3b83d05a7311d",
+  "sourceSha256": "89f8db52245769c3cc5faff3286a7046d188494a3c66a335bbe425c8bdf7ec69",
   "counts": {
     "public": {
       "skills": 41,
@@ -70961,5 +70961,5 @@
     }
   },
   "inventorySha256": "4ebbd40d9d0abf976794d311c52b39e9c514dc7bdfe293ff6270a705a10efcf7",
-  "manifestSha256": "bfc158df7bf2350927670307954a311bc0b0bf4b5b22c1fb0e6229e602279ad3"
+  "manifestSha256": "4b30681520ff7a8bec5150507ce4bc86c3f6725c5c054948150c0841b905c053"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b8861b865e21456478c0f9a64adb24dfce2cb35d",
-    "sourceSha256": "6438b7c89b809364f35f7b75dd7c0e7f3870c058903f8acbdb34b10732516181",
+    "head": "ff38f95f4c5821bdc0e97ccc71b51b1fb8696a59",
+    "sourceSha256": "82825bec0803fb3610fed0ddbd9136261171ffd06f6351a5da58008ffb4ab38d",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b8861b865e21456478c0f9a64adb24dfce2cb35d",
-  "sourceSha256": "6438b7c89b809364f35f7b75dd7c0e7f3870c058903f8acbdb34b10732516181",
+  "head": "ff38f95f4c5821bdc0e97ccc71b51b1fb8696a59",
+  "sourceSha256": "82825bec0803fb3610fed0ddbd9136261171ffd06f6351a5da58008ffb4ab38d",
   "counts": {
     "public": {
       "skills": 41,
@@ -70921,5 +70921,5 @@
     }
   },
   "inventorySha256": "32d2e17fbac06048b28f33016ba70977b91930114ee6033f48d5826d1afb3b64",
-  "manifestSha256": "8ea842f7719613e32564a8738a2a8f5c94e83e5845235f6340fa78d128682454"
+  "manifestSha256": "f497731a3171ee207dccaa7472436ba1f78fa533fe4905e7717bf728801724a5"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "ff38f95f4c5821bdc0e97ccc71b51b1fb8696a59",
-    "sourceSha256": "82825bec0803fb3610fed0ddbd9136261171ffd06f6351a5da58008ffb4ab38d",
+    "head": "0670a9729a740c6bf3394428274c09777dd1d2a2",
+    "sourceSha256": "059e74d0fee69b1bf5bfb676a7e3a0e3bdd9067b4edd1753647deb429c289c62",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "ff38f95f4c5821bdc0e97ccc71b51b1fb8696a59",
-  "sourceSha256": "82825bec0803fb3610fed0ddbd9136261171ffd06f6351a5da58008ffb4ab38d",
+  "head": "0670a9729a740c6bf3394428274c09777dd1d2a2",
+  "sourceSha256": "059e74d0fee69b1bf5bfb676a7e3a0e3bdd9067b4edd1753647deb429c289c62",
   "counts": {
     "public": {
       "skills": 41,
@@ -36456,6 +36456,11 @@
         "path": "tests/integration/multirepo-workspace.test.ts"
       },
       {
+        "id": "tests/integration/task-list-identity-stop.test.ts",
+        "kind": "other",
+        "path": "tests/integration/task-list-identity-stop.test.ts"
+      },
+      {
         "id": "tests/integration/workflow-profile-keyword-activation.test.ts",
         "kind": "other",
         "path": "tests/integration/workflow-profile-keyword-activation.test.ts"
@@ -42680,6 +42685,11 @@
       {
         "from": "src/__tests__/pre-tool-enforcer.test.ts",
         "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/pre-tool-enforcer.test.ts",
+        "to": "external:crypto",
         "kind": "imports"
       },
       {
@@ -70668,6 +70678,36 @@
         "kind": "imports"
       },
       {
+        "from": "tests/integration/task-list-identity-stop.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/integration/task-list-identity-stop.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/integration/task-list-identity-stop.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/integration/task-list-identity-stop.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/integration/task-list-identity-stop.test.ts",
+        "to": "external:node:url",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/integration/task-list-identity-stop.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/integration/workflow-profile-keyword-activation.test.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -70914,12 +70954,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6174,
-      "edgeCount": 6876,
-      "importEdgeCount": 5615,
+      "nodeCount": 6175,
+      "edgeCount": 6883,
+      "importEdgeCount": 5622,
       "registerEdgeCount": 69
     }
   },
-  "inventorySha256": "32d2e17fbac06048b28f33016ba70977b91930114ee6033f48d5826d1afb3b64",
-  "manifestSha256": "f497731a3171ee207dccaa7472436ba1f78fa533fe4905e7717bf728801724a5"
+  "inventorySha256": "4ebbd40d9d0abf976794d311c52b39e9c514dc7bdfe293ff6270a705a10efcf7",
+  "manifestSha256": "bfc158df7bf2350927670307954a311bc0b0bf4b5b22c1fb0e6229e602279ad3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "5f14364343d52aa2f08da4c917d3b83d05a7311d",
-    "sourceSha256": "89f8db52245769c3cc5faff3286a7046d188494a3c66a335bbe425c8bdf7ec69",
+    "head": "41d6753967d39e5bb4193b8b744b9137e23de0e6",
+    "sourceSha256": "f91236a9a542edaee7ef5c75793bcc89a302407f9d22a31b87593916dddaba4f",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "5f14364343d52aa2f08da4c917d3b83d05a7311d",
-  "sourceSha256": "89f8db52245769c3cc5faff3286a7046d188494a3c66a335bbe425c8bdf7ec69",
+  "head": "41d6753967d39e5bb4193b8b744b9137e23de0e6",
+  "sourceSha256": "f91236a9a542edaee7ef5c75793bcc89a302407f9d22a31b87593916dddaba4f",
   "counts": {
     "public": {
       "skills": 41,
@@ -70961,5 +70961,5 @@
     }
   },
   "inventorySha256": "4ebbd40d9d0abf976794d311c52b39e9c514dc7bdfe293ff6270a705a10efcf7",
-  "manifestSha256": "4b30681520ff7a8bec5150507ce4bc86c3f6725c5c054948150c0841b905c053"
+  "manifestSha256": "1cb0ec97aac58c863a8065994eefe794b6adbc9c48c7b89d1e66705371dce7d5"
 }

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -752,13 +752,25 @@ function getActiveSubagentCount(stateDir) {
 
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
+ *
+ * Claude Code resolves the task-store identity as CLAUDE_CODE_TASK_LIST_ID
+ * first, then a team context, then the session id (issue #3732). Hook payloads
+ * only carry session_id, so honor the env override when present.
  */
 function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return 0;
 
+  const override = process.env.CLAUDE_CODE_TASK_LIST_ID;
+  const identity =
+    typeof override === "string" &&
+    override.trim() &&
+    /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(override)
+      ? override.trim()
+      : sessionId;
+
   const cfgDir = getClaudeConfigDir();
-  const taskDir = join(cfgDir, "tasks", sessionId);
+  const taskDir = join(cfgDir, "tasks", identity);
   if (!existsSync(taskDir)) return 0;
 
   let count = 0;

--- a/scripts/persistent-mode.cjs
+++ b/scripts/persistent-mode.cjs
@@ -753,9 +753,11 @@ function getActiveSubagentCount(stateDir) {
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
  *
- * Claude Code resolves the task-store identity as CLAUDE_CODE_TASK_LIST_ID
- * first, then a team context, then the session id (issue #3732). Hook payloads
- * only carry session_id, so honor the env override when present.
+ * Identity contract (issue #3732): the task store is read at
+ * ~/.claude/tasks/<identity>/ where <identity> is the
+ * CLAUDE_CODE_TASK_LIST_ID env override when set and valid, otherwise the
+ * session id. Hook payloads expose no observable team/teammate identity
+ * field, so no implicit team inference is attempted.
  */
 function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -921,9 +921,11 @@ function isValidSessionId(sessionId) {
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
  *
- * Claude Code resolves the task-store identity as CLAUDE_CODE_TASK_LIST_ID
- * first, then a team context, then the session id (issue #3732). Hook payloads
- * only carry session_id, so honor the env override when present.
+ * Identity contract (issue #3732): the task store is read at
+ * ~/.claude/tasks/<identity>/ where <identity> is the
+ * CLAUDE_CODE_TASK_LIST_ID env override when set and valid, otherwise the
+ * session id. Hook payloads expose no observable team/teammate identity
+ * field, so no implicit team inference is attempted.
  */
 function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;

--- a/scripts/persistent-mode.mjs
+++ b/scripts/persistent-mode.mjs
@@ -920,13 +920,25 @@ function isValidSessionId(sessionId) {
 
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
+ *
+ * Claude Code resolves the task-store identity as CLAUDE_CODE_TASK_LIST_ID
+ * first, then a team context, then the session id (issue #3732). Hook payloads
+ * only carry session_id, so honor the env override when present.
  */
 function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return 0;
 
+  const override = process.env.CLAUDE_CODE_TASK_LIST_ID;
+  const identity =
+    typeof override === "string" &&
+    override.trim() &&
+    /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(override)
+      ? override.trim()
+      : sessionId;
+
   const cfgDir = getClaudeConfigDir();
-  const taskDir = join(cfgDir, "tasks", sessionId);
+  const taskDir = join(cfgDir, "tasks", identity);
   if (!existsSync(taskDir)) return 0;
 
   let count = 0;

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -858,13 +858,20 @@ function extractJsonField(input, field, defaultValue = '') {
 // directly. When no sessionId is observable only the two legacy filenames are
 // probed.
 async function getAgentTrackingInfo(stateDir, directory, sessionId = '') {
-  const stateNames = sessionId
+  // The session id arrives from the hook payload and is influenceable, so it
+  // is validated against the canonical allowlist BEFORE any scoped resolution.
+  // An invalid id must skip every session-scoped candidate and only probe the
+  // safe legacy roots: the canonical resolver would throw on it, and the
+  // unvalidated path would let a payload like `../evil` escape the sessions
+  // directory and read unrelated state (issue #3732 review).
+  const safeSessionId = isValidSessionId(sessionId) ? sessionId : '';
+  const stateNames = safeSessionId
     ? ['subagent-tracking', 'subagent-tracking.json']
     : ['subagent-tracking.json'];
   const candidates = [];
   for (const stateName of stateNames) {
     try {
-      const { readPath } = await resolveSessionStatePathsForHook(directory, stateName, sessionId || undefined);
+      const { readPath } = await resolveSessionStatePathsForHook(directory, stateName, safeSessionId || undefined);
       candidates.push(readPath);
     } catch {}
   }
@@ -876,8 +883,14 @@ async function getAgentTrackingInfo(stateDir, directory, sessionId = '') {
 
   for (const trackingFile of candidates) {
     const data = readJsonFile(trackingFile);
-    if (!data) continue;
-    const running = (data.agents || []).filter(a => a.status === 'running').length;
+    // Shape-validate per candidate: a parseable file with a non-array `agents`
+    // field is a malformed candidate, never a reason to abort the whole hook
+    // (which would drop the spawn advisory and any configured model injection).
+    // Skip it and continue with the next canonical/legacy candidate.
+    if (!data || typeof data !== 'object' || Array.isArray(data) || !Array.isArray(data.agents)) {
+      continue;
+    }
+    const running = data.agents.filter(a => a && typeof a === 'object' && a.status === 'running').length;
     return { running, total: data.total_spawned || 0 };
   }
   return { running: 0, total: 0 };

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -851,8 +851,10 @@ function extractJsonField(input, field, defaultValue = '') {
 //
 // Name note: the canonical resolver normalizes `subagent-tracking` to
 // `<stateDir>/sessions/<sid>/subagent-tracking-state.json` (Wave-A layout) with
-// read fallback to `<stateDir>/subagent-tracking-state.json`. The pre-Wave-A
-// legacy file was plain `subagent-tracking.json` (still read by
+// read fallback to `<stateDir>/subagent-tracking-state.json`. When the
+// session-scoped file exists but is malformed, the canonical legacy file for
+// the same name is probed explicitly (never skipped). The pre-Wave-A legacy
+// file was plain `subagent-tracking.json` (still read by
 // session-end/post-tool-verifier and written by pre-Wave-A installs), so after
 // the canonical probe finds nothing the plain legacy filename is read
 // directly. When no sessionId is observable only the two legacy filenames are
@@ -865,16 +867,22 @@ async function getAgentTrackingInfo(stateDir, directory, sessionId = '') {
   // unvalidated path would let a payload like `../evil` escape the sessions
   // directory and read unrelated state (issue #3732 review).
   const safeSessionId = isValidSessionId(sessionId) ? sessionId : '';
-  const stateNames = safeSessionId
-    ? ['subagent-tracking', 'subagent-tracking.json']
-    : ['subagent-tracking.json'];
   const candidates = [];
-  for (const stateName of stateNames) {
-    try {
-      const { readPath } = await resolveSessionStatePathsForHook(directory, stateName, safeSessionId || undefined);
-      candidates.push(readPath);
-    } catch {}
-  }
+  try {
+    // Session-scoped effective read for the canonical state name (scoped-first
+    // with canonical-legacy read fallback).
+    const { readPath } = await resolveSessionStatePathsForHook(directory, 'subagent-tracking', safeSessionId || undefined);
+    candidates.push(readPath);
+    // Explicit canonical legacy read: when the session-scoped file exists but
+    // is malformed the effective read above points at it, and without this
+    // probe the valid <stateDir>/subagent-tracking-state.json would be
+    // silently skipped. The canonical legacy file is probed even when no
+    // session id is observable (issue #3732 review). Both reads stay owned by
+    // the canonical resolver — never the suffixed `subagent-tracking.json`
+    // state name, which the resolver would corrupt into `-state.json`.
+    const legacy = await resolveSessionStatePathsForHook(directory, 'subagent-tracking', undefined);
+    if (legacy.readPath !== readPath) candidates.push(legacy.readPath);
+  } catch {}
   // Pre-Wave-A legacy filename, read directly (outside the canonical naming
   // scheme) so old installs keep working. resolveSessionStatePathsForHook
   // appends `-state.json`, which would corrupt a name that already ends in

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -841,16 +841,28 @@ function extractJsonField(input, field, defaultValue = '') {
   }
 }
 
-// Get agent tracking info from state file
-function getAgentTrackingInfo(stateDir) {
-  const trackingFile = join(stateDir, 'subagent-tracking.json');
-  try {
-    if (existsSync(trackingFile)) {
-      const data = JSON.parse(readFileSync(trackingFile, 'utf-8'));
-      const running = (data.agents || []).filter(a => a.status === 'running').length;
-      return { running, total: data.total_spawned || 0 };
-    }
-  } catch {}
+// Get agent tracking info from state file.
+// Checks session-scoped path first (Wave A layout), then legacy fallback.
+// Issue #3732: reading legacy-only hid session-scoped state and produced
+// contradicting agent counts vs post-tool-verifier::getAgentCompletionSummary,
+// which already read session-scoped first. sessionId is extracted from the
+// hook payload; when absent only the legacy path is tried.
+function getAgentTrackingInfo(stateDir, sessionId = '') {
+  const safeSessionId = sessionId && SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
+  const candidates = [
+    safeSessionId ? join(stateDir, 'sessions', safeSessionId, 'subagent-tracking-state.json') : null,
+    join(stateDir, 'subagent-tracking.json'),
+  ].filter(Boolean);
+
+  for (const trackingFile of candidates) {
+    try {
+      if (existsSync(trackingFile)) {
+        const data = JSON.parse(readFileSync(trackingFile, 'utf-8'));
+        const running = (data.agents || []).filter(a => a.status === 'running').length;
+        return { running, total: data.total_spawned || 0 };
+      }
+    } catch {}
+  }
   return { running: 0, total: 0 };
 }
 
@@ -1377,7 +1389,7 @@ function generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId) {
   const model = toolInput.model || 'inherit';
   const desc = toolInput.description || '';
   const bg = toolInput.run_in_background ? ' [BACKGROUND]' : '';
-  const tracking = getAgentTrackingInfo(stateDir);
+  const tracking = getAgentTrackingInfo(stateDir, sessionId);
 
   // Team-routing guidance:
   // Claude Code 2.1.178+ removed TeamCreate/TeamDelete. When OMC team state is

--- a/scripts/pre-tool-enforcer.mjs
+++ b/scripts/pre-tool-enforcer.mjs
@@ -16,7 +16,7 @@ import { getClaudeConfigDir } from './lib/config-dir.mjs';
 import { encodeProjectPath } from './lib/encode-project-path.mjs';
 import { evaluateAgentHeavyPreflight } from './lib/pre-tool-enforcer-preflight.mjs';
 import { evaluateForceAgentDelegation } from './lib/force-agent-delegation-preflight.mjs';
-import { resolveOmcStateRoot } from './lib/state-root.mjs';
+import { resolveOmcStateRoot, resolveSessionStatePathsForHook } from './lib/state-root.mjs';
 import { readStdin } from './lib/stdin.mjs';
 import { resolveConfiguredAgentModel } from './lib/agent-model-config.mjs';
 import { BOUNDED_GIT_TIMEOUT_MS } from './lib/bounded-git-timeout.mjs';
@@ -842,26 +842,43 @@ function extractJsonField(input, field, defaultValue = '') {
 }
 
 // Get agent tracking info from state file.
-// Checks session-scoped path first (Wave A layout), then legacy fallback.
-// Issue #3732: reading legacy-only hid session-scoped state and produced
-// contradicting agent counts vs post-tool-verifier::getAgentCompletionSummary,
-// which already read session-scoped first. sessionId is extracted from the
-// hook payload; when absent only the legacy path is tried.
-function getAgentTrackingInfo(stateDir, sessionId = '') {
-  const safeSessionId = sessionId && SESSION_ID_PATTERN.test(sessionId) ? sessionId : '';
-  const candidates = [
-    safeSessionId ? join(stateDir, 'sessions', safeSessionId, 'subagent-tracking-state.json') : null,
-    join(stateDir, 'subagent-tracking.json'),
-  ].filter(Boolean);
+// Path resolution is owned by the canonical resolveSessionStatePathsForHook()
+// helper (validation/migration-aware, session-scoped-first read with legacy
+// fallback), so this reader cannot drift from the other OmC consumers again.
+// Issue #3732: the pre-fix manual path construction read legacy-only while
+// post-tool-verifier::getAgentCompletionSummary read session-scoped first,
+// producing contradicting agent counts for the same session.
+//
+// Name note: the canonical resolver normalizes `subagent-tracking` to
+// `<stateDir>/sessions/<sid>/subagent-tracking-state.json` (Wave-A layout) with
+// read fallback to `<stateDir>/subagent-tracking-state.json`. The pre-Wave-A
+// legacy file was plain `subagent-tracking.json` (still read by
+// session-end/post-tool-verifier and written by pre-Wave-A installs), so after
+// the canonical probe finds nothing the plain legacy filename is read
+// directly. When no sessionId is observable only the two legacy filenames are
+// probed.
+async function getAgentTrackingInfo(stateDir, directory, sessionId = '') {
+  const stateNames = sessionId
+    ? ['subagent-tracking', 'subagent-tracking.json']
+    : ['subagent-tracking.json'];
+  const candidates = [];
+  for (const stateName of stateNames) {
+    try {
+      const { readPath } = await resolveSessionStatePathsForHook(directory, stateName, sessionId || undefined);
+      candidates.push(readPath);
+    } catch {}
+  }
+  // Pre-Wave-A legacy filename, read directly (outside the canonical naming
+  // scheme) so old installs keep working. resolveSessionStatePathsForHook
+  // appends `-state.json`, which would corrupt a name that already ends in
+  // `.json`, hence the direct join here under the resolved state root.
+  candidates.push(join(stateDir, 'subagent-tracking.json'));
 
   for (const trackingFile of candidates) {
-    try {
-      if (existsSync(trackingFile)) {
-        const data = JSON.parse(readFileSync(trackingFile, 'utf-8'));
-        const running = (data.agents || []).filter(a => a.status === 'running').length;
-        return { running, total: data.total_spawned || 0 };
-      }
-    } catch {}
+    const data = readJsonFile(trackingFile);
+    if (!data) continue;
+    const running = (data.agents || []).filter(a => a.status === 'running').length;
+    return { running, total: data.total_spawned || 0 };
   }
   return { running: 0, total: 0 };
 }
@@ -1379,7 +1396,7 @@ function getActiveTeamState(stateDir, sessionId) {
 }
 
 // Generate agent spawn message with metadata
-function generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId) {
+async function generateAgentSpawnMessage(toolInput, stateDir, directory, todoStatus, sessionId) {
   if (!toolInput || typeof toolInput !== 'object') {
     if (QUIET_LEVEL >= 2) return '';
     return `${todoStatus}Launch multiple agents in parallel when tasks are independent. Use run_in_background for long operations.`;
@@ -1389,7 +1406,7 @@ function generateAgentSpawnMessage(toolInput, stateDir, todoStatus, sessionId) {
   const model = toolInput.model || 'inherit';
   const desc = toolInput.description || '';
   const bg = toolInput.run_in_background ? ' [BACKGROUND]' : '';
-  const tracking = getAgentTrackingInfo(stateDir, sessionId);
+  const tracking = await getAgentTrackingInfo(stateDir, directory, sessionId);
 
   // Team-routing guidance:
   // Claude Code 2.1.178+ removed TeamCreate/TeamDelete. When OMC team state is
@@ -1913,7 +1930,7 @@ async function main() {
     if (toolName === 'Task' || toolName === 'Agent') {
       const toolInput = data.toolInput || data.tool_input || null;
       // Reflect any injected per-agent model (issue #3242) in the advisory label.
-      message = generateAgentSpawnMessage(updatedToolInput || toolInput, stateDir, todoStatus, sessionId);
+      message = await generateAgentSpawnMessage(updatedToolInput || toolInput, stateDir, directory, todoStatus, sessionId);
     } else {
       message = generateMessage(toolName, todoStatus, modeActive);
     }

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
+import { createHash } from 'crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.unmock('child_process');
@@ -2902,6 +2903,60 @@ describe('pre-tool-enforcer session-scoped agent tracking (issue #3732)', () => 
 
     const output = spawnAdvisory(sessionId);
     const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+  it('falls back to the canonical resolver legacy name when no session-scoped or plain legacy file exists', () => {
+    const sessionId = 'session-3732-canonical-legacy';
+    // The canonical resolver's legacy read path is
+    // .omc/state/subagent-tracking-state.json (normalized name), distinct from
+    // the pre-Wave-A plain subagent-tracking.json. The read must route through
+    // resolveSessionStatePathsForHook and honor this name too.
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'c1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 11,
+      total_completed: 10,
+      total_failed: 0,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = spawnAdvisory(sessionId);
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+
+  it('resolves the session-scoped tracking read through OMC_STATE_DIR centralized state', () => {
+    const sessionId = 'session-3732-centralized';
+    const centralRoot = mkdtempSync(join(tmpdir(), 'pre-tool-enforcer-central-'));
+    const stateRoot = join(centralRoot, `${basename(tempDir)}-${createHash('sha256').update(tempDir).digest('hex').slice(0, 16)}`);
+    writeJson(join(stateRoot, 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'z1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 4,
+      total_completed: 3,
+      total_failed: 0,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = runPreToolEnforcerWithEnv(
+      {
+        tool_name: 'Task',
+        cwd: tempDir,
+        session_id: sessionId,
+        toolInput: {
+          subagent_type: 'oh-my-claudecode:executor',
+          description: 'issue #3732 centralized regression',
+        },
+      },
+      { OMC_STATE_DIR: centralRoot },
+    );
+    rmSync(centralRoot, { recursive: true, force: true });
+
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    // The canonical resolver (not manual join(stateDir, ...)) routes the read
+    // into the centralized state root; a manual stateDir join would miss it.
     expect(advisory).toContain('Active agents: 1');
   });
 });

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2821,3 +2821,87 @@ describe('pre-tool-enforcer skill vs agent namespace guard (issue #3667)', () =>
     });
   });
 });
+
+describe('pre-tool-enforcer session-scoped agent tracking (issue #3732)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pre-tool-enforcer-session-tracking-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function spawnAdvisory(sessionId: string): Record<string, unknown> {
+    return runPreToolEnforcer({
+      tool_name: 'Task',
+      cwd: tempDir,
+      session_id: sessionId,
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'issue #3732 regression',
+      },
+    });
+  }
+
+  it('reports running agents from the session-scoped tracking file', () => {
+    const sessionId = 'session-3732-scoped';
+    writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'a1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+        { agent_id: 'a2', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 203,
+      total_completed: 185,
+      total_failed: 0,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = spawnAdvisory(sessionId);
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 2');
+  });
+
+  it('prefers session-scoped state over a stale legacy file', () => {
+    const sessionId = 'session-3732-precedence';
+    writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'a1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 203,
+      total_completed: 185,
+      total_failed: 0,
+      last_updated: new Date().toISOString(),
+    });
+    // Stale legacy file with contradictory counters (the 160-vs-203 symptom).
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking.json'), {
+      agents: [],
+      total_spawned: 160,
+      total_completed: 0,
+      total_failed: 0,
+      last_updated: new Date(0).toISOString(),
+    });
+
+    const output = spawnAdvisory(sessionId);
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+
+  it('falls back to the legacy file when no session-scoped state exists', () => {
+    const sessionId = 'session-3732-legacy';
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking.json'), {
+      agents: [
+        { agent_id: 'b1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 7,
+      total_completed: 2,
+      total_failed: 0,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = spawnAdvisory(sessionId);
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+});

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -2959,4 +2959,74 @@ describe('pre-tool-enforcer session-scoped agent tracking (issue #3732)', () => 
     // into the centralized state root; a manual stateDir join would miss it.
     expect(advisory).toContain('Active agents: 1');
   });
+
+  it('rejects invalid session ids before scoped resolution (no escaped read)', () => {
+    // A payload with a path-traversal id must not reach the escaped
+    // .omc/state/evil/ location: only the safe legacy roots may be probed.
+    // Under the pre-fix code the unvalidated id flowed into the inline
+    // resolver fallback, join()-normalized `sessions/../evil` into `state/evil`,
+    // and reported counters from the unrelated file below.
+    writeJson(join(tempDir, '.omc', 'state', 'evil', 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'x1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+        { agent_id: 'x2', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 99,
+      last_updated: new Date().toISOString(),
+    });
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking.json'), {
+      agents: [
+        { agent_id: 'l1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 7,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = spawnAdvisory('../evil');
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    // Safe legacy roots still work for invalid ids...
+    expect(advisory).toContain('Active agents: 1');
+    // ...but the escaped session-scoped file is never read.
+    expect(advisory).not.toContain('Active agents: 2');
+  });
+
+  it('skips a malformed session-scoped candidate and falls back to the legacy file', () => {
+    const sessionId = 'session-3732-malformed';
+    // Parseable but shape-corrupt: `agents` is not an array. This candidate
+    // must be skipped locally so the legacy fallback still resolves and the
+    // hook keeps running instead of aborting into suppressOutput.
+    writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {
+      agents: 'corrupt',
+    });
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking.json'), {
+      agents: [
+        { agent_id: 'l1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 7,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = spawnAdvisory(sessionId);
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+
+  it('survives all-malformed tracking candidates with a zero count', () => {
+    const sessionId = 'session-3732-all-malformed';
+    writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {
+      agents: 'corrupt',
+    });
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking.json'), {
+      agents: { agent_id: 'nope' },
+      total_spawned: 42,
+    });
+
+    const output = spawnAdvisory(sessionId);
+    expect(output.continue).toBe(true);
+    // The spawn advisory still flows (no abort into the broad catch's
+    // suppressOutput-only path), with a zero agent count.
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Spawning agent:');
+    expect(advisory).not.toContain('Active agents:');
+  });
 });

--- a/src/__tests__/pre-tool-enforcer.test.ts
+++ b/src/__tests__/pre-tool-enforcer.test.ts
@@ -3011,6 +3011,53 @@ describe('pre-tool-enforcer session-scoped agent tracking (issue #3732)', () => 
     expect(advisory).toContain('Active agents: 1');
   });
 
+  it('does not let a malformed scoped canonical file suppress the canonical legacy file', () => {
+    const sessionId = 'session-3732-malformed-scoped-canonical';
+    // The session-scoped canonical file exists but is shape-corrupt; the
+    // canonical legacy file for the SAME state name holds the valid data. The
+    // resolver's effective read points at the (malformed) scoped file, so the
+    // legacy file must still be probed explicitly instead of being skipped.
+    writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {
+      agents: 'corrupt',
+    });
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'c1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 11,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = spawnAdvisory(sessionId);
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+
+  it('reads the canonical legacy file when no session id is observable', () => {
+    // No session_id in the payload: the canonical legacy
+    // subagent-tracking-state.json must still be probed (the suffixed state
+    // name the pre-fix reader used normalizes to a nonexistent
+    // `-state.json` name and silently skipped it).
+    writeJson(join(tempDir, '.omc', 'state', 'subagent-tracking-state.json'), {
+      agents: [
+        { agent_id: 'c1', agent_type: 'oh-my-claudecode:executor', status: 'running' },
+      ],
+      total_spawned: 11,
+      last_updated: new Date().toISOString(),
+    });
+
+    const output = runPreToolEnforcer({
+      tool_name: 'Task',
+      cwd: tempDir,
+      toolInput: {
+        subagent_type: 'oh-my-claudecode:executor',
+        description: 'issue #3732 no-session regression',
+      },
+    });
+    const advisory = (output.hookSpecificOutput as Record<string, unknown>).additionalContext as string;
+    expect(advisory).toContain('Active agents: 1');
+  });
+
   it('survives all-malformed tracking candidates with a zero count', () => {
     const sessionId = 'session-3732-all-malformed';
     writeJson(join(tempDir, '.omc', 'state', 'sessions', sessionId, 'subagent-tracking-state.json'), {

--- a/src/__tests__/task-continuation.test.ts
+++ b/src/__tests__/task-continuation.test.ts
@@ -61,6 +61,75 @@ describe('Task System Support', () => {
     });
   });
 
+  describe('task list identity resolution (issue #3732)', () => {
+    const ORIGINAL_OVERRIDE = process.env.CLAUDE_CODE_TASK_LIST_ID;
+
+    afterEach(() => {
+      if (ORIGINAL_OVERRIDE === undefined) {
+        delete process.env.CLAUDE_CODE_TASK_LIST_ID;
+      } else {
+        process.env.CLAUDE_CODE_TASK_LIST_ID = ORIGINAL_OVERRIDE;
+      }
+    });
+
+    it('should resolve the task directory from CLAUDE_CODE_TASK_LIST_ID when set', () => {
+      process.env.CLAUDE_CODE_TASK_LIST_ID = 'my-team-tasks';
+      const result = getTaskDirectory('session-123');
+      // Reads the store Claude Code actually writes under the override, not
+      // the session dir — otherwise successful writes look like they vanished.
+      expect(result).toBe(path.join(mockHomedir, '.claude', 'tasks', 'my-team-tasks'));
+    });
+
+    it('should fall back to the session id directory when the override is absent', () => {
+      delete process.env.CLAUDE_CODE_TASK_LIST_ID;
+      const result = getTaskDirectory('session-123');
+      expect(result).toBe(path.join(mockHomedir, '.claude', 'tasks', 'session-123'));
+    });
+
+    it('should reject a path-traversal override and fall back to the session id', () => {
+      process.env.CLAUDE_CODE_TASK_LIST_ID = '../evil';
+      const result = getTaskDirectory('session-123');
+      expect(result).toBe(path.join(mockHomedir, '.claude', 'tasks', 'session-123'));
+    });
+
+    it('should reject an empty override and fall back to the session id', () => {
+      process.env.CLAUDE_CODE_TASK_LIST_ID = '   ';
+      const result = getTaskDirectory('session-123');
+      expect(result).toBe(path.join(mockHomedir, '.claude', 'tasks', 'session-123'));
+    });
+
+    it('checkIncompleteTasks reads tasks written under the task-list override', () => {
+      process.env.CLAUDE_CODE_TASK_LIST_ID = 'my-team-tasks';
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue(['1.json'] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ id: '1', subject: 'Task 1', status: 'pending' })
+      );
+
+      const result = checkIncompleteTasks('session-123');
+      expect(result.count).toBe(1);
+      // The read must have targeted the override dir, not the session dir.
+      expect(vi.mocked(fs.readdirSync).mock.calls[0][0]).toBe(
+        path.join(mockHomedir, '.claude', 'tasks', 'my-team-tasks')
+      );
+    });
+
+    it('checkIncompleteTasks returns zero when only a foreign store exists', () => {
+      delete process.env.CLAUDE_CODE_TASK_LIST_ID;
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p: any) => typeof p === 'string' && p.includes('my-team-tasks')
+      );
+      vi.mocked(fs.readdirSync).mockReturnValue(['1.json'] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ id: '1', subject: 'Task 1', status: 'pending' })
+      );
+
+      // Tasks exist only under the team store; session dir is absent.
+      const result = checkIncompleteTasks('session-123');
+      expect(result.count).toBe(0);
+    });
+  });
+
   describe('isValidTask', () => {
     it('should return true for valid Task object', () => {
       const validTask = {

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -546,16 +546,29 @@ function isIncomplete(todo: Todo): boolean {
 /**
  * Get the Task directory for a session
  *
- * NOTE: This path (~/.claude/tasks/{sessionId}/) is inferred from Claude Code's
- * implementation. Anthropic has not officially documented this structure.
- * The Task files are created by Claude Code's TaskCreate tool.
+ * NOTE: This path (~/.claude/tasks/{taskListId}/) mirrors Claude Code's task
+ * store. The store identity is NOT always the session id: Claude Code resolves
+ * the active task list id as CLAUDE_CODE_TASK_LIST_ID env override first, then
+ * a team context name, then the session id. OmC hooks only receive session_id
+ * in hook payloads, so we honor the documented env override here; when it is
+ * absent the session id is the identity (the single-session case).
+ *
+ * Issue #3732: reading with the session id while Claude Code writes under a
+ * CLAUDE_CODE_TASK_LIST_ID/team identity makes successful writes invisible to
+ * OmC readers — the "tasks disappeared" symptom.
  */
 export function getTaskDirectory(sessionId: string): string {
-  // Security: validate sessionId before constructing path
-  if (!isValidSessionId(sessionId)) {
+  // Claude Code's documented task-list identity override takes precedence.
+  const override = process.env.CLAUDE_CODE_TASK_LIST_ID;
+  const identity =
+    typeof override === 'string' && override.trim() && isValidSessionId(override)
+      ? override.trim()
+      : sessionId;
+  // Security: validate identity before constructing path
+  if (!isValidSessionId(identity)) {
     return ''; // Return empty string for invalid sessions
   }
-  return join(getClaudeConfigDir(), 'tasks', sessionId);
+  return join(getClaudeConfigDir(), 'tasks', identity);
 }
 
 /**

--- a/src/hooks/todo-continuation/index.ts
+++ b/src/hooks/todo-continuation/index.ts
@@ -547,15 +547,16 @@ function isIncomplete(todo: Todo): boolean {
  * Get the Task directory for a session
  *
  * NOTE: This path (~/.claude/tasks/{taskListId}/) mirrors Claude Code's task
- * store. The store identity is NOT always the session id: Claude Code resolves
- * the active task list id as CLAUDE_CODE_TASK_LIST_ID env override first, then
- * a team context name, then the session id. OmC hooks only receive session_id
- * in hook payloads, so we honor the documented env override here; when it is
- * absent the session id is the identity (the single-session case).
+ * store. The store identity is NOT always the session id: when the documented
+ * CLAUDE_CODE_TASK_LIST_ID env override is set, Claude Code reads and writes
+ * the store keyed by that id. Hook payloads carry only session_id and no
+ * observable team/teammate identity field, so OmC honors exactly the
+ * observable contract: the env override when set and valid, otherwise the
+ * session id (the single-session default).
  *
  * Issue #3732: reading with the session id while Claude Code writes under a
- * CLAUDE_CODE_TASK_LIST_ID/team identity makes successful writes invisible to
- * OmC readers — the "tasks disappeared" symptom.
+ * CLAUDE_CODE_TASK_LIST_ID identity makes successful writes invisible to OmC
+ * readers — the "tasks disappeared" symptom.
  */
 export function getTaskDirectory(sessionId: string): string {
   // Claude Code's documented task-list identity override takes precedence.

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -743,9 +743,11 @@ function getActiveSubagentCount(stateDir) {
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
  *
- * Claude Code resolves the task-store identity as CLAUDE_CODE_TASK_LIST_ID
- * first, then a team context, then the session id (issue #3732). Hook payloads
- * only carry session_id, so honor the env override when present.
+ * Identity contract (issue #3732): the task store is read at
+ * ~/.claude/tasks/<identity>/ where <identity> is the
+ * CLAUDE_CODE_TASK_LIST_ID env override when set and valid, otherwise the
+ * session id. Hook payloads expose no observable team/teammate identity
+ * field, so no implicit team inference is attempted.
  */
 function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;

--- a/templates/hooks/persistent-mode.mjs
+++ b/templates/hooks/persistent-mode.mjs
@@ -742,12 +742,24 @@ function getActiveSubagentCount(stateDir) {
 
 /**
  * Count incomplete Tasks from Claude Code's native Task system.
+ *
+ * Claude Code resolves the task-store identity as CLAUDE_CODE_TASK_LIST_ID
+ * first, then a team context, then the session id (issue #3732). Hook payloads
+ * only carry session_id, so honor the env override when present.
  */
 function countIncompleteTasks(sessionId) {
   if (!sessionId || typeof sessionId !== "string") return 0;
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(sessionId)) return 0;
 
-  const taskDir = join(getClaudeConfigDir(), "tasks", sessionId);
+  const override = process.env.CLAUDE_CODE_TASK_LIST_ID;
+  const identity =
+    typeof override === "string" &&
+    override.trim() &&
+    /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/.test(override)
+      ? override.trim()
+      : sessionId;
+
+  const taskDir = join(getClaudeConfigDir(), "tasks", identity);
   if (!existsSync(taskDir)) return 0;
 
   let count = 0;

--- a/tests/integration/task-list-identity-stop.test.ts
+++ b/tests/integration/task-list-identity-stop.test.ts
@@ -74,12 +74,18 @@ function writeActiveUltrawork(f: Fixture) {
 }
 
 function invokeStop(f: Fixture, extraEnv: Record<string, string> = {}) {
+  // Start from a deterministic base: an inherited CLAUDE_CODE_TASK_LIST_ID
+  // from the parent process would silently change the no-override scenarios
+  // (issue #3732 review). Delete it here; extraEnv re-applies an override for
+  // the tests that need one.
+  const baseEnv = { ...process.env };
+  delete baseEnv.CLAUDE_CODE_TASK_LIST_ID;
   const stdout = execFileSync(process.execPath, [f.hook], {
     cwd: f.project,
     input: JSON.stringify({ hook_event_name: 'Stop', session_id: 'stop-session', cwd: f.project }),
     encoding: 'utf8',
     env: {
-      ...process.env,
+      ...baseEnv,
       HOME: f.home,
       USERPROFILE: f.home,
       CLAUDE_CONFIG_DIR: f.claudeConfigDir,
@@ -197,5 +203,41 @@ describe('Stop hook task-store identity mirror parity', () => {
     for (const [name, source] of sources) {
       expect(source, name).toContain('CLAUDE_CODE_TASK_LIST_ID');
     }
+  });
+});
+
+describe('Stop hook inherited task-list override isolation (issue #3732 review)', () => {
+  let previousOverride: string | undefined;
+  let hadPrevious = false;
+
+  // Restore the parent env in cleanup even when the assertion fails.
+  afterEach(() => {
+    if (hadPrevious) {
+      if (previousOverride === undefined) delete process.env.CLAUDE_CODE_TASK_LIST_ID;
+      else process.env.CLAUDE_CODE_TASK_LIST_ID = previousOverride;
+      hadPrevious = false;
+    }
+  });
+
+  it('ignores an inherited CLAUDE_CODE_TASK_LIST_ID in the no-override child env', () => {
+    // Simulate a parent process that already has the override exported: the
+    // base child env in invokeStop() deletes it, so the no-override scenario
+    // stays deterministic and resolves the session store.
+    previousOverride = process.env.CLAUDE_CODE_TASK_LIST_ID;
+    hadPrevious = true;
+    process.env.CLAUDE_CODE_TASK_LIST_ID = 'inherited-override';
+
+    const f = makeFixture('mjs');
+    writeActiveUltrawork(f);
+    // The inherited store is non-empty; the session store is the identity the
+    // no-override child must resolve to.
+    writeTaskStore(f.claudeConfigDir, 'inherited-override', ['pending', 'pending']);
+    writeTaskStore(f.claudeConfigDir, 'stop-session', ['pending']);
+
+    const result = invokeStop(f, {});
+
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('1 incomplete Tasks remain');
+    expect(result.reason).not.toContain('2 incomplete Tasks remain');
   });
 });

--- a/tests/integration/task-list-identity-stop.test.ts
+++ b/tests/integration/task-list-identity-stop.test.ts
@@ -1,0 +1,201 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// The three shipped Stop-hook variants that must agree on task-store identity
+// resolution (issue #3732): the plugin ESM script, its CJS mirror, and the
+// installer template.
+const pluginHookMjs = join(root, 'scripts', 'persistent-mode.mjs');
+const pluginHookCjs = join(root, 'scripts', 'persistent-mode.cjs');
+
+const created: string[] = [];
+
+function makeFixture(kind: 'mjs' | 'cjs' | 'template') {
+  const dir = mkdtempSync(join(tmpdir(), `task-override-${kind}-`));
+  created.push(dir);
+  const home = join(dir, 'home');
+  const project = join(dir, 'project');
+  const claudeConfigDir = join(home, 'claude-config');
+  mkdirSync(project, { recursive: true });
+
+  let hook = pluginHookMjs;
+  if (kind === 'cjs') {
+    hook = pluginHookCjs;
+  } else if (kind === 'template') {
+    // The installer template ships as a directory of standalone scripts
+    // (templates/hooks/** including lib/), so copy the whole tree like a real
+    // install does and run the copied persistent-mode.mjs.
+    const installed = join(dir, 'installed-hooks');
+    cpSync(join(root, 'templates', 'hooks'), installed, { recursive: true });
+    hook = join(installed, 'persistent-mode.mjs');
+  }
+
+  return { dir, home, project, claudeConfigDir, hook, kind };
+}
+
+type Fixture = ReturnType<typeof makeFixture>;
+
+function writeTaskStore(claudeConfigDir: string, identity: string, statuses: string[]) {
+  const taskDir = join(claudeConfigDir, 'tasks', identity);
+  mkdirSync(taskDir, { recursive: true });
+  statuses.forEach((status, index) => {
+    writeFileSync(
+      join(taskDir, `${index + 1}.json`),
+      JSON.stringify({ id: String(index + 1), subject: `task-${index + 1}`, status }),
+    );
+  });
+}
+
+function ultraworkStatePath(f: Fixture): string {
+  return join(f.project, '.omc', 'state', 'sessions', 'stop-session', 'ultrawork-state.json');
+}
+
+function writeActiveUltrawork(f: Fixture) {
+  const statePath = ultraworkStatePath(f);
+  mkdirSync(dirname(statePath), { recursive: true });
+  const now = new Date().toISOString();
+  writeFileSync(
+    statePath,
+    JSON.stringify({
+      active: true,
+      session_id: 'stop-session',
+      project_path: f.project,
+      started_at: now,
+      last_checked_at: now,
+      reinforcement_count: 0,
+    }),
+  );
+  return statePath;
+}
+
+function invokeStop(f: Fixture, extraEnv: Record<string, string> = {}) {
+  const stdout = execFileSync(process.execPath, [f.hook], {
+    cwd: f.project,
+    input: JSON.stringify({ hook_event_name: 'Stop', session_id: 'stop-session', cwd: f.project }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: f.home,
+      USERPROFILE: f.home,
+      CLAUDE_CONFIG_DIR: f.claudeConfigDir,
+      OMC_PERSISTENT_MODE_TIMEOUT_MS: '3000',
+      ...extraEnv,
+    },
+    timeout: 20_000,
+  });
+  return JSON.parse(stdout.trim());
+}
+
+afterEach(() => {
+  while (created.length) rmSync(created.pop(), { recursive: true, force: true });
+});
+
+// Identity contract under test (issue #3732): the Stop hook reads Claude Code's
+// native task store at ~/.claude/tasks/<identity>/ where <identity> is the
+// CLAUDE_CODE_TASK_LIST_ID override when set and valid, else the session id.
+// Invalid/empty overrides fall back to the session id; no implicit team
+// identity is inferred (hook payloads expose none).
+describe.each(['mjs', 'cjs', 'template'] as const)(
+  'Stop hook task-store identity resolution (%s)',
+  (kind) => {
+    it('counts tasks from the CLAUDE_CODE_TASK_LIST_ID override store when set and valid', () => {
+      const f = makeFixture(kind);
+      writeActiveUltrawork(f);
+      // Override store has one pending task; the session store is absent.
+      writeTaskStore(f.claudeConfigDir, 'team-list-override', ['pending']);
+
+      const result = invokeStop(f, { CLAUDE_CODE_TASK_LIST_ID: 'team-list-override' });
+
+      // Claude Code writes tasks under the override identity, so the Stop hook
+      // must read the same store or successful writes look vanished.
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('1 incomplete Tasks remain');
+    });
+
+    it('prefers the override store over a non-empty session store', () => {
+      const f = makeFixture(kind);
+      const statePath = writeActiveUltrawork(f);
+      // Session store has two pending tasks; the override store is complete.
+      writeTaskStore(f.claudeConfigDir, 'stop-session', ['pending', 'pending']);
+      writeTaskStore(f.claudeConfigDir, 'team-list-override', ['completed']);
+
+      const result = invokeStop(f, { CLAUDE_CODE_TASK_LIST_ID: 'team-list-override' });
+
+      // Identity resolution, not counting heuristics, is under test: the two
+      // session-store tasks must be invisible because the override identity
+      // points elsewhere. The variants express "nothing incomplete" two ways
+      // (the CJS/template mirrors auto-clear per #2419; the plugin ESM script
+      // still blocks), but neither may report the session store's tasks.
+      const reason = String(result.reason ?? '');
+      expect(reason).not.toContain('1 incomplete');
+      expect(reason).not.toContain('2 incomplete');
+      if (result.decision === 'block') {
+        expect(reason).toContain('No incomplete tasks detected');
+      } else {
+        expect(result).toEqual({ continue: true, suppressOutput: true });
+        expect(JSON.parse(readFileSync(statePath, 'utf8')).deactivated_reason).toBe('task_completion');
+      }
+    });
+
+    it('falls back to the session id store when the override is invalid (path traversal)', () => {
+      const f = makeFixture(kind);
+      writeActiveUltrawork(f);
+      // Session store has one in_progress task; the traversal target must not be read.
+      writeTaskStore(f.claudeConfigDir, 'stop-session', ['in_progress']);
+      writeTaskStore(f.claudeConfigDir, 'etc', ['pending', 'pending', 'pending']);
+
+      const result = invokeStop(f, { CLAUDE_CODE_TASK_LIST_ID: '../etc' });
+
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('1 incomplete Tasks remain');
+      expect(result.reason).not.toContain('3 incomplete Tasks remain');
+    });
+
+    it('falls back to the session id store when the override is whitespace', () => {
+      const f = makeFixture(kind);
+      writeActiveUltrawork(f);
+      writeTaskStore(f.claudeConfigDir, 'stop-session', ['pending']);
+
+      const result = invokeStop(f, { CLAUDE_CODE_TASK_LIST_ID: '   ' });
+
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('1 incomplete Tasks remain');
+    });
+
+    it('reads the session id store when no override is set', () => {
+      const f = makeFixture(kind);
+      writeActiveUltrawork(f);
+      // A foreign store exists but must not be read without an override.
+      writeTaskStore(f.claudeConfigDir, 'team-list-override', ['pending', 'pending']);
+      writeTaskStore(f.claudeConfigDir, 'stop-session', ['pending']);
+
+      const result = invokeStop(f, {});
+
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('1 incomplete Tasks remain');
+    });
+  },
+);
+
+describe('Stop hook task-store identity mirror parity', () => {
+  it('keeps the observable override/fallback contract identical across mjs, cjs, and template variants', () => {
+    // The executable parity is proven by the describe.each suite above running
+    // the same fixtures through each shipped variant. This structural guard
+    // catches accidental removal of the override handling from any single
+    // mirror, including the TypeScript reader of the same store.
+    const sources = [
+      ['scripts/persistent-mode.mjs', readFileSync(pluginHookMjs, 'utf8')],
+      ['scripts/persistent-mode.cjs', readFileSync(pluginHookCjs, 'utf8')],
+      ['templates/hooks/persistent-mode.mjs', readFileSync(join(root, 'templates', 'hooks', 'persistent-mode.mjs'), 'utf8')],
+      ['src/hooks/todo-continuation/index.ts', readFileSync(join(root, 'src', 'hooks', 'todo-continuation', 'index.ts'), 'utf8')],
+    ] as const;
+    for (const [name, source] of sources) {
+      expect(source, name).toContain('CLAUDE_CODE_TASK_LIST_ID');
+    }
+  });
+});


### PR DESCRIPTION
## Root cause and fix for #3732

### What was actually wrong

Two independent OmC-owned read-path defects caused successful Claude Code task writes to look vanished and produced contradicting agent counters in the same session.

#### Defect 1 — subagent-tracker counter divergence

`scripts/pre-tool-enforcer.mjs::getAgentTrackingInfo` read **only** the legacy state path (`<stateDir>/subagent-tracking.json`) and ignored the session-scoped path written by the Wave-A tracker (`<stateDir>/sessions/<sid>/subagent-tracking-state.json`). Its sibling reader `scripts/post-tool-verifier.mjs::getAgentCompletionSummary` already read session-scoped first, so the two OmC components reported **contradictory counts for the same session** — e.g. `total_spawned` 160 (enforcer) vs 203 (verifier) while `total_completed` stayed at 185. This is the exact "PostToolUse counters fluctuated 160→203" symptom from the report.

#### Defect 2 — task-store identity mismatch

Claude Code's native task store is keyed by a task-list identity that is **not always the session id**: when the documented `CLAUDE_CODE_TASK_LIST_ID` env override is set, Claude Code reads and writes the store under that id. OmC readers keyed only on `session_id` saw an **empty store** while tasks were being written under the override identity — the "tasks disappeared" symptom.

**Identity contract claimed (observable only):** `CLAUDE_CODE_TASK_LIST_ID` when set and valid, otherwise the session id. Hook payloads expose no observable team/teammate identity field, so **no implicit team inference is claimed or attempted**; honoring a runtime team identity would require a proven observable field and is out of scope here.

### The fix

| File | Change |
|---|---|
| `scripts/pre-tool-enforcer.mjs` | `getAgentTrackingInfo` resolves read paths through the canonical `resolveSessionStatePathsForHook()` (validation/migration-aware, session-scoped-first with legacy read fallback) instead of manual path construction; `OMC_STATE_DIR` centralized state flows through the same resolver. The pre-Wave-A plain `subagent-tracking.json` legacy filename is probed directly after the canonical names (the resolver's `-state.json` normalization would corrupt it). |
| `src/hooks/todo-continuation/index.ts` | `getTaskDirectory` honors `CLAUDE_CODE_TASK_LIST_ID` when valid, falling back to session id. Invalid/path-traversal overrides are rejected by the existing allowlist. |
| `scripts/persistent-mode.{mjs,cjs}` | `countIncompleteTasks` applies the same identity resolution. |
| `templates/hooks/persistent-mode.mjs` | Same identity resolution (template mirror). |

### What is NOT OmC-owned

The pure **single-session + compaction** "TaskList empty" scenario (report clue #4, no override active) is upstream Claude Code: compaction does **not** change the session id, so the task-store identity is stable there. OmC does not write to or delete from `~/.claude/tasks/` and cannot make Claude Code's own `TaskList` return empty in that path. OmC only owns the two read-path divergences fixed here.

### Regression tests

- `src/__tests__/task-continuation.test.ts`: +6 tests (identity override resolution, fallback, path-traversal rejection, foreign-store zero).
- `src/__tests__/pre-tool-enforcer.test.ts`: +5 tests (session-scoped read, precedence over stale legacy, plain legacy fallback, canonical legacy name fallback, `OMC_STATE_DIR` centralized-state routing).
- `tests/integration/task-list-identity-stop.test.ts`: **new execution-level suite** — runs the three shipped Stop-hook variants (`scripts/persistent-mode.mjs`, `.cjs`, `templates/hooks/persistent-mode.mjs` install-shaped copy) as child processes against override-backed task stores: valid override store read, override preferred over a non-empty session store, path-traversal/whitespace override fallback to session id, no-override session read, plus structural parity across all variants and the TS reader (16 tests).

### Verification (replacement head `0670a9729`)

- `npx vitest run src/__tests__/pre-tool-enforcer.test.ts` → 151 passed
- `npx vitest run src/__tests__/task-continuation.test.ts` → 99 passed
- `npx vitest run tests/integration/task-list-identity-stop.test.ts` → 16 passed
- Combined persistent-mode/state-root/integration suites → 728 passed
- `npx tsc --noEmit` → clean
- `npm run lint` → 0 errors (19 pre-existing warnings unchanged)
- `node scripts/generate-inventory-graph.mjs --check` → clean
- `git diff --check` → clean

Fixes #3732