### PR TITLE
test(update): lock 4.15.7L HUD suffix vs 5.0.0 channel (#3867)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "c31cd103c27f2cdc314f39bc274a2418fb9f1b1b",
-    "sourceSha256": "9e1f9a5f7ea9923a12e5a7e17091112a726c03c72f9e77ee46db5d22861e7e10",
+    "head": "ec434d8ce8292dde9fc6bd4b50532f239f6db79c",
+    "sourceSha256": "8397954ea620996c9d2d1398ed8ddeb02c40e1cc4f40212cfb5e2184b5bfbe63",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "c31cd103c27f2cdc314f39bc274a2418fb9f1b1b",
-  "sourceSha256": "9e1f9a5f7ea9923a12e5a7e17091112a726c03c72f9e77ee46db5d22861e7e10",
+  "head": "ec434d8ce8292dde9fc6bd4b50532f239f6db79c",
+  "sourceSha256": "8397954ea620996c9d2d1398ed8ddeb02c40e1cc4f40212cfb5e2184b5bfbe63",
   "counts": {
     "public": {
       "skills": 31,
@@ -28,8 +28,8 @@
       "toolFiles": 59,
       "libFiles": 36,
       "templateHooks": 21,
-      "srcFiles": 1274,
-      "total": 1295
+      "srcFiles": 1275,
+      "total": 1296
     },
     "generated": {
       "distFiles": 4955,
@@ -34155,6 +34155,11 @@
         "path": "src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts"
       },
       {
+        "id": "src/__tests__/issue-3867-legacy-l-update.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/issue-3867-legacy-l-update.test.ts"
+      },
+      {
         "id": "src/__tests__/job-management-sqlite.test.ts",
         "kind": "src",
         "path": "src/__tests__/job-management-sqlite.test.ts"
@@ -45150,6 +45155,31 @@
         "from": "src/__tests__/issue-2652-runtime-wiring-and-output-contract.test.ts",
         "to": "external:vitest",
         "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/issue-3867-legacy-l-update.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/issue-3867-legacy-l-update.test.ts",
+        "to": "src/features/auto-update.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/issue-3867-legacy-l-update.test.ts",
+        "to": "src/hud/render.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/issue-3867-legacy-l-update.test.ts",
+        "to": "src/hud/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/issue-3867-legacy-l-update.test.ts",
+        "to": "src/hud/types.ts",
+        "kind": "type-imports"
       },
       {
         "from": "src/__tests__/job-management-sqlite.test.ts",
@@ -74848,12 +74878,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6794,
-      "edgeCount": 6921,
-      "importEdgeCount": 5685,
+      "nodeCount": 6795,
+      "edgeCount": 6926,
+      "importEdgeCount": 5689,
       "registerEdgeCount": 52
     }
   },
-  "inventorySha256": "0d46a0037a3546f5d443daa840253235b6826e95064d84f56a0383e06050a6bf",
-  "manifestSha256": "bcc26e330657332dddf04c42bff3923c2d55a964380f0ffeb3384ba83e4ba60e"
+  "inventorySha256": "711ee021e41dc6d2e423bcc936e42694dff27bf8cfc06638ceef2d7d44e83b73",
+  "manifestSha256": "7ac1ca26e03c555122956c7c5a09ec5812b7e71c64315a0663a5b125daec6d31"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "8324d5e62463b7721031d4056e488fc5649513ee",
-    "sourceSha256": "55537698e28449dc22f28cec792cad67d65f73955644f85e921c8c0710183505",
+    "head": "c31cd103c27f2cdc314f39bc274a2418fb9f1b1b",
+    "sourceSha256": "9e1f9a5f7ea9923a12e5a7e17091112a726c03c72f9e77ee46db5d22861e7e10",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "8324d5e62463b7721031d4056e488fc5649513ee",
-  "sourceSha256": "55537698e28449dc22f28cec792cad67d65f73955644f85e921c8c0710183505",
+  "head": "c31cd103c27f2cdc314f39bc274a2418fb9f1b1b",
+  "sourceSha256": "9e1f9a5f7ea9923a12e5a7e17091112a726c03c72f9e77ee46db5d22861e7e10",
   "counts": {
     "public": {
       "skills": 31,
@@ -74855,5 +74855,5 @@
     }
   },
   "inventorySha256": "0d46a0037a3546f5d443daa840253235b6826e95064d84f56a0383e06050a6bf",
-  "manifestSha256": "0ddbfd8135e55484d1ed485e6db446df4558cccf8ab76bf8dbe757aba9202d6a"
+  "manifestSha256": "bcc26e330657332dddf04c42bff3923c2d55a964380f0ffeb3384ba83e4ba60e"
 }

