### PR TITLE
fix(team): bound startup evidence and teardown providers (#3798)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "3e74c6115a52a72b843ad5053cb3e0bf5268877c",
+    "head": "209a3c21680f5e967916a780e7f32402fee42ea4",
     "sourceSha256": "d3bf0efdd58dd96616d5512ef9c78186c087d3efe699681e62e3749bf61e4e1a",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "3e74c6115a52a72b843ad5053cb3e0bf5268877c",
+  "head": "209a3c21680f5e967916a780e7f32402fee42ea4",
   "sourceSha256": "d3bf0efdd58dd96616d5512ef9c78186c087d3efe699681e62e3749bf61e4e1a",
   "counts": {
     "public": {
@@ -74908,5 +74908,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "77b4688af12687ea55f3c0d11e274d8f0279aaa08e886d3c3d086b8c6b7ccbb1"
+  "manifestSha256": "6e0803587a178837f91a9f336009bdb94b21193e9303ec32d6096d59d8a2e938"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "d8042206139babfbcf4fb42bf7e6fd03ff6f626c",
-    "sourceSha256": "1afffe56340305c9a8b1680ec3babcbd2797b7ac26cbdd8180eeb538bbb1b666",
+    "head": "3e74c6115a52a72b843ad5053cb3e0bf5268877c",
+    "sourceSha256": "d3bf0efdd58dd96616d5512ef9c78186c087d3efe699681e62e3749bf61e4e1a",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "d8042206139babfbcf4fb42bf7e6fd03ff6f626c",
-  "sourceSha256": "1afffe56340305c9a8b1680ec3babcbd2797b7ac26cbdd8180eeb538bbb1b666",
+  "head": "3e74c6115a52a72b843ad5053cb3e0bf5268877c",
+  "sourceSha256": "d3bf0efdd58dd96616d5512ef9c78186c087d3efe699681e62e3749bf61e4e1a",
   "counts": {
     "public": {
       "skills": 31,
@@ -74908,5 +74908,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "3976857dc7a8bc45cd12d0a958a12df97e9fb080344a474170fe0fc6cdbae24a"
+  "manifestSha256": "77b4688af12687ea55f3c0d11e274d8f0279aaa08e886d3c3d086b8c6b7ccbb1"
 }

--- a/src/team/__tests__/recovery-pane-rollback.test.ts
+++ b/src/team/__tests__/recovery-pane-rollback.test.ts
@@ -173,6 +173,62 @@ describe('recovery pane rollback evidence', () => {
     await expectRecoveryLockReleased(teamName, 'worker-1', 'cleanup-failure');
   });
 
+  it('preserves the recovery pane when provider containment cannot be verified', async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'recovery-provider-unverified-'));
+    const teamName = 'provider-unverified-team';
+    const requestId = 'provider-unverified-request';
+    const recoveryId = 'provider-unverified-recovery';
+    const configPath = absPath(cwd, TeamPaths.config(teamName));
+    mkdirSync(join(configPath, '..'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      name: teamName,
+      worker_count: 1,
+      workers: [{ name: 'worker-1', index: 1, ...launchMetadata, replacement_generation: 1 }],
+      agent_type: 'claude',
+      created_at: new Date().toISOString(),
+      tmux_session: `${teamName}:0`,
+      lifecycle_state: 'active',
+      state_revision: 1,
+      leader_pane_id: '%leader',
+    }));
+    await attachPersistedPriorLaunch(teamName, configPath);
+    reserveRecoveryRequest(cwd, requestId, { operation: 'recover-worker',
+      workspaceHash: createHash('sha256').update(cwd).digest('hex'), teamName, workerName: 'worker-1' }, recoveryId);
+    paneMocks.getWorkerLiveness.mockResolvedValueOnce('dead').mockResolvedValue('alive');
+    paneMocks.spawnOwnedWorkerInPane.mockImplementationOnce(async (_sessionName, ownership) => {
+      const attempt = await prepareWorkerLaunchAttempt({ cwd, teamName, workerName: 'worker-1', paneId: ownership.paneId,
+        provider: 'claude', runtimeCliPath: '/runtime-cli.cjs', context: { kind: 'recovery',
+          recovery_id: recoveryId, replacement_generation: 2, pane_attempt_id: 'test-pane-attempt' } });
+      const expected = JSON.parse(readFileSync(attempt.expectedPath, 'utf8'));
+      writeFileSync(attempt.ackPath, JSON.stringify({ ...expected, kind: 'worker_launch_ack', written_at: new Date().toISOString() }));
+      await awaitWorkerLaunchAcknowledgement(attempt, { timeoutMs: 1_000, pollIntervalMs: 5 });
+      let reads = 0;
+      return Object.defineProperty({ ownership }, 'attempt', {
+        enumerable: true,
+        get: () => {
+          if (reads++ === 0) throw new Error('activation record failed');
+          return attempt;
+        },
+      });
+    });
+
+    await expect(executeRecoverDeadWorkerV2Owner({ teamName, cwd, workerName: 'worker-1', requestId }))
+      .resolves.toMatchObject({ outcome: 'failed', error: 'spawn_failed', recoveryId });
+
+    expect(paneMocks.killOwnedWorkerPane).not.toHaveBeenCalled();
+    expect(paneMocks.killTeamPane).not.toHaveBeenCalled();
+    const evidenceRoot = absPath(cwd, `.omc/state/team/${teamName}/recovery/rollback-failures/${recoveryId}`);
+    const evidenceFiles = readdirSync(evidenceRoot);
+    expect(evidenceFiles.length).toBeGreaterThan(0);
+    const evidence = JSON.parse(readFileSync(join(evidenceRoot, evidenceFiles.at(-1)!), 'utf8'));
+    expect(evidence).toMatchObject({
+      recovery_id: recoveryId,
+      pane_id: '%2',
+      reason: 'activation record failed:provider_cleanup_unverified',
+      liveness: 'alive',
+    });
+  });
+
   it('reconciles an accepted initial launch pointer before treating the worker as already running', async () => {
     cwd = mkdtempSync(join(tmpdir(), 'omc-recovery-initial-pointer-'));
     const teamName = 'initial-pointer-team';

--- a/src/team/__tests__/recovery-pane-rollback.test.ts
+++ b/src/team/__tests__/recovery-pane-rollback.test.ts
@@ -117,7 +117,9 @@ async function attachPersistedPriorLaunch(teamName: string, configPath: string):
   await expect(awaitWorkerLaunchAcknowledgement(attempt, { timeoutMs: 1_000, pollIntervalMs: 5 })).resolves.toEqual({ ok: true });
   writeFileSync(`${attempt.startedPath}.terminal`, JSON.stringify({ ...expected,
     kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
-    pid: 999_999, process_start_identity: '1', written_at: new Date().toISOString() }));
+    pid: 999_999, process_start_identity: '1',
+    ...(process.platform !== 'win32' ? { process_group_id: 999_999 } : {}),
+    written_at: new Date().toISOString() }));
   worker.pane_id = '%1';
   worker.launch_attempt_id = attempt.attempt_id;
   writeFileSync(configPath, JSON.stringify(config));

