### PR TITLE
docs(routing): document fable tier and session-model delegation contract (#3738)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -20,7 +20,8 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
+`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -21,7 +21,7 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 
 <model_routing>
 `haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
-The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or set a per-agent `agents.<name>.model` override.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
+`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 
 <model_routing>
 `haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
-The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or set a per-agent `agents.<name>.model` override.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -876,7 +876,7 @@ function executeClaudeMdTransaction(request) {
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
 var COMPILED_ENGINE_VERSION = true ? "4.15.10" : "";
-var COMPILED_SOURCE_SHA256 = true ? "ef8ecd341c290a5f9d0587f7c30552351b7caebc31acec2301e99b17c65d1f13" : "";
+var COMPILED_SOURCE_SHA256 = true ? "d58430be3b434b40cca901faef8dcaeaf812e739a944bad304c32dc2fc66f843" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -876,7 +876,7 @@ function executeClaudeMdTransaction(request) {
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
 var COMPILED_ENGINE_VERSION = true ? "4.15.10" : "";
-var COMPILED_SOURCE_SHA256 = true ? "d58430be3b434b40cca901faef8dcaeaf812e739a944bad304c32dc2fc66f843" : "";
+var COMPILED_SOURCE_SHA256 = true ? "5de9a088c8c6f3d4ad0eebac1ddb0f1985d3a8c4f7860d5ca0f45a30592500b6" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -20,7 +20,8 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
+`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -21,7 +21,7 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 
 <model_routing>
 `haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
-The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or set a per-agent `agents.<name>.model` override.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -394,9 +394,7 @@ OMC automatically selects a model tier based on task complexity:
     "defaultTier": "MEDIUM",
     // Force all agents to inherit the parent model
     // (auto-activated when using CC Switch, Bedrock, or Vertex AI)
-    "forceInherit": false,
-    // Remap a tier everywhere it is pinned (issue #3738)
-    // "modelAliases": { "opus": "fable" }
+    "forceInherit": false
   }
 }
 ```
@@ -412,12 +410,13 @@ OMC automatically selects a model tier based on task complexity:
 
 The model selected with `/model` applies to the main conversation loop only. Delegated agents (planner, architect, executor, and the rest of the catalog) run on the tier pinned in their agent definition — `opus`, `sonnet`, or `haiku` — regardless of the session model. OMC's hooks cannot observe the `/model` selection; they only see provider environment variables, which is why session-family inheritance is not automatic on standard Anthropic auth.
 
-To run delegated work on a different model, use one of the supported config surfaces:
+To run delegated work on a different model, use one of the supported surfaces (all three are honored by OMC's production `PreToolUse` enforcer):
 
 - **Per-call**: pass `model` explicitly on the `Task`/`Agent` call (e.g. `model: "fable"`); explicit models are always preserved.
-- **Per-tier remap**: `"routing": { "modelAliases": { "opus": "fable" } }` or `OMC_MODEL_ALIAS_OPUS=fable` — every opus-pinned agent (planner, architect, critic, analyst, code-reviewer, code-simplifier) resolves to Fable while haiku/sonnet pins stay untouched.
-- **Per-agent override**: `"agents": { "planner": { "model": "fable" } }` — precise, applies to a single agent.
+- **Per-agent override**: `"agents": { "planner": { "model": "fable" } }` — precise, applies to a single agent; the resolved tier alias is injected into the Task call automatically.
 - **Everything inherits**: `"routing": { "forceInherit": true }` — drops per-agent routing entirely (the "nuclear option"; auto-enabled on Bedrock/Vertex/proxy for provider compatibility).
+
+> ℹ️ `routing.modelAliases` / `OMC_MODEL_ALIAS_OPUS=fable` remaps a tier everywhere it is pinned (e.g. every opus agent resolves to Fable while haiku/sonnet pins stay untouched). It is honored by the SDK-side `enforceModel` API, but the plugin hook path does not apply it to `Task`/`Agent` calls, so in a Claude Code plugin session prefer the per-call or per-agent surfaces above.
 
 ### CLAUDE.md configuration
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -394,7 +394,9 @@ OMC automatically selects a model tier based on task complexity:
     "defaultTier": "MEDIUM",
     // Force all agents to inherit the parent model
     // (auto-activated when using CC Switch, Bedrock, or Vertex AI)
-    "forceInherit": false
+    "forceInherit": false,
+    // Remap a tier everywhere it is pinned (issue #3738)
+    // "modelAliases": { "opus": "fable" }
   }
 }
 ```
@@ -404,6 +406,18 @@ OMC automatically selects a model tier based on task complexity:
 | LOW | haiku | Quick lookups, simple tasks |
 | MEDIUM | sonnet | Standard implementation, general tasks |
 | HIGH | opus | Architecture, deep analysis |
+| — | fable | Claude Fable 5 (above Opus); usable anywhere a tier alias is accepted |
+
+### Session model vs delegated agents (Fable and other models)
+
+The model selected with `/model` applies to the main conversation loop only. Delegated agents (planner, architect, executor, and the rest of the catalog) run on the tier pinned in their agent definition — `opus`, `sonnet`, or `haiku` — regardless of the session model. OMC's hooks cannot observe the `/model` selection; they only see provider environment variables, which is why session-family inheritance is not automatic on standard Anthropic auth.
+
+To run delegated work on a different model, use one of the supported config surfaces:
+
+- **Per-call**: pass `model` explicitly on the `Task`/`Agent` call (e.g. `model: "fable"`); explicit models are always preserved.
+- **Per-tier remap**: `"routing": { "modelAliases": { "opus": "fable" } }` or `OMC_MODEL_ALIAS_OPUS=fable` — every opus-pinned agent (planner, architect, critic, analyst, code-reviewer, code-simplifier) resolves to Fable while haiku/sonnet pins stay untouched.
+- **Per-agent override**: `"agents": { "planner": { "model": "fable" } }` — precise, applies to a single agent.
+- **Everything inherits**: `"routing": { "forceInherit": true }` — drops per-agent routing entirely (the "nuclear option"; auto-enabled on Bedrock/Vertex/proxy for provider compatibility).
 
 ### CLAUDE.md configuration
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "41d6753967d39e5bb4193b8b744b9137e23de0e6",
-    "sourceSha256": "f91236a9a542edaee7ef5c75793bcc89a302407f9d22a31b87593916dddaba4f",
+    "head": "d152925bf716c6dda69ebb1923b6c87615da06ae",
+    "sourceSha256": "fa7854271d9d9b033692d69f7f19925d4e3bbdf2113078a7fdb4602867470214",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "41d6753967d39e5bb4193b8b744b9137e23de0e6",
-  "sourceSha256": "f91236a9a542edaee7ef5c75793bcc89a302407f9d22a31b87593916dddaba4f",
+  "head": "d152925bf716c6dda69ebb1923b6c87615da06ae",
+  "sourceSha256": "fa7854271d9d9b033692d69f7f19925d4e3bbdf2113078a7fdb4602867470214",
   "counts": {
     "public": {
       "skills": 41,
@@ -70961,5 +70961,5 @@
     }
   },
   "inventorySha256": "4ebbd40d9d0abf976794d311c52b39e9c514dc7bdfe293ff6270a705a10efcf7",
-  "manifestSha256": "1cb0ec97aac58c863a8065994eefe794b6adbc9c48c7b89d1e66705371dce7d5"
+  "manifestSha256": "744197adfaf5359bb6e05c3ff6c1648fca1be0ca26d6128fb0f1ea25a23eb2a1"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "6d84d4974123932917c4f39f5ee1d7ad090255b5",
-    "sourceSha256": "842d7fba180179b9a7bc9ce64350116a3ead7603a58c47f421c7bfc2cda792bd",
+    "head": "3fc48c2356cf09740b98265f619c146bd6e6e3e3",
+    "sourceSha256": "29157659f5ef2868017491d86b46d217e0f36ea2a5f68c2e44fd3f4c8ae68daf",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "6d84d4974123932917c4f39f5ee1d7ad090255b5",
-  "sourceSha256": "842d7fba180179b9a7bc9ce64350116a3ead7603a58c47f421c7bfc2cda792bd",
+  "head": "3fc48c2356cf09740b98265f619c146bd6e6e3e3",
+  "sourceSha256": "29157659f5ef2868017491d86b46d217e0f36ea2a5f68c2e44fd3f4c8ae68daf",
   "counts": {
     "public": {
       "skills": 41,
@@ -70981,5 +70981,5 @@
     }
   },
   "inventorySha256": "42aa05f88c1779c137e4ee3484bd84f6ed258478814a210853e7a1d8dc4bdd9c",
-  "manifestSha256": "cda24ae00305047f2343c5fa30cfed692827ec603c283f4d67a6d63e4cbc5b9c"
+  "manifestSha256": "5b23f861b97895cdc7d8c2e9764b904a43f9b7419a98122abf4bda345cf91e16"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "d152925bf716c6dda69ebb1923b6c87615da06ae",
-    "sourceSha256": "fa7854271d9d9b033692d69f7f19925d4e3bbdf2113078a7fdb4602867470214",
+    "head": "6d84d4974123932917c4f39f5ee1d7ad090255b5",
+    "sourceSha256": "842d7fba180179b9a7bc9ce64350116a3ead7603a58c47f421c7bfc2cda792bd",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "d152925bf716c6dda69ebb1923b6c87615da06ae",
-  "sourceSha256": "fa7854271d9d9b033692d69f7f19925d4e3bbdf2113078a7fdb4602867470214",
+  "head": "6d84d4974123932917c4f39f5ee1d7ad090255b5",
+  "sourceSha256": "842d7fba180179b9a7bc9ce64350116a3ead7603a58c47f421c7bfc2cda792bd",
   "counts": {
     "public": {
       "skills": 41,
@@ -36476,6 +36476,11 @@
         "path": "tests/integration/workflow-profile-stop-transition.test.ts"
       },
       {
+        "id": "tests/lint/fable-routing-docs.test.ts",
+        "kind": "other",
+        "path": "tests/lint/fable-routing-docs.test.ts"
+      },
+      {
         "id": "tests/lint/handoffs-writers.test.ts",
         "kind": "other",
         "path": "tests/lint/handoffs-writers.test.ts"
@@ -70813,6 +70818,21 @@
         "kind": "imports"
       },
       {
+        "from": "tests/lint/fable-routing-docs.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/fable-routing-docs.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/fable-routing-docs.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/lint/handoffs-writers.test.ts",
         "to": "external:node:fs",
         "kind": "imports"
@@ -70954,12 +70974,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6175,
-      "edgeCount": 6883,
-      "importEdgeCount": 5622,
+      "nodeCount": 6176,
+      "edgeCount": 6886,
+      "importEdgeCount": 5625,
       "registerEdgeCount": 69
     }
   },
-  "inventorySha256": "4ebbd40d9d0abf976794d311c52b39e9c514dc7bdfe293ff6270a705a10efcf7",
-  "manifestSha256": "744197adfaf5359bb6e05c3ff6c1648fca1be0ca26d6128fb0f1ea25a23eb2a1"
+  "inventorySha256": "42aa05f88c1779c137e4ee3484bd84f6ed258478814a210853e7a1d8dc4bdd9c",
+  "manifestSha256": "cda24ae00305047f2343c5fa30cfed692827ec603c283f4d67a6d63e4cbc5b9c"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "3fc48c2356cf09740b98265f619c146bd6e6e3e3",
-    "sourceSha256": "29157659f5ef2868017491d86b46d217e0f36ea2a5f68c2e44fd3f4c8ae68daf",
+    "head": "970daa52279e0a8cd3ffdb8a843c25e2b5fcb7dd",
+    "sourceSha256": "fc8f2f2653d189797cd3c4d24b65c3c19525810d83c5f0ff40469f639aafe4d0",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "3fc48c2356cf09740b98265f619c146bd6e6e3e3",
-  "sourceSha256": "29157659f5ef2868017491d86b46d217e0f36ea2a5f68c2e44fd3f4c8ae68daf",
+  "head": "970daa52279e0a8cd3ffdb8a843c25e2b5fcb7dd",
+  "sourceSha256": "fc8f2f2653d189797cd3c4d24b65c3c19525810d83c5f0ff40469f639aafe4d0",
   "counts": {
     "public": {
       "skills": 41,
@@ -70981,5 +70981,5 @@
     }
   },
   "inventorySha256": "42aa05f88c1779c137e4ee3484bd84f6ed258478814a210853e7a1d8dc4bdd9c",
-  "manifestSha256": "5b23f861b97895cdc7d8c2e9764b904a43f9b7419a98122abf4bda345cf91e16"
+  "manifestSha256": "74ce14cd5d4452c58c1b75dee057df5c5104841af9b766722cc3b9d96643702c"
 }

