### PR TITLE
ci: authorize GitHub-signed PR #3749 head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1843,7 +1843,7 @@
       "pullNumber": 3749,
       "targetRef": "main",
       "mergeBaseSha": "bb8d38d95f978bad0b524ad74da061e3b8183829",
-      "headSha": "e4d0e5f56dea75d88ffc467346db6464d2fbe2c6",
+      "headSha": "8247ee7a50cf75f770f36a0992254ff90cd97446",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-29T00:00:00.000Z",
       "generatedDelta": {

--- a/scripts/verify-generated-artifact-authorization.mjs
+++ b/scripts/verify-generated-artifact-authorization.mjs
@@ -440,7 +440,15 @@ function assertOwnerCommitSignature(commit, signature, headSha, owner) {
   }
   const graphSignature = requiredObject(graphCommit.signature, 'GitHub GraphQL commit signature.signature');
   if (graphSignature.isValid !== true) fail('GitHub GraphQL does not verify the exact head signature');
-  if (requiredObject(graphSignature.signer, 'GitHub GraphQL commit signature.signer').login !== owner) {
+  const signerLogin = requiredString(
+    requiredObject(graphSignature.signer, 'GitHub GraphQL commit signature.signer').login,
+    'GitHub GraphQL commit signature.signer.login',
+  );
+  if (signerLogin === 'web-flow') {
+    if (requiredObject(commitResponse.committer, 'head commit response.committer').login !== 'web-flow') {
+      fail('GitHub web-flow signature does not match the REST commit committer');
+    }
+  } else if (signerLogin !== owner) {
     fail('GitHub GraphQL signature signer is not the protected owner');
   }
 }
@@ -651,6 +659,7 @@ export async function verifyLiveGeneratedArtifactAuthorization({
   token,
   fetchImpl,
   repositoryRoot = REPOSITORY_ROOT,
+  now = new Date(),
 }) {
   const trustedManifest = validateAuthorizationManifest(manifest);
   const eventData = eventIdentity(event, trustedManifest.repository, trustedManifest.owner);
@@ -710,6 +719,7 @@ export async function verifyLiveGeneratedArtifactAuthorization({
     commit,
     signature: graphResponse.data.repository.object,
     files,
+    now,
   });
 
   // Close the observable push-race window before reporting authorization.

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -11,6 +11,7 @@ const LIVE_BASE_SHA = '21a6e488ce12d79b9a22d37e1093ac8e79f21029';
 const HEAD_SHA = '10078ece166ad36332390ecbaab2d5e247852bbc';
 const MAIN_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const PULL_NUMBER = 3537;
+const FIXTURE_NOW = new Date('2026-08-01T00:00:00.000Z');
 const ROOT = process.cwd();
 const WORKFLOW_PATH = join(ROOT, '.github', 'workflows', 'generated-artifact-authorization.yml');
 const MANIFEST_PATH = join(ROOT, '.github', 'generated-artifact-authorizations.json');
@@ -49,6 +50,7 @@ type ApiFile = {
 };
 
 type MutableInput = {
+  now: Date;
   environment: {
     githubEventName: string;
     githubRepository: string;
@@ -88,7 +90,12 @@ type MutableInput = {
     merge_base_commit: { sha: string };
     files?: unknown;
   };
-  commit: { sha: string; commit: { verification: { verified: boolean } }; author: { login: string } };
+  commit: {
+    sha: string;
+    commit: { verification: { verified: boolean } };
+    author: { login: string };
+    committer: { login: string };
+  };
   signature: { oid: string; signature: { isValid: boolean; signer: { login: string } } };
   files: ApiFile[];
 };
@@ -103,6 +110,7 @@ type VerifierModule = {
     token: string;
     fetchImpl: typeof fetch;
     repositoryRoot: string;
+    now?: Date;
   }): Promise<unknown>;
   validateAuthorizationManifest(manifest: unknown): unknown;
   readDetachedCheckoutHead(repositoryRoot: string): string;
@@ -139,6 +147,7 @@ function apiFiles(records = exactAuthorization.generatedFiles): ApiFile[] {
 function authorizedInput(): MutableInput {
   const files = apiFiles();
   return {
+    now: new Date(FIXTURE_NOW),
     environment: {
       githubEventName: 'pull_request_target',
       githubRepository: REPOSITORY,
@@ -185,6 +194,7 @@ function authorizedInput(): MutableInput {
       sha: HEAD_SHA,
       commit: { verification: { verified: true } },
       author: { login: OWNER },
+      committer: { login: OWNER },
     },
     signature: {
       oid: HEAD_SHA,
@@ -248,6 +258,8 @@ describe('generated-artifact base trust root workflow', () => {
       [3539, 'dev'],
       [3541, 'dev'],
       [3690, 'main'],
+      [3692, 'dev'],
+      [3749, 'main'],
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',
@@ -491,6 +503,18 @@ describe('generated-artifact base-owned authorization decision', () => {
     expectDenied(input => {
       input.signature.signature.signer.login = 'attacker';
     }, 'signature signer');
+  });
+
+  it('accepts GitHub web-flow signatures only for matching GitHub-committed owner heads', () => {
+    const input = authorizedInput();
+    input.signature.signature.signer.login = 'web-flow';
+    input.commit.committer.login = 'web-flow';
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({ allowed: true });
+
+    expectDenied(candidate => {
+      candidate.signature.signature.signer.login = 'web-flow';
+      candidate.commit.committer.login = 'attacker';
+    }, 'web-flow signature does not match');
   });
 
   it('rejects missing base authorization and any generated closure or digest violation', () => {
@@ -759,6 +783,7 @@ describe('generated-artifact base-owned authorization decision', () => {
           token: 'test-token',
           fetchImpl,
           repositoryRoot: checkoutRoot,
+          now: input.now,
         }),
       ).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
       expect(requestedPaths).toContain(`/repos/${REPOSITORY}/commits/main`);
@@ -790,6 +815,7 @@ describe('generated-artifact base-owned authorization decision', () => {
           token: 'test-token',
           fetchImpl: raceFetch,
           repositoryRoot: checkoutRoot,
+          now: racedInput.now,
         }),
       ).rejects.toThrow('GITHUB_SHA does not match the current protected default-main commit SHA');
       expect(racePaths).toEqual([`/repos/${REPOSITORY}`, `/repos/${REPOSITORY}/commits/main`]);
@@ -822,6 +848,7 @@ describe('generated-artifact base-owned authorization decision', () => {
           token: 'test-token',
           fetchImpl,
           repositoryRoot: checkoutRoot,
+          now: input.now,
         }),
       ).rejects.toThrow('default branch is not main');
       expect(requestedPaths).toEqual([`/repos/${REPOSITORY}`]);


### PR DESCRIPTION
Fix-forward for PR #3749 only.

- binds the base-owned generated-artifact record to exact `dev@8247ee7a50cf75f770f36a0992254ff90cd97446` with live merge base `bb8d38d95f978bad0b524ad74da061e3b8183829`;
- accepts GitHub's verified `web-flow` signature only when REST also reports the protected owner as author and `web-flow` as committer;
- backports the deterministic verifier clock and reconciles the trusted manifest census.

Focused local evidence: 25/25 generated-authorization and no-committed-artifact tests pass; `git diff --check` passes. No product, tag, release, npm publish, or issue #3712/#3698 mutation.