### PR TITLE
fix(wiki): require callerLabel on ForeignWorkingDirectoryError (#3858)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "43db638446c47ce4601ad3e20593886037874597",
-    "sourceSha256": "22cef0d00d570cef912674448b0becd1226a8033311436327fa0fdc2e9e71daf",
+    "head": "3fd82c66e6903a59d15c65038fe285ac916913d7",
+    "sourceSha256": "d1df7e1a36e48702549feaea3f1befb05d4b1d0890144740a744eb6738e9d515",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "43db638446c47ce4601ad3e20593886037874597",
-  "sourceSha256": "22cef0d00d570cef912674448b0becd1226a8033311436327fa0fdc2e9e71daf",
+  "head": "3fd82c66e6903a59d15c65038fe285ac916913d7",
+  "sourceSha256": "d1df7e1a36e48702549feaea3f1befb05d4b1d0890144740a744eb6738e9d515",
   "counts": {
     "public": {
       "skills": 31,
@@ -74715,5 +74715,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "0b271412958c7d344047743b9ebccd078acb854a4aecfceadd50587b1ce31dfc"
+  "manifestSha256": "a88cb22875ff90013c76f9707e5d10a34b8fb36ba517a574bee06b48f7e9e4b8"
 }

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -110,6 +110,21 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     }
   });
 
+  it('ForeignWorkingDirectoryError requires callerLabel and never renders canonical provided/trusted roots', () => {
+    const error = new ForeignWorkingDirectoryError(
+      '/canonical/foreign-vault',
+      '/canonical/session-project',
+      '../foreign-vault',
+    );
+    expect(error.callerLabel).toBe('../foreign-vault');
+    expect(error.providedRoot).toBe('/canonical/foreign-vault');
+    expect(error.trustedRoot).toBe('/canonical/session-project');
+    expect(error.message).toContain('../foreign-vault');
+    expect(error.message).toContain('session-project');
+    expect(error.message).not.toContain('/canonical/foreign-vault');
+    expect(error.message).not.toContain('/canonical/session-project');
+  });
+
   it('relative foreign alias keeps the caller-supplied label and hides canonical host paths', () => {
     const relativeAlias = join('..', 'foreign-vault');
     const resolution = resolveWorkingDirectoryOrLinkedWorktree(relativeAlias);

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1327,13 +1327,15 @@ export type WorkingDirectoryResolution =
  * `.message` is the caller-visible contract: the original workingDirectory
  * label plus a basename-only trusted-root identity. Canonical `providedRoot`
  * and `trustedRoot` stay on the instance for internal validation.
+ * `callerLabel` is required so a two-argument construction cannot echo
+ * canonical `providedRoot` into the message.
  */
 export class ForeignWorkingDirectoryError extends Error {
   readonly providedRoot: string;
   readonly trustedRoot: string;
   readonly callerLabel: string;
 
-  constructor(providedRoot: string, trustedRoot: string, callerLabel: string = providedRoot) {
+  constructor(providedRoot: string, trustedRoot: string, callerLabel: string) {
     super(
       `workingDirectory '${callerLabel}' belongs to a different repository than '${callerVisibleTrustedRootLabel(trustedRoot)}' and was not used. ` +
         `Cross-repository access is not permitted; pass a path inside the current repository or start the session there.`


### PR DESCRIPTION
## Summary

One-commit follow-up from exact-head review of merged PR #3860.

`ForeignWorkingDirectoryError` defaulted `callerLabel` to canonical `providedRoot`. Current wiki/resolver call sites already pass the original label, so production handlers do not leak today — but a two-argument construction would reintroduce the #3858 path-disclosure.

This makes `callerLabel` required. Constructor test asserts canonical provided/trusted paths stay out of `.message`.

Refs #3858 (already closed after #3860). Do not reopen.

## Verification

- `bun test src/lib/__tests__/worktree-paths-foreign-root.test.ts src/tools/__tests__/wiki-tools-foreign-root.test.ts` — 24 pass
- `npx tsc --noEmit` clean
- inventory baseline refreshed
- `dist/`/`bridge/` unrestaged