### PR TITLE
fix: derive cancel-signal expiry from a single captured timestamp in tests (#3712)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "5463afbdcfd9d7477a91a875ce32e33e8ab4df34",
-    "sourceSha256": "8e358f295296db06056e4ee3a3afd85adf8b6c67ab5faa97037478dbaa326d1e",
+    "head": "8247ee7a50cf75f770f36a0992254ff90cd97446",
+    "sourceSha256": "c9cd13bcf453e501e6adf60016a1fe18587fed0b435c5dbf0af2d572a75248c4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "5463afbdcfd9d7477a91a875ce32e33e8ab4df34",
-  "sourceSha256": "8e358f295296db06056e4ee3a3afd85adf8b6c67ab5faa97037478dbaa326d1e",
+  "head": "8247ee7a50cf75f770f36a0992254ff90cd97446",
+  "sourceSha256": "c9cd13bcf453e501e6adf60016a1fe18587fed0b435c5dbf0af2d572a75248c4",
   "counts": {
     "public": {
       "skills": 31,
@@ -74716,5 +74716,5 @@
     }
   },
   "inventorySha256": "1d89540ec7601148a9d0c2622974011e9f1e508adbb6f2d8fd710b2c5ed3e836",
-  "manifestSha256": "8099b4782ab870137f2952a704d8c6bd5c1cdcdfe11ac27d5b5e4c709c9858ca"
+  "manifestSha256": "9384e8d99ddc14ddc021f8c6e9adf06f972a40dc8a25c2d4472d4b2881dc38e1"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "8247ee7a50cf75f770f36a0992254ff90cd97446",
-    "sourceSha256": "c9cd13bcf453e501e6adf60016a1fe18587fed0b435c5dbf0af2d572a75248c4",
+    "head": "594b4991a70287acb5a5887aeb47dac33c3b8890",
+    "sourceSha256": "9f3b49047eaaa5069ecece8345ce911f37e6e70c94f62bf28741f71f58d3c97e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "8247ee7a50cf75f770f36a0992254ff90cd97446",
-  "sourceSha256": "c9cd13bcf453e501e6adf60016a1fe18587fed0b435c5dbf0af2d572a75248c4",
+  "head": "594b4991a70287acb5a5887aeb47dac33c3b8890",
+  "sourceSha256": "9f3b49047eaaa5069ecece8345ce911f37e6e70c94f62bf28741f71f58d3c97e",
   "counts": {
     "public": {
       "skills": 31,
@@ -74716,5 +74716,5 @@
     }
   },
   "inventorySha256": "1d89540ec7601148a9d0c2622974011e9f1e508adbb6f2d8fd710b2c5ed3e836",
-  "manifestSha256": "9384e8d99ddc14ddc021f8c6e9adf06f972a40dc8a25c2d4472d4b2881dc38e1"
+  "manifestSha256": "0e0be59995ec1b795e6c9085993cde92781dc3290df401ee71089e53a25300ab"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "594b4991a70287acb5a5887aeb47dac33c3b8890",
-    "sourceSha256": "9f3b49047eaaa5069ecece8345ce911f37e6e70c94f62bf28741f71f58d3c97e",
+    "head": "31a5fe8c782084c30d64897ac76e105e93eb8a4b",
+    "sourceSha256": "f0099d0dce131970f85a7b15b79b24f3b3615a875802c420a6a68a7c729a70ea",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "594b4991a70287acb5a5887aeb47dac33c3b8890",
-  "sourceSha256": "9f3b49047eaaa5069ecece8345ce911f37e6e70c94f62bf28741f71f58d3c97e",
+  "head": "31a5fe8c782084c30d64897ac76e105e93eb8a4b",
+  "sourceSha256": "f0099d0dce131970f85a7b15b79b24f3b3615a875802c420a6a68a7c729a70ea",
   "counts": {
     "public": {
       "skills": 31,
@@ -40341,6 +40341,11 @@
         "path": "tests/integration/workflow-profile-stop-transition.test.ts"
       },
       {
+        "id": "tests/lint/cancel-signal-fixture-ttl.test.ts",
+        "kind": "other",
+        "path": "tests/lint/cancel-signal-fixture-ttl.test.ts"
+      },
+      {
         "id": "tests/lint/fable-routing-docs.test.ts",
         "kind": "other",
         "path": "tests/lint/fable-routing-docs.test.ts"
@@ -74553,6 +74558,21 @@
         "kind": "imports"
       },
       {
+        "from": "tests/lint/cancel-signal-fixture-ttl.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/cancel-signal-fixture-ttl.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/cancel-signal-fixture-ttl.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/lint/fable-routing-docs.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -74709,12 +74729,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6819,
-      "edgeCount": 6860,
-      "importEdgeCount": 5620,
+      "nodeCount": 6820,
+      "edgeCount": 6863,
+      "importEdgeCount": 5623,
       "registerEdgeCount": 52
     }
   },
-  "inventorySha256": "1d89540ec7601148a9d0c2622974011e9f1e508adbb6f2d8fd710b2c5ed3e836",
-  "manifestSha256": "0e0be59995ec1b795e6c9085993cde92781dc3290df401ee71089e53a25300ab"
+  "inventorySha256": "701586753abe736094554bb05bb7f721f9813c8a171f2b664b51c8d63bf06087",
+  "manifestSha256": "68b8b8c04ddc41c3f4743b49f2a3437dc5af4b5654ce44e99eca595e14b2b4ff"
 }

