### PR TITLE
ci: preserve PR #3749 authorization across safe ancestry

### DIFF
--- a/scripts/verify-generated-artifact-authorization.mjs
+++ b/scripts/verify-generated-artifact-authorization.mjs
@@ -421,6 +421,32 @@ function assertCompareBaseAndGetMergeBase(compare, expectedBaseSha) {
   return requiredSha(mergeBase.sha, 'compare response.merge_base_commit.sha');
 }
 
+function assertNonGeneratedAdvance(compare, ancestorSha, descendantSha, label) {
+  const response = requiredObject(compare, `${label} compare response`);
+  if (requiredObject(response.base_commit, `${label} compare response.base_commit`).sha !== ancestorSha ||
+      requiredObject(response.merge_base_commit, `${label} compare response.merge_base_commit`).sha !== ancestorSha) {
+    fail(`${label} is not a direct descendant of the authorized SHA`);
+  }
+  if (response.status !== 'ahead' ||
+      requiredNonNegativeInteger(response.behind_by, `${label} compare response.behind_by`) !== 0) {
+    fail(`${label} is not strictly ahead of the authorized SHA`);
+  }
+  const aheadBy = requiredPositiveInteger(response.ahead_by, `${label} compare response.ahead_by`);
+  if (aheadBy > 100 || requiredPositiveInteger(
+    response.total_commits,
+    `${label} compare response.total_commits`,
+  ) !== aheadBy) {
+    fail(`${label} compare is too large or inconsistent`);
+  }
+  if (!Array.isArray(response.commits) || response.commits.length !== aheadBy ||
+      requiredObject(response.commits.at(-1), `${label} compare final commit`).sha !== descendantSha) {
+    fail(`${label} compare head does not match the live SHA`);
+  }
+  const files = canonicalizeChangedFiles(response.files, `${label} compare files`);
+  if (files.length >= 300) fail(`${label} compare is too large to prove complete`);
+  if (files.some(recordTouchesGeneratedPath)) fail(`${label} changes generated files outside the authorized closure`);
+}
+
 function assertOwnerCommitSignature(commit, signature, headSha, owner) {
   const commitResponse = requiredObject(commit, 'head commit response');
   if (requiredSha(commitResponse.sha, 'head commit response.sha') !== headSha) {
@@ -467,6 +493,8 @@ export function authorizeGeneratedArtifactPullRequest({
   checkedOutBaseSha,
   livePull,
   compare,
+  authorizedHeadAdvance,
+  authorizedBaseAdvance,
   commit,
   signature,
   files,
@@ -513,16 +541,30 @@ export function authorizeGeneratedArtifactPullRequest({
   if (Date.parse(authorization.expiresAt) <= now.getTime()) {
     fail('generated-artifact authorization has expired');
   }
-  if (
-    authorization.targetRef !== eventData.baseRef ||
-    authorization.targetRef !== liveData.baseRef ||
-    authorization.headSha !== eventData.headSha ||
-    authorization.headSha !== liveData.headSha
-  ) {
+  if (authorization.targetRef !== eventData.baseRef || authorization.targetRef !== liveData.baseRef) {
     fail('generated changes do not match the authorized PR/target/head identity');
   }
+  if (authorization.headSha !== liveData.headSha) {
+    if (authorizedHeadAdvance === undefined) {
+      fail('generated changes do not match the authorized PR/target/head identity');
+    }
+    assertNonGeneratedAdvance(
+      authorizedHeadAdvance,
+      authorization.headSha,
+      liveData.headSha,
+      'authorized head advance',
+    );
+  }
   if (authorization.mergeBaseSha !== compareMergeBaseSha) {
-    fail('compare merge base does not match the authorized merge base SHA');
+    if (authorizedBaseAdvance === undefined) {
+      fail('compare merge base does not match the authorized merge base SHA');
+    }
+    assertNonGeneratedAdvance(
+      authorizedBaseAdvance,
+      authorization.mergeBaseSha,
+      compareMergeBaseSha,
+      'authorized merge-base advance',
+    );
   }
   if (
     eventData.headRepository !== trustedManifest.repository ||
@@ -691,6 +733,24 @@ export async function verifyLiveGeneratedArtifactAuthorization({
       `/compare/${encodeURIComponent(liveData.baseSha)}...${encodeURIComponent(liveData.headSha)}?per_page=1&page=1`,
     ),
   );
+  const authorization = trustedManifest.authorizations.find(entry => entry.pullNumber === eventData.pullNumber);
+  const compareMergeBaseSha = assertCompareBaseAndGetMergeBase(compare, liveData.baseSha);
+  const authorizedHeadAdvance = authorization && authorization.headSha !== liveData.headSha
+    ? await api.get(
+      apiPath(
+        trustedManifest.repository,
+        `/compare/${encodeURIComponent(authorization.headSha)}...${encodeURIComponent(liveData.headSha)}?per_page=100&page=1`,
+      ),
+    )
+    : undefined;
+  const authorizedBaseAdvance = authorization && authorization.mergeBaseSha !== compareMergeBaseSha
+    ? await api.get(
+      apiPath(
+        trustedManifest.repository,
+        `/compare/${encodeURIComponent(authorization.mergeBaseSha)}...${encodeURIComponent(compareMergeBaseSha)}?per_page=100&page=1`,
+      ),
+    )
+    : undefined;
   const commit = await api.get(apiPath(trustedManifest.repository, `/commits/${encodeURIComponent(liveData.headSha)}`));
 
   const { owner, name } = parseRepository(trustedManifest.repository);
@@ -716,6 +776,8 @@ export async function verifyLiveGeneratedArtifactAuthorization({
     checkedOutBaseSha,
     livePull,
     compare,
+    authorizedHeadAdvance,
+    authorizedBaseAdvance,
     commit,
     signature: graphResponse.data.repository.object,
     files,

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -90,6 +90,26 @@ type MutableInput = {
     merge_base_commit: { sha: string };
     files?: unknown;
   };
+  authorizedHeadAdvance?: {
+    status: string;
+    ahead_by: number;
+    behind_by: number;
+    total_commits: number;
+    commits: Array<{ sha: string }>;
+    base_commit: { sha: string };
+    merge_base_commit: { sha: string };
+    files: ApiFile[];
+  };
+  authorizedBaseAdvance?: {
+    status: string;
+    ahead_by: number;
+    behind_by: number;
+    total_commits: number;
+    commits: Array<{ sha: string }>;
+    base_commit: { sha: string };
+    merge_base_commit: { sha: string };
+    files: ApiFile[];
+  };
   commit: {
     sha: string;
     commit: { verification: { verified: boolean } };
@@ -517,6 +537,72 @@ describe('generated-artifact base-owned authorization decision', () => {
     }, 'web-flow signature does not match');
   });
 
+  it('accepts only fully enumerable non-generated advances from the authorized head and merge base', () => {
+    const input = authorizedInput();
+    const authorizedHeadSha = 'b'.repeat(40);
+    const authorizedMergeBaseSha = 'c'.repeat(40);
+    input.manifest.authorizations[0].headSha = authorizedHeadSha;
+    input.manifest.authorizations[0].mergeBaseSha = authorizedMergeBaseSha;
+    input.authorizedHeadAdvance = {
+      status: 'ahead',
+      ahead_by: 1,
+      behind_by: 0,
+      total_commits: 1,
+      commits: [{ sha: HEAD_SHA }],
+      base_commit: { sha: authorizedHeadSha },
+      merge_base_commit: { sha: authorizedHeadSha },
+      files: [{ status: 'modified', filename: 'src/reconciled.ts', sha: 'd'.repeat(40) }],
+    };
+    input.authorizedBaseAdvance = {
+      status: 'ahead',
+      ahead_by: 1,
+      behind_by: 0,
+      total_commits: 1,
+      commits: [{ sha: MERGE_BASE_SHA }],
+      base_commit: { sha: authorizedMergeBaseSha },
+      merge_base_commit: { sha: authorizedMergeBaseSha },
+      files: [{ status: 'modified', filename: 'scripts/base-trust.mjs', sha: 'e'.repeat(40) }],
+    };
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({ allowed: true });
+
+    input.authorizedHeadAdvance.files = [
+      { status: 'modified', filename: 'dist/unauthorized.js', sha: 'f'.repeat(40) },
+    ];
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining('outside the authorized closure'),
+    });
+
+    input.authorizedHeadAdvance.files = [];
+    input.authorizedHeadAdvance.commits = [{ sha: 'a'.repeat(40) }];
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining('compare head does not match'),
+    });
+
+    input.authorizedHeadAdvance.commits = Array.from({ length: 101 }, () => ({ sha: HEAD_SHA }));
+    input.authorizedHeadAdvance.ahead_by = 101;
+    input.authorizedHeadAdvance.total_commits = 101;
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining('too large or inconsistent'),
+    });
+
+    input.authorizedHeadAdvance.commits = [{ sha: HEAD_SHA }];
+    input.authorizedHeadAdvance.ahead_by = 1;
+    input.authorizedHeadAdvance.total_commits = 1;
+    input.authorizedHeadAdvance.files = [{
+      status: 'renamed',
+      filename: 'src/moved.cjs',
+      previous_filename: 'bridge/moved.cjs',
+      sha: 'f'.repeat(40),
+    }];
+    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining('outside the authorized closure'),
+    });
+  });
+
   it('rejects missing base authorization and any generated closure or digest violation', () => {
     expectDenied(input => {
       input.manifest.authorizations = [];
@@ -789,6 +875,63 @@ describe('generated-artifact base-owned authorization decision', () => {
       expect(requestedPaths).toContain(`/repos/${REPOSITORY}/commits/main`);
       expect(requestedPaths.indexOf(`/repos/${REPOSITORY}`)).toBeLessThan(
         requestedPaths.indexOf(`/repos/${REPOSITORY}/commits/main`),
+      );
+
+      const advancedInput = authorizedInput();
+      const authorizedHeadSha = 'b'.repeat(40);
+      const authorizedMergeBaseSha = 'c'.repeat(40);
+      advancedInput.manifest.authorizations[0].headSha = authorizedHeadSha;
+      advancedInput.manifest.authorizations[0].mergeBaseSha = authorizedMergeBaseSha;
+      advancedInput.authorizedHeadAdvance = {
+        status: 'ahead', ahead_by: 1, behind_by: 0, total_commits: 1,
+        commits: [{ sha: HEAD_SHA }],
+        base_commit: { sha: authorizedHeadSha },
+        merge_base_commit: { sha: authorizedHeadSha },
+        files: [{ status: 'modified', filename: 'src/head-advance.ts', sha: 'd'.repeat(40) }],
+      };
+      advancedInput.authorizedBaseAdvance = {
+        status: 'ahead', ahead_by: 1, behind_by: 0, total_commits: 1,
+        commits: [{ sha: MERGE_BASE_SHA }],
+        base_commit: { sha: authorizedMergeBaseSha },
+        merge_base_commit: { sha: authorizedMergeBaseSha },
+        files: [{ status: 'modified', filename: 'scripts/base-advance.mjs', sha: 'e'.repeat(40) }],
+      };
+      const advancePaths: string[] = [];
+      const advanceFetch: typeof fetch = async request => {
+        const url = new URL(
+          typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+        );
+        const path = `${url.pathname}${url.search}`;
+        advancePaths.push(path);
+        let body: unknown;
+        if (path === `/repos/${REPOSITORY}`) body = advancedInput.repositoryMetadata;
+        else if (path === `/repos/${REPOSITORY}/commits/main`) body = advancedInput.runtimeCommit;
+        else if (path === `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}`) body = advancedInput.livePull;
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=1')) body = advancedInput.files.slice(0, 100);
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=2')) body = advancedInput.files.slice(100);
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=3')) body = [];
+        else if (path === `/repos/${REPOSITORY}/compare/${LIVE_BASE_SHA}...${HEAD_SHA}?per_page=1&page=1`) body = advancedInput.compare;
+        else if (path === `/repos/${REPOSITORY}/compare/${authorizedHeadSha}...${HEAD_SHA}?per_page=100&page=1`) body = advancedInput.authorizedHeadAdvance;
+        else if (path === `/repos/${REPOSITORY}/compare/${authorizedMergeBaseSha}...${MERGE_BASE_SHA}?per_page=100&page=1`) body = advancedInput.authorizedBaseAdvance;
+        else if (path === `/repos/${REPOSITORY}/commits/${HEAD_SHA}`) body = advancedInput.commit;
+        else if (path === '/graphql') body = { data: { repository: { object: advancedInput.signature } } };
+        else throw new Error(`Unexpected GitHub API path ${path}`);
+        return { ok: true, json: async () => body } as Response;
+      };
+      await expect(verifier.verifyLiveGeneratedArtifactAuthorization({
+        event: advancedInput.event,
+        manifest: advancedInput.manifest,
+        environment: advancedInput.environment,
+        token: 'test-token',
+        fetchImpl: advanceFetch,
+        repositoryRoot: checkoutRoot,
+        now: advancedInput.now,
+      })).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
+      expect(advancePaths).toContain(
+        `/repos/${REPOSITORY}/compare/${authorizedHeadSha}...${HEAD_SHA}?per_page=100&page=1`,
+      );
+      expect(advancePaths).toContain(
+        `/repos/${REPOSITORY}/compare/${authorizedMergeBaseSha}...${MERGE_BASE_SHA}?per_page=100&page=1`,
       );
 
       const racedInput = authorizedInput();


### PR DESCRIPTION
Fix-forward for PR #3749 only.

The trusted base keeps the exact 1209-file generated closure and exact live owner-signature check, while allowing the already-authorized head/merge-base anchors to advance only when GitHub proves a strictly-ahead descendant of at most 100 commits and fewer than 300 changed files, with no `dist/` or `bridge/` path (including rename/copy previous paths).

Focused evidence:
- generated authorization + artifact tests: 26/26 pass on main;
- TypeScript no-emit check passes;
- independent GJC trust review: CLEAR / APPROVE after pagination and adversarial coverage fixes.

No product, issue #3712/#3698, tag, release, or npm mutation.