### PR TITLE
fix(ci): require exact generated authorization tuple

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "7704866fea19ff8a6b10c9656f5a9b275a460b62",
-    "sourceSha256": "f435f74ea93c8a4ded2175360113b01a8321100445d08294502b37b02885605a",
+    "head": "2cbc223131d165506bb4d8334f0bb2f047f22282",
+    "sourceSha256": "ab5506a545a4e70f3e1190164f1f1360362ab4e1ba86f642fd90814e0a9bd63d",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "7704866fea19ff8a6b10c9656f5a9b275a460b62",
-  "sourceSha256": "f435f74ea93c8a4ded2175360113b01a8321100445d08294502b37b02885605a",
+  "head": "2cbc223131d165506bb4d8334f0bb2f047f22282",
+  "sourceSha256": "ab5506a545a4e70f3e1190164f1f1360362ab4e1ba86f642fd90814e0a9bd63d",
   "counts": {
     "public": {
       "skills": 31,
@@ -75153,5 +75153,5 @@
     }
   },
   "inventorySha256": "4eaef9dd6b734acf7c47e6b313fbe4b075bacdf4f3f6bb174263233412aea6a3",
-  "manifestSha256": "87a852d3d8d3a4f9d434f2b4a6d0f42b585d40134274716da0a841673d1b1653"
+  "manifestSha256": "9a9e9ed6b92e87c1bc055a142bfce086f2eaf6b10476f170b0f04a5d25e4bae4"
 }

--- a/scripts/verify-generated-artifact-authorization.mjs
+++ b/scripts/verify-generated-artifact-authorization.mjs
@@ -421,32 +421,6 @@ function assertCompareBaseAndGetMergeBase(compare, expectedBaseSha) {
   return requiredSha(mergeBase.sha, 'compare response.merge_base_commit.sha');
 }
 
