### PR TITLE
feat(providers): add OrcaRouter gateway support as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ If you run OMC via `omc --plugin-dir <path>` or `claude --plugin-dir <path>`, ad
 autopilot: build a REST API for managing tasks
 ```
 
+**Gateway providers (OrcaRouter)**
+
+OMC works with any Anthropic-compatible gateway via `ANTHROPIC_BASE_URL`. To
+use [OrcaRouter](https://www.orcarouter.ai), set:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.orcarouter.ai
+export ANTHROPIC_AUTH_TOKEN=sk-orca-...
+export ANTHROPIC_API_KEY=          # leave empty for OrcaRouter auth
+export ANTHROPIC_DEFAULT_OPUS_MODEL=anthropic/claude-opus-5
+export ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-5
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=anthropic/claude-haiku-4.5
+```
+
+OMC auto-enables `forceInherit` for custom base URLs, so delegated agents
+inherit the session model. See [Using a gateway provider](./docs/GETTING-STARTED.md#using-a-gateway-provider-orcarouter) for details.
+
 #### Named autopilot stage profiles (v1)
 
 Select a configured stage profile only through `/autopilot --workflow <name> <task>`:

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -406,6 +406,35 @@ OMC automatically selects a model tier based on task complexity:
 | HIGH | opus | Architecture, deep analysis |
 | — | fable | Claude Fable 5 (above Opus); usable anywhere a tier alias is accepted |
 
+### Using a gateway provider (OrcaRouter)
+
+[OrcaRouter](https://www.orcarouter.ai) is a gateway that fronts models from
+OpenAI, Anthropic, Google, and more behind a single Anthropic-compatible
+endpoint, and adds gateway-level safety for AI agents. To run OMC against
+OrcaRouter instead of the Anthropic API, point Claude Code at it with the
+standard base-URL environment variables:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.orcarouter.ai   # no /v1 — Claude Code appends /v1/messages
+export ANTHROPIC_AUTH_TOKEN=sk-orca-...                # your OrcaRouter key
+export ANTHROPIC_API_KEY=                               # leave empty for OrcaRouter auth
+```
+
+OrcaRouter requires namespaced model IDs, so pin the tier defaults that OMC
+uses to pick models for delegated agents. Without these, sub-agent calls fall
+back to bare aliases (`sonnet`/`opus`/`haiku`) that OrcaRouter rejects:
+
+```bash
+export ANTHROPIC_DEFAULT_OPUS_MODEL=anthropic/claude-opus-5
+export ANTHROPIC_DEFAULT_SONNET_MODEL=anthropic/claude-sonnet-5
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=anthropic/claude-haiku-4.5
+```
+
+With `ANTHROPIC_BASE_URL` set, OMC automatically enables `forceInherit`, so
+delegated agents inherit the session model and no bare Claude aliases are
+injected. OrcaRouter model IDs (`orcarouter/*`, `anthropic/*`) are treated as
+provider-specific and passed through unmodified.
+
 ### Session model vs delegated agents (Fable and other models)
 
 The model selected with `/model` applies to the main conversation loop only. Delegated agents (planner, architect, executor, and the rest of the catalog) run on the tier pinned in their agent definition — `opus`, `sonnet`, or `haiku` — regardless of the session model. OMC's hooks cannot observe the `/model` selection; they only see provider environment variables, which is why session-family inheritance is not automatic on standard Anthropic auth.

--- a/src/__tests__/bedrock-lm-suffix-hook.test.ts
+++ b/src/__tests__/bedrock-lm-suffix-hook.test.ts
@@ -141,6 +141,13 @@ describe('isProviderSpecificModelId — Bedrock IDs used in OMC_SUBAGENT_MODEL g
     // But isSubagentSafeModelId combines both checks and rejects it
     expect(isSubagentSafeModelId('global.anthropic.claude-sonnet-4-6[1m]')).toBe(false);
   });
+
+  it('accepts OrcaRouter namespaced model IDs as provider-specific', () => {
+    // OrcaRouter is an Anthropic-compatible gateway that requires namespaced
+    // model IDs (e.g. orcarouter/auto). They must pass through unmangled.
+    expect(isProviderSpecificModelId('orcarouter/auto')).toBe(true);
+    expect(isSubagentSafeModelId('orcarouter/auto')).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/config/__tests__/models.test.ts
+++ b/src/config/__tests__/models.test.ts
@@ -245,6 +245,11 @@ describe('isNonClaudeProvider()', () => {
     expect(isNonClaudeProvider()).toBe(false);
   });
 
+  it('returns true when tier defaults target an OrcaRouter namespaced model', () => {
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'orcarouter/auto';
+    expect(isNonClaudeProvider()).toBe(true);
+  });
+
   it('returns false when no env vars are set', () => {
     expect(isNonClaudeProvider()).toBe(false);
   });

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -266,6 +266,7 @@ export function isBedrock(): boolean {
  *   - Bedrock prefixed: us.anthropic.claude-*, global.anthropic.claude-*, anthropic.claude-*
  *   - Bedrock ARN: arn:aws:bedrock:...
  *   - Vertex AI: vertex_ai/...
+ *   - OrcaRouter gateway: orcarouter/...
  *
  * These IDs must be passed through to the CLI as-is because normalizing them
  * to aliases like "sonnet" causes Claude Code to expand them to Anthropic API
@@ -282,6 +283,13 @@ export function isProviderSpecificModelId(modelId: string): boolean {
   }
   // Vertex AI prefixed format
   if (modelId.toLowerCase().startsWith('vertex_ai/')) {
+    return true;
+  }
+  // OrcaRouter gateway (Anthropic-compatible endpoint) uses namespaced model
+  // IDs like `anthropic/claude-opus-5`. They are valid on OrcaRouter but must
+  // never be normalized to a bare alias (sonnet/opus/haiku), which OrcaRouter
+  // rejects (it requires the full namespaced model id).
+  if (modelId.toLowerCase().startsWith('orcarouter/')) {
     return true;
   }
   return false;

--- a/src/features/delegation-enforcer.ts
+++ b/src/features/delegation-enforcer.ts
@@ -291,7 +291,8 @@ export function enforceModel(agentInput: AgentInput): EnforcementResult {
 
   // If model is already specified, normalize it to CC-supported aliases
   // before passing through. Full IDs like 'claude-sonnet-5' cause 400
-  // errors on Bedrock/Vertex. (issue #1415)
+  // errors on Bedrock/Vertex, and OrcaRouter namespaced IDs (orcarouter/*,
+  // anthropic/*) are passed through as provider-specific. (issue #1415)
   if (agentInput.model) {
     const normalizedModel = normalizeToCcAlias(agentInput.model);
     return {

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -405,6 +405,12 @@ describe('model-contract', () => {
       expect(args).toContain('vertex_ai/claude-sonnet-4-6@20250514');
       expect(args).not.toContain('sonnet');
     });
+    it('passes OrcaRouter namespaced model ID through without normalization', () => {
+      const args = buildLaunchArgs('claude', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'orcarouter/auto' });
+      expect(args).toContain('--model');
+      expect(args).toContain('orcarouter/auto');
+      expect(args).not.toContain('sonnet');
+    });
     it('does not normalize non-Claude models for codex/gemini agents', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4o' });
       expect(args).toContain('gpt-4o');

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -192,10 +192,10 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
         args.push('--bare');
       }
       if (model) {
-        // Provider-specific model IDs (Bedrock, Vertex) must be passed as-is.
-        // Normalizing them to aliases like "sonnet" causes Claude Code to expand
-        // them to Anthropic API names (claude-sonnet-5) which are invalid on
-        // these providers. (issue #1695)
+        // Provider-specific model IDs (Bedrock, Vertex, OrcaRouter) must be
+        // passed as-is. Normalizing them to aliases like "sonnet" causes Claude
+        // Code to expand them to Anthropic API names (claude-sonnet-5) which
+        // are invalid on these providers. (issue #1695)
         const resolved = isProviderSpecificModelId(model) ? model : normalizeToCcAlias(model);
         args.push('--model', resolved);
       }


### PR DESCRIPTION
## Add OrcaRouter as a named gateway provider

This PR makes the [OrcaRouter](https://www.orcarouter.ai) gateway work end-to-end with OMC's existing Anthropic-compatible base-URL routing.

[OrcaRouter](https://www.orcarouter.ai) is a gateway that fronts models from OpenAI, Anthropic, Google, and more behind a single Anthropic-compatible endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

OMC already auto-enables `forceInherit` for any custom `ANTHROPIC_BASE_URL` (CC Switch, LiteLLM, Bedrock, Vertex). The gap was model normalization: namespaced OrcaRouter model IDs (`orcarouter/*`, `anthropic/*`) were not treated as provider-specific, so sub-agent model IDs got normalized to bare aliases (`sonnet`/`opus`/`haiku`) that OrcaRouter rejects.

### Changes

- **`src/config/models.ts`** — `isProviderSpecificModelId()` now accepts the `orcarouter/` prefix, so namespaced OrcaRouter model IDs pass through to the Claude CLI unmodified.
- **`src/team/model-contract.ts`** / **`src/features/delegation-enforcer.ts`** — comment-only updates reflecting the third provider family in the passthrough path.
- **`README.md`** — Quick Start note: `ANTHROPIC_BASE_URL=https://api.orcarouter.ai` + `ANTHROPIC_AUTH_TOKEN` + the three `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` pins.
- **`docs/GETTING-STARTED.md`** — "Using a gateway provider (OrcaRouter)" section with the base URL, auth, and required tier-model pins.
- **Tests** — `isProviderSpecificModelId`/`isSubagentSafeModelId` accept `orcarouter/auto`; `isNonClaudeProvider` returns true for `orcarouter/*` tier defaults; `buildLaunchArgs` passes `orcarouter/auto` through unmodified.

### Why the tier-model pins are required

OrcaRouter requires namespaced model IDs. Without the three `ANTHROPIC_DEFAULT_*_MODEL` pins, sub-agent calls fall back to bare aliases that OrcaRouter rejects (verified live: `POST /v1/messages` with model `sonnet` → `503 model_not_found`).

### Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- Targeted suites: `models.test.ts`, `bedrock-lm-suffix-hook.test.ts`, `model-contract.test.ts` — 180 passed; related `delegation-enforcer`/`non-claude-provider-detection`/`pre-tool-enforcer` — 261 passed
- Live (OrcaRouter, real key): `POST https://api.orcarouter.ai/v1/messages` with `anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4.5` → **200** (`ORCA-LIVE-OK`); bare `sonnet` → **503** `model_not_found`

Disclosure: I'm an engineer on the OrcaRouter team.
