### PR TITLE
fix(team): propagate provider home directory

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "db70d3a2a5eac3fd52393e72ba12b167a1047c5e",
-    "sourceSha256": "059767e88ccf093579ce171d261765a385ed3289d506d8f01ed185fc3da757cf",
+    "head": "bb440f06359f5499c190e211da61ef75811a2f41",
+    "sourceSha256": "78770d389b38b062bfb61aa7bc549ebcd71f95d0bfdd98ad19d68ef2a6aeef52",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "db70d3a2a5eac3fd52393e72ba12b167a1047c5e",
-  "sourceSha256": "059767e88ccf093579ce171d261765a385ed3289d506d8f01ed185fc3da757cf",
+  "head": "bb440f06359f5499c190e211da61ef75811a2f41",
+  "sourceSha256": "78770d389b38b062bfb61aa7bc549ebcd71f95d0bfdd98ad19d68ef2a6aeef52",
   "counts": {
     "public": {
       "skills": 31,
@@ -68889,6 +68889,11 @@
       },
       {
         "from": "src/team/__tests__/worker-launch-ack.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-ack.test.ts",
         "to": "external:node:fs/promises",
         "kind": "imports"
       },
@@ -74780,11 +74785,11 @@
     ],
     "stats": {
       "nodeCount": 6820,
-      "edgeCount": 6873,
-      "importEdgeCount": 5632,
+      "edgeCount": 6874,
+      "importEdgeCount": 5633,
       "registerEdgeCount": 52
     }
   },
   "inventorySha256": "701586753abe736094554bb05bb7f721f9813c8a171f2b664b51c8d63bf06087",
-  "manifestSha256": "2d0fecd37ca2c3b8427c8b69a9f4625e2ff6314f010f5c203ba3f37da323e05e"
+  "manifestSha256": "e4ec44c7af1327b6302812215bb34580d85e210065e2ffb47ed9e5254bc832c8"
 }

