### PR TITLE
fix(wiki): sanitize caller-visible workingDirectory rejection paths (#3858)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "4c380abbee03182d3f5a05fc8394e781ab9a7860",
-    "sourceSha256": "aaef95d505aeff50ca22425ebe443f66dbdd9d221dedbe53c671c28eae15ea5e",
+    "head": "43db638446c47ce4601ad3e20593886037874597",
+    "sourceSha256": "22cef0d00d570cef912674448b0becd1226a8033311436327fa0fdc2e9e71daf",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "4c380abbee03182d3f5a05fc8394e781ab9a7860",
-  "sourceSha256": "aaef95d505aeff50ca22425ebe443f66dbdd9d221dedbe53c671c28eae15ea5e",
+  "head": "43db638446c47ce4601ad3e20593886037874597",
+  "sourceSha256": "22cef0d00d570cef912674448b0becd1226a8033311436327fa0fdc2e9e71daf",
   "counts": {
     "public": {
       "skills": 31,
@@ -74715,5 +74715,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "f19d4addf19c0ce963ef15dd1457f09d74bb22685cdf4bc7bed52d3551f67c55"
+  "manifestSha256": "0b271412958c7d344047743b9ebccd078acb854a4aecfceadd50587b1ce31dfc"
 }

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  symlinkSync,
+  realpathSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, basename, relative } from 'node:path';
 import {
   clearWorktreeCache,
   resolveWorkingDirectoryOrLinkedWorktree,
@@ -15,6 +23,10 @@ function git(cwd: string, command: string): void {
   execSync(`git ${command}`, { cwd, stdio: 'pipe' });
 }
 
+function canonical(path: string): string {
+  return realpathSync(path);
+}
+
 describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-root', () => {
   let tempDir: string;
   let originalCwd: string;
@@ -22,6 +34,8 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
   let foreignRepo: string;
   let linkedWorktree: string;
   let plainDir: string;
+  let canonicalSession: string;
+  let canonicalForeign: string;
 
   beforeEach(() => {
     originalCwd = process.cwd();
@@ -54,6 +68,8 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
 
     process.chdir(sessionRepo);
     clearWorktreeCache();
+    canonicalSession = canonical(sessionRepo);
+    canonicalForeign = canonical(foreignRepo);
   });
 
   afterEach(() => {
@@ -66,8 +82,9 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     const resolution = resolveWorkingDirectoryOrLinkedWorktree(foreignRepo);
     expect(resolution).toEqual({
       status: 'foreign_repository',
-      providedRoot: foreignRepo,
-      trustedRoot: sessionRepo,
+      providedRoot: canonicalForeign,
+      trustedRoot: canonicalSession,
+      callerLabel: foreignRepo,
     });
     if (resolution.status === 'foreign_repository') {
       expect('root' in resolution).toBe(false);
@@ -82,10 +99,58 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     } catch (error) {
       expect(error).toBeInstanceOf(ForeignWorkingDirectoryError);
       const foreign = error as ForeignWorkingDirectoryError;
-      expect(foreign.providedRoot).toBe(foreignRepo);
-      expect(foreign.trustedRoot).toBe(sessionRepo);
+      expect(foreign.providedRoot).toBe(canonicalForeign);
+      expect(foreign.trustedRoot).toBe(canonicalSession);
+      expect(foreign.callerLabel).toBe(foreignRepo);
       expect(foreign.message).toContain('belongs to a different repository');
       expect(foreign.message).toContain('not used');
+      expect(foreign.message).toContain(foreignRepo);
+      expect(foreign.message).toContain(basename(sessionRepo));
+      expect(foreign.message).not.toContain(canonicalSession);
+    }
+  });
+
+  it('relative foreign alias keeps the caller-supplied label and hides canonical host paths', () => {
+    const relativeAlias = join('..', 'foreign-vault');
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree(relativeAlias);
+    expect(resolution.status).toBe('foreign_repository');
+    if (resolution.status !== 'foreign_repository') return;
+
+    expect(resolution.providedRoot).toBe(canonicalForeign);
+    expect(resolution.trustedRoot).toBe(canonicalSession);
+    expect(resolution.callerLabel).toBe(relativeAlias);
+
+    try {
+      validateWorkingDirectoryOrLinkedWorktree(relativeAlias);
+      expect.unreachable('must throw');
+    } catch (error) {
+      const foreign = error as ForeignWorkingDirectoryError;
+      expect(foreign.message).toContain(relativeAlias);
+      expect(foreign.message).not.toContain(canonicalForeign);
+      expect(foreign.message).not.toContain(canonicalSession);
+      expect(foreign.message).toContain(basename(sessionRepo));
+    }
+  });
+
+  it('symlink foreign alias keeps the symlink label and hides the canonical target', () => {
+    const symlinkAlias = join(tempDir, 'foreign-alias');
+    symlinkSync(foreignRepo, symlinkAlias);
+
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree(symlinkAlias);
+    expect(resolution.status).toBe('foreign_repository');
+    if (resolution.status !== 'foreign_repository') return;
+
+    expect(resolution.providedRoot).toBe(canonicalForeign);
+    expect(resolution.callerLabel).toBe(symlinkAlias);
+
+    try {
+      validateWorkingDirectoryOrLinkedWorktree(symlinkAlias);
+      expect.unreachable('must throw');
+    } catch (error) {
+      const foreign = error as ForeignWorkingDirectoryError;
+      expect(foreign.message).toContain(symlinkAlias);
+      expect(foreign.message).not.toContain(canonicalForeign);
+      expect(foreign.message).not.toContain(canonicalSession);
     }
   });
 
@@ -107,10 +172,58 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     expect(validateWorkingDirectoryOrLinkedWorktree(sub)).toBe(sessionRepo);
   });
 
