### PR TITLE
test(session-start): pin CLAUDE_CONFIG_DIR in #3867 fixtures

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "ec434d8ce8292dde9fc6bd4b50532f239f6db79c",
-    "sourceSha256": "8397954ea620996c9d2d1398ed8ddeb02c40e1cc4f40212cfb5e2184b5bfbe63",
+    "head": "263e1ea5cf52f44a22c5ef87f3ea13a26b3d8ac7",
+    "sourceSha256": "83d456b4ebf8c18ba69ee09fb1d1a5056c0f0f3c698e67e568c1b236912cb76c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "ec434d8ce8292dde9fc6bd4b50532f239f6db79c",
-  "sourceSha256": "8397954ea620996c9d2d1398ed8ddeb02c40e1cc4f40212cfb5e2184b5bfbe63",
+  "head": "263e1ea5cf52f44a22c5ef87f3ea13a26b3d8ac7",
+  "sourceSha256": "83d456b4ebf8c18ba69ee09fb1d1a5056c0f0f3c698e67e568c1b236912cb76c",
   "counts": {
     "public": {
       "skills": 31,
@@ -74885,5 +74885,5 @@
     }
   },
   "inventorySha256": "711ee021e41dc6d2e423bcc936e42694dff27bf8cfc06638ceef2d7d44e83b73",
-  "manifestSha256": "7ac1ca26e03c555122956c7c5a09ec5812b7e71c64315a0663a5b125daec6d31"
+  "manifestSha256": "98936521f8f988565bfe2ee2cd8f0c82efe5b7cb03d836e39175dcc8f3b5a820"
 }

--- a/src/__tests__/session-start-script-context.test.ts
+++ b/src/__tests__/session-start-script-context.test.ts
@@ -591,6 +591,7 @@ ${'- oversized startup guidance\n'.repeat(700)}
         HOME: fakeHome,
         USERPROFILE: fakeHome,
         CLAUDE_PLUGIN_ROOT: pluginRoot,
+        CLAUDE_CONFIG_DIR: join(fakeHome, '.claude'),
         OMC_NOTIFY: '0',
       },
       timeout: 15000,
@@ -630,6 +631,14 @@ ${'- oversized startup guidance\n'.repeat(700)}
         source: 'npm',
       }),
     );
+    // CLAUDE_CONFIG_DIR beats HOME. A leaked host/empty config dir would hide
+    // the fixture marketplace clone and leave the npm 5.0.0 cache in place.
+    const leakedHostConfigDir = join(tempDir, 'host-empty-claude-config');
+    mkdirSync(leakedHostConfigDir, { recursive: true });
+    const leakedHostEnv = {
+      ...process.env,
+      CLAUDE_CONFIG_DIR: leakedHostConfigDir,
+    };
 
     const result = spawnSync(NODE, [SCRIPT_PATH], {
       input: JSON.stringify({
@@ -639,10 +648,11 @@ ${'- oversized startup guidance\n'.repeat(700)}
       }),
       encoding: 'utf-8',
       env: {
-        ...process.env,
+        ...leakedHostEnv,
         HOME: fakeHome,
         USERPROFILE: fakeHome,
         CLAUDE_PLUGIN_ROOT: pluginRoot,
+        CLAUDE_CONFIG_DIR: join(fakeHome, '.claude'),
         OMC_NOTIFY: '0',
       },
       timeout: 15000,


### PR DESCRIPTION
## Summary

Follow-up to merged #3868 (`263e1ea5`) for reopened #3867.

Exact-head review of #3868 requested changes: the two added session-start child-process fixtures inherit host `CLAUDE_CONFIG_DIR` via `...process.env` while overriding `HOME` / `USERPROFILE` / `CLAUDE_PLUGIN_ROOT`. `CLAUDE_CONFIG_DIR` takes precedence over `HOME`, so an external empty config dir hides the fixture marketplace clone and leaves the npm `5.0.0` cache in place.

## Change

- Pin `CLAUDE_CONFIG_DIR` to `join(fakeHome, '.claude')` in both added env objects.
- In the managed `4.15.7` case, leak an empty host `CLAUDE_CONFIG_DIR` first so the pin is the explicit regression.
- Refresh `inventory/inventory-graph.json` `sourceSha256` for that fixture edit.

Production diagnosis/recovery is unchanged. No release/tag/publish.

## Test plan

- [x] `npx vitest run src/__tests__/session-start-script-context.test.ts -t "3867"`
- [x] Related session-start / HUD #3867 fixtures
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors)
- [x] `npm test -- --run` (fixture file 12/12; 3 unrelated pre-existing flakes: python-sandbox timeout, post-tool-verifier HUD leak, inventory until refresh)
- [x] `npm run generate:inventory:verify`
- [x] `npm run build`
- [x] `npm pack --dry-run`

Fixes #3867