### PR TITLE
fix(team): skip cleaned startup panes as split targets

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "55971c5c3c0ff2febabc2e0b35355afbf62c7988",
-    "sourceSha256": "96418572ba59ff09a1a1f8d78260365365643d67db37b5a765a9f9811599376b",
+    "head": "c9bee54ed5f5d8ecf54715ce93507457faaeec45",
+    "sourceSha256": "f7c2be4f325a924739ec7cdd7949ecbb943345d45e8927b38895cc5b6483db37",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "55971c5c3c0ff2febabc2e0b35355afbf62c7988",
-  "sourceSha256": "96418572ba59ff09a1a1f8d78260365365643d67db37b5a765a9f9811599376b",
+  "head": "c9bee54ed5f5d8ecf54715ce93507457faaeec45",
+  "sourceSha256": "f7c2be4f325a924739ec7cdd7949ecbb943345d45e8927b38895cc5b6483db37",
   "counts": {
     "public": {
       "skills": 31,
@@ -74781,5 +74781,5 @@
     }
   },
   "inventorySha256": "701586753abe736094554bb05bb7f721f9813c8a171f2b664b51c8d63bf06087",
-  "manifestSha256": "2d0e90a93a0db7e1e02b0a0de4dc53191bd3ad3dcea2a4ebeefab803799ec61b"
+  "manifestSha256": "ab31735dd86020a9584d2436fd5860ad36e9bd87639cd62e53bf403f220159d1"
 }

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -170,10 +170,12 @@ describe('runtime v2 startup inbox dispatch', () => {
     mocks.resolveSplitPaneWorkerPaneIds.mockReset();
     mocks.killOwnedWorkerPane.mockClear();
     mocks.getWorkerLiveness.mockReset();
+    mocks.workerPaneBelongsToProviderTarget.mockReset();
     mocks.killTeamSession.mockResolvedValue(undefined);
     mocks.killWorkerPanes.mockResolvedValue(undefined);
     mocks.resolveSplitPaneWorkerPaneIds.mockImplementation(async (_session: string | undefined, paneIds: string[]) => paneIds);
     mocks.getWorkerLiveness.mockImplementation(async () => mocks.killOwnedWorkerPane.mock.calls.length > 0 ? 'dead' : 'alive');
+    mocks.workerPaneBelongsToProviderTarget.mockResolvedValue(true);
     mocks.execFile.mockReset();
     mocks.spawnSync.mockReset();
     modelContractMocks.buildWorkerArgv.mockReset();
@@ -996,7 +998,7 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(mocks.killOwnedWorkerPane).toHaveBeenCalled();
   });
 
-  it('tears down the owned worker launch when startup readiness fails', async () => {
+  it('does not retain a torn-down worker pane as a future split target when startup readiness fails', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-no-autokill-ready-'));
     mocks.deliverStartupInbox.mockResolvedValueOnce({ ok: false, reason: 'readiness_timeout' });
     const { startTeamV2 } = await import('../runtime-v2.js');
@@ -1014,6 +1016,46 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(mocks.execFile.mock.calls.some((call) => call[1]?.[0] === 'kill-pane')).toBe(false);
     expect(mocks.killOwnedWorkerPane).toHaveBeenCalledWith(expect.objectContaining({ paneId: '%2' }));
   });
+
+  it.each(['readiness_timeout', 'copy_mode'])(
+    'uses a live pane after a cleaned %s startup failure',
+    async (failureReason) => {
+      cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-cleaned-pane-split-'));
+      const deadPaneIds = new Set<string>();
+      mocks.deliverStartupInbox.mockResolvedValueOnce({ ok: false, reason: failureReason });
+      mocks.nextStartupTaskId = 2;
+      mocks.killOwnedWorkerPane.mockImplementationOnce(async (...args: unknown[]) => {
+        const [ownership] = args as [{ paneId: string }];
+        deadPaneIds.add(ownership.paneId);
+      });
+      mocks.workerPaneBelongsToProviderTarget.mockImplementation(async (...args: unknown[]) => {
+        const [{ paneId }] = args as [{ paneId: string }];
+        return !deadPaneIds.has(paneId);
+      });
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      const runtime = await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 2,
+        agentTypes: ['claude', 'claude'],
+        tasks: [
+          { subject: 'First dispatch', description: 'This worker fails startup and is cleaned up' },
+          { subject: 'Second dispatch', description: 'This worker starts from a live split target' },
+        ],
+        cwd,
+      });
+
+      expect(runtime.config.workers[0]?.pane_id).toBe('%2');
+      expect(runtime.config.workers[1]).toMatchObject({ pane_id: '%3', assigned_tasks: ['2'] });
+      expect(mocks.spawnWorkerInPane).toHaveBeenNthCalledWith(
+        2,
+        'dispatch-session',
+        '%3',
+        expect.objectContaining({ workerName: 'worker-2' }),
+      );
+      expect(mocks.killOwnedWorkerPane).toHaveBeenCalledWith(expect.objectContaining({ paneId: '%2' }));
+    },
+  );
 
   it('tears down the owned worker launch when startup notification fails', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-v2-no-autokill-notify-'));

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -3390,7 +3390,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     });
 
     if (workerLaunch.paneId) {
-      workerPaneIds.push(workerLaunch.paneId);
+      if (workerLaunch.startupAssigned) workerPaneIds.push(workerLaunch.paneId);
       launchedWorkers.push({
         name: wName, paneId: workerLaunch.paneId,
         ...(workerLaunch.launchAttemptId ? { launchAttemptId: workerLaunch.launchAttemptId } : {}),


### PR DESCRIPTION
Fixes #3771

A worker whose startup dispatch fails is cleaned up but previously remained in `workerPaneIds`. The next worker then attempted to split from that dead pane.

This retains failed-launch accounting and rollback metadata while admitting only `startupAssigned` panes as future split targets.

Regression coverage exercises `readiness_timeout` and `copy_mode` failures followed by a successful second worker. Thanks to @tomichill for the detailed reproduction.