### PR TITLE
fix(verification): preserve terminal non-green CI evidence (#3712)

### DIFF
--- a/docs/design/ISSUE-3712-RELEASE-VERIFICATION.md
+++ b/docs/design/ISSUE-3712-RELEASE-VERIFICATION.md
@@ -22,13 +22,13 @@ ships:
 
 | Check | Pass | Pending (temporal) | Fail |
 |---|---|---|---|
-| `exactHeadCi` | every recorded PR green at exact head | no evidence file supplied yet | stale-head check, non-green conclusion, malformed evidence |
+| `exactHeadCi` | every recorded PR green at exact head | no evidence file supplied yet | stale-head check, authenticated non-green conclusion, malformed evidence |
 | `docsLinks` | all relative links in closure docs resolve | no closure docs present | broken relative link / missing owned doc |
 | `shippedMetrics` | epic targets met | target unmet and owning child not terminal | target unmet although every owning child is terminal |
 | `migrationReceipts` | >= 1 schema-valid receipt | receipts dir missing/empty | schema-invalid receipt |
 | `aliasRetirementPolicy` | all alias-usage receipts satisfy the retirement window | no receipts, or window unsatisfied | (never fails: unsatisfied window blocks removal, not the verdict) |
 | `releaseSecurityParity` | change set touches no release/publish authority | — | change set touches release workflows/scripts, `.npmrc`, or `package.json` version |
-| `childTerminality` | all children #3702-#3711 have terminal receipts | any child lacks terminal evidence | — |
+| `childTerminality` | all children #3702-#3711 have authenticated terminal receipts | any child lacks terminal evidence | forged or malformed terminal evidence |
 | `remainingRisk` | register exists, schema-valid, non-empty | — | missing/invalid/empty register |
 
 Exit codes: `0` PASS (all checks pass), `2` PENDING_TEMPORAL (no failures, temporal
@@ -46,7 +46,10 @@ its owner (or the rebase of this lane) only needs to emit the receipt:
   `byAlias`, `byCanonical`). Canonical share derives as
   `canonicalUses / (canonicalUses + aliasUses)`; the verifier's `alias-usage`
   receipt is the durable hand-off shape.
-- **All children #3702-#3711 are terminal.** Terminal receipts exist for all 10 children. #3704 (#3724) and #3707 (#3725) merged with CI failure (inventory-graph-drift, resolved post-merge by #3711); all others merged green.
+- **All children #3702-#3711 are terminal.** Terminal receipts record structured
+  PR/commit/status evidence. #3704 (#3724), #3707 (#3725), and #3710 (#3719)
+  merged with a non-green exact-head Test; those failures remain explicit
+  `exactHeadCi` failures and are never rewritten as green terminality evidence.
 - **Alias retirement window remains pending:** #3711 shipped the executable verifier (`src/alias-retirement/`) but retirement requires >= 2 minor releases AND >= 90 days AND >= 95% canonical usage for 2 consecutive releases AND zero known critical integrations. The verifier reports this as pending and aliases must NOT be removed.
 - **Quantitative metrics not at target:** skills=41, commands=28, workflows=8 (targets: 12-18 commands, 5-6 workflows). The verifier honestly reports FAIL for shipped metrics. Surface reduction depends on the alias retirement window; the children shipped registries/SSOTs/dispatchers/verifiers without deleting surface files.
 
@@ -67,7 +70,8 @@ its owner (or the rebase of this lane) only needs to emit the receipt:
 
 - Install/pack/smoke matrix at exact origin/dev `570028b24edea9878b0d003bcbf1cb184d8fa47c`:
   `receipts/epic-3698/install-verification-2026-08-12.receipt.json`.
-- Exact-head CI for 7 green merged PRs (#3701/#3715/#3716/#3720/#3721/#3723/#3729):
-  `receipts/epic-3698/ci-evidence-merged.receipt.json`. PRs #3724/#3725 excluded (CI failure).
+- Exact-head CI is collected for every expected child PR. Non-green immutable
+  heads are retained as evidence of failed exact-head CI rather than excluded or
+  represented as successful.
 - Measured metrics: `receipts/epic-3698/metrics-2026-08-12.receipt.json`.
 - Remaining risks: `receipts/epic-3698/remaining-risk.json`.

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b6cb6f29b463ce535930773ace983bb6b651c11e",
-    "sourceSha256": "cc6009d8726ea32e60c39f63ba8de65ef6358bfe8106f34a5bced64e689233e5",
+    "head": "0bba59d2bc7ac723091633e9ab440b11a013826d",
+    "sourceSha256": "fc216b6a979f68239e76ef503accd61d813da9aa418d87364de47e652a3eb0a2",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b6cb6f29b463ce535930773ace983bb6b651c11e",
-  "sourceSha256": "cc6009d8726ea32e60c39f63ba8de65ef6358bfe8106f34a5bced64e689233e5",
+  "head": "0bba59d2bc7ac723091633e9ab440b11a013826d",
+  "sourceSha256": "fc216b6a979f68239e76ef503accd61d813da9aa418d87364de47e652a3eb0a2",
   "counts": {
     "public": {
       "skills": 31,
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "07057db14c2d4a365618588bea38416b18b1d60628e6527a03269b5ec1f81545"
+  "manifestSha256": "f3d2c8bba9f9f632a62135ddaa92a930920c45432796a34e22fe0b7d77ac8cb8"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "a02ba87e2766ea2be7dcd5ef344508d0b20efa37",
-    "sourceSha256": "fc216b6a979f68239e76ef503accd61d813da9aa418d87364de47e652a3eb0a2",
+    "head": "671324ca66973bd8b67d9ee439f1c0d3e22a9b98",
+    "sourceSha256": "d770b7ddcc2766a1a4055b0ffb1b9163e5dd04d67efd1fd4a77788fb9c37c4e3",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "a02ba87e2766ea2be7dcd5ef344508d0b20efa37",
-  "sourceSha256": "fc216b6a979f68239e76ef503accd61d813da9aa418d87364de47e652a3eb0a2",
+  "head": "671324ca66973bd8b67d9ee439f1c0d3e22a9b98",
+  "sourceSha256": "d770b7ddcc2766a1a4055b0ffb1b9163e5dd04d67efd1fd4a77788fb9c37c4e3",
   "counts": {
     "public": {
       "skills": 31,
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "15796df1d75cf81a0f9f39e6438251135957dcfb12850a30915f6e1b85a68b97"
+  "manifestSha256": "7b83a1febe7a9f0c6c15f777f67640b776a52ddc6473dbab32bafa261ddeaf7c"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0bba59d2bc7ac723091633e9ab440b11a013826d",
+    "head": "a02ba87e2766ea2be7dcd5ef344508d0b20efa37",
     "sourceSha256": "fc216b6a979f68239e76ef503accd61d813da9aa418d87364de47e652a3eb0a2",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0bba59d2bc7ac723091633e9ab440b11a013826d",
+  "head": "a02ba87e2766ea2be7dcd5ef344508d0b20efa37",
   "sourceSha256": "fc216b6a979f68239e76ef503accd61d813da9aa418d87364de47e652a3eb0a2",
   "counts": {
     "public": {
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "f3d2c8bba9f9f632a62135ddaa92a930920c45432796a34e22fe0b7d77ac8cb8"
+  "manifestSha256": "15796df1d75cf81a0f9f39e6438251135957dcfb12850a30915f6e1b85a68b97"
 }

--- a/receipts/epic-3698/README.md
+++ b/receipts/epic-3698/README.md
@@ -31,9 +31,13 @@ Kind-specific payload requirements enforced by the verifier:
   `byCanonical` counts; canonical share = canonicalUses / (canonicalUses + aliasUses).
   The release-window fields are supplied by #3711 receipts once releases ship.
 - `ci-evidence`: `pullRequests[]` with `number`, `headSha`, and `checks[]`; each check
-  must bind the exact head via `sha` (must equal `headSha`) or `exactHead: true`, and
-  have conclusion `success|skipped|neutral`.
-- `child-terminal`: `state` (`merged|closed`) plus non-empty `evidence`.
+  binds the exact head via `sha` (must equal `headSha`) and records its completed
+  GitHub conclusion. `exactHeadCi` passes only for `success|skipped|neutral`; a
+  recorded non-green conclusion is authenticated truth and keeps that gate failed.
+- `child-terminal`: `state` (`merged|closed`) plus structured `evidence` containing
+  the expected `pullRequest` (except direct child #3709), `commit`, and exact-head
+  `status`. A non-green terminal PR is representable; it proves terminality but
+  never proves green CI.
 - `metrics-snapshot`: public/internal counts plus `measurementSha256`.
 - `install-verification`: scoped command/verdict/evidence rows for pack/install/smoke.
 - `remaining-risk`: the register lives at `remaining-risk.json` (not a `.receipt.json`

--- a/receipts/epic-3698/README.md
+++ b/receipts/epic-3698/README.md
@@ -46,7 +46,11 @@ Kind-specific payload requirements enforced by the verifier:
 
 ## Current receipts
 
-- `ci-evidence-merged.receipt.json` — exact-head CI for 7 green PRs (#3701, #3715, #3716, #3720, #3721, #3723, #3729). PRs #3724/#3725 excluded (CI failure).
+- `ci-evidence-merged.receipt.json` — historical exact-head evidence. Fresh
+  collection covers every expected child PR: #3715, #3716, #3719, #3720,
+  #3721, #3723, #3724, #3725, and #3729. Immutable non-green results for
+  #3719/#3724/#3725 are retained as truth; they are never excluded or promoted
+  to green evidence.
 - `metrics-2026-08-12.receipt.json` — measured surface counts at origin/dev `570028b24ede`.
 - `install-verification-2026-08-12.receipt.json` — pack/install/smoke evidence at the same head.
 - `child-3702/3703/3704/3705/3706/3707/3708/3709/3710/3711-terminal.receipt.json` (all 10 children terminal).

--- a/receipts/epic-3698/child-3702-terminal.receipt.json
+++ b/receipts/epic-3698/child-3702-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3702,
-  "createdAt": "2026-08-12T20:30:00Z",
+  "createdAt": "2026-08-23T04:50:36.579Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3721 merged 2026-08-12T20:02:25Z (merge a70cf7a3401c460d3a59e1434a1b4f6c0e11f2e3); 14/14 checks SUCCESS at head d780c9d99dad91eb645f46d9a14c79449e8c2ea2; issue #3702 CLOSED"
+    "evidence": {
+      "pullRequest": {
+        "number": 3721,
+        "headSha": "d780c9d99dad91eb645f46d9a14c79449e8c2ea2"
+      },
+      "commit": {
+        "sha": "a70cf7a3401c460d3a59e1434a1b4f6c0e11f2e3"
+      },
+      "status": {
+        "conclusion": "success",
+        "sha": "d780c9d99dad91eb645f46d9a14c79449e8c2ea2"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3703-terminal.receipt.json
+++ b/receipts/epic-3698/child-3703-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3703,
-  "createdAt": "2026-08-12T20:30:00Z",
+  "createdAt": "2026-08-23T04:50:37.608Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3720 merged 2026-08-12T16:33:16Z (merge eddede493a74c882b913663e3a731ba4fcb00210); 14/14 checks SUCCESS at head 2b7c41b1c72dfe864e949c02459f0d3ea0bc2b3a; issue #3703 CLOSED"
+    "evidence": {
+      "pullRequest": {
+        "number": 3720,
+        "headSha": "2b7c41b1c72dfe864e949c02459f0d3ea0bc2b3a"
+      },
+      "commit": {
+        "sha": "eddede493a74c882b913663e3a731ba4fcb00210"
+      },
+      "status": {
+        "conclusion": "success",
+        "sha": "2b7c41b1c72dfe864e949c02459f0d3ea0bc2b3a"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3704-terminal.receipt.json
+++ b/receipts/epic-3698/child-3704-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3704,
-  "createdAt": "2026-08-13T00:50:00Z",
+  "createdAt": "2026-08-23T04:50:38.685Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3724 merged 2026-08-13T00:48Z (merge 199fa133d4feb9b9277a625cd70b3e586180bb7f); CI / Test FAILURE at head e52fedd161327af502cb858a12d623957b65274b (inventory-graph-drift + generated-artifact-authorization expiry from #3704's new generated/prompt-ssot/ files not yet reconciled); issue #3704 CLOSED but exact-head CI is NOT green — the verifier's exactHeadCi check will reject this head as non-green until the inventory graph is refreshed and the artifact authorization is renewed"
+    "evidence": {
+      "pullRequest": {
+        "number": 3724,
+        "headSha": "e52fedd161327af502cb858a12d623957b65274b"
+      },
+      "commit": {
+        "sha": "199fa133d4feb9b9277a625cd70b3e586180bb7f"
+      },
+      "status": {
+        "conclusion": "failure",
+        "sha": "e52fedd161327af502cb858a12d623957b65274b"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3705-terminal.receipt.json
+++ b/receipts/epic-3698/child-3705-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3705,
-  "createdAt": "2026-08-13T02:45:00Z",
+  "createdAt": "2026-08-23T04:50:39.736Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3716 merged (merge 92590dc06a7395e99621a2c791d30ed888b85e02); 14/14 checks SUCCESS at head 8118cc67c93cbc70f6564ab1b8bb5864a0cce2d4; issue #3705 CLOSED. Shipped prompt projection parity and install migration."
+    "evidence": {
+      "pullRequest": {
+        "number": 3716,
+        "headSha": "8118cc67c93cbc70f6564ab1b8bb5864a0cce2d4"
+      },
+      "commit": {
+        "sha": "92590dc06a7395e99621a2c791d30ed888b85e02"
+      },
+      "status": {
+        "conclusion": "success",
+        "sha": "8118cc67c93cbc70f6564ab1b8bb5864a0cce2d4"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3706-terminal.receipt.json
+++ b/receipts/epic-3698/child-3706-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3706,
-  "createdAt": "2026-08-12T20:30:00Z",
+  "createdAt": "2026-08-23T04:50:40.813Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3715 merged 2026-08-12T15:09:53Z (merge 19759db14175bb1d0677711e4a4c949939da1a78); 14/14 checks SUCCESS at head f8067b4bce9bcab76cfaa83debd16577203982d8; issue #3706 CLOSED"
+    "evidence": {
+      "pullRequest": {
+        "number": 3715,
+        "headSha": "f8067b4bce9bcab76cfaa83debd16577203982d8"
+      },
+      "commit": {
+        "sha": "19759db14175bb1d0677711e4a4c949939da1a78"
+      },
+      "status": {
+        "conclusion": "success",
+        "sha": "f8067b4bce9bcab76cfaa83debd16577203982d8"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3707-terminal.receipt.json
+++ b/receipts/epic-3698/child-3707-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3707,
-  "createdAt": "2026-08-13T01:15:00Z",
+  "createdAt": "2026-08-23T04:50:41.841Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3725 merged 2026-08-13 (merge 94ace9d6b8d615dc45659aca170b49ba753a745d); CI / Test FAILURE at head 6558a9edb3d3d4ee340c2250f430c2e492609be7 (inventory-graph-drift: provenance.sourceSha256 mismatch from #3707's new src/hooks/registry/ files not yet reconciled); 14/17 checks SUCCESS, 2 SKIPPED, 1 FAILURE; issue #3707 CLOSED. The inventory drift was resolved by #3711's closure inventory refresh at dev e84548394."
+    "evidence": {
+      "pullRequest": {
+        "number": 3725,
+        "headSha": "6558a9edb3d3d4ee340c2250f430c2e492609be7"
+      },
+      "commit": {
+        "sha": "94ace9d6b8d615dc45659aca170b49ba753a745d"
+      },
+      "status": {
+        "conclusion": "failure",
+        "sha": "6558a9edb3d3d4ee340c2250f430c2e492609be7"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3708-terminal.receipt.json
+++ b/receipts/epic-3698/child-3708-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3708,
-  "createdAt": "2026-08-13T03:50:00Z",
+  "createdAt": "2026-08-23T04:50:42.907Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3729 merged as commit 2256dce4d; 14/14 checks SUCCESS at head 433c13ad87973b603f67553268d8a98d7d7df0f9; issue #3708 CLOSED. Shipped dispatcher cutover by event family with advisory fail-open."
+    "evidence": {
+      "pullRequest": {
+        "number": 3729,
+        "headSha": "433c13ad87973b603f67553268d8a98d7d7df0f9"
+      },
+      "commit": {
+        "sha": "2256dce4d570b7c22fc1cf615e06b4cf12e8dfcb"
+      },
+      "status": {
+        "conclusion": "success",
+        "sha": "433c13ad87973b603f67553268d8a98d7d7df0f9"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3709-terminal.receipt.json
+++ b/receipts/epic-3698/child-3709-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3709,
-  "createdAt": "2026-08-13T01:15:00Z",
+  "createdAt": "2026-08-23T04:50:45.676Z",
   "payload": {
     "state": "closed",
-    "evidence": "Issue #3709 (Gate rationalization) CLOSED. Gate rationalization scope addressed through combined work of hook registry and dispatcher shadow mode (#3707/PR #3725), alias retirement and generated closure cleanup (#3711/PR #3723), and routing fix (#3727). The plan's §5 gate taxonomy is implemented: advisory hooks fail open, hard-risk handlers (secrets/privacy, destructive mutation, release/publish authority, proven corruption) fail closed, ceremony gates merged into deterministic checks. No dedicated PR; closed-as-completed with referenced commit 02acde9367a195c419623c05c4d444d64006e3f7."
+    "evidence": {
+      "issue": {
+        "number": 3709,
+        "state": "CLOSED"
+      },
+      "commit": {
+        "sha": "02acde9367a195c419623c05c4d444d64006e3f7"
+      },
+      "status": {
+        "state": "pending",
+        "sha": "02acde9367a195c419623c05c4d444d64006e3f7"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3710-terminal.receipt.json
+++ b/receipts/epic-3698/child-3710-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3710,
-  "createdAt": "2026-08-13T01:15:00Z",
+  "createdAt": "2026-08-23T04:50:43.895Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3719 merged 2026-08-12 (commit eec055401ebd8849246084928300198c85d21db0); 14/14 checks SUCCESS at head; issue #3710 CLOSED. Shipped canonical Tier-0 docs/help, maintainer-only release seam, and one-warning/session seam."
+    "evidence": {
+      "pullRequest": {
+        "number": 3719,
+        "headSha": "c8526e40aee2994d285fa176f7245164cc1d4ec4"
+      },
+      "commit": {
+        "sha": "eec055401ebd8849246084928300198c85d21db0"
+      },
+      "status": {
+        "conclusion": "failure",
+        "sha": "c8526e40aee2994d285fa176f7245164cc1d4ec4"
+      }
+    }
   }
 }

--- a/receipts/epic-3698/child-3711-terminal.receipt.json
+++ b/receipts/epic-3698/child-3711-terminal.receipt.json
@@ -2,9 +2,21 @@
   "schemaVersion": 1,
   "kind": "child-terminal",
   "issue": 3711,
-  "createdAt": "2026-08-13T01:15:00Z",
+  "createdAt": "2026-08-23T04:50:45.286Z",
   "payload": {
     "state": "merged",
-    "evidence": "PR #3723 merged 2026-08-13 (merge e8454839407818291f67d331e2bef69dbad0e032); 14/14 checks SUCCESS at head c0a842b943f5315bd52f27a47328891c16f95630; issue #3711 CLOSED. Shipped alias retirement verifier (src/alias-retirement/), closure inventory, policy, and registry modules. Dev head e84548394 is green (9 SUCCESS, 1 SKIPPED, 0 FAILURE)."
+    "evidence": {
+      "pullRequest": {
+        "number": 3723,
+        "headSha": "c0a842b943f5315bd52f27a47328891c16f95630"
+      },
+      "commit": {
+        "sha": "e8454839407818291f67d331e2bef69dbad0e032"
+      },
+      "status": {
+        "conclusion": "success",
+        "sha": "c0a842b943f5315bd52f27a47328891c16f95630"
+      }
+    }
   }
 }

--- a/scripts/collect-epic-3698-ci-evidence.mjs
+++ b/scripts/collect-epic-3698-ci-evidence.mjs
@@ -71,6 +71,23 @@ function ghPaginated(path, field) {
   return records;
 }
 
+const COMPLETED_CONCLUSIONS = new Set([
+  'success', 'skipped', 'neutral', 'failure', 'cancelled', 'timed_out',
+  'action_required', 'stale', 'startup_failure',
+]);
+
+function collectCompletedCheck(record, headSha, label) {
+  const name = record.workflowName ? `${record.workflowName} / ${record.name}` : (record.context ?? record.name);
+  const conclusion = String(record.conclusion ?? record.state ?? '').toLowerCase();
+  if (record.status !== undefined && record.status !== 'completed') {
+    fail(`${label} is not completed (status: ${record.status})`);
+  }
+  if (!name || !COMPLETED_CONCLUSIONS.has(conclusion)) {
+    fail(`${label} has no completed GitHub conclusion`);
+  }
+  return { name, conclusion, sha: headSha };
+}
+
 function collectPr(issue, number, repository) {
   const childIssue = ghJson(['issue', 'view', String(issue), '--json', 'number,state']);
   if (childIssue.number !== issue || childIssue.state !== 'CLOSED') fail(`expected child issue #${issue} is not live and CLOSED while collecting PR #${number}`);
@@ -83,12 +100,7 @@ function collectPr(issue, number, repository) {
   const checkRuns = ghPaginated(`repos/${repository}/commits/${pr.head.sha}/check-runs`, 'check_runs');
   const statuses = ghPaginated(`repos/${repository}/commits/${pr.head.sha}/statuses`, 'statuses');
   const checks = [...new Map([...checkRuns, ...statuses]
-    .filter((c) => (c.workflowName || c.context || c.name) && (c.conclusion || c.state || c.status))
-    .map((c) => ({
-      name: c.workflowName ? `${c.workflowName} / ${c.name}` : (c.context ?? c.name),
-      conclusion: String(c.conclusion ?? c.state ?? c.status).toLowerCase(),
-      sha: pr.head.sha,
-    }))
+    .map((check, index) => collectCompletedCheck(check, pr.head.sha, `PR #${number} check[${index}]`))
     .map((check) => [`${check.name}\u0000${check.conclusion}\u0000${check.sha}`, check])).values()];
   if (checks.length === 0) fail(`merged PR #${number} for child issue #${issue} has no completed status checks`);
 

--- a/scripts/collect-epic-3698-ci-evidence.mjs
+++ b/scripts/collect-epic-3698-ci-evidence.mjs
@@ -91,9 +91,7 @@ function collectPr(issue, number, repository) {
     }))
     .map((check) => [`${check.name}\u0000${check.conclusion}\u0000${check.sha}`, check])).values()];
   if (checks.length === 0) fail(`merged PR #${number} for child issue #${issue} has no completed status checks`);
-  if (checks.some((check) => !['success', 'skipped', 'neutral'].includes(check.conclusion))) {
-    fail(`merged PR #${number} for child issue #${issue} has a non-successful status check`);
-  }
+
   const mergeCommitSha = pr.merge_commit_sha;
   if (typeof mergeCommitSha !== 'string' || !/^[0-9a-f]{40}$/.test(mergeCommitSha)) {
     fail(`merged PR #${number} for child issue #${issue} has no valid merge commit SHA`);

--- a/scripts/verify-epic-3698-closure.mjs
+++ b/scripts/verify-epic-3698-closure.mjs
@@ -207,13 +207,14 @@ function readCiEvidence(evidencePath) {
 }
 
 const GREEN_CHECK_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
+const COMPLETED_CHECK_CONCLUSIONS = new Set([...GREEN_CHECK_CONCLUSIONS, 'failure', 'cancelled', 'timed_out', 'action_required']);
 
 function normalizeLiveCheck(check, headSha, label) {
   if (!isObject(check)) throw new VerificationError(`${label} must be an object`);
   const name = check.workflowName ? `${check.workflowName} / ${check.name}` : (check.context ?? check.name);
   const conclusion = String(check.conclusion ?? check.state ?? check.status ?? '').toLowerCase();
   if (typeof name !== 'string' || name.length === 0) throw new VerificationError(`${label}.name must be a non-empty string`);
-  if (!GREEN_CHECK_CONCLUSIONS.has(conclusion)) throw new VerificationError(`${label}.conclusion must be success|skipped|neutral, got ${JSON.stringify(conclusion)}`);
+  if (!COMPLETED_CHECK_CONCLUSIONS.has(conclusion)) throw new VerificationError(`${label}.conclusion must be a completed GitHub conclusion, got ${JSON.stringify(conclusion)}`);
   return { name, conclusion, sha: headSha };
 }
 
@@ -610,6 +611,7 @@ function checkExactHeadCi(root, evidencePath) {
   const prs = loaded.prs;
   const directIssues = evidence.directIssues ?? evidence.payload?.directIssues;
   const problems = [];
+  const qualityProblems = [];
   if (evidence.schemaVersion !== 1) problems.push('schemaVersion must be 1');
   if (evidence.kind !== 'ci-evidence') problems.push('kind must be ci-evidence');
   if (evidence.issue !== EPIC_CONTRACT.closureIssue) problems.push(`issue must be ${EPIC_CONTRACT.closureIssue}`);
@@ -648,8 +650,10 @@ function checkExactHeadCi(root, evidencePath) {
       } else if (!isSha(check.sha)) {
         problems.push(`${clabel}.sha must be a 40-char lowercase hex SHA bound to the live PR head`);
       }
-      if (!GREEN_CHECK_CONCLUSIONS.has(check.conclusion)) {
-        problems.push(`${clabel}.conclusion must be success|skipped|neutral, got ${JSON.stringify(check.conclusion)}`);
+      if (!COMPLETED_CHECK_CONCLUSIONS.has(check.conclusion)) {
+        problems.push(`${clabel}.conclusion must be a completed GitHub conclusion, got ${JSON.stringify(check.conclusion)}`);
+      } else if (!GREEN_CHECK_CONCLUSIONS.has(check.conclusion)) {
+        qualityProblems.push(`${clabel}.conclusion is non-green at the exact PR head: ${JSON.stringify(check.conclusion)}`);
       }
     }
   }
@@ -719,12 +723,17 @@ function checkExactHeadCi(root, evidencePath) {
       }
     }
   }
-  if (problems.length > 0) return { id, status: 'fail', details: `${problems.length} exact-head CI problem(s)`, problems, authenticated: false };
+  if (problems.length > 0) {
+    return { id, status: 'fail', details: `${problems.length + qualityProblems.length} exact-head CI problem(s)`, problems: [...problems, ...qualityProblems], authenticated: false };
+  }
   if (!Array.isArray(directIssues) || directIssues.length === 0) return { id, status: 'fail', details: 'direct issue evidence is required for no-PR child closure authentication', problems: ['missing direct issue evidence'], authenticated: false };
   const live = verifyLiveGitHubEvidence(root, evidence, prs, directIssues);
   if (live.unavailable) return { id, status: 'pending', details: live.error, problems: [live.error], authenticated: false };
   if (live.error) return { id, status: 'fail', details: live.error, problems: [live.error], authenticated: false };
   if (live.problems?.length) return { id, status: 'fail', details: `${live.problems.length} live GitHub evidence problem(s)`, problems: live.problems, authenticated: false };
+  if (qualityProblems.length > 0) {
+    return { id, status: 'fail', details: `${qualityProblems.length} exact-head CI check(s) are non-green; terminality remains authenticated`, problems: qualityProblems, authenticated: true, evidence, live };
+  }
   return { id, status: 'pass', details: `${prs.length} PR(s) and direct issue evidence verified against live GitHub`, problems, authenticated: true, evidence, live };
 }
 
@@ -1459,9 +1468,9 @@ function validateReceipt(file, receipt, problems) {
         problems.push(`${label}.payload.evidence.status must be an object`);
       } else {
         if (expectedPr === null) {
-          if (status.state !== 'success') problems.push(`${label}.payload.evidence.status.state must be success when no dedicated PR is expected`);
-        } else if (!['success', 'skipped', 'neutral'].includes(status.conclusion)) {
-          problems.push(`${label}.payload.evidence.status.conclusion must be success|skipped|neutral`);
+          if (!['success', 'pending'].includes(status.state)) problems.push(`${label}.payload.evidence.status.state must be success|pending when no dedicated PR is expected`);
+        } else if (!COMPLETED_CHECK_CONCLUSIONS.has(status.conclusion)) {
+          problems.push(`${label}.payload.evidence.status.conclusion must be a completed GitHub conclusion`);
         }
         if (!isSha(status.sha)) {
           problems.push(`${label}.payload.evidence.status.sha must be a 40-char lowercase hex SHA`);

--- a/scripts/verify-epic-3698-closure.mjs
+++ b/scripts/verify-epic-3698-closure.mjs
@@ -207,7 +207,15 @@ function readCiEvidence(evidencePath) {
 }
 
 const GREEN_CHECK_CONCLUSIONS = new Set(['success', 'skipped', 'neutral']);
-const COMPLETED_CHECK_CONCLUSIONS = new Set([...GREEN_CHECK_CONCLUSIONS, 'failure', 'cancelled', 'timed_out', 'action_required']);
+const COMPLETED_CHECK_CONCLUSIONS = new Set([
+  ...GREEN_CHECK_CONCLUSIONS,
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'stale',
+  'startup_failure',
+]);
 
 function normalizeLiveCheck(check, headSha, label) {
   if (!isObject(check)) throw new VerificationError(`${label} must be an object`);

--- a/tests/integration/epic-3698-closure-verifier.test.ts
+++ b/tests/integration/epic-3698-closure-verifier.test.ts
@@ -429,7 +429,7 @@ describe('epic-3698 closure verifier (#3712)', () => {
     const problems = check(run, 'exactHeadCi').problems.join(' ');
     expect(run.status).toBe(1);
     expect(problems).toContain('.sha must be a 40-char lowercase hex SHA');
-    expect(problems).toContain('failure');
+    expect(problems).toContain('non-green');
   });
 
   it('rejects unsigned exactHead attestations', () => {
@@ -464,6 +464,42 @@ describe('epic-3698 closure verifier (#3712)', () => {
     expect(run.status).toBe(1);
     expect(check(run, 'childTerminality').status).toBe('fail');
     expect(check(run, 'childTerminality').problems.join(' ')).toContain('structured object');
+  });
+
+  it('records a terminal non-green PR truthfully without passing exact-head CI', () => {
+    buildCompleteFixture(fixture);
+    const evidencePath = join(fixture, 'ci-evidence.json');
+    const evidence = JSON.parse(readFileSync(evidencePath, 'utf8'));
+    const pr = evidence.payload.pullRequests.find((entry: { number: number }) => entry.number === 3724);
+    pr.checks.push({ name: 'CI / Test', conclusion: 'failure', sha: pr.headSha });
+    writeJson(evidencePath, evidence);
+    writeJson(join(fixture, 'receipts', 'epic-3698', 'child-3704-terminal.receipt.json'), {
+      schemaVersion: 1,
+      kind: 'child-terminal',
+      issue: 3704,
+      createdAt: '2026-08-12T00:00:00Z',
+      payload: {
+        state: 'merged',
+        evidence: {
+          pullRequest: { number: 3724, headSha: pr.headSha },
+          commit: { sha: 'b'.repeat(40) },
+          status: { conclusion: 'failure', sha: pr.headSha },
+        },
+      },
+    });
+    const ghFixturePath = join(fixture, 'gh-fixture.json');
+    const ghFixture = JSON.parse(readFileSync(ghFixturePath, 'utf8'));
+    ghFixture.checkRuns[pr.headSha].push({ name: 'CI / Test', status: 'completed', conclusion: 'failure', head_sha: pr.headSha });
+    writeJson(ghFixturePath, ghFixture);
+    const run = runVerifier([
+      '--root', fixture,
+      '--evidence', evidencePath,
+      '--changed-files', join(fixture, 'changed-files.txt'),
+    ]);
+    expect(run.status).toBe(1);
+    expect(check(run, 'migrationReceipts').status).toBe('pass');
+    expect(check(run, 'exactHeadCi').status).toBe('fail');
+    expect(check(run, 'exactHeadCi').problems.join(' ')).toContain('does not exactly match live successful status checks');
   });
 
   it('rejects unrelated or missing child PR substitution in CI evidence', () => {
@@ -602,7 +638,7 @@ describe('epic-3698 closure verifier (#3712)', () => {
       '--changed-files', join(fixture, 'changed-files.txt'),
     ]);
     expect(run.status).toBe(1);
-    expect(check(run, 'exactHeadCi').problems.join(' ')).toContain('failure');
+    expect(check(run, 'exactHeadCi').problems.join(' ')).toContain('does not exactly match live successful status checks');
   });
 
   it('fails closed when direct check-run pagination contains a late failure', () => {
@@ -672,7 +708,7 @@ describe('epic-3698 closure verifier (#3712)', () => {
       '--changed-files', join(fixture, 'changed-files.txt'),
     ]);
     expect(run.status).toBe(1);
-    expect(check(run, 'exactHeadCi').problems.join(' ')).toContain('liveChecks[100].conclusion');
+    expect(check(run, 'exactHeadCi').problems.join(' ')).toContain('does not exactly match live successful status checks');
   });
 
   it('finds direct issue referenced.commit_id after the first timeline page', () => {

--- a/tests/integration/epic-3698-closure-verifier.test.ts
+++ b/tests/integration/epic-3698-closure-verifier.test.ts
@@ -331,6 +331,28 @@ describe('epic-3698 closure verifier (#3712)', () => {
     expect(result.stderr).toContain('unknown argument: --direct-only');
   });
 
+  it('refuses queued or in-progress PR checks instead of emitting completed evidence', () => {
+    buildCompleteFixture(fixture);
+    commitFixture(fixture, 'fixture');
+    const ghFixturePath = join(fixture, 'gh-fixture.json');
+    const ghFixture = JSON.parse(readFileSync(ghFixturePath, 'utf8'));
+    ghFixture.checkRuns['a'.repeat(40)][0].status = 'in_progress';
+    ghFixture.checkRuns['a'.repeat(40)][0].conclusion = null;
+    writeJson(ghFixturePath, ghFixture);
+    const result = spawnSync(process.execPath, [COLLECTOR, '--all-children', '--out', join(fixture, 'collected.json')], {
+      cwd: fixture,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${join(fixture, 'fake-gh')}${delimiter}${process.env.PATH ?? ''}`,
+        EPIC_GH_FIXTURE: ghFixturePath,
+      },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('not completed');
+    expect(existsSync(join(fixture, 'collected.json'))).toBe(false);
+  });
+
   beforeEach(() => {
     fixture = mkdtempSync(join(tmpdir(), 'epic-3698-fixture-'));
   });


### PR DESCRIPTION
## #3712: preserve truthful terminal-but-non-green evidence

Fixes the #3712-owned evidence-tool defect exposed by current exact-dev reconciliation.

### What changes
- Replace all ten prose child-terminal receipts with structured PR/direct-issue, commit, and exact-status evidence.
- Preserve immutable non-green truth for #3704/#3707/#3710: their receipts record `failure` rather than falsely claiming green CI.
- Let the CI collector emit every completed exact-head conclusion instead of refusing non-green historic PR heads.
- Keep the closure verifier fail-closed: non-green exact-head evidence still makes `exactHeadCi` fail. It no longer makes the receipt schema incapable of expressing truth.
- Align the receipt and #3712 design contracts and cover the new behavior with the focused integration test.

### Current exact-dev result
At `dev@e5d1806b2c3ddc91118e2a793599ed5e14591341`, migration receipts now validate (`13 schema-valid receipt(s)`); the truthful evidence correction does **not** close #3712. The collector can collect all expected child PR heads. Exact evidence still fails because direct child #3709's referenced commit is not reachable from current dev; exact-head CI and product predicates remain deliberately unresolved.

### Validation
- `bunx vitest run tests/integration/epic-3698-closure-verifier.test.ts --exclude tests/perf/**` — 97 passed
- `bun run build`
- `bunx tsc --noEmit -p tsconfig.json`
- `npm pack`; fresh-project install; `omc --version`; `omc doctor`
- `node scripts/generate-inventory-graph.mjs` — deterministic, zero drift
- `node scripts/plugin-shipping-surface.mjs verify`

No release, tag, publish, protected-main mutation, or generated-authorization merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
