### PR TITLE
ci: reauthorize PR #3851 head after inventory refresh

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -12543,7 +12543,7 @@
       "pullNumber": 3851,
       "targetRef": "dev",
       "mergeBaseSha": "fa440fcfb5bcf342195292ac11dd609adbf638cf",
-      "headSha": "025950c9406f7e295795507b09850d9a084c5970",
+      "headSha": "ebecf3f82827a8488ce214535a55be97a5bafb2a",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-09-07T00:00:00.000Z",
       "generatedDelta": {

--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -12543,7 +12543,7 @@
       "pullNumber": 3851,
       "targetRef": "dev",
       "mergeBaseSha": "fa440fcfb5bcf342195292ac11dd609adbf638cf",
-      "headSha": "ebecf3f82827a8488ce214535a55be97a5bafb2a",
+      "headSha": "bfec9d9c6b63704c1322663e1291f6709f76e81a",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-09-07T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
Replaces the PR #3851 authorization tuple stale head `025950c9` with the inventory-refresh head `ebecf3f82827a8488ce214535a55be97a5bafb2a` (merge base `fa440fcfb5bcf342195292ac11dd609adbf638cf`).

- generatedDelta unchanged: 9 files, sha256 `074f53ee74f6cd8cdaea20a5ffec0ea6de500c4650f69282c5280dd8503768be`
- Companion to #3851.