-function assertNonGeneratedAdvance(compare, ancestorSha, descendantSha, label) {
-  const response = requiredObject(compare, `${label} compare response`);
-  if (requiredObject(response.base_commit, `${label} compare response.base_commit`).sha !== ancestorSha ||
-      requiredObject(response.merge_base_commit, `${label} compare response.merge_base_commit`).sha !== ancestorSha) {
-    fail(`${label} is not a direct descendant of the authorized SHA`);
-  }
-  if (response.status !== 'ahead' ||
-      requiredNonNegativeInteger(response.behind_by, `${label} compare response.behind_by`) !== 0) {
-    fail(`${label} is not strictly ahead of the authorized SHA`);
-  }
-  const aheadBy = requiredPositiveInteger(response.ahead_by, `${label} compare response.ahead_by`);
-  if (aheadBy > 100 || requiredPositiveInteger(
-    response.total_commits,
-    `${label} compare response.total_commits`,
-  ) !== aheadBy) {
-    fail(`${label} compare is too large or inconsistent`);
-  }
-  if (!Array.isArray(response.commits) || response.commits.length !== aheadBy ||
-      requiredObject(response.commits.at(-1), `${label} compare final commit`).sha !== descendantSha) {
-    fail(`${label} compare head does not match the live SHA`);
-  }
-  const files = canonicalizeChangedFiles(response.files, `${label} compare files`);
-  if (files.length >= 300) fail(`${label} compare is too large to prove complete`);
-  if (files.some(recordTouchesGeneratedPath)) fail(`${label} changes generated files outside the authorized closure`);
-}
-
 function assertOwnerCommitSignature(commit, signature, headSha, owner) {
   const commitResponse = requiredObject(commit, 'head commit response');
   if (requiredSha(commitResponse.sha, 'head commit response.sha') !== headSha) {
@@ -493,8 +467,6 @@ export function authorizeGeneratedArtifactPullRequest({
   checkedOutBaseSha,
   livePull,
   compare,
-  authorizedHeadAdvance,
-  authorizedBaseAdvance,
   commit,
   signature,
   files,
@@ -545,26 +517,10 @@ export function authorizeGeneratedArtifactPullRequest({
     fail('generated changes do not match the authorized PR/target/head identity');
   }
   if (authorization.headSha !== liveData.headSha) {
-    if (authorizedHeadAdvance === undefined) {
-      fail('generated changes do not match the authorized PR/target/head identity');
-    }
-    assertNonGeneratedAdvance(
-      authorizedHeadAdvance,
-      authorization.headSha,
-      liveData.headSha,
-      'authorized head advance',
-    );
+    fail('generated changes do not match the authorized PR/target/head identity');
   }
   if (authorization.mergeBaseSha !== compareMergeBaseSha) {
-    if (authorizedBaseAdvance === undefined) {
-      fail('compare merge base does not match the authorized merge base SHA');
-    }
-    assertNonGeneratedAdvance(
-      authorizedBaseAdvance,
-      authorization.mergeBaseSha,
-      compareMergeBaseSha,
-      'authorized merge-base advance',
-    );
+    fail('compare merge base does not match the authorized merge base SHA');
   }
   if (
     eventData.headRepository !== trustedManifest.repository ||
@@ -733,24 +689,6 @@ export async function verifyLiveGeneratedArtifactAuthorization({
       `/compare/${encodeURIComponent(liveData.baseSha)}...${encodeURIComponent(liveData.headSha)}?per_page=1&page=1`,
     ),
   );
-  const authorization = trustedManifest.authorizations.find(entry => entry.pullNumber === eventData.pullNumber);
-  const compareMergeBaseSha = assertCompareBaseAndGetMergeBase(compare, liveData.baseSha);
-  const authorizedHeadAdvance = authorization && authorization.headSha !== liveData.headSha
-    ? await api.get(
-      apiPath(
-        trustedManifest.repository,
-        `/compare/${encodeURIComponent(authorization.headSha)}...${encodeURIComponent(liveData.headSha)}?per_page=100&page=1`,
-      ),
-    )
-    : undefined;
-  const authorizedBaseAdvance = authorization && authorization.mergeBaseSha !== compareMergeBaseSha
-    ? await api.get(
-      apiPath(
-        trustedManifest.repository,
-        `/compare/${encodeURIComponent(authorization.mergeBaseSha)}...${encodeURIComponent(compareMergeBaseSha)}?per_page=100&page=1`,
-      ),
-    )
-    : undefined;
   const commit = await api.get(apiPath(trustedManifest.repository, `/commits/${encodeURIComponent(liveData.headSha)}`));
 
   const { owner, name } = parseRepository(trustedManifest.repository);
@@ -776,8 +714,6 @@ export async function verifyLiveGeneratedArtifactAuthorization({
     checkedOutBaseSha,
     livePull,
     compare,
-    authorizedHeadAdvance,
-    authorizedBaseAdvance,
     commit,
     signature: graphResponse.data.repository.object,
     files,

--- a/src/__tests__/generated-artifact-authorization.test.ts
+++ b/src/__tests__/generated-artifact-authorization.test.ts
@@ -90,26 +90,7 @@ type MutableInput = {
     merge_base_commit: { sha: string };
     files?: unknown;
   };
-  authorizedHeadAdvance?: {
-    status: string;
-    ahead_by: number;
-    behind_by: number;
-    total_commits: number;
-    commits: Array<{ sha: string }>;
-    base_commit: { sha: string };
-    merge_base_commit: { sha: string };
-    files: ApiFile[];
-  };
-  authorizedBaseAdvance?: {
-    status: string;
-    ahead_by: number;
-    behind_by: number;
-    total_commits: number;
-    commits: Array<{ sha: string }>;
-    base_commit: { sha: string };
-    merge_base_commit: { sha: string };
-    files: ApiFile[];
-  };
+
   commit: {
     sha: string;
     commit: { verification: { verified: boolean } };
@@ -573,69 +554,21 @@ describe('generated-artifact base-owned authorization decision', () => {
     }, 'web-flow signature does not match');
   });
 
-  it('accepts only fully enumerable non-generated advances from the authorized head and merge base', () => {
+  it('rejects any live head or merge-base mismatch from the authorized tuple', () => {
     const input = authorizedInput();
     const authorizedHeadSha = 'b'.repeat(40);
     const authorizedMergeBaseSha = 'c'.repeat(40);
     input.manifest.authorizations[0].headSha = authorizedHeadSha;
     input.manifest.authorizations[0].mergeBaseSha = authorizedMergeBaseSha;
-    input.authorizedHeadAdvance = {
-      status: 'ahead',
-      ahead_by: 1,
-      behind_by: 0,
-      total_commits: 1,
-      commits: [{ sha: HEAD_SHA }],
-      base_commit: { sha: authorizedHeadSha },
-      merge_base_commit: { sha: authorizedHeadSha },
-      files: [{ status: 'modified', filename: 'src/reconciled.ts', sha: 'd'.repeat(40) }],
-    };
-    input.authorizedBaseAdvance = {
-      status: 'ahead',
-      ahead_by: 1,
-      behind_by: 0,
-      total_commits: 1,
-      commits: [{ sha: MERGE_BASE_SHA }],
-      base_commit: { sha: authorizedMergeBaseSha },
-      merge_base_commit: { sha: authorizedMergeBaseSha },
-      files: [{ status: 'modified', filename: 'scripts/base-trust.mjs', sha: 'e'.repeat(40) }],
-    };
-    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({ allowed: true });
-
-    input.authorizedHeadAdvance.files = [
-      { status: 'modified', filename: 'dist/unauthorized.js', sha: 'f'.repeat(40) },
-    ];
     expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
       allowed: false,
-      reason: expect.stringContaining('outside the authorized closure'),
+      reason: expect.stringContaining('authorized PR/target/head identity'),
     });
 
-    input.authorizedHeadAdvance.files = [];
-    input.authorizedHeadAdvance.commits = [{ sha: 'a'.repeat(40) }];
+    input.manifest.authorizations[0].headSha = HEAD_SHA;
     expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
       allowed: false,
-      reason: expect.stringContaining('compare head does not match'),
-    });
-
-    input.authorizedHeadAdvance.commits = Array.from({ length: 101 }, () => ({ sha: HEAD_SHA }));
-    input.authorizedHeadAdvance.ahead_by = 101;
-    input.authorizedHeadAdvance.total_commits = 101;
-    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
-      allowed: false,
-      reason: expect.stringContaining('too large or inconsistent'),
-    });
-
-    input.authorizedHeadAdvance.commits = [{ sha: HEAD_SHA }];
-    input.authorizedHeadAdvance.ahead_by = 1;
-    input.authorizedHeadAdvance.total_commits = 1;
-    input.authorizedHeadAdvance.files = [{
-      status: 'renamed',
-      filename: 'src/moved.cjs',
-      previous_filename: 'bridge/moved.cjs',
-      sha: 'f'.repeat(40),
-    }];
-    expect(verifier.evaluateGeneratedArtifactAuthorization(input)).toMatchObject({
-      allowed: false,
-      reason: expect.stringContaining('outside the authorized closure'),
+      reason: expect.stringContaining('authorized merge base SHA'),
     });
   });
 
@@ -1002,23 +935,7 @@ describe('generated-artifact base-owned authorization decision', () => {
 
       const advancedInput = authorizedInput();
       const authorizedHeadSha = 'b'.repeat(40);
-      const authorizedMergeBaseSha = 'c'.repeat(40);
       advancedInput.manifest.authorizations[0].headSha = authorizedHeadSha;
-      advancedInput.manifest.authorizations[0].mergeBaseSha = authorizedMergeBaseSha;
-      advancedInput.authorizedHeadAdvance = {
-        status: 'ahead', ahead_by: 1, behind_by: 0, total_commits: 1,
-        commits: [{ sha: HEAD_SHA }],
-        base_commit: { sha: authorizedHeadSha },
-        merge_base_commit: { sha: authorizedHeadSha },
-        files: [{ status: 'modified', filename: 'src/head-advance.ts', sha: 'd'.repeat(40) }],
-      };
-      advancedInput.authorizedBaseAdvance = {
-        status: 'ahead', ahead_by: 1, behind_by: 0, total_commits: 1,
-        commits: [{ sha: MERGE_BASE_SHA }],
-        base_commit: { sha: authorizedMergeBaseSha },
-        merge_base_commit: { sha: authorizedMergeBaseSha },
-        files: [{ status: 'modified', filename: 'scripts/base-advance.mjs', sha: 'e'.repeat(40) }],
-      };
       const advancePaths: string[] = [];
       const advanceFetch: typeof fetch = async request => {
         const url = new URL(
@@ -1034,8 +951,6 @@ describe('generated-artifact base-owned authorization decision', () => {
         else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=2')) body = advancedInput.files.slice(100);
         else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=3')) body = [];
         else if (path === `/repos/${REPOSITORY}/compare/${LIVE_BASE_SHA}...${HEAD_SHA}?per_page=1&page=1`) body = advancedInput.compare;
-        else if (path === `/repos/${REPOSITORY}/compare/${authorizedHeadSha}...${HEAD_SHA}?per_page=100&page=1`) body = advancedInput.authorizedHeadAdvance;
-        else if (path === `/repos/${REPOSITORY}/compare/${authorizedMergeBaseSha}...${MERGE_BASE_SHA}?per_page=100&page=1`) body = advancedInput.authorizedBaseAdvance;
         else if (path === `/repos/${REPOSITORY}/commits/${HEAD_SHA}`) body = advancedInput.commit;
         else if (path === '/graphql') body = { data: { repository: { object: advancedInput.signature } } };
         else throw new Error(`Unexpected GitHub API path ${path}`);
@@ -1049,11 +964,44 @@ describe('generated-artifact base-owned authorization decision', () => {
         fetchImpl: advanceFetch,
         repositoryRoot: checkoutRoot,
         now: advancedInput.now,
-      })).resolves.toMatchObject({ requiresAuthorization: true, pullNumber: PULL_NUMBER });
-      expect(advancePaths).toContain(
+      })).rejects.toThrow('authorized PR/target/head identity');
+      expect(advancePaths).not.toContain(
         `/repos/${REPOSITORY}/compare/${authorizedHeadSha}...${HEAD_SHA}?per_page=100&page=1`,
       );
-      expect(advancePaths).toContain(
+
+      const mergeBaseAdvancedInput = authorizedInput();
+      const authorizedMergeBaseSha = 'c'.repeat(40);
+      mergeBaseAdvancedInput.manifest.authorizations[0].mergeBaseSha = authorizedMergeBaseSha;
+      const mergeBaseAdvancePaths: string[] = [];
+      const mergeBaseAdvanceFetch: typeof fetch = async request => {
+        const url = new URL(
+          typeof request === 'string' ? request : request instanceof URL ? request.href : request.url,
+        );
+        const path = `${url.pathname}${url.search}`;
+        mergeBaseAdvancePaths.push(path);
+        let body: unknown;
+        if (path === `/repos/${REPOSITORY}`) body = mergeBaseAdvancedInput.repositoryMetadata;
+        else if (path === `/repos/${REPOSITORY}/commits/main`) body = mergeBaseAdvancedInput.runtimeCommit;
+        else if (path === `/repos/${REPOSITORY}/pulls/${PULL_NUMBER}`) body = mergeBaseAdvancedInput.livePull;
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=1')) body = mergeBaseAdvancedInput.files.slice(0, 100);
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=2')) body = mergeBaseAdvancedInput.files.slice(100);
+        else if (path.includes(`/pulls/${PULL_NUMBER}/files`) && path.endsWith('page=3')) body = [];
+        else if (path === `/repos/${REPOSITORY}/compare/${LIVE_BASE_SHA}...${HEAD_SHA}?per_page=1&page=1`) body = mergeBaseAdvancedInput.compare;
+        else if (path === `/repos/${REPOSITORY}/commits/${HEAD_SHA}`) body = mergeBaseAdvancedInput.commit;
+        else if (path === '/graphql') body = { data: { repository: { object: mergeBaseAdvancedInput.signature } } };
+        else throw new Error(`Unexpected GitHub API path ${path}`);
+        return { ok: true, json: async () => body } as Response;
+      };
+      await expect(verifier.verifyLiveGeneratedArtifactAuthorization({
+        event: mergeBaseAdvancedInput.event,
+        manifest: mergeBaseAdvancedInput.manifest,
+        environment: mergeBaseAdvancedInput.environment,
+        token: 'test-token',
+        fetchImpl: mergeBaseAdvanceFetch,
+        repositoryRoot: checkoutRoot,
+        now: mergeBaseAdvancedInput.now,
+      })).rejects.toThrow('authorized merge base SHA');
+      expect(mergeBaseAdvancePaths).not.toContain(
         `/repos/${REPOSITORY}/compare/${authorizedMergeBaseSha}...${MERGE_BASE_SHA}?per_page=100&page=1`,
       );
 


### PR DESCRIPTION
Closes #3840.

## Summary
- require generated-artifact authorization head equality
- require authorized merge-base equality
- remove source-only head/base advancement API fallback
- replace accepting advancement tests with fail-closed mismatch coverage

## Verification
- `npx vitest run src/__tests__/generated-artifact-authorization.test.ts` — 23 passed
- `npx tsc --noEmit` — passed
- `git diff --check` — passed

Focused ESLint invocation on the standalone `.mjs` reports its existing Node-global configuration errors (`process`/`console`); no new warnings were suppressed.

No authorization manifest, #3749, main, release, tag, or publish surfaces changed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
