### PR TITLE
ci: authorize exact PR #3749 inventory head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1843,7 +1843,7 @@
       "pullNumber": 3749,
       "targetRef": "main",
       "mergeBaseSha": "bb8d38d95f978bad0b524ad74da061e3b8183829",
-      "headSha": "3590d865e955fc7d340ff4b5e5e25550ca22776b",
+      "headSha": "fcde58d90936e0ee4c01f71ba944455f0e4dbe2c",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-29T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Updates only the protected base-owned authorization identity for PR #3749 after the canonical inventory provenance refresh changed its exact dev head. The merge base and generated closure are unchanged; this preserves the authorized 1,209-file closure while binding it to `fcde58d90936e0ee4c01f71ba944455f0e4dbe2c`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*