### PR TITLE
fix(team): reject a zero max_workers cap in persisted config validation

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0fdccb1797818772fff6307d93e609fa3b8b6c30",
-    "sourceSha256": "da4963ee037a3d05baccc10e88f4b5f5adccaa5e5eab09215f7f8fafb549044c",
+    "head": "8f061c533b55e147172f22b90f811d8d9d307b6d",
+    "sourceSha256": "4c9e0b1eccb8993b1f03f4b048e31730b226efd9a8339539afec78f00fe8530e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0fdccb1797818772fff6307d93e609fa3b8b6c30",
-  "sourceSha256": "da4963ee037a3d05baccc10e88f4b5f5adccaa5e5eab09215f7f8fafb549044c",
+  "head": "8f061c533b55e147172f22b90f811d8d9d307b6d",
+  "sourceSha256": "4c9e0b1eccb8993b1f03f4b048e31730b226efd9a8339539afec78f00fe8530e",
   "counts": {
     "public": {
       "skills": 41,
@@ -70986,5 +70986,5 @@
     }
   },
   "inventorySha256": "42aa05f88c1779c137e4ee3484bd84f6ed258478814a210853e7a1d8dc4bdd9c",
-  "manifestSha256": "995277d248c7cf59635fbee4eedcb8276e119d6c418d8e9f591f88ab0d240eb4"
+  "manifestSha256": "4a54a87424be2e5210dfb681d8e75a29f150e17d1637f3ada0ed22ff97e18ca2"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "8f061c533b55e147172f22b90f811d8d9d307b6d",
-    "sourceSha256": "4c9e0b1eccb8993b1f03f4b048e31730b226efd9a8339539afec78f00fe8530e",
+    "head": "09423938a5c514f67726516a9f2407dc68092a6a",
+    "sourceSha256": "6176204ce179c2ee50aac57592445ee0f43b7a98457b4b9f354047c34ac7ea4d",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "8f061c533b55e147172f22b90f811d8d9d307b6d",
-  "sourceSha256": "4c9e0b1eccb8993b1f03f4b048e31730b226efd9a8339539afec78f00fe8530e",
+  "head": "09423938a5c514f67726516a9f2407dc68092a6a",
+  "sourceSha256": "6176204ce179c2ee50aac57592445ee0f43b7a98457b4b9f354047c34ac7ea4d",
   "counts": {
     "public": {
       "skills": 41,
@@ -70986,5 +70986,5 @@
     }
   },
   "inventorySha256": "42aa05f88c1779c137e4ee3484bd84f6ed258478814a210853e7a1d8dc4bdd9c",
-  "manifestSha256": "4a54a87424be2e5210dfb681d8e75a29f150e17d1637f3ada0ed22ff97e18ca2"
+  "manifestSha256": "4e899a0088418afcd40607ab6227da17ff8877c3ea95a31faa8c86346ae53a81"
 }

--- a/src/team/__tests__/legacy-config-classification.test.ts
+++ b/src/team/__tests__/legacy-config-classification.test.ts
@@ -35,4 +35,20 @@ describe('legacy on-disk config classification (exact-head 70d5 P1)', () => {
     // Empty workers array is OK only if agentTypes is still present for classification
     expect(loaded.agentTypes).toEqual(['codex']);
   });
+
+  it.each([0, -1, 1.5])('rejects an invalid persisted V1 max_workers cap of %s', async maxWorkers => {
+    const configPath = absPath(cwd, TeamPaths.config(teamName));
+    mkdirSync(join(configPath, '..'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      name: teamName,
+      task: 'legacy task',
+      agentTypes: ['codex'],
+      tmuxSession: 'omc-team-legacy',
+      workerCount: 2,
+      tmuxOwnsWindow: false,
+      max_workers: maxWorkers,
+    }));
+
+    await expect(teamReadConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+  });
 });

--- a/src/team/__tests__/team-config-revision-lock.test.ts
+++ b/src/team/__tests__/team-config-revision-lock.test.ts
@@ -262,36 +262,37 @@ describe('team config revision transaction', () => {
       await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
     });
 
