### PR TITLE
chore(ci): reauthorize rebased PR 3772 head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -9990,8 +9990,8 @@
     {
       "pullNumber": 3772,
       "targetRef": "dev",
-      "mergeBaseSha": "0c4be7677c8ccf741ae08060ff644669e86c4ccd",
-      "headSha": "0f1bac4a8e3e5cf44c35861c68cef9230b257df7",
+      "mergeBaseSha": "71d83ff6b9eac9654214d4797dc1c6236ba6fce5",
+      "headSha": "5c553cfbf1dcca72ad6d8aac0f51fa055ae6b66f",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-09-22T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Updates the base-owned #3772 authorization identity after its rebase onto dev.

The six-file generated closure and SHA-256 digest are unchanged; only `mergeBaseSha` and `headSha` are advanced to the exact current #3772 identity.

Refs #3772