### PR TITLE
ci: authorize final PR #3749 security closure

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1843,12 +1843,12 @@
       "pullNumber": 3749,
       "targetRef": "main",
       "mergeBaseSha": "94e71c3630acbfb4f26dee6df4b78af30bab1563",
-      "headSha": "9045c4dd796d78fabd87e3baa60a5e951e652dcd",
+      "headSha": "61398e62d0aff68ddeabe6dbd66eba6ae4e79f0a",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-29T00:00:00.000Z",
       "generatedDelta": {
-        "count": 1209,
-        "sha256": "16cb44d6561be47ee46756f110233a0d64c2a615b3d776d6ba6811a37fc46028"
+        "count": 1224,
+        "sha256": "3b72c9ab3ddf6a5dd2d1aedd84856242687856862a7fbcac9a764b75ac6bf143"
       },
       "generatedFiles": [
         {
@@ -2506,6 +2506,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/__tests__/package-dir-resolution-regression.test.js",
+          "sha": "9b4542b5ca04fdf650d278f92be15c2522953c48",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/package-dir-resolution-regression.test.js.map",
+          "sha": "c18e4fa6061879b257408609cb51e2b38c45b990",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/__tests__/plugin-shipping-surface.test.d.ts",
           "sha": "40accf3f69562564f3822a0cc3da7549b0f6cdae",
@@ -2914,6 +2926,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/__tests__/session-start-cache-cleanup.test.js",
+          "sha": "4963628a3348fb38478bbf00be2da2d7c858aada",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/session-start-cache-cleanup.test.js.map",
+          "sha": "ef2484603e4a04bd30c5b9b0a617edc4b48aabd0",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.d.ts",
           "sha": "e3764db70a992e141b802c72bd1b95b041265cbd",
@@ -2928,13 +2952,13 @@
         {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.js",
-          "sha": "438b03f4ad3c33ebcf5505fad85831b23fc2e83a",
+          "sha": "5987d88855013f987b42840f837d9319c4b1a751",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.js.map",
-          "sha": "a6aa7e3979b3c84a6c2a01fa7b841932d24bb1f4",
+          "sha": "cd1c8b5fc25c6fdaaa6d4450b2c16242ef557844",
           "previousFilename": null
         },
         {
@@ -3067,6 +3091,18 @@
           "status": "modified",
           "filename": "dist/__tests__/tier0-contracts.test.js.map",
           "sha": "0793443c7585b8d411f7caef7e1edb583698684a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/tier0-docs-consistency.test.js",
+          "sha": "0880e4e346fe8b505e21a4902f16da1ceb755414",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/tier0-docs-consistency.test.js.map",
+          "sha": "4a7489960e779e755b8f13b20a288c86e93c69ae",
           "previousFilename": null
         },
         {
@@ -4374,13 +4410,13 @@
         {
           "status": "added",
           "filename": "dist/hooks/__tests__/precompact-restore.test.js",
-          "sha": "3a355c5bcd205f651d281faead0954f749890302",
+          "sha": "7283d17fd02928414b672a1e1be8308c06c17533",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/__tests__/precompact-restore.test.js.map",
-          "sha": "49d3b4a3aba68837a063cd579210b8d61a2e2c8c",
+          "sha": "85e5bf7717cd8cdc7a4ace725f9d3c4c3644f48e",
           "previousFilename": null
         },
         {
@@ -4985,6 +5021,18 @@
         },
         {
           "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/cancel-race.test.js",
+          "sha": "a80ea75690b0fc332a00779ab1dd7db446181b1a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/cancel-race.test.js.map",
+          "sha": "1476d270a68fff64b279e9fa9205ebee62bbc1e1",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
           "filename": "dist/hooks/persistent-mode/__tests__/error-handling.test.js",
           "sha": "d0356dd7d3cc4429d09f376d8743570ea664e0e6",
           "previousFilename": null
@@ -5005,6 +5053,18 @@
           "status": "modified",
           "filename": "dist/hooks/persistent-mode/__tests__/idle-repo-state.test.js.map",
           "sha": "0388a773c947d3152327e9d4e76ecc88906f75ee",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/team-ralplan-stop.test.js",
+          "sha": "6a9f70ae1350d30102cdbb98d21304549295a615",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/team-ralplan-stop.test.js.map",
+          "sha": "4e528739c87cd65fb187f9e2b43d0e3a34d7a5c8",
           "previousFilename": null
         },
         {
@@ -5112,25 +5172,25 @@
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.d.ts",
-          "sha": "3f4cb663e8c4f5dadcae7acde50bf00d7a6c1681",
+          "sha": "d59c225e405cbf09bf7b765bb232122628a79717",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.d.ts.map",
-          "sha": "e12a727668a6203f087ddb5ac4fab4ea6c7391ab",
+          "sha": "63e1b6644b82bc602bf6e3f7b1d519a1a37df158",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.js",
-          "sha": "926cd46b4cad8f5aaaf021c2c1a7f50a41b28a38",
+          "sha": "44c754c5105873ca01fb07f665cc7e2dbd3495a1",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.js.map",
-          "sha": "a20e636d552be306b1507371cbfa25a53aff1198",
+          "sha": "6e5ae9e423354fbe6f13f4fc38050bee5cc298ce",
           "previousFilename": null
         },
         {
@@ -6372,13 +6432,13 @@
         {
           "status": "modified",
           "filename": "dist/installer/__tests__/hook-templates.test.js",
-          "sha": "5aeb701734a1ed686cee6268d1c5e2e38dbfd87e",
+          "sha": "f2fb195cc44b7cca8c8cff99b7294d485cfef38b",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/__tests__/hook-templates.test.js.map",
-          "sha": "4d4e56bd553a2b56098037438512ba5664459dda",
+          "sha": "e7b923945ac8611dd1397e83db94823d49c14296",
           "previousFilename": null
         },
         {
@@ -8860,6 +8920,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/utils/__tests__/frontmatter.test.js",
+          "sha": "4a5cf35cb70543812a7083dc905e1cb458bc67b7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/__tests__/frontmatter.test.js.map",
+          "sha": "7eb902ee8e5ab44509dff1daedade461372ed924",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/utils/__tests__/jsonc.test.d.ts",
           "sha": "c8c2b8d22f6263cfc5c8a2c26439181984d74b60",
@@ -8905,6 +8977,24 @@
           "status": "added",
           "filename": "dist/utils/cache-occupancy.js.map",
           "sha": "89aeba3271f08d243042a0f0564ec9d3f942e652",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/frontmatter.d.ts.map",
+          "sha": "db2ee6259828dbe5fab835ea27880001b2c36c19",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/frontmatter.js",
+          "sha": "aee3f71ffa00679c5d6f9cc84835f47ad36b6bb0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/frontmatter.js.map",
+          "sha": "415b52ecc1122f0f055a72cdd9e802d315476978",
           "previousFilename": null
         },
         {

--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1842,49 +1842,49 @@
     {
       "pullNumber": 3749,
       "targetRef": "main",
-      "mergeBaseSha": "bb8d38d95f978bad0b524ad74da061e3b8183829",
-      "headSha": "8247ee7a50cf75f770f36a0992254ff90cd97446",
+      "mergeBaseSha": "94e71c3630acbfb4f26dee6df4b78af30bab1563",
+      "headSha": "9045c4dd796d78fabd87e3baa60a5e951e652dcd",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-29T00:00:00.000Z",
       "generatedDelta": {
         "count": 1209,
-        "sha256": "ba45c12b2a2ba470247a7385928148bbb07f225799a866a44b8e4536059ce7e8"
+        "sha256": "16cb44d6561be47ee46756f110233a0d64c2a615b3d776d6ba6811a37fc46028"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
-          "sha": "fc965177b47e2bdcbc2b38cbe3b5045e0693cbcb",
+          "sha": "09490253ccbf7c537a1a36caf96ab477148bcca1",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "bea9acbad953c6b12837628dc80675762bc7f2b4",
+          "sha": "f80814e27febe1abff8f0bc43426da427119b94c",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/mcp-server.cjs",
-          "sha": "41a5353a7cfdb124a362236cc5b858e59f0e643d",
+          "sha": "fb4ec3b2509df48dcb3ee16e195589c0d138de6f",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/runtime-cli.cjs",
-          "sha": "7aed036b4d52a80997b3eafe5e5ee634e6fe789e",
+          "sha": "5cf949c7693877ddd6370a0342da2b2b325db5b0",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/team-mcp.cjs",
-          "sha": "72aa7cf6a6c0753b48390a3e3de518491616fc5f",
+          "sha": "64bae2bb42b0eb92c77fbadcdda23d3fc3a047ee",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/team.js",
-          "sha": "e106593d0fc3697574186868673c560025a90310",
+          "sha": "d7f90bcc6e156825ce2cb906b29548b4989d69b6",
           "previousFilename": null
         },
         {
@@ -1914,13 +1914,13 @@
         {
           "status": "modified",
           "filename": "dist/__tests__/auto-slash-aliases.test.js",
-          "sha": "43603758dc15b70a4d36eb9e346bc7d6092a571c",
+          "sha": "f27a32090f5d0c7d8d4cd62661360fc8cc067ca5",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/auto-slash-aliases.test.js.map",
-          "sha": "02251ad95a5e80a21ef55cd083efcca9cadd775c",
+          "sha": "15bf43abd7842902a4ebae6f476cabb81b381834",
           "previousFilename": null
         },
         {
@@ -2094,13 +2094,13 @@
         {
           "status": "added",
           "filename": "dist/__tests__/generated-artifact-authorization.test.js",
-          "sha": "5df12ce473aa7f9b23160afe06d02ca629242e33",
+          "sha": "4ea8151d1487e01e56b930cd53aa185a096a855c",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/generated-artifact-authorization.test.js.map",
-          "sha": "e907dfa50e004a3b67894f3929d31847dce5ca39",
+          "sha": "ea09b290d7b098753e676b2538ebdb95ee61f317",
           "previousFilename": null
         },
         {
@@ -2736,25 +2736,25 @@
         {
           "status": "added",
           "filename": "dist/__tests__/release-boundary.test.js",
-          "sha": "932a852cc8a443d522211d44774b8ee1765b8c5c",
+          "sha": "e2b6f27c959b7602eb1daf3b37827c2393415b51",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/release-boundary.test.js.map",
-          "sha": "3da7b5a4d87641f8031968f806584cc6eadefb7e",
+          "sha": "b7d466f00585d50a91e049cd3f2c68c6f5a995d9",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/release-generation.test.js",
-          "sha": "a7a7b8f01335a29a40ffb736f6b0e945e2082512",
+          "sha": "b79569d0140bb3140571c96298a63051703131a1",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/release-generation.test.js.map",
-          "sha": "164eab64cdec36f35b4bea396ff6de806aa55544",
+          "sha": "3b0d8115bf29542d6f455e9723fc312329594f90",
           "previousFilename": null
         },
         {
@@ -2928,13 +2928,13 @@
         {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.js",
-          "sha": "553f9b6e9841127c8655622c4935c99750f74b87",
+          "sha": "438b03f4ad3c33ebcf5505fad85831b23fc2e83a",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.js.map",
-          "sha": "3f8733928a27c97dd7b4926bf10f31dc3c416785",
+          "sha": "a6aa7e3979b3c84a6c2a01fa7b841932d24bb1f4",
           "previousFilename": null
         },
         {
@@ -4338,13 +4338,13 @@
         {
           "status": "modified",
           "filename": "dist/hooks/__tests__/bridge-routing.test.js",
-          "sha": "4478d58a3d7fb1e0aec6b6ca59aa920ae2790ee3",
+          "sha": "d4ffcb921a26d3f4d5cce8378d44f3e0a9952b78",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/__tests__/bridge-routing.test.js.map",
-          "sha": "189493e7ec0f5096660850c4d139629a691a7774",
+          "sha": "62c11cce7867696ee6947be1fb5441d9572521bd",
           "previousFilename": null
         },
         {
@@ -4374,13 +4374,13 @@
         {
           "status": "added",
           "filename": "dist/hooks/__tests__/precompact-restore.test.js",
-          "sha": "eda029b0c9f764f031af86797e600b3f86ac7cf8",
+          "sha": "3a355c5bcd205f651d281faead0954f749890302",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/__tests__/precompact-restore.test.js.map",
-          "sha": "de3d59e9797d8fb428b1caa30171827cd14a2485",
+          "sha": "49d3b4a3aba68837a063cd579210b8d61a2e2c8c",
           "previousFilename": null
         },
         {
@@ -4734,19 +4734,19 @@
         {
           "status": "modified",
           "filename": "dist/hooks/bridge.d.ts.map",
-          "sha": "e4feb6ca36a2097c3e7da9f9e6a851099925e246",
+          "sha": "0a89e8efcbfd7bbcf4d1f8c0e770cd5d1329dca3",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/bridge.js",
-          "sha": "46b8142c241d40a5af402e9cb7a840d5da195b3f",
+          "sha": "7abed6bdbcb06e23e6180f5984053bcee826f37b",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/bridge.js.map",
-          "sha": "5eaf4d34b7a11db72e74c3a5554185de1e643076",
+          "sha": "34514b0b7d3e05a1353f868f337e8fc98359b217",
           "previousFilename": null
         },
         {
@@ -5076,13 +5076,13 @@
         {
           "status": "modified",
           "filename": "dist/hooks/persistent-mode/session-isolation.test.js",
-          "sha": "e71cbfe3aa255a998c04a7eae524f78104252c54",
+          "sha": "cc9eb9d003608fb32e361eb3b122c1a6889389d1",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/persistent-mode/session-isolation.test.js.map",
-          "sha": "014e1bbe89664aac27fb10a632405ccfa5ab2c27",
+          "sha": "c6520eea997a5f56526c43207214384309310753",
           "previousFilename": null
         },
         {
@@ -5112,25 +5112,25 @@
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.d.ts",
-          "sha": "6fa52359b0c79c2a940013d3b1049ba7051023d2",
+          "sha": "3f4cb663e8c4f5dadcae7acde50bf00d7a6c1681",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.d.ts.map",
-          "sha": "a892d6b2e129096d172f8d4a19df143c7b02f241",
+          "sha": "e12a727668a6203f087ddb5ac4fab4ea6c7391ab",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.js",
-          "sha": "b02f42bd3badbeab67621fa92fa63998262458da",
+          "sha": "926cd46b4cad8f5aaaf021c2c1a7f50a41b28a38",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.js.map",
-          "sha": "04a35d0886bd0d8fa40892e8d99195e78255909f",
+          "sha": "a20e636d552be306b1507371cbfa25a53aff1198",
           "previousFilename": null
         },
         {
@@ -5442,25 +5442,25 @@
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.d.ts",
-          "sha": "7165885096f764877694028f3ba46a19fc2950dc",
+          "sha": "efb8ebc0a1c9d49c726ddf420ba8c036d95c921e",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.d.ts.map",
-          "sha": "591f0906046a098d25f8127c371e30a2cb1866b9",
+          "sha": "aa3d459835fe937d8c5ddaa4d5832a8f4f42b011",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.js",
-          "sha": "7c7557e28bec88ec66aad389bf09c2a5e4b30953",
+          "sha": "2628d7a210e155d10aac55f2c771edd01b9a9ef0",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.js.map",
-          "sha": "c78e2d8f26612fd5d589a84da5b0fa61395eec70",
+          "sha": "ae2440f1e16b8c1fc88d94488ba8a1a4ea25ef53",
           "previousFilename": null
         },
         {
@@ -6372,13 +6372,13 @@
         {
           "status": "modified",
           "filename": "dist/installer/__tests__/hook-templates.test.js",
-          "sha": "4fee5c740c0e4a5a86c74e2885ab40291417b0de",
+          "sha": "5aeb701734a1ed686cee6268d1c5e2e38dbfd87e",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/__tests__/hook-templates.test.js.map",
-          "sha": "af2b75e6c82e9896db4eb60445dd2f6da84b3263",
+          "sha": "4d4e56bd553a2b56098037438512ba5664459dda",
           "previousFilename": null
         },
         {
@@ -8886,25 +8886,25 @@
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.d.ts",
-          "sha": "0a851bd97569c486197118017a73fd618c0680a7",
+          "sha": "69fe82eebbc85eae207b54a0e43eaa94d90d6f25",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.d.ts.map",
-          "sha": "e4263f8a5e4bcc739681ce09fd6e8f4eb452e71d",
+          "sha": "11f127586bd4e1f5e0e5002aac0bb75164bbaa8d",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.js",
-          "sha": "a490f176669e506c46e4190c7b8bb6f23a4e0a61",
+          "sha": "90e7aeff57b4bccb2710e1c39fc61811e0b9070f",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.js.map",
-          "sha": "37cd0581b285024b0f02ea8ec9c6e05e5e5a6a24",
+          "sha": "89aeba3271f08d243042a0f0564ec9d3f942e652",
           "previousFilename": null
         },
         {
@@ -8916,19 +8916,19 @@
         {
           "status": "modified",
           "filename": "dist/utils/paths.d.ts.map",
-          "sha": "b1867dada899e1f539f3d505059371d6a25a3b8a",
+          "sha": "1119d505eafc84bba18badbbef03aa69a9d766e2",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/utils/paths.js",
-          "sha": "fdbf696ed2f6ecb51635122792f1f6a048c118df",
+          "sha": "b0d4eb2e26c9b45d2671af2a2ee4889b822697f7",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/utils/paths.js.map",
-          "sha": "af5b34febf9eb98e71760e3f5e1783dbfd3cd3fd",
+          "sha": "e5c0da0cf26a591c0c49008cd0db5a35732e4f8f",
           "previousFilename": null
         },
         {


### PR DESCRIPTION
Fix-forward for PR #3749 only.

Trusted manifest update:
- head `9045c4dd796d78fabd87e3baa60a5e951e652dcd`
- merge base `94e71c3630acbfb4f26dee6df4b78af30bab1563`
- generated files `1209`
- generated digest `16cb44d6561be47ee46756f110233a0d64c2a615b3d776d6ba6811a37fc46028`

All other authorization records are byte-preserved. Focused base-owned authorization/artifact tests pass 26/26. No release/tag/npm/product or issue mutation.