### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -336,7 +336,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Dieses Projekt unterstützen
 

--- a/README.es.md
+++ b/README.es.md
@@ -371,7 +371,7 @@ MIT
 
 ## Historial de Estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Apoya Este Proyecto
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -336,7 +336,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Soutenir ce projet
 

--- a/README.it.md
+++ b/README.it.md
@@ -327,7 +327,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Supporta questo progetto
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -380,7 +380,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 このプロジェクトを支援
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -385,7 +385,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 이 프로젝트 후원하기
 

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Top personal non-fork, non-archived repos from all-time OMC contributors (100+ G
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Support This Project
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -378,7 +378,7 @@ MIT
 
 ## Histórico de Stars
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Apoie Este Projeto
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -336,7 +336,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Поддержите этот проект
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -336,7 +336,7 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Bu Projeyi Destekleyin
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -378,7 +378,7 @@ MIT
 
 ## Lịch sử sao
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 Ủng hộ dự án này
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -380,7 +380,7 @@ MIT
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://www.star-history.com/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)](https://star-history.dera.page/#Yeachan-Heo/oh-my-claudecode&type=date&legend=top-left)
 
 ## 💖 支持本项目
 


### PR DESCRIPTION
The star history chart in the READMEs is currently broken, so visitors no longer see the project's stargazer growth. This change updates the chart image and its wrapping link across all README translations to a working endpoint that renders the same star history data.