-    it('keeps a configured cap of 1 valid', async () => {
-      writeLegacyConfig(1);
-      writeMergeManifest();
-
-      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 1 });
-    });
-
-    it('rejects a legacy config carrying a zero cap as invalid persisted state', async () => {
-      writeLegacyConfig(0);
+    it.each([0, -1, 1.5])('rejects a legacy config carrying invalid cap %s through every reader and migration', async maxWorkers => {
+      writeLegacyConfig(maxWorkers);
       writeMergeManifest();
 
       await expect(readTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
-    });
-
-    it('rejects a revisioned config carrying a zero cap on read and migrate', async () => {
-      writeConfig({ ...initialConfig(), max_workers: 0 });
-
+      await expect(teamReadConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
       await expect(readRevisionedTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
       await expect(migrateTeamConfigRevision(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
     });
 
-    it('refuses to persist a zero cap', async () => {
-      await expect(saveTeamConfig({ ...initialConfig(), max_workers: 0 }, cwd)).rejects.toThrow('invalid_persisted_state');
-    });
-
-    it('rejects a negative cap', async () => {
-      writeLegacyConfig(-1);
-      writeMergeManifest();
+    it.each([0, -1, 1.5])('rejects a revisioned config carrying invalid cap %s through every reader and migration', async maxWorkers => {
+      writeConfig({ ...initialConfig(), max_workers: maxWorkers });
 
       await expect(readTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+      await expect(teamReadConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+      await expect(readRevisionedTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+      await expect(migrateTeamConfigRevision(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+    });
+
+    it.each([0, -1, 1.5])('refuses to persist invalid cap %s through both writers', async maxWorkers => {
+      await expect(saveTeamConfig({ ...initialConfig(), max_workers: maxWorkers }, cwd)).rejects.toThrow('invalid_persisted_state');
+      await expect(saveTeamConfigAtRevision({ ...initialConfig(), max_workers: maxWorkers, state_revision: 2 }, 1, cwd))
+        .rejects.toThrow('invalid_persisted_state');
+    });
+
+    it.each([1, 20])('keeps configured boundary cap %s valid through both readers', async maxWorkers => {
+      writeLegacyConfig(maxWorkers);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: maxWorkers });
+      await expect(teamReadConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: maxWorkers });
     });
   });
 

--- a/src/team/__tests__/team-config-revision-lock.test.ts
+++ b/src/team/__tests__/team-config-revision-lock.test.ts
@@ -261,6 +261,38 @@ describe('team config revision transaction', () => {
       await expect(migrateTeamConfigRevision(teamName, cwd)).resolves.toMatchObject({ config: { max_workers: 20 } });
       await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 20 });
     });
+
+    it('keeps a configured cap of 1 valid', async () => {
+      writeLegacyConfig(1);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).resolves.toMatchObject({ max_workers: 1 });
+    });
+
+    it('rejects a legacy config carrying a zero cap as invalid persisted state', async () => {
+      writeLegacyConfig(0);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+    });
+
+    it('rejects a revisioned config carrying a zero cap on read and migrate', async () => {
+      writeConfig({ ...initialConfig(), max_workers: 0 });
+
+      await expect(readRevisionedTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+      await expect(migrateTeamConfigRevision(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+    });
+
+    it('refuses to persist a zero cap', async () => {
+      await expect(saveTeamConfig({ ...initialConfig(), max_workers: 0 }, cwd)).rejects.toThrow('invalid_persisted_state');
+    });
+
+    it('rejects a negative cap', async () => {
+      writeLegacyConfig(-1);
+      writeMergeManifest();
+
+      await expect(readTeamConfig(teamName, cwd)).rejects.toThrow('invalid_persisted_state');
+    });
   });
 
   it('never lets a divergent manifest override revisioned config authority', async () => {

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -112,6 +112,10 @@ function isSafeCounter(value: unknown): value is number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
+export function isValidPersistedMaxWorkers(value: unknown): value is number | undefined {
+  return value === undefined || (isSafeCounter(value) && value >= 1);
+}
+
 function isTimestamp(value: unknown): value is string {
   return typeof value === 'string' && Number.isFinite(Date.parse(value));
 }
@@ -204,7 +208,7 @@ function isTeamConfig(value: unknown, requireRevision: boolean, expectedTeamName
     || (value.task !== undefined && typeof value.task !== 'string')
     || (value.worker_launch_mode !== undefined && !['interactive', 'prompt'].includes(value.worker_launch_mode as string))
     || !isSafeCounter(value.worker_count)
-    || (value.max_workers !== undefined && (!isSafeCounter(value.max_workers) || value.max_workers < 1))
+    || !isValidPersistedMaxWorkers(value.max_workers)
     || !Array.isArray(value.workers) || value.worker_count !== value.workers.length
     || !value.workers.every(isWorkerInfo) || !hasUniqueWorkerIdentity(value.workers)
     || !isTimestamp(value.created_at) || !isNonEmptyString(value.tmux_session)

--- a/src/team/monitor.ts
+++ b/src/team/monitor.ts
@@ -204,7 +204,7 @@ function isTeamConfig(value: unknown, requireRevision: boolean, expectedTeamName
     || (value.task !== undefined && typeof value.task !== 'string')
     || (value.worker_launch_mode !== undefined && !['interactive', 'prompt'].includes(value.worker_launch_mode as string))
     || !isSafeCounter(value.worker_count)
-    || (value.max_workers !== undefined && !isSafeCounter(value.max_workers))
+    || (value.max_workers !== undefined && (!isSafeCounter(value.max_workers) || value.max_workers < 1))
     || !Array.isArray(value.workers) || value.worker_count !== value.workers.length
     || !value.workers.every(isWorkerInfo) || !hasUniqueWorkerIdentity(value.workers)
     || !isTimestamp(value.created_at) || !isNonEmptyString(value.tmux_session)

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -17,7 +17,7 @@ import { dirname, join } from 'node:path';
 import { TeamPaths, absPath } from './state-paths.js';
 import { normalizeTeamManifest, resolveMaxWorkers } from './governance.js';
 import { normalizeTeamGovernance } from './governance.js';
-import { migrateTeamConfigRevision, readRevisionedTeamConfig, saveTeamConfigAtRevision } from './monitor.js';
+import { isValidPersistedMaxWorkers, migrateTeamConfigRevision, readRevisionedTeamConfig, saveTeamConfigAtRevision } from './monitor.js';
 import { withProcessIdentityFileLock } from './process-identity-lock.js';
 import {
   isTerminalTeamTaskStatus,
@@ -267,6 +267,7 @@ export async function teamReadConfig(teamName: string, cwd: string): Promise<Tea
     readJsonSafe<TeamConfig & { agentTypes?: unknown[] }>(configPath),
   ]);
   if (!config && existsSync(configPath)) throw new Error('invalid_persisted_state');
+  if (config && !isValidPersistedMaxWorkers(config.max_workers)) throw new Error('invalid_persisted_state');
   // Preserve raw V1 agentTypes provenance before any worker canonicalization.
   // Canonicalization must not erase the only signal used to route legacy cleanup.
   if (config && Array.isArray((config as { agentTypes?: unknown[] }).agentTypes)) {


### PR DESCRIPTION
Follow-up to #3744, on the one value that survived the fix in #3745.

## What was wrong

`isSafeCounter` (`src/team/monitor.ts:111`) accepts any non-negative integer, so `max_workers: 0` passed validation. Negatives and non-integers were already rejected there, which left `0` as the single out-of-contract value reaching the runtime.

A team persisted with a zero cap then fails every scale-up. `count` is forced to `>= 1` at `src/team/scaling.ts:191`, and the guard at line 212 compares `currentCount + count > maxWorkers`, so the result is always:

```
Cannot add 1 workers: would exceed max_workers (0 + 1 > 0)
```

That reads like a defect in the tool rather than a mistake in the config, and there is no path that succeeds.

## Why the validator and not the helper

`resolveMaxWorkers` documents that it only resolves the default-vs-cap decision, that value shape stays the responsibility of the persisted-state validators, and that out-of-contract values are never silently rewritten there. Adding a floor to the helper would contradict that contract, so the bound goes where the contract says it belongs.

The same file already applies this pattern to every other positive-only field: worker `index` (`monitor.ts:125`), `pid` (`:129`), `epoch` (`:155`), `next_worker_index` (`:271`). `max_workers` was the only one without it.

## Scope

This covers the paths that run through `isTeamConfig`: `readTeamConfig`, `readRevisionedTeamConfig`, `migrateTeamConfigRevision`, `saveTeamConfig` and `saveTeamConfigAtRevision`.

`teamReadConfig` in `src/team/team-ops.ts` does not call this validator and is deliberately untouched here, so it can still return a zero cap read straight from disk. Happy to address that separately if you consider it in scope.

An existing team with a hand-edited `max_workers: 0` will now fail as `invalid_persisted_state` instead of failing every scale-up with a misleading message. Both states are broken; this one says so.

## Tests

`src/team/__tests__/team-config-revision-lock.test.ts`, alongside the existing `#3744` block:

- zero cap on the legacy config/manifest merge path
- zero cap on revisioned read and on migrate
- zero cap refused at save
- a cap of `1` staying valid (boundary, guards against off-by-one)
- a negative cap staying rejected (already true, pinned so it stays that way)

Verified that the three zero-cap tests fail without the one-line change and pass with it. `inventory/inventory-graph.json` regenerated with `npm run generate:inventory`.

Closes nothing on its own; #3744 is already closed by #3745.
