### PR TITLE
fix(wiki): hide canonical roots from serialization (#3858)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "94e6fc530d7e656205e87b128b1cbca2d68784b5",
-    "sourceSha256": "fed7cd16b62ada58445b48679754825313107a252b0fc62e50ac09f36d8a5000",
+    "head": "9648730ea878dbf31519dcf5d540e540727f2ba4",
+    "sourceSha256": "04926230840e87f5ad8b6010d6df7d25da18021912fa32055dfaf964609e314a",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "94e6fc530d7e656205e87b128b1cbca2d68784b5",
-  "sourceSha256": "fed7cd16b62ada58445b48679754825313107a252b0fc62e50ac09f36d8a5000",
+  "head": "9648730ea878dbf31519dcf5d540e540727f2ba4",
+  "sourceSha256": "04926230840e87f5ad8b6010d6df7d25da18021912fa32055dfaf964609e314a",
   "counts": {
     "public": {
       "skills": 31,
@@ -74730,5 +74730,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "dcd98a26184dcc36ee868542686c9362d719e1f8e29bfa66839438fbd524caf3"
+  "manifestSha256": "618b30a82972ed33eab31200fec37b97fa84a1c1a067c3f40ce047e076dcf8f3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "3fd82c66e6903a59d15c65038fe285ac916913d7",
-    "sourceSha256": "d1df7e1a36e48702549feaea3f1befb05d4b1d0890144740a744eb6738e9d515",
+    "head": "28f290267d78dc1ca938518076e3ac427a297f6b",
+    "sourceSha256": "b886a7b435d23995b64e09a0c4bc8235a2a9d09bbfc08e266504907c0756c0b2",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "3fd82c66e6903a59d15c65038fe285ac916913d7",
-  "sourceSha256": "d1df7e1a36e48702549feaea3f1befb05d4b1d0890144740a744eb6738e9d515",
+  "head": "28f290267d78dc1ca938518076e3ac427a297f6b",
+  "sourceSha256": "b886a7b435d23995b64e09a0c4bc8235a2a9d09bbfc08e266504907c0756c0b2",
   "counts": {
     "public": {
       "skills": 31,
@@ -32365,6 +32365,11 @@
         "path": "node:url"
       },
       {
+        "id": "external:node:util",
+        "kind": "external",
+        "path": "node:util"
+      },
+      {
         "id": "external:node:worker_threads",
         "kind": "external",
         "path": "node:worker_threads"
@@ -62763,6 +62768,11 @@
       },
       {
         "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:node:util",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
         "to": "external:vitest",
         "kind": "imports"
       },
@@ -74708,12 +74718,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6789,
-      "edgeCount": 6899,
-      "importEdgeCount": 5663,
+      "nodeCount": 6790,
+      "edgeCount": 6900,
+      "importEdgeCount": 5664,
       "registerEdgeCount": 52
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "a88cb22875ff90013c76f9707e5d10a34b8fb36ba517a574bee06b48f7e9e4b8"
+  "manifestSha256": "d08467c5aa0ee0e27e61b7cfd85357ea8c115c327a83ba44c48e8f636c9bb182"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "61bc6901f317209667dee04425738e55ae84727c",
-    "sourceSha256": "a13b0a00cc6b37e4b12b15e60e5b73a192a146ec7f8ce30a279d81e21ce012d3",
+    "head": "94e6fc530d7e656205e87b128b1cbca2d68784b5",
+    "sourceSha256": "fed7cd16b62ada58445b48679754825313107a252b0fc62e50ac09f36d8a5000",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "61bc6901f317209667dee04425738e55ae84727c",
-  "sourceSha256": "a13b0a00cc6b37e4b12b15e60e5b73a192a146ec7f8ce30a279d81e21ce012d3",
+  "head": "94e6fc530d7e656205e87b128b1cbca2d68784b5",
+  "sourceSha256": "fed7cd16b62ada58445b48679754825313107a252b0fc62e50ac09f36d8a5000",
   "counts": {
     "public": {
       "skills": 31,
@@ -74730,5 +74730,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "6fcf4adc3e32cea3d1dd5ce15f4231f1d8231f48e6e9d15b20e5e35312ee4ec5"
+  "manifestSha256": "dcd98a26184dcc36ee868542686c9362d719e1f8e29bfa66839438fbd524caf3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "28f290267d78dc1ca938518076e3ac427a297f6b",
-    "sourceSha256": "b886a7b435d23995b64e09a0c4bc8235a2a9d09bbfc08e266504907c0756c0b2",
+    "head": "5735007495c433f3480120db132a33e163d94fdd",
+    "sourceSha256": "058d8838906dc682313ec7422010500aa18cc4ca050772a570dbd9de73e6b36e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "28f290267d78dc1ca938518076e3ac427a297f6b",
-  "sourceSha256": "b886a7b435d23995b64e09a0c4bc8235a2a9d09bbfc08e266504907c0756c0b2",
+  "head": "5735007495c433f3480120db132a33e163d94fdd",
+  "sourceSha256": "058d8838906dc682313ec7422010500aa18cc4ca050772a570dbd9de73e6b36e",
   "counts": {
     "public": {
       "skills": 31,
@@ -74725,5 +74725,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "d08467c5aa0ee0e27e61b7cfd85357ea8c115c327a83ba44c48e8f636c9bb182"
+  "manifestSha256": "7f2f57134d0cefd547f5a32e14f69c50f01b65c9aa7a786551fa8c22a36ed25d"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "5735007495c433f3480120db132a33e163d94fdd",
-    "sourceSha256": "058d8838906dc682313ec7422010500aa18cc4ca050772a570dbd9de73e6b36e",
+    "head": "61bc6901f317209667dee04425738e55ae84727c",
+    "sourceSha256": "a13b0a00cc6b37e4b12b15e60e5b73a192a146ec7f8ce30a279d81e21ce012d3",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "5735007495c433f3480120db132a33e163d94fdd",
-  "sourceSha256": "058d8838906dc682313ec7422010500aa18cc4ca050772a570dbd9de73e6b36e",
+  "head": "61bc6901f317209667dee04425738e55ae84727c",
+  "sourceSha256": "a13b0a00cc6b37e4b12b15e60e5b73a192a146ec7f8ce30a279d81e21ce012d3",
   "counts": {
     "public": {
       "skills": 31,
@@ -62768,6 +62768,11 @@
       },
       {
         "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
+        "to": "external:node:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
         "to": "external:node:util",
         "kind": "imports"
       },
@@ -74719,11 +74724,11 @@
     ],
     "stats": {
       "nodeCount": 6790,
-      "edgeCount": 6900,
-      "importEdgeCount": 5664,
+      "edgeCount": 6901,
+      "importEdgeCount": 5665,
       "registerEdgeCount": 52
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "7f2f57134d0cefd547f5a32e14f69c50f01b65c9aa7a786551fa8c22a36ed25d"
+  "manifestSha256": "6fcf4adc3e32cea3d1dd5ce15f4231f1d8231f48e6e9d15b20e5e35312ee4ec5"
 }

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { inspect } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import {
   mkdtempSync,
@@ -11,7 +12,7 @@ import {
   realpathSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, basename, relative } from 'node:path';
+import { join, basename, relative, resolve } from 'node:path';
 import {
   clearWorktreeCache,
   resolveWorkingDirectoryOrLinkedWorktree,
@@ -209,6 +210,19 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     expect(inspected).toContain('../foreign-vault');
     expect(inspected).not.toContain('/canonical/foreign-vault');
     expect(inspected).not.toContain('/canonical/session-project');
+    const sourceFile = fileURLToPath(import.meta.url);
+    const sourceRoot = resolve(sourceFile, '../../../..');
+    const overlapping = new ForeignWorkingDirectoryError(
+      sourceFile,
+      sourceRoot,
+      '../foreign-vault',
+    );
+    const overlappingInspect = inspect(overlapping, { depth: 8, getters: true, showHidden: false });
+    expect(overlappingInspect).toContain('at ');
+    expect(overlappingInspect).toContain('../foreign-vault');
+    expect(overlappingInspect).not.toContain(sourceFile);
+    expect(overlappingInspect).not.toContain(sourceRoot);
+    expect(overlappingInspect).toContain('<redacted>');
   });
 
   it('foreign_repository resolution and thrown error keep canonical roots opaque under serialization', () => {

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -204,6 +204,11 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
       trustedRoot: '/canonical/session-project',
       callerLabel: '../foreign-vault',
     });
+    const inspected = inspect(error, { depth: 8, getters: true, showHidden: false });
+    expect(inspected).toContain('at ');
+    expect(inspected).toContain('../foreign-vault');
+    expect(inspected).not.toContain('/canonical/foreign-vault');
+    expect(inspected).not.toContain('/canonical/session-project');
   });
 
   it('foreign_repository resolution and thrown error keep canonical roots opaque under serialization', () => {

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -230,6 +230,14 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     expect(rawInspect).not.toContain(sourceFile);
     expect(rawInspect).not.toContain(sourceRoot);
     expect(JSON.stringify({ message: overlapping.message, stack: overlapping.stack })).not.toContain(sourceRoot);
+    const absoluteCaller = sourceFile;
+    const absoluteError = new ForeignWorkingDirectoryError(absoluteCaller, sourceRoot, absoluteCaller);
+    expect(absoluteError.message).toContain(absoluteCaller);
+    expect(absoluteError.stack).toContain(absoluteCaller);
+    expect(inspect(absoluteError)).toContain(absoluteCaller);
+    const absoluteFrames = (absoluteError.stack ?? '').split('\n').slice(1).join('\n');
+    expect(absoluteFrames).not.toContain(sourceRoot);
+    expect(absoluteFrames).not.toContain(sourceFile);
   });
 
   it('foreign_repository resolution and thrown error keep canonical roots opaque under serialization', () => {

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -218,11 +218,18 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
       '../foreign-vault',
     );
     const overlappingInspect = inspect(overlapping, { depth: 8, getters: true, showHidden: false });
+    const rawInspect = inspect(overlapping, { depth: 8, customInspect: false, showHidden: false });
     expect(overlappingInspect).toContain('at ');
     expect(overlappingInspect).toContain('../foreign-vault');
     expect(overlappingInspect).not.toContain(sourceFile);
     expect(overlappingInspect).not.toContain(sourceRoot);
     expect(overlappingInspect).toContain('<redacted>');
+    expect(overlapping.stack).toContain('at ');
+    expect(overlapping.stack).not.toContain(sourceFile);
+    expect(overlapping.stack).not.toContain(sourceRoot);
+    expect(rawInspect).not.toContain(sourceFile);
+    expect(rawInspect).not.toContain(sourceRoot);
+    expect(JSON.stringify({ message: overlapping.message, stack: overlapping.stack })).not.toContain(sourceRoot);
   });
 
   it('foreign_repository resolution and thrown error keep canonical roots opaque under serialization', () => {

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { inspect } from 'node:util';
 import { execSync } from 'node:child_process';
 import {
   mkdtempSync,
@@ -26,6 +27,80 @@ function git(cwd: string, command: string): void {
 function canonical(path: string): string {
   return realpathSync(path);
 }
+function loggerLikeWrap(value: unknown): unknown {
+  if (value instanceof Error) {
+    const wrapped: Record<string, unknown> = { ...value };
+    wrapped.name = value.name;
+    wrapped.message = value.message;
+    wrapped.cause = value.cause !== undefined ? loggerLikeWrap(value.cause) : undefined;
+    return wrapped;
+  }
+  if (value !== null && typeof value === 'object') {
+    return { ...value };
+  }
+  return value;
+}
+
+function assertOpaqueCanonicalSerialization(
+  value: { providedRoot: string; trustedRoot: string; callerLabel: string },
+  opts: { providedRoot: string; trustedRoot: string; callerLabel: string },
+): void {
+  expect(value.providedRoot).toBe(opts.providedRoot);
+  expect(value.trustedRoot).toBe(opts.trustedRoot);
+  expect(value.callerLabel).toBe(opts.callerLabel);
+
+  const provided = Object.getOwnPropertyDescriptor(value, 'providedRoot');
+  const trusted = Object.getOwnPropertyDescriptor(value, 'trustedRoot');
+  const caller = Object.getOwnPropertyDescriptor(value, 'callerLabel');
+  expect(provided).toMatchObject({
+    enumerable: false,
+    writable: false,
+    configurable: false,
+    value: opts.providedRoot,
+  });
+  expect(trusted).toMatchObject({
+    enumerable: false,
+    writable: false,
+    configurable: false,
+    value: opts.trustedRoot,
+  });
+  expect(caller?.enumerable).toBe(true);
+  expect(caller?.value).toBe(opts.callerLabel);
+  expect(Object.keys(value)).not.toContain('providedRoot');
+  expect(Object.keys(value)).not.toContain('trustedRoot');
+  expect(Object.keys(value)).toContain('callerLabel');
+
+  const spread = { ...value };
+  expect(spread).not.toHaveProperty('providedRoot');
+  expect(spread).not.toHaveProperty('trustedRoot');
+  expect(spread.callerLabel).toBe(opts.callerLabel);
+
+  const cloned = structuredClone(value);
+  const wrappedError = new Error('logger wrap', { cause: value as unknown as Error });
+  const clonedWrapper = structuredClone(wrappedError);
+  const payloads = [
+    JSON.stringify(value),
+    JSON.stringify(spread),
+    JSON.stringify(cloned),
+    JSON.stringify(loggerLikeWrap(value)),
+    JSON.stringify(loggerLikeWrap(wrappedError)),
+    JSON.stringify({ err: value, cause: value }),
+    JSON.stringify({ ...clonedWrapper, cause: clonedWrapper.cause }),
+    inspect(value, { depth: 8, getters: true, showHidden: false }),
+  ];
+
+  for (const path of [opts.providedRoot, opts.trustedRoot]) {
+    for (const payload of payloads) {
+      expect(payload).not.toContain(path);
+    }
+  }
+
+  const parsed = JSON.parse(JSON.stringify(value)) as { callerLabel?: string };
+  expect(parsed.callerLabel).toBe(opts.callerLabel);
+  expect(parsed).not.toHaveProperty('providedRoot');
+  expect(parsed).not.toHaveProperty('trustedRoot');
+}
+
 
 describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-root', () => {
   let tempDir: string;
@@ -80,15 +155,16 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
 
   it('resolveWorkingDirectoryOrLinkedWorktree returns foreign_repository for a different repo, never a root', () => {
     const resolution = resolveWorkingDirectoryOrLinkedWorktree(foreignRepo);
+    expect(resolution.status).toBe('foreign_repository');
+    if (resolution.status !== 'foreign_repository') return;
+    expect(resolution.providedRoot).toBe(canonicalForeign);
+    expect(resolution.trustedRoot).toBe(canonicalSession);
+    expect(resolution.callerLabel).toBe(foreignRepo);
+    expect('root' in resolution).toBe(false);
     expect(resolution).toEqual({
       status: 'foreign_repository',
-      providedRoot: canonicalForeign,
-      trustedRoot: canonicalSession,
       callerLabel: foreignRepo,
     });
-    if (resolution.status === 'foreign_repository') {
-      expect('root' in resolution).toBe(false);
-    }
   });
 
   it('validateWorkingDirectoryOrLinkedWorktree throws ForeignWorkingDirectoryError instead of substituting', () => {
@@ -123,6 +199,40 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     expect(error.message).toContain('session-project');
     expect(error.message).not.toContain('/canonical/foreign-vault');
     expect(error.message).not.toContain('/canonical/session-project');
+    assertOpaqueCanonicalSerialization(error, {
+      providedRoot: '/canonical/foreign-vault',
+      trustedRoot: '/canonical/session-project',
+      callerLabel: '../foreign-vault',
+    });
+  });
+
+  it('foreign_repository resolution and thrown error keep canonical roots opaque under serialization', () => {
+    const relativeAlias = join('..', 'foreign-vault');
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree(relativeAlias);
+    expect(resolution.status).toBe('foreign_repository');
+    if (resolution.status !== 'foreign_repository') return;
+
+    assertOpaqueCanonicalSerialization(resolution, {
+      providedRoot: canonicalForeign,
+      trustedRoot: canonicalSession,
+      callerLabel: relativeAlias,
+    });
+
+    try {
+      validateWorkingDirectoryOrLinkedWorktree(relativeAlias);
+      expect.unreachable('must throw');
+    } catch (error) {
+      const foreign = error as ForeignWorkingDirectoryError;
+      expect(foreign.message).toContain(relativeAlias);
+      expect(foreign.message).not.toContain(canonicalForeign);
+      expect(foreign.message).not.toContain(canonicalSession);
+      expect(foreign.message).toContain(basename(sessionRepo));
+      assertOpaqueCanonicalSerialization(foreign, {
+        providedRoot: canonicalForeign,
+        trustedRoot: canonicalSession,
+        callerLabel: relativeAlias,
+      });
+    }
   });
 
   it('relative foreign alias keeps the caller-supplied label and hides canonical host paths', () => {

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1399,7 +1399,7 @@ export class ForeignWorkingDirectoryError extends Error {
   }
 
   [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return `${this.name}: ${this.message} { callerLabel: ${JSON.stringify(this.callerLabel)} }`;
+    return this.stack ?? `${this.name}: ${this.message}`;
   }
 }
 

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1205,6 +1205,46 @@ function formatOutsideTrustedRootMessage(workingDirectory: string, trustedRoot: 
     `is outside the trusted worktree root '${callerVisibleTrustedRootLabel(trustedRoot)}'.`
   );
 }
+function defineOpaqueCanonicalRoots(
+  target: object,
+  providedRoot: string,
+  trustedRoot: string,
+): void {
+  const descriptor = {
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  } as const;
+  Object.defineProperties(target, {
+    providedRoot: { ...descriptor, value: providedRoot },
+    trustedRoot: { ...descriptor, value: trustedRoot },
+  });
+}
+
+function foreignRepositoryResolution(
+  providedRoot: string,
+  trustedRoot: string,
+  callerLabel: string,
+): Extract<WorkingDirectoryResolution, { status: 'foreign_repository' }> {
+  const resolution = {
+    status: 'foreign_repository' as const,
+    providedRoot,
+    trustedRoot,
+    callerLabel,
+  };
+  defineOpaqueCanonicalRoots(resolution, providedRoot, trustedRoot);
+  Object.defineProperty(resolution, 'toJSON', {
+    enumerable: false,
+    writable: false,
+    configurable: false,
+    value: (): { status: 'foreign_repository'; callerLabel: string } => ({
+      status: 'foreign_repository',
+      callerLabel,
+    }),
+  });
+  return resolution;
+}
+
 
 /**
  * Validate that a workingDirectory is within the trusted git top-level.
@@ -1305,10 +1345,14 @@ function getGitCommonDir(cwd: string): string | null {
  *   Callers MUST NOT use it and MUST NOT silently fall back to the trusted
  *   root; they are expected to surface the rejection to their caller.
  *
- * `providedRoot` and `trustedRoot` are canonical paths for internal
- * validation only. Caller-visible text must use `callerLabel` (the original
+ * Canonical `providedRoot` / `trustedRoot` remain readable for internal
+ * resolver consumers but are attached as non-enumerable, non-writable data
+ * properties so JSON.stringify, object spread, structuredClone, and
+ * logger-like wrapping cannot serialize host paths the caller did not
+ * supply. Caller-visible text must use `callerLabel` (the original
  * workingDirectory string) and a basename-only trusted-root label — never
  * `providedRoot` / `trustedRoot` verbatim.
+ * `callerLabel` stays enumerable so the caller-supplied label is explicit.
  */
 export type WorkingDirectoryResolution =
   | { status: 'ok'; root: string }
@@ -1326,13 +1370,14 @@ export type WorkingDirectoryResolution =
  *
  * `.message` is the caller-visible contract: the original workingDirectory
  * label plus a basename-only trusted-root identity. Canonical `providedRoot`
- * and `trustedRoot` stay on the instance for internal validation.
- * `callerLabel` is required so a two-argument construction cannot echo
- * canonical `providedRoot` into the message.
+ * and `trustedRoot` stay on the instance for internal validation as
+ * non-enumerable opaque fields so serialization and object spread cannot
+ * disclose them. `callerLabel` is required and enumerable so a two-argument
+ * construction cannot echo canonical `providedRoot` into the message.
  */
 export class ForeignWorkingDirectoryError extends Error {
-  readonly providedRoot: string;
-  readonly trustedRoot: string;
+  declare readonly providedRoot: string;
+  declare readonly trustedRoot: string;
   readonly callerLabel: string;
 
   constructor(providedRoot: string, trustedRoot: string, callerLabel: string) {
@@ -1341,9 +1386,20 @@ export class ForeignWorkingDirectoryError extends Error {
         `Cross-repository access is not permitted; pass a path inside the current repository or start the session there.`
     );
     this.name = 'ForeignWorkingDirectoryError';
-    this.providedRoot = providedRoot;
-    this.trustedRoot = trustedRoot;
     this.callerLabel = callerLabel;
+    defineOpaqueCanonicalRoots(this, providedRoot, trustedRoot);
+  }
+
+  toJSON(): { name: string; message: string; callerLabel: string } {
+    return {
+      name: this.name,
+      message: this.message,
+      callerLabel: this.callerLabel,
+    };
+  }
+
+  [Symbol.for('nodejs.util.inspect.custom')](): string {
+    return `${this.name}: ${this.message} { callerLabel: ${JSON.stringify(this.callerLabel)} }`;
   }
 }
 
@@ -1395,12 +1451,7 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
 
     // Different repository (#3858): reject visibly instead of silently
     // substituting the trusted root.
-    return {
-      status: 'foreign_repository',
-      providedRoot: providedRootReal,
-      trustedRoot: trustedRootReal,
-      callerLabel: workingDirectory,
-    };
+    return foreignRepositoryResolution(providedRootReal, trustedRootReal, workingDirectory);
   }
 
   let resolvedReal: string;

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1399,6 +1399,12 @@ export class ForeignWorkingDirectoryError extends Error {
     this.name = 'ForeignWorkingDirectoryError';
     this.callerLabel = callerLabel;
     defineOpaqueCanonicalRoots(this, providedRoot, trustedRoot);
+    Object.defineProperty(this, 'stack', {
+      value: redactCanonicalRoots(this.stack ?? `${this.name}: ${this.message}`, providedRoot, trustedRoot),
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
   }
 
   toJSON(): { name: string; message: string; callerLabel: string } {
@@ -1410,8 +1416,7 @@ export class ForeignWorkingDirectoryError extends Error {
   }
 
   [Symbol.for('nodejs.util.inspect.custom')](): string {
-    const raw = this.stack ?? `${this.name}: ${this.message}`;
-    return redactCanonicalRoots(raw, this.providedRoot, this.trustedRoot);
+    return this.stack ?? `${this.name}: ${this.message}`;
   }
 }
 

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1230,6 +1230,16 @@ function redactCanonicalRoots(text: string, providedRoot: string, trustedRoot: s
   }
   return redacted;
 }
+function redactErrorStack(stack: string, providedRoot: string, trustedRoot: string): string {
+  const newline = stack.includes('\r\n') ? '\r\n' : '\n';
+  const lines = stack.split(/\r?\n/);
+  if (lines.length <= 1) {
+    return stack;
+  }
+  const [header, ...frames] = lines;
+  return [header, ...frames.map((frame) => redactCanonicalRoots(frame, providedRoot, trustedRoot))].join(newline);
+}
+
 
 
 function foreignRepositoryResolution(
@@ -1400,7 +1410,7 @@ export class ForeignWorkingDirectoryError extends Error {
     this.callerLabel = callerLabel;
     defineOpaqueCanonicalRoots(this, providedRoot, trustedRoot);
     Object.defineProperty(this, 'stack', {
-      value: redactCanonicalRoots(this.stack ?? `${this.name}: ${this.message}`, providedRoot, trustedRoot),
+      value: redactErrorStack(this.stack ?? `${this.name}: ${this.message}`, providedRoot, trustedRoot),
       enumerable: false,
       configurable: true,
       writable: true,

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1220,6 +1220,17 @@ function defineOpaqueCanonicalRoots(
     trustedRoot: { ...descriptor, value: trustedRoot },
   });
 }
+function redactCanonicalRoots(text: string, providedRoot: string, trustedRoot: string): string {
+  let redacted = text;
+  const roots = [providedRoot, trustedRoot]
+    .filter((root) => root.length > 0)
+    .sort((a, b) => b.length - a.length);
+  for (const root of roots) {
+    redacted = redacted.split(root).join('<redacted>');
+  }
+  return redacted;
+}
+
 
 function foreignRepositoryResolution(
   providedRoot: string,
@@ -1399,7 +1410,8 @@ export class ForeignWorkingDirectoryError extends Error {
   }
 
   [Symbol.for('nodejs.util.inspect.custom')](): string {
-    return this.stack ?? `${this.name}: ${this.message}`;
+    const raw = this.stack ?? `${this.name}: ${this.message}`;
+    return redactCanonicalRoots(raw, this.providedRoot, this.trustedRoot);
   }
 }
 

--- a/src/tools/__tests__/wiki-tools-foreign-root.test.ts
+++ b/src/tools/__tests__/wiki-tools-foreign-root.test.ts
@@ -41,8 +41,10 @@ function assertVisibleRejectionWithoutCanonicalLeak(
   expect(text).toContain(opts.trustedBasename);
   expect(text).not.toContain('No wiki pages match');
   expect(text).not.toContain('Wiki page not found');
+  const serialized = JSON.stringify(result);
   for (const path of opts.forbidden) {
     expect(text).not.toContain(path);
+    expect(serialized).not.toContain(path);
   }
 }
 


### PR DESCRIPTION
## Summary

One-commit follow-up for reopened #3858 after #3860 (sanitized `.message`) and #3861 (required `callerLabel`).

Exact-head review of #3860 still blocked on enumerable canonical fields:

- `ForeignWorkingDirectoryError` assigned enumerable `providedRoot` / `trustedRoot`
- `foreign_repository` resolution exported enumerable canonical roots

Those values leaked through `JSON.stringify`, object spread, `structuredClone`, logger-like wrapping, and error `cause` wrappers even though caller-visible `.message` was already sanitized.

This attaches canonical roots as non-enumerable, non-writable data properties (still readable internally), keeps `callerLabel` enumerable, and adds `toJSON` / `inspect.custom` so serialization cannot disclose host paths the caller did not supply.

Refs #3858

## Verification

- `npx vitest run src/lib/__tests__/worktree-paths-foreign-root.test.ts src/tools/__tests__/wiki-tools-foreign-root.test.ts src/lib/__tests__/worktree-paths.test.ts src/tools/__tests__/wiki-tools-working-directory.test.ts` — 115 pass
- serialization + property-descriptor coverage for resolution and `ForeignWorkingDirectoryError`
- seven wiki tools still reject before IO with sanitized errors (relative/symlink/non-git/submodule/same-root/linked worktree)
- `npx tsc --noEmit` clean
- `npx eslint` clean on changed files
- inventory baseline refreshed and verified
- `npm run build` succeeded
- `npm pack --ignore-scripts` produced `oh-my-claude-sisyphus-5.0.0.tgz`
- `dist/` / `bridge/` unrestaged