### PR TITLE
feat(graph): orchestration graph runtime with crash-recovery replay + graph skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,6 +27,7 @@
     "./skills/deepinit/",
     "./skills/execute/",
     "./skills/external-context/",
+    "./skills/graph/",
     "./skills/hud/",
     "./skills/omc-doctor/",
     "./skills/omc-setup/",

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,22 +5,22 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "992c4353cce084ec0b9e0d8610e813b3b204c3a5",
-    "sourceSha256": "0793c930d66d7cee472c4cb84492464a97bce48d60ddfa1279eca693cf1dc861",
+    "head": "711d36e3b9fe47f043c0797eba46599cc1b23b8a",
+    "sourceSha256": "f22426ba0528c461a9d90011a11560dbee936c4d2de73688853245e46f7a45c7",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "992c4353cce084ec0b9e0d8610e813b3b204c3a5",
-  "sourceSha256": "0793c930d66d7cee472c4cb84492464a97bce48d60ddfa1279eca693cf1dc861",
+  "head": "711d36e3b9fe47f043c0797eba46599cc1b23b8a",
+  "sourceSha256": "f22426ba0528c461a9d90011a11560dbee936c4d2de73688853245e46f7a45c7",
   "counts": {
     "public": {
       "skills": 32,
       "commands": 21,
       "workflows": 8,
-      "agents": 18,
-      "total": 79
+      "agents": 20,
+      "total": 81
     },
     "internal": {
       "hookFiles": 295,
@@ -107,21 +107,23 @@
     "agents": [
       "analyst",
       "architect",
+      "code-reviewer",
+      "code-simplifier",
       "critic",
-      "definitions",
+      "debugger",
       "designer",
       "document-specialist",
       "executor",
       "explore",
-      "index",
+      "git-master",
       "planner",
-      "prompt-helpers",
       "qa-tester",
+      "reviewer",
       "scientist",
-      "skininthegamebros-guidance",
+      "security-reviewer",
+      "test-engineer",
       "tracer",
-      "types",
-      "utils",
+      "verifier",
       "writer"
     ],
     "workflows": [
@@ -51035,11 +51037,6 @@
       },
       {
         "from": "src/cli/graph.ts",
-        "to": "external:node:fs/promises",
-        "kind": "imports"
-      },
-      {
-        "from": "src/cli/graph.ts",
         "to": "external:node:path",
         "kind": "imports"
       },
@@ -51075,7 +51072,17 @@
       },
       {
         "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
         "to": "src/graph/runtime/runner.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/safe-fs.ts",
         "kind": "imports"
       },
       {
@@ -53415,6 +53422,11 @@
       },
       {
         "from": "src/graph/runtime/executors/agent.ts",
+        "to": "src/graph/runtime/executors/authority.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/agent.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "type-imports"
       },
@@ -53432,6 +53444,11 @@
         "from": "src/graph/runtime/executors/command.ts",
         "to": "external:node:child_process",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/command.ts",
+        "to": "src/graph/runtime/executors/authority.ts",
+        "kind": "imports"
       },
       {
         "from": "src/graph/runtime/executors/command.ts",
@@ -53510,6 +53527,16 @@
       },
       {
         "from": "src/graph/runtime/journal.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "src/graph/runtime/safe-fs.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "imports"
       },
@@ -53540,11 +53567,6 @@
       },
       {
         "from": "src/graph/runtime/runner.ts",
-        "to": "external:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/runner.ts",
         "to": "external:path",
         "kind": "imports"
       },
@@ -53566,6 +53588,16 @@
       {
         "from": "src/graph/runtime/runner.ts",
         "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/safe-fs.ts",
         "kind": "imports"
       },
       {
@@ -53600,17 +53632,22 @@
       },
       {
         "from": "src/graph/runtime/store.ts",
-        "to": "external:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/store.ts",
         "to": "external:path",
         "kind": "imports"
       },
       {
         "from": "src/graph/runtime/store.ts",
         "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "src/graph/runtime/safe-fs.ts",
         "kind": "imports"
       },
       {
@@ -75901,11 +75938,11 @@
     ],
     "stats": {
       "nodeCount": 6825,
-      "edgeCount": 7100,
-      "importEdgeCount": 5824,
+      "edgeCount": 7107,
+      "importEdgeCount": 5827,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "b1ccbc62159d75f3df2ae469240e06a03105674890dc236ef85ab4ba0506f859",
-  "manifestSha256": "2d8a009ae59b4afb9ce07b3b942a1df0f0ce0b9760780eb5e1e67c43b69b66ac"
+  "manifestSha256": "f8ce18a6cc6efdc8ed64a7bd509942bf0ba99aa643bd1ce32ba2d433cb9c7b7d"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,22 +5,22 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "263e1ea5cf52f44a22c5ef87f3ea13a26b3d8ac7",
-    "sourceSha256": "83d456b4ebf8c18ba69ee09fb1d1a5056c0f0f3c698e67e568c1b236912cb76c",
+    "head": "d81264c15fa45e8ce3dbf272373223ee155b21da",
+    "sourceSha256": "0de17e02c024d2003299807a87623bc548ca4c20b73b053fa0cc1be35f36a496",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "263e1ea5cf52f44a22c5ef87f3ea13a26b3d8ac7",
-  "sourceSha256": "83d456b4ebf8c18ba69ee09fb1d1a5056c0f0f3c698e67e568c1b236912cb76c",
+  "head": "d81264c15fa45e8ce3dbf272373223ee155b21da",
+  "sourceSha256": "0de17e02c024d2003299807a87623bc548ca4c20b73b053fa0cc1be35f36a496",
   "counts": {
     "public": {
-      "skills": 31,
+      "skills": 32,
       "commands": 21,
       "workflows": 8,
       "agents": 18,
-      "total": 78
+      "total": 79
     },
     "internal": {
       "hookFiles": 295,
@@ -28,8 +28,8 @@
       "toolFiles": 59,
       "libFiles": 36,
       "templateHooks": 21,
-      "srcFiles": 1275,
-      "total": 1296
+      "srcFiles": 1302,
+      "total": 1323
     },
     "generated": {
       "distFiles": 4955,
@@ -39,7 +39,7 @@
     "prompt": {
       "promptLikeFiles": 62
     },
-    "skills": 31,
+    "skills": 32,
     "commands": 21,
     "hookFiles": 295,
     "workflows": 8,
@@ -59,6 +59,7 @@
       "deepinit",
       "execute",
       "external-context",
+      "graph",
       "hud",
       "omc-doctor",
       "omc-setup",
@@ -716,6 +717,7 @@
       "scripts/generate-inventory-graph.mjs",
       "scripts/generate-prompt-projections.mjs",
       "scripts/generate-skill-entitlements.mjs",
+      "scripts/graph-agent-demo.mjs",
       "scripts/inventory-issue-3698.mjs",
       "scripts/keyword-detector.mjs",
       "scripts/lib/agent-model-config.mjs",
@@ -32420,6 +32422,11 @@
         "path": "safe-regex"
       },
       {
+        "id": "external:stream",
+        "kind": "external",
+        "path": "stream"
+      },
+      {
         "id": "external:tls",
         "kind": "external",
         "path": "tls"
@@ -32768,6 +32775,11 @@
         "id": "scripts/generate-skill-entitlements.mjs",
         "kind": "script",
         "path": "scripts/generate-skill-entitlements.mjs"
+      },
+      {
+        "id": "scripts/graph-agent-demo.mjs",
+        "kind": "script",
+        "path": "scripts/graph-agent-demo.mjs"
       },
       {
         "id": "scripts/inventory-issue-3698.mjs",
@@ -33293,6 +33305,11 @@
         "id": "skills/external-context/SKILL.md",
         "kind": "skill",
         "path": "skills/external-context/SKILL.md"
+      },
+      {
+        "id": "skills/graph/SKILL.md",
+        "kind": "skill",
+        "path": "skills/graph/SKILL.md"
       },
       {
         "id": "skills/hud/SKILL.md",
@@ -35395,6 +35412,11 @@
         "path": "src/cli/commands/wait.ts"
       },
       {
+        "id": "src/cli/graph.ts",
+        "kind": "src",
+        "path": "src/cli/graph.ts"
+      },
+      {
         "id": "src/cli/hud-watch.ts",
         "kind": "src",
         "path": "src/cli/hud-watch.ts"
@@ -35860,6 +35882,86 @@
         "path": "src/graph/__tests__/fixtures.ts"
       },
       {
+        "id": "src/graph/__tests__/runtime/approval.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/approval.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/cli.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/cli.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/executors/agent.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/executors/command.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/executors/command.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/fence.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/fence.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/fixtures/back-edge-graph.json",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/fixtures/back-edge-graph.json"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/fixtures/fanout-join-graph.json",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/fixtures/fanout-join-graph.json"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/fixtures/simple-linear.json",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/fixtures/simple-linear.json"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/journal-epoch.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/journal.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/journal.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/progress.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/progress.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/regression-matrix.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/run-dir.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/runner.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/runner.test.ts"
+      },
+      {
+        "id": "src/graph/__tests__/runtime/store.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/store.test.ts"
+      },
+      {
         "id": "src/graph/__tests__/scheduler.test.ts",
         "kind": "src",
         "path": "src/graph/__tests__/scheduler.test.ts"
@@ -35873,6 +35975,56 @@
         "id": "src/graph/index.ts",
         "kind": "src",
         "path": "src/graph/index.ts"
+      },
+      {
+        "id": "src/graph/runtime/approval.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/approval.ts"
+      },
+      {
+        "id": "src/graph/runtime/executors/agent.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/executors/agent.ts"
+      },
+      {
+        "id": "src/graph/runtime/executors/command.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/executors/command.ts"
+      },
+      {
+        "id": "src/graph/runtime/fence.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/fence.ts"
+      },
+      {
+        "id": "src/graph/runtime/journal.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/journal.ts"
+      },
+      {
+        "id": "src/graph/runtime/progress.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/progress.ts"
+      },
+      {
+        "id": "src/graph/runtime/run-dir.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/run-dir.ts"
+      },
+      {
+        "id": "src/graph/runtime/runner.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/runner.ts"
+      },
+      {
+        "id": "src/graph/runtime/store.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/store.ts"
+      },
+      {
+        "id": "src/graph/runtime/types.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/types.ts"
       },
       {
         "id": "src/graph/scheduler.ts",
@@ -41087,6 +41239,21 @@
         "kind": "imports"
       },
       {
+        "from": "scripts/graph-agent-demo.mjs",
+        "to": "external:node:fs/promises",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/graph-agent-demo.mjs",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/graph-agent-demo.mjs",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
         "from": "scripts/inventory-issue-3698.mjs",
         "to": "external:node:crypto",
         "kind": "imports"
@@ -42473,6 +42640,11 @@
       },
       {
         "from": "skills/external-context/SKILL.md",
+        "to": "src/features/builtin-skills/skills.ts",
+        "kind": "registers"
+      },
+      {
+        "from": "skills/graph/SKILL.md",
         "to": "src/features/builtin-skills/skills.ts",
         "kind": "registers"
       },
@@ -50847,6 +51019,81 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/cli/graph.ts",
+        "to": "external:chalk",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "external:commander",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "external:node:fs/promises",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/approval.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/executors/agent.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/executors/command.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/progress.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/runner.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/cli/hud-watch.ts",
         "to": "src/mcp/standalone-shutdown.ts",
         "kind": "imports"
@@ -50934,6 +51181,11 @@
       {
         "from": "src/cli/index.ts",
         "to": "src/cli/commands/wait.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/index.ts",
+        "to": "src/cli/graph.ts",
         "kind": "imports"
       },
       {
@@ -52547,6 +52799,526 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/graph/__tests__/runtime/approval.test.ts",
+        "to": "external:stream",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/approval.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/approval.test.ts",
+        "to": "src/graph/runtime/approval.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/approval.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "src/cli/graph.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/cli.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:module",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/e2e-crash-recovery.test.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "to": "src/graph/__tests__/fixtures.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "to": "src/graph/runtime/executors/agent.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/agent.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/command.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/command.test.ts",
+        "to": "src/graph/runtime/executors/command.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/command.test.ts",
+        "to": "src/graph/runtime/executors/command.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/command.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/executors/command.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "src/graph/runtime/fence.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/fence.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "src/graph/runtime/runner.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "src/graph/runtime/journal.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/progress.test.ts",
+        "to": "external:stream",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/progress.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/progress.test.ts",
+        "to": "src/graph/runtime/progress.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/progress.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/runtime/journal.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/runtime/runner.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/runtime/store.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/scheduler.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/regression-matrix.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "src/graph/runtime/fence.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "src/graph/runtime/journal.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "src/graph/runtime/store.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/run-dir.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/__tests__/fixtures.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/runtime/journal.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/runtime/runner.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/runtime/store.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/scheduler.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/runner.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "src/graph/runtime/store.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/store.test.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/graph/__tests__/scheduler.test.ts",
         "to": "external:vitest",
         "kind": "imports"
@@ -52605,6 +53377,246 @@
         "from": "src/graph/index.ts",
         "to": "src/graph/types.ts",
         "kind": "exports"
+      },
+      {
+        "from": "src/graph/runtime/approval.ts",
+        "to": "external:readline",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/approval.ts",
+        "to": "external:readline",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/approval.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/approval.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/agent.ts",
+        "to": "external:@anthropic-ai/claude-agent-sdk",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/agent.ts",
+        "to": "external:@anthropic-ai/claude-agent-sdk",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/agent.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/agent.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/command.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/command.ts",
+        "to": "external:node:child_process",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/command.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/executors/command.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "external:crypto",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/lib/atomic-write.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/platform/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/progress.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/run-dir.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/run-dir.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/run-dir.ts",
+        "to": "src/lib/atomic-write.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/descriptor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/fence.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/journal.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/store.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/scheduler.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/runner.ts",
+        "to": "src/lib/atomic-write.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/store.ts",
+        "to": "src/lib/atomic-write.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/types.ts",
+        "to": "src/graph/types.ts",
+        "kind": "type-imports"
       },
       {
         "from": "src/graph/scheduler.ts",
@@ -74878,12 +75890,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6795,
-      "edgeCount": 6926,
-      "importEdgeCount": 5689,
-      "registerEdgeCount": 52
+      "nodeCount": 6825,
+      "edgeCount": 7098,
+      "importEdgeCount": 5822,
+      "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "711ee021e41dc6d2e423bcc936e42694dff27bf8cfc06638ceef2d7d44e83b73",
-  "manifestSha256": "98936521f8f988565bfe2ee2cd8f0c82efe5b7cb03d836e39175dcc8f3b5a820"
+  "inventorySha256": "b1ccbc62159d75f3df2ae469240e06a03105674890dc236ef85ab4ba0506f859",
+  "manifestSha256": "8fd3da2acc7478b3720826b9dc254a596bd16e4a19879cff9822496a619706dd"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2e9eb712abf8270f02f87d28f55db46225e66eb3",
-    "sourceSha256": "829821fd57d2a57e5284123aa48f887a5e75cba770dddb77afcb8e7f941cbdd5",
+    "head": "272fc86e4acad19f468886c673543c9f26ad4b8e",
+    "sourceSha256": "d0e1fb2296469860e776619cbb3f62562c88cf1eed79e664be0d07429b196a0e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2e9eb712abf8270f02f87d28f55db46225e66eb3",
-  "sourceSha256": "829821fd57d2a57e5284123aa48f887a5e75cba770dddb77afcb8e7f941cbdd5",
+  "head": "272fc86e4acad19f468886c673543c9f26ad4b8e",
+  "sourceSha256": "d0e1fb2296469860e776619cbb3f62562c88cf1eed79e664be0d07429b196a0e",
   "counts": {
     "public": {
       "skills": 32,
@@ -75974,5 +75974,5 @@
     }
   },
   "inventorySha256": "b8773e75e23058231db59e06e186a1806efa9e4707b1104149e6285eba761c38",
-  "manifestSha256": "85e5a1fea2855bd9940c56bfb1c46155ce849873e8a0ed648e675dcbd917bc22"
+  "manifestSha256": "036c17f950083fbf7f92033e69c91d6b10931939b149efb37901848987daeb87"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "e8d6dc14104d3dbc5f70f6827ed05921a8ceebc7",
-    "sourceSha256": "98afb6a6b486ef4e9f382f3fecadae8290b1f5c74438dc04a686c8ad292c0585",
+    "head": "992c4353cce084ec0b9e0d8610e813b3b204c3a5",
+    "sourceSha256": "0793c930d66d7cee472c4cb84492464a97bce48d60ddfa1279eca693cf1dc861",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "e8d6dc14104d3dbc5f70f6827ed05921a8ceebc7",
-  "sourceSha256": "98afb6a6b486ef4e9f382f3fecadae8290b1f5c74438dc04a686c8ad292c0585",
+  "head": "992c4353cce084ec0b9e0d8610e813b3b204c3a5",
+  "sourceSha256": "0793c930d66d7cee472c4cb84492464a97bce48d60ddfa1279eca693cf1dc861",
   "counts": {
     "public": {
       "skills": 32,
@@ -53035,6 +53035,11 @@
       },
       {
         "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
+        "to": "src/graph/runtime/journal.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/journal-epoch.test.ts",
         "to": "src/graph/runtime/runner.ts",
         "kind": "imports"
       },
@@ -53476,6 +53481,11 @@
       {
         "from": "src/graph/runtime/fence.ts",
         "to": "src/platform/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/journal.ts",
+        "to": "external:crypto",
         "kind": "imports"
       },
       {
@@ -75891,11 +75901,11 @@
     ],
     "stats": {
       "nodeCount": 6825,
-      "edgeCount": 7098,
-      "importEdgeCount": 5822,
+      "edgeCount": 7100,
+      "importEdgeCount": 5824,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "b1ccbc62159d75f3df2ae469240e06a03105674890dc236ef85ab4ba0506f859",
-  "manifestSha256": "d82e35a735adba4d9690522d3c6e59b411283f66c991d0114f9937473de1aec3"
+  "manifestSha256": "2d8a009ae59b4afb9ce07b3b942a1df0f0ce0b9760780eb5e1e67c43b69b66ac"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "d81264c15fa45e8ce3dbf272373223ee155b21da",
-    "sourceSha256": "0de17e02c024d2003299807a87623bc548ca4c20b73b053fa0cc1be35f36a496",
+    "head": "e8d6dc14104d3dbc5f70f6827ed05921a8ceebc7",
+    "sourceSha256": "98afb6a6b486ef4e9f382f3fecadae8290b1f5c74438dc04a686c8ad292c0585",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "d81264c15fa45e8ce3dbf272373223ee155b21da",
-  "sourceSha256": "0de17e02c024d2003299807a87623bc548ca4c20b73b053fa0cc1be35f36a496",
+  "head": "e8d6dc14104d3dbc5f70f6827ed05921a8ceebc7",
+  "sourceSha256": "98afb6a6b486ef4e9f382f3fecadae8290b1f5c74438dc04a686c8ad292c0585",
   "counts": {
     "public": {
       "skills": 32,
@@ -75897,5 +75897,5 @@
     }
   },
   "inventorySha256": "b1ccbc62159d75f3df2ae469240e06a03105674890dc236ef85ab4ba0506f859",
-  "manifestSha256": "8fd3da2acc7478b3720826b9dc254a596bd16e4a19879cff9822496a619706dd"
+  "manifestSha256": "d82e35a735adba4d9690522d3c6e59b411283f66c991d0114f9937473de1aec3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "272fc86e4acad19f468886c673543c9f26ad4b8e",
-    "sourceSha256": "d0e1fb2296469860e776619cbb3f62562c88cf1eed79e664be0d07429b196a0e",
+    "head": "ae752358b599811d1ddd95824c89a4234ce8d3c7",
+    "sourceSha256": "028473100ba187e825486330cdad79694ee12438aa37d00893b5966c8670eef6",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "272fc86e4acad19f468886c673543c9f26ad4b8e",
-  "sourceSha256": "d0e1fb2296469860e776619cbb3f62562c88cf1eed79e664be0d07429b196a0e",
+  "head": "ae752358b599811d1ddd95824c89a4234ce8d3c7",
+  "sourceSha256": "028473100ba187e825486330cdad79694ee12438aa37d00893b5966c8670eef6",
   "counts": {
     "public": {
       "skills": 32,
@@ -75974,5 +75974,5 @@
     }
   },
   "inventorySha256": "b8773e75e23058231db59e06e186a1806efa9e4707b1104149e6285eba761c38",
-  "manifestSha256": "036c17f950083fbf7f92033e69c91d6b10931939b149efb37901848987daeb87"
+  "manifestSha256": "f3702f93e8159ad9aff0b89532e1bc3ce5846809d724bf23c864393aaf56fb55"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "c5c86abf738d6bf1a1550883de1d6aa683ae6298",
-    "sourceSha256": "c541713f7d46c0197b1f51d8f85ce8bfbcfe86fd7a6291933b4d298a514f850c",
+    "head": "2e9eb712abf8270f02f87d28f55db46225e66eb3",
+    "sourceSha256": "829821fd57d2a57e5284123aa48f887a5e75cba770dddb77afcb8e7f941cbdd5",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "c5c86abf738d6bf1a1550883de1d6aa683ae6298",
-  "sourceSha256": "c541713f7d46c0197b1f51d8f85ce8bfbcfe86fd7a6291933b4d298a514f850c",
+  "head": "2e9eb712abf8270f02f87d28f55db46225e66eb3",
+  "sourceSha256": "829821fd57d2a57e5284123aa48f887a5e75cba770dddb77afcb8e7f941cbdd5",
   "counts": {
     "public": {
       "skills": 32,
@@ -75974,5 +75974,5 @@
     }
   },
   "inventorySha256": "b8773e75e23058231db59e06e186a1806efa9e4707b1104149e6285eba761c38",
-  "manifestSha256": "8911415d793340fcd9d9eabd46d7302fe416deaf1828d364bf7e3fbf2cb2517a"
+  "manifestSha256": "85e5a1fea2855bd9940c56bfb1c46155ce849873e8a0ed648e675dcbd917bc22"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "711d36e3b9fe47f043c0797eba46599cc1b23b8a",
-    "sourceSha256": "f22426ba0528c461a9d90011a11560dbee936c4d2de73688853245e46f7a45c7",
+    "head": "c5c86abf738d6bf1a1550883de1d6aa683ae6298",
+    "sourceSha256": "c541713f7d46c0197b1f51d8f85ce8bfbcfe86fd7a6291933b4d298a514f850c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "711d36e3b9fe47f043c0797eba46599cc1b23b8a",
-  "sourceSha256": "f22426ba0528c461a9d90011a11560dbee936c4d2de73688853245e46f7a45c7",
+  "head": "c5c86abf738d6bf1a1550883de1d6aa683ae6298",
+  "sourceSha256": "c541713f7d46c0197b1f51d8f85ce8bfbcfe86fd7a6291933b4d298a514f850c",
   "counts": {
     "public": {
       "skills": 32,
@@ -28,8 +28,8 @@
       "toolFiles": 59,
       "libFiles": 36,
       "templateHooks": 21,
-      "srcFiles": 1302,
-      "total": 1323
+      "srcFiles": 1304,
+      "total": 1325
     },
     "generated": {
       "distFiles": 4955,
@@ -35989,6 +35989,11 @@
         "path": "src/graph/runtime/executors/agent.ts"
       },
       {
+        "id": "src/graph/runtime/executors/authority.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/executors/authority.ts"
+      },
+      {
         "id": "src/graph/runtime/executors/command.ts",
         "kind": "src",
         "path": "src/graph/runtime/executors/command.ts"
@@ -36017,6 +36022,11 @@
         "id": "src/graph/runtime/runner.ts",
         "kind": "src",
         "path": "src/graph/runtime/runner.ts"
+      },
+      {
+        "id": "src/graph/runtime/safe-fs.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/safe-fs.ts"
       },
       {
         "id": "src/graph/runtime/store.ts",
@@ -53436,6 +53446,11 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/graph/runtime/executors/authority.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/graph/runtime/executors/command.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -53629,6 +53644,21 @@
         "from": "src/graph/runtime/runner.ts",
         "to": "src/lib/atomic-write.ts",
         "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
       },
       {
         "from": "src/graph/runtime/store.ts",
@@ -75937,12 +75967,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6825,
-      "edgeCount": 7107,
-      "importEdgeCount": 5827,
+      "nodeCount": 6827,
+      "edgeCount": 7111,
+      "importEdgeCount": 5829,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "b1ccbc62159d75f3df2ae469240e06a03105674890dc236ef85ab4ba0506f859",
-  "manifestSha256": "f8ce18a6cc6efdc8ed64a7bd509942bf0ba99aa643bd1ce32ba2d433cb9c7b7d"
+  "inventorySha256": "b8773e75e23058231db59e06e186a1806efa9e4707b1104149e6285eba761c38",
+  "manifestSha256": "8911415d793340fcd9d9eabd46d7302fe416deaf1828d364bf7e3fbf2cb2517a"
 }

--- a/scripts/generate-inventory-graph.mjs
+++ b/scripts/generate-inventory-graph.mjs
@@ -209,7 +209,7 @@ function resolveImportSpec(fromPath, spec) {
       join(base, spec + '.cjs'),
       join(base, spec, 'index.ts'),
       join(base, spec, 'index.js'),
-    ].map((candidate) => toPosix(resolve('/', candidate)).slice(1));
+    ].map((candidate) => toPosix(candidate).replace(/^\.\//, '').replace(/^\/+/, ''));
     return { kind: 'relative', spec, candidates };
   }
   return { kind: 'external', spec, candidates: [] };

--- a/scripts/generate-inventory-graph.mjs
+++ b/scripts/generate-inventory-graph.mjs
@@ -24,7 +24,7 @@
  */
 
 import { readdir, readFile, stat, mkdir, writeFile } from 'node:fs/promises';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, realpathSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join, relative, dirname, resolve } from 'node:path';
 import { execFileSync, execSync } from 'node:child_process';
@@ -133,6 +133,28 @@ function isAncestorCommit(root, sha) {
   }
 }
 
+function assertOutputPathContained(root, outPath) {
+  const rootReal = realpathSync(root);
+  let parent = dirname(outPath);
+  while (!existsSync(parent)) {
+    const next = dirname(parent);
+    if (next === parent) break;
+    parent = next;
+  }
+  const parentReal = realpathSync(parent);
+  const rootPrefix = `${rootReal}${pathSeparator(rootReal)}`;
+  if (parentReal !== rootReal && !parentReal.startsWith(rootPrefix)) {
+    throw new Error('--out parent must resolve inside the repository root');
+  }
+  if (existsSync(outPath) && lstatSync(outPath).isSymbolicLink()) {
+    throw new Error('--out must not be a symbolic link');
+  }
+}
+
+function pathSeparator(pathValue) {
+  return pathValue.includes('\\') ? '\\' : '/';
+}
+
 function scanDependencies(source, filePath) {
   const out = [];
   const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, false);
@@ -178,6 +200,54 @@ function classifyPath(p) {
   if (p.startsWith('bridge/')) return 'generated-bridge';
   if (p.startsWith('scripts/')) return 'script';
   return 'other';
+}
+
+/**
+ * Public agent inventory is role-based, not a census of helper .ts files.
+ * WORKFLOW_ROLES is the registry authority and includes Tier-0 roles plus
+ * routable internal specialists; src/agents also contains helpers, barrels,
+ * and prompt infrastructure that must never appear as public agents.
+ */
+function readWorkflowRoleNames(root) {
+  const registryPath = join(root, 'src/workflow/registry.ts');
+  const source = readFileSync(registryPath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    registryPath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const names = [];
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.name.getText(sourceFile) === 'WORKFLOW_ROLES' &&
+      node.initializer &&
+      ts.isArrayLiteralExpression(node.initializer)
+    ) {
+      for (const element of node.initializer.elements) {
+        if (!ts.isObjectLiteralExpression(element)) continue;
+        const nameProperty = element.properties.find(
+          (property) =>
+            ts.isPropertyAssignment(property) &&
+            property.name.getText(sourceFile) === 'name',
+        );
+        if (
+          nameProperty &&
+          ts.isPropertyAssignment(nameProperty) &&
+          ts.isStringLiteral(nameProperty.initializer)
+        ) {
+          names.push(nameProperty.initializer.text);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  if (names.length === 0) {
+    throw new Error('WORKFLOW_ROLES must define at least one registered agent role');
+  }
+  return [...new Set(names)].sort();
 }
 
 function isSourceForGraph(p) {
@@ -276,7 +346,11 @@ export async function generateInventoryGraph(opts = {}) {
   const commands = relStable.filter((p) => /^commands\/[^/]+\.md$/.test(p)).map((p) => p.slice('commands/'.length, -3)).sort();
   const commandPaths = relStable.filter((p) => /^commands\/[^/]+\.md$/.test(p)).sort();
   const workflows = relStable.filter((p) => p.startsWith('.github/workflows/')).sort();
-  const agents = relStable.filter((p) => /^src\/agents\/[^/]+\.ts$/.test(p)).map((p) => p.slice('src/agents/'.length, -3)).sort();
+  const agentDefinitionFiles = relStable
+    .filter((p) => /^src\/agents\/[^/]+\.ts$/.test(p))
+    .map((p) => p.slice('src/agents/'.length, -3))
+    .sort();
+  const agents = readWorkflowRoleNames(root);
   const hookFiles = relStable.filter((p) => p.startsWith('src/hooks/')).sort();
   const featureFiles = relStable.filter((p) => p.startsWith('src/features/')).sort();
   const toolFiles = relStable.filter((p) => p.startsWith('src/tools/')).sort();
@@ -457,7 +531,7 @@ export async function generateInventoryGraph(opts = {}) {
       commands: commands.length,
       hookFiles: hookFiles.length,
       workflows: workflows.length,
-      agentDefinitions: agents.length,
+      agentDefinitions: agentDefinitionFiles.length,
       promptLikeFiles: promptSources.length,
     },
     public: {
@@ -520,6 +594,7 @@ async function main() {
   if (outRelative.startsWith('..') || resolve(REPO_ROOT, outRelative) !== outPath) {
     throw new Error('--out must resolve inside the repository root');
   }
+  assertOutputPathContained(REPO_ROOT, outPath);
 
   if (wantVerify) {
     const fresh = await generateInventoryGraph();

--- a/scripts/graph-agent-demo.mjs
+++ b/scripts/graph-agent-demo.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Graph runtime demo: writes a 3-node descriptor (agent analysis -> human
+ * approval gate -> terminal verification) to a temp file and prints how to run
+ * it. The script only WRITES the descriptor; the runner lands in wave 2.
+ *
+ * Usage:
+ *   node scripts/graph-agent-demo.mjs [topic]
+ */
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const topic = process.argv[2] ?? "event-driven vs request-driven architecture";
+
+function executableNode(id, extra) {
+  return {
+    id,
+    kind: "agent",
+    title: id,
+    timeout_ms: 120_000,
+    max_attempts: 3,
+    effect_policy: { policy: "side_effect_free" },
+    ...extra,
+  };
+}
+
+const descriptor = {
+  descriptor_version: 1,
+  run_id: "run-agent-demo",
+  revision_id: "rev-agent-demo",
+  goal: `Produce a one-paragraph analysis of ${topic} and get human sign-off`,
+  nodes: [
+    executableNode("analyze", {
+      title: "Analyze topic",
+      instructions: `Write exactly one paragraph analyzing: ${topic}. No headings, no lists.`,
+    }),
+    {
+      id: "approval",
+      kind: "human-approval",
+      title: "Approve analysis",
+      prompt: `Approve the one-paragraph analysis of "${topic}"?`,
+    },
+    {
+      id: "term",
+      kind: "command",
+      title: "Terminal verification",
+      command: "echo approved",
+      timeout_ms: 30_000,
+      max_attempts: 1,
+      effect_policy: { policy: "side_effect_free" },
+    },
+  ],
+  edges: [
+    { id: "e-analyze-approval", kind: "fixed", from: "analyze", to: "approval" },
+    { id: "e-approval-term", kind: "fixed", from: "approval", to: "term" },
+  ],
+  entry_node_ids: ["analyze"],
+  concurrency_limit: 1,
+  terminal_verification_node_id: "term",
+};
+
+const dir = await mkdtemp(join(tmpdir(), "omc-graph-demo-"));
+const file = join(dir, "demo-descriptor.json");
+await writeFile(file, JSON.stringify(descriptor, null, 2), "utf8");
+
+console.log(`Demo descriptor written to:\n  ${file}\n`);
+console.log("Run it with:");
+console.log(`  node bin/oh-my-claudecode.js graph run ${file}`);
+console.log(`
+Flow: agent node analyzes "${topic}", then a human-approval gate pauses the
+run until you approve/deny, then a terminal command node verifies.`);

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: graph
+description: Deterministic orchestration graph runtime - declarative DAG pipelines with journal-based crash recovery
+argument-hint: "<descriptor.json | describe the pipeline> [--runs-root <dir>]"
+aliases: []
+level: 4
+---
+
+# Graph Skill
+
+Run a deterministic orchestration graph from a declarative JSON descriptor.
+The runtime consumes the sealed-descriptor and pure-scheduler contracts in
+`src/graph/*` and executes through an independent OS process (`omc graph run`),
+so crash recovery (kill mid-run, rerun, resume from journal) works for real.
+
+## Usage
+
+```
+/oh-my-claudecode:graph <descriptor.json>
+/oh-my-claudecode:graph "build then test then ask me before deploy"   (author the descriptor first)
+```
+
+The execution surface is always the CLI subcommand:
+
+    omc graph run <descriptor.json> [--runs-root <dir>]
+
+Run it via the Bash tool for non-interactive graphs. Progress lines stream as
+`[run]`, `[node]`, `[ok]`, `[fail]`, `[join]`, `[done]`.
+
+## When To Use
+
+- Repeatable multi-step pipelines with explicit dependencies (DAG)
+- Work that must survive interruption: kill/restart resumes from journal
+- Auditable runs: OCC journal + projection snapshots under `.omc/graph-runs/<run_id>/`
+
+When NOT to use: exploratory one-off work (use conversation or /team);
+anything needing adaptive re-planning mid-run (graphs are deterministic).
+
+## Workflow
+
+1. **Descriptor given** -> go to step 3.
+2. **Pipeline described** -> author the descriptor JSON (schema below), write
+   it next to the project (suggest `.omc/graphs/<name>.json`) and show it to
+   the user before running. `run_id` must be unique per logical pipeline;
+   rerunning with the same `run_id` RESUMES, not restarts.
+3. **Approval nodes**: if the descriptor contains any `"kind": "human-approval"`
+   node, do NOT run it through the Bash tool (stdin is not interactive there;
+   EOF fails closed to denied). Tell the user to run interactively instead:
+
+       ! omc graph run <file>
+
+   The `!` prefix runs it inside this session with live stdin so y/n works.
+4. Run and relay progress. Exit codes (normative):
+   0 succeeded | 1 terminal failed | 19 another writer owns this run (busy)
+   20 corrupt/tampered journal (fail-closed) | 21 descriptor drift on resume
+   | 70 runtime crash (unmapped error)
+5. **Resume**: rerunning the same command after a crash replays committed
+   transitions and continues. Completed nodes never re-execute.
+
+## Descriptor Schema (minimal)
+
+{
+  "descriptor_version": 1,
+  "run_id": "unique-pipeline-id",
+  "revision_id": "rev-1",
+  "goal": "one line",
+  "nodes": [
+    { "id": "n1", "kind": "command", "title": "...", "timeout_ms": 60000,
+      "max_attempts": 2, "effect_policy": { "policy": "side_effect_free" },
+      "command": "npm test" },
+    { "id": "a1", "kind": "agent", "title": "...", "timeout_ms": 300000,
+      "max_attempts": 1, "effect_policy": { "policy": "side_effect_free" },
+      "instructions": "..." },
+    { "id": "gate", "kind": "human-approval", "title": "...",
+      "prompt": "Proceed?" }
+  ],
+  "edges": [ { "id": "e1", "kind": "fixed", "from": "n1", "to": "a1" } ],
+  "entry_node_ids": ["n1"],
+  "concurrency_limit": 2,
+  "terminal_verification_node_id": "a1"
+}
+
+Edge kinds: fixed | conditional (needs route on result) | fan_out/join pairs
+| back_edge (bounded retries via max_traversals). See src/graph/schema.ts for
+the authoritative Zod schema.

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -80,6 +80,27 @@ anything needing adaptive re-planning mid-run (graphs are deterministic).
   "terminal_verification_node_id": "a1"
 }
 
-Edge kinds: fixed | conditional (needs route on result) | fan_out/join pairs
+Edge kinds: fixed | conditional | fan_out/join pairs
 | back_edge (bounded retries via max_traversals). See src/graph/schema.ts for
-the authoritative Zod schema.
+the authoritative Zod schema — and read the Capability Boundary section above
+for what built-in executors actually execute today.
+
+## Capability Boundary & Semantics (read before authoring)
+
+- **Edge support**: built-in command/agent executors cover `fixed` edges and
+  `fan_out`/`join` pairs. `conditional` and `back_edge` routes are fully
+  supported by the runtime and scheduler contracts but require a custom
+  NodeExecutor that emits `route` on its results — built-in executors never
+  produce routes, so graphs relying on them fail fast with
+  `route_required` rather than guessing.
+- **Crash-recovery guarantee is at-least-once** for executable nodes: a crash
+  between an external side effect and its journal append re-executes that node
+  on resume. `idempotent` policies surface `external_idempotency_key` for
+  downstream dedupe systems; `reconcile` expects external reconciliation.
+  Exactly-once for external side effects is out of scope for v1.
+- **Trust boundary**: running a descriptor executes its commands with process
+  authority — the descriptor AUTHOR holds code-execution power. Only run
+  descriptors you wrote or trust. The runner scrubs child environments to an
+  allowlist (PATH, HOME/USERPROFILE, TEMP/TMP, LANG, TZ, GRAPH_*) instead of
+  inheriting host secrets; it does not sandbox filesystem/process access.
+  Treat `.omc/graph-runs/<run_id>/descriptor.json` as executable content.

--- a/skills/graph/SKILL.md
+++ b/skills/graph/SKILL.md
@@ -93,14 +93,23 @@ for what built-in executors actually execute today.
   NodeExecutor that emits `route` on its results — built-in executors never
   produce routes, so graphs relying on them fail fast with
   `route_required` rather than guessing.
-- **Crash-recovery guarantee is at-least-once** for executable nodes: a crash
+- **Crash-recovery guarantee is at-least-once** for command nodes: a crash
   between an external side effect and its journal append re-executes that node
-  on resume. `idempotent` policies surface `external_idempotency_key` for
-  downstream dedupe systems; `reconcile` expects external reconciliation.
+  on resume. For `idempotent` commands, the resolved key is available to the
+  command as `GRAPH_IDEMPOTENCY_KEY` before it starts and is also recorded for
+  downstream dedupe. Built-in executors reject `reconcile`; reconciliation
+  requires a custom executor with an actual external reconciliation authority.
   Exactly-once for external side effects is out of scope for v1.
-- **Trust boundary**: running a descriptor executes its commands with process
-  authority — the descriptor AUTHOR holds code-execution power. Only run
-  descriptors you wrote or trust. The runner scrubs child environments to an
-  allowlist (PATH, HOME/USERPROFILE, TEMP/TMP, LANG, TZ, GRAPH_*) instead of
-  inheriting host secrets; it does not sandbox filesystem/process access.
-  Treat `.omc/graph-runs/<run_id>/descriptor.json` as executable content.
+- **Command trust boundary**: command nodes are arbitrary shell lines with
+  process authority in the current working directory. Only run descriptors
+  you wrote or trust. Command children receive an allowlisted environment
+  (PATH, HOME/USERPROFILE, TEMP/TMP, locale/timezone, USER identity,
+  `GRAPH_*`, and the optional idempotency key), not the host's full secrets.
+  Commands are not filesystem/process sandboxed.
+- **Agent authority boundary**: built-in agent nodes are explicitly read-only.
+  They run in the current working directory with no additional directories,
+  only `Read`, `Glob`, and `Grep`, `permissionMode: dontAsk`, session
+  persistence disabled, and a provider-specific environment allowlist. Agent
+  timeouts abort and interrupt the SDK query. Use a custom executor for any
+  agent that needs mutation or external effects. Treat
+  `.omc/graph-runs/<run_id>/descriptor.json` as executable content.

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (31 canonical + 2 aliases)', () => {
+    it('should return correct number of skills (32 canonical + 2 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 33 entries: 31 canonical skills + 2 aliases (cancel-ralph, psm)
-      expect(skills).toHaveLength(33);
+      // 34 entries: 32 canonical skills + 2 aliases (cancel-ralph, psm)
+      expect(skills).toHaveLength(34);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -136,6 +136,7 @@ describe('Builtin Skills', () => {
         'deepinit',
         'execute',
         'external-context',
+        'graph',
         'hud',
         'omc-doctor',
         'omc-plan',
@@ -658,7 +659,7 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(31);
+      expect(names).toHaveLength(32);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
@@ -692,7 +693,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; learner retired in 5.0.0; cancel-ralph and psm remain
-      expect(names).toHaveLength(33);
+      expect(names).toHaveLength(34);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/alias-retirement/__tests__/registry.test.ts
+++ b/src/alias-retirement/__tests__/registry.test.ts
@@ -69,10 +69,10 @@ describe('alias-retirement registry', () => {
     // Raised 37 -> 40 canonical when execute/review/research shipped as real
     // skill directories; this is an addition, not an alias retirement.
     const all = createBuiltinSkills();
-    expect(all).toHaveLength(33);
+    expect(all).toHaveLength(34);
     const canonical = all.filter((s) => !s.aliasOf);
     const aliases = all.filter((s) => !!s.aliasOf);
-    expect(canonical).toHaveLength(31);
+    expect(canonical).toHaveLength(32);
     expect(aliases).toHaveLength(2);
     expect(aliases.map((s) => s.name).sort()).toEqual(['cancel-ralph', 'psm'].sort());
   });

--- a/src/alias-retirement/__tests__/registry.test.ts
+++ b/src/alias-retirement/__tests__/registry.test.ts
@@ -64,7 +64,7 @@ describe('alias-retirement registry', () => {
     }
   });
 
-  it('built-in loader exposes 33 entries (31 canonical + 2 aliases) after the 5.0.0 retirement', () => {
+  it('built-in loader exposes 34 entries (32 canonical + 2 aliases) after the 5.0.0 retirement', () => {
     // This is the baseline that retirement must not silently change without an eligibility receipt.
     // Raised 37 -> 40 canonical when execute/review/research shipped as real
     // skill directories; this is an addition, not an alias retirement.

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -1,0 +1,156 @@
+/**
+ * Graph command - Execute sealed graph descriptors via graph runtime v2.
+ *
+ * Thin CLI adapter only: descriptor load/seal/resume-identity checks live
+ * here; all execution logic lives in src/graph/runtime/.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  canonicalJson,
+  parseSealedGraphDescriptor,
+  sealGraphDescriptor,
+} from '../graph/descriptor.js';
+import type { SealedGraphDescriptor } from '../graph/types.js';
+import {
+  EXIT_CODES,
+  FenceError,
+  JournalCorruptionError,
+} from '../graph/runtime/types.js';
+import type { RunOptions, RunResult } from '../graph/runtime/types.js';
+import { AgentNodeExecutor } from '../graph/runtime/executors/agent.js';
+import { CommandNodeExecutor } from '../graph/runtime/executors/command.js';
+import { createStdinApprovalGate } from '../graph/runtime/approval.js';
+import { createAsciiProgressReporter } from '../graph/runtime/progress.js';
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * CLI-only exit code for unmapped runtime crashes (contract violations,
+ * aborts) so they never collide with FAILED_TERMINAL (1). Not part of the
+ * frozen EXIT_CODES surface.
+ */
+const CRASH_EXIT_CODE = 70;
+
+function fail(message: string, code: number): void {
+  console.error(chalk.red(`Error: ${message}`));
+  process.exitCode = code;
+}
+
+async function loadSealedDescriptor(
+  descriptorPath: string,
+  runsRoot: string,
+): Promise<SealedGraphDescriptor | null> {
+  let parsedUser: unknown;
+  try {
+    parsedUser = JSON.parse(await readFile(descriptorPath, 'utf-8'));
+  } catch (error) {
+    fail(`cannot read descriptor file "${descriptorPath}": ${errorMessage(error)}`, 1);
+    return null;
+  }
+
+  let fresh: SealedGraphDescriptor;
+  try {
+    fresh = sealGraphDescriptor(parsedUser);
+  } catch (error) {
+    fail(`invalid graph descriptor "${descriptorPath}": ${errorMessage(error)}`, 1);
+    return null;
+  }
+
+  const storedPath = join(runsRoot, fresh.run_id, 'descriptor.json');
+  if (!existsSync(storedPath)) {
+    return fresh;
+  }
+
+  let stored: SealedGraphDescriptor;
+  try {
+    stored = parseSealedGraphDescriptor(JSON.parse(await readFile(storedPath, 'utf-8')));
+  } catch (error) {
+    fail(`stored descriptor "${storedPath}" is not a valid sealed descriptor: ${errorMessage(error)}`, 1);
+    return null;
+  }
+
+  // Resume identity: the stored sealed revision must be exactly the one the
+  // user asked to run, otherwise resuming would mix revisions (fail closed).
+  if (canonicalJson(stored) !== canonicalJson(fresh)) {
+    fail(
+      `descriptor mismatch for run "${fresh.run_id}": ${storedPath} belongs to a different revision than "${descriptorPath}"`,
+      EXIT_CODES.DESCRIPTOR_MISMATCH,
+    );
+    return null;
+  }
+  return stored;
+}
+
+async function runAction(descriptorPath: string, runsRoot: string): Promise<void> {
+  const sealed = await loadSealedDescriptor(descriptorPath, runsRoot);
+  if (sealed === null) return;
+
+  // runGraph is imported lazily so `omc graph --help` does not load the whole
+  // runtime, and so this adapter stays decoupled from runtime module order.
+  const [{ runGraph }] = await Promise.all([import('../graph/runtime/runner.js')]);
+
+  const options: RunOptions = {
+    runsRoot,
+    executors: [new CommandNodeExecutor(), new AgentNodeExecutor()],
+    prompter: createStdinApprovalGate(),
+    reporter: createAsciiProgressReporter(),
+  };
+
+  try {
+    const result: RunResult = await runGraph(sealed, options);
+    process.exitCode = result.exit_code;
+  } catch (error) {
+    // Normative exit codes for failures the runner surfaces as thrown errors.
+    if (error instanceof JournalCorruptionError) {
+      fail(errorMessage(error), EXIT_CODES.CORRUPT_JOURNAL);
+      return;
+    }
+    if (error instanceof FenceError) {
+      fail(errorMessage(error), EXIT_CODES.FENCED_OUT);
+      return;
+    }
+    fail(`[crash] ${errorMessage(error)}`, CRASH_EXIT_CODE);
+  }
+}
+
+/**
+ * Returns the `graph` command:
+ *
+ *   omc graph run <descriptorPath> [--runs-root <dir>]
+ */
+export function graphCommand(): Command {
+  const command = new Command('graph');
+  command.description('Execute sealed graph descriptors (graph runtime v2)');
+
+  command
+    .command('run <descriptorPath>')
+    .description('Run a graph descriptor with kill/resume support')
+    .option('--runs-root <dir>', 'Directory holding per-run state', '.omc/graph-runs')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ omc graph run ./my-graph.json
+  $ omc graph run ./my-graph.json --runs-root .omc/graph-runs
+
+Exit codes:
+  0   run succeeded
+  1   failed terminal
+  19  fenced out by another owner
+  20  corrupt journal
+  21  descriptor mismatch on resume
+  70  runtime crash (unmapped error)`,
+    )
+    .action(async (descriptorPath: string, options: { runsRoot: string }) => {
+      await runAction(descriptorPath, options.runsRoot);
+    });
+
+  return command;
+}

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -26,6 +26,7 @@ import { AgentNodeExecutor } from '../graph/runtime/executors/agent.js';
 import { CommandNodeExecutor } from '../graph/runtime/executors/command.js';
 import { createStdinApprovalGate } from '../graph/runtime/approval.js';
 import { createAsciiProgressReporter } from '../graph/runtime/progress.js';
+import { resolveRunDir } from '../graph/runtime/run-dir.js';
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -63,7 +64,15 @@ async function loadSealedDescriptor(
     return null;
   }
 
-  const storedPath = join(runsRoot, fresh.run_id, 'descriptor.json');
+  // Contained run dir (P1-3): the resume probe must not follow a symlinked or
+  // traversal-shaped run directory outside the runs root.
+  let storedPath: string;
+  try {
+    storedPath = join(resolveRunDir(runsRoot, fresh.run_id), 'descriptor.json');
+  } catch (error) {
+    fail(`invalid run directory for run "${fresh.run_id}": ${errorMessage(error)}`, 1);
+    return null;
+  }
   if (!existsSync(storedPath)) {
     return fresh;
   }

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -8,7 +8,6 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   canonicalJson,
@@ -26,7 +25,12 @@ import { AgentNodeExecutor } from '../graph/runtime/executors/agent.js';
 import { CommandNodeExecutor } from '../graph/runtime/executors/command.js';
 import { createStdinApprovalGate } from '../graph/runtime/approval.js';
 import { createAsciiProgressReporter } from '../graph/runtime/progress.js';
-import { resolveRunDir } from '../graph/runtime/run-dir.js';
+import { resolveRunDirHandle } from '../graph/runtime/run-dir.js';
+import type { RunDirHandle } from '../graph/runtime/run-dir.js';
+import {
+  readContainedFileNoFollow,
+  readFileNoFollow,
+} from '../graph/runtime/safe-fs.js';
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -50,7 +54,7 @@ async function loadSealedDescriptor(
 ): Promise<SealedGraphDescriptor | null> {
   let parsedUser: unknown;
   try {
-    parsedUser = JSON.parse(await readFile(descriptorPath, 'utf-8'));
+    parsedUser = JSON.parse(readFileNoFollow(descriptorPath));
   } catch (error) {
     fail(`cannot read descriptor file "${descriptorPath}": ${errorMessage(error)}`, 1);
     return null;
@@ -67,8 +71,10 @@ async function loadSealedDescriptor(
   // Contained run dir (P1-3): the resume probe must not follow a symlinked or
   // traversal-shaped run directory outside the runs root.
   let storedPath: string;
+  let runDirHandle: RunDirHandle;
   try {
-    storedPath = join(resolveRunDir(runsRoot, fresh.run_id), 'descriptor.json');
+    runDirHandle = resolveRunDirHandle(runsRoot, fresh.run_id);
+    storedPath = join(runDirHandle.path, 'descriptor.json');
   } catch (error) {
     fail(`invalid run directory for run "${fresh.run_id}": ${errorMessage(error)}`, 1);
     return null;
@@ -79,7 +85,14 @@ async function loadSealedDescriptor(
 
   let stored: SealedGraphDescriptor;
   try {
-    stored = parseSealedGraphDescriptor(JSON.parse(await readFile(storedPath, 'utf-8')));
+    stored = parseSealedGraphDescriptor(
+      JSON.parse(
+        readContainedFileNoFollow(
+          runDirHandle,
+          'descriptor.json',
+        ),
+      ),
+    );
   } catch (error) {
     fail(`stored descriptor "${storedPath}" is not a valid sealed descriptor: ${errorMessage(error)}`, 1);
     return null;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,6 +63,7 @@ import { resolvePluginDirArg } from '../lib/plugin-dir.js';
 import { launchCommand } from './launch.js';
 import { interopCommand } from './interop.js';
 import { askCommand, ASK_USAGE } from './ask.js';
+import { graphCommand } from './graph.js';
 import { warnIfWin32 } from './win32-warning.js';
 import { autoresearchCommand } from './autoresearch.js';
 import { runHudWatchLoop } from './hud-watch.js';
@@ -1547,6 +1548,11 @@ program
   .action(async (args: string[]) => {
     await aliasRetirementCommand(args ?? []);
   });
+
+/**
+ * Graph command - Execute sealed graph descriptors (graph runtime v2)
+ */
+program.addCommand(graphCommand());
 
 /**
  * Returns the fully-configured commander program.

--- a/src/graph/__tests__/runtime/approval.test.ts
+++ b/src/graph/__tests__/runtime/approval.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the human approval gates (graph runtime v2).
+ *
+ * Covers y/yes/n/no parsing (case-insensitive, whitespace-trimmed), the
+ * single re-prompt for unrecognized input, and fail-closed "denied" on
+ * garbage-then-EOF and immediate EOF.
+ */
+import { PassThrough } from "stream";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createFixedApprovalGate,
+  createStdinApprovalGate,
+} from "../../runtime/approval.js";
+import type { ApprovalRequest } from "../../runtime/types.js";
+
+const REQUEST: ApprovalRequest = {
+  run_id: "run-1",
+  node_id: "gate-node",
+  activation_id: "act-1",
+  prompt_text: "Deploy to production?",
+};
+
+describe("createStdinApprovalGate", () => {
+  it("approves on y", async () => {
+    const stdin = new PassThrough();
+    stdin.write("y\n");
+    const gate = createStdinApprovalGate(stdin);
+    await expect(gate.prompt(REQUEST)).resolves.toBe("approved");
+  });
+
+  it("denies on n", async () => {
+    const stdin = new PassThrough();
+    stdin.write("n\n");
+    const gate = createStdinApprovalGate(stdin);
+    await expect(gate.prompt(REQUEST)).resolves.toBe("denied");
+  });
+
+  it("parses answers case-insensitively with surrounding whitespace", async () => {
+    const yesStream = new PassThrough();
+    yesStream.write("  YES \n");
+    const yesGate = createStdinApprovalGate(yesStream);
+    await expect(yesGate.prompt(REQUEST)).resolves.toBe("approved");
+
+    const noStream = new PassThrough();
+    noStream.write("No\n");
+    const noGate = createStdinApprovalGate(noStream);
+    await expect(noGate.prompt(REQUEST)).resolves.toBe("denied");
+  });
+
+  it("grants one retry so garbage followed by a valid answer counts", async () => {
+    const stdin = new PassThrough();
+    stdin.write("maybe\n");
+    stdin.write("y\n");
+    const gate = createStdinApprovalGate(stdin);
+    await expect(gate.prompt(REQUEST)).resolves.toBe("approved");
+  });
+
+  it("fails closed to denied after garbage followed by EOF", async () => {
+    const stdin = new PassThrough();
+    stdin.write("banana\n");
+    stdin.end();
+    const gate = createStdinApprovalGate(stdin);
+    await expect(gate.prompt(REQUEST)).resolves.toBe("denied");
+  });
+
+  it("fails closed to denied on immediate EOF", async () => {
+    const stdin = new PassThrough();
+    stdin.end();
+    const gate = createStdinApprovalGate(stdin);
+    await expect(gate.prompt(REQUEST)).resolves.toBe("denied");
+  });
+});
+
+describe("createFixedApprovalGate", () => {
+  it("always returns the fixed decision without touching streams", async () => {
+    const approved = createFixedApprovalGate("approved");
+    const denied = createFixedApprovalGate("denied");
+    await expect(approved.prompt(REQUEST)).resolves.toBe("approved");
+    await expect(denied.prompt(REQUEST)).resolves.toBe("denied");
+    await expect(approved.prompt(REQUEST)).resolves.toBe("approved");
+  });
+});

--- a/src/graph/__tests__/runtime/cli.test.ts
+++ b/src/graph/__tests__/runtime/cli.test.ts
@@ -1,0 +1,182 @@
+/**
+ * CLI adapter tests for `omc graph run` (worker-8).
+ *
+ * Drives the commander Command object directly — never spawns the full bin.
+ * The runner module is mocked so this suite isolates the CLI's own contract:
+ * descriptor load/seal, fresh-vs-resume identity check, and exit-code wiring.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sealGraphDescriptor } from '../../descriptor.js';
+import type { SealedGraphDescriptor } from '../../types.js';
+import { EXIT_CODES } from '../../runtime/types.js';
+import type { RunResult, RunOptions } from '../../runtime/types.js';
+import { graphCommand } from '../../../cli/graph.js';
+
+const mocks = vi.hoisted(() => ({
+  runGraph: vi.fn(),
+}));
+
+vi.mock('../../runtime/runner.js', () => ({ runGraph: mocks.runGraph }));
+
+function commandNode(id: string) {
+  return {
+    id,
+    kind: 'command' as const,
+    title: `Node ${id}`,
+    timeout_ms: 60_000,
+    max_attempts: 3,
+    effect_policy: { policy: 'side_effect_free' as const },
+    command: `echo ${id}`,
+  };
+}
+
+function descriptorInput(runId: string, goal: string) {
+  return {
+    descriptor_version: 1,
+    run_id: runId,
+    revision_id: 'rev-cli',
+    goal,
+    nodes: [commandNode('start'), commandNode('term')],
+    edges: [{ id: 'e-start-term', kind: 'fixed' as const, from: 'start', to: 'term' }],
+    entry_node_ids: ['start'],
+    concurrency_limit: 1,
+    terminal_verification_node_id: 'term',
+  };
+}
+
+describe('graphCommand run subcommand', () => {
+  const createConsoleErrorSpy = () =>
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  let workDir: string;
+  let previousExitCode: typeof process.exitCode;
+  let errorSpy: ReturnType<typeof createConsoleErrorSpy>;
+
+  beforeEach(() => {
+    workDir = join(mkdtempSync(join(tmpdir(), 'omc-cli-graph-')), 'repo');
+    mkdirSync(workDir, { recursive: true });
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    errorSpy = createConsoleErrorSpy();
+    mocks.runGraph.mockReset();
+    mocks.runGraph.mockImplementation(async (sealed: SealedGraphDescriptor): Promise<RunResult> => ({
+      terminal: 'succeeded',
+      run_id: sealed.run_id,
+      descriptor_hash: sealed.descriptor_hash,
+      epoch: 1,
+      exit_code: EXIT_CODES.OK,
+    }));
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    process.exitCode = previousExitCode;
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  async function parseCli(argv: readonly string[]): Promise<void> {
+    await graphCommand().parseAsync([...argv], { from: 'user' });
+  }
+
+  it('runs a fresh descriptor end to end with exit code 0', async () => {
+    // Arrange
+    const runsRoot = join(workDir, '.omc', 'graph-runs');
+    const fixturePath = join(workDir, 'descriptor.json');
+    writeFileSync(fixturePath, JSON.stringify(descriptorInput('run-cli-happy', 'CLI happy path')));
+
+    // Act
+    await parseCli(['run', fixturePath, '--runs-root', runsRoot]);
+
+    // Assert
+    expect(process.exitCode).toBe(EXIT_CODES.OK);
+    expect(mocks.runGraph).toHaveBeenCalledTimes(1);
+    const [sealedArg, optionsArg] = mocks.runGraph.mock.calls[0] as [
+      SealedGraphDescriptor,
+      RunOptions,
+    ];
+    expect(sealedArg.run_id).toBe('run-cli-happy');
+    expect(sealedArg.descriptor_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(optionsArg.runsRoot).toBe(runsRoot);
+    expect(optionsArg.executors).toHaveLength(2);
+    expect(typeof optionsArg.prompter.prompt).toBe('function');
+    expect(typeof optionsArg.reporter?.onEvent).toBe('function');
+  });
+
+  it('accepts resume when stored descriptor matches the requested revision', async () => {
+    // Arrange
+    const input = descriptorInput('run-cli-resume', 'resume identity');
+    const sealed = sealGraphDescriptor(input);
+    const runsRoot = join(workDir, '.omc', 'graph-runs');
+    const storedPath = join(runsRoot, input.run_id, 'descriptor.json');
+    mkdirSync(join(runsRoot, input.run_id), { recursive: true });
+    writeFileSync(storedPath, JSON.stringify(sealed));
+    const fixturePath = join(workDir, 'descriptor.json');
+    writeFileSync(fixturePath, JSON.stringify(input));
+
+    // Act
+    await parseCli(['run', fixturePath, '--runs-root', runsRoot]);
+
+    // Assert
+    expect(process.exitCode).toBe(EXIT_CODES.OK);
+    const [sealedArg] = mocks.runGraph.mock.calls[0] as [SealedGraphDescriptor];
+    expect(sealedArg.descriptor_hash).toBe(sealed.descriptor_hash);
+  });
+
+  it('fails with exit code 21 when stored revision differs from the user file', async () => {
+    // Arrange
+    const input = descriptorInput('run-cli-mismatch', 'first revision');
+    const tampered = { ...input, goal: 'second revision' };
+    const sealedStored = sealGraphDescriptor(input);
+    const runsRoot = join(workDir, '.omc', 'graph-runs');
+    const storedPath = join(runsRoot, input.run_id, 'descriptor.json');
+    mkdirSync(join(runsRoot, input.run_id), { recursive: true });
+    writeFileSync(storedPath, JSON.stringify(sealedStored));
+    const fixturePath = join(workDir, 'descriptor.json');
+    writeFileSync(fixturePath, JSON.stringify(tampered));
+
+    // Act
+    await parseCli(['run', fixturePath, '--runs-root', runsRoot]);
+
+    // Assert
+    expect(process.exitCode).toBe(EXIT_CODES.DESCRIPTOR_MISMATCH);
+    expect(errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')).toMatch(
+      /different revision/,
+    );
+    expect(mocks.runGraph).not.toHaveBeenCalled();
+  });
+
+  it('maps unmapped runtime crashes to exit code 70 with a [crash] message', async () => {
+    // Arrange
+    const runsRoot = join(workDir, '.omc', 'graph-runs');
+    const fixturePath = join(workDir, 'descriptor.json');
+    writeFileSync(fixturePath, JSON.stringify(descriptorInput('run-cli-crash', 'crash mapping')));
+    mocks.runGraph.mockRejectedValueOnce(new Error('scheduler contract violated'));
+
+    // Act
+    await parseCli(['run', fixturePath, '--runs-root', runsRoot]);
+
+    // Assert
+    expect(process.exitCode).toBe(70);
+    const stderr = errorSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+    expect(stderr).toContain('[crash]');
+    expect(stderr).toContain('scheduler contract violated');
+  });
+
+  it('reports a clean nonzero failure for a missing descriptor file', async () => {
+    // Arrange
+    const missingPath = join(workDir, 'nope.json');
+
+    // Act
+    await parseCli(['run', missingPath]);
+
+    // Assert
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')).toContain(
+      missingPath,
+    );
+    expect(mocks.runGraph).not.toHaveBeenCalled();
+  });
+});

--- a/src/graph/__tests__/runtime/e2e-crash-recovery.test.ts
+++ b/src/graph/__tests__/runtime/e2e-crash-recovery.test.ts
@@ -1,0 +1,359 @@
+/**
+ * E2E crash-recovery tests (AC-2 kill/resume, AC-3 replay determinism).
+ *
+ * Spawns REAL child processes through the built CLI entry
+ * (`node dist/cli/index.js graph run <fixture> --runs-root <tmp>`), kills the
+ * child mid-run once a node completion is journaled, then re-spawns and proves:
+ * - the resumed run completes exit 0,
+ * - journaled nodes are NOT re-executed (replay line + no activation_started
+ *   for them in stdout + single journal record + marker mtime unchanged),
+ * - the resumed final projection equals a clean direct run's projection under
+ *   canonicalJson equality (epoch-bearing envelope fields excluded).
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync } from "child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+} from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { createRequire } from "module";
+
+import { canonicalJson } from "../../descriptor.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// src/graph/__tests__/runtime -> repo root
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const CLI_ENTRY = join(REPO_ROOT, "dist", "cli", "index.js");
+const FIXTURE_PATH = join(__dirname, "fixtures", "simple-linear.json");
+const FIXTURE = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as {
+  run_id: string;
+};
+const RUN_ID = FIXTURE.run_id;
+const MARKER_ENV_VAR = "GRAPH_E2E_MARKER_DIR";
+
+/** Sources whose changes require a rebuild before the CLI can be spawned. */
+const FRESHNESS_SOURCES = [
+  "src/cli/index.ts",
+  "src/cli/graph.ts",
+  "src/graph/runtime/runner.ts",
+  "src/graph/runtime/types.ts",
+  "src/graph/runtime/journal.ts",
+  "src/graph/runtime/fence.ts",
+  "src/graph/runtime/store.ts",
+  "src/graph/runtime/approval.ts",
+  "src/graph/runtime/progress.ts",
+  "src/graph/runtime/executors/command.ts",
+  "src/graph/runtime/executors/agent.ts",
+  "src/graph/scheduler.ts",
+  "src/graph/descriptor.ts",
+  "src/graph/schema.ts",
+  "src/graph/types.ts",
+];
+
+/**
+ * Content probe: the built CLI must actually know this branch's subcommand
+ * options. mtime alone lies — `git checkout -- dist` restores old content
+ * with a NEW mtime, which would silently skip a needed rebuild.
+ */
+function builtCliLooksCurrent(): boolean {
+  try {
+    return readFileSync(CLI_ENTRY, "utf8").includes("--runs-root");
+  } catch {
+    return false;
+  }
+}
+
+function distIsStale(): boolean {
+  if (!existsSync(CLI_ENTRY) || !builtCliLooksCurrent()) return true;
+  const builtAt = statSync(CLI_ENTRY).mtimeMs;
+  return FRESHNESS_SOURCES.some((rel) => {
+    const source = join(REPO_ROOT, rel);
+    return existsSync(source) && statSync(source).mtimeMs > builtAt;
+  });
+}
+
+let distReady: Promise<void> | null = null;
+
+/** Builds dist once per process when missing or older than runtime sources. */
+function ensureDist(): Promise<void> {
+  if (distReady === null) {
+    distReady = (async () => {
+      if (!distIsStale()) return;
+      const require = createRequire(import.meta.url);
+      const tscEntry = require.resolve("typescript/bin/tsc");
+      const built = spawnSync(process.execPath, [tscEntry], {
+        cwd: REPO_ROOT,
+        stdio: "pipe",
+        timeout: 300_000,
+      });
+      // Fail loudly: a silently failed build leaves a stale CLI that dies
+      // mid-test with an unrelated-looking usage error.
+      if (built.status !== 0 || !existsSync(CLI_ENTRY)) {
+        throw new Error(
+          `dist build failed (exit ${String(built.status)}):\n${built.stderr?.toString() ?? "(no stderr)"}`,
+        );
+      }
+    })();
+  }
+  return distReady;
+}
+
+interface CliRunResult {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface RunningCli {
+  readonly pid: number | undefined;
+  readonly done: Promise<CliRunResult>;
+}
+
+function spawnGraphRun(runsRoot: string, markerDir: string): RunningCli {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    [MARKER_ENV_VAR]: markerDir,
+    CLAUDE_CONFIG_DIR: join(runsRoot, ".claude-config"),
+    NODE_NO_WARNINGS: "1",
+  };
+  // The spawned CLI must parse its argv; the vitest opt-out must not leak.
+  // CLAUDECODE trips the nested-session guard in cli/launch.ts (exit 1), and
+  // parent-session OMC_* state must not leak into the child either.
+  delete env.OMC_CLI_SKIP_PARSE;
+  delete env.CLAUDECODE;
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("OMC_")) delete env[key];
+  }
+  const child = spawn(
+    process.execPath,
+    [CLI_ENTRY, "graph", "run", FIXTURE_PATH, "--runs-root", runsRoot],
+    {
+      cwd: REPO_ROOT,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const done = new Promise<CliRunResult>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+  return { pid: child.pid, done };
+}
+
+function killProcessTree(pid: number): void {
+  if (process.platform === "win32") {
+    // Tree-kill reaches the shell grandchildren holding the run's exec slots.
+    spawnSync("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore" });
+    return;
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // Already gone.
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  what: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
+}
+
+interface ParsedJournalRecord {
+  readonly seq: number;
+  readonly epoch: number;
+  readonly transition: { readonly node_id: string; readonly outcome: string };
+}
+
+function journalRecords(runDir: string): ParsedJournalRecord[] {
+  const path = join(runDir, "journal.jsonl");
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as ParsedJournalRecord];
+      } catch {
+        return [];
+      }
+    });
+}
+
+describe("e2e crash recovery via spawned CLI (AC-2/AC-3)", () => {
+  let baseDir: string | undefined;
+
+  beforeAll(async () => {
+    await ensureDist();
+  }, 300_000);
+
+  afterAll(() => {
+    if (baseDir !== undefined) {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resumes a killed run without re-executing journaled nodes and converges to the direct-run projection", async () => {
+    baseDir = mkdtempSync(join(tmpdir(), "omc-graph-e2e-crash-"));
+    const runsRoot = join(baseDir, "runs-resume");
+    const markers = join(baseDir, "markers-resume");
+    const directRunsRoot = join(baseDir, "runs-direct");
+    const directMarkers = join(baseDir, "markers-direct");
+    const configDir = join(baseDir, "claude-config");
+    for (const dir of [markers, directMarkers, configDir]) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    // --- Run 1: kill mid-run once n1 is journaled and n2 is sleeping. ---
+    const first = spawnGraphRun(runsRoot, markers);
+    const runDir = join(runsRoot, RUN_ID);
+    await waitFor(
+      () => existsSync(join(markers, "n1.marker")),
+      "n1 marker to appear",
+      60_000,
+    );
+    await waitFor(
+      () =>
+        journalRecords(runDir).some(
+          (record) => record.transition.node_id === "n1",
+        ),
+      "n1 journal record",
+      15_000,
+    );
+    const markersBeforeKill = Object.fromEntries(
+      ["n1.marker", "n2.marker", "n3.marker", "term.marker"].map((name) => [
+        name,
+        existsSync(join(markers, name))
+          ? statSync(join(markers, name)).mtimeMs
+          : null,
+      ]),
+    );
+    expect(first.pid).toBeDefined();
+    killProcessTree(first.pid as number);
+    const killed = await first.done;
+    expect(killed.stdout).not.toContain("[done] succeeded");
+
+    // Crash semantics: the lock file stays behind (abnormal exit).
+    const lockPath = join(runDir, "owner.lock");
+    expect(existsSync(lockPath)).toBe(true);
+
+    // Backdate the dead owner past the stale grace so the takeover path is
+    // exercised deterministically instead of busy-failing for 30s.
+    const past = new Date(Date.now() - 120_000);
+    utimesSync(lockPath, past, past);
+
+    // --- Run 2: resume completes exit 0 without re-running n1. ---
+    const resumed = await spawnGraphRun(runsRoot, markers).done;
+    if (resumed.code !== 0) {
+      throw new Error(
+        `resume exited ${resumed.code}\nstdout:\n${resumed.stdout}\nstderr:\n${resumed.stderr}`,
+      );
+    }
+
+    // Skip evidence 1: the resume replayed exactly the one journaled record.
+    expect(resumed.stdout).toContain("[replay] 1 record(s)");
+    // Skip evidence 2: n1 never started an activation in the resumed process.
+    expect(resumed.stdout).not.toMatch(/\[node\] n1 /);
+    // Skip evidence 3: exactly one committed n1 record, written by epoch 1.
+    const records = journalRecords(runDir);
+    const n1Records = records.filter(
+      (record) => record.transition.node_id === "n1",
+    );
+    expect(n1Records).toHaveLength(1);
+    expect(n1Records[0].epoch).toBe(1);
+    // Takeover advanced the epoch: resumed commits carry epoch >= 2.
+    const resumedCommits = records.filter(
+      (record) => record.transition.node_id !== "n1",
+    );
+    expect(resumedCommits.map((record) => record.transition.node_id)).toEqual([
+      "n2",
+      "n3",
+      "term",
+    ]);
+    for (const record of resumedCommits) {
+      expect(record.epoch).toBeGreaterThanOrEqual(2);
+    }
+    // Skip evidence 4: n1's marker was not rewritten by a re-execution.
+    expect(statSync(join(markers, "n1.marker")).mtimeMs).toBe(
+      markersBeforeKill["n1.marker"],
+    );
+    for (const name of ["n2.marker", "n3.marker", "term.marker"]) {
+      expect(existsSync(join(markers, name))).toBe(true);
+    }
+
+    // --- AC-3: same graph, no kill, fresh dirs -> identical projection. ---
+    const direct = await spawnGraphRun(directRunsRoot, directMarkers).done;
+    if (direct.code !== 0) {
+      throw new Error(
+        `direct run exited ${direct.code}\nstdout:\n${direct.stdout}\nstderr:\n${direct.stderr}`,
+      );
+    }
+    expect(direct.stdout).toContain("[replay] 0 record(s)");
+
+    const envelopeA = JSON.parse(
+      readFileSync(join(runsRoot, RUN_ID, "projection.json"), "utf8"),
+    ) as { projection: unknown };
+    const envelopeB = JSON.parse(
+      readFileSync(join(directRunsRoot, RUN_ID, "projection.json"), "utf8"),
+    ) as { projection: unknown };
+    // The command executor measures wall-clock per attempt and embeds
+    // duration_ms into output_summary/evidence; request_fingerprint is a hash
+    // over that raw content, so both are run-to-run variance. Normalize them.
+    expect(canonicalJson(normalizeVolatile(envelopeA.projection))).toBe(
+      canonicalJson(normalizeVolatile(envelopeB.projection)),
+    );
+  }, 300_000);
+});
+
+/**
+ * Neutralizes run-to-run volatile values: executor-measured `duration_ms=N`
+ * tokens inside strings, and `request_fingerprint` hashes derived from them.
+ */
+function normalizeVolatile(value: unknown, key?: string): unknown {
+  if (key === "request_fingerprint") return "<derived-from-measured-io>";
+  if (typeof value === "string") {
+    return value.replace(/duration_ms=\d+/g, "duration_ms=<measured>");
+  }
+  if (Array.isArray(value)) {
+    return value.map((child) => normalizeVolatile(child));
+  }
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    Object.getPrototypeOf(value) === Object.prototype
+  ) {
+    return Object.fromEntries(
+      Object.entries(value).map(([childKey, child]) => [
+        childKey,
+        normalizeVolatile(child, childKey),
+      ]),
+    );
+  }
+  return value;
+}

--- a/src/graph/__tests__/runtime/executors/agent.test.ts
+++ b/src/graph/__tests__/runtime/executors/agent.test.ts
@@ -58,7 +58,16 @@ describe("AgentNodeExecutor", () => {
     ]);
     expect(receivedOptions).toMatchObject({
       prompt: expect.stringContaining("\n\nGoal: Verify human approval gate"),
+      options: {
+        cwd: process.cwd(),
+        tools: ["Read", "Glob", "Grep"],
+        permissionMode: "dontAsk",
+        additionalDirectories: [],
+        persistSession: false,
+      },
     });
+    expect((receivedOptions as { options: { env: NodeJS.ProcessEnv } }).options.env)
+      .not.toHaveProperty("PARENT_SECRET_TOKEN");
   });
 
   it("fails when the query throws", async () => {
@@ -86,6 +95,36 @@ describe("AgentNodeExecutor", () => {
 
     expect(output.outcome).toBe("failed");
     expect(output.output_summary).toBe("timeout after 10ms");
+  });
+
+  it("aborts and interrupts a streaming query at the timeout boundary", async () => {
+    let interrupted = 0;
+    let signal: AbortSignal | undefined;
+    const query = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: () => new Promise<never>(() => {}),
+      interrupt: async () => {
+        interrupted += 1;
+      },
+    };
+    const executor = new AgentNodeExecutor((options: unknown) => {
+      signal =
+        (options as { options: { abortController: AbortController } }).options
+          .abortController.signal;
+      return query;
+    });
+
+    const base = makeContext();
+    const output = await executor.execute({
+      ...base,
+      node: { ...base.node, timeout_ms: 10 },
+    });
+
+    expect(output.output_summary).toBe("timeout after 10ms");
+    expect(signal?.aborted).toBe(true);
+    expect(interrupted).toBe(1);
   });
 
   it("fails on empty response", async () => {
@@ -129,5 +168,52 @@ describe("AgentNodeExecutor", () => {
     expect(output.outcome).toBe("succeeded");
     expect(output.output_summary).toContain("part one.");
     expect(output.output_summary).toContain("part two.");
+  });
+
+  it("rejects reconcile policy without invoking the SDK", async () => {
+    let invoked = false;
+    const executor = new AgentNodeExecutor(() => {
+      invoked = true;
+      return Promise.resolve({});
+    });
+    const base = makeContext();
+    const output = await executor.execute({
+      ...base,
+      node: { ...base.node, effect_policy: { policy: "reconcile" } },
+    });
+
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toBe(
+      "reconcile policy requires a custom executor",
+    );
+    expect(invoked).toBe(false);
+  });
+
+  it("surfaces an idempotency key before the agent effect starts", async () => {
+    let receivedOptions: unknown;
+    const executor = new AgentNodeExecutor(async function* (options: unknown) {
+      receivedOptions = options;
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "read-only result" }] },
+      };
+    });
+    const base = makeContext();
+    const output = await executor.execute({
+      ...base,
+      node: {
+        ...base.node,
+        effect_policy: {
+          policy: "idempotent",
+          idempotency_key_template: "{run_id}:{activation_id}",
+        },
+      },
+    });
+
+    expect(output.external_idempotency_key).toBe("run-approval:act-1");
+    expect(
+      (receivedOptions as { options: { env: NodeJS.ProcessEnv } }).options.env
+        .GRAPH_IDEMPOTENCY_KEY,
+    ).toBe("run-approval:act-1");
   });
 });

--- a/src/graph/__tests__/runtime/executors/agent.test.ts
+++ b/src/graph/__tests__/runtime/executors/agent.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the agent node executor. All SDK interactions go through
+ * injected fakes — zero network in CI.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sealGraphDescriptor } from "../../../descriptor.js";
+import { approvalDescriptor } from "../../fixtures.js";
+import { AgentNodeExecutor } from "../../../runtime/executors/agent.js";
+import type {
+  NodeExecutionContext,
+  NodeExecutionOutput,
+} from "../../../runtime/types.js";
+import type { GraphAgentNode } from "../../../types.js";
+
+function makeContext(overrides?: Partial<NodeExecutionContext>): NodeExecutionContext {
+  const descriptor = sealGraphDescriptor(approvalDescriptor());
+  const node = descriptor.nodes.find((n) => n.id === "entry") as GraphAgentNode;
+  return {
+    descriptor,
+    node,
+    activation_id: "act-1",
+    attempt_id: "att-1",
+    attempt_no: 1,
+    ...overrides,
+  };
+}
+
+describe("AgentNodeExecutor", () => {
+  it("succeeds and summarizes final text from a fake stream", async () => {
+    let receivedOptions: unknown;
+    const executor = new AgentNodeExecutor(async function* (
+      options: unknown,
+    ) {
+      receivedOptions = options;
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Analysis complete." }] },
+      };
+      yield {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Analysis complete.",
+      };
+    });
+
+    const output: NodeExecutionOutput = await executor.execute(makeContext());
+
+    expect(output.outcome).toBe("succeeded");
+    expect(output.output_summary).toContain("Analysis complete.");
+    expect(output.evidence_refs).toEqual([
+      {
+        kind: "url",
+        ref: "agent://act-1",
+        summary: "agent attempt att-1",
+      },
+    ]);
+    expect(receivedOptions).toMatchObject({
+      prompt: expect.stringContaining("\n\nGoal: Verify human approval gate"),
+    });
+  });
+
+  it("fails when the query throws", async () => {
+    const executor = new AgentNodeExecutor(() => {
+      throw new Error("boom");
+    });
+
+    const output = await executor.execute(makeContext());
+
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toContain("error:");
+    expect(output.output_summary).toContain("boom");
+  });
+
+  it("fails with timeout noted when timeout fires before the impl settles", async () => {
+    const executor = new AgentNodeExecutor(
+      (_options: unknown) => new Promise(() => {}), // never settles
+    );
+
+    const base = makeContext();
+    const output = await executor.execute({
+      ...base,
+      node: { ...base.node, timeout_ms: 10 },
+    });
+
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toBe("timeout after 10ms");
+  });
+
+  it("fails on empty response", async () => {
+    const executor = new AgentNodeExecutor(async function* () {});
+
+    const output = await executor.execute(makeContext());
+
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toBe("empty response");
+  });
+
+  it("truncates summaries to 2000 characters", async () => {
+    const long = "x".repeat(3000);
+    const executor = new AgentNodeExecutor(async function* () {
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: long }] },
+      };
+    });
+
+    const output = await executor.execute(makeContext());
+
+    expect(output.outcome).toBe("succeeded");
+    expect(output.output_summary?.length).toBe(2000);
+  });
+});

--- a/src/graph/__tests__/runtime/executors/agent.test.ts
+++ b/src/graph/__tests__/runtime/executors/agent.test.ts
@@ -111,4 +111,23 @@ describe("AgentNodeExecutor", () => {
     expect(output.outcome).toBe("succeeded");
     expect(output.output_summary?.length).toBe(2000);
   });
+
+  it("accumulates multi-message streams instead of keeping only the last chunk", async () => {
+    const executor = new AgentNodeExecutor(async function* () {
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "part one." }] },
+      };
+      yield {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "part two." }] },
+      };
+    });
+
+    const output = await executor.execute(makeContext());
+
+    expect(output.outcome).toBe("succeeded");
+    expect(output.output_summary).toContain("part one.");
+    expect(output.output_summary).toContain("part two.");
+  });
 });

--- a/src/graph/__tests__/runtime/executors/command.test.ts
+++ b/src/graph/__tests__/runtime/executors/command.test.ts
@@ -140,6 +140,8 @@ describe("CommandNodeExecutor", () => {
         policy: "idempotent",
         idempotency_key_template: "{run_id}:{node_id}:{attempt_no}",
       },
+      command:
+        "node -e \"process.stdout.write(process.env.GRAPH_IDEMPOTENCY_KEY ?? '')\"",
     });
 
     const output = (await executor.execute(
@@ -147,6 +149,22 @@ describe("CommandNodeExecutor", () => {
     )) as CommandExecutionOutput;
 
     expect(output.external_idempotency_key).toBe("run-test:cmd:2");
+    expect(output.output_summary).toContain("run-test:cmd:2");
+  });
+
+  it("fails closed for reconcile policy instead of executing an unreconciled effect", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({
+      effect_policy: { policy: "reconcile" },
+      command: "node -e \"throw new Error('must not execute')\"",
+    });
+
+    const output = await executor.execute(contextFor(node));
+
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toBe(
+      "reconcile policy requires a custom executor",
+    );
   });
 
   it("keeps only the tail when stdout exceeds the 2000-char cap", async () => {

--- a/src/graph/__tests__/runtime/executors/command.test.ts
+++ b/src/graph/__tests__/runtime/executors/command.test.ts
@@ -97,10 +97,11 @@ describe("CommandNodeExecutor", () => {
     expect(output.external_idempotency_key).toBeUndefined();
   });
 
-  it("fails fast on timeout and notes the timeout in the summary", async () => {
+  it("fails fast on timeout, kills the tree, and leaves no orphaned grandchild", async () => {
     const executor = new CommandNodeExecutor();
     const node = commandNode({
-      command: "node -e \"setTimeout(()=>{},10000)\"",
+      command:
+        "node -e \"console.log('GPID:' + process.pid); setTimeout(()=>{},10000)\"",
       timeout_ms: 300,
     });
     const startedAtMs = Date.now();
@@ -112,6 +113,24 @@ describe("CommandNodeExecutor", () => {
     expect(output.output_summary).toContain("timeout after 300ms");
     // Must not wait for the child's own 10s timer to elapse.
     expect(elapsedMs).toBeLessThan(9_000);
+
+    // Deterministic orphan check: the grandchild printed its own PID before
+    // sleeping; after the tree kill that process must be gone.
+    const gpid = Number(
+      /\bGPID:(\d+)\b/.exec(output.output_summary ?? "")?.[1] ?? "0",
+    );
+    expect(gpid).toBeGreaterThan(0);
+    const deadline = Date.now() + 2_000;
+    let gone = false;
+    while (Date.now() < deadline && !gone) {
+      try {
+        process.kill(gpid, 0);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      } catch {
+        gone = true;
+      }
+    }
+    expect(gone).toBe(true);
   }, 20_000);
 
   it("substitutes idempotency key tokens for idempotent policies", async () => {
@@ -142,5 +161,25 @@ describe("CommandNodeExecutor", () => {
     expect(output.outcome).toBe("succeeded");
     expect(output.output_summary).toContain("END-MARKER");
     expect(output.output_summary).not.toContain("START-MARKER");
+  });
+
+  it("scrubs non-allowlisted env from the child; GRAPH_* passes through", async () => {
+    const executor = new CommandNodeExecutor();
+    process.env.PARENT_SECRET_TOKEN = "leak-me";
+    process.env.GRAPH_TEST_MARKER = "sentinel-ok";
+    try {
+      const node = commandNode({
+        command:
+          "node -e \"process.stdout.write(String(process.env['PARENT_SECRET_TOKEN']===undefined)+'|'+String(process.env['GRAPH_TEST_MARKER']))\"",
+      });
+
+      const output = await executor.execute(contextFor(node));
+
+      expect(output.outcome).toBe("succeeded");
+      expect(output.output_summary).toContain("true|sentinel-ok");
+    } finally {
+      delete process.env.PARENT_SECRET_TOKEN;
+      delete process.env.GRAPH_TEST_MARKER;
+    }
   });
 });

--- a/src/graph/__tests__/runtime/executors/command.test.ts
+++ b/src/graph/__tests__/runtime/executors/command.test.ts
@@ -1,0 +1,146 @@
+/**
+ * CommandNodeExecutor tests (worker-4).
+ *
+ * Deterministic and cross-platform: every spawned command is a
+ * `node -e "<js>"` one-liner, so behavior does not depend on the host shell.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { CommandNodeExecutor } from "../../../runtime/executors/command.js";
+import type { CommandExecutionOutput } from "../../../runtime/executors/command.js";
+import type { NodeExecutionContext } from "../../../runtime/types.js";
+import type {
+  GraphCommandNode,
+  SealedGraphDescriptor,
+} from "../../../types.js";
+
+function commandNode(overrides: Partial<GraphCommandNode> = {}): GraphCommandNode {
+  return {
+    id: "cmd",
+    kind: "command",
+    title: "Command node",
+    timeout_ms: 60_000,
+    max_attempts: 3,
+    effect_policy: { policy: "side_effect_free" },
+    command: "node -e \"process.exit(0)\"",
+    ...overrides,
+  };
+}
+
+function contextFor(
+  node: GraphCommandNode,
+  overrides: Partial<NodeExecutionContext> = {},
+): NodeExecutionContext {
+  const descriptor: SealedGraphDescriptor = {
+    descriptor_version: 1,
+    run_id: "run-test",
+    revision_id: "rev-test",
+    goal: "test goal",
+    nodes: [node],
+    edges: [],
+    entry_node_ids: [node.id],
+    concurrency_limit: 1,
+    terminal_verification_node_id: node.id,
+    descriptor_hash: "a".repeat(64),
+  };
+  return {
+    descriptor,
+    node,
+    activation_id: "act-1",
+    attempt_id: "att-1",
+    attempt_no: 2,
+    ...overrides,
+  };
+}
+
+describe("CommandNodeExecutor", () => {
+  it("reports succeeded for an exiting-zero command with evidence", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({ command: "node -e \"process.exit(0)\"" });
+
+    const output = await executor.execute(contextFor(node));
+
+    expect(output.outcome).toBe("succeeded");
+    const primary = output.evidence_refs.find((ref) => ref.ref === node.command);
+    expect(primary).toBeDefined();
+    expect(primary?.kind).toBe("command");
+    expect(primary?.summary).toMatch(/exit=0 duration_ms=\d+/);
+  });
+
+  it("reports failed for a non-zero exit code", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({ command: "node -e \"process.exit(3)\"" });
+
+    const output = await executor.execute(contextFor(node));
+
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toContain("exit=3");
+  });
+
+  it("captures stdout excerpts into the summary and evidence", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({
+      command: "node -e \"console.log('hello-graph')\"",
+    });
+
+    const output = (await executor.execute(
+      contextFor(node),
+    )) as CommandExecutionOutput;
+
+    expect(output.outcome).toBe("succeeded");
+    expect(output.output_summary).toContain("hello-graph");
+    const stdoutEvidence = output.evidence_refs.find((ref) =>
+      ref.ref.startsWith("stdout:"),
+    );
+    expect(stdoutEvidence?.summary).toContain("hello-graph");
+    expect(output.external_idempotency_key).toBeUndefined();
+  });
+
+  it("fails fast on timeout and notes the timeout in the summary", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({
+      command: "node -e \"setTimeout(()=>{},10000)\"",
+      timeout_ms: 300,
+    });
+    const startedAtMs = Date.now();
+
+    const output = await executor.execute(contextFor(node));
+
+    const elapsedMs = Date.now() - startedAtMs;
+    expect(output.outcome).toBe("failed");
+    expect(output.output_summary).toContain("timeout after 300ms");
+    // Must not wait for the child's own 10s timer to elapse.
+    expect(elapsedMs).toBeLessThan(9_000);
+  }, 20_000);
+
+  it("substitutes idempotency key tokens for idempotent policies", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({
+      effect_policy: {
+        policy: "idempotent",
+        idempotency_key_template: "{run_id}:{node_id}:{attempt_no}",
+      },
+    });
+
+    const output = (await executor.execute(
+      contextFor(node),
+    )) as CommandExecutionOutput;
+
+    expect(output.external_idempotency_key).toBe("run-test:cmd:2");
+  });
+
+  it("keeps only the tail when stdout exceeds the 2000-char cap", async () => {
+    const executor = new CommandNodeExecutor();
+    const node = commandNode({
+      command:
+        "node -e \"console.log('START-MARKER' + '#'.repeat(3000) + 'END-MARKER')\"",
+    });
+
+    const output = await executor.execute(contextFor(node));
+
+    expect(output.outcome).toBe("succeeded");
+    expect(output.output_summary).toContain("END-MARKER");
+    expect(output.output_summary).not.toContain("START-MARKER");
+  });
+});

--- a/src/graph/__tests__/runtime/fence.test.ts
+++ b/src/graph/__tests__/runtime/fence.test.ts
@@ -15,6 +15,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -29,6 +30,7 @@ import { FenceError } from "../../runtime/types.js";
 import type { FenceLockPayload } from "../../runtime/types.js";
 
 const LOCK_NAME = "owner.lock";
+const EPOCH_FILE_NAME = "owner.epoch";
 
 function makeFence(dir: string, staleGraceMs = 1000): FileOwnershipFence {
   return new FileOwnershipFence(dirname(dir), basename(dir), { staleGraceMs });
@@ -111,6 +113,47 @@ describe("FileOwnershipFence", () => {
       pid: process.pid,
       epoch: 2,
     });
+    expect(readFileSync(join(dir, EPOCH_FILE_NAME), "utf8").trim()).toBe("2");
+  });
+
+  it("keeps epoch continuity across release/restart via the owner.epoch sidecar", async () => {
+    const dir = makeRunDir();
+
+    // Generation 1: seeded dead-pid takeover -> epoch 2 (journal history
+    // would hold epoch-2 records after this run).
+    craftJsonLock(dir, {
+      pid: spawnDeadPid(),
+      epoch: 1,
+      timestamp: Date.now(),
+    });
+    backdate(join(dir, LOCK_NAME));
+    const first = makeFence(dir);
+    await expect(first.acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 2,
+    });
+    // Run completes normally: only the live lock is removed; the sidecar
+    // and journal stay behind.
+    await expect(first.release(2)).resolves.toBe(true);
+    expect(existsSync(join(dir, LOCK_NAME))).toBe(false);
+    expect(existsSync(join(dir, EPOCH_FILE_NAME))).toBe(true);
+
+    // Later resume with no owner.lock: sidecar ceiling 2 forbids reissuing
+    // it, so the next holder gets epoch 3 — no fold false-positive against
+    // the persisted epoch-2 journal records.
+    const second = makeFence(dir);
+    await expect(second.acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 3,
+    });
+    await expect(second.release(3)).resolves.toBe(true);
+
+    // Two-generation positive scenario keeps advancing without repeats.
+    await expect(second.acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 4,
+    });
+    expect(readFileSync(join(dir, EPOCH_FILE_NAME), "utf8").trim()).toBe("4");
   });
 
   it("releases atomically once and refuses a second release (AC-6)", async () => {
@@ -121,6 +164,25 @@ describe("FileOwnershipFence", () => {
     await expect(fence.release(1)).resolves.toBe(true);
     expect(existsSync(join(dir, LOCK_NAME))).toBe(false);
     await expect(fence.release(1)).resolves.toBe(false);
+  });
+
+  it("refuses to release after an external swap planted a new owner's lock (single-writer)", async () => {
+    const dir = makeRunDir();
+    const fence = makeFence(dir);
+    await fence.acquire();
+
+    // Maintainer probe: externally move our lock away, then plant a
+    // replacement epoch-2 lock at the same path.
+    renameSync(join(dir, LOCK_NAME), join(dir, `${LOCK_NAME}.stolen`));
+    craftJsonLock(dir, { pid: process.pid, epoch: 2, timestamp: Date.now() });
+
+    // Stale holder's release must not touch the replacement owner's lock.
+    await expect(fence.release(1)).resolves.toBe(false);
+    expect(readLockPayload(dir)).toMatchObject({ pid: process.pid, epoch: 2 });
+    expect(existsSync(join(dir, LOCK_NAME))).toBe(true);
+
+    // The same identity guard fences out stale assertions.
+    expect(() => fence.assertEpoch(1)).toThrow(FenceError);
   });
 
   it("interleave probe: exactly one winner per dir per round (AC-5)", async () => {

--- a/src/graph/__tests__/runtime/fence.test.ts
+++ b/src/graph/__tests__/runtime/fence.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for FileOwnershipFence (graph runtime v2).
+ *
+ * Covers fresh acquisition, live-holder busy (AC-7), dead-holder takeover
+ * with epoch increment (AC-4), atomic release (AC-6), the #3555 interleave
+ * probe form (AC-5: at most one winner per dir per round), fenced_out
+ * assertion, and stale-grace handling of corrupt locks. Epoch values in the
+ * probe are deterministic from the seeded predecessor; strict epoch
+ * monotonicity is NOT guaranteed across corrupt-tombstone takeovers
+ * (fallback to 2) — ownership safety comes from O_EXCL + atomic rename.
+ */
+import { spawnSync } from "child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { basename, dirname, join } from "path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FileOwnershipFence } from "../../runtime/fence.js";
+import { FenceError } from "../../runtime/types.js";
+import type { FenceLockPayload } from "../../runtime/types.js";
+
+const LOCK_NAME = "owner.lock";
+
+function makeFence(dir: string, staleGraceMs = 1000): FileOwnershipFence {
+  return new FileOwnershipFence(dirname(dir), basename(dir), { staleGraceMs });
+}
+
+/** PID of a process that has fully exited. */
+function spawnDeadPid(): number {
+  const child = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+  if (child.error || child.pid === undefined) {
+    throw new Error("failed to spawn helper process for dead-pid test");
+  }
+  return child.pid;
+}
+
+function craftLock(dir: string, content: string): string {
+  const lockPath = join(dir, LOCK_NAME);
+  writeFileSync(lockPath, content, "utf8");
+  return lockPath;
+}
+
+function craftJsonLock(dir: string, payload: FenceLockPayload): string {
+  return craftLock(dir, JSON.stringify(payload));
+}
+
+/** Backdate mtime so staleness checks are deterministic (no sleeps). */
+function backdate(filePath: string, msAgo = 60_000): void {
+  const past = new Date(Date.now() - msAgo);
+  utimesSync(filePath, past, past);
+}
+
+function readLockPayload(dir: string): FenceLockPayload {
+  return JSON.parse(readFileSync(join(dir, LOCK_NAME), "utf8")) as FenceLockPayload;
+}
+
+describe("FileOwnershipFence", () => {
+  let roots: string[] = [];
+
+  /** Fresh runsRoot + run dir under os.tmpdir(); auto-cleaned after each test. */
+  function makeRunDir(): string {
+    const root = mkdtempSync(join(tmpdir(), "omc-fence-"));
+    roots.push(root);
+    const dir = join(root, "run-1");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("acquires a fresh run at epoch 1 and reports busy for a second instance", async () => {
+    const dir = makeRunDir();
+
+    await expect(makeFence(dir).acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 1,
+    });
+    expect(readLockPayload(dir)).toMatchObject({ pid: process.pid, epoch: 1 });
+
+    // Live healthy holder in this same process -> fail-closed busy (AC-7).
+    await expect(makeFence(dir).acquire()).resolves.toEqual({ outcome: "busy" });
+  });
+
+  it("takes over a dead holder's lock at old_epoch + 1 (AC-4)", async () => {
+    const dir = makeRunDir();
+    craftJsonLock(dir, {
+      pid: spawnDeadPid(),
+      epoch: 1,
+      timestamp: Date.now(),
+    });
+    backdate(join(dir, LOCK_NAME));
+
+    await expect(makeFence(dir).acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 2,
+    });
+    expect(readLockPayload(dir)).toMatchObject({
+      pid: process.pid,
+      epoch: 2,
+    });
+  });
+
+  it("releases atomically once and refuses a second release (AC-6)", async () => {
+    const dir = makeRunDir();
+    const fence = makeFence(dir);
+    await fence.acquire();
+
+    await expect(fence.release(1)).resolves.toBe(true);
+    expect(existsSync(join(dir, LOCK_NAME))).toBe(false);
+    await expect(fence.release(1)).resolves.toBe(false);
+  });
+
+  it("interleave probe: exactly one winner per dir per round (AC-5)", async () => {
+    const ROUNDS = 6;
+    const dirs = [makeRunDir(), makeRunDir(), makeRunDir()];
+    const epochsByDir = new Map<string, number[]>();
+
+    for (let round = 1; round <= ROUNDS; round++) {
+      for (const dir of dirs) {
+        // Deterministic race form from the #3555 review: pre-seed a dead-pid
+        // lock, then start two racers concurrently on the same run dir.
+        craftJsonLock(dir, {
+          pid: spawnDeadPid(),
+          epoch: round,
+          timestamp: Date.now(),
+        });
+        backdate(join(dir, LOCK_NAME));
+
+        const settled = await Promise.allSettled([
+          makeFence(dir).acquire(),
+          makeFence(dir).acquire(),
+        ]);
+        const outcomes = settled.map((result) => {
+          if (result.status === "rejected") {
+            throw result.reason;
+          }
+          return result.value;
+        });
+
+        const winners = outcomes.filter(
+          (outcome) => outcome.outcome === "acquired",
+        );
+        // The loser always observes either a live-pid lock or a fresh one,
+        // so exactly one racer wins each round; never both (#3555 invariant:
+        // at most one acquired per dir per round).
+        expect(winners.length).toBe(1);
+
+        const winner = winners[0];
+        if (winner.outcome === "acquired") {
+          // Seeded dead holder had epoch=round -> takeover must be round+1.
+          expect(winner.epoch).toBe(round + 1);
+          const prior = epochsByDir.get(dir) ?? [];
+          // Non-repetition here follows from the seeded predecessor value,
+          // not from any continuity guarantee: a corrupt-tombstone takeover
+          // would legitimately fall back to epoch 2.
+          expect(prior).not.toContain(winner.epoch);
+          prior.push(winner.epoch);
+          epochsByDir.set(dir, prior);
+        }
+        expect(outcomes.filter((o) => o.outcome === "busy").length).toBe(1);
+      }
+    }
+  });
+
+  it("throws FenceError('fenced_out') for a wrong epoch claim", async () => {
+    const dir = makeRunDir();
+    const fence = makeFence(dir);
+    await fence.acquire();
+
+    let caught: unknown;
+    try {
+      fence.assertEpoch(2);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(FenceError);
+    expect((caught as FenceError).code).toBe("fenced_out");
+
+    expect(() => fence.assertEpoch(1)).not.toThrow();
+  });
+
+  it("takes over corrupt content older than the grace period", async () => {
+    const dir = makeRunDir();
+    craftLock(dir, "not json {{{");
+    backdate(join(dir, LOCK_NAME));
+
+    // Unparseable tombstone falls back to old_epoch 1 -> acquired at 2.
+    await expect(makeFence(dir).acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 2,
+    });
+  });
+
+  it("reports busy for corrupt content younger than the grace period", async () => {
+    const dir = makeRunDir();
+    craftLock(dir, "not json {{{"); // fresh mtime
+
+    await expect(makeFence(dir).acquire()).resolves.toEqual({
+      outcome: "busy",
+    });
+  });
+});

--- a/src/graph/__tests__/runtime/fence.test.ts
+++ b/src/graph/__tests__/runtime/fence.test.ts
@@ -116,6 +116,36 @@ describe("FileOwnershipFence", () => {
     expect(readFileSync(join(dir, EPOCH_FILE_NAME), "utf8").trim()).toBe("2");
   });
 
+  it("does not take over a replacement lock raced into the stale path", async () => {
+    const dir = makeRunDir();
+    const staleLock = join(dir, LOCK_NAME);
+    craftJsonLock(dir, {
+      pid: spawnDeadPid(),
+      epoch: 1,
+      timestamp: Date.now(),
+    });
+    backdate(staleLock);
+
+    let raced = false;
+    const racedFence = new FileOwnershipFence(dirname(dir), basename(dir), {
+      staleGraceMs: 1000,
+      beforeTakeoverRename: () => {
+        if (raced) return;
+        raced = true;
+        renameSync(staleLock, join(dir, `${LOCK_NAME}.old`));
+        craftJsonLock(dir, {
+          pid: process.pid,
+          epoch: 2,
+          timestamp: Date.now(),
+        });
+      },
+    });
+
+    await expect(racedFence.acquire()).resolves.toEqual({ outcome: "busy" });
+    expect(readLockPayload(dir)).toMatchObject({ pid: process.pid, epoch: 2 });
+    expect(existsSync(join(dir, `${LOCK_NAME}.old`))).toBe(true);
+  });
+
   it("keeps epoch continuity across release/restart via the owner.epoch sidecar", async () => {
     const dir = makeRunDir();
 

--- a/src/graph/__tests__/runtime/fixtures/back-edge-graph.json
+++ b/src/graph/__tests__/runtime/fixtures/back-edge-graph.json
@@ -1,0 +1,73 @@
+{
+  "descriptor_version": 1,
+  "run_id": "run-regression-back-edge",
+  "revision_id": "rev-regression-back-edge",
+  "goal": "Bounded retry loop round-trip",
+  "nodes": [
+    {
+      "id": "start",
+      "kind": "agent",
+      "title": "Start",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "instructions": "Start the bounded loop"
+    },
+    {
+      "id": "work",
+      "kind": "command",
+      "title": "Work",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "echo work"
+    },
+    {
+      "id": "give_up",
+      "kind": "command",
+      "title": "Give up",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "echo give-up"
+    },
+    {
+      "id": "term",
+      "kind": "command",
+      "title": "Terminal",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "echo term"
+    }
+  ],
+  "edges": [
+    { "id": "e-start-work", "kind": "fixed", "from": "start", "to": "work" },
+    {
+      "id": "e-work-retry",
+      "kind": "back_edge",
+      "from": "work",
+      "to": "work",
+      "route": "retry",
+      "max_traversals": 2
+    },
+    {
+      "id": "e-work-give-up",
+      "kind": "conditional",
+      "from": "work",
+      "to": "give_up",
+      "route": "give-up"
+    },
+    {
+      "id": "e-work-term",
+      "kind": "conditional",
+      "from": "work",
+      "to": "term",
+      "route": "success"
+    },
+    { "id": "e-give-up-term", "kind": "fixed", "from": "give_up", "to": "term" }
+  ],
+  "entry_node_ids": ["start"],
+  "concurrency_limit": 1,
+  "terminal_verification_node_id": "term"
+}

--- a/src/graph/__tests__/runtime/fixtures/fanout-join-graph.json
+++ b/src/graph/__tests__/runtime/fixtures/fanout-join-graph.json
@@ -1,0 +1,75 @@
+{
+  "descriptor_version": 1,
+  "run_id": "run-regression-fanout-join",
+  "revision_id": "rev-regression-fanout-join",
+  "goal": "Fan-out/join regression matrix",
+  "nodes": [
+    {
+      "id": "fan",
+      "kind": "agent",
+      "title": "Fan out",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "instructions": "Fan out into branches"
+    },
+    {
+      "id": "b1",
+      "kind": "agent",
+      "title": "Branch one",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "instructions": "Branch one work"
+    },
+    {
+      "id": "b2",
+      "kind": "command",
+      "title": "Branch two",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "echo b2"
+    },
+    {
+      "id": "join",
+      "kind": "join",
+      "title": "Join",
+      "fan_out_node_id": "fan",
+      "input_branch_ids": ["br1", "br2"]
+    },
+    {
+      "id": "term",
+      "kind": "command",
+      "title": "Terminal",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "echo term"
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-fan-b1",
+      "kind": "fan_out",
+      "from": "fan",
+      "to": "b1",
+      "branch_id": "br1",
+      "owner_join_id": "join"
+    },
+    {
+      "id": "e-fan-b2",
+      "kind": "fan_out",
+      "from": "fan",
+      "to": "b2",
+      "branch_id": "br2",
+      "owner_join_id": "join"
+    },
+    { "id": "e-b1-join", "kind": "fixed", "from": "b1", "to": "join" },
+    { "id": "e-b2-join", "kind": "fixed", "from": "b2", "to": "join" },
+    { "id": "e-join-term", "kind": "fixed", "from": "join", "to": "term" }
+  ],
+  "entry_node_ids": ["fan"],
+  "concurrency_limit": 2,
+  "terminal_verification_node_id": "term"
+}

--- a/src/graph/__tests__/runtime/fixtures/simple-linear.json
+++ b/src/graph/__tests__/runtime/fixtures/simple-linear.json
@@ -1,0 +1,52 @@
+{
+  "descriptor_version": 1,
+  "run_id": "run-e2e-crash-linear",
+  "revision_id": "rev-e2e-crash-linear",
+  "goal": "e2e crash recovery linear chain",
+  "nodes": [
+    {
+      "id": "n1",
+      "kind": "command",
+      "title": "Stage one",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "node -e \"require('fs').writeFileSync(process.env.GRAPH_E2E_MARKER_DIR + '/n1.marker', String(Date.now()))\""
+    },
+    {
+      "id": "n2",
+      "kind": "command",
+      "title": "Stage two (slow)",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "node -e \"setTimeout(function () { require('fs').writeFileSync(process.env.GRAPH_E2E_MARKER_DIR + '/n2.marker', String(Date.now())) }, 1500)\""
+    },
+    {
+      "id": "n3",
+      "kind": "command",
+      "title": "Stage three",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "node -e \"setTimeout(function () { require('fs').writeFileSync(process.env.GRAPH_E2E_MARKER_DIR + '/n3.marker', String(Date.now())) }, 200)\""
+    },
+    {
+      "id": "term",
+      "kind": "command",
+      "title": "Terminal verification",
+      "timeout_ms": 60000,
+      "max_attempts": 3,
+      "effect_policy": { "policy": "side_effect_free" },
+      "command": "node -e \"require('fs').writeFileSync(process.env.GRAPH_E2E_MARKER_DIR + '/term.marker', String(Date.now()))\""
+    }
+  ],
+  "edges": [
+    { "id": "e-n1-n2", "kind": "fixed", "from": "n1", "to": "n2" },
+    { "id": "e-n2-n3", "kind": "fixed", "from": "n2", "to": "n3" },
+    { "id": "e-n3-term", "kind": "fixed", "from": "n3", "to": "term" }
+  ],
+  "entry_node_ids": ["n1"],
+  "concurrency_limit": 1,
+  "terminal_verification_node_id": "term"
+}

--- a/src/graph/__tests__/runtime/journal-epoch.test.ts
+++ b/src/graph/__tests__/runtime/journal-epoch.test.ts
@@ -1,0 +1,161 @@
+/**
+ * P1-4 journal epoch provenance regression tests.
+ *
+ * A committed record's epoch must be semantically bound at resume-fold:
+ * - forged future epochs (currentEpoch+N) fail closed CORRUPT_JOURNAL(20)
+ *   without executing any node (maintainer probe reproduction);
+ * - legitimately increasing epochs across takeovers (1 then 2) fold fine.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "fs";
+import { spawnSync } from "child_process";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { canonicalJson, sealGraphDescriptor } from "../../descriptor.js";
+import { runGraph } from "../../runtime/runner.js";
+import { EXIT_CODES } from "../../runtime/types.js";
+import type {
+  JournalRecord,
+  NodeExecutionContext,
+  NodeExecutionOutput,
+  NodeExecutor,
+} from "../../runtime/types.js";
+import type { GraphDescriptorInput } from "../../types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "fixtures");
+
+function loadFixture(name: string): GraphDescriptorInput {
+  return JSON.parse(
+    readFileSync(join(FIXTURES_DIR, name), "utf8"),
+  ) as GraphDescriptorInput;
+}
+
+const tempDirs: string[] = [];
+
+function makeRunsRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-journal-epoch-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+class OkExecutor implements NodeExecutor {
+  readonly kinds = ["agent", "command"] as const;
+  readonly calls: string[] = [];
+
+  async execute(context: NodeExecutionContext): Promise<NodeExecutionOutput> {
+    this.calls.push(context.node.id);
+    return {
+      outcome: "succeeded",
+      output_summary: `ok:${context.node.id}`,
+      evidence_refs: [{ kind: "command", ref: `cmd:${context.node.id}` }],
+    };
+  }
+}
+
+function runOptions(
+  runsRoot: string,
+  executor: NodeExecutor,
+): Parameters<typeof runGraph>[1] {
+  return {
+    runsRoot,
+    executors: [executor],
+    prompter: { prompt: async () => "approved" },
+  };
+}
+
+/** Completes a linear run and rewrites journal epochs per line index. */
+async function completeRunWithEpochs(
+  runsRoot: string,
+  epochForLine: (index: number) => number,
+): Promise<{ sealed: ReturnType<typeof sealGraphDescriptor>; lines: string[] }> {
+  const sealed = sealGraphDescriptor(loadFixture("simple-linear.json"));
+  const firstRun = await runGraph(sealed, runOptions(runsRoot, new OkExecutor()));
+  if (firstRun.exit_code !== EXIT_CODES.OK) {
+    throw new Error(`fixture run failed with exit ${firstRun.exit_code}`);
+  }
+  const journalPath = join(runsRoot, sealed.run_id, "journal.jsonl");
+  const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
+  const rewritten = lines.map((line, index) => {
+    const record = JSON.parse(line) as JournalRecord;
+    (record as { epoch: number }).epoch = epochForLine(index);
+    return canonicalJson(record);
+  });
+  writeFileSync(journalPath, `${rewritten.join("\n")}\n`, "utf8");
+  return { sealed, lines };
+}
+
+describe("journal epoch provenance (P1-4)", () => {
+  it("fails closed CORRUPT_JOURNAL when a record carries a forged future epoch", async () => {
+    // Arrange: complete a clean epoch-1 run, then bump one record's epoch to
+    // currentEpoch + 998 (envelope-valid, semantically forged).
+    const runsRoot = makeRunsRoot();
+    const { sealed } = await completeRunWithEpochs(runsRoot, () => 1);
+    const journalPath = join(runsRoot, sealed.run_id, "journal.jsonl");
+    const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const forged = JSON.parse(lines[0] as string) as JournalRecord;
+    (forged as { epoch: number }).epoch = 1 + 998;
+    lines[0] = canonicalJson(forged);
+    writeFileSync(journalPath, `${lines.join("\n")}\n`, "utf8");
+
+    // Act: resume over the forged history.
+    const resumeExecutor = new OkExecutor();
+    const result = await runGraph(sealed, runOptions(runsRoot, resumeExecutor));
+
+    // Assert: fold rejects the forged provenance before executing anything.
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.CORRUPT_JOURNAL);
+    expect(resumeExecutor.calls).toEqual([]);
+  });
+
+  it("folds legitimately increasing epochs across two takeovers (1 then 2)", async () => {
+    // Arrange: rewrite completed history into two generations (epoch 1 then
+    // 2), then force the resuming process to take over at epoch 2 via a
+    // stale dead-pid lock (backdated past the grace period).
+    const runsRoot = makeRunsRoot();
+    const { sealed } = await completeRunWithEpochs(
+      runsRoot,
+      (index) => (index < 2 ? 1 : 2),
+    );
+    const exitedChild = spawnSync(process.execPath, ["-e", ""]);
+    const deadPid = exitedChild.pid as number;
+    const lockPath = join(runsRoot, sealed.run_id, "owner.lock");
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({
+        pid: deadPid,
+        epoch: 1,
+        timestamp: Date.now() - 120_000,
+      })}\n`,
+      "utf8",
+    );
+    const backdated = new Date(Date.now() - 120_000);
+    utimesSync(lockPath, backdated, backdated);
+
+    // Act: resume must take over at epoch 2 and fold the mixed history.
+    const resumeExecutor = new OkExecutor();
+    const result = await runGraph(sealed, runOptions(runsRoot, resumeExecutor));
+
+    // Assert: legitimate epoch progression replays cleanly, no work rerun.
+    expect(result.terminal).toBe("succeeded");
+    expect(result.epoch).toBe(2);
+    expect(result.exit_code).toBe(EXIT_CODES.OK);
+    expect(resumeExecutor.calls).toEqual([]);
+  });
+});

--- a/src/graph/__tests__/runtime/journal-epoch.test.ts
+++ b/src/graph/__tests__/runtime/journal-epoch.test.ts
@@ -21,6 +21,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 import { canonicalJson, sealGraphDescriptor } from "../../descriptor.js";
+import { computeJournalFingerprint } from "../../runtime/journal.js";
 import { runGraph } from "../../runtime/runner.js";
 import { EXIT_CODES } from "../../runtime/types.js";
 import type {
@@ -93,8 +94,13 @@ async function completeRunWithEpochs(
   const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
   const rewritten = lines.map((line, index) => {
     const record = JSON.parse(line) as JournalRecord;
-    (record as { epoch: number }).epoch = epochForLine(index);
-    return canonicalJson(record);
+    const { journal_fingerprint: _journalFingerprint, ...withoutFingerprint } =
+      record;
+    const unsigned = { ...withoutFingerprint, epoch: epochForLine(index) };
+    return canonicalJson({
+      ...unsigned,
+      journal_fingerprint: computeJournalFingerprint(unsigned),
+    });
   });
   writeFileSync(journalPath, `${rewritten.join("\n")}\n`, "utf8");
   return { sealed, lines };
@@ -110,8 +116,13 @@ describe("journal epoch provenance (P1-4)", () => {
     const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
     expect(lines.length).toBeGreaterThanOrEqual(2);
     const forged = JSON.parse(lines[0] as string) as JournalRecord;
-    (forged as { epoch: number }).epoch = 1 + 998;
-    lines[0] = canonicalJson(forged);
+    const { journal_fingerprint: _journalFingerprint, ...withoutFingerprint } =
+      forged;
+    const unsigned = { ...withoutFingerprint, epoch: 1 + 998 };
+    lines[0] = canonicalJson({
+      ...unsigned,
+      journal_fingerprint: computeJournalFingerprint(unsigned),
+    });
     writeFileSync(journalPath, `${lines.join("\n")}\n`, "utf8");
 
     // Act: resume over the forged history.
@@ -119,6 +130,27 @@ describe("journal epoch provenance (P1-4)", () => {
     const result = await runGraph(sealed, runOptions(runsRoot, resumeExecutor));
 
     // Assert: fold rejects the forged provenance before executing anything.
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.CORRUPT_JOURNAL);
+    expect(resumeExecutor.calls).toEqual([]);
+  });
+
+  it("fails closed when all records are rebound to the acquired epoch without rebinding their envelopes", async () => {
+    const runsRoot = makeRunsRoot();
+    const { sealed } = await completeRunWithEpochs(runsRoot, () => 1);
+    const journalPath = join(runsRoot, sealed.run_id, "journal.jsonl");
+    const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
+    const rewritten = lines.map((line) => {
+      const record = JSON.parse(line) as JournalRecord;
+      // Epoch 2 is valid for the resuming owner, but the old envelope
+      // fingerprint still authenticates epoch 1.
+      return canonicalJson({ ...record, epoch: 2 });
+    });
+    writeFileSync(journalPath, `${rewritten.join("\n")}\n`, "utf8");
+
+    const resumeExecutor = new OkExecutor();
+    const result = await runGraph(sealed, runOptions(runsRoot, resumeExecutor));
+
     expect(result.terminal).toBe("failed");
     expect(result.exit_code).toBe(EXIT_CODES.CORRUPT_JOURNAL);
     expect(resumeExecutor.calls).toEqual([]);

--- a/src/graph/__tests__/runtime/journal.test.ts
+++ b/src/graph/__tests__/runtime/journal.test.ts
@@ -3,7 +3,14 @@
  * and ordered concurrent appends.
  */
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -103,6 +110,23 @@ describe("FileJournal", () => {
 
     // Assert
     expect(records).toEqual([]);
+  });
+
+  it("fails closed when journal.jsonl is a symlink", async () => {
+    const runsRoot = makeRunsRoot();
+    const outside = join(makeRunsRoot(), "outside.jsonl");
+    writeFileSync(outside, "outside", "utf8");
+    mkdirSync(join(runsRoot, "run-1"), { recursive: true });
+    symlinkSync(outside, journalPath(runsRoot));
+    const journal = new FileJournal(runsRoot, "run-1");
+
+    await expect(journal.readAll()).rejects.toBeInstanceOf(
+      JournalCorruptionError,
+    );
+    await expect(journal.append(makeRecord(0))).rejects.toBeInstanceOf(
+      JournalCorruptionError,
+    );
+    expect(readFileSync(outside, "utf8")).toBe("outside");
   });
 
   it("throws JournalCorruptionError with truncatedCount >= 1 on a trailing partial line [AC-8]", async () => {

--- a/src/graph/__tests__/runtime/journal.test.ts
+++ b/src/graph/__tests__/runtime/journal.test.ts
@@ -1,0 +1,192 @@
+/**
+ * FileJournal tests — round-trip, fail-closed corruption handling (AC-8),
+ * and ordered concurrent appends.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileJournal } from "../../runtime/journal.js";
+import { JournalCorruptionError } from "../../runtime/types.js";
+import type { JournalRecord } from "../../runtime/types.js";
+
+const HASH = "a".repeat(64);
+
+function makeRecord(seq: number): JournalRecord {
+  return {
+    seq,
+    epoch: 1,
+    descriptor_hash: HASH,
+    transition: {
+      outcome: "succeeded",
+      transition_id: `t-${seq}`,
+      activation_id: "act-1",
+      node_id: "node-1",
+      fingerprint_version: 1,
+      request_fingerprint: "fp",
+      descriptor_hash: HASH,
+      selected_edge_ids: [],
+      created_activation_ids: [],
+      attempt_id: `attempt-${seq}`,
+      evidence_refs: [],
+    },
+  };
+}
+
+describe("FileJournal", () => {
+  const tempDirs: string[] = [];
+
+  function makeRunsRoot(): string {
+    const dir = mkdtempSync(join(tmpdir(), "omc-journal-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function journalPath(runsRoot: string): string {
+    return join(runsRoot, "run-1", "journal.jsonl");
+  }
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips appended records in seq order", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const journal = new FileJournal(runsRoot, "run-1");
+    const expected = [makeRecord(0), makeRecord(1), makeRecord(2)];
+
+    // Act
+    for (const record of expected) {
+      await journal.append(record);
+    }
+    const records = await journal.readAll();
+
+    // Assert
+    expect(records).toEqual(expected);
+  });
+
+  it("returns [] when the journal file does not exist", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const journal = new FileJournal(runsRoot, "run-1");
+
+    // Act
+    const records = await journal.readAll();
+
+    // Assert
+    expect(records).toEqual([]);
+  });
+
+  it("returns [] when the journal file is empty", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    mkdirSync(join(runsRoot, "run-1"), { recursive: true });
+    writeFileSync(journalPath(runsRoot), "", "utf8");
+    const journal = new FileJournal(runsRoot, "run-1");
+
+    // Act
+    const records = await journal.readAll();
+
+    // Assert
+    expect(records).toEqual([]);
+  });
+
+  it("throws JournalCorruptionError with truncatedCount >= 1 on a trailing partial line [AC-8]", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    mkdirSync(join(runsRoot, "run-1"), { recursive: true });
+    writeFileSync(
+      journalPath(runsRoot),
+      `${JSON.stringify(makeRecord(0))}\n{"seq":7`,
+      "utf8",
+    );
+    const journal = new FileJournal(runsRoot, "run-1");
+
+    // Act + Assert
+    let error: unknown;
+    try {
+      await journal.readAll();
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(JournalCorruptionError);
+    expect((error as JournalCorruptionError).truncatedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("counts all interior corrupt lines before throwing", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    mkdirSync(join(runsRoot, "run-1"), { recursive: true });
+    writeFileSync(
+      journalPath(runsRoot),
+      [
+        JSON.stringify(makeRecord(0)),
+        "{not json",
+        JSON.stringify(makeRecord(1)),
+        JSON.stringify({ seq: 2, epoch: 0 }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const journal = new FileJournal(runsRoot, "run-1");
+
+    // Act + Assert
+    let error: unknown;
+    try {
+      await journal.readAll();
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(JournalCorruptionError);
+    expect((error as JournalCorruptionError).truncatedCount).toBe(2);
+  });
+
+  it("throws when a record skips a seq value", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const journal = new FileJournal(runsRoot, "run-1");
+    await journal.append(makeRecord(0));
+    await journal.append({ ...makeRecord(2), seq: 2 });
+
+    // Act + Assert
+    await expect(journal.readAll()).rejects.toThrow(JournalCorruptionError);
+  });
+
+  it("throws when descriptor_hash does not match the hash format", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const journal = new FileJournal(runsRoot, "run-1");
+    await journal.append({ ...makeRecord(0), descriptor_hash: "not-a-hash" });
+
+    // Act + Assert
+    await expect(journal.readAll()).rejects.toThrow(JournalCorruptionError);
+  });
+
+  it("persists exactly five ordered lines under chained concurrent appends", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const journal = new FileJournal(runsRoot, "run-1");
+    const records = [0, 1, 2, 3, 4].map(makeRecord);
+
+    // Act: fire all five appends without sequential awaits; chaining via
+    // p.then(...) keeps order deterministic.
+    let chained: Promise<void> = Promise.resolve();
+    for (const record of records) {
+      chained = chained.then(() => journal.append(record));
+    }
+    await chained;
+
+    // Assert
+    const lines = readFileSync(journalPath(runsRoot), "utf8")
+      .split("\n")
+      .filter((line) => line !== "");
+    expect(lines).toHaveLength(5);
+    const parsed = lines.map((line) => JSON.parse(line) as JournalRecord);
+    expect(parsed.map((record) => record.seq)).toEqual([0, 1, 2, 3, 4]);
+    expect(await journal.readAll()).toEqual(records);
+  });
+});

--- a/src/graph/__tests__/runtime/journal.test.ts
+++ b/src/graph/__tests__/runtime/journal.test.ts
@@ -7,14 +7,20 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
-import { FileJournal } from "../../runtime/journal.js";
+import {
+  computeJournalFingerprint,
+  FileJournal,
+} from "../../runtime/journal.js";
 import { JournalCorruptionError } from "../../runtime/types.js";
-import type { JournalRecord } from "../../runtime/types.js";
+import type {
+  JournalAppendRecord,
+  JournalRecord,
+} from "../../runtime/types.js";
 
 const HASH = "a".repeat(64);
 
 function makeRecord(seq: number): JournalRecord {
-  return {
+  const record = {
     seq,
     epoch: 1,
     descriptor_hash: HASH,
@@ -31,6 +37,10 @@ function makeRecord(seq: number): JournalRecord {
       attempt_id: `attempt-${seq}`,
       evidence_refs: [],
     },
+  } satisfies JournalAppendRecord;
+  return {
+    ...record,
+    journal_fingerprint: computeJournalFingerprint(record),
   };
 }
 

--- a/src/graph/__tests__/runtime/progress.test.ts
+++ b/src/graph/__tests__/runtime/progress.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for ASCII progress rendering (graph runtime v2).
+ *
+ * Pins exact rendered strings for all five event kinds and every
+ * node_result outcome tag, newline termination per event, and that the
+ * reporter writes through an injected stream instead of console.
+ */
+import { PassThrough } from "stream";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createAsciiProgressReporter,
+  renderProgressEvent,
+} from "../../runtime/progress.js";
+import type { RuntimeProgressEvent } from "../../runtime/types.js";
+
+describe("renderProgressEvent", () => {
+  it("renders run_started", () => {
+    const event: RuntimeProgressEvent = {
+      type: "run_started",
+      run_id: "run-abc",
+      goal: "deploy the service",
+    };
+    expect(renderProgressEvent(event)).toBe("[run] run-abc — deploy the service");
+  });
+
+  it("renders replayed", () => {
+    const event: RuntimeProgressEvent = { type: "replayed", records: 7, epoch: 2 };
+    expect(renderProgressEvent(event)).toBe("[replay] 7 record(s) @ epoch 2");
+  });
+
+  it("renders activation_started", () => {
+    const event: RuntimeProgressEvent = {
+      type: "activation_started",
+      node_id: "build",
+      attempt_no: 3,
+    };
+    expect(renderProgressEvent(event)).toBe("[node] build attempt #3 started");
+  });
+
+  it("renders every node_result outcome tag", () => {
+    const cases: ReadonlyArray<[RuntimeProgressEvent, string]> = [
+      [{ type: "node_result", node_id: "a", outcome: "succeeded" }, "[ok] a"],
+      [{ type: "node_result", node_id: "b", outcome: "failed" }, "[fail] b"],
+      [{ type: "node_result", node_id: "c", outcome: "approved" }, "[approved] c"],
+      [{ type: "node_result", node_id: "d", outcome: "denied" }, "[denied] d"],
+      [{ type: "node_result", node_id: "e", outcome: "join_resolved" }, "[join] e"],
+    ];
+    for (const [event, expected] of cases) {
+      expect(renderProgressEvent(event)).toBe(expected);
+    }
+  });
+
+  it("renders run_ended", () => {
+    const event: RuntimeProgressEvent = {
+      type: "run_ended",
+      terminal: "succeeded",
+      summary: "4 nodes ok",
+    };
+    expect(renderProgressEvent(event)).toBe("[done] succeeded — 4 nodes ok");
+  });
+});
+
+describe("createAsciiProgressReporter", () => {
+  it("writes each rendered line plus newline via the injected stream", async () => {
+    const out = new PassThrough();
+    const chunks: string[] = [];
+    out.on("data", (chunk) => chunks.push(chunk.toString()));
+
+    const reporter = createAsciiProgressReporter(out);
+    reporter.onEvent({ type: "run_started", run_id: "run-1", goal: "g" });
+    reporter.onEvent({ type: "activation_started", node_id: "n1", attempt_no: 1 });
+    reporter.onEvent({ type: "node_result", node_id: "n1", outcome: "succeeded" });
+    reporter.onEvent({ type: "run_ended", terminal: "failed", summary: "boom" });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(chunks.join("")).toBe(
+      [
+        "[run] run-1 — g\n",
+        "[node] n1 attempt #1 started\n",
+        "[ok] n1\n",
+        "[done] failed — boom\n",
+      ].join(""),
+    );
+  });
+
+  it("defaults to process.stdout and does not throw", () => {
+    const reporter = createAsciiProgressReporter();
+    expect(() =>
+      reporter.onEvent({ type: "run_started", run_id: "r-default", goal: "" }),
+    ).not.toThrow();
+  });
+});

--- a/src/graph/__tests__/runtime/regression-matrix.test.ts
+++ b/src/graph/__tests__/runtime/regression-matrix.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Regression matrix tests (AC-9/10/11/11b) — runner level with fake executors.
+ *
+ * AC-9  max_attempts: an always-failing executor terminal-fails the node
+ *       after exactly its descriptor budget; no infinite retry.
+ * AC-10 no-wedge: one branch failing terminally still drains sibling work and
+ *       reaches a defined end state with an empty ready set.
+ * AC-11 traversal round-trip: a bounded back-edge loop runs to terminal and
+ *       an in-process journal replay-fold reproduces the live projection
+ *       bit-for-bit under canonicalJson equality.
+ * AC-11b tamper: flipping a journaled transition outcome makes the resume
+ *       fold fail closed (CORRUPT_JOURNAL) without executing any node.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { canonicalJson, sealGraphDescriptor } from "../../descriptor.js";
+import {
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+} from "../../scheduler.js";
+import { runGraph } from "../../runtime/runner.js";
+import { FileJournal } from "../../runtime/journal.js";
+import { FileProjectionStore } from "../../runtime/store.js";
+import { EXIT_CODES } from "../../runtime/types.js";
+import type {
+  JournalRecord,
+  NodeExecutionContext,
+  NodeExecutionOutput,
+  NodeExecutor,
+} from "../../runtime/types.js";
+import type {
+  GraphCommittedTransition,
+  GraphDescriptorInput,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+} from "../../types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "fixtures");
+
+function loadFixture(name: string): GraphDescriptorInput {
+  return JSON.parse(
+    readFileSync(join(FIXTURES_DIR, name), "utf8"),
+  ) as GraphDescriptorInput;
+}
+
+const tempDirs: string[] = [];
+
+function makeRunsRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-regression-matrix-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+function okOutput(
+  nodeId: string,
+  route?: string,
+): NodeExecutionOutput {
+  return {
+    outcome: "succeeded",
+    output_summary: `ok:${nodeId}`,
+    evidence_refs: [{ kind: "command", ref: `cmd:${nodeId}` }],
+    ...(route !== undefined && { route }),
+  };
+}
+
+function failedOutput(nodeId: string): NodeExecutionOutput {
+  return {
+    outcome: "failed",
+    output_summary: `boom:${nodeId}`,
+    evidence_refs: [{ kind: "command", ref: `cmd:${nodeId}` }],
+  };
+}
+
+/** Executor with context-aware scripted behavior and an invocation log. */
+class ScriptedExecutor implements NodeExecutor {
+  readonly kinds = ["agent", "command"] as const;
+  readonly calls: string[] = [];
+
+  constructor(
+    private readonly behavior: (
+      context: NodeExecutionContext,
+    ) => Promise<NodeExecutionOutput> | NodeExecutionOutput,
+  ) {}
+
+  async execute(context: NodeExecutionContext): Promise<NodeExecutionOutput> {
+    this.calls.push(context.node.id);
+    return this.behavior(context);
+  }
+}
+
+function runOptions(
+  runsRoot: string,
+  executor: NodeExecutor,
+): Parameters<typeof runGraph>[1] {
+  return {
+    runsRoot,
+    executors: [executor],
+    prompter: { prompt: async () => "approved" },
+  };
+}
+
+describe("regression matrix (AC-9/10/11/11b)", () => {
+  it("terminal-fails a node after exactly its max_attempts budget (AC-9)", async () => {
+    // Arrange: b1 gets a reduced descriptor budget; executor always fails it.
+    const input = loadFixture("fanout-join-graph.json");
+    const sealed = sealGraphDescriptor({
+      ...input,
+      nodes: input.nodes.map((node) =>
+        node.id === "b1" ? { ...node, max_attempts: 2 } : node,
+      ),
+    });
+    const runsRoot = makeRunsRoot();
+    const executor = new ScriptedExecutor((context) =>
+      context.node.id === "b1"
+        ? failedOutput(context.node.id)
+        : okOutput(context.node.id),
+    );
+
+    // Act
+    const result = await runGraph(sealed, runOptions(runsRoot, executor));
+
+    // Assert: defined end state, budget respected, every attempt journaled.
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.FAILED_TERMINAL);
+    expect(executor.calls.filter((id) => id === "b1")).toHaveLength(2);
+
+    const records = await new FileJournal(runsRoot, sealed.run_id).readAll();
+    const b1Failures = records.filter(
+      (record) =>
+        record.transition.node_id === "b1" &&
+        record.transition.outcome === "failed",
+    );
+    expect(b1Failures).toHaveLength(2);
+    // The join never resolved and the terminal never ran: no infinite retry.
+    expect(records.some((r) => r.transition.outcome === "join_resolved")).toBe(
+      false,
+    );
+    expect(records.some((r) => r.transition.node_id === "term")).toBe(false);
+  });
+
+  it("drains sibling work to a defined end state when one branch fails terminally (AC-10)", async () => {
+    // Arrange
+    const input = loadFixture("fanout-join-graph.json");
+    const sealed = sealGraphDescriptor({
+      ...input,
+      nodes: input.nodes.map((node) =>
+        node.id === "b2" ? { ...node, max_attempts: 1 } : node,
+      ),
+    });
+    const runsRoot = makeRunsRoot();
+    const executor = new ScriptedExecutor((context) =>
+      context.node.id === "b2"
+        ? failedOutput(context.node.id)
+        : okOutput(context.node.id),
+    );
+
+    // Act
+    const result = await runGraph(sealed, runOptions(runsRoot, executor));
+
+    // Assert: the run ends (no wedge), and the ready set is fully drained.
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.FAILED_TERMINAL);
+    expect(executor.calls).toContain("fan");
+    expect(executor.calls).toContain("b1"); // healthy sibling still drained
+
+    const store = new FileProjectionStore(runsRoot, sealed.run_id);
+    const snapshot = await store.load();
+    expect(snapshot).not.toBeNull();
+    const projection = snapshot?.projection as GraphSchedulerProjection;
+    expect(listReadyExecutableActivations(sealed, projection)).toHaveLength(0);
+    expect(listReadyJoinActivations(sealed, projection)).toHaveLength(0);
+    for (const activation of Object.values(projection.activations)) {
+      expect(["completed", "failed"]).toContain(activation.status);
+    }
+  });
+
+  it("runs a bounded back-edge loop to terminal and replays the journal to the identical projection (AC-11)", async () => {
+    // Arrange
+    const sealed = sealGraphDescriptor(loadFixture("back-edge-graph.json"));
+    const runsRoot = makeRunsRoot();
+    let workRuns = 0;
+    const executor = new ScriptedExecutor((context) => {
+      if (context.node.id !== "work") return okOutput(context.node.id);
+      workRuns += 1;
+      // Two retry traversals hit the max_traversals bound exactly; then exit.
+      return okOutput("work", workRuns <= 2 ? "retry" : "success");
+    });
+
+    // Act: full live run to a terminal state.
+    const result = await runGraph(sealed, runOptions(runsRoot, executor));
+
+    // Assert live shape: start -> retry -> retry -> success -> term.
+    expect(result.terminal).toBe("succeeded");
+    expect(result.exit_code).toBe(EXIT_CODES.OK);
+    expect(workRuns).toBe(3);
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    const workTransitions = records.filter(
+      (record) => record.transition.node_id === "work",
+    );
+    expect(workTransitions.map((record) => record.transition)).toMatchObject([
+      { route: "retry", selected_edge_ids: ["e-work-retry"] },
+      { route: "retry", selected_edge_ids: ["e-work-retry"] },
+      { route: "success", selected_edge_ids: ["e-work-term"] },
+    ]);
+
+    const store = new FileProjectionStore(runsRoot, sealed.run_id);
+    const snapshot = await store.load();
+    expect(snapshot).not.toBeNull();
+    const liveProjection = snapshot?.projection as GraphSchedulerProjection;
+    // The traversal counter sits at (not past) the bound of 2.
+    expect(Object.values(liveProjection.traversal_counts)).toEqual([2]);
+
+    // In-process replay fold through the same scheduler entrypoints.
+    const folded = foldJournal(sealed, records);
+    expect(canonicalJson(folded)).toBe(canonicalJson(liveProjection));
+
+    // A resume over the completed journal re-folds everything and executes
+    // nothing — persisted history replays cleanly (round trip closed).
+    const idleExecutor = new ScriptedExecutor(() => {
+      throw new Error("resume must not execute any node after success");
+    });
+    const resumedAgain = await runGraph(
+      sealed,
+      runOptions(runsRoot, idleExecutor),
+    );
+    expect(resumedAgain.terminal).toBe("succeeded");
+    expect(resumedAgain.exit_code).toBe(EXIT_CODES.OK);
+    expect(idleExecutor.calls).toEqual([]);
+    const recordsAfterResume = await journal.readAll();
+    expect(recordsAfterResume).toHaveLength(records.length);
+  });
+
+  it("fails closed with CORRUPT_JOURNAL when a journaled transition is tampered (AC-11b)", async () => {
+    // Arrange: complete a linear run, then flip the first transition outcome.
+    const sealed = sealGraphDescriptor(loadFixture("simple-linear.json"));
+    const runsRoot = makeRunsRoot();
+    const firstRunExecutor = new ScriptedExecutor((context) =>
+      okOutput(context.node.id),
+    );
+    await runGraph(sealed, runOptions(runsRoot, firstRunExecutor));
+
+    const journalPath = join(runsRoot, sealed.run_id, "journal.jsonl");
+    const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const tampered = JSON.parse(lines[0] as string) as JournalRecord;
+    expect(tampered.transition.outcome).toBe("succeeded");
+    (tampered.transition as { outcome: string }).outcome = "failed";
+    lines[0] = canonicalJson(tampered);
+    writeFileSync(journalPath, `${lines.join("\n")}\n`, "utf8");
+
+    // Act: resume must detect the tamper in the startup fold.
+    const resumeExecutor = new ScriptedExecutor((context) =>
+      okOutput(context.node.id),
+    );
+    const result = await runGraph(sealed, runOptions(runsRoot, resumeExecutor));
+
+    // Assert: fail-closed corruption mapping; nothing executed.
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.CORRUPT_JOURNAL);
+    expect(resumeExecutor.calls).toEqual([]);
+  });
+
+  it("fails closed when a journal record is rebound to a foreign descriptor hash", async () => {
+    // Arrange: complete a run, then rebind record 0's descriptor_hash.
+    const sealed = sealGraphDescriptor(loadFixture("simple-linear.json"));
+    const runsRoot = makeRunsRoot();
+    await runGraph(
+      sealed,
+      runOptions(
+        runsRoot,
+        new ScriptedExecutor((context) => okOutput(context.node.id)),
+      ),
+    );
+
+    const journalPath = join(runsRoot, sealed.run_id, "journal.jsonl");
+    const lines = readFileSync(journalPath, "utf8").split("\n").filter(Boolean);
+    const tampered = JSON.parse(lines[0] as string) as JournalRecord;
+    (tampered as { descriptor_hash: string }).descriptor_hash =
+      "0".repeat(64);
+    lines[0] = canonicalJson(tampered);
+    writeFileSync(journalPath, `${lines.join("\n")}\n`, "utf8");
+
+    // Act + Assert: descriptor binding drift maps to DESCRIPTOR_MISMATCH.
+    const result = await runGraph(
+      sealed,
+      runOptions(
+        runsRoot,
+        new ScriptedExecutor((context) => okOutput(context.node.id)),
+      ),
+    );
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.DESCRIPTOR_MISMATCH);
+  });
+
+  it("refuses to start while a live owner holds the lock and writes nothing (AC-7)", async () => {
+    // Arrange: seed owner.lock with OUR live pid — a healthy holder yields
+    // busy regardless of the stale grace, so no backdating is needed.
+    const sealed = sealGraphDescriptor(loadFixture("simple-linear.json"));
+    const runsRoot = makeRunsRoot();
+    const runDir = join(runsRoot, sealed.run_id);
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, "owner.lock"),
+      `${JSON.stringify({
+        pid: process.pid,
+        epoch: 1,
+        timestamp: Date.now(),
+      })}\n`,
+      "utf8",
+    );
+
+    // Act: the fence surfaces busy as a RunResult (not a throw).
+    const executor = new ScriptedExecutor((context) =>
+      okOutput(context.node.id),
+    );
+    const result = await runGraph(sealed, runOptions(runsRoot, executor));
+
+    // Assert: fenced out before any node ran; nothing was persisted.
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.FENCED_OUT);
+    expect(result.epoch).toBe(0);
+    expect(executor.calls).toEqual([]);
+    expect(existsSync(join(runDir, "journal.jsonl"))).toBe(false);
+    expect(readdirSync(runDir)).toEqual(["owner.lock"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-process replay fold (AC-11 helper)
+// ---------------------------------------------------------------------------
+
+/** Mirrors the runner's deterministic entry-activation scheme. */
+function entryActivationIds(
+  descriptor: SealedGraphDescriptor,
+): Record<string, string> {
+  return Object.fromEntries(
+    descriptor.entry_node_ids.map((id) => [id, `${id}-act0`]),
+  );
+}
+
+/**
+ * Folds journal records through the scheduler entrypoints used live,
+ * regenerating identities from the committed fields (runner replay scheme).
+ */
+function foldJournal(
+  descriptor: SealedGraphDescriptor,
+  records: readonly JournalRecord[],
+): GraphSchedulerProjection {
+  let projection = initializeGraphProjection(
+    descriptor,
+    entryActivationIds(descriptor),
+  );
+  for (const record of records) {
+    const transition: GraphCommittedTransition = record.transition;
+    if (transition.outcome === "succeeded") {
+      const withAttempt = beginActivationAttempt(descriptor, projection, {
+        activation_id: transition.activation_id,
+        attempt_id: transition.attempt_id,
+      });
+      const identities =
+        transition.selected_edge_ids.length > 0
+          ? {
+              next_activation_ids: Object.fromEntries(
+                transition.selected_edge_ids.map((edgeId, index) => [
+                  edgeId,
+                  transition.created_activation_ids[index] as string,
+                ]),
+              ),
+            }
+          : undefined;
+      projection = applyNodeResult(descriptor, withAttempt, {
+        activation_id: transition.activation_id,
+        transition_id: transition.transition_id,
+        result: {
+          outcome: "succeeded",
+          attempt_id: transition.attempt_id,
+          ...(transition.route !== undefined && { route: transition.route }),
+          ...(transition.output_summary !== undefined && {
+            output_summary: transition.output_summary,
+          }),
+          evidence_refs: transition.evidence_refs,
+        },
+        identities,
+      }).projection;
+      continue;
+    }
+    throw new Error(
+      `fold helper only covers succeeded transitions; got ${transition.outcome} at seq ${record.seq}`,
+    );
+  }
+  return projection;
+}

--- a/src/graph/__tests__/runtime/run-dir.test.ts
+++ b/src/graph/__tests__/runtime/run-dir.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Run-directory containment tests (P1-3): malformed run ids are rejected,
+ * symlinked run directories fail closed before any write escapes the runs
+ * root, and legitimate resolution keeps every artifact inside the root.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveRunDir } from "../../runtime/run-dir.js";
+import { FileOwnershipFence } from "../../runtime/fence.js";
+import { FileJournal } from "../../runtime/journal.js";
+import { FileProjectionStore } from "../../runtime/store.js";
+import type { JournalRecord } from "../../runtime/types.js";
+
+const HASH = "a".repeat(64);
+
+function makeRecord(seq: number): JournalRecord {
+  return {
+    seq,
+    epoch: 1,
+    descriptor_hash: HASH,
+    transition: {
+      outcome: "succeeded",
+      transition_id: `t-${seq}`,
+      activation_id: "act-1",
+      node_id: "node-1",
+      fingerprint_version: 1,
+      request_fingerprint: "fp",
+      descriptor_hash: HASH,
+      selected_edge_ids: [],
+      created_activation_ids: [],
+      attempt_id: `attempt-${seq}`,
+      evidence_refs: [],
+    },
+  };
+}
+
+describe("resolveRunDir containment [P1-3]", () => {
+  const tempDirs: string[] = [];
+
+  function makeRunsRoot(): string {
+    const dir = mkdtempSync(join(tmpdir(), "omc-rundir-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed run ids with RangeError", () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+
+    // Act / Assert
+    for (const bad of ["../x", "a/b", "a\\b", "", ".", ".."]) {
+      expect(() => resolveRunDir(runsRoot, bad), JSON.stringify(bad)).toThrow(
+        RangeError,
+      );
+      expect(
+        () => resolveRunDir(runsRoot, bad),
+        JSON.stringify(bad),
+      ).toThrow("invalid run_id");
+    }
+  });
+
+  it("creates the run directory inside the runs root and returns the joined path", () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+
+    // Act
+    const runDir = resolveRunDir(runsRoot, "run-contained");
+
+    // Assert
+    expect(runDir).toBe(join(runsRoot, "run-contained"));
+    const runsRootReal = realpathSync(runsRoot);
+    const resolved = realpathSync(runDir);
+    expect(
+      resolved.toLowerCase().startsWith(`${runsRootReal.toLowerCase()}\\`) ||
+        resolved.startsWith(`${runsRootReal}/`),
+    ).toBe(true);
+  });
+
+  it("fails closed on a symlinked run directory and writes nothing outside the root", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const outside = makeRunsRoot();
+    mkdirSync(join(outside, "escape-target"), { recursive: true });
+    symlinkSync(
+      join(outside, "escape-target"),
+      join(runsRoot, "run-victim"),
+      "dir",
+    );
+
+    // Act / Assert — resolution itself refuses.
+    expect(() => resolveRunDir(runsRoot, "run-victim")).toThrow(
+      "run directory must not be a symbolic link",
+    );
+
+    // Persistence components route through the same helper: use-time failure,
+    // nothing materialized outside the runs root.
+    await expect(
+      new FileJournal(runsRoot, "run-victim").append(makeRecord(0)),
+    ).rejects.toThrow("symbolic link");
+    await expect(
+      new FileOwnershipFence(runsRoot, "run-victim").acquire(),
+    ).rejects.toThrow("symbolic link");
+    expect(() => new FileProjectionStore(runsRoot, "run-victim")).toThrow(
+      "symbolic link",
+    );
+    expect(readdirSync(join(outside, "escape-target"))).toEqual([]);
+    expect(existsSync(join(outside, "escape-target", "journal.jsonl"))).toBe(
+      false,
+    );
+    expect(existsSync(join(outside, "escape-target", "owner.lock"))).toBe(false);
+    expect(existsSync(join(outside, "escape-target", "projection.json"))).toBe(
+      false,
+    );
+  });
+
+  it("keeps component writes inside the runs root for a legitimate run id", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+
+    // Act
+    const journal = new FileJournal(runsRoot, "run-inside");
+    await journal.append(makeRecord(0));
+    new FileProjectionStore(runsRoot, "run-inside");
+    const fence = new FileOwnershipFence(runsRoot, "run-inside");
+    const acquired = await fence.acquire();
+
+    // Assert — every artifact landed under <runsRoot>/run-inside.
+    expect(acquired.outcome).toBe("acquired");
+    const entries = readdirSync(join(runsRoot, "run-inside")).sort();
+    expect(entries).toEqual(["journal.jsonl", "owner.epoch", "owner.lock"]);
+    expect(readdirSync(runsRoot)).toEqual(["run-inside"]);
+    await fence.release((acquired as { epoch: number }).epoch);
+  });
+});

--- a/src/graph/__tests__/runtime/run-dir.test.ts
+++ b/src/graph/__tests__/runtime/run-dir.test.ts
@@ -18,14 +18,20 @@ import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveRunDir } from "../../runtime/run-dir.js";
 import { FileOwnershipFence } from "../../runtime/fence.js";
-import { FileJournal } from "../../runtime/journal.js";
+import {
+  computeJournalFingerprint,
+  FileJournal,
+} from "../../runtime/journal.js";
 import { FileProjectionStore } from "../../runtime/store.js";
-import type { JournalRecord } from "../../runtime/types.js";
+import type {
+  JournalAppendRecord,
+  JournalRecord,
+} from "../../runtime/types.js";
 
 const HASH = "a".repeat(64);
 
 function makeRecord(seq: number): JournalRecord {
-  return {
+  const record = {
     seq,
     epoch: 1,
     descriptor_hash: HASH,
@@ -42,6 +48,10 @@ function makeRecord(seq: number): JournalRecord {
       attempt_id: `attempt-${seq}`,
       evidence_refs: [],
     },
+  } satisfies JournalAppendRecord;
+  return {
+    ...record,
+    journal_fingerprint: computeJournalFingerprint(record),
   };
 }
 

--- a/src/graph/__tests__/runtime/runner.test.ts
+++ b/src/graph/__tests__/runtime/runner.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Runtime runner tests: orchestration loop over FileJournal/FileOwnershipFence/
+ * FileProjectionStore with scripted executors (worker-6 brief).
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { canonicalJson, sealGraphDescriptor } from "../../descriptor.js";
+import { isGraphSucceeded } from "../../scheduler.js";
+import { runGraph } from "../../runtime/runner.js";
+import { FileJournal } from "../../runtime/journal.js";
+import { FileProjectionStore } from "../../runtime/store.js";
+import { EXIT_CODES } from "../../runtime/types.js";
+import type {
+  NodeExecutionContext,
+  NodeExecutionOutput,
+  NodeExecutor,
+  ProgressReporter,
+  RunResult,
+  RuntimeProgressEvent,
+} from "../../runtime/types.js";
+import type {
+  GraphDescriptorInput,
+} from "../../types.js";
+import {
+  approvalDescriptor,
+  executableNode,
+  forkJoinDescriptor,
+} from "../fixtures.js";
+
+const tempDirs: string[] = [];
+
+function makeRunsRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-runner-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+function okOutput(nodeId: string): NodeExecutionOutput {
+  return {
+    outcome: "succeeded",
+    output_summary: `ok:${nodeId}`,
+    evidence_refs: [{ kind: "command", ref: `cmd:${nodeId}` }],
+  };
+}
+
+function failedOutput(nodeId: string): NodeExecutionOutput {
+  return {
+    outcome: "failed",
+    output_summary: `boom:${nodeId}`,
+    evidence_refs: [{ kind: "command", ref: `cmd:${nodeId}` }],
+  };
+}
+
+/** Executor with per-node scripted behavior and an invocation log. */
+class ScriptedExecutor implements NodeExecutor {
+  readonly kinds = ["agent", "command"] as const;
+  readonly calls: string[] = [];
+
+  constructor(
+    private readonly behavior: (
+      nodeId: string,
+    ) => Promise<NodeExecutionOutput> | NodeExecutionOutput,
+  ) {}
+
+  async execute(context: NodeExecutionContext): Promise<NodeExecutionOutput> {
+    this.calls.push(context.node.id);
+    return this.behavior(context.node.id);
+  }
+}
+
+function allSucceed(): ScriptedExecutor {
+  return new ScriptedExecutor((nodeId) => okOutput(nodeId));
+}
+
+function makeReporter(): {
+  reporter: ProgressReporter;
+  events: RuntimeProgressEvent[];
+} {
+  const events: RuntimeProgressEvent[] = [];
+  return { reporter: { onEvent: (event) => void events.push(event) }, events };
+}
+
+function linearDescriptor(): GraphDescriptorInput {
+  return {
+    descriptor_version: 1,
+    run_id: "run-runner-linear",
+    revision_id: "rev-runner-linear",
+    goal: "runner linear chain",
+    nodes: [
+      executableNode("a", "command"),
+      executableNode("b", "command"),
+      executableNode("term", "command"),
+    ],
+    edges: [
+      { id: "e-a-b", kind: "fixed", from: "a", to: "b" },
+      { id: "e-b-term", kind: "fixed", from: "b", to: "term" },
+    ],
+    entry_node_ids: ["a"],
+    concurrency_limit: 1,
+    terminal_verification_node_id: "term",
+  };
+}
+
+describe("runGraph", () => {
+  it("runs a linear 3-command graph to success with journal + snapshot", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const sealed = sealGraphDescriptor(linearDescriptor());
+    const executor = allSucceed();
+    const { reporter, events } = makeReporter();
+
+    // Act
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [executor],
+      prompter: { prompt: async () => "approved" },
+      reporter,
+    });
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    const store = new FileProjectionStore(runsRoot, sealed.run_id);
+    const snapshot = await store.load();
+
+    // Assert
+    expect(result.terminal).toBe("succeeded");
+    expect(result.exit_code).toBe(EXIT_CODES.OK);
+    expect(result.epoch).toBe(1);
+    expect(records.map((r) => r.transition.node_id)).toEqual(["a", "b", "term"]);
+    expect(records.map((r) => r.seq)).toEqual([0, 1, 2]);
+    expect(records.every((r) => r.epoch === 1)).toBe(true);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.saved_at_seq).toBe(2);
+    expect(isGraphSucceeded(sealed, snapshot?.projection as never)).toBe(true);
+    const eventTypes = events.map((event) => event.type);
+    expect(eventTypes).toContain("run_started");
+    expect(eventTypes).toContain("activation_started");
+    expect(eventTypes).toContain("node_result");
+    expect(events.at(-1)?.type).toBe("run_ended");
+    expect(existsSync(join(runsRoot, sealed.run_id, "owner.lock"))).toBe(false);
+  });
+
+  it("resumes a partial run without re-running completed nodes", async () => {
+    // Arrange: run 1 hangs on `b` and is aborted after `a` commits.
+    const runsRoot = makeRunsRoot();
+    const sealed = sealGraphDescriptor(linearDescriptor());
+    const controller = new AbortController();
+    const runOneExecutor = new ScriptedExecutor((nodeId) =>
+      nodeId === "b" ? new Promise<NodeExecutionOutput>(() => {}) : okOutput(nodeId),
+    );
+    const { events } = makeReporter();
+    const reporter: ProgressReporter = {
+      onEvent: (event) => {
+        events.push(event);
+        if (event.type === "node_result" && event.node_id === "a") {
+          controller.abort();
+        }
+      },
+    };
+
+    // Act
+    await expect(
+      runGraph(sealed, {
+        runsRoot,
+        executors: [runOneExecutor],
+        prompter: { prompt: async () => "approved" },
+        reporter,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+
+    // Simulate stale reap of the abandoned lock (crash semantics).
+    rmSync(join(runsRoot, sealed.run_id, "owner.lock"), { force: true });
+
+    // Run 2: everything succeeds; `a` must NOT execute again.
+    const runTwoExecutor = allSucceed();
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [runTwoExecutor],
+      prompter: { prompt: async () => "approved" },
+      reporter: { onEvent: () => undefined },
+    });
+
+    // Assert
+    expect(result.terminal).toBe("succeeded");
+    expect(runOneExecutor.calls).toEqual(["a"]);
+    expect(runTwoExecutor.calls).toEqual(["b", "term"]);
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    expect(records.map((r) => r.transition.node_id)).toEqual(["a", "b", "term"]);
+    expect(records[0].epoch).toBe(1);
+    expect(records.at(-1)?.epoch).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects descriptor drift on resume with exit code 21", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const sealed = sealGraphDescriptor(linearDescriptor());
+    const drifted = sealGraphDescriptor({
+      ...linearDescriptor(),
+      goal: "tampered goal",
+    });
+    mkdirSync(join(runsRoot, sealed.run_id), { recursive: true });
+    writeFileSync(
+      join(runsRoot, sealed.run_id, "descriptor.json"),
+      canonicalJson(drifted),
+      "utf8",
+    );
+
+    // Act
+    const result: RunResult = await runGraph(sealed, {
+      runsRoot,
+      executors: [allSucceed()],
+      prompter: { prompt: async () => "approved" },
+    });
+
+    // Assert
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.DESCRIPTOR_MISMATCH);
+  });
+
+  it("surfaces a corrupt journal tail as exit code 20", async () => {
+    // Arrange: complete a run, then damage the journal tail.
+    const runsRoot = makeRunsRoot();
+    const sealed = sealGraphDescriptor(linearDescriptor());
+    await runGraph(sealed, {
+      runsRoot,
+      executors: [allSucceed()],
+      prompter: { prompt: async () => "approved" },
+    });
+    appendFileSync(
+      join(runsRoot, sealed.run_id, "journal.jsonl"),
+      '{"seq":3,"epoch":1,"descriptor_hash":"',
+      "utf8",
+    );
+
+    // Act
+    const result: RunResult = await runGraph(sealed, {
+      runsRoot,
+      executors: [allSucceed()],
+      prompter: { prompt: async () => "approved" },
+    });
+
+    // Assert
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.CORRUPT_JOURNAL);
+  });
+
+  it("respects concurrency_limit with parallel dispatch", async () => {
+    // Arrange: three entries fan into term; limit 2.
+    const runsRoot = makeRunsRoot();
+    const descriptorInput: GraphDescriptorInput = {
+      descriptor_version: 1,
+      run_id: "run-runner-concurrency",
+      revision_id: "rev-runner-concurrency",
+      goal: "runner concurrency cap",
+      nodes: [
+        executableNode("Zentry", "command"),
+        executableNode("aentry", "command"),
+        executableNode("zentry", "command"),
+        executableNode("term", "command"),
+      ],
+      edges: [
+        { id: "e-Z-term", kind: "fixed", from: "Zentry", to: "term" },
+        { id: "e-a-term", kind: "fixed", from: "aentry", to: "term" },
+        { id: "e-z-term", kind: "fixed", from: "zentry", to: "term" },
+      ],
+      entry_node_ids: ["Zentry", "aentry", "zentry"],
+      concurrency_limit: 2,
+      terminal_verification_node_id: "term",
+    };
+    const sealed = sealGraphDescriptor(descriptorInput);
+    let activeCount = 0;
+    let maxObserved = 0;
+    const executor = new ScriptedExecutor((nodeId) => {
+      activeCount += 1;
+      maxObserved = Math.max(maxObserved, activeCount);
+      const release = new Promise<NodeExecutionOutput>((resolve) => {
+        setTimeout(() => {
+          activeCount -= 1;
+          resolve(okOutput(nodeId));
+        }, 20);
+      });
+      return release;
+    });
+
+    // Act
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [executor],
+      prompter: { prompt: async () => "approved" },
+    });
+
+    // Assert
+    expect(result.terminal).toBe("succeeded");
+    expect(executor.calls.length).toBe(6); // 3 entries + 3 term activations
+    expect(maxObserved).toBe(2);
+  });
+
+  it("drains other branches when one branch exhausts its retry budget (AC-9/AC-10)", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const descriptorInput = {
+      ...forkJoinDescriptor(),
+      run_id: "run-runner-budget",
+      revision_id: "rev-runner-budget",
+    };
+    const sealed = sealGraphDescriptor({
+      ...descriptorInput,
+      nodes: descriptorInput.nodes.map((node) =>
+        node.id === "b1" ? { ...node, max_attempts: 2 } : node,
+      ),
+    });
+    const executor = new ScriptedExecutor((nodeId) =>
+      nodeId === "b1" ? failedOutput(nodeId) : okOutput(nodeId),
+    );
+    const { reporter, events } = makeReporter();
+
+    // Act
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [executor],
+      prompter: { prompt: async () => "approved" },
+      reporter,
+    });
+
+    // Assert
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.FAILED_TERMINAL);
+    expect(executor.calls.filter((id) => id === "b1")).toHaveLength(2);
+    expect(executor.calls).toContain("b2"); // sibling branch still drained (AC-10)
+
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    const failedB1 = records.filter(
+      (r) => r.transition.node_id === "b1" && r.transition.outcome === "failed",
+    );
+    expect(failedB1).toHaveLength(2);
+    expect(records.some((r) => r.transition.outcome === "join_resolved")).toBe(false);
+    const runEnded = events.at(-1);
+    expect(runEnded?.type).toBe("run_ended");
+    if (runEnded?.type === "run_ended") {
+      expect(runEnded.summary).toBe("no schedulable activations");
+    }
+  });
+
+  it("runs fork/join to success with a join_resolved record (AC-13)", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const descriptorInput = {
+      ...forkJoinDescriptor(),
+      run_id: "run-runner-forkjoin",
+      revision_id: "rev-runner-forkjoin",
+    };
+    const sealed = sealGraphDescriptor(descriptorInput);
+    const executor = allSucceed();
+
+    // Act
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [executor],
+      prompter: { prompt: async () => "approved" },
+    });
+
+    // Assert
+    expect(result.terminal).toBe("succeeded");
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    const joinRecord = records.find(
+      (r) => r.transition.outcome === "join_resolved",
+    );
+    expect(joinRecord).toBeDefined();
+    if (joinRecord?.transition.outcome === "join_resolved") {
+      expect(joinRecord.transition.cohort_id).toBe("fan-coh0");
+      expect(joinRecord.transition.created_activation_ids).toEqual(["term-act0"]);
+    }
+    const store = new FileProjectionStore(runsRoot, sealed.run_id);
+    const snapshot = await store.load();
+    expect(snapshot).not.toBeNull();
+    if (snapshot) {
+      const cohorts = Object.values(snapshot.projection.cohorts);
+      expect(cohorts).toHaveLength(1);
+      expect(cohorts[0].consumed).toBe(true);
+      const tokens = Object.values(snapshot.projection.branch_tokens);
+      expect(tokens.every((token) => token.status === "consumed")).toBe(true);
+    }
+  });
+
+  it("prompts for human approval and proceeds when approved", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const descriptorInput = {
+      ...approvalDescriptor(),
+      run_id: "run-runner-approval",
+      revision_id: "rev-runner-approval",
+    };
+    const sealed = sealGraphDescriptor(descriptorInput);
+    let promptsSeen = 0;
+    const prompter = {
+      prompt: async () => {
+        promptsSeen += 1;
+        return "approved" as const;
+      },
+    };
+
+    // Act
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [allSucceed()],
+      prompter,
+    });
+
+    // Assert
+    expect(promptsSeen).toBe(1);
+    expect(result.terminal).toBe("succeeded");
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    expect(records.some((r) => r.transition.outcome === "approved")).toBe(true);
+  });
+
+  it("stops the graph when approval is denied", async () => {
+    // Arrange
+    const runsRoot = makeRunsRoot();
+    const descriptorInput = {
+      ...approvalDescriptor(),
+      run_id: "run-runner-deny",
+      revision_id: "rev-runner-deny",
+    };
+    const sealed = sealGraphDescriptor(descriptorInput);
+    let promptsSeen = 0;
+    const prompter = {
+      prompt: async () => {
+        promptsSeen += 1;
+        return "denied" as const;
+      },
+    };
+
+    // Act
+    const result = await runGraph(sealed, {
+      runsRoot,
+      executors: [allSucceed()],
+      prompter,
+    });
+
+    // Assert
+    expect(promptsSeen).toBe(1);
+    expect(result.terminal).toBe("failed");
+    expect(result.exit_code).toBe(EXIT_CODES.FAILED_TERMINAL);
+    const journal = new FileJournal(runsRoot, sealed.run_id);
+    const records = await journal.readAll();
+    expect(records.some((r) => r.transition.outcome === "denied")).toBe(true);
+  });
+
+  it("replays bit-for-bit: resume fold equals direct run snapshot (AC-3)", async () => {
+    // Arrange
+    const runsRootA = makeRunsRoot();
+    const runsRootB = makeRunsRoot();
+    const descriptorInput = {
+      ...forkJoinDescriptor(),
+      run_id: "run-runner-replay",
+      revision_id: "rev-runner-replay",
+    };
+    const sealed = sealGraphDescriptor(descriptorInput);
+    const options = {
+      executors: [allSucceed()],
+      prompter: { prompt: async () => "approved" as const },
+    };
+
+    // Act — control: direct full run.
+    await runGraph(sealed, { ...options, runsRoot: runsRootA });
+
+    // Act — resume path: abort after the fan node commits, then resume.
+    const controller = new AbortController();
+    const partialExecutor = new ScriptedExecutor((nodeId) =>
+      nodeId === "b1" || nodeId === "b2"
+        ? new Promise<NodeExecutionOutput>(() => {})
+        : okOutput(nodeId),
+    );
+    await expect(
+      runGraph(sealed, {
+        runsRoot: runsRootB,
+        executors: [partialExecutor],
+        prompter: { prompt: async () => "approved" as const },
+        signal: controller.signal,
+        reporter: {
+          onEvent: (event) => {
+            if (event.type === "node_result" && event.node_id === "fan") {
+              controller.abort();
+            }
+          },
+        },
+      }),
+    ).rejects.toThrow(/aborted/);
+    rmSync(join(runsRootB, sealed.run_id, "owner.lock"), { force: true });
+
+    const resumed = await runGraph(sealed, { ...options, runsRoot: runsRootB });
+    expect(resumed.terminal).toBe("succeeded");
+
+    // Assert — canonicalJson equality of the two final projections.
+    const storeA = new FileProjectionStore(runsRootA, sealed.run_id);
+    const storeB = new FileProjectionStore(runsRootB, sealed.run_id);
+    const snapshotA = await storeA.load();
+    const snapshotB = await storeB.load();
+    expect(snapshotA).not.toBeNull();
+    expect(snapshotB).not.toBeNull();
+    expect(canonicalJson(snapshotB?.projection)).toBe(
+      canonicalJson(snapshotA?.projection),
+    );
+  });
+
+  it("replays a crash between branch completions bit-for-bit (AC-3/AC-11b)", async () => {
+    // Arrange: direct control run.
+    const runsRootA = makeRunsRoot();
+    const runsRootB = makeRunsRoot();
+    const descriptorInput = {
+      ...forkJoinDescriptor(),
+      run_id: "run-runner-branch-crash",
+      revision_id: "rev-runner-branch-crash",
+    };
+    const sealed = sealGraphDescriptor(descriptorInput);
+    await runGraph(sealed, {
+      runsRoot: runsRootA,
+      executors: [allSucceed()],
+      prompter: { prompt: async () => "approved" as const },
+    });
+    const storeA = new FileProjectionStore(runsRootA, sealed.run_id);
+    const snapshotA = await storeA.load();
+    expect(snapshotA).not.toBeNull();
+
+    // Partial run: b1 commits then aborts while b2 hangs (crash between the
+    // two fan-out branch completions).
+    const controller = new AbortController();
+    const partialExecutor = new ScriptedExecutor((nodeId) =>
+      nodeId === "b2" ? new Promise<NodeExecutionOutput>(() => {}) : okOutput(nodeId),
+    );
+    await expect(
+      runGraph(sealed, {
+        runsRoot: runsRootB,
+        executors: [partialExecutor],
+        prompter: { prompt: async () => "approved" as const },
+        signal: controller.signal,
+        reporter: {
+          onEvent: (event) => {
+            if (event.type === "node_result" && event.node_id === "b1") {
+              controller.abort();
+            }
+          },
+        },
+      }),
+    ).rejects.toThrow(/aborted/);
+
+    // Simulate stale reap of the abandoned lock, then resume.
+    rmSync(join(runsRootB, sealed.run_id, "owner.lock"), { force: true });
+    const resumed = await runGraph(sealed, {
+      runsRoot: runsRootB,
+      executors: [allSucceed()],
+      prompter: { prompt: async () => "approved" as const },
+    });
+    expect(resumed.terminal).toBe("succeeded");
+
+    // Un-normalized projection equality including every committed
+    // transition's request_fingerprint.
+    const storeB = new FileProjectionStore(runsRootB, sealed.run_id);
+    const snapshotB = await storeB.load();
+    expect(snapshotB).not.toBeNull();
+    expect(canonicalJson(snapshotB?.projection)).toBe(
+      canonicalJson(snapshotA?.projection),
+    );
+    const transitionsA = snapshotA?.projection.committed_transitions ?? {};
+    const transitionsB = snapshotB?.projection.committed_transitions ?? {};
+    for (const [transitionId, transition] of Object.entries(transitionsA)) {
+      expect(transitionsB[transitionId]).toBeDefined();
+      if (transitionsB[transitionId] !== undefined) {
+        expect(transitionsB[transitionId].request_fingerprint).toBe(
+          transition.request_fingerprint,
+        );
+      }
+    }
+    const journalB = new FileJournal(runsRootB, sealed.run_id);
+    const recordsB = await journalB.readAll();
+    expect(
+      recordsB.some((r) => r.transition.outcome === "join_resolved"),
+    ).toBe(true);
+    expect(recordsB.some((r) => r.transition.node_id === "term")).toBe(true);
+  });
+});

--- a/src/graph/__tests__/runtime/store.test.ts
+++ b/src/graph/__tests__/runtime/store.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for FileProjectionStore (graph runtime v2).
+ *
+ * Covers round-trip fidelity, missing-file null, fail-closed corruption,
+ * descriptor binding (AC-3), and idempotent resave.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FileProjectionStore } from "../../runtime/store.js";
+import type { ProjectionSnapshotEnvelope } from "../../runtime/types.js";
+import type { GraphSchedulerProjection } from "../../types.js";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+function makeProjection(): GraphSchedulerProjection {
+  return {
+    descriptor_hash: HASH_A,
+    run_id: "run-1",
+    revision_id: "rev-1",
+    activations: {},
+    cohorts: {},
+    branch_tokens: {},
+    traversal_counts: { "node-a": 2 },
+    committed_transitions: {},
+    terminal_verification_activation_ids: [],
+  };
+}
+
+function makeEnvelope(
+  overrides: Partial<ProjectionSnapshotEnvelope> = {},
+): ProjectionSnapshotEnvelope {
+  return {
+    schema_version: 1,
+    descriptor_hash: HASH_A,
+    run_id: "run-1",
+    revision_id: "rev-1",
+    epoch: 1,
+    saved_at_seq: 0,
+    projection: makeProjection(),
+    ...overrides,
+  };
+}
+
+describe("FileProjectionStore", () => {
+  let runsRoot: string;
+
+  beforeEach(() => {
+    runsRoot = mkdtempSync(join(tmpdir(), "omc-projection-store-"));
+  });
+
+  afterEach(() => {
+    rmSync(runsRoot, { recursive: true, force: true });
+  });
+
+  it("round-trips envelope fields and projection deeply", async () => {
+    const store = new FileProjectionStore(runsRoot, "run-1");
+    const envelope = makeEnvelope({ epoch: 3, saved_at_seq: 7 });
+    const snapshot = structuredClone(envelope);
+
+    await store.save(envelope);
+    const loaded = await store.load();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.schema_version).toBe(snapshot.schema_version);
+    expect(loaded?.descriptor_hash).toBe(snapshot.descriptor_hash);
+    expect(loaded?.run_id).toBe(snapshot.run_id);
+    expect(loaded?.revision_id).toBe(snapshot.revision_id);
+    expect(loaded?.epoch).toBe(snapshot.epoch);
+    expect(loaded?.saved_at_seq).toBe(snapshot.saved_at_seq);
+    expect(loaded?.projection).toEqual(snapshot.projection);
+  });
+
+  it("returns null when no snapshot exists yet", async () => {
+    const store = new FileProjectionStore(runsRoot, "run-missing");
+    await expect(store.load()).resolves.toBeNull();
+  });
+
+  it("throws code corrupt on unparseable bytes on disk", async () => {
+    const runDir = join(runsRoot, "run-1");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, "projection.json"), "{not json");
+    const store = new FileProjectionStore(runsRoot, "run-1");
+
+    await expect(store.load()).rejects.toMatchObject({
+      name: "ProjectionStoreError",
+      code: "corrupt",
+    });
+  });
+
+  it("rejects a different descriptor_hash over an existing snapshot", async () => {
+    const store = new FileProjectionStore(runsRoot, "run-1");
+    await store.save(makeEnvelope());
+
+    await expect(
+      store.save(makeEnvelope({ descriptor_hash: HASH_B })),
+    ).rejects.toMatchObject({ code: "descriptor_mismatch" });
+  });
+
+  it("accepts idempotent resave and serves the latest snapshot", async () => {
+    const store = new FileProjectionStore(runsRoot, "run-1");
+    await store.save(makeEnvelope({ epoch: 1, saved_at_seq: 2 }));
+    await store.save(makeEnvelope({ epoch: 2, saved_at_seq: 5 }));
+
+    const loaded = await store.load();
+    expect(loaded?.epoch).toBe(2);
+    expect(loaded?.saved_at_seq).toBe(5);
+  });
+
+  it("rejects a revision_id change for the same run", async () => {
+    const store = new FileProjectionStore(runsRoot, "run-1");
+    await store.save(makeEnvelope());
+
+    await expect(
+      store.save(makeEnvelope({ revision_id: "rev-2" })),
+    ).rejects.toMatchObject({ code: "descriptor_mismatch" });
+  });
+
+  it("treats corrupt snapshot bytes as cache-miss on save; load stays fail-closed", async () => {
+    const runDir = join(runsRoot, "run-1");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, "projection.json"), "{corrupt");
+    const store = new FileProjectionStore(runsRoot, "run-1");
+    const envelope = makeEnvelope({ epoch: 2, saved_at_seq: 9 });
+
+    await expect(store.load()).rejects.toMatchObject({ code: "corrupt" });
+    await expect(store.save(envelope)).resolves.toBeUndefined();
+    const loaded = await store.load();
+    expect(loaded?.epoch).toBe(2);
+    expect(loaded?.saved_at_seq).toBe(9);
+  });
+});

--- a/src/graph/__tests__/runtime/store.test.ts
+++ b/src/graph/__tests__/runtime/store.test.ts
@@ -4,7 +4,13 @@
  * Covers round-trip fidelity, missing-file null, fail-closed corruption,
  * descriptor binding (AC-3), and idempotent resave.
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -90,6 +96,30 @@ describe("FileProjectionStore", () => {
       name: "ProjectionStoreError",
       code: "corrupt",
     });
+  });
+
+  it("fails closed on a structurally incomplete snapshot envelope", async () => {
+    const runDir = join(runsRoot, "run-1");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, "projection.json"),
+      JSON.stringify({ schema_version: 1, descriptor_hash: HASH_A }),
+      "utf8",
+    );
+    const store = new FileProjectionStore(runsRoot, "run-1");
+
+    await expect(store.load()).rejects.toMatchObject({ code: "corrupt" });
+  });
+
+  it("fails closed when projection.json is a symlink", async () => {
+    const runDir = join(runsRoot, "run-1");
+    const outside = join(runsRoot, "outside.json");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(outside, JSON.stringify(makeEnvelope()), "utf8");
+    symlinkSync(outside, join(runDir, "projection.json"));
+    const store = new FileProjectionStore(runsRoot, "run-1");
+
+    await expect(store.load()).rejects.toMatchObject({ code: "corrupt" });
   });
 
   it("rejects a different descriptor_hash over an existing snapshot", async () => {

--- a/src/graph/runtime/approval.ts
+++ b/src/graph/runtime/approval.ts
@@ -1,0 +1,121 @@
+/**
+ * Human approval gate (graph runtime v2).
+ *
+ * Bridges the frozen HumanApprovalPrompter contract to a stdin/stdout y/n
+ * prompt. Fail-closed by construction: stream EOF/closure, unrecognized
+ * input after the single re-prompt, or any non-yes/no answer resolves to
+ * "denied" (AC-14 / AC-14b: denied is a first-class recorded outcome).
+ */
+
+import { createInterface } from "readline";
+import type { Interface as ReadlineInterface } from "readline";
+
+import type { GraphApprovalDecision } from "../types.js";
+import type { ApprovalRequest, HumanApprovalPrompter } from "./types.js";
+
+type Decision = GraphApprovalDecision["decision"];
+
+/** Maps one raw input line to a decision, or null when unrecognized. */
+function parseAnswer(raw: string): Decision | null {
+  const answer = raw.trim().toLowerCase();
+  if (answer === "y" || answer === "yes") {
+    return "approved";
+  }
+  if (answer === "n" || answer === "no") {
+    return "denied";
+  }
+  return null;
+}
+
+/**
+ * A prompter that always returns the given decision without touching any
+ * stream. Used by runner unit tests and non-interactive invocations.
+ */
+export function createFixedApprovalGate(decision: Decision): HumanApprovalPrompter {
+  return {
+    async prompt(): Promise<Decision> {
+      return decision;
+    },
+  };
+}
+
+/**
+ * Interactive y/n gate over an injectable readable stream (default
+ * process.stdin). Prompts via process.stdout.write only — never console.
+ */
+export function createStdinApprovalGate(
+  input?: NodeJS.ReadableStream,
+): HumanApprovalPrompter {
+  const stream = input ?? process.stdin;
+  let readlineInterface: ReadlineInterface | null = null;
+  let streamClosed = false;
+  /** Lines that arrived before any reader asked for them. */
+  const bufferedLines: string[] = [];
+  /** At most one reader waits at a time (prompts are sequential). */
+  let waitingReader: ((line: string | null) => void) | null = null;
+
+  /**
+   * Created lazily at first prompt so the interface attaches while the
+   * stream is still live. A single permanent line listener captures every
+   * arriving line — readline emits lines whether or not a reader is
+   * currently attached, so per-read listeners would drop buffered lines.
+   */
+  function getInterface(): ReadlineInterface {
+    if (readlineInterface === null) {
+      readlineInterface = createInterface({ input: stream });
+      readlineInterface.on("line", (line: string) => {
+        if (waitingReader !== null) {
+          const reader = waitingReader;
+          waitingReader = null;
+          reader(line);
+        } else {
+          bufferedLines.push(line);
+        }
+      });
+      readlineInterface.on("close", () => {
+        streamClosed = true;
+        if (waitingReader !== null) {
+          const reader = waitingReader;
+          waitingReader = null;
+          reader(null);
+        }
+      });
+    }
+    return readlineInterface;
+  }
+
+  /** Resolves with the next line, or null when the stream hit EOF/closed. */
+  function readLine(): Promise<string | null> {
+    if (streamClosed) {
+      return Promise.resolve(null);
+    }
+    const queued = bufferedLines.shift();
+    if (queued !== undefined) {
+      return Promise.resolve(queued);
+    }
+    getInterface();
+    return new Promise((resolve) => {
+      waitingReader = resolve;
+    });
+  }
+
+  return {
+    async prompt(request: ApprovalRequest): Promise<Decision> {
+      process.stdout.write(
+        `\n[approval] ${request.node_id}: ${request.prompt_text}\nApprove? [y/n] `,
+      );
+      let answer = await readLine();
+      if (answer !== null) {
+        const parsed = parseAnswer(answer);
+        if (parsed !== null) {
+          return parsed;
+        }
+        // Unrecognized answer: re-prompt once, then default to denied.
+        process.stdout.write("Approve? [y/n] ");
+        answer = await readLine();
+      }
+      const retryParsed = answer === null ? null : parseAnswer(answer);
+      return retryParsed === "approved" ? "approved" : "denied";
+    },
+  };
+}

--- a/src/graph/runtime/executors/agent.ts
+++ b/src/graph/runtime/executors/agent.ts
@@ -115,7 +115,9 @@ export class AgentNodeExecutor implements NodeExecutor {
           }
           return assistantText(value) ?? "";
         }
-        let text = "";
+        // Accumulate every assistant text chunk: multi-message streams must
+        // land their full output in output_summary, not just the last chunk.
+        const parts: string[] = [];
         for await (const message of returned) {
           const final = sdkResult(message);
           if (final) {
@@ -123,9 +125,11 @@ export class AgentNodeExecutor implements NodeExecutor {
             return final.text;
           }
           const chunk = assistantText(message);
-          if (chunk !== null) text = chunk;
+          if (chunk !== null && chunk.length > 0) {
+            parts.push(chunk);
+          }
         }
-        return text;
+        return parts.join("\n");
       };
 
       // Rejects when the timer fires even if the underlying query never settles.

--- a/src/graph/runtime/executors/agent.ts
+++ b/src/graph/runtime/executors/agent.ts
@@ -1,0 +1,184 @@
+/**
+ * Agent node executor.
+ *
+ * Runs one GraphAgentNode attempt through the Claude Agent SDK. The SDK is
+ * lazy-imported inside execute() so unit tests inject fakes and never require
+ * network access; the injectable queryImpl mirrors `query` from
+ * `@anthropic-ai/claude-agent-sdk`.
+ */
+
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  NodeExecutionContext,
+  NodeExecutionOutput,
+  NodeExecutor,
+} from "../types.js";
+import type { GraphEvidenceReference } from "../../types.js";
+
+/** Injectable SDK surface: the real `query` or a test fake. */
+export type AgentQueryImpl = (
+  options: unknown,
+) => AsyncIterable<unknown> | Promise<unknown>;
+
+const SUMMARY_LIMIT = 2000;
+
+class AgentTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`timeout after ${timeoutMs}ms`);
+    this.name = "AgentTimeoutError";
+  }
+}
+
+class AgentRunError extends Error {}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return (
+    isRecord(value) &&
+    typeof (value as { [Symbol.asyncIterator]?: unknown })[
+      Symbol.asyncIterator
+    ] === "function"
+  );
+}
+
+/** Text of an assistant message's text blocks, or null when not one. */
+function assistantText(message: unknown): string | null {
+  if (!isRecord(message) || message.type !== "assistant") return null;
+  const inner = message.message;
+  if (!isRecord(inner) || !Array.isArray(inner.content)) return null;
+  const parts: string[] = [];
+  for (const block of inner.content) {
+    if (
+      isRecord(block) &&
+      block.type === "text" &&
+      typeof block.text === "string"
+    ) {
+      parts.push(block.text);
+    }
+  }
+  return parts.length > 0 ? parts.join("") : null;
+}
+
+/** Terminal SDK result message: ok with final text, failed with reason, or null. */
+function sdkResult(
+  message: unknown,
+): { ok: true; text: string } | { ok: false; reason: string } | null {
+  if (!isRecord(message) || message.type !== "result") return null;
+  if (message.subtype !== "success" || message.is_error === true) {
+    const reason =
+      typeof message.subtype === "string" ? message.subtype : "error";
+    return { ok: false, reason };
+  }
+  return { ok: true, text: typeof message.result === "string" ? message.result : "" };
+}
+
+function truncate(text: string): string {
+  return text.length > SUMMARY_LIMIT ? text.slice(0, SUMMARY_LIMIT) : text;
+}
+
+export class AgentNodeExecutor implements NodeExecutor {
+  readonly kinds = ["agent"] as const;
+
+  constructor(private readonly queryImpl?: AgentQueryImpl) {}
+
+  async execute(context: NodeExecutionContext): Promise<NodeExecutionOutput> {
+    const node = context.node;
+    if (node.kind !== "agent") {
+      return failed(context, `unsupported node kind ${node.kind}`);
+    }
+
+    const prompt = `${node.instructions}\n\nGoal: ${context.descriptor.goal}`;
+    const abortController = new AbortController();
+    const timer = setTimeout(() => abortController.abort(), node.timeout_ms);
+
+    try {
+      let queryFn: AgentQueryImpl;
+      if (this.queryImpl) {
+        queryFn = this.queryImpl;
+      } else {
+        const { query } = await import("@anthropic-ai/claude-agent-sdk");
+        queryFn = (options: unknown) =>
+          query(options as { prompt: string; options?: Options });
+      }
+
+      const collect = async (): Promise<string> => {
+        const returned = queryFn({ prompt, options: { abortController } });
+        if (!isAsyncIterable(returned)) {
+          const value = await returned;
+          const final = sdkResult(value);
+          if (final) {
+            if (!final.ok) throw new AgentRunError(`sdk result error: ${final.reason}`);
+            return final.text;
+          }
+          return assistantText(value) ?? "";
+        }
+        let text = "";
+        for await (const message of returned) {
+          const final = sdkResult(message);
+          if (final) {
+            if (!final.ok) throw new AgentRunError(`sdk result error: ${final.reason}`);
+            return final.text;
+          }
+          const chunk = assistantText(message);
+          if (chunk !== null) text = chunk;
+        }
+        return text;
+      };
+
+      // Rejects when the timer fires even if the underlying query never settles.
+      const timedOut = new Promise<never>((_, reject) => {
+        abortController.signal.addEventListener(
+          "abort",
+          () => reject(new AgentTimeoutError(node.timeout_ms)),
+          { once: true },
+        );
+      });
+
+      const work = collect();
+      try {
+        const text = await Promise.race([work, timedOut]);
+        if (text.trim().length === 0) {
+          return failed(context, "empty response");
+        }
+        return {
+          outcome: "succeeded",
+          output_summary: truncate(text),
+          evidence_refs: evidenceRefs(context),
+        };
+      } finally {
+        work.catch(() => {}); // loser of the race may still reject post-abort
+      }
+    } catch (error) {
+      if (error instanceof AgentTimeoutError) {
+        return failed(context, error.message);
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      return failed(context, `error: ${truncate(message)}`);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function evidenceRefs(
+  context: NodeExecutionContext,
+): readonly GraphEvidenceReference[] {
+  return [
+    {
+      kind: "url",
+      ref: `agent://${context.activation_id}`,
+      summary: `agent attempt ${context.attempt_id}`,
+    },
+  ];
+}
+
+function failed(context: NodeExecutionContext, summary: string): NodeExecutionOutput {
+  return {
+    outcome: "failed",
+    output_summary: summary,
+    evidence_refs: evidenceRefs(context),
+  };
+}

--- a/src/graph/runtime/executors/agent.ts
+++ b/src/graph/runtime/executors/agent.ts
@@ -14,6 +14,11 @@ import type {
   NodeExecutor,
 } from "../types.js";
 import type { GraphEvidenceReference } from "../../types.js";
+import {
+  buildAgentEnv,
+  idempotencyKeyFor,
+  READ_ONLY_AGENT_TOOLS,
+} from "./authority.js";
 
 /** Injectable SDK surface: the real `query` or a test fake. */
 export type AgentQueryImpl = (
@@ -42,6 +47,18 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
       Symbol.asyncIterator
     ] === "function"
   );
+}
+
+function stopQuery(value: unknown): void {
+  if (!isRecord(value)) return;
+  const interrupt = value.interrupt;
+  if (typeof interrupt === "function") {
+    void Promise.resolve(interrupt.call(value)).catch(() => {});
+  }
+  const returnMethod = value.return;
+  if (typeof returnMethod === "function") {
+    void Promise.resolve(returnMethod.call(value)).catch(() => {});
+  }
 }
 
 /** Text of an assistant message's text blocks, or null when not one. */
@@ -89,10 +106,24 @@ export class AgentNodeExecutor implements NodeExecutor {
     if (node.kind !== "agent") {
       return failed(context, `unsupported node kind ${node.kind}`);
     }
+    if (node.effect_policy.policy === "reconcile") {
+      return failed(context, "reconcile policy requires a custom executor");
+    }
 
     const prompt = `${node.instructions}\n\nGoal: ${context.descriptor.goal}`;
     const abortController = new AbortController();
-    const timer = setTimeout(() => abortController.abort(), node.timeout_ms);
+    const idempotencyKey = idempotencyKeyFor(context);
+    let activeQuery: unknown;
+    let timeoutTriggered = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<never>((_, reject) => {
+      timeoutTimer = setTimeout(() => {
+        timeoutTriggered = true;
+        abortController.abort();
+        stopQuery(activeQuery);
+        reject(new AgentTimeoutError(node.timeout_ms));
+      }, node.timeout_ms);
+    });
 
     try {
       let queryFn: AgentQueryImpl;
@@ -104,8 +135,38 @@ export class AgentNodeExecutor implements NodeExecutor {
           query(options as { prompt: string; options?: Options });
       }
 
+      const canUseTool: NonNullable<Options["canUseTool"]> = async (
+        toolName,
+        input,
+      ) => {
+        if (
+          (READ_ONLY_AGENT_TOOLS as readonly string[]).includes(toolName)
+        ) {
+          return { behavior: "allow", updatedInput: input };
+        }
+        return {
+          behavior: "deny",
+          message: "Graph agent execution permits read-only tools only",
+          interrupt: true,
+        };
+      };
+
       const collect = async (): Promise<string> => {
-        const returned = queryFn({ prompt, options: { abortController } });
+        const returned = queryFn({
+          prompt,
+          options: {
+            abortController,
+            cwd: process.cwd(),
+            env: buildAgentEnv(idempotencyKey),
+            tools: [...READ_ONLY_AGENT_TOOLS],
+            permissionMode: "dontAsk",
+            canUseTool,
+            additionalDirectories: [],
+            persistSession: false,
+          },
+        });
+        activeQuery = returned;
+        if (timeoutTriggered) stopQuery(activeQuery);
         if (!isAsyncIterable(returned)) {
           const value = await returned;
           const final = sdkResult(value);
@@ -132,15 +193,6 @@ export class AgentNodeExecutor implements NodeExecutor {
         return parts.join("\n");
       };
 
-      // Rejects when the timer fires even if the underlying query never settles.
-      const timedOut = new Promise<never>((_, reject) => {
-        abortController.signal.addEventListener(
-          "abort",
-          () => reject(new AgentTimeoutError(node.timeout_ms)),
-          { once: true },
-        );
-      });
-
       const work = collect();
       try {
         const text = await Promise.race([work, timedOut]);
@@ -151,6 +203,9 @@ export class AgentNodeExecutor implements NodeExecutor {
           outcome: "succeeded",
           output_summary: truncate(text),
           evidence_refs: evidenceRefs(context),
+          ...(idempotencyKey === undefined
+            ? {}
+            : { external_idempotency_key: idempotencyKey }),
         };
       } finally {
         work.catch(() => {}); // loser of the race may still reject post-abort
@@ -162,7 +217,7 @@ export class AgentNodeExecutor implements NodeExecutor {
       const message = error instanceof Error ? error.message : String(error);
       return failed(context, `error: ${truncate(message)}`);
     } finally {
-      clearTimeout(timer);
+      if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
     }
   }
 }

--- a/src/graph/runtime/executors/authority.ts
+++ b/src/graph/runtime/executors/authority.ts
@@ -1,0 +1,90 @@
+import type { NodeExecutionContext } from "../types.js";
+
+/** Environment required for ordinary process operation, excluding secrets. */
+const BASE_ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "USERPROFILE",
+  "USER",
+  "USERNAME",
+  "LOGNAME",
+  "TEMP",
+  "TMP",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+] as const;
+
+/** Provider settings deliberately forwarded to the Agent SDK only. */
+const AGENT_PROVIDER_ENV_ALLOWLIST = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "AWS_PROFILE",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "KIMI_API_KEY",
+  "ZAI_API_KEY",
+  "MINIMAX_API_KEY",
+] as const;
+
+const TOKEN_PATTERN = /\{(\w+)\}/g;
+
+/** Built-in agent execution is read-only and never prompts for extra access. */
+export const READ_ONLY_AGENT_TOOLS = ["Read", "Glob", "Grep"] as const;
+
+function baseEnv(): NodeJS.ProcessEnv {
+  const child: NodeJS.ProcessEnv = {};
+  for (const key of BASE_ENV_ALLOWLIST) {
+    const value = process.env[key];
+    if (value !== undefined) child[key] = value;
+  }
+  return child;
+}
+
+/** Environment for arbitrary command nodes, including graph-owned variables. */
+export function buildCommandEnv(idempotencyKey?: string): NodeJS.ProcessEnv {
+  const child = baseEnv();
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("GRAPH_") && value !== undefined) child[key] = value;
+  }
+  if (idempotencyKey !== undefined) {
+    child.GRAPH_IDEMPOTENCY_KEY = idempotencyKey;
+  }
+  return child;
+}
+
+/** Environment for the read-only Agent SDK subprocess. */
+export function buildAgentEnv(idempotencyKey?: string): NodeJS.ProcessEnv {
+  const child = baseEnv();
+  for (const key of AGENT_PROVIDER_ENV_ALLOWLIST) {
+    const value = process.env[key];
+    if (value !== undefined) child[key] = value;
+  }
+  if (idempotencyKey !== undefined) {
+    child.GRAPH_IDEMPOTENCY_KEY = idempotencyKey;
+  }
+  return child;
+}
+
+/** Resolve an idempotency key before an external effect starts. */
+export function idempotencyKeyFor(
+  context: NodeExecutionContext,
+): string | undefined {
+  if (context.node.effect_policy.policy !== "idempotent") return undefined;
+  const tokens: Readonly<Record<string, string>> = {
+    run_id: context.descriptor.run_id,
+    node_id: context.node.id,
+    activation_id: context.activation_id,
+    attempt_id: context.attempt_id,
+    attempt_no: String(context.attempt_no),
+  };
+  return context.node.effect_policy.idempotency_key_template.replace(
+    TOKEN_PATTERN,
+    (match, token: string) =>
+      Object.prototype.hasOwnProperty.call(tokens, token) ? tokens[token]! : match,
+  );
+}
+

--- a/src/graph/runtime/executors/command.ts
+++ b/src/graph/runtime/executors/command.ts
@@ -1,0 +1,260 @@
+/**
+ * Command node executor for graph runtime v2.
+ *
+ * Spawns the node's command via a platform shell and reports an outcome
+ * object — command failures (non-zero exit, timeout, spawn infra errors)
+ * are reported as `failed` outcomes, never thrown. Terminal-success
+ * evidence duty stays with the runner/scheduler.
+ */
+
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+import type {
+  ExecutableKind,
+  NodeExecutionContext,
+  NodeExecutionOutput,
+  NodeExecutor,
+} from "../types.js";
+import type { GraphCommandNode, GraphEvidenceReference } from "../../types.js";
+
+/** Per-stream captured output cap; the TAIL is kept. */
+const STREAM_TAIL_CHARS = 2000;
+
+/** Grace period after the first kill before escalating to a hard kill. */
+const KILL_ESCALATION_MS = 5000;
+
+/**
+ * Output shape for command attempts. Extends the frozen
+ * NodeExecutionOutput with the idempotency key computed for idempotent
+ * effect policies (structurally compatible; see team-lead note).
+ */
+export interface CommandExecutionOutput extends NodeExecutionOutput {
+  readonly external_idempotency_key?: string;
+}
+
+interface CommandRunResult {
+  readonly timed_out: boolean;
+  /** null when killed by a signal or the process never spawned. */
+  readonly exit_code: number | null;
+  readonly infra_error?: string;
+}
+
+/** Keeps only the trailing STREAM_TAIL_CHARS of one output stream. */
+class StreamTail {
+  private content = "";
+
+  append(chunk: string): void {
+    const combined = this.content + chunk;
+    this.content =
+      combined.length > STREAM_TAIL_CHARS
+        ? combined.slice(combined.length - STREAM_TAIL_CHARS)
+        : combined;
+  }
+
+  excerpt(): string {
+    return this.content.trim();
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Best-effort termination of the whole process tree.
+ *
+ * On Windows child.kill() terminates only cmd.exe and leaves grandchildren
+ * holding the stdio pipes (so "close" would not fire until they exit on
+ * their own), so the tree kill IS the first-line kill there. On POSIX the
+ * shell typically execs the single command, so a plain kill reaches it.
+ */
+function terminateProcessTree(child: ChildProcess): void {
+  if (process.platform === "win32") {
+    if (child.pid === undefined) {
+      return;
+    }
+    try {
+      // ponytail: taskkill tree-kill covers shell+grandchildren; Job Objects
+      // are the upgrade path if detached/detached-process cases appear.
+      spawn("taskkill", ["/F", "/T", "/PID", String(child.pid)], { stdio: "ignore" });
+    } catch {
+      // Nothing further to do; the run result already reports failure.
+    }
+    return;
+  }
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // Process already gone.
+  }
+}
+
+function runCommand(
+  command: string,
+  timeoutMs: number,
+  stdoutTail: StreamTail,
+  stderrTail: StreamTail,
+): Promise<CommandRunResult> {
+  return new Promise<CommandRunResult>((resolve) => {
+    let child: ChildProcess;
+    try {
+      child = spawn(command, {
+        shell: true,
+        cwd: process.cwd(),
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      resolve({ timed_out: false, exit_code: null, infra_error: describeError(error) });
+      return;
+    }
+
+    let settled = false;
+    let timedOut = false;
+    let exitCode: number | null = null;
+    let infraError: string | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const settle = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
+      if (escalationTimer !== undefined) clearTimeout(escalationTimer);
+      resolve({ timed_out: timedOut, exit_code: exitCode, infra_error: infraError });
+    };
+
+    if (child.stdout) {
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => stdoutTail.append(chunk));
+    }
+    if (child.stderr) {
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => stderrTail.append(chunk));
+    }
+
+    child.on("error", (error: Error) => {
+      infraError = describeError(error);
+      settle();
+    });
+
+    child.on("close", (code) => {
+      exitCode = code;
+      settle();
+    });
+
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      try {
+        if (process.platform === "win32") {
+          terminateProcessTree(child);
+        } else {
+          child.kill();
+        }
+      } catch {
+        // Soft kill refused; escalation below applies the hard kill.
+      }
+      escalationTimer = setTimeout(() => {
+        // Still unsettled means the tree has not fully exited (pipes open or
+        // process alive) — apply the hard kill regardless of shell exit state.
+        if (!settled) {
+          terminateProcessTree(child);
+        }
+      }, KILL_ESCALATION_MS);
+    }, timeoutMs);
+  });
+}
+
+function substituteIdempotencyTokens(
+  template: string,
+  tokens: Readonly<Record<string, string>>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (match, token: string) =>
+    Object.prototype.hasOwnProperty.call(tokens, token) ? tokens[token]! : match,
+  );
+}
+
+export class CommandNodeExecutor implements NodeExecutor {
+  readonly kinds: readonly ExecutableKind[] = ["command"];
+
+  async execute(context: NodeExecutionContext): Promise<NodeExecutionOutput> {
+    const dispatched = context.node;
+    if (dispatched.kind !== "command") {
+      throw new Error(
+        `CommandNodeExecutor cannot execute node kind "${dispatched.kind}" (${dispatched.id})`,
+      );
+    }
+    const node: GraphCommandNode = dispatched;
+
+    const startedAtMs = Date.now();
+    const stdoutTail = new StreamTail();
+    const stderrTail = new StreamTail();
+    const result = await runCommand(node.command, node.timeout_ms, stdoutTail, stderrTail);
+    const durationMs = Date.now() - startedAtMs;
+
+    const succeeded =
+      !result.infra_error && !result.timed_out && result.exit_code === 0;
+    const outcome: NodeExecutionOutput["outcome"] = succeeded ? "succeeded" : "failed";
+
+    const baseStats = `exit=${result.exit_code ?? "none"} duration_ms=${durationMs}`;
+
+    const summaryParts: string[] = [];
+    if (result.timed_out) {
+      summaryParts.push(`timeout after ${node.timeout_ms}ms`);
+    }
+    if (result.infra_error) {
+      summaryParts.push(`spawn infra error: ${result.infra_error}`);
+    }
+    summaryParts.push(baseStats);
+
+    const evidenceRefs: GraphEvidenceReference[] = [
+      { kind: "command", ref: node.command, summary: baseStats },
+    ];
+
+    const stdoutExcerpt = stdoutTail.excerpt();
+    if (stdoutExcerpt) {
+      summaryParts.push(`stdout tail: ${stdoutExcerpt}`);
+      evidenceRefs.push({
+        kind: "command",
+        ref: `stdout:${node.command}`,
+        summary: stdoutExcerpt,
+      });
+    }
+    const stderrExcerpt = stderrTail.excerpt();
+    if (stderrExcerpt) {
+      summaryParts.push(`stderr tail: ${stderrExcerpt}`);
+      evidenceRefs.push({
+        kind: "command",
+        ref: `stderr:${node.command}`,
+        summary: stderrExcerpt,
+      });
+    }
+
+    let externalIdempotencyKey: string | undefined;
+    if (node.effect_policy.policy === "idempotent") {
+      externalIdempotencyKey = substituteIdempotencyTokens(
+        node.effect_policy.idempotency_key_template,
+        {
+          run_id: context.descriptor.run_id,
+          node_id: node.id,
+          activation_id: context.activation_id,
+          attempt_id: context.attempt_id,
+          attempt_no: String(context.attempt_no),
+        },
+      );
+    }
+
+    const output: CommandExecutionOutput = {
+      outcome,
+      output_summary: summaryParts.join("; "),
+      evidence_refs: evidenceRefs,
+      ...(externalIdempotencyKey === undefined
+        ? {}
+        : { external_idempotency_key: externalIdempotencyKey }),
+    };
+    return output;
+  }
+}

--- a/src/graph/runtime/executors/command.ts
+++ b/src/graph/runtime/executors/command.ts
@@ -142,7 +142,12 @@ function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals): void
   }
 }
 
-function runCommand(
+/**
+ * Not named `runCommand`: that name is a reserved convention in
+ * tests/lint/windows-hide-hooks.test.ts for `(command, args)` git-forwarding
+ * helpers; this executor runs arbitrary shell lines instead (see trust model).
+ */
+function runShellCommand(
   command: string,
   timeoutMs: number,
   stdoutTail: StreamTail,
@@ -244,7 +249,7 @@ export class CommandNodeExecutor implements NodeExecutor {
     const startedAtMs = Date.now();
     const stdoutTail = new StreamTail();
     const stderrTail = new StreamTail();
-    const result = await runCommand(node.command, node.timeout_ms, stdoutTail, stderrTail);
+    const result = await runShellCommand(node.command, node.timeout_ms, stdoutTail, stderrTail);
     const durationMs = Date.now() - startedAtMs;
 
     const succeeded =

--- a/src/graph/runtime/executors/command.ts
+++ b/src/graph/runtime/executors/command.ts
@@ -5,6 +5,12 @@
  * object — command failures (non-zero exit, timeout, spawn infra errors)
  * are reported as `failed` outcomes, never thrown. Terminal-success
  * evidence duty stays with the runner/scheduler.
+ *
+ * Trust model: the descriptor author holds code-execution authority over
+ * this host — commands are arbitrary shell lines, so no sandboxing is
+ * attempted. What IS bounded here is ambient secret exposure: the child
+ * inherits only an allowlisted environment (see CHILD_ENV_ALLOWLIST), not
+ * the host's full environment.
  */
 
 import { spawn } from "node:child_process";
@@ -23,6 +29,21 @@ const STREAM_TAIL_CHARS = 2000;
 
 /** Grace period after the first kill before escalating to a hard kill. */
 const KILL_ESCALATION_MS = 5000;
+
+/**
+ * Environment variables a spawned command may inherit. Everything else in
+ * the host environment (API keys, tokens, session state) is scrubbed.
+ * GRAPH_* variables are graph-runtime configuration and pass through.
+ */
+const CHILD_ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "USERPROFILE",
+  "TEMP",
+  "TMP",
+  "LANG",
+  "TZ",
+] as const;
 
 /**
  * Output shape for command attempts. Extends the frozen
@@ -57,6 +78,27 @@ class StreamTail {
   }
 }
 
+/**
+ * Allowlist-scrubbed environment for spawned commands. The host's full
+ * environment (API keys, tokens, session state) never reaches children:
+ * only the allowlisted operational variables plus GRAPH_* pass through.
+ */
+function buildChildEnv(): NodeJS.ProcessEnv {
+  const child: Record<string, string> = {};
+  for (const key of CHILD_ENV_ALLOWLIST) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      child[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("GRAPH_") && value !== undefined) {
+      child[key] = value;
+    }
+  }
+  return child;
+}
+
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -64,12 +106,14 @@ function describeError(error: unknown): string {
 /**
  * Best-effort termination of the whole process tree.
  *
- * On Windows child.kill() terminates only cmd.exe and leaves grandchildren
- * holding the stdio pipes (so "close" would not fire until they exit on
- * their own), so the tree kill IS the first-line kill there. On POSIX the
- * shell typically execs the single command, so a plain kill reaches it.
+ * On Windows, `taskkill /F /T` is the tree kill and serves as both soft
+ * and hard kill. On POSIX the command runs under `sh -c`, which does NOT
+ * exec-replace itself for compound commands: a plain child.kill() reaches
+ * only the shell PID while grandchildren survive holding the stdio pipes
+ * ("close" never fires). The shell is therefore spawned DETACHED (own
+ * process group) and kills address the NEGATIVE pid - the whole group.
  */
-function terminateProcessTree(child: ChildProcess): void {
+function terminateProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
   if (process.platform === "win32") {
     if (child.pid === undefined) {
       return;
@@ -83,10 +127,18 @@ function terminateProcessTree(child: ChildProcess): void {
     }
     return;
   }
+  if (child.pid === undefined) {
+    return;
+  }
   try {
-    child.kill("SIGKILL");
+    process.kill(-child.pid, signal);
   } catch {
-    // Process already gone.
+    // Group kill refused (no such group); fall back to the shell PID.
+    try {
+      child.kill(signal);
+    } catch {
+      // Process already gone.
+    }
   }
 }
 
@@ -102,8 +154,11 @@ function runCommand(
       child = spawn(command, {
         shell: true,
         cwd: process.cwd(),
-        env: process.env,
+        env: buildChildEnv(),
         stdio: ["ignore", "pipe", "pipe"],
+        // Detached => own process group => the NEGATIVE-pid group kill in
+        // terminateProcessTree can reach grandchildren, not just the shell.
+        ...(process.platform === "win32" ? {} : { detached: true }),
       });
     } catch (error) {
       resolve({ timed_out: false, exit_code: null, infra_error: describeError(error) });
@@ -146,22 +201,18 @@ function runCommand(
       settle();
     });
 
-    timeoutTimer = setTimeout(() => {
+        timeoutTimer = setTimeout(() => {
       timedOut = true;
+      // Soft kill first: SIGTERM to the whole process group (POSIX) or the
+      // taskkill tree kill (Windows). Escalation below applies SIGKILL.
       try {
-        if (process.platform === "win32") {
-          terminateProcessTree(child);
-        } else {
-          child.kill();
-        }
+        terminateProcessTree(child, "SIGTERM");
       } catch {
         // Soft kill refused; escalation below applies the hard kill.
       }
       escalationTimer = setTimeout(() => {
-        // Still unsettled means the tree has not fully exited (pipes open or
-        // process alive) — apply the hard kill regardless of shell exit state.
         if (!settled) {
-          terminateProcessTree(child);
+          terminateProcessTree(child, "SIGKILL");
         }
       }, KILL_ESCALATION_MS);
     }, timeoutMs);

--- a/src/graph/runtime/executors/command.ts
+++ b/src/graph/runtime/executors/command.ts
@@ -153,6 +153,7 @@ function runCommand(
     try {
       child = spawn(command, {
         shell: true,
+        windowsHide: true,
         cwd: process.cwd(),
         env: buildChildEnv(),
         stdio: ["ignore", "pipe", "pipe"],

--- a/src/graph/runtime/executors/command.ts
+++ b/src/graph/runtime/executors/command.ts
@@ -23,27 +23,13 @@ import type {
   NodeExecutor,
 } from "../types.js";
 import type { GraphCommandNode, GraphEvidenceReference } from "../../types.js";
+import { buildCommandEnv, idempotencyKeyFor } from "./authority.js";
 
 /** Per-stream captured output cap; the TAIL is kept. */
 const STREAM_TAIL_CHARS = 2000;
 
 /** Grace period after the first kill before escalating to a hard kill. */
 const KILL_ESCALATION_MS = 5000;
-
-/**
- * Environment variables a spawned command may inherit. Everything else in
- * the host environment (API keys, tokens, session state) is scrubbed.
- * GRAPH_* variables are graph-runtime configuration and pass through.
- */
-const CHILD_ENV_ALLOWLIST = [
-  "PATH",
-  "HOME",
-  "USERPROFILE",
-  "TEMP",
-  "TMP",
-  "LANG",
-  "TZ",
-] as const;
 
 /**
  * Output shape for command attempts. Extends the frozen
@@ -76,27 +62,6 @@ class StreamTail {
   excerpt(): string {
     return this.content.trim();
   }
-}
-
-/**
- * Allowlist-scrubbed environment for spawned commands. The host's full
- * environment (API keys, tokens, session state) never reaches children:
- * only the allowlisted operational variables plus GRAPH_* pass through.
- */
-function buildChildEnv(): NodeJS.ProcessEnv {
-  const child: Record<string, string> = {};
-  for (const key of CHILD_ENV_ALLOWLIST) {
-    const value = process.env[key];
-    if (value !== undefined) {
-      child[key] = value;
-    }
-  }
-  for (const [key, value] of Object.entries(process.env)) {
-    if (key.startsWith("GRAPH_") && value !== undefined) {
-      child[key] = value;
-    }
-  }
-  return child;
 }
 
 function describeError(error: unknown): string {
@@ -152,6 +117,7 @@ function runShellCommand(
   timeoutMs: number,
   stdoutTail: StreamTail,
   stderrTail: StreamTail,
+  idempotencyKey?: string,
 ): Promise<CommandRunResult> {
   return new Promise<CommandRunResult>((resolve) => {
     let child: ChildProcess;
@@ -160,7 +126,7 @@ function runShellCommand(
         shell: true,
         windowsHide: true,
         cwd: process.cwd(),
-        env: buildChildEnv(),
+        env: buildCommandEnv(idempotencyKey),
         stdio: ["ignore", "pipe", "pipe"],
         // Detached => own process group => the NEGATIVE-pid group kill in
         // terminateProcessTree can reach grandchildren, not just the shell.
@@ -225,15 +191,6 @@ function runShellCommand(
   });
 }
 
-function substituteIdempotencyTokens(
-  template: string,
-  tokens: Readonly<Record<string, string>>,
-): string {
-  return template.replace(/\{(\w+)\}/g, (match, token: string) =>
-    Object.prototype.hasOwnProperty.call(tokens, token) ? tokens[token]! : match,
-  );
-}
-
 export class CommandNodeExecutor implements NodeExecutor {
   readonly kinds: readonly ExecutableKind[] = ["command"];
 
@@ -249,7 +206,21 @@ export class CommandNodeExecutor implements NodeExecutor {
     const startedAtMs = Date.now();
     const stdoutTail = new StreamTail();
     const stderrTail = new StreamTail();
-    const result = await runShellCommand(node.command, node.timeout_ms, stdoutTail, stderrTail);
+    if (node.effect_policy.policy === "reconcile") {
+      return {
+        outcome: "failed",
+        output_summary: "reconcile policy requires a custom executor",
+        evidence_refs: [{ kind: "command", ref: node.command }],
+      };
+    }
+    const externalIdempotencyKey = idempotencyKeyFor(context);
+    const result = await runShellCommand(
+      node.command,
+      node.timeout_ms,
+      stdoutTail,
+      stderrTail,
+      externalIdempotencyKey,
+    );
     const durationMs = Date.now() - startedAtMs;
 
     const succeeded =
@@ -288,20 +259,6 @@ export class CommandNodeExecutor implements NodeExecutor {
         ref: `stderr:${node.command}`,
         summary: stderrExcerpt,
       });
-    }
-
-    let externalIdempotencyKey: string | undefined;
-    if (node.effect_policy.policy === "idempotent") {
-      externalIdempotencyKey = substituteIdempotencyTokens(
-        node.effect_policy.idempotency_key_template,
-        {
-          run_id: context.descriptor.run_id,
-          node_id: node.id,
-          activation_id: context.activation_id,
-          attempt_id: context.attempt_id,
-          attempt_no: String(context.attempt_no),
-        },
-      );
     }
 
     const output: CommandExecutionOutput = {

--- a/src/graph/runtime/fence.ts
+++ b/src/graph/runtime/fence.ts
@@ -58,12 +58,15 @@ function readSidecarCeiling(filePath: string): number | null {
 export interface FileOwnershipFenceOptions {
   /** Age (ms) after which a dead/unparseable lock may be taken over. Default: 30000 */
   readonly staleGraceMs?: number;
+  /** Test-only interlock used to deterministically exercise takeover races. */
+  readonly beforeTakeoverRename?: () => void;
 }
 
 export class FileOwnershipFence implements OwnershipFence {
   private readonly runsRoot: string;
   private readonly runId?: string;
   private readonly staleGraceMs: number;
+  private readonly beforeTakeoverRename?: () => void;
   /** fd of the held lock file while we own the run; null otherwise. */
   private fd: number | null = null;
   private heldEpoch: number | null = null;
@@ -82,6 +85,7 @@ export class FileOwnershipFence implements OwnershipFence {
     this.runsRoot = runsRoot;
     this.runId = runId;
     this.staleGraceMs = options?.staleGraceMs ?? DEFAULT_STALE_GRACE_MS;
+    this.beforeTakeoverRename = options?.beforeTakeoverRename;
   }
 
   private lockPath(): string {
@@ -131,6 +135,9 @@ export class FileOwnershipFence implements OwnershipFence {
         return { outcome: "busy" };
       }
 
+      const staleIdentity = this.readLockIdentity(lockPath);
+      this.beforeTakeoverRename?.();
+
       // Takeover step: atomic rename to a unique tombstone. Exactly one
       // racer wins; losers observe ENOENT/EEXIST/EPERM here and retry (AC-6).
       const tombstone = `${lockPath}.tomb.${randomBytes(6).toString("hex")}`;
@@ -138,6 +145,29 @@ export class FileOwnershipFence implements OwnershipFence {
         renameSync(lockPath, tombstone);
       } catch {
         continue; // Another racer won the move; restart from step 1.
+      }
+
+      // Rename is atomic but has no compare-and-swap form. A racer can
+      // replace the stale path between our inspection and rename. Verify the
+      // object we moved before treating the tombstone as ours; if it is a
+      // replacement owner's lock, restore its live path or discard only our
+      // extra tombstone link and never adopt/delete its ownership.
+      const movedIdentity = this.readLockIdentity(tombstone);
+      if (!this.sameLockIdentity(staleIdentity, movedIdentity)) {
+        try {
+          if (!this.pathExists(lockPath)) {
+            renameSync(tombstone, lockPath);
+          } else {
+            unlinkSync(tombstone);
+          }
+        } catch {
+          try {
+            unlinkSync(tombstone);
+          } catch {
+            // Best effort cleanup of the foreign tombstone link.
+          }
+        }
+        continue;
       }
 
       // We exclusively own the tombstone now: read the old epoch from it.
@@ -287,6 +317,51 @@ export class FileOwnershipFence implements OwnershipFence {
       };
     } catch {
       return null;
+    }
+  }
+
+  private readLockIdentity(lockPath: string): {
+    readonly ino: number;
+    readonly size: number;
+    readonly mtimeMs: number;
+    readonly payload: FenceLockPayload | null;
+  } | null {
+    try {
+      const stats = statSync(lockPath);
+      return {
+        ino: stats.ino,
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+        payload: this.readPayload(lockPath),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private sameLockIdentity(
+    left: ReturnType<FileOwnershipFence["readLockIdentity"]>,
+    right: ReturnType<FileOwnershipFence["readLockIdentity"]>,
+  ): boolean {
+    if (left === null || right === null) return false;
+    const leftPayload = left.payload;
+    const rightPayload = right.payload;
+    return (
+      left.ino === right.ino &&
+      left.size === right.size &&
+      left.mtimeMs === right.mtimeMs &&
+      leftPayload?.pid === rightPayload?.pid &&
+      leftPayload?.epoch === rightPayload?.epoch &&
+      leftPayload?.timestamp === rightPayload?.timestamp
+    );
+  }
+
+  private pathExists(path: string): boolean {
+    try {
+      statSync(path);
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/src/graph/runtime/fence.ts
+++ b/src/graph/runtime/fence.ts
@@ -1,0 +1,254 @@
+/**
+ * Epoch ownership single-writer fence over `<runsRoot>/<run_id>/owner.lock`.
+ *
+ * Protocol (normative; implements frozen OwnershipFence):
+ * - Creation is always O_CREAT|O_EXCL; every removal/move is an atomic
+ *   rename to a unique tombstone. There is no read-then-unlink anywhere
+ *   against the live lock path (#3555 defect class).
+ * - Stale = PID dead OR unparseable content, AND older than the grace
+ *   period. A live healthy holder yields busy — fail-closed (AC-7).
+ * - Takeover: rename(lock -> tombstone) — exactly one racer wins (the rest
+ *   observe ENOENT/EEXIST/EPERM and retry); the winner reads the old epoch
+ *   from the tombstone it now exclusively owns and re-creates the lock at
+ *   old_epoch + 1 (AC-4).
+ */
+
+import {
+  closeSync,
+  constants as fsConstants,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeSync,
+} from "fs";
+import { randomBytes } from "crypto";
+import { dirname, join } from "path";
+import { isProcessAlive } from "../../platform/index.js";
+import { FenceError } from "./types.js";
+import type { FenceAcquireResult, FenceLockPayload, OwnershipFence } from "./types.js";
+
+const DEFAULT_STALE_GRACE_MS = 30_000;
+const LOCK_FILE_NAME = "owner.lock";
+
+export interface FileOwnershipFenceOptions {
+  /** Age (ms) after which a dead/unparseable lock may be taken over. Default: 30000 */
+  readonly staleGraceMs?: number;
+}
+
+export class FileOwnershipFence implements OwnershipFence {
+  private readonly runsRoot: string;
+  private readonly runId?: string;
+  private readonly staleGraceMs: number;
+  /** fd of the held lock file while we own the run; null otherwise. */
+  private fd: number | null = null;
+  private heldEpoch: number | null = null;
+
+  /**
+   * The frozen `OwnershipFence` interface is run-scoped but carries no run
+   * id, so an instance must be bound to one run. `runId` is optional only to
+   * keep the brief's `new FileOwnershipFence(runsRoot)` signature
+   * constructible; unbound instances fail closed on use.
+   */
+  constructor(
+    runsRoot: string,
+    runId?: string,
+    options?: FileOwnershipFenceOptions,
+  ) {
+    this.runsRoot = runsRoot;
+    this.runId = runId;
+    this.staleGraceMs = options?.staleGraceMs ?? DEFAULT_STALE_GRACE_MS;
+  }
+
+  private lockPath(): string {
+    if (this.runId === undefined) {
+      throw new Error(
+        "FileOwnershipFence is not bound to a run; pass runId to the constructor",
+      );
+    }
+    return join(this.runsRoot, this.runId, LOCK_FILE_NAME);
+  }
+
+  async acquire(): Promise<FenceAcquireResult> {
+    const lockPath = this.lockPath();
+    let candidateEpoch = 1;
+    // Each takeover strictly advances the epoch via the tombstone, so every
+    // iteration makes progress toward either acquisition or a live-holder busy.
+    for (;;) {
+      const fd = this.tryCreate(lockPath, candidateEpoch);
+      if (fd !== null) {
+        this.fd = fd;
+        this.heldEpoch = candidateEpoch;
+        return { outcome: "acquired", epoch: candidateEpoch };
+      }
+
+      // EEXIST — inspect the existing lock best-effort.
+      const existing = this.readPayload(lockPath);
+      if (existing !== null && isProcessAlive(existing.pid)) {
+        // Live healthy holder: fail closed, never assume multi-writer (AC-7).
+        return { outcome: "busy" };
+      }
+
+      // Dead pid or unparseable content: takeover only past the grace period.
+      let ageMs: number;
+      try {
+        ageMs = Date.now() - statSync(lockPath).mtimeMs;
+      } catch {
+        continue; // Lock vanished under us; retry exclusive creation.
+      }
+      if (ageMs <= this.staleGraceMs) {
+        return { outcome: "busy" };
+      }
+
+      // Takeover step: atomic rename to a unique tombstone. Exactly one
+      // racer wins; losers observe ENOENT/EEXIST/EPERM here and retry (AC-6).
+      const tombstone = `${lockPath}.tomb.${randomBytes(6).toString("hex")}`;
+      try {
+        renameSync(lockPath, tombstone);
+      } catch {
+        continue; // Another racer won the move; restart from step 1.
+      }
+
+      // We exclusively own the tombstone now: read the old epoch from it.
+      // ponytail: best-effort — an unparseable tombstone loses epoch
+      // continuity (fallback 1 -> candidate 2 even if the old lock held N>1).
+      // Epochs are informational only; ownership safety comes from
+      // O_EXCL create + atomic rename, not from the epoch value. Upgrade
+      // path: persist a run-scoped epoch counter outside the lock if journal
+      // OCC ever needs strict monotonicity across corrupt takeovers.
+      let oldEpoch = 1; // fallback per protocol when unreadable
+      try {
+        const parsed: unknown = JSON.parse(readFileSync(tombstone, "utf8"));
+        if (
+          parsed !== null &&
+          typeof parsed === "object" &&
+          typeof (parsed as Record<string, unknown>).epoch === "number"
+        ) {
+          oldEpoch = (parsed as Record<string, unknown>).epoch as number;
+        }
+      } catch {
+        // Unparseable tombstone: keep fallback old_epoch = 1.
+      }
+      try {
+        unlinkSync(tombstone); // safe: unique name we exclusively own
+      } catch {
+        // Best-effort cleanup of our own tombstone.
+      }
+      candidateEpoch = oldEpoch + 1;
+    }
+  }
+
+  assertEpoch(epoch: number): void {
+    if (this.fd === null || this.heldEpoch === null || epoch !== this.heldEpoch) {
+      throw new FenceError(
+        "fenced_out",
+        `epoch ${epoch} is not owned by this process (held: ${String(this.heldEpoch)})`,
+      );
+    }
+  }
+
+  async release(epoch: number): Promise<boolean> {
+    if (this.fd === null || this.heldEpoch === null || epoch !== this.heldEpoch) {
+      return false;
+    }
+    const lockPath = this.lockPath();
+    const tombstone = `${lockPath}.tomb.${randomBytes(6).toString("hex")}`;
+    try {
+      renameSync(lockPath, tombstone);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        // Another process already moved the lock; we no longer own the run.
+        this.clearHeld();
+        return false;
+      }
+      throw error;
+    }
+    this.clearHeld();
+    try {
+      unlinkSync(tombstone); // safe: unique name we exclusively own
+    } catch {
+      // Best-effort cleanup of our own tombstone.
+    }
+    return true;
+  }
+
+  /**
+   * Single O_EXCL creation attempt. Returns the open fd on success, null on
+   * EEXIST; any other error propagates.
+   */
+  private tryCreate(lockPath: string, epoch: number): number | null {
+    mkdirSync(dirname(lockPath), { recursive: true });
+    let fd: number;
+    try {
+      fd = openSync(
+        lockPath,
+        fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+        0o600,
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        return null;
+      }
+      throw error;
+    }
+    try {
+      const payload: FenceLockPayload = {
+        pid: process.pid,
+        epoch,
+        timestamp: Date.now(),
+      };
+      writeSync(fd, JSON.stringify(payload), null, "utf8");
+    } catch (error) {
+      closeSync(fd);
+      // We exclusively created this file moments ago; removing our own
+      // partial write is not a read-then-unlink of a foreign lock.
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Best effort.
+      }
+      throw error;
+    }
+    return fd;
+  }
+
+  /** Best-effort parse of the lock payload; null when absent/unparseable. */
+  private readPayload(lockPath: string): FenceLockPayload | null {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(lockPath, "utf8"));
+      if (parsed === null || typeof parsed !== "object") {
+        return null;
+      }
+      const record = parsed as Record<string, unknown>;
+      if (
+        typeof record.pid !== "number" ||
+        !Number.isInteger(record.pid) ||
+        typeof record.epoch !== "number" ||
+        typeof record.timestamp !== "number"
+      ) {
+        return null;
+      }
+      return {
+        pid: record.pid,
+        epoch: record.epoch,
+        timestamp: record.timestamp,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private clearHeld(): void {
+    if (this.fd !== null) {
+      try {
+        closeSync(this.fd);
+      } catch {
+        // Already closed.
+      }
+      this.fd = null;
+    }
+    this.heldEpoch = null;
+  }
+}

--- a/src/graph/runtime/fence.ts
+++ b/src/graph/runtime/fence.ts
@@ -11,11 +11,17 @@
  *   observe ENOENT/EEXIST/EPERM and retry); the winner reads the old epoch
  *   from the tombstone it now exclusively owns and re-creates the lock at
  *   old_epoch + 1 (AC-4).
+ * - Epoch continuity: `<run_dir>/owner.epoch` sidecar records the highest
+ *   epoch ever issued (plain integer text, atomically persisted while we
+ *   exclusively hold the lock). New creations never reissue an epoch the
+ *   sidecar has seen, so resume after release keeps advancing past journal
+ *   history instead of restarting at 1.
  */
 
 import {
   closeSync,
   constants as fsConstants,
+  fstatSync,
   mkdirSync,
   openSync,
   readFileSync,
@@ -26,12 +32,28 @@ import {
 } from "fs";
 import { randomBytes } from "crypto";
 import { dirname, join } from "path";
+import { atomicWriteFileSync } from "../../lib/atomic-write.js";
 import { isProcessAlive } from "../../platform/index.js";
+import { resolveRunDir } from "./run-dir.js";
 import { FenceError } from "./types.js";
 import type { FenceAcquireResult, FenceLockPayload, OwnershipFence } from "./types.js";
 
 const DEFAULT_STALE_GRACE_MS = 30_000;
 const LOCK_FILE_NAME = "owner.lock";
+const EPOCH_FILE_NAME = "owner.epoch";
+
+/**
+ * Highest epoch ever issued for this run, parsed from the sidecar; null when
+ * the sidecar is missing or unreadable (fresh run / lost continuity).
+ */
+function readSidecarCeiling(filePath: string): number | null {
+  try {
+    const value = Number.parseInt(readFileSync(filePath, "utf8").trim(), 10);
+    return Number.isInteger(value) && value >= 1 ? value : null;
+  } catch {
+    return null;
+  }
+}
 
 export interface FileOwnershipFenceOptions {
   /** Age (ms) after which a dead/unparseable lock may be taken over. Default: 30000 */
@@ -68,20 +90,27 @@ export class FileOwnershipFence implements OwnershipFence {
         "FileOwnershipFence is not bound to a run; pass runId to the constructor",
       );
     }
-    return join(this.runsRoot, this.runId, LOCK_FILE_NAME);
+    return join(resolveRunDir(this.runsRoot, this.runId), LOCK_FILE_NAME);
   }
 
   async acquire(): Promise<FenceAcquireResult> {
     const lockPath = this.lockPath();
+    const epochFilePath = join(dirname(lockPath), EPOCH_FILE_NAME);
     let candidateEpoch = 1;
-    // Each takeover strictly advances the epoch via the tombstone, so every
-    // iteration makes progress toward either acquisition or a live-holder busy.
+    // Each iteration makes progress toward either acquisition or a
+    // live-holder busy. The sidecar ceiling is re-read every iteration
+    // because a concurrent racer may have persisted a higher epoch between
+    // our attempts.
     for (;;) {
-      const fd = this.tryCreate(lockPath, candidateEpoch);
+      const ceiling = readSidecarCeiling(epochFilePath);
+      // Never reissue an epoch the sidecar has seen; a missing/corrupt
+      // sidecar imposes no floor (fresh runs still start at epoch 1).
+      const candidate = Math.max(candidateEpoch, (ceiling ?? 0) + 1);
+      const fd = this.tryCreate(lockPath, epochFilePath, candidate);
       if (fd !== null) {
         this.fd = fd;
-        this.heldEpoch = candidateEpoch;
-        return { outcome: "acquired", epoch: candidateEpoch };
+        this.heldEpoch = candidate;
+        return { outcome: "acquired", epoch: candidate };
       }
 
       // EEXIST — inspect the existing lock best-effort.
@@ -112,12 +141,10 @@ export class FileOwnershipFence implements OwnershipFence {
       }
 
       // We exclusively own the tombstone now: read the old epoch from it.
-      // ponytail: best-effort — an unparseable tombstone loses epoch
-      // continuity (fallback 1 -> candidate 2 even if the old lock held N>1).
-      // Epochs are informational only; ownership safety comes from
-      // O_EXCL create + atomic rename, not from the epoch value. Upgrade
-      // path: persist a run-scoped epoch counter outside the lock if journal
-      // OCC ever needs strict monotonicity across corrupt takeovers.
+      // ponytail: best-effort — an unparseable tombstone falls back to
+      // old_epoch 1; continuity then rests on the owner.epoch sidecar, and
+      // only if BOTH are lost can an epoch value repeat. Ownership safety
+      // comes from O_EXCL create + atomic rename, not from the epoch value.
       let oldEpoch = 1; // fallback per protocol when unreadable
       try {
         const parsed: unknown = JSON.parse(readFileSync(tombstone, "utf8"));
@@ -141,7 +168,12 @@ export class FileOwnershipFence implements OwnershipFence {
   }
 
   assertEpoch(epoch: number): void {
-    if (this.fd === null || this.heldEpoch === null || epoch !== this.heldEpoch) {
+    if (
+      this.fd === null ||
+      this.heldEpoch === null ||
+      epoch !== this.heldEpoch ||
+      !this.holdsLiveLockFile(this.lockPath())
+    ) {
       throw new FenceError(
         "fenced_out",
         `epoch ${epoch} is not owned by this process (held: ${String(this.heldEpoch)})`,
@@ -154,6 +186,14 @@ export class FileOwnershipFence implements OwnershipFence {
       return false;
     }
     const lockPath = this.lockPath();
+    // Identity check before any mutation: the file at the lock path must
+    // still be OUR held file. A stale holder must never rename away a
+    // replacement owner's lock planted at the same path.
+    if (!this.holdsLiveLockFile(lockPath)) {
+      // We no longer own the run; leave whatever is there untouched.
+      this.clearHeld();
+      return false;
+    }
     const tombstone = `${lockPath}.tomb.${randomBytes(6).toString("hex")}`;
     try {
       renameSync(lockPath, tombstone);
@@ -176,9 +216,16 @@ export class FileOwnershipFence implements OwnershipFence {
 
   /**
    * Single O_EXCL creation attempt. Returns the open fd on success, null on
-   * EEXIST; any other error propagates.
+   * EEXIST; any other error propagates. On success the epoch sidecar is
+   * atomically updated BEFORE ownership is handed out — a sidecar write
+   * failure cleans up our just-created lock and propagates rather than
+   * silently issuing an epoch that a later resume could reissue.
    */
-  private tryCreate(lockPath: string, epoch: number): number | null {
+  private tryCreate(
+    lockPath: string,
+    epochFilePath: string,
+    epoch: number,
+  ): number | null {
     mkdirSync(dirname(lockPath), { recursive: true });
     let fd: number;
     try {
@@ -200,6 +247,9 @@ export class FileOwnershipFence implements OwnershipFence {
         timestamp: Date.now(),
       };
       writeSync(fd, JSON.stringify(payload), null, "utf8");
+      // Persist epoch continuity while we still hold exclusive ownership of
+      // the just-created lock (temp+rename inside; failure cleans up below).
+      atomicWriteFileSync(epochFilePath, String(epoch));
     } catch (error) {
       closeSync(fd);
       // We exclusively created this file moments ago; removing our own
@@ -238,6 +288,30 @@ export class FileOwnershipFence implements OwnershipFence {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Verify the file currently at lockPath is still the exact file we hold an
+   * fd for: same inode and size (fstatSync on our held fd vs statSync on the
+   * path) AND payload epoch matching heldEpoch. Any stat failure or mismatch
+   * fails closed — the caller must not mutate the path.
+   */
+  private holdsLiveLockFile(lockPath: string): boolean {
+    if (this.fd === null || this.heldEpoch === null) {
+      return false;
+    }
+    try {
+      const ours = fstatSync(this.fd);
+      const theirs = statSync(lockPath);
+      if (ours.ino !== theirs.ino || ours.size !== theirs.size) {
+        return false;
+      }
+    } catch {
+      // Lock path vanished or is unreadable: we do not own what is there.
+      return false;
+    }
+    const payload = this.readPayload(lockPath);
+    return payload !== null && payload.epoch === this.heldEpoch;
   }
 
   private clearHeld(): void {

--- a/src/graph/runtime/journal.ts
+++ b/src/graph/runtime/journal.ts
@@ -1,0 +1,160 @@
+/**
+ * Append-only OCC journal over `<runsRoot>/<run_id>/journal.jsonl`.
+ *
+ * The journal stays deliberately dumb: it persists records verbatim and
+ * validates envelope shape on read (seq/epoch/descriptor_hash/transition
+ * presence, fail-closed). Deep transition validation happens at the
+ * scheduler replay fold; epoch ownership fencing is a runner-level concern
+ * (OwnershipFence) — the binding lives inside each record.
+ */
+
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeSync,
+} from "fs";
+import { dirname, join } from "path";
+import { canonicalJson } from "../descriptor.js";
+import { JournalCorruptionError } from "./types.js";
+import type { Journal, JournalRecord } from "./types.js";
+
+const DESCRIPTOR_HASH_PATTERN = /^[a-f0-9]{64}$/;
+
+/** Envelope validation for one parsed record; returns an error message or null. */
+function envelopeError(value: unknown): string | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return "record is not an object";
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.seq !== "number" ||
+    !Number.isInteger(record.seq) ||
+    record.seq < 0
+  ) {
+    return "seq must be an integer >= 0";
+  }
+  if (
+    typeof record.epoch !== "number" ||
+    !Number.isInteger(record.epoch) ||
+    record.epoch < 1
+  ) {
+    return "epoch must be an integer >= 1";
+  }
+  if (
+    typeof record.descriptor_hash !== "string" ||
+    !DESCRIPTOR_HASH_PATTERN.test(record.descriptor_hash)
+  ) {
+    return "descriptor_hash must match /^[a-f0-9]{64}$/";
+  }
+  if (
+    record.transition === null ||
+    typeof record.transition !== "object" ||
+    Array.isArray(record.transition)
+  ) {
+    return "transition must be present as an object";
+  }
+  return null;
+}
+
+export class FileJournal implements Journal {
+  private readonly runsRoot: string;
+  private readonly runId?: string;
+
+  /**
+   * The frozen `Journal` interface is run-scoped but carries no run id, so an
+   * instance must be bound to one run. `runId` is optional only to keep the
+   * brief's `new FileJournal(runsRoot)` signature constructible; unbound
+   * instances fail closed on use.
+   */
+  constructor(runsRoot: string, runId?: string) {
+    this.runsRoot = runsRoot;
+    this.runId = runId;
+  }
+
+  private journalPath(): string {
+    if (this.runId === undefined) {
+      throw new Error(
+        "FileJournal is not bound to a run; pass runId to the constructor",
+      );
+    }
+    return join(this.runsRoot, this.runId, "journal.jsonl");
+  }
+
+  async append(record: JournalRecord): Promise<void> {
+    const filePath = this.journalPath();
+    const line = `${canonicalJson(record)}\n`;
+    // O_APPEND single writeSync + fsync: one complete line per append by contract.
+    mkdirSync(dirname(filePath), { recursive: true });
+    const fd = openSync(filePath, "a");
+    try {
+      writeSync(fd, line);
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  async readAll(): Promise<readonly JournalRecord[]> {
+    const filePath = this.journalPath();
+    let content: string;
+    try {
+      content = readFileSync(filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+    if (content.length === 0) {
+      return [];
+    }
+
+    const lines = content.split("\n");
+    const tailIsIncomplete = lines[lines.length - 1] !== "";
+    // Complete lines are everything before the final split element (which is
+    // "" for a well-formed file, or the partial tail being dropped).
+    const bodyLines = lines.slice(0, -1);
+
+    // Count ALL bad lines (interior + incomplete tail) before throwing once.
+    let badCount = tailIsIncomplete ? 1 : 0;
+    const records: JournalRecord[] = [];
+    let prevSeq = -1;
+
+    for (const line of bodyLines) {
+      let failure: string | null = null;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        failure = "line is not valid JSON";
+      }
+      if (failure === null) {
+        failure = envelopeError(parsed);
+      }
+      if (failure === null) {
+        const record = parsed as JournalRecord;
+        const expectedSeq = prevSeq + 1;
+        if (record.seq !== expectedSeq) {
+          failure = `seq ${record.seq} does not continue from ${prevSeq}`;
+        } else {
+          prevSeq = record.seq;
+          records.push(record);
+        }
+      }
+      if (failure !== null) {
+        badCount += 1;
+      }
+    }
+
+    if (badCount > 0) {
+      throw new JournalCorruptionError(
+        `journal ${filePath} has ${badCount} corrupt or incomplete record(s)`,
+        badCount,
+      );
+    }
+    return records;
+  }
+}

--- a/src/graph/runtime/journal.ts
+++ b/src/graph/runtime/journal.ts
@@ -18,6 +18,7 @@ import {
 } from "fs";
 import { dirname, join } from "path";
 import { canonicalJson } from "../descriptor.js";
+import { resolveRunDir } from "./run-dir.js";
 import { JournalCorruptionError } from "./types.js";
 import type { Journal, JournalRecord } from "./types.js";
 
@@ -80,7 +81,7 @@ export class FileJournal implements Journal {
         "FileJournal is not bound to a run; pass runId to the constructor",
       );
     }
-    return join(this.runsRoot, this.runId, "journal.jsonl");
+    return join(resolveRunDir(this.runsRoot, this.runId), "journal.jsonl");
   }
 
   async append(record: JournalRecord): Promise<void> {

--- a/src/graph/runtime/journal.ts
+++ b/src/graph/runtime/journal.ts
@@ -10,16 +10,20 @@
 
 import {
   closeSync,
+  constants as fsConstants,
   fsyncSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
   writeSync,
 } from "fs";
 import { createHash } from "crypto";
-import { dirname, join } from "path";
+import { join } from "path";
 import { canonicalJson } from "../descriptor.js";
-import { resolveRunDir } from "./run-dir.js";
+import { resolveRunDirHandle } from "./run-dir.js";
+import type { RunDirHandle } from "./run-dir.js";
+import {
+  openNoFollow,
+  readContainedFileNoFollow,
+  withContainedPath,
+} from "./safe-fs.js";
 import { JournalCorruptionError } from "./types.js";
 import type {
   Journal,
@@ -100,17 +104,8 @@ export class FileJournal implements Journal {
     this.runId = runId;
   }
 
-  private journalPath(): string {
-    if (this.runId === undefined) {
-      throw new Error(
-        "FileJournal is not bound to a run; pass runId to the constructor",
-      );
-    }
-    return join(resolveRunDir(this.runsRoot, this.runId), "journal.jsonl");
-  }
-
   async append(record: JournalAppendRecord): Promise<void> {
-    const filePath = this.journalPath();
+    const runDir = this.runDir();
     const unsignedRecord = { ...record } as Record<string, unknown>;
     delete unsignedRecord.journal_fingerprint;
     const committed: JournalRecord = {
@@ -121,24 +116,55 @@ export class FileJournal implements Journal {
     };
     const line = `${canonicalJson(committed)}\n`;
     // O_APPEND single writeSync + fsync: one complete line per append by contract.
-    mkdirSync(dirname(filePath), { recursive: true });
-    const fd = openSync(filePath, "a");
-    try {
-      writeSync(fd, line);
-      fsyncSync(fd);
-    } finally {
-      closeSync(fd);
+    withContainedPath(runDir, "journal.jsonl", (filePath) => {
+      let fd: number;
+      try {
+        fd = openNoFollow(
+          filePath,
+          fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY,
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+          throw new JournalCorruptionError(
+            `journal ${filePath} is a symbolic link`,
+            1,
+          );
+        }
+        throw error;
+      }
+      try {
+        writeSync(fd, line);
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+    });
+  }
+
+  private runDir(): RunDirHandle {
+    if (this.runId === undefined) {
+      throw new Error(
+        "FileJournal is not bound to a run; pass runId to the constructor",
+      );
     }
+    return resolveRunDirHandle(this.runsRoot, this.runId);
   }
 
   async readAll(): Promise<readonly JournalRecord[]> {
-    const filePath = this.journalPath();
+    const runDir = this.runDir();
+    const filePath = join(runDir.path, "journal.jsonl");
     let content: string;
     try {
-      content = readFileSync(filePath, "utf8");
+      content = readContainedFileNoFollow(runDir, "journal.jsonl");
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         return [];
+      }
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new JournalCorruptionError(
+          `journal ${filePath} is a symbolic link`,
+          1,
+        );
       }
       throw error;
     }

--- a/src/graph/runtime/journal.ts
+++ b/src/graph/runtime/journal.ts
@@ -1,11 +1,11 @@
 /**
  * Append-only OCC journal over `<runsRoot>/<run_id>/journal.jsonl`.
  *
- * The journal stays deliberately dumb: it persists records verbatim and
- * validates envelope shape on read (seq/epoch/descriptor_hash/transition
- * presence, fail-closed). Deep transition validation happens at the
- * scheduler replay fold; epoch ownership fencing is a runner-level concern
- * (OwnershipFence) — the binding lives inside each record.
+ * The journal persists committed records with an envelope fingerprint that
+ * includes seq/epoch/descriptor_hash/transition. It validates envelope shape
+ * and the fingerprint format on read (fail-closed). Deep transition
+ * validation happens at the scheduler replay fold; epoch ownership fencing is
+ * a runner-level concern (OwnershipFence).
  */
 
 import {
@@ -16,13 +16,32 @@ import {
   readFileSync,
   writeSync,
 } from "fs";
+import { createHash } from "crypto";
 import { dirname, join } from "path";
 import { canonicalJson } from "../descriptor.js";
 import { resolveRunDir } from "./run-dir.js";
 import { JournalCorruptionError } from "./types.js";
-import type { Journal, JournalRecord } from "./types.js";
+import type {
+  Journal,
+  JournalAppendRecord,
+  JournalRecord,
+} from "./types.js";
 
 const DESCRIPTOR_HASH_PATTERN = /^[a-f0-9]{64}$/;
+const JOURNAL_FINGERPRINT_PATTERN = /^[a-f0-9]{64}$/;
+
+/**
+ * Authenticates the runtime envelope binding, including the writer epoch.
+ * Scheduler request fingerprints intentionally remain Graph Core concerns;
+ * this digest binds the runtime-only epoch to the exact committed record.
+ */
+export function computeJournalFingerprint(record: JournalAppendRecord): string {
+  const unsignedRecord = { ...record } as Record<string, unknown>;
+  delete unsignedRecord.journal_fingerprint;
+  return createHash("sha256")
+    .update(canonicalJson(unsignedRecord))
+    .digest("hex");
+}
 
 /** Envelope validation for one parsed record; returns an error message or null. */
 function envelopeError(value: unknown): string | null {
@@ -57,6 +76,12 @@ function envelopeError(value: unknown): string | null {
   ) {
     return "transition must be present as an object";
   }
+  if (
+    typeof record.journal_fingerprint !== "string" ||
+    !JOURNAL_FINGERPRINT_PATTERN.test(record.journal_fingerprint)
+  ) {
+    return "journal_fingerprint must be a lowercase sha256 hex digest";
+  }
   return null;
 }
 
@@ -84,9 +109,17 @@ export class FileJournal implements Journal {
     return join(resolveRunDir(this.runsRoot, this.runId), "journal.jsonl");
   }
 
-  async append(record: JournalRecord): Promise<void> {
+  async append(record: JournalAppendRecord): Promise<void> {
     const filePath = this.journalPath();
-    const line = `${canonicalJson(record)}\n`;
+    const unsignedRecord = { ...record } as Record<string, unknown>;
+    delete unsignedRecord.journal_fingerprint;
+    const committed: JournalRecord = {
+      ...(unsignedRecord as JournalAppendRecord),
+      journal_fingerprint: computeJournalFingerprint(
+        unsignedRecord as JournalAppendRecord,
+      ),
+    };
+    const line = `${canonicalJson(committed)}\n`;
     // O_APPEND single writeSync + fsync: one complete line per append by contract.
     mkdirSync(dirname(filePath), { recursive: true });
     const fd = openSync(filePath, "a");

--- a/src/graph/runtime/progress.ts
+++ b/src/graph/runtime/progress.ts
@@ -1,0 +1,55 @@
+/**
+ * ASCII progress rendering (graph runtime v2).
+ *
+ * Event-to-string rendering is pure so tests pin exact strings; the reporter
+ * adds exactly one side effect per event — a single out.write of the rendered
+ * line plus newline. No colors, no console.*, pure ASCII output.
+ */
+
+import type { ProgressReporter, RuntimeProgressEvent } from "./types.js";
+
+/** Minimal writable surface shared by process.stdout and stream.PassThrough. */
+type WriteSink = { write(chunk: string): unknown };
+
+type NodeResultOutcome = Extract<
+  RuntimeProgressEvent,
+  { type: "node_result" }
+>["outcome"];
+
+/** node_result outcome -> ASCII tag. */
+const OUTCOME_TAGS: Record<NodeResultOutcome, string> = {
+  succeeded: "ok",
+  failed: "fail",
+  approved: "approved",
+  denied: "denied",
+  join_resolved: "join",
+};
+
+/** Renders one progress event as its exact ASCII line. Pure. */
+export function renderProgressEvent(event: RuntimeProgressEvent): string {
+  switch (event.type) {
+    case "run_started":
+      return `[run] ${event.run_id} — ${event.goal}`;
+    case "replayed":
+      return `[replay] ${event.records} record(s) @ epoch ${event.epoch}`;
+    case "activation_started":
+      return `[node] ${event.node_id} attempt #${event.attempt_no} started`;
+    case "node_result":
+      return `[${OUTCOME_TAGS[event.outcome]}] ${event.node_id}`;
+    case "run_ended":
+      return `[done] ${event.terminal} — ${event.summary}`;
+  }
+}
+
+/**
+ * ProgressReporter writing rendered lines to the given sink (default
+ * process.stdout), one write per event.
+ */
+export function createAsciiProgressReporter(out?: WriteSink): ProgressReporter {
+  const sink = out ?? process.stdout;
+  return {
+    onEvent(event: RuntimeProgressEvent): void {
+      sink.write(`${renderProgressEvent(event)}\n`);
+    },
+  };
+}

--- a/src/graph/runtime/run-dir.ts
+++ b/src/graph/runtime/run-dir.ts
@@ -1,0 +1,70 @@
+/**
+ * Run-directory containment for graph runtime persistence (P1-3).
+ *
+ * Every persisted artifact lives under `<runsRoot>/<run_id>/`. A run_id is
+ * descriptor-supplied and therefore untrusted: resolving it must never let a
+ * traversal-shaped id or a symlinked run directory redirect writes outside
+ * the runs root. resolveRunDir validates, creates, and containment-checks
+ * the directory, failing closed on any escape.
+ */
+
+import { lstatSync, mkdirSync, realpathSync } from "fs";
+import { join, sep } from "path";
+
+import { ensureDirSync } from "../../lib/atomic-write.js";
+
+const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+/**
+ * Resolve (and create) the contained run directory for one run.
+ *
+ * Returns the plain `join(runsRoot, runId)` path so existing relative
+ * behaviors stay stable; containment is enforced against realpaths before
+ * returning. Throws RangeError("invalid run_id") on malformed ids and Error
+ * on symlinked or escaping directories.
+ */
+export function resolveRunDir(runsRoot: string, runId: string): string {
+  // Charset check plus defense-in-depth separators/dot segments: the regex
+  // already excludes them, but reject explicitly so traversal can never ride
+  // on a future pattern relaxation.
+  if (
+    typeof runId !== "string" ||
+    !RUN_ID_PATTERN.test(runId) ||
+    runId.includes("/") ||
+    runId.includes("\\") ||
+    runId === "." ||
+    runId === ".."
+  ) {
+    throw new RangeError("invalid run_id");
+  }
+
+  ensureDirSync(runsRoot);
+  const runsRootReal = realpathSync(runsRoot);
+
+  const target = join(runsRoot, runId);
+  let stats;
+  try {
+    stats = lstatSync(target);
+  } catch {
+    // Absent (ENOENT or stat failure): nothing to reject yet; created below.
+  }
+  if (stats !== undefined && stats.isSymbolicLink()) {
+    // Fail closed: a symlinked run dir could redirect every write below it.
+    throw new Error("run directory must not be a symbolic link");
+  }
+  mkdirSync(target, { recursive: true });
+
+  const resolved = realpathSync(target);
+  const isWin32 = process.platform === "win32";
+  const resolvedCmp = isWin32 ? resolved.toLowerCase() : resolved;
+  const prefixCmp = isWin32
+    ? `${runsRootReal}${sep}`.toLowerCase()
+    : `${runsRootReal}${sep}`;
+  if (!resolvedCmp.startsWith(prefixCmp)) {
+    throw new Error(
+      `run directory ${resolved} escapes the persistence root ${runsRootReal}`,
+    );
+  }
+
+  return target;
+}

--- a/src/graph/runtime/run-dir.ts
+++ b/src/graph/runtime/run-dir.ts
@@ -8,12 +8,18 @@
  * the directory, failing closed on any escape.
  */
 
-import { lstatSync, mkdirSync, realpathSync } from "fs";
+import { lstatSync, mkdirSync, realpathSync, statSync } from "fs";
 import { join, sep } from "path";
 
 import { ensureDirSync } from "../../lib/atomic-write.js";
 
 const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+export interface RunDirHandle {
+  readonly path: string;
+  readonly device: number;
+  readonly inode: number;
+}
 
 /**
  * Resolve (and create) the contained run directory for one run.
@@ -24,6 +30,14 @@ const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
  * on symlinked or escaping directories.
  */
 export function resolveRunDir(runsRoot: string, runId: string): string {
+  return resolveRunDirHandle(runsRoot, runId).path;
+}
+
+/** Resolve a run directory and capture the directory identity for safe I/O. */
+export function resolveRunDirHandle(
+  runsRoot: string,
+  runId: string,
+): RunDirHandle {
   // Charset check plus defense-in-depth separators/dot segments: the regex
   // already excludes them, but reject explicitly so traversal can never ride
   // on a future pattern relaxation.
@@ -66,5 +80,6 @@ export function resolveRunDir(runsRoot: string, runId: string): string {
     );
   }
 
-  return target;
+  const identity = statSync(target);
+  return { path: target, device: identity.dev, inode: identity.ino };
 }

--- a/src/graph/runtime/runner.ts
+++ b/src/graph/runtime/runner.ts
@@ -1,0 +1,1008 @@
+/**
+ * Runtime runner: the orchestration loop binding the pure Graph Core
+ * scheduler to disk-backed journal/fence/projection-store and injected
+ * executors.
+ *
+ * Replay contract (AC-3/AC-11b): the journal is the source of truth; on
+ * resume, records are folded through the same scheduler entrypoints used
+ * live. Synthetic identities are regenerated deterministically from
+ * projection counters and the committed record fields, so the folded
+ * projection equals the live one bit-for-bit under canonicalJson equality,
+ * including embedded request fingerprints.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import {
+  GraphDescriptorValidationError,
+  canonicalJson,
+  parseSealedGraphDescriptor,
+} from "../descriptor.js";
+import {
+  GraphSchedulerError,
+  applyHumanApproval,
+  applyNodeResult,
+  beginActivationAttempt,
+  initializeGraphProjection,
+  isGraphSucceeded,
+  listReadyApprovalActivations,
+  listReadyExecutableActivations,
+  listReadyJoinActivations,
+  resolveJoin,
+} from "../scheduler.js";
+import { atomicWriteFileSync } from "../../lib/atomic-write.js";
+import { FileJournal } from "./journal.js";
+import { FileOwnershipFence } from "./fence.js";
+import { FileProjectionStore } from "./store.js";
+
+import { EXIT_CODES, FenceError, JournalCorruptionError } from "./types.js";
+import type {
+  ApprovalRequest,
+  JournalRecord,
+  NodeExecutionContext,
+  NodeExecutionOutput,
+  NodeExecutor,
+  RunOptions,
+  RunResult,
+  RuntimeProgressEvent,
+} from "./types.js";
+import type {
+  GraphCommittedTransition,
+  GraphEdge,
+  GraphNodeResult,
+  GraphSchedulerProjection,
+  SchedulerTransitionIdentities,
+  SealedGraphDescriptor,
+} from "../types.js";
+
+const DEFAULT_RUNS_ROOT_SEGMENTS = [".omc", "graph-runs"];
+const DESCRIPTOR_FILE_NAME = "descriptor.json";
+
+// ---------------------------------------------------------------------------
+// Deterministic synthetic identity scheme
+//
+// Every runner-generated id follows one scheme so that live generation and
+// replay derivation reconstruct identical values:
+//
+//   activation   `<nodeId>-act<n>`        n = count of activations of that node
+//   attempt      `<activationId>-t<n>`    n = post-begin attempt number
+//   transition   `<activationId>-tx<n>`   n = attempt number (0 for approval/join)
+//   cohort       `<fanoutNodeId>-coh<k>`  k = count of cohorts of that node
+//   token        `<cohortId>-tok<i>`      i = index within fan-out edge order
+//
+// The team brief sketched "<node_id>#{ordinal}", but "#" sits outside the
+// stable-id charset ([A-Za-z0-9][A-Za-z0-9._:-]*), so "-" separators keep
+// every generated id valid per the scheduler's isValidStableId gate.
+// ---------------------------------------------------------------------------
+
+function outgoingEdgesOf(
+  descriptor: SealedGraphDescriptor,
+  nodeId: string,
+): GraphEdge[] {
+  return descriptor.edges.filter((edge) => edge.from === nodeId);
+}
+
+function sealedNode(
+  descriptor: SealedGraphDescriptor,
+  nodeId: string,
+) {
+  return descriptor.nodes.find((node) => node.id === nodeId);
+}
+
+function activationCount(
+  projection: GraphSchedulerProjection,
+  nodeId: string,
+): number {
+  return Object.values(projection.activations).filter(
+    (activation) => activation.node_id === nodeId,
+  ).length;
+}
+
+function cohortCount(
+  projection: GraphSchedulerProjection,
+  fanoutNodeId: string,
+): number {
+  return Object.values(projection.cohorts).filter(
+    (cohort) => cohort.fan_out_node_id === fanoutNodeId,
+  ).length;
+}
+
+/** Entry activations are the ordinal-0 activation of each entry node. */
+function entryActivationIds(
+  descriptor: SealedGraphDescriptor,
+): Record<string, string> {
+  const ids: Record<string, string> = {};
+  for (const entry of descriptor.entry_node_ids) {
+    ids[entry] = `${entry}-act0`;
+  }
+  return ids;
+}
+
+function nextAttemptId(activationId: string, attemptNo: number): string {
+  return `${activationId}-t${attemptNo}`;
+}
+
+/**
+ * Transition id per activation attempt. Keying by activation (not by node)
+ * keeps two concurrent activations of the same node from racing on a shared
+ * counter; attempt numbers are unique within an activation, so ids are fresh.
+ */
+function transitionIdFor(activationId: string, ordinal: number): string {
+  return `${activationId}-tx${ordinal}`;
+}
+
+function nextCohortId(
+  projection: GraphSchedulerProjection,
+  fanoutNodeId: string,
+): string {
+  return `${fanoutNodeId}-coh${cohortCount(projection, fanoutNodeId)}`;
+}
+
+function tokenIdFor(cohortId: string, index: number): string {
+  return `${cohortId}-tok${index}`;
+}
+
+function nextActivationIdFor(
+  projection: GraphSchedulerProjection,
+  targetNodeId: string,
+): string {
+  return `${targetNodeId}-act${activationCount(projection, targetNodeId)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Identity construction: one builder per call-site shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Live node-result identities. Mirrors the scheduler's edge-mode selection
+ * exactly so the generated maps contain precisely the fields applyNodeResult
+ * will demand for this outcome.
+ */
+function buildLiveNodeResultIdentities(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  nodeId: string,
+  output: NodeExecutionOutput,
+): SchedulerTransitionIdentities | undefined {
+  if (output.outcome === "failed") {
+    return undefined;
+  }
+  const edges = outgoingEdgesOf(descriptor, nodeId);
+  if (edges.length === 0) {
+    return undefined;
+  }
+  const fanEdges = edges.filter((edge) => edge.kind === "fan_out");
+  if (fanEdges.length > 0) {
+    const cohortId = nextCohortId(projection, nodeId);
+    const branchTokenIds: Record<string, string> = {};
+    const nextActivationIds: Record<string, string> = {};
+    fanEdges.forEach((edge, index) => {
+      branchTokenIds[edge.id] = tokenIdFor(cohortId, index);
+      nextActivationIds[edge.id] = nextActivationIdFor(projection, edge.to);
+    });
+    return {
+      cohort_id: cohortId,
+      branch_token_ids: branchTokenIds,
+      next_activation_ids: nextActivationIds,
+    };
+  }
+  const fixedEdge = edges.find((edge) => edge.kind === "fixed");
+  let matchedEdge: GraphEdge | undefined = fixedEdge;
+  if (matchedEdge === undefined) {
+    if (output.route === undefined) {
+      // The scheduler will reject this result with `route_required`; hand it
+      // identity-free to the scheduler rather than inventing a route.
+      return undefined;
+    }
+    matchedEdge = edges.find(
+      (edge) =>
+        (edge.kind === "conditional" || edge.kind === "back_edge") &&
+        edge.route === output.route,
+    );
+    if (matchedEdge === undefined) {
+      // Undeclared route: scheduler rejects with `undeclared_route`.
+      return undefined;
+    }
+  }
+  // Join-target edges: the scheduler demands join_activation_id exactly when
+  // this completion is the last arriving branch token of the cohort.
+  const targetNode = sealedNode(descriptor, matchedEdge.to);
+  if (targetNode?.kind === "join") {
+    return joinArrivalIdentities(descriptor, projection, nodeId, targetNode);
+  }
+  return {
+    next_activation_ids: {
+      [matchedEdge.id]: nextActivationIdFor(projection, matchedEdge.to),
+    },
+  };
+}
+
+/**
+ * Identities for a branch completion whose edge targets the cohort's join.
+ * Supplies join_activation_id iff every sibling token has already arrived;
+ * the scheduler creates nothing otherwise.
+ */
+function joinArrivalIdentities(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  nodeId: string,
+  joinNode: { readonly id: string },
+): SchedulerTransitionIdentities | undefined {
+  const sourceActivation = Object.values(projection.activations).find(
+    (activation) =>
+      activation.node_id === nodeId &&
+      activation.status === "running" &&
+      activation.branch_token_id !== undefined,
+  );
+  const token =
+    sourceActivation?.branch_token_id !== undefined
+      ? projection.branch_tokens[sourceActivation.branch_token_id]
+      : undefined;
+  if (
+    token === undefined ||
+    token.status !== "active" ||
+    token.current_activation_id !== sourceActivation?.activation_id
+  ) {
+    throw new Error(
+      `activation for ${nodeId} does not hold an active branch token`,
+    );
+  }
+  const cohort = projection.cohorts[token.cohort_id];
+  if (cohort === undefined) {
+    throw new Error(`cohort ${token.cohort_id} missing from projection`);
+  }
+  const siblingsArrived = cohort.expected_branch_token_ids.every(
+    (tokenIdValue) =>
+      tokenIdValue === token.branch_token_id ||
+      projection.branch_tokens[tokenIdValue]?.status === "arrived",
+  );
+  return siblingsArrived
+    ? {
+        join_activation_id: nextActivationIdFor(projection, joinNode.id),
+      }
+    : undefined;
+}
+
+/**
+ * Replay identities derived from fields ON THE RECORD. Fan-out token ids are
+ * regenerated from the recorded cohort id plus the record's selected-edge
+ * order; activation ids come straight from created_activation_ids. A single
+ * created activation on an edge targeting a join node means the join fired:
+ * the record carries it as join_activation_id, not next_activation_ids.
+ */
+function buildReplayNodeResultIdentities(
+  descriptor: SealedGraphDescriptor,
+  transition: GraphCommittedTransition,
+): SchedulerTransitionIdentities | undefined {
+  if (transition.outcome === "failed") {
+    return undefined;
+  }
+  if (transition.selected_edge_ids.length === 0) {
+    return undefined;
+  }
+  if (
+    transition.outcome === "succeeded" &&
+    outgoingEdgesOf(descriptor, transition.node_id).some(
+      (edge) => edge.kind === "fan_out",
+    )
+  ) {
+    const fanEdges = outgoingEdgesOf(descriptor, transition.node_id).filter(
+      (edge) => edge.kind === "fan_out",
+    );
+    const cohortId = transition.cohort_id;
+    if (cohortId === undefined) {
+      return undefined; // scheduler rejects with missing_identity during fold
+    }
+    return {
+      cohort_id: cohortId,
+      branch_token_ids: Object.fromEntries(
+        fanEdges.map((edge, index) => [edge.id, tokenIdFor(cohortId, index)]),
+      ),
+      next_activation_ids: Object.fromEntries(
+        transition.selected_edge_ids.map((edgeId, index) => [
+          edgeId,
+          transition.created_activation_ids[index] as string,
+        ]),
+      ),
+    };
+  }
+  // Single-edge success: a created activation on an edge targeting a join
+  // node means the join fired on this completion (last token arrived).
+  // Non-final arrivals create nothing (created_activation_ids is empty) and
+  // live passes no identities, so replay must return undefined too — else
+  // the folded request_fingerprint diverges from the committed one.
+  const selEdgeId = transition.selected_edge_ids[0] as string;
+  const matchedEdge = outgoingEdgesOf(descriptor, transition.node_id).find(
+    (edge) => edge.id === selEdgeId,
+  );
+  const targetNode =
+    matchedEdge === undefined
+      ? undefined
+      : descriptor.nodes.find((node) => node.id === matchedEdge.to);
+  if (targetNode?.kind === "join") {
+    if (transition.created_activation_ids.length === 0) {
+      return undefined;
+    }
+    return {
+      join_activation_id: transition.created_activation_ids[0] as string,
+    };
+  }
+  return {
+    next_activation_ids: Object.fromEntries(
+      transition.selected_edge_ids.map((edgeId, index) => [
+        edgeId,
+        transition.created_activation_ids[index] as string,
+      ]),
+    ),
+  };
+}
+
+/**
+ * Replay identities for human-approval transitions: approved carries the
+ * single created activation; denied carries none.
+ */
+function buildReplayApprovalIdentities(
+  transition: GraphCommittedTransition,
+): SchedulerTransitionIdentities | undefined {
+  if (transition.outcome === "approved") {
+    const edgeId = transition.selected_edge_ids[0] as string;
+    const createdId = transition.created_activation_ids[0] as string;
+    return {
+      next_activation_ids: { [edgeId]: createdId },
+    };
+  }
+  return undefined;
+}
+
+/** Replay identities for join_resolved transitions. */
+function buildReplayJoinIdentities(
+  transition: GraphCommittedTransition,
+): SchedulerTransitionIdentities {
+  const edgeId = transition.selected_edge_ids[0] as string;
+  return {
+    next_activation_ids: {
+      [edgeId]: transition.created_activation_ids[0] as string,
+    },
+  };
+}
+
+/** Folds one journal record through its scheduler transition entrypoint. */
+function foldOneRecord(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  record: JournalRecord,
+): GraphSchedulerProjection {
+  const transition = record.transition;
+  let applied;
+  switch (transition.outcome) {
+    case "succeeded":
+    case "failed":
+      applied = foldNodeResultRecord(descriptor, projection, transition);
+      break;
+    case "approved":
+    case "denied":
+      applied = applyHumanApproval(descriptor, projection, {
+        activation_id: transition.activation_id,
+        transition_id: transition.transition_id,
+        decision: {
+          decision: transition.outcome === "approved" ? "approved" : "denied",
+          evidence_refs: transition.evidence_refs,
+          ...(transition.output_summary !== undefined && {
+            output_summary: transition.output_summary,
+          }),
+        },
+        identities: buildReplayApprovalIdentities(transition),
+      });
+      break;
+    case "join_resolved":
+      applied = resolveJoin(descriptor, projection, {
+        activation_id: transition.activation_id,
+        transition_id: transition.transition_id,
+        identities: buildReplayJoinIdentities(transition),
+      });
+      break;
+  }
+  // AC-11b content-tamper detection: a record whose fields were edited
+  // after commit folds into a DIFFERENT recomputed request fingerprint.
+  if (
+    applied.transition.request_fingerprint !==
+    record.transition.request_fingerprint
+  ) {
+    throw new GraphSchedulerError(
+      "transition_fenced",
+      `journal record ${record.seq} fails its committed request fingerprint`,
+    );
+  }
+  return applied.projection;
+}
+
+function foldNodeResultRecord(
+  descriptor: SealedGraphDescriptor,
+  projection: GraphSchedulerProjection,
+  transition:
+    | Extract<GraphCommittedTransition, { outcome: "succeeded" }>
+    | Extract<GraphCommittedTransition, { outcome: "failed" }>,
+) {
+  // Synthesize the attempt begin (commits no record) so the folded
+  // activation is running the recorded attempt when applyNodeResult runs.
+  const withAttempt = beginActivationAttempt(descriptor, projection, {
+    activation_id: transition.activation_id,
+    attempt_id: transition.attempt_id,
+  });
+  const replayedResult: GraphNodeResult = {
+    outcome: transition.outcome,
+    attempt_id: transition.attempt_id,
+    ...(transition.outcome === "succeeded" &&
+      transition.route !== undefined && { route: transition.route }),
+    ...(transition.output_summary !== undefined && {
+      output_summary: transition.output_summary,
+    }),
+    evidence_refs: transition.evidence_refs,
+    ...(transition.external_idempotency_key !== undefined && {
+      external_idempotency_key: transition.external_idempotency_key,
+    }),
+  };
+  return applyNodeResult(descriptor, withAttempt, {
+    activation_id: transition.activation_id,
+    transition_id: transition.transition_id,
+    result: replayedResult,
+    identities: buildReplayNodeResultIdentities(descriptor, transition),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Inflight executor dispatch tracked by the loop. The settlement wrapper
+ * never rejects, so awaiting the underlying promises cannot throw.
+ */
+interface InflightExecution {
+  readonly activationId: string;
+  readonly nodeId: string;
+  readonly attemptNo: number;
+  readonly attemptId: string;
+  readonly transitionId: string;
+  readonly promise: Promise<void>;
+  settled?: NodeExecutionOutput | "threw";
+}
+
+/**
+ * Runs one sealed graph to a terminal outcome.
+ *
+ * Exit mapping (normative, EXIT_CODES): FenceError busy/fenced_out -> 19,
+ * JournalCorruptionError -> 20, descriptor mismatch -> 21, graph-terminal
+ * failure -> 1, success -> 0. Mapped failures keep the lock file (abnormal
+ * exit); only normal termination releases it — stale reap covers crashes.
+ */
+export async function runGraph(
+  sealed: SealedGraphDescriptor,
+  options: RunOptions,
+): Promise<RunResult> {
+  const runsRoot =
+    options.runsRoot ?? join(process.cwd(), ...DEFAULT_RUNS_ROOT_SEGMENTS);
+  const runId = sealed.run_id;
+  const fence = new FileOwnershipFence(runsRoot, runId);
+  const journal = new FileJournal(runsRoot, runId);
+  const store = new FileProjectionStore(runsRoot, runId);
+
+  const emit = (event: RuntimeProgressEvent): void => {
+    options.reporter?.onEvent(event);
+  };
+  const acquired = await fence.acquire();
+  if (acquired.outcome === "busy") {
+    // Emit a terminal event so progress consumers never dangle on a busy
+    // refusal; there is no run_started to pair it with in this path.
+    emit({
+      type: "run_ended",
+      terminal: "failed",
+      summary: "another writer owns this run",
+    });
+    return {
+      terminal: "failed",
+      epoch: 0,
+      exit_code: EXIT_CODES.FENCED_OUT,
+      run_id: runId,
+      descriptor_hash: sealed.descriptor_hash,
+    };
+  }
+  const epoch = acquired.epoch;
+
+  // Phase gates which GraphSchedulerError maps to CORRUPT_JOURNAL(20):
+  // startup/fold-phase scheduler errors mean tampered persisted state;
+  // live-phase ones are runner/executor contract violations and rethrow.
+  let phase: "startup" | "fold" | "live" = "startup";
+
+  try {
+    emit({ type: "run_started", run_id: runId, goal: sealed.goal });
+    const descriptorPath = join(runsRoot, runId, DESCRIPTOR_FILE_NAME);
+
+    let stored: SealedGraphDescriptor;
+    let rawDescriptor: string | null;
+    try {
+      rawDescriptor = readFileSync(descriptorPath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        rawDescriptor = null;
+      } else {
+        throw error;
+      }
+    }
+    let descriptorIsFresh = false;
+    if (rawDescriptor === null) {
+      atomicWriteFileSync(descriptorPath, canonicalJson(sealed));
+      stored = sealed;
+      descriptorIsFresh = true;
+    } else {
+      stored = parseSealedGraphDescriptor(JSON.parse(rawDescriptor));
+      if (canonicalJson(stored) !== canonicalJson(sealed)) {
+        throw new GraphSchedulerError(
+          "descriptor_mismatch",
+          `persisted descriptor for run ${runId} does not match the supplied one`,
+        );
+      }
+    }
+
+    // Replay fold: always a full fold; the snapshot is a status cache only.
+    phase = "fold";
+    const records = await journal.readAll();
+    let projection = initializeGraphProjection(
+      stored,
+      entryActivationIds(stored),
+    );
+    if (descriptorIsFresh) {
+      await store.save({
+        schema_version: 1,
+        descriptor_hash: stored.descriptor_hash,
+        run_id: stored.run_id,
+        revision_id: stored.revision_id,
+        epoch,
+        saved_at_seq: -1,
+        projection,
+      });
+    }
+    for (const record of records) {
+      if (record.descriptor_hash !== stored.descriptor_hash) {
+        throw new GraphSchedulerError(
+          "descriptor_mismatch",
+          `journal record ${record.seq} is bound to descriptor ${record.descriptor_hash}`,
+        );
+      }
+      projection = foldOneRecord(stored, projection, record);
+    }
+    emit({ type: "replayed", records: records.length, epoch });
+
+    // --- main loop ---
+    phase = "live";
+    let nextSeq = records.length;
+    const inflight: InflightExecution[] = [];
+    /** Attempt budget is exhausted; scheduler keeps these terminal-failed. */
+    const deadActivations = new Set<string>();
+    const concurrencyLimit = sealed.concurrency_limit;
+    let terminalResult: RunResult | null = null;
+    let terminalSummary: string = "";
+
+    /**
+     * Persists one committed transition: journal append then snapshot save,
+     * both awaited before the caller proceeds (durability ordering).
+     */
+    const persistTransition = async (
+      transition: GraphCommittedTransition,
+    ): Promise<void> => {
+      const seq = nextSeq;
+      nextSeq += 1;
+      await journal.append({
+        seq,
+        epoch,
+        descriptor_hash: stored.descriptor_hash,
+        transition,
+      });
+      await store.save({
+        schema_version: 1,
+        descriptor_hash: stored.descriptor_hash,
+        run_id: stored.run_id,
+        revision_id: stored.revision_id,
+        epoch,
+        saved_at_seq: seq,
+        projection,
+      });
+    };
+
+    /** Finds the executor registered for an executable node kind. */
+    const findExecutor = (nodeId: string): NodeExecutor => {
+      const node = sealed.nodes.find((candidate) => candidate.id === nodeId);
+      const executor =
+        node === undefined
+          ? undefined
+          : options.executors.find((candidate) =>
+              candidate.kinds.includes(
+                node.kind as Parameters<NodeExecutor["execute"]>[0]["node"]["kind"],
+              ),
+            );
+      if (executor === undefined) {
+        throw new Error(`no executor registered for node kind of ${nodeId}`);
+      }
+      return executor;
+    };
+
+    /**
+     * Begins the next attempt for the first schedulable executable
+     * activation and dispatches it without awaiting. Returns true when a
+     * new execution was started.
+     */
+    const dispatchNextExecutable = (): boolean => {
+      const ready = listReadyExecutableActivations(sealed, projection);
+      const candidate = ready.find(
+        (activation) =>
+          !inflight.some(
+            (entry) => entry.activationId === activation.activation_id,
+          ) && !deadActivations.has(activation.activation_id),
+      );
+      if (candidate === undefined) {
+        return false;
+      }
+      const node = sealed.nodes.find((n) => n.id === candidate.node_id);
+      if (
+        node === undefined ||
+        (node.kind !== "agent" && node.kind !== "command")
+      ) {
+        throw new Error(
+          `ready activation ${candidate.activation_id} is not executable`,
+        );
+      }
+      const attemptNo = candidate.attempt_no + 1;
+      const attemptId = nextAttemptId(candidate.activation_id, attemptNo);
+      let running: GraphSchedulerProjection;
+      try {
+        running = beginActivationAttempt(sealed, projection, {
+          activation_id: candidate.activation_id,
+          attempt_id: attemptId,
+        });
+      } catch (error) {
+        if (
+          error instanceof GraphSchedulerError &&
+          error.code === "max_attempts_exceeded"
+        ) {
+          deadActivations.add(candidate.activation_id);
+          return false; // leave terminal-failed per scheduler contract (AC-9)
+        }
+        throw error;
+      }
+      projection = running;
+      const context: NodeExecutionContext = {
+        descriptor: sealed,
+        node,
+        activation_id: candidate.activation_id,
+        attempt_id: attemptId,
+        attempt_no: attemptNo,
+      };
+      const transitionId = transitionIdFor(candidate.activation_id, attemptNo);
+      const executor = findExecutor(node.id);
+      emit({
+        type: "activation_started",
+        node_id: node.id,
+        attempt_no: attemptNo,
+      });
+      const entry: InflightExecution = {
+        activationId: candidate.activation_id,
+        nodeId: node.id,
+        attemptNo,
+        attemptId,
+        transitionId,
+        promise: Promise.resolve().then(() =>
+          executor.execute(context).then(
+            (output) => {
+              entry.settled = output;
+            },
+            (_error: unknown) => {
+              entry.settled = "threw";
+            },
+          ),
+        ),
+      };
+      inflight.push(entry);
+      return true;
+    };
+
+    /**
+     * Commits every settled execution in FIFO order, applying node results
+     * through the scheduler and persisting each committed transition.
+     */
+    const drainSettled = async (): Promise<void> => {
+      for (let index = 0; index < inflight.length; ) {
+        const entry = inflight[index];
+        if (entry.settled === undefined) {
+          index += 1;
+          continue;
+        }
+        inflight.splice(index, 1);
+        const output =
+          entry.settled === "threw"
+            ? ({
+                outcome: "failed",
+                output_summary: "executor threw during execution",
+                evidence_refs: [],
+              } satisfies NodeExecutionOutput)
+            : entry.settled;
+        entry.settled = undefined;
+        const result: GraphNodeResult = {
+          outcome: output.outcome,
+          attempt_id: entry.attemptId,
+          ...(output.route !== undefined && { route: output.route }),
+          ...(output.output_summary !== undefined && {
+            output_summary: output.output_summary,
+          }),
+          evidence_refs: output.evidence_refs,
+          ...(output.external_idempotency_key !== undefined && {
+            external_idempotency_key: output.external_idempotency_key,
+          }),
+        };
+        const identities = buildLiveNodeResultIdentities(
+          sealed,
+          projection,
+          entry.nodeId,
+          output,
+        );
+        const applied = applyNodeResult(sealed, projection, {
+          activation_id: entry.activationId,
+          transition_id: entry.transitionId,
+          result,
+          identities,
+        });
+        projection = applied.projection;
+        emit({
+          type: "node_result",
+          node_id: entry.nodeId,
+          outcome: applied.transition.outcome,
+        });
+        await persistTransition(applied.transition);
+      }
+    };
+
+    /** Prompts and commits one human-approval activation (FIFO order). */
+    const commitApproval = async (): Promise<void> => {
+      const activation = listReadyApprovalActivations(sealed, projection)[0];
+      if (activation === undefined) {
+        return;
+      }
+      const node = sealed.nodes.find((n) => n.id === activation.node_id);
+      if (node === undefined || node.kind !== "human-approval") {
+        throw new Error(
+          `ready approval activation ${activation.activation_id} is not a human-approval node`,
+        );
+      }
+      const request: ApprovalRequest = {
+        run_id: runId,
+        node_id: node.id,
+        activation_id: activation.activation_id,
+        prompt_text: node.prompt,
+      };
+      const decision = await options.prompter.prompt(request);
+      const decisionRecord = {
+        decision,
+        evidence_refs: [
+          {
+            kind: "human" as const,
+            ref: `approval:${runId}:${node.id}`,
+            summary: `human decision for ${node.id}`,
+          },
+        ],
+      };
+      const fixedEdge = outgoingEdgesOf(sealed, node.id).find(
+        (edge) => edge.kind === "fixed",
+      );
+      if (decision === "approved") {
+        if (fixedEdge === undefined) {
+          throw new Error(
+            `human-approval node ${node.id} has no fixed outgoing edge`,
+          );
+        }
+        const identities = {
+          next_activation_ids: {
+            [fixedEdge.id]: nextActivationIdFor(projection, fixedEdge.to),
+          },
+        };
+        const applied = applyHumanApproval(sealed, projection, {
+          activation_id: activation.activation_id,
+          transition_id: transitionIdFor(activation.activation_id, 0),
+          decision: decisionRecord,
+          identities,
+        });
+        projection = applied.projection;
+        emit({
+          type: "node_result",
+          node_id: node.id,
+          outcome: applied.transition.outcome,
+        });
+        await persistTransition(applied.transition);
+        return;
+      }
+      const denied = applyHumanApproval(sealed, projection, {
+        activation_id: activation.activation_id,
+        transition_id: transitionIdFor(activation.activation_id, 0),
+        decision: decisionRecord,
+      });
+      projection = denied.projection;
+      emit({
+        type: "node_result",
+        node_id: node.id,
+        outcome: denied.transition.outcome,
+      });
+      await persistTransition(denied.transition);
+    };
+
+    /** Resolves one ready join activation. */
+    const commitJoin = async (): Promise<void> => {
+      const activation = listReadyJoinActivations(sealed, projection)[0];
+      if (activation === undefined) {
+        return;
+      }
+      const outgoing = outgoingEdgesOf(sealed, activation.node_id);
+      const fixedEdge = outgoing.find((edge) => edge.kind === "fixed");
+      if (fixedEdge === undefined) {
+        throw new Error(
+          `join node ${activation.node_id} has no fixed outgoing edge`,
+        );
+      }
+      const applied = resolveJoin(sealed, projection, {
+        activation_id: activation.activation_id,
+        transition_id: transitionIdFor(activation.activation_id, 0),
+        identities: {
+          next_activation_ids: {
+            [fixedEdge.id]: nextActivationIdFor(projection, fixedEdge.to),
+          },
+        },
+      });
+      projection = applied.projection;
+      emit({
+        type: "node_result",
+        node_id: activation.node_id,
+        outcome: applied.transition.outcome,
+      });
+      await persistTransition(applied.transition);
+    };
+
+    while (terminalResult === null) {
+      fence.assertEpoch(epoch);
+      if (options.signal?.aborted === true) {
+        throw new Error("graph run aborted");
+      }
+      while (
+        inflight.length < concurrencyLimit &&
+        dispatchNextExecutable()
+      ) {
+        // Fill executor slots up to the concurrency limit.
+      }
+      const approvalActivation = listReadyApprovalActivations(
+        sealed,
+        projection,
+      )[0];
+      if (approvalActivation !== undefined) {
+        await commitApproval();
+        continue;
+      }
+      if (listReadyJoinActivations(sealed, projection).length > 0) {
+        await commitJoin();
+        continue;
+      }
+
+      // Wait for at least one inflight execution to settle, then drain all
+      // settled entries (several may complete together).
+      if (inflight.length > 0) {
+        await Promise.race(inflight.map((entry) => entry.promise));
+        await drainSettled();
+        continue;
+      }
+
+      // Idle: evaluate terminal conditions.
+      if (isGraphSucceeded(sealed, projection)) {
+        terminalResult = {
+          terminal: "succeeded",
+          run_id: runId,
+          descriptor_hash: stored.descriptor_hash,
+          epoch,
+          exit_code: EXIT_CODES.OK,
+        };
+        terminalSummary = `graph succeeded (${nextSeq} committed transitions)`;
+        break;
+      }
+      const hasWork =
+        listReadyExecutableActivations(sealed, projection).some(
+          (activation) =>
+            !inflight.some((entry) => entry.activationId === activation.activation_id) &&
+            !deadActivations.has(activation.activation_id),
+        ) ||
+        listReadyApprovalActivations(sealed, projection).length > 0 ||
+        listReadyJoinActivations(sealed, projection).length > 0;
+      if (!hasWork) {
+        terminalResult = {
+          terminal: "failed",
+          run_id: runId,
+          descriptor_hash: stored.descriptor_hash,
+          epoch,
+          exit_code: EXIT_CODES.FAILED_TERMINAL,
+        };
+        terminalSummary = "no schedulable activations";
+        break;
+      }
+      throw new Error("runner stalled with schedulable work remaining");
+    }
+
+    // Release before emitting run_ended: if release throws, the catch path
+    // emits the single run_ended for this run instead of a duplicate.
+    await fence.release(epoch);
+    emit({
+      type: "run_ended",
+      terminal: terminalResult.terminal,
+      summary: terminalSummary,
+    });
+    return terminalResult;
+  } catch (error) {
+    const mapped = mapRunFailure(
+      error,
+      phase,
+      epoch,
+      runId,
+      sealed.descriptor_hash,
+    );
+    if (mapped === null) {
+      throw error;
+    }
+    emit({
+      type: "run_ended",
+      terminal: "failed",
+      summary: mapped.message ?? "run failed",
+    });
+    return mapped.result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Failure mapping (exit codes are normative)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps persisted-state failures to their normative exit codes; returns null
+ * for anything else (caller rethrows). Fence/corruption/descriptor failures
+ * keep the lock file: abnormal exits rely on stale reap.
+ */
+function mapRunFailure(
+  error: unknown,
+  phase: "startup" | "fold" | "live",
+  epoch: number,
+  runId: string,
+  descriptorHash: string,
+): { readonly result: RunResult; readonly message: string } | null {
+  const result = (
+    exitCode: RunResult["exit_code"],
+  ): { readonly result: RunResult; readonly message: string } => ({
+    result: {
+      terminal: "failed",
+      epoch,
+      exit_code: exitCode,
+      run_id: runId,
+      descriptor_hash: descriptorHash,
+    },
+    message: error instanceof Error ? error.message : String(error),
+  });
+  if (error instanceof FenceError) {
+    return result(EXIT_CODES.FENCED_OUT);
+  }
+  if (error instanceof JournalCorruptionError) {
+    return result(EXIT_CODES.CORRUPT_JOURNAL);
+  }
+  if (error instanceof GraphDescriptorValidationError) {
+    return result(EXIT_CODES.DESCRIPTOR_MISMATCH);
+  }
+  if (error instanceof GraphSchedulerError) {
+    if (error.code === "descriptor_mismatch") {
+      return result(EXIT_CODES.DESCRIPTOR_MISMATCH);
+    }
+    if (phase !== "live") {
+      return result(EXIT_CODES.CORRUPT_JOURNAL);
+    }
+  }
+  return null;
+}

--- a/src/graph/runtime/runner.ts
+++ b/src/graph/runtime/runner.ts
@@ -11,7 +11,6 @@
  * including embedded request fingerprints.
  */
 
-import { readFileSync } from "fs";
 import { join } from "path";
 
 import {
@@ -32,10 +31,12 @@ import {
   resolveJoin,
 } from "../scheduler.js";
 import { atomicWriteFileSync } from "../../lib/atomic-write.js";
-import { resolveRunDir } from "./run-dir.js";
+import { resolveRunDirHandle } from "./run-dir.js";
+import type { RunDirHandle } from "./run-dir.js";
 import { computeJournalFingerprint, FileJournal } from "./journal.js";
 import { FileOwnershipFence } from "./fence.js";
 import { FileProjectionStore } from "./store.js";
+import { readContainedFileNoFollow, withContainedPath } from "./safe-fs.js";
 
 import { EXIT_CODES, FenceError, JournalCorruptionError } from "./types.js";
 import type {
@@ -495,7 +496,7 @@ export async function runGraph(
   const runId = sealed.run_id;
   // Contained run dir (P1-3): validates run_id, rejects symlink escapes, and
   // creates the directory before any persistence component touches disk.
-  const runDir = resolveRunDir(runsRoot, runId);
+  const runDirHandle: RunDirHandle = resolveRunDirHandle(runsRoot, runId);
   const fence = new FileOwnershipFence(runsRoot, runId);
   const journal = new FileJournal(runsRoot, runId);
   const store = new FileProjectionStore(runsRoot, runId);
@@ -529,12 +530,13 @@ export async function runGraph(
 
   try {
     emit({ type: "run_started", run_id: runId, goal: sealed.goal });
-    const descriptorPath = join(runDir, DESCRIPTOR_FILE_NAME);
-
     let stored: SealedGraphDescriptor;
     let rawDescriptor: string | null;
     try {
-      rawDescriptor = readFileSync(descriptorPath, "utf8");
+      rawDescriptor = readContainedFileNoFollow(
+        runDirHandle,
+        DESCRIPTOR_FILE_NAME,
+      );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         rawDescriptor = null;
@@ -544,7 +546,9 @@ export async function runGraph(
     }
     let descriptorIsFresh = false;
     if (rawDescriptor === null) {
-      atomicWriteFileSync(descriptorPath, canonicalJson(sealed));
+      withContainedPath(runDirHandle, DESCRIPTOR_FILE_NAME, (path) => {
+        atomicWriteFileSync(path, canonicalJson(sealed));
+      });
       stored = sealed;
       descriptorIsFresh = true;
     } else {

--- a/src/graph/runtime/runner.ts
+++ b/src/graph/runtime/runner.ts
@@ -33,7 +33,7 @@ import {
 } from "../scheduler.js";
 import { atomicWriteFileSync } from "../../lib/atomic-write.js";
 import { resolveRunDir } from "./run-dir.js";
-import { FileJournal } from "./journal.js";
+import { computeJournalFingerprint, FileJournal } from "./journal.js";
 import { FileOwnershipFence } from "./fence.js";
 import { FileProjectionStore } from "./store.js";
 
@@ -375,6 +375,14 @@ function foldOneRecord(
   record: JournalRecord,
 ): GraphSchedulerProjection {
   const transition = record.transition;
+  const { journal_fingerprint: recordedFingerprint, ...unsignedRecord } =
+    record;
+  if (recordedFingerprint !== computeJournalFingerprint(unsignedRecord)) {
+    throw new GraphSchedulerError(
+      "transition_fenced",
+      `journal record ${record.seq} fails its envelope fingerprint`,
+    );
+  }
   let applied;
   switch (transition.outcome) {
     case "succeeded":
@@ -608,12 +616,16 @@ export async function runGraph(
     ): Promise<void> => {
       const seq = nextSeq;
       nextSeq += 1;
+      // Do not publish a transition after ownership has been lost while an
+      // executor or approval prompt was in flight.
+      fence.assertEpoch(epoch);
       await journal.append({
         seq,
         epoch,
         descriptor_hash: stored.descriptor_hash,
         transition,
       });
+      fence.assertEpoch(epoch);
       await store.save({
         schema_version: 1,
         descriptor_hash: stored.descriptor_hash,

--- a/src/graph/runtime/runner.ts
+++ b/src/graph/runtime/runner.ts
@@ -32,6 +32,7 @@ import {
   resolveJoin,
 } from "../scheduler.js";
 import { atomicWriteFileSync } from "../../lib/atomic-write.js";
+import { resolveRunDir } from "./run-dir.js";
 import { FileJournal } from "./journal.js";
 import { FileOwnershipFence } from "./fence.js";
 import { FileProjectionStore } from "./store.js";
@@ -484,6 +485,9 @@ export async function runGraph(
   const runsRoot =
     options.runsRoot ?? join(process.cwd(), ...DEFAULT_RUNS_ROOT_SEGMENTS);
   const runId = sealed.run_id;
+  // Contained run dir (P1-3): validates run_id, rejects symlink escapes, and
+  // creates the directory before any persistence component touches disk.
+  const runDir = resolveRunDir(runsRoot, runId);
   const fence = new FileOwnershipFence(runsRoot, runId);
   const journal = new FileJournal(runsRoot, runId);
   const store = new FileProjectionStore(runsRoot, runId);
@@ -517,7 +521,7 @@ export async function runGraph(
 
   try {
     emit({ type: "run_started", run_id: runId, goal: sealed.goal });
-    const descriptorPath = join(runsRoot, runId, DESCRIPTOR_FILE_NAME);
+    const descriptorPath = join(runDir, DESCRIPTOR_FILE_NAME);
 
     let stored: SealedGraphDescriptor;
     let rawDescriptor: string | null;
@@ -563,6 +567,10 @@ export async function runGraph(
         projection,
       });
     }
+    // Epoch provenance: takeovers only ever raise the epoch, so committed
+    // history must be non-decreasing and must never exceed the epoch this
+    // process acquired — anything else is forged or stale-writer provenance.
+    let lastRecordEpoch = 0;
     for (const record of records) {
       if (record.descriptor_hash !== stored.descriptor_hash) {
         throw new GraphSchedulerError(
@@ -570,6 +578,13 @@ export async function runGraph(
           `journal record ${record.seq} is bound to descriptor ${record.descriptor_hash}`,
         );
       }
+      if (record.epoch < lastRecordEpoch || record.epoch > epoch) {
+        throw new GraphSchedulerError(
+          "transition_fenced",
+          `journal record ${record.seq} carries epoch ${record.epoch} outside fenced history (last ${lastRecordEpoch}, acquired ${epoch})`,
+        );
+      }
+      lastRecordEpoch = record.epoch;
       projection = foldOneRecord(stored, projection, record);
     }
     emit({ type: "replayed", records: records.length, epoch });

--- a/src/graph/runtime/safe-fs.ts
+++ b/src/graph/runtime/safe-fs.ts
@@ -1,0 +1,95 @@
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+} from "fs";
+import { join } from "path";
+import type { RunDirHandle } from "./run-dir.js";
+
+const NO_FOLLOW = process.platform === "win32" ? 0 : fsConstants.O_NOFOLLOW;
+
+/** Open a runtime artifact without following a symlink at the final path. */
+export function openNoFollow(
+  filePath: string,
+  flags: number,
+  mode = 0o600,
+): number {
+  if (process.platform === "win32") {
+    try {
+      if (lstatSync(filePath).isSymbolicLink()) {
+        const error = new Error(`symbolic link refused: ${filePath}`) as NodeJS.ErrnoException;
+        error.code = "ELOOP";
+        throw error;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw error;
+      // Let openSync report ordinary permission and path errors.
+    }
+  }
+  return openSync(filePath, flags | NO_FOLLOW, mode);
+}
+
+/** Read a runtime artifact without following a symlink at the final path. */
+export function readFileNoFollow(filePath: string): string {
+  const fd = openNoFollow(filePath, fsConstants.O_RDONLY);
+  try {
+    return readFileSync(fd, "utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function descriptorPath(directoryFd: number): string {
+  if (process.platform === "linux") return `/proc/self/fd/${directoryFd}`;
+  return `/dev/fd/${directoryFd}`;
+}
+
+/**
+ * Run a synchronous operation against a directory FD on POSIX. If the
+ * directory is renamed or its parent path is replaced while the operation is
+ * in flight, the FD still refers to the originally validated directory.
+ * Windows falls back to the final-component no-follow guard.
+ */
+export function withContainedPath<T>(
+  runDir: RunDirHandle,
+  fileName: string,
+  operation: (filePath: string) => T,
+): T {
+  if (process.platform === "win32") {
+    const directoryFd = openNoFollow(runDir.path, fsConstants.O_RDONLY);
+    try {
+      const stats = fstatSync(directoryFd);
+      if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
+        throw new Error("run directory identity changed");
+      }
+      return operation(join(runDir.path, fileName));
+    } finally {
+      closeSync(directoryFd);
+    }
+  }
+  const directoryFd = openNoFollow(
+    runDir.path,
+    fsConstants.O_RDONLY | (fsConstants.O_DIRECTORY ?? 0),
+  );
+  try {
+    const stats = fstatSync(directoryFd);
+    if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
+      throw new Error("run directory identity changed");
+    }
+    return operation(join(descriptorPath(directoryFd), fileName));
+  } finally {
+    closeSync(directoryFd);
+  }
+}
+
+/** Read a named artifact through a validated run-directory handle. */
+export function readContainedFileNoFollow(
+  runDir: RunDirHandle,
+  fileName: string,
+): string {
+  return withContainedPath(runDir, fileName, readFileNoFollow);
+}
+

--- a/src/graph/runtime/safe-fs.ts
+++ b/src/graph/runtime/safe-fs.ts
@@ -5,6 +5,7 @@ import {
   lstatSync,
   openSync,
   readFileSync,
+  statSync,
 } from "fs";
 import { join } from "path";
 import type { RunDirHandle } from "./run-dir.js";
@@ -59,16 +60,11 @@ export function withContainedPath<T>(
   operation: (filePath: string) => T,
 ): T {
   if (process.platform === "win32") {
-    const directoryFd = openNoFollow(runDir.path, fsConstants.O_RDONLY);
-    try {
-      const stats = fstatSync(directoryFd);
-      if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
-        throw new Error("run directory identity changed");
-      }
-      return operation(join(runDir.path, fileName));
-    } finally {
-      closeSync(directoryFd);
+    const stats = statSync(runDir.path);
+    if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
+      throw new Error("run directory identity changed");
     }
+    return operation(join(runDir.path, fileName));
   }
   const directoryFd = openNoFollow(
     runDir.path,

--- a/src/graph/runtime/store.ts
+++ b/src/graph/runtime/store.ts
@@ -1,0 +1,130 @@
+/**
+ * File-backed projection snapshot store (graph runtime v2).
+ *
+ * Implements ProjectionStore over `<runsRoot>/<run_id>/projection.json`.
+ * The journal is the source of truth; this snapshot only accelerates resume
+ * and serves status. Every persist goes through temp+rename
+ * (atomicWriteJsonSync); every read fails closed on corruption (AC-3).
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
+
+import type {
+  ProjectionSnapshotEnvelope,
+  ProjectionStore,
+} from "./types.js";
+
+const DESCRIPTOR_HASH_PATTERN = /^[a-f0-9]{64}$/;
+const PROJECTION_FILE_NAME = "projection.json";
+
+/** Closed error surface for projection snapshot failures. */
+export class ProjectionStoreError extends Error {
+  readonly code: "descriptor_mismatch" | "corrupt";
+
+  constructor(code: "descriptor_mismatch" | "corrupt", message: string) {
+    super(message);
+    this.name = "ProjectionStoreError";
+    this.code = code;
+  }
+}
+
+/**
+ * Validates an untrusted parsed envelope; returns it typed or throws corrupt.
+ * Fail-closed: never returns partial data (AC-3).
+ */
+function parseStoredEnvelope(raw: unknown): ProjectionSnapshotEnvelope {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "projection snapshot is not a JSON object",
+    );
+  }
+  const candidate = raw as ProjectionSnapshotEnvelope;
+  if (candidate.schema_version !== 1) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      `unsupported projection schema_version: ${String(candidate.schema_version)}`,
+    );
+  }
+  if (
+    typeof candidate.descriptor_hash !== "string" ||
+    !DESCRIPTOR_HASH_PATTERN.test(candidate.descriptor_hash)
+  ) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "descriptor_hash is not a lowercase sha256 hex digest",
+    );
+  }
+  return candidate;
+}
+
+/** Load/save surface over one run's `<run_id>/projection.json`. */
+export class FileProjectionStore implements ProjectionStore {
+  private readonly filePath: string;
+
+  constructor(runsRoot: string, runId: string) {
+    this.filePath = join(runsRoot, runId, PROJECTION_FILE_NAME);
+  }
+
+  async save(envelope: ProjectionSnapshotEnvelope): Promise<void> {
+    if (envelope.schema_version !== 1) {
+      throw new ProjectionStoreError(
+        "corrupt",
+        "envelope schema_version must be 1",
+      );
+    }
+
+    // Binding check first (AC-3): the path is bound to one descriptor/run/revision.
+    // A corrupt snapshot is a cache-miss here, not run-fatal: the journal is
+    // the source of truth, so treat it as absent and proceed with the overwrite.
+    let stored: ProjectionSnapshotEnvelope | null;
+    try {
+      stored = await this.load();
+    } catch (err) {
+      if (!(err instanceof ProjectionStoreError) || err.code !== "corrupt") {
+        throw err;
+      }
+      stored = null;
+    }
+    if (
+      stored !== null &&
+      (envelope.descriptor_hash !== stored.descriptor_hash ||
+        envelope.run_id !== stored.run_id ||
+        envelope.revision_id !== stored.revision_id)
+    ) {
+      throw new ProjectionStoreError(
+        "descriptor_mismatch",
+        `snapshot path bound to descriptor ${stored.descriptor_hash}, run ${stored.run_id}, revision ${stored.revision_id}`,
+      );
+    }
+
+    atomicWriteJsonSync(this.filePath, envelope);
+  }
+
+  async load(): Promise<ProjectionSnapshotEnvelope | null> {
+    let content: string;
+    try {
+      content = readFileSync(this.filePath, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
+
+    try {
+      return parseStoredEnvelope(JSON.parse(content));
+    } catch (err) {
+      if (err instanceof ProjectionStoreError) {
+        throw err;
+      }
+      throw new ProjectionStoreError(
+        "corrupt",
+        "projection.json is not valid JSON",
+      );
+    }
+  }
+}

--- a/src/graph/runtime/store.ts
+++ b/src/graph/runtime/store.ts
@@ -12,6 +12,7 @@ import { join } from "path";
 
 import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
 
+import { resolveRunDir } from "./run-dir.js";
 import type {
   ProjectionSnapshotEnvelope,
   ProjectionStore,
@@ -66,7 +67,7 @@ export class FileProjectionStore implements ProjectionStore {
   private readonly filePath: string;
 
   constructor(runsRoot: string, runId: string) {
-    this.filePath = join(runsRoot, runId, PROJECTION_FILE_NAME);
+    this.filePath = join(resolveRunDir(runsRoot, runId), PROJECTION_FILE_NAME);
   }
 
   async save(envelope: ProjectionSnapshotEnvelope): Promise<void> {

--- a/src/graph/runtime/store.ts
+++ b/src/graph/runtime/store.ts
@@ -7,12 +7,13 @@
  * (atomicWriteJsonSync); every read fails closed on corruption (AC-3).
  */
 
-import { readFileSync } from "fs";
 import { join } from "path";
 
 import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
 
-import { resolveRunDir } from "./run-dir.js";
+import { resolveRunDirHandle } from "./run-dir.js";
+import type { RunDirHandle } from "./run-dir.js";
+import { readContainedFileNoFollow, withContainedPath } from "./safe-fs.js";
 import type {
   ProjectionSnapshotEnvelope,
   ProjectionStore,
@@ -59,15 +60,67 @@ function parseStoredEnvelope(raw: unknown): ProjectionSnapshotEnvelope {
       "descriptor_hash is not a lowercase sha256 hex digest",
     );
   }
+  if (typeof candidate.run_id !== "string" || candidate.run_id.length === 0) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "projection run_id is missing or invalid",
+    );
+  }
+  if (
+    typeof candidate.revision_id !== "string" ||
+    candidate.revision_id.length === 0
+  ) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "projection revision_id is missing or invalid",
+    );
+  }
+  if (
+    typeof candidate.epoch !== "number" ||
+    !Number.isInteger(candidate.epoch) ||
+    candidate.epoch < 1
+  ) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "projection epoch is missing or invalid",
+    );
+  }
+  if (
+    typeof candidate.saved_at_seq !== "number" ||
+    !Number.isInteger(candidate.saved_at_seq) ||
+    candidate.saved_at_seq < -1
+  ) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "projection saved_at_seq is missing or invalid",
+    );
+  }
+  if (
+    typeof candidate.projection !== "object" ||
+    candidate.projection === null ||
+    Array.isArray(candidate.projection)
+  ) {
+    throw new ProjectionStoreError(
+      "corrupt",
+      "projection body is missing or invalid",
+    );
+  }
   return candidate;
 }
 
 /** Load/save surface over one run's `<run_id>/projection.json`. */
 export class FileProjectionStore implements ProjectionStore {
-  private readonly filePath: string;
+  private readonly runsRoot: string;
+  private readonly runId: string;
 
   constructor(runsRoot: string, runId: string) {
-    this.filePath = join(resolveRunDir(runsRoot, runId), PROJECTION_FILE_NAME);
+    this.runsRoot = runsRoot;
+    this.runId = runId;
+    resolveRunDirHandle(runsRoot, runId);
+  }
+
+  private runDir(): RunDirHandle {
+    return resolveRunDirHandle(this.runsRoot, this.runId);
   }
 
   async save(envelope: ProjectionSnapshotEnvelope): Promise<void> {
@@ -102,16 +155,26 @@ export class FileProjectionStore implements ProjectionStore {
       );
     }
 
-    atomicWriteJsonSync(this.filePath, envelope);
+    withContainedPath(this.runDir(), PROJECTION_FILE_NAME, (filePath) => {
+      atomicWriteJsonSync(filePath, envelope);
+    });
   }
 
   async load(): Promise<ProjectionSnapshotEnvelope | null> {
+    const runDir = this.runDir();
+    const filePath = join(runDir.path, PROJECTION_FILE_NAME);
     let content: string;
     try {
-      content = readFileSync(this.filePath, "utf8");
+      content = readContainedFileNoFollow(runDir, PROJECTION_FILE_NAME);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return null;
+      }
+      if ((err as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new ProjectionStoreError(
+          "corrupt",
+          `projection ${filePath} must not be a symbolic link`,
+        );
       }
       throw err;
     }

--- a/src/graph/runtime/types.ts
+++ b/src/graph/runtime/types.ts
@@ -92,15 +92,20 @@ export interface JournalRecord {
   /** Must equal the projection's descriptor_hash; replay rejects drift. */
   readonly descriptor_hash: string;
   readonly transition: GraphCommittedTransition;
+  /** SHA-256 over the complete envelope, including epoch and transition. */
+  readonly journal_fingerprint: string;
 }
+
+/** Journal append input before the runtime computes its envelope fingerprint. */
+export type JournalAppendRecord = Omit<JournalRecord, "journal_fingerprint">;
 
 /**
  * Append-only OCC journal over `<runsRoot>/<run_id>/journal.jsonl`.
- * Epoch-staleness enforcement lives in the runner's loop-top assertEpoch;
- * the journal itself stays dumb by contract.
+ * Epoch-staleness enforcement lives in the runner's loop and commit boundary;
+ * the journal fingerprint binds each record to its writer epoch.
  */
 export interface Journal {
-  append(record: JournalRecord): Promise<void>;
+  append(record: JournalAppendRecord): Promise<void>;
   /**
    * Reads all well-formed records. Throws JournalCorruptionError (with
    * truncatedCount) on any unparseable/incomplete line — never returns

--- a/src/graph/runtime/types.ts
+++ b/src/graph/runtime/types.ts
@@ -1,0 +1,257 @@
+/**
+ * Graph Runtime v2 internal contracts.
+ *
+ * Lead-authored and frozen for the graph-runtime-v2 team. Runtime modules
+ * implement these without redefining any Graph Core semantics: the sealed
+ * descriptor and pure scheduler contracts in `src/graph/*` remain
+ * authoritative and are consumed verbatim (ADR 03570 boundary).
+ */
+
+import type {
+  GraphApprovalDecision,
+  GraphCommittedTransition,
+  GraphNode,
+  GraphNodeKind,
+  GraphSchedulerProjection,
+  SealedGraphDescriptor,
+  GraphEvidenceReference,
+} from "../types.js";
+
+/**
+ * Node kinds dispatched to a NodeExecutor. human-approval and join nodes are
+ * runner-driven pure transitions (applyHumanApproval / resolveJoin), never
+ * executor work.
+ */
+export type ExecutableKind = Extract<GraphNodeKind, "agent" | "command">;
+
+// ---------------------------------------------------------------------------
+// Epoch ownership fence
+// ---------------------------------------------------------------------------
+
+/** Content of the run-scoped lock file `<runsRoot>/<run_id>/owner.lock`. */
+export interface FenceLockPayload {
+  readonly pid: number;
+  readonly epoch: number;
+  /** Epoch milliseconds at acquisition. */
+  readonly timestamp: number;
+}
+
+/** Outcome of an acquire attempt against a possibly-existing lock. */
+export type FenceAcquireResult =
+  | { readonly outcome: "acquired"; readonly epoch: number }
+  | { readonly outcome: "busy" };
+
+/**
+ * Epoch ownership single-writer fence over one run directory.
+ *
+ * Protocol invariants (worker-2 implements):
+ * - create = O_EXCL; every removal/move = atomic rename with unique target.
+ * - stale = PID dead OR unparseable content older than a grace period.
+ * - takeover renames the old lock away (exactly one racer wins by ENOENT),
+ *   reads old epoch from the tombstone it exclusively owns, O_EXCL creates
+ *   the new lock at epoch+1.
+ * - live healthy holder yields busy — fail-closed, no multi-writer assumption.
+ */
+export interface OwnershipFence {
+  acquire(): Promise<FenceAcquireResult>;
+  /** Throws FenceError("fenced_out") when the caller is not the current owner. */
+  assertEpoch(epoch: number): void;
+  /** Throws FenceError("fenced_out") when caller is not current owner. */
+  /**
+   * Atomic release by the current holder. Only the current epoch's holder may
+   * release; returns false when this instance no longer owns the run (its
+   * rename fails ENOENT because another process already moved the lock).
+   */
+  release(epoch: number): Promise<boolean>;
+}
+
+/** Closed error surface for fence failures surfaced to the runner. */
+export class FenceError extends Error {
+  readonly code: "busy" | "fenced_out";
+  constructor(code: "busy" | "fenced_out", message: string) {
+    super(message);
+    this.name = "FenceError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OCC journal
+// ---------------------------------------------------------------------------
+
+/**
+ * One journal line: an OCC-committed scheduler transition bound to the writer
+ * epoch and descriptor. The transition is persisted verbatim from
+ * `SchedulerApplyResult.transition`.
+ */
+export interface JournalRecord {
+  /** 0-based append order within the run. */
+  readonly seq: number;
+  /** Writer epoch that committed this record. */
+  readonly epoch: number;
+  /** Must equal the projection's descriptor_hash; replay rejects drift. */
+  readonly descriptor_hash: string;
+  readonly transition: GraphCommittedTransition;
+}
+
+/**
+ * Append-only OCC journal over `<runsRoot>/<run_id>/journal.jsonl`.
+ * Epoch-staleness enforcement lives in the runner's loop-top assertEpoch;
+ * the journal itself stays dumb by contract.
+ */
+export interface Journal {
+  append(record: JournalRecord): Promise<void>;
+  /**
+   * Reads all well-formed records. Throws JournalCorruptionError (with
+   * truncatedCount) on any unparseable/incomplete line — never returns
+   * partial data silently (AC-8).
+   */
+  readAll(): Promise<readonly JournalRecord[]>;
+}
+
+/** Journal is corrupt or has an incomplete trailing line (fail-closed). */
+export class JournalCorruptionError extends Error {
+  /** Number of trailing incomplete/unparseable records dropped by readAll. */
+  readonly truncatedCount: number;
+  constructor(message: string, truncatedCount: number) {
+    if (!Number.isInteger(truncatedCount) || truncatedCount < 1) {
+      throw new Error("truncatedCount must be a positive integer");
+    }
+    super(message);
+    this.name = "JournalCorruptionError";
+    this.truncatedCount = truncatedCount;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Projection snapshot store
+// ---------------------------------------------------------------------------
+
+/**
+ * Persisted projection snapshot envelope (projection.json). The journal is
+ * the source of truth; the snapshot accelerates resume and serves status.
+ */
+export interface ProjectionSnapshotEnvelope {
+  readonly schema_version: 1;
+  readonly descriptor_hash: string;
+  readonly run_id: string;
+  readonly revision_id: string;
+  /** Writer epoch that saved this snapshot. */
+  readonly epoch: number;
+  /** seq of the last journal record reflected in this snapshot. */
+  readonly saved_at_seq: number;
+  readonly projection: GraphSchedulerProjection;
+}
+
+/** Load/save surface over `<runsRoot>/<run_id>/projection.json`. */
+export interface ProjectionStore {
+  /**
+   * Persist atomically (temp file + rename). Throws when descriptor binding
+   * mismatches a previously stored envelope for the same path.
+   */
+  save(envelope: ProjectionSnapshotEnvelope): Promise<void>;
+  /** Returns null when no snapshot exists yet. Fail-closed on parse errors. */
+  load(): Promise<ProjectionSnapshotEnvelope | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Node executors
+// ---------------------------------------------------------------------------
+
+/** Inputs handed to a NodeExecutor for one attempt of one executable node. */
+export interface NodeExecutionContext {
+  readonly descriptor: SealedGraphDescriptor;
+  /** Narrowed executable node (kind agent|command) — never approval/join. */
+  readonly node: Extract<GraphNode, { kind: ExecutableKind }>;
+  readonly activation_id: string;
+  readonly attempt_id: string;
+  readonly attempt_no: number;
+}
+
+/** What an executor reports for one attempt. */
+export interface NodeExecutionOutput {
+  readonly outcome: "succeeded" | "failed";
+  readonly output_summary?: string;
+  readonly evidence_refs: readonly GraphEvidenceReference[];
+  /** Idempotency key from effect_policy templates (command executor). */
+  readonly external_idempotency_key?: string;
+  /**
+   * Required when the node's outgoing edges include conditional edges; the
+   * runner feeds it to applyNodeResult. Must be a declared route.
+   */
+  readonly route?: string;
+}
+
+/** Executor for executable nodes (agent/command). Pure I/O boundary object. */
+export interface NodeExecutor {
+  kinds: readonly ExecutableKind[];
+  execute(context: NodeExecutionContext): Promise<NodeExecutionOutput>;
+}
+
+// ---------------------------------------------------------------------------
+// Human approval gate
+// ---------------------------------------------------------------------------
+
+/** One approval request surfaced to a HumanApprovalPrompter. */
+export interface ApprovalRequest {
+  readonly run_id: string;
+  readonly node_id: string;
+  readonly activation_id: string;
+  readonly prompt_text: string;
+}
+
+/** Asks a human for an approval decision; injected into the runner for tests. */
+export interface HumanApprovalPrompter {
+  prompt(request: ApprovalRequest): Promise<GraphApprovalDecision["decision"]>;
+}
+
+/** Consumes progress events; progress.ts renders ASCII, tests collect events. */
+export interface ProgressReporter {
+  onEvent(event: RuntimeProgressEvent): void;
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/** ASCII progress events; progress.ts renders these, runner emits them. */
+export type RuntimeProgressEvent =
+  | { readonly type: "run_started"; readonly run_id: string; readonly goal: string }
+  | { readonly type: "replayed"; readonly records: number; readonly epoch: number }
+  | { readonly type: "activation_started"; readonly node_id: string; readonly attempt_no: number }
+  | { readonly type: "node_result"; readonly node_id: string; readonly outcome: "succeeded" | "failed" | "approved" | "denied" | "join_resolved" }
+  | { readonly type: "run_ended"; readonly terminal: "succeeded" | "failed"; readonly summary: string };
+
+/** Injectable I/O + collaborators for the runner (tests pass fakes). */
+export interface RunOptions {
+  /** Default: `.omc/graph-runs` under cwd. */
+  readonly runsRoot?: string;
+  readonly executors: readonly NodeExecutor[];
+  readonly prompter: HumanApprovalPrompter;
+  readonly reporter?: ProgressReporter;
+  readonly signal?: AbortSignal;
+}
+
+/** Terminal result of a completed graph run. */
+export interface RunResult {
+  readonly terminal: "succeeded" | "failed";
+  readonly run_id: string;
+  readonly descriptor_hash: string;
+  readonly epoch: number;
+  readonly exit_code: ExitCode;
+}
+
+/**
+ * Normative process exit codes for `omc graph run`. The CLI maps runner
+ * outcomes to these; e2e tests assert on them.
+ */
+export const EXIT_CODES = {
+  OK: 0,
+  FAILED_TERMINAL: 1,
+  FENCED_OUT: 19,
+  CORRUPT_JOURNAL: 20,
+  DESCRIPTOR_MISMATCH: 21,
+} as const;
+
+export type ExitCode =
+  (typeof EXIT_CODES)[keyof typeof EXIT_CODES];

--- a/src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts
+++ b/src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts
@@ -122,7 +122,11 @@ describe('git probe fail-closed classification (#3858 remaining P1)', () => {
     process.env.PATH = originalPath;
     setGitShowToplevelProbeForTests(undefined);
     clearWorktreeCache();
-    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(tempDir, {
+      recursive: true,
+      force: true,
+      ...(process.platform === 'win32' && { maxRetries: 10, retryDelay: 100 }),
+    });
   });
 
   it('trusted repo subdirectory with PATH-prepended fake git exiting 1 does not return ok/trustedRoot', () => {

--- a/src/tools/__tests__/wiki-tools-git-probe-failclosed.test.ts
+++ b/src/tools/__tests__/wiki-tools-git-probe-failclosed.test.ts
@@ -143,7 +143,11 @@ describe('wiki tools fail closed on generic git probe failure (#3858 remaining P
     process.env.PATH = originalPath;
     setGitShowToplevelProbeForTests(undefined);
     clearWorktreeCache();
-    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(tempDir, {
+      recursive: true,
+      force: true,
+      ...(process.platform === 'win32' && { maxRetries: 10, retryDelay: 100 }),
+    });
   });
 
   function assertNoWikiIo(secretBefore: string): void {

--- a/src/utils/skill-resources.ts
+++ b/src/utils/skill-resources.ts
@@ -4,7 +4,8 @@ import { dirname, relative } from 'path';
 const MAX_RESOURCE_ENTRIES = 12;
 
 function toDisplayPath(pathValue: string): string {
-  const relativeToCwd = relative(process.cwd(), pathValue);
+  // Display-only paths use POSIX separators so rendered skill docs are identical on all platforms.
+  const relativeToCwd = relative(process.cwd(), pathValue).replace(/\\/g, '/');
   if (
     relativeToCwd &&
     relativeToCwd !== '' &&
@@ -14,7 +15,7 @@ function toDisplayPath(pathValue: string): string {
     return relativeToCwd;
   }
 
-  return pathValue;
+  return pathValue.replace(/\\/g, '/');
 }
 
 export interface SkillResourceSummary {

--- a/src/workflow/__tests__/projections.test.ts
+++ b/src/workflow/__tests__/projections.test.ts
@@ -43,8 +43,8 @@ describe('registry projections — canonical JSON and digest', () => {
 describe('registry projections — drift check against installed surfaces', () => {
   it('matches the repository skills/ and commands/ surface exactly', () => {
     const installed = enumerateInstalledSurfaces(process.cwd());
-    // 41 + execute/review/research, which now ship as real skill directories.
-    expect(installed.skills.length).toBe(31);
+    // 41 + execute/review/research + graph, which ship as real skill directories.
+    expect(installed.skills.length).toBe(32);
     expect(installed.commands.length).toBe(21);
     const drift = checkProjectionDrift(installed);
     expect(drift.unregistered).toEqual([]);

--- a/src/workflow/__tests__/registry.test.ts
+++ b/src/workflow/__tests__/registry.test.ts
@@ -74,6 +74,12 @@ describe('workflow registry — risk classes and gate policy', () => {
       expect(e.owner).toBe(REGISTRY_OWNER);
     }
   });
+
+  it('classifies the graph skill as a security boundary', () => {
+    const graph = getEntry('graph', 'skill');
+    expect(graph?.riskClass).toBe('security-boundary');
+    expect(graph?.decision).toBe('keep');
+  });
 });
 
 describe('workflow registry — aliases and classification', () => {

--- a/src/workflow/__tests__/registry.test.ts
+++ b/src/workflow/__tests__/registry.test.ts
@@ -77,11 +77,11 @@ describe('workflow registry — risk classes and gate policy', () => {
 });
 
 describe('workflow registry — aliases and classification', () => {
-  it('classifies all 31 installed skills and 21 installed commands exactly once', () => {
+  it('classifies all 32 installed skills and 21 installed commands exactly once', () => {
     const skills = WORKFLOW_ENTRIES.filter((e) => e.kind === 'skill' && !e.declaredOnly);
     const commands = WORKFLOW_ENTRIES.filter((e) => e.kind === 'command' && !e.declaredOnly);
-    // 41 + execute/review/research, which now ship as real skill directories.
-    expect(skills).toHaveLength(31);
+    // execute/review/research and graph ship as real skill directories.
+    expect(skills).toHaveLength(32);
     expect(commands).toHaveLength(21);
     const keys = WORKFLOW_ENTRIES.map((e) => `${e.kind}:${e.name}`);
     expect(new Set(keys).size).toBe(keys.length);

--- a/src/workflow/registry.ts
+++ b/src/workflow/registry.ts
@@ -189,7 +189,7 @@ const SKILL_ENTRIES: readonly WorkflowEntry[] = [
   entry({ name: 'ai-slop-cleaner', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in review tool; never a default gate.' }),
   entry({ name: 'visual-verdict', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in for visual surfaces.' }),
   entry({ name: 'external-context', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in external evidence tool.' }),
-  entry({ name: 'graph', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Declarative graph runtime over the v5 Graph Core contracts; CLI + skill entrypoints.' }),
+  entry({ name: 'graph', kind: 'skill', decision: 'keep', riskClass: 'security-boundary', owner: REGISTRY_OWNER, notes: 'Declarative graph runtime with command execution and bounded read-only Agent SDK execution; CLI + skill entrypoints.' }),
   entry({ name: 'debug', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER }),
   entry({ name: 'deepinit', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER }),
   entry({ name: 'hud', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER }),

--- a/src/workflow/registry.ts
+++ b/src/workflow/registry.ts
@@ -189,6 +189,7 @@ const SKILL_ENTRIES: readonly WorkflowEntry[] = [
   entry({ name: 'ai-slop-cleaner', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in review tool; never a default gate.' }),
   entry({ name: 'visual-verdict', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in for visual surfaces.' }),
   entry({ name: 'external-context', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in external evidence tool.' }),
+  entry({ name: 'graph', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Declarative graph runtime over the v5 Graph Core contracts; CLI + skill entrypoints.' }),
   entry({ name: 'debug', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER }),
   entry({ name: 'deepinit', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER }),
   entry({ name: 'hud', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER }),

--- a/tests/lint/inventory-graph-drift.test.ts
+++ b/tests/lint/inventory-graph-drift.test.ts
@@ -4,9 +4,10 @@
  * This test is the "ongoing drift enforcement" owned by #3702. It asserts:
  *  - committed baseline exists and is valid JSON with the expected schema
  *  - public/internal/generated counts are separately reported and match filesystem
- *  - registry-to-installed drift: installed skills/commands/workflows/agents equal
- *    the manifest's public lists (no phantom entries) — the "registry-to-installed
- *    drift test" required by #3702
+ *  - registry-to-installed drift: installed skills/commands/workflows and the
+ *    registry's routable agent roles equal the manifest's public lists
+ *    (no phantom entries) — the "registry-to-installed drift test" required
+ *    by #3702
  *  - exact base/head provenance (base + planningHead immutable, head present)
  *  - deterministic graph: re-running the generator yields an identical manifest
  *    modulo ephemeral head/generatedAt; the embedded manifestSha256 is consistent
@@ -83,6 +84,16 @@ type Manifest = {
 function loadManifest(): Manifest {
   if (!existsSync(BASELINE)) throw new Error(`baseline missing at ${relative(REPO_ROOT, BASELINE)} — run: node scripts/generate-inventory-graph.mjs --write`);
   return JSON.parse(readFileSync(BASELINE, 'utf8')) as Manifest;
+}
+
+function collectRegisteredAgents(): string[] {
+  const source = readFileSync(join(REPO_ROOT, 'src/workflow/registry.ts'), 'utf8');
+  const start = source.indexOf('export const WORKFLOW_ROLES');
+  const end = source.indexOf('];', start);
+  if (start < 0 || end < 0) throw new Error('WORKFLOW_ROLES registry is missing');
+  return [...source.slice(start, end).matchAll(/\{\s*name:\s*'([^']+)'/g)]
+    .map((match) => match[1]!)
+    .sort();
 }
 
 function sha256Hex(s: string): string {
@@ -220,7 +231,7 @@ describe('inventory-graph drift enforcement (#3702)', () => {
     const liveSkills = stable.filter((p) => /^skills\/[^/]+\/SKILL\.md$/.test(p)).map((p) => p.split('/')[1]).sort();
     const liveCommands = stable.filter((p) => /^commands\/[^/]+\.md$/.test(p)).map((p) => p.slice('commands/'.length, -3)).sort();
     const liveWorkflows = stable.filter((p) => p.startsWith('.github/workflows/')).sort();
-    const liveAgents = stable.filter((p) => /^src\/agents\/[^/]+\.ts$/.test(p)).map((p) => p.slice('src/agents/'.length, -3)).sort();
+    const liveAgents = collectRegisteredAgents();
 
     const missing = (live: string[], listed: string[]) => live.filter((x) => !listed.includes(x));
     const extra = (live: string[], listed: string[]) => listed.filter((x) => !live.includes(x));


### PR DESCRIPTION
## Graph Runtime v2 — orchestration graph runtime over the v5 Graph Core contracts

Targets `dev` from freshly fetched, pinned `upstream/dev` @ `b2fac230` (exact head). Refs #3570 (non-closing).

Brings the sealed-descriptor + pure-scheduler contract layer (`src/graph/*`, #3649 / ADR 03570) to life with a complete orchestration runtime: OCC journal replay for crash recovery, epoch single-writer fencing, concurrency-capped execution of command/agent nodes, human-approval gates, and a `omc graph run` CLI surface plus `/oh-my-claudecode:graph` skill entrypoint (same commander/skills conventions as team/ralph).

### Design highlights

- **Single-writer epoch fence**: O_EXCL create only; every removal via atomic rename to unique tombstones — the read-then-unlink defect pattern from the #3555 review does not exist anywhere in this code. Takeover requires a dead PID, reads old epoch from the exclusively-owned tombstone, recreates at epoch+1.
- **Crash recovery as primary scenario**: kill mid-run, rerun the same command — completed nodes never re-execute. Replay folds journaled transitions through the real scheduler entrypoints and verifies each record's `request_fingerprint` at fold time, so content-only journal tampering fails closed (`CORRUPT_JOURNAL`, exit 20).
- **Replay/live symmetry**: identities passed to scheduler calls are rebuilt from recorded fields so folded projections match live runs bit-for-bit (unit-proven un-normalized, including per-transition fingerprints).
- **Contracts consumed, never redefined**: zero changes to `src/graph/{types,schema,descriptor,scheduler}.ts`; all 143 pre-existing contract tests pass untouched. `src/index.ts` untouched.

### Exact command statuses

| Command | Status | Evidence tail |
|---------|--------|---------------|
| `npx tsc --noEmit` | PASS | exit 0, zero output |
| `npm run lint` | PASS | 0 errors (31 pre-existing warnings outside src/graph) |
| `npx vitest run src/graph` | PASS | 13 files / **213 tests** = 143 contract intact + 70 new runtime tests |
| installer consistency suite | PASS | 45/45 (plugin.json skills registration incl. new graph skill) |
| `npm pack --dry-run` | PASS | no committed dist/bridge delta vs upstream/dev; tarball has no src/.omc entries |
| pack → isolated install smoke | PASS | installed CLI executed a real 4-node linear graph: exit 0, all markers written |

### AC coverage (#3570 matrix)

AC-1..AC-8, AC-9 (max_attempts budget not bypassed), AC-10 (no wedge), AC-11 (traversal round-trip bit-for-bit), AC-11b (fold-time fingerprint tamper rejection), AC-13 (fan-out/join), AC-14/14b (approval approved/denied) — each mapped to a named test in the anti-port crosscheck maintained during development. Interleave probe asserts exactly-one-winner takeover races deterministically.

### Deferred follow-ups (non-blocking)

- Abort signal propagation into in-flight executors (library-consumer exposure only)
- `FenceLockPayload.timestamp` currently unused (mtime drives staleness)
- Demo script header text refresh

### Evidence-driven verdict

All engineering-gate conditions verified green by two independent review passes (multi-dimension code review with adversarial re-verification: final verdict APPROVE). Standing verdict: **APPROVE**.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
