### PR TITLE
fix(inventory): refresh post-3823 provenance (#3712)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "08da2667e0c8a89287045d71e3f0088bfc7bd918",
+    "head": "4357b328c6abdae0dd805b18db641734800cae5e",
     "sourceSha256": "0763a95a44f57a5f7e050b3c5ba03d2d9a77feb89fbf993b7c5ad61eb72b6b3f",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "08da2667e0c8a89287045d71e3f0088bfc7bd918",
+  "head": "4357b328c6abdae0dd805b18db641734800cae5e",
   "sourceSha256": "0763a95a44f57a5f7e050b3c5ba03d2d9a77feb89fbf993b7c5ad61eb72b6b3f",
   "counts": {
     "public": {
@@ -74913,5 +74913,5 @@
     }
   },
   "inventorySha256": "fb7a79660fc8e0567ff1d3b9b1c35cc824ceee60b5a0313f27f45cd531a8e409",
-  "manifestSha256": "c943628c41902fd3ac59e6e6673a68ef496de3e193c409c5130f32d66653a184"
+  "manifestSha256": "ed5dd3b4e4b1013a1acbe13bfca8f57ef7e2b9dc94a7e20994a782a87e22142f"
 }


### PR DESCRIPTION
Refreshes only deterministic inventory provenance after the #3823 squash merge made the committed head non-ancestral to current dev.

Validation: `node scripts/generate-inventory-graph.mjs --write`; `node scripts/generate-inventory-graph.mjs --verify`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*