--- a/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
+++ b/src/hooks/persistent-mode/__tests__/cancel-race.test.ts
@@ -68,13 +68,14 @@ describe('persistent-mode cancel race guard (issue #921)', () => {
       execFileSync('git', ['init'], { cwd: tempDir, stdio: 'pipe' });
       const stateDir = makeRalphSession(tempDir, sessionId);
 
+      const requestedAt = Date.now();
       writeFileSync(
         join(stateDir, 'cancel-signal-state.json'),
         JSON.stringify(
           {
             active: true,
-            requested_at: new Date().toISOString(),
-            expires_at: new Date(Date.now() + 30_000).toISOString(),
+            requested_at: new Date(requestedAt).toISOString(),
+            expires_at: new Date(requestedAt + 30_000).toISOString(),
             source: 'test'
           },
           null,
@@ -112,13 +113,14 @@ describe('persistent-mode cancel race guard (issue #921)', () => {
       const resumedDir = join(tempDir, '.omc', 'state', 'sessions', resumedSessionId);
       mkdirSync(resumedDir, { recursive: true });
 
+      const requestedAt = Date.now();
       writeFileSync(
         join(ownerDir, 'cancel-signal-state.json'),
         JSON.stringify(
           {
             active: true,
-            requested_at: new Date().toISOString(),
-            expires_at: new Date(Date.now() + 30_000).toISOString(),
+            requested_at: new Date(requestedAt).toISOString(),
+            expires_at: new Date(requestedAt + 30_000).toISOString(),
             mode: 'ralph',
             source: 'state_clear'
           },

--- a/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
+++ b/src/hooks/persistent-mode/__tests__/team-ralplan-stop.test.ts
@@ -438,10 +438,15 @@ describe('team pipeline standalone stop enforcement', () => {
       mkdirSync(stateDir, { recursive: true });
       writeFileSync(
         join(stateDir, 'cancel-signal-state.json'),
-        JSON.stringify({
-          requested_at: new Date().toISOString(),
-          expires_at: new Date(Date.now() + 30000).toISOString(),
-        })
+        JSON.stringify(
+          (() => {
+            const requestedAt = Date.now();
+            return {
+              requested_at: new Date(requestedAt).toISOString(),
+              expires_at: new Date(requestedAt + 30_000).toISOString(),
+            };
+          })()
+        )
       );
 
       const result = await checkPersistentModes(sessionId, tempDir);
@@ -879,10 +884,15 @@ describe('ralplan standalone stop enforcement', () => {
       mkdirSync(stateDir, { recursive: true });
       writeFileSync(
         join(stateDir, 'cancel-signal-state.json'),
-        JSON.stringify({
-          requested_at: new Date().toISOString(),
-          expires_at: new Date(Date.now() + 30000).toISOString(),
-        })
+        JSON.stringify(
+          (() => {
+            const requestedAt = Date.now();
+            return {
+              requested_at: new Date(requestedAt).toISOString(),
+              expires_at: new Date(requestedAt + 30_000).toISOString(),
+            };
+          })()
+        )
       );
 
       const result = await checkPersistentModes(sessionId, tempDir);

--- a/src/hooks/persistent-mode/session-isolation.test.ts
+++ b/src/hooks/persistent-mode/session-isolation.test.ts
@@ -144,14 +144,17 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
       state.project_path = tempDir;
       writeFileSync(join(sessionDir, "autopilot-state.json"), JSON.stringify(state));
       const signalPath = join(sessionDir, "cancel-signal-state.json");
-      const signal = (target_state_sha256?: string) => ({
-        active: true,
-        mode: "autopilot",
-        source: "state_clear",
-        requested_at: new Date().toISOString(),
-        expires_at: new Date(Date.now() + 30_000).toISOString(),
-        ...(target_state_sha256 ? { target_state_sha256 } : {}),
-      });
+      const signal = (target_state_sha256?: string) => {
+        const requestedAt = Date.now();
+        return {
+          active: true,
+          mode: "autopilot",
+          source: "state_clear",
+          requested_at: new Date(requestedAt).toISOString(),
+          expires_at: new Date(requestedAt + 30_000).toISOString(),
+          ...(target_state_sha256 ? { target_state_sha256 } : {}),
+        };
+      };
 
       writeFileSync(signalPath, JSON.stringify(signal()));
       await expect(checkPersistentModes(sessionId, tempDir)).resolves.toMatchObject({
@@ -252,12 +255,13 @@ describe("Persistent Mode Session Isolation (Issue #311)", () => {
       const statePath = join(sessionDir, 'autopilot-state.json');
       const signalPath = join(sessionDir, 'cancel-signal-state.json');
       writeFileSync(statePath, JSON.stringify(state));
+      const requestedAt = Date.now();
       writeFileSync(signalPath, JSON.stringify({
         active: true,
         mode: 'autopilot',
         source: 'state_clear',
-        requested_at: new Date().toISOString(),
-        expires_at: new Date(Date.now() + 30_000).toISOString(),
+        requested_at: new Date(requestedAt).toISOString(),
+        expires_at: new Date(requestedAt + 30_000).toISOString(),
         target_state_sha256: createHash('sha256').update(JSON.stringify(state)).digest('hex'),
       }));
       writeFileSync(statePath, JSON.stringify(replace(state as unknown as Record<string, unknown>)));

--- a/tests/integration/workflow-profile-stop-transition.test.ts
+++ b/tests/integration/workflow-profile-stop-transition.test.ts
@@ -402,12 +402,13 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
     const state = workflowState(f);
     writeState(f, state);
     const signalPath = join(dirname(f.statePath), 'cancel-signal-state.json');
+    const requestedAt = Date.now();
     writeFileSync(signalPath, JSON.stringify({
       active: true,
       mode: 'autopilot',
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
       target_workflow_run_id: '22222222-2222-4222-8222-222222222222',
     }));
 
@@ -422,11 +423,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   ])('does not let a deleted autopilot signal with %s cancel Ralph', (_name, marker) => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
       ...marker,
     }));
 
@@ -436,11 +438,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   it('still honors a fresh targetless generic cancellation after confirming no autopilot target', () => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
     }));
 
     expect(invoke(f)).toEqual({ continue: true, suppressOutput: true });
@@ -449,11 +452,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   it('honors a targetless generic cancellation when exclusive locking is unavailable and no autopilot state exists', () => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
     }));
 
     expect(invoke(f, {}, { OMC_TEST_FLOCK_AVAILABLE: '0' })).toEqual({ continue: true, suppressOutput: true });
@@ -462,11 +466,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   it('fails closed for a targetless generic cancellation while the absent autopilot state remains locked', () => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
     }));
     writeFileSync(`${f.statePath}.mutation.lock`, liveLockOwner());
 
@@ -475,11 +480,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
 
   it('rechecks a generic cancellation after concurrent autopilot activation commits under the state lock', async () => {
     const f = fixture(kind);
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
     }));
     const lockPath = `${f.statePath}.mutation.lock`;
     writeFileSync(lockPath, liveLockOwner());
@@ -494,11 +500,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   it('fails closed when concurrent autopilot activation commits after lock retries expire', async () => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
     }));
     const lockPath = `${f.statePath}.mutation.lock`;
     writeFileSync(lockPath, liveLockOwner());
@@ -513,12 +520,13 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   it('does not let a target-bound autopilot signal cancel Ralph when the absent autopilot state is locked', () => {
     const f = fixture(kind);
     writeFileSync(join(dirname(f.statePath), 'ralph-state.json'), JSON.stringify(ralphState(f)));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       mode: 'autopilot',
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
       target_state_sha256: '0'.repeat(64),
     }));
     writeFileSync(`${f.statePath}.mutation.lock`, liveLockOwner());
@@ -529,11 +537,12 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
   it('does not let a generic cancellation bypass an active autopilot when exclusive locking is unavailable', () => {
     const f = fixture(kind);
     writeState(f, workflowState(f));
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
     }));
 
     expect(invoke(f, {}, { OMC_TEST_FLOCK_AVAILABLE: '0' }).reason).toBe(expectedStagePrompt('ralplan'));
@@ -541,12 +550,13 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
 
   it('does not let an absent-generation exact autopilot signal suppress concurrent activation', async () => {
     const f = fixture(kind);
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       mode: 'autopilot',
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
       target_state_sha256: createHash('sha256').update('{}').digest('hex'),
       target_workflow_run_id: '22222222-2222-4222-8222-222222222222',
     }));