--- a/src/team/__tests__/recovery-pane-rollback.test.ts
+++ b/src/team/__tests__/recovery-pane-rollback.test.ts
@@ -163,13 +163,13 @@ describe('recovery pane rollback evidence', () => {
     expect(paneMocks.applyMainVerticalLayout).toHaveBeenCalledWith(`${teamName}:0`, { required: true });
     expect(paneMocks.applyMainVerticalLayout.mock.invocationCallOrder[0])
       .toBeLessThan(paneMocks.spawnOwnedWorkerInPane.mock.invocationCallOrder[0]);
-    expect(paneMocks.killTeamPane).toHaveBeenCalledTimes(2);
+    expect(paneMocks.killTeamPane).not.toHaveBeenCalled();
     const evidenceRoot = absPath(cwd, `.omc/state/team/${teamName}/recovery/rollback-failures/${recoveryId}`);
     const evidenceFiles = readdirSync(evidenceRoot);
     expect(evidenceFiles).toHaveLength(1);
     const evidence = JSON.parse(readFileSync(join(evidenceRoot, evidenceFiles[0]!), 'utf8'));
     expect(evidence).toMatchObject({ schema_version: 1, team_name: teamName, worker_name: 'worker-1',
-      request_id: requestId, recovery_id: recoveryId, pane_id: '%2', reason: 'spawn failed --api-key=<redacted> after pane creation', liveness: 'alive' });
+      request_id: requestId, recovery_id: recoveryId, pane_id: '%2', reason: 'spawn failed --api-key=<redacted> after pane creation:provider_cleanup_unverified', liveness: 'alive' });
     await expectRecoveryLockReleased(teamName, 'worker-1', 'cleanup-failure');
   });
 

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -6,7 +6,11 @@ import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 
 import { listDispatchRequests } from '../dispatch-queue.js';
