### PR TITLE
feat(skills): add migration-guide skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -33,6 +33,7 @@
     "./skills/local-build-reminder/",
     "./skills/merge-readiness/",
     "./skills/mcp-setup/",
+    "./skills/migration-guide/",
     "./skills/omc-doctor/",
     "./skills/omc-reference/",
     "./skills/omc-setup/",

--- a/commands/migration-guide.md
+++ b/commands/migration-guide.md
@@ -1,0 +1,18 @@
+---
+description: ""
+---
+
+# OMC migration-guide
+
+This compatibility command keeps `/oh-my-claudecode:migration-guide` available without loading the full `migration-guide` skill description in every Claude Code session.
+
+## Dispatch
+
+1. Read the full bundled skill instructions from the active OMC plugin/install: `skills/migration-guide/SKILL.md`.
+2. Follow that SKILL.md exactly, treating the user's arguments as:
+
+```text
+$ARGUMENTS
+```
+
+If the file is not directly readable from the current working directory, locate it under the active `CLAUDE_PLUGIN_ROOT`/`OMC_PLUGIN_ROOT`, package root, or installed OMC plugin directory, then continue.

--- a/skills/migration-guide/SKILL.md
+++ b/skills/migration-guide/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: migration-guide
+description: Plan and execute library, framework, or language version migrations with structured breaking-change analysis and step-by-step guidance
+argument-hint: "<source>@<old-version> → <target>@<new-version> [--plan-only] [--scope <path>]"
+---
+
+# Migration Guide
+
+Use this skill when the user wants to migrate a dependency, framework, or language version and needs a structured plan that identifies breaking changes, maps affected code, and provides a safe execution path.
+
+## When to Use
+
+- Upgrading a major version of a library or framework (e.g., React 18 → 19, Next.js 14 → 15, Express 4 → 5)
+- Replacing one library with another (e.g., Moment.js → date-fns, Enzyme → Testing Library)
+- Upgrading a language runtime (e.g., Node.js 18 → 22, Python 3.9 → 3.12, Go 1.21 → 1.23)
+- Moving between build tools (e.g., Webpack → Vite, CRA → Vite)
+- The user says "migrate", "upgrade", "move from X to Y", or "update to latest"
+
+## When Not to Use
+
+- The task is a general refactor with no version/library migration intent; use `/ai-slop-cleaner` or standard refactoring
+- The user wants to build a new feature on top of a new library (that's implementation, not migration)
+- The migration is trivial (patch version bump with no breaking changes) — just do it directly
+- The user wants a full project rewrite from scratch; use `/ralph` or `/autopilot`
+
+## Workflow
+
+### Phase 1: Discovery
+
+1. Identify the migration source and target:
+   - Current version/library (from lockfile, package.json, go.mod, Cargo.toml, etc.)
+   - Target version/library
+   - Scope: entire project or specific paths (`--scope`)
+
+2. Gather migration intelligence:
+   - Read official migration guides, changelogs, and release notes (use WebSearch/WebFetch)
+   - Identify breaking changes, deprecated APIs, and removed features
+   - Note new features or patterns that replace removed ones
+   - Check for codemods or automated migration tools
+
+3. Scan the codebase for affected patterns:
+   - Search for deprecated API usage
+   - Identify files that import/use the migrating dependency
+   - Map transitive dependencies that may also need updates
+   - Check test files for patterns that will break
+
+### Phase 2: Migration Plan
+
+Produce a structured migration plan:
+
+```markdown
+## Migration Plan: <source> → <target>
+
+### Summary
+- **From:** <library>@<version>
+- **To:** <library>@<version>
+- **Breaking changes:** <count>
+- **Files affected:** <count>
+- **Estimated effort:** <low/medium/high>
+- **Codemod available:** <yes/no — link if yes>
+
+### Breaking Changes
+
+| # | Change | Severity | Files Affected | Migration Path |
+|---|--------|----------|----------------|----------------|
+| 1 | <description> | high/medium/low | <file list> | <how to fix> |
+
+### Migration Steps
+
+1. **Preparation** — lock behavior with tests before changing anything
+2. **Dependency update** — update package versions
+3. **Automated fixes** — run codemods if available
+4. **Manual fixes** — address remaining breaking changes by priority
+5. **Verification** — run tests, typecheck, build
+
+### Risks & Rollback
+- <identified risks>
+- Rollback: revert dependency + revert code changes (atomic commit strategy)
+```
+
+If `--plan-only` is specified, stop here and present the plan for review.
+
+### Phase 3: Execution
+
+When executing (no `--plan-only` flag):
+
+1. **Lock behavior first**: ensure existing tests pass before any changes. If test coverage is insufficient for affected areas, note this explicitly.
+2. **Update dependencies**: modify lockfile/manifest atomically.
+3. **Apply codemods**: run official migration tools if available (e.g., `npx @next/codemod`, `npx react-codemod`).
+4. **Fix remaining breaks**: address each breaking change from the plan, highest severity first.
+5. **Verify incrementally**: typecheck and run tests after each logical group of changes.
+6. **Final verification**: full build + test suite must pass.
+
+### Phase 4: Report
+
+Output a migration report:
+
+```markdown
+## Migration Complete: <source> → <target>
+
+### Changes Made
+- <file>: <what changed and why>
+
+### Verification
+- Typecheck: ✅/❌
+- Tests: ✅/❌ (<pass>/<total>)
+- Build: ✅/❌
+
+### Remaining Manual Steps
+- <anything that requires human decision or external action>
+
+### Notes for Reviewers
+- <key decisions made during migration>
+- <patterns that changed project-wide>
+```
+
+## Rules
+
+- Always check for official migration guides before inventing migration paths.
+- Prefer codemods and automated tooling over manual find-and-replace.
+- Never silently drop functionality — if a feature has no equivalent in the target, flag it explicitly.
+- Keep changes atomic: dependency bump + code changes should be reviewable together.
+- If the migration surface is too large for one pass, recommend splitting into phases and explain the split.
+- Do not introduce new patterns that conflict with the project's existing conventions.
+- When uncertain about a migration path, present options and ask the user to choose.
+
+## Examples
+
+```bash
+# Plan a React version upgrade
+/oh-my-claudecode:migration-guide react@18 → react@19 --plan-only
+
+# Migrate from Express to Fastify with scope
+/oh-my-claudecode:migration-guide express@4 → fastify@5 --scope src/api/
+
+# Upgrade Node.js runtime
+/oh-my-claudecode:migration-guide node@18 → node@22
+
+# Replace a library
+/oh-my-claudecode:migration-guide moment → date-fns
+```
+
+## Integration
+
+- Uses WebSearch/WebFetch for official migration docs and changelogs
+- Can hand off to `/ralph` or `/autopilot` for execution of large migrations
+- Can invoke `/verify` after execution to confirm the migration succeeded
+- Works with `/plan` for pre-migration architectural decisions on complex migrations

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (37 canonical + 4 aliases)', () => {
+    it('should return correct number of skills (38 canonical + 4 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 41 entries: 37 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
-      expect(skills).toHaveLength(41);
+      // 42 entries: 38 canonical skills + 4 aliases (cancel-ralph, learner, psm, understanding-gate)
+      expect(skills).toHaveLength(42);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -865,7 +865,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(37);
+      expect(names).toHaveLength(38);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -903,7 +903,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; cancel-ralph, psm, and learner aliases still exist
-      expect(names).toHaveLength(41);
+      expect(names).toHaveLength(42);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');


### PR DESCRIPTION
## Summary

Adds a new `migration-guide` skill that provides structured guidance for library, framework, or language version migrations.

## What it does

The skill follows a 4-phase workflow:

1. **Discovery** — identifies migration source/target, gathers official migration guides via WebSearch, scans codebase for affected patterns
2. **Migration Plan** — produces a structured plan with breaking changes, severity, affected files, and step-by-step instructions
3. **Execution** — applies changes incrementally with verification at each step (skipped with `--plan-only`)
4. **Report** — outputs what changed, verification results, and remaining manual steps

## Example usage

```bash
# Plan a React version upgrade
/oh-my-claudecode:migration-guide react@18 → react@19 --plan-only

# Replace a library
/oh-my-claudecode:migration-guide moment → date-fns

# Upgrade with scoped path
/oh-my-claudecode:migration-guide express@4 → fastify@5 --scope src/api/
```

## Why this is valuable

- **Common pain point**: Major version upgrades and library replacements are one of the most frequent developer tasks, yet no existing skill addresses this
- **Structured approach**: Enforces a safe migration workflow (lock behavior first → update → verify) that prevents the common mistake of updating everything at once
- **Integrates naturally**: Works with existing skills (`/verify`, `/ralph`, `/plan`) for complex migrations
- **Fills the gap**: The project has `security-reviewer` (agent), `ai-slop-cleaner` (refactoring), `verify` (validation) — but nothing for structured migrations

## Files changed

| File | Purpose |
|------|---------|
| `skills/migration-guide/SKILL.md` | Full skill definition with workflow, rules, examples |
| `commands/migration-guide.md` | Slash-command dispatch shim (matches existing pattern) |
| `.claude-plugin/plugin.json` | Register new skill in plugin manifest |
| `src/__tests__/skills.test.ts` | Update skill count assertions (37→38 canonical) |

## Conventions followed

- YAML frontmatter with `name`, `description`, `argument-hint` (matches existing skills like `external-context`, `merge-readiness`)
- Command shim follows the exact pattern of `deep-dive.md`, `autoresearch.md`, etc.
- Plugin.json entry added in alphabetical order
- Test assertions updated to reflect new skill count
- No build artifacts modified