### PR TITLE
chore(ci): authorize PR 3772 generated artifacts

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -9986,6 +9986,56 @@
           "previousFilename": null
         }
       ]
+    },
+    {
+      "pullNumber": 3772,
+      "targetRef": "dev",
+      "mergeBaseSha": "0c4be7677c8ccf741ae08060ff644669e86c4ccd",
+      "headSha": "0f1bac4a8e3e5cf44c35861c68cef9230b257df7",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-09-22T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 6,
+        "sha256": "2fea2afade8ef6c147ade8dbe3cadac614e72c5cae2cbbc839d3a44114cdaaba"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/runtime-cli.cjs",
+          "sha": "fffbef1cf779f6c53d9c9da39803f3ec5a31ec8f",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "bridge/team.js",
+          "sha": "dc0cf0d601843864caed4f5467e505969724ba66",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/__tests__/runtime-v2.dispatch.test.js",
+          "sha": "5893a5a1fc6a7eeb5fdf76dfbf76a3d620786030",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/__tests__/runtime-v2.dispatch.test.js.map",
+          "sha": "37c8aa8f4c4bce58f02f1ebc43e6ff6a676773bb",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js",
+          "sha": "a415c80238ab061a3170b5c16e3d05e731ad82c7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js.map",
+          "sha": "b17208405cc6e847fb4f3a108f610206e2f90b67",
+          "previousFilename": null
+        }
+      ]
     }
   ]
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "86c743a3491a66c1a61d7b04da2c3c3606add5f3",
-    "sourceSha256": "0c9232c44fb2668bdf4e2d12642e500bf83c6f65542c4b551dbb96b9d0221cf0",
+    "head": "648dcf97f96a6761b30f697e5fb6a1841c29eac6",
+    "sourceSha256": "b147f4ede84e355f7b0a1ec3f3904812bf63e7f3b3370a44ca22b3cad5a6c87d",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "86c743a3491a66c1a61d7b04da2c3c3606add5f3",
-  "sourceSha256": "0c9232c44fb2668bdf4e2d12642e500bf83c6f65542c4b551dbb96b9d0221cf0",
+  "head": "648dcf97f96a6761b30f697e5fb6a1841c29eac6",
+  "sourceSha256": "b147f4ede84e355f7b0a1ec3f3904812bf63e7f3b3370a44ca22b3cad5a6c87d",
   "counts": {
     "public": {
       "skills": 31,
@@ -74781,5 +74781,5 @@
     }
   },
   "inventorySha256": "701586753abe736094554bb05bb7f721f9813c8a171f2b664b51c8d63bf06087",
-  "manifestSha256": "198afd2f513bc0a2a44dab26fa56a42ef2820bc41b44465e333f2ce6373f2d44"
+  "manifestSha256": "a34ecbee3e4e1b1c0a3c35976edf60886578453bd77fd9ac35e5cb19322f3a9b"
 }

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -290,6 +290,7 @@ describe('generated-artifact base trust root workflow', () => {
       [3692, 'dev'],
       [3697, 'dev'],
       [3749, 'main'],
+      [3772, 'dev'],
     ]);
     expect(manifest.authorizations.find(entry => entry.pullNumber === 3538)).toMatchObject({
       targetRef: 'dev',


### PR DESCRIPTION
Authorizes the exact six-file `dist/`/`bridge/` closure for #3772 at `0f1bac4a8e3e5cf44c35861c68cef9230b257df7`.

This base-owned manifest entry is intentionally limited to the verified generated blob records and expires on 2026-09-22.

Refs #3772