### PR TITLE
fix(inventory): regenerate graph after #3858 receipt

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "3043e8ae8e190ee4766de445c2e0211403a69701",
-    "sourceSha256": "8bdfb61a5e05bf5dad946c59888dd8848dcf290b9a8c4ac0c6952da318f6ba74",
+    "head": "8324d5e62463b7721031d4056e488fc5649513ee",
+    "sourceSha256": "55537698e28449dc22f28cec792cad67d65f73955644f85e921c8c0710183505",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "3043e8ae8e190ee4766de445c2e0211403a69701",
-  "sourceSha256": "8bdfb61a5e05bf5dad946c59888dd8848dcf290b9a8c4ac0c6952da318f6ba74",
+  "head": "8324d5e62463b7721031d4056e488fc5649513ee",
+  "sourceSha256": "55537698e28449dc22f28cec792cad67d65f73955644f85e921c8c0710183505",
   "counts": {
     "public": {
       "skills": 31,
@@ -32623,6 +32623,11 @@
         "id": "receipts/epic-3698/remaining-risk.json",
         "kind": "other",
         "path": "receipts/epic-3698/remaining-risk.json"
+      },
+      {
+        "id": "receipts/issue-3858/merged.receipt.json",
+        "kind": "other",
+        "path": "receipts/issue-3858/merged.receipt.json"
       },
       {
         "id": "research/hephaestus-vs-deep-executor-comparison.md",
@@ -74843,12 +74848,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6793,
+      "nodeCount": 6794,
       "edgeCount": 6921,
       "importEdgeCount": 5685,
       "registerEdgeCount": 52
     }
   },
-  "inventorySha256": "b11f24e66cc72a4cd4458d678680de6c493d9ff09c741eb51bdce4f257f357e2",
-  "manifestSha256": "b52131801d076663b162fab67cc3d441bb791d6ec1198065fc004019f1f88b31"
+  "inventorySha256": "0d46a0037a3546f5d443daa840253235b6826e95064d84f56a0383e06050a6bf",
+  "manifestSha256": "0ddbfd8135e55484d1ed485e6db446df4558cccf8ab76bf8dbe757aba9202d6a"
 }


### PR DESCRIPTION
## Summary

Fixes inventory-graph drift on exact `origin/dev@8324d5e62463b7721031d4056e488fc5649513ee` after the post-merge #3858 receipt commit added `receipts/issue-3858/merged.receipt.json` without regenerating `inventory/inventory-graph.json`.

Push CI that went red: run `32766717309`, Test job `97557933631`.

## Reproduced

On that SHA:

- `node scripts/generate-inventory-graph.mjs --verify` → exit 2: `provenance.sourceSha256 must match the current inventoried source content`
- `tests/lint/inventory-graph-drift.test.ts` → `inventorySha256` expected `0d46a0037a3546f5d443daa840253235b6826e95064d84f56a0383e06050a6bf` received `b11f24e66cc72a4cd4458d678680de6c493d9ff09c741eb51bdce4f257f357e2`

## Repair

Ran canonical `node scripts/generate-inventory-graph.mjs --write` after the receipt was present.

Delta is **only** `inventory/inventory-graph.json`:

- `head` `3043e8ae…` → `8324d5e62463b7721031d4056e488fc5649513ee`
- `sourceSha256` → `55537698e28449dc22f28cec792cad67d65f73955644f85e921c8c0710183505`
- `inventorySha256` → `0d46a0037a3546f5d443daa840253235b6826e95064d84f56a0383e06050a6bf`
- graph nodeCount `6793` → `6794` including `receipts/issue-3858/merged.receipt.json`

Receipt file preserved. No product behavior change. No `dist/` or `bridge/` changes. No #3698 work.

## Verification

- `node scripts/generate-inventory-graph.mjs --verify` ok after write and after commit
- `npx vitest run tests/lint/inventory-graph-drift.test.ts` 11/11
- `npx tsc --noEmit` exit 0
- `npm run lint` 0 errors
- `npm test -- --run` inventory suite green; two local env failures isolated (python sandbox timeout flake; post-tool-verifier session-stats pollution, 118/118 with clean `HOME`) and not present in the original CI Test job

## Exact refs

- Base: `dev` @ `8324d5e62463b7721031d4056e488fc5649513ee`
- Head: `fix/issue-3865-inventory-drift` @ `f83a3d719be83da9da9589df2d0670ab1516cd57`

Fixes #3865