### PR TITLE
fix(team): recognize Cursor idle prompt

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0eb316a55592846b14daf5dd5e749c66cad9d80e",
-    "sourceSha256": "558f23cb3d61aa8a2e9cfc2f7eb210a7cff222cbeeae7189cd627896ed216476",
+    "head": "2ccdc1f6c0f680491f62e8be51405d33fc168b85",
+    "sourceSha256": "4e1ef675f62a574a547f3992b7ff13b9cb7abde0a1b07c745c2c3e469cb43932",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0eb316a55592846b14daf5dd5e749c66cad9d80e",
-  "sourceSha256": "558f23cb3d61aa8a2e9cfc2f7eb210a7cff222cbeeae7189cd627896ed216476",
+  "head": "2ccdc1f6c0f680491f62e8be51405d33fc168b85",
+  "sourceSha256": "4e1ef675f62a574a547f3992b7ff13b9cb7abde0a1b07c745c2c3e469cb43932",
   "counts": {
     "public": {
       "skills": 31,
@@ -23,13 +23,13 @@
       "total": 78
     },
     "internal": {
-      "hookFiles": 306,
+      "hookFiles": 307,
       "featureFiles": 68,
       "toolFiles": 56,
       "libFiles": 34,
       "templateHooks": 19,
-      "srcFiles": 1275,
-      "total": 1294
+      "srcFiles": 1277,
+      "total": 1296
     },
     "generated": {
       "distFiles": 4986,
@@ -37,14 +37,14 @@
       "total": 4995
     },
     "prompt": {
-      "promptLikeFiles": 62
+      "promptLikeFiles": 63
     },
     "skills": 31,
     "commands": 21,
-    "hookFiles": 306,
+    "hookFiles": 307,
     "workflows": 8,
     "agentDefinitions": 18,
-    "promptLikeFiles": 62
+    "promptLikeFiles": 63
   },
   "public": {
     "skills": [
@@ -153,6 +153,7 @@
       "src/hooks/__tests__/prompt-prerequisites.test.ts",
       "src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts",
       "src/hooks/__tests__/team-dispatch-cooldown.test.ts",
+      "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
       "src/hooks/__tests__/team-worker-heartbeat.test.ts",
       "src/hooks/__tests__/team-worker-idle-outstanding.test.ts",
       "src/hooks/__tests__/workflow-drift-guard-script.test.ts",
@@ -671,6 +672,7 @@
       "src/features/model-routing/prompts/opus.ts",
       "src/features/model-routing/prompts/sonnet.ts",
       "src/hooks/__tests__/prompt-prerequisites.test.ts",
+      "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
       "src/hooks/autopilot/__tests__/prompts.test.ts",
       "src/hooks/autopilot/prompts.ts",
       "src/hooks/persistent-mode/__tests__/prompt-truncation.test.ts",
@@ -5815,6 +5817,7 @@
       "src/hooks/__tests__/prompt-prerequisites.test.ts",
       "src/hooks/__tests__/stop-hook-openclaw-cooldown.test.ts",
       "src/hooks/__tests__/team-dispatch-cooldown.test.ts",
+      "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
       "src/hooks/__tests__/team-worker-heartbeat.test.ts",
       "src/hooks/__tests__/team-worker-idle-outstanding.test.ts",
       "src/hooks/__tests__/workflow-drift-guard-script.test.ts",
@@ -6158,6 +6161,7 @@
       "src/features/model-routing/prompts/opus.ts",
       "src/features/model-routing/prompts/sonnet.ts",
       "src/hooks/__tests__/prompt-prerequisites.test.ts",
+      "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
       "src/hooks/autopilot/__tests__/prompts.test.ts",
       "src/hooks/autopilot/prompts.ts",
       "src/hooks/persistent-mode/__tests__/prompt-truncation.test.ts",
@@ -36126,6 +36130,11 @@
         "path": "src/hooks/__tests__/team-dispatch-cooldown.test.ts"
       },
       {
+        "id": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "kind": "hook",
+        "path": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts"
+      },
+      {
         "id": "src/hooks/__tests__/team-worker-heartbeat.test.ts",
         "kind": "hook",
         "path": "src/hooks/__tests__/team-worker-heartbeat.test.ts"
@@ -39474,6 +39483,11 @@
         "id": "src/team/outbox-reader.ts",
         "kind": "src",
         "path": "src/team/outbox-reader.ts"
+      },
+      {
+        "id": "src/team/pane-readiness.ts",
+        "kind": "src",
+        "path": "src/team/pane-readiness.ts"
       },
       {
         "id": "src/team/permissions.ts",
@@ -53123,6 +53137,36 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "to": "external:fs/promises",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "to": "src/hooks/team-dispatch-hook.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts",
+        "to": "src/team/dispatch-queue.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/hooks/__tests__/team-worker-heartbeat.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -59705,6 +59749,16 @@
       {
         "from": "src/hooks/team-dispatch-hook.ts",
         "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/hooks/team-dispatch-hook.ts",
+        "to": "src/team/model-contract.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/hooks/team-dispatch-hook.ts",
+        "to": "src/team/pane-readiness.ts",
         "kind": "imports"
       },
       {
@@ -68609,6 +68663,11 @@
       },
       {
         "from": "src/team/__tests__/tmux-session.startup.test.ts",
+        "to": "src/team/pane-readiness.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/tmux-session.startup.test.ts",
         "to": "src/team/tmux-session.ts",
         "kind": "imports"
       },
@@ -70358,6 +70417,11 @@
         "kind": "imports"
       },
       {
+        "from": "src/team/pane-readiness.ts",
+        "to": "src/team/model-contract.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/team/permissions.ts",
         "to": "external:node:path",
         "kind": "imports"
@@ -71651,6 +71715,11 @@
         "from": "src/team/tmux-session.ts",
         "to": "src/team/model-contract.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/team/tmux-session.ts",
+        "to": "src/team/pane-readiness.ts",
+        "kind": "imports"
       },
       {
         "from": "src/team/tmux-session.ts",
@@ -74784,12 +74853,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6820,
-      "edgeCount": 6874,
-      "importEdgeCount": 5633,
+      "nodeCount": 6822,
+      "edgeCount": 6885,
+      "importEdgeCount": 5641,
       "registerEdgeCount": 52
     }
   },
