### PR TITLE
fix(prompt-ssot): union repeated n-gram positions

### DIFF
--- a/docs/design/issue-3704-prompt-ssot/measurements.json
+++ b/docs/design/issue-3704-prompt-ssot/measurements.json
@@ -3,7 +3,7 @@
   "issue": 3704,
   "epic": 3698,
   "sourceRevision": "2026-08-13.1",
-  "measuredAt": "2026-08-13T00:34:53.300Z",
+  "measuredAt": "2026-08-23T06:16:21.876Z",
   "baselineCorpus": [
     "CLAUDE.md",
     "docs/CLAUDE.md",
@@ -29,21 +29,21 @@
     "agents/writer.md"
   ],
   "baseline": {
-    "totalTokens": 23838,
-    "uniqueTokens": 3409,
-    "uniqueNGrams": 21384,
-    "repeatedClauseRatio": 1.1430489134994546,
-    "repeatedTokens": 19576
+    "totalTokens": 23859,
+    "uniqueTokens": 3416,
+    "uniqueNGrams": 21391,
+    "repeatedClauseRatio": 0.18219539796303283,
+    "repeatedTokens": 3107
   },
   "ssot": {
     "totalTokens": 899,
     "uniqueTokens": 448,
     "uniqueNGrams": 875,
-    "repeatedClauseRatio": 0.3025583982202447,
-    "repeatedTokens": 136
+    "repeatedClauseRatio": 0.05339265850945495,
+    "repeatedTokens": 24
   },
-  "repeatedTokenReduction": 0.9931,
-  "repeatedClauseRatioReduction": 0.8405,
+  "repeatedTokenReduction": 0.9923,
+  "repeatedClauseRatioReduction": 0.1288,
   "projectionDrift": {
     "coordinator": 0,
     "role-planner": 0,

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "c5bf8d060f364495cedc275820282256a29a7a33",
-    "sourceSha256": "d770b7ddcc2766a1a4055b0ffb1b9163e5dd04d67efd1fd4a77788fb9c37c4e3",
+    "head": "2069293c667db8aa44be30c4863b94739bcfdf0a",
+    "sourceSha256": "23036be134e186f57e3b09527229c64011328a291591917fd03100d0f76a79e0",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "c5bf8d060f364495cedc275820282256a29a7a33",
-  "sourceSha256": "d770b7ddcc2766a1a4055b0ffb1b9163e5dd04d67efd1fd4a77788fb9c37c4e3",
+  "head": "2069293c667db8aa44be30c4863b94739bcfdf0a",
+  "sourceSha256": "23036be134e186f57e3b09527229c64011328a291591917fd03100d0f76a79e0",
   "counts": {
     "public": {
       "skills": 31,
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "6aeb27aa665bd3b186dd66d0d3fdfaf7724783591ccd67ed605f3b9ad2c7cf8d"
+  "manifestSha256": "eab1cda766281375ce7b32d2af8f45bf594481131a704c40d0fff49a9b3cc102"
 }

--- a/src/agents/prompt-ssot/__tests__/prompt-ssot.test.ts
+++ b/src/agents/prompt-ssot/__tests__/prompt-ssot.test.ts
@@ -187,6 +187,38 @@ describe('metrics', () => {
     }
   });
 
+  it('counts the union of overlapping repeated n-gram positions', () => {
+    expect(corpusStats(['a a a a'], 2)).toMatchObject({
+      totalTokens: 4,
+      repeatedClauseRatio: 1,
+      repeatedTokens: 3,
+    });
+  });
+
+  it('unions positions across distinct overlapping repeated n-grams', () => {
+    expect(corpusStats(['a b a b a b'], 2)).toMatchObject({
+      totalTokens: 6,
+      repeatedClauseRatio: 1,
+      repeatedTokens: 4,
+    });
+  });
+
+  it('counts adjacent repeated n-gram windows once per token position', () => {
+    expect(corpusStats(['a b a b'], 2)).toMatchObject({
+      totalTokens: 4,
+      repeatedClauseRatio: 1,
+      repeatedTokens: 2,
+    });
+  });
+
+  it('counts disjoint repeated n-gram windows independently', () => {
+    expect(corpusStats(['a b x y a b'], 2)).toMatchObject({
+      totalTokens: 6,
+      repeatedClauseRatio: 4 / 6,
+      repeatedTokens: 2,
+    });
+  });
+
   it('measures lower repeated-clause ratio in SSOT sources than legacy corpus', () => {
     const root = join(__dirname, '..', '..', '..', '..');
     const legacyFiles = ['CLAUDE.md', 'docs/CLAUDE.md', '.github/CLAUDE.md'].filter((f) =>

--- a/src/agents/prompt-ssot/metrics.ts
+++ b/src/agents/prompt-ssot/metrics.ts
@@ -35,25 +35,31 @@ export interface CorpusStats {
 
 export function corpusStats(texts: readonly string[], nGramSize = 8): CorpusStats {
   const tokens = texts.flatMap((t) => tokenize(t));
-  const ngramCounts = new Map<string, number>();
+  const ngramPositions = new Map<string, number[]>();
   for (let i = 0; i + nGramSize <= tokens.length; i++) {
     const gram = tokens.slice(i, i + nGramSize).join(' ');
-    ngramCounts.set(gram, (ngramCounts.get(gram) ?? 0) + 1);
+    const positions = ngramPositions.get(gram) ?? [];
+    positions.push(i);
+    ngramPositions.set(gram, positions);
   }
-  let repeatedPositions = 0;
-  let extraOccurrences = 0;
-  for (const count of ngramCounts.values()) {
-    if (count > 1) {
-      repeatedPositions += count * nGramSize;
-      extraOccurrences += (count - 1) * nGramSize;
+  const repeatedPositions = new Set<number>();
+  const extraOccurrencePositions = new Set<number>();
+  for (const positions of ngramPositions.values()) {
+    if (positions.length > 1) {
+      for (const [occurrence, start] of positions.entries()) {
+        for (let position = start; position < start + nGramSize; position++) {
+          repeatedPositions.add(position);
+          if (occurrence > 0) extraOccurrencePositions.add(position);
+        }
+      }
     }
   }
   return {
     totalTokens: tokens.length,
     uniqueTokens: new Set(tokens).size,
-    uniqueNGrams: ngramCounts.size,
-    repeatedClauseRatio: tokens.length === 0 ? 0 : repeatedPositions / tokens.length,
-    repeatedTokens: extraOccurrences,
+    uniqueNGrams: ngramPositions.size,
+    repeatedClauseRatio: tokens.length === 0 ? 0 : repeatedPositions.size / tokens.length,
+    repeatedTokens: extraOccurrencePositions.size,
   };
 }
 


### PR DESCRIPTION
Fixes #3816.\n\n## Evidence\n- Signed commit: `387d2b1c349a44bd9948319319e9aa3681e0b8ee` (GPG good signature).\n- Focused tests: `bunx vitest run src/agents/prompt-ssot/__tests__/prompt-ssot.test.ts` (21 passed).\n- Typecheck: `bunx tsc --noEmit` passed.\n- Deterministic checks: `npm run prompt-ssot:check` and `npm run generate:inventory:verify` passed.\n- Measurement receipt regenerated: `docs/design/issue-3704-prompt-ssot/measurements.json`.\n\nScope is limited to #3816 metric semantics, its tests, measurement receipt, and the required deterministic inventory projection. No main/release/tag/publish actions.