### PR TITLE
ci: reauthorize PR #3827 head after base advance

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -10968,8 +10968,8 @@
     {
       "pullNumber": 3827,
       "targetRef": "dev",
-      "mergeBaseSha": "5e1681239fc59e79760fe4756d8736f04fd44934",
-      "headSha": "fe57b8a8ef1c772542e10202b77fa0b54d516aa2",
+      "mergeBaseSha": "02e34590a017f85d21ecb84f4b111061b3947a48",
+      "headSha": "5a8fb2597d66b4c9c1f422002873b1e1e95e87a2",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-08-30T00:00:00.000Z",
       "generatedDelta": {

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "4875a2eaf9b66f882263ece824d95fcee0cd68f6",
+    "head": "677f0185333f03d3fee4e26a7550eb4df5263833",
     "sourceSha256": "0b839bede2f3c1222466dd492aec33025d834fcab2c2b0fb4c7b683b84539fc0",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "4875a2eaf9b66f882263ece824d95fcee0cd68f6",
+  "head": "677f0185333f03d3fee4e26a7550eb4df5263833",
   "sourceSha256": "0b839bede2f3c1222466dd492aec33025d834fcab2c2b0fb4c7b683b84539fc0",
   "counts": {
     "public": {
@@ -75095,5 +75095,5 @@
     }
   },
   "inventorySha256": "f87ce5b82ba93aa0f25b13865de71d4acab9d7e6211b33178720a927f2780d32",
-  "manifestSha256": "122786aed5a0d1e67a069c8672523e10cfaac9cc97839d2a7012339bed27f1c4"
+  "manifestSha256": "1d38ffa28778568078d7cb14d9bd368b4630027ed707bb98b77cc2a608ae8135"
 }


### PR DESCRIPTION
Replaces the PR #3827 authorization tuple stale head `fe57b8a8` with the rebased head `6a39a8dccf719c5b65225146986029a1775838c7` (merge base `02e34590a017f85d21ecb84f4b111061b3947a48`).

- generatedDelta unchanged: 260 files, sha256 `8a011dbb45f9560a86e954f640177f8e605a310cd3db27f53579252ab6610662` (recomputed from the exact base/head diff; tree content identical to the previously authorized closure)
- Tuple fully recomputed after the dependent branch rebase; no stale tuple reused.