-  "inventorySha256": "701586753abe736094554bb05bb7f721f9813c8a171f2b664b51c8d63bf06087",
-  "manifestSha256": "a67d614d75ac5ee052a3caafe2738d2cb656d785b1e63cbb3525c480af0b9462"
+  "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
+  "manifestSha256": "d4f7a2fdc8602be55f12b32b7f62439ec278a220fa2782d60972dd12b78f8d33"
 }

--- a/src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts
+++ b/src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const tmuxUtilsMocks = vi.hoisted(() => ({
+  tmuxExecAsync: vi.fn(async (_args: string[]) => ({ stdout: '', stderr: '' })),
+}));
+
+vi.mock('../../cli/tmux-utils.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../cli/tmux-utils.js')>(),
+  tmuxExecAsync: tmuxUtilsMocks.tmuxExecAsync,
+}));
+
+import { drainPendingTeamDispatch } from '../team-dispatch-hook.js';
+import type { TeamDispatchRequest } from '../../team/dispatch-queue.js';
+
+const TEAM = 'dispatch-prompt-readiness-team';
+const WORKER = 'worker-1';
+const PANE = '%1';
+
+let root: string;
+let stateDir: string;
+let logsDir: string;
+let teamDir: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+function makeRequest(): TeamDispatchRequest {
+  const now = new Date().toISOString();
+  return {
+    request_id: 'request-1',
+    kind: 'inbox',
+    team_name: TEAM,
+    to_worker: WORKER,
+    worker_index: 1,
+    pane_id: PANE,
+    trigger_message: 'Review the inbox now',
+    transport_preference: 'hook_preferred_with_fallback',
+    fallback_allowed: true,
+    status: 'pending',
+    attempt_count: 0,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+async function seed(workerCli?: string): Promise<void> {
+  await writeFile(
+    join(teamDir, 'config.json'),
+    JSON.stringify({
+      tmux_session: 'dispatch-session',
+      workers: [{ name: WORKER, index: 1, pane_id: PANE, ...(workerCli === undefined ? {} : { worker_cli: workerCli }) }],
+    }),
+  );
+  await writeFile(join(teamDir, 'dispatch', 'requests.json'), JSON.stringify([makeRequest()]));
+}
+
+async function seedMismatchedTarget(): Promise<void> {
+  await writeFile(
+    join(teamDir, 'config.json'),
+    JSON.stringify({
+      tmux_session: 'dispatch-session',
+      workers: [
+        { name: WORKER, index: 1, pane_id: '%2', worker_cli: 'cursor' },
+        { name: 'worker-2', index: 2, pane_id: PANE, worker_cli: 'claude' },
+      ],
+    }),
+  );
+  await writeFile(join(teamDir, 'dispatch', 'requests.json'), JSON.stringify([makeRequest()]));
+}
+
+async function seedIncompleteCursorTarget(): Promise<void> {
+  await seed('cursor');
+  const request = makeRequest();
+  delete request.pane_id;
+  delete request.worker_index;
+  await writeFile(join(teamDir, 'dispatch', 'requests.json'), JSON.stringify([request]));
+}
+
+async function runDefaultInjector(): Promise<{ result: Awaited<ReturnType<typeof drainPendingTeamDispatch>>; request: TeamDispatchRequest }> {
+  const result = await drainPendingTeamDispatch({ cwd: root, stateDir, logsDir, maxPerTick: 1 });
+  const requests = JSON.parse(await readFile(join(teamDir, 'dispatch', 'requests.json'), 'utf8')) as TeamDispatchRequest[];
+  return { result, request: requests[0]! };
+}
+
+describe('team dispatch provider-aware prompt readiness', () => {
+  beforeEach(async () => {
+    tmuxUtilsMocks.tmuxExecAsync.mockReset().mockImplementation(async (args: string[]) => {
+      if (args[0] === 'display-message') return { stdout: '0\n', stderr: '' };
+      if (args[0] === 'capture-pane') return { stdout: '→ ', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+
+    root = await mkdtemp(join(tmpdir(), 'omc-dispatch-prompt-readiness-'));
+    stateDir = join(root, 'state');
+    logsDir = join(root, 'logs');
+    teamDir = join(stateDir, 'team', TEAM);
+    await mkdir(join(teamDir, 'dispatch'), { recursive: true });
+
+    savedEnv = { ...process.env };
+    delete process.env.OMC_TEAM_WORKER;
+    process.env.OMC_TEAM_DISPATCH_ISSUE_COOLDOWN_MS = '0';
+    process.env.OMC_TEAM_DISPATCH_TRIGGER_COOLDOWN_MS = '0';
+  });
+
+  afterEach(async () => {
+    process.env = savedEnv;
+    if (root) await rm(root, { recursive: true, force: true });
+  });
+
+  it('confirms and notifies a persisted Cursor worker from its arrow prompt', async () => {
+    await seed('cursor');
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 1, failed: 0 });
+    expect(request).toMatchObject({ status: 'notified', last_reason: 'tmux_send_keys_confirmed' });
+  });
+
+  it('keeps an otherwise identical Claude worker unconfirmed on its first arrow-prompt retry', async () => {
+    await seed('claude');
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 0, skipped: 1, failed: 0 });
+    expect(request).toMatchObject({
+      status: 'pending',
+      attempt_count: 1,
+      last_reason: 'tmux_send_keys_unconfirmed',
+    });
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['unknown', 'not-a-supported-provider'],
+  ])('does not treat an arrow prompt as generic when the provider is %s', async (_label, workerCli) => {
+    await seed(workerCli);
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 0, skipped: 1, failed: 0 });
+    expect(request).toMatchObject({
+      status: 'pending',
+      attempt_count: 1,
+      last_reason: 'tmux_send_keys_unconfirmed',
+    });
+  });
+
+  it('fails closed when worker name, pane, and index identify different workers', async () => {
+    await seedMismatchedTarget();
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 1, skipped: 0, failed: 1 });
+    expect(request).toMatchObject({
+      status: 'failed',
+      attempt_count: 1,
+      last_reason: 'provider_identity_unverified',
+    });
+    expect(tmuxUtilsMocks.tmuxExecAsync).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a Cursor request lacks explicit pane and index identity', async () => {
+    await seedIncompleteCursorTarget();
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 1, skipped: 0, failed: 1 });
+    expect(request).toMatchObject({
+      status: 'failed',
+      attempt_count: 1,
+      last_reason: 'provider_identity_unverified',
+    });
+    expect(tmuxUtilsMocks.tmuxExecAsync).not.toHaveBeenCalled();
+  });
+
+  it('recognizes the Cursor active-task stop marker after injection', async () => {
+    await seed('cursor');
+    tmuxUtilsMocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'display-message') return { stdout: '0\n', stderr: '' };
+      if (args[0] === 'capture-pane') {
+        return { stdout: '→ Plan, search, build anything\nWorking on the task\nctrl+c to stop', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 1, failed: 0 });
+    expect(request).toMatchObject({
+      status: 'notified',
+      last_reason: 'tmux_send_keys_confirmed_active_task',
+    });
+  });
+});