@@ -590,7 +600,7 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
       mode: 'autopilot',
       source: 'state_clear',
       requested_at: now,
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      expires_at: new Date(Date.parse(now) + 30_000).toISOString(),
       target_state_sha256: createHash('sha256').update(JSON.stringify(readState(f))).digest('hex'),
     }));
 
@@ -610,12 +620,13 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
       replacement = workflowState(f);
       replacement.workflowRunId = '22222222-2222-4222-8222-222222222222';
     }
+    const requestedAt = Date.now();
     writeFileSync(join(dirname(f.statePath), 'cancel-signal-state.json'), JSON.stringify({
       active: true,
       mode: 'autopilot',
       source: 'state_clear',
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(requestedAt).toISOString(),
+      expires_at: new Date(requestedAt + 30_000).toISOString(),
       target_workflow_run_id: state.workflowRunId,
       target_state_sha256: createHash('sha256').update(JSON.stringify(readState(f))).digest('hex'),
     }));
@@ -673,10 +684,11 @@ describe.each(['plugin', 'installed-template'])('workflow profile stop transitio
     expect(invoke(f).reason).toBe(expectedStagePrompt('ralplan'));
     expect(existsSync(signalPath)).toBe(false);
 
+    const forgedRequestedAt = Date.now();
     const forged = {
       ...expired,
-      requested_at: new Date().toISOString(),
-      expires_at: new Date(Date.now() + 30_000).toISOString(),
+      requested_at: new Date(forgedRequestedAt).toISOString(),
+      expires_at: new Date(forgedRequestedAt + 30_000).toISOString(),
       target_state_sha256: '0'.repeat(64),
     };
     writeFileSync(signalPath, JSON.stringify(forged));

--- a/tests/lint/cancel-signal-fixture-ttl.test.ts
+++ b/tests/lint/cancel-signal-fixture-ttl.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Lint contract: cancel-signal fixtures must derive `expires_at` from the same
+ * captured clock read as `requested_at` (issue #3712).
+ *
+ * `src/hooks/persistent-mode/index.ts` enforces
+ * `expiresAt - requestedAt <= CANCEL_SIGNAL_TTL_MS` (30_000) for every cancel
+ * signal. Test fixtures that build the two fields from two separate clock
+ * reads can observe a 30_001ms window when a tick lands between the reads,
+ * which makes `validateSignal` reject the signal and silently breaks the
+ * expected cancellation — this exact pattern flaked exact-head CI (runs
+ * 32550947694, 32549962350).
+ *
+ * The deterministic idiom is one captured timestamp:
+ *   const requestedAt = Date.now();
+ *   { requested_at: new Date(requestedAt).toISOString(),
+ *     expires_at: new Date(requestedAt + 30_000).toISOString() }
+ *
+ * This guard scans all test sources under `src/` and `tests/` for inline
+ * `cancel-signal-state` fixture literals and rejects any that still couple
+ * `requested_at: new Date()` with `expires_at: new Date(Date.now() + N)`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const SCAN_ROOTS = [join(REPO_ROOT, 'src'), join(REPO_ROOT, 'tests')];
+const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mjs|js|mts|cts)$/;
+
+/** Two separate clock reads: expires_at derived from a fresh Date.now() (+/- any offset expression). */
+const TWO_CLOCK_READS_RE = /requested_at:\s*new Date\(\)\.toISOString\(\)[\s\S]{0,200}?expires_at:\s*new Date\(Date\.now\(\)\s*[+-]/;
+
+function collectTestFiles(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === 'dist' || entry === '.git') continue;
+      collectTestFiles(full, out);
+    } else if (TEST_FILE_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function toForwardSlash(p: string): string {
+  return p.split(sep).join('/');
+}
+
+describe('cancel-signal strict-TTL fixture guard (#3712)', () => {
+  it('derives no cancel-signal fixture expiry from a second clock read', () => {
+    const offenders: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      for (const file of collectTestFiles(root)) {
+        let source: string;
+        try {
+          source = readFileSync(file, 'utf8');
+        } catch {
+          continue;
+        }
+        if (TWO_CLOCK_READS_RE.test(source)) {
+          offenders.push(toForwardSlash(relative(REPO_ROOT, file)));
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Test fixtures deriving cancel-signal expires_at from a second clock read (issue #3712 flake).\n` +
+        `Fix by capturing one timestamp and deriving both fields from it:\n` +
+        `  const requestedAt = Date.now();\n` +
+        `  { requested_at: new Date(requestedAt).toISOString(),\n` +
+        `    expires_at: new Date(requestedAt + 30_000).toISOString() }\n` +
+        `Offending files:\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #3712
Refs #3698 (no epic mutation performed here)

## What

Removes a measured nondeterministic failure in cancel-signal test fixtures that turned exact-head dev CI red at `dev@e4d0e5f5`.

## Root cause

`cancel-signal-state.json` fixtures computed `requested_at` and `expires_at` from **two separate `Date.now()` calls**:

```js
requested_at: new Date().toISOString(),
expires_at:   new Date(Date.now() + 30_000).toISOString(),
```

`scripts/persistent-mode.mjs` enforces `expires_at - requested_at <= CANCEL_SIGNAL_TTL_MS` (`30_000`, with **no slack**). When the clock ticked a millisecond between the two calls, the window became `30001ms` and `validateSignal` rejected the signal, so a test expecting an honored cancellation instead observed the persistent-mode block path.

Measured on this machine: **308 / 300 000 constructions produce a 30001ms window (~0.1% per fixture build)**.

## Evidence (exact heads)

| CI run | Head | Job | Failing test | Cause match |
|---|---|---|---|---|
| `32550947694` (push CI) | `e4d0e5f5` | Test | `workflow-profile-stop-transition.test.ts` "honors a targetless generic cancellation when exclusive locking is unavailable and no autopilot state exists" — received `{decision:'block', reason:'[RALPH LOOP - ITERATION 2/10]…'}` instead of `{continue:true, suppressOutput:true}` | yes (line 455-456 fixture) |
| `32549962350` (PR CI) | `fcde58d9` | Test | `session-isolation.test.ts` "requires an authenticated exact digest before cancelling an active legacy autopilot target" (plus an inventory-drift failure fixed by `fcde58d9`/`e4d0e5f5` themselves) | yes (line 151-152 fixture) |

Cross-check: the same suite at the same head passed in run `32551015545` (Test SUCCESS) — consistent with a low-probability race, not a deterministic defect. The prior-head push CI (`32549959179`, `fcde58d9`) was green.

## Fix

All **17** racy fixtures across three files now capture a single `requestedAt` and derive both fields from it — the deterministic idiom already used elsewhere in the same files (e.g. lines 650/702 of `workflow-profile-stop-transition.test.ts`):

- `tests/integration/workflow-profile-stop-transition.test.ts` (13 sites)
- `src/hooks/persistent-mode/session-isolation.test.ts` (2 sites)
- `src/hooks/persistent-mode/__tests__/cancel-race.test.ts` (2 sites)

`inventory/inventory-graph.json` baseline refreshed for the test-source digest changes (same convention as `fcde58d9`); `generate:inventory:verify` passes. No `dist/`/`bridge/` delta — generated artifacts remain owned by the authorization lane.

## Verification (worktree at `e4d0e5f5` + this commit `c54bfefe`)

- `npx vitest run` on the three modified files + `inventory-graph-drift` + `epic-3698-closure-verifier`: **258/258 passed**
- Previously-flaky selection ×3 repeat runs: 6/6 each run
- Full local suite remaining failures were classified: all pass in isolation, differ between runs (load flakes on a busy host), or reproduce at **pristine HEAD without this diff** (`post-tool-verifier.test.mjs`); none are introduced by this change
- `npx tsc --noEmit`: clean; `npm run lint`: 0 errors
- `npm run build`: SUCCESS; `npm pack`: SUCCESS (`oh-my-claude-sisyphus-4.15.10.tgz`, 5298 files)
- `node scripts/verify-epic-3698-closure.mjs --evidence receipts/epic-3698/ci-evidence-merged.receipt.json`: docsLinks/migrationReceipts/releaseSecurityParity/childTerminality/remainingRisk PASS; metrics FAIL (31 skills/21 commands/8 workflows/18 agents) and aliasRetirementPolicy PENDING — unchanged product-surface facts, tracked on #3712

No release/tag/publish/main mutation.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
