### PR TITLE
fix(test): make generated-artifact authorization suite wall-clock deterministic

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "410af40b8f20c71480ed05f9528f1ece22a16865",
-    "sourceSha256": "15c5da4dc0394e60d05a2e962b978dd82150ba0659eab1565aec155895525b65",
+    "head": "05f0ba6288a9b857ce7a1af267fb88ded24c9e81",
+    "sourceSha256": "b8ed0223fd96fe6524c82c32954f71b45dcd1681b745b01873eb774c4512fc1c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "410af40b8f20c71480ed05f9528f1ece22a16865",
-  "sourceSha256": "15c5da4dc0394e60d05a2e962b978dd82150ba0659eab1565aec155895525b65",
+  "head": "05f0ba6288a9b857ce7a1af267fb88ded24c9e81",
+  "sourceSha256": "b8ed0223fd96fe6524c82c32954f71b45dcd1681b745b01873eb774c4512fc1c",
   "counts": {
     "public": {
       "skills": 31,
@@ -74721,5 +74721,5 @@
     }
   },
   "inventorySha256": "a5e0979491f038c33f656eed63cee7116707b1320b492ed8f19099027ebccb88",
-  "manifestSha256": "57522aaa0d4368c8135c4c476d2f1f4ab33bc19b4b9439fac83bb5266953be77"
+  "manifestSha256": "5d8bd7a9d8dac2275e432819466b631a0d764169babb3c13e433d5c3038690e0"
 }

--- a/scripts/verify-generated-artifact-authorization.mjs
+++ b/scripts/verify-generated-artifact-authorization.mjs
@@ -651,6 +651,7 @@ export async function verifyLiveGeneratedArtifactAuthorization({
   token,
   fetchImpl,
   repositoryRoot = REPOSITORY_ROOT,
+  now = new Date(),
 }) {
   const trustedManifest = validateAuthorizationManifest(manifest);
   const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
@@ -710,6 +711,7 @@ export async function verifyLiveGeneratedArtifactAuthorization({
     commit,
     signature: graphResponse.data.repository.object,
     files,
+    now,
   });
 
   // Close the observable push-race window before reporting authorization.

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -105,6 +105,7 @@ type VerifierModule = {
     token: string;
     fetchImpl: typeof fetch;
     repositoryRoot: string;
+    now?: Date;
   }): Promise<unknown>;
   validateAuthorizationManifest(manifest: unknown): unknown;
   readDetachedCheckoutHead(repositoryRoot: string): string;
@@ -124,6 +125,8 @@ const exactAuthorization = (() => {
   if (!authorization) throw new Error('Missing exact #3537 base-owned authorization fixture');
   return authorization;
 })();
+const EXPIRES_AT = exactAuthorization.expiresAt;
+const EXPIRY_INSTANT = Date.parse(EXPIRES_AT);
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
@@ -524,14 +527,91 @@ describe('generated-artifact base-owned authorization decision', () => {
     }, 'authorized closure');
   });
 