--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -19,6 +19,8 @@ import { dirname, join, resolve } from 'path';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 import { tmuxExecAsync } from '../cli/tmux-utils.js';
 import { getOmcRoot } from '../lib/worktree-paths.js';
+import type { CliAgentType } from '../team/model-contract.js';
+import { isCliAgentType, paneLineLooksLikeIdlePrompt } from '../team/pane-readiness.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -282,6 +284,30 @@ function defaultInjectTarget(
   return null;
 }
 
+type TargetProviderResolution =
+  | { ok: true; provider?: CliAgentType }
+  | { ok: false };
+
+function resolveTargetProvider(request: DispatchRequest, config: TeamConfig): TargetProviderResolution {
+  if (request.to_worker === 'leader-fixed' || !Array.isArray(config.workers)) return { ok: true };
+
+  const byName = config.workers.find((worker) => worker.name === request.to_worker);
+  const byPane = request.pane_id
+    ? config.workers.find((worker) => worker.pane_id === request.pane_id)
+    : undefined;
+  const byIndex = typeof request.worker_index === 'number'
+    ? config.workers.find((worker) => Number(worker.index) === request.worker_index)
+    : undefined;
+
+  const candidates = [byName, byPane, byIndex].filter((worker) => worker !== undefined);
+  const identitiesConflict = candidates.some((worker) => worker !== candidates[0]);
+  const cursorIdentityIncomplete = candidates.some((worker) => worker.worker_cli === 'cursor')
+    && (!byName || !byPane || !byIndex);
+  if (identitiesConflict || cursorIdentityIncomplete) return { ok: false };
+  if (!byName || !byPane || !byIndex) return { ok: true };
+  return isCliAgentType(byName.worker_cli) ? { ok: true, provider: byName.worker_cli } : { ok: true };
+}
+
 function normalizeCaptureText(value: string): string {
   return safeString(value).replace(/\r/g, '').replace(/\s+/g, ' ').trim();
 }