-  it('still throws for a non-git path outside the trusted root', () => {
+  it('still throws for a non-git path outside the trusted root without leaking the full trusted root', () => {
     expect(() => validateWorkingDirectoryOrLinkedWorktree(plainDir)).toThrow(
       'is outside the trusted worktree root'
     );
+    try {
+      validateWorkingDirectoryOrLinkedWorktree(plainDir);
+      expect.unreachable('must throw');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain(plainDir);
+      expect(message).toContain(basename(sessionRepo));
+      expect(message).not.toContain(canonicalSession);
+    }
+  });
+
+  it('rejects a superproject path from a submodule cwd without leaking canonical trusted/foreign roots', () => {
+    const parentDir = join(tempDir, 'superproject');
+    mkdirSync(parentDir, { recursive: true });
+    git(parentDir, 'init');
+    git(parentDir, 'config user.email "test@example.com"');
+    git(parentDir, 'config user.name "Test User"');
+    git(parentDir, 'commit --allow-empty -m parent-init');
+    execSync(`git -c protocol.file.allow=always submodule add "${sessionRepo}" mysub`, {
+      cwd: parentDir,
+      stdio: 'pipe',
+    });
+    const submodulePath = join(parentDir, 'mysub');
+    process.chdir(submodulePath);
+    clearWorktreeCache();
+
+    const canonicalSubmodule = canonical(submodulePath);
+    const canonicalParent = canonical(parentDir);
+    const relativeParent = relative(submodulePath, parentDir);
+
+    expect(() => validateWorkingDirectoryOrLinkedWorktree(parentDir)).toThrow(ForeignWorkingDirectoryError);
+
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree(relativeParent);
+    expect(resolution.status).toBe('foreign_repository');
+    if (resolution.status !== 'foreign_repository') return;
+    expect(resolution.callerLabel).toBe(relativeParent);
+    expect(resolution.providedRoot).toBe(canonicalParent);
+
+    try {
+      validateWorkingDirectoryOrLinkedWorktree(relativeParent);
+      expect.unreachable('must throw');
+    } catch (error) {
+      const foreign = error as ForeignWorkingDirectoryError;
+      expect(foreign.message).toContain(relativeParent);
+      expect(foreign.message).toContain(basename(submodulePath));
+      expect(foreign.message).not.toContain(canonicalSubmodule);
+      expect(foreign.message).not.toContain(canonicalParent);
+    }
   });
 
   it('linked-worktree wiki flows keep working end to end (no regression from #2880)', async () => {

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1189,6 +1189,22 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
   // Callers should handle non-existent paths gracefully.
   return transcriptPath;
 }
+/**
+ * Caller-visible workingDirectory labels for rejection errors (#3858).
+ * Retain the original caller-supplied string; never substitute realpath.
+ * Trusted root is basename-only so the full host path is not disclosed.
+ */
+function callerVisibleTrustedRootLabel(trustedRoot: string): string {
+  const label = basename(trustedRoot);
+  return label.length > 0 ? label : 'current repository';
+}
+
+function formatOutsideTrustedRootMessage(workingDirectory: string, trustedRoot: string): string {
+  return (
+    `workingDirectory '${workingDirectory}' ` +
+    `is outside the trusted worktree root '${callerVisibleTrustedRootLabel(trustedRoot)}'.`
+  );
+}
 
 /**
  * Validate that a workingDirectory is within the trusted git top-level.
@@ -1255,7 +1271,7 @@ export function validateWorkingDirectory(workingDirectory?: string): string {
 
   const rel = relative(trustedRootReal, resolvedReal);
   if (rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(`workingDirectory '${workingDirectory}' is outside the trusted worktree root '${trustedRoot}'.`);
+    throw new Error(formatOutsideTrustedRootMessage(workingDirectory, trustedRoot));
   }
 
   // Directory is under trusted root but git failed — return trusted root,
@@ -1288,28 +1304,44 @@ function getGitCommonDir(cwd: string): string | null {
  * - `foreign_repository`: the directory belongs to a different git repository.
  *   Callers MUST NOT use it and MUST NOT silently fall back to the trusted
  *   root; they are expected to surface the rejection to their caller.
+ *
+ * `providedRoot` and `trustedRoot` are canonical paths for internal
+ * validation only. Caller-visible text must use `callerLabel` (the original
+ * workingDirectory string) and a basename-only trusted-root label — never
+ * `providedRoot` / `trustedRoot` verbatim.
  */
 export type WorkingDirectoryResolution =
   | { status: 'ok'; root: string }
-  | { status: 'foreign_repository'; providedRoot: string; trustedRoot: string };
+  | {
+      status: 'foreign_repository';
+      providedRoot: string;
+      trustedRoot: string;
+      callerLabel: string;
+    };
 
 /**
  * Typed error thrown when a workingDirectory resolves to a different git
  * repository than the trusted startup repository. The rejection must reach the
  * tool caller; it is never silently substituted (#3858).
+ *
+ * `.message` is the caller-visible contract: the original workingDirectory
+ * label plus a basename-only trusted-root identity. Canonical `providedRoot`
+ * and `trustedRoot` stay on the instance for internal validation.
  */
 export class ForeignWorkingDirectoryError extends Error {
   readonly providedRoot: string;
   readonly trustedRoot: string;
+  readonly callerLabel: string;
 
-  constructor(providedRoot: string, trustedRoot: string) {
+  constructor(providedRoot: string, trustedRoot: string, callerLabel: string = providedRoot) {
     super(
-      `workingDirectory '${providedRoot}' belongs to a different repository than '${trustedRoot}' and was not used. ` +
+      `workingDirectory '${callerLabel}' belongs to a different repository than '${callerVisibleTrustedRootLabel(trustedRoot)}' and was not used. ` +
         `Cross-repository access is not permitted; pass a path inside the current repository or start the session there.`
     );
     this.name = 'ForeignWorkingDirectoryError';
     this.providedRoot = providedRoot;
     this.trustedRoot = trustedRoot;
+    this.callerLabel = callerLabel;
   }
 }
 
@@ -1361,7 +1393,12 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
 
     // Different repository (#3858): reject visibly instead of silently
     // substituting the trusted root.
-    return { status: 'foreign_repository', providedRoot: providedRootReal, trustedRoot: trustedRootReal };
+    return {
+      status: 'foreign_repository',
+      providedRoot: providedRootReal,
+      trustedRoot: trustedRootReal,
+      callerLabel: workingDirectory,
+    };
   }
 
   let resolvedReal: string;
@@ -1373,7 +1410,7 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
 
   const rel = relative(trustedRootReal, resolvedReal);
   if (rel.startsWith('..') || isAbsolute(rel)) {
-    throw new Error(`workingDirectory '${workingDirectory}' is outside the trusted worktree root '${trustedRoot}'.`);
+    throw new Error(formatOutsideTrustedRootMessage(workingDirectory, trustedRoot));
   }
 
   return { status: 'ok', root: trustedRoot };
@@ -1394,7 +1431,11 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
 export function validateWorkingDirectoryOrLinkedWorktree(workingDirectory?: string): string {
   const resolution = resolveWorkingDirectoryOrLinkedWorktree(workingDirectory);
   if (resolution.status === 'foreign_repository') {
-    throw new ForeignWorkingDirectoryError(resolution.providedRoot, resolution.trustedRoot);
+    throw new ForeignWorkingDirectoryError(
+      resolution.providedRoot,
+      resolution.trustedRoot,
+      resolution.callerLabel,
+    );
   }
   return resolution.root;
 }

--- a/src/tools/__tests__/wiki-tools-foreign-root.test.ts
+++ b/src/tools/__tests__/wiki-tools-foreign-root.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, basename } from 'node:path';
+import { join, basename, relative } from 'node:path';
 import { clearWorktreeCache } from '../../lib/worktree-paths.js';
 import {
   wikiIngestTool,
@@ -17,6 +17,41 @@ import {
 function git(cwd: string, command: string): void {
   execSync(`git ${command}`, { cwd, stdio: 'pipe' });
 }
+type WikiResult = { isError?: boolean; content: Array<{ text: string }> };
+
+async function invokeAllWikiTools(workingDirectory: string): Promise<Array<{ name: string; result: WikiResult }>> {
+  return [
+    { name: 'wiki_ingest', result: await wikiIngestTool.handler({ title: 'Foreign Page', content: 'should never be written', tags: ['x'], category: 'reference', workingDirectory }) },
+    { name: 'wiki_add', result: await wikiAddTool.handler({ title: 'Foreign Page', content: 'should never be written', workingDirectory }) },
+    { name: 'wiki_query', result: await wikiQueryTool.handler({ query: 'aaPanel', workingDirectory }) },
+    { name: 'wiki_read', result: await wikiReadTool.handler({ page: 'aapanel-setup', workingDirectory }) },
+    { name: 'wiki_list', result: await wikiListTool.handler({ workingDirectory }) },
+    { name: 'wiki_lint', result: await wikiLintTool.handler({ workingDirectory }) },
+    { name: 'wiki_delete', result: await wikiDeleteTool.handler({ page: 'aapanel-setup', workingDirectory }) },
+  ];
+}
+
+function assertVisibleRejectionWithoutCanonicalLeak(
+  result: WikiResult,
+  opts: { expectedLabel: string; forbidden: string[]; trustedBasename: string },
+): void {
+  expect(result.isError).toBe(true);
+  const text = result.content[0].text;
+  expect(text).toContain(opts.expectedLabel);
+  expect(text).toContain(opts.trustedBasename);
+  expect(text).not.toContain('No wiki pages match');
+  expect(text).not.toContain('Wiki page not found');
+  for (const path of opts.forbidden) {
+    expect(text).not.toContain(path);
+  }
+}
+
+function assertNoFallbackWrites(sessionRepo: string, foreignRepo: string): void {
+  expect(existsSync(join(sessionRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+  expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+  expect(existsSync(join(sessionRepo, '.omc', 'wiki'))).toBe(false);
+}
+
 
 describe('wiki tools foreign-repository workingDirectory (#3858)', () => {
   let tempDir: string;
@@ -147,6 +182,112 @@ describe('wiki tools foreign-repository workingDirectory (#3858)', () => {
     const listResult = await wikiListTool.handler({ workingDirectory: foreignRepo });
     expect(listResult.isError).toBe(true);
     expect(listResult.content[0].text).toContain('belongs to a different repository');
+  });
+
+  it('all seven wiki tools reject a relative foreign alias without leaking canonical paths or writing', async () => {
+    const relativeAlias = join('..', 'foreign-vault');
+    const canonicalForeign = realpathSync(foreignRepo);
+    const canonicalSession = realpathSync(sessionRepo);
+    const results = await invokeAllWikiTools(relativeAlias);
+
+    expect(results.map((entry) => entry.name)).toEqual([
+      'wiki_ingest',
+      'wiki_add',
+      'wiki_query',
+      'wiki_read',
+      'wiki_list',
+      'wiki_lint',
+      'wiki_delete',
+    ]);
+
+    for (const { result } of results) {
+      assertVisibleRejectionWithoutCanonicalLeak(result, {
+        expectedLabel: relativeAlias,
+        forbidden: [canonicalForeign, canonicalSession],
+        trustedBasename: basename(sessionRepo),
+      });
+    }
+    assertNoFallbackWrites(sessionRepo, foreignRepo);
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'aapanel-setup.md'))).toBe(true);
+  });
+
+  it('all seven wiki tools reject a symlink foreign alias without leaking the canonical target', async () => {
+    const symlinkAlias = join(tempDir, 'foreign-alias');
+    symlinkSync(foreignRepo, symlinkAlias);
+    const canonicalForeign = realpathSync(foreignRepo);
+    const canonicalSession = realpathSync(sessionRepo);
+    const results = await invokeAllWikiTools(symlinkAlias);
+
+    for (const { result } of results) {
+      assertVisibleRejectionWithoutCanonicalLeak(result, {
+        expectedLabel: symlinkAlias,
+        forbidden: [canonicalForeign, canonicalSession],
+        trustedBasename: basename(sessionRepo),
+      });
+    }
+    assertNoFallbackWrites(sessionRepo, foreignRepo);
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'aapanel-setup.md'))).toBe(true);
+  });
+
+  it('all seven wiki tools reject a non-git outside path without leaking the full trusted root', async () => {
+    const plainDir = join(tempDir, 'plain-notes');
+    mkdirSync(plainDir, { recursive: true });
+    const canonicalSession = realpathSync(sessionRepo);
+    const results = await invokeAllWikiTools(plainDir);
+
+    for (const { result } of results) {
+      expect(result.isError).toBe(true);
+      const text = result.content[0].text;
+      expect(text).toContain('is outside the trusted worktree root');
+      expect(text).toContain(plainDir);
+      expect(text).toContain(basename(sessionRepo));
+      expect(text).not.toContain(canonicalSession);
+    }
+    assertNoFallbackWrites(sessionRepo, foreignRepo);
+  });
+
+  it('all seven wiki tools reject a superproject path from a submodule cwd', async () => {
+    const parentDir = join(tempDir, 'superproject');
+    mkdirSync(parentDir, { recursive: true });
+    git(parentDir, 'init');
+    git(parentDir, 'config user.email "test@example.com"');
+    git(parentDir, 'config user.name "Test User"');
+    git(parentDir, 'commit --allow-empty -m parent-init');
+    execSync(`git -c protocol.file.allow=always submodule add "${sessionRepo}" mysub`, {
+      cwd: parentDir,
+      stdio: 'pipe',
+    });
+    const submodulePath = join(parentDir, 'mysub');
+    process.chdir(submodulePath);
+    clearWorktreeCache();
+
+    const relativeParent = relative(submodulePath, parentDir);
+    const canonicalParent = realpathSync(parentDir);
+    const canonicalSubmodule = realpathSync(submodulePath);
+    const results = await invokeAllWikiTools(relativeParent);
+
+    for (const { result } of results) {
+      assertVisibleRejectionWithoutCanonicalLeak(result, {
+        expectedLabel: relativeParent,
+        forbidden: [canonicalParent, canonicalSubmodule],
+        trustedBasename: basename(submodulePath),
+      });
+    }
+    expect(existsSync(join(submodulePath, '.omc', 'wiki'))).toBe(false);
+    expect(existsSync(join(parentDir, '.omc', 'wiki'))).toBe(false);
+  });
+
+  it('same-root subdirectory is accepted without fallback writes to a foreign repo', async () => {
+    const sub = join(sessionRepo, 'docs');
+    mkdirSync(sub, { recursive: true });
+    const result = await wikiQueryTool.handler({ query: 'aaPanel', workingDirectory: sub });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('No wiki pages match "aaPanel"');
+    expect(result.content[0].text).toContain(basename(sessionRepo));
+    expect(result.content[0].text).not.toContain(sessionRepo);
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'aapanel-setup.md'))).toBe(true);
+    expect(existsSync(join(foreignRepo, '.omc', 'wiki', 'foreign-page.md'))).toBe(false);
+    expect(existsSync(join(sub, '.omc', 'wiki'))).toBe(false);
   });
 
   it('the trusted repository is identified by basename only, not absolute path', async () => {

--- a/src/tools/wiki-tools.ts
+++ b/src/tools/wiki-tools.ts
@@ -34,8 +34,9 @@ const WIKI_CATEGORIES: [string, ...string[]] = [
 /**
  * Resolve the wiki root for a tool call, rejecting foreign-repository
  * workingDirectory values visibly (#3858). The rejection reaches the MCP
- * caller as isError; the trusted repository is identified by basename only so
- * sensitive absolute paths are not echoed beyond what the caller supplied.
+ * caller as isError. Canonical provided/trusted roots stay internal; the
+ * error message uses the caller-supplied label and a basename-only trusted
+ * root so host paths the caller did not supply are not disclosed.
  */
 function resolveWikiRoot(
   workingDirectory: string | undefined,
@@ -46,7 +47,8 @@ function resolveWikiRoot(
       ok: false,
       error: new ForeignWorkingDirectoryError(
         resolution.providedRoot,
-        basename(resolution.trustedRoot),
+        resolution.trustedRoot,
+        resolution.callerLabel,
       ),
     };
   }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #3859 for reopened #3858. The visible foreign-repo rejection shipped, but exact-head review found two remaining **path-disclosure** leaks on `dev@43db6384`:

1. `resolveWorkingDirectoryOrLinkedWorktree` canonicalizes relative/symlink foreign input to `providedRootReal`, and `wiki-tools.ts` rendered `resolution.providedRoot` verbatim — disclosing the canonical host path the caller did not supply.
2. The non-git outside-root error included the full `trustedRoot`, and wiki handlers returned that message verbatim.

This preserves the security boundary and the useful visible rejection. It only sanitizes **caller-visible** error text.

Refs #3858

## Caller-visible error contract

- Retain the original caller-supplied `workingDirectory` label (absolute, relative, or symlink) in the message.
- Identify the trusted repository by **basename only**.
- Never echo canonical `providedRootReal` or the full `trustedRoot` to the MCP caller.
- Canonical paths stay on the resolution/error object for internal validation only.

`ForeignWorkingDirectoryError` and `formatOutsideTrustedRootMessage` implement that contract. All seven wiki tools plus `resolveWikiRoot()` use it.

## Tests

- Resolver: absolute caller path, relative alias, symlink alias, non-git outside path, same-root/subdir, linked worktree, submodule — message assertions forbid canonical foreign/trusted paths.
- Real handlers: all seven wiki tools reject relative/symlink/non-git/submodule cases without fallback reads/writes.

## Verification

- `bun test` focused privacy suites: 24 pass / 0 fail
- `npx tsc --noEmit` clean
- `npm run build` green
- `npm pack --dry-run` packages
- inventory graph baseline refreshed
- `dist/` and `bridge/` unrestaged (zero generated delta)

Do **not** auto-close #3858 from this PR. Close only after exact-head review, merge, and merged-dev dogfood with a reporter-facing correction of the premature #3859 close.