### PR TITLE
fix(team): honor explicit max_workers below the hard ceiling

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "10b6dc2f499c8f52af562976bbea63a86c4cdc78",
-    "sourceSha256": "f6b9fa8abd8a25cf614ad960679a9b33d23c96b966a4e4a493fcb85079a0237f",
+    "head": "0fdccb1797818772fff6307d93e609fa3b8b6c30",
+    "sourceSha256": "da4963ee037a3d05baccc10e88f4b5f5adccaa5e5eab09215f7f8fafb549044c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "10b6dc2f499c8f52af562976bbea63a86c4cdc78",
-  "sourceSha256": "f6b9fa8abd8a25cf614ad960679a9b33d23c96b966a4e4a493fcb85079a0237f",
+  "head": "0fdccb1797818772fff6307d93e609fa3b8b6c30",
+  "sourceSha256": "da4963ee037a3d05baccc10e88f4b5f5adccaa5e5eab09215f7f8fafb549044c",
   "counts": {
     "public": {
       "skills": 41,
@@ -65685,6 +65685,11 @@
       {
         "from": "src/team/governance.ts",
         "to": "src/team/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/governance.ts",
+        "to": "src/team/types.ts",
         "kind": "type-imports"
       },
       {
@@ -70975,11 +70980,11 @@
     ],
     "stats": {
       "nodeCount": 6176,
-      "edgeCount": 6886,
-      "importEdgeCount": 5625,
+      "edgeCount": 6887,
+      "importEdgeCount": 5626,
       "registerEdgeCount": 69
     }
   },
   "inventorySha256": "42aa05f88c1779c137e4ee3484bd84f6ed258478814a210853e7a1d8dc4bdd9c",
-  "manifestSha256": "f5861ef59af43768bc92ed73d5c6efcf6052ff46ebf3c7243f186cf7729b5eb2"
+  "manifestSha256": "995277d248c7cf59635fbee4eedcb8276e119d6c418d8e9f591f88ab0d240eb4"
 }

--- a/src/team/__tests__/scaling.test.ts
+++ b/src/team/__tests__/scaling.test.ts
@@ -484,6 +484,21 @@ describe('scaleUp duplicate worker guard', () => {
     expect(config.workers.map((worker) => worker.name)).toEqual(['worker-1', 'worker-2', 'worker-3']);
   });
 