@@ -304,12 +330,13 @@ function capturedPaneContainsTriggerNearTail(captured: string, trigger: string, 
   return normalizeCaptureText(tail).includes(normalizedTrigger);
 }
 
-function paneHasActiveTask(captured: string): boolean {
+function paneHasActiveTask(captured: string, provider?: CliAgentType): boolean {
   const lines = safeString(captured)
     .split('\n')
     .map((line) => line.replace(/\r/g, '').trim())
     .filter((line) => line.length > 0);
   const tail = lines.slice(-40);
+  if (provider === 'cursor' && tail.some((line) => /ctrl\+c\s+to\s+stop/i.test(line))) return true;
   if (tail.some((line) => /\b\d+\s+background terminal running\b/i.test(line))) return true;
   if (tail.some((line) => /esc to interrupt/i.test(line))) return true;
   if (tail.some((line) => /\bbackground terminal running\b/i.test(line))) return true;
@@ -329,15 +356,7 @@ function paneIsBootstrapping(captured: string): boolean {
   );
 }
 
-function paneLineLooksLikeIdlePrompt(line: string): boolean {
-  // Claude Code can render its idle input prompt inside a box/left gutter
-  // (for example "│ ❯"). Treat that as ready while still requiring the prompt
-  // glyph to be at the visual start of the line, not embedded in arbitrary
-  // output text.
-  return /^\s*(?:[│┃║▌▐▏▕╎┆┊]\s*)?[›>❯]\s*/u.test(line);
-}
-
-function paneLooksReady(captured: string): boolean {
+function paneLooksReady(captured: string, provider?: CliAgentType): boolean {
   const content = safeString(captured).trimEnd();
   if (content === '') return false;
   const lines = content
@@ -346,8 +365,8 @@ function paneLooksReady(captured: string): boolean {
     .filter((line) => line.trim() !== '');
   if (paneIsBootstrapping(content)) return false;
   const lastLine = lines.length > 0 ? lines[lines.length - 1]! : '';
-  if (paneLineLooksLikeIdlePrompt(lastLine)) return true;
-  return lines.some(paneLineLooksLikeIdlePrompt);
+  if (paneLineLooksLikeIdlePrompt(lastLine, provider)) return true;
+  return lines.some((line) => paneLineLooksLikeIdlePrompt(line, provider));
 }
 
 async function runProcess(cmd: string, args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
@@ -361,6 +380,9 @@ async function runProcess(cmd: string, args: string[], timeoutMs: number): Promi
 async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cwd: string): Promise<InjectionResult> {
   const target = defaultInjectTarget(request, config);
   if (!target) return { ok: false, reason: 'missing_tmux_target' };
+  const providerResolution = resolveTargetProvider(request, config);
+  if (!providerResolution.ok) return { ok: false, reason: 'provider_identity_unverified' };
+  const targetProvider = providerResolution.provider;
 
   const paneTarget = target.value;
   try {
@@ -415,10 +437,10 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
       const narrowCap = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], { timeout: 2000 });
       const wideCap = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p'], { timeout: 2000 });
 
-      if (paneHasActiveTask(wideCap.stdout)) {
+      if (paneHasActiveTask(wideCap.stdout, targetProvider)) {
         return { ok: true, reason: 'tmux_send_keys_confirmed_active_task', pane: paneTarget };
       }
-      if (request.to_worker !== 'leader-fixed' && !paneLooksReady(wideCap.stdout)) {
+      if (request.to_worker !== 'leader-fixed' && !paneLooksReady(wideCap.stdout, targetProvider)) {
         continue;
       }
       const triggerInNarrow = capturedPaneContainsTrigger(narrowCap.stdout, request.trigger_message);

--- a/src/team/__tests__/tmux-session.startup.test.ts
+++ b/src/team/__tests__/tmux-session.startup.test.ts
@@ -139,9 +139,11 @@ import {
   spawnWorkerInPane,
   spawnOwnedWorkerInPane,
   retryStartupInboxSubmit,
+  waitForStartupPaneReady,
   type StartupPaneContext,
   type WorkerPaneOwnership,
 } from '../tmux-session.js';
+import { paneLineLooksLikeIdlePrompt } from '../pane-readiness.js';
 import {
   awaitWorkerLaunchAcknowledgement,
   prepareWorkerLaunchAttempt,
@@ -209,6 +211,42 @@ async function acceptedContext(provider: StartupPaneContext['provider']): Promis
 }
 
 describe('worker pane startup safety', () => {
+  it.each([
+    ['legacy Codex prompt', undefined, '› ', true],
+    ['legacy Claude prompt', undefined, '❯ ', true],
+    ['legacy generic prompt', undefined, '> ', true],
+    ['legacy Cursor arrow', undefined, '→ ', false],
+    ['Cursor prompt', 'cursor', '→ ', true],
+    ['Claude rejects Cursor arrow', 'claude', '→ ', false],
+    ['Codex rejects Cursor arrow', 'codex', '→ ', false],
+    ['Cursor rejects embedded arrow', 'cursor', 'completed → next', false],
+    ['existing Gemini prompt behavior', 'gemini', '❯ ', true],
+  ] as const)('detects %s', (_name, provider, line, expected) => {
+    expect(paneLineLooksLikeIdlePrompt(line, provider)).toBe(expected);
+  });
+
+  it.each([
+    ['cursor', '→ ', { ok: true }],
+    ['claude', '→ ', { ok: false, reason: 'readiness_timeout' }],
+    ['codex', '→ ', { ok: false, reason: 'readiness_timeout' }],
+    ['cursor', 'completed → next', { ok: false, reason: 'readiness_timeout' }],
+    ['claude', '❯ ', { ok: true }],
+    ['codex', '› ', { ok: true }],
+  ] as const)('waits for the %s startup prompt without generic arrow matching', async (provider, capture, expected) => {
+    const context = await acceptedContext(provider);
+    tmuxState.captures = [capture];
+    await expect(waitForStartupPaneReady(context, { timeoutMs: expected.ok ? 50 : 5, pollIntervalMs: 1 }))
+      .resolves.toEqual(expected);
+  });
+
+  it('rejects a Cursor prompt retained above its active-task stop marker', async () => {
+    const context = await acceptedContext('cursor');
+    tmuxState.captures = ['→ Plan, search, build anything\nWorking on the task\nctrl+c to stop'];
+
+    await expect(waitForStartupPaneReady(context, { timeoutMs: 50, pollIntervalMs: 1 }))
+      .resolves.toEqual({ ok: false, reason: 'pane_busy' });
+  });
+
   it.each([
     ['leader_alias', '%1', '%1', []],
     ['split_target_alias', '%3', '%1', []],

--- a/src/team/pane-readiness.ts
+++ b/src/team/pane-readiness.ts
@@ -1,0 +1,26 @@
+import type { CliAgentType } from './model-contract.js';
+
+const LEGACY_IDLE_PROMPT_LINE = /^\s*(?:[│┃║▌▐▏▕╎┆┊]\s*)?[›>❯]\s*/u;
+const CURSOR_IDLE_PROMPT_LINE = /^\s*(?:[│┃║▌▐▏▕╎┆┊]\s*)?[›>❯→]\s*/u;
+
+const PROVIDER_IDLE_PROMPT_LINES: Readonly<Record<CliAgentType, RegExp>> = {
+  claude: LEGACY_IDLE_PROMPT_LINE,
+  codex: LEGACY_IDLE_PROMPT_LINE,
+  gemini: LEGACY_IDLE_PROMPT_LINE,
+  cursor: CURSOR_IDLE_PROMPT_LINE,
+  grok: LEGACY_IDLE_PROMPT_LINE,
+  antigravity: LEGACY_IDLE_PROMPT_LINE,
+};
+
+export function isCliAgentType(value: unknown): value is CliAgentType {
+  return typeof value === 'string'
+    && Object.prototype.hasOwnProperty.call(PROVIDER_IDLE_PROMPT_LINES, value);
+}
+
+export function paneLineLooksLikeIdlePrompt(
+  line: string,
+  provider?: CliAgentType,
+): boolean {
+  if (provider === undefined) return LEGACY_IDLE_PROMPT_LINE.test(line);
+  return PROVIDER_IDLE_PROMPT_LINES[provider].test(line);
+}

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -810,7 +810,7 @@ export async function spawnWorkerForTask(
   if (!usePromptMode) {
     // Interactive mode: wait for pane readiness, handle trust-confirm, then
     // send instruction via tmux send-keys.
-    const paneReady = await waitForPaneReady(paneId);
+    const paneReady = await waitForPaneReady(paneId, { provider: agentType });
     if (!paneReady) {
       await killWorkerPane(runtime, workerNameValue, paneId);
       await resetTaskToPending(root, taskId, runtime.teamName, runtime.cwd);

--- a/src/team/scaling.ts
+++ b/src/team/scaling.ts
@@ -731,7 +731,7 @@ export async function scaleUpOwned(
       const skipReadyWait = env.OMC_TEAM_SKIP_READY_WAIT === '1';
       if (!skipReadyWait) {
         try {
-          await waitForPaneReady(paneId, { timeoutMs: readyTimeoutMs });
+          await waitForPaneReady(paneId, { timeoutMs: readyTimeoutMs, provider: workerAgentType });
         } catch {
           // Non-fatal: worker may still become ready
         }

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -19,6 +19,7 @@ import { tmuxExec, tmuxExecAsync, tmuxShell, tmuxCmdAsync } from '../cli/tmux-ut
 import { configureTmuxClipboardForSession, configureTmuxClipboardForSessionAsync } from '../cli/tmux-clipboard.js';
 import type { MailboxNotificationTarget, MailboxTargetOwnership } from './mailbox-notification-guard.js';
 import type { CliAgentType } from './model-contract.js';
+import { paneLineLooksLikeIdlePrompt } from './pane-readiness.js';
 import {
   awaitWorkerLaunchAcknowledgement,
   awaitWorkerLaunchProviderStarted,
@@ -1602,13 +1603,13 @@ export function paneHasTrustPrompt(captured: string): boolean {
   return detectPaneTrustPromptKind(captured) !== null;
 }
 
-function paneHasClaudeStartupBanner(captured: string): boolean {
+function paneHasClaudeStartupBanner(captured: string, provider?: CliAgentType): boolean {
   const lines = captured
     .split('\n')
     .map((line) => line.replace(/\r/g, '').trim())
     .filter((line) => line.length > 0)
     .slice(-20);
-  const lastPromptIndex = lines.findLastIndex(paneLineLooksLikeIdlePrompt);
+  const lastPromptIndex = lines.findLastIndex(line => paneLineLooksLikeIdlePrompt(line, provider));
   // Claude Code v2.1.x renders the permission-mode indicator
   // ("⏵⏵ bypass permissions on (shift+tab to cycle)") *below* the prompt
   // as a persistent idle-state UI element. If a prompt is present anywhere
@@ -1623,8 +1624,8 @@ function paneHasClaudeStartupBanner(captured: string): boolean {
   return lastStartupBannerIndex >= 0;
 }
 
-function paneIsBootstrapping(captured: string): boolean {
-  if (paneHasClaudeStartupBanner(captured)) return true;
+function paneIsBootstrapping(captured: string, provider?: CliAgentType): boolean {
+  if (paneHasClaudeStartupBanner(captured, provider)) return true;
   const lines = captured
     .split('\n')
     .map((line) => line.replace(/\r/g, '').trim())
@@ -1636,9 +1637,10 @@ function paneIsBootstrapping(captured: string): boolean {
   );
 }
 
-export function paneHasActiveTask(captured: string): boolean {
+export function paneHasActiveTask(captured: string, provider?: CliAgentType): boolean {
   const lines = captured.split('\n').map(l => l.replace(/\r/g, '').trim()).filter(l => l.length > 0);
   const tail = lines.slice(-40);
+  if (provider === 'cursor' && tail.some(l => /ctrl\+c\s+to\s+stop/i.test(l))) return true;
   if (tail.some(l => /\b\d+\s+background terminal running\b/i.test(l))) return true;
   if (tail.some(l => /esc to interrupt/i.test(l))) return true;
   if (tail.some(l => /\bbackground terminal running\b/i.test(l))) return true;
@@ -1646,15 +1648,7 @@ export function paneHasActiveTask(captured: string): boolean {
   return false;
 }
 
-function paneLineLooksLikeIdlePrompt(line: string): boolean {
-  // Claude Code can render its idle input prompt inside a box/left gutter
-  // (for example "│ ❯"). Treat that as ready while still requiring the prompt
-  // glyph to be at the visual start of the line, not embedded in arbitrary
-  // output text.
-  return /^\s*(?:[│┃║▌▐▏▕╎┆┊]\s*)?[›>❯]\s*/u.test(line);
-}
-
-export function paneLooksReady(captured: string): boolean {
+export function paneLooksReady(captured: string, provider?: CliAgentType): boolean {
   const content = captured.trimEnd();
   if (content === '') return false;
   const lines = content
@@ -1663,17 +1657,18 @@ export function paneLooksReady(captured: string): boolean {
     .filter(line => line.trim() !== '');
   if (lines.length === 0) return false;
   if (paneHasTrustPrompt(content)) return true;
-  if (paneIsBootstrapping(content)) return false;
+  if (paneIsBootstrapping(content, provider)) return false;
 
   const lastLine = lines[lines.length - 1]!;
-  if (paneLineLooksLikeIdlePrompt(lastLine)) return true;
-  return lines.some(paneLineLooksLikeIdlePrompt);
+  if (paneLineLooksLikeIdlePrompt(lastLine, provider)) return true;
+  return lines.some(line => paneLineLooksLikeIdlePrompt(line, provider));
 }
 
 export interface WaitForPaneReadyOptions {
   timeoutMs?: number;
   pollIntervalMs?: number;
   attemptAlreadyFenced?: boolean;
+  provider?: CliAgentType;
 }
 
 export async function waitForPaneReady(
@@ -1691,7 +1686,7 @@ export async function waitForPaneReady(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const captured = await capturePaneAsync(paneId);
-    if (paneLooksReady(captured) && !paneHasActiveTask(captured)) {
+    if (paneLooksReady(captured, opts.provider) && !paneHasActiveTask(captured, opts.provider)) {
       return true;
     }
     await sleep(pollIntervalMs);
@@ -1777,8 +1772,8 @@ export async function waitForStartupPaneReady(
       await sleep(pollIntervalMs);
       continue;
     }
-    if (paneHasActiveTask(captured)) return { ok: false, reason: 'pane_busy' };
-    if (paneLooksReady(captured)) return { ok: true };
+    if (paneHasActiveTask(captured, context.provider)) return { ok: false, reason: 'pane_busy' };
+    if (paneLooksReady(captured, context.provider)) return { ok: true };
     await sleep(pollIntervalMs);
   }
   return { ok: false, reason: 'readiness_timeout' };


### PR DESCRIPTION
## Summary
- centralize pane idle-prompt glyph detection and preserve the existing `›`, `>`, and `❯` behavior
- admit Cursor CLI's `→` (U+2192) only when validated provider context is `cursor`
- thread provider identity through startup, runtime, scale-up, and hook-dispatch readiness paths
- reject Cursor busy frames carrying `ctrl+c to stop` even when the idle placeholder remains visible
- fail before any tmux mutation when hook dispatch worker name, pane, and index conflict or a Cursor identity is incomplete
- refresh required inventory provenance; prompt projections regenerate without drift

## Reproduction
The prior predicate `/^\s*(?:[│┃║▌▐▏▕╎┆┊]\s*)?[›>❯]\s*/u` returns `false` for both `→ ` and `│ → `. Cursor's fully booted interactive pane therefore reaches `readiness_timeout` after #3788 is fixed. The regression tests reproduce the predicate separately from the startup provider context and the default hook injector, and prove a retained prompt above `ctrl+c to stop` remains busy.

## Verification
- `npx vitest run src/team/__tests__/tmux-session.startup.test.ts src/team/__tests__/tmux-session.test.ts src/team/__tests__/runtime-prompt-mode.test.ts src/team/__tests__/idle-nudge.test.ts src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts tests/lint/inventory-graph-drift.test.ts` — 193 passed, 4 platform-gated skips
- `npx tsc --noEmit` — passed
- focused ESLint — 0 errors; one pre-existing unused `runProcess` warning in `team-dispatch-hook.ts`
- `node scripts/generate-inventory-graph.mjs --verify` — passed
- `npm run prompt-ssot:check` — 5 projections fresh
- required prompt projection regeneration — no committed diff
- signed commit chain verified; merge base is exact `dev@b3ffac4166b87b31a3c4d88a3d9cbdaadbbf97ec`

## Scope
Fixes #3789 only. The merged #3788 HOME implementation is inherited exactly from current dev; #3790/#3798 are unchanged. No main merge, release, tag, or publish action is included.

Signed-off-by: gaebal-gajae <clawdbot@users.noreply.github.com>


