### PR TITLE
ci: authorize PR 3749 exact head e2591c49

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -1842,49 +1842,49 @@
     {
       "pullNumber": 3749,
       "targetRef": "main",
-      "mergeBaseSha": "bb8d38d95f978bad0b524ad74da061e3b8183829",
-      "headSha": "8247ee7a50cf75f770f36a0992254ff90cd97446",
+      "mergeBaseSha": "94e71c3630acbfb4f26dee6df4b78af30bab1563",
+      "headSha": "e2591c49cc20ad850c73523779fd71373f6c710d",
       "owner": "Yeachan-Heo",
-      "expiresAt": "2026-08-29T00:00:00.000Z",
+      "expiresAt": "2026-08-30T00:00:00.000Z",
       "generatedDelta": {
-        "count": 1209,
-        "sha256": "ba45c12b2a2ba470247a7385928148bbb07f225799a866a44b8e4536059ce7e8"
+        "count": 1235,
+        "sha256": "cfc2888ae17a78ae7b1f238d17e9fba9798fbde6bde5c17b265c86271c562d0e"
       },
       "generatedFiles": [
         {
           "status": "modified",
           "filename": "bridge/claude-md-coordinator.cjs",
-          "sha": "fc965177b47e2bdcbc2b38cbe3b5045e0693cbcb",
+          "sha": "09490253ccbf7c537a1a36caf96ab477148bcca1",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/cli.cjs",
-          "sha": "bea9acbad953c6b12837628dc80675762bc7f2b4",
+          "sha": "e893d5d0e138cf3651f922da52a9a4c181655ee5",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/mcp-server.cjs",
-          "sha": "41a5353a7cfdb124a362236cc5b858e59f0e643d",
+          "sha": "d96c97053905ea08d1385f2ba8ccc491b098de41",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/runtime-cli.cjs",
-          "sha": "7aed036b4d52a80997b3eafe5e5ee634e6fe789e",
+          "sha": "1eb1637c48cac8ae80068c118a0fbc050c1e22a2",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/team-mcp.cjs",
-          "sha": "72aa7cf6a6c0753b48390a3e3de518491616fc5f",
+          "sha": "1f66cbb4ce60a9df4b9d2b0d2a5b932e76ea04b9",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "bridge/team.js",
-          "sha": "e106593d0fc3697574186868673c560025a90310",
+          "sha": "b4279f36b1619c9c379260502a1333f7843ba8cc",
           "previousFilename": null
         },
         {
@@ -1914,13 +1914,13 @@
         {
           "status": "modified",
           "filename": "dist/__tests__/auto-slash-aliases.test.js",
-          "sha": "43603758dc15b70a4d36eb9e346bc7d6092a571c",
+          "sha": "f27a32090f5d0c7d8d4cd62661360fc8cc067ca5",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/auto-slash-aliases.test.js.map",
-          "sha": "02251ad95a5e80a21ef55cd083efcca9cadd775c",
+          "sha": "15bf43abd7842902a4ebae6f476cabb81b381834",
           "previousFilename": null
         },
         {
@@ -2094,13 +2094,13 @@
         {
           "status": "added",
           "filename": "dist/__tests__/generated-artifact-authorization.test.js",
-          "sha": "5df12ce473aa7f9b23160afe06d02ca629242e33",
+          "sha": "d3b8376f29afac08d246507cec0097dbf7f4b972",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/generated-artifact-authorization.test.js.map",
-          "sha": "e907dfa50e004a3b67894f3929d31847dce5ca39",
+          "sha": "584a75c90940c2981fd7e66a03d6e21e8eaf95fa",
           "previousFilename": null
         },
         {
@@ -2506,6 +2506,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/__tests__/package-dir-resolution-regression.test.js",
+          "sha": "9b4542b5ca04fdf650d278f92be15c2522953c48",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/package-dir-resolution-regression.test.js.map",
+          "sha": "c18e4fa6061879b257408609cb51e2b38c45b990",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/__tests__/plugin-shipping-surface.test.d.ts",
           "sha": "40accf3f69562564f3822a0cc3da7549b0f6cdae",
@@ -2736,25 +2748,25 @@
         {
           "status": "added",
           "filename": "dist/__tests__/release-boundary.test.js",
-          "sha": "932a852cc8a443d522211d44774b8ee1765b8c5c",
+          "sha": "c408fe908506a6d41f899c0596c6554aaddbcd19",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/release-boundary.test.js.map",
-          "sha": "3da7b5a4d87641f8031968f806584cc6eadefb7e",
+          "sha": "add34053f4969295a2ee5f3f90cd2482409dd1b2",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/release-generation.test.js",
-          "sha": "a7a7b8f01335a29a40ffb736f6b0e945e2082512",
+          "sha": "5920b8fce1efc267a6a723a5c727f0702ec0d256",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/release-generation.test.js.map",
-          "sha": "164eab64cdec36f35b4bea396ff6de806aa55544",
+          "sha": "af4f6f821d6bee3b22011264bc4b1d0c47147064",
           "previousFilename": null
         },
         {
@@ -2832,13 +2844,13 @@
         {
           "status": "modified",
           "filename": "dist/__tests__/run-cjs-graceful-fallback.test.js",
-          "sha": "c218301002fb0183e4314bb0a55ca5422b9382f3",
+          "sha": "cd6023bbcb64ec5bb894fd6a924dd57d25e344a5",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/__tests__/run-cjs-graceful-fallback.test.js.map",
-          "sha": "8fded95889154e7bb2b8e2ac45ec63988b6ad086",
+          "sha": "ed2ae19268d31681be62d409c5b07362ff809e65",
           "previousFilename": null
         },
         {
@@ -2914,6 +2926,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/__tests__/session-start-cache-cleanup.test.js",
+          "sha": "4963628a3348fb38478bbf00be2da2d7c858aada",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/session-start-cache-cleanup.test.js.map",
+          "sha": "ef2484603e4a04bd30c5b9b0a617edc4b48aabd0",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.d.ts",
           "sha": "e3764db70a992e141b802c72bd1b95b041265cbd",
@@ -2928,13 +2952,13 @@
         {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.js",
-          "sha": "553f9b6e9841127c8655622c4935c99750f74b87",
+          "sha": "574be94a1fd5005222da344409997545df5e79b7",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/__tests__/session-start-precompact-restore.test.js.map",
-          "sha": "3f8733928a27c97dd7b4926bf10f31dc3c416785",
+          "sha": "b06153216ff03037d60245916bafcf39b6ebaa0e",
           "previousFilename": null
         },
         {
@@ -3067,6 +3091,18 @@
           "status": "modified",
           "filename": "dist/__tests__/tier0-contracts.test.js.map",
           "sha": "0793443c7585b8d411f7caef7e1edb583698684a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/tier0-docs-consistency.test.js",
+          "sha": "0880e4e346fe8b505e21a4902f16da1ceb755414",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/__tests__/tier0-docs-consistency.test.js.map",
+          "sha": "4a7489960e779e755b8f13b20a288c86e93c69ae",
           "previousFilename": null
         },
         {
@@ -4338,13 +4374,13 @@
         {
           "status": "modified",
           "filename": "dist/hooks/__tests__/bridge-routing.test.js",
-          "sha": "4478d58a3d7fb1e0aec6b6ca59aa920ae2790ee3",
+          "sha": "d4ffcb921a26d3f4d5cce8378d44f3e0a9952b78",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/__tests__/bridge-routing.test.js.map",
-          "sha": "189493e7ec0f5096660850c4d139629a691a7774",
+          "sha": "62c11cce7867696ee6947be1fb5441d9572521bd",
           "previousFilename": null
         },
         {
@@ -4374,13 +4410,13 @@
         {
           "status": "added",
           "filename": "dist/hooks/__tests__/precompact-restore.test.js",
-          "sha": "eda029b0c9f764f031af86797e600b3f86ac7cf8",
+          "sha": "dff53a236fc8d24f66e12dedfc3c084b29aac1e0",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/__tests__/precompact-restore.test.js.map",
-          "sha": "de3d59e9797d8fb428b1caa30171827cd14a2485",
+          "sha": "d8af6c7131acfa4cdb63afbf37ec8d30cf783818",
           "previousFilename": null
         },
         {
@@ -4734,19 +4770,19 @@
         {
           "status": "modified",
           "filename": "dist/hooks/bridge.d.ts.map",
-          "sha": "e4feb6ca36a2097c3e7da9f9e6a851099925e246",
+          "sha": "0a89e8efcbfd7bbcf4d1f8c0e770cd5d1329dca3",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/bridge.js",
-          "sha": "46b8142c241d40a5af402e9cb7a840d5da195b3f",
+          "sha": "7abed6bdbcb06e23e6180f5984053bcee826f37b",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/bridge.js.map",
-          "sha": "5eaf4d34b7a11db72e74c3a5554185de1e643076",
+          "sha": "34514b0b7d3e05a1353f868f337e8fc98359b217",
           "previousFilename": null
         },
         {
@@ -4985,6 +5021,18 @@
         },
         {
           "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/cancel-race.test.js",
+          "sha": "a80ea75690b0fc332a00779ab1dd7db446181b1a",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/cancel-race.test.js.map",
+          "sha": "1476d270a68fff64b279e9fa9205ebee62bbc1e1",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
           "filename": "dist/hooks/persistent-mode/__tests__/error-handling.test.js",
           "sha": "d0356dd7d3cc4429d09f376d8743570ea664e0e6",
           "previousFilename": null
@@ -5005,6 +5053,18 @@
           "status": "modified",
           "filename": "dist/hooks/persistent-mode/__tests__/idle-repo-state.test.js.map",
           "sha": "0388a773c947d3152327e9d4e76ecc88906f75ee",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/team-ralplan-stop.test.js",
+          "sha": "6a9f70ae1350d30102cdbb98d21304549295a615",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/persistent-mode/__tests__/team-ralplan-stop.test.js.map",
+          "sha": "4e528739c87cd65fb187f9e2b43d0e3a34d7a5c8",
           "previousFilename": null
         },
         {
@@ -5076,61 +5136,61 @@
         {
           "status": "modified",
           "filename": "dist/hooks/persistent-mode/session-isolation.test.js",
-          "sha": "e71cbfe3aa255a998c04a7eae524f78104252c54",
+          "sha": "cc9eb9d003608fb32e361eb3b122c1a6889389d1",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/persistent-mode/session-isolation.test.js.map",
-          "sha": "014e1bbe89664aac27fb10a632405ccfa5ab2c27",
+          "sha": "c6520eea997a5f56526c43207214384309310753",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/pre-compact/index.d.ts",
-          "sha": "11ddb9af0e52084de0ae4103e3942d07bc5fa5e6",
+          "sha": "bce4a7cbda8399bc70f2470201962896cb8f3796",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/pre-compact/index.d.ts.map",
-          "sha": "09efbc959c646324f938a5bac81fc9551b8544c7",
+          "sha": "59e6738760659185a0da533674f91e4356571a99",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/pre-compact/index.js",
-          "sha": "b04ef8486bd005e9fea5733ca6e411b2c083ff9d",
+          "sha": "0772ec5276eb6ebcf0b0dd43586bc017ae84bdfb",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/hooks/pre-compact/index.js.map",
-          "sha": "c8c00462729a6b10cc45a8ccef6f040a6c7ea2f0",
+          "sha": "8fb17bc6e1a0e996705d87e41ee0a79753b9ebb4",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.d.ts",
-          "sha": "6fa52359b0c79c2a940013d3b1049ba7051023d2",
+          "sha": "9c0cff56a1312695d73c0325fe5f813bc6651a28",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.d.ts.map",
-          "sha": "a892d6b2e129096d172f8d4a19df143c7b02f241",
+          "sha": "06a90489986f8c0305ac7dcfc003d547df8a4e9c",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.js",
-          "sha": "b02f42bd3badbeab67621fa92fa63998262458da",
+          "sha": "b8b0196ca967f388f2a1a7d8689820f58c1978c9",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/pre-compact/restore.js.map",
-          "sha": "04a35d0886bd0d8fa40892e8d99195e78255909f",
+          "sha": "133e253ba6a5ab82cddd82c2f7a4f799e15aab31",
           "previousFilename": null
         },
         {
@@ -5442,25 +5502,25 @@
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.d.ts",
-          "sha": "7165885096f764877694028f3ba46a19fc2950dc",
+          "sha": "efb8ebc0a1c9d49c726ddf420ba8c036d95c921e",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.d.ts.map",
-          "sha": "591f0906046a098d25f8127c371e30a2cb1866b9",
+          "sha": "aa3d459835fe937d8c5ddaa4d5832a8f4f42b011",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.js",
-          "sha": "7c7557e28bec88ec66aad389bf09c2a5e4b30953",
+          "sha": "2628d7a210e155d10aac55f2c771edd01b9a9ef0",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/hooks/registry/cutover.js.map",
-          "sha": "c78e2d8f26612fd5d589a84da5b0fa61395eec70",
+          "sha": "ae2440f1e16b8c1fc88d94488ba8a1a4ea25ef53",
           "previousFilename": null
         },
         {
@@ -5993,6 +6053,24 @@
         },
         {
           "status": "modified",
+          "filename": "dist/hooks/team-dispatch-hook.d.ts.map",
+          "sha": "15e3feef4fc2ecfd2320f6faeb116891489940e3",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/team-dispatch-hook.js",
+          "sha": "f999bca7fbf03ae9dba560c5f8183f47fb41e7a9",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/hooks/team-dispatch-hook.js.map",
+          "sha": "57514eb7126152f21bf0a452d50ba9e532ead573",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
           "filename": "dist/hooks/team-leader-nudge-hook.d.ts.map",
           "sha": "6fe1acb23c216e7f28fdd3b60ec09a34b4347d25",
           "previousFilename": null
@@ -6372,13 +6450,13 @@
         {
           "status": "modified",
           "filename": "dist/installer/__tests__/hook-templates.test.js",
-          "sha": "4fee5c740c0e4a5a86c74e2885ab40291417b0de",
+          "sha": "f2fb195cc44b7cca8c8cff99b7294d485cfef38b",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/installer/__tests__/hook-templates.test.js.map",
-          "sha": "af2b75e6c82e9896db4eb60445dd2f6da84b3263",
+          "sha": "e7b923945ac8611dd1397e83db94823d49c14296",
           "previousFilename": null
         },
         {
@@ -7248,13 +7326,13 @@
         {
           "status": "added",
           "filename": "dist/team/__tests__/recovery-pane-rollback.test.js",
-          "sha": "cddc8cad613dcb3e0deb1c4e5e2e6a892d8e12b2",
+          "sha": "fe0c6cf3676863bb228e36e5f6b187d103d3bc16",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/team/__tests__/recovery-pane-rollback.test.js.map",
-          "sha": "f31a842bdf788edf05d5a2d8ad5a8ffc9ee9fd96",
+          "sha": "630aa82380791e5f5a7523e67c1360397143c1cc",
           "previousFilename": null
         },
         {
@@ -7414,6 +7492,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/team/__tests__/runtime-prompt-mode.test.js",
+          "sha": "c7756685d4d2302ccb624db580654c45920d1f8c",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/__tests__/runtime-prompt-mode.test.js.map",
+          "sha": "1eb6fb27dd2fe384139c63a862cf185f406ebded",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/team/__tests__/runtime-v2.cursor-routing.test.d.ts",
           "sha": "381a1f6ae51b924cf5bc85858588565910a18eca",
@@ -7440,13 +7530,13 @@
         {
           "status": "modified",
           "filename": "dist/team/__tests__/runtime-v2.dispatch.test.js",
-          "sha": "fc29324bf54825cd32e891d5108c9592011f40e6",
+          "sha": "57d9aacd0427b67553d3078456675bd50f2e6355",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/team/__tests__/runtime-v2.dispatch.test.js.map",
-          "sha": "43b1e6ae1ae3f853b4cece83de75fceb4c2bcb2b",
+          "sha": "033899df6e8b5408b7c420a1b6f257ae0e5b9a68",
           "previousFilename": null
         },
         {
@@ -7776,13 +7866,13 @@
         {
           "status": "added",
           "filename": "dist/team/__tests__/tmux-session.startup.test.js",
-          "sha": "0796ba56945b7b4378c7acec98a9bf548c8c7699",
+          "sha": "c285ca1c8783356d2bbbf03ae7acccc12c302d73",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/team/__tests__/tmux-session.startup.test.js.map",
-          "sha": "90fbbe0ab3200b2112ac410ffd809fde324d95d4",
+          "sha": "ee80b059ff506dd9b3da38e94eb03bce96b0da66",
           "previousFilename": null
         },
         {
@@ -7812,13 +7902,13 @@
         {
           "status": "modified",
           "filename": "dist/team/__tests__/tmux-session.test.js",
-          "sha": "7536985f75e954d25b6f89153a893316a37fe42a",
+          "sha": "25b04ec2ec081309287f9f54f6d5dc129ad3571b",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/team/__tests__/tmux-session.test.js.map",
-          "sha": "05fd8308f8167962caaf755789c8bbd02690a4fa",
+          "sha": "571caf301b03a3d605ac57ef499588f800d1097b",
           "previousFilename": null
         },
         {
@@ -7896,13 +7986,13 @@
         {
           "status": "added",
           "filename": "dist/team/__tests__/worker-launch-ack.test.js",
-          "sha": "c9bbcc8ea5d9fc9f2cd94c40d4029f09b91258a8",
+          "sha": "9a8e5e71f9a970758e39937a3f2a7156186d32fe",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/team/__tests__/worker-launch-ack.test.js.map",
-          "sha": "ea25d65dd4a3cbd1764eb97f50e68c935353479e",
+          "sha": "1c5dd15656c51a391f8265b73deda15a81774d15",
           "previousFilename": null
         },
         {
@@ -8208,25 +8298,37 @@
         {
           "status": "modified",
           "filename": "dist/team/runtime-v2.d.ts.map",
-          "sha": "8b2188c638fbf26cf64d1bcd018ed0b7b44ce958",
+          "sha": "dce12b9b6cba345c20027e7b4e2873195ccb74a0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime-v2.js",
+          "sha": "17eebdd1dc479a60b35cbf669bf8bbb4a01d5a93",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/team/runtime-v2.js.map",
-          "sha": "2f65eaf3449b80e6d62f94248bc8916f69f07255",
+          "sha": "b71b082dcd2def82afba9c3edf8068f015c10c2d",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/team/runtime.d.ts.map",
-          "sha": "a841c647c755d213d46939aefeb300d07df1a02e",
+          "sha": "b4f4d5ab2bd813960feb0fb95147b7881eef8ca3",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/runtime.js",
+          "sha": "88400458998871c3e8dea60e30eb0b6a9cdb41b1",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/team/runtime.js.map",
-          "sha": "82bc765114129f5abee3d54c262fb60828c19a06",
+          "sha": "8b0f5a5f325aaae9c80d9c518f782ead61304db8",
           "previousFilename": null
         },
         {
@@ -8237,8 +8339,14 @@
         },
         {
           "status": "modified",
+          "filename": "dist/team/scaling.js",
+          "sha": "f42f3fc2467d51d5c35cdb0123c49dc6d580234e",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
           "filename": "dist/team/scaling.js.map",
-          "sha": "21cbd49b0c0288e63b8c1776a8acf0c6df193b8a",
+          "sha": "b9eb0f22da3224e67b207b584e71b45968de6252",
           "previousFilename": null
         },
         {
@@ -8333,14 +8441,26 @@
         },
         {
           "status": "modified",
+          "filename": "dist/team/tmux-session.d.ts",
+          "sha": "c33cdccd8d606cfdefe8d6b4fab8661ea4a5d442",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
           "filename": "dist/team/tmux-session.d.ts.map",
-          "sha": "720237e1c8f83e1628bb7ff94810936fad05a379",
+          "sha": "33d341ddcc98490f685f048a4c9d3a73fa386b52",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/tmux-session.js",
+          "sha": "a1a90ab5ea9f806c59bff4ac30b5bcef906ad5f4",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/team/tmux-session.js.map",
-          "sha": "ea1abc1afdfa0f544c118a795fabf5cf3bea5e63",
+          "sha": "0ebbf705a03da5e12e97ad450044abe9b255f40a",
           "previousFilename": null
         },
         {
@@ -8412,13 +8532,19 @@
         {
           "status": "added",
           "filename": "dist/team/worker-launch-ack.d.ts.map",
-          "sha": "d2732e3ad791e61ceb4225550b2fae08226abf3b",
+          "sha": "99fd746e7d74b913162cff2cfaba700728a8da9d",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/team/worker-launch-ack.js",
+          "sha": "7b5dc05de8c97c8315abab08a947eb8c311cc6f5",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/team/worker-launch-ack.js.map",
-          "sha": "cb1273534d06784307675a2444dcfd6505df46a1",
+          "sha": "8a7db7b02d93d38a6f51497df1b327ad8bb1b991",
           "previousFilename": null
         },
         {
@@ -8860,6 +8986,18 @@
           "previousFilename": null
         },
         {
+          "status": "modified",
+          "filename": "dist/utils/__tests__/frontmatter.test.js",
+          "sha": "4a5cf35cb70543812a7083dc905e1cb458bc67b7",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/__tests__/frontmatter.test.js.map",
+          "sha": "7eb902ee8e5ab44509dff1daedade461372ed924",
+          "previousFilename": null
+        },
+        {
           "status": "added",
           "filename": "dist/utils/__tests__/jsonc.test.d.ts",
           "sha": "c8c2b8d22f6263cfc5c8a2c26439181984d74b60",
@@ -8886,25 +9024,43 @@
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.d.ts",
-          "sha": "0a851bd97569c486197118017a73fd618c0680a7",
+          "sha": "69fe82eebbc85eae207b54a0e43eaa94d90d6f25",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.d.ts.map",
-          "sha": "e4263f8a5e4bcc739681ce09fd6e8f4eb452e71d",
+          "sha": "11f127586bd4e1f5e0e5002aac0bb75164bbaa8d",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.js",
-          "sha": "a490f176669e506c46e4190c7b8bb6f23a4e0a61",
+          "sha": "90e7aeff57b4bccb2710e1c39fc61811e0b9070f",
           "previousFilename": null
         },
         {
           "status": "added",
           "filename": "dist/utils/cache-occupancy.js.map",
-          "sha": "37cd0581b285024b0f02ea8ec9c6e05e5e5a6a24",
+          "sha": "89aeba3271f08d243042a0f0564ec9d3f942e652",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/frontmatter.d.ts.map",
+          "sha": "db2ee6259828dbe5fab835ea27880001b2c36c19",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/frontmatter.js",
+          "sha": "aee3f71ffa00679c5d6f9cc84835f47ad36b6bb0",
+          "previousFilename": null
+        },
+        {
+          "status": "modified",
+          "filename": "dist/utils/frontmatter.js.map",
+          "sha": "415b52ecc1122f0f055a72cdd9e802d315476978",
           "previousFilename": null
         },
         {
@@ -8916,19 +9072,19 @@
         {
           "status": "modified",
           "filename": "dist/utils/paths.d.ts.map",
-          "sha": "b1867dada899e1f539f3d505059371d6a25a3b8a",
+          "sha": "1119d505eafc84bba18badbbef03aa69a9d766e2",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/utils/paths.js",
-          "sha": "fdbf696ed2f6ecb51635122792f1f6a048c118df",
+          "sha": "b0d4eb2e26c9b45d2671af2a2ee4889b822697f7",
           "previousFilename": null
         },
         {
           "status": "modified",
           "filename": "dist/utils/paths.js.map",
-          "sha": "af5b34febf9eb98e71760e3f5e1783dbfd3cd3fd",
+          "sha": "e5c0da0cf26a591c0c49008cd0db5a35732e4f8f",
           "previousFilename": null
         },
         {


### PR DESCRIPTION
Fresh base-owned generated-artifact authorization for PR #3749 only.

Exact binding:
- target PR: #3749
- target/base: `main@94e71c3630acbfb4f26dee6df4b78af30bab1563`
- target/head: `e2591c49cc20ad850c73523779fd71373f6c710d`
- fully paginated target pull-file records: 1,526 (16 pages plus empty page 17)
- generated closure: 1,235 records, SHA-256 `cfc2888ae17a78ae7b1f238d17e9fba9798fbde6bde5c17b265c86271c562d0e`
- expiry: `2026-08-30T00:00:00.000Z`

The only diff is `.github/generated-artifact-authorizations.json`; verifier and workflow trust roots are unchanged. This replaces closed stale #3806, which bound `af9eae76`. No main merge, release, tag, or publish.