### PR TITLE
fix(wiki): reject foreign-repo workingDirectory visibly across wiki_* tools (#3858)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b4577041af669f8e28161a124f9d24afa22a36c1",
+    "head": "4c380abbee03182d3f5a05fc8394e781ab9a7860",
     "sourceSha256": "aaef95d505aeff50ca22425ebe443f66dbdd9d221dedbe53c671c28eae15ea5e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b4577041af669f8e28161a124f9d24afa22a36c1",
+  "head": "4c380abbee03182d3f5a05fc8394e781ab9a7860",
   "sourceSha256": "aaef95d505aeff50ca22425ebe443f66dbdd9d221dedbe53c671c28eae15ea5e",
   "counts": {
     "public": {
@@ -74715,5 +74715,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "2185cff4d54fb6c2f9dff6234e0e4c8c1637218e2e36c4b9d5a3ea67cad609bb"
+  "manifestSha256": "f19d4addf19c0ce963ef15dd1457f09d74bb22685cdf4bc7bed52d3551f67c55"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "800c464d532980e95eb89e645e0d92955e76a9a9",
-    "sourceSha256": "4aef8443fce3c32250ebd595fc81461659937147d45545fb8f935e4392e84f8e",
+    "head": "b4577041af669f8e28161a124f9d24afa22a36c1",
+    "sourceSha256": "aaef95d505aeff50ca22425ebe443f66dbdd9d221dedbe53c671c28eae15ea5e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "800c464d532980e95eb89e645e0d92955e76a9a9",
-  "sourceSha256": "4aef8443fce3c32250ebd595fc81461659937147d45545fb8f935e4392e84f8e",
+  "head": "b4577041af669f8e28161a124f9d24afa22a36c1",
+  "sourceSha256": "aaef95d505aeff50ca22425ebe443f66dbdd9d221dedbe53c671c28eae15ea5e",
   "counts": {
     "public": {
       "skills": 31,
@@ -25,11 +25,11 @@
     "internal": {
       "hookFiles": 295,
       "featureFiles": 68,
-      "toolFiles": 56,
-      "libFiles": 34,
+      "toolFiles": 57,
+      "libFiles": 35,
       "templateHooks": 21,
-      "srcFiles": 1269,
-      "total": 1290
+      "srcFiles": 1271,
+      "total": 1292
     },
     "generated": {
       "distFiles": 4955,
@@ -509,6 +509,7 @@
       "src/tools/__tests__/memory-tools.test.ts",
       "src/tools/__tests__/schema-conversion.test.ts",
       "src/tools/__tests__/state-tools.test.ts",
+      "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
       "src/tools/__tests__/wiki-tools-working-directory.test.ts",
       "src/tools/ast-tools.ts",
       "src/tools/deepinit-manifest.ts",
@@ -571,6 +572,7 @@
       "src/lib/__tests__/sync-publication-short-write.test.ts",
       "src/lib/__tests__/truncate-prompt.test.ts",
       "src/lib/__tests__/worktree-cleanup-safety.test.ts",
+      "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
       "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
       "src/lib/__tests__/worktree-paths.test.ts",
       "src/lib/atomic-write.ts",
@@ -6207,6 +6209,7 @@
       "src/tools/__tests__/memory-tools.test.ts",
       "src/tools/__tests__/schema-conversion.test.ts",
       "src/tools/__tests__/state-tools.test.ts",
+      "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
       "src/tools/__tests__/wiki-tools-working-directory.test.ts",
       "src/tools/ast-tools.ts",
       "src/tools/deepinit-manifest.ts",
@@ -37842,6 +37845,11 @@
         "path": "src/lib/__tests__/worktree-cleanup-safety.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-foreign-root.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts"
@@ -39475,6 +39483,11 @@
         "id": "src/tools/__tests__/state-tools.test.ts",
         "kind": "tool",
         "path": "src/tools/__tests__/state-tools.test.ts"
+      },
+      {
+        "id": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "kind": "tool",
+        "path": "src/tools/__tests__/wiki-tools-foreign-root.test.ts"
       },
       {
         "id": "src/tools/__tests__/wiki-tools-working-directory.test.ts",
@@ -62729,6 +62742,41 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "src/tools/wiki-tools.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -71869,6 +71917,41 @@
         "kind": "imports"
       },
       {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/__tests__/wiki-tools-foreign-root.test.ts",
+        "to": "src/tools/wiki-tools.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/tools/__tests__/wiki-tools-working-directory.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -73110,6 +73193,11 @@
       },
       {
         "from": "src/tools/wiki-tools.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/wiki-tools.ts",
         "to": "external:zod",
         "kind": "imports"
       },
@@ -73142,6 +73230,11 @@
         "from": "src/tools/wiki-tools.ts",
         "to": "src/lib/worktree-paths.ts",
         "kind": "imports"
+      },
+      {
+        "from": "src/tools/wiki-tools.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "type-imports"
       },
       {
         "from": "src/tools/wiki-tools.ts",
@@ -74615,12 +74708,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6787,
-      "edgeCount": 6883,
-      "importEdgeCount": 5648,
+      "nodeCount": 6789,
+      "edgeCount": 6899,
+      "importEdgeCount": 5663,
       "registerEdgeCount": 52
     }
   },
-  "inventorySha256": "b6c734e8e5d1059ba3422be3bc077737b4fe8b16f985cf1348f0cdc4fb6b2269",
-  "manifestSha256": "190961641284e61b3ab64a728c0c5fc890bae49daca538f1eea6257ae9b61d26"
+  "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
+  "manifestSha256": "2185cff4d54fb6c2f9dff6234e0e4c8c1637218e2e36c4b9d5a3ea67cad609bb"
 }

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearWorktreeCache,
+  resolveWorkingDirectoryOrLinkedWorktree,
+  validateWorkingDirectoryOrLinkedWorktree,
+  ForeignWorkingDirectoryError,
+} from '../../lib/worktree-paths.js';
+import { wikiQueryTool, wikiReadTool } from '../../tools/wiki-tools.js';
+
+function git(cwd: string, command: string): void {
+  execSync(`git ${command}`, { cwd, stdio: 'pipe' });
+}
+
+describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-root', () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let sessionRepo: string;
+  let foreignRepo: string;
+  let linkedWorktree: string;
+  let plainDir: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = mkdtempSync(join(tmpdir(), 'resolver-3858-'));
+    clearWorktreeCache();
+
+    sessionRepo = join(tempDir, 'session-project');
+    mkdirSync(sessionRepo, { recursive: true });
+    git(sessionRepo, 'init');
+    git(sessionRepo, 'config user.email "test@example.com"');
+    git(sessionRepo, 'config user.name "Test User"');
+    writeFileSync(join(sessionRepo, 'README.md'), 'session\n');
+    git(sessionRepo, 'add README.md');
+    git(sessionRepo, 'commit -m initial');
+
+    foreignRepo = join(tempDir, 'foreign-vault');
+    mkdirSync(foreignRepo, { recursive: true });
+    git(foreignRepo, 'init');
+    git(foreignRepo, 'config user.email "test@example.com"');
+    git(foreignRepo, 'config user.name "Test User"');
+    writeFileSync(join(foreignRepo, 'README.md'), 'vault\n');
+    git(foreignRepo, 'add README.md');
+    git(foreignRepo, 'commit -m initial');
+
+    linkedWorktree = join(tempDir, 'session-linked');
+    git(sessionRepo, `worktree add -b linked ${linkedWorktree}`);
+
+    plainDir = join(tempDir, 'plain-notes');
+    mkdirSync(plainDir, { recursive: true });
+
+    process.chdir(sessionRepo);
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    clearWorktreeCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolveWorkingDirectoryOrLinkedWorktree returns foreign_repository for a different repo, never a root', () => {
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree(foreignRepo);
+    expect(resolution).toEqual({
+      status: 'foreign_repository',
+      providedRoot: foreignRepo,
+      trustedRoot: sessionRepo,
+    });
+    if (resolution.status === 'foreign_repository') {
+      expect('root' in resolution).toBe(false);
+    }
+  });
+
+  it('validateWorkingDirectoryOrLinkedWorktree throws ForeignWorkingDirectoryError instead of substituting', () => {
+    expect(() => validateWorkingDirectoryOrLinkedWorktree(foreignRepo)).toThrow(ForeignWorkingDirectoryError);
+    try {
+      validateWorkingDirectoryOrLinkedWorktree(foreignRepo);
+      expect.unreachable('must throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ForeignWorkingDirectoryError);
+      const foreign = error as ForeignWorkingDirectoryError;
+      expect(foreign.providedRoot).toBe(foreignRepo);
+      expect(foreign.trustedRoot).toBe(sessionRepo);
+      expect(foreign.message).toContain('belongs to a different repository');
+      expect(foreign.message).toContain('not used');
+    }
+  });
+
+  it('accepts a linked worktree of the same repository (preserves #2880)', () => {
+    expect(validateWorkingDirectoryOrLinkedWorktree(linkedWorktree)).toBe(linkedWorktree);
+    expect(resolveWorkingDirectoryOrLinkedWorktree(linkedWorktree)).toEqual({
+      status: 'ok',
+      root: linkedWorktree,
+    });
+  });
+
+  it('accepts the same root and a subdirectory of the trusted repo', () => {
+    expect(validateWorkingDirectoryOrLinkedWorktree(sessionRepo)).toBe(sessionRepo);
+    expect(validateWorkingDirectoryOrLinkedWorktree()).toBe(sessionRepo);
+
+    const sub = join(sessionRepo, 'docs');
+    mkdirSync(sub, { recursive: true });
+    // Non-repo directory inside the trusted root normalizes to the trusted root.
+    expect(validateWorkingDirectoryOrLinkedWorktree(sub)).toBe(sessionRepo);
+  });
+
+  it('still throws for a non-git path outside the trusted root', () => {
+    expect(() => validateWorkingDirectoryOrLinkedWorktree(plainDir)).toThrow(
+      'is outside the trusted worktree root'
+    );
+  });
+
+  it('linked-worktree wiki flows keep working end to end (no regression from #2880)', async () => {
+    const readResult = await wikiReadTool.handler({ page: 'missing', workingDirectory: linkedWorktree });
+    expect(readResult.isError).toBe(true);
+    expect(readResult.content[0].text).toContain('Wiki page not found: missing.md');
+    expect(readResult.content[0].text).not.toContain('different repository');
+
+    const queryResult = await wikiQueryTool.handler({ query: 'anything', workingDirectory: linkedWorktree });
+    expect(queryResult.isError).toBeUndefined();
+    expect(queryResult.content[0].text).toContain('No wiki pages match "anything"');
+    expect(existsSync(join(sessionRepo, '.omc', 'wiki'))).toBe(false);
+  });
+});