--- a/src/team/__tests__/worker-launch-ack.test.ts
+++ b/src/team/__tests__/worker-launch-ack.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -22,6 +23,7 @@ import {
   retireAndCleanupCurrentWorkerLaunchAttempt,
   terminateWorkerLaunchProvider,
   revokeWorkerLaunchAttempt,
+  buildProviderEnvironment,
   buildProviderSpawnInvocation,
   materializeProviderSpawnInvocation,
   quoteWindowsCreateProcessArgument,
@@ -694,7 +696,12 @@ describe('worker launch acknowledgement', () => {
       nonce: launchAttempt.nonce,
     });
     expect(descriptor.provider_argv).toEqual(providerArgv);
-    expect(descriptor.provider_env).toEqual(providerEnv);
+    const homeKey = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+    const ambientHome = process.env[homeKey];
+    expect(descriptor.provider_env).toEqual({
+      ...providerEnv,
+      ...(ambientHome ? { [homeKey]: ambientHome } : {}),
+    });
     await expect(materializeWorkerLaunchTransport({
       attempt: launchAttempt,
       providerArgv: ['codex'],
@@ -760,6 +767,72 @@ describe('worker launch acknowledgement', () => {
     await expect(readFile(launchAttempt.bootstrapDescriptorPath, 'utf8')).resolves.toContain(launchAttempt.attempt_id);
   });
 
+  it('propagates only the canonical home variable for each platform', () => {
+    const posix = buildProviderEnvironment(undefined, {
+      PATH: '/usr/bin:/bin',
+      HOME: '/home/provider',
+      USERPROFILE: 'C:\\Users\\wrong-platform',
+      GH_TOKEN: 'ambient-secret',
+    }, 'linux');
+    expect(posix).toEqual({ PATH: '/usr/bin:/bin', HOME: '/home/provider' });
+
+    const windows = buildProviderEnvironment(undefined, {
+      PATH: 'C:\\Windows\\System32',
+      HOME: '/home/wrong-platform',
+      USERPROFILE: 'C:\\Users\\provider',
+      SystemRoot: 'C:\\Windows',
+      GH_TOKEN: 'ambient-secret',
+    }, 'win32');
+    expect(windows).toEqual({
+      PATH: 'C:\\Windows\\System32',
+      SystemRoot: 'C:\\Windows',
+      USERPROFILE: 'C:\\Users\\provider',
+    });
+  });
+
+  it('omits missing or empty ambient homes while preserving explicit overrides', () => {
+    expect(buildProviderEnvironment(undefined, { PATH: '/usr/bin:/bin' }, 'linux'))
+      .toEqual({ PATH: '/usr/bin:/bin' });
+    expect(buildProviderEnvironment(undefined, {
+      PATH: '/usr/bin:/bin', HOME: '', USERPROFILE: 'C:\\Users\\wrong-platform',
+    }, 'linux')).toEqual({ PATH: '/usr/bin:/bin' });
+    expect(buildProviderEnvironment(undefined, {
+      PATH: 'C:\\Windows\\System32', USERPROFILE: '', HOME: '/home/wrong-platform',
+    }, 'win32')).toEqual({ PATH: 'C:\\Windows\\System32' });
+
+    expect(buildProviderEnvironment({ HOME: '/home/explicit' }, {
+      PATH: '/usr/bin:/bin', HOME: '/home/ambient',
+    }, 'linux')).toMatchObject({ PATH: '/usr/bin:/bin', HOME: '/home/explicit' });
+    expect(buildProviderEnvironment({ USERPROFILE: 'D:\\Users\\explicit' }, {
+      PATH: 'C:\\Windows\\System32', USERPROFILE: 'C:\\Users\\ambient',
+    }, 'win32')).toMatchObject({ PATH: 'C:\\Windows\\System32', USERPROFILE: 'D:\\Users\\explicit' });
+    expect(buildProviderEnvironment({ userprofile: 'D:\\Users\\mixed-case' }, {
+      PATH: 'C:\\Windows\\System32', USERPROFILE: 'C:\\Users\\ambient',
+    }, 'win32')).toEqual({ PATH: 'C:\\Windows\\System32', userprofile: 'D:\\Users\\mixed-case' });
+    expect(buildProviderEnvironment({ HOME: '' }, {
+      PATH: '/usr/bin:/bin', HOME: '/home/ambient',
+    }, 'linux')).toMatchObject({ PATH: '/usr/bin:/bin', HOME: '' });
+  });
+
+  it.runIf(process.platform !== 'win32' && Boolean(process.env.HOME) && existsSync('/bin/bash'))(
+    'passes HOME to a real set -u bash provider wrapper',
+    async () => {
+      const launchAttempt = await attempt();
+      const marker = join(cwd, 'provider-home.txt');
+      const spec = buildWorkerLaunchBootstrapSpec(
+        launchAttempt,
+        ['/bin/bash', '--noprofile', '--norc', '-u', '-c', 'set -u; printf "%s" "$HOME" > "$1"; sleep 0.2', 'bash-provider', marker],
+        cwd,
+        { releaseAfterSpawn: true },
+      );
+      const bootstrap = runWorkerLaunchBootstrap(spec);
+      await expect(awaitWorkerLaunchAcknowledgement(launchAttempt, { timeoutMs: 2_000, pollIntervalMs: 5 }))
+        .resolves.toEqual({ ok: true });
+      await expect(bootstrap).resolves.toEqual({ outcome: 'ran', exitCode: 0, signal: null });
+      await expect(readFile(marker, 'utf8')).resolves.toBe(process.env.HOME);
+    },
+  );
+
   it('validates provider environment keys and propagates only explicit provider values', async () => {
     const launchAttempt = await attempt();
     expect(() => buildWorkerLaunchBootstrapSpec(launchAttempt, ['codex'], cwd, {
@@ -791,6 +864,19 @@ describe('worker launch acknowledgement', () => {
       value: 'provider-value',
       attempt: launchAttempt.attempt_id,
     });
+  });
+
+  it('rejects provider environment tampering through the authority digest', async () => {
+    const launchAttempt = await attempt();
+    const spec = buildWorkerLaunchBootstrapSpec(launchAttempt, ['codex'], cwd, {
+      providerEnv: { HOME: '/home/authority-original' },
+    });
+    const tampered = {
+      ...spec,
+      provider_env: { ...spec.provider_env, HOME: '/home/authority-tampered' },
+    };
+    expect(tampered.authority_digest).toBe(spec.authority_digest);
+    await expect(runWorkerLaunchBootstrap(tampered)).resolves.toEqual({ outcome: 'invalid_spec' });
   });
 
   it('routes native Windows batch shims through a percent-safe temporary wrapper without changing POSIX argv', async () => {
@@ -935,7 +1021,7 @@ describe('worker launch acknowledgement', () => {
   it('excludes ambient secret environment values and rejects Windows aliases', async () => {
     const launchAttempt = await attempt();
     const spec = buildWorkerLaunchBootstrapSpec(launchAttempt, ['codex'], cwd, { providerEnv: { EXPLICIT: 'yes' } });
-    for (const key of ['GH_TOKEN', 'AWS_SECRET_ACCESS_KEY', 'ANTHROPIC_API_KEY', 'NODE_OPTIONS', 'HTTPS_PROXY', 'HOME', 'USERPROFILE']) {
+    for (const key of ['GH_TOKEN', 'AWS_SECRET_ACCESS_KEY', 'ANTHROPIC_API_KEY', 'NODE_OPTIONS', 'HTTPS_PROXY']) {
       expect(spec.provider_env).not.toHaveProperty(key);
     }
     const originalPlatform = process.platform;

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -234,6 +234,12 @@ export function buildProviderEnvironment(
     const value = sourceEnv[key];
     if (typeof value === 'string' && value.length > 0) baseline[key] = value;
   }
+  const homeKey = platform === 'win32' ? 'USERPROFILE' : 'HOME';
+  const home = sourceEnv[homeKey];
+  const hasExplicitHome = Object.keys(normalized).some(key => (
+    platform === 'win32' ? key.toUpperCase() === homeKey : key === homeKey
+  ));
+  if (!hasExplicitHome && typeof home === 'string' && home.length > 0) baseline[homeKey] = home;
   if (platform === 'win32') {
     const systemRoot = sourceEnv.SystemRoot ?? sourceEnv.SYSTEMROOT;
     if (typeof systemRoot === 'string' && /^[A-Za-z]:\\/.test(systemRoot)) baseline.SystemRoot = systemRoot;


### PR DESCRIPTION
## Summary
- propagate only the platform-native provider home variable (`HOME` on POSIX, `USERPROFILE` on Windows)
- preserve the fixed environment allowlist, explicit overrides, Windows case-insensitive home aliases, and secret exclusion
- prove the added `provider_env` value remains bound by `canonicalAuthorityDigest`
- refresh required inventory provenance

## Reproduction
Before the patch, a sanitized provider environment omitted `HOME`; a real bash wrapper using `set -u` and `$HOME` exited nonzero with `HOME: unbound variable`. The regression test launches that wrapper through the worker bootstrap and verifies the propagated home value.

## Verification
- `vitest run src/team/__tests__/worker-launch-ack.test.ts tests/lint/inventory-graph-drift.test.ts` — 53 passed, 4 platform-gated skips
- `tsc --noEmit` — passed
- focused ESLint — passed
- inventory graph `--verify` — passed
- full suite baseline run: 685 files passed; unrelated existing failures remained in post-tool verifier and Python sandbox timing (the inventory drift failure was resolved by the required provenance refresh)

## Scope
Fixes #3788 only. #3789 (Cursor readiness glyph) and #3790 (tmux layout timing) are separate and unchanged.

Signed-off-by: gaebal-gajae <clawdbot@users.noreply.github.com>