### PR TITLE
feat(hud): add opt-in `organization` element

### DIFF
--- a/skills/hud/SKILL.md
+++ b/skills/hud/SKILL.md
@@ -187,6 +187,7 @@ You can manually edit the config file. Each option can be set individually - any
     "thinkingFormat": "text",
     "permissionStatus": false,
     "apiKeySource": false,
+    "organization": false,
     "profile": true,
     "promptTime": true,
     "sessionHealth": true,
@@ -209,6 +210,23 @@ You can manually edit the config file. Each option can be set individually - any
   }
 }
 ```
+
+### organization
+
+Shows the Claude account's organization, e.g. `org:Acme·team`. Off by default.
+
+```json
+{ "elements": { "organization": true } }
+```
+
+Claude Code does not send organization info on the statusline stdin, so the value
+is read from the local `.claude.json` the CLI writes at login
+(`$CLAUDE_CONFIG_DIR/.claude.json`, falling back to `~/.claude.json`). Only the
+organization *name* is read — never the account email or any UUID stored beside it.
+
+Renders nothing when no organization is on record (API-key auth or logged out).
+A trailing plan qualifier is collapsed to keep the token narrow:
+`"Acme (Team)"` renders as `org:Acme·team`.
 
 ### callCountsFormat
 

--- a/src/__tests__/hud-organization.test.ts
+++ b/src/__tests__/hud-organization.test.ts
@@ -1,0 +1,168 @@
+/**
+ * OMC HUD - Organization Element Tests
+ *
+ * Covers resolving the Claude account organization from the local config and
+ * rendering it as a statusline token.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getOrganizationName, renderOrganization } from '../hud/elements/organization.js';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  statSync: vi.fn(),
+}));
+
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}));
+
+vi.mock('../utils/config-dir.js', () => ({
+  getClaudeConfigDir: vi.fn(() => '/home/user/.claude'),
+}));
+
+import { existsSync, readFileSync, statSync } from 'fs';
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedStatSync = vi.mocked(statSync);
+
+const PROFILE_CONFIG = '/home/user/.claude/.claude.json';
+const HOME_CONFIG = '/home/user/.claude.json';
+
+/** Strip ANSI so assertions describe content, not color. */
+const plain = (value: string | null): string | null =>
+  // eslint-disable-next-line no-control-regex
+  value === null ? null : value.replace(/\u001b\[[0-9;]*m/g, '');
+
+/** Serve `contents` for the given paths; every other path is "missing". */
+function withConfigs(contents: Record<string, string>, size = 1024): void {
+  mockedExistsSync.mockImplementation((path) => path.toString() in contents);
+  mockedStatSync.mockImplementation(() => ({ size }) as ReturnType<typeof statSync>);
+  mockedReadFileSync.mockImplementation((path) => {
+    const found = contents[path.toString()];
+    if (found === undefined) throw new Error('ENOENT');
+    return found;
+  });
+}
+
+const configWithOrg = (name: unknown): string =>
+  JSON.stringify({
+    userID: 'abc123',
+    oauthAccount: {
+      accountUuid: '00000000-0000-0000-0000-000000000000',
+      emailAddress: 'someone@example.com',
+      organizationUuid: '11111111-1111-1111-1111-111111111111',
+      organizationName: name,
+    },
+  });
+
+describe('Organization Element', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getOrganizationName', () => {
+    it('reads the organization from the config-dir config', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('Acme (Team)') });
+      expect(getOrganizationName()).toBe('Acme (Team)');
+    });
+
+    it('prefers the config-dir config over the home config', () => {
+      withConfigs({
+        [PROFILE_CONFIG]: configWithOrg('Profile Org'),
+        [HOME_CONFIG]: configWithOrg('Home Org'),
+      });
+      expect(getOrganizationName()).toBe('Profile Org');
+    });
+
+    it('falls back to the home config when the config-dir file is missing', () => {
+      withConfigs({ [HOME_CONFIG]: configWithOrg('Home Org') });
+      expect(getOrganizationName()).toBe('Home Org');
+    });
+
+    it('falls back to the home config when the config-dir file has no organization', () => {
+      withConfigs({
+        [PROFILE_CONFIG]: JSON.stringify({ oauthAccount: {} }),
+        [HOME_CONFIG]: configWithOrg('Home Org'),
+      });
+      expect(getOrganizationName()).toBe('Home Org');
+    });
+
+    it('trims surrounding whitespace', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('  Acme  ') });
+      expect(getOrganizationName()).toBe('Acme');
+    });
+
+    it('returns null when no config exists', () => {
+      withConfigs({});
+      expect(getOrganizationName()).toBeNull();
+    });
+
+    it('returns null when there is no oauthAccount block (API-key auth)', () => {
+      withConfigs({ [PROFILE_CONFIG]: JSON.stringify({ userID: 'abc123' }) });
+      expect(getOrganizationName()).toBeNull();
+    });
+
+    it('returns null when organizationName is empty or not a string', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('   ') });
+      expect(getOrganizationName()).toBeNull();
+
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg(42) });
+      expect(getOrganizationName()).toBeNull();
+    });
+
+    it('returns null on unparseable config instead of throwing', () => {
+      withConfigs({ [PROFILE_CONFIG]: '{ not json' });
+      expect(getOrganizationName()).toBeNull();
+    });
+
+    it('skips configs above the size cap', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('Acme') }, 6 * 1024 * 1024);
+      expect(getOrganizationName()).toBeNull();
+      expect(mockedReadFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('renderOrganization', () => {
+    it('collapses the trailing plan qualifier', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('Acme (Team)') });
+      expect(plain(renderOrganization())).toBe('org:Acme·team');
+    });
+
+    it('renders the name as-is when there is no qualifier', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('Acme') });
+      expect(plain(renderOrganization())).toBe('org:Acme');
+    });
+
+    it('elides names longer than the width cap', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('A'.repeat(40)) });
+      const rendered = plain(renderOrganization());
+      expect(rendered).toBe(`org:${'A'.repeat(27)}…`);
+      expect(rendered?.length).toBe('org:'.length + 28);
+    });
+
+    it('returns null when no organization is on record', () => {
+      withConfigs({});
+      expect(renderOrganization()).toBeNull();
+    });
+
+    it('never surfaces the account email or any UUID', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('Acme (Team)') });
+      const rendered = renderOrganization() ?? '';
+      expect(rendered).not.toContain('someone@example.com');
+      expect(rendered).not.toContain('00000000-0000-0000-0000-000000000000');
+      expect(rendered).not.toContain('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('colors the value and dims the label', () => {
+      withConfigs({ [PROFILE_CONFIG]: configWithOrg('Acme') });
+      expect(renderOrganization()).toContain('\u001b[');
+    });
+  });
+});

--- a/src/hud/elements/index.ts
+++ b/src/hud/elements/index.ts
@@ -25,3 +25,4 @@ export { renderMissionBoard } from './mission-board.js';
 export { renderSessionSummary, type SessionSummaryState } from './session-summary.js';
 export { renderLastTool } from './last-tool.js';
 export { renderHostname } from './hostname.js';
+export { renderOrganization, getOrganizationName } from './organization.js';

--- a/src/hud/elements/organization.ts
+++ b/src/hud/elements/organization.ts
@@ -1,0 +1,103 @@
+/**
+ * OMC HUD - Organization Element
+ *
+ * Renders the Claude account's organization, e.g. `org:Acme·team`. Useful when
+ * switching between personal and team accounts (or between profiles via
+ * CLAUDE_CONFIG_DIR) — the statusline makes it obvious which organization the
+ * current session bills to before you start a long run.
+ *
+ * Claude Code does not include organization info in the statusline stdin
+ * payload, so the value is read from the local `.claude.json` the CLI writes at
+ * login.
+ *
+ * Only the organization *name* is ever surfaced. The account email, account
+ * UUID, and organization UUID stored alongside it are never read.
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { cyan, dim } from '../colors.js';
+import { getClaudeConfigDir } from '../../utils/config-dir.js';
+
+/**
+ * `.claude.json` also holds per-project history, so it can grow. Skip parsing
+ * pathological sizes rather than paying for them on every statusline render.
+ */
+const MAX_CONFIG_BYTES = 5 * 1024 * 1024;
+
+/** Keep the statusline token short; longer names are elided. */
+const MAX_NAME_LENGTH = 28;
+
+/**
+ * Read `oauthAccount.organizationName` out of one candidate config file.
+ *
+ * @returns The trimmed name, or null when the file is missing, too large,
+ *          unparseable, or has no organization on record.
+ */
+function readOrganizationName(filePath: string): string | null {
+  try {
+    if (!existsSync(filePath)) return null;
+    if (statSync(filePath).size > MAX_CONFIG_BYTES) return null;
+    const config = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const name = config?.oauthAccount?.organizationName;
+    if (typeof name !== 'string') return null;
+    const trimmed = name.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the organization name from the local Claude config.
+ *
+ * Checks `$CLAUDE_CONFIG_DIR/.claude.json` first so profile-scoped installs
+ * report their own organization, then falls back to `~/.claude.json`.
+ *
+ * @returns The organization name, or null when none is on record (API-key auth,
+ *          logged out, or a config without an `oauthAccount` block).
+ */
+export function getOrganizationName(): string | null {
+  const candidates: string[] = [];
+
+  try {
+    const configDir = getClaudeConfigDir();
+    if (configDir) candidates.push(join(configDir, '.claude.json'));
+  } catch {
+    // Fall through to the home-directory location.
+  }
+  candidates.push(join(homedir(), '.claude.json'));
+
+  for (const candidate of candidates) {
+    const name = readOrganizationName(candidate);
+    if (name) return name;
+  }
+
+  return null;
+}
+
+/**
+ * Collapse the trailing plan qualifier the API appends for team accounts so the
+ * token stays narrow: `"Acme (Team)"` becomes `"Acme·team"`.
+ */
+function compactName(name: string): string {
+  const qualified = name.match(/^(.*\S)\s*\(([^()]+)\)$/);
+  const compacted = qualified ? `${qualified[1]}·${qualified[2].toLowerCase()}` : name;
+  return compacted.length > MAX_NAME_LENGTH
+    ? `${compacted.slice(0, MAX_NAME_LENGTH - 1)}…`
+    : compacted;
+}
+
+/**
+ * Render the organization element.
+ *
+ * Format: `org:Acme·team`
+ *
+ * @returns Rendered label, or null when no organization is on record.
+ */
+export function renderOrganization(): string | null {
+  const name = getOrganizationName();
+  if (!name) return null;
+  return `${dim('org:')}${cyan(compactName(name))}`;
+}

--- a/src/hud/render.ts
+++ b/src/hud/render.ts
@@ -35,6 +35,7 @@ import { renderPromptTime } from "./elements/prompt-time.js";
 import { renderAutopilot } from "./elements/autopilot.js";
 import { renderCwd } from "./elements/cwd.js";
 import { renderHostname } from "./elements/hostname.js";
+import { renderOrganization } from "./elements/organization.js";
 import { renderGitRepo, renderGitBranch, renderGitStatus } from "./elements/git.js";
 import { renderMultiRepo } from "./elements/multi-repo.js";
 import { renderModel } from "./elements/model.js";
@@ -247,6 +248,11 @@ export async function render(
   if (enabledElements.hostname) {
     const hostnameElement = renderHostname();
     if (hostnameElement) rendered.set("hostname", hostnameElement);
+  }
+
+  if (enabledElements.organization) {
+    const organizationElement = renderOrganization();
+    if (organizationElement) rendered.set("organization", organizationElement);
   }
 
   if (enabledElements.cwd) {

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -608,6 +608,7 @@ export interface HudElementConfig {
   thinkingFormat: ThinkingFormat;  // Thinking indicator format
   apiKeySource: boolean;       // Show API key source (project/global/env)
   hostname: boolean;           // Show machine hostname (useful for multi-host SSH workflows)
+  organization: boolean;       // Show Claude account organization (useful when switching team/personal accounts)
   profile: boolean;            // Show active profile name (from CLAUDE_CONFIG_DIR)
   missionBoard?: boolean;      // Show opt-in mission board above existing HUD detail lines
   promptTime: boolean;        // Show last prompt submission time (HH:MM:SS)
@@ -670,7 +671,7 @@ export interface LayoutConfig {
  * Used as fallback when no layout is configured.
  */
 export const DEFAULT_ELEMENT_ORDER: Required<LayoutConfig> = {
-  line1: ['hostname', 'cwd', 'gitRepo', 'gitBranch', 'gitStatus', 'apiKeySource', 'profile'],
+  line1: ['hostname', 'organization', 'cwd', 'gitRepo', 'gitBranch', 'gitStatus', 'apiKeySource', 'profile'],
   main: [
     'omcLabel', 'model', 'enterpriseCost', 'rateLimits', 'customBuckets', 'permission', 'thinking',
     'promptTime', 'session', 'tokens', 'ralph', 'autopilot', 'prd',
@@ -741,6 +742,7 @@ export const DEFAULT_HUD_CONFIG: HudConfig = {
     thinkingFormat: 'text',   // Text format for backward compatibility
     apiKeySource: false, // Disabled by default
     hostname: false,
+    organization: false,
     profile: true,  // Show profile name when CLAUDE_CONFIG_DIR is set
     missionBoard: false,  // Opt-in mission board for whole-run progress tracking
     promptTime: true,  // Show last prompt time by default
@@ -802,6 +804,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: false,
     hostname: false,
+    organization: false,
     profile: true,
     missionBoard: false,
     promptTime: false,
@@ -845,6 +848,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: false,
     hostname: false,
+    organization: false,
     profile: true,
     missionBoard: false,
     promptTime: true,
@@ -888,6 +892,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: true,
     hostname: false,
+    organization: false,
     profile: true,
     missionBoard: false,
     promptTime: true,
@@ -931,6 +936,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: false,
     hostname: false,
+    organization: false,
     profile: true,
     missionBoard: false,
     promptTime: true,
@@ -974,6 +980,7 @@ export const PRESET_CONFIGS: Record<HudPreset, Partial<HudElementConfig>> = {
     thinkingFormat: 'text',
     apiKeySource: true,
     hostname: false,
+    organization: false,
     profile: true,
     missionBoard: false,
     promptTime: true,


### PR DESCRIPTION
## What

Adds an opt-in HUD element that shows the Claude account's organization:

```
org:Acme·team | branch:main | profile:work
[OMC#4.15.10] | Model: Opus 5 | 5h:17% wk:33% | ctx:44%
```

```json
{ "elements": { "organization": true } }
```

Off by default, so no existing statusline changes.

## Why

When you switch between a personal account and a team account — or between profiles via `CLAUDE_CONFIG_DIR` — nothing on the statusline tells you which organization the session bills to. `profile:` shows the config directory name, which is not the same thing. This makes it visible before you kick off a long run.

## Where the value comes from

Claude Code does **not** include organization info in the statusline stdin payload. Verified against a real payload:

```
session_id, transcript_path, cwd, prompt_id, effort, session_name, model,
workspace, version, output_style, cost, context_window,
exceeds_200k_tokens, fast_mode, thinking, rate_limits
```

`workspace` carries only directories and the git repo. So the element reads the local `.claude.json` the CLI writes at login — `$CLAUDE_CONFIG_DIR/.claude.json` first (so profile-scoped installs report their own org), falling back to `~/.claude.json`.

**Only the organization name is read.** The account email, account UUID, and organization UUID sit in the same `oauthAccount` block and are never touched. A test asserts none of them can reach the rendered output.

## Shape

Follows `hostname` — the closest existing analogue:

| | |
|---|---|
| Renderer | standalone, no context plumbing through `HudContext` |
| Layout | `line1`, next to `hostname` / `apiKeySource` / `profile` |
| Presets | `false` in all six, so existing statuslines are unchanged |

Details worth calling out:

- `.claude.json` also holds per-project history and can grow, so reads above 5 MB are skipped rather than parsed on every render.
- A trailing plan qualifier is collapsed to keep the token narrow: `"Acme (Team)"` renders as `org:Acme·team`. Names over 28 chars are elided.
- Renders nothing when no organization is on record (API-key auth or logged out).

## Verification

- `tsc --noEmit` clean
- 16 new tests in `src/__tests__/hud-organization.test.ts` pass
- All 10 existing `hud-*.test.ts` files (168 tests) still pass — the preset defaults were touched, so this was the regression that mattered
- End-to-end against a built `dist/hud/index.js` with an isolated `CLAUDE_CONFIG_DIR`: element appears when enabled, absent by default, and no email or UUID in the output

`dist/` is untouched (it is gitignored, though some artifacts are still tracked).

## Open to changing

Placement on `line1` follows the sibling elements. If you would rather have it inline on the main HUD line, say so and I will move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
