### PR TITLE
fix(inventory): refresh post-squash provenance (#3712)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "671324ca66973bd8b67d9ee439f1c0d3e22a9b98",
+    "head": "c5bf8d060f364495cedc275820282256a29a7a33",
     "sourceSha256": "d770b7ddcc2766a1a4055b0ffb1b9163e5dd04d67efd1fd4a77788fb9c37c4e3",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "671324ca66973bd8b67d9ee439f1c0d3e22a9b98",
+  "head": "c5bf8d060f364495cedc275820282256a29a7a33",
   "sourceSha256": "d770b7ddcc2766a1a4055b0ffb1b9163e5dd04d67efd1fd4a77788fb9c37c4e3",
   "counts": {
     "public": {
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "7b83a1febe7a9f0c6c15f777f67640b776a52ddc6473dbab32bafa261ddeaf7c"
+  "manifestSha256": "6aeb27aa665bd3b186dd66d0d3fdfaf7724783591ccd67ed605f3b9ad2c7cf8d"
 }


### PR DESCRIPTION
Repairs the current-dev inventory gate regression introduced by the squash integration of #3815: the committed provenance head was the pre-squash PR commit and is not an ancestor of merged dev. This refresh records `c5bf8d06` as the provenance head.

Validation: `node scripts/generate-inventory-graph.mjs --write`; `node scripts/generate-inventory-graph.mjs --verify`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*