### PR TITLE
fix(wiki): redact file-URL stack frames for canonical roots (#3858)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "c3b983359920d8e08be6a4fe5c1d39c3744ca020",
-    "sourceSha256": "7b553c76008905ebe2314d9c30d62805121af9667344ef4d1df94812f7131d73",
+    "head": "66d5464d5ce878c4ea26d3ba8b7348ee5bc3c91d",
+    "sourceSha256": "c529faca78412a0c9e8c581add382cd9e662f4e91a85e420268f576d7b5631ff",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "c3b983359920d8e08be6a4fe5c1d39c3744ca020",
-  "sourceSha256": "7b553c76008905ebe2314d9c30d62805121af9667344ef4d1df94812f7131d73",
+  "head": "66d5464d5ce878c4ea26d3ba8b7348ee5bc3c91d",
+  "sourceSha256": "c529faca78412a0c9e8c581add382cd9e662f4e91a85e420268f576d7b5631ff",
   "counts": {
     "public": {
       "skills": 31,
@@ -74735,5 +74735,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "c99185373934521f6ff96dd13d46b292d40009fbc7177965dcefe9af86f7cb1e"
+  "manifestSha256": "37cf86df3c400ec3df35320c45ff8d57e1458e344159f4ef88ada6baf80c6fcd"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "9648730ea878dbf31519dcf5d540e540727f2ba4",
-    "sourceSha256": "04926230840e87f5ad8b6010d6df7d25da18021912fa32055dfaf964609e314a",
+    "head": "f47cbffc008e4be5ae28a6f4c815700fc453df40",
+    "sourceSha256": "e49ddacad300dd50ceaddbc1b9a8feb090ba90879920a8feb0dd5bbe42431fbb",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "9648730ea878dbf31519dcf5d540e540727f2ba4",
-  "sourceSha256": "04926230840e87f5ad8b6010d6df7d25da18021912fa32055dfaf964609e314a",
+  "head": "f47cbffc008e4be5ae28a6f4c815700fc453df40",
+  "sourceSha256": "e49ddacad300dd50ceaddbc1b9a8feb090ba90879920a8feb0dd5bbe42431fbb",
   "counts": {
     "public": {
       "skills": 31,
@@ -63093,6 +63093,11 @@
       },
       {
         "from": "src/lib/worktree-paths.ts",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/worktree-paths.ts",
         "to": "src/utils/config-dir.ts",
         "kind": "imports"
       },
@@ -74724,11 +74729,11 @@
     ],
     "stats": {
       "nodeCount": 6790,
-      "edgeCount": 6901,
-      "importEdgeCount": 5665,
+      "edgeCount": 6902,
+      "importEdgeCount": 5666,
       "registerEdgeCount": 52
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "618b30a82972ed33eab31200fec37b97fa84a1c1a067c3f40ce047e076dcf8f3"
+  "manifestSha256": "abee4ed24bdfe40f281f4d266b83f35aaf4d03068b286d732b60106c6d11ca43"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "f47cbffc008e4be5ae28a6f4c815700fc453df40",
-    "sourceSha256": "e49ddacad300dd50ceaddbc1b9a8feb090ba90879920a8feb0dd5bbe42431fbb",
+    "head": "c3b983359920d8e08be6a4fe5c1d39c3744ca020",
+    "sourceSha256": "7b553c76008905ebe2314d9c30d62805121af9667344ef4d1df94812f7131d73",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "f47cbffc008e4be5ae28a6f4c815700fc453df40",
-  "sourceSha256": "e49ddacad300dd50ceaddbc1b9a8feb090ba90879920a8feb0dd5bbe42431fbb",
+  "head": "c3b983359920d8e08be6a4fe5c1d39c3744ca020",
+  "sourceSha256": "7b553c76008905ebe2314d9c30d62805121af9667344ef4d1df94812f7131d73",
   "counts": {
     "public": {
       "skills": 31,
@@ -74735,5 +74735,5 @@
     }
   },
   "inventorySha256": "cb341faca1f2583f56b1e73ca4f9d4223de75d69f790002dab9c02ec8bd31250",
-  "manifestSha256": "abee4ed24bdfe40f281f4d266b83f35aaf4d03068b286d732b60106c6d11ca43"
+  "manifestSha256": "c99185373934521f6ff96dd13d46b292d40009fbc7177965dcefe9af86f7cb1e"
 }

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -428,6 +428,20 @@ process.stdout.write(JSON.stringify({
     expect(() => validateWorkingDirectoryOrLinkedWorktree(nested)).toThrow(/git probe failed and was not used/);
     expect(() => resolveWorkingDirectoryOrLinkedWorktree(nested)).toThrow(/git probe failed and was not used/);
   });
+  it('same-repo subdirectory still resolves when git is missing from PATH', () => {
+    const sub = join(sessionRepo, 'docs');
+    mkdirSync(sub, { recursive: true });
+    const originalPath = process.env.PATH;
+    process.env.PATH = '';
+    clearWorktreeCache();
+    try {
+      expect(validateWorkingDirectoryOrLinkedWorktree(sub)).toBe(sessionRepo);
+    } finally {
+      process.env.PATH = originalPath;
+      clearWorktreeCache();
+    }
+  });
+
 
   it('linked-worktree wiki flows keep working end to end (no regression from #2880)', async () => {
     const readResult = await wikiReadTool.handler({ page: 'missing', workingDirectory: linkedWorktree });

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -18,6 +18,7 @@ import {
   resolveWorkingDirectoryOrLinkedWorktree,
   validateWorkingDirectoryOrLinkedWorktree,
   ForeignWorkingDirectoryError,
+  getCanonicalWorkingDirectoryRoots,
 } from '../../lib/worktree-paths.js';
 import { wikiQueryTool, wikiReadTool } from '../../tools/wiki-tools.js';
 
@@ -43,28 +44,21 @@ function loggerLikeWrap(value: unknown): unknown {
 }
 
 function assertOpaqueCanonicalSerialization(
-  value: { providedRoot: string; trustedRoot: string; callerLabel: string },
+  value: { callerLabel: string },
   opts: { providedRoot: string; trustedRoot: string; callerLabel: string },
 ): void {
-  expect(value.providedRoot).toBe(opts.providedRoot);
-  expect(value.trustedRoot).toBe(opts.trustedRoot);
+  const roots = getCanonicalWorkingDirectoryRoots(value);
+  expect(roots.providedRoot).toBe(opts.providedRoot);
+  expect(roots.trustedRoot).toBe(opts.trustedRoot);
   expect(value.callerLabel).toBe(opts.callerLabel);
 
-  const provided = Object.getOwnPropertyDescriptor(value, 'providedRoot');
-  const trusted = Object.getOwnPropertyDescriptor(value, 'trustedRoot');
+  expect(Object.getOwnPropertyDescriptor(value, 'providedRoot')).toBeUndefined();
+  expect(Object.getOwnPropertyDescriptor(value, 'trustedRoot')).toBeUndefined();
+  expect(Object.getOwnPropertyNames(value)).not.toContain('providedRoot');
+  expect(Object.getOwnPropertyNames(value)).not.toContain('trustedRoot');
+  expect(Reflect.ownKeys(value)).not.toContain('providedRoot');
+  expect(Reflect.ownKeys(value)).not.toContain('trustedRoot');
   const caller = Object.getOwnPropertyDescriptor(value, 'callerLabel');
-  expect(provided).toMatchObject({
-    enumerable: false,
-    writable: false,
-    configurable: false,
-    value: opts.providedRoot,
-  });
-  expect(trusted).toMatchObject({
-    enumerable: false,
-    writable: false,
-    configurable: false,
-    value: opts.trustedRoot,
-  });
   expect(caller?.enumerable).toBe(true);
   expect(caller?.value).toBe(opts.callerLabel);
   expect(Object.keys(value)).not.toContain('providedRoot');
@@ -77,6 +71,7 @@ function assertOpaqueCanonicalSerialization(
   expect(spread.callerLabel).toBe(opts.callerLabel);
 
   const cloned = structuredClone(value);
+  expect(() => getCanonicalWorkingDirectoryRoots(cloned as object)).toThrow();
   const wrappedError = new Error('logger wrap', { cause: value as unknown as Error });
   const clonedWrapper = structuredClone(wrappedError);
   const payloads = [
@@ -88,6 +83,7 @@ function assertOpaqueCanonicalSerialization(
     JSON.stringify({ err: value, cause: value }),
     JSON.stringify({ ...clonedWrapper, cause: clonedWrapper.cause }),
     inspect(value, { depth: 8, getters: true, showHidden: false }),
+    inspect(value, { depth: 8, getters: true, showHidden: true, customInspect: false }),
   ];
 
   for (const path of [opts.providedRoot, opts.trustedRoot]) {
@@ -158,8 +154,9 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     const resolution = resolveWorkingDirectoryOrLinkedWorktree(foreignRepo);
     expect(resolution.status).toBe('foreign_repository');
     if (resolution.status !== 'foreign_repository') return;
-    expect(resolution.providedRoot).toBe(canonicalForeign);
-    expect(resolution.trustedRoot).toBe(canonicalSession);
+    const foreignRoots = getCanonicalWorkingDirectoryRoots(resolution);
+    expect(foreignRoots.providedRoot).toBe(canonicalForeign);
+    expect(foreignRoots.trustedRoot).toBe(canonicalSession);
     expect(resolution.callerLabel).toBe(foreignRepo);
     expect('root' in resolution).toBe(false);
     expect(resolution).toEqual({
@@ -176,8 +173,8 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     } catch (error) {
       expect(error).toBeInstanceOf(ForeignWorkingDirectoryError);
       const foreign = error as ForeignWorkingDirectoryError;
-      expect(foreign.providedRoot).toBe(canonicalForeign);
-      expect(foreign.trustedRoot).toBe(canonicalSession);
+      expect(getCanonicalWorkingDirectoryRoots(foreign).providedRoot).toBe(canonicalForeign);
+      expect(getCanonicalWorkingDirectoryRoots(foreign).trustedRoot).toBe(canonicalSession);
       expect(foreign.callerLabel).toBe(foreignRepo);
       expect(foreign.message).toContain('belongs to a different repository');
       expect(foreign.message).toContain('not used');
@@ -194,8 +191,8 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
       '../foreign-vault',
     );
     expect(error.callerLabel).toBe('../foreign-vault');
-    expect(error.providedRoot).toBe('/canonical/foreign-vault');
-    expect(error.trustedRoot).toBe('/canonical/session-project');
+    expect(getCanonicalWorkingDirectoryRoots(error).providedRoot).toBe('/canonical/foreign-vault');
+    expect(getCanonicalWorkingDirectoryRoots(error).trustedRoot).toBe('/canonical/session-project');
     expect(error.message).toContain('../foreign-vault');
     expect(error.message).toContain('session-project');
     expect(error.message).not.toContain('/canonical/foreign-vault');
@@ -305,8 +302,8 @@ process.stdout.write(JSON.stringify({
     expect(resolution.status).toBe('foreign_repository');
     if (resolution.status !== 'foreign_repository') return;
 
-    expect(resolution.providedRoot).toBe(canonicalForeign);
-    expect(resolution.trustedRoot).toBe(canonicalSession);
+    expect(getCanonicalWorkingDirectoryRoots(resolution).providedRoot).toBe(canonicalForeign);
+    expect(getCanonicalWorkingDirectoryRoots(resolution).trustedRoot).toBe(canonicalSession);
     expect(resolution.callerLabel).toBe(relativeAlias);
 
     try {
@@ -329,7 +326,7 @@ process.stdout.write(JSON.stringify({
     expect(resolution.status).toBe('foreign_repository');
     if (resolution.status !== 'foreign_repository') return;
 
-    expect(resolution.providedRoot).toBe(canonicalForeign);
+    expect(getCanonicalWorkingDirectoryRoots(resolution).providedRoot).toBe(canonicalForeign);
     expect(resolution.callerLabel).toBe(symlinkAlias);
 
     try {
@@ -401,7 +398,7 @@ process.stdout.write(JSON.stringify({
     expect(resolution.status).toBe('foreign_repository');
     if (resolution.status !== 'foreign_repository') return;
     expect(resolution.callerLabel).toBe(relativeParent);
-    expect(resolution.providedRoot).toBe(canonicalParent);
+    expect(getCanonicalWorkingDirectoryRoots(resolution).providedRoot).toBe(canonicalParent);
 
     try {
       validateWorkingDirectoryOrLinkedWorktree(relativeParent);
@@ -413,6 +410,23 @@ process.stdout.write(JSON.stringify({
       expect(foreign.message).not.toContain(canonicalSubmodule);
       expect(foreign.message).not.toContain(canonicalParent);
     }
+  });
+
+  it('nested git metadata with a failed probe rejects instead of falling back to the trusted root', () => {
+    const nested = join(sessionRepo, 'vendor', 'nested-foreign');
+    mkdirSync(nested, { recursive: true });
+    git(nested, 'init');
+    git(nested, 'config user.email "test@example.com"');
+    git(nested, 'config user.name "Test User"');
+    writeFileSync(join(nested, 'README.md'), 'nested\n');
+    git(nested, 'add README.md');
+    git(nested, 'commit -m nested');
+    rmSync(join(nested, '.git'), { recursive: true, force: true });
+    writeFileSync(join(nested, '.git'), 'gitdir: /nonexistent-omc-3858-gitdir\n');
+    clearWorktreeCache();
+
+    expect(() => validateWorkingDirectoryOrLinkedWorktree(nested)).toThrow(/git probe failed and was not used/);
+    expect(() => resolveWorkingDirectoryOrLinkedWorktree(nested)).toThrow(/git probe failed and was not used/);
   });
 
   it('linked-worktree wiki flows keep working end to end (no regression from #2880)', async () => {

--- a/src/lib/__tests__/worktree-paths-foreign-root.test.ts
+++ b/src/lib/__tests__/worktree-paths-foreign-root.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { inspect } from 'node:util';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { execSync } from 'node:child_process';
 import {
   mkdtempSync,
@@ -239,6 +239,36 @@ describe('shared resolver #3858: foreign repo, linked worktree, non-git, same-ro
     expect(absoluteFrames).not.toContain(sourceRoot);
     expect(absoluteFrames).not.toContain(sourceFile);
   });
+  it('redacts percent-encoded file-URL stack frames for roots with spaces', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'session project-'));
+    const probe = join(dir, 'probe.mjs');
+    const moduleHref = pathToFileURL(resolve(originalCwd, 'src/lib/worktree-paths.ts')).href;
+    const rootHref = pathToFileURL(dir).href;
+    writeFileSync(
+      probe,
+      `import { ForeignWorkingDirectoryError } from ${JSON.stringify(moduleHref)};
+import { inspect } from 'node:util';
+const root = ${JSON.stringify(dir)};
+const err = new ForeignWorkingDirectoryError(root, root, '../alias');
+const frames = (err.stack ?? '').split('\\n').slice(1).join('\\n');
+process.stdout.write(JSON.stringify({
+  frames,
+  inspect: inspect(err),
+  fileUrl: ${JSON.stringify(rootHref)},
+}));
+`,
+    );
+    const output = execSync(`npx tsx ${JSON.stringify(probe)}`, {
+      encoding: 'utf8',
+      cwd: originalCwd,
+    });
+    const parsed = JSON.parse(output) as { frames: string; inspect: string; fileUrl: string };
+    expect(parsed.frames).not.toContain(dir);
+    expect(parsed.frames).not.toContain(parsed.fileUrl);
+    expect(parsed.inspect).toContain('../alias');
+    expect(parsed.inspect).not.toContain(parsed.fileUrl);
+  });
+
 
   it('foreign_repository resolution and thrown error keep canonical roots opaque under serialization', () => {
     const relativeAlias = join('..', 'foreign-vault');

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -60,6 +60,7 @@ const worktreeCacheMap = new Map<string, string>();
 const toplevelCacheMap = new Map<string, string>();
 /** LRU cache for outermost superproject root lookups, including negative results. */
 const superprojectCacheMap = new Map<string, string | null>();
+const canonicalWorkingDirectoryRoots = new WeakMap<object, { providedRoot: string; trustedRoot: string }>();
 
 /**
  * LRU cache for workspace marker lookups.
@@ -237,20 +238,72 @@ function resolveStateAnchorRoot(worktreeRoot?: string): string {
  * anchoring and would widen the boundary across submodule borders; see #3349
  * and the Codex review on PR #3350).
  */
-export function getGitTopLevel(cwd?: string): string | null {
-  const effectiveCwd = cwd || process.cwd();
+type GitTopLevelProbe =
+  | { status: 'ok'; root: string }
+  | { status: 'not_a_repository' }
+  | { status: 'probe_failed'; detail: string };
 
-  // Return cached value if present (LRU: move to end on access)
-  if (toplevelCacheMap.has(effectiveCwd)) {
-    const root = toplevelCacheMap.get(effectiveCwd)!;
-    toplevelCacheMap.delete(effectiveCwd);
-    toplevelCacheMap.set(effectiveCwd, root);
-    return root || null;
+function gitErrorStderr(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+  const err = error as { stderr?: Buffer | string; message?: string };
+  if (Buffer.isBuffer(err.stderr)) {
+    return err.stderr.toString('utf8');
+  }
+  if (typeof err.stderr === 'string') {
+    return err.stderr;
+  }
+  return typeof err.message === 'string' ? err.message : '';
+}
+
+function isNotAGitRepositoryError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const err = error as { status?: number; code?: string };
+  if (err.code === 'ENOENT' || err.code === 'ETIMEDOUT' || err.code === 'EACCES') {
+    return false;
+  }
+  const stderr = gitErrorStderr(error);
+  return err.status === 128 && /not a git repository/i.test(stderr);
+}
+
+function formatGitProbeDetail(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return String(error);
+  }
+  const err = error as { code?: string; status?: number; message?: string };
+  if (err.code === 'ENOENT') {
+    return 'git executable not found';
+  }
+  if (err.code === 'ETIMEDOUT') {
+    return 'git probe timed out';
+  }
+  const stderr = gitErrorStderr(error).trim();
+  if (stderr.length > 0) {
+    return stderr.split('\n')[0] ?? stderr;
+  }
+  if (typeof err.message === 'string' && err.message.length > 0) {
+    return err.message;
+  }
+  if (typeof err.status === 'number') {
+    return `git exited ${err.status}`;
+  }
+  return 'unknown git probe failure';
+}
+
+function probeGitTopLevel(cwd: string): GitTopLevelProbe {
+  if (toplevelCacheMap.has(cwd)) {
+    const root = toplevelCacheMap.get(cwd)!;
+    toplevelCacheMap.delete(cwd);
+    toplevelCacheMap.set(cwd, root);
+    return { status: 'ok', root };
   }
 
   try {
     const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
-      cwd: effectiveCwd,
+      cwd,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
@@ -261,12 +314,40 @@ export function getGitTopLevel(cwd?: string): string | null {
       const oldest = toplevelCacheMap.keys().next().value;
       if (oldest !== undefined) toplevelCacheMap.delete(oldest);
     }
-    toplevelCacheMap.set(effectiveCwd, root);
-    return root;
-  } catch {
-    // Not in a git repository - do NOT cache so a later git init re-detects.
-    return null;
+    toplevelCacheMap.set(cwd, root);
+    return { status: 'ok', root };
+  } catch (error) {
+    if (isNotAGitRepositoryError(error)) {
+      return { status: 'not_a_repository' };
+    }
+    return { status: 'probe_failed', detail: formatGitProbeDetail(error) };
   }
+}
+
+export function getGitTopLevel(cwd?: string): string | null {
+  const probe = probeGitTopLevel(cwd || process.cwd());
+  return probe.status === 'ok' ? probe.root : null;
+}
+
+function findGitMetadataDir(start: string): string | null {
+  let current = start;
+  for (;;) {
+    if (existsSync(join(current, '.git'))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function formatGitProbeFailedMessage(workingDirectory: string): string {
+  return (
+    `workingDirectory '${workingDirectory}' git probe failed and was not used. ` +
+    `Cross-repository access is not permitted; pass a path inside the current repository or start the session there.`
+  );
 }
 
 /**
@@ -1206,21 +1287,24 @@ function formatOutsideTrustedRootMessage(workingDirectory: string, trustedRoot: 
     `is outside the trusted worktree root '${callerVisibleTrustedRootLabel(trustedRoot)}'.`
   );
 }
-function defineOpaqueCanonicalRoots(
+function attachCanonicalWorkingDirectoryRoots(
   target: object,
   providedRoot: string,
   trustedRoot: string,
 ): void {
-  const descriptor = {
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  } as const;
-  Object.defineProperties(target, {
-    providedRoot: { ...descriptor, value: providedRoot },
-    trustedRoot: { ...descriptor, value: trustedRoot },
-  });
+  canonicalWorkingDirectoryRoots.set(target, { providedRoot, trustedRoot });
 }
+
+export function getCanonicalWorkingDirectoryRoots(
+  target: object,
+): { providedRoot: string; trustedRoot: string } {
+  const roots = canonicalWorkingDirectoryRoots.get(target);
+  if (!roots) {
+    throw new Error('canonical working directory roots are not attached');
+  }
+  return roots;
+}
+
 function canonicalRootAliases(root: string): string[] {
   if (root.length === 0) {
     return [];
@@ -1272,11 +1356,9 @@ function foreignRepositoryResolution(
 ): Extract<WorkingDirectoryResolution, { status: 'foreign_repository' }> {
   const resolution = {
     status: 'foreign_repository' as const,
-    providedRoot,
-    trustedRoot,
     callerLabel,
   };
-  defineOpaqueCanonicalRoots(resolution, providedRoot, trustedRoot);
+  attachCanonicalWorkingDirectoryRoots(resolution, providedRoot, trustedRoot);
   Object.defineProperty(resolution, 'toJSON', {
     enumerable: false,
     writable: false,
@@ -1389,21 +1471,17 @@ function getGitCommonDir(cwd: string): string | null {
  *   Callers MUST NOT use it and MUST NOT silently fall back to the trusted
  *   root; they are expected to surface the rejection to their caller.
  *
- * Canonical `providedRoot` / `trustedRoot` remain readable for internal
- * resolver consumers but are attached as non-enumerable, non-writable data
- * properties so JSON.stringify, object spread, structuredClone, and
- * logger-like wrapping cannot serialize host paths the caller did not
- * supply. Caller-visible text must use `callerLabel` (the original
- * workingDirectory string) and a basename-only trusted-root label — never
- * `providedRoot` / `trustedRoot` verbatim.
- * `callerLabel` stays enumerable so the caller-supplied label is explicit.
+ * Canonical roots are stored in a WeakMap keyed by the resolution or error
+ * object. They are not own properties and cannot be recovered by
+ * JSON.stringify, object spread, structuredClone, showHidden inspection,
+ * or getOwnPropertyNames. Internal consumers use
+ * `getCanonicalWorkingDirectoryRoots()`. Caller-visible text must use
+ * `callerLabel` and a basename-only trusted-root label.
  */
 export type WorkingDirectoryResolution =
   | { status: 'ok'; root: string }
   | {
       status: 'foreign_repository';
-      providedRoot: string;
-      trustedRoot: string;
       callerLabel: string;
     };
 
@@ -1413,15 +1491,10 @@ export type WorkingDirectoryResolution =
  * tool caller; it is never silently substituted (#3858).
  *
  * `.message` is the caller-visible contract: the original workingDirectory
- * label plus a basename-only trusted-root identity. Canonical `providedRoot`
- * and `trustedRoot` stay on the instance for internal validation as
- * non-enumerable opaque fields so serialization and object spread cannot
- * disclose them. `callerLabel` is required and enumerable so a two-argument
- * construction cannot echo canonical `providedRoot` into the message.
+ * label plus a basename-only trusted-root identity. Canonical roots are
+ * WeakMap-only internal diagnostics. `callerLabel` is required and enumerable.
  */
 export class ForeignWorkingDirectoryError extends Error {
-  declare readonly providedRoot: string;
-  declare readonly trustedRoot: string;
   readonly callerLabel: string;
 
   constructor(providedRoot: string, trustedRoot: string, callerLabel: string) {
@@ -1431,7 +1504,7 @@ export class ForeignWorkingDirectoryError extends Error {
     );
     this.name = 'ForeignWorkingDirectoryError';
     this.callerLabel = callerLabel;
-    defineOpaqueCanonicalRoots(this, providedRoot, trustedRoot);
+    attachCanonicalWorkingDirectoryRoots(this, providedRoot, trustedRoot);
     Object.defineProperty(this, 'stack', {
       value: redactErrorStack(this.stack ?? `${this.name}: ${this.message}`, providedRoot, trustedRoot),
       enumerable: false,
@@ -1479,9 +1552,13 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
     trustedRootReal = trustedRoot;
   }
 
-  const providedRoot = getGitTopLevel(resolved);
+  const providedProbe = probeGitTopLevel(resolved);
+  if (providedProbe.status === 'probe_failed') {
+    throw new Error(formatGitProbeFailedMessage(workingDirectory));
+  }
 
-  if (providedRoot) {
+  if (providedProbe.status === 'ok') {
+    const providedRoot = providedProbe.root;
     let providedRootReal: string;
     try {
       providedRootReal = realpathSync(providedRoot);
@@ -1511,6 +1588,19 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
     throw new Error(`workingDirectory '${workingDirectory}' does not exist or is not accessible.`);
   }
 
+  const gitMetadataDir = findGitMetadataDir(resolvedReal);
+  if (gitMetadataDir) {
+    let gitMetadataReal = gitMetadataDir;
+    try {
+      gitMetadataReal = realpathSync(gitMetadataDir);
+    } catch {
+      gitMetadataReal = gitMetadataDir;
+    }
+    if (gitMetadataReal !== trustedRootReal) {
+      throw new Error(formatGitProbeFailedMessage(workingDirectory));
+    }
+  }
+
   const rel = relative(trustedRootReal, resolvedReal);
   if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error(formatOutsideTrustedRootMessage(workingDirectory, trustedRoot));
@@ -1534,9 +1624,10 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
 export function validateWorkingDirectoryOrLinkedWorktree(workingDirectory?: string): string {
   const resolution = resolveWorkingDirectoryOrLinkedWorktree(workingDirectory);
   if (resolution.status === 'foreign_repository') {
+    const roots = getCanonicalWorkingDirectoryRoots(resolution);
     throw new ForeignWorkingDirectoryError(
-      resolution.providedRoot,
-      resolution.trustedRoot,
+      roots.providedRoot,
+      roots.trustedRoot,
       resolution.callerLabel,
     );
   }

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1553,9 +1553,6 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
   }
 
   const providedProbe = probeGitTopLevel(resolved);
-  if (providedProbe.status === 'probe_failed') {
-    throw new Error(formatGitProbeFailedMessage(workingDirectory));
-  }
 
   if (providedProbe.status === 'ok') {
     const providedRoot = providedProbe.root;

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -14,6 +14,7 @@ import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFileSync, unlinkSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
+import { pathToFileURL } from 'url';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { encodeProjectPath } from '../utils/encode-project-path.js';
 
@@ -1220,10 +1221,32 @@ function defineOpaqueCanonicalRoots(
     trustedRoot: { ...descriptor, value: trustedRoot },
   });
 }
+function canonicalRootAliases(root: string): string[] {
+  if (root.length === 0) {
+    return [];
+  }
+  const aliases = new Set<string>([root]);
+  try {
+    aliases.add(pathToFileURL(root).href);
+  } catch {
+    // Ignore roots that cannot be represented as file URLs.
+  }
+  try {
+    const real = realpathSync(root);
+    aliases.add(real);
+    aliases.add(pathToFileURL(real).href);
+  } catch {
+    // Root may not exist on disk (synthetic test paths).
+  }
+  if (sep === '\\') {
+    aliases.add(root.replaceAll('\\', '/'));
+  }
+  return [...aliases].sort((a, b) => b.length - a.length);
+}
+
 function redactCanonicalRoots(text: string, providedRoot: string, trustedRoot: string): string {
   let redacted = text;
-  const roots = [providedRoot, trustedRoot]
-    .filter((root) => root.length > 0)
+  const roots = [...canonicalRootAliases(providedRoot), ...canonicalRootAliases(trustedRoot)]
     .sort((a, b) => b.length - a.length);
   for (const root of roots) {
     redacted = redacted.split(root).join('<redacted>');

--- a/src/tools/__tests__/wiki-tools-foreign-root.test.ts
+++ b/src/tools/__tests__/wiki-tools-foreign-root.test.ts
@@ -279,6 +279,30 @@ describe('wiki tools foreign-repository workingDirectory (#3858)', () => {
     expect(existsSync(join(parentDir, '.omc', 'wiki'))).toBe(false);
   });
 
+  it('all seven wiki tools reject a nested git probe failure before IO', async () => {
+    const nested = join(sessionRepo, 'vendor', 'nested-foreign');
+    mkdirSync(nested, { recursive: true });
+    git(nested, 'init');
+    git(nested, 'config user.email "test@example.com"');
+    git(nested, 'config user.name "Test User"');
+    writeFileSync(join(nested, 'README.md'), 'nested\n');
+    git(nested, 'add README.md');
+    git(nested, 'commit -m nested');
+    rmSync(join(nested, '.git'), { recursive: true, force: true });
+    writeFileSync(join(nested, '.git'), 'gitdir: /nonexistent-omc-3858-gitdir\n');
+    clearWorktreeCache();
+
+    const results = await invokeAllWikiTools(nested);
+    for (const { result } of results) {
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('git probe failed and was not used');
+      expect(result.content[0].text).not.toContain('No wiki pages match');
+      expect(result.content[0].text).not.toContain('Wiki page not found');
+    }
+    assertNoFallbackWrites(sessionRepo, foreignRepo);
+    expect(existsSync(join(nested, '.omc', 'wiki'))).toBe(false);
+  });
+
   it('same-root subdirectory is accepted without fallback writes to a foreign repo', async () => {
     const sub = join(sessionRepo, 'docs');
     mkdirSync(sub, { recursive: true });

--- a/src/tools/wiki-tools.ts
+++ b/src/tools/wiki-tools.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import {
   resolveWorkingDirectoryOrLinkedWorktree,
   ForeignWorkingDirectoryError,
+  getCanonicalWorkingDirectoryRoots,
   type WorkingDirectoryResolution,
 } from '../lib/worktree-paths.js';
 import {
@@ -43,11 +44,12 @@ function resolveWikiRoot(
 ): { ok: true; root: string } | { ok: false; error: ForeignWorkingDirectoryError } {
   const resolution: WorkingDirectoryResolution = resolveWorkingDirectoryOrLinkedWorktree(workingDirectory);
   if (resolution.status === 'foreign_repository') {
+    const roots = getCanonicalWorkingDirectoryRoots(resolution);
     return {
       ok: false,
       error: new ForeignWorkingDirectoryError(
-        resolution.providedRoot,
-        resolution.trustedRoot,
+        roots.providedRoot,
+        roots.trustedRoot,
         resolution.callerLabel,
       ),
     };


### PR DESCRIPTION
## Summary

Fix-forward for the GitHub Codex P1 posted on merged PR #3862 exact head `9a1e51cc` after MERGE_READY.

Node ESM stack frames use `file:` URLs. A trusted root like `/tmp/session project` appears as `file:///tmp/session%20project/...`. Literal filesystem `split(root)` left those frames intact.

This expands canonical-root aliases with `pathToFileURL` / `realpathSync` forms (and Windows slash aliases) and redacts them in stack frames only. Header/`callerLabel` is unchanged.

Refs #3858

## Verification

- `npx vitest run src/lib/__tests__/worktree-paths-foreign-root.test.ts src/tools/__tests__/wiki-tools-foreign-root.test.ts` — 26 pass
- includes spaced-directory ESM probe for percent-encoded `file:` frames
- `npx tsc --noEmit` clean
- inventory baseline refreshed