-import { promptModeRecoveryRequiresProgressEvidence } from '../runtime-v2.js';
+import {
+  getWorkerStartupEvidencePolicy,
+  promptModeRecoveryRequiresProgressEvidence,
+  waitForStartupEvidenceBudget,
+} from '../runtime-v2.js';
 
 const mocks = vi.hoisted(() => ({
   createTeamSession: vi.fn(),
@@ -337,6 +341,7 @@ describe('runtime v2 startup inbox dispatch', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     process.chdir(originalCwd);
     if (cwd) await rm(cwd, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   });
@@ -1219,6 +1224,78 @@ describe('runtime v2 startup inbox dispatch', () => {
     const requests = await listDispatchRequests('dispatch-team', cwd, { kind: 'inbox' });
     expect(requests).toHaveLength(1);
     expect(requests[0]?.status).toBe('failed');
+  });
+
+  it('accepts delayed Codex evidence at exactly 18s within the provider evidence budget', async () => {
+    vi.useFakeTimers();
+    const policy = getWorkerStartupEvidencePolicy('codex');
+    const startedAt = Date.now();
+    let hasEvidence = false;
+    setTimeout(() => { hasEvidence = true; }, 18_000);
+    const wait = (budgetMs: number) => waitForStartupEvidenceBudget(async () => hasEvidence, budgetMs);
+    const evidencePromise = (async () => {
+      if (await wait(policy.initialBudgetMs)) return true;
+      return wait(policy.finalRecheckBudgetMs);
+    })();
+    let settled = false;
+    void evidencePromise.finally(() => { settled = true; });
+
+    await vi.advanceTimersByTimeAsync(17_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(evidencePromise).resolves.toBe(true);
+    expect(Date.now() - startedAt).toBe(18_000);
+    expect(policy.resubmitAttempts).toBe(0);
+  });
+
+  it('times out Codex evidence at exactly 31s after one read-only recheck window', async () => {
+    vi.useFakeTimers();
+    const policy = getWorkerStartupEvidencePolicy('codex');
+    const startedAt = Date.now();
+    const wait = (budgetMs: number) => waitForStartupEvidenceBudget(async () => false, budgetMs);
+    const evidencePromise = (async () => {
+      if (await wait(policy.initialBudgetMs)) return true;
+      return wait(policy.finalRecheckBudgetMs);
+    })();
+    let settled = false;
+    void evidencePromise.finally(() => { settled = true; });
+
+    await vi.advanceTimersByTimeAsync(30_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(evidencePromise).resolves.toBe(false);
+    expect(Date.now() - startedAt).toBe(31_000);
+    expect(policy).toMatchObject({
+      initialBudgetMs: 30_000,
+      finalRecheckBudgetMs: 1_000,
+      resubmitAttempts: 0,
+      resubmitBudgetMs: 0,
+    });
+  });
+
+  it('accepts Codex evidence at 30.25s only through the final read-only recheck', async () => {
+    vi.useFakeTimers();
+    const policy = getWorkerStartupEvidencePolicy('codex');
+    const startedAt = Date.now();
+    let hasEvidence = false;
+    setTimeout(() => { hasEvidence = true; }, 30_250);
+    const wait = (budgetMs: number) => waitForStartupEvidenceBudget(async () => hasEvidence, budgetMs);
+    const evidencePromise = (async () => {
+      if (await wait(policy.initialBudgetMs)) return true;
+      return wait(policy.finalRecheckBudgetMs);
+    })();
+
+    await vi.advanceTimersByTimeAsync(30_249);
+    let settled = false;
+    void evidencePromise.finally(() => { settled = true; });
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(evidencePromise).resolves.toBe(true);
+    expect(Date.now() - startedAt).toBe(30_250);
+    expect(policy.resubmitAttempts).toBe(0);
   });
 
   it('rejects a stale worker status that predates the current startup trigger', async () => {

--- a/src/team/__tests__/runtime-v2.shutdown.test.ts
+++ b/src/team/__tests__/runtime-v2.shutdown.test.ts
@@ -48,7 +48,9 @@ async function prepareAcceptedLaunch(cwd: string, teamName: string, workerName: 
   await awaitWorkerLaunchAcknowledgement(attempt, { timeoutMs: 1_000, pollIntervalMs: 5 });
   writeFileSync(`${attempt.startedPath}.terminal`, JSON.stringify({ ...expected,
     kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
-    pid: 999_999, process_start_identity: '1', written_at: new Date().toISOString() }));
+    pid: 999_999, process_start_identity: '1',
+    ...(process.platform !== 'win32' ? { process_group_id: 999_999 } : {}),
+    written_at: new Date().toISOString() }));
   return attempt;
 }
 

--- a/src/team/__tests__/worker-launch-ack.test.ts
+++ b/src/team/__tests__/worker-launch-ack.test.ts
@@ -269,7 +269,9 @@ describe('worker launch acknowledgement', () => {
     await expect(awaitWorkerLaunchAcknowledgement(launchAttempt, { timeoutMs: 500, pollIntervalMs: 5 })).resolves.toEqual({ ok: true });
     await writeFile(`${launchAttempt.startedPath}.terminal`, JSON.stringify({ ...expected,
       kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
-      pid: 999_999, process_start_identity: '1', written_at: new Date().toISOString() }), 'utf8');
+      pid: 999_999, process_start_identity: '1',
+      ...(process.platform !== 'win32' ? { process_group_id: 999_999 } : {}),
+      written_at: new Date().toISOString() }), 'utf8');
     const firstCleanup = vi.fn(async () => true);
     await expect(retireAndCleanupCurrentWorkerLaunchAttempt(launchAttempt, 'partial_shutdown', firstCleanup)).resolves.toBe(true);
     expect(firstCleanup).toHaveBeenCalledOnce();
@@ -311,12 +313,29 @@ describe('worker launch acknowledgement', () => {
     await writeFile(`${launchAttempt.startedPath}.terminal`, JSON.stringify({ ...expected,
       kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
       pid: process.pid, process_start_identity: staleIdentity, written_at: new Date().toISOString() }), 'utf8');
-    await expect(terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(true);
+    await expect(terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
     expect(isProcessAlive(process.pid)).toBe(true);
     expect(currentIdentity).toBeTruthy();
     await writeFile(launchAttempt.startedPath, JSON.stringify({ ...expected, kind: 'worker_launch_provider_started',
       pid: process.pid, process_start_identity: currentIdentity, written_at: new Date().toISOString() }), 'utf8');
     await expect(terminateWorkerLaunchProvider(launchAttempt, 0)).resolves.toBe(false);
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it.runIf(process.platform !== 'win32')('rejects terminal cleanup proof bound to the wrong process group', async () => {
+    const launchAttempt = await attempt();
+    const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+    const currentIdentity = await getProcessStartIdentity(process.pid);
+    await writeFile(launchAttempt.startedPath, JSON.stringify({ ...expected,
+      kind: 'worker_launch_provider_started', pid: process.pid,
+      process_start_identity: currentIdentity, process_group_id: 999_998,
+      written_at: new Date().toISOString() }), 'utf8');
+    await writeFile(`${launchAttempt.startedPath}.terminal`, JSON.stringify({ ...expected,
+      kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
+      pid: process.pid, process_start_identity: currentIdentity, process_group_id: 999_999,
+      written_at: new Date().toISOString() }), 'utf8');
+
+    await expect(terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
     expect(isProcessAlive(process.pid)).toBe(true);
   });
 
@@ -405,7 +424,7 @@ describe('worker launch acknowledgement', () => {
     }, { timeout: 2_000, interval: 20 });
   });
 
-  it('retires and terminates the exact started provider process tree', async () => {
+  it('terminates the exact started provider process group before failed-startup pane cleanup', async () => {
     const launchAttempt = await attempt();
     const pidMarker = join(cwd, 'started-provider-tree-pids.json');
     const providerScript = [
@@ -428,8 +447,21 @@ describe('worker launch acknowledgement', () => {
       timeoutMs: 2_000,
       pollIntervalMs: 5,
     })).resolves.toBe(true);
-    await expect(retireWorkerLaunchAttempt(launchAttempt, 'pane_cleanup')).resolves.toBe(true);
-    await expect(terminateWorkerLaunchProvider(launchAttempt)).resolves.toBe(true);
+    const started = JSON.parse(await readFile(launchAttempt.startedPath, 'utf8')) as { process_group_id: number };
+    const cleanup = vi.fn(async () => {
+      const pids = JSON.parse(await readFile(pidMarker, 'utf8')) as { parent: number; child: number };
+      expect(isProcessAlive(pids.parent)).toBe(false);
+      expect(isProcessAlive(pids.child)).toBe(false);
+      expect(isProcessAlive(process.pid)).toBe(true);
+      expect(() => process.kill(-started.process_group_id, 0)).toThrow(expect.objectContaining({ code: 'ESRCH' }));
+      return true;
+    });
+    await expect(retireAndCleanupCurrentWorkerLaunchAttempt(
+      launchAttempt,
+      'startup_dispatch_failed',
+      cleanup,
+    )).resolves.toBe(true);
+    expect(cleanup).toHaveBeenCalledOnce();
     await expect(bootstrap).resolves.toMatchObject({ outcome: 'ran' });
     const pids = JSON.parse(await readFile(pidMarker, 'utf8')) as { parent: number; child: number };
     await vi.waitFor(() => {
@@ -1048,6 +1080,9 @@ describe('worker launch acknowledgement', () => {
     expect(assign).toBeGreaterThan(create);
     expect(resume).toBeGreaterThan(assign);
     expect(source).toContain('TerminateJobObject');
+    expect(source).toContain('if (-not [O]::TerminateJobObject');
+    expect(source).toContain('WaitForSingleObject($job, 5000)');
+    expect(source).toContain('worker_launch_job_cleanup_timeout');
     expect(source).toContain('process_start_identity=("ticks:" +');
     expect(source).toContain('containment_nonce=$payload.containment_nonce');
     expect(source).toContain('finally {');

--- a/src/team/__tests__/worker-launch-ack.test.ts
+++ b/src/team/__tests__/worker-launch-ack.test.ts
@@ -280,7 +280,7 @@ describe('worker launch acknowledgement', () => {
     expect(retryCleanup).not.toHaveBeenCalled();
   });
 
-  it.runIf(process.platform !== 'win32')('publishes termination-complete on an identity-bound already-dead retry after a prior request', async () => {
+  it.runIf(process.platform !== 'win32')('does not synthesize completion from an already-dead retry after a prior request', async () => {
     const launchAttempt = await attempt();
     const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
     await writeFile(launchAttempt.startedPath, JSON.stringify({ ...expected,
@@ -291,11 +291,8 @@ describe('worker launch acknowledgement', () => {
       process_start_identity: '1', containment_nonce: launchAttempt.nonce,
       written_at: new Date().toISOString() }), 'utf8');
 
-    await expect(terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(true);
-    await expect(readFile(`${launchAttempt.startedPath}.termination-complete`, 'utf8').then(JSON.parse))
-      .resolves.toMatchObject({ ...expected,
-        kind: 'worker_launch_termination_complete', cleanup_verified: true,
-        pid: 999_999_999, process_start_identity: '1' });
+    await expect(terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
+    await expect(readFile(`${launchAttempt.startedPath}.termination-complete`, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('does not treat a reused provider PID as cleaned without terminal descendant proof', async () => {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -1327,6 +1327,17 @@ async function cleanupRecoveryPaneAttempt(
       },
     ).catch(() => false);
   }
+  if (!providerStopped) {
+    const liveness = await getWorkerLiveness(pending.ownership.paneId).catch(() => 'unknown' as const);
+    await recordRecoveryPaneRollbackFailure(
+      input,
+      recoveryId,
+      pending,
+      `${reason}:provider_cleanup_unverified`,
+      liveness,
+    );
+    return false;
+  }
   let liveness: WorkerPaneLiveness = 'unknown';
   for (let attempt = 0; attempt < 2; attempt++) {
     await killOwnedWorkerPane(pending.ownership).catch(() => undefined);

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -2785,7 +2785,8 @@ export async function executeRecoverDeadWorkerV2Owner(
           : null;
         const statusBaseline = startupBaseline?.statusFingerprint
           ?? workerStatusStartupFingerprint(await readWorkerStatus(input.teamName, sagaInput.workerName, input.cwd));
-        const waitForCurrentEvidence = () => primaryTaskId && startupBaseline
+        const evidencePolicy = getWorkerStartupEvidencePolicy(pending.agentType);
+        const waitForCurrentEvidence = (budgetMs: number) => primaryTaskId && startupBaseline
           ? waitForWorkerStartupEvidence(
               input.teamName,
               sagaInput.workerName,
@@ -2793,7 +2794,7 @@ export async function executeRecoverDeadWorkerV2Owner(
               input.cwd,
               startupBaseline,
               startupAttemptId,
-              2_750,
+              budgetMs,
             )
           : waitForWorkerStatusTransition(
               input.teamName,
@@ -2802,6 +2803,19 @@ export async function executeRecoverDeadWorkerV2Owner(
               statusBaseline,
               startupAttemptId,
             );
+        const waitForBoundedStartupEvidence = async (
+          resubmit?: () => Promise<boolean>,
+        ): Promise<boolean> => {
+          let settled = await waitForCurrentEvidence(evidencePolicy.initialBudgetMs);
+          for (let attempt = 1; !settled && resubmit && attempt <= evidencePolicy.resubmitAttempts; attempt++) {
+            if (!await resubmit()) break;
+            settled = await waitForCurrentEvidence(evidencePolicy.resubmitBudgetMs);
+          }
+          if (!settled && evidencePolicy.finalRecheckBudgetMs > 0) {
+            settled = await waitForCurrentEvidence(evidencePolicy.finalRecheckBudgetMs);
+          }
+          return settled;
+        };
         const instruction = continuations.length > 0
           ? continuations.map(continuation => renderRecoveryContinuationInstruction({
             teamName: input.teamName,
@@ -2867,7 +2881,7 @@ export async function executeRecoverDeadWorkerV2Owner(
         const effects = await withWorkerLaunchAttemptFence(startupContext.attempt, async () => {
           await ensureFence();
           if (promptModeRecoveryRequiresProgressEvidence(pending.promptMode, continuations.length)) {
-            if (!await waitForCurrentEvidence()) return { ok: false as const, error: `${pending.agentType}_startup_evidence_missing` };
+            if (!await waitForBoundedStartupEvidence()) return { ok: false as const, error: `${pending.agentType}_startup_evidence_missing` };
           } else if (pending.promptMode) {
             // Idle prompt-mode recoveries (for example Gemini with no owned tasks)
             // intentionally have no task/status progress to prove. At this point
@@ -2896,7 +2910,9 @@ export async function executeRecoverDeadWorkerV2Owner(
               if (!attempted.ok) {
                 return { ok: false, transport: 'tmux_send_keys' as const, reason: `worker_notify_failed:${attempted.reason}` };
               }
-              const settled = await waitForCurrentEvidence();
+              const settled = await waitForBoundedStartupEvidence(
+                () => retryStartupInboxSubmit(startupContext, triggerMessage, { attemptAlreadyFenced: true }),
+              );
               return settled
                 ? { ok: true, transport: 'tmux_send_keys' as const, reason: 'worker_startup_confirmed' }
                 : { ok: false, transport: 'tmux_send_keys' as const, reason: 'worker_startup_evidence_missing' };

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -905,6 +905,46 @@ async function hasCurrentWorkerStartupEvidence(
   return currentClaim || currentStatus;
 }
 
+export interface WorkerStartupEvidencePolicy {
+  initialBudgetMs: number;
+  finalRecheckBudgetMs: number;
+  resubmitAttempts: number;
+  resubmitBudgetMs: number;
+}
+
+const WORKER_STARTUP_EVIDENCE_POLL_INTERVAL_MS = 250;
+const WORKER_STARTUP_EVIDENCE_POLICIES: Readonly<Record<CliAgentType, WorkerStartupEvidencePolicy>> = {
+  // Claude's interactive transport can lose a submit, so retain the existing
+  // bounded resubmit behavior and its effective 6 + (4 * 12) poll windows.
+  claude: { initialBudgetMs: 1_250, finalRecheckBudgetMs: 0, resubmitAttempts: 4, resubmitBudgetMs: 2_750 },
+  // External providers can be visibly ready before they publish task/status
+  // evidence. Give that distinct evidence gate enough time for a cold start,
+  // then perform one bounded read-only recheck without duplicating the inbox.
+  codex: { initialBudgetMs: 30_000, finalRecheckBudgetMs: 1_000, resubmitAttempts: 0, resubmitBudgetMs: 0 },
+  gemini: { initialBudgetMs: 30_000, finalRecheckBudgetMs: 1_000, resubmitAttempts: 0, resubmitBudgetMs: 0 },
+  cursor: { initialBudgetMs: 30_000, finalRecheckBudgetMs: 1_000, resubmitAttempts: 0, resubmitBudgetMs: 0 },
+  grok: { initialBudgetMs: 30_000, finalRecheckBudgetMs: 1_000, resubmitAttempts: 0, resubmitBudgetMs: 0 },
+  antigravity: { initialBudgetMs: 30_000, finalRecheckBudgetMs: 1_000, resubmitAttempts: 0, resubmitBudgetMs: 0 },
+};
+
+export function getWorkerStartupEvidencePolicy(agentType: CliAgentType): WorkerStartupEvidencePolicy {
+  return WORKER_STARTUP_EVIDENCE_POLICIES[agentType];
+}
+
+export async function waitForStartupEvidenceBudget(
+  hasEvidence: () => Promise<boolean>,
+  budgetMs: number,
+  delayMs = WORKER_STARTUP_EVIDENCE_POLL_INTERVAL_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, budgetMs);
+  for (;;) {
+    if (await hasEvidence()) return true;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return false;
+    await new Promise(resolve => setTimeout(resolve, Math.min(delayMs, remainingMs)));
+  }
+}
+
 async function waitForWorkerStartupEvidence(
   teamName: string,
   workerName: string,
@@ -912,14 +952,14 @@ async function waitForWorkerStartupEvidence(
   cwd: string,
   baseline: WorkerStartupBaseline,
   launchAttemptId: string,
-  attempts = 3,
-  delayMs = 250,
+  budgetMs: number,
+  delayMs = WORKER_STARTUP_EVIDENCE_POLL_INTERVAL_MS,
 ): Promise<boolean> {
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    if (await hasCurrentWorkerStartupEvidence(teamName, workerName, taskId, cwd, baseline, launchAttemptId)) return true;
-    if (attempt < attempts) await new Promise(resolve => setTimeout(resolve, delayMs));
-  }
-  return false;
+  return waitForStartupEvidenceBudget(
+    () => hasCurrentWorkerStartupEvidence(teamName, workerName, taskId, cwd, baseline, launchAttemptId),
+    budgetMs,
+    delayMs,
+  );
 }
 
 async function waitForWorkerStatusTransition(
@@ -1083,15 +1123,29 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     }).catch(() => false);
     if (!cleaned) throw new Error(`worker_startup_cleanup_unverified:${opts.workerName}:${paneId}`);
   };
-  const waitForCurrentEvidence = (attempts = 12) => waitForWorkerStartupEvidence(
+  try {
+    await applyMainVerticalLayout(opts.sessionName);
+  } catch (error) {
+    await cleanupStartedLaunch('startup_layout_failed');
+    throw error;
+  }
+
+  const evidencePolicy = getWorkerStartupEvidencePolicy(opts.agentType);
+  const waitForCurrentEvidence = (budgetMs: number) => waitForWorkerStartupEvidence(
     opts.teamName,
     opts.workerName,
     opts.taskId,
     opts.cwd,
     startupBaseline,
     startupContext.attempt.attempt_id,
-    attempts,
+    budgetMs,
   );
+  const waitForBoundedStartupEvidence = async (): Promise<boolean> => {
+    if (await waitForCurrentEvidence(evidencePolicy.initialBudgetMs)) return true;
+    return evidencePolicy.finalRecheckBudgetMs > 0
+      ? waitForCurrentEvidence(evidencePolicy.finalRecheckBudgetMs)
+      : false;
+  };
   const fencedDispatch = await (async () => {
     try {
       return await withWorkerLaunchAttemptFence(startupContext.attempt, async () => {
@@ -1113,7 +1167,7 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     inboxCorrelationKey: `startup:${opts.workerName}:${opts.taskId}:${startupContext.attempt.attempt_id}`,
     notify: async (_target, triggerMessage) => {
       if (usePromptMode) {
-        const settled = await waitForCurrentEvidence();
+        const settled = await waitForBoundedStartupEvidence();
         return settled
           ? { ok: true, transport: 'prompt_stdin' as const, reason: 'prompt_mode_worker_confirmed' }
           : { ok: false, transport: 'prompt_stdin' as const, reason: `${opts.agentType}_startup_evidence_missing` };
@@ -1123,10 +1177,13 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
       if (!attempted.ok) {
         return { ok: false, transport: 'tmux_send_keys' as const, reason: `worker_notify_failed:${attempted.reason}` };
       }
-      let settled = await waitForCurrentEvidence(opts.agentType === 'claude' ? 6 : 12);
-      for (let attempt = 1; !settled && opts.agentType === 'claude' && attempt <= 4; attempt++) {
+      let settled = await waitForCurrentEvidence(evidencePolicy.initialBudgetMs);
+      for (let attempt = 1; !settled && attempt <= evidencePolicy.resubmitAttempts; attempt++) {
         if (!await retryStartupInboxSubmit(startupContext, triggerMessage, { attemptAlreadyFenced: true })) break;
-        settled = await waitForCurrentEvidence();
+        settled = await waitForCurrentEvidence(evidencePolicy.resubmitBudgetMs);
+      }
+      if (!settled && evidencePolicy.finalRecheckBudgetMs > 0) {
+        settled = await waitForCurrentEvidence(evidencePolicy.finalRecheckBudgetMs);
       }
       return settled
         ? { ok: true, transport: 'tmux_send_keys' as const, reason: 'worker_startup_confirmed' }
@@ -2725,7 +2782,7 @@ export async function executeRecoverDeadWorkerV2Owner(
               input.cwd,
               startupBaseline,
               startupAttemptId,
-              12,
+              2_750,
             )
           : waitForWorkerStatusTransition(
               input.teamName,

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -1121,13 +1121,6 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
     }).catch(() => false);
     if (!cleaned) throw new Error(`worker_startup_cleanup_unverified:${opts.workerName}:${paneId}`);
   };
-  try {
-    await applyMainVerticalLayout(opts.sessionName);
-  } catch (error) {
-    await cleanupStartedLaunch('startup_layout_failed');
-    throw error;
-  }
-
   const evidencePolicy = getWorkerStartupEvidencePolicy(opts.agentType);
   const waitForCurrentEvidence = (budgetMs: number) => waitForWorkerStartupEvidence(
     opts.teamName,

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -1310,7 +1310,10 @@ async function cleanupRecoveryPaneAttempt(
   pending: PendingRecoveryPane,
   reason: string,
 ): Promise<boolean> {
-  let providerStopped = true;
+  // A spawn rejection can occur after its bootstrap created an owned process
+  // but before it returned the launch context. Without that context, cleanup
+  // containment is unproven and the pane must be retained for investigation.
+  let providerStopped = false;
   if (pending.startupContext) {
     providerStopped = await retireAndCleanupCurrentWorkerLaunchAttempt(
       pending.startupContext.attempt,

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -968,16 +968,14 @@ async function waitForWorkerStatusTransition(
   cwd: string,
   baselineFingerprint: string,
   launchAttemptId: string,
-  attempts = 12,
+  budgetMs: number,
   delayMs = 250,
 ): Promise<boolean> {
-  for (let attempt = 1; attempt <= attempts; attempt++) {
+  return waitForStartupEvidenceBudget(async () => {
     const status = await readWorkerStatus(teamName, workerName, cwd);
-    if (status.state !== 'unknown' && status.launch_attempt_id === launchAttemptId
-      && workerStatusStartupFingerprint(status) !== baselineFingerprint) return true;
-    if (attempt < attempts) await new Promise(resolve => setTimeout(resolve, delayMs));
-  }
-  return false;
+    return status.state !== 'unknown' && status.launch_attempt_id === launchAttemptId
+      && workerStatusStartupFingerprint(status) !== baselineFingerprint;
+  }, budgetMs, delayMs);
 }
 
 export function promptModeRecoveryRequiresProgressEvidence(
@@ -2802,6 +2800,7 @@ export async function executeRecoverDeadWorkerV2Owner(
               input.cwd,
               statusBaseline,
               startupAttemptId,
+              budgetMs,
             );
         const waitForBoundedStartupEvidence = async (
           resubmit?: () => Promise<boolean>,

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -46,7 +46,7 @@ export function buildWindowsSupervisorSource(): string {
     '  $si = New-Object O+STARTUPINFO; $si.cb = [Runtime.InteropServices.Marshal]::SizeOf($si); $flags = 0x00000004 -bor 0x00000400; if (-not [O]::CreateProcessW($null, $cmd, [IntPtr]::Zero, [IntPtr]::Zero, $false, $flags, $envPtr, $payload.cwd, [ref]$si, [ref]$pi)) { throw "worker_launch_create_process_failed" }',
     '  $job = [O]::CreateJobObjectW([IntPtr]::Zero, $null); if ($job -eq [IntPtr]::Zero) { throw "worker_launch_create_job_failed" }; $info = New-Object O+JOBOBJECT_EXTENDED_LIMIT_INFORMATION; $info.BasicLimitInformation.LimitFlags = 0x2000; $ptr = [Runtime.InteropServices.Marshal]::AllocHGlobal([Runtime.InteropServices.Marshal]::SizeOf($info)); try { [Runtime.InteropServices.Marshal]::StructureToPtr($info, $ptr, $false); if (-not [O]::SetInformationJobObject($job, 9, $ptr, [Runtime.InteropServices.Marshal]::SizeOf($info))) { throw "worker_launch_job_config_failed" } } finally { [Runtime.InteropServices.Marshal]::FreeHGlobal($ptr) }; if (-not [O]::AssignProcessToJobObject($job, $pi.hProcess)) { throw "worker_launch_assign_job_failed" }; if ([O]::ResumeThread($pi.hThread) -eq [uint32]0xffffffff) { throw "worker_launch_resume_failed" }',
     '  $ticks = ([DateTime]((Get-Process -Id $pi.dwProcessId).StartTime)).ToUniversalTime().Ticks; $ready = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="ready"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; process_start_identity=("ticks:" + $ticks) } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($ready); [Console]::Out.Flush()',
-    '  $readTask = [Console]::In.ReadLineAsync(); while ($true) { if ([O]::WaitForSingleObject($pi.hProcess, 50) -eq 0) { $exitCode = [uint32]0; [O]::GetExitCodeProcess($pi.hProcess, [ref]$exitCode) | Out-Null; [O]::TerminateJobObject($job, $exitCode) | Out-Null; $terminal = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="terminal"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; outcome="exit"; cleanup_verified=$true; exit_code=$exitCode } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($terminal); [Console]::Out.Flush(); break }; if (-not $readTask.IsCompleted) { continue }; $line = $readTask.Result; if ($null -eq $line) { throw "worker_launch_authority_lost" }; $readTask = [Console]::In.ReadLineAsync(); if ([string]::IsNullOrWhiteSpace($line) -or $line.Length -gt 4096) { continue }; try { $msg = $line | ConvertFrom-Json } catch { continue }; if ($msg.protocol -ne "' + WINDOWS_SUPERVISOR_PROTOCOL + '" -or $msg.attempt_id -ne $payload.identity.attempt_id -or $msg.authority_digest -ne $payload.authority_digest -or $msg.containment_nonce -ne $payload.containment_nonce -or $msg.kind -ne "terminate") { continue }; [O]::TerminateJobObject($job, 1) | Out-Null; [O]::WaitForSingleObject($pi.hProcess, 5000) | Out-Null; $terminal = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="terminal"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; outcome="terminated"; cleanup_verified=$true } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($terminal); [Console]::Out.Flush(); break }',
+    '  $readTask = [Console]::In.ReadLineAsync(); while ($true) { if ([O]::WaitForSingleObject($pi.hProcess, 50) -eq 0) { $exitCode = [uint32]0; [O]::GetExitCodeProcess($pi.hProcess, [ref]$exitCode) | Out-Null; if (-not [O]::TerminateJobObject($job, $exitCode)) { throw "worker_launch_job_terminate_failed" }; if ([O]::WaitForSingleObject($job, 5000) -ne 0) { throw "worker_launch_job_cleanup_timeout" }; $terminal = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="terminal"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; outcome="exit"; cleanup_verified=$true; exit_code=$exitCode } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($terminal); [Console]::Out.Flush(); break }; if (-not $readTask.IsCompleted) { continue }; $line = $readTask.Result; if ($null -eq $line) { throw "worker_launch_authority_lost" }; $readTask = [Console]::In.ReadLineAsync(); if ([string]::IsNullOrWhiteSpace($line) -or $line.Length -gt 4096) { continue }; try { $msg = $line | ConvertFrom-Json } catch { continue }; if ($msg.protocol -ne "' + WINDOWS_SUPERVISOR_PROTOCOL + '" -or $msg.attempt_id -ne $payload.identity.attempt_id -or $msg.authority_digest -ne $payload.authority_digest -or $msg.containment_nonce -ne $payload.containment_nonce -or $msg.kind -ne "terminate") { continue }; if (-not [O]::TerminateJobObject($job, 1)) { throw "worker_launch_job_terminate_failed" }; if ([O]::WaitForSingleObject($job, 5000) -ne 0) { throw "worker_launch_job_cleanup_timeout" }; $terminal = @{ protocol="' + WINDOWS_SUPERVISOR_PROTOCOL + '"; kind="terminal"; attempt_id=$payload.identity.attempt_id; authority_digest=$payload.authority_digest; containment_nonce=$payload.containment_nonce; pid=$pi.dwProcessId; outcome="terminated"; cleanup_verified=$true } | ConvertTo-Json -Compress; [Console]::Out.WriteLine($terminal); [Console]::Out.Flush(); break }',
     '} catch { if ($pi.hProcess -ne [IntPtr]::Zero) { if ($job -ne [IntPtr]::Zero) { [O]::TerminateJobObject($job, 1) | Out-Null } else { [O]::TerminateProcess($pi.hProcess, 1) | Out-Null }; [O]::WaitForSingleObject($pi.hProcess, 5000) | Out-Null }; throw } finally { if ($envPtr -ne [IntPtr]::Zero) { [Runtime.InteropServices.Marshal]::FreeHGlobal($envPtr) }; if ($pi.hThread -ne [IntPtr]::Zero) { [O]::CloseHandle($pi.hThread) | Out-Null }; if ($pi.hProcess -ne [IntPtr]::Zero) { [O]::CloseHandle($pi.hProcess) | Out-Null }; if ($job -ne [IntPtr]::Zero) { [O]::CloseHandle($job) | Out-Null } }',
   ].join("`n");
 }
@@ -945,6 +945,14 @@ async function readWorkerLaunchCleanupProof(
   started?: Partial<WorkerLaunchProviderStarted>,
 ): Promise<boolean> {
   const startedPath = 'startedPath' in attempt ? attempt.startedPath : attempt.started_path;
+  const matchesProcessGroup = (value: Record<string, unknown>): boolean => {
+    if (process.platform === 'win32') return true;
+    if (!Number.isSafeInteger(value.process_group_id) || Number(value.process_group_id) <= 0) return false;
+    return started === undefined
+      || (Number.isSafeInteger(started.process_group_id)
+        && Number(started.process_group_id) > 0
+        && value.process_group_id === started.process_group_id);
+  };
   const terminal = await readJson(`${startedPath}.terminal`);
   if (terminal.kind === 'value') {
     const value = terminal.value as Partial<WorkerLaunchIdentity> & Record<string, unknown>;
@@ -953,7 +961,8 @@ async function readWorkerLaunchCleanupProof(
     if (matchesStarted && identityMatches(value, attempt) && value.kind === 'worker_launch_provider_terminal'
       && value.outcome === 'exit' && value.cleanup_verified === true
       && Number.isSafeInteger(value.pid) && Number(value.pid) > 0
-      && isValidProcessStartIdentity(value.process_start_identity)) return true;
+      && isValidProcessStartIdentity(value.process_start_identity)
+      && matchesProcessGroup(value)) return true;
   }
   const completed = await readJson(`${startedPath}.termination-complete`);
   if (completed.kind === 'value') {
@@ -962,7 +971,8 @@ async function readWorkerLaunchCleanupProof(
       && value.process_start_identity === started.process_start_identity);
     if (matchesStarted && identityMatches(value, attempt) && value.kind === 'worker_launch_termination_complete'
       && value.cleanup_verified === true && Number.isSafeInteger(value.pid) && Number(value.pid) > 0
-      && isValidProcessStartIdentity(value.process_start_identity)) return true;
+      && isValidProcessStartIdentity(value.process_start_identity)
+      && matchesProcessGroup(value)) return true;
   }
   return false;
 }
@@ -1047,21 +1057,13 @@ export async function terminateWorkerLaunchProvider(
       && await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record));
   }
   if (result !== 'terminated') return false;
-  if (!await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record)) {
-    // The completion-record write failed after a successful termination.
-    // Retry: verify the process is dead, then re-attempt the write so a
-    // later retry can safely resume from the termination-request + proven
-    // process absence. Never infer from PID absence without request identity.
-    const deadline = Date.parse(deadlineAt);
-    const liveness = await isProcessIdentityLive(record.pid!, record.process_start_identity, deadline);
-    if ((liveness === 'dead' || liveness === 'mismatch')
-      && await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record)) return true;
-    return false;
-  }
   const deadline = Date.parse(deadlineAt);
   while (Date.now() < deadline) {
     const liveness = await isProcessIdentityLive(record.pid!, record.process_start_identity, deadline);
-    if (liveness === 'dead' || liveness === 'mismatch') return true;
+    if ((liveness === 'dead' || liveness === 'mismatch')
+      && isProcessGroupAbsent(record.process_group_id)) {
+      return publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record);
+    }
     if (liveness === 'unknown') return false;
     await sleep(20);
   }
@@ -1078,6 +1080,14 @@ function isProcessGroupAbsent(processGroupId: unknown): boolean {
   }
 }
 
+async function waitForProcessGroupAbsence(processGroupId: unknown, deadlineAt: number): Promise<boolean> {
+  while (Date.now() < deadlineAt) {
+    if (isProcessGroupAbsent(processGroupId)) return true;
+    await sleep(20);
+  }
+  return isProcessGroupAbsent(processGroupId);
+}
+
 async function publishWorkerLaunchTerminationComplete(
   terminationCompletePath: string,
   attempt: WorkerLaunchAttempt,
@@ -1088,7 +1098,9 @@ async function publishWorkerLaunchTerminationComplete(
     try {
       await writeExclusiveAtomic(terminationCompletePath, {
         ...identityOf(attempt), kind: 'worker_launch_termination_complete', cleanup_verified: true,
-        pid: record.pid, process_start_identity: record.process_start_identity, written_at: new Date().toISOString(),
+        pid: record.pid, process_start_identity: record.process_start_identity,
+        ...(process.platform !== 'win32' ? { process_group_id: record.process_group_id } : {}),
+        written_at: new Date().toISOString(),
       });
       return true;
     } catch {
@@ -1100,7 +1112,8 @@ async function publishWorkerLaunchTerminationComplete(
     : null;
   return !!value && identityMatches(value, attempt) && value.kind === 'worker_launch_termination_complete'
     && value.cleanup_verified === true && value.pid === record.pid
-    && value.process_start_identity === record.process_start_identity;
+    && value.process_start_identity === record.process_start_identity
+    && (process.platform === 'win32' || value.process_group_id === record.process_group_id);
 }
 
 async function readValidProviderStarted(
@@ -1505,16 +1518,21 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
           }
           const effectiveExitCode = supervisedExitCode ?? exitCode;
           const effectiveSignal = supervisedExitCode === null ? signal : null;
-          const cleanupVerified = process.platform === 'win32'
+          const terminationVerified = process.platform === 'win32'
             ? await awaitExternalTerminationCompletion(spec) || await readWorkerLaunchCleanupProof(spec)
             : terminationResult
               ? ['terminated', 'already-dead', 'identity-mismatch'].includes(await terminationResult)
               : await awaitExternalTerminationCompletion(spec) || await readWorkerLaunchCleanupProof(spec)
                 || await isCorrelatedTerminationDead(spec);
+          const cleanupVerified = terminationVerified && (process.platform === 'win32'
+            || (launchGroup !== null
+              && await waitForProcessGroupAbsence(launchGroup.processGroupId, Date.now() + 2_000)));
           await atomicWriteJson(`${spec.started_path}.terminal`, {
             ...identityOf(spec), kind: 'worker_launch_provider_terminal',
             outcome: cleanupVerified ? 'exit' : 'cleanup_unverified', cleanup_verified: cleanupVerified,
-            pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity, exit_code: effectiveExitCode, signal: effectiveSignal, written_at: new Date().toISOString(),
+            pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity,
+            ...(process.platform !== 'win32' && launchGroup ? { process_group_id: launchGroup.processGroupId } : {}),
+            exit_code: effectiveExitCode, signal: effectiveSignal, written_at: new Date().toISOString(),
           }).catch(() => undefined);
           await invocation.cleanup().catch(() => undefined);
           resolve(cleanupVerified

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -999,7 +999,6 @@ export async function terminateWorkerLaunchProvider(
   const terminationRequestPath = `${attempt.startedPath}.termination-request`;
   const terminationCompletePath = `${attempt.startedPath}.termination-complete`;
   const existingRequest = await readJson(terminationRequestPath);
-  let hadExistingValidTerminationRequest = false;
   if (process.platform === 'win32') {
     if (existingRequest.kind === 'absent') {
       try {
@@ -1044,7 +1043,6 @@ export async function terminateWorkerLaunchProvider(
       : null;
     if (!value || !identityMatches(value, attempt) || value.kind !== 'worker_launch_termination_request'
       || value.pid !== record.pid || value.process_start_identity !== record.process_start_identity) return false;
-    hadExistingValidTerminationRequest = true;
   }
   const deadlineAt = new Date(Date.now() + timeoutMs).toISOString();
   const result = await terminateOwnedProcessGroup({
@@ -1052,9 +1050,7 @@ export async function terminateWorkerLaunchProvider(
     processGroupId: record.process_group_id!, deadlineAt, force: true,
   });
   if (result === 'already-dead' || result === 'identity-mismatch') {
-    return terminalCleanupVerified || (hadExistingValidTerminationRequest
-      && isProcessGroupAbsent(record.process_group_id)
-      && await publishWorkerLaunchTerminationComplete(terminationCompletePath, attempt, record));
+    return terminalCleanupVerified;
   }
   if (result !== 'terminated') return false;
   const deadline = Date.parse(deadlineAt);


### PR DESCRIPTION
Closes #3798.

## Problem

Non-Claude workers passed the pane readiness gate, then received only about 3 seconds to publish task/status startup evidence. Codex cold starts can take around 18 seconds. The runtime therefore recorded `worker_startup_evidence_missing` and tore down the pane while the detached provider process group could continue headlessly and mutate team state.

Readiness and evidence are separate gates: this change does not modify layout or readiness behavior from #3790 / #3796. #3788 and #3789 remain out of scope.

## Change

- Add an explicit provider-aware startup-evidence policy.
  - Claude preserves its bounded submit retry behavior.
  - Non-Claude providers get a 30,000 ms evidence window plus one 1,000 ms read-only recheck.
  - Non-Claude startup performs zero inbox resubmits, avoiding duplicate execution.
- Use deadline-based evidence polling so the wall-clock budget is exact and bounded.
- Require failed-startup teardown to prove the exact owned provider containment is gone before pane cleanup succeeds.
  - POSIX: positive matching process-group identity, root death, and process-group absence precede durable cleanup proof.
  - Windows: the supervisor checks `TerminateJobObject` and waits for the Job handle before authenticated terminal proof.
- Refresh inventory provenance and update cleanup-proof fixtures for the stronger process-group contract.

## Exact timeline coverage

- Evidence at T+18.000s succeeds.
- Evidence at T+30.250s succeeds only in the final read-only recheck.
- Missing evidence fails at exactly T+31.000s.
- The startup inbox is not resubmitted for Codex.
- Failed-startup pane cleanup runs only after provider parent, descendant, and POSIX process group are absent.

## Verification

Passed locally:

- `npx tsc --noEmit`
- `npm run lint --if-present` (0 errors; 21 pre-existing warnings)
- `npx vitest run src/team/__tests__/runtime-v2.dispatch.test.ts src/team/__tests__/worker-launch-ack.test.ts` (81 passed, 4 skipped)
- `npx vitest run src/team/__tests__/recovery-pane-rollback.test.ts src/team/__tests__/runtime-v2.shutdown.test.ts` (30 passed)
- `npx vitest run tests/lint/inventory-graph-drift.test.ts` (passed)
- `npm exec vitest -- run tests/perf/subagent-lock.bench.ts --fileParallelism=false --maxWorkers=1` (3 passed)
- `npm run plugin:shipping:verify`
- `node scripts/ci/check-multirepo-paths.mjs`
- `npm run build`
- `node scripts/generate-inventory-graph.mjs --verify`

The full local suite completed 12,930 passing tests; remaining failures were unrelated environment/load-sensitive session-start and 1-second Python subprocess tests. The affected suites and all prior failures pass in isolation. GitHub CI is the exact clean-run authority.

## Signed evidence

- Base: `bb440f06359f5499c190e211da61ef75811a2f41`
- Head: `43afce3b869447df7ce5991d21faa34120ce3c5b`
- Commit signature: Good ED25519 signature, key `04D7A66ECE3B8013B060B8148817F4143F84F5E7`, identity `gaebal-gajae <clawdbot@users.noreply.github.com>`
- Independent GJC review: `MERGE_READY`, zero findings (review receipt `1-Issue3798MergeReview`).
- Layout exclusion verified: no diff in `src/team/tmux-session.ts` or `src/team/layout-stabilizer.ts`.

No main merge, release, tag, or publish is included.