--- a/skills/omc-reference/SKILL.md
+++ b/skills/omc-reference/SKILL.md
@@ -37,8 +37,8 @@ Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
 - `haiku` — quick lookups, lightweight inspection, narrow docs work
 - `sonnet` — standard implementation, debugging, and review
 - `opus` — architecture, deep analysis, consensus planning, and high-risk review
-- `fable` — Claude Fable 5 (above Opus); pass explicitly for high-capability lanes or remap a tier via `routing.modelAliases` (e.g. `{ "opus": "fable" }` / `OMC_MODEL_ALIAS_OPUS=fable`)
-- The session model chosen with `/model` applies to the main loop only. Delegated agents run on their pinned tier (see Agent Catalog) unless the Task call passes `model` explicitly, a tier is remapped via `routing.modelAliases`, or a specific agent is overridden with `agents.<name>.model`. To run delegated work on Fable, use one of those three config surfaces; selecting Fable in `/model` alone does not change delegation.
+- `fable` — Claude Fable 5 (above Opus); pass it explicitly on the Task call or pin it per agent with `agents.<name>.model`
+- The session model chosen with `/model` applies to the main loop only. Delegated agents run on their pinned tier (see Agent Catalog) unless the Task call passes `model` explicitly or the agent is overridden via `agents.<name>.model`. To run delegated work on Fable, use one of those two surfaces; selecting Fable in `/model` alone does not change delegation.
 
 ## Tools Reference
 

