### PR TITLE
fix(skills): preserve top-level frontmatter metadata

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "bcd08214264e378b12d844ae81a66f96254b7113",
-    "sourceSha256": "09372f8428627ace59989b2f753cce0dfab179de8eb3111eb077af2c6a4e4732",
+    "head": "02300521b08a203f025da10520921ead96d167b0",
+    "sourceSha256": "117afaff0208003e39c56e9be8096d199d385f7fa34c6d2e2a5ba97533577cbe",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "bcd08214264e378b12d844ae81a66f96254b7113",
-  "sourceSha256": "09372f8428627ace59989b2f753cce0dfab179de8eb3111eb077af2c6a4e4732",
+  "head": "02300521b08a203f025da10520921ead96d167b0",
+  "sourceSha256": "117afaff0208003e39c56e9be8096d199d385f7fa34c6d2e2a5ba97533577cbe",
   "counts": {
     "public": {
       "skills": 31,
@@ -74721,5 +74721,5 @@
     }
   },
   "inventorySha256": "a5e0979491f038c33f656eed63cee7116707b1320b492ed8f19099027ebccb88",
-  "manifestSha256": "2d9dd58d694ff70580e4b7a2b8851cb623c40cecca1a82d638d8f249ecd8ee05"
+  "manifestSha256": "205d3bea71800024e51f63fdcfc7449d18be32c37ce6d0dd2dcb1fece42c1ce3"
 }

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -242,6 +242,42 @@ Compatibility body`
     expect(result.replacementText).toContain('`templates/`');
   });
 
+  it('keeps top-level descriptions for compatibility skills with nested metadata', async () => {
+    mkdirSync(join(tempProjectDir, '.agents', 'skills', 'nested-metadata-skill'), { recursive: true });
+    writeFileSync(
+      join(tempProjectDir, '.agents', 'skills', 'nested-metadata-skill', 'SKILL.md'),
+      `---
+name: nested-metadata-skill
+description: Top-level skill description
+metadata:
+  optionalEnv:
+    - name: EXAMPLE_SECRET
+      description: Nested environment description
+---
+
+Nested metadata skill body`
+    );
+
+    const { findCommand, executeSlashCommand, listAvailableCommands } = await loadExecutor();
+
+    expect(findCommand('nested-metadata-skill')?.metadata.description).toBe('Top-level skill description');
+    expect(listAvailableCommands()).toContainEqual({
+      name: 'nested-metadata-skill',
+      description: 'Top-level skill description',
+      scope: 'skill',
+    });
+
+    const result = executeSlashCommand({
+      command: 'nested-metadata-skill',
+      args: '',
+      raw: '/nested-metadata-skill',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.replacementText).toContain('**Description**: Top-level skill description');
+    expect(result.replacementText).not.toContain('Nested environment description');
+  });
+
   it('discovers workspace-local Claude Code skills from .claude/skills before OMC compatibility skills', async () => {
     mkdirSync(join(tempProjectDir, '.claude', 'skills', 'workspace-skill', 'references'), { recursive: true });
     writeFileSync(

--- a/src/__tests__/auto-slash-aliases.test.ts
+++ b/src/__tests__/auto-slash-aliases.test.ts
@@ -247,12 +247,12 @@ Compatibility body`
     writeFileSync(
       join(tempProjectDir, '.agents', 'skills', 'nested-metadata-skill', 'SKILL.md'),
       `---
-name: nested-metadata-skill
-description: Top-level skill description
-metadata:
-  optionalEnv:
-    - name: EXAMPLE_SECRET
-      description: Nested environment description
+  name: nested-metadata-skill
+  description: Top-level skill description
+  metadata:
+    optionalEnv:
+      - name: EXAMPLE_SECRET
+        description: Nested environment description
 ---
 
 Nested metadata skill body`

--- a/src/utils/__tests__/frontmatter.test.ts
+++ b/src/utils/__tests__/frontmatter.test.ts
@@ -128,6 +128,25 @@ Line 3`;
     const result = parseFrontmatter(content);
     expect(result.body).toBe('Line 1\nLine 2\nLine 3');
   });
+
+  it('does not promote nested mapping fields to top-level metadata', () => {
+    const content = `---
+name: compatibility-skill
+description: Top-level description
+metadata:
+  integration:
+    description: Nested integration description
+    model: nested-model
+---
+Body`;
+    const result = parseFrontmatter(content);
+
+    expect(result.metadata).toEqual({
+      name: 'compatibility-skill',
+      description: 'Top-level description',
+      metadata: '',
+    });
+  });
 });
 
 describe('parseFrontmatterAliases', () => {

--- a/src/utils/__tests__/frontmatter.test.ts
+++ b/src/utils/__tests__/frontmatter.test.ts
@@ -168,6 +168,21 @@ Body`;
       metadata: '',
     });
   });