--- a/src/__tests__/issue-3867-legacy-l-update.test.ts
+++ b/src/__tests__/issue-3867-legacy-l-update.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { compareVersions } from '../features/auto-update.js';
+import { render } from '../hud/render.js';
+import { DEFAULT_HUD_CONFIG } from '../hud/types.js';
+import type { HudRenderContext, HudConfig } from '../hud/types.js';
+
+vi.mock('../lib/version.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/version.js')>()),
+  isRuntimePackageLocal: () => true,
+}));
+
+function createMinimalContext(overrides: Partial<HudRenderContext> = {}): HudRenderContext {
+  return {
+    contextPercent: 30,
+    modelName: 'claude-sonnet-4.6',
+    ralph: null,
+    ultrawork: null,
+    prd: null,
+    autopilot: null,
+    activeAgents: [],
+    todos: [],
+    backgroundTasks: [],
+    cwd: '/tmp/test',
+    lastSkill: null,
+    rateLimitsResult: null,
+    customBuckets: null,
+    pendingPermission: null,
+    thinkingState: null,
+    sessionHealth: null,
+    omcVersion: null,
+    updateAvailable: null,
+    toolCallCount: 0,
+    agentCallCount: 0,
+    skillCallCount: 0,
+    promptTime: null,
+    apiKeySource: null,
+    profileName: null,
+    sessionSummary: null,
+    ...overrides,
+  };
+}
+
+function createMinimalConfig(overrides: Partial<HudConfig['elements']> = {}): HudConfig {
+  return {
+    ...DEFAULT_HUD_CONFIG,
+    elements: {
+      ...DEFAULT_HUD_CONFIG.elements,
+      omcLabel: true,
+      rateLimits: false,
+      ralph: false,
+      autopilot: false,
+      prdStory: false,
+      activeSkills: false,
+      lastSkill: false,
+      contextBar: false,
+      agents: false,
+      backgroundTasks: false,
+      todos: false,
+      permissionStatus: false,
+      thinking: false,
+      sessionHealth: false,
+      ...overrides,
+    },
+  };
+}
+
+describe('issue #3867 4.15.7L update display', () => {
+  it('treats 4.15.7 as older than the supported 5.0.0 channel', () => {
+    expect(compareVersions('4.15.7', '5.0.0')).toBeLessThan(0);
+    expect(compareVersions('5.0.0', '4.15.7')).toBeGreaterThan(0);
+  });
+
+  it('still ranks a leaked HUD L suffix below 5.0.0', () => {
+    expect(compareVersions('4.15.7L', '5.0.0')).toBeLessThan(0);
+    expect(compareVersions('4.15.7L', '4.15.7')).toBe(0);
+  });
+
+  it('renders HUD L as display-only while still showing a 5.0.0 update arrow', async () => {
+    const ctx = createMinimalContext({
+      omcVersion: '4.15.7',
+      updateAvailable: '5.0.0',
+    });
+    const output = await render(ctx, createMinimalConfig());
+    expect(output).toContain('[OMC#4.15.7L]');
+    expect(output).toContain('-> 5.0.0');
+    expect(output).toContain('omc update');
+  });
+
+  it('does not invent an L-suffixed package version in the update arrow', async () => {
+    const ctx = createMinimalContext({
+      omcVersion: '4.15.7',
+      updateAvailable: '5.0.0',
+    });
+    const output = await render(ctx, createMinimalConfig());
+    expect(output).not.toContain('-> 5.0.0L');
+    expect(output).not.toContain('#4.15.7L ->');
+  });
+});

--- a/src/__tests__/session-start-script-context.test.ts
+++ b/src/__tests__/session-start-script-context.test.ts
@@ -559,4 +559,105 @@ ${'- oversized startup guidance\n'.repeat(700)}
     expect(combined).not.toContain('4.15.5');
   });
 