+  it('rejects scale-up that would exceed a configured cap below the hard ceiling (#3744)', async () => {
+    config = makeConfig({ max_workers: 2, next_worker_index: 2 });
+
+    const result = await scaleUp('demo-team', 2, 'claude', [
+      { subject: 'demo-a', description: 'demo task' },
+      { subject: 'demo-b', description: 'demo task' },
+    ], cwd, { OMC_TEAM_SCALING_ENABLED: '1' } as NodeJS.ProcessEnv);
+
+    expect(result).toEqual({ ok: false, error: 'Cannot add 2 workers: would exceed max_workers (1 + 2 > 2)' });
+    expect(config.workers.map((worker) => worker.name)).toEqual(['worker-1']);
+    expect(monitorMocks.saveTeamConfigAtRevision).not.toHaveBeenCalled();
+    expect(tmuxUtilsMocks.tmuxSpawn.mock.calls.some(([args]) => args[0] === 'split-window')).toBe(false);
+    expect(teamOpsMocks.teamWriteWorkerIdentity).not.toHaveBeenCalled();
+  });
+
   it('allows legacy session-only tmux_session configs while still validating the session before split-window', async () => {
     config = makeConfig({
       worker_count: 0,

--- a/src/team/__tests__/team-config-revision-lock.test.ts
+++ b/src/team/__tests__/team-config-revision-lock.test.ts
@@ -205,6 +205,64 @@ describe('team config revision transaction', () => {
     });
   });
 
+  describe('legacy config/manifest max_workers merge (#3744)', () => {
+    function writeLegacyConfig(maxWorkers: number | undefined): void {
+      const { state_revision: _revision, active_recovery: _recovery, max_workers: _default, ...legacy } = initialConfig();
+      writeConfig({ ...legacy, ...(maxWorkers === undefined ? {} : { max_workers: maxWorkers }) } as TeamConfig);
+    }
+
+    function writeMergeManifest(): void {
+      writeFileSync(absPath(cwd, TeamPaths.manifest(teamName)), JSON.stringify({ schema_version: 2, name: teamName,
+        workers: [{ name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [], pane_id: '%manifest' }],
+        worker_count: 1, next_task_id: 1, created_at: new Date().toISOString(), tmux_session: `${teamName}:0` }));
+    }
+
+    it('honors an explicit configured cap below the legacy default of 20 in both read paths', async () => {
+      writeLegacyConfig(3);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 3 });
+      await expect(teamReadConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 3 });
+    });
+
+    it('keeps the default cap of 20 when the legacy config omits max_workers', async () => {
+      writeLegacyConfig(undefined);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
+      await expect(teamReadConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
+    });
+
+    it('clamps an oversized configured cap to the hard ceiling of 20 in both read paths', async () => {
+      writeLegacyConfig(50);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
+      await expect(teamReadConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
+    });
+
+    it('returns a revisioned sub-ceiling cap verbatim without consulting the manifest merge', async () => {
+      writeConfig({ ...initialConfig(), max_workers: 3 });
+      writeFileSync(absPath(cwd, TeamPaths.manifest(teamName)), JSON.stringify({ schema_version: 2,
+        state_revision: 99, name: teamName, next_task_id: 99,
+        workers: [{ name: 'worker-1', index: 1, role: 'executor', assigned_tasks: [], pane_id: '%manifest' }],
+        worker_count: 1 }));
+
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 3, next_task_id: 1 });
+      await expect(teamReadConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 3, next_task_id: 1 });
+      expect((await teamReadConfig(teamName, cwd))?.workers[0]?.pane_id).not.toBe('%manifest');
+      await expect(readRevisionedTeamConfig(teamName, cwd)).resolves.toMatchObject({ config: { max_workers: 3, next_task_id: 1 } });
+    });
+
+    it('migrates a manifest-only team at the legacy default cap', async () => {
+      unlinkSync(absPath(cwd, TeamPaths.config(teamName)));
+      writeMergeManifest();
+
+      await expect(migrateTeamConfigRevision(teamName, cwd)).resolves.toMatchObject({ config: { max_workers: 20 } });
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
+    });
+  });
+
   it('never lets a divergent manifest override revisioned config authority', async () => {
     const manifestPath = absPath(cwd, TeamPaths.manifest(teamName));
     writeFileSync(manifestPath, JSON.stringify({ schema_version: 2, state_revision: 99, name: teamName,

--- a/src/team/governance.ts
+++ b/src/team/governance.ts
@@ -5,6 +5,7 @@ import type {
   TeamPolicy,
   TeamTransportPolicy,
 } from './types.js';
+import { DEFAULT_MAX_WORKERS } from './types.js';
 
 export type LifecycleProfile = 'default' | 'linked_ralph';
 
@@ -22,6 +23,21 @@ export const DEFAULT_TEAM_GOVERNANCE: TeamGovernance = {
   one_team_per_leader_session: true,
   cleanup_requires_all_workers_inactive: true,
 };
+
+/**
+ * Resolve the effective worker cap when merging a persisted config with a
+ * legacy manifest projection. The manifest always supplies the legacy default
+ * of 20, so an explicit configured cap below 20 must win (issue #3744), a
+ * missing value keeps the default, and anything above 20 is clamped to the
+ * hard ceiling. This helper only resolves the default-vs-cap decision; the
+ * shape of a persisted value itself stays the responsibility of the
+ * persisted-state validators, and out-of-contract values are never silently
+ * rewritten here.
+ */
+export function resolveMaxWorkers(configured: number | undefined): number {
+  if (configured === undefined) return DEFAULT_MAX_WORKERS;
+  return Math.min(configured, DEFAULT_MAX_WORKERS);
+}
 
 type LegacyPolicyLike = Partial<TeamPolicy> & Partial<TeamTransportPolicy> & Partial<TeamGovernance>;
 

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -33,7 +33,7 @@ import type {
   TeamSummaryPerformance,
 } from './types.js';
 import type { TeamPhase } from './phase-controller.js';
-import { normalizeTeamManifest } from './governance.js';
+import { normalizeTeamManifest, resolveMaxWorkers } from './governance.js';
 import { canonicalizeTeamConfigWorkers } from './worker-canonicalization.js';
 
 // ---------------------------------------------------------------------------
@@ -358,7 +358,7 @@ export async function readTeamConfig(teamName: string, cwd: string): Promise<Tea
     workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
     worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
     next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
-    max_workers: Math.max(config.max_workers ?? 0, 20),
+    max_workers: resolveMaxWorkers(config.max_workers),
   });
 }
 

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -15,7 +15,7 @@ import { appendFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 import { TeamPaths, absPath } from './state-paths.js';
-import { normalizeTeamManifest } from './governance.js';
+import { normalizeTeamManifest, resolveMaxWorkers } from './governance.js';
 import { normalizeTeamGovernance } from './governance.js';
 import { migrateTeamConfigRevision, readRevisionedTeamConfig, saveTeamConfigAtRevision } from './monitor.js';
 import { withProcessIdentityFileLock } from './process-identity-lock.js';
@@ -255,7 +255,7 @@ function mergeTeamConfigSources(config: TeamConfig | null, manifest: TeamManifes
     workers: [...(config.workers ?? []), ...(manifest.workers ?? [])],
     worker_count: Math.max(config.worker_count ?? 0, manifest.worker_count ?? 0),
     next_task_id: Math.max(config.next_task_id ?? 1, manifest.next_task_id ?? 1),
-    max_workers: Math.max(config.max_workers ?? 0, 20),
+    max_workers: resolveMaxWorkers(config.max_workers),
   });
 }
 


### PR DESCRIPTION
## Summary

`mergeTeamConfigSources` (`src/team/team-ops.ts`) and `readTeamConfig` (`src/team/monitor.ts`) both computed the merged worker cap as `Math.max(config.max_workers ?? 0, 20)`, so every explicitly configured `max_workers` below 20 was silently inflated to 20 during config+manifest merges. `src/team/scaling.ts` already enforces `config.max_workers ?? 20` correctly — the bug was only in the two merge paths.

Both call sites now share one narrow helper, `resolveMaxWorkers` in `src/team/governance.ts`:

- explicit configured cap **wins** over the manifest's legacy default of 20 (values 1..20 are honored)
- missing `max_workers` keeps the default **20**
- values above 20 **clamp** to the hard ceiling of 20
- invalid persisted values (0/negative/fractional) keep failing closed in the existing persisted-state validators (`isSafeCounter`) — no new validation contract is invented

## Tests

- `src/team/__tests__/team-config-revision-lock.test.ts` — new describe covering the legacy config+manifest merge through **both** read paths (`readTeamConfig` + `teamReadConfig`): explicit cap 3 survives the merge, absent value → 20, oversized value 50 → 20.
- `src/team/__tests__/scaling.test.ts` — scale-up requesting 2 workers against `max_workers: 2` with 1 existing worker is rejected with the would-exceed error and no side effects.

## Verification

- `npm test -- --run src/team` → 1645 passed | 9 skipped (0 failed)
- `npm test -- --run` focused: team-config-revision-lock (62), scaling (37), plus team-ops/task-locking, cli/team, mcp convergence suites → all green
- `npm run build` → green
- `npm run lint` → 0 errors (19 pre-existing warnings, identical to base)

Closes #3744