+
+  it('ignores comments at the detected root indentation', () => {
+    const content = `---
+  name: indented-skill
+  # fake: comment
+  description: Root description
+---
+Body`;
+    const result = parseFrontmatter(content);
+
+    expect(result.metadata).toEqual({
+      name: 'indented-skill',
+      description: 'Root description',
+    });
+  });
 });
 
 describe('parseFrontmatterAliases', () => {

--- a/src/utils/__tests__/frontmatter.test.ts
+++ b/src/utils/__tests__/frontmatter.test.ts
@@ -169,6 +169,25 @@ Body`;
     });
   });
 
+  it('ignores de-indented members of multiline flow mappings', () => {
+    const content = `---
+  name: indented-skill
+  metadata: {
+integration: remote,
+model: nested-model
+  }
+  description: Root description
+---
+Body`;
+    const result = parseFrontmatter(content);
+
+    expect(result.metadata).toEqual({
+      name: 'indented-skill',
+      metadata: '{',
+      description: 'Root description',
+    });
+  });
+
   it('ignores comments at the detected root indentation', () => {
     const content = `---
   name: indented-skill

--- a/src/utils/__tests__/frontmatter.test.ts
+++ b/src/utils/__tests__/frontmatter.test.ts
@@ -147,6 +147,27 @@ Body`;
       metadata: '',
     });
   });
+
+  it('preserves uniformly indented root mappings without promoting nested fields', () => {
+    const content = `---
+# comment: does not define mapping indentation
+  name: indented-skill
+  description: Indented root description
+  model: opus
+  metadata:
+    description: Nested description
+    model: nested-model
+---
+Body`;
+    const result = parseFrontmatter(content);
+
+    expect(result.metadata).toEqual({
+      name: 'indented-skill',
+      description: 'Indented root description',
+      model: 'opus',
+      metadata: '',
+    });
+  });
 });
 
 describe('parseFrontmatterAliases', () => {

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -35,6 +35,8 @@ export function parseFrontmatter(content: string): { metadata: Record<string, st
   const metadata: Record<string, string> = {};
 
   for (const line of yamlContent.split('\n')) {
+    if (/^\s/.test(line)) continue;
+
     const colonIndex = line.indexOf(':');
     if (colonIndex === -1) continue;
 

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -43,6 +43,8 @@ export function parseFrontmatter(content: string): { metadata: Record<string, st
   }, undefined);
 
   for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
     if (line.length - line.trimStart().length !== rootIndent) continue;
 
     const colonIndex = line.indexOf(':');

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -34,13 +34,11 @@ export function parseFrontmatter(content: string): { metadata: Record<string, st
   const [, yamlContent, body] = match;
   const metadata: Record<string, string> = {};
   const lines = yamlContent.split('\n');
-  const rootIndent = lines.reduce<number | undefined>((minimum, line) => {
+  const rootLine = lines.find((line) => {
     const trimmed = line.trimStart();
-    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes(':')) return minimum;
-
-    const indentation = line.length - trimmed.length;
-    return minimum === undefined ? indentation : Math.min(minimum, indentation);
-  }, undefined);
+    return trimmed.length > 0 && !trimmed.startsWith('#') && trimmed.includes(':');
+  });
+  const rootIndent = rootLine === undefined ? undefined : rootLine.length - rootLine.trimStart().length;
 
   for (const line of lines) {
     const trimmed = line.trimStart();

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -33,9 +33,17 @@ export function parseFrontmatter(content: string): { metadata: Record<string, st
 
   const [, yamlContent, body] = match;
   const metadata: Record<string, string> = {};
+  const lines = yamlContent.split('\n');
+  const rootIndent = lines.reduce<number | undefined>((minimum, line) => {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes(':')) return minimum;
 
-  for (const line of yamlContent.split('\n')) {
-    if (/^\s/.test(line)) continue;
+    const indentation = line.length - trimmed.length;
+    return minimum === undefined ? indentation : Math.min(minimum, indentation);
+  }, undefined);
+
+  for (const line of lines) {
+    if (line.length - line.trimStart().length !== rootIndent) continue;
 
     const colonIndex = line.indexOf(':');
     if (colonIndex === -1) continue;


### PR DESCRIPTION
## Summary

- Anchor shared frontmatter parsing to the first root mapping entry.
- Ignore nested mapping and comment entries without dropping indented root metadata.
- Cover parser behavior and `.agents/skills` slash discovery.

## Reproduction

A valid, uniformly indented Skill frontmatter can contain a multiline flow mapping whose members start at column zero. The previous global-minimum calculation treated those members as the root. It then dropped real root fields and promoted nested fields.

I reproduced the original compatibility defect with the public Xquik X Twitter Scraper Skill. OMC loaded and executed the copied `.agents/skills` package, including its resources, but displayed its nested webhook-secret description instead of the Skill description.

This patch fixes the existing compatibility path. It adds no public OMC Skill or command.

Closes #3756.

## Validation

- `npx vitest run src/utils/__tests__/frontmatter.test.ts src/__tests__/auto-slash-aliases.test.ts`: 41 passed
- `npx vitest run tests/lint/inventory-graph-drift.test.ts`: 10 passed
- `npm run generate:inventory:verify`: passed
- `npx tsc --noEmit --pretty false`: passed
- `npm run lint`: 0 errors; 21 existing warnings outside this patch
- `npm run plugin:shipping:verify`: passed
- `npm run build`: passed; generated `dist` and `bridge` output excluded from the commit
- Copied Xquik Skill integration: correct description, body, resources, and request reference loaded