-  it('keeps expiry validation effective after the frozen fixture date', () => {
-    const input = authorizedInput();
-    input.now = new Date('2026-08-20T00:00:00.000Z');
+  it('enforces the exact expiry boundary of the authorized manifest entry', () => {
+    const lastValid = authorizedInput();
+    lastValid.now = new Date(EXPIRY_INSTANT - 1);
+    expect(verifier.evaluateGeneratedArtifactAuthorization(lastValid)).toMatchObject({ allowed: true });
 
-    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toEqual({
+    const expired = authorizedInput();
+    expired.now = new Date(EXPIRY_INSTANT);
+    expect(verifier.evaluateGeneratedArtifactAuthorization(expired)).toEqual({
       allowed: false,
       reason: 'generated-artifact authorization has expired',
     });
+
+    const farFuture = authorizedInput();
+    farFuture.now = new Date('2999-01-01T00:00:00.000Z');
+    expect(verifier.evaluateGeneratedArtifactAuthorization(farFuture)).toEqual({
+      allowed: false,
+      reason: 'generated-artifact authorization has expired',
+    });
+  });
+
+  it('keeps the live decision green under a wall clock far past the fixture expiry', async () => {
+    // #3759 regression: the live path must consult the injected fixture clock,
+    // never the system clock. Freeze the system clock far past every manifest
+    // expiry and prove the exact-head live verification still authorizes.
+    vi.useFakeTimers({
+      now: new Date('2999-01-01T00:00:00.000Z'),
+      toFake: ['Date'],
+    });
+    try {
+      expect(Date.now()).toBe(Date.parse('2999-01-01T00:00:00.000Z'));
+
+      const checkoutRoot = mkdtempSync(join(tmpdir(), 'generated-artifact-authorization-'));
+      mkdirSync(join(checkoutRoot, '.git'));
+      writeFileSync(join(checkoutRoot, '.git', 'HEAD'), `${LIVE_BASE_SHA}\n`);
+      try {
+        const input = authorizedInput();
+        const fetchImpl: typeof fetch = async request => {
+          const url = new URL(
+            typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+          );
+          const path = `${url.pathname}${url.search}`;
+          let body: unknown;
+          if (path === `/repos/${REPOSITORY}`) body = input.repositoryMetadata;
+          else if (path === `/repos/${REPOSITORY}/commits/main`) body = input.runtimeCommit;
+          else if (path === `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}`) body = input.livePull;
+          else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=1')) body = input.files.slice(0, 100);
+          else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=2')) body = input.files.slice(100);
+          else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=3')) body = [];
+          else if (path.startsWith(`/repos/${REPOSITORY}/compare/`)) body = input.compare;
+          else if (path === `/repos/${REPOSITORY}/commits/${HEAD_SHA}`) body = input.commit;
+          else if (path === '/graphql') body = { data: { repository: { object: input.signature } } };
+          else throw new Error(`Unexpected GitHub API path ${path}`);
+          return { ok: true, json: async () => body } as Response;
+        };
+
+        await expect(
+          verifier.verifyLiveGeneratedArtifactAuthorization({
+            event: input.event,
+            manifest: input.manifest,
+            environment: input.environment,
+            token: 'test-token',
+            fetchImpl,
+            repositoryRoot: checkoutRoot,
+            now: input.now,
+          }),
+        ).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
+
+        // The same live input must fail closed without the injected clock once
+        // the real (faked far-future) clock is consulted: expiry still bites.
+        await expect(
+          verifier.verifyLiveGeneratedArtifactAuthorization({
+            event: input.event,
+            manifest: input.manifest,
+            environment: input.environment,
+            token: 'test-token',
+            fetchImpl,
+            repositoryRoot: checkoutRoot,
+          }),
+        ).rejects.toThrow('generated-artifact authorization has expired');
+      } finally {
+        rmSync(checkoutRoot, { recursive: true, force: true });
+      }
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('requires exact authorization for generated-path rename, copy, and deletion records', () => {
@@ -781,6 +861,7 @@ describe('generated-artifact base-owned authorization decision', () => {
           token: 'test-token',
           fetchImpl,
           repositoryRoot: checkoutRoot,
+          now: input.now,
         }),
       ).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
       expect(requestedPaths).toContain(`/repos/${REPOSITORY}/commits/main`);
@@ -812,6 +893,7 @@ describe('generated-artifact base-owned authorization decision', () => {
           token: 'test-token',
           fetchImpl: raceFetch,
           repositoryRoot: checkoutRoot,
+          now: racedInput.now,
         }),
       ).rejects.toThrow('GITHUB_SHA does not match the current protected default-main commit SHA');
       expect(racePaths).toEqual([`/repos/${REPOSITORY}`, `/repos/${REPOSITORY}/commits/main`]);
@@ -844,6 +926,7 @@ describe('generated-artifact base-owned authorization decision', () => {
           token: 'test-token',
           fetchImpl,
           repositoryRoot: checkoutRoot,
+          now: input.now,
         }),
       ).rejects.toThrow('default branch is not main');
       expect(requestedPaths).toEqual([`/repos/${REPOSITORY}`]);


### PR DESCRIPTION
Fixes #3759

## Root cause

`#3695` froze the clock for the **sync** evaluate path only (`input.now` / `FIXTURE_NOW`). The **async live path** — `verifyLiveGeneratedArtifactAuthorization` — never forwarded a clock into `authorizeGeneratedArtifactPullRequest`, whose default is `now = new Date()`. Once the retained #3537 manifest entry's `expiresAt` (`2026-08-19T00:00:00.000Z`) passed the wall clock, `fetches and binds the protected main commit before live pull evidence` began rejecting `generated-artifact authorization has expired` (observed 2026-08-21; also reproduced independently by the PR #3757 lane with its changes stashed).

A second, smaller rot vector: the regression test itself hardcoded `2026-08-20` — another wall-relative literal.

## Fix (smallest correct, durable)

- **Verifier**: thread an optional `now` (default `new Date()`) through `verifyLiveGeneratedArtifactAuthorization` and forward it to the authorization decision. Production `main()` is unchanged and still uses the real clock.
- **Tests**: live-path tests now pass the fixture clock (`input.now`, `FIXTURE_NOW = 2026-08-01`).
- **Expiry boundary assertions derive from the manifest entry's actual `expiresAt`** (`EXPIRY_INSTANT`): one millisecond before expiry → allowed; at expiry → denied; far future (2999) → denied. No hardcoded calendar date that can rot.
- **New regression test**: fakes the system clock (`vi.useFakeTimers({ toFake: ['Date'] })`) at 2999-01-01 and proves (a) the injected-clock live decision still authorizes and (b) the un-injected path still fails closed with `authorization has expired` — production expiry enforcement is intact.
- Inventory baseline refreshed for the source change.

## Evidence

- Old verifier + new tests: 2 failures (original `fetches and binds…` failure reproduces #3759 exactly) — fix direction proven.
- New verifier + new tests: 21/21 pass, 3× deterministic rerun.
- Focused suites on rebased head: 31/31 pass (authorization + inventory drift), `tsc --noEmit` clean, focused eslint clean, `npm run build` green, `generate-inventory-graph --verify` ok.

## Scope discipline

- No change to manifest data, authorization semantics, workflow, or expiry enforcement policy.
- Expired one-shot manifest-entry lifecycle cleanup intentionally not touched (canonical base-owned data; out of scope).
- No #3757 parser or #3749 promotion surfaces modified; branch is rebased on current dev (`2e027324`) for a clean merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*