### PR TITLE
fix(team): make watchdog dead-pane cleanup idempotent

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0e7212f7a2d818b39e771d17cae131e4593eb693",
-    "sourceSha256": "66580f018c924aa2ee69e5d9c2f9599503cb5a9dc03b418355145955c5a7102b",
+    "head": "b6cb6f29b463ce535930773ace983bb6b651c11e",
+    "sourceSha256": "cc6009d8726ea32e60c39f63ba8de65ef6358bfe8106f34a5bced64e689233e5",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0e7212f7a2d818b39e771d17cae131e4593eb693",
-  "sourceSha256": "66580f018c924aa2ee69e5d9c2f9599503cb5a9dc03b418355145955c5a7102b",
+  "head": "b6cb6f29b463ce535930773ace983bb6b651c11e",
+  "sourceSha256": "cc6009d8726ea32e60c39f63ba8de65ef6358bfe8106f34a5bced64e689233e5",
   "counts": {
     "public": {
       "skills": 31,
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "15dd8c4e20be2a78bf0005a9960341675e9bb1c311e9d9aaa1cd8299ffe9417b"
+  "manifestSha256": "07057db14c2d4a365618588bea38416b18b1d60628e6527a03269b5ec1f81545"
 }

--- a/src/team/__tests__/runtime-watchdog-retry.test.ts
+++ b/src/team/__tests__/runtime-watchdog-retry.test.ts
@@ -153,6 +153,25 @@ describe('watchdogCliWorkers dead-pane retry behavior', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dead pane — requeuing task 1 (retry 1/5)'));
   });
 
+  it('recovers when the dead pane is already absent during cleanup', async () => {
+    const teamName = 'dead-pane-missing-during-cleanup-team';
+    const root = initTask(cwd, teamName);
+    tmuxMocks.killTeamPane.mockRejectedValueOnce(new Error("can't find pane: %1"));
+    const runtime = makeRuntime(cwd, teamName);
+    const stop = watchdogCliWorkers(runtime, 20);
+    await runTick();
+    await stop();
+
+    const task = JSON.parse(readFileSync(join(root, 'tasks', '1.json'), 'utf8')) as { status: string; owner: string | null };
+    expect(['pending', 'in_progress']).toContain(task.status);
+    expect(task.owner === null || task.owner === 'worker-1').toBe(true);
+    expect(readTaskFailure(teamName, '1', { cwd })?.retryCount).toBe(1);
+    expect(tmuxMocks.splitTeamWorkerPane).toHaveBeenCalledWith('%0', 'right', cwd);
+    expect(tmuxMocks.spawnWorkerInPane).toHaveBeenCalledTimes(1);
+    expect(runtime.workerPaneIds).toEqual(['%42']);
+    expect(runtime.activeWorkers).toHaveProperty('size', 1);
+  });
+
   it('reassigns the requeued first task before a later pending task', async () => {
     const teamName = 'multi-task-requeue-team';
     const root = initTask(cwd, teamName);

--- a/src/team/runtime.ts
+++ b/src/team/runtime.ts
@@ -756,7 +756,7 @@ export async function spawnWorkerForTask(
   ): Promise<never> => {
     let paneCleanupError: unknown;
     try {
-      await killWorkerPane(runtime, workerNameValue, paneId);
+      await killWorkerPane(runtime, workerNameValue, paneId, { strict: true });
     } catch (cleanupError) {
       paneCleanupError = cleanupError;
     }
@@ -917,11 +917,17 @@ export async function spawnWorkerForTask(
 export async function killWorkerPane(
   runtime: TeamRuntime,
   workerNameValue: string,
-  paneId: string
+  paneId: string,
+  options: { strict?: boolean } = {},
 ): Promise<void> {
-  // Propagate pane cleanup failures so startup rollback can fail closed instead
-  // of reporting success while an orphaned worker pane may still be running.
-  await killTeamPane(paneId);
+  try {
+    await killTeamPane(paneId);
+  } catch (error) {
+    // Watchdog recovery is idempotent: a pane can disappear between the
+    // liveness probe and cleanup. Rollback callers opt into strict cleanup so
+    // an actual kill failure still fails closed instead of hiding an orphan.
+    if (options.strict) throw error;
+  }
 
   const paneIndex = runtime.workerPaneIds.indexOf(paneId);
   if (paneIndex >= 0) {


### PR DESCRIPTION
## Problem

At `dev@b6cb6f29b463ce535930773ace983bb6b651c11e`, ordinary watchdog cleanup propagated an already-missing tmux pane error (`can't find pane`). That aborted stale worker-state deletion and task reassignment even though the pane was already terminally absent.

This is distinct from strict startup rollback cleanup, which must remain fail-closed and observable.

## Change

- `killWorkerPane` now takes `options: { strict?: boolean }`. By default a `killTeamPane` failure is swallowed so watchdog recovery is idempotent for dead/missing panes: runtime pane/worker bookkeeping is cleaned and task reassignment proceeds.
- The startup rollback caller (`rollbackStartupFailure`) opts into `{ strict: true }`, preserving the fail-closed containment from b6cb6f29 — a real teardown denial still surfaces as `paneCleanupError` in the rollback error cause.
- Regression coverage: `recovers when the dead pane is already absent during cleanup` in `runtime-watchdog-retry.test.ts` asserts requeue (`retryCount 1`), pane respawn, and runtime bookkeeping when `killTeamPane` rejects with `can't find pane: %1`.
- `inventory/inventory-graph.json` regenerated (provenance head anchored to base b6cb6f29 per the generator's lineage-anchor contract).

## Verification

- Preserved handoff patch independently revalidated: committed two-file diff SHA-256 `421cc1810bd8a4fb98acd14e1687cfa1110a883051b33bd6e80f866925eb33ad` matches the issue evidence exactly.
- Focused matrix 42/42 (`runtime-watchdog-retry` 9/9 + `runtime-prompt-mode` 33/33, including the three startup-rollback fail-closed assertions).
- Full `src/team`: 124 files, 1702 passed.
- `tsc --noEmit`: clean. `npm run lint`: 0 errors (21 pre-existing warnings).
- `generate:inventory:verify`: ok. `verify:prompt-projections`: ok.
- No dist/bridge artifacts committed (candidate-side generated-artifact gate stays clean).

Closes #3813

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*