--- a/src/lib/__tests__/worktree-paths.test.ts
+++ b/src/lib/__tests__/worktree-paths.test.ts
@@ -24,6 +24,7 @@ import {
   resolveToWorktreeRoot,
   validateWorkingDirectory,
   validateWorkingDirectoryOrLinkedWorktree,
+  ForeignWorkingDirectoryError,
   getWorktreeRoot,
   getProjectIdentifier,
   clearDualDirWarnings,
@@ -328,14 +329,16 @@ describe('worktree-paths', () => {
         const parentRoot = canonicalTestPath(parentDir);
         const defaultRoot = canonicalTestPath(validateWorkingDirectory());
         const explicitParentRoot = canonicalTestPath(validateWorkingDirectory(parentDir));
-        const linkedParentRoot = canonicalTestPath(validateWorkingDirectoryOrLinkedWorktree(parentDir));
 
         expect(defaultRoot).toBe(expectedSubmoduleRoot);
         expect(explicitParentRoot).toBe(expectedSubmoduleRoot);
-        expect(linkedParentRoot).toBe(expectedSubmoduleRoot);
         expect(defaultRoot).not.toBe(parentRoot);
         expect(explicitParentRoot).not.toBe(parentRoot);
-        expect(linkedParentRoot).not.toBe(parentRoot);
+
+        // #3858: the superproject is a different git repository than the
+        // submodule. The linked-worktree validator must reject it visibly
+        // instead of silently substituting the trusted submodule root.
+        expect(() => validateWorkingDirectoryOrLinkedWorktree(parentDir)).toThrow(ForeignWorkingDirectoryError);
       } finally {
         process.chdir(originalCwd);
         clearWorktreeCache();

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1279,21 +1279,55 @@ function getGitCommonDir(cwd: string): string | null {
 }
 
 /**
- * Validate a workingDirectory while permitting linked git worktrees for the
- * same repository.
+ * Result of resolving a caller-provided workingDirectory against the trusted
+ * startup repository (#3858).
  *
- * This preserves validateWorkingDirectory's default cwd behavior and its
- * same-root/subdirectory normalization, but allows a per-call directory to
- * resolve to a sibling manual `git worktree` when both worktrees share the
- * same git common directory. Other unrelated git repositories still fall back
- * to the trusted startup cwd, and non-repo paths outside the trusted root are
- * rejected.
+ * - `ok`: the directory is usable as the wiki/root; `root` is either the
+ *   trusted root (default, subdirectory, or non-repo directory under it) or an
+ *   accepted same-repo/same-common-dir worktree root.
+ * - `foreign_repository`: the directory belongs to a different git repository.
+ *   Callers MUST NOT use it and MUST NOT silently fall back to the trusted
+ *   root; they are expected to surface the rejection to their caller.
  */
-export function validateWorkingDirectoryOrLinkedWorktree(workingDirectory?: string): string {
+export type WorkingDirectoryResolution =
+  | { status: 'ok'; root: string }
+  | { status: 'foreign_repository'; providedRoot: string; trustedRoot: string };
+
+/**
+ * Typed error thrown when a workingDirectory resolves to a different git
+ * repository than the trusted startup repository. The rejection must reach the
+ * tool caller; it is never silently substituted (#3858).
+ */
+export class ForeignWorkingDirectoryError extends Error {
+  readonly providedRoot: string;
+  readonly trustedRoot: string;
+
+  constructor(providedRoot: string, trustedRoot: string) {
+    super(
+      `workingDirectory '${providedRoot}' belongs to a different repository than '${trustedRoot}' and was not used. ` +
+        `Cross-repository access is not permitted; pass a path inside the current repository or start the session there.`
+    );
+    this.name = 'ForeignWorkingDirectoryError';
+    this.providedRoot = providedRoot;
+    this.trustedRoot = trustedRoot;
+  }
+}
+
+/**
+ * Resolve a workingDirectory while permitting linked git worktrees for the same
+ * repository, returning a typed result (#3858).
+ *
+ * Same-root and linked-worktree (shared git common directory) directories
+ * resolve to `ok` with the provided root. A directory inside a *different* git
+ * repository resolves to `foreign_repository` — callers must reject it
+ * visibly. Non-repo paths outside the trusted root are rejected by throwing,
+ * matching validateWorkingDirectory.
+ */
+export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: string): WorkingDirectoryResolution {
   const trustedRoot = getGitTopLevel(process.cwd()) || process.cwd();
 
   if (!workingDirectory) {
-    return trustedRoot;
+    return { status: 'ok', root: trustedRoot };
   }
 
   const resolved = resolve(workingDirectory);
@@ -1316,21 +1350,18 @@ export function validateWorkingDirectoryOrLinkedWorktree(workingDirectory?: stri
     }
 
     if (providedRootReal === trustedRootReal) {
-      return providedRoot;
+      return { status: 'ok', root: providedRoot };
     }
 
     const trustedCommonDir = getGitCommonDir(trustedRoot);
     const providedCommonDir = getGitCommonDir(providedRoot);
     if (trustedCommonDir && providedCommonDir && providedCommonDir === trustedCommonDir) {
-      return providedRoot;
+      return { status: 'ok', root: providedRoot };
     }
 
-    console.error('[worktree] workingDirectory resolved to different git worktree root, using trusted root', {
-      workingDirectory: resolved,
-      providedRoot: providedRootReal,
-      trustedRoot: trustedRootReal,
-    });
-    return trustedRoot;
+    // Different repository (#3858): reject visibly instead of silently
+    // substituting the trusted root.
+    return { status: 'foreign_repository', providedRoot: providedRootReal, trustedRoot: trustedRootReal };
   }
 
   let resolvedReal: string;
@@ -1345,5 +1376,25 @@ export function validateWorkingDirectoryOrLinkedWorktree(workingDirectory?: stri
     throw new Error(`workingDirectory '${workingDirectory}' is outside the trusted worktree root '${trustedRoot}'.`);
   }
 
-  return trustedRoot;
+  return { status: 'ok', root: trustedRoot };
+}
+
+/**
+ * Validate a workingDirectory while permitting linked git worktrees for the
+ * same repository.
+ *
+ * This preserves validateWorkingDirectory's default cwd behavior and its
+ * same-root/subdirectory normalization, but allows a per-call directory to
+ * resolve to a sibling manual `git worktree` when both worktrees share the
+ * same git common directory. A directory inside a different git repository is
+ * rejected with ForeignWorkingDirectoryError instead of silently falling back
+ * to the trusted startup cwd (#3858); non-repo paths outside the trusted root
+ * are rejected by throwing.
+ */
+export function validateWorkingDirectoryOrLinkedWorktree(workingDirectory?: string): string {
+  const resolution = resolveWorkingDirectoryOrLinkedWorktree(workingDirectory);
+  if (resolution.status === 'foreign_repository') {
+    throw new ForeignWorkingDirectoryError(resolution.providedRoot, resolution.trustedRoot);
+  }
+  return resolution.root;
 }

--- a/src/tools/__tests__/wiki-tools-foreign-root.test.ts
+++ b/src/tools/__tests__/wiki-tools-foreign-root.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import { clearWorktreeCache } from '../../lib/worktree-paths.js';
+import {
+  wikiIngestTool,
+  wikiAddTool,
+  wikiQueryTool,
+  wikiReadTool,
+  wikiListTool,
+  wikiLintTool,
+  wikiDeleteTool,
+} from '../wiki-tools.js';
+
+function git(cwd: string, command: string): void {
+  execSync(`git ${command}`, { cwd, stdio: 'pipe' });
+}
+
+describe('wiki tools foreign-repository workingDirectory (#3858)', () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let originalOmcStateDir: string | undefined;
+  let sessionRepo: string;
+  let foreignRepo: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalOmcStateDir = process.env.OMC_STATE_DIR;
+    delete process.env.OMC_STATE_DIR;
+    tempDir = mkdtempSync(join(tmpdir(), 'wiki-foreign-3858-'));
+    clearWorktreeCache();
+
+    sessionRepo = join(tempDir, 'session-project');
+    mkdirSync(sessionRepo, { recursive: true });
+    git(sessionRepo, 'init');
+    git(sessionRepo, 'config user.email "test@example.com"');
+    git(sessionRepo, 'config user.name "Test User"');
+    writeFileSync(join(sessionRepo, 'README.md'), 'session project\n');
+    git(sessionRepo, 'add README.md');
+    git(sessionRepo, 'commit -m initial');
+
+    foreignRepo = join(tempDir, 'foreign-vault');
+    mkdirSync(foreignRepo, { recursive: true });
+    git(foreignRepo, 'init');
+    git(foreignRepo, 'config user.email "test@example.com"');
+    git(foreignRepo, 'config user.name "Test User"');
+    writeFileSync(join(foreignRepo, 'README.md'), 'foreign vault\n');
+    git(foreignRepo, 'add README.md');
+    git(foreignRepo, 'commit -m initial');
+    // Populated wiki corpus in the foreign repository.
+    mkdirSync(join(foreignRepo, '.omc', 'wiki'), { recursive: true });
+    writeFileSync(
+      join(foreignRepo, '.omc', 'wiki', 'aapanel-setup.md'),
+      '---\ntitle: aaPanel Setup\ncategory: reference\nconfidence: high\ntags: [aapanel, hosting]\nupdated: 2026-08-24\n---\n\naaPanel reverse proxy notes for the vault.\n',
+    );
+
+    process.chdir(sessionRepo);
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    clearWorktreeCache();
+    if (originalOmcStateDir === undefined) {
+      delete process.env.OMC_STATE_DIR;
+    } else {
+      process.env.OMC_STATE_DIR = originalOmcStateDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('wiki_query rejects a foreign-repository workingDirectory visibly instead of returning empty matches', async () => {
+    const result = await wikiQueryTool.handler({ query: 'aaPanel', workingDirectory: foreignRepo });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain('belongs to a different repository');
+    expect(text).toContain('not used');
+    expect(text).toContain(basename(foreignRepo));
+    // No silent "no results" answer for knowledge that exists elsewhere.
+    expect(text).not.toContain('No wiki pages match');
+  });
+
+  it('wiki_read rejects a foreign-repository workingDirectory instead of reporting not-found', async () => {
+    const result = await wikiReadTool.handler({ page: 'aapanel-setup', workingDirectory: foreignRepo });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain('belongs to a different repository');
+    expect(text).not.toContain('Wiki page not found');
+  });
+
+  it('wiki_ingest rejects a foreign-repository workingDirectory and writes to neither repository', async () => {
+    const before = {
+      sessionWiki: existsSync(join(sessionRepo, '.omc', 'wiki')),
+      foreignPages: existsSync(join(foreignRepo, '.omc', 'wiki', 'foreign-page.md')),
+    };
+
+    const result = await wikiIngestTool.handler({
+      title: 'Foreign Page',
+      content: 'should never be written',
+      tags: ['x'],
+      category: 'reference',
+      workingDirectory: foreignRepo,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('belongs to a different repository');
+    // No fallback-root write: the session repo must not gain a wiki directory,
+    // and the foreign repo must not gain the page.
+    expect(existsSync(join(sessionRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+    if (!before.sessionWiki) {
+      expect(existsSync(join(sessionRepo, '.omc', 'wiki'))).toBe(false);
+    }
+  });
+
+  it('wiki_add rejects a foreign-repository workingDirectory without writing', async () => {
+    const result = await wikiAddTool.handler({
+      title: 'Foreign Page',
+      content: 'should never be written',
+      workingDirectory: foreignRepo,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('belongs to a different repository');
+    expect(existsSync(join(sessionRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+  });
+
+  it('wiki_delete rejects a foreign-repository workingDirectory without touching either wiki', async () => {
+    const result = await wikiDeleteTool.handler({ page: 'aapanel-setup', workingDirectory: foreignRepo });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('belongs to a different repository');
+    // The foreign page still exists — no cross-repo deletion, no fallback hit.
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'aapanel-setup.md'))).toBe(true);
+  });
+
+  it('wiki_lint and wiki_list reject a foreign-repository workingDirectory', async () => {
+    const lintResult = await wikiLintTool.handler({ workingDirectory: foreignRepo });
+    expect(lintResult.isError).toBe(true);
+    expect(lintResult.content[0].text).toContain('belongs to a different repository');
+
+    const listResult = await wikiListTool.handler({ workingDirectory: foreignRepo });
+    expect(listResult.isError).toBe(true);
+    expect(listResult.content[0].text).toContain('belongs to a different repository');
+  });
+
+  it('the trusted repository is identified by basename only, not absolute path', async () => {
+    const result = await wikiQueryTool.handler({ query: 'aaPanel', workingDirectory: foreignRepo });
+    const text = result.content[0].text;
+
+    expect(text).toContain(basename(sessionRepo));
+    expect(text).not.toContain(sessionRepo);
+  });
+
+  it('wiki_query reports searched root and corpus size for a genuine no-match inside the trusted repo', async () => {
+    // Seed one page in the session repo so the corpus is non-empty.
+    const addResult = await wikiAddTool.handler({
+      title: 'Session Note',
+      content: 'belongs to session repo wiki',
+    });
+    expect(addResult.isError).toBeUndefined();
+
+    const result = await wikiQueryTool.handler({ query: 'aaPanel' });
+    expect(result.isError).toBeUndefined();
+    const text = result.content[0].text;
+    expect(text).toContain('No wiki pages match "aaPanel".');
+    expect(text).toContain('searched 1 page');
+    expect(text).toContain(basename(sessionRepo));
+    expect(text).not.toContain(sessionRepo);
+  });
+
+  it('wiki_list names the searched root when the wiki is empty', async () => {
+    const result = await wikiListTool.handler({});
+    expect(result.isError).toBeUndefined();
+    const text = result.content[0].text;
+    expect(text).toContain('Wiki is empty.');
+    expect(text).toContain('searched 0 pages');
+    expect(text).toContain(basename(sessionRepo));
+    expect(text).not.toContain(sessionRepo);
+  });
+});

--- a/src/tools/wiki-tools.ts
+++ b/src/tools/wiki-tools.ts
@@ -7,7 +7,9 @@
 
 import { z } from 'zod';
 import {
-  validateWorkingDirectoryOrLinkedWorktree,
+  resolveWorkingDirectoryOrLinkedWorktree,
+  ForeignWorkingDirectoryError,
+  type WorkingDirectoryResolution,
 } from '../lib/worktree-paths.js';
 import {
   readPage,
@@ -21,12 +23,40 @@ import { ingestKnowledge } from '../hooks/wiki/ingest.js';
 import { queryWiki } from '../hooks/wiki/query.js';
 import { lintWiki } from '../hooks/wiki/lint.js';
 import type { WikiCategory } from '../hooks/wiki/types.js';
+import { basename } from 'node:path';
 import { ToolDefinition } from './types.js';
 
 const WIKI_CATEGORIES: [string, ...string[]] = [
   'architecture', 'decision', 'pattern', 'debugging',
   'environment', 'session-log', 'reference', 'convention',
 ];
+
+/**
+ * Resolve the wiki root for a tool call, rejecting foreign-repository
+ * workingDirectory values visibly (#3858). The rejection reaches the MCP
+ * caller as isError; the trusted repository is identified by basename only so
+ * sensitive absolute paths are not echoed beyond what the caller supplied.
+ */
+function resolveWikiRoot(
+  workingDirectory: string | undefined,
+): { ok: true; root: string } | { ok: false; error: ForeignWorkingDirectoryError } {
+  const resolution: WorkingDirectoryResolution = resolveWorkingDirectoryOrLinkedWorktree(workingDirectory);
+  if (resolution.status === 'foreign_repository') {
+    return {
+      ok: false,
+      error: new ForeignWorkingDirectoryError(
+        resolution.providedRoot,
+        basename(resolution.trustedRoot),
+      ),
+    };
+  }
+  return { ok: true, root: resolution.root };
+}
+
+/** Searched-root suffix for empty/no-match results: basename + corpus size (#3858). */
+function searchedSuffix(root: string, pages: number): string {
+  return ` (searched ${pages} page${pages === 1 ? '' : 's'} in ${basename(root)}/.omc/wiki)`;
+}
 
 // ============================================================================
 // wiki_ingest
@@ -54,7 +84,17 @@ export const wikiIngestTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error ingesting into wiki: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
 
       const result = ingestKnowledge(root, {
         title: args.title,
@@ -105,7 +145,17 @@ export const wikiQueryTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error querying wiki: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
       const matches = queryWiki(root, args.query, {
         tags: args.tags,
         category: args.category as WikiCategory | undefined,
@@ -116,7 +166,7 @@ export const wikiQueryTool: ToolDefinition<{
         return {
           content: [{
             type: 'text' as const,
-            text: `No wiki pages match "${args.query}".`,
+            text: `No wiki pages match "${args.query}".${searchedSuffix(root, listPages(root).length)}`,
           }],
         };
       }
@@ -160,7 +210,17 @@ export const wikiLintTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error linting wiki: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
       const report = lintWiki(root);
 
       if (report.issues.length === 0) {
@@ -221,7 +281,17 @@ export const wikiAddTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error adding wiki page: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
       const slug = titleToSlug(args.title);
 
       // Guard: reject if page already exists — use wiki_ingest to merge
@@ -275,7 +345,17 @@ export const wikiListTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error listing wiki: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
       const index = readIndex(root);
 
       if (!index) {
@@ -284,7 +364,7 @@ export const wikiListTool: ToolDefinition<{
           return {
             content: [{
               type: 'text' as const,
-              text: 'Wiki is empty. Use wiki_add or wiki_ingest to create pages.',
+              text: `Wiki is empty.${searchedSuffix(root, 0)} Use wiki_add or wiki_ingest to create pages.`,
             }],
           };
         }
@@ -330,7 +410,17 @@ export const wikiReadTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error reading wiki page: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
       const filename = args.page.endsWith('.md') ? args.page : `${args.page}.md`;
       const page = readPage(root, filename);
 
@@ -388,7 +478,17 @@ export const wikiDeleteTool: ToolDefinition<{
   },
   handler: async (args) => {
     try {
-      const root = validateWorkingDirectoryOrLinkedWorktree(args.workingDirectory);
+      const resolved = resolveWikiRoot(args.workingDirectory);
+      if (!resolved.ok) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Error deleting wiki page: ${resolved.error.message}`,
+          }],
+          isError: true,
+        };
+      }
+      const root = resolved.root;
       const filename = args.page.endsWith('.md') ? args.page : `${args.page}.md`;
       const deleted = deletePage(root, filename);
 


### PR DESCRIPTION
## Summary

Fixes #3858 — the seven `wiki_*` MCP tools silently substituted the trusted session root when `workingDirectory` pointed at a **different git repository**:

- `wiki_query` returned `No wiki pages match "…"` (`isError: false`) for knowledge that exists in the foreign repo
- `wiki_read` reported `Wiki page not found` for pages that exist in the foreign repo
- `wiki_ingest` wrote new pages into the **fallback trusted root**, fragmenting knowledge across unrelated projects
- the only trace was a `console.error` on the MCP server's stderr, invisible to the calling agent

This preserves the security boundary exactly: foreign repository roots are **never used** and **never silently substituted** — the rejection is now visible to the MCP caller.

## Root cause

`validateWorkingDirectoryOrLinkedWorktree()` (`src/lib/worktree-paths.ts`): after the same-root and linked-worktree (`providedCommonDir === trustedCommonDir`, #2880) accept paths, the different-repo branch fell through to `console.error(...); return trustedRoot;`. All seven wiki tools took that return value as the wiki root and never learned substitution occurred. The strictly-more-surprising case (valid foreign repo) failed silently while the non-git outside path threw a visible error.

## Change

**`src/lib/worktree-paths.ts`** — smallest coherent typed resolution contract:

- new `WorkingDirectoryResolution = { status: 'ok'; root: string } | { status: 'foreign_repository'; providedRoot; trustedRoot }`
- new `resolveWorkingDirectoryOrLinkedWorktree()` returning the typed result; the `foreign_repository` branch carries both roots and **no root to use**
- new `ForeignWorkingDirectoryError` typed error; `validateWorkingDirectoryOrLinkedWorktree()` now **throws** it instead of substituting, so no caller can silently ignore the rejection

**`src/tools/wiki-tools.ts`** — all seven tools (`wiki_ingest`, `wiki_query`, `wiki_lint`, `wiki_add`, `wiki_list`, `wiki_read`, `wiki_delete`) route through a shared `resolveWikiRoot()` helper:

- `foreign_repository` → MCP-visible `isError: true` response naming the provided root and the trusted repo **basename** (`workingDirectory '<provided>' belongs to a different repository than '<trusted-basename>' and was not used. Cross-repository access is not permitted; pass a path inside the current repository or start the session there.`)
- write tools (`wiki_ingest`, `wiki_add`, `wiki_delete`) reject **before any filesystem mutation** — no writes to the fallback root after rejection
- `wiki_query` no-match and `wiki_list` empty results now report the searched root basename + corpus size: `No wiki pages match "q" (searched 0 pages in session-project/.omc/wiki)` — an empty corpus is self-evident regardless of cause (issue's suggested fix #2)
- no sensitive absolute paths beyond what the caller itself supplied: provided path is echoed back, trusted side is basename-only

## Reproduction (before → after)

On base `c1bd53f2`, cwd = session repo B, `workingDirectory` = foreign repo A with populated `.omc/wiki/aapanel-setup.md`:

| Tool | before | after |
|---|---|---|
| `wiki_query "aaPanel"` | `No wiki pages match "aaPanel".` (isError: false) | isError: `belongs to a different repository … was not used` |
| `wiki_read aapanel-setup` | `Wiki page not found` | isError: foreign-repo rejection |
| `wiki_ingest` | success message; page written into **repo B** fallback | isError; **no write in either repo** |
| non-git outside path | visible throw | unchanged visible throw |
| linked worktree (#2880) | accepted | accepted (unchanged) |

## Tests

- `src/lib/__tests__/worktree-paths-foreign-root.test.ts` (new) — typed resolver: `foreign_repository` result shape (no `root` key), `ForeignWorkingDirectoryError` from the validate wrapper, linked-worktree accept (#2880 preserved), same-root/subdirectory/default accept, non-git outside throw, end-to-end linked-worktree wiki flow
- `src/tools/__tests__/wiki-tools-foreign-root.test.ts` (new) — all seven tools reject visibly; ingest/add write **nowhere**; delete cannot touch the foreign page; basename-only trusted identification; corpus-size reporting on genuine no-match/empty
- `src/lib/__tests__/worktree-paths.test.ts` — the submodule-boundary case now asserts the superproject is rejected (`ForeignWorkingDirectoryError`) instead of silently substituted
- existing `wiki-tools-working-directory.test.ts` linked-worktree regression unchanged and green

Verification: focused suites (6 files, 130 tests) pass, `tsc --noEmit` clean, `npm run build` green, `npm pack --dry-run` packages (5283 files), inventory graph regenerated.

Closes #3858
