### PR TITLE
ci: authorize final PR #3749 inventory head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1843,7 +1843,7 @@
       "pullNumber": 3749,
       "targetRef": "main",
       "mergeBaseSha": "bb8d38d95f978bad0b524ad74da061e3b8183829",
-      "headSha": "fcde58d90936e0ee4c01f71ba944455f0e4dbe2c",
+      "headSha": "e4d0e5f56dea75d88ffc467346db6464d2fbe2c6",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-29T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Updates only the protected base-owned authorization identity for the final inventory provenance repair at `e4d0e5f56dea75d88ffc467346db6464d2fbe2c6`. Generated closure and merge base are unchanged.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*