### PR TITLE
fix(prompt-ssot): validate n-gram size

### DIFF
--- a/docs/design/issue-3704-prompt-ssot/measurements.json
+++ b/docs/design/issue-3704-prompt-ssot/measurements.json
@@ -3,7 +3,7 @@
   "issue": 3704,
   "epic": 3698,
   "sourceRevision": "2026-08-13.1",
-  "measuredAt": "2026-08-23T06:16:21.876Z",
+  "measuredAt": "2026-08-23T06:53:40.459Z",
   "baselineCorpus": [
     "CLAUDE.md",
     "docs/CLAUDE.md",

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2069293c667db8aa44be30c4863b94739bcfdf0a",
-    "sourceSha256": "23036be134e186f57e3b09527229c64011328a291591917fd03100d0f76a79e0",
+    "head": "e1dc06e189058d6b190e48f93c056294fe9654c7",
+    "sourceSha256": "81e633fadc9ba2515c0947655a858bb80fe27783c5666ddaacade409725d873e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2069293c667db8aa44be30c4863b94739bcfdf0a",
-  "sourceSha256": "23036be134e186f57e3b09527229c64011328a291591917fd03100d0f76a79e0",
+  "head": "e1dc06e189058d6b190e48f93c056294fe9654c7",
+  "sourceSha256": "81e633fadc9ba2515c0947655a858bb80fe27783c5666ddaacade409725d873e",
   "counts": {
     "public": {
       "skills": 31,
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "eab1cda766281375ce7b32d2af8f45bf594481131a704c40d0fff49a9b3cc102"
+  "manifestSha256": "7bb67654cffe78fca8cd31fccf14ed90aa797e9172d42eec2698aeb0cbf5b1e8"
 }

--- a/src/agents/prompt-ssot/__tests__/prompt-ssot.test.ts
+++ b/src/agents/prompt-ssot/__tests__/prompt-ssot.test.ts
@@ -180,6 +180,15 @@ describe('metrics', () => {
     expect(tokenize('Hello,  WORLD\nhello')).toEqual(['hello', 'world', 'hello']);
   });
 
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects invalid n-gram size %s before scanning',
+    (nGramSize) => {
+      expect(() => corpusStats(['a b a b'], nGramSize)).toThrow(
+        'nGramSize must be a finite positive integer.',
+      );
+    },
+  );
+
   it('reports zero projection drift for freshly composed bodies', () => {
     const composed = composeAll(PROMPT_SSOT_MANIFEST, PROMPT_SECTIONS);
     for (const p of composed) {

--- a/src/agents/prompt-ssot/metrics.ts
+++ b/src/agents/prompt-ssot/metrics.ts
@@ -34,6 +34,9 @@ export interface CorpusStats {
 }
 
 export function corpusStats(texts: readonly string[], nGramSize = 8): CorpusStats {
+  if (!Number.isFinite(nGramSize) || !Number.isInteger(nGramSize) || nGramSize <= 0) {
+    throw new RangeError('nGramSize must be a finite positive integer.');
+  }
   const tokens = texts.flatMap((t) => tokenize(t));
   const ngramPositions = new Map<string, number[]>();
   for (let i = 0; i + nGramSize <= tokens.length; i++) {


### PR DESCRIPTION
Fixes #3816.\n\n## Signed evidence\n- Signed commit: `7755b9240ca756a3d8b1b1f964f996464cc1677d` (GPG good signature).\n- `corpusStats` now rejects non-finite, non-integer, and non-positive `nGramSize` before entering the n-gram scan.\n- Regressions cover 0, negative, fractional, NaN, +Infinity, and -Infinity; all fail synchronously, preventing the prior -Infinity non-terminating loop.\n- Existing union-overlap, adjacent, and disjoint metric tests remain covered.\n- Focused Vitest: 28 passed; no-emit typecheck, prompt projection freshness, and inventory verification passed.\n\nScope is limited to #3816 plus its required measurement receipt and deterministic inventory projection. No main/release/tag/publish actions.