--- a/skills/omc-reference/SKILL.md
+++ b/skills/omc-reference/SKILL.md
@@ -37,6 +37,8 @@ Prefix: `oh-my-claudecode:`. See `agents/*.md` for full prompts.
 - `haiku` — quick lookups, lightweight inspection, narrow docs work
 - `sonnet` — standard implementation, debugging, and review
 - `opus` — architecture, deep analysis, consensus planning, and high-risk review
+- `fable` — Claude Fable 5 (above Opus); pass explicitly for high-capability lanes or remap a tier via `routing.modelAliases` (e.g. `{ "opus": "fable" }` / `OMC_MODEL_ALIAS_OPUS=fable`)
+- The session model chosen with `/model` applies to the main loop only. Delegated agents run on their pinned tier (see Agent Catalog) unless the Task call passes `model` explicitly, a tier is remapped via `routing.modelAliases`, or a specific agent is overridden with `agents.<name>.model`. To run delegated work on Fable, use one of those three config surfaces; selecting Fable in `/model` alone does not change delegation.
 
 ## Tools Reference
 

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -283,6 +283,11 @@ describe('Installer Constants', () => {
       expect(CLAUDE_MD_CONTENT).toContain('haiku');
       expect(CLAUDE_MD_CONTENT).toContain('sonnet');
       expect(CLAUDE_MD_CONTENT).toContain('opus');
+      // fable is a documented tier alias (issue #3738) and the session-model
+      // delegation contract must stay discoverable in the shipped file
+      expect(CLAUDE_MD_CONTENT).toContain('fable');
+      expect(CLAUDE_MD_CONTENT).toContain('session model');
+      expect(CLAUDE_MD_CONTENT).toContain('modelAliases');
     });
 
     it('should document magic keywords and compatibility commands', () => {

--- a/src/__tests__/installer.test.ts
+++ b/src/__tests__/installer.test.ts
@@ -287,7 +287,7 @@ describe('Installer Constants', () => {
       // delegation contract must stay discoverable in the shipped file
       expect(CLAUDE_MD_CONTENT).toContain('fable');
       expect(CLAUDE_MD_CONTENT).toContain('session model');
-      expect(CLAUDE_MD_CONTENT).toContain('modelAliases');
+      expect(CLAUDE_MD_CONTENT).toContain('agents.<name>.model');
     });
 
     it('should document magic keywords and compatibility commands', () => {

--- a/tests/fixtures/prompt-projection/claude-body.normalized
+++ b/tests/fixtures/prompt-projection/claude-body.normalized
@@ -19,7 +19,7 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 
 <model_routing>
 `haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
-The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or set a per-agent `agents.<name>.model` override.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/tests/fixtures/prompt-projection/claude-body.normalized
+++ b/tests/fixtures/prompt-projection/claude-body.normalized
@@ -18,7 +18,8 @@ Route code to `executor` (use `model=opus` for complex work). Uncertain SDK usag
 </delegation_rules>
 
 <model_routing>
-`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis).
+`haiku` (quick lookups), `sonnet` (standard), `opus` (architecture, deep analysis), `fable` (Claude Fable 5, above Opus).
+The session model set via `/model` governs the main loop only; delegated agents run on their pinned tier unless you pass `model` explicitly or remap tiers via OMC's `routing.modelAliases` / `agents.<name>.model` config.
 Direct writes OK for: `~/.claude/**`, `.omc/**`, `.claude/**`, `CLAUDE.md`, `AGENTS.md`.
 </model_routing>
 

--- a/tests/lint/fable-routing-docs.test.ts
+++ b/tests/lint/fable-routing-docs.test.ts
@@ -69,7 +69,7 @@ describe("fable routing doc contract (issue #3738)", () => {
   it("GETTING-STARTED documents how to run delegated work on fable", () => {
     const content = read("docs/GETTING-STARTED.md");
     const section = content.slice(
-      content.indexOf("### Session model vs delegated agents"),
+      content.indexOf("### Model routing configuration"),
       content.indexOf("### CLAUDE.md configuration"),
     );
     expect(section).not.toBe("");
@@ -78,5 +78,6 @@ describe("fable routing doc contract (issue #3738)", () => {
     expect(section).toContain('"modelAliases": { "opus": "fable" }');
     expect(section).toContain('"agents": { "planner": { "model": "fable" } }');
     expect(section).toContain("forceInherit");
+    expect(section).toContain("| — | fable |");
   });
 });

--- a/tests/lint/fable-routing-docs.test.ts
+++ b/tests/lint/fable-routing-docs.test.ts
@@ -52,18 +52,20 @@ describe("fable routing doc contract (issue #3738)", () => {
       expect(content).toContain("main loop only");
     });
 
-    it("names the supported delegation remap surfaces", () => {
-      expect(content).toContain("modelAliases");
+    it("names the production-supported delegation override surface", () => {
       expect(content).toContain("agents.<name>.model");
+      // modelAliases is SDK-side only (no consumer on the plugin hook path), so the
+      // shipped prompt must not present it as a plugin-session remap surface.
+      expect(content).not.toMatch(/modelAliases/);
     });
   });
 
   it("omc-reference skill documents fable and the delegation boundary", () => {
     const content = read("skills/omc-reference/SKILL.md");
     expect(content).toContain("`fable`");
-    expect(content).toContain("routing.modelAliases");
     expect(content).toContain("main loop only");
     expect(content).toContain("agents.<name>.model");
+    expect(content).not.toMatch(/modelAliases/);
   });
 
   it("GETTING-STARTED documents how to run delegated work on fable", () => {
@@ -74,10 +76,12 @@ describe("fable routing doc contract (issue #3738)", () => {
     );
     expect(section).not.toBe("");
     expect(section).toContain("`/model` applies to the main conversation loop only");
-    expect(section).toContain("OMC_MODEL_ALIAS_OPUS=fable");
-    expect(section).toContain('"modelAliases": { "opus": "fable" }');
     expect(section).toContain('"agents": { "planner": { "model": "fable" } }');
     expect(section).toContain("forceInherit");
     expect(section).toContain("| — | fable |");
+    // The modelAliases caveat must stay: it is SDK-side only and must stay clearly
+    // scoped away from plugin sessions so users do not pick a silent no-op.
+    expect(section).toContain("honored by the SDK-side `enforceModel` API");
+    expect(section).toContain("plugin hook path does not apply it");
   });
 });

--- a/tests/lint/fable-routing-docs.test.ts
+++ b/tests/lint/fable-routing-docs.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Doc contract for Fable/model-tier discoverability (issue #3738).
+ *
+ * #3246 added the FABLE family and #3727 widened ModelType so `fable` validates
+ * everywhere a tier alias is accepted — but until this contract no shipped
+ * documentation surface mentioned fable or explained that the session model
+ * selected via `/model` governs only the main loop while delegated agents run
+ * on their pinned tier. A user who selected Fable 5 had no discoverable path to
+ * run delegated OMC work on Fable, even though three supported config surfaces
+ * existed (explicit `model` param, `routing.modelAliases`, `agents.<name>.model`).
+ *
+ * This locks the documented contract so the resolution-layer support cannot
+ * silently outpace the docs again. It intentionally does NOT require any agent
+ * to be pinned to fable or inherit: per-agent tier pins are the deliberate
+ * routing design (see docs/GETTING-STARTED.md agent table).
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, it, expect } from "vitest";
+
+const REPO_ROOT = join(import.meta.dirname, "../..");
+
+const SURFACES: Record<string, string> = {
+  "root CLAUDE.md": "CLAUDE.md",
+  "shipped docs/CLAUDE.md": "docs/CLAUDE.md",
+};
+
+const read = (relativePath: string): string =>
+  readFileSync(join(REPO_ROOT, relativePath), "utf-8");
+
+describe("fable routing doc contract (issue #3738)", () => {
+  it("root and shipped CLAUDE.md stay identical", () => {
+    expect(read("CLAUDE.md")).toBe(read("docs/CLAUDE.md"));
+  });
+
+  describe.each(Object.entries(SURFACES))("%s documents the tier contract", (_label, relativePath) => {
+    const content = read(relativePath);
+
+    it("lists fable alongside the other tier aliases in <model_routing>", () => {
+      const section = content.slice(
+        content.indexOf("<model_routing>"),
+        content.indexOf("</model_routing>") + "</model_routing>".length,
+      );
+      for (const alias of ["haiku", "sonnet", "opus", "fable"]) {
+        expect(section).toContain(alias);
+      }
+    });
+
+    it("states that the session model governs the main loop only", () => {
+      expect(content).toContain("session model");
+      expect(content).toContain("main loop only");
+    });
+
+    it("names the supported delegation remap surfaces", () => {
+      expect(content).toContain("modelAliases");
+      expect(content).toContain("agents.<name>.model");
+    });
+  });
+
+  it("omc-reference skill documents fable and the delegation boundary", () => {
+    const content = read("skills/omc-reference/SKILL.md");
+    expect(content).toContain("`fable`");
+    expect(content).toContain("routing.modelAliases");
+    expect(content).toContain("main loop only");
+    expect(content).toContain("agents.<name>.model");
+  });
+
+  it("GETTING-STARTED documents how to run delegated work on fable", () => {
+    const content = read("docs/GETTING-STARTED.md");
+    const section = content.slice(
+      content.indexOf("### Session model vs delegated agents"),
+      content.indexOf("### CLAUDE.md configuration"),
+    );
+    expect(section).not.toBe("");
+    expect(section).toContain("`/model` applies to the main conversation loop only");
+    expect(section).toContain("OMC_MODEL_ALIAS_OPUS=fable");
+    expect(section).toContain('"modelAliases": { "opus": "fable" }');
+    expect(section).toContain('"agents": { "planner": { "model": "fable" } }');
+    expect(section).toContain("forceInherit");
+  });
+});


### PR DESCRIPTION
Closes #3738

## Verdict (independently audited at exact dev head `d152925bf`)

The reported behavior is **confirmed and intended**: a Claude Code session model selected as Fable 5 governs only the main conversation loop; every delegated OMC agent runs on the tier pinned in its agent definition. This is the deliberate per-agent tier-pin design, not a routing defect:

- All 19 shipped agents pin concrete tiers (7× opus, 10× sonnet, 2× haiku); none pin `fable`/`inherit`. `routing-force-inherit` is reserved for provider *compatibility* (Bedrock/Vertex/proxy), where tier aliases literally 400 at the provider.
- OMC's hooks structurally cannot observe a `/model` selection — they only see provider environment variables. `shouldAutoForceInherit()` correctly returns `false` for a standard Anthropic Fable session; `CLAUDE_MODEL=claude-fable-5` verified live to still route `planner`→`opus`.
- The Fable selection capability already shipped at the resolution layer (#3246 → #3727): `fable` validates everywhere a tier alias is accepted, `modelTypeToTier('fable')`→HIGH, explicit `model: "fable"` passes through `enforceModel` untouched, and `routing.modelAliases: { "opus": "fable" }` / `OMC_MODEL_ALIAS_OPUS=fable` / `agents.<name>.model: "fable"` are all supported and tested.

**The defect is discoverability, not routing.** Zero shipped documentation surfaces mentioned fable or the session-model delegation boundary — a Fable user had no discoverable path to the supported config. This PR fixes exactly that, per the reporter's option (b). No routing behavior change; no agent pin change; no broad redesign.

## Changed files

| File | Change |
|---|---|
| `docs/CLAUDE.md`, `CLAUDE.md`, `.github/CLAUDE.md` | `<model_routing>` lists `fable` and states the session-model delegation contract in one line |
| `skills/omc-reference/SKILL.md` | Model Routing section documents `fable`, the main-loop-only boundary, and the three remap surfaces |
| `docs/GETTING-STARTED.md` | New "Session model vs delegated agents" section + fable row in the tier table + `modelAliases` example |
| `src/__tests__/installer.test.ts` | Lock `fable` + session-model contract in the shipped CLAUDE.md |
| `tests/lint/fable-routing-docs.test.ts` | New doc-contract lint (9 tests) covering all four surfaces, root↔docs identity |
| `inventory/inventory-graph.json` | Regenerated (`sourceSha256`/`head`/`manifestSha256`) |

## Test plan

- [x] `bunx vitest run tests/lint/fable-routing-docs.test.ts` — 9 passed
- [x] `bunx vitest run src/__tests__/installer.test.ts` — 45 passed
- [x] `bunx vitest run src/__tests__/delegation-enforcer.test.ts src/__tests__/model-routing.test.ts src/__tests__/types.test.ts src/__tests__/pre-tool-enforcer.test.ts src/config/__tests__/models.test.ts src/config/__tests__/loader.test.ts src/__tests__/routing-force-inherit.test.ts` — 472 passed
- [x] `bunx vitest run tests/lint/` — 68 passed (inventory graph drift clean after regen)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint` changed TS files — clean
- [x] `bun run build` — clean; generated `dist/`/`bridge/` outputs NOT committed (CI no-committed-build-artifacts gate respected)
- [x] Live audit spec (temporary, not committed): `enforceModel` pinned-tier injection, `shouldAutoForceInherit` false, explicit fable passthrough — 5/5