+  it('shows an npm update from unmanaged 4.15.7 local plugin roots (#3867)', () => {
+    const claudeDir = join(fakeHome, '.claude');
+    const pluginRoot = join(tempDir, 'local-plugin-4.15.7');
+    mkdirSync(join(claudeDir, '.omc'), { recursive: true });
+    mkdirSync(join(claudeDir, 'hud'), { recursive: true });
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '4.15.7', type: 'module' }));
+    writeFileSync(join(claudeDir, 'hud', 'omc-hud.mjs'), '');
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({ statusLine: 'node ~/.claude/hud/omc-hud.mjs' }));
+    writeFileSync(
+      join(claudeDir, '.omc', 'update-check.json'),
+      JSON.stringify({
+        timestamp: Date.now(),
+        latestVersion: '5.0.0',
+        currentVersion: '4.15.7',
+        updateAvailable: true,
+        source: 'npm',
+      }),
+    );
+
+    const result = spawnSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'session-3867-unmanaged-4157',
+        cwd: fakeProject,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        OMC_NOTIFY: '0',
+      },
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const output = JSON.parse(result.stdout) as { systemMessage?: string };
+    expect(output.systemMessage).toContain('[OMC UPDATE AVAILABLE]');
+    expect(output.systemMessage).toContain('v5.0.0');
+    expect(output.systemMessage).toContain('current: v4.15.7');
+    expect(output.systemMessage).not.toContain('4.15.7L');
+  });
+
+  it('does not advertise npm 5.0.0 when managed marketplace channel is still 4.15.7 (#3867)', () => {
+    const claudeDir = join(fakeHome, '.claude');
+    const pluginRoot = join(claudeDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode', '4.15.7');
+    const marketplaceRoot = join(claudeDir, 'plugins', 'marketplaces', 'omc');
+    mkdirSync(join(claudeDir, '.omc'), { recursive: true });
+    mkdirSync(join(claudeDir, 'hud'), { recursive: true });
+    mkdirSync(pluginRoot, { recursive: true });
+    mkdirSync(join(marketplaceRoot, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '4.15.7', type: 'module' }));
+    writeFileSync(join(marketplaceRoot, '.claude-plugin', 'marketplace.json'), JSON.stringify({
+      plugins: [{ name: 'oh-my-claudecode', version: '4.15.7' }],
+      version: '4.15.7',
+    }));
+    writeFileSync(join(claudeDir, 'hud', 'omc-hud.mjs'), '');
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify({ statusLine: 'node ~/.claude/hud/omc-hud.mjs' }));
+    writeFileSync(
+      join(claudeDir, '.omc', 'update-check.json'),
+      JSON.stringify({
+        timestamp: Date.now(),
+        latestVersion: '5.0.0',
+        currentVersion: '4.15.7',
+        updateAvailable: true,
+        source: 'npm',
+      }),
+    );
+
+    const result = spawnSync(NODE, [SCRIPT_PATH], {
+      input: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'session-3867-managed-4157',
+        cwd: fakeProject,
+      }),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        USERPROFILE: fakeHome,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        OMC_NOTIFY: '0',
+      },
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    const output = JSON.parse(result.stdout) as { systemMessage?: string };
+    expect(output.systemMessage ?? '').not.toContain('[OMC UPDATE AVAILABLE]');
+    expect(output.systemMessage ?? '').not.toContain('5.0.0');
+    expect(JSON.parse(readFileSync(join(claudeDir, '.omc', 'update-check.json'), 'utf-8'))).toMatchObject({
+      latestVersion: '4.15.7',
+      currentVersion: '4.15.7',
+      updateAvailable: false,
+      source: 'marketplace',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Issue #3867 reports autoupdate stuck at `OMC#4.15.7L` with no newer-version suggestion.

Diagnosis on `origin/dev` @ `c31cd103`: this is **user install-state**, not a product parser regression.

- HUD `L` is a local/src/symlink payload marker from `isRuntimePackageLocal()`, not a published version. Runtime version is `4.15.7`.
- npm latest / `origin/main` / `origin/dev` advertise `5.0.0`.
- Managed plugin installs compare against the **local marketplace clone**, not npm. A stale clone at 4.15.7 yields no suggestion even when npm is 5.0.0.
- Silent auto-update is opt-in and has no effect in plugin mode.

This PR adds a deterministic fixture for that split: unmanaged `4.15.7` still surfaces npm `5.0.0`; managed marketplace `4.15.7` does not; HUD renders `4.15.7L` as display-only while still showing a `5.0.0` arrow when an update is actually available.

No production behavior change. No release/tag/publish.

## Test plan

- [x] `npx vitest run src/__tests__/issue-3867-legacy-l-update.test.ts src/__tests__/session-start-script-context.test.ts src/__tests__/hud/version-display.test.ts`
- [x] `npx vitest run tests/lint/inventory-graph-drift.test.ts`
- [x] `npx eslint src/__tests__/issue-3867-legacy-l-update.test.ts src/__tests__/session-start